### PR TITLE
Plane: improved crash detection when on the ground

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -515,6 +515,9 @@ private:
         // debounce timer
         uint32_t debounce_timer_ms;
 
+        // delay time for debounce to count to
+        uint32_t debounce_time_total_ms;
+
         // length of time impact_detected has been true. Times out after a few seconds. Used to clip isFlyingProbability
         uint32_t impact_timer_ms;
     } crash_state;


### PR DESCRIPTION
- fixes bug where a delayed (bungee) launch is configured but the aircraft gets bumped and triggers the prop to spin up. A regression to the crash detection caused a crash to never be detected until launch causing the motor to spin forever. This will now detect that 'crash' and disable the motor