### PR TITLE
Added .vagrant to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Make.dep
 *.tlog
 
 .DS_Store
+.vagrant


### PR DESCRIPTION
Relates to pull request #183 (Automated dev environment distribution) and leaves vagrant instance specific configs outside git control.
