### PR TITLE
Plane: make the initialization of the gcs instances follow the define

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -144,14 +144,10 @@ void Plane::init_ardupilot()
     usb_connected = true;
     check_usb_mux();
 
-    // setup serial port for telem1
-    gcs[1].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
-
-    // setup serial port for telem2
-    gcs[2].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 1);
-
-    // setup serial port for fourth telemetry port (not used by default)
-    gcs[3].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 2);
+    // setup all other telem slots with  serial ports
+    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
+        gcs[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, (i - 1));
+    }
 
     // setup frsky
 #if FRSKY_TELEM_ENABLED == ENABLED


### PR DESCRIPTION
Use a for loop rather then explicitly initing all the serial ports, which means that it aligns better with the MAVLINK_COMM_NUM_BUFFERS define that is used to specify the size of the gcs array.

Orginally noted by @kwikius in #3545. It also saves something like 16 bytes of flash (not that I think thats a real problem here).