### PR TITLE
Arduplane: fixes #138

### DIFF
--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1408,13 +1408,16 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         if (packet.count > MAX_WAYPOINTS) {
             packet.count = MAX_WAYPOINTS;
         }
-        g.command_total.set_and_save(packet.count - 1);
+
+        // clear all commands before receiving new mission
+        g.command_total.set_and_save(0);
+
 
         waypoint_timelast_receive = millis();
         waypoint_timelast_request = 0;
         waypoint_receiving   = true;
         waypoint_request_i   = 0;
-        waypoint_request_last= g.command_total;
+        waypoint_request_last= packet.count - 1;
         break;
     }
 

--- a/ArduPlane/commands.pde
+++ b/ArduPlane/commands.pde
@@ -99,7 +99,8 @@ static struct Location get_cmd_with_index(int16_t i)
 // -------
 static void set_cmd_with_index(struct Location temp, int16_t i)
 {
-    i = constrain_int16(i, 0, g.command_total.get());
+    // Constrain adding so there is no empty commands on the mission
+    i = constrain_int16(i, 0, g.command_total.get()+1); 
     uint16_t mem = WP_START_BYTE + (i * WP_SIZE);
 
     // force home wp to absolute height
@@ -125,6 +126,10 @@ static void set_cmd_with_index(struct Location temp, int16_t i)
 
     mem += 4;
     hal.storage->write_dword(mem, temp.lng);
+
+    // Make sure our WP_total
+    if(g.command_total < (i))
+        g.command_total.set_and_save(i);
 }
 
 static void decrement_cmd_index()


### PR DESCRIPTION
If a waypoint transmission is corrupted uses only the received waypoints.

Tested on APM1.
