### PR TITLE
Plane: Add FENCE_ACTION DisarmMotor and new FENCE_AUTOENABLE options

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -842,13 +842,17 @@ void Plane::set_flight_stage(AP_SpdHgtControl::FlightStage fs)
         gcs_send_text_fmt(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude());
         auto_state.land_in_progress = true;
 #if GEOFENCE_ENABLED == ENABLED 
-        if (g.fence_autoenable == 1) {
+        if ((g.fence_autoenable == TAKEOFF_GFENABLE ||
+                                 g.fence_autoenable == AUTOMODE_GFENABLE) &&
+                                                       geofence_enabled()) {
             if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
                 gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
             } else {
                 gcs_send_text(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");
             }
-        } else if (g.fence_autoenable == 2) {
+        } else if ((g.fence_autoenable == TAKEOFF_NOFLOOR_GFENABLE ||
+                         g.fence_autoenable == AUTOMODE_NOFLOOR_GFENABLE) &&
+                                                       geofence_enabled()) {
             if (! geofence_set_floor_enabled(false)) {
                 gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
             } else {

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -410,8 +410,8 @@ const AP_Param::Info Plane::var_info[] = {
 #if GEOFENCE_ENABLED == ENABLED
     // @Param: FENCE_ACTION
     // @DisplayName: Action on geofence breach
-    // @Description: What to do on fence breach. If this is set to 0 then no action is taken, and geofencing is disabled. If this is set to 1 then the plane will enter GUIDED mode, with the target waypoint as the fence return point. If this is set to 2 then the fence breach is reported to the ground station, but no other action is taken. If set to 3 then the plane enters guided mode but the pilot retains manual throttle control. If set to 4 the plane enters RTL mode, with the target waypoint as the closest rally point (or home point if there are no rally points).
-    // @Values: 0:None,1:GuidedMode,2:ReportOnly,3:GuidedModeThrPass,4:RTL_Mode
+    // @Description: What to do on fence breach. If this is set to 0 then no action is taken, and geofencing is disabled. If this is set to 1 then the plane will enter GUIDED mode, with the target waypoint as the fence return point. If this is set to 2 then the fence breach is reported to the ground station, but no other action is taken. If set to 3 then the plane enters guided mode but the pilot retains manual throttle control. If set to 4 the plane enters RTL mode, with the target waypoint as the closest rally point (or home point if there are no rally points). If set to 5, after a fence breach lasting more than five seconds the flight mode is changed to STABILIZED and the motor is disarmed (glide to ground).
+    // @Values: 0:None,1:GuidedMode,2:ReportOnly,3:GuidedModeThrPass,4:RTL_Mode,5:DisarmMotor
     // @User: Standard
     GSCALAR(fence_action,           "FENCE_ACTION",   0),
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -456,8 +456,8 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: FENCE_AUTOENABLE
     // @DisplayName: Fence automatic enable
-    // @Description: When set to 1, geofence automatically enables after an auto takeoff and automatically disables at the beginning of an auto landing.  When on the ground before takeoff the fence is disabled.  When set to 2, the fence autoenables after an auto takeoff, but only disables the fence floor during landing. It is highly recommended to not use this option for line of sight flying and use a fence enable channel instead.
-    // @Values: 0:NoAutoEnable,1:AutoEnable,2:AutoEnableDisableFloorOnly
+    // @Description: When set to 1, geofence automatically enables after an auto takeoff and automatically disables at the beginning of an auto landing. When on the ground before takeoff the fence is disabled. When set to 2, the fence autoenables after an auto takeoff, but only disables the fence floor during landing. When set to 3, geofence automatically enables after the AUTO flight mode is engaged and automatically disables at the beginning of an auto landing. When set to 4, the fence autoenables after the AUTO flight mode is engaged, but only disables the fence floor during landing. When set to 5, geofence enables after the motor is armed (and does not automatically disable later). It is recommended to not use this option for line of sight flying and use a fence enable channel instead.
+    // @Values: 0:NoAutoEnable,1:AutoTakeoffEnable,2:AutoTakeoffEnableDisableFloorOnly,3:AutoModeEnable,4:AutoModeEnableDisableFloorOnly,5:MotorArmEnable
     // @User: Standard
     GSCALAR(fence_autoenable,       "FENCE_AUTOENABLE", 0),
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -156,9 +156,9 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
             }
         } else { //commanding to only disable floor
             if (! geofence_set_floor_enabled(false)) {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Unabled to disable fence floor");
+                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Unable to disable fence floor");
             } else {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Fence floor disabled");
+                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Fence floor disabled");
             }
         }    
 #endif
@@ -537,11 +537,13 @@ bool Plane::verify_takeoff()
         next_WP_loc = prev_WP_loc = current_loc;
 
 #if GEOFENCE_ENABLED == ENABLED
-        if (g.fence_autoenable > 0) {
+        if ((g.fence_autoenable == TAKEOFF_GFENABLE ||
+                          g.fence_autoenable == TAKEOFF_NOFLOOR_GFENABLE) &&
+                                                      !geofence_enabled()) {
             if (! geofence_set_enabled(true, AUTO_TOGGLED)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Enable fence failed (cannot autoenable");
+                gcs_send_text(MAV_SEVERITY_WARNING, "Enable fence failed (cannot autoenable");
             } else {
-                gcs_send_text(MAV_SEVERITY_INFO, "Fence enabled (autoenabled)");
+                gcs_send_text(MAV_SEVERITY_INFO, "Fence enabled by auto takeoff");
             }
         }
 #endif

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -91,8 +91,21 @@ typedef enum GeofenceEnableReason {
     NOT_ENABLED = 0,     //The fence is not enabled
     PWM_TOGGLED,         //Fence enabled/disabled by PWM signal
     AUTO_TOGGLED,        //Fence auto enabled/disabled at takeoff.
-    GCS_TOGGLED          //Fence enabled/disabled by the GCS via Mavlink
+    GCS_TOGGLED,         //Fence enabled/disabled by the GCS via Mavlink
+    ARM_ENABLED          //Fence enabled via motor arming
 } GeofenceEnableReason;
+
+/*
+ * Values for FENCE_AUTOENABLE
+ */
+enum GeofenceAutoEnableOption {
+    NO_AUTO_GFENABLE = 0,          //No auto enable
+    TAKEOFF_GFENABLE = 1,          //Enabled on auto-mode takeoff
+    TAKEOFF_NOFLOOR_GFENABLE = 2,  //Enabled on auto-mode takeoff, disable floor only
+    AUTOMODE_GFENABLE = 3,         //Enabled by auto-mode
+    AUTOMODE_NOFLOOR_GFENABLE = 4, //Enabled by auto-mode, disable floor only
+    ARM_GFENABLE = 5               //Enabled by arming
+};
 
 //repeating events
 #define NO_REPEAT 0


### PR DESCRIPTION
[![flyaway_track_s](https://cloud.githubusercontent.com/assets/3822131/12013694/422543d6-acea-11e5-9d77-a2c7c91acaff.jpg)](https://cloud.githubusercontent.com/assets/3822131/12013585/066cac0a-ace8-11e5-9ee4-9525ccd8456d.jpg)

I've been experimenting with APM:Plane autonomous flight using a lightweight foam airplane, and was having good results until one day I had a fly-away.  The plane could not complete one of its turns in the mission pattern, and instead flew off in a slow arc.  Part of the mission had the plane going inverted and doing rolls, so one possible explanation is that the accelerometer lost its zero-level position.  Other possibilities are that the flight-controller board mount came loose, or there was some kind of mechanical issue with the control surfaces.

Whatever the cause, it's clear that the flight controller did not have a good fallback response to the sensor and GPS input, which was showing that the plane was way off course.  So, I've been working on modifications to improve this, and this "FenceActionDisarm" patch is one of two that I've implemented.  (See [here](https://github.com/diydrones/ardupilot/pull/3386) for the second patch.)

During the fly-away, the GPS position continued to be tracked and received via telemetry (see above [pic](https://cloud.githubusercontent.com/assets/3822131/12013585/066cac0a-ace8-11e5-9ee4-9525ccd8456d.jpg)).  If a geo-fence was in place, a breach would have been detected and the plane would have attempted to fly back to the return point, but it was already attempting (and failing) to fly back, so this wouldn't have helped.  What I see as needed is a new FENCE_ACTION option that can shut off the motor -- this can at least down the plane before it flies further away.

This patch adds a new FENCE_ACTION action called "DisarmMotor", where, after a geo-fence breach lasting more than five seconds is detected, the flight mode is changed to STABILIZED and the motor is disarmed.  The idea is to have the plane glide down to the ground as gently as possible.

When testing, I found that I really wanted options for having the geo-fence be automatically enabled when entering AUTO mode or when arming the motor, so I added the following options to the FENCE_AUTOENABLE setting:  AutoModeEnable, AutoModeEnableDisableFloorOnly, and MotorArmEnable.

Source and firmware files are also posted here:  http://www.etheli.com/APM/ArduPlane_FenceActDis_GPSfHdlr

I've successfully flown and tested this patch (applied to v3.5.3-release) on my lightweight foam airplane.  Below is a doc update.

--ET

---

Action on geofence breach (ArduPlane:FENCE_ACTION)

What to do on fence breach. If this is set to 0 then no action is taken, and geofencing is disabled. If this is set to 1 then the plane will enter GUIDED mode, with the target waypoint as the fence return point. If this is set to 2 then the fence breach is reported to the ground station, but no other action is taken. If set to 3 then the plane enters guided mode but the pilot retains manual throttle control. If set to 4 the plane enters RTL mode, with the target waypoint as the closest rally point (or home point if there are no rally points). If set to 5, after a fence breach lasting more than five seconds the flight mode is changed to STABILIZED and the motor is disarmed (glide to ground).

Value   Meaning
0   None
1   GuidedMode
2   ReportOnly
3   GuidedModeThrPass
4   RTL_Mode
5   DisarmMotor

---

Fence automatic enable (ArduPlane:FENCE_AUTOENABLE)

When set to 1, geofence automatically enables after an auto takeoff and automatically disables at the beginning of an auto landing. When on the ground before takeoff the fence is disabled. When set to 2, the fence autoenables after an auto takeoff, but only disables the fence floor during landing. When set to 3, geofence automatically enables after the AUTO flight mode is engaged and automatically disables at the beginning of an auto landing. When set to 4, the fence autoenables after the AUTO flight mode is engaged, but only disables the fence floor during landing. When set to 5, geofence enables after the motor is armed (and does not automatically disable later). It is recommended to not use this option for line of sight flying and use a fence enable channel instead.

Value   Meaning
0   NoAutoEnable
1   AutoTakeoffEnable
2   AutoTakeoffEnableDisableFloorOnly
3   AutoModeEnable
4   AutoModeEnableDisableFloorOnly
5   MotorArmEnable
