### PR TITLE
Failsafe gps lost bug fix

### DIFF
--- a/ArduCopter/events.pde
+++ b/ArduCopter/events.pde
@@ -18,7 +18,7 @@ static void failsafe_radio_on_event()
             // if throttle is zero disarm motors
             if (g.rc_3.control_in == 0) {
                 init_disarm_motors();
-            }else if(ap.home_is_set == true && g_gps->status() != GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
+            }else if(ap.home_is_set == true && g_gps->status() == GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
                 set_mode(RTL);
             }else{
                 // We have no GPS or are very close to home so we will land
@@ -38,7 +38,7 @@ static void failsafe_radio_on_event()
             // if failsafe_throttle is 2 (i.e. FS_THR_ENABLED_CONTINUE_MISSION) no need to do anything
             break;
         default:
-            if(ap.home_is_set == true && g_gps->status() != GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
+            if(ap.home_is_set == true && g_gps->status() == GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
                 set_mode(RTL);
             }else{
                 // We have no GPS or are very close to home so we will land
@@ -77,7 +77,7 @@ static void low_battery_event(void)
                 }
                 break;
             case AUTO:
-                if(ap.home_is_set == true && g_gps->status() != GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
+                if(ap.home_is_set == true && g_gps->status() == GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
                     set_mode(RTL);
                 }else{
                     // We have no GPS or are very close to home so we will land
@@ -190,7 +190,7 @@ static void failsafe_gcs_check()
             // if throttle is zero disarm motors
             if (g.rc_3.control_in == 0) {
                 init_disarm_motors();
-            }else if(ap.home_is_set == true && g_gps->status() != GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
+            }else if(ap.home_is_set == true && g_gps->status() == GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
                 set_mode(RTL);
             }else{
                 // We have no GPS or are very close to home so we will land
@@ -210,7 +210,7 @@ static void failsafe_gcs_check()
             // if failsafe_throttle is 2 (i.e. FS_THR_ENABLED_CONTINUE_MISSION) no need to do anything
             break;
         default:
-            if(ap.home_is_set == true && g_gps->status() != GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
+            if(ap.home_is_set == true && g_gps->status() == GPS::GPS_OK_FIX_3D && home_distance > wp_nav.get_waypoint_radius()) {
                 set_mode(RTL);
             }else{
                 // We have no GPS or are very close to home so we will land


### PR DESCRIPTION
if gps is lost before/when failsafe triggered - triggering of RTL would result in set_mode returning to STABILIZE - aka quad plummets from sky if radio loss.  This commit forces correct behaviour - e.g. LAND if no GPS.

Two commits - sorry got boolean operation around wrong way on first one.
