### PR TITLE
waf:  use file list for ROMFS files

### DIFF
--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -106,6 +106,9 @@ class px4_copy(Task.Task):
     def keyword(self):
         return "PX4: Copying %s to" % self.inputs[0].name
 
+    def __str__(self):
+        return self.outputs[0].path_from(self.generator.bld.bldnode)
+
 class px4_add_git_hashes(Task.Task):
     run_str = '${PYTHON} ${PX4_ADD_GIT_HASHES} --ardupilot ${PX4_APM_ROOT} --px4 ${PX4_ROOT} --nuttx ${PX4_NUTTX_ROOT} --uavcan ${PX4_UAVCAN_ROOT} ${SRC} ${TGT}'
     color = 'CYAN'


### PR DESCRIPTION
Hi all,

Copying text from last commit's message :-)

> Files that are not really part of the ROMFS in the folder might cause problems.
> 
> One problem that motivated this patch was caused because the make-based build
> system copies the bootloader to the ROMFS in the source tree (mk/PX4/ROMFS)
> instead of the build tree. That potentially could cause race condition between
> the tasks created by 'px4_romfs_static_files' and 'px4_romfs_bootloader'.
> 
> Also, now we have only one task generator for static files.

Best regards,
Gustavo Sousa