### PR TITLE
Added RSSI_RANGE parameter to rescale rssi input voltage

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -90,6 +90,7 @@ public:
         k_param_battery,
         k_param_fs_batt_mah,
         k_param_angle_rate_max,         // 38
+	k_param_rssi_range,
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -307,6 +308,7 @@ public:
                                                 // lighting system
 
     AP_Int8         rssi_pin;
+    AP_Float        rssi_range;                 // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
     AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
     AP_Int16        angle_max;                  // maximum lean angle of the copter in centi-degrees
     AP_Int32        angle_rate_max;             // maximum rotation rate in roll/pitch axis requested by angle controller used in stabilize, loiter, rtl, auto flight modes

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -171,10 +171,17 @@ const AP_Param::Info var_info[] PROGMEM = {
 
     // @Param: RSSI_PIN
     // @DisplayName: Receiver RSSI sensing pin
-    // @Description: This selects an analog pin for the receiver RSSI voltage. It assumes the voltage is 5V for max rssi, 0V for minimum
+    // @Description: This selects an analog pin for the receiver RSSI voltage. It assumes the voltage is RSSI_RANGE for max rssi, 0V for minimum
     // @Values: -1:Disabled, 0:A0, 1:A1, 2:A2, 13:A13
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
+    
+    // @Param: RSSI_RANGE
+    // @DisplayName: Receiver RSSI voltage range
+    // @Description: This sets receiver RSSI voltage range. Set e.g. 5.0, 3.3 etc
+    // @Units: Volt
+    // @User: Standard
+    GSCALAR(rssi_range,          "RSSI_RANGE",         5.0),
 
     // @Param: WP_YAW_BEHAVIOR
     // @DisplayName: Yaw behaviour during missions

--- a/ArduCopter/sensors.pde
+++ b/ArduCopter/sensors.pde
@@ -120,6 +120,6 @@ static void read_battery(void)
 void read_receiver_rssi(void)
 {
     rssi_analog_source->set_pin(g.rssi_pin);
-    float ret = rssi_analog_source->voltage_average() * 50;
+    float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
     receiver_rssi = constrain_int16(ret, 0, 255);
 }


### PR DESCRIPTION
Added ability to rescale rssi input voltage. Useful for receivers like FrSky which have 3.3V output.

Request issue found here
https://github.com/diydrones/ardupilot/issues/648

Here more
http://diydrones.com/profiles/blogs/apm-rssi-3-3v-input
