### PR TITLE
Fixes Broken Airspeed Calibration

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -170,6 +170,7 @@ void AP_Airspeed::read(void)
     }
     airspeed_pressure       = get_pressure();
     airspeed_pressure       = max(airspeed_pressure - _offset, 0);
+    _last_pressure          = airspeed_pressure;
     _raw_airspeed           = sqrtf(airspeed_pressure * _ratio);
     _airspeed               = 0.7f * _airspeed  +  0.3f * _raw_airspeed;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -106,7 +106,7 @@ public:
     // return the differential pressure in Pascal for the last
     // airspeed reading. Used by the calibration code
     float get_differential_pressure(void) const {
-        return max(_last_pressure - _offset, 0);
+        return max(_last_pressure, 0);
     }
 
     // set the apparent to true airspeed ratio


### PR DESCRIPTION
This fixes a bug introduced at some time between completion of testing on the airspeed calibration functionality and the 2.75 release that caused the airspeed calibration to be sent a zero value for airspeed. This resulted in the airspeed ratio going to the maximum value of 4 and staying there. This could cause the aircraft to fly significantly slower than intended and potentially stall.
