### PR TITLE
Copter: remove gyro cal prearm check

### DIFF
--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -357,14 +357,6 @@ static void pre_arm_checks(bool display_failure)
             return;
         }
 
-        // check gyros calibrated successfully
-        if(!ins.gyro_calibrated_ok_all()) {
-            if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Gyro calibration failed"));
-            }
-            return;
-        }
-
 #if INS_MAX_INSTANCES > 1
         // check all gyros are consistent
         if (ins.get_gyro_count() > 1) {


### PR DESCRIPTION
This is no longer necessary - it has been replaced by an arming check.

If left in, this piece of code is going to be a user experience nightmare. The only solution to this check failing is to re-power the copter or to disable the INS pre-arm check. Users that don't have a GCS for feedback could wait upwards of 10-15 minutes for prearm checks to pass, only to get frustrated and re-power (the only solution). Users that do have a GCS could still wait a long time for the rest of the prearm checks to pass, only to discover that they must re-power the copter.

The result will be a lot of users disabling the check, and the result of that will be crashes.
