### PR TITLE
Fix for AnalogIn.cpp:42: undefined references

### DIFF
--- a/libraries/AP_HAL_Empty/AnalogIn.cpp
+++ b/libraries/AP_HAL_Empty/AnalogIn.cpp
@@ -1,4 +1,3 @@
-
 #include "AnalogIn.h"
 
 using namespace Empty;
@@ -22,6 +21,11 @@ float EmptyAnalogSource::read_latest() {
 void EmptyAnalogSource::set_pin(uint8_t p)
 {}
 
+void EmptyAnalogSource::set_stop_pin(uint8_t p)
+{}
+
+void EmptyAnalogSource::set_settle_time(uint16_t settle_time_ms)
+{}
 
 EmptyAnalogIn::EmptyAnalogIn()
 {}


### PR DESCRIPTION
Was getting the following errors compiling on in Cygwin on Win7 x32. Added empty functions to reflect header file to mimic setpin()

Full error msgs:
/cygdrive/c/MAVPRO~1/ardupilot/libraries/AP_HAL_Empty/AnalogIn.cpp:42: undefined reference to `Empty::EmptyAnalogSource::set_stop_pin(unsigned char)'
/cygdrive/c/MAVPRO~1/ardupilot/libraries/AP_HAL_Empty/AnalogIn.cpp:42: undefined reference to`Empty::EmptyAnalogSource::set_settle_time(unsigned short)'
