### PR TITLE
Copter : Change ap.pre_arm_check from boolean to a full status

### DIFF
--- a/ArduCopter/AP_State.pde
+++ b/ArduCopter/AP_State.pde
@@ -110,11 +110,11 @@ void set_land_complete(bool b)
 
 // ---------------------------------------------
 
-void set_pre_arm_check(bool b)
+void set_pre_arm_check(uint8_t status)
 {
-    if(ap.pre_arm_check != b) {
-        ap.pre_arm_check = b;
-        AP_Notify::flags.pre_arm_check = b;
+    if(ap.pre_arm_check != status) {
+        ap.pre_arm_check = status;
+        AP_Notify::flags.pre_arm_check = (status == ARM_OK);
     }
 }
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -364,6 +364,31 @@ enum FlipState {
 #define ARMING_CHECK_RC                     0x40
 #define ARMING_CHECK_VOLTAGE                0x80
 
+// Arming check status
+#define ARM_OK                             0x00
+#define ARM_RC_NOT_CAL                     0x01
+#define ARM_BARO_NOT_HEALTHY               0x02
+#define ARM_ALT_DISPARITY                  0x03
+#define ARM_COMPASS_NOT_HEALTHY            0x04
+#define ARM_COMPASS_NOT_CALIBRATED         0x05
+#define ARM_COMPASS_OFFSET_HIGH            0x06
+#define ARM_CHECK_MAG_FIELD                0x07
+#define ARM_INS_NOT_CALIBRATED             0x08
+#define ARM_INS_NOT_HEALTHY                0x09
+#define ARM_BOARD_VOLTAGE                  0x10
+#define ARM_CH7_CH8_SAME                   0x11
+#define ARM_FS_THR_VALUE                   0x12
+#define ARM_ANGLE_MAX                      0x13
+#define ARM_ACRO_BAL                       0x14
+#define ARM_GPS_GLITCH                     0x15
+#define ARM_GPS_NO_3D                      0x16
+#define ARM_GPS_VELOCITY                   0x17
+#define ARM_GPS_HDOP_HIGH                  0x18
+#define ARM_THR_BELOW_FS                   0x19
+#define ARM_LEANING                        0x20
+#define ARM_SAFETY_SWITCH                  0x21
+
+
 // Radio failsafe definitions (FS_THR parameter)
 #define FS_THR_DISABLED                    0
 #define FS_THR_ENABLED_ALWAYS_RTL          1


### PR DESCRIPTION
ap.pre_arm_check global variable is an integer but only used as a boolean. This is now changed to use different Error status for the prearm and arm checks. This will enable the possiblity to send an Id via mavlink and to send an id via frsky telemetry
