### PR TITLE
Add support for rotation direction parameter of MAV_CMD_CONDITION_YAW

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -663,7 +663,6 @@ static uint8_t roll_pitch_mode;
 // The current desired control scheme for altitude hold
 static uint8_t throttle_mode;
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // flight specific
 ////////////////////////////////////////////////////////////////////////////////
@@ -726,7 +725,8 @@ static int32_t yaw_look_at_WP_bearing;
 static int32_t yaw_look_at_heading;
 // Deg/s we should turn
 static int16_t yaw_look_at_heading_slew;
-
+// The desired rotation direction for Yaw in auto modes
+static uint8_t nav_yaw_rot_dir;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1419,7 +1419,7 @@ static void update_GPS(void)
 // set_yaw_mode - update yaw mode and initialise any variables required
 bool set_yaw_mode(uint8_t new_yaw_mode)
 {
-    // boolean to ensure proper initialisation of throttle modes
+	// boolean to ensure proper initialisation of throttle modes
     bool yaw_initialised = false;
 
     // return immediately if no change

--- a/ArduCopter/commands_logic.pde
+++ b/ArduCopter/commands_logic.pde
@@ -765,11 +765,13 @@ static void do_yaw()
         yaw_look_at_heading_slew = constrain_int32(turn_rate, 1, 360);    // deg / sec
     }
 
+    // Set clockwise / counter clockwise rotation. 0 = shortest, 1 = clockwise, 2 = counterclockwise
+    // https://pixhawk.ethz.ch/mavlink/ says we should use -1 and 1 for cw and ccw, but that would require signed int
+    nav_yaw_rot_dir=command_cond_queue.p1;
+
     // set yaw mode
     set_yaw_mode(YAW_LOOK_AT_HEADING);
 
-    // TO-DO: restore support for clockwise / counter clockwise rotation held in command_cond_queue.p1
-    // command_cond_queue.p1; // 0 = undefined, 1 = clockwise, -1 = counterclockwise
 }
 
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -204,6 +204,11 @@
 #define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL    2   // auto pilot will face next waypoint except when doing RTL at which time it will stay in it's last 
 #define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicotpers)
 
+// Yaw rotation direction held in nav_yaw_rot_dir variable
+#define YAW_SHORTEST	0
+#define YAW_CW			1
+#define YAW_CCW			2
+
 // TOY mixing options
 #define TOY_LOOKUP_TABLE 0
 #define TOY_LINEAR_MIXER 1

--- a/ArduCopter/navigation.pde
+++ b/ArduCopter/navigation.pde
@@ -196,7 +196,16 @@ static void reset_nav_params(void)
 // assumes it is called at 100hz so centi-degrees and update rate cancel each other out
 static int32_t get_yaw_slew(int32_t current_yaw, int32_t desired_yaw, int16_t deg_per_sec)
 {
-    return wrap_360_cd(current_yaw + constrain_int16(wrap_180_cd(desired_yaw - current_yaw), -deg_per_sec, deg_per_sec));
+	int32_t slew_diff = constrain_int16(wrap_180_cd(desired_yaw - current_yaw), -deg_per_sec, deg_per_sec);
+	switch (nav_yaw_rot_dir){
+	case YAW_CW:
+		return current_yaw + abs(slew_diff);
+	case YAW_CCW:
+		return current_yaw - abs(slew_diff);
+	default:
+		return current_yaw + slew_diff;
+	}
+
 }
 
 


### PR DESCRIPTION
This is the completion of an existing TO-DO in the code which adds support for the Mavlink parameter of MAV_CMD_CONDITION_YAW that determines what in direction yaw will occur. One complication was that Mavlink expects a value of -1 to indicate counterclockwise, but we are using an unsigned int for this parameter of the location struct so I figured we could just use 0, 1, and 2 to indicate default behaviour, clockwise, and counterclockwise, respectively.

It has been tested in SITL and didn't present any issues. I think it's ready for master.
