### PR TITLE
Allow MAV_COMP_ID_ALL for component in MAV_CMD_COMPONENT_ARM_DISARM call

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1233,7 +1233,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_COMPONENT_ARM_DISARM:
-            if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
+            if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL || packet.target_component == MAV_COMP_ID_ALL) {
                 if (packet.param1 == 1.0f) {
                     // run pre_arm_checks and arm_checks and display failures
                     pre_arm_checks(true);

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1270,7 +1270,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_COMPONENT_ARM_DISARM:
-            if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
+            if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL || packet.target_component == MAV_COMP_ID_ALL) {
                 if (packet.param1 == 1.0f) {
                     // run pre_arm_checks and arm_checks and display failures
                     if (arming.arm(AP_Arming::MAVLINK)) {

--- a/Tools/AntennaTracker/GCS_Mavlink.pde
+++ b/Tools/AntennaTracker/GCS_Mavlink.pde
@@ -902,7 +902,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             }
 
             case MAV_CMD_COMPONENT_ARM_DISARM:
-                if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
+                if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL || packet.target_component == MAV_COMP_ID_ALL) {
                     if (packet.param1 == 1.0f) {
                         arm_servos();
                         result = MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
This mechanism mirrors how the px4fmu stack is checking component ids. It allows for QGroundControl (or any other generic mavlink system) to be able to send the same arm/disarm command to both px4fmu and APM board/stack such that it will work correctly on both without the need for special casing by board type or fmu stack. Since the check is an "or" it will not disrupt any existing APM Planner or Mission Planner code which is using MAV_COMP_ID_SYSTEM_CONTROL.

In reality, it's odd there is a component id check here at all since in general APM stack disregards component id. But I changed it this way since it was already there. If it makes sense to just remove the component id check altogether I can update this pull that way.
