### PR TITLE
Make: Use generic app descriptior for mac spotlight search

### DIFF
--- a/mk/find_arduino.mk
+++ b/mk/find_arduino.mk
@@ -8,7 +8,7 @@ ifeq ($(ARDUINO),)
   #
   ifeq ($(SYSTYPE),Darwin)
     # use Spotlight to find Arduino.app
-    ARDUINO_QUERY	=	'kMDItemKind == Application && kMDItemFSName == Arduino.app'
+    ARDUINO_QUERY	=	'kMDItemContentType == com.apple.application-bundle && kMDItemFSName == Arduino.app'
     ARDUINOS		:=	$(addsuffix /Contents/Resources/Java,$(shell mdfind -literal $(ARDUINO_QUERY)))
     ifeq ($(ARDUINOS),)
       $(error ERROR: Spotlight cannot find Arduino on your system.)


### PR DESCRIPTION
kMDItemKinde is a localized string, only in EN OSX versions the value
is Application, changed to generic ContentType metafild
