### PR TITLE
AP_Mount: implement super simple gimbal control option

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -213,6 +213,13 @@ const AP_Param::GroupInfo AP_Mount::var_info[] PROGMEM = {
     AP_GROUPINFO("JSTICK_SPD",  16, AP_Mount, _joystick_speed, 0),
 #endif
 
+    // @Param: DRIVE_MODE
+    // @DisplayName: Drive mode for mount
+    // @Description: 0 for a standard mount with a servo per axis, 1 for super simple gimbal style mount
+    // @Values: 0:standard,1:super_simple
+    // @User: Standard
+    AP_GROUPINFO("DRIVE_MODE",  17, AP_Mount, _drive_mode,  0),
+
     AP_GROUPEND
 };
 
@@ -403,9 +410,17 @@ void AP_Mount::update_mount_position()
 #endif
 
     // write the results to the servos
-    move_servo(_roll_idx, _roll_angle*10, _roll_angle_min*0.1f, _roll_angle_max*0.1f);
-    move_servo(_tilt_idx, _tilt_angle*10, _tilt_angle_min*0.1f, _tilt_angle_max*0.1f);
-    move_servo(_pan_idx,  _pan_angle*10,  _pan_angle_min*0.1f,  _pan_angle_max*0.1f);
+    if (_drive_mode == 1) {
+        // Super Simple Gimbal, need to mix tilt and roll angles to move both servos at once
+        move_servo(_roll_idx, (_tilt_angle+_roll_angle)*10, _roll_angle_min*0.1f, _roll_angle_max*0.1f);
+        move_servo(_tilt_idx, (_tilt_angle-_roll_angle)*10, _tilt_angle_min*0.1f, _tilt_angle_max*0.1f);
+        move_servo(_pan_idx,  _pan_angle*10,  _pan_angle_min*0.1f,  _pan_angle_max*0.1f);
+    } else {
+        // Standard drive, one servo per axis
+        move_servo(_roll_idx, _roll_angle*10, _roll_angle_min*0.1f, _roll_angle_max*0.1f);
+        move_servo(_tilt_idx, _tilt_angle*10, _tilt_angle_min*0.1f, _tilt_angle_max*0.1f);
+        move_servo(_pan_idx,  _pan_angle*10,  _pan_angle_min*0.1f,  _pan_angle_max*0.1f);
+    }
 }
 
 void AP_Mount::set_mode(enum MAV_MOUNT_MODE mode)

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -106,6 +106,8 @@ private:
     float                           _pan_angle;  ///< degrees
 
     // EEPROM parameters
+    AP_Int8                         _drive_mode; ///< (0 = standard, 1 = super simple)
+
     AP_Int8                         _stab_roll; ///< (1 = yes, 0 = no)
     AP_Int8                         _stab_tilt; ///< (1 = yes, 0 = no)
     AP_Int8                         _stab_pan;  ///< (1 = yes, 0 = no)


### PR DESCRIPTION
Allows the user to select the "drive mode" of their camera mount between 'standard' one servo per axis style (the default) and 'super simple' where two servos motion needs to be combined to move in a single axis.

Some commentary,

I've taken the ideas of Rikard Andersson and built on them to add a config option (dataflash parameter) to allow a choice of a "standard drive" (where a single servo controls a single axis) or "super simple drive" (where both servos need to move in unison to move the camera in a single axis).

Currently the parameter only shows up in the Advanced parameters list, but it could be added to the mount config screen in Mission Planner.  The switch in the code is written in a way that the "standard drive" is the default mount drive so no-one will get the "super simple drive" by accident.  My friend (Gyrobot in the diydrones thread) has tested this firmware with his 3d Printable Super Simple gimbal and confirmed it works.

Original Super Simple Gimbal design page
- http://www.rcgroups.com/forums/showthread.php?t=1793759

Thread from DiyDrones from which I took the main control code, credit to Rikard Andersson for working out what needed to be done to drive the servos:
- http://diydrones.com/forum/topics/super-simple-gimbal?id=705844%3ATopic%3A1066619&page=3

Some test videos:
 - http://youtu.be/3YsO_PlHaEI
 - http://youtu.be/O-t6QLfsSHY
 - http://youtu.be/B533l5o7bSo

The 3d Printable gimbal:
 - http://www.thingiverse.com/thing:348970