### PR TITLE
AP_HAL_Linux: Bypass manual CS assertion for SPI_CS_KERNEL mode

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -150,6 +150,11 @@ void LinuxSPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
     if (i == LINUX_SPI_DEVICE_NUM_DEVICES) {
         hal.scheduler->panic("Bad device type");
     }
+
+    // Kernel-mode CS handling
+    if(_device[i]._cs_pin == SPI_CS_KERNEL)
+        return;
+
     for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
         if (_device[i]._bus != bus) {
             // not the same bus


### PR DESCRIPTION
Missed from initial patch series

Signed-off-by: John Williams john@whelanwilliams.net
