### PR TITLE
AP_NavEKF : Clear compass fail on transition between armed and disarmed

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -608,6 +608,9 @@ void NavEKF::UpdateFilter()
         ResetPosition();
         ResetHeight();
         StoreStatesReset();
+        // clear the magnetometer failed status as the failure may have been
+        // caused by external field disturbances associated with pre-flight activities
+        magFailed = false;
         calcQuatAndFieldStates(_ahrs->roll, _ahrs->pitch);
         prevStaticMode = staticMode;
     }


### PR DESCRIPTION
This allows a compass that has been declared failed, possibly because of
external disturbances (eg movement of hatches, proximity of tools, etc)
to be given a second chance when the vehicle is armed.
