### PR TITLE
Plane: prevent load factor over speed condition

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -734,6 +734,7 @@ private:
     void demo_servos(uint8_t i);
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
+    void calculate_load_factor(void);
     void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);


### PR DESCRIPTION
Updates the load factor after the new roll limits have been applied so that the TECS controller is using the correct value.
Limits the maximum roll angle so that arspd_fbw_max is respected when the load factor is applied.
Fixes #3844

