### PR TITLE
Fix for Spring loaded throttle in manual throttle modes

### DIFF
--- a/ArduCopter/AP_State.pde
+++ b/ArduCopter/AP_State.pde
@@ -140,3 +140,10 @@ void set_pre_arm_rc_check(bool b)
     }
 }
 
+// ---------------------------------------------
+
+// set land complete maybe flag
+void set_throttle_disengaged(bool b)
+{
+    ap.throttle_disengaged = b;
+}

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -381,6 +381,7 @@ static union {
         uint8_t initialised         : 1; // 17  // true once the init_ardupilot function has completed.  Extended status to GCS is not sent until this completes
         uint8_t land_complete_maybe : 1; // 18  // true if we may have landed (less strict version of land_complete)
         uint8_t throttle_zero       : 1; // 19  // true if the throttle stick is at zero, debounced
+        uint8_t throttle_disengaged : 1; // 20  // 
     };
     uint32_t value;
 } ap;

--- a/ArduCopter/flight_mode.pde
+++ b/ArduCopter/flight_mode.pde
@@ -251,6 +251,7 @@ static bool manual_flight_mode(uint8_t mode) {
     switch(mode) {
         case ACRO:
         case STABILIZE:
+        case DRIFT:
             return true;
         default:
             return false;

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -569,22 +569,17 @@ static bool arm_checks(bool display_failure, bool arming_from_gcs)
     }
     #endif  // HELI_FRAME
 
+    // check throttle is down, if not disengage it for safety
+    if (manual_flight_mode(control_mode)){
+        set_throttle_disengaged(g.rc_3.control_in > 0);
+    }
+
     // succeed if arming checks are disabled
     if (g.arming_check == ARMING_CHECK_NONE) {
         return true;
     }
 
-    // check throttle is down
-    if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
-        if (g.rc_3.control_in > 0) {
-            if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Throttle too high"));
-            }
-            return false;
-        }
-    }
-
-    // check Baro & inav alt are within 1m
+        // check Baro & inav alt are within 1m
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_BARO)) {
         if(fabs(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
             if (display_failure) {
@@ -698,6 +693,10 @@ set_servos_4()
         // To-Do: implement improved stability patch for tri so that we do not need to limit throttle input to motors
         g.rc_3.servo_out = min(g.rc_3.servo_out, 800);
 #endif
+        // if we cannot safely output throttle, set it to throttle min
+        if(ap.throttle_disengaged){
+            g.rc_3.servo_out = 0;
+        }
         motors.output();
     }
 }

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -14,7 +14,7 @@ static void arm_motors_check()
     static int16_t arming_counter;
 
     // ensure throttle is down
-    if (g.rc_3.control_in > 0) {
+    if (g.rc_3.control_in > 0 && !ap.throttle_disengaged) {
         arming_counter = 0;
         return;
     }
@@ -578,6 +578,18 @@ static bool arm_checks(bool display_failure, bool arming_from_gcs)
     if (g.arming_check == ARMING_CHECK_NONE) {
         return true;
     }
+
+    // check throttle is down
+    if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
+        if (g.rc_3.control_in > 0 && !manual_flight_mode(control_mode)) {
+            if (display_failure) {
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Throttle too high"));
+            }
+            return false;
+        }
+    }
+ 
+    // check Baro & inav alt are within 1m
 
         // check Baro & inav alt are within 1m
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_BARO)) {

--- a/ArduCopter/radio.pde
+++ b/ArduCopter/radio.pde
@@ -185,6 +185,12 @@ static void set_throttle_zero_flag(int16_t throttle_control)
     } else if (tnow_ms - last_nonzero_throttle_ms > THROTTLE_ZERO_DEBOUNCE_TIME_MS) {
         ap.throttle_zero = true;
     }
+    
+    // check if we should enable throttle
+    // if throttle is low, make sure it is engaged
+    if(ap.throttle_disengaged && ap.throttle_zero){
+        set_throttle_disengaged(false);
+    }
 }
 
 static void trim_radio()


### PR DESCRIPTION
This is a patch which introduces a throttle control for disengaging throttle when arming via mavlink while in a manual mode such as Acro or Stabilize. 

All other modes with alt hold don't need to check throttle position so this removes the "Arm: Throttle too high" check. 

UX : user enters stabilize mode, presses ARM on Droidplanner. motors spool up to idle and the user brings throttle to zero. Throttle engages at zero and as it is raised it works normally. 
