### PR TITLE
Copter:  Add precision landing status to telemetry

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -714,6 +714,15 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
 #endif
         break;
 
+    case MSG_LANDING_TARGET:
+#if PRECISION_LANDING == ENABLED
+        CHECK_PAYLOAD_SIZE(LANDING_TARGET);
+        if (copter.precland.enabled()) {
+            copter.precland.send_landing_target(chan);
+        }
+#endif
+        break;
+
     case MSG_GIMBAL_REPORT:
 #if MOUNT == ENABLED
         CHECK_PAYLOAD_SIZE(GIMBAL_REPORT);
@@ -982,6 +991,7 @@ GCS_MAVLINK::data_stream_send(void)
         send_message(MSG_EKF_STATUS_REPORT);
         send_message(MSG_VIBRATION);
         send_message(MSG_RPM);
+        send_message(MSG_LANDING_TARGET);
     }
 }
 

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -311,7 +311,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Precision Landing with companion computer or IRLock sensor
 #ifndef PRECISION_LANDING
- # define PRECISION_LANDING DISABLED
+ # define PRECISION_LANDING ENABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -390,7 +390,7 @@
  # define LAND_SPEED    50          // the descent speed for the final stage of landing in cm/s
 #endif
 #ifndef LAND_START_ALT
- # define LAND_START_ALT 1000         // altitude in cm where land controller switches to slow rate of descent
+ # define LAND_START_ALT 60000         // altitude in cm where land controller switches to slow rate of descent
 #endif
 #ifndef LAND_REQUIRE_MIN_THROTTLE_TO_DISARM
  # define LAND_REQUIRE_MIN_THROTTLE_TO_DISARM DISABLED  // we do not require pilot to reduce throttle to minimum before vehicle will disarm in AUTO, LAND or RTL

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -347,6 +347,12 @@ void Copter::auto_land_run()
 
     // process roll, pitch inputs
     wp_nav.set_pilot_desired_acceleration(roll_control, pitch_control);
+#if PRECISION_LANDING == ENABLED
+    // run precision landing
+    if (!ap.land_repo_active) {
+        wp_nav.shift_loiter_target(precland.get_target_shift(wp_nav.get_loiter_target()));
+    }
+#endif
 
     // run loiter controller
     wp_nav.update_loiter(ekfGndSpdLimit, ekfNavVelGainScaler);

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -184,7 +184,7 @@ void AC_PrecLand::calc_angles_and_pos(float alt_above_terrain_cm)
     // convert earth-frame angles to earth-frame position offset
     _target_pos_offset.x = alt*tanf(_ef_angle_to_target.x);
     _target_pos_offset.y = alt*tanf(_ef_angle_to_target.y);
-    _target_pos_offset.z = 0;  // not used
+    _target_pos_offset.z = alt;  // not used
 
     _have_estimate = true;
 }
@@ -196,4 +196,21 @@ void AC_PrecLand::handle_msg(mavlink_message_t* msg)
     if (_backend != NULL) {
         _backend->handle_msg(msg);
     }
+}
+
+// send landing target mavlink message to ground station
+void AC_PrecLand::send_landing_target(mavlink_channel_t chan) const
+{
+    float angle_x = _ef_angle_to_target.x, angle_y = _ef_angle_to_target.y, distance = _target_pos_offset.z;
+    if (!_have_estimate) {
+        angle_x = 0;
+        angle_y = 0;
+        distance = 0;
+    }
+    mavlink_msg_landing_target_send(chan,
+        AP_HAL::micros64(),
+        _have_estimate,
+        MAV_FRAME_GLOBAL_TERRAIN_ALT,
+        angle_x, angle_y, distance, 0.0, 0.0);
+
 }

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -7,6 +7,7 @@
 #include <AC_PID/AC_PI_2D.h>
 #include <AP_InertialNav/AP_InertialNav.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <stdint.h>
 
 // definitions
 #define AC_PRECLAND_SPEED_XY_DEFAULT            100.0f  // maximum horizontal speed
@@ -97,6 +98,8 @@ private:
 
     // internal variables
     float                       _dt;                // time difference (in seconds) between calls from the main program
+    uint32_t                    _last_updated;  //epoch time in millisecond when update is called
+    uint32_t                    _last_consumed; //epoch time in millisecond when  get_target_shift is called;
 
     // output from sensor (stored for logging)
     Vector2f                    _angle_to_target;   // last raw sensor angle to target

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -6,6 +6,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AC_PID/AC_PI_2D.h>
 #include <AP_InertialNav/AP_InertialNav.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 // definitions
 #define AC_PRECLAND_SPEED_XY_DEFAULT            100.0f  // maximum horizontal speed
@@ -69,6 +70,9 @@ public:
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
+
+    // send GCS_MAVLink message
+    void send_landing_target(mavlink_channel_t chan) const;
 
 private:
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -69,6 +69,7 @@ enum ap_message {
     MSG_VIBRATION,
     MSG_RPM,
     MSG_MISSION_ITEM_REACHED,
+    MSG_LANDING_TARGET,
     MSG_RETRY_DEFERRED // this must be last
 };
 


### PR DESCRIPTION
Issue #3348. If precision landing is enabled, arducopter publishes LANDING_TARGET MAVLINK message to ground stations.This should help debug precision landing sensors. 
