### PR TITLE
documentation: Add a contributing & maintainers file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# How to contribute to the APM project?
+
+If you are reading this page, you are possibly interested in contributing to our project.  We have a very active (and friendly) developer group and would love to have the help!  Possible ways you can help:
+
+* Testing the code
+* Filing issues on github, when you see a problem (or adding detail to existing issues that effect you)
+* Fixing issues
+* Adding new features
+* Reviewing existing pull requests, and notifying the maintainer if it passes your code review.
+
+# How to make a good bug report...
+
+(FIXME - someone please add)
+
+# Submitting patches
+
+Please see our [wiki article](http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/).
+
+# Development Team
+
+The ArduPilot project is open source and [maintained](MAINTAINERS.md) by a team of volunteers.
+
+To contribute, you can send a pull request on Github. You can also
+join the [development discussion on Google
+Groups](https://groups.google.com/forum/?fromgroups#!forum/drones-discuss). Note
+that the Google Groups mailing lists are NOT for user tech support,
+and are moderated for new users to prevent off-topic discussion.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+# Ardupilot maintainers
+
+To facilitate development we have a number of maintainers who have volunteered to coordinate development on subsections of the project.  When submitting pull requests please follow the conventions preferred by each maintainer.  See below
+
+* Plane mantainer @tridge.
+* Quads/Hex/etc... maintainer @rmackay9
+* Rover maintainer @tridge
+* LogAnalyzer maintainer @chapman
+* Anything else: @Craig3DRobotics
+
+When submitting pull requests, please include the subsystem (Plane, copter, VRBRAIN, etc... as the first part of the commit) and follow the rules listed in [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Per our devcall last week.  Adding now mainly so we can start pointing
LogAnalyzer fixes to @chapman and quickly get them into master.

@tridge & @randy - I kinda guessed at the maintainers list, we can
update later as needed.
