### PR TITLE
Fix implementation of _parse_decimal_100() in AP_GPS_NMEA

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -307,8 +307,36 @@ bool AP_GPS_NMEA::_term_complete()
                     state.ground_course_cd = wrap_360_cd(_new_course);
                     make_gps_time(_new_date, _new_time * 10);
                     state.last_gps_time_ms = AP_HAL::millis();
-                    // To-Do: add support for proper reporting of 2D and 3D fix
-                    state.status           = AP_GPS::GPS_OK_FIX_3D;
+                    // To-Do: add support for proper reporting of 2D and 3D fix (requires GPGSA messages)
+                    switch(_new_mode_indicator) {
+                    case 'A': // Autonomous mode
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
+                        break;
+                    case 'D': // Differential mode
+                        state.status = AP_GPS::GPS_OK_FIX_3D_DGPS;
+                        break;
+                    case 'F': // Float RTK  (specific for NV08C (not official NMEA 0813))
+                        state.status = AP_GPS::GPS_OK_FIX_3D_RTK;
+                        break;
+                    case 'R': // Real Time Kinematic (specific for NV08C (not official NMEA 0813))
+                        state.status = AP_GPS::GPS_OK_FIX_3D_RTK;
+                        break;
+                    case 'E': // Estimated (dead reckoning) mode
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
+                        break;
+                    case 'M': // Manual input mode
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    case 'S': // Simulator mode
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    case 'N': // Data not valid
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    default:
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    }
                     fill_3d_velocity();
                     break;
                 case _GPS_SENTENCE_GPGGA:
@@ -317,8 +345,39 @@ bool AP_GPS_NMEA::_term_complete()
                     state.location.lng  = _new_longitude;
                     state.num_sats      = _new_satellite_count;
                     state.hdop          = _new_hdop;
-                    // To-Do: add support for proper reporting of 2D and 3D fix
-                    state.status        = AP_GPS::GPS_OK_FIX_3D;
+                    // To-Do: add support for proper reporting of 2D and 3D fix (requires GPGSA messages)
+                    switch(_new_quality_indicator) {
+                    case 0: // Fix not available or invalid
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    case 1: // GPS SPS Mode, fix valid
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
+                        break;
+                    case 2: // Differential GPS, SPS Mode, fix valid
+                        state.status = AP_GPS::GPS_OK_FIX_3D_DGPS;
+                        break;
+                    case 3: // GPS PPS Mode, fix valid
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
+                        break;
+                    case 4: // Real Time Kinematic. System used in RTK mode with fixed integers
+                        state.status = AP_GPS::GPS_OK_FIX_3D_RTK;
+                        break;
+                    case 5: // Float RTK. Satellite system used in RTK mode, floating integers
+                        state.status = AP_GPS::GPS_OK_FIX_3D_RTK;
+                        break;
+                    case 6: // Estimated (dead reckoning) Mode
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
+                        break;
+                    case 7: // Manual Input Mode
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    case 8: // Simulator Mode
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    default:
+                        state.status = AP_GPS::NO_FIX;
+                        break;
+                    }
                     break;
                 case _GPS_SENTENCE_GPVTG:
                     state.ground_speed     = _new_speed*0.01f;
@@ -370,7 +429,21 @@ bool AP_GPS_NMEA::_term_complete()
         case _GPS_SENTENCE_GPRMC + 2: // validity (RMC)
             _gps_data_good = _term[0] == 'A';
             break;
+        case _GPS_SENTENCE_GPRMC + 12: // Mode indicator (RMC)
+            /* A = Autonomous mode
+             * D = Differential mode
+             * F = Float RTK  (specific for NV08C (not official NMEA 0813))
+             * R = Real Time Kinematic (specific for NV08C (not official NMEA 0813))
+             * E = Estimated (dead reckoning) mode
+             * M = Manual input mode
+             * S = Simulator mode
+             * N = Data not valid
+             */
+            _new_mode_indicator = _term[0];
+            _gps_data_good = ((_term[0] == 'A') || (_term[0] == 'D') || (_term[0] == 'F') || (_term[0] == 'R') || (_term[0] == 'E'));
+            break;
         case _GPS_SENTENCE_GPGGA + 6: // Fix data (GGA)
+            _new_quality_indicator = DIGIT_TO_VAL(_term[0]);
             _gps_data_good = _term[0] > '0';
             break;
         case _GPS_SENTENCE_GPVTG + 9: // validity (VTG) (we may not see this field)

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -191,17 +191,26 @@ int16_t AP_GPS_NMEA::_from_hex(char a)
         return a - '0';
 }
 
-uint32_t AP_GPS_NMEA::_parse_decimal_100()
+int32_t AP_GPS_NMEA::_parse_decimal_100()
 {
     char *p = _term;
-    uint32_t ret = 100UL * atol(p);
+    int32_t ret = 100UL * atol(p);
+    int32_t sign = 1;
+    if (*p == '+') ++p;
+    else if (*p == '-') {
+        ++p;
+        sign = -1;
+    }
     while (isdigit(*p))
         ++p;
     if (*p == '.') {
         if (isdigit(p[1])) {
-            ret += 10 * DIGIT_TO_VAL(p[1]);
-            if (isdigit(p[2]))
-                ret += DIGIT_TO_VAL(p[2]);
+            ret += sign * 10 * DIGIT_TO_VAL(p[1]);
+            if (isdigit(p[2])) {
+                ret += sign * DIGIT_TO_VAL(p[2]);
+                if (isdigit(p[3]))
+                    ret += sign * (DIGIT_TO_VAL(p[3]) >= 5);
+            }
         }
     }
     return ret;
@@ -371,7 +380,7 @@ bool AP_GPS_NMEA::_term_complete()
             _new_satellite_count = atol(_term);
             break;
         case _GPS_SENTENCE_GPGGA + 8: // HDOP (GGA)
-            _new_hdop = _parse_decimal_100();
+            _new_hdop = (uint16_t)_parse_decimal_100();
             break;
 
         // time and date

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -93,7 +93,7 @@ private:
     /// @returns		The value expressed by the string in _term,
     ///					multiplied by 100.
     ///
-    uint32_t    _parse_decimal_100();
+    int32_t    _parse_decimal_100();
 
     /// Parses the current term as a NMEA-style degrees + minutes
     /// value with up to four decimal digits.

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -138,6 +138,8 @@ private:
     int32_t _new_course;                                        ///< course parsed from a term
     uint16_t _new_hdop;                                                 ///< HDOP parsed from a term
     uint8_t _new_satellite_count;                       ///< satellite count parsed from a term
+    uint8_t _new_quality_indicator;                                     ///< GPS quality indicator parsed from a term
+    char _new_mode_indicator;                                           ///< GPS mode indicator parsed from a term
 
     uint32_t _last_GPRMC_ms = 0;
     uint32_t _last_GPGGA_ms = 0;


### PR DESCRIPTION
_parse_decimal_100() did not parse the fractional part for negative numbers. Furthermore, use the third decimal (when present) for proper rounding.