### PR TITLE
MAVLink: updated severity values to conform to RFC-5424

### DIFF
--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -782,7 +782,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             uint8_t result = MAV_RESULT_UNSUPPORTED;
 
             // do command
-            send_text_P(SEVERITY_LOW,PSTR("command received: "));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("command received: "));
 
             switch(packet.command) {
 
@@ -962,10 +962,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
         {
             // mark the firmware version in the tlog
-            send_text_P(SEVERITY_LOW, PSTR(FIRMWARE_STRING));
+            send_text_P(MAV_SEVERITY_WARNING, PSTR(FIRMWARE_STRING));
 
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
-            send_text_P(SEVERITY_LOW, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
+            send_text_P(MAV_SEVERITY_WARNING, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
 #endif
             handle_param_request_list(msg);
             break;
@@ -1197,7 +1197,7 @@ static void mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Initialising APM..."));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Initialising APM..."));
     }
     check_usb_mux();
 
@@ -1244,7 +1244,7 @@ static void gcs_update(void)
     }
 }
 
-static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
+static void gcs_send_text_P(int severity, const prog_char_t *str)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
@@ -1264,7 +1264,7 @@ static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
 void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 {
     va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)SEVERITY_LOW;
+    gcs[0].pending_status.severity = (uint8_t)MAV_SEVERITY_WARNING;
     va_start(arg_list, fmt);
     hal.util->vsnprintf_P((char *)gcs[0].pending_status.text,
             sizeof(gcs[0].pending_status.text), fmt, arg_list);

--- a/APMrover2/Steering.pde
+++ b/APMrover2/Steering.pde
@@ -29,7 +29,7 @@ static bool auto_check_trigger(void)
 
     // check for user pressing the auto trigger to off
     if (auto_triggered && g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 1) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("AUTO triggered off"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("AUTO triggered off"));
         auto_triggered = false;
         return false; 
     }
@@ -47,7 +47,7 @@ static bool auto_check_trigger(void)
     }
  
     if (g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Triggered AUTO with pin"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Triggered AUTO with pin"));
         auto_triggered = true;
         return true;            
     }

--- a/APMrover2/commands.pde
+++ b/APMrover2/commands.pde
@@ -28,7 +28,7 @@ static void set_next_WP(const struct Location& loc)
     // location as the previous waypoint, to prevent immediately
     // considering the waypoint complete
     if (location_passed_point(current_loc, prev_WP, next_WP)) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Resetting prev_WP"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Resetting prev_WP"));
         prev_WP = current_loc;
     }
 
@@ -61,7 +61,7 @@ void init_home()
         return;
     }
 
-	gcs_send_text_P(SEVERITY_LOW, PSTR("init home"));
+	gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("init home"));
 
     ahrs.set_home(gps.location());
 	home_is_set = true;

--- a/APMrover2/commands_logic.pde
+++ b/APMrover2/commands_logic.pde
@@ -170,7 +170,7 @@ static bool verify_command(const AP_Mission::Mission_Command& cmd)
                 // this is a command that doesn't require verify
                 return true;
             }
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("verify_conditon: Unsupported command"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("verify_conditon: Unsupported command"));
             return true;
             break;
 	}
@@ -219,7 +219,7 @@ static bool verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 static bool verify_RTL()
 {
 	if (wp_distance <= g.waypoint_radius) {
-		gcs_send_text_P(SEVERITY_LOW,PSTR("Reached home"));
+		gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Reached home"));
                 rtl_complete = true;
 		return true;
 	}

--- a/APMrover2/navigation.pde
+++ b/APMrover2/navigation.pde
@@ -20,7 +20,7 @@ static void navigate()
 	wp_distance = get_distance(current_loc, next_WP);
 
 	if (wp_distance < 0){
-		gcs_send_text_P(SEVERITY_HIGH,PSTR("<navigate> WP error - distance < 0"));
+		gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("<navigate> WP error - distance < 0"));
 		return;
 	}
 

--- a/APMrover2/sensors.pde
+++ b/APMrover2/sensors.pde
@@ -2,9 +2,9 @@
 
 static void init_barometer(void)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Calibrating barometer"));    
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Calibrating barometer"));
     barometer.calibrate();
-    gcs_send_text_P(SEVERITY_LOW, PSTR("barometer calibration complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("barometer calibration complete"));
 }
 
 static void init_sonar(void)

--- a/APMrover2/system.pde
+++ b/APMrover2/system.pde
@@ -151,10 +151,10 @@ static void init_ardupilot()
 #if LOGGING_ENABLED == ENABLED
 	DataFlash.Init(log_structure, sizeof(log_structure)/sizeof(log_structure[0]));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("No dataflash card inserted"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("No dataflash card inserted"));
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedErase()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("ERASING LOGS"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("ERASING LOGS"));
 		do_erase_logs();
     }
 	if (g.log_bitmask != 0) {
@@ -241,10 +241,10 @@ static void startup_ground(void)
 {
     set_mode(INITIALISING);
 
-	gcs_send_text_P(SEVERITY_LOW,PSTR("<startup_ground> GROUND START"));
+	gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("<startup_ground> GROUND START"));
 
 	#if(GROUND_START_DELAY > 0)
-		gcs_send_text_P(SEVERITY_LOW,PSTR("<startup_ground> With Delay"));
+		gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("<startup_ground> With Delay"));
 		delay(GROUND_START_DELAY * 1000);
 	#endif
 
@@ -265,7 +265,7 @@ static void startup_ground(void)
     hal.uartB->set_blocking_writes(false);
     hal.uartC->set_blocking_writes(false);
 
