### PR TITLE
Travis: split builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,9 @@ env:
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "FjIwqZQV2FhNPWYITX5LZXTE38yYqBaQdbm3QmbEg/30wnPTm1ZOLIU7o/aSvX615ImR8kHoryvFPDQDWc6wWfqTEs3Ytq2kIvcIJS2Y5l/0PFfpWJoH5gRd6hDThnoi+1oVMLvj1+bhn4yFlCCQ2vT/jxoGfiQqqgvHtv4fLzI="
   matrix:
-    - CI_BUILD_TARGET="px4-v2 sitl linux"
-    - CI_BUILD_TARGET="navio raspilot minlure bebop"
+    - CI_BUILD_TARGET="px4-v2"
+    - CI_BUILD_TARGET="sitl linux minlure"
+    - CI_BUILD_TARGET="navio raspilot bebop"
     - CI_BUILD_TARGET="sitltest"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "FjIwqZQV2FhNPWYITX5LZXTE38yYqBaQdbm3QmbEg/30wnPTm1ZOLIU7o/aSvX615ImR8kHoryvFPDQDWc6wWfqTEs3Ytq2kIvcIJS2Y5l/0PFfpWJoH5gRd6hDThnoi+1oVMLvj1+bhn4yFlCCQ2vT/jxoGfiQqqgvHtv4fLzI="
   matrix:
-    - CI_BUILD_TARGET="px4-v2"
+    - CI_BUILD_TARGET="px4-v2 px4-v4"
     - CI_BUILD_TARGET="sitl linux minlure"
     - CI_BUILD_TARGET="navio raspilot bebop"
     - CI_BUILD_TARGET="sitltest"


### PR DESCRIPTION
Now that Waf is compiling all frame types for Copter, Travis is failing with lack of time. This PR splits Travis builds to one more job - when we don't use the Make build system this can probably be merged again.

This also adds PX4-v4 build to Travis (~~it is already in Semaphore~~ it seems this was recently removed from Semaphore, isn't it wanted?).