### PR TITLE
AP_NavEKF : Fix bug that leaves height unconstrained in static mode

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -618,7 +618,7 @@ void NavEKF::SelectVelPosFusion()
         // we only fuse position and height in static mode
         fuseVelData = false;
         fusePosData = true;
-        fusePosData = true;
+        fuseHgtData = true;
     }
 
     // Perform fusion if conditions are met


### PR DESCRIPTION
This bug results in significant height and height rate transients in EKF after arming in Copter.
