### PR TITLE
AP_NavEKF : Fix bug in initial East mag field state variance

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -618,7 +618,7 @@ void NavEKF::SelectVelPosFusion()
         // we only fuse position and height in static mode
         fuseVelData = false;
         fusePosData = true;
-        fusePosData = true;
+        fuseHgtData = true;
     }
 
     // Perform fusion if conditions are met


### PR DESCRIPTION
This fixes a bug that leaves height effectively unconstrained in static mode which results in height and vertical velocity transients on arming. This could significantly effect copter height performance if flown in alt hold mode immediately after arming
