### PR TITLE
Plane: Add GPS_FAIL_ACTION and XTRACK_FAIL_LIM

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -674,6 +674,22 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     GSCALAR(gcs_heartbeat_fs_enabled, "FS_GCS_ENABL", GCS_FAILSAFE_OFF),
 
+    // @Param: GPS_FAIL_ACTION
+    // @DisplayName: Action on GPS Fail
+    // @Description: Action to be taken when a GPS failure is detected while in the AUTO, GUIDED, RTL or LOITER flight mode. A GPS failure is when its fix is lost for more than five seconds. If 0 then no action. If 1 then change to CIRCLE flight mode (and restore the previous flight mode if a GPS fix is regained). If 2 through 7 then change to CIRCLE flight mode for the given time, and then, if a GPS fix has not been regained, disarm the motor. If a GPS fix is regained then the previous flight mode is restored. If 8 then change to STABILIZED flight mode and disarm the motor immediately (glide to ground).
+    // @Values: 0:NoAction,1:Circle,2:Circle5SecDisarm,3:Circle10SecDisarm,4:Circle30SecDisarm,5:Circle1MinDisarm,6:Circle2MinDisarm,7:Circle5MinDisarm,8:DisarmMotor
+    // @User: Standard
+    GSCALAR(gps_fail_action,        "GPS_FAIL_ACTION", GPSFAIL_NO_ACTION),
+
+    // @Param: XTRACK_FAIL_LIM
+    // @DisplayName: Crosstrack Failure Limit
+    // @Description: When this setting is greater than zero, the fight mode is AUTO, GUIDED, RTL or LOITER, and the navigation crosstrack error (xtrack_error) is larger than this setting for more than five seconds, the action configured by GPS_FAIL_ACTION will be taken. The setting is specified in meters. A large crosstrack error can indicate sensor or mechanical failure. A value of 200 (meters) is effective for detecting failures.
+    // @Units: Meters
+    // @Range: 0 32767
+    // @Increment: 1
+    // @User: Standard
+    GSCALAR(xtrack_fail_lim,        "XTRACK_FAIL_LIM", 0),
+
     // @Param: FLTMODE_CH
     // @DisplayName: Flightmode channel
     // @Description: RC Channel to use for flight mode control

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -344,6 +344,9 @@ public:
         k_param_mixing_offset,
         k_param_dspoiler_rud_rate,
 
+        k_param_gps_fail_action,
+        k_param_xtrack_fail_lim,
+
         k_param_DataFlash = 253, // Logging Group
 
         // 254,255: reserved
@@ -526,6 +529,8 @@ public:
 #endif
     AP_Int16 gcs_pid_mask;
     AP_Int8 parachute_channel;
+    AP_Int8 gps_fail_action;
+    AP_Int16 xtrack_fail_lim;
 
     // RC channels
     RC_Channel rc_1;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -352,6 +352,13 @@ private:
     // before recording our home position (and executing a ground start if we booted with an air start)
     uint8_t ground_start_count = 5;
 
+    // Variables used by 'handle_gps_xtrk_failure()'
+    GPSFailCurrentState gps_fail_state = GPS_FAIL_NONE;    //state tracker
+    uint32_t last_handler_timems = 0;       //last GPS-fail time
+    uint32_t fail_start_timems = 0;         //saved fail start time
+    FlightMode prev_cntrl_mode = MANUAL;    //previous flight mode
+    int16_t circle_disarm_secs = 0;         //delay before disarm
+
     // true if we have a position estimate from AHRS
     bool have_position;
 
@@ -876,6 +883,7 @@ private:
     void autotune_restore(void);
     void autotune_enable(bool enable);
     bool fly_inverted(void);
+    bool current_control_mode_uses_GPS(void);
     void failsafe_short_on_event(enum failsafe_state fstype);
     void failsafe_long_on_event(enum failsafe_state fstype);
     void failsafe_short_off_event();
@@ -1009,6 +1017,8 @@ private:
     void calc_nav_roll();
     void calc_nav_pitch();
     void update_flight_stage();
+    GPSFailCurrentState handle_gps_xtrk_failure(bool gps_ok_flag,
+                    bool xtrk_ok_flag, GPSFailCurrentState hdlr_fail_state);
     void update_navigation();
     void set_flight_stage(AP_SpdHgtControl::FlightStage fs);
     bool is_flying(void);

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -162,3 +162,22 @@ bool Plane::fly_inverted(void)
     }
     return false;
 }