-	gcs_send_text_P(SEVERITY_LOW,PSTR("\n\n Ready to drive."));
+	gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("\n\n Ready to drive."));
 }
 
 /*
@@ -369,12 +369,12 @@ static void failsafe_trigger(uint8_t failsafe_type, bool on)
 
 static void startup_INS_ground(bool force_accel_level)
 {
-    gcs_send_text_P(SEVERITY_MEDIUM, PSTR("Warming up ADC..."));
+    gcs_send_text_P(MAV_SEVERITY_ALERT, PSTR("Warming up ADC..."));
  	mavlink_delay(500);
 
 	// Makes the servos wiggle twice - about to begin INS calibration - HOLD LEVEL AND STILL!!
 	// -----------------------
-    gcs_send_text_P(SEVERITY_MEDIUM, PSTR("Beginning INS calibration; do not move vehicle"));
+    gcs_send_text_P(MAV_SEVERITY_ALERT, PSTR("Beginning INS calibration; do not move vehicle"));
 	mavlink_delay(1000);
 
     ahrs.init();

--- a/AntennaTracker/GCS_Mavlink.pde
+++ b/AntennaTracker/GCS_Mavlink.pde
@@ -596,7 +596,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         uint8_t result = MAV_RESULT_UNSUPPORTED;
         
         // do command
-        send_text_P(SEVERITY_LOW,PSTR("command received: "));
+        send_text_P(MAV_SEVERITY_WARNING,PSTR("command received: "));
         
         switch(packet.command) {
             
@@ -795,7 +795,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         // check if this is the HOME wp
         if (packet.seq == 0) {
             set_home(tell_command); // New home in EEPROM
-            send_text_P(SEVERITY_LOW,PSTR("new HOME received"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("new HOME received"));
             waypoint_receiving = false;
         }
 
@@ -926,7 +926,7 @@ static void mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Initialising APM..."));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Initialising APM..."));
     }
     in_mavlink_delay = false;
 }
@@ -971,7 +971,7 @@ static void gcs_update(void)
     }
 }
 
-static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
+static void gcs_send_text_P(int severity, const prog_char_t *str)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
@@ -991,7 +991,7 @@ static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
 void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 {
     va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)SEVERITY_LOW;
+    gcs[0].pending_status.severity = (uint8_t)MAV_SEVERITY_WARNING;
     va_start(arg_list, fmt);
     hal.util->vsnprintf_P((char *)gcs[0].pending_status.text,
             sizeof(gcs[0].pending_status.text), fmt, arg_list);

--- a/AntennaTracker/sensors.pde
+++ b/AntennaTracker/sensors.pde
@@ -2,9 +2,9 @@
 
 static void init_barometer(void)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Calibrating barometer"));    
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Calibrating barometer"));
     barometer.calibrate();
-    gcs_send_text_P(SEVERITY_LOW, PSTR("barometer calibration complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("barometer calibration complete"));
 }
 
 // read the barometer and return the updated altitude in meters

--- a/AntennaTracker/system.pde
+++ b/AntennaTracker/system.pde
@@ -94,7 +94,7 @@ static void init_tracker()
         get_home_eeprom(current_loc);
     }
 
-    gcs_send_text_P(SEVERITY_LOW,PSTR("\nReady to track."));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("\nReady to track."));
     hal.scheduler->delay(1000); // Why????
 
     set_mode(AUTO); // tracking
@@ -113,7 +113,7 @@ static void init_tracker()
 // Requires that the tracker be physically 'level' and horizontal
 static void calibrate_ins()
 {
-    gcs_send_text_P(SEVERITY_MEDIUM, PSTR("Beginning INS calibration; do not move tracker"));
+    gcs_send_text_P(MAV_SEVERITY_ALERT, PSTR("Beginning INS calibration; do not move tracker"));
     ahrs.init();
     ins.init(AP_InertialSensor::COLD_START, ins_sample_rate);
     ins.init_accel();

--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -900,10 +900,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:         // MAV ID: 21
     {
         // mark the firmware version in the tlog
-        send_text_P(SEVERITY_LOW, PSTR(FIRMWARE_STRING));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR(FIRMWARE_STRING));
 
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
-        send_text_P(SEVERITY_LOW, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
 #endif
         handle_param_request_list(msg);
         break;
@@ -1344,12 +1344,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         
         if (packet.idx >= rally.get_rally_total() || 
             packet.idx >= rally.get_rally_max()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message ID"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message ID"));
             break;
         }
 
         if (packet.count != rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message count"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message count"));
             break;
         }
 
@@ -1362,7 +1362,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         rally_point.flags = packet.flags;
 
         if (!rally.set_rally_point_with_index(packet.idx, rally_point)) {
-            send_text_P(SEVERITY_HIGH, PSTR("error setting rally point"));
+            send_text_P(MAV_SEVERITY_CRITICAL, PSTR("error setting rally point"));
         }
 
         break;
@@ -1370,29 +1370,29 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     //send a rally point to the GCS
     case MAVLINK_MSG_ID_RALLY_FETCH_POINT: {
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 1")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 1")); // #### TEMP
 
         mavlink_rally_fetch_point_t packet;
         mavlink_msg_rally_fetch_point_decode(msg, &packet);
         if (mavlink_check_target(packet.target_system, packet.target_component))
             break;
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 2")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 2")); // #### TEMP
 
         if (packet.idx > rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW, PSTR("bad rally point index"));   
+            send_text_P(MAV_SEVERITY_WARNING, PSTR("bad rally point index"));
             break;
         }
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 3")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 3")); // #### TEMP
 
         RallyLocation rally_point;
         if (!rally.get_rally_point_with_index(packet.idx, rally_point)) {
-           send_text_P(SEVERITY_LOW, PSTR("failed to set rally point"));   
+           send_text_P(MAV_SEVERITY_WARNING, PSTR("failed to set rally point"));
            break;
         }
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 4")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 4")); // #### TEMP
 
         mavlink_msg_rally_point_send_buf(msg,
                                          chan, msg->sysid, msg->compid, packet.idx, 
@@ -1400,7 +1400,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                                          rally_point.alt, rally_point.break_alt, rally_point.land_dir, 
                                          rally_point.flags);
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 5")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 5")); // #### TEMP
 
         break;
     }  
@@ -1439,7 +1439,7 @@ static void mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Initialising APM..."));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Initialising APM..."));
     }
     check_usb_mux();
 
@@ -1486,7 +1486,7 @@ static void gcs_check_input(void)
     }
 }
 
-static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
+static void gcs_send_text_P(int severity, const prog_char_t *str)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
@@ -1503,7 +1503,7 @@ static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
 void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 {
     va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)SEVERITY_LOW;
+    gcs[0].pending_status.severity = (uint8_t)MAV_SEVERITY_WARNING;
     va_start(arg_list, fmt);
     hal.util->vsnprintf_P((char *)gcs[0].pending_status.text,
             sizeof(gcs[0].pending_status.text), fmt, arg_list);

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -156,9 +156,9 @@ process_logs(uint8_t argc, const Menu::arg *argv)
 
 static void do_erase_logs(void)
 {
-	gcs_send_text_P(SEVERITY_LOW, PSTR("Erasing logs\n"));
+	gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Erasing logs\n"));
     DataFlash.EraseAll();
-	gcs_send_text_P(SEVERITY_LOW, PSTR("Log erase complete\n"));
+	gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Log erase complete\n"));
 }
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/compassmot.pde
+++ b/ArduCopter/compassmot.pde
@@ -31,7 +31,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
 
     // check compass is enabled
     if (!g.compass_enabled) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("compass disabled\n"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("compass disabled\n"));
         ap.compass_mot = false;
         return 1;
     }
@@ -40,7 +40,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     compass.read();
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (!compass.healthy(i)) {
-            gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("check compass"));
+            gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("check compass"));
             ap.compass_mot = false;
             return 1;
         }
@@ -49,7 +49,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     // check if radio is calibrated
     pre_arm_rc_checks();
     if (!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("RC not calibrated"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("RC not calibrated"));
         ap.compass_mot = false;
         return 1;
     }
@@ -57,14 +57,14 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     // check throttle is at zero
     read_radio();
     if (g.rc_3.control_in != 0) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("thr not zero"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("thr not zero"));
         ap.compass_mot = false;
         return 1;
     }
 
     // check we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Not landed"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Not landed"));
         ap.compass_mot = false;
         return 1;
     }
@@ -89,13 +89,13 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     AP_Notify::flags.esc_calibration = true;
 
     // warn user we are starting calibration
-    gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("STARTING CALIBRATION"));
+    gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("STARTING CALIBRATION"));
 
     // inform what type of compensation we are attempting
     if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("CURRENT"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("CURRENT"));
     } else{
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("THROTTLE"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("THROTTLE"));
     }
 
     // disable throttle and battery failsafe
@@ -240,10 +240,10 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
         }
         compass.save_motor_compensation();
         // display success message
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Calibration Successful!"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Calibration Successful!"));
     } else {
         // compensation vector never updated, report failure
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Failed!"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Failed!"));
         compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
     }
 

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -851,16 +851,16 @@ void autotune_update_gcs(uint8_t message_id)
 {
     switch (message_id) {
         case AUTOTUNE_MESSAGE_STARTED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Started"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Started"));
             break;
         case AUTOTUNE_MESSAGE_STOPPED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Stopped"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Stopped"));
             break;
         case AUTOTUNE_MESSAGE_SUCCESS:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Success"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Success"));
             break;
         case AUTOTUNE_MESSAGE_FAILED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Failed"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Failed"));
             break;
     }
 }

--- a/ArduCopter/crash_check.pde
+++ b/ArduCopter/crash_check.pde
@@ -55,7 +55,7 @@ void crash_check()
             // log an error in the dataflash
             Log_Write_Error(ERROR_SUBSYSTEM_CRASH_CHECK, ERROR_CODE_CRASH_CHECK_CRASH);
             // send message to gcs
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("Crash: Disarming"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Crash: Disarming"));
             // disarm motors
             init_disarm_motors();
         }
@@ -157,7 +157,7 @@ void parachute_check()
 static void parachute_release()
 {
     // send message to gcs and dataflash
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("Parachute: Released!"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Parachute: Released!"));
     Log_Write_Event(DATA_PARACHUTE_RELEASED);
 
     // disarm motors
@@ -179,7 +179,7 @@ static void parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if (ap.land_complete || (parachute.alt_min() != 0 && (baro_alt < (uint32_t)parachute.alt_min() * 100))) {
         // warn user of reason for failure
-        gcs_send_text_P(SEVERITY_HIGH,PSTR("Parachute: Too Low"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Parachute: Too Low"));
         // log an error in the dataflash
         Log_Write_Error(ERROR_SUBSYSTEM_PARACHUTE, ERROR_CODE_PARACHUTE_TOO_LOW);
         return;

--- a/ArduCopter/ekf_check.pde
+++ b/ArduCopter/ekf_check.pde
@@ -68,7 +68,7 @@ void ekf_check()
                 Log_Write_Error(ERROR_SUBSYSTEM_EKFINAV_CHECK, ERROR_CODE_EKFINAV_CHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((hal.scheduler->millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs_send_text_P(SEVERITY_HIGH,PSTR("EKF variance"));
+                    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("EKF variance"));
                     ekf_check_state.last_warn_time = hal.scheduler->millis();
                 }
                 failsafe_ekf_event();

--- a/ArduCopter/events.pde
+++ b/ArduCopter/events.pde
@@ -164,7 +164,7 @@ static void failsafe_battery_event(void)
     set_failsafe_battery(true);
 
     // warn the ground station and log to dataflash
-    gcs_send_text_P(SEVERITY_LOW,PSTR("Low Battery!"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("Low Battery!"));
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
 
 }
@@ -205,7 +205,7 @@ static void failsafe_gps_check()
     // GPS failsafe event has occured
     // update state, warn the ground station and log to dataflash
     set_failsafe_gps(true);
-    gcs_send_text_P(SEVERITY_LOW,PSTR("Lost GPS!"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("Lost GPS!"));
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_GPS, ERROR_CODE_FAILSAFE_OCCURRED);
 
     // take action based on flight mode and FS_GPS_ENABLED parameter

--- a/ArduCopter/motor_test.pde
+++ b/ArduCopter/motor_test.pde
@@ -72,19 +72,19 @@ static bool mavlink_motor_test_check(mavlink_channel_t chan)
     // check rc has been calibrated
     pre_arm_rc_checks();
     if(!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: RC not calibrated"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: RC not calibrated"));
         return false;
     }
 
     // ensure we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: vehicle not landed"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: vehicle not landed"));
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: Safety Switch"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: Safety Switch"));
         return false;
     }
 

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -145,7 +145,7 @@ static void init_arm_motors()
 #endif
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_AVR_SITL
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("ARMING MOTORS"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("ARMING MOTORS"));
 #endif
 
     // Remember Orientation
@@ -235,7 +235,7 @@ static void pre_arm_checks(bool display_failure)
     pre_arm_rc_checks();
     if(!ap.pre_arm_rc_check) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: RC not calibrated"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: RC not calibrated"));
         }
         return;
     }
@@ -245,14 +245,14 @@ static void pre_arm_checks(bool display_failure)
         // barometer health check
         if(!barometer.healthy()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Baro not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Baro not healthy"));
             }
             return;
         }
         // check Baro & inav alt are within 1m
         if(fabs(inertial_nav.get_altitude() - baro_alt) > 100) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Alt disparity"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Alt disparity"));
             }
             return;
         }
@@ -263,7 +263,7 @@ static void pre_arm_checks(bool display_failure)
         // check the primary compass is healthy
         if(!compass.healthy(0)) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not healthy"));
             }
             return;
         }
@@ -271,7 +271,7 @@ static void pre_arm_checks(bool display_failure)
         // check compass learning is on or offsets have been set
         if(!compass.configured()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not calibrated"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not calibrated"));
             }
             return;
         }
@@ -280,7 +280,7 @@ static void pre_arm_checks(bool display_failure)
         Vector3f offsets = compass.get_offsets();
         if(offsets.length() > 500) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass offsets too high"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass offsets too high"));
             }
             return;
         }
@@ -289,7 +289,7 @@ static void pre_arm_checks(bool display_failure)
         float mag_field = compass.get_field().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65 || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check mag field"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check mag field"));
             }
             return;
         }
@@ -306,7 +306,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = mag_vec - prime_mag_vec;
                 if (vec_diff.length() > COMPASS_ACCEPTABLE_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: compasses inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: compasses inconsistent"));
                     }
                     return;
                 }
@@ -336,7 +336,7 @@ static void pre_arm_checks(bool display_failure)
         // check accelerometers have been calibrated
         if(!ins.calibrated()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: INS not calibrated"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: INS not calibrated"));
             }
             return;
         }
@@ -344,7 +344,7 @@ static void pre_arm_checks(bool display_failure)
         // check accels are healthy
         if(!ins.get_accel_health_all()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Accels not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Accels not healthy"));
             }
             return;
         }
@@ -359,7 +359,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = accel_vec - prime_accel_vec;
                 if (vec_diff.length() > PREARM_MAX_ACCEL_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Accels inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Accels inconsistent"));
                     }
                     return;
                 }
@@ -370,7 +370,7 @@ static void pre_arm_checks(bool display_failure)
         // check gyros are healthy
         if(!ins.get_gyro_health_all()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Gyros not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Gyros not healthy"));
             }
             return;
         }
@@ -383,7 +383,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = ins.get_gyro(i) - ins.get_gyro();
                 if (vec_diff.length() > PREARM_MAX_GYRO_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Gyros inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Gyros inconsistent"));
                     }
                     return;
                 }
@@ -397,7 +397,7 @@ static void pre_arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
         if(hal.analogin->board_voltage() < BOARD_VOLTAGE_MIN || hal.analogin->board_voltage() > BOARD_VOLTAGE_MAX) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check Board Voltage"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check Board Voltage"));
             }
             return;
         }
@@ -411,7 +411,7 @@ static void pre_arm_checks(bool display_failure)
         // ensure ch7 and ch8 have different functions
         if ((g.ch7_option != 0 || g.ch8_option != 0) && g.ch7_option == g.ch8_option) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Ch7&Ch8 Opt cannot be same"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Ch7&Ch8 Opt cannot be same"));
             }
             return;
         }
@@ -421,7 +421,7 @@ static void pre_arm_checks(bool display_failure)
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
             if (g.rc_3.radio_min <= g.failsafe_throttle_value+10 || g.failsafe_throttle_value < 910) {
                 if (display_failure) {
-                    gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check FS_THR_VALUE"));
+                    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check FS_THR_VALUE"));
                 }
                 return;
             }
@@ -430,7 +430,7 @@ static void pre_arm_checks(bool display_failure)
         // lean angle parameter check
     if (aparm.angle_max < 1000 || aparm.angle_max > 8000) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check ANGLE_MAX"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check ANGLE_MAX"));
             }
             return;
         }
@@ -438,7 +438,7 @@ static void pre_arm_checks(bool display_failure)
         // acro balance parameter check
         if ((g.acro_balance_roll > g.p_stabilize_roll.kP()) || (g.acro_balance_pitch > g.p_stabilize_pitch.kP())) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: ACRO_BAL_ROLL/PITCH"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: ACRO_BAL_ROLL/PITCH"));
             }
             return;
         }
@@ -489,7 +489,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // check GPS is not glitching
     if (gps_glitch.glitching()) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: GPS Glitch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: GPS Glitch"));
         }
         return false;
     }
@@ -497,7 +497,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // ensure GPS is ok
     if (!GPS_ok()) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Need 3D Fix"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Need 3D Fix"));
         }
         return false;
     }
@@ -505,7 +505,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // check speed is below 50cm/s
     if (speed_cms == 0 || speed_cms > PREARM_MAX_VELOCITY_CMS) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Bad Velocity"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Bad Velocity"));
         }
         return false;
     }
@@ -513,7 +513,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (gps.get_hdop() > g.gps_hdop_good) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: High GPS HDOP"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: High GPS HDOP"));
         }
         return false;
     }
@@ -535,7 +535,7 @@ static bool arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_BARO)) {
         if(fabs(inertial_nav.get_altitude() - baro_alt) > 100) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Alt disparity"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Alt disparity"));
             }
             return false;
         }
@@ -553,7 +553,7 @@ static bool arm_checks(bool display_failure)
         // check throttle is above failsafe throttle
         if (g.failsafe_throttle != FS_THR_DISABLED && g.rc_3.radio_in < g.failsafe_throttle_value) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Thr below FS"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Thr below FS"));
             }
             return false;
         }
@@ -563,7 +563,7 @@ static bool arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {
         if (labs(ahrs.roll_sensor) > aparm.angle_max || labs(ahrs.pitch_sensor) > aparm.angle_max) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Leaning"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Leaning"));
             }
             return false;
         }
@@ -572,7 +572,7 @@ static bool arm_checks(bool display_failure)
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Safety Switch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Safety Switch"));
         }
         return false;
     }
@@ -590,7 +590,7 @@ static void init_disarm_motors()
     }
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_AVR_SITL
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("DISARMING MOTORS"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("DISARMING MOTORS"));
 #endif
 
     motors.armed(false);

--- a/ArduCopter/sensors.pde
+++ b/ArduCopter/sensors.pde
@@ -9,13 +9,13 @@ static void init_sonar(void)
 
 static void init_barometer(bool full_calibration)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Calibrating barometer"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Calibrating barometer"));
     if (full_calibration) {
         barometer.calibrate();
     }else{
         barometer.update_calibration();
     }
-    gcs_send_text_P(SEVERITY_LOW, PSTR("barometer calibration complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("barometer calibration complete"));
 }
 
 // return barometric altitude in centimeters

--- a/ArduCopter/switches.pde
+++ b/ArduCopter/switches.pde
@@ -455,7 +455,7 @@ static void save_trim()
     float pitch_trim = ToRad((float)g.rc_2.control_in/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     Log_Write_Event(DATA_SAVE_TRIM);
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("Trim saved"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Trim saved"));
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -186,10 +186,10 @@ static void init_ardupilot()
 #if LOGGING_ENABLED == ENABLED
     DataFlash.Init(log_structure, sizeof(log_structure)/sizeof(log_structure[0]));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("No dataflash inserted"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("No dataflash inserted"));
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedErase()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("ERASING LOGS"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("ERASING LOGS"));
         do_erase_logs();
         gcs[0].reset_cli_timeout();
     }
@@ -251,7 +251,7 @@ static void init_ardupilot()
     while (barometer.get_last_update() == 0) {
         // the barometer begins updating when we get the first
         // HIL_STATE message
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Waiting for first HIL_STATE message"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Waiting for first HIL_STATE message"));
         delay(1000);
     }
 #endif
@@ -303,7 +303,7 @@ static void init_ardupilot()
 //******************************************************************************
 static void startup_ground(bool force_gyro_cal)
 {
-    gcs_send_text_P(SEVERITY_LOW,PSTR("GROUND START"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("GROUND START"));
 
     // initialise ahrs (may push imu calibration into the mpu6000 if using that device).
     ahrs.init();

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1329,7 +1329,7 @@ static void update_flight_mode(void)
             if (tdrag_mode && !auto_state.fbwa_tdrag_takeoff_mode) {
                 if (auto_state.highest_airspeed < g.takeoff_tdrag_speed1) {
                     auto_state.fbwa_tdrag_takeoff_mode = true;
-                    gcs_send_text_P(SEVERITY_LOW, PSTR("FBWA tdrag mode\n"));
+                    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("FBWA tdrag mode\n"));
                 }
             }
         }
@@ -1446,9 +1446,9 @@ static void set_flight_stage(AP_SpdHgtControl::FlightStage fs)
 #if GEOFENCE_ENABLED == ENABLED 
         if (g.fence_autoenable == 1) {
             if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
-                gcs_send_text_P(SEVERITY_HIGH, PSTR("Disable fence failed (autodisable)"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Disable fence failed (autodisable)"));
             } else {
-                gcs_send_text_P(SEVERITY_HIGH, PSTR("Fence disabled (autodisable)"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Fence disabled (autodisable)"));
             }
         }
 #endif

--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -975,7 +975,7 @@ static bool demoing_servos;
 static void demo_servos(uint8_t i) 
 {
     while(i > 0) {
-        gcs_send_text_P(SEVERITY_LOW,PSTR("Demo Servos!"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("Demo Servos!"));
         demoing_servos = true;
         servo_write(1, 1400);
         mavlink_delay(400);

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -940,7 +940,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         uint8_t result = MAV_RESULT_UNSUPPORTED;
 
         // do command
-        send_text_P(SEVERITY_LOW,PSTR("command received: "));
+        send_text_P(MAV_SEVERITY_WARNING,PSTR("command received: "));
 
         switch(packet.command) {
 
@@ -1197,10 +1197,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
     {
         // mark the firmware version in the tlog
-        send_text_P(SEVERITY_LOW, PSTR(FIRMWARE_STRING));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR(FIRMWARE_STRING));
 
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
-        send_text_P(SEVERITY_LOW, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
 #endif
         handle_param_request_list(msg);
         break;
@@ -1259,9 +1259,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         if (mavlink_check_target(packet.target_system, packet.target_component))
             break;
         if (g.fence_action != FENCE_ACTION_NONE) {
-            send_text_P(SEVERITY_LOW,PSTR("fencing must be disabled"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("fencing must be disabled"));
         } else if (packet.count != g.fence_total) {
-            send_text_P(SEVERITY_LOW,PSTR("bad fence point"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad fence point"));
         } else {
             Vector2l point;
             point.x = packet.lat*1.0e7f;
@@ -1278,7 +1278,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         if (mavlink_check_target(packet.target_system, packet.target_component))
             break;
         if (packet.idx >= g.fence_total) {
-            send_text_P(SEVERITY_LOW,PSTR("bad fence point"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad fence point"));
         } else {
             Vector2l point = get_fence_point_with_index(packet.idx);
             mavlink_msg_fence_point_send_buf(msg, chan, msg->sysid, msg->compid, packet.idx, g.fence_total,
@@ -1297,12 +1297,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         
         if (packet.idx >= rally.get_rally_total() || 
             packet.idx >= rally.get_rally_max()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message ID"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message ID"));
             break;
         }
 
         if (packet.count != rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message count"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message count"));
             break;
         }
 
@@ -1324,12 +1324,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         if (mavlink_check_target(packet.target_system, packet.target_component))
             break;
         if (packet.idx > rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW, PSTR("bad rally point index"));   
+            send_text_P(MAV_SEVERITY_WARNING, PSTR("bad rally point index"));
             break;
         }
         RallyLocation rally_point;
         if (!rally.get_rally_point_with_index(packet.idx, rally_point)) {
-            send_text_P(SEVERITY_LOW, PSTR("failed to set rally point"));   
+            send_text_P(MAV_SEVERITY_WARNING, PSTR("failed to set rally point"));
             break;
         }
 
@@ -1554,7 +1554,7 @@ static void mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Initialising APM..."));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Initialising APM..."));
     }
     check_usb_mux();
 
@@ -1601,7 +1601,7 @@ static void gcs_update(void)
     }
 }
 
-static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
+static void gcs_send_text_P(int severity, const prog_char_t *str)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
@@ -1621,7 +1621,7 @@ static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
 void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 {
     va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)SEVERITY_LOW;
+    gcs[0].pending_status.severity = (uint8_t)MAV_SEVERITY_WARNING;
     va_start(arg_list, fmt);
     hal.util->vsnprintf_P((char *)gcs[0].pending_status.text,
             sizeof(gcs[0].pending_status.text), fmt, arg_list);

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -95,9 +95,9 @@ dump_log(uint8_t argc, const Menu::arg *argv)
 
 static void do_erase_logs(void)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Erasing logs"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Erasing logs"));
     DataFlash.EraseAll();
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Log erase complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Log erase complete"));
 }
 
 static int8_t

--- a/ArduPlane/commands.pde
+++ b/ArduPlane/commands.pde
@@ -50,7 +50,7 @@ static void set_next_WP(const struct Location &loc)
     // location as the previous waypoint, to prevent immediately
     // considering the waypoint complete
     if (location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Resetting prev_WP"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Resetting prev_WP"));
         prev_WP_loc = current_loc;
     }
 
@@ -98,7 +98,7 @@ static void set_guided_WP(void)
 // -------------------------------
 static void init_home()
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("init home"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("init home"));
 
     ahrs.set_home(gps.location());
     home_is_set = true;

--- a/ArduPlane/commands_logic.pde
+++ b/ArduPlane/commands_logic.pde
@@ -238,9 +238,9 @@ static bool verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
     default:
         // error message
         if (AP_Mission::is_nav_cmd(cmd)) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("verify_nav: Invalid or no current Nav cmd"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("verify_nav: Invalid or no current Nav cmd"));
         }else{
-        gcs_send_text_P(SEVERITY_HIGH,PSTR("verify_conditon: Invalid or no current Condition cmd"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("verify_conditon: Invalid or no current Condition cmd"));
     }
         // return true so that we do not get stuck at this command
         return true;
@@ -356,9 +356,9 @@ static bool verify_takeoff()
 #if GEOFENCE_ENABLED == ENABLED
         if (g.fence_autoenable == 1) {
             if (! geofence_set_enabled(true, AUTO_TOGGLED)) {
-                gcs_send_text_P(SEVERITY_HIGH, PSTR("Enable fence failed (cannot autoenable"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Enable fence failed (cannot autoenable"));
             } else {
-                gcs_send_text_P(SEVERITY_HIGH, PSTR("Fence enabled. (autoenabled)"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Fence enabled. (autoenabled)"));
             }
         }
 #endif
@@ -434,7 +434,7 @@ static bool verify_loiter_time()
             loiter.start_time_ms = millis();
         }
     } else if ((millis() - loiter.start_time_ms) > loiter.time_max_ms) {
-        gcs_send_text_P(SEVERITY_LOW,PSTR("verify_nav: LOITER time complete"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("verify_nav: LOITER time complete"));
         return true;
     }
     return false;
@@ -445,7 +445,7 @@ static bool verify_loiter_turns()
     update_loiter();
     if (loiter.sum_cd > loiter.total_cd) {
         loiter.total_cd = 0;
-        gcs_send_text_P(SEVERITY_LOW,PSTR("verify_nav: LOITER orbits complete"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("verify_nav: LOITER orbits complete"));
         // clear the command queue;
         return true;
     }
@@ -457,7 +457,7 @@ static bool verify_RTL()
     update_loiter();
 	if (wp_distance <= (uint32_t)max(g.waypoint_radius,0) || 
         nav_controller->reached_loiter_target()) {
-			gcs_send_text_P(SEVERITY_LOW,PSTR("Reached home"));
+			gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("Reached home"));
 			return true;
     } else {
         return false;

--- a/ArduPlane/events.pde
+++ b/ArduPlane/events.pde
@@ -6,7 +6,7 @@ static void failsafe_short_on_event(enum failsafe_state fstype)
     // This is how to handle a short loss of control signal failsafe.
     failsafe.state = fstype;
     failsafe.ch3_timer_ms = millis();
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Failsafe - Short event on, "));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Failsafe - Short event on, "));
     switch(control_mode)
     {
     case MANUAL:
@@ -51,7 +51,7 @@ static void failsafe_short_on_event(enum failsafe_state fstype)
 static void failsafe_long_on_event(enum failsafe_state fstype)
 {
     // This is how to handle a long loss of control signal failsafe.
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Failsafe - Long event on, "));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Failsafe - Long event on, "));
     //  If the GCS is locked up we allow control to revert to RC
     hal.rcin->clear_overrides();
     failsafe.state = fstype;
@@ -88,7 +88,7 @@ static void failsafe_long_on_event(enum failsafe_state fstype)
         break;
     }
     if (fstype == FAILSAFE_GCS) {
-        gcs_send_text_P(SEVERITY_HIGH, PSTR("No GCS heartbeat."));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("No GCS heartbeat."));
     }
     gcs_send_text_fmt(PSTR("flight mode = %u"), (unsigned)control_mode);
 }
@@ -96,7 +96,7 @@ static void failsafe_long_on_event(enum failsafe_state fstype)
 static void failsafe_short_off_event()
 {
     // We're back in radio contact
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Failsafe - Short event off"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Failsafe - Short event off"));
     failsafe.state = FAILSAFE_NONE;
 
     // re-read the switch so we can return to our preferred mode

--- a/ArduPlane/geofence.pde
+++ b/ArduPlane/geofence.pde
@@ -133,13 +133,13 @@ static void geofence_load(void)
     geofence_state->boundary_uptodate = true;
     geofence_state->fence_triggered = false;
 
-    gcs_send_text_P(SEVERITY_LOW,PSTR("geo-fence loaded"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("geo-fence loaded"));
     gcs_send_message(MSG_FENCE_STATUS);
     return;
 
 failed:
     g.fence_action.set(FENCE_ACTION_NONE);
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("geo-fence setup error"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("geo-fence setup error"));
 }
 
 /*
@@ -310,7 +310,7 @@ static void geofence_check(bool altitude_check_only)
         if (geofence_state->fence_triggered && !altitude_check_only) {
             // we have moved back inside the fence
             geofence_state->fence_triggered = false;
-            gcs_send_text_P(SEVERITY_LOW,PSTR("geo-fence OK"));
+            gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("geo-fence OK"));
  #if FENCE_TRIGGERED_PIN > 0
             hal.gpio->pinMode(FENCE_TRIGGERED_PIN, HAL_GPIO_OUTPUT);
             hal.gpio->write(FENCE_TRIGGERED_PIN, 0);
@@ -340,7 +340,7 @@ static void geofence_check(bool altitude_check_only)
     hal.gpio->write(FENCE_TRIGGERED_PIN, 1);
  #endif
 
-    gcs_send_text_P(SEVERITY_LOW,PSTR("geo-fence triggered"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("geo-fence triggered"));
     gcs_send_message(MSG_FENCE_STATUS);
 
     // see what action the user wants

--- a/ArduPlane/sensors.pde
+++ b/ArduPlane/sensors.pde
@@ -2,10 +2,10 @@
 
 static void init_barometer(void)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Calibrating barometer"));    
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Calibrating barometer"));
     barometer.calibrate();
 
-    gcs_send_text_P(SEVERITY_LOW, PSTR("barometer calibration complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("barometer calibration complete"));
 }
 
 static void init_rangefinder(void)
@@ -43,7 +43,7 @@ static void read_airspeed(void)
 static void zero_airspeed(void)
 {
     airspeed.calibrate();
-    gcs_send_text_P(SEVERITY_LOW,PSTR("zero airspeed calibrated"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("zero airspeed calibrated"));
 }
 
 // read_battery - reads battery voltage and current and invokes failsafe

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -135,10 +135,10 @@ static void init_ardupilot()
 #if LOGGING_ENABLED == ENABLED
     DataFlash.Init(log_structure, sizeof(log_structure)/sizeof(log_structure[0]));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("No dataflash card inserted"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("No dataflash card inserted"));
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedErase()) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("ERASING LOGS"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("ERASING LOGS"));
         do_erase_logs();
         for (uint8_t i=0; i<num_gcs; i++) {
             gcs[i].reset_cli_timeout();
@@ -222,10 +222,10 @@ static void startup_ground(void)
 {
     set_mode(INITIALISING);
 
-    gcs_send_text_P(SEVERITY_LOW,PSTR("<startup_ground> GROUND START"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("<startup_ground> GROUND START"));
 
 #if (GROUND_START_DELAY > 0)
-    gcs_send_text_P(SEVERITY_LOW,PSTR("<startup_ground> With Delay"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("<startup_ground> With Delay"));
     delay(GROUND_START_DELAY * 1000);
 #endif
 
@@ -272,7 +272,7 @@ static void startup_ground(void)
         hal.uartD->set_blocking_writes(false);
     }
 
-    gcs_send_text_P(SEVERITY_LOW,PSTR("\n\n Ready to FLY."));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("\n\n Ready to FLY."));
 }
 
 static enum FlightMode get_previous_mode() {
@@ -466,7 +466,7 @@ static void startup_INS_ground(bool do_accel_init)
     while (barometer.get_last_update() == 0) {
         // the barometer begins updating when we get the first
         // HIL_STATE message
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Waiting for first HIL_STATE message"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Waiting for first HIL_STATE message"));
         delay(1000);
     }
 #endif
@@ -479,7 +479,7 @@ static void startup_INS_ground(bool do_accel_init)
     }
 
     if (style == AP_InertialSensor::COLD_START) {
-        gcs_send_text_P(SEVERITY_MEDIUM, PSTR("Beginning INS calibration; do not move plane"));
+        gcs_send_text_P(MAV_SEVERITY_ALERT, PSTR("Beginning INS calibration; do not move plane"));
         mavlink_delay(100);
     }
 
@@ -504,7 +504,7 @@ static void startup_INS_ground(bool do_accel_init)
         // --------------------------
         zero_airspeed();
     } else {
-        gcs_send_text_P(SEVERITY_LOW,PSTR("NO airspeed"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("NO airspeed"));
     }
 }
 

--- a/ArduPlane/takeoff.pde
+++ b/ArduPlane/takeoff.pde
@@ -163,7 +163,7 @@ static int8_t takeoff_tail_hold(void)
 
 return_zero:
     if (auto_state.fbwa_tdrag_takeoff_mode) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("FBWA tdrag off"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("FBWA tdrag off"));
         auto_state.fbwa_tdrag_takeoff_mode = false;
     }
     return 0;

--- a/FollowMe/simplegcs.cpp
+++ b/FollowMe/simplegcs.cpp
@@ -76,7 +76,7 @@ bool simplegcs_try_send_statustext(mavlink_channel_t chan, const char *text, int
     lock = 1;
     mavlink_msg_statustext_send(
             chan,
-            1, /* SEVERITY_LOW */
+            4, /* MAV_SEVERITY_WARNING */
             statustext);
     lock = 0;
     return true;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -79,7 +79,7 @@ bool AP_Arming::barometer_checks(bool report)
         (checks_to_perform & ARMING_CHECK_BARO)) {
         if (! barometer.healthy()) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Baro not healthy!"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Baro not healthy!"));
             }
             return false;
         }
