### PR TITLE
Plane: Motor spins while booting in AVR chips.

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -8,9 +8,6 @@
 
 class AP_HAL::Util {
 public:
-    // soft_armed starts out true
-    Util() : soft_armed(true), capabilities(0) {}
-
     int snprintf(char* str, size_t size,
                  const char *format, ...);
 
@@ -85,8 +82,11 @@ public:
     virtual AP_HAL::Stream *get_shell_stream() { return NULL; }
 
 protected:
-    bool soft_armed;
-    uint64_t capabilities;
+    // we start soft_armed false, so that actuators don't send any 
+    // values until the vehicle code has fully started 
+    bool soft_armed = false; 
+    uint64_t capabilities = 0; 
+
 };
 
 #endif // __AP_HAL_UTIL_H__


### PR DESCRIPTION
Hello everyone,

The current version of the Util.h file in the AVR-Stable Release branch can cause serious personal injury. If you are using arm/disarm options and you connect your battery to APM1 / APM2, it will turn on your engine if your TX RC radio is off. PLEASE, UPGRADE OFFICIAL AVR BRANCH WITH THIS PATCH.

Regards from Spain,
Dario.