### PR TITLE
Rover: Fix INS test in CLI to quit on enter

### DIFF
--- a/APMrover2/test.pde
+++ b/APMrover2/test.pde
@@ -371,9 +371,9 @@ test_ins(uint8_t argc, const Menu::arg *argv)
                             (uint16_t)ahrs.yaw_sensor / 100,
                             gyros.x, gyros.y, gyros.z,
                             accels.x, accels.y, accels.z);
-    }
-    if(cliSerial->available() > 0){
-        return (0);
+        if(cliSerial->available() > 0){
+            return (0);
+        }
     }
 }
 


### PR DESCRIPTION
The curly brace was in the wrong spot.
