### PR TITLE
autotest: added link for QUpgrader to web-firmware/index.html

### DIFF
--- a/Tools/autotest/web-firmware/index.html
+++ b/Tools/autotest/web-firmware/index.html
@@ -109,7 +109,19 @@ The meanings of the versions are
 For each vehicle type a firmware image is available for each type of
 autopilot board supported by that vehicle type
 
-<h2>How to load your firmware</h2>
+<h2>Load your firmware using QUpgrade</h2>
+
+<p>QUpgrade is a standalone firmware upgrade tool. It can be used to download and flash the appropriate firmware for your autopilot.</p>
+
+<h3>Download QUpgrade</h3>
+<ul>
+<li><b>Windows: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.1.exe.zip">QUpgrade Installer (exe, zipped) v0.1 BETA</a></li>
+<li><b>Mac: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.1.dmg.zip">QUpgrade Installer (dmg, zipped) v0.1 BETA</a></li>
+<li><b>Linux: </b>Soon available, or build from <a href="https://github.com/LorenzMeier/qupgrade/">Source</a></li>
+</ul>
+
+
+<h2>Load your firmware using APM Mission Planner</h2>
 
 After downloading a firmware image from one of the links above you will
 need to load it into your board. If you are using


### PR DESCRIPTION
I just added the link for QUpgrader.

However, in my opinion, there should one page that lists the firmware files and one that lists the software tools. The firmware list would then be the page that is displayed in QUpgrade. Right now you see in the interface of QUpgrade how to download Qupgrade so this doesn't make sense.
