### PR TITLE
Fixed build for APM2 Beta hardware

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -41,7 +41,7 @@
 #include <AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
 
 #include <AP_HAL.h>
-#if CONFIG_HAL_BOARD == HAL_BOARD_APM1
+#if CONFIG_HAL_BOARD == HAL_BOARD_APM1 || APM2_BETA_HARDWARE
 #include "AP_Baro_BMP085.h"
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
Small mistake in BMP baro sensor code is currently preventing the code to be built for APM2 beta hardware.
