### PR TITLE
Allow the SITL scripts to run on platforms without gnome-terminal

### DIFF
--- a/Tools/autotest/sim_arducopter.sh
+++ b/Tools/autotest/sim_arducopter.sh
@@ -6,6 +6,8 @@ pkill -f sim_multicopter.py
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 target=sitl
 frame="+"
 
@@ -32,12 +34,12 @@ make clean $target
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf"
-gnome-terminal -e /tmp/ArduCopter.build/ArduCopter.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf" &
+$APMTERM -e /tmp/ArduCopter.build/ArduCopter.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,180"
+$APMTERM -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,180" &
 sleep 2
 popd
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 --quadcopter $*

--- a/Tools/autotest/sim_arducopter10.sh
+++ b/Tools/autotest/sim_arducopter10.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 if [ $# -eq 1 ]; then
     frame="$1"
     target="sitl-$frame"
@@ -28,12 +30,12 @@ make clean $target-mavlink10
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf"
-gnome-terminal -e /tmp/ArduCopter.build/ArduCopter.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf" &
+$APMTERM -e /tmp/ArduCopter.build/ArduCopter.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270"
+$APMTERM -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270" &
 sleep 2
 popd
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 --quadcopter --mav10

--- a/Tools/autotest/sim_arducopter_randy.sh
+++ b/Tools/autotest/sim_arducopter_randy.sh
@@ -6,6 +6,8 @@ pkill -f sim_multicopter.py
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 target=sitl
 frame="X"
 
@@ -17,12 +19,12 @@ make clean $target
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf"
-gnome-terminal -e /tmp/ArduCopter.build/ArduCopter.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf" &
+$APMTERM -e /tmp/ArduCopter.build/ArduCopter.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270"
+$APMTERM -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270" &
 sleep 2
 popd
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 --out 192.168.1.13:14550 --console --map --aircraft test --quadcopter $*

--- a/Tools/autotest/sim_arducopter_randy_valgrind.sh
+++ b/Tools/autotest/sim_arducopter_randy_valgrind.sh
@@ -6,6 +6,8 @@ pkill -f sim_multicopter.py
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 target=sitl
 frame="X"
 
@@ -17,12 +19,12 @@ make clean $target
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf"
-#gnome-terminal -e /tmp/ArduCopter.build/ArduCopter.elf
-gnome-terminal -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduCopter.build/ArduCopter.elf" &
+#$APMTERM -e /tmp/ArduCopter.build/ArduCopter.elf &
+$APMTERM -e "valgrind -q /tmp/ArduCopter.build/ArduCopter.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270"
+$APMTERM -e "../Tools/autotest/pysim/sim_multicopter.py --frame=$frame --home=-35.362938,149.165085,584,270" &
 sleep 2
 popd
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 --out 192.168.1.12:14550 --console --map --aircraft test --quadcopter $*

--- a/Tools/autotest/sim_arduplane.sh
+++ b/Tools/autotest/sim_arduplane.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+: ${APMTERM=xterm}
+
 # home location lat, lon, alt, heading
 SIMHOME="-35.363261,149.165230,584,353"
 
@@ -46,12 +48,14 @@ make clean sitl
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
-gnome-terminal -e "/tmp/ArduPlane.build/ArduPlane.elf -I$INSTANCE"
-#gnome-terminal -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "/tmp/ArduPlane.build/ArduPlane.elf -I$INSTANCE"
+$APMTERM -e "/tmp/ArduPlane.build/ArduPlane.elf -I$INSTANCE" &
+#$APMTERM -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
 sleep 2
 rm -f $tfile
-gnome-terminal -e "../Tools/autotest/jsbsim/runsim.py --home=$SIMHOME --simin=$SIMIN_PORT --simout=$SIMOUT_PORT --fgout=$FG_PORT"
+#$APMTERM -e "../Tools/autotest/jsbsim/runsim.py --home=$SIMHOME --simin=$SIMIN_PORT --simout=$SIMOUT_PORT --fgout=$FG_PORT"
+$APMTERM -e "../Tools/autotest/jsbsim/runsim.py --home=$SIMHOME --simin=$SIMIN_PORT --simout=$SIMOUT_PORT --fgout=$FG_PORT" &
 sleep 2
 popd
 

--- a/Tools/autotest/sim_arduplane10.sh
+++ b/Tools/autotest/sim_arduplane10.sh
@@ -3,18 +3,20 @@
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../ArduPlane
 make clean sitl-mavlink10
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
-gnome-terminal -e /tmp/ArduPlane.build/ArduPlane.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf" &
+$APMTERM -e /tmp/ArduPlane.build/ArduPlane.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270'
+$APMTERM -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270' &
 sleep 2
 popd
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 --mav10

--- a/Tools/autotest/sim_arduplane_elevon.sh
+++ b/Tools/autotest/sim_arduplane_elevon.sh
@@ -7,18 +7,20 @@ pkill -f runsim.py
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../ArduPlane
 make clean sitl
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
-gnome-terminal -e /tmp/ArduPlane.build/ArduPlane.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf" &
+$APMTERM -e /tmp/ArduPlane.build/ArduPlane.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270 --elevon'
+$APMTERM -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270 --elevon' &
 sleep 2
 popd
 

--- a/Tools/autotest/sim_arduplane_hil.sh
+++ b/Tools/autotest/sim_arduplane_hil.sh
@@ -6,7 +6,9 @@ pkill -f runsim.py
 set -e
 set -x
 
-gnome-terminal -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270'
+: ${APMTERM=xterm}
+
+$APMTERM -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270'
 sleep 2
 
 mavproxy.py --out 127.0.0.1:14550 --load-module=HIL $*

--- a/Tools/autotest/sim_arduplane_kingaroy.sh
+++ b/Tools/autotest/sim_arduplane_kingaroy.sh
@@ -7,18 +7,20 @@ pkill -f runsim.py
 killall -q JSBSim
 set -e
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../ArduPlane
 make clean obc-sitl
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
-gnome-terminal -e /tmp/ArduPlane.build/ArduPlane.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf" &
+$APMTERM -e /tmp/ArduPlane.build/ArduPlane.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e '../Tools/autotest/jsbsim/runsim.py --home=-26.582218,151.840113,440.3,169'
+$APMTERM -e '../Tools/autotest/jsbsim/runsim.py --home=-26.582218,151.840113,440.3,169' &
 sleep 2
 popd
 mavproxy.py --aircraft=test --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 $*

--- a/Tools/autotest/sim_arduplane_vtail.sh
+++ b/Tools/autotest/sim_arduplane_vtail.sh
@@ -7,18 +7,20 @@ pkill -f runsim.py
 set -e
 set -x
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../ArduPlane
 make clean sitl
 
 tfile=$(mktemp)
 echo r > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf"
-gnome-terminal -e /tmp/ArduPlane.build/ArduPlane.elf
-#gnome-terminal -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/ArduPlane.build/ArduPlane.elf" &
+$APMTERM -e /tmp/ArduPlane.build/ArduPlane.elf &
+#$APMTERM -e "valgrind -q /tmp/ArduPlane.build/ArduPlane.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270 --vtail'
+$APMTERM -e '../Tools/autotest/jsbsim/runsim.py --home=-35.362938,149.165085,584,270 --vtail' &
 sleep 2
 popd
 

--- a/Tools/autotest/sim_rover.sh
+++ b/Tools/autotest/sim_rover.sh
@@ -6,6 +6,8 @@ killall -q APMrover2.elf
 pkill -f sim_rover.py
 set -e
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../APMrover2
 make clean sitl
@@ -14,12 +16,12 @@ tfile=$(mktemp)
 (
 echo r
 ) > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/APMrover2.build/APMrover2.elf"
-gnome-terminal -e "nice /tmp/APMrover2.build/APMrover2.elf"
-#gnome-terminal -e "valgrind --db-attach=yes -q /tmp/APMrover2.build/APMrover2.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/APMrover2.build/APMrover2.elf" &
+$APMTERM -e "nice /tmp/APMrover2.build/APMrover2.elf" &
+#$APMTERM -e "valgrind --db-attach=yes -q /tmp/APMrover2.build/APMrover2.elf" &
 sleep 2
 rm -f $tfile
-gnome-terminal -e "nice ../Tools/autotest/pysim/sim_rover.py --home=40.071374969556928,-105.22978898137808,1583.702759,246 --rate=400"
+$APMTERM -e "nice ../Tools/autotest/pysim/sim_rover.py --home=40.071374969556928,-105.22978898137808,1583.702759,246 --rate=400" &
 sleep 2
 popd
 mavproxy.py --aircraft=test --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 $*

--- a/Tools/autotest/sim_rover_hil.sh
+++ b/Tools/autotest/sim_rover_hil.sh
@@ -5,6 +5,8 @@ set -x
 pkill -f sim_rover.py
 set -e
 
-gnome-terminal -e "nice ../Tools/autotest/pysim/sim_rover.py --home=40.071374969556928,-105.22978898137808,1583.702759,246 --rate=400"
+: ${APMTERM=xterm}
+
+$APMTERM -e "nice ../Tools/autotest/pysim/sim_rover.py --home=40.071374969556928,-105.22978898137808,1583.702759,246 --rate=400" &
 sleep 2
 mavproxy.py --aircraft=test --out 127.0.0.1:14550 --load-module=HIL $*

--- a/Tools/autotest/sim_rover_skid.sh
+++ b/Tools/autotest/sim_rover_skid.sh
@@ -6,6 +6,8 @@ killall -q APMrover2.elf
 pkill -f sim_rover.py
 set -e
 
+: ${APMTERM=xterm}
+
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../APMrover2
 make clean sitl
@@ -14,13 +16,13 @@ tfile=$(mktemp)
 (
 echo r
 ) > $tfile
-#gnome-terminal -e "gdb -x $tfile --args /tmp/APMrover2.build/APMrover2.elf"
-gnome-terminal -e /tmp/APMrover2.build/APMrover2.elf
-#gnome-terminal -e "valgrind --db-attach=yes -q /tmp/APMrover2.build/APMrover2.elf"
+#$APMTERM -e "gdb -x $tfile --args /tmp/APMrover2.build/APMrover2.elf" &
+$APMTERM -e /tmp/APMrover2.build/APMrover2.elf &
+#$APMTERM -e "valgrind --db-attach=yes -q /tmp/APMrover2.build/APMrover2.elf" &
 sleep 2
 rm -f $tfile
-#gnome-terminal -e "../Tools/autotest/pysim/sim_rover.py --home=-35.362938,149.165085,584,270 --rate=400"
-gnome-terminal -e "../Tools/autotest/pysim/sim_rover.py --skid-steering --home=-35.362938,149.165085,584,270 --rate=400"
+#$APMTERM -e "../Tools/autotest/pysim/sim_rover.py --home=-35.362938,149.165085,584,270 --rate=400" &
+$APMTERM -e "../Tools/autotest/pysim/sim_rover.py --skid-steering --home=-35.362938,149.165085,584,270 --rate=400" &
 sleep 2
 popd
 mavproxy.py --aircraft=test --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551


### PR DESCRIPTION
Introduce a new variable $APMTERM that specfies the terminal window
to spawn.  Defaults to xterm as the most commonly available option.

This changes the look and feel of the non-interactive terminals only so
most people won't notice a difference, but of course old behaviour can be
restored with

APMTERM=gnome-terminal sim_ardu...

or a bashrc export.
