### PR TITLE
Fixed GPS_ok() status checking

### DIFF
--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -328,7 +328,7 @@ static void startup_ground(bool force_gyro_cal)
 // returns true if the GPS is ok and home position is set
 static bool GPS_ok()
 {
-    if (ap.home_is_set && gps.status() == AP_GPS::GPS_OK_FIX_3D && 
+    if (ap.home_is_set && gps.status() >= AP_GPS::GPS_OK_FIX_3D && 
         !gps_glitch.glitching() && !failsafe.gps) {
         return true;
     }else{


### PR DESCRIPTION
Fixed the GPS_ok() so that TRUE is returned in the cases of DGPS and Assisted GPS fixes, not just 3D fix.
