### PR TITLE
GPS status notification - use the best GPS not the first one.

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -349,8 +349,7 @@ AP_GPS::update(void)
         update_instance(i);
     }
 
-    // update notify with gps status. We always base this on the first GPS
-    AP_Notify::flags.gps_status = state[0].status;
+    primary_instance=0;
 
 #if GPS_MAX_INSTANCES > 1
     // work out which GPS is the primary, and how many sensors we have
@@ -376,13 +375,15 @@ AP_GPS::update(void)
                 // position shift to the controllers.
                 primary_instance = i;
             }
-        } else {
-            primary_instance = 0;
         }
     }
 #else
     num_instances = 1;
 #endif // GPS_MAX_INSTANCES
+    
+    
+    // update notify with gps status. We always base this on the best GPS
+    AP_Notify::flags.gps_status = state[primary_instance].status;
 }
 
 /*


### PR DESCRIPTION
GPS status notification - use the best GPS not the first one. This fix is required when the first GPS has a ( GPS_Status== NO_GPS or GPS_Status== NO_FIX) AND  (the second GPS GPS_Status == GPS_OK_FIX...)
