### PR TITLE
Update gcc-arm version from q2 to q4

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -51,19 +51,19 @@ if [ ! -d ../PX4NuttX ]; then
 fi
 
 if [ ! -d ~/gcc-arm-none-eabi-4_6-2012q2 ]; then
-    ARM_TARBALL=gcc-arm-none-eabi-4_6-2012q2-20120614.tar.bz2
+    ARM_TARBALL=gcc-arm-none-eabi-4_6-2012q4-20121016.tar.bz2
     (
         cd ~;
-        curl -OL "https://launchpad.net/gcc-arm-embedded/4.6/4.6-2012-q2-update/+download/$ARM_TARBALL";
+        curl -OL "https://launchpad.net/gcc-arm-embedded/4.6/4.6-2012-q4-update/+download/$ARM_TARBALL";
         tar xjf ${ARM_TARBALL};
         rm ${ARM_TARBALL};
     )
 fi
-exportline="export PATH=$HOME/gcc-arm-none-eabi-4_6-2012q2/bin:\$PATH";
+exportline="export PATH=$HOME/gcc-arm-none-eabi-4_6-2012q4/bin:\$PATH";
 if ! grep -Fxq "$exportline" ~/.profile ; then
-    if maybe_prompt_user "Add $HOME/gcc-arm-none-eabi-4_6-2012q2/bin to your PATH [Y/n]?" ; then
+    if maybe_prompt_user "Add $HOME/gcc-arm-none-eabi-4_6-2012q4/bin to your PATH [Y/n]?" ; then
         echo $exportline >> ~/.profile
     else
-        echo "Skipping adding $HOME/gcc-arm-none-eabi-4_6-2012q2/bin to PATH."
+        echo "Skipping adding $HOME/gcc-arm-none-eabi-4_6-2012q4/bin to PATH."
     fi
 fi


### PR DESCRIPTION
This fixes the installation script since version q2 has been removed
from launchpad.
