### PR TITLE
AP_HAL_Linux: Scheduler reboot fix

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -384,7 +384,7 @@ void LinuxScheduler::system_initialized()
 
 void LinuxScheduler::reboot(bool hold_in_bootloader) 
 {
-    for(;;);
+    exit(1);
 }
 
 void LinuxScheduler::stop_clock(uint64_t time_usec)


### PR DESCRIPTION
Exit from the autopilot when reboot is commanded.
The software assumes that the code is being
launched in an infinite loop thereby an exit
will make it reboot.
