### PR TITLE
AP_AHRS: Change airspeed_estimate to const in children of AP_AHRS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -872,7 +872,7 @@ bool AP_AHRS_DCM::get_position(struct Location &loc)
 }
 
 // return an airspeed estimate if available
-bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret)
+bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret) const
 {
 	bool ret = false;
 	if (_airspeed && _airspeed->use()) {

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -74,7 +74,7 @@ public:
 
     // return an airspeed estimate if available. return true
     // if we have an estimate
-    bool airspeed_estimate(float *airspeed_ret);
+    bool airspeed_estimate(float *airspeed_ret) const;
 
     bool            use_compass(void);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -132,7 +132,7 @@ Vector3f AP_AHRS_NavEKF::wind_estimate(void)
 
 // return an airspeed estimate if available. return true
 // if we have an estimate
-bool AP_AHRS_NavEKF::airspeed_estimate(float *airspeed_ret)
+bool AP_AHRS_NavEKF::airspeed_estimate(float *airspeed_ret) const
 {
     return AP_AHRS_DCM::airspeed_estimate(airspeed_ret);
 }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -67,7 +67,7 @@ public:
 
     // return an airspeed estimate if available. return true
     // if we have an estimate
-    bool airspeed_estimate(float *airspeed_ret);
+    bool airspeed_estimate(float *airspeed_ret) const;
 
     // true if compass is being used
     bool use_compass(void);


### PR DESCRIPTION
Allows roll/pitch controllers to use DCM's airspeed estimate. Thanks to Kevin Hester for assistance in finding this.
