### PR TITLE
Climb speed fixes

### DIFF
--- a/ArduCopter/control_althold.pde
+++ b/ArduCopter/control_althold.pde
@@ -9,6 +9,11 @@ static bool althold_init(bool ignore_checks)
 {
     // initialise altitude target to stopping point
     pos_control.set_target_to_stopping_point_z();
+
+    // initialize vertical speeds and leash lengths
+    pos_control.set_speed_z(-g.pilot_velocity_z_max, g.pilot_velocity_z_max);
+    pos_control.calc_leash_length_z();
+
     return true;
 }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -190,7 +190,7 @@ void AC_PosControl::calc_leash_length_z()
 {
     if (_flags.recalc_leash_z) {
         _leash_up_z = calc_leash_length(_speed_up_cms, _accel_z_cms, _p_alt_pos.kP());
-        _leash_down_z = calc_leash_length(_speed_down_cms, _accel_z_cms, _p_alt_pos.kP());
+        _leash_down_z = calc_leash_length(-_speed_down_cms, _accel_z_cms, _p_alt_pos.kP());
         _flags.recalc_leash_z = false;
     }
 }


### PR DESCRIPTION
ALT_HOLD was limited to the default climb/descend speeds of +2.5 and -1.5 m/s, regardless of PILOT_VELZ_MAX setting. These patches add a proper initialization of the z leash for ALT_HOLD and fix a bug in vertical leash length calculation. Flight tests were successful.
