### PR TITLE
Minimum airspeed for throttle engagement on auto-takeoff

### DIFF
--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -395,10 +395,11 @@ static bool suppress_throttle(void)
         return false;
     }
 
-    if (control_mode==AUTO && takeoff_complete == false &&
-            g_gps != NULL &&
-            g_gps->status() == GPS::GPS_OK &&
-            g_gps->ground_speed >= g.takeoff_throttle_min_speed) {
+    if (control_mode==AUTO &&
+        takeoff_complete == false &&
+        g_gps != NULL &&
+        g_gps->status() == GPS::GPS_OK &&
+        g_gps->ground_speed >= g.takeoff_throttle_min_speed*100) {
         // we're in auto takeoff 
         throttle_suppressed = false;
         return false;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -356,7 +356,7 @@ public:
     AP_Int8 inverted_flight_ch;             // 0=disabled, 1-8 is channel for inverted flight trigger
     AP_Int8 stick_mixing;
     AP_Int8 rudder_steer;
-    AP_Int8 takeoff_throttle_min_speed;
+    AP_Float takeoff_throttle_min_speed;
 
     // RC channels
     RC_Channel channel_roll;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -90,8 +90,8 @@ const AP_Param::Info var_info[] PROGMEM = {
 
     // @Param: TKOFF_THR_MINSPD
     // @DisplayName: Takeoff throttle min speed
-    // @Description: Min speed in cm/s before un-suppressing throttle in auto-takeoff
-    // @Units: cm/s
+    // @Description: Min speed in m/s before un-suppressing throttle in auto-takeoff
+    // @Units: m/s
     // @User: User
     GSCALAR(takeoff_throttle_min_speed,     "TKOFF_THR_MINSPD",  0),
 


### PR DESCRIPTION
Adds enhancement requested in issue #81 as per discussion on http://diydrones.com/forum/topics/auto-takeoff-sequencing-problem

Fix is to add a new parameter that specifies a minimum GPS ground speed that must be exceeded before throttle is engaged. Default is at 0 to maintain current default behaviour of instant-start when stationary.

As this has some safety implications the default value might be better set at a value greater than 0, but this may also introduce bad behaviour at low values where the throttle may start intermittently with bad GPS readings.

This also introduces a strict dependence on GPS lock for auto-takeoff which may be a good thing.
