### PR TITLE
Fix broken duplicate check for adding libraries to the data structure

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -69,7 +69,7 @@ for vehicle in vehicles:
                 setattr(l, field[0], field[1])
             else:
                 error("unknown parameter metadata field '%s'" % field[0])
-        if l not in libraries:
+        if not any(l.name == parsed_l.name for parsed_l in libraries):
             libraries.append(l)
         
         


### PR DESCRIPTION
There are many duplicates of most parameters in all of the output from this script. One copy per vehicle of each library is added. The "in" check was not working because two instances of a class are not the same instance even if they contain the same data. I first encountered the problem when I noticed this odd compass parameter behaviour in apmplanner2, found the root cause of the problem, and fixed it.

![plannercompassprob](https://cloud.githubusercontent.com/assets/854789/3205040/06dd60a0-edb1-11e3-88d8-7618b9576135.jpg)
