### PR TITLE
Fix for disarm bug - issue #756

### DIFF
--- a/ArduCopter/Attitude.pde
+++ b/ArduCopter/Attitude.pde
@@ -1126,7 +1126,7 @@ static bool update_land_detector()
                 land_detector = 0;
             }
         }
-    }else{
+    }else if (g.rc_3.control_in != 0 || failsafe.radio){ // Fix for disarm bug - We can't leave land while throttle is 0
         // we've sensed movement up or down so reset land_detector
         land_detector = 0;
         if(ap.land_complete) {


### PR DESCRIPTION
Due to baro disturbed by ground effect. Explanation here
https://github.com/diydrones/ardupilot/issues/756

The idea of the fix is we can't leave land while throttle is 0 and then
we ignore the baro and it's disturbances.
