### PR TITLE
AC: Further disambiguate the various causes of "Bad GPS Pos"

### DIFF
--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -409,10 +409,26 @@ static bool pre_arm_gps_checks(bool display_failure)
 {
     float speed_cms = inertial_nav.get_velocity().length();     // speed according to inertial nav in cm/s
 
-    // ensure GPS is ok and our speed is below 50cm/s
-    if (!GPS_ok() || gps_glitch.glitching() || speed_cms == 0 || speed_cms > PREARM_MAX_VELOCITY_CMS) {
+    // Not currently glitching?
+    if (gps_glitch.glitching()) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Bad GPS Pos"));
+            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: GPS Glitch"));
+        }
+        return false;
+    }
+
+    // ensure GPS is ok
+    if (!GPS_ok()) {
+        if (display_failure) {
+            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Need 3D Fix"));
+        }
+        return false;
+    }
+
+    // our speed is below 50cm/s
+    if (speed_cms == 0 || speed_cms > PREARM_MAX_VELOCITY_CMS) {
+        if (display_failure) {
+            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Bad Velocity"));
         }
         return false;
     }


### PR DESCRIPTION
I've seen a fair number of user questions where they are confused by
"Bad GPS Pos" on their GCS/not being allowed to arm.  This change splits
the remaining causes of this fault into separate messages.

Hopefully this increases the odds of the user self diagnosing...
