### PR TITLE
AP_Baro : Indicated to true airspeed scaler and improved altitude accuracy

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -36,6 +36,9 @@ public:
     // of the last calibrate() call
     float        get_altitude(void);
 
+    // get scale factor required to convert equivalent to true airspeed
+    float        get_EAS2TAS(void);
+
     // return how many pressure samples were used to obtain
     // the last pressure reading
     uint8_t        get_pressure_samples(void) {
@@ -67,6 +70,8 @@ private:
     AP_Float                            _ground_temperature;
     AP_Float                            _ground_pressure;
     float                               _altitude;
+    float                               _last_altitude_EAS2TAS;
+    float                               _EAS2TAS;
     uint32_t                            _last_altitude_t;
     DerivativeFilterFloat_Size7         _climb_rate_filter;
 };


### PR DESCRIPTION
The baro altitude calculation has been adjusted to use the exact equations for the international standard atmosphere tropopause ( 0 - 11km AMSL). The old calculation would have the plane flying 300m low at 5000m with the error increasing exponentially with height.

Also a method for calculating the scaler from equivalent/indicated to true airspeed has been added. This can be used by speed/height control and other navigation functions.
