### PR TITLE
AP_NavEKF : Fix bug in reset of GPS glitch offset

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -411,8 +411,6 @@ void NavEKF::ResetPosition(void)
         state.position.x = gpsPosNE.x + gpsPosGlitchOffsetNE.x + 0.001f*velNED.x*float(_msecPosDelay);
         state.position.y = gpsPosNE.y + gpsPosGlitchOffsetNE.y + 0.001f*velNED.y*float(_msecPosDelay);
     }
-    // reset the glitch ofset correction states
-    gpsPosGlitchOffsetNE.zero();
     // stored horizontal position states to prevent subsequent GPS measurements from being rejected
     for (uint8_t i=0; i<=49; i++){
         storedStates[i].position[0] = state.position[0];


### PR DESCRIPTION
If the GPS glitch radius had been exceeded and if the EKF had also hit the 10 second timeout limit for rejecting GPS data (10 seconds for copter, 20 seconds for plane), then the position was being reset to the GPS position + offset, however the offset was then zeroed, which meant that subsequent GPS measurement would be rejected. The result was that the EKF could end up using GPS velocities only for extended periods of time. The position error in this period could be up to 100m. The angles were not affected and the velocity outputs were good during this period.

This addresses an issue reported here:

https://groups.google.com/forum/#!topic/drones-discuss/IkDlqSxIXuY
