### PR TITLE
ACRO_TRAINER_DIRECT acro variant

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -626,7 +626,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: ACRO_TRAINER
     // @DisplayName: Acro Trainer
     // @Description: Type of trainer used in acro mode
-    // @Values: 0:Disabled,1:Leveling,2:Leveling and Limited
+    // @Values: 0:Disabled,1:Leveling,2:Leveling and Limited,3:Direct Gyro
     // @User: Advanced
     GSCALAR(acro_trainer,   "ACRO_TRAINER",     ACRO_TRAINER_LIMITED),
 

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -16,6 +16,8 @@ bool Copter::acro_init(bool ignore_checks)
    // set target altitude to zero for reporting
    pos_control.set_alt_target(0);
 
+   attitude_control.reset_angle_error_integrator();
+   // successfully enter acro
    return true;
 }
 
@@ -28,6 +30,7 @@ void Copter::acro_run()
 
     // if motors not running reset angle targets
     if(!motors.armed() || ap.throttle_zero) {
+        attitude_control.reset_angle_error_integrator();
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // slow start if landed
         if (ap.land_complete) {
@@ -43,7 +46,7 @@ void Copter::acro_run()
     pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->control_in);
 
     // run attitude controller
-    attitude_control.rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+    attitude_control.rate_bf_roll_pitch_yaw_integrated(target_roll, target_pitch, target_yaw);
 
     // output pilot's throttle without angle boost
     attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -14,9 +14,7 @@ bool Copter::acro_init(bool ignore_checks)
        return false;
    }
 
-   if (g.acro_trainer == ACRO_TRAINER_DIRECT) {
-       attitude_control.reset_angle_error_integrator();
-   }
+   attitude_control.reset_angle_error_integrator();
 
    // set target altitude to zero for reporting
    pos_control.set_alt_target(0);
@@ -34,9 +32,7 @@ void Copter::acro_run()
 
     // if motors not running reset angle targets
     if(!motors.armed() || ap.throttle_zero) {
-        if (g.acro_trainer == ACRO_TRAINER_DIRECT) {
-            attitude_control.reset_angle_error_integrator();
-        }
+        attitude_control.reset_angle_error_integrator();
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // slow start if landed
         if (ap.land_complete) {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -152,6 +152,7 @@ enum tuning_func {
 #define ACRO_TRAINER_DISABLED   0
 #define ACRO_TRAINER_LEVELING   1
 #define ACRO_TRAINER_LIMITED    2
+#define ACRO_TRAINER_DIRECT     3
 
 // RC Feel roll/pitch definitions
 #define RC_FEEL_RP_VERY_SOFT        0

--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -18,6 +18,10 @@ bool Copter::heli_acro_init(bool ignore_checks)
     // set stab collective false to use full collective pitch range
     input_manager.set_use_stab_col(false);
 
+    if (g.acro_trainer == ACRO_TRAINER_DIRECT) {
+        attitude_control.reset_angle_error_integrator();
+    }
+    
     // always successfully enter acro
     return true;
 }
@@ -61,8 +65,13 @@ void Copter::heli_acro_run()
             target_yaw = channel_yaw->pwm_to_angle_dz(0);
         }
 
-        // run attitude controller
-        attitude_control.rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+        if (g.acro_trainer == ACRO_TRAINER_DIRECT) {
+            // run direct controller
+            attitude_control.rate_bf_roll_pitch_yaw_integrated(target_roll, target_pitch, target_yaw);
+        } else {
+            // run attitude controller
+            attitude_control.rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+        }
     }else{
         /*
           for fly-bar passthrough use control_in values with no

--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -18,9 +18,7 @@ bool Copter::heli_acro_init(bool ignore_checks)
     // set stab collective false to use full collective pitch range
     input_manager.set_use_stab_col(false);
 
-    if (g.acro_trainer == ACRO_TRAINER_DIRECT) {
-        attitude_control.reset_angle_error_integrator();
-    }
+    attitude_control.reset_angle_error_integrator();
     
     // always successfully enter acro
     return true;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -471,10 +471,12 @@ void AC_AttitudeControl::rate_bf_roll_pitch_yaw_integrated(float roll_rate_bf, f
     update_rate_bf_targets();
 
     // just for logging:
+    // _angle_err_quat is rotation from current angle to desired angle
+    // angle_target_quat is rotation from 0,0,0 to estimated copter orientation
     Quaternion angle_target_quat;
     angle_target_quat.from_rotation_matrix(_ahrs.get_dcm_matrix());
     angle_target_quat *= _angle_err_quat;
-    angle_target_quat.to_axis_angle(_angle_ef_target);
+    angle_target_quat.to_euler(_angle_ef_target.x,_angle_ef_target.y,_angle_ef_target.z);
     _angle_ef_target *= degrees(1.0f)*100.0f;
 }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -478,6 +478,8 @@ void AC_AttitudeControl::rate_bf_roll_pitch_yaw_integrated(float roll_rate_bf, f
     angle_target_quat *= _angle_err_quat;
     angle_target_quat.to_euler(_angle_ef_target.x,_angle_ef_target.y,_angle_ef_target.z);
     _angle_ef_target *= degrees(1.0f)*100.0f;
+
+    _rate_bf_target += _rate_bf_desired;
 }
 
 //

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -457,6 +457,13 @@ void AC_AttitudeControl::rate_bf_roll_pitch_yaw_integrated(float roll_rate_bf, f
     // compute angle_bf_error
     _angle_err_quat.to_axis_angle(_angle_bf_error);
 
+    static const float err_lim_rad = radians(AC_ATTITUDE_RATE_STAB_ACRO_OVERSHOOT_ANGLE_MAX*0.01f);
+    float angle_bf_error_mag = _angle_bf_error.length();
+    if (angle_bf_error_mag > err_lim_rad) {
+        _angle_bf_error *= err_lim_rad/angle_bf_error_mag;
+        _angle_err_quat.from_axis_angle(_angle_bf_error);
+    }
+
     // convert to centidegrees (kill it with fire)
     _angle_bf_error *= degrees(1.0f)*100.0f;
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -138,6 +138,9 @@ public:
     // rate_bf_roll_pitch_yaw - attempts to maintain a roll, pitch and yaw rate (all body frame)
     virtual void rate_bf_roll_pitch_yaw(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf);
 
+    void rate_bf_roll_pitch_yaw_integrated(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf);
+    void reset_angle_error_integrator();
+
     //
     // rate_controller_run - run lowest level body-frame rate controller and send outputs to the motors
     //      should be called at 100hz or more
@@ -306,6 +309,10 @@ protected:
 
     // throttle based angle limits
     LowPassFilterFloat  _throttle_in_filt;      // throttle input from pilot or alt hold controller
+
+
+    // quaternion controller
+    Quaternion          _angle_err_quat;
 };
 
 #define AC_ATTITUDE_CONTROL_LOG_FORMAT(msg) { msg, sizeof(AC_AttitudeControl::log_Attitude),	\


### PR DESCRIPTION
This adds a new ACRO_TRAINER=3 option which uses the quaternion acro mode from Jon which is independent of the EKF attitude solution. This makes it a great recovery mode, especially for helicopters. 
I have done several flights with this on a 250 sized quad with good results
