### PR TITLE
SITL: added missing parameters to sim_multicopter.py call

### DIFF
--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -259,7 +259,7 @@ case $VEHICLE in
         fi
         ;;
     ArduCopter)
-        RUNSIM="nice $autotest/pysim/sim_multicopter.py --home=$SIMHOME $EXTRA_SIM"
+        RUNSIM="nice $autotest/pysim/sim_multicopter.py --home=$SIMHOME --simin=$SIMIN_PORT --simout=$SIMOUT_PORT --fgout=$FG_PORT $EXTRA_SIM"
         PARMS="copter_params.parm"
         ;;
     APMrover2)


### PR DESCRIPTION
When using additional instances of ArduCopter, the new port locations were not passed to sim_multicopter.py and defaults were being used. This prevented any additional instances beyond the initial one.
