### PR TITLE
Function calculates the wrong pan angle to a location

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -150,7 +150,7 @@ void AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vec
 
     // pan calcs
     if (calc_pan) {
-        // calc absolute heading and then onvert to vehicle relative yaw
-        angles_to_target_rad.z = wrap_PI(atan2f(GPS_vector_x, GPS_vector_y) - _frontend._ahrs.yaw);
+        // calc absolute heading (relative to true North)
+        angles_to_target_rad.z = wrap_PI(atan2f(GPS_vector_x, GPS_vector_y));
     }
 }


### PR DESCRIPTION
The AP_Mount_Backend::calc_angle_to_location(...) function should set 'angles_to_target_rad.z' to the pan angle relative to True North, not to
the angle relative to the vehicle yaw angle. The function's description comment indicates the output angles are in the 'earth frame'.