+
+/*
+  Returns true if current flight mode depends on GPS.
+ */
+bool Plane::current_control_mode_uses_GPS(void)
+{
+    switch (control_mode) {
+    case AUTO:
+        return true;
+    case RTL:
+        return true;
+    case GUIDED:
+        return true;
+    case LOITER:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -94,6 +94,31 @@ typedef enum GeofenceEnableReason {
     GCS_TOGGLED          //Fence enabled/disabled by the GCS via Mavlink
 } GeofenceEnableReason;
 
+/*
+ * Values for GPS_FAIL_ACTION
+ */
+enum GPSFailActions {
+    GPSFAIL_NO_ACTION = 0,          //No action on GPS failure
+    GPSFAIL_CIRCLE = 1,             //Change flight mode to CIRCLE
+    GPSFAIL_CIRCLE_5SECDISARM = 2,  //CIRCLE, disarm after 5 seconds
+    GPSFAIL_CIRCLE_10SECDISARM = 3, //CIRCLE, disarm after 10 seconds
+    GPSFAIL_CIRCLE_30SECDISARM = 4, //CIRCLE, disarm after 30 seconds
+    GPSFAIL_CIRCLE_1MINDISARM = 5,  //CIRCLE, disarm after 1 minute
+    GPSFAIL_CIRCLE_2MINDISARM = 6,  //CIRCLE, disarm after 2 minutes
+    GPSFAIL_CIRCLE_5MINDISARM = 7,  //CIRCLE, disarm after 5 minutes
+    GPSFAIL_DISARM_MOTOR = 8        //Disarm motor immediately
+};
+
+/*
+ * State values for 'handle_gps_xtrk_failure()'
+ */
+typedef enum GPSFailCurrentState {
+    GPS_FAIL_NONE = 0,       //no GPS failure action
+    GPS_FAIL_INITWAIT,       //initial wait after failure
+    GPS_FAIL_CIRCLING,       //flight mode changed to CIRCLE
+    GPS_FAIL_DISARMED        //motor disarmed
+} GPSFailCurrentState;
+
 //repeating events
 #define NO_REPEAT 0
 #define CH_5_TOGGLE 1


### PR DESCRIPTION
[![flyaway_xtrackerr_s](https://cloud.githubusercontent.com/assets/3822131/12013851/ccd0c3f4-aced-11e5-8205-b003ad3d9d0c.jpg)](https://cloud.githubusercontent.com/assets/3822131/12013842/96956600-aced-11e5-92dd-462a30f6ac23.jpg)

This "GPSFailHandler" patch is the second of two patches I've implemented for better APM:Plane handling of possible fly-away situations.  (See [here](https://github.com/diydrones/ardupilot/pull/3385) for the first patch.)  In tests that I've done with the current code, if the GPS fails (i.e., broken wire, lost fix) when flying in a GPS-dependent mode, the plane's heading becomes uncontrolled.

To address this, I've implemented a new parameter called GPS_FAIL_ACTION, which sets the action to be taken when a GPS failure is detected while in the AUTO, GUIDED, RTL or LOITER flight mode.  A GPS failure is when its data connection or its fix is lost for more than five seconds.  The available options are:  Enter the CIRCLE flight mode (indefinitely), enter the CIRCLE flight mode for a period of time and then disarm the motor, or disarm the motor immediately after a GPS failure is detected (after the five seconds).  While in CIRCLE mode, if a GPS fix is regained then the previous flight mode is restored.

When I had a fly-away while experimenting with APM:Plane autonomous flight, I noticed in the telemetry data that the 'xtrack_error' values clearly indicated when the problem occurred (see above [pic](https://cloud.githubusercontent.com/assets/3822131/12013842/96956600-aced-11e5-92dd-462a30f6ac23.jpg)).  To make use of this, I've also implemented a new parameter called XTRACK_FAIL_LIM:  When this setting is greater than zero, the fight mode is AUTO, GUIDED, RTL or LOITER, and the navigation crosstrack error (xtrack_error) is larger than this setting for more than five seconds, the action configured by GPS_FAIL_ACTION will be taken.  In my testing I found that an XTRACK_FAIL_LIM value of 200 is effective for detecting failures.

Source and firmware files are also posted here:  http://www.etheli.com/APM/ArduPlane_FenceActDis_GPSfHdlr

I've successfully flown and tested this patch (applied to v3.4.0-release) on my lightweight foam airplane.  This PR is applied to the v3.4.1dev "master" code as of 2015-12-24.  Below is a doc update.

For those who would like to test GPS failures, below is code that I used at the top of the 'update_GPS_10Hz()' function in the "ArduPlane.cpp" file.  When the RC channel 5 input is less than 1100, the GPS data connection is disabled:

```
    // *** temp DEBUG test ***
    static bool last_dtstflg = (hal.rcin->read(4) > 500 && hal.rcin->read(4) < 1100);
    bool dtstflg = (hal.rcin->read(4) > 500 && hal.rcin->read(4) < 1100);
    if (dtstflg != last_dtstflg) {
        gps.lock_port(0, dtstflg);
        last_dtstflg = dtstflg;
        if (dtstflg) {
            gcs_send_text(MAV_SEVERITY_WARNING,
                                            "DEBUG gps-fail simulate FAIL");
        } else {
            gcs_send_text(MAV_SEVERITY_WARNING,
                                            "DEBUG gps-fail simulate OK");
        }
    }
```

--ET

---

Action on GPS Fail (ArduPlane:GPS_FAIL_ACTION)

Action to be taken when a GPS failure is detected while in the AUTO, GUIDED, RTL or LOITER flight mode. A GPS failure is when its fix is lost for more than five seconds. If 0 then no action. If 1 then change to CIRCLE flight mode (and restore the previous flight mode if a GPS fix is regained). If 2 through 7 then change to CIRCLE flight mode for the given time, and then, if a GPS fix has not been regained, disarm the motor. If a GPS fix is regained then the previous flight mode is restored. If 8 then change to STABILIZED flight mode and disarm the motor immediately (glide to ground).

Value   Meaning
0   NoAction
1   Circle
2   Circle5SecDisarm
3   Circle10SecDisarm
4   Circle30SecDisarm
5   Circle1MinDisarm
6   Circle2MinDisarm
7   Circle5MinDisarm
8   DisarmMotor

---

Crosstrack Failure Limit (ArduPlane:XTRACK_FAIL_LIM)
When this setting is greater than zero, the fight mode is AUTO, GUIDED, RTL or LOITER, and the navigation crosstrack error (xtrack_error) is larger than this setting for more than five seconds, the action configured by GPS_FAIL_ACTION will be taken. The setting is specified in meters. A large crosstrack error can indicate sensor or mechanical failure. A value of 200 (meters) is effective for detecting failures.
