### PR TITLE
Added Save trim to Disarm Stick 15Sec

### DIFF
--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -2,6 +2,7 @@
 
 #define ARM_DELAY               20  // called at 10hz so 2 seconds
 #define DISARM_DELAY            20  // called at 10hz so 2 seconds
+#define SAVETRIM_DELAY          150 // called at 10hz so 15 seconds
 #define AUTO_TRIM_DELAY         100 // called at 10hz so 10 seconds
 #define AUTO_DISARMING_DELAY    15  // called at 1hz so 15 seconds
 
@@ -73,8 +74,8 @@ static void arm_motors_check()
     // full left
     }else if (tmp < -4000) {
 
-        // increase the counter to a maximum of 1 beyond the disarm delay
-        if( arming_counter <= DISARM_DELAY ) {
+        // increase the counter to a maximum of 1 beyond the SAVETRIM_DELAY
+        if( arming_counter <= SAVETRIM_DELAY ) {
             arming_counter++;
         }
 
@@ -82,10 +83,17 @@ static void arm_motors_check()
         if (arming_counter == DISARM_DELAY && motors.armed()) {
             init_disarm_motors();
         }
+                
+        // Save Trim
+        if (arming_counter == SAVETRIM_DELAY) {
+            save_trim();
+            AP_Notify::flags.savetrim_manual = true;
+        }
 
-    // Yaw is centered so reset arming counter
+    // Yaw is centred so reset arming counter and notify flags
     }else{
         AP_Notify::flags.arming_failed = false;
+        AP_Notify::flags.savetrim_manual = false;
         arming_counter = 0;
     }
 }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -46,6 +46,7 @@ public:
         uint16_t failsafe_gps       : 1;    // 1 if gps failsafe
         uint16_t arming_failed      : 1;    // 1 if copter failed to arm after user input
         uint16_t parachute_release  : 1;    // 1 if parachute is being released
+        uint16_t savetrim_manual    : 1;    // 1 if savetrim_manual
 
         // additional flags
         uint16_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -148,6 +148,15 @@ void Buzzer::update()
         }
         return;
     }
+    
+    // check if savetrim_manual status has changed
+    if (_flags.savetrim_manual != AP_Notify::flags.savetrim_manual) {
+        _flags.savetrim_manual = AP_Notify::flags.savetrim_manual;
+        if (_flags.savetrim_manual) {
+            play_pattern(DOUBLE_BUZZ);
+        }
+        return;
+    }
 
     // if battery failsafe constantly single buzz
     if (AP_Notify::flags.failsafe_battery) {

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -61,6 +61,7 @@ private:
         uint8_t armed               : 1;    // 0 = disarmed, 1 = armed
         uint8_t failsafe_battery    : 1;    // 1 if battery failsafe has triggered
         uint8_t failsafe_gps        : 1;    // 1 if gps failsafe
+        uint8_t savetrim_manual     : 1;    // 1 = savetrim_manual
     } _flags;
 
     uint8_t         _counter;           // reduces 50hz update down to 10hz for internal processing


### PR DESCRIPTION
Added savetrim_manual flag to AP_Notify.h and Buzzer.h
Added if in Buzzer.cpp
Added SAVETRIM_DELAY to motors.pde
increased arming(disarm) counter to SAVETRIM_DELAY +1
set AP_Notify::flags.savetrim_manual = true; after save trim
Reset AP_Notify::flags.savetrim_manual = false; on yaw center

I will update wiki after request has been approved but please update
release notes for me.