### PR TITLE
AP_AHRS: Fixed DCM get_gyro function

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -40,7 +40,7 @@ public:
 
     // return the smoothed gyro vector corrected for drift
     const Vector3f get_gyro(void) const {
-        return _omega + _omega_P + _omega_yaw_P;
+        return _omega;
     }
 
     // return rotation matrix representing rotaton from body to earth axes


### PR DESCRIPTION
Previously incorporated the attitude correction terms into the return. Now only returns the drift-corrected gyro.
