### PR TITLE
code style: add indentation rules for makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,17 +11,15 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-tab_size = 8
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.coffee]
-indent_size = 2
+[*.mk]
+indent_style = tab
+indent_size = 8
 
-[*.js]
-indent_size = 2
-
-# [*.md]
-# trim_trailing_whitespace = false
+[{makefile,Makefile}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
I've added the required tab rules for makefile editing...

(and remove some web file types that will probably never be in APM)
