### PR TITLE
AFS termination changes to be compatible with AUVSI Student UAS Competition

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -292,7 +292,7 @@ void Plane::obc_fs_check(void)
 {
 #if OBC_FAILSAFE == ENABLED
     // perform OBC failsafe checks
-    obc.check(OBC_MODE(control_mode), failsafe.last_heartbeat_ms, geofence_breached(), failsafe.last_valid_rc_ms);
+    obc.check(OBC_MODE(control_mode), failsafe.last_heartbeat_ms, geofence_breached(), failsafe.AFS_last_valid_rc_ms);
 #endif
 }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1770,6 +1770,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         if (hal.rcin->set_overrides(v, 8)) {
             plane.failsafe.last_valid_rc_ms = AP_HAL::millis();
+            plane.failsafe.AFS_last_valid_rc_ms =  plane.failsafe.last_valid_rc_ms;
         }
 
         // a RC override message is consiered to be a 'heartbeat' from

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -343,6 +343,10 @@ private:
         uint32_t ch3_timer_ms;
         
         uint32_t last_valid_rc_ms;
+
+        //keeps track of the last valid rc as it relates to the AFS system
+        //Does not count rc inputs as valid if the standard failsafe is on
+        uint32_t AFS_last_valid_rc_ms;
     } failsafe;
 
     // A counter used to count down valid gps fixes to allow the gps estimate to settle

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -164,8 +164,10 @@ void Plane::read_radio()
 
     if(!failsafe.ch3_failsafe)
     {
-        failsafe.last_valid_rc_ms = millis();
+        failsafe.AFS_last_valid_rc_ms = millis();
     }
+
+    failsafe.last_valid_rc_ms = millis();
 
     elevon.ch1_temp = channel_roll->read();
     elevon.ch2_temp = channel_pitch->read();

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -162,7 +162,10 @@ void Plane::read_radio()
         return;
     }
 
-    failsafe.last_valid_rc_ms = millis();
+    if(!failsafe.ch3_failsafe)
+    {
+        failsafe.last_valid_rc_ms = millis();
+    }
 
     elevon.ch1_temp = channel_roll->read();
     elevon.ch2_temp = channel_pitch->read();

--- a/libraries/APM_OBC/APM_OBC.cpp
+++ b/libraries/APM_OBC/APM_OBC.cpp
@@ -123,29 +123,23 @@ const AP_Param::GroupInfo APM_OBC::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("GEOFENCE",     15, APM_OBC, _enable_geofence_fs, 1),
 
-    // @Param: GPS
-    // @DisplayName: Enable GPS Advanced Failsafe
-    // @Description: This enables the GPS part of the AFS. Will only be in effect if AFS_ENABLE is also 1
-    // @User: Advanced
-    AP_GROUPINFO("GPS",          16, APM_OBC, _enable_gps_fs, 1),
-
     // @Param: RC
     // @DisplayName: Enable RC Advanced Failsafe
     // @Description: This enables the RC part of the AFS. Will only be in effect if AFS_ENABLE is also 1
     // @User: Advanced
-    AP_GROUPINFO("RC",           17, APM_OBC, _enable_RC_fs, 1),
+    AP_GROUPINFO("RC",           16, APM_OBC, _enable_RC_fs, 1),
 
-    // @Param: GCS
-    // @DisplayName: Enable Ground Control Station Advanced Failsafe
-    // @Description: This enables the Ground Control station part of the AFS. Will only be in effect if AFS_ENABLE is also 1.
-    // @User: Advanced
-    AP_GROUPINFO("GCS",          18, APM_OBC, _enable_gcs_fs, 1),
-
-    // @Param: RC_MANUAL
-    // @DisplayName: Enable RC Termination only in Manual modes
+    // @Param: RC_MAN_ONLY
+    // @DisplayName: Enable RC Termination only in manual control modes
     // @Description: If this parameter is set to 1, then an RC loss will only cause the plane to terminate in manual control modes. If it is 0, then the plane will terminate in any flight mode.
     // @User: Advanced
