### PR TITLE
AP_HAL_Linux: Add support for in-kernel SPI CS handling

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDriver.h
+++ b/libraries/AP_HAL_Linux/SPIDriver.h
@@ -13,12 +13,20 @@
 #define LINUX_SPI_DEVICE_NUM_DEVICES 0
 #endif
 
+// Most platforms won't need to declare the spidev bus offset
+#ifndef LINUX_SPIDEV_BUS_OFFSET
+#define LINUX_SPIDEV_BUS_OFFSET 0
+#endif
+
 #define LINUX_SPI_MAX_BUSES 3
+
+// Fake CS pin to indicate in-kernel handling
+#define SPI_CS_KERNEL -1
 
 class Linux::LinuxSPIDeviceDriver : public AP_HAL::SPIDeviceDriver {
 public:
     friend class Linux::LinuxSPIDeviceManager;
-    LinuxSPIDeviceDriver(uint8_t bus, enum AP_HAL::SPIDevice type, uint8_t mode, uint8_t bitsPerWord, uint8_t cs_pin, uint32_t lowspeed, uint32_t highspeed);
+    LinuxSPIDeviceDriver(uint16_t bus, uint16_t subdev, enum AP_HAL::SPIDevice type, uint8_t mode, uint8_t bitsPerWord, int16_t cs_pin, uint32_t lowspeed, uint32_t highspeed);
     void init();
     AP_HAL::Semaphore *get_semaphore();
     void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
@@ -30,7 +38,9 @@ public:
     void set_bus_speed(enum bus_speed speed);
 
 private:
-    uint8_t _cs_pin;
+    uint16_t _bus;
+    uint16_t _subdev;
+    int16_t _cs_pin;
     AP_HAL::DigitalSource *_cs;
     uint8_t _mode;
     uint8_t _bitsPerWord;
@@ -38,7 +48,7 @@ private:
     uint32_t _highspeed;
     uint32_t _speed;
     enum AP_HAL::SPIDevice _type;
-    uint8_t _bus;
+    int _fd;	// Per-device FD.
 };
 
 class Linux::LinuxSPIDeviceManager : public AP_HAL::SPIDeviceManager {
@@ -46,7 +56,7 @@ public:
     void init(void *);
     AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice);
 
-    static AP_HAL::Semaphore *get_semaphore(uint8_t bus);
+    static AP_HAL::Semaphore *get_semaphore(uint16_t bus);
 
     static void cs_assert(enum AP_HAL::SPIDevice type);
     static void cs_release(enum AP_HAL::SPIDevice type);
@@ -55,7 +65,6 @@ public:
 private:
     static LinuxSPIDeviceDriver _device[LINUX_SPI_DEVICE_NUM_DEVICES];
     static LinuxSemaphore _semaphore[LINUX_SPI_MAX_BUSES];
-    static int _fd[LINUX_SPI_MAX_BUSES];
 };
 
 #endif // __AP_HAL_LINUX_SPIDRIVER_H__


### PR DESCRIPTION
Add support for /dev/spidev<bus>.<cs> in-kernel SPI CS handling, and convert
existing SPI devices over.
- Add a new member _subdev to the LinuxSPIDeviceDriver class, and initialiser
  in LinuxSPIDevice constructor.  Use subdev 0 for GPIO-managed CS
- Extend the _cs_pin to signed 16 bits and define SPI_CS_KERNEL (-1) for
  kernel-managed CS
- Move to per-device file descriptors (required for in-kernel CS)
- Extend spidev filenames to include bus and subdevice numbers, possibly
  longer than 1 digit each
- Allow support for platforms enumerating /dev/spidevNNN from non-zero bases
- Convert existing users over to the new API

Signed-off-by: John Williams john@whelanwilliams.net
