### PR TITLE
PX4IO update and serial port change

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -64,10 +64,10 @@ fi
 
 if [ $BOARD == FMUv1 ]
 then
-   set deviceC /dev/ttyS2
+   set deviceC /dev/ttyS1
    if [ -f /fs/microsd/APM/uartD.en ]
    then
-      set deviceD /dev/ttyS1
+      set deviceD /dev/ttyS2
    else
       set deviceD /dev/null
    fi


### PR DESCRIPTION
This pull request addresses two issues identified by Rob: It uses force update for the initial FW update which allows to update from the pre-force state to the current new method. It requires the patches in PX4Firmware. The second change decommissions UART2 as PWM output and moves the radio to UART2. This strips four PWM outputs, but avoids issues due to the dual use of UART5.

Please cross check with existing setups, but I strongly advise to change the default port, since it will be a constant source of confusion else. I have not heard that users fly more than 8 PWM outputs on FMU + IO, and for the FMU-only setups UART5 or UART1 can be safely used for telemetry.
