### PR TITLE
Tools/autotest/sim_vehicle.sh: Added option to run the sim_vehicle framework with an external simulator

### DIFF
--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -20,6 +20,7 @@ REVERSE_THROTTLE=0
 NO_REBUILD=0
 START_HIL=0
 TRACKER_ARGS=""
+EXTERNAL_SIM=0
 
 usage()
 {
@@ -45,6 +46,7 @@ Options:
                      for planes can choose elevon or vtail
     -j NUM_PROC      number of processors to use during build (default 1)
     -H               start HIL
+    -e               use external simulator
 
 mavproxy_options:
     --map            start with a map
@@ -61,7 +63,7 @@ EOF
 
 
 # parse options. Thanks to http://wiki.bash-hackers.org/howto/getopts_tutorial
-while getopts ":I:VgGcj:TA:t:L:v:hwf:RNH" opt; do
+while getopts ":I:VgGcj:TA:t:L:v:hwf:RNHe" opt; do
   case $opt in
     v)
       VEHICLE=$OPTARG
@@ -112,6 +114,9 @@ while getopts ":I:VgGcj:TA:t:L:v:hwf:RNH" opt; do
       ;;
     w)
       WIPE_EEPROM=1
+      ;;
+    e)
+      EXTERNAL_SIM=1
       ;;
     h)
       usage
@@ -302,11 +307,15 @@ trap kill_tasks SIGINT
 
 sleep 2
 rm -f $tfile
-$autotest/run_in_terminal_window.sh "Simulator" $RUNSIM || {
-    echo "Failed to start simulator: $RUNSIM"
-    exit 1
-}
-sleep 2
+if [ $EXTERNAL_SIM == 0 ]; then
+    $autotest/run_in_terminal_window.sh "Simulator" $RUNSIM || {
+        echo "Failed to start simulator: $RUNSIM"
+        exit 1
+    }
+    sleep 2
+else
+    echo "Using external simulator"
+fi
 
 # mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551 
 options=""


### PR DESCRIPTION
As the title says, this commit simply enables the option -e for sim_vehicle.sh.
It allows the user/developer to use an external simulator with the sim_vehicle framework, by not starting e.g. the python-simulator for copter, etc.
