### PR TITLE
Frsky: improve capabilies and compatibility of Smart Port implementation

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -494,7 +494,7 @@ bool Rover::should_log(uint32_t mask)
 #if FRSKY_TELEM_ENABLED == ENABLED
 void Rover::frsky_telemetry_send(void)
 {
-    frsky_telemetry.send_frames((uint8_t)control_mode);
+    frsky_telemetry.send_frames((uint8_t)control_mode, arming.is_armed());
 }
 #endif
 

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -61,7 +61,7 @@ Copter::Copter(void) :
     loiter_time_max(0),
     loiter_time(0),
 #if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry(ahrs, battery),
+    frsky_telemetry(ahrs, battery, &barometer),
 #endif
     climb_rate(0),
     sonar_alt(0),

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -431,7 +431,7 @@ void Copter::check_usb_mux(void)
 #if FRSKY_TELEM_ENABLED == ENABLED
 void Copter::frsky_telemetry_send(void)
 {
-    frsky_telemetry.send_frames((uint8_t)control_mode);
+    frsky_telemetry.send_frames((uint8_t)control_mode, motors.armed());
 }
 #endif
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -383,7 +383,7 @@ private:
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry {ahrs, battery};
+    AP_Frsky_Telem frsky_telemetry {ahrs, battery, &barometer};
 #endif
 
     // Airspeed Sensors

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -766,7 +766,7 @@ bool Plane::should_log(uint32_t mask)
 #if FRSKY_TELEM_ENABLED == ENABLED
 void Plane::frsky_telemetry_send(void)
 {
-    frsky_telemetry.send_frames((uint8_t)control_mode);
+    frsky_telemetry.send_frames((uint8_t)control_mode, arming.is_armed());
 }
 #endif
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -303,10 +303,10 @@ void AP_Frsky_Telem::sport_tick(void)
                 if (_battery_data_ready) {
                     switch (_fas_call) {
                     case 0:
-                        send_batt_volts();
+                        send_smart_batt_volts();
                         break;
                     case 1:
-                        send_current();
+                        send_smart_current();
                         break;
                     }
                     _fas_call++;
@@ -681,6 +681,25 @@ void AP_Frsky_Telem::send_batt_volts(void)
 void AP_Frsky_Telem::send_current(void)
 {
     frsky_send_data(FRSKY_ID_CURRENT, _batt_amps);
+}
+
+
+/*
+ * send battery voltage, Smart Port format
+ */
+void AP_Frsky_Telem::send_smart_batt_volts(void)
+{
+    // battery voltage * 100 (already multiplied by 10 previously)
+    int32_t volts = (int)_batt_volts*10;
+    frsky_send_data_smart(SMARTPORT_ID_VFAS, volts);
+}
+
+/*
+ * send current consumptiom, Smart Port format
+ */
+void AP_Frsky_Telem::send_smart_current(void)
+{
+    frsky_send_data_smart(SMARTPORT_ID_CURR, (int32_t)_batt_amps);
 }
 
 /*

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -80,6 +80,9 @@ extern const AP_HAL::HAL& hal;
 #define SMARTPORT_ID_GPS_SPD       0x0830
 #define SMARTPORT_ID_GPS_CRS       0x0840
 #define SMARTPORT_ID_GPS_TIME      0x0850
+#define SMARTPORT_ID_ADC3          0x0900
+#define SMARTPORT_ID_ADC4          0x0910
+
 
 // Default sensor data IDs (Physical IDs + CRC)
 #define DATA_ID_VARIO            0x00 // 0
@@ -376,9 +379,12 @@ void AP_Frsky_Telem::sport_tick(void)
                         _mode_data_ready = false;
                     }
                     break;
+                case 2:
+                    send_smart_attitude();
+                    break;
                 }
                 _various_call++;
-                if (_various_call > 1) {
+                if (_various_call > 2) {
                     _various_call = 0;
                 }
                 break;
@@ -680,6 +686,18 @@ void AP_Frsky_Telem::send_smart_vario(void)
         int32_t vario = _baro->get_climb_rate()*100;
         frsky_send_data_smart(SMARTPORT_ID_VARIO, vario);
     }
+}
+
+/*
+ * send attitude, Smart Port format
+ */
+void AP_Frsky_Telem::send_smart_attitude(void)
+{
+    // transmit pitch angle in deg*100
+    uint32_t pitch = _ahrs.pitch_sensor+18000;
+    uint32_t roll  = _ahrs.roll_sensor+18000;
+    uint32_t attitude = (roll << 16) | pitch;
+    frsky_send_data_smart(SMARTPORT_ID_ADC3, attitude);
 }
 
 /*

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -23,6 +23,52 @@
 #include "AP_Frsky_Telem.h"
 extern const AP_HAL::HAL& hal;
 
+/* FrSky sensor hub data IDs */
+#define FRSKY_ID_GPS_ALT_BP     0x01
+#define FRSKY_ID_TEMP1          0x02
+#define FRSKY_ID_RPM            0x03
+#define FRSKY_ID_FUEL           0x04
+#define FRSKY_ID_TEMP2          0x05
+#define FRSKY_ID_VOLTS          0x06
+#define FRSKY_ID_GPS_ALT_AP     0x09
+#define FRSKY_ID_BARO_ALT_BP    0x10
+#define FRSKY_ID_GPS_SPEED_BP   0x11
+#define FRSKY_ID_GPS_LONG_BP    0x12
+#define FRSKY_ID_GPS_LAT_BP     0x13
+#define FRSKY_ID_GPS_COURS_BP   0x14
+#define FRSKY_ID_GPS_DAY_MONTH  0x15
+#define FRSKY_ID_GPS_YEAR       0x16
+#define FRSKY_ID_GPS_HOUR_MIN   0x17
+#define FRSKY_ID_GPS_SEC        0x18
+#define FRSKY_ID_GPS_SPEED_AP   0x19
+#define FRSKY_ID_GPS_LONG_AP    0x1A
+#define FRSKY_ID_GPS_LAT_AP     0x1B
+#define FRSKY_ID_GPS_COURS_AP   0x1C
+#define FRSKY_ID_MOTOR_FLAGS    0x1D
+#define FRSKY_ID_BARO_ALT_AP    0x21
+#define FRSKY_ID_GPS_LONG_EW    0x22
+#define FRSKY_ID_GPS_LAT_NS     0x23
+#define FRSKY_ID_ACCEL_X        0x24
+#define FRSKY_ID_ACCEL_Y        0x25
+#define FRSKY_ID_ACCEL_Z        0x26
+#define FRSKY_ID_CURRENT        0x28
+#define FRSKY_ID_VARIO          0x30
+#define FRSKY_ID_VFAS           0x39
+#define FRSKY_ID_VOLTS_BP       0x3A
+#define FRSKY_ID_VOLTS_AP       0x3B
+
+// Default sensor data IDs (Physical IDs + CRC)
+#define DATA_ID_VARIO            0x00 // 0
+#define DATA_ID_FLVSS            0xA1 // 1
+#define DATA_ID_FAS              0x22 // 2
+#define DATA_ID_GPS              0x83 // 3
+#define DATA_ID_RPM              0xE4 // 4
+#define DATA_ID_SP2UH            0x45 // 5
+#define DATA_ID_SP2UR            0xC6 // 6
+
+#define SPORT_START_FRAME 0x7E
+
+
 //constructor
 AP_Frsky_Telem::AP_Frsky_Telem(AP_AHRS &ahrs, AP_BattMonitor &battery) :
     _ahrs(ahrs),

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -134,6 +134,7 @@ AP_Frsky_Telem::AP_Frsky_Telem(AP_AHRS &ahrs, AP_BattMonitor &battery, AP_Baro *
     _baro_alt_cm(0),
     _mode_data_ready(false),
     _mode(0),
+    _armed(false),
     _fas_call(0),
     _gps_call(0),
     _vario_call(0),
@@ -176,7 +177,7 @@ void AP_Frsky_Telem::init(const AP_SerialManager& serial_manager)
   should be called by main program at 50hz to allow poll for serial bytes
   coming from the receiver for the SPort protocol
 */
-void AP_Frsky_Telem::send_frames(uint8_t control_mode)
+void AP_Frsky_Telem::send_frames(uint8_t control_mode, bool armed)
 {
     // return immediately if not initialised
     if (!_initialised_uart) {
@@ -206,6 +207,7 @@ void AP_Frsky_Telem::send_frames(uint8_t control_mode)
         }
     } else {
         _mode=control_mode;
+        _armed=armed;
         send_hub_frame();
     }
 }
@@ -660,7 +662,8 @@ void AP_Frsky_Telem::send_smart_gps_sats()
  */
 void AP_Frsky_Telem::send_mode(void)
 {
-    frsky_send_data(FRSKY_ID_TEMP1, _mode);
+    uint16_t mode = (uint8_t)_armed<<8 | _mode;
+    frsky_send_data(FRSKY_ID_TEMP1, mode);
 }
 
 /*
@@ -668,7 +671,8 @@ void AP_Frsky_Telem::send_mode(void)
  */
 void AP_Frsky_Telem::send_smart_mode(void)
 {
-    frsky_send_data_smart(SMARTPORT_ID_T1, _mode);
+    uint32_t mode = (uint8_t)_armed<<8 | _mode;
+    frsky_send_data_smart(SMARTPORT_ID_T1, mode);
 }
 
 /*

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -369,13 +369,13 @@ void AP_Frsky_Telem::sport_tick(void)
                 switch (_various_call) {
                 case 0 :
                     if ( _sats_data_ready ) {
-                        send_gps_sats();
+                        send_smart_gps_sats();
                         _sats_data_ready = false;
                     }
                     break;
                 case 1:
                     if ( _mode_data_ready ) {
-                        send_mode();
+                        send_smart_mode();
                         _mode_data_ready = false;
                     }
                     break;
@@ -643,11 +643,32 @@ void AP_Frsky_Telem::send_gps_sats()
 }
 
 /*
+ * send number of gps satellite and gps status, Smart Port format
+ */
+void AP_Frsky_Telem::send_smart_gps_sats()
+{
+    // send GPS status word containing the following information:
+    //   lower 16bit: num_sats*10 + status
+    //   upper 16bit: hdop in cm (lower 8 bits used)
+    uint32_t status = gps_sats;
+    status |= (_gps.get_hdop()<<16);
+    frsky_send_data_smart(SMARTPORT_ID_T2, status);
+}
+
+/*
  * send control_mode as Temperature 1 (TEMP1)
  */
 void AP_Frsky_Telem::send_mode(void)
 {
     frsky_send_data(FRSKY_ID_TEMP1, _mode);
+}
+
+/*
+ * send control_mode as Temperature 1 (TEMP1)
+ */
+void AP_Frsky_Telem::send_smart_mode(void)
+{
+    frsky_send_data_smart(SMARTPORT_ID_T1, _mode);
 }
 
 /*

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -76,7 +76,9 @@ private:
 
     // methods to send individual pieces of data down telemetry link
     void send_gps_sats(void);
+    void send_smart_gps_sats(void);
     void send_mode(void);
+    void send_smart_mode(void);
     void send_baro_alt_m(void);
     void send_baro_alt_cm(void);
     void send_smart_baro_alt(void);

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -44,7 +44,7 @@ public:
     // send_frames - sends updates down telemetry link for both DPORT and SPORT protocols
     //  should be called by main program at 50hz to allow poll for serial bytes
     //  coming from the receiver for the SPort protocol
-    void send_frames(uint8_t control_mode);
+    void send_frames(uint8_t control_mode, bool armed);
 
 private:
 
@@ -149,6 +149,7 @@ private:
 
     bool _mode_data_ready;
     uint8_t _mode; 
+    bool _armed;
 
     uint8_t _fas_call;
     uint8_t _gps_call;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -65,6 +65,7 @@ private:
     void frsky_send_hub_startstop();
     void frsky_send_sport_prim();
     void frsky_send_data(uint8_t id, int16_t data);
+    void frsky_send_data_smart(uint16_t id, uint32_t data);
 
     // methods to convert flight controller data to frsky telemetry format
     void calc_baro_alt();
@@ -83,6 +84,11 @@ private:
     void send_current(void);
     void send_prearm_error(void);
     void send_heading(void);
+    void send_smart_gps_lat(void);
+    void send_smart_gps_lon(void);
+    void send_smart_gps_cog(void);
+    void send_smart_gps_alt(void);
+    void send_smart_gps_spd(void);
     void send_gps_lat_dd(void);
     void send_gps_lat_mm(void);
     void send_gps_lat_ns(void);
@@ -125,6 +131,9 @@ private:
     int16_t _speed_in_meter;
     uint16_t _speed_in_centimeter;
 
+    float _lon;
+    float _lat;
+
     bool _baro_data_ready;
     int16_t _baro_alt_meters;
     uint16_t _baro_alt_cm;
@@ -138,4 +147,6 @@ private:
     uint8_t _various_call;
 
     uint8_t _sport_status;
+
+    const AP_GPS& _gps;
 };

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -29,7 +29,7 @@ class AP_Frsky_Telem
 {
 public:
     //constructor
-    AP_Frsky_Telem(AP_AHRS &ahrs, AP_BattMonitor &battery);
+    AP_Frsky_Telem(AP_AHRS &ahrs, AP_BattMonitor &battery, AP_Baro* baro = NULL);
 
     // supported protocols
     enum FrSkyProtocol {
@@ -79,6 +79,9 @@ private:
     void send_mode(void);
     void send_baro_alt_m(void);
     void send_baro_alt_cm(void);
+    void send_smart_baro_alt(void);
+    void send_smart_vario(void);
+    void send_smart_attitude(void);
     void send_batt_remain(void);
     void send_batt_volts(void);
     void send_current(void);
@@ -104,6 +107,7 @@ private:
 
     AP_AHRS &_ahrs;                         // reference to attitude estimate
     AP_BattMonitor &_battery;               // reference to battery monitor object
+    AP_Baro *_baro;                         // pointer to (optional) baro object
     AP_HAL::UARTDriver *_port;              // UART used to send data to receiver
     bool _initialised_uart;                 // true when we have detected the protocol and UART has been initialised
     enum FrSkyProtocol _protocol;           // protocol used - detected using SerialManager's SERIALX_PROTOCOL parameter
@@ -135,6 +139,7 @@ private:
 
     float _lon;
     float _lat;
+    float _baro_alt;
 
     bool _baro_data_ready;
     int16_t _baro_alt_meters;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -24,49 +24,6 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
-/* FrSky sensor hub data IDs */
-#define FRSKY_ID_GPS_ALT_BP     0x01
-#define FRSKY_ID_TEMP1          0x02
-#define FRSKY_ID_RPM            0x03
-#define FRSKY_ID_FUEL           0x04
-#define FRSKY_ID_TEMP2          0x05
-#define FRSKY_ID_VOLTS          0x06
-#define FRSKY_ID_GPS_ALT_AP     0x09
-#define FRSKY_ID_BARO_ALT_BP    0x10
-#define FRSKY_ID_GPS_SPEED_BP   0x11
-#define FRSKY_ID_GPS_LONG_BP    0x12
-#define FRSKY_ID_GPS_LAT_BP     0x13
-#define FRSKY_ID_GPS_COURS_BP   0x14
-#define FRSKY_ID_GPS_DAY_MONTH  0x15
-#define FRSKY_ID_GPS_YEAR       0x16
-#define FRSKY_ID_GPS_HOUR_MIN   0x17
-#define FRSKY_ID_GPS_SEC        0x18
-#define FRSKY_ID_GPS_SPEED_AP   0x19
-#define FRSKY_ID_GPS_LONG_AP    0x1A
-#define FRSKY_ID_GPS_LAT_AP     0x1B
-#define FRSKY_ID_GPS_COURS_AP   0x1C
-#define FRSKY_ID_BARO_ALT_AP    0x21
-#define FRSKY_ID_GPS_LONG_EW    0x22
-#define FRSKY_ID_GPS_LAT_NS     0x23
-#define FRSKY_ID_ACCEL_X        0x24
-#define FRSKY_ID_ACCEL_Y        0x25
-#define FRSKY_ID_ACCEL_Z        0x26
-#define FRSKY_ID_CURRENT        0x28
-#define FRSKY_ID_VARIO          0x30
-#define FRSKY_ID_VFAS           0x39
-#define FRSKY_ID_VOLTS_BP       0x3A
-#define FRSKY_ID_VOLTS_AP       0x3B
-
-// Default sensor data IDs (Physical IDs + CRC)
-#define DATA_ID_VARIO            0x00 // 0
-#define DATA_ID_FLVSS            0xA1 // 1
-#define DATA_ID_FAS              0x22 // 2
-#define DATA_ID_GPS              0x83 // 3
-#define DATA_ID_RPM              0xE4 // 4
-#define DATA_ID_SP2UH            0x45 // 5
-#define DATA_ID_SP2UR            0xC6 // 6
-
-#define SPORT_START_FRAME 0x7E
 
 class AP_Frsky_Telem
 {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -82,6 +82,8 @@ private:
     void send_batt_remain(void);
     void send_batt_volts(void);
     void send_current(void);
+    void send_smart_batt_volts(void);
+    void send_smart_current(void);
     void send_prearm_error(void);
     void send_heading(void);
     void send_smart_gps_lat(void);


### PR DESCRIPTION
With the introduction of the Smart Port protocol, FrSky has extended the width of the data fields from 16 to 32bits. The current Smart Port code runs in a kind of a compatibility mode, using only 16 bits of 32 and filling the rest with zeros. Larger values are split into multiple frames, effectively doubling the bandwidth required.

This PR adds some marginal extensions to the transfer code, that allows to send true Smart Port datagrams. I have also added Smart port versions of datagram functions, while trying to keep the impact on existing hub frame code minimal. The over-all update rate of most information has significantly improved. Additionally some information about attitude, climb rate and GPS HDOP are now sent, as the changes freed up lots of link bandwidth. 

Together with OpenTx 2.1, almost all data fields are auto-detected with their correct units, as they use reasonable FrSky sensor ids.
