### PR TITLE
Copter: Send valid MAVLink data via the NAV message when in STABILIZE

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1052,7 +1052,8 @@ GCS_MAVLINK::data_stream_send(void)
     if (gcs_out_of_time) return;
 
     if (stream_trigger(STREAM_RAW_CONTROLLER)) {
-        send_message(MSG_SERVO_OUT);
+        send_message(MSG_NAV_CONTROLLER_OUTPUT);
+        send_message(MSG_ATTITUDE);
     }
 
     if (gcs_out_of_time) return;


### PR DESCRIPTION
Currently the nav_pitch and nav_roll fields only have garbage when in STABILIZE mode. This takes use of those fields to send something useful like the current requested angle.
