### PR TITLE
Low-altitude Fence

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -289,12 +289,22 @@ void Copter::set_accel_throttle_I_from_pilot_throttle(int16_t pilot_throttle)
 void Copter::update_poscon_alt_max()
 {
     float alt_limit_cm = 0.0f;  // interpreted as no limit if left as zero
+    int alt_low_cm = 0; // no limit if left as zero
 
 #if AC_FENCE == ENABLED
     // set fence altitude limit in position controller
     if ((fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) != 0) {
         alt_limit_cm = pv_alt_above_origin(fence.get_safe_alt()*100.0f);
     }
+
+    if ((fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MIN) != 0) {
+        alt_low_cm = pv_alt_above_origin(fence.get_safe_min_alt() * 100);
+
+        // Minimum-alt fence only counts if outside the low-alt radius.
+        if((home_distance / 100) <= fence.get_low_alt_radius()) {
+            alt_low_cm = 0;
+        }
+    }    
 #endif
 
     // get alt limit from EKF (limited during optical flow flight)
@@ -305,8 +315,9 @@ void Copter::update_poscon_alt_max()
         }
     }
 
-    // pass limit to pos controller
+    // pass limits to pos controller
     pos_control.set_alt_max(alt_limit_cm);
+    pos_control.set_alt_min(alt_low_cm);
 }
 
 // rotate vector from vehicle's perspective to North-East frame

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -54,6 +54,7 @@ AC_PosControl::AC_PosControl(const AP_AHRS& ahrs, const AP_InertialNav& inav,
     _roll_target(0.0f),
     _pitch_target(0.0f),
     _alt_max(0.0f),
+    _alt_min(0.0f),
     _distance_to_target(0.0f),
     _accel_target_jerk_limited(0.0f,0.0f),
     _accel_target_filter(POSCONTROL_ACCEL_FILTER_HZ)
@@ -175,6 +176,13 @@ void AC_PosControl::set_alt_target_from_climb_rate(float climb_rate_cms, float d
     if (_alt_max > 0 && _pos_target.z > _alt_max) {
         _pos_target.z = _alt_max;
         _limit.pos_up = true;
+        // decelerate feed forward to zero
+        _vel_desired.z = constrain_float(0.0f, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
+    }
+    // ...or below
+    else if (_alt_min > 0 && _pos_target.z <= _alt_min) {
+        _pos_target.z = _alt_min;
+        _limit.pos_down = true;
         // decelerate feed forward to zero
         _vel_desired.z = constrain_float(0.0f, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
     }

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -82,6 +82,11 @@ public:
     ///   set to zero to disable limit
     void set_alt_max(float alt) { _alt_max = alt; }
 
+    /// set_alt_min - sets minimum altitude above home in cm
+    ///   only enforced when set_alt_target_from_climb_rate is used
+    ///   set to zero to disable limit
+    void set_alt_min(float alt) { _alt_min = alt; }
+
     /// set_speed_z - sets maximum climb and descent rates
     ///     speed_down can be positive or negative but will always be interpreted as a descent speed
     ///     leash length will be recalculated the next time update_z_controller() is called
@@ -383,6 +388,7 @@ private:
     Vector3f    _accel_error;           // desired acceleration in cm/s/s  // To-Do: are xy actually required?
     Vector3f    _accel_feedforward;     // feedforward acceleration in cm/s/s
     float       _alt_max;               // max altitude - should be updated from the main code with altitude limit from fence
+    float       _alt_min;               // min altitude - should be updated from the main code with low-alt limit from fence
     float       _distance_to_target;    // distance to position target - for reporting only
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -15,7 +15,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] PROGMEM = {
     // @Param: TYPE
     // @DisplayName: Fence Type
     // @Description: Enabled fence types held as bitmask
-    // @Values: 0:None,1:Altitude,2:Circle,3:Altitude and Circle
+    // @Values: 0:None,1:Altitude,2:Circle,3:Altitude and Circle,4:Altitude Circle and Low-Altitude
     // @User: Standard
     AP_GROUPINFO("TYPE",        1,  AC_Fence,   _enabled_fences,  AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE),
 
@@ -50,7 +50,27 @@ const AP_Param::GroupInfo AC_Fence::var_info[] PROGMEM = {
     // @Range: 1 10
     // @User: Standard
     AP_GROUPINFO("MARGIN",      5,  AC_Fence,   _margin, AC_FENCE_MARGIN_DEFAULT),
-    
+
+    // (low-alt)
+
+    // @Param: ALT_MIN
+    // @DisplayName: Fence Minimum Altitude
+    // @Description: Minimum altitude allowed before Fence triggers
+    // @Units: Meters
+    // @Range: 10 1000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("ALT_MIN",     6,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT),
+
+    // @Param: LOW_RADIUS
+    // @DisplayName: Low-alt fence-active radius
+    // @Description: Radius beyond which low-altitude fence is active
+    // @Units: Meters
+    // @Range: 10 1000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("LOW_RADIUS",     7,  AC_Fence,   _lowalt_radius,       AC_FENCE_LOWALT_RADIUS_DEFAULT),
+
     AP_GROUPEND
 };
 
@@ -58,8 +78,10 @@ const AP_Param::GroupInfo AC_Fence::var_info[] PROGMEM = {
 AC_Fence::AC_Fence(const AP_InertialNav& inav) :
     _inav(inav),
     _alt_max_backup(0),
+    _alt_min_backup(0),
     _circle_radius_backup(0),
     _alt_max_breach_distance(0),
+    _alt_min_breach_distance(0),
     _circle_breach_distance(0),
     _home_distance(0),
     _breached_fences(AC_FENCE_TYPE_NONE),
@@ -69,12 +91,26 @@ AC_Fence::AC_Fence(const AP_InertialNav& inav) :
 {
     AP_Param::setup_object_defaults(this, var_info);
 
-    // check for silly fence values
+    // check for silly fence values:
+
+    // max altitude
     if (_alt_max < 0.0f) {
         _alt_max.set_and_save(AC_FENCE_ALT_MAX_DEFAULT);
     }
+
+    // circle
     if (_circle_radius < 0) {
         _circle_radius.set_and_save(AC_FENCE_CIRCLE_RADIUS_DEFAULT);
+    }
+
+    // min altitude
+    if(_alt_min < 0.0f) {
+        _alt_min.set_and_save(AC_FENCE_ALT_MIN_DEFAULT);
+    }
+
+    // low-alt radius
+    if(_lowalt_radius < 0.0) {
+        _lowalt_radius.set_and_save(AC_FENCE_LOWALT_RADIUS_DEFAULT);
     }
 }
 
@@ -158,6 +194,31 @@ uint8_t AC_Fence::check_fence(float curr_alt)
                 _alt_max_backup = 0.0f;
                 _alt_max_breach_distance = 0.0f;
             }
+        }
+    }
+
+    // min-altitude fence check
+    if ((_enabled_fences & AC_FENCE_TYPE_ALT_MIN) != 0) {
+        // check if we are on/outside the low-alt fence trigger radius
+        // and under the minimum-altitude fence
+        if(_home_distance >= _lowalt_radius && curr_alt <= _alt_min) {
+            // record distance below breach
+            _alt_min_breach_distance = _alt_min - curr_alt;
+
+            // check for a new breach or a breach of the backup fence
+            if ((_breached_fences & AC_FENCE_TYPE_ALT_MIN) == 0 || (!is_zero(_alt_min_backup) && curr_alt <= _alt_min_backup)) {
+
+                // record that we have breached the upper limit
+                record_breach(AC_FENCE_TYPE_ALT_MIN);
+                ret = ret | AC_FENCE_TYPE_ALT_MIN;
+
+                // create a backup fence 1m lower
+                _alt_min_backup = curr_alt - AC_FENCE_ALT_MIN_BACKUP_DISTANCE;
+            }
+        } else {
+            clear_breach(AC_FENCE_TYPE_ALT_MIN);
+            _alt_min_backup = 0.0f;
+            _alt_max_breach_distance = 0.0f;
         }
     }
 


### PR DESCRIPTION
Low-altitude Fence

Add a low-altitude fence type.

Once the copter has flown beyond a certain range
from launch (FENCE_LOW_RADIUS), the copter maintains
at least the altitude given by FENCE_ALT_MIN. Inside
the range, the min-altitude fence becomes inactive,
allowing for landing the copter.

Params:

. FENCE_ALT_MIN - Minimum allowed altitude
. FENCE_LOW_RADIUS - Trigger radius for low-alt fence
. FENCE_TYPE (new value) 4 - low-alt-fence
