### PR TITLE
Make autotest work with recent mavlink

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -106,7 +106,7 @@ def convert_gpx():
     mavlog = glob.glob(util.reltopdir("../buildlogs/*.mavlog"))
     for m in mavlog:
         try:
-            util.run_cmd(util.reltopdir("../mavlink/pymavlink/examples/wptogpx.py") + m)
+            util.run_cmd(util.reltopdir("../mavlink/pymavlink/examples/wptogpx.py ") + m)
         except:
             # We have an old version of mavlink, before mavtogpx was renamed to wptogpx
             util.run_cmd(util.reltopdir("../mavlink/pymavlink/examples/mavtogpx.py") + " --nofixcheck " + m)


### PR DESCRIPTION
Fix the autotest script so that it can deal with the renaming of the waypoint to gpx script in latest mavlink (https://github.com/mavlink/mavlink/commit/7cefdc26d81f2282f560d3c90446a9c29c424222).
