### PR TITLE
AP_TECS : Allows accln launch detection without airspeed sensor

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -170,18 +170,12 @@ void AP_TECS::update_50hz(float hgt_afe)
     }
 
 	// Update and average speed rate of change
-    // Only required if airspeed is being measured and controlled
-    float temp = 0;
-	if (_ahrs.airspeed_sensor_enabled() && _ahrs.airspeed_estimate_true(&_EAS)) {
-        // Get DCM
-        const Matrix3f &rotMat = _ahrs.get_dcm_matrix();
-	    // Calculate speed rate of change
-	    temp = rotMat.c.x * GRAVITY_MSS + _ahrs.get_ins().get_accel().x;
-	    // take 5 point moving average
-        _vel_dot = _vdot_filter.apply(temp);
-    } else {
-       _vel_dot = 0.0f;
-    }
+    // Get DCM
+    const Matrix3f &rotMat = _ahrs.get_dcm_matrix();
+	// Calculate speed rate of change
+	float temp = rotMat.c.x * GRAVITY_MSS + _ahrs.get_ins().get_accel().x;
+	// take 5 point moving average
+    _vel_dot = _vdot_filter.apply(temp);
 
 }
 


### PR DESCRIPTION
The 50Hz inertial speed rate of change calculation was not being run when no airspeed sensor was being used or available. This prevented accel based detection of hand launches without airspeed sensors fitted. This patch ensures that the speed rate of change is always calculated.
