### PR TITLE
GPS: Parameter to specify a base station position for DGPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -62,6 +62,35 @@ const AP_Param::GroupInfo AP_GPS::var_info[] PROGMEM = {
     // @Values: 0:Any,50:FloatRTK,100:IntegerRTK
     // @User: Advanced
     AP_GROUPINFO("MIN_DGPS", 4, AP_GPS, _min_dgps, 100),
+
+    // @Param: DGPS_GIVEN_BASE
+    // @DisplayName:  Specify, don't calculate a DGPS base station position
+    // @Description: Use the GDPS_BASE_LAT/LON/ALT parameter as the base station position for DGPS.
+    // @Values: 0:False, 1:True
+    // @User: Advanced
+    AP_GROUPINFO("DGPS_GIVEN_BASE", 5, AP_GPS, _dgps_use_given_base, 0),
+
+    // @Param: DGPS_BASE_LAT
+    // @DisplayName: DGPS Base Station Latitude in WGS84 (deg*1e7)
+    // @Description: Use this value as the DGPS base station position.
+    // @Values: deg * 1e7 
+    // @User: Advanced
+    AP_GROUPINFO("DGPS_BASE_LAT", 6, AP_GPS, _dgps_base_lat_wgs, 0),
+
+    // @Param: DGPS_BASE_LON
+    // @DisplayName: DGPS Base Station Latitude in WGS84 (deg*1e7)
+    // @Description: Use this value as the DGPS base station position.
+    // @Values: deg * 1e7
+    // @User: Advanced
+    AP_GROUPINFO("DGPS_BASE_LON", 7, AP_GPS, _dgps_base_lon_wgs, 0),
+
+    // @Param: DGPS_BASE_ALT
+    // @DisplayName: DGPS Base Station Altitude in WGS84 (cm)
+    // @Description: Use this value as the DGPS base station position.
+    // @Values: cm
+    // @User: Advanced
+    AP_GROUPINFO("DGPS_BASE_ALT", 8, AP_GPS, _dgps_base_alt_wgs, 0),
+
 #endif
 
     AP_GROUPEND
@@ -79,6 +108,24 @@ void AP_GPS::init(DataFlash_Class *dataflash)
     }
 #endif
 }
+
+#if GPS_RTK_AVAILABLE
+bool AP_GPS::dgps_given_base() 
+{
+    return _dgps_use_given_base > 0;
+}
+
+bool AP_GPS::dgps_given_base_llh(Vector3d& v) 
+{
+    if (_dgps_use_given_base > 0) {
+        v[0] = (((double)_dgps_base_lat_wgs) / 1e7) * DEG_TO_RAD_DOUBLE;
+        v[1] = (((double)_dgps_base_lon_wgs) / 1e7) * DEG_TO_RAD_DOUBLE;
+        v[2] = ((double)_dgps_base_alt_wgs) / 1e2;   
+        return true;
+    }
+    return false;
+}
+#endif
 
 // baudrates to try to detect GPSes with
 const uint32_t AP_GPS::_baudrates[] PROGMEM = {4800U, 38400U, 115200U, 57600U, 9600U};

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -293,6 +293,22 @@ public:
     AP_Int8 _auto_switch;
     AP_Int8 _min_dgps;
 #endif
+
+#if GPS_RTK_AVAILABLE
+    AP_Int8 _dgps_use_given_base;
+    AP_Int32 _dgps_base_lat_wgs;
+    AP_Int32 _dgps_base_lon_wgs;
+    AP_Int32 _dgps_base_alt_wgs;
+
+    // Returns true if we have a stored base station position to use.
+    bool dgps_given_base();
+
+    // Returns true and sets the given vector
+    // to the stored base position.
+    // LLH in radians and meters according to the WGS84 ellipse.
+    bool dgps_given_base_llh(Vector3d&);
+
+#endif
     
     // handle sending of initialisation strings to the GPS
     void send_blob_start(uint8_t instance, const prog_char *_blob, uint16_t size);

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -83,6 +83,8 @@ AP_GPS_SBP::AP_GPS_SBP(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriv
     last_healthcheck_millis(0)
 {
 
+    reset_base_pos();
+
     parser_state.state = sbp_parser_state_t::WAITING;
 
     state.status = AP_GPS::NO_FIX;
@@ -138,10 +140,17 @@ AP_GPS_SBP::calculate_base_pos(void)
         base_pos_ecef[1],
         base_pos_ecef[2]);
 }
+
 void
-AP_GPS_SBP::invalidate_base_pos()
+AP_GPS_SBP::reset_base_pos()
 {
     has_rtk_base_pos = false;
+
+    if (gps.dgps_given_base()) {
+        Vector3d base_llh;
+        has_rtk_base_pos = gps.dgps_given_base_llh(base_llh);
+        wgsllh2ecef(base_llh, base_pos_ecef);
+    }
 }
 
 bool 
@@ -598,7 +607,7 @@ AP_GPS_SBP::sbp_process_iar_state(uint8_t* msg)
 void 
 AP_GPS_SBP::sbp_process_startup(uint8_t* msg)
 {
-    invalidate_base_pos();
+    reset_base_pos();
 }
 
 bool

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -54,7 +54,7 @@ public:
 
     void calculate_base_pos(void);
 
-    void invalidate_base_pos(void);
+    void reset_base_pos(void);
 
     AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK; }
 


### PR DESCRIPTION
This commit adds four parameters. These parameters allow users to hardcode a base station absolute position for differential GPS usage.

To force using this base station position by the GPS driver, set DGPS_GIVEN_BASE = 1
