### PR TITLE
disable low battery buzzer if usb connected

### DIFF
--- a/ArduCopter/events.pde
+++ b/ArduCopter/events.pde
@@ -124,7 +124,9 @@ static void low_battery_event(void)
 
 #if COPTER_LEDS == ENABLED
     // Only Activate if a battery is connected to avoid alarm on USB only
-    piezo_on();
+    if (!ap_system.usb_connected) {
+        piezo_on();
+    }
 #endif // COPTER_LEDS
 }
 


### PR DESCRIPTION
Disable low battery piezo buzzer if usb connected: there was a comment here saying it should only activate if a battery is connected, but it wasn't actually doing the check. Super annoying to have the loud piezo buzzer go off when you're tethered to download logs!
