### PR TITLE
[WIP] Copter: add guided_optical_track

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -38,7 +38,7 @@
 
 // features below are disabled by default on all boards
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
-//#define PRECISION_LANDING     ENABLED             // enable precision landing using companion computer or IRLock sensor
+#define PRECISION_LANDING     ENABLED             // enable precision landing using companion computer or IRLock sensor
 //#define GNDEFFECT_COMPENSATION ENABLED            // enable ground effect compensation for barometer (if propwash interferes with the barometer on the ground)
 
 // other settings

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -757,6 +757,7 @@ private:
     void guided_vel_control_start();
     void guided_posvel_control_start();
     void guided_angle_control_start();
+    void guided_optical_track_control_start();
     void guided_set_destination(const Vector3f& destination);
     void guided_set_velocity(const Vector3f& velocity);
     void guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity);
@@ -767,6 +768,7 @@ private:
     void guided_vel_control_run();
     void guided_posvel_control_run();
     void guided_angle_control_run();
+    void guided_optical_track_control_run();
     void guided_limit_clear();
     void guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
     void guided_limit_init_time_and_pos();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1798,6 +1798,11 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             // configure or release parachute
             result = MAV_RESULT_ACCEPTED;
             copter.precland.handle_msg(msg);
+
+            // If vehicle is in Guided, set the Guided mode to Guided_Optical_Track
+            if (copter.control_mode == GUIDED && copter.guided_mode != Guided_Optical_Track) {
+                copter.guided_optical_track_control_start();
+            }
 #endif
 
 #if CAMERA == ENABLED

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -186,6 +186,7 @@ enum GuidedMode {
     Guided_Velocity,
     Guided_PosVel,
     Guided_Angle,
+    Guided_Optical_Track,
 };
 
 // RTL states


### PR DESCRIPTION
@rmackay9 
Trying to fix #3344. The idea is that if I'm in Guided, then sending a `LANDING_TARGET` should change to a new guided submode which should make the copter hover over the target.  In SITL, I send a few `LANDING_TARGET`s with the script below.  The copter goes in the wrong direction and doesn't stop.  It speeds up until there are EKF problems and it dies.  Am I missing some initialization thing for pos_control?

```
#!/usr/bin/python2
import time
from dronekit import connect, VehicleMode

vehicle = connect('udpin:0.0.0.0:14550',wait_ready=False)

def send_land_message(x, y):
    msg = vehicle.message_factory.landing_target_encode(
        0,       # time_boot_ms (not used)
        0,       # target num
        0,       # frame
        x,
        y,
        0,       #altitude.  Not supported.
        0,0)     # size of target in radians
    vehicle.send_mavlink(msg)
    vehicle.flush()

for i in range(5):
    send_land_message(1,1)
    time.sleep(0.25)
```
