### PR TITLE
PX4: Remove -Os because I've changed the px4 tree to have that as the

### DIFF
--- a/mk/px4_targets.mk
+++ b/mk/px4_targets.mk
@@ -20,7 +20,6 @@ $(BUILDROOT)/module.mk:
 	$(v) echo "MODULE_COMMAND = ArduPilot" >> $@
 	$(v) echo "SRCS = $(SKETCH).cpp $(SKETCHLIBSRCS)" >> $@
 	$(v) echo "MODULE_STACKSIZE = 4096" >> $@
-	$(v) echo "MAXOPTIMIZATION  = -Os" >> $@
 
 px4: $(PX4_ROOT)/Archives/px4fmu.export $(SKETCHCPP) $(BUILDROOT)/module.mk
 	$(RULEHDR)


### PR DESCRIPTION
default

See related PR: https://github.com/diydrones/PX4Firmware/pull/1
