### PR TITLE
Save trim feedback

### DIFF
--- a/ArduCopter/control_modes.pde
+++ b/ArduCopter/control_modes.pde
@@ -285,6 +285,7 @@ static void save_trim()
     float roll_trim = ToRad((float)g.rc_1.control_in/100.0f);
     float pitch_trim = ToRad((float)g.rc_2.control_in/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
+    gcs_send_text_P(SEVERITY_HIGH, PSTR("Trim saved"));
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions


### PR DESCRIPTION
Trim save gives no feedback, so I've added a gcs_send_text() call to
print "Trim saved" so the user knows to re-center trims again
