### PR TITLE
ArduCopter: send MISSION_ITEM_REACHED on guided mode (v2)

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -336,6 +336,8 @@ private:
 
     // Guided
     GuidedMode guided_mode;  // controls which controller is run (pos or vel)
+    GuidedMode guided_prev_mode;
+    bool guided_reached_notified; // has guided reached destination been notified?
 
     // RTL
     RTLState rtl_state;  // records state of rtl (initial climb, returning home, etc)
@@ -763,6 +765,7 @@ private:
     void guided_set_angle(const Quaternion &q, float climb_rate_cms);
     void guided_run();
     void guided_takeoff_run();
+    void guided_reached_destination_notify(bool check_altitude);
     void guided_pos_control_run();
     void guided_vel_control_run();
     void guided_posvel_control_run();

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -39,6 +39,7 @@ struct Guided_Limit {
 bool Copter::guided_init(bool ignore_checks)
 {
     if (position_ok() || ignore_checks) {
+        guided_reached_notified = false;
         // initialise yaw
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));
         // start in position control mode
@@ -212,6 +213,31 @@ void Copter::guided_set_angle(const Quaternion &q, float climb_rate_cms)
     guided_angle_state.update_time_ms = millis();
 }
 
+// guided_reached_destination_notify - notify if we've reached the destination
+// on guided mode - if we're taking off we consider altitude
+void Copter::guided_reached_destination_notify(bool check_altitude)
+{
+    bool reached_alt = true;
+
+    if (guided_prev_mode != guided_mode) {
+        guided_reached_notified = false;
+    }
+
+    if (check_altitude) {
+        const Vector3f& curr_pos = inertial_nav.get_position();
+        const Vector3f& target_pos = wp_nav.get_wp_destination();
+
+        if (curr_pos.z < target_pos.z) {
+            reached_alt = false;
+        }
+    }
+
+    if (reached_alt && wp_nav.reached_wp_destination() && !guided_reached_notified) {
+        gcs_send_mission_item_reached_message(0);
+        guided_reached_notified = true;
+    }
+}
+
 // guided_run - runs the guided controller
 // should be called at 100hz or more
 void Copter::guided_run()
@@ -222,11 +248,13 @@ void Copter::guided_run()
     case Guided_TakeOff:
         // run takeoff controller
         guided_takeoff_run();
+        guided_reached_destination_notify(true);
         break;
 
     case Guided_WP:
         // run position controller
         guided_pos_control_run();
+        guided_reached_destination_notify(false);
         break;
 
     case Guided_Velocity:
@@ -244,6 +272,8 @@ void Copter::guided_run()
         guided_angle_control_run();
         break;
     }
+
+    guided_prev_mode = guided_mode;
  }
 
 // guided_takeoff_run - takeoff in guided mode


### PR DESCRIPTION
## Changes
- v2 (since #3360):
  - upstream rebased;
  - fixed coding style - suggested by @magicrub;
## Rationale

This patch changes the ArduCopter to send MISSION_ITEM_REACHED message
for the cases of takeoff and way point navigation on guided mode.

With that, applications running on companion boards - for example -
controlling the drone's navigation would become way much simpler, not
having to calculate positioning and keeping track of commands, missions
and so on to be sure we've reached a destination and the next operation
should take place. APM holds all of that already, the user needs only to
be notified about.
