### PR TITLE
copter: add message to GCS in case of GPS glitch (to tell pilot)

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1393,6 +1393,7 @@ static void update_GPS(void)
         if (AP_Notify::flags.gps_glitching != gps_glitch.glitching()) {
             if (gps_glitch.glitching()) {
                 Log_Write_Error(ERROR_SUBSYSTEM_GPS, ERROR_CODE_GPS_GLITCH);
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("Glitch detected"));
             }else{
                 Log_Write_Error(ERROR_SUBSYSTEM_GPS, ERROR_CODE_ERROR_RESOLVED);
             }


### PR DESCRIPTION
Hi @rmackay9 and @tridge - I think this is a good change for now, but this does give me an idea which we might want to consider for the future.  What about changing Log_Write_Error to also send a mavlink message to the client?  The nice thing about log_write_error is that the codes are numeric, which makes them nicely localizable inside the GCS.

The GCS could provide an appropriate mapping for the users language (just like any other localized string) - falling back to english as needed.

This also would give us the beginning of structured faults, so we could have a list of currently pending faults and faults could be cleared/set as needed.
