### PR TITLE
Add STB_ANGLEBOOST Parameter (Enable/Disable) Enabled by default

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -115,6 +115,7 @@ public:
         k_param_serial0_baud,
         k_param_serial1_baud,
         k_param_serial2_baud,
+        k_param_stb_angleboost = 56,         // 56
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -428,6 +429,7 @@ public:
     AP_Float                acro_balance_roll;
     AP_Float                acro_balance_pitch;
     AP_Int8                 acro_trainer;
+    AP_Int8                 stb_angleboost;
 
     // PI/D controllers
 #if FRAME_CONFIG == HELI_FRAME

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -575,6 +575,13 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     ACRO_TRAINER_LIMITED),
 
+    // @Param: STB_ANGLEBOOST
+    // @DisplayName: Angle boost in stabilize mode
+    // @Description: If you like having full throttle control in stabilize mode you can disable angle boost here.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    GSCALAR(stb_angleboost,   "STB_ANGLEBOOST",     1),
+
     // PID controller
     //---------------
 

--- a/ArduCopter/control_stabilize.pde
+++ b/ArduCopter/control_stabilize.pde
@@ -56,5 +56,10 @@ static void stabilize_run()
     }
 
     // output pilot's throttle
-    attitude_control.set_throttle_out(pilot_throttle_scaled, true);
+    if (g.stb_angleboost == 1) {
+        attitude_control.set_throttle_out(pilot_throttle_scaled, true);
+    }else{
+        attitude_control.set_throttle_out(pilot_throttle_scaled, false);
+    }
+    
 }


### PR DESCRIPTION
This allows people to disable angle boost in stabilize mode only for maximum throttle control

https://github.com/diydrones/ardupilot/issues/546