### PR TITLE
Copter: restore symmetry to stability patch for Tricopters

### DIFF
--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -67,8 +67,6 @@ void AP_MotorsTri::enable()
 // output_min - sends minimum values out to the motors
 void AP_MotorsTri::output_min()
 {
-    // set lower limit flag
-    limit.throttle_lower = true;
     // fill the motor_out[] array for HIL use
     motor_out[AP_MOTORS_MOT_1] = _rc_throttle->radio_min;
     motor_out[AP_MOTORS_MOT_2] = _rc_throttle->radio_min;
@@ -86,9 +84,6 @@ void AP_MotorsTri::output_armed()
 {
     int16_t out_min = _rc_throttle->radio_min + _min_throttle;
     int16_t out_max = _rc_throttle->radio_max;
-
-    // initialize lower limit flag
-    limit.throttle_lower = false;
 
     // Throttle is 0 to 1000 only
     _rc_throttle->servo_out = constrain_int16(_rc_throttle->servo_out, 0, _max_throttle);
@@ -111,18 +106,10 @@ void AP_MotorsTri::output_armed()
         motor_out[AP_MOTORS_MOT_1] = _rc_throttle->radio_min + _spin_when_armed;
         motor_out[AP_MOTORS_MOT_2] = _rc_throttle->radio_min + _spin_when_armed;
         motor_out[AP_MOTORS_MOT_4] = _rc_throttle->radio_min + _spin_when_armed;
-
-        // Every thing is limited
-        limit.throttle_lower = true;
-		
     }else{
         int16_t roll_out            = (float)_rc_roll->pwm_out * 0.866f;
         int16_t pitch_out           = _rc_pitch->pwm_out / 2;
 
-        // check if throttle is below limit
-        if (_rc_throttle->radio_out <= out_min) {
-            limit.throttle_lower = true;
-        }
         //left front
         motor_out[AP_MOTORS_MOT_2] = _rc_throttle->radio_out + roll_out + pitch_out;
         //right front


### PR DESCRIPTION
Removes the "Increase opposing motors by 1/2 the overage of the high
motor" logic and merely moves all 3 motors down by the same amount if
one is over during the tests.  This eliminates the asymmetric scaling of
the previous logic. This resolves #537
