### PR TITLE
LogAnalyzer - add DataflashSQL

### DIFF
--- a/Tools/LogAnalyzer/DataflashLog.py
+++ b/Tools/LogAnalyzer/DataflashLog.py
@@ -20,7 +20,7 @@ class Format(object):
         self.msgLen  = msgLen
         self.name    = name
         self.types   = types
-        self.labels  = labels.split(',')
+        self.labels  = labels
 
     def __str__(self):
         return "%8s %s" % (self.name, `self.labels`)
@@ -41,13 +41,14 @@ class Format(object):
         return value
 
     def to_class(self):
+        labels = self.labels.split(',')
         members = dict(
             NAME = self.name,
-            labels = self.labels[:],
+            labels = labels[:],
         )
 
         fieldtypes = [i for i in self.types]
-        fieldlabels = self.labels[:]
+        fieldlabels = labels[:]
 
         # field access
         for (label, _type) in zip(fieldlabels, fieldtypes):

--- a/Tools/LogAnalyzer/DataflashSQL.py
+++ b/Tools/LogAnalyzer/DataflashSQL.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python
+
+import DataflashLog
+
+import sqlalchemy
+from sqlalchemy import Table, MetaData, Column, ForeignKey, Integer, String, Float
+from sqlalchemy.orm import mapper
+from sqlalchemy.schema import ForeignKeyConstraint
+
+
+class DataflashSQL(object):
+    """Use SQLAlchemy to convert a DataflashLog to a sqlite Database
+    Tables are created per log type when reading FMT messages and have the same name
+    as indicated in the FMT message
+    Columns are learned of the FMT messages as well,
+    the column _{tablename} is special -the primary key- useful for self joins
+
+    *special* tables/views are prefixed with _
+
+    _record is a list of all parsed lines, with the TimeMS of the closest message carrying a TimeMS value
+    GPS TimeMS values currently get ignored, as their TimeMS value drifts different to the other TimeMS values
+
+    _timems is a table "unioning" all available TimeMS values (but GPS)
+
+    _mode is a view on the flight modes used, adding Start/Stop line and TimeMS values
+    """
+
+    metadata = MetaData()
+    tables = {}
+    classes = {}
+    mapping = {}
+
+    def __init__(self, db):
+        self.engine = sqlalchemy.create_engine('sqlite:///{}'.format(db))#, isolation_level='SERIALIZABLE', echo=True)
+        Session = sqlalchemy.orm.sessionmaker(bind=self.engine)
+        self.session = Session()
+        DataflashSQL.metadata.create_all(self.engine)
+
+    def insert(self, line, obj):
+        if obj.NAME not in self.tables:
+            return
+        if obj.NAME == 'FMT':
+            self.session.add(SQLFormat.from_object(line, obj))
+            self.session.commit()
+            if obj.name == 'FMT':
+                return
+            DataflashSQL.classes[obj.name] = self.class_from_FMT(obj)
+            DataflashSQL.tables[obj.name] = self.table_from_FMT(obj)
+            DataflashSQL.mapping[obj.name] = mapper(
+                DataflashSQL.classes[obj.name],
+                DataflashSQL.tables[obj.name],
+                inherits=SQLRecord,
+                polymorphic_identity=obj.name,
+                primary_key=DataflashSQL.tables[obj.name].c.line,
+            )
+            self.session.commit()
+            DataflashSQL.metadata.create_all(self.engine, tables=[DataflashSQL.tables[obj.name]])
+        else:
+            self.session.add(DataflashSQL.classes[obj.NAME](line, obj.NAME, obj))
+
+    def commit(self):
+        self.session.commit()
+
+    def finish(self):
+        self._finish_timems()
+        self._finish_record()
+        self._finish_mode()
+
+    def _finish_timems(self):
+        # update timems table
+        # a view is possible but very slow
+        names = []
+        for name, cls in DataflashSQL.tables.items():
+            if name.startswith("GPS"):
+                # gps timestamps differ to much and do not drift as the other timestamps do
+                continue
+            try:
+                x = cls.c.TimeMS
+                names.append(cls)
+            except:
+                continue
+        if len(names) == 0:
+            return
+        stmts = []
+        for i in names:
+            q = """SELECT
+    line AS line,
+    type AS type,
+    timems AS timems
+FROM
+    "{cls}"
+""".format(cls=i.name)
+            stmts.append(q)
+
+        stmt = "INSERT INTO _timems (line,type,TimeMS) {stmts}".format(stmts="\nUNION\n".join(stmts))
+#        self.session.execute("DELETE FROM _timems")
+        self.session.execute(stmt)
+        self.session.commit()
+
+    def _finish_record(self):
+        # set _TimeMS guess in _record
+        self.session.execute("""UPDATE
+    _record
+SET
+    _TimeMS =
+        CASE WHEN
+            IFNULL(abs(_record.line-(SELECT line from _timems WHERE line <= _record.line ORDER BY line DESC LIMIT 1)),999999) <
+            IFNULL(abs(_record.line-(SELECT line from _timems WHERE line >= _record.line ORDER BY line ASC LIMIT 1)),999999)
+        THEN
+            (SELECT TimeMS from _timems WHERE line <= _record.line ORDER BY line DESC LIMIT 1)
+        ELSE
+            (SELECT TimeMS from _timems WHERE line >= _record.line ORDER BY line ASC LIMIT 1)
+        END;""")
+        self.session.commit()
+
+    def _finish_mode(self):
+        # create _mode View
+        self.session.execute("""CREATE VIEW _mode AS SELECT
+    begin.Mode,
+    begin.line AS StartLine,
+    IFNULL(end.line, (SELECT MAX(r.line) FROM _record AS r)) AS StopLine,
+    rb._TimeMS AS StartTime,
+    IFNULL(re._TimeMS,(SELECT MAX(r._TimeMS) FROM _record AS r)) AS StopTime,
+    (IFNULL(re._TimeMS,(SELECT MAX(r._TimeMS) FROM _record AS r))-rb._TimeMS) / 1000 AS interval
+FROM
+    mode as begin
+    LEFT OUTER JOIN mode AS end ON( (begin._mode+1) = end._mode)
+    JOIN _record AS rb on (rb.line = begin.line)
+    LEFT OUTER JOIN _record AS re ON( re.line = end.line )""")
+        self.session.commit()
+
+    def table_from_FMT(self, obj):
+        cols = []
+        fieldtypes = [i for i in obj.types]
+        fieldlabels = obj.labels.split(",")
+
+        for (label, _type) in zip(fieldlabels, fieldtypes):
+            if _type in "fcCeEL":
+                t = Float
+            elif _type in "bBhHiIM":
+                t = Integer
+            elif _type in "nNZ":
+                t = String
+            cols.append(Column(label, t))#, nullable=False))
+        return Table(obj.name.lower(),
+                     DataflashSQL.metadata,
+                     Column('_{}'.format(obj.name.lower()), Integer, nullable=False, primary_key=True),
+                     Column('line', Integer, nullable=False, index=True),
+                     Column('type', String(8), nullable=False, default=obj.name),
+                     ForeignKeyConstraint(['line', 'type'], ['_record.line', '_record.type']),
+                     *cols)
+
+    def class_from_FMT(self, obj):
+        labels = obj.labels.split(",")
+        def init(a, line, fmt, obj):
+            SQLRecord.__init__(a, line, fmt)
+            for l in labels:
+                try:
+                    setattr(a, l, getattr(obj,l))
+                except Exception as e:
+                    print("{} {} failed".format(a,l))
+                    print(e)
+
+        members = {}
+        members['__init__'] = init
+        members['__repr__'] = lambda x: "<{cls} {data}>".format(cls=x.__class__.__name__, data = ' '.join(["{}:{}".format(k,getattr(x,k,None)) for k in labels]))
+
+        # create the class
+        cls = type(\
+            'SQL__{:s}'.format(obj.name),
+            (SQLRecord,),
+            members
+        )
+        return cls
+
+DataflashSQL.tables['_record'] = Table('_record', DataflashSQL.metadata,
+    Column('line', Integer, primary_key=True, nullable=False),
+    Column('type', String(8), nullable=False, index=True),
+    Column('_TimeMS', Integer, nullable=True),
+)
+
+DataflashSQL.tables['FMT'] = Table('fmt', DataflashSQL.metadata,
+    Column('_fmt', Integer, nullable=False, primary_key=True),
+    Column('line', Integer, nullable=False, index=True),
+    Column('type', String(8), nullable=False, default='FMT'),
+    Column('length', Integer, nullable=True),
+    Column('name', String(4), nullable=False),
+    Column('types', String(16), nullable=False),
+    Column('labels', String(64), nullable=False),
+    ForeignKeyConstraint(['line', 'type'], ['_record.line', '_record.type'])
+)
+
+DataflashSQL.tables['_timems'] = Table('_timems', DataflashSQL.metadata,
+    Column('line', Integer, nullable=False, index=True, primary_key=True),
+    Column('type', String(8), nullable=False, default='FMT'),
+    Column('TimeMS', Integer, nullable=True),
+)
+
+class SQLRecord(object):
+    def __init__(self, line, type):
+        self.line = line
+        self.type = type
+
+DataflashSQL.classes['_record'] = SQLRecord
+
+DataflashSQL.mapping['_record'] = mapper(
+    SQLRecord,
+    DataflashSQL.tables['_record'],
+    polymorphic_on=DataflashSQL.tables['_record'].c.type,
+    with_polymorphic='*'
+)
+
+
+class SQLFormat(SQLRecord):
+    def __init__(self, line, length, name, types, labels):
+        SQLRecord.__init__(self, line, 'FMT')
+        self.length = length
+        self.name = name
+        self.types = types
+        self.labels = labels
+    @staticmethod
+    def from_object(line, obj):
+        l = getattr(obj,'length', -1) # Text Log files lack length
+        return SQLFormat(line, l, obj.name, obj.types, obj.labels)
+
+DataflashSQL.mapping['FMT'] = mapper(
+    SQLFormat,
+    DataflashSQL.tables['FMT'],
+    inherits=SQLRecord,
+    polymorphic_identity='FMT',
+    primary_key=DataflashSQL.tables['FMT'].c.line,
+)
+
+
+# FOREIGN KEYS break multi row inserts in SQLite
+#
+#@sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "connect")
+#
+#def on_connect(con, cr):
+#    cursor = con.cursor()
+#    cursor.execute("PRAGMA foreign_keys=ON")
+#    cursor.close()
+
+class Import(DataflashLog.DataflashLog):
+    def __init__(self, dbx, logfile, format):
+        DataflashLog.DataflashLog.__init__(self)
+        self.db = dbx
+        self.logfile=logfile
+        self.format=format
+    def run(self):
+        self.read(self.logfile, self.format, True)
+
+    def process(self, lineNumber, e):
+        if e.NAME == 'FMT':
+            cls = e.to_class()
+            if cls is not None: # FMT messages can be broken ...
+                if hasattr(e, 'type') and e.type not in self._formats: # binary log specific
+                    self._formats[e.type] = cls
+                if cls.NAME not in self.formats:
+                    self.formats[cls.NAME] = cls
+        try:
+            self.db.insert(lineNumber, e)
+        except Exception as ex:
+            print(ex)
+
+    def close(self):
+        self.db.commit()
+        self.db.finish()
+
+
+class Explorer(object):
+    def __init__(self):
+        pass
+
+class ExampleAutotune(object):
+    AUTOTUNE_INITIALISED       = 30
+    AUTOTUNE_OFF               = 31
+    AUTOTUNE_RESTART           = 32
+    AUTOTUNE_SUCCESS           = 33
+    AUTOTUNE_FAILED            = 34
+    AUTOTUNE_REACHED_LIMIT     = 35
+    AUTOTUNE_PILOT_TESTING     = 36
+    AUTOTUNE_SAVEDGAINS        = 37
+    def __init__(self):
+        pass
+
+    def run(self, db, verbose):
+        if 'ATUN' not in db.mapping:
+            return
+
+        self.db = db
+        sessions = self.db.session.execute("""SELECT
+    Id,
+    begin.line AS StartLine,
+    IFNULL(MIN(end.line)-1,MAX(end.max)) AS StopLine
+FROM
+    ev as begin,
+    (SELECT e.line AS line,r.line AS max from _record AS r LEFT OUTER JOIN ev AS e USING(line) where e.Id is null or e.Id = {id} ) AS end
+WHERE
+    begin.Id = {id} AND
+    IFNULL(end.line,end.max) > begin.line
+GROUP BY
+    begin.line""".format(id=self.AUTOTUNE_INITIALISED))
+
+        for s in sessions:
+            EV = self.db.mapping['EV']
+
+            q = self.db.session.query(EV.c.Id)
+            q = q.filter(EV.c.line >= s.StartLine, EV.c.line <= s.StopLine) # limit to session
+            q = q.filter(EV.c.Id >= self.AUTOTUNE_INITIALISED , EV.c.Id <= self.AUTOTUNE_SAVEDGAINS) # only AUTOTUNE related Id
+
+            events = set([i for (i,) in q.all()])
+
+            if self.AUTOTUNE_SUCCESS in events:
+                print("Autotune {}-{} +++".format(s.StartLine,s.StopLine))
+            else:
+                print("Autotune {}-{} ---".format(s.StartLine,s.StopLine))
+            if verbose:
+                _record = self.db.mapping['_record']
+
+                q = self.db.session.query(_record)
+                q = q.with_polymorphic([self.db.mapping['EV'],self.db.mapping['ATUN']]) # polymorphic lookup only for tables required
+                q = q.filter(_record.c.line >= s.StartLine, _record.c.line <= s.StopLine) # limit to session
+                q = q.filter(_record.c.type.in_(['ATUN','EV'])) # we only want ATUN & EV
+                q = q.order_by(sqlalchemy.asc(_record.c.line)) # order by line ascending
+
+                for i in q.all():
+                    print(i)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Analyze an APM Dataflash log for known issues')
+    parser.add_argument('--logfile', type=argparse.FileType('r'), help='path to Dataflash log file (or - for stdin)', default=None)
+    parser.add_argument('--db', type=str, help='path to Dataflash Database file ', default=":memory:")
+    parser.add_argument('-f', '--format',  metavar='', type=str, action='store', choices=['bin','log','auto'], default='auto')
+    parser.add_argument('-v', '--verbose', metavar='', action='store_const', const=True, help='verbose output')
+    args = parser.parse_args()
+
+    db = DataflashSQL(args.db)
+
+    if args.logfile:
+        i = Import(db, args.logfile.name, args.format)
+        i.run()
+        i.close()
+
+    x = ExampleAutotune()
+    x.run(db, args.verbose)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
 - SQLAlchemy powered DataflashLog to sqlite database
   Full SQLAlchemy mapping.
   Importing data takes some time, but it improves data accessibility.
   Databases can be queried externally as well (sqliteman)
   or in ipython notebooks for development/debugging purposes.
 - ExampleAutotune as an example how to query/access data in a Test.

Many LogAnalyzer Tests could be reduced to a SQL query and the resulting message, if the database takes care of things.

I'm aware this adds SQLAlchemy as dependency,
I'm aware the time to import data to the database is a turnoff, 
but the ease of use is really convincing.

These images were created using ipython notebook/matplotlib and the database.
In case autotune works, they are entertaining at best ...
![77_success](https://cloud.githubusercontent.com/assets/164513/3729756/c858d414-16c2-11e4-85e7-28b7f379f498.png)
![autotune_success](https://cloud.githubusercontent.com/assets/164513/3729769/fe0d459a-16c2-11e4-900e-6efa8e6099a8.png)

but if autotune fails, they really help.
![autotune_fail_p_low](https://cloud.githubusercontent.com/assets/164513/3729782/595d9b48-16c3-11e4-97b4-4e7953c7b4bf.png)

In this case the initial D was too high, so P got lowered until the lower limit was hit.