### PR TITLE
Copter: reset battery_fs after dis/rearming

### DIFF
--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -202,6 +202,9 @@ static void init_arm_motors()
     // log flight mode in case it was changed while vehicle was disarmed
     Log_Write_Mode(control_mode);
 
+    // reset battery failsafe
+    set_failsafe_battery(false);
+
     // reenable failsafe
     failsafe_enable();
 }


### PR DESCRIPTION
A user pointed out that one the battery_failsafe was trigged, and you landed/disarmed, you were free to take off, and the fs would not be trigged again. 
http://ardupilot.com/forum/viewtopic.php?t=9590&p=22905#p22905
- I added some code to reset it upon arming.