@@ -95,14 +95,14 @@ bool AP_Arming::compass_checks(bool report)
 
         if (!_compass.healthy()) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not healthy!"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not healthy!"));
             }
             return false;
         }
         // check compass learning is on or offsets have been set
         if (!_compass.learn_offsets_enabled() && !_compass.configured()) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not calibrated"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not calibrated"));
             }
             return false;
         }
@@ -124,7 +124,7 @@ bool AP_Arming::gps_checks(bool report)
             AP_Notify::flags.gps_glitching ||
             AP_Notify::flags.failsafe_gps) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Bad GPS Pos"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Bad GPS Pos"));
             }
             return false;
         }      
@@ -140,7 +140,7 @@ bool AP_Arming::battery_checks(bool report)
 
         if (AP_Notify::flags.failsafe_battery) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Battery failsafe on."));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Battery failsafe on."));
             }
             return false;
         }
@@ -154,7 +154,7 @@ bool AP_Arming::hardware_safety_check(bool report)
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (report) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Hardware Safety Switch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Hardware Safety Switch"));
         }
         return false;
     }
@@ -169,7 +169,7 @@ bool AP_Arming::manual_transmitter_checks(bool report)
 
         if (AP_Notify::flags.failsafe_radio) {
             if (report) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Radio failsafe on."));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Radio failsafe on."));
             }
             return false;
         }
