### PR TITLE
AP_NavEKF : Fix bug that causes false positive on EKF divergence test

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3418,7 +3418,7 @@ void NavEKF::checkDivergence()
     float tempLength = tempVec.length();
     if (tempLength != 0.0f) {
         float temp = constrain_float((P[10][10] + P[11][11] + P[12][12]),1e-12f,1e-8f);
-        scaledDeltaGyrBiasLgth = (5e-7f / temp) * tempVec.length() / dtIMU;
+        scaledDeltaGyrBiasLgth = (5e-8f / temp) * tempVec.length() / dtIMU;
     }
     bool divergenceDetected = (scaledDeltaGyrBiasLgth > 1.0f);
     lastGyroBias = state.gyro_bias;


### PR DESCRIPTION
The introduction of the EKF smoothing patch means that when manoeuvring rapidly, the EKF does GPS fusion immediately rather than spreading it. This improves stability of the filter, but has had the unintended consequence of making it easier to false trigger the divergence check because teh bias changes caused by incorporating GPS measurements can occur all at once rather than being spread across several cycles. 
The following figures are the divergence test level taken from two flights, one with rapid 5 rad/sec continuous yaw of an IRIS+ and one with hammerhead manoueves on a trad heli. A test value of 100 will cause the divergence check to false trigger, so it can be seen from these logs the trigger margin needs to be raised. 

![iris rapid yaw divergence test](https://cloud.githubusercontent.com/assets/3596952/4268547/370774c0-3cb0-11e4-9644-b38672d661d2.png)

![trad heli aerobatics divergence test](https://cloud.githubusercontent.com/assets/3596952/4268549/3f48ca12-3cb0-11e4-998f-fdd42d2429dc.png)
