### PR TITLE
Travis: remove cache since it isn't used currently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: cpp
 sudo: required
 
-cache:
-  directories:
-    - $HOME/opt
-
 addons:
   coverity_scan:
     project:


### PR DESCRIPTION
Travis builds used container-based environment for a little while and used the cache to speed things up. Right now we aren't using the container-based environment which means cache isn't available for our open-source project.

Unfortunately, about three weeks ago, Travis started trying to use cache despite it not being available. It always fails and I've complained to Travis but they only promised to try to look at it...
Removing the cache will gain us about 1 minute for each job.