### PR TITLE
PX4: Provide a way to enable px4io sbus1 output

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -7,6 +7,7 @@
 # To enable mkblctrl_+ startup add a /fs/microsd/APM/mkblctrl_+ file
 # To enable mkblctrl_x startup add a /fs/microsd/APM/mkblctrl_x file
 # To enable PWM on FMUv1 on ttyS1 add a /fs/microsd/APM/AUXPWM.en file
+# To enable SBUS1 output on px4io add a /fs/microsd/APM/sbus1_out file
 
 set deviceA /dev/ttyACM0
 
@@ -168,6 +169,12 @@ then
                tone_alarm MNGGG
         fi
     fi
+    if [ -f /fs/microsd/APM/sbus1_out ]
+    then
+        echo "Setting up sbus1 output
+        px4io sbus1_out
+     fi
+fi
 else
     echo "No PX4IO board found"
     echo "No PX4IO board found" >> $logfile


### PR DESCRIPTION
Simplest way to turn on "px4io sbus1_out" for ArduPlane. 

The other option is to add a new parameter and pass through to PX4 (I think it is just one ioctl). This would be a little more invasive I guess.