-    AP_GROUPINFO("RC_MANUAL",    19, APM_OBC, _rc_term_manual_only, 1),
+    AP_GROUPINFO("RC_MAN_ONLY",    17, APM_OBC, _rc_term_manual_only, 1),
+
+    // @Param: DUAL_LOSS
+    // @DisplayName: Enable dual loss terminate due to failure of both GCS and GPS simultaneously
+    // @Description: This enables the dual loss termination part of the AFS system. If this parameter is 1 and both GPS and the ground control station fail simultaneously, this will be considered a "dual loss" and cause termination.
+    // @User: Advanced
+    AP_GROUPINFO("DUAL_LOSS",      18, APM_OBC, _enable_dual_loss, 1),
 
     AP_GROUPEND
 };
@@ -159,21 +153,26 @@ APM_OBC::check(APM_OBC::control_mode mode, uint32_t last_heartbeat_ms, bool geof
         return;
     }
     // we always check for fence breach
-    if (geofence_breached || check_altlimit()) {
-        if (!_terminate) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Fence TERMINATE");
-            _terminate.set(1);
+    if(_enable_geofence_fs) {
+        if (geofence_breached || check_altlimit()) {
+            if (!_terminate) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Fence TERMINATE");
+                _terminate.set(1);
+            }
         }
     }
 
-    // check for RC failure in manual mode
-    if (_state != STATE_PREFLIGHT && 
-        (mode == OBC_MANUAL || mode == OBC_FBW) && 
-        _rc_fail_time != 0 && 
-        (AP_HAL::millis() - last_valid_rc_ms) > (unsigned)_rc_fail_time.get()) {
-        if (!_terminate) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "RC failure terminate");
-            _terminate.set(1);
+    // check if RC termination is enabled
+    if(_enable_RC_fs) {
+        // check for RC failure in manual mode or RC failure when AFS_RC_MANUAL is 0
+        if (_state != STATE_PREFLIGHT && 
+            (mode == OBC_MANUAL || mode == OBC_FBW || !_rc_term_manual_only) && 
+            _rc_fail_time != 0 && 
+            (AP_HAL::millis() - last_valid_rc_ms) > (unsigned)_rc_fail_time.get()) {
+            if (!_terminate) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "RC failure terminate");
+                _terminate.set(1);
+            }
         }
     }
     
