### PR TITLE
CameraFeedback: added CAMERA_FEEDBACK_FLAGS for open/closed loop

### DIFF
--- a/libraries/GCS_MAVLink/message_definitions/ardupilotmega.xml
+++ b/libraries/GCS_MAVLink/message_definitions/ardupilotmega.xml
@@ -90,6 +90,8 @@
     <enum name="CAMERA_FEEDBACK_FLAGS">
         <entry name="VIDEO"       value="1"> <description>Shooting video, not stills</description></entry>
         <entry name="BADEXPOSURE" value="2"> <description>Unable to achieve requested exposure (e.g. shutter speed too low)</description></entry>
+        <entry name="CLOSEDLOOP"  value="3"> <description>Closed loop feedback from camera, we know for sure it has successfully taken a picture</description></entry>
+        <entry name="OPENLOOP"    value="4"> <description>Open loop camera, an image trigger has been requested but we can't know for sure it has successfully taken a picture</description></entry>
     </enum>
 
       </enums>


### PR DESCRIPTION
This is so a GCS can tell if a certain picture was definitely captured
(e.g. with a CCB or machine vision cam) or only requested in the blink
(e.g. uni-directional CHDK)
