### PR TITLE
Print the version when requesting parameters

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -897,6 +897,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:         // MAV ID: 21
     {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("Firmware: " FIRMWARE_STRING));
         handle_param_request_list(msg);
         break;
     }


### PR DESCRIPTION
Currently there is no good way to get the firmware version from the GCS.

This prints the FIRMWARE_STRING every time a new parameter list is requested.
