### PR TITLE
Compensate long-term baro drift

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -195,6 +195,14 @@ void Copter::barometer_accumulate(void)
     barometer.accumulate();
 }
 
+/*
+  adjust baro for changing air pressure
+ */
+void Copter::barometer_adjust(void)
+{
+    barometer.update_alt_target(pos_control->get_alt_target()*0.01f);
+}
+
 void Copter::perf_update(void)
 {
     if (should_log(MASK_LOG_PM))
@@ -519,6 +527,9 @@ void Copter::one_hz_loop()
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
     update_sensor_status_flags();
+
+    // update barometer drift compensation
+    barometer_adjust();
 }
 
 // called at 50hz
@@ -557,6 +568,7 @@ void Copter::update_GPS(void)
 #endif
         }
     }
+    barometer.update_gps_alt(float(gps.location().alt)*0.01f);
 }
 
 void Copter::init_simple_bearing()

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -625,6 +625,7 @@ private:
     void compass_accumulate(void);
     void compass_cal_update(void);
     void barometer_accumulate(void);
+    void barometer_adjust(void);
     void perf_update(void);
     void fast_loop();
     void rc_loop();

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -49,6 +49,9 @@ bool Copter::set_home_to_current_location() {
 bool Copter::set_home_to_current_location_and_lock()
 {
     if (set_home_to_current_location()) {
+        // tell barometer about GPS altitude (for air pressure drift compensation)
+        barometer.set_home_alt(gps.location().alt*0.01f);
+
         set_home_state(HOME_SET_AND_LOCKED);
         return true;
     }
@@ -78,6 +81,9 @@ bool Copter::set_home(const Location& loc)
 
     // set ahrs home (used for RTL)
     ahrs.set_home(loc);
+
+    // tell barometer about HOME altitude (for air pressure drift compensation)
+    barometer.set_home_alt(loc.alt*0.01f);
 
     // init inav and compass declination
     if (ap.home_state == HOME_UNSET) {

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -149,6 +149,24 @@ public:
     // get baro drift amount
     float get_baro_drift_offset(void) { return _alt_offset_active; }
 
+    // update altitude_target
+    // alt_target: meters above home
+    void update_alt_target(float alt_target);
+
+
+    // store and buffer a single GPS alt reading
+    // gps_alt: GPS altitude in meters (AMSL)
+    void update_gps_alt(float gps_alt);
+
+    // set altitude reference (in meters)
+    void set_home_alt(float gps_alt);
+
+    // current alt_offset (in meters)
+    float get_offset() { return _alt_offset.get(); }
+
+    // current filtered gps altitude
+    float get_gps() { return _gps_alt_over_home.get(); }
+
 private:
     // how many drivers do we have?
     uint8_t _num_drivers;
@@ -176,6 +194,9 @@ private:
     float                               _alt_offset_active;
     AP_Int8                             _primary_baro; // primary chosen by user
     AP_Int8                             _ext_bus; // bus number for external barometer
+    AP_Float                            _adj_step;
+    AP_Int16                            _adj_delay;
+    AP_Int16                            _adj_timeconstant;
     float                               _last_altitude_EAS2TAS;
     float                               _EAS2TAS;
     float                               _external_temperature;
@@ -188,6 +209,10 @@ private:
 
     // when did we last notify the GCS of new pressure reference?
     uint32_t                            _last_notify_ms;
+    float                               _home_alt;          // GPS altitude of HOME in meters
+    float                               _last_alt_target;          // alt target above home in meters
+    uint16_t                            _adj_sample_count;         // GPS samples to pass before adjustment starts
+    LowPassFilterFloat                  _gps_alt_over_home;        // GPS alt over home in meters
 
     void SimpleAtmosphere(const float alt, float &sigma, float &delta, float &theta);
     bool _add_backend(AP_Baro_Backend *backend);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -785,6 +785,8 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
         sample_time_ms: baro.get_last_update(0),
         drift_offset  : drift_offset,
         ground_temp   : ground_temp,
+        correction       : baro.get_offset(),
+        gpsalt_over_home : baro.get_gps()
     };
     WriteBlock(&pkt, sizeof(pkt));
 
@@ -799,6 +801,8 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
             sample_time_ms: baro.get_last_update(1),
             drift_offset  : drift_offset,
             ground_temp   : ground_temp,
+            correction       : baro.get_offset(),
+            gpsalt_over_home : baro.get_gps()
         };
         WriteBlock(&pkt2, sizeof(pkt2));
     }
@@ -814,6 +818,8 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
             sample_time_ms: baro.get_last_update(2),
             drift_offset  : drift_offset,
             ground_temp   : ground_temp,
+            correction       : baro.get_offset(),
+            gpsalt_over_home : baro.get_gps()
         };
         WriteBlock(&pkt3, sizeof(pkt3));
     }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -192,6 +192,8 @@ struct PACKED log_BARO {
     uint32_t sample_time_ms;
     float   drift_offset;
     float   ground_temp;
+    float   correction;
+    float   gpsalt_over_home;
 };
 
 struct PACKED log_AHRS {
@@ -758,8 +760,8 @@ struct PACKED log_Rally {
 #define ACC_FMT "QQfff"
 
 // see "struct sensor" in AP_Baro.h and "Log_Write_Baro":
-#define BARO_LABELS "TimeUS,Alt,Press,Temp,CRt,SMS,Offset,GndTemp"
-#define BARO_FMT   "QffcfIff"
+#define BARO_LABELS "TimeUS,Alt,Press,Temp,CRt,SMS,Offset,GndTemp,Corr,GpsOH"
+#define BARO_FMT   "QffcfIffff"
 
 #define ESC_LABELS "TimeUS,RPM,Volt,Curr,Temp"
 #define ESC_FMT   "Qcccc"


### PR DESCRIPTION
This PR slowly corrects the barometric base altitude (ALT_OFFSET parameter) during flight using a low pass filtered signal derived from GPS altitude. 

Correcting the base altitude is important during long AUTO missings, otherwise the actual flight altitude above home slowly drifts away from the altitude target. I have regularly seen drifts of more then 20m per hour of flight. This could easily lead to a violation of protected air spaces or to controlled flight into terrain.

The compensation starts after a certain period of flight with constant alt target (configurable by parameter ADJ_DELAY). The rate of compensation (paramter ADJ_RATE) and the time constant for filtering the GPS altitude (parameter ADJ_TC) are configurable as well. The compensation is disabled by default and has to be enabled by the user by setting a non-zero ADJ_RATE.

Fixes https://github.com/diydrones/ardupilot/issues/2022 . 
