### PR TITLE
AP_HAL_PX4: Add semphore to io of UARTDriver

### DIFF
--- a/libraries/AP_HAL_PX4/Semaphore.h
+++ b/libraries/AP_HAL_PX4/Semaphore.h
@@ -1,0 +1,14 @@
+#include <semaphore.h>
+class Semaphore {
+    sem_t _sem;
+    
+public:
+    Semaphore(sem_t &semaphore ) : _sem(semaphore)
+    {  }
+    
+    ~Semaphore() { 
+	sem_post(&_sem);
+    }
+    
+    int try_wait() { return sem_trywait(&_sem); }
+};

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -41,6 +41,8 @@ extern const AP_HAL::HAL& hal;
 
 void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS) 
 {
+    sem_init (&_semaphore, 0 ,1);
+
     if (strcmp(_devpath, "/dev/null") == 0) {
         // leave uninitialised
         return;
@@ -198,6 +200,9 @@ void PX4UARTDriver::try_initialise(void)
 
 void PX4UARTDriver::end() 
 {
+    sem_wait (&_semaphore);
+    sem_destroy (&_semaphore);
+
     _initialised = false;
     while (_in_timer) hal.scheduler->delay(1);
     if (_fd != -1) {
@@ -285,6 +290,10 @@ int16_t PX4UARTDriver::read()
     if (BUF_EMPTY(_readbuf)) {
         return -1;
     }
+    Semaphore sem(_semaphore);
+    if (sem.try_wait ()){
+        return -1;
+    }
     c = _readbuf[_readbuf_head];
     BUF_ADVANCEHEAD(_readbuf, 1);
 	return c;
@@ -299,8 +308,8 @@ size_t PX4UARTDriver::write(uint8_t c)
         try_initialise();
         return 0;
     }
-    if (hal.scheduler->in_timerprocess()) {
-        // not allowed from timers
+    Semaphore sem(_semaphore);
+    if (sem.try_wait ()){
         return 0;
     }
     uint16_t _head;
@@ -325,8 +334,9 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
         try_initialise();
 		return 0;
 	}
-    if (hal.scheduler->in_timerprocess()) {
-        // not allowed from timers
+
+     Semaphore sem(_semaphore);
+     if (sem.try_wait ()){
         return 0;
     }
 

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -3,6 +3,7 @@
 #define __AP_HAL_PX4_UARTDRIVER_H__
 
 #include <AP_HAL_PX4.h>
+#include <Semaphore.h>
 #include <systemlib/perf_counter.h>
 
 class PX4::PX4UARTDriver : public AP_HAL::UARTDriver {
@@ -75,6 +76,7 @@ private:
     uint32_t _total_read;
     uint32_t _total_written;
     enum flow_control _flow_control;
+    sem_t _semaphore;
 };
 
 #endif // __AP_HAL_PX4_UARTDRIVER_H__


### PR DESCRIPTION
In order to avoid concurrent acces to the uartdriver, the IO are protected by a semaphore. Now, the lib will accept different thread accesing the uart. This is usefull for Frsky telemetry to be able to run in a separate thread.
