### PR TITLE
Define the RC speed in the RCOutput example script

### DIFF
--- a/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
@@ -6,9 +6,13 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
+#define RC_SPEED 50
+
 void setup (void) 
 {
     hal.console->println("Starting AP_HAL::RCOutput test");
+    hal.rcout->set_freq(0xFF, RC_SPEED);   // Set RC Speed
+
     for (uint8_t i=0; i<14; i++) {
         hal.rcout->enable_ch(i);
     }
@@ -31,7 +35,7 @@ void loop (void)
             hal.console->printf("reversing\n");
         }
     }
-    hal.scheduler->delay(5);
+    hal.scheduler->delay(10);
 }
 
 AP_HAL_MAIN();


### PR DESCRIPTION
The default value of 490 Hz can cause issues with servos (usually driven at 50 Hz).  This allows for the RC update speed to be changed within the example script without affecting the default values.

Doubled the delay between loops as the very fast driving was causing servo overheats.