### PR TITLE
Fix SITL build on OSX

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
@@ -33,6 +33,14 @@ using namespace AVR_SITL;
 
 #define LISTEN_BASE_PORT 5760
 
+// On OSX, MSG_NOSIGNAL doesn't exist. The equivalent is to set SO_NOSIGPIPE
+// in setsockopt for the socket. However, if we just skip that, and don't use
+// MSG_NOSIGNAL, everything seems to work fine and SIGPIPE doesn't seem to be
+// generated.
+#if defined(__APPLE__)
+#define MSG_NOSIGNAL 0
+#endif
+
 bool SITLUARTDriver::_console;
 
 /* UARTDriver method implementations */

--- a/mk/board_avr_sitl.mk
+++ b/mk/board_avr_sitl.mk
@@ -18,7 +18,10 @@ CXXOPTS         =   -ffunction-sections -fdata-sections -fno-exceptions -fsigned
 COPTS           =   -ffunction-sections -fdata-sections -fsigned-char
 
 ASOPTS          =   -x assembler-with-cpp 
+
+ifneq ($(SYSTYPE),Darwin)
 LISTOPTS        =   -adhlns=$(@:.o=.lst)
+endif
 
 CPUFLAGS     = -D_GNU_SOURCE
 CPULDFLAGS   = -g
@@ -31,7 +34,10 @@ CFLAGS         +=   $(WARNFLAGS) $(DEPFLAGS) $(COPTS)
 ASFLAGS         =   -g $(CPUFLAGS) $(DEFINES) -Wa,$(LISTOPTS) $(DEPFLAGS)
 ASFLAGS        +=   $(ASOPTS)
 LDFLAGS         =   -g $(CPUFLAGS) $(OPTFLAGS) $(WARNFLAGS)
+
+ifneq ($(SYSTYPE),Darwin)
 LDFLAGS        +=   -Wl,--gc-sections -Wl,-Map -Wl,$(SKETCHMAP)
+endif
 
 LIBS = -lm
 


### PR DESCRIPTION
The SITL build was not compiling successfully on OSX and would fail with error. `make sitl` would produce the following error:

```
FATAL:/usr/bin/../libexec/as/x86_64/as: I don't understand 'a' flag! make: [/var/folders/1z/nrvllnvx6znf1z436jsn_3jw0000gn/T/ArduCopter?.build/ArduCopter?.o] Error 1
```

It looks like the assembler and linker flags in the SITL makefile are incompatible with OSX's version of as and ld. This change removes those flags when building on OSX.

Additionally, MSG_NOSIGNAL is only defined in Linux and not OSX (or BSD). I removed the MSG_NOSIGNAL flag when compiling on OSX. This doesn't seem to have any adverse effects as SIGPIPE still doesn't seem to be generated on the OSX version of SITL, even when repeatedly connecting then disconnecting to the TCP socket. Perhaps a more equivalent change would be to add the following in the appropriate places when compiling on OSX:

```
setsockopt(_listen_fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
```

However, this simple `#define MSG_NOSIGNAL 0` seems to work, and is minimally invasive.

With this change I am able to `make sitl` on OSX. I tested by running the ArduCopter SITL with sim_multicopter.py and verifying it was working as expected.
