### PR TITLE
AP_HAL_Linux: [Bugfix] prevent memory acces violation in process_dsm_pul...

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -249,6 +249,11 @@ void LinuxRCInput::_process_dsm_pulse(uint16_t width_s0, uint16_t width_s1)
 
     byte_ofs = dsm_state.bit_ofs/10;
     bit_ofs = dsm_state.bit_ofs%10;
+    
+    if(byte_ofs > 15) {
+        // invalid data
+        goto reset;
+    }
 
     // pull in the high bits
     nbits = bits_s0;


### PR DESCRIPTION
...se

When a S.Bus signal is fed into the rcin-Pin AruPlane on the BBB get's a
Segmentation fault. This patch prevents the memory acces to dsm_state.bytes[16] outside
of the array bounds. The patch should be reviewed by sombody who knows the DSM protocol,
as i don't.
