### PR TITLE
AP_AHRS_DCM.cpp: correction to position projection for crosswind operations

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -886,7 +886,7 @@ bool AP_AHRS_DCM::get_position(struct Location &loc)
     loc.flags.terrain_alt = 0;
     location_offset(loc, _position_offset_north, _position_offset_east);
     if (_flags.fly_forward && _have_position) {
-        location_update(loc, degrees(yaw), _gps.ground_speed() * _gps.get_lag());
+        location_update(loc, _gps.ground_course_cd() * 0.01, _gps.ground_speed() * _gps.get_lag());
     }
     return _have_position;
 }


### PR DESCRIPTION
Dear APM 

the AP_AHRS_DCM::get_position() is used i.a. for logging the position of a photo taken by the camera and it uses a position projection to allow for a delay in the triggering mechanism and the camera itself. However, the position projection was using the yaw angle of the airframe and not the actual ground course, so in hisgh crosswind conditions the picture positions were all logged slightly to the wind (as the airplane's nose is pointing there to maintain its track).

Regards,
Przemek
