### PR TITLE
PX4: disable PX4IO RC handling in a clean way

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -112,7 +112,7 @@ fi
 # try the px4io start twice. Some FMUv2 board don't
 # come up the first time
 set HAVE_PX4IO false
-if px4io start
+if px4io start norc
 then
     set HAVE_PX4IO true
 else
@@ -128,7 +128,7 @@ else
         tone_alarm MNGGG
     fi
     sleep 1
-    if px4io start
+    if px4io start norc
     then
         set HAVE_PX4IO true
         # play happy tune again
@@ -149,7 +149,7 @@ then
         if px4io forceupdate 14662 /etc/px4io/px4io.bin
         then
                sleep 1
-               if px4io start
+               if px4io start norc
                then
                   echo "PX4IO restart OK"
                   echo "PX4IO restart OK" >> $logfile    


### PR DESCRIPTION
Upstream PX4 Firmware provides a clean way to disable PX4IO handling by supplying the argument "norc" to "px4io start". After applying this fix to the rc.APM startup script, the quick hack contained in commit 180cceee of diydrones/PX4Firmware can be safely reverted.

Applying this fix also improves compatibilty of ardupilot with unmodified (newer) upstream versions of PX4 Firmware.
