### PR TITLE
HAL_Linux:Updated ToneAlarm Library with suggested changes

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -62,7 +62,7 @@ public:
     /*
         ToneAlarm Driver
     */
-    virtual int8_t toneAlarm_init() { return -1;}
+    virtual bool toneAlarm_init() { return false;}
     virtual void toneAlarm_set_tune(uint8_t tune) {}
     virtual void _toneAlarm_timer_tick() {}
     

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -30,6 +30,7 @@ namespace Linux {
     class LinuxSemaphore;
     class LinuxScheduler;
     class LinuxUtil;
+	class ToneAlarm;					//limit the scope of ToneAlarm driver to Linux_HAL only
 }
 
 #endif // __AP_HAL_LINUX_NAMESPACE_H__

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Private.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Private.h
@@ -19,6 +19,7 @@
 #include "RCOutput_ZYNQ.h"
 #include "Semaphores.h"
 #include "Scheduler.h"
+#include "ToneAlarmDriver.h"
 #include "Util.h"
 
 #endif // __AP_HAL_LINUX_PRIVATE_H__

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -325,7 +325,7 @@ void *LinuxScheduler::_tonealarm_thread(void)
         poll(NULL, 0, 1);        
     }
     while (true) {
-        _microsleep(5000);
+        _microsleep(10000);
 
         // process tone command
         ((LinuxUtil *)hal.util)->_toneAlarm_timer_tick();

--- a/libraries/AP_HAL_Linux/ToneAlarmDriver.h
+++ b/libraries/AP_HAL_Linux/ToneAlarmDriver.h
@@ -1,0 +1,144 @@
+#ifndef __TONE_ALARM_DRIVER_H__
+#define __TONE_ALARM_DRIVER_H__
+
+#include <AP_HAL.h>
+#include "AP_HAL_Linux_Namespace.h"
+
+#define OCTAVE_OFFSET 0
+
+#define NOTE_B0  31
+#define NOTE_C1  33
+#define NOTE_CS1 35
+#define NOTE_D1  37
+#define NOTE_DS1 39
+#define NOTE_E1  41
+#define NOTE_F1  44
+#define NOTE_FS1 46
+#define NOTE_G1  49
+#define NOTE_GS1 52
+#define NOTE_A1  55
+#define NOTE_AS1 58
+#define NOTE_B1  62
+#define NOTE_C2  65
+#define NOTE_CS2 69
+#define NOTE_D2  73
+#define NOTE_DS2 78
+#define NOTE_E2  82
+#define NOTE_F2  87
+#define NOTE_FS2 93
+#define NOTE_G2  98
+#define NOTE_GS2 104
+#define NOTE_A2  110
+#define NOTE_AS2 117
+#define NOTE_B2  123
+#define NOTE_C3  131
+#define NOTE_CS3 139
+#define NOTE_D3  147
+#define NOTE_DS3 156
+#define NOTE_E3  165
+#define NOTE_F3  175
+#define NOTE_FS3 185
+#define NOTE_G3  196
+#define NOTE_GS3 208
+#define NOTE_A3  220
+#define NOTE_AS3 233
+#define NOTE_B3  247
+#define NOTE_C4  262
+#define NOTE_CS4 277
+#define NOTE_D4  294
+#define NOTE_DS4 311
+#define NOTE_E4  330
+#define NOTE_F4  349
+#define NOTE_FS4 370
+#define NOTE_G4  392
+#define NOTE_GS4 415
+#define NOTE_A4  440
+#define NOTE_AS4 466
+#define NOTE_B4  494
+#define NOTE_C5  523
+#define NOTE_CS5 554
+#define NOTE_D5  587
+#define NOTE_DS5 622
+#define NOTE_E5  659
+#define NOTE_F5  698
+#define NOTE_FS5 740
+#define NOTE_G5  784
+#define NOTE_GS5 831
+#define NOTE_A5  880
+#define NOTE_AS5 932
+#define NOTE_B5  988
+#define NOTE_C6  1047
+#define NOTE_CS6 1109
+#define NOTE_D6  1175
+#define NOTE_DS6 1245
+#define NOTE_E6  1319
+#define NOTE_F6  1397
+#define NOTE_FS6 1480
+#define NOTE_G6  1568
+#define NOTE_GS6 1661
+#define NOTE_A6  1760
+#define NOTE_AS6 1865
+#define NOTE_B6  1976
+#define NOTE_C7  2093
+#define NOTE_CS7 2217
+#define NOTE_D7  2349
+#define NOTE_DS7 2489
+#define NOTE_E7  2637
+#define NOTE_F7  2794
+#define NOTE_FS7 2960
+#define NOTE_G7  3136
+#define NOTE_GS7 3322
+#define NOTE_A7  3520
+#define NOTE_AS7 3729
+#define NOTE_B7  3951
+#define NOTE_C8  4186
+#define NOTE_CS8 4435
+#define NOTE_D8  4699
+#define NOTE_DS8 4978
+
+#define     TONE_STARTUP_TUNE                   0
+#define     TONE_ERROR_TUNE                     1
+#define     TONE_NOTIFY_POSITIVE_TUNE           2
+#define     TONE_NOTIFY_NEUTRAL_TUNE            3
+#define     TONE_NOTIFY_NEGATIVE_TUNE           4
+#define     TONE_ARMING_WARNING_TUNE            5
+#define     TONE_BATTERY_WARNING_SLOW_TUNE      6
+#define     TONE_BATTERY_WARNING_FAST_TUNE      7
+#define     TONE_GPS_WARNING_TUNE               8
+#define     TONE_ARMING_FAILURE_TUNE            9    
+#define     TONE_PARACHUTE_RELEASE_TUNE         10
+
+#define TONE_NUMBER_OF_TUNES 11
+
+class Linux::ToneAlarm{
+public:
+	ToneAlarm();
+	void set_tune(uint8_t tone);
+	bool init();
+	bool is_tune_comp();
+	void stop();
+	bool play();
+	bool set_note();
+	bool init_tune();
+
+private:
+	bool tune_comp;
+	static const char *tune[TONE_NUMBER_OF_TUNES];
+	static bool tune_repeat[TONE_NUMBER_OF_TUNES];
+	bool tune_changed;
+	uint8_t default_oct;
+	uint8_t default_dur;
+	uint16_t bpm;
+	uint16_t wholenote;
+	uint16_t cur_note;
+	uint16_t duration;
+	int32_t prev_tune_num;
+	uint32_t prev_time;
+	int32_t period_fd;
+	int32_t duty_fd;
+	int32_t run_fd;
+	int8_t tune_num;
+	uint8_t tune_pos;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -11,6 +11,9 @@ extern const AP_HAL::HAL& hal;
 #include "Util.h"
 using namespace Linux;
 
+
+static int state;
+ToneAlarm LinuxUtil::_toneAlarm;
 /**
    return commandline arguments, if available
 */
@@ -20,4 +23,31 @@ void LinuxUtil::commandline_arguments(uint8_t &argc, char * const *&argv)
     argv = saved_argv;
 }
 
+bool LinuxUtil::toneAlarm_init()
+{
+    return _toneAlarm.init();
+}
+
+void LinuxUtil::toneAlarm_set_tune(uint8_t tone)
+{
+    _toneAlarm.set_tune(tone);
+}
+
+void LinuxUtil::_toneAlarm_timer_tick(){
+    if(state == 0){
+        state = state + _toneAlarm.init_tune();
+    }else if(state == 1){
+        state = state + _toneAlarm.set_note();
+    }
+    if(state == 2){
+        state = state + _toneAlarm.play();
+    }else if(state == 3){
+        state = 1;
+    }
+    
+    if(_toneAlarm.is_tune_comp()){
+        state = 0;
+    }
+    
+}
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -4,119 +4,13 @@
 
 #include <AP_HAL.h>
 #include "AP_HAL_Linux_Namespace.h"
-
-#define OCTAVE_OFFSET 0
-
-#define NOTE_B0  31
-#define NOTE_C1  33
-#define NOTE_CS1 35
-#define NOTE_D1  37
-#define NOTE_DS1 39
-#define NOTE_E1  41
-#define NOTE_F1  44
-#define NOTE_FS1 46
-#define NOTE_G1  49
-#define NOTE_GS1 52
-#define NOTE_A1  55
-#define NOTE_AS1 58
-#define NOTE_B1  62
-#define NOTE_C2  65
-#define NOTE_CS2 69
-#define NOTE_D2  73
-#define NOTE_DS2 78
-#define NOTE_E2  82
-#define NOTE_F2  87
-#define NOTE_FS2 93
-#define NOTE_G2  98
-#define NOTE_GS2 104
-#define NOTE_A2  110
-#define NOTE_AS2 117
-#define NOTE_B2  123
-#define NOTE_C3  131
-#define NOTE_CS3 139
-#define NOTE_D3  147
-#define NOTE_DS3 156
-#define NOTE_E3  165
-#define NOTE_F3  175
-#define NOTE_FS3 185
-#define NOTE_G3  196
-#define NOTE_GS3 208
-#define NOTE_A3  220
-#define NOTE_AS3 233
-#define NOTE_B3  247
-#define NOTE_C4  262
-#define NOTE_CS4 277
-#define NOTE_D4  294
-#define NOTE_DS4 311
-#define NOTE_E4  330
-#define NOTE_F4  349
-#define NOTE_FS4 370
-#define NOTE_G4  392
-#define NOTE_GS4 415
-#define NOTE_A4  440
-#define NOTE_AS4 466
-#define NOTE_B4  494
-#define NOTE_C5  523
-#define NOTE_CS5 554
-#define NOTE_D5  587
-#define NOTE_DS5 622
-#define NOTE_E5  659
-#define NOTE_F5  698
-#define NOTE_FS5 740
-#define NOTE_G5  784
-#define NOTE_GS5 831
-#define NOTE_A5  880
-#define NOTE_AS5 932
-#define NOTE_B5  988
-#define NOTE_C6  1047
-#define NOTE_CS6 1109
-#define NOTE_D6  1175
-#define NOTE_DS6 1245
-#define NOTE_E6  1319
-#define NOTE_F6  1397
-#define NOTE_FS6 1480
-#define NOTE_G6  1568
-#define NOTE_GS6 1661
-#define NOTE_A6  1760
-#define NOTE_AS6 1865
-#define NOTE_B6  1976
-#define NOTE_C7  2093
-#define NOTE_CS7 2217
-#define NOTE_D7  2349
-#define NOTE_DS7 2489
-#define NOTE_E7  2637
-#define NOTE_F7  2794
-#define NOTE_FS7 2960
-#define NOTE_G7  3136
-#define NOTE_GS7 3322
-#define NOTE_A7  3520
-#define NOTE_AS7 3729
-#define NOTE_B7  3951
-#define NOTE_C8  4186
-#define NOTE_CS8 4435
-#define NOTE_D8  4699
-#define NOTE_DS8 4978
-
-#define     TONE_STARTUP_TUNE                   0
-#define     TONE_ERROR_TUNE                     1
-#define     TONE_NOTIFY_POSITIVE_TUNE           2
-#define     TONE_NOTIFY_NEUTRAL_TUNE            3
-#define     TONE_NOTIFY_NEGATIVE_TUNE           4
-#define     TONE_ARMING_WARNING_TUNE            5
-#define     TONE_BATTERY_WARNING_SLOW_TUNE      6
-#define     TONE_BATTERY_WARNING_FAST_TUNE      7
-#define     TONE_GPS_WARNING_TUNE               8
-#define     TONE_ARMING_FAILURE_TUNE            9    
-#define     TONE_PARACHUTE_RELEASE_TUNE         10
-
-#define TONE_NUMBER_OF_TUNES 11
+#include "ToneAlarmDriver.h"
 
 class Linux::LinuxUtil : public AP_HAL::Util {
 public:
     void init(int argc, char * const *argv) {
         saved_argc = argc;
         saved_argv = argv;
-        toneAlarm();
     }
 
 
@@ -127,35 +21,13 @@ public:
      */
     void commandline_arguments(uint8_t &argc, char * const *&argv);
 
-    int8_t toneAlarm_init();
+    bool toneAlarm_init();
     void toneAlarm_set_tune(uint8_t tune);
     
     void _toneAlarm_timer_tick();
-    
-    private:
-    void toneAlarm(void);
-    void stop();
-    bool play();
-    void play_tune();
-    bool set_note();
-	bool init_tune();
-    static const char *tune[TONE_NUMBER_OF_TUNES];
-    static bool tune_repeat[TONE_NUMBER_OF_TUNES];
-    bool tune_changed;
-	uint8_t default_oct;
-	uint8_t default_dur;
-	uint16_t bpm;
-    uint16_t wholenote;
-    uint16_t cur_note;
-    uint16_t duration;
-    int32_t prev_tune_num;
-	uint32_t prev_time;
-    int32_t period_fd;
-    int32_t duty_fd;
-    int32_t run_fd;
-    int8_t tune_num;
-    uint8_t tune_pos;
-    
+
+private:
+	static Linux::ToneAlarm _toneAlarm;
     int saved_argc;
     char* const *saved_argv;
 };

--- a/libraries/AP_Notify/ToneAlarm_Linux.cpp
+++ b/libraries/AP_Notify/ToneAlarm_Linux.cpp
@@ -37,7 +37,7 @@ bool ToneAlarm_Linux::init()
 {
     // open the tone alarm device
     err = hal.util->toneAlarm_init();
-    if (err == -1) {
+    if (err) {
         hal.console->printf("\nAP_Notify: Failed to initialise ToneAlarm");
         return false;
     }

--- a/libraries/AP_Notify/ToneAlarm_Linux.h
+++ b/libraries/AP_Notify/ToneAlarm_Linux.h
@@ -36,7 +36,7 @@ private:
     /// play_tune - play one of the pre-defined tunes
     bool play_tune(uint8_t tune_number);
 
-    int err;
+    bool err;
 
     /// tonealarm_type - bitmask of states we track
     struct tonealarm_type {


### PR DESCRIPTION
Following are the suggestions made by @tridge which are worked upon under this pull request

> - I'd like to see ::printf() calls to show failure to open the period, duty and run files in case the module doesn't load, so the user knows how to debug it (that happened to me due to a module issue)
> - the tune[] array should really be a constant array of structures, like the LinuxSPIDeviceManager::_device array, instead of copying the string pointers at startup
> - the str, str1, str2 strings are not really needed
> - I think toneAlarm_init() should return a bool, and ::printf() an error on failure
> - I have fixed some of the places that write() is used where dprintf() should be used, but there are some others (eg. in stop()). See the dprintf() patch I pushed
> - the magic constant 10 should be replaced by TOTAL_NUMBER_OF_TUNES-1 (or add a MAX_TUNE)
> - I'd like to see some more paranoid checking in play_tune() to make sure it can't loop forever. This thread runs at top priority, and if it loops then we will fall out of the sky as nothing else will run at all. We need to make absolutely sure it will never loop forever. Defensive coding would be a good idea
> - the NOTE_ and TONE_ defines should move to a separate ToneAlarmDriver.h I think
> - it would be better if ToneAlarmDriver was a separate class, which Util instantiated as a private object
