### PR TITLE
GCS_Mavlink.pde: Fix for a possible segfault after passing ARSPD_FBW_MIN

### DIFF
--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1629,9 +1629,11 @@ void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 static void gcs_send_airspeed_calibration(const Vector3f &vg)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (comm_get_txspace((mavlink_channel_t)i) >= 
-            MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_LEN) {
-            airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
+        if (gcs[i].initialised) {
+            if (comm_get_txspace((mavlink_channel_t)i) - MAVLINK_NUM_NON_PAYLOAD_BYTES >= 
+                MAVLINK_MSG_ID_AIRSPEED_AUTOCAL_LEN) {
+                airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
+            }
         }
     }
 }


### PR DESCRIPTION
Dear APM maintainer,

When experimenting a little with the PX4 serial ports and intending to use the GCS[2] port for sending out some internal APM data, I have noticed that the APM build on PX4 crashes when the aircraft flies faster than ARSPD_FBW_MIN. This was caused by the airspeed calibration data being redistributed via all gcs channels, even though one of the gcs channels was not used (nor initialized). Hence I added one additional if cause... I hope this fix helps someone with similar troubles.

Regards,