@@ -234,10 +233,12 @@ APM_OBC::check(APM_OBC::control_mode mode, uint32_t last_heartbeat_ms, bool geof
     case STATE_DATA_LINK_LOSS:
         if (!gps_lock_ok) {
             // losing GPS lock when data link is lost
-            // leads to termination
-            if (!_terminate) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Dual loss TERMINATE");
-                _terminate.set(1);
+            // leads to termination if AFS_DUAL_LOSS is 1
+            if(_enable_dual_loss) {
+                if (!_terminate) {
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Dual loss TERMINATE");
+                    _terminate.set(1);
+                }
             }
         } else if (gcs_link_ok) {
             _state = STATE_AUTO;
@@ -255,10 +256,12 @@ APM_OBC::check(APM_OBC::control_mode mode, uint32_t last_heartbeat_ms, bool geof
     case STATE_GPS_LOSS:
         if (!gcs_link_ok) {
             // losing GCS link when GPS lock lost
-            // leads to termination
-            if (!_terminate) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Dual loss TERMINATE");
-                _terminate.set(1);
+            // leads to termination if AFS_DUAL_LOSS is 1
+            if(_enable_dual_loss) {
+                if (!_terminate) {
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Dual loss TERMINATE");
+                    _terminate.set(1);
+                }
             }
         } else if (gps_lock_ok) {
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "GPS OK");

--- a/libraries/APM_OBC/APM_OBC.cpp
+++ b/libraries/APM_OBC/APM_OBC.cpp
@@ -117,6 +117,36 @@ const AP_Param::GroupInfo APM_OBC::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("MAX_COM_LOSS", 14, APM_OBC, _max_comms_loss, 0),
 
+    // @Param: GEOFENCE
+    // @DisplayName: Enable geofence Advanced Failsafe
+    // @Description: This enables the geofence part of the AFS. Will only be in effect if AFS_ENABLE is also 1
+    // @User: Advanced
+    AP_GROUPINFO("GEOFENCE",     15, APM_OBC, _enable_geofence_fs, 1),
+
+    // @Param: GPS
+    // @DisplayName: Enable GPS Advanced Failsafe
+    // @Description: This enables the GPS part of the AFS. Will only be in effect if AFS_ENABLE is also 1
+    // @User: Advanced
+    AP_GROUPINFO("GPS",          16, APM_OBC, _enable_gps_fs, 1),
+
+    // @Param: RC
+    // @DisplayName: Enable RC Advanced Failsafe
+    // @Description: This enables the RC part of the AFS. Will only be in effect if AFS_ENABLE is also 1
+    // @User: Advanced
+    AP_GROUPINFO("RC",           17, APM_OBC, _enable_RC_fs, 1),
+
+    // @Param: GCS
+    // @DisplayName: Enable Ground Control Station Advanced Failsafe
+    // @Description: This enables the Ground Control station part of the AFS. Will only be in effect if AFS_ENABLE is also 1.
+    // @User: Advanced
+    AP_GROUPINFO("GCS",          18, APM_OBC, _enable_gcs_fs, 1),
+
+    // @Param: RC_MANUAL
+    // @DisplayName: Enable RC Termination only in Manual modes
+    // @Description: If this parameter is set to 1, then an RC loss will only cause the plane to terminate in manual control modes. If it is 0, then the plane will terminate in any flight mode.
+    // @User: Advanced
+    AP_GROUPINFO("RC_MANUAL",    19, APM_OBC, _rc_term_manual_only, 1),
+
     AP_GROUPEND
 };
 

--- a/libraries/APM_OBC/APM_OBC.h
+++ b/libraries/APM_OBC/APM_OBC.h
@@ -99,9 +99,14 @@ private:
     AP_Float _qnh_pressure;
     AP_Int32 _amsl_limit;
     AP_Int32 _amsl_margin_gps;
-    AP_Int16 _rc_fail_time;
+    AP_Int32 _rc_fail_time;
     AP_Int8  _max_gps_loss;
     AP_Int8  _max_comms_loss;
+    AP_Int8  _enable_geofence_fs;
+    AP_Int8  _enable_gps_fs;
+    AP_Int8  _enable_RC_fs;
+    AP_Int8  _enable_gcs_fs;
+    AP_Int8  _rc_term_manual_only;
 
     bool _heartbeat_pin_value;
 

--- a/libraries/APM_OBC/APM_OBC.h
+++ b/libraries/APM_OBC/APM_OBC.h
@@ -103,10 +103,9 @@ private:
     AP_Int8  _max_gps_loss;
     AP_Int8  _max_comms_loss;
     AP_Int8  _enable_geofence_fs;
-    AP_Int8  _enable_gps_fs;
     AP_Int8  _enable_RC_fs;
-    AP_Int8  _enable_gcs_fs;
     AP_Int8  _rc_term_manual_only;
+    AP_Int8  _enable_dual_loss;
 
     bool _heartbeat_pin_value;
 


### PR DESCRIPTION
This makes the AFS termination system compatible with the AUVSI student UAS competition given the RC transmitter as the primary communication link.

It adds options to disable termination on leaving geofence and disable "dual loss" termination, while leaving the rest of the AFS system active.

It also gives an option to enable RC termination to happen in non-manual control modes.

Finally, it makes the AFS_RC_FAIL_MS parameter 32 bits to allow for a 3 minute delay before termination as required by the competition rules.

All AFS behavior is kept the same as it was before this commit by default - only by changing parameters will the behavior change.

(The commits fail the build test but likely only because the build tests failed at the time it was forked; when I upstream merged the changes, they then passed the build test)