### PR TITLE
AP_NavEKF : Modified compass fail logic

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -733,35 +733,40 @@ void NavEKF::SelectVelPosFusion()
 // select fusion of magnetometer data
 void NavEKF::SelectMagFusion()
 {
-    // check for and read new magnetometer measurements
-    readMagData();
+    if(!magFailed) {
+        // check for and read new magnetometer measurements
+        readMagData();
 
-    // If we are using the compass and the magnetometer has been unhealthy for too long we declare it failed
-    if (magHealth) {
-        lastHealthyMagTime_ms = hal.scheduler->millis();
-    } else {
-        if ((hal.scheduler->millis() - lastHealthyMagTime_ms) > _magFailTimeLimit_ms && use_compass()) {
-            magTimeout = true;
+        // If we are using the compass and the magnetometer has been unhealthy for too long we declare a timeout
+        // If we have a vehicle that can fly without a compass (a vehicle that doesn't have significant sideslip) then the compass is permanently failed and will not be used until the filter is reset
+        if (magHealth) {
+            lastHealthyMagTime_ms = hal.scheduler->millis();
         } else {
-            magTimeout = false;
+            if ((hal.scheduler->millis() - lastHealthyMagTime_ms) > _magFailTimeLimit_ms && use_compass()) {
+                magTimeout = true;
+                if (assume_zero_sideslip()) {
+                    magFailed = true;
+                }
+            } else {
+                magTimeout = false;
+            }
         }
-    }
 
-    // determine if conditions are right to start a new fusion cycle
-    bool dataReady = statesInitialised && use_compass() && newDataMag;
-    if (dataReady)
-    {
-        MAGmsecPrev = IMUmsec;
-        fuseMagData = true;
-    }
-    else
-    {
-        fuseMagData = false;
-    }
+        // determine if conditions are right to start a new fusion cycle
+        bool dataReady = statesInitialised && use_compass() && newDataMag;
+        if (dataReady)
+        {
+            MAGmsecPrev = IMUmsec;
+            fuseMagData = true;
+        }
+        else
+        {
+            fuseMagData = false;
+        }
 
-    // call the function that performs fusion of magnetometer data
-    FuseMagnetometer();
-
+        // call the function that performs fusion of magnetometer data
+        FuseMagnetometer();
+    }
 }
 
 // select fusion of true airspeed measurements
@@ -3304,6 +3309,9 @@ void NavEKF::ZeroVariables()
     posTimeout = false;
     hgtTimeout = false;
     filterDiverged = false;
+    magTimeout = false;
+    magFailed = false;
+    lastHealthyMagTime_ms = hal.scheduler->millis();
     lastStateStoreTime_ms = 0;
     lastFixTime_ms = 0;
     secondLastFixTime_ms = 0;
@@ -3363,7 +3371,7 @@ bool NavEKF::static_mode_demanded(void) const
 // return true if we should use the compass
 bool NavEKF::use_compass(void) const
 {
-    return _ahrs->get_compass() && _ahrs->get_compass()->use_for_yaw();
+    return _ahrs->get_compass() && _ahrs->get_compass()->use_for_yaw() && !magFailed;
 }
 
 // decay GPS horizontal position offset to close to zero at a rate of 1 m/s

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -358,6 +358,7 @@ private:
     bool hgtTimeout;                // boolean true if height measurements have failed innovation consistency check and timed out
     bool magTimeout;                // boolean true if magnetometer measurements have failed for too long and have timed out
     bool filterDiverged;            // boolean true if the filter has diverged
+    bool magFailed;                 // boolean true if the magnetometer has failed
 
     Vector31 Kfusion;               // Kalman gain vector
     Matrix22 KH;                    // intermediate result used for covariance updates


### PR DESCRIPTION
If the vehicle can fly without a compass (a fly forward vehicle)
then if the compass times out (large errors for more than 10 seconds,
then it will be declared permanently failed and will not be
used until the filter is reset
