### PR TITLE
enabling mkblctrl for fmuv1/fmuv2

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -4,6 +4,8 @@
 
 # To disable APM startup add a /fs/microsd/APM/nostart file
 # To enable mkblctrl startup add a /fs/microsd/APM/mkblctrl file
+# To enable mkblctrl_+ startup add a /fs/microsd/APM/mkblctrl_+ file
+# To enable mkblctrl_x startup add a /fs/microsd/APM/mkblctrl_x file
 # To enable PWM on FMUv1 on ttyS1 add a /fs/microsd/APM/AUXPWM.en file
 
 set deviceA /dev/ttyACM0
@@ -84,6 +86,28 @@ else
     sh /etc/init.d/rc.error
 fi
 
+# start mkblctrl driver if configured
+if [ -f /fs/microsd/APM/mkblctrl ]
+then
+    echo "Setting up mkblctrl driver"
+    echo "Setting up mkblctrl driver" >> $logfile
+    mkblctrl -d /dev/pwm_output
+fi
+
+if [ -f /fs/microsd/APM/mkblctrl_+ ]
+then
+    echo "Setting up mkblctrl driver +"
+    echo "Setting up mkblctrl driver +" >> $logfile
+    mkblctrl -mkmode + -d /dev/pwm_output
+fi
+
+if [ -f /fs/microsd/APM/mkblctrl_x ]
+then
+    echo "Setting up mkblctrl driver x"
+    echo "Setting up mkblctrl driver x" >> $logfile
+    mkblctrl -mkmode x -d /dev/pwm_output
+fi
+
 
 # try the px4io start twice. Some FMUv2 board don't
 # come up the first time
@@ -149,15 +173,6 @@ else
     if [ $BOARD == FMUv2 ]
     then
        sh /etc/init.d/rc.error
-    fi
-
-    if [ -f /fs/microsd/APM/mkblctrl ]
-    then
-   	echo "APM/mkblctrl found - switch to MK I2C ESCs"
-   	echo "APM/mkblctrl found - switch to MK I2C ESCs" >> $logfile
-	echo "Setting up mkblctrl driver"
-	echo "Setting up mkblctrl driver" >> $logfile
-	mkblctrl -mkmode x
     fi
 fi
 

--- a/mk/PX4/config_px4fmu-v2_APM.mk
+++ b/mk/PX4/config_px4fmu-v2_APM.mk
@@ -35,9 +35,7 @@ MODULES		+= drivers/blinkm
 MODULES		+= drivers/airspeed
 MODULES		+= drivers/ets_airspeed
 MODULES		+= drivers/meas_airspeed
-
-# mkblctrl does not compile on FMUv2 yet
-# MODULES		+= drivers/mkblctrl
+MODULES		+= drivers/mkblctrl
 
 #
 # System commands


### PR DESCRIPTION
Re-enabling the Mikrokopter I2C ESC Support for FMUv1 and FMUv2 (Pixhawk).
Mikrokopter ESCs have to be connected I2C Bus on Pixhawk/FMU. 

Arducopter Mode:
To enable mkblctrl startup add a /fs/microsd/APM/mkblctrl file
In this configuration the ESCs must be ordered in the same order as the ArduCopter is numbering them.
In this Mode all Frametypes of ArduCopter are supported.

Mikrokopter Mode:
To enable Mikrokopter native Frame Addressing (Order) support:
For X Type Frame add:
/fs/microsd/APM/mkblctrl_x

For + Type Frame add:
/fs/microsd/APM/mkblctrl_+

With Mikrokopter Frame Addressing, it is very easy to convert a Mikrokopter to ArduCopter. Just replacing
the Flight-CTRL against a Pixhawk, and your are done after initial Setup.

In Mikrokopter Mode there are only X and + Type Quadro, Hexa and Octo Frames Supported.
In Mission Planner the right Frame have to be set.

Attention:
There can be only one startup File on the SDCard (mkblctrl, mkblctrl_x, mkblctrl_+)
