### PR TITLE
all: Change the editorconfig so that it won't want to reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,8 +13,8 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+trim_trailing_whitespace = false # These are the correct rules for APM coding standards, but fixing up old files causes git spam
+insert_final_newline = false
 
 [*.mk]
 indent_style = tab


### PR DESCRIPTION
.editorconfig is a great way to ensure developers follow our
line ending/tab conventions, but we shouldn't have it default
to fixing any lines that were not edited.
