### PR TITLE
Notify about saturated motor outputs

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -441,6 +441,7 @@ private:
     uint32_t control_sensors_present;
     uint32_t control_sensors_enabled;
     uint32_t control_sensors_health;
+    uint16_t motor_limits;
     
     // Altitude
     // The cm/s we are moving up or down based on filtered data - Positive = UP

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -129,7 +129,8 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
         battery_remaining,      // in %
         0, // comm drops %,
         0, // comm drops in pkts,
-        0, 0, 0, 0);
+	motor_limits,
+        0, 0, 0);
 }
 
 void NOINLINE Copter::send_location(mavlink_channel_t chan)

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -349,6 +349,7 @@ void Copter::update_sensor_status_flags(void)
     // set motors outputs as enabled if safety switch is not disarmed (i.e. either NONE or ARMED)
     if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS;
+	motor_limits =  (motors->limit.motor_upper << AP_MOTORS_MAX_NUM_MOTORS) | motors->limit.motor_lower;
     }
 
     if (copter.DataFlash.logging_enabled()) {

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -166,6 +166,10 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     float   unused_range;               // amount of yaw we can fit in the current channel
     float   thr_adj;                    // the difference between the pilot's desired throttle and throttle_thrust_best_rpy
 
+    // init motor limit flags
+    limit.motor_upper = 0;
+    limit.motor_lower = 0;
+
     // apply voltage and air pressure compensation
     roll_thrust = _roll_in * get_compensation_gain();
     pitch_thrust = _pitch_in * get_compensation_gain();
@@ -287,6 +291,13 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             _thrust_rpyt_out[i] = constrain_float(_thrust_rpyt_out[i], 0.0f, 1.0f);
+            if (_thrust_rpyt_out[i] > 1-_thr_warn_threshold) {
+                limit.motor_upper |= (1<<i);
+            }
+            else if (_thrust_rpyt_out[i] < _thr_warn_threshold) {
+                limit.motor_lower |= (1<<i);
+            }
+
         }
     }
 }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -163,6 +163,14 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SPOOL_TIME",   36, AP_MotorsMulticopter,  _spool_up_time, AP_MOTORS_SPOOL_UP_TIME_DEFAULT),
     
+    // @Param: THR_WARN
+    // @DisplayName: Throttle Warn range
+    // @Description: Warn, if a motor output signal is closer than THR_WARN percent to minimum or maximum throttle in flight. 0 disables warning.
+    // @Range: 0 1
+    // @Units: 1
+    // @User: Advanced
+    AP_GROUPINFO("THR_WARN", 37, AP_MotorsMulticopter, _thr_warn_threshold, AP_MOTORS_THR_WARN_DEFAULT),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -26,6 +26,11 @@
 #define AP_MOTORS_BAT_CURR_TC_DEFAULT   5.0f    // Time constant used to limit the maximum current
 #define AP_MOTORS_BATT_VOLT_FILT_HZ     0.5f    // battery voltage filtered at 0.5hz
 
+#define AP_MOTORS_THR_MIX_MIN_DEFAULT   0.1f    // minimum throttle mix
+#define AP_MOTORS_THR_MIX_MID_DEFAULT   0.5f    // manual throttle mix
+#define AP_MOTORS_THR_MIX_MAX_DEFAULT   0.5f    // maximum throttle mix default
+#define AP_MOTORS_THR_WARN_DEFAULT      0.1f    // output warning threshould (default: warning disabled)
+
 // spool definition
 #define AP_MOTORS_SPOOL_UP_TIME_DEFAULT 0.5f    // time (in seconds) for throttle to increase from zero to min throttle, and min throttle to full throttle.
 
@@ -162,6 +167,7 @@ protected:
     AP_Float            _throttle_hover;        // estimated throttle required to hover throttle in the range 0 ~ 1
     AP_Int8             _throttle_hover_learn;  // enable/disabled hover thrust learning
     AP_Int8             _disarm_disable_pwm;    // disable PWM output while disarmed
+    AP_Float            _thr_warn_threshold;    // motor output warning threshould
 
     // Maximum lean angle of yaw servo in degrees. This is specific to tricopter
     AP_Float            _yaw_servo_angle_max_deg;

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -56,6 +56,8 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     limit.yaw = true;
     limit.throttle_lower = true;
     limit.throttle_upper = true;
+    limit.motor_lower = 0;
+    limit.motor_upper = 0;
 };
 
 void AP_Motors::armed(bool arm)

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -115,6 +115,8 @@ public:
         uint8_t yaw             : 1; // we have reached yaw limit
         uint8_t throttle_lower  : 1; // we have reached throttle's lower limit
         uint8_t throttle_upper  : 1; // we have reached throttle's upper limit
+        uint8_t motor_lower     : AP_MOTORS_MAX_NUM_MOTORS; // a certain motor has reached the lower warning threshold
+        uint8_t motor_upper     : AP_MOTORS_MAX_NUM_MOTORS; // a certain motor has reached the upper warning threshold
     } limit;
 
     //


### PR DESCRIPTION
Send warning to the pilot when a single motor aproaches low or high output limit. The limit is configurable by a new parameter MOT_THR_WARN. The rate of warnings is limited to one per second. 

Fixes #2666
