### PR TITLE
AP_Motors: properly constrain thr_adj_max

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -250,7 +250,7 @@ void AP_MotorsMatrix::output_armed()
         thr_adj = _rc_throttle.radio_out - out_best_thr_pwm;
 
         // calc upper and lower limits of thr_adj
-        int16_t thr_adj_max = out_max_pwm-(out_best_thr_pwm+rpy_high);
+        int16_t thr_adj_max = max(out_max_pwm-(out_best_thr_pwm+rpy_high),0);
 
         // if we are increasing the throttle (situation #2 above)..
         if (thr_adj > 0) {


### PR DESCRIPTION
This fixes a crashomatic bug. Per Leonard, thr_adj_max should never be allowed to be negative.
Please also backport to 3.1.2 and release as 3.1.3.
