### PR TITLE
AC: fix autodocs for SUPER_SIMPLE so the GCSes can show the right option...

### DIFF
--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -153,8 +153,8 @@ const AP_Param::Info var_info[] PROGMEM = {
 
     // @Param: SUPER_SIMPLE
     // @DisplayName: Enable Super Simple Mode
-    // @Description: Setting this to Enabled(1) will enable Super Simple Mode. Setting this to Disabled(0) will disable Super Simple Mode
-    // @Values: 0:Disabled,1:Enabled
+    // @Description: Enabling this turn on one of the Super Simple Mode variants. Setting this to Disabled(0) will disable Super Simple Mode
+    // @Values: 0:Disabled,1:Mode1,2:Mode2,3:Mode1+2,4:Mode3,5:Mode1+3,6:Mode2+3,7:Mode1+2+3,8:Mode4,9:Mode1+4,10:Mode2+4,11:Mode1+2+4,12:Mode3+4,13:Mode1+3+4,14:Mode2+3+4,15:Mode1+2+3+4,16:Mode5,17:Mode1+5,18:Mode2+5,19:Mode1+2+5,20:Mode3+5,21:Mode1+3+5,22:Mode2+3+5,23:Mode1+2+3+5,24:Mode4+5,25:Mode1+4+5,26:Mode2+4+5,27:Mode1+2+4+5,28:Mode3+4+5,29:Mode1+3+4+5,30:Mode2+3+4+5,31:Mode1+2+3+4+5,32:Mode6,33:Mode1+6,34:Mode2+6,35:Mode1+2+6,36:Mode3+6,37:Mode1+3+6,38:Mode2+3+6,39:Mode1+2+3+6,40:Mode4+6,41:Mode1+4+6,42:Mode2+4+6,43:Mode1+2+4+6,44:Mode3+4+6,45:Mode1+3+4+6,46:Mode2+3+4+6,47:Mode1+2+3+4+6,48:Mode5+6,49:Mode1+5+6,50:Mode2+5+6,51:Mode1+2+5+6,52:Mode3+5+6,53:Mode1+3+5+6,54:Mode2+3+5+6,55:Mode1+2+3+5+6,56:Mode4+5+6,57:Mode1+4+5+6,58:Mode2+4+5+6,59:Mode1+2+4+5+6,60:Mode3+4+5+6,61:Mode1+3+4+5+6,62:Mode2+3+4+5+6,63:Mode1+2+3+4+5+6
     // @User: Standard
     GSCALAR(super_simple,   "SUPER_SIMPLE",     SUPER_SIMPLE),
 


### PR DESCRIPTION
I've just sent in a PR to fixup the docs for this param - so Andropilot and Mission Planner should get this 'for free'.  Alas our paramdocs standard doesn't understand bitfields yet, so I just had emacs spit out a really long params line...

<param humanName="Enable Super Simple Mode" name="ArduCopter:SUPER_SIMPLE" documentation="Enabling this turn on one of the Super Simple Mode variants. Setting this to Disabled(0) will disable Super Simple Mode" user="Standard">
<values>
<value code="0">Disabled</value>
<value code="1">Mode1</value>
<value code="2">Mode2</value>
<value code="3">Mode1+2</value>
...
