### PR TITLE
Allow direct use of autotune mode

### DIFF
--- a/ArduCopter/switches.pde
+++ b/ArduCopter/switches.pde
@@ -345,8 +345,6 @@ static void do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             switch(ch_flag) {
                 case AUX_SWITCH_LOW:
                 case AUX_SWITCH_MIDDLE:
-                    // stop the autotune and return to original gains
-                    autotune_stop();
                     // restore flight mode based on flight mode switch position
                     if (control_mode == AUTOTUNE) {
                         reset_control_switch();
@@ -354,7 +352,7 @@ static void do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                     break;
                 case AUX_SWITCH_HIGH:
                     // start an autotuning session
-                    autotune_start();
+                    set_mode(AUTOTUNE);
                     break;
             }
             break;


### PR DESCRIPTION
Make direct use of autotune mode (via ch5 for example) equivalent to starting autotune via sw7/8.

This could use more testing, but I believe this should be enough to allow direct use of autotune via mode change sw5 or ground station.
