### PR TITLE
Arducopter/AP_Mount: retract camera mount near ground

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -5,6 +5,7 @@
 // If you used to define your CONFIG_APM_HARDWARE setting here, it is no longer
 // valid! You should switch to using a HAL_BOARD flag in your local config.mk.
 
+
 //#define FRAME_CONFIG QUAD_FRAME
 /*  options:
  *  QUAD_FRAME
@@ -38,6 +39,7 @@
 //#define OPTFLOW               ENABLED             // enable optical flow sensor and OF_LOITER flight mode at a cost of 5K of flash space
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
 //#define EPM_ENABLED           ENABLED             // enable epm cargo gripper costs 500bytes of flash
+#define MNT_AUTO_RETRACT      ENABLED             // enable automatic retracting of camera mount
 
 // other settings
 //#define THROTTLE_IN_DEADBAND   100                // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1028,7 +1028,43 @@ static void update_mount()
 #if MOUNT == ENABLED
     // update camera mount's position
     camera_mount.update_mount_position();
-#endif
+    
+    // lasts < 10 us on APM2
+    // automatically retract camera mount before hitting the ground
+#if CONFIG_SONAR == ENABLED
+#if MNT_AUTO_RETRACT == ENABLED  
+    if ( (g.mnt_autortrct_h > 0) && (g.sonar_enabled) )  // mnt_autortrct_h = 0 to disable auto retract  
+    {
+        // retract mount if approaching the ground
+        if ((sonar_alt < g.mnt_autortrct_h) && (sonar_alt_health >= SONAR_ALT_HEALTH_MAX))
+        {   
+            camera_mount.auto_retract(true);
+        }
+
+        // move out again if we're flying higher
+        switch (control_mode) 
+        {
+        case STABILIZE:
+        case RTL:
+        case LAND:
+            break;
+
+        default:   
+            //  move out only when not in stabilize, rtl, land 
+            //  sonar reports wrong alt after landing on lawn
+            if (sonar_alt_health < SONAR_ALT_HEALTH_MAX) break;
+            if (sonar_alt > (g.mnt_autortrct_h + 100))
+            {
+                // return to previous position
+                camera_mount.auto_retract(false);
+            }
+            break;
+        } // switch
+    } // (g.mnt_autortrct_h > 0)  
+#endif // MNT_AUTO_RETRACT     
+#endif // CONFIG_SONAR
+
+#endif // MOUNT
 
 #if MOUNT2 == ENABLED
     // update camera mount's position

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1033,34 +1033,35 @@ static void update_mount()
     // automatically retract camera mount before hitting the ground
 #if CONFIG_SONAR == ENABLED
 #if MNT_AUTO_RETRACT == ENABLED  
-    if ( (g.mnt_autortrct_h > 0) && (g.sonar_enabled) )  // mnt_autortrct_h = 0 to disable auto retract  
+    if ( (camera_mount.get_autoretract_hight() > 0) && (sonar_enabled) )  // mnt_autortrct_h = 0 to disable auto retract  
     {
-        // retract mount if approaching the ground
-        if ((sonar_alt < g.mnt_autortrct_h) && (sonar_alt_health >= SONAR_ALT_HEALTH_MAX))
-        {   
-            camera_mount.auto_retract(true);
-        }
-
-        // move out again if we're flying higher
+        sonar.healthy();
         switch (control_mode) 
         {
-        case STABILIZE:
+        case STABILIZE:  // do not move out when flying these modes
         case RTL:
+            break;
         case LAND:
+            // retract mount if approaching the ground
+            if ((sonar_alt < camera_mount.get_autoretract_hight()) && (sonar_alt_health >= SONAR_ALT_HEALTH_MAX))
+            {   
+                camera_mount.auto_retract(true);
+            }
             break;
 
         default:   
+            //  move out again if we're flying higher
             //  move out only when not in stabilize, rtl, land 
             //  sonar reports wrong alt after landing on lawn
             if (sonar_alt_health < SONAR_ALT_HEALTH_MAX) break;
-            if (sonar_alt > (g.mnt_autortrct_h + 100))
+            if (sonar_alt > (camera_mount.get_autoretract_hight() + 100))
             {
                 // return to previous position
                 camera_mount.auto_retract(false);
             }
             break;
         } // switch
-    } // (g.mnt_autortrct_h > 0)  
+    } // (camera_mount.get_autoretract_hight > 0)  
 #endif // MNT_AUTO_RETRACT     
 #endif // CONFIG_SONAR
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -115,7 +115,6 @@ public:
         k_param_serial0_baud,
         k_param_serial1_baud,
         k_param_serial2_baud,
-        k_param_mnt_autortrct_h,
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -384,7 +383,6 @@ public:
     AP_Int8         ch7_option;
     AP_Int8         ch8_option;
     AP_Int8         arming_check;
-    AP_Int8         mnt_autortrct_h;
 
 
 #if FRAME_CONFIG ==     HELI_FRAME

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -115,6 +115,7 @@ public:
         k_param_serial0_baud,
         k_param_serial1_baud,
         k_param_serial2_baud,
+        k_param_mnt_autortrct_h,
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -383,6 +384,8 @@ public:
     AP_Int8         ch7_option;
     AP_Int8         ch8_option;
     AP_Int8         arming_check;
+    AP_Int8         mnt_autortrct_h;
+
 
 #if FRAME_CONFIG ==     HELI_FRAME
     // Heli

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -574,6 +574,14 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Values: 0:Disabled,1:Leveling,2:Leveling and Limited
     // @User: Advanced
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     ACRO_TRAINER_LIMITED),
+    
+    
+    // @Param: MNT_AUTORTRCT_H
+    // @DisplayName: Mnt AutoRetract Hight
+    // @Description: retract camera mount below this hight(cm) (stabilize/land/rtl mode)
+    // @User: Standard
+    // @Range: 0 255
+    GSCALAR(mnt_autortrct_h, "MNT_AUTORTRCT_H", MNT_AUTORTRCT_H),    
 
     // PID controller
     //---------------

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -576,12 +576,6 @@ const AP_Param::Info var_info[] PROGMEM = {
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     ACRO_TRAINER_LIMITED),
     
     
-    // @Param: MNT_AUTORTRCT_H
-    // @DisplayName: Mnt AutoRetract Hight
-    // @Description: retract camera mount below this hight(cm) (stabilize/land/rtl mode)
-    // @User: Standard
-    // @Range: 0 255
-    GSCALAR(mnt_autortrct_h, "MNT_AUTORTRCT_H", MNT_AUTORTRCT_H),    
 
     // PID controller
     //---------------

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -401,4 +401,7 @@ enum FlipState {
 #define FS_GPS_ALTHOLD                      2       // switch to ALTHOLD mode on GPS failsafe
 #define FS_GPS_LAND_EVEN_STABILIZE          3       // switch to LAND mode on GPS failsafe even if in a manual flight mode like Stabilize
 
+// Camera mount
+#define MNT_AUTORTRCT_H 100 // cm
+
 #endif // _DEFINES_H

--- a/Tools/GIT_Test/GIT_Success.txt
+++ b/Tools/GIT_Test/GIT_Success.txt
@@ -16,3 +16,4 @@ Phil Rowse was here :)
 Nils Högberg (Vizual54) testing
 Linus Penzlien 
 Hazy
+Matthias Krause cloned here

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -218,6 +218,16 @@ const AP_Param::GroupInfo AP_Mount::var_info[] PROGMEM = {
     AP_GROUPINFO("JSTICK_SPD",  16, AP_Mount, _joystick_speed, 0),
 #endif
 
+#if MNT_AUTO_RETRACT == ENABLED 
+    // @Param: AUTORETR_H
+    // @DisplayName: mount auto retract altitude
+    // @Description: automatically retract camera mount below AUTORETR_H. AUTORETR_H = 0 disables this function.
+    // @Range: 0 500
+    // @Increment: 50
+    // @User: Standard
+    AP_GROUPINFO("AUTORETR_H",  17, AP_Mount, _autoretract_hight, 100),
+#endif
+
     AP_GROUPEND
 };
 
@@ -698,7 +708,7 @@ AP_Mount::move_servo(uint8_t function_idx, int16_t angle, int16_t angle_min, int
 
 
 /// true = retract camera mount; false = move out
-void 
+void
 AP_Mount::auto_retract(bool retract_mount)
 {
 #if MNT_AUTO_RETRACT == ENABLED

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -61,6 +61,8 @@ public:
     void                    update_mount_position();
     void                    update_mount_type(); ///< Auto-detect the mount gimbal type depending on the functions assigned to the servos
     void                    debug_output();      ///< For testing and development. Called in the medium loop.
+    void                    auto_retract(bool retract_mount);  
+
     // Accessors
     enum MountType          get_mount_type() {
         return _mount_type;

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -67,13 +67,19 @@ public:
     enum MountType          get_mount_type() {
         return _mount_type;
     }
+   
+    int16_t                 get_autoretract_hight() {
+        return _autoretract_hight;
+    }
+
     // hook for eeprom variables
     static const struct AP_Param::GroupInfo        var_info[];
+
+    void                    set_mode(enum MAV_MOUNT_MODE mode);
 
 private:
 
     //methods
-    void                            set_mode(enum MAV_MOUNT_MODE mode);
 
     void                            set_retract_angles(float roll, float tilt, float pan); ///< set mount retracted position
     void                            set_neutral_angles(float roll, float tilt, float pan);
@@ -126,6 +132,8 @@ private:
     AP_Int16                        _pan_angle_max;  ///< max angle limit of actuated surface in 0.01 degree units
 
     AP_Int8                         _joystick_speed;
+    
+    AP_Int16                        _autoretract_hight;
 
     AP_Vector3f                     _retract_angles; ///< retracted position for mount, vector.x = roll vector.y = tilt, vector.z=pan
     AP_Vector3f                     _neutral_angles; ///< neutral position for mount, vector.x = roll vector.y = tilt, vector.z=pan


### PR DESCRIPTION
Retract camera mount at low altitude to prevent crash when landing.

While flying around in any flight mode the camera mount will be retracted as soon as the rangefinder (sonar_alt) reports an altitude below mnt_autortrct_h [cm](parameter can be changed in Missionplanner. 0 disables auto retract)

As soon as the altitude gets high enough again (100 cm above mnt_autortrct_h) the camera mount returns to its former position (neutral, rc_targeting, …). At this point it is necessary to exclude all take off and landing modes (I think this only affects Stabilize, Land, maybe RTL). The reason is that the sonar reports a wrong (1-2m to high) altitude eg. when the copter lands on lawn.

Auto retract in general and auto move out can be included/excluded via #defines in Apm_config.h and AP_mount.cpp
