### PR TITLE
Waf: fix Clang toolchain detection

### DIFF
--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -49,7 +49,10 @@ def _clang_cross_support(cfg):
 
     prefix = cfg.env.TOOLCHAIN + '-'
 
-    cfg.find_program(prefix + 'gcc', var='CROSS_GCC')
+    try:
+        cfg.find_program(prefix + 'gcc', var='CROSS_GCC')
+    except Errors.ConfigurationError as e:
+        cfg.fatal('toolchain: clang: couldn\'t find cross GCC', ex=e)
 
     environ = dict(os.environ)
     if 'TOOLCHAIN_CROSS_AR' in environ:


### PR DESCRIPTION
If we didn't have the GCC toolchain available it would give an error (_Execution failure: [Errno 2] No such file or directory_) instead of _not found_ when trying to use Clang as cross-compiler.