### PR TITLE
Updated DIGICAM messages for MAVLink

### DIFF
--- a/libraries/GCS_MAVLink/message_definitions/ardupilotmega.xml
+++ b/libraries/GCS_MAVLink/message_definitions/ardupilotmega.xml
@@ -21,18 +21,19 @@
 	  </enum>
 
 	  <enum name="MAV_CMD" >
-	    <!-- Camera Controller Mission Commands Enumeration -->
+	  	
+ 	  <!-- Camera Controller Mission Commands Enumeration -->
 	    <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
 	      <description>Mission command to configure an on-board camera controller system.</description>
 	      <param index="1">Modes: P, TV, AV, M, Etc</param>
-	      <param index="2">Shutter speed: Divisor number for one second</param>
-	      <param index="3">Aperture: F stop number</param>
-	      <param index="4">ISO number e.g. 80, 100, 200, Etc</param>
-	      <param index="5">Exposure type enumerator</param>
-	      <param index="6">Command Identity</param>
-	      <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
+	      <param index="2">Shutter speed. APEX96 - additive logarithmic values. Eg.: (-384 to 1117)</param>
+	      <param index="3">Aperture. APEX96 - additive logarithmic values. Eg.: (201 to 576)</param>
+	      <param index="4">ISO. APEX96 - additive logarithmic values. Eg.: (300 to 800)</param>
+	      <param index="5">Command Identity</param>
+	      <param index="6">GeoShooting. Enable/Disable. Special shooting who saves GPS and AHRS data on cameras SD card.</param>
+	      <param index="7">Empty</param>
 	    </entry>
-	    
+
 	    <entry name="MAV_CMD_DO_DIGICAM_CONTROL" value="203">
 	      <description>Mission command to control an on-board camera controller system.</description>
 	      <param index="1">Session control e.g. show/hide lens</param>
@@ -41,7 +42,7 @@
 	      <param index="4">Focus Locking, Unlocking or Re-locking</param>
 	      <param index="5">Shooting Command</param>
 	      <param index="6">Command Identity</param>
-	      <param index="7">Empty</param>
+	      <param index="7">Custom Lua script call. String with up to 100 bytes.</param>
 	    </entry>
 	    
 	    <!-- Camera Mount Mission Commands Enumeration -->
@@ -185,25 +186,24 @@
 	    <field name="target_system" type="uint8_t">System ID</field>      
 	    <field name="target_component" type="uint8_t">Component ID</field>
 	    <field name="mode" type="uint8_t">Mode enumeration from 1 to N //P, TV, AV, M, Etc (0 means ignore)</field>
-	    <field name="shutter_speed" type="uint16_t">Divisor number //e.g. 1000 means 1/1000 (0 means ignore)</field>
-	    <field name="aperture" type="uint8_t">F stop number x 10 //e.g. 28 means 2.8 (0 means ignore)</field>
-	    <field name="iso" type="uint8_t">ISO enumeration from 1 to N //e.g. 80, 100, 200, Etc (0 means ignore)</field>
-	    <field name="exposure_type" type="uint8_t">Exposure type enumeration from 1 to N (0 means ignore)</field>
+	    <field name="shutter_speed" type="int16_t">Shutter speed. APEX96 - additive logarithmic values. Eg.: (-384 to 1117)</field>
+	    <field name="aperture" type="uint16_t">Aperture. APEX96 - additive logarithmic values. Eg.: (201 to 576)</field>
+	    <field name="iso" type="uint16_t">ISO. APEX96 - additive logarithmic values. Eg.: (300 to 800)</field>
 	    <field name="command_id" type="uint8_t">Command Identity (incremental loop: 0 to 255)//A command sent multiple times will be executed or pooled just once</field>
- 	    <field name="engine_cut_off" type="uint8_t">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</field>
+ 	    <field name="geo_shooting" type="uint8_t"> 0: disabled, 1:enabled. Special shooting who saves GPS and AHRS data on cameras SD card.</field>
 	    <field name="extra_param" type="uint8_t">Extra parameters enumeration (0 means ignore)</field>
 	    <field name="extra_value" type="float">Correspondent value to given extra_param</field>
 	  </message>
-
+	  
 	  <message name="DIGICAM_CONTROL" id="155">
 	    <description>Control on-board Camera Control System to take shots.</description>
 	    <field name="target_system" type="uint8_t">System ID</field>
 	    <field name="target_component" type="uint8_t">Component ID</field>
 	    <field name="session" type="uint8_t">0: stop, 1: start or keep it up //Session control e.g. show/hide lens</field>
 	    <field name="zoom_pos" type="uint8_t">1 to N //Zoom's absolute position (0 means ignore)</field>
-	    <field name="zoom_step" type="int8_t">-100 to 100 //Zooming step value to offset zoom from the current position</field>
-	    <field name="focus_lock" type="uint8_t">0: unlock focus or keep unlocked, 1: lock focus or keep locked, 3: re-lock focus</field>
+	    <field name="focus_lock" type="uint8_t">0: unlock focus and keep unlocked, 1: lock focus or reset the focus and keep locked</field>
 	    <field name="shot" type="uint8_t">0: ignore, 1: shot or start filming</field>
+	    <field name="lua_script" type="char[100]">Custom Lua script call. String with up to 100 bytes.</field>
 	    <field name="command_id" type="uint8_t">Command Identity (incremental loop: 0 to 255)//A command sent multiple times will be executed or pooled just once</field>
 	    <field name="extra_param" type="uint8_t">Extra parameters enumeration (0 means ignore)</field>
 	    <field name="extra_value" type="float">Correspondent value to given extra_param</field>


### PR DESCRIPTION
Updated messages for camera controlling:
*APEX96 instead of Market LUT (Shutter, Aperture, ISO).
*Lua script field for custom commands.
*GeoShooting: enable/disable.
