### PR TITLE
common.py: Removed timeout reset in wait_altitude

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -66,8 +66,6 @@ def wait_altitude(mav, alt_min, alt_max, timeout=30):
         climb_rate =  m.alt - previous_alt
         previous_alt = m.alt
         print("Wait Altitude: Cur:%u, min_alt:%u, climb_rate: %u" % (m.alt, alt_min , climb_rate))
-        if abs(climb_rate) > 0:
-            tstart = time.time();
         if m.alt >= alt_min and m.alt <= alt_max:
             print("Altitude OK")
             return True


### PR DESCRIPTION
common.py:wait_altitude contained an if statement that, if the plane was changing altitude at all would reset tstart, making the timeout effectively useless. Removing this line allows wait_altitude to respect the timeout the user sets.
