### PR TITLE
LogAnalyzer: Binary Logs may end with \xff

### DIFF
--- a/Tools/LogAnalyzer/DataflashLog.py
+++ b/Tools/LogAnalyzer/DataflashLog.py
@@ -615,7 +615,7 @@ class DataflashLog(object):
                     raise ValueError(h)
                 else:
                     if h.head1 == 0xff and h.head2 == 0xff and h.msgid == 0xff:
-                        print("Assuming EOF due to dataflash block tail filled with \\xff... (offset={off})".format(off=offset))
+                        print("Assuming EOF due to dataflash block tail filled with \\xff... (offset={off})".format(off=offset), file=sys.stderr)
                         break
 
             if h.msgid in self._formats:


### PR DESCRIPTION
- ignoreBadlines can be used to assume this is a proper EOF
