### PR TITLE
ArduCopter: modify stability patch to eliminate ground bouncing and other bad behavior

### DIFF
--- a/ArduCopter/Attitude.pde
+++ b/ArduCopter/Attitude.pde
@@ -470,6 +470,8 @@ get_rate_roll(int32_t target_rate)
 
     // constrain output
     output = constrain(output, -5000, 5000);
+    
+    motors.set_roll_musthave_pct((float)i/output);
 
 #if LOGGING_ENABLED == ENABLED
     // log output if PID logging is on and we are tuning the rate P, I or D gains
@@ -511,6 +513,8 @@ get_rate_pitch(int32_t target_rate)
 
     // constrain output
     output = constrain(output, -5000, 5000);
+    
+    motors.set_pitch_musthave_pct((float)i/output);
 
 #if LOGGING_ENABLED == ENABLED
     // log output if PID logging is on and we are tuning the rate P, I or D gains

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -26,7 +26,10 @@ public:
     /// Constructor
     AP_MotorsMatrix( RC_Channel* rc_roll, RC_Channel* rc_pitch, RC_Channel* rc_throttle, RC_Channel* rc_yaw, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
         AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, speed_hz),
-        _num_motors(0) {
+        _num_motors(0),
+        _roll_musthave_percent(1.0f),
+        _pitch_musthave_percent(1.0f)
+        {
     };
 
     // init
@@ -66,7 +69,10 @@ public:
     virtual void        setup_motors() {
         remove_all_motors();
     };
-
+    
+    virtual void set_roll_musthave_pct(float);
+    virtual void set_pitch_musthave_pct(float);
+    
     // matrix
     AP_Int8         test_order[AP_MOTORS_MAX_NUM_MOTORS];               // order of the motors in the test sequence
 
@@ -82,6 +88,8 @@ protected:
     float               _roll_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to roll
     float               _pitch_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to pitch
     float               _yaw_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to yaw (normally 1 or -1)
+    float _roll_musthave_percent;
+    float _pitch_musthave_percent;
 };
 
 #endif  // AP_MOTORSMATRIX


### PR DESCRIPTION
This patch changes the stability patch so that only a given percentage of the roll and pitch command is considered "must have."

The percentage used is the percentage of the command that comes from the integrator. This means that disturbances don't cause an immediate increase in throttle - only steady-state error does.

In my testing, this reduced or eliminated several bad behaviors:
1. Landing bounces were eliminated.
2. Wobble caused by the user thrashing the stick causes far less climb.
3. Wobble caused by tuning rate P or D too high no longer causes an uncontrollable, unstoppable climb. (The cause of several crashes that I know of.)
4. Any climbs that still occur can be effectively prevented by the throttle controller or by the user's throttle input.

Note: it is my recommendation that the integrator limit on the rate controllers be increased to 3000 or 4500, and the default integrator be increased to 0.2 or 0.3.