@@ -223,7 +223,7 @@ bool AP_Arming::arm(uint8_t method)
     if (checks_to_perform == ARMING_CHECK_NONE) {
         armed = true;
         arming_method = NONE;
-        gcs_send_text_P(SEVERITY_HIGH,PSTR("Throttle armed!"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Throttle armed!"));
         return true;
     }
 
@@ -231,7 +231,7 @@ bool AP_Arming::arm(uint8_t method)
         armed = true;
         arming_method = method;
 
-        gcs_send_text_P(SEVERITY_HIGH,PSTR("Throttle armed!"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Throttle armed!"));
 
         //TODO: Log motor arming to the dataflash
         //Can't do this from this class until there is a unified logging library
@@ -252,7 +252,7 @@ bool AP_Arming::disarm()
     }
     armed = false;
 
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("Throttle disarmed!"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Throttle disarmed!"));
 
     //TODO: Log motor disarming to the dataflash
     //Can't do this from this class until there is a unified logging library.

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -36,7 +36,7 @@ public:
     };
 
     //for the hacky funciton pointer to gcs_send_text_p
-    typedef void (*gcs_send_t_p)(gcs_severity, const prog_char_t*);
+    typedef void (*gcs_send_t_p)(int, const prog_char_t*);
 
     AP_Arming(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
               const bool &home_set, gcs_send_t_p);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
@@ -42,6 +42,6 @@ void AP_InertialSensor_UserInteract_MAVLink::_printf_P(const prog_char* fmt, ...
     while (comm_get_txspace(_chan) < MAVLINK_NUM_NON_PAYLOAD_BYTES + (int)sizeof(mavlink_statustext_t)) {
         hal.scheduler->delay(1);        
     }
-    mavlink_msg_statustext_send(_chan, SEVERITY_USER_RESPONSE, msg);
+    mavlink_msg_statustext_send(_chan, MAV_SEVERITY_NOTICE, msg);
 }
 

--- a/libraries/GCS_Console/examples/Console/simplegcs.cpp
+++ b/libraries/GCS_Console/examples/Console/simplegcs.cpp
@@ -50,7 +50,7 @@ bool try_send_statustext(mavlink_channel_t chan, const char *text, int len) {
     }
     mavlink_msg_statustext_send(
             chan,
-            1, /* SEVERITY_LOW */
+            4, /* MAV_SEVERITY_WARNING */
             statustext);
     return true;
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -107,7 +107,7 @@ public:
     /// @param	severity	A value describing the importance of the message.
     /// @param	str			The text to be sent.
     ///
-    void        send_text(gcs_severity severity, const char *str) {
+    void        send_text(int severity, const char *str) {
     }
 
     /// Send a text message with a PSTR()
@@ -115,7 +115,7 @@ public:
     /// @param	severity	A value describing the importance of the message.
     /// @param	str			The text to be sent.
     ///
-    void        send_text_P(gcs_severity severity, const prog_char_t *str) {
+    void        send_text_P(int severity, const prog_char_t *str) {
     }
 
     // send streams which match frequency range
@@ -149,8 +149,8 @@ public:
     void        init(AP_HAL::UARTDriver *port);
     void        setup_uart(AP_HAL::UARTDriver *port, uint32_t baudrate, uint16_t rxS, uint16_t txS);
     void        send_message(enum ap_message id);
-    void        send_text(gcs_severity severity, const char *str);
-    void        send_text_P(gcs_severity severity, const prog_char_t *str);
+    void        send_text(int severity, const char *str);
+    void        send_text_P(int severity, const prog_char_t *str);
     void        data_stream_send(void);
     void        queued_param_send();
     void        queued_waypoint_send();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -399,7 +399,7 @@ void GCS_MAVLINK::handle_mission_write_partial_list(AP_Mission &mission, mavlink
     if ((unsigned)packet.start_index > mission.num_commands() ||
         (unsigned)packet.end_index > mission.num_commands() ||
         packet.end_index < packet.start_index) {
-        send_text_P(SEVERITY_LOW,PSTR("flight plan update rejected"));
+        send_text_P(MAV_SEVERITY_WARNING,PSTR("flight plan update rejected"));
         return;
     }
 
@@ -515,7 +515,7 @@ void GCS_MAVLINK::handle_param_request_list(mavlink_message_t *msg)
     // send system ID if we can
     char sysid[40];
     if (hal.util->get_system_id(sysid)) {
-        send_text(SEVERITY_LOW, sysid);
+        send_text(MAV_SEVERITY_WARNING, sysid);
     }
 #endif
 
@@ -634,9 +634,9 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
 
 
 void
-GCS_MAVLINK::send_text(gcs_severity severity, const char *str)
+GCS_MAVLINK::send_text(int severity, const char *str)
 {
-    if (severity != SEVERITY_LOW && 
+    if (severity != MAV_SEVERITY_WARNING &&
         comm_get_txspace(chan) >= 
         MAVLINK_NUM_NON_PAYLOAD_BYTES+MAVLINK_MSG_ID_STATUSTEXT_LEN) {
         // send immediately
@@ -651,7 +651,7 @@ GCS_MAVLINK::send_text(gcs_severity severity, const char *str)
 }
 
 void
-GCS_MAVLINK::send_text_P(gcs_severity severity, const prog_char_t *str)
+GCS_MAVLINK::send_text_P(int severity, const prog_char_t *str)
 {
     mavlink_statustext_t m;
     uint8_t i;
@@ -788,7 +788,7 @@ void GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
             msg->compid,
             MAV_MISSION_ACCEPTED);
         
-        send_text_P(SEVERITY_LOW,PSTR("flight plan received"));
+        send_text_P(MAV_SEVERITY_WARNING,PSTR("flight plan received"));
         waypoint_receiving = false;
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
@@ -1148,11 +1148,11 @@ void GCS_MAVLINK::send_statustext_all(const prog_char_t *msg)
                 char msg2[50];
                 strncpy_P(msg2, msg, sizeof(msg2));
                 mavlink_msg_statustext_send(chan,
-                                            SEVERITY_HIGH,
+                                            MAV_SEVERITY_CRITICAL,
                                             msg2);
 #else
                 mavlink_msg_statustext_send(chan,
-                                            SEVERITY_HIGH,
+                                            MAV_SEVERITY_CRITICAL,
                                             msg);
 #endif
             }

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -136,15 +136,6 @@ uint8_t mav_var_type(enum ap_var_type t);
 // return CRC byte for a mavlink message ID
 uint8_t mavlink_get_message_crc(uint8_t msgid);
 
-// severity levels used in STATUSTEXT messages
-enum gcs_severity {
-    SEVERITY_LOW=1,
-    SEVERITY_MEDIUM,
-    SEVERITY_HIGH,
-    SEVERITY_CRITICAL,
-    SEVERITY_USER_RESPONSE
-};
-
 #pragma GCC diagnostic pop
 
 #endif // GCS_MAVLink_h

--- a/libraries/GCS_MAVLink/include/mavlink/v0.9/common/mavlink_msg_statustext.h
+++ b/libraries/GCS_MAVLink/include/mavlink/v0.9/common/mavlink_msg_statustext.h
@@ -4,7 +4,7 @@
 
 typedef struct __mavlink_statustext_t
 {
- uint8_t severity; ///< Severity of status, 0 = info message, 255 = critical fault
+ uint8_t severity; ///< Severity of status, see the RFC-5424 standards for severity
  int8_t text[50]; ///< Status text message, without null termination character
 } mavlink_statustext_t;
 
@@ -28,7 +28,7 @@ typedef struct __mavlink_statustext_t
  * @param component_id ID of this component (e.g. 200 for IMU)
  * @param msg The MAVLink message to compress the data into
  *
- * @param severity Severity of status, 0 = info message, 255 = critical fault
+ * @param severity Severity of status, see the RFC-5424 standards for severity
  * @param text Status text message, without null termination character
  * @return length of the message in bytes (excluding serial stream start sign)
  */
@@ -57,7 +57,7 @@ static inline uint16_t mavlink_msg_statustext_pack(uint8_t system_id, uint8_t co
  * @param component_id ID of this component (e.g. 200 for IMU)
  * @param chan The MAVLink channel this message was sent over
  * @param msg The MAVLink message to compress the data into
- * @param severity Severity of status, 0 = info message, 255 = critical fault
+ * @param severity Severity of status, see the RFC-5424 standards for severity
  * @param text Status text message, without null termination character
  * @return length of the message in bytes (excluding serial stream start sign)
  */
@@ -98,7 +98,7 @@ static inline uint16_t mavlink_msg_statustext_encode(uint8_t system_id, uint8_t 
  * @brief Send a statustext message
  * @param chan MAVLink channel to send the message
  *
- * @param severity Severity of status, 0 = info message, 255 = critical fault
+ * @param severity Severity of status, see the RFC-5424 standards for severity
  * @param text Status text message, without null termination character
  */
 #ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
@@ -126,7 +126,7 @@ static inline void mavlink_msg_statustext_send(mavlink_channel_t chan, uint8_t s
 /**
  * @brief Get field severity from statustext message
  *
- * @return Severity of status, 0 = info message, 255 = critical fault
+ * @return Severity of status, see the RFC-5424 standards for severity
  */
 static inline uint8_t mavlink_msg_statustext_get_severity(const mavlink_message_t* msg)
 {


### PR DESCRIPTION
Closes #901 

Here's how I changed severities:

| was | is |
| --- | --- |
| SEVERITY_LOW | MAV_SEVERITY_WARNING |
| SEVERITY_MEDIUM | MAV_SEVERITY_ALERT |
| SEVERITY_HIGH | MAV_SEVERITY_CRITICAL |
| SEVERITY_USER_RESPONSE | MAV_SEVERITY_NOTICE |

I also removed the old enum which is no longer needed, and changed some methods which wanted a 'gcs_severity' to want an 'int'.

Tested on a copter only (that's all I have).  But build_all.sh returns no errors.
