### PR TITLE
Copter: reset ROI when requested, regardless of current MOUNT_MODE

### DIFF
--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -518,7 +518,7 @@ static void set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, i
 static void set_auto_yaw_roi(const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
-    if (auto_yaw_mode == AUTO_YAW_ROI && (roi_location.alt == 0 && roi_location.lat == 0 && roi_location.lng == 0)) {
+    if (roi_location.alt == 0 && roi_location.lat == 0 && roi_location.lng == 0) {
         // set auto yaw mode back to default assuming the active command is a waypoint command.  A more sophisticated method is required to ensure we return to the proper yaw control for the active command
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));
 #if MOUNT == ENABLED


### PR DESCRIPTION
Through a certain combination of buttons on DroidPlanner, it was possible to send a `reset ROI` (an ROI with 0,0,0) twice.  But sending a `reset ROI` if the ROI is already at the default position will cause ROI to turn on again and point to 0,0,0.  The user would then lose RC control of the gimbal.

It doesn't make sense for the GCS to need to check the ROI mode before resetting ROI.  A `reset` command should always reset, regardless of what the current mode is.
