### PR TITLE
ArduCopter: Guided mode packet has option to not set_mode(GUIDED)

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1688,7 +1688,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 guided_WP.alt += home.alt;
             }
 
-            set_mode(GUIDED);
+            if (!(guided_WP.options & WP_OPTION_NO_MODE_CHANGE)) {
+                set_mode(GUIDED);
+            }
 
             // verify we recevied the command
             mavlink_msg_mission_ack_send(

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -217,7 +217,7 @@
 #define WP_OPTION_YAW                           4
 #define WP_OPTION_ALT_REQUIRED                  8
 #define WP_OPTION_RELATIVE                      16
-//#define WP_OPTION_					32
+#define WP_OPTION_NO_MODE_CHANGE                32
 //#define WP_OPTION_					64
 #define WP_OPTION_NEXT_CMD                      128
 


### PR DESCRIPTION
This change is required for implementation of a better followme device:

Allows a GCS to send a packet to update the guided mode waypoint without causing the autopilot to enter guided mode. This means the GCS can update the guided mode waypoint as often as it wants without worrying about taking mode control away from the pilot's RC transmitter, or a separate GCS.

Haven't flight tested this change, but its simple enough.
