### PR TITLE
Build: Cygwin Windows build and upload fixes

### DIFF
--- a/mk/apm.mk
+++ b/mk/apm.mk
@@ -1,6 +1,12 @@
 # find the mk/ directory, which is where this makefile fragment
 # lives. (patsubst strips the trailing slash.)
-MK_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+SYSTYPE			:=	$(shell uname)
+
+ifneq ($(findstring CYGWIN, $(SYSTYPE)),) 
+  MK_DIR := $(shell cygpath -m ../mk)
+else
+  MK_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+endif
 
 include $(MK_DIR)/environ.mk
 

--- a/mk/board_avr.mk
+++ b/mk/board_avr.mk
@@ -85,7 +85,12 @@ HARDWARE_CORE :=	$(shell grep $(BOARD).build.core $(BOARDFILE) | cut -d = -f 2)
 UPLOAD_SPEED :=	$(shell grep $(BOARD).upload.speed $(BOARDFILE) | cut -d = -f 2)
 
 # User can define USERAVRDUDEFLAGS = -V in their config.mk to skip verification
-USERAVRDUDEFLAGS ?= 
+#make sure the avrdude conf file is referenced correctly in cygwin
+ifneq ($(findstring CYGWIN, $(SYSTYPE)),) 
+  USERAVRDUDEFLAGS := -C $(ARDUINO)/hardware/tools/avr/etc/avrdude.conf
+else
+  USERAVRDUDEFLAGS ?= 
+endif
 
 ifeq ($(UPLOAD_PROTOCOL),)
   UPLOAD_PROTOCOL	:=	$(shell grep $(BOARD).upload.protocol $(BOARDFILE) | cut -d = -f 2)
@@ -97,6 +102,11 @@ ifeq ($(BOARD),mega)
   UPLOAD_PROTOCOL	:=	arduino
 endif
 
+#On Cygwin, the wiring programmer will perform the DTR reset for us
+ifneq ($(findstring CYGWIN, $(SYSTYPE)),) 
+  UPLOAD_PROTOCOL	:=	wiring
+endif
+ 
 ifeq ($(MCU),)
 $(error ERROR: Could not locate board $(BOARD) in $(BOARDFILE))
 endif

--- a/mk/environ.mk
+++ b/mk/environ.mk
@@ -47,7 +47,7 @@ else
 endif
 ifneq ($(findstring CYGWIN, $(SYSTYPE)),) 
     # Convert cygwin path into a windows normal path
-    SKETCHBOOK	:=	$(shell cygpath ${SKETCHBOOK})
+    SKETCHBOOK	:=	$(shell cygpath -m ${SKETCHBOOK})
 endif
 
 #

--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -87,9 +87,5 @@ etags:
 	cd .. && etags -f APMrover2/TAGS --lang=c++ $$(git ls-files APMrover2 libraries)
 
 clean:
-ifneq ($(findstring CYGWIN, $(SYSTYPE)),)
-	@del /S $(BUILDROOT)
-else
 	@rm -fr $(BUILDROOT)
-endif
 


### PR DESCRIPTION
AVR and SITL-based builds and uploads work under Windows (via Cygwin).
