### PR TITLE
SITL: Avoid SIGPIPE on all platforms with a no-op SIGPIPE handler

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_AVR_SITL/SITL_State.cpp
@@ -65,6 +65,8 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 	int opt;
 
 	signal(SIGFPE, _sig_fpe);
+	// No-op SIGPIPE handler
+	signal(SIGPIPE, SIG_IGN);
 
     setvbuf(stdout, (char *)0, _IONBF, 0);
     setvbuf(stderr, (char *)0, _IONBF, 0);

--- a/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
@@ -33,14 +33,6 @@ using namespace AVR_SITL;
 
 #define LISTEN_BASE_PORT 5760
 
-// On OSX, MSG_NOSIGNAL doesn't exist. The equivalent is to set SO_NOSIGPIPE
-// in setsockopt for the socket. However, if we just skip that, and don't use
-// MSG_NOSIGNAL, everything seems to work fine and SIGPIPE doesn't seem to be
-// generated.
-#ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL 0
-#endif
-
 bool SITLUARTDriver::_console;
 
 /* UARTDriver method implementations */
@@ -132,7 +124,7 @@ int16_t SITLUARTDriver::read(void)
         return ::read(0, &c, 1);
     }
 
-    int n = recv(_fd, &c, 1, MSG_DONTWAIT | MSG_NOSIGNAL);
+    int n = recv(_fd, &c, 1, MSG_DONTWAIT);
     if (n <= 0) {
         // the socket has reached EOF
         close(_fd);
@@ -153,7 +145,7 @@ void SITLUARTDriver::flush(void)
 
 size_t SITLUARTDriver::write(uint8_t c) 
 {
-    int flags = MSG_NOSIGNAL;
+    int flags = 0;
     _check_connection();
     if (!_connected) {
         return 0;


### PR DESCRIPTION
This is a followup from diydrones/ardupilot#420

As suggested by @tridge, this commit uses a no-op `SIGPIPE` handler instead of `MSG_NOSIGNAL` for avoiding `SIGPIPE`. `MSG_NOSIGNAL` is Linux-only and thus does not work for avoiding `SIGPIPE` on OSX. This is a simpler, multi-platform solution.
