### PR TITLE
build: fix paths in install-prereqs-ubuntu.sh

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -8,6 +8,12 @@ PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \
           zip genromfs"
 ASSUME_YES=false
 
+# GNU Tools for ARM Embedded Processors
+# (see https://launchpad.net/gcc-arm-embedded/)
+ARM_ROOT="gcc-arm-none-eabi-4_8-2013q4"
+ARM_TARBALL="$ARM_ROOT-20131204-linux.tar.bz2"
+ARM_TARBALL_URL="https://launchpad.net/gcc-arm-embedded/4.8/4.8-2013-q4-major/+download/$ARM_TARBALL"
+
 function maybe_prompt_user() {
     if $ASSUME_YES; then
         return 0
@@ -42,28 +48,28 @@ fi
 $APT_GET update
 $APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS
 
-if [ ! -d ../PX4-Firmware ]; then
-    git clone https://github.com/diydrones/PX4Firmware.git
+if [ ! -d ~/PX4Firmware ]; then
+    git clone https://github.com/diydrones/PX4Firmware.git ~/PX4Firmware
 fi
 
-if [ ! -d ../PX4NuttX ]; then
-    git clone https://github.com/diydrones/PX4NuttX.git
+if [ ! -d ~/PX4NuttX ]; then
+    git clone https://github.com/diydrones/PX4NuttX.git ~/PX4NuttX
 fi
 
-if [ ! -d ~/gcc-arm-none-eabi-4_6-2012q2 ]; then
-    ARM_TARBALL=gcc-arm-none-eabi-4_6-2012q2-20120614.tar.bz2
+if [ ! -d ~/$ARM_ROOT ]; then
     (
         cd ~;
-        curl -OL "https://launchpad.net/gcc-arm-embedded/4.6/4.6-2012-q2-update/+download/$ARM_TARBALL";
+        curl -OL $ARM_TARBALL_URL;
         tar xjf ${ARM_TARBALL};
         rm ${ARM_TARBALL};
     )
 fi
-exportline="export PATH=$HOME/gcc-arm-none-eabi-4_6-2012q2/bin:\$PATH";
+exportline="export PATH=$HOME/$ARM_ROOT/bin:\$PATH";
 if ! grep -Fxq "$exportline" ~/.profile ; then
-    if maybe_prompt_user "Add $HOME/gcc-arm-none-eabi-4_6-2012q2/bin to your PATH [Y/n]?" ; then
+    if maybe_prompt_user "Add $HOME/$ARM_ROOT/bin to your PATH [Y/n]?" ; then
         echo $exportline >> ~/.profile
+        $exportline
     else
-        echo "Skipping adding $HOME/gcc-arm-none-eabi-4_6-2012q2/bin to PATH."
+        echo "Skipping adding $HOME/$ARM_ROOT/bin to PATH."
     fi
 fi


### PR DESCRIPTION
Also upgrade to the slightly more recent 2012q4
"GNU Tools for ARM Embedded Processors" toolchain
since the 2012q2 release is no longer available.
