### PR TITLE
Make install-prereqs-ubuntu.sh work with newer versions of Ubuntu

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+CWD=$(pwd)
+OPT="/opt"
+
 BASE_PKGS="gawk make git arduino-core curl"
 SITL_PKGS="g++ python-pip python-matplotlib python-serial python-wxgtk2.8 python-scipy python-opencv python-numpy python-pyparsing ccache"
 PYTHON_PKGS="pymavlink MAVProxy droneapi"
@@ -18,7 +21,6 @@ ARM_TARBALL_URL="https://launchpad.net/gcc-arm-embedded/4.8/4.8-2013-q4-major/+d
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="ardupilot/Tools/autotest"
-
 
 function maybe_prompt_user() {
     if $ASSUME_YES; then
@@ -59,40 +61,40 @@ $APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $UBUNTU64_PKGS
 sudo pip -q install $PYTHON_PKGS
 
 
-if [ ! -d ~/PX4Firmware ]; then
-    git clone https://github.com/diydrones/PX4Firmware.git ~/PX4Firmware
+if [ ! -d PX4Firmware ]; then
+    git clone https://github.com/diydrones/PX4Firmware.git
 fi
 
-if [ ! -d ~/PX4NuttX ]; then
-    git clone https://github.com/diydrones/PX4NuttX.git ~/PX4NuttX
+if [ ! -d PX4NuttX ]; then
+    git clone https://github.com/diydrones/PX4NuttX.git
 fi
 
-if [ ! -d ~/$ARM_ROOT ]; then
+if [ ! -d $OPT/$ARM_ROOT ]; then
     (
-        cd ~;
-        curl -OL $ARM_TARBALL_URL;
-        tar xjf ${ARM_TARBALL};
-        rm ${ARM_TARBALL};
+        cd $OPT;
+        sudo wget $ARM_TARBALL_URL;
+        sudo tar xjf ${ARM_TARBALL};
+        sudo rm ${ARM_TARBALL};
     )
 fi
 
-exportline="export PATH=$HOME/$ARM_ROOT/bin:\$PATH";
+exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
 if ! grep -Fxq "$exportline" ~/.profile ; then
-    if maybe_prompt_user "Add $HOME/$ARM_ROOT/bin to your PATH [Y/n]?" ; then
+    if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [Y/n]?" ; then
         echo $exportline >> ~/.profile
         $exportline
     else
-        echo "Skipping adding $HOME/$ARM_ROOT/bin to PATH."
+        echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
     fi
 fi
 
-exportline2="export PATH=$HOME/$ARDUPILOT_TOOLS:\$PATH";
+exportline2="export PATH=$CWD/$ARDUPILOT_TOOLS:\$PATH";
 if ! grep -Fxq "$exportline2" ~/.profile ; then
-    if maybe_prompt_user "Add $HOME/$ARDUPILOT_TOOLS to your PATH [Y/n]?" ; then
+    if maybe_prompt_user "Add $CWD/$ARDUPILOT_TOOLS to your PATH [Y/n]?" ; then
         echo $exportline2 >> ~/.profile
         $exportline2
     else
-        echo "Skipping adding $HOME/$ARDUPILOT_TOOLS to PATH."
+        echo "Skipping adding $CWD/$ARDUPILOT_TOOLS to PATH."
     fi
 fi
 


### PR DESCRIPTION
Currently, the following setup pages both have something missing when trying to compile or simulate.
http://dev.ardupilot.com/wiki/building-px4-for-linux-with-make/
http://dev.ardupilot.com/wiki/setting-up-sitl-on-linux/

I tried to fix this by making the _install-prereqs-ubuntu.sh_ correctly install everything that's needed. Here are the changes I did:
- Install libraries for 64bit Ubuntu systems.
- Less noise apt-get output
- Install packages required for SITL simulation
- Install pymavlink, MAVProxy and droneapi
- Remove modemmanager package
- Add `Tools/autotest/` to the path
- Support for relative paths
- Install ARM toolchain at `/opt`

The script has been tested in a VM running a clean install of _Ubuntu 14.04 LTS_. 
### How to use it

The steps required for installing the environment are: 
(please not that you will need to checkout my _ubuntu_script_ branch while this PR is not merged)

```
# Install git
sudo apt-get -qq -y install git

# Clone the source
git clone https://github.com/diydrones/ardupilot.git

# Run the install-prereqs-ubuntu.sh script
ardupilot/Tools/scripts/install-prereqs-ubuntu.sh -y

# Reload the path (log-out and log-in to make permanent)
. ~/.profile
```

To build the code (e.g. AC for pixhawk):

```
# Build for ArduCopter
cd ~/ardupilot/ArduCopter
make configure
make px4-v2
```

To run a SITL simulation:

```
cd ~/ardupilot/ArduCopter
make configure
sim_vehicle.sh
```
