### PR TITLE
Plane: Fix continuous reboot HIL_MODE_ATTITUDE with MAG_ENABLE=1

### DIFF
--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -208,6 +208,8 @@
  #define CONFIG_PITOT_SOURCE_ANALOG_PIN -1
  #undef CONFIG_PITOT_SCALING
  #define CONFIG_PITOT_SCALING 4.0
+ #undef  CONFIG_COMPASS
+ #define CONFIG_COMPASS  AP_COMPASS_HIL
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
After Plane: cleanup driver declaration 4d9a74d, HIL_MODE_ATTITUDE with MAG_ENABLE=1 set results in continuous reboot/APM crash.  Added define for AP_COMPASS_HIL when HIL_MODE_ATTITUDE is enabled.
