### PR TITLE
AP_InertialSensor: Use return value of blocking_read to handle calibration timeouts

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -412,7 +412,10 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
                 PSTR("Place vehicle %S and press any key.\n"), msg);
 
         // wait for user input
-        interact->blocking_read();
+        if (interact->blocking_read()) {
+            //No need to use interact->printf_P for an error, blocking_read does this when it fails
+            goto failed;
+        }
 
         // clear out any existing samples from ins
         update();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
@@ -25,7 +25,7 @@ uint8_t AP_InertialSensor_UserInteract_MAVLink::blocking_read(void)
         }
     }
     hal.console->println_P(PSTR("Timed out waiting for user response"));
-    return 0;
+    return 1;
 }
 
 void AP_InertialSensor_UserInteract_MAVLink::_printf_P(const prog_char* fmt, ...) 


### PR DESCRIPTION
When the ground station requests an Inertial sensor calibration, if it does not respond with a CMD_ACK in 30 seconds the blocking_read times out and continues the next calibration step regardless of if the user wants to continue. Since there is no way to cancel an in-progress calibration, this pull changes it to fail calibration on a timeout.
