### PR TITLE
DataFlash: log parameter changes while disarmed even if MASK_LOG_WHEN…

### DIFF
--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -441,7 +441,19 @@ void DataFlash_Class::Log_Write_Mode(uint8_t mode, uint8_t reason)
 
 void DataFlash_Class::Log_Write_Parameter(const char *name, float value)
 {
+    bool writes_disabled = false;
+    if (_next_backend != 0) {
+	writes_disabled = !backends[0]->GetWritesEnabled();
+    }
+    if (writes_disabled) {
+	// temporary enable writes
+	EnableWrites(true);
+    }
     FOR_EACH_BACKEND(Log_Write_Parameter(name, value));
+    if (writes_disabled) {
+	// disable writes if disabled before
+	EnableWrites(false);
+    }
 }
 
 void DataFlash_Class::Log_Write_Mission_Cmd(const AP_Mission &mission,

--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -52,6 +52,7 @@ public:
     virtual void ListAvailableLogs(AP_HAL::BetterStream *port) = 0;
 
     void EnableWrites(bool enable) { _writes_enabled = enable; }
+    bool GetWritesEnabled() { return _writes_enabled; }
     virtual bool logging_started(void) const { return log_write_started; }
 
     virtual void Init() {


### PR DESCRIPTION
…_DISARMED is not set

Fixes #3778
