### PR TITLE
AP_Compass: avoid division by zero if we haven't received any magreports on PX4 platforms

### DIFF
--- a/libraries/AP_Compass/AP_Compass_PX4.cpp
+++ b/libraries/AP_Compass/AP_Compass_PX4.cpp
@@ -92,6 +92,9 @@ bool AP_Compass_PX4::read(void)
     }
 
     for (uint8_t i=0; i<_num_instances; i++) {
+        // avoid division by zero if we haven't received any mag reports
+        if (_count[i] == 0) continue;
+
         _sum[i] /= _count[i];
         _sum[i] *= 1000;
 


### PR DESCRIPTION
Otherwise, get_field() will return NaNs after once every few calls to
read() during compassmot on PX4 platforms, which causes compassmot to fail.

This is a quick hack around the deeper issue, which could be something
like the PX4 mag driver experiencing starvation and skipping mag reports,
buffer overrun or something else that causes mag reports to be dropped.
Or perhaps we should never expect in the first place that we will always
receive at least one mag report between calls to read().

Related issue: https://github.com/diydrones/ardupilot/issues/790
