### PR TITLE
AP_GPS: improve GPS switching logic to reduce switch frequency

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -424,11 +424,12 @@ AP_GPS::update(void)
 
         switch (_auto_switch) {
         default:
-        case 0: // auto-switch disabled, always use GPS1 as primary
+        case GPS_AUTO_SWITCH_DISABLED:
+            // auto-switch disabled, always use GPS1 as primary
             primary_instance = 0;
             break;
 
-        case 1: // Use the better lock
+        case GPS_AUTO_SWITCH_BETTER_LOCK:
             if (state[0].status > state[1].status) {
                 // there is a higher status lock, change GPS
                 primary_instance = 0;
@@ -438,7 +439,7 @@ AP_GPS::update(void)
             }
             break;
 
-        case 2: // Treat GPS2 as backup
+        case GPS_AUTO_SWITCH_GPS2_AS_BACKUP:
             if (state[0].status >= GPS_OK_FIX_3D || // GPS1 has a lock
                     state[0].status >= state[1].status || // GPS1 lock >= GPS2 lock
                     timing[0].last_fix_time_ms == 0) { // GPS1 has never locked before. GPS2 is an in-flight backup, not pre-flight backup.

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -101,6 +101,13 @@ public:
        GPS_ALL_CONFIGURED = 255
    };
 
+   // GPS auto-switching modes
+   enum GPS_Auto_Switch {
+       GPS_AUTO_SWITCH_DISABLED = 0,
+       GPS_AUTO_SWITCH_BETTER_LOCK = 1,
+       GPS_AUTO_SWITCH_GPS2_AS_BACKUP = 2
+   };
+
     /*
       The GPS_State structure is filled in by the backend driver as it
       parses each message from the GPS.

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -369,6 +369,8 @@ private:
 
     /// primary GPS instance
     uint8_t primary_instance:2;
+    uint8_t primary_instance_change_request:2;
+    uint32_t primary_instance_change_debounce_ms;
 
     /// number of GPS instances present
     uint8_t num_instances:2;


### PR DESCRIPTION
param "GPS_AUTO_SWITCH" now has a 3rd option
- 0:Disabled,1:Use the better lock,2:Treat GPS2 as backup

follow along here: https://github.com/diydrones/ardupilot/issues/3754