### PR TITLE
Fixes bug that causes coupling from g to roll and pitch when using AHRS_TRIM parameters

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -62,23 +62,26 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] PROGMEM = {
 
     // @Param: TRIM_X
     // @DisplayName: AHRS Trim Roll
-    // @Description: Compensates for the roll angle difference between the control board and the frame
+    // @Description: Compensates for the roll angle difference between the control board and the frame. Positive values make the vehicle roll right.
     // @Units: Radians
-    // @Range: -10 10
-    // @User: Advanced
+    // @Range: -0.1745 +0.1745
+    // @Increment: 0.01
+    // @User: User
 
     // @Param: TRIM_Y
     // @DisplayName: AHRS Trim Pitch
-    // @Description: Compensates for the pitch angle difference between the control board and the frame
+    // @Description: Compensates for the pitch angle difference between the control board and the frame. Positive values make the vehicle pitch up/back.
     // @Units: Radians
-    // @Range: -10 10
-    // @User: Advanced
+    // @Range: -0.1745 +0.1745
+    // @Increment: 0.01
+    // @User: User
 
     // @Param: TRIM_Z
     // @DisplayName: AHRS Trim Yaw
     // @Description: Not Used
     // @Units: Radians
-    // @Range: -10 10
+    // @Range: -0.1745 +0.1745
+    // @Increment: 0.01
     // @User: Advanced
     AP_GROUPINFO("TRIM", 8, AP_AHRS, _trim, 0),
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -42,8 +42,10 @@ public:
     const Vector3f get_gyro(void) const {
         return _omega + _omega_P + _omega_yaw_P;
     }
+
+    // return rotation matrix representing rotaton from body to earth axes
     const Matrix3f &get_dcm_matrix(void) const {
-        return _dcm_matrix;
+        return _body_dcm_matrix;
     }
 
     // return the current drift correction integrator value
@@ -92,8 +94,11 @@ private:
     void            estimate_wind(Vector3f &velocity);
     bool            have_gps(void) const;
 
-    // primary representation of attitude
+    // primary representation of attitude of board used for all inertial calculations
     Matrix3f _dcm_matrix;
+
+    // primary representation of attitude of flight vehicle body
+    Matrix3f _body_dcm_matrix;
 
     Vector3f _omega_P;                          // accel Omega proportional correction
     Vector3f _omega_yaw_P;                      // proportional yaw correction

--- a/libraries/AP_Math/matrix3.cpp
+++ b/libraries/AP_Math/matrix3.cpp
@@ -98,6 +98,25 @@ void Matrix3<T>::rotateXY(const Vector3<T> &g)
     (*this) += temp_matrix;
 }
 
+// apply an additional inverse rotation to a rotation matrix but 
+// only use X, Y elements from rotation vector
+template <typename T>
+void Matrix3<T>::rotateXYinv(const Vector3<T> &g)
+{
+    Matrix3f temp_matrix;
+    temp_matrix.a.x =   a.z * g.y;
+    temp_matrix.a.y = - a.z * g.x;
+    temp_matrix.a.z = - a.x * g.y + a.y * g.x;
+    temp_matrix.b.x =   b.z * g.y;
+    temp_matrix.b.y = - b.z * g.x;
+    temp_matrix.b.z = - b.x * g.y + b.y * g.x;
+    temp_matrix.c.x =   c.z * g.y;
+    temp_matrix.c.y = - c.z * g.x;
+    temp_matrix.c.z = - c.x * g.y + c.y * g.x;
+
+    (*this) += temp_matrix;
+}
+
 // multiplication by a vector
 template <typename T>
 Vector3<T> Matrix3<T>::operator *(const Vector3<T> &v) const
@@ -161,6 +180,7 @@ void Matrix3<T>::zero(void)
 template void Matrix3<float>::zero(void);
 template void Matrix3<float>::rotate(const Vector3<float> &g);
 template void Matrix3<float>::rotateXY(const Vector3<float> &g);
+template void Matrix3<float>::rotateXYinv(const Vector3<float> &g);
 template void Matrix3<float>::from_euler(float roll, float pitch, float yaw);
 template void Matrix3<float>::to_euler(float *roll, float *pitch, float *yaw);
 template Vector3<float> Matrix3<float>::operator *(const Vector3<float> &v) const;

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -215,6 +215,10 @@ public:
     // apply an additional rotation from a body frame gyro vector
     // to a rotation matrix but only use X, Y elements from gyro vector
     void        rotateXY(const Vector3<T> &g);
+
+    // apply an additional inverse rotation to a rotation matrix but 
+    // only use X, Y elements from rotation vector
+    void        rotateXYinv(const Vector3<T> &g);
 };
 
 typedef Matrix3<int16_t>                Matrix3i;


### PR DESCRIPTION
The current code uses the AHRS_TRIM_X and AHRS_TRIM_Y parameters to correct for angular misalignments between gyros and accelerometers. This can cause undesirable coupling from manoeuvre G to errors in roll and pitch angles if these trim values are used to correct for alignment differences between the control board and the airframe as indicated by the documentation.

This patch moves the angular correction such that it is applied to the roll_sensor,pitch_sensor and yaw_sensor output calculation and also to the get_dcm_matrix method that are used by control and navigation functions.
