### PR TITLE
Close log file after disarming

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -18,8 +18,9 @@ const AP_Param::Info Rover::var_info[] = {
 	// misc
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
-    // @Description: Two byte bitmap of log types to enable in dataflash
+    // @Description: 4 byte bitmap of log types to enable
     // @Values: 0:Disabled,3950:Default,4078:Default+IMU
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:SONAR,11:COMPASS,12:CAMERA,13:STEERING,14:RC,19:IMU_RAW
     // @User: Advanced
 	GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 	GSCALAR(num_resets,             "SYS_NUM_RESETS",   0),

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -90,7 +90,6 @@ enum mode {
 #define MASK_LOG_STEERING  		(1<<13)
 #define MASK_LOG_RC     		(1<<14)
 #define MASK_LOG_ARM_DISARM     (1<<15)
-#define MASK_LOG_WHEN_DISARMED  (1UL<<16)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
 
 // Waypoint Modes

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -476,14 +476,22 @@ uint8_t Rover::check_digital_pin(uint8_t pin)
  */
 bool Rover::should_log(uint32_t mask)
 {
+#if LOGGING_ENABLED == ENABLED
     if (!(mask & g.log_bitmask) || in_mavlink_delay) {
         return false;
     }
-    bool ret = hal.util->get_soft_armed() || (g.log_bitmask & MASK_LOG_WHEN_DISARMED) != 0;
-    if (ret && !DataFlash.logging_started() && !in_log_download) {
+
+    bool logWhenDisarmed = DataFlash.get_log_behaviour() == LOG_WHEN_DISARMED;
+    bool shouldLog = hal.util->get_soft_armed() || logWhenDisarmed;
+
+    if (!DataFlash.logging_started() && shouldLog && !in_log_download) {
+        // we have to set in_mavlink_delay to prevent logging while writing headers
         start_logging();
     }
-    return ret;
+    return shouldLog;
+#else
+    return false;
+#endif
 }
 
 /*

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -791,16 +791,10 @@ void Copter::Log_Write_Vehicle_Startup_Messages()
 // start a new log
 void Copter::start_logging() 
 {
-    if (g.log_bitmask != 0) {
-        if (!ap.logging_started) {
-            ap.logging_started = true;
-            DataFlash.set_mission(&mission);
-            DataFlash.setVehicle_Startup_Log_Writer(FUNCTOR_BIND(&copter, &Copter::Log_Write_Vehicle_Startup_Messages, void));
-            DataFlash.StartNewLog();
-        }
-        // enable writes
-        DataFlash.EnableWrites(true);
-    }
+    DataFlash.set_mission(&mission);
+    DataFlash.setVehicle_Startup_Log_Writer(FUNCTOR_BIND(&copter, &Copter::Log_Write_Vehicle_Startup_Messages, void));
+
+    DataFlash.StartNewLog();
 }
 
 void Copter::log_init(void)

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -351,8 +351,8 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable
-    // @Values: 830:Default,894:Default+RCIN,958:Default+IMU,1854:Default+Motors,-6146:NearlyAll-AC315,45054:NearlyAll,131070:All+DisarmedLogging,131071:All+FastATT,262142:All+MotBatt,393214:All+FastIMU,397310:All+FastIMU+PID,655358:All+FullIMU,0:Disabled
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,16:WHEN_DISARMED,17:MOTBATT,18:IMU_FAST,19:IMU_RAW
+    // @Values: 830:Default,894:Default+RCIN,958:Default+IMU,1854:Default+Motors,-6146:NearlyAll-AC315,45054:NearlyAll,65534:All,65535:All+FastATT,196606:All+MotBatt,327678:All+FastIMU,397310:All+FastIMU+PID,589822:All+FullIMU,0:Disabled
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,17:MOTBATT,18:IMU_FAST,19:IMU_RAW
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -491,11 +491,6 @@ bool Copter::pre_arm_ekf_attitude_check()
 //  has side-effect that logging is started
 bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
 {
-    #if LOGGING_ENABLED == ENABLED
-    // start dataflash
-    start_logging();
-    #endif
-
     // check accels and gyro are healthy
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {
         //check if accelerometers have calibrated and require reboot

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -270,7 +270,6 @@ enum FlipState {
 #define MASK_LOG_COMPASS                (1<<13)
 #define MASK_LOG_INAV                   (1<<14) // deprecated
 #define MASK_LOG_CAMERA                 (1<<15)
-#define MASK_LOG_WHEN_DISARMED          (1UL<<16)
 #define MASK_LOG_MOTBATT                (1UL<<17)
 #define MASK_LOG_IMU_FAST               (1UL<<18)
 #define MASK_LOG_IMU_RAW                (1UL<<19)

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -245,11 +245,6 @@ void Copter::init_disarm_motors()
     // reset the mission
     mission.reset();
 
-    // suspend logging
-    if (!(g.log_bitmask & MASK_LOG_WHEN_DISARMED)) {
-        DataFlash.EnableWrites(false);
-    }
-
     // disable gps velocity based centrefugal force compensation
     ahrs.set_correct_centrifugal(false);
     hal.util->set_soft_armed(false);

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -441,11 +441,20 @@ bool Copter::should_log(uint32_t mask)
     if (!(mask & g.log_bitmask) || in_mavlink_delay) {
         return false;
     }
-    bool ret = motors.armed() || (g.log_bitmask & MASK_LOG_WHEN_DISARMED) != 0;
-    if (ret && !DataFlash.logging_started() && !in_log_download) {
+
+    bool logWhenDisarmed = DataFlash.get_log_behaviour() == LOG_WHEN_DISARMED;
+    bool shouldLog = hal.util->get_soft_armed() || logWhenDisarmed;
+
+    if (DataFlash.logging_started() && !hal.util->get_soft_armed() && DataFlash.get_log_behaviour()  == LOG_ARMED_REOPEN_FILE) {
+        // we call stop_logging once after disarming so next time we arm we begin a new log file
+        DataFlash.stop_logging();
+    }
+
+    if (!DataFlash.logging_started() && shouldLog && !in_log_download) {
+        // we have to set in_mavlink_delay to prevent logging while writing headers
         start_logging();
     }
-    return ret;
+    return shouldLog;
 #else
     return false;
 #endif

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -782,9 +782,9 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
-    // @Description: Bitmap of what log types to enable in dataflash. This values is made up of the sum of each of the log types you want to be saved on dataflash. On a PX4 or Pixhawk the large storage size of a microSD card means it is usually best just to enable all log types by setting this to 65535. On APM2 the smaller 4 MByte dataflash means you need to be more selective in your logging or you may run out of log space while flying (in which case it will wrap and overwrite the start of the log). The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Sonar=16384, Arming=32768, LogWhenDisarmed=65536, FullLogsArmedOnly=65535, FullLogsWhenDisarmed=131071
+    // @Description: Bitmap of what log types to enable in dataflash. This values is made up of the sum of each of the log types you want to be saved on dataflash. On a PX4 or Pixhawk the large storage size of a microSD card means it is usually best just to enable all log types by setting this to 65535. On APM2 the smaller 4 MByte dataflash means you need to be more selective in your logging or you may run out of log space while flying (in which case it will wrap and overwrite the start of the log). The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Sonar=16384, Arming=32768, FullLogs=65535
     // @Values: 0:Disabled,5190:APM2-Default,65535:PX4/Pixhawk-Default
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,16:WHEN_DISARMED,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,19:IMU_RAW
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",    DEFAULT_LOG_BITMASK),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -135,7 +135,6 @@ enum log_messages {
 #define MASK_LOG_RC                     (1<<13)
 #define MASK_LOG_SONAR                  (1<<14)
 #define MASK_LOG_ARM_DISARM             (1<<15)
-#define MASK_LOG_WHEN_DISARMED          (1UL<<16)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
 
 // Waypoint Modes

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -701,13 +701,20 @@ bool Plane::should_log(uint32_t mask)
     if (!(mask & g.log_bitmask) || in_mavlink_delay) {
         return false;
     }
-    bool ret = hal.util->get_soft_armed() || (g.log_bitmask & MASK_LOG_WHEN_DISARMED) != 0;
-    if (ret && !DataFlash.logging_started() && !in_log_download) {
-        // we have to set in_mavlink_delay to prevent logging while
-        // writing headers
+
+    bool logWhenDisarmed = DataFlash.get_log_behaviour() == LOG_WHEN_DISARMED;
+    bool shouldLog = hal.util->get_soft_armed() || logWhenDisarmed;
+
+    if (DataFlash.logging_started() && !hal.util->get_soft_armed() && DataFlash.get_log_behaviour()  == LOG_ARMED_REOPEN_FILE) {
+        // we call stop_logging once after disarming so next time we arm we begin a new log file
+        DataFlash.stop_logging();
+    }
+
+    if (!DataFlash.logging_started() && shouldLog && !in_log_download) {
+        // we have to set in_mavlink_delay to prevent logging while writing headers
         start_logging();
     }
-    return ret;
+    return shouldLog;
 #else
     return false;
 #endif

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -16,6 +16,13 @@ const AP_Param::GroupInfo DataFlash_Class::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_FILE_BUFSIZE",  1, DataFlash_Class, _params.file_bufsize,       16),
 
+    // @Param: _BEHAVIOUR
+    // @DisplayName: Log behaviour
+    // @Description: Control when to start and stop logging regarding to the state of the vehicle. LogWhenDisarmed: Always logging, a single log file is created on startup. LogArmedSingleFile: Log only while vehicle is armed, a single log file is created first time we arm. LogArmedReopenFile: Log while armed but new log files are	generated after each arm.
+    // @Values: 0:LogWhenDisarmed,1:LogArmedSingleFile ,2:LogArmedReopenFile
+    // @User: Advanced
+    AP_GROUPINFO("_BEHAVIOUR", 2, DataFlash_Class, _params.behaviour, LOG_ARMED_SINGLE_FILE),
+
     AP_GROUPEND
 };
 
@@ -52,6 +59,10 @@ void DataFlash_Class::WriteCriticalBlock(const void *pBuffer, uint16_t size) {
 
 void DataFlash_Class::WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical) {
     FOR_EACH_BACKEND(WritePrioritisedBlock(pBuffer, size, is_critical));
+}
+
+void DataFlash_Class::stop_logging() {
+    FOR_EACH_BACKEND(stop_logging());
 }
 
 // change me to "DoTimeConsumingPreparations"?
@@ -215,6 +226,9 @@ void DataFlash_Class::Log_Write_Mission_Cmd(const AP_Mission &mission,
     FOR_EACH_BACKEND(Log_Write_Mission_Cmd(mission, cmd));
 }
 
+uint8_t DataFlash_Class::get_log_behaviour(void) {
+    return _params.behaviour;
+}
 
 // end functions pass straight through to backend
 

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -38,6 +38,12 @@ enum DataFlash_Backend_Type {
     DATAFLASH_BACKEND_BOTH = 3,
 };
 
+enum Log_Behaviour {
+    LOG_WHEN_DISARMED = 0,
+    LOG_ARMED_SINGLE_FILE = 1,
+    LOG_ARMED_REOPEN_FILE =2,
+};
+
 class DataFlash_Class
 {
     friend class DataFlash_Backend; // for _num_types
@@ -137,6 +143,8 @@ public:
 
     bool logging_started(void);
 
+    void stop_logging(void);
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     // currently only DataFlash_File support this:
     void flush(void);
@@ -154,6 +162,8 @@ public:
     bool Log_Write_Parameter(const AP_Param *ap, const AP_Param::ParamToken &token, 
                              enum ap_var_type type);
 
+    uint8_t get_log_behaviour(void);
+
     vehicle_startup_message_Log_Writer _vehicle_messages;
 
     // parameter support
@@ -161,6 +171,7 @@ public:
     struct {
         AP_Int8 backend_types;
         AP_Int8 file_bufsize; // in kilobytes
+        AP_Int8 behaviour;
     } _params;
 
     const struct LogStructure *structure(uint16_t num) const;

--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -67,6 +67,7 @@ public:
     virtual uint16_t bufferspace_available() = 0;
 
     virtual uint16_t start_new_log(void) = 0;
+    virtual void stop_logging(void) {}
     bool log_write_started;
 
     void Log_Fill_Format(const struct LogStructure *structure, struct log_Format &pkt);


### PR DESCRIPTION
With this PR Pixhawk and any other file oriented board will create a new log file each time the vehicle is armed. Only Plane and Copter are modified (there is no arm/disamr on ArduRover). The reason for this feature was described in #2501 

The code to close a log file is already implemented in the function stop_logging() in Dataflash_File.cpp. However, it was not accessible from outside.

The proposal is to call stop_logging() in should_log() function when we are about to log but the vehicle is disarmed. This way next time motor is armed start_logging() will be called, creating a new log file.

These changes worked with no problem on ArduPlane but for ArduCopter I had some trouble.
The problem with Copter is because an additional logging_started variable interferes with Dataflash.loging_started().

I removed some lines to not to use the unnecessary variable and unified the functions on ArduCopter/Arduplane. Now it works great and it is easier to track.