### PR TITLE
Add GPS mixing of the Z axis to the IntertialNav library

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -2275,9 +2275,9 @@ static void tuning(){
 #endif
 
     case CH6_INAV_TC:
-        // To-Do: allowing tuning TC for xy and z separately
+        // To-Do: allowing tuning TC for xy and both GPS and Baro z components separately
         inertial_nav.set_time_constant_xy(tuning_value);
-        inertial_nav.set_time_constant_z(tuning_value);
+        inertial_nav.set_time_constant_z(tuning_value, -1);
         break;
 
     case CH6_DECLINATION:

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -128,7 +128,7 @@ static void init_home()
     set_cmd_with_index(home, 0);
 
     // set inertial nav's home position
-    inertial_nav.set_home_position(g_gps->longitude, g_gps->latitude);
+    inertial_nav.set_home_position(g_gps->longitude, g_gps->latitude, g_gps->altitude_cm);
 
     if (g.log_bitmask & MASK_LOG_CMD)
         Log_Write_Cmd(0, &home);


### PR DESCRIPTION
The baro and gps are used symmetrically, each with their own time
constants which can be changed mid-mission.  This allows optimal
mixing based on the sensor characteristics at any given time.

This doesn't attempt to use the GPS to compensate for long-term
baro drift, that's a deeper change to the INAV library.

The specific use case is flying close to chimneys for inspection
purposes.  The heat and turbulence stuffs up the baro readings
while the good quality GPS we have works better.  Conversely,
while lower to the ground, the obstructed sky view means the baro
is much better.  Having the pair of tuning knobs allows us to get
good behaviour at all points of the mission.
