### PR TITLE
Plane : Fixes scaler incorrectly applied to pitch and roll integrators

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -172,7 +172,7 @@ int32_t AP_PitchController::get_servo_out(int32_t angle, float scaler, bool stab
 	if (!stabilize && ki_rate > 0) {
 		//only integrate if gain and time step are positive and airspeed above min value.
 		if (dt > 0 && aspeed > float(aspd_min)) {
-		    float integrator_delta = rate_error * ki_rate * scaler * delta_time;
+		    float integrator_delta = rate_error * ki_rate * delta_time;
 			if (_last_out < -45) {
 				// prevent the integrator from increasing if surface defln demand is above the upper limit
 				integrator_delta = max(integrator_delta , 0);

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -122,7 +122,7 @@ int32_t AP_RollController::get_servo_out(int32_t angle, float scaler, bool stabi
 	if (!stabilize && ki_rate > 0) {
 		//only integrate if gain and time step are positive and airspeed above min value.
 		if (dt > 0 && aspeed > float(aspd_min)) {
-		    float integrator_delta = rate_error * ki_rate * scaler * delta_time;
+		    float integrator_delta = rate_error * ki_rate * delta_time;
 			// prevent the integrator from increasing if surface defln demand is above the upper limit
 			if (_last_out < -45) {
                 integrator_delta = max(integrator_delta , 0);


### PR DESCRIPTION
The current APM controllers had the airspeed scaler applied unnecessarily to the integrator path. This patch will give a more consistent integrator response across a wider range of airspeeds. This will only be noticed by users that run high integrator gains on models with a wide (> 2:1) speed range.
