### PR TITLE
AP_NavEKF: Reduce vulnerability to ground magnetic interference

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -474,6 +474,9 @@ private:
     float tasTestRatio;             // sum of squares of true airspeed innovation divided by fail threshold
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
+    float firstArmPosD;             // vertical position at the first arming (transition from sttatic mode) after start up
+    bool firstArmComplete;          // true when first transition out of static mode has been performed after start up
+    bool finalMagYawInit;           // true when the final post takeoff initialisation of earth field and yaw angle has been performed
 
     // Used by smoothing of state corrections
     float gpsIncrStateDelta[10];    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
This fixes a vulnerability to bad ground based magnetic interference observed here:

https://groups.google.com/forum/#!topic/drones-discuss/3dTM3rjpcNE

Re-initialisation of the magnetic field states and yaw angle is now only performed a maximum of two times after start-up.
- Once when coming out of static modefor the first time (first arm event)
- Again (for copter only) when the altitude gain above the arming altitude exceeds 1.5m

This prevents magnetic interference present at arming (eg arming on a metal roof)from corrupting the magnetic field states enough to cause bad heading errors and toilet bowling on copter.
It also prevents learned compass and earth field offsets being discarded each time the vehicle lands and is disarmed, helping with accuracy for users doing multiple short missions on the one battery pack

It has been tested with a takeoff from a car roof. The following figure shows magnetometer innovations for a flight off a car roof with 90 degrees of heading error. Immediately after takeoff the innovations rise to very large values and then step down when the realignment occurs.

![magnetometerinnovations](https://cloud.githubusercontent.com/assets/3596952/5259917/144a1e62-7a5c-11e4-89be-4cc7bdf7b558.png)

The following figure shows the yaw angle. The yaw realignment can be seen at the start.

![yaw](https://cloud.githubusercontent.com/assets/3596952/5259963/8b9ab346-7a5c-11e4-899c-e73065b1959c.png)
