### PR TITLE
Old version number of QUpgrade in the link

### DIFF
--- a/Tools/autotest/web-firmware/index.html
+++ b/Tools/autotest/web-firmware/index.html
@@ -115,8 +115,8 @@ autopilot board supported by that vehicle type
 
 <h3>Download QUpgrade</h3>
 <ul>
-<li><b>Windows: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.1.exe.zip">QUpgrade Installer (exe, zipped) v0.1 BETA</a></li>
-<li><b>Mac: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.1.dmg.zip">QUpgrade Installer (dmg, zipped) v0.1 BETA</a></li>
+<li><b>Windows: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.2.exe.zip">QUpgrade Installer (exe, zipped) v0.2 BETA</a></li>
+<li><b>Mac: </b><a href="https://pixhawk.ethz.ch/px4/_media/downloads/qupgrade-v0.2.dmg.zip">QUpgrade Installer (dmg, zipped) v0.2 BETA</a></li>
 <li><b>Linux: </b>Soon available, or build from <a href="https://github.com/LorenzMeier/qupgrade/">Source</a></li>
 </ul>
 


### PR DESCRIPTION
Sorry, the version number of QUpgrade has already changed from v0.1 to v0.2.
I corrected the links. Maybe for the future a download "latest" would make sense to avoid these changes.
