### PR TITLE
ArduPlane: attempt to send GCS a message when the GCS heartbeat is not detected

### DIFF
--- a/ArduPlane/events.pde
+++ b/ArduPlane/events.pde
@@ -87,6 +87,9 @@ static void failsafe_long_on_event(enum failsafe_state fstype)
     default:
         break;
     }
+    if (fstype == FAILSAFE_GCS) {
+        gcs_send_text_P(SEVERITY_HIGH, PSTR("No GCS heartbeat."));
+    }
     gcs_send_text_fmt(PSTR("flight mode = %u"), (unsigned)control_mode);
 }
 


### PR DESCRIPTION
If GCS heartbeat stops being received (and FS_GCS_ENABL is 2) then Plane tries to send a message to the GCS alerting it of the problem.  This is especially helpful during testing (helps in knowing failsafe is working as expected).  In the field the link to the GCS might be tenuous if the conditions which require this message exist, but it is also possible the message might arrive at the GCS and increase the situational awareness of the GCS operator.
