### PR TITLE
Use std::isnan and std::isinf to make things build on glibc >= 2.23

### DIFF
--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -139,7 +139,7 @@ void Tracker::tracking_update_pressure(const mavlink_scaled_pressure_t &msg)
 
     // calculate altitude difference based on difference in barometric pressure
     float alt_diff = barometer.get_altitude_difference(local_pressure, aircraft_pressure);
-    if (!isnan(alt_diff)) {
+    if (!std::isnan(alt_diff)) {
         nav_status.altitude_difference = alt_diff + nav_status.altitude_offset;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -268,11 +268,11 @@ void AP_AHRS::update_trig(void)
         _cos_yaw = 1.0f;
     }
 
-    if (isinf(_cos_roll) || isnan(_cos_roll)) {
+    if (std::isinf(_cos_roll) || std::isnan(_cos_roll)) {
         _cos_roll = cosf(roll);
     }
 
-    if (isinf(_sin_roll) || isnan(_sin_roll)) {
+    if (std::isinf(_sin_roll) || std::isnan(_sin_roll)) {
         _sin_roll = sinf(roll);
     }
 }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -143,7 +143,7 @@ AP_AHRS_DCM::reset(bool recover_eulers)
     // if the caller wants us to try to recover to the current
     // attitude then calculate the dcm matrix from the current
     // roll/pitch/yaw values
-    if (recover_eulers && !isnan(roll) && !isnan(pitch) && !isnan(yaw)) {
+    if (recover_eulers && !std::isnan(roll) && !std::isnan(pitch) && !std::isnan(yaw)) {
         _dcm_matrix.from_euler(roll, pitch, yaw);
     } else {
 

--- a/libraries/AP_AccelCal/AccelCalibrator.cpp
+++ b/libraries/AP_AccelCal/AccelCalibrator.cpp
@@ -370,7 +370,7 @@ void AccelCalibrator::run_fit(uint8_t max_iterations, float& fitness)
 
         fitness = calc_mean_squared_residuals(fit_param.s);
 
-        if (isnan(fitness) || isinf(fitness)) {
+        if (std::isnan(fitness) || std::isinf(fitness)) {
             return;
         }
 

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -132,7 +132,7 @@ void AP_Airspeed::update_calibration(const Vector3f &vground)
 
     float zratio = _calibration.update(true_airspeed, vground);
 
-    if (isnan(zratio) || isinf(zratio)) {
+    if (std::isnan(zratio) || std::isinf(zratio)) {
         return;
     }
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -368,12 +368,12 @@ void AP_Baro::update(void)
         if (sensors[i].healthy) {
             // update altitude calculation
             float ground_pressure = sensors[i].ground_pressure;
-            if (is_zero(ground_pressure) || isnan(ground_pressure) || isinf(ground_pressure)) {
+            if (is_zero(ground_pressure) || std::isnan(ground_pressure) || std::isinf(ground_pressure)) {
                 sensors[i].ground_pressure = sensors[i].pressure;
             }
             float altitude = get_altitude_difference(sensors[i].ground_pressure, sensors[i].pressure);
             // sanity check altitude
-            sensors[i].alt_ok = !(isnan(altitude) || isinf(altitude));
+            sensors[i].alt_ok = !(std::isnan(altitude) || std::isinf(altitude));
             if (sensors[i].alt_ok) {
                 sensors[i].altitude = altitude + _alt_offset_active;
             }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -151,7 +151,7 @@ void CompassCalibrator::update(bool &failure) {
 
     if(_status == COMPASS_CAL_RUNNING_STEP_ONE) {
         if (_fit_step >= 10) {
-            if(is_equal(_fitness,_initial_fitness) || isnan(_fitness)) {           //if true, means that fitness is diverging instead of converging
+            if(is_equal(_fitness,_initial_fitness) || std::isnan(_fitness)) {           //if true, means that fitness is diverging instead of converging
                 set_status(COMPASS_CAL_FAILED);
                 failure = true;
             }
@@ -305,7 +305,7 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
 }
 
 bool CompassCalibrator::fit_acceptable() {
-    if( !isnan(_fitness) &&
+    if( !std::isnan(_fitness) &&
         _params.radius > 150 && _params.radius < 950 && //Earth's magnetic field strength range: 250-850mG
         fabsf(_params.offset.x) < 1000 &&
         fabsf(_params.offset.y) < 1000 &&
@@ -515,7 +515,7 @@ void CompassCalibrator::run_sphere_fit()
     }
     //--------------------Levenberg-Marquardt-part-ends-here--------------------------------//
 
-    if(!isnan(fitness) && fitness < _fitness) {
+    if(!std::isnan(fitness) && fitness < _fitness) {
         _fitness = fitness;
         _params = fit1_params;
     }

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -6,7 +6,7 @@
 // returned.
 float safe_asin(float v)
 {
-    if (isnan(v)) {
+    if (std::isnan(v)) {
         return 0.0f;
     }
     if (v >= 1.0f) {
@@ -26,7 +26,7 @@ float safe_asin(float v)
 float safe_sqrt(float v)
 {
     float ret = sqrtf(v);
-    if (isnan(ret)) {
+    if (std::isnan(ret)) {
         return 0;
     }
     return ret;

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -77,7 +77,7 @@ static inline float constrain_float(float amt, float low, float high)
 	// floating point errors through any function that uses
 	// constrain_float(). The normal float semantics already handle -Inf
 	// and +Inf
-	if (isnan(amt)) {
+	if (std::isnan(amt)) {
 		return (low+high)*0.5f;
 	}
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));

--- a/libraries/AP_Math/examples/eulers/eulers.cpp
+++ b/libraries/AP_Math/examples/eulers/eulers.cpp
@@ -26,9 +26,9 @@ static void check_result(const char *msg,
                          float roll, float pitch, float yaw,
                          float roll2, float pitch2, float yaw2)
 {
-    if (isnan(roll2) ||
-        isnan(pitch2) ||
-        isnan(yaw2)) {
+    if (std::isnan(roll2) ||
+        std::isnan(pitch2) ||
+        std::isnan(yaw2)) {
         hal.console->printf("%s NAN eulers roll=%f pitch=%f yaw=%f\n",
                             msg, roll, pitch, yaw);
     }

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -211,7 +211,7 @@ bool mat_inverse(float* A, float* inv, uint8_t n)
     //check sanity of results
     for(uint8_t i = 0; i < n; i++) {
         for(uint8_t j = 0; j < n; j++) {
-            if(isnan(inv_pivoted[i*n+j]) || isinf(inv_pivoted[i*n+j])){
+            if(std::isnan(inv_pivoted[i*n+j]) || std::isinf(inv_pivoted[i*n+j])){
                 ret = false;
             }
         }

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -48,7 +48,7 @@ public:
     // check if any elements are NAN
     bool        is_nan(void) const
     {
-        return isnan(q1) || isnan(q2) || isnan(q3) || isnan(q4);
+        return std::isnan(q1) || std::isnan(q2) || std::isnan(q3) || std::isnan(q4);
     }
 
     // return the rotation matrix equivalent for this quaternion

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -66,13 +66,13 @@ Vector2<T> &Vector2<T>::operator -=(const Vector2<T> &v)
 template <typename T>
 bool Vector2<T>::is_nan(void) const
 {
-    return isnan(x) || isnan(y);
+    return std::isnan(x) || std::isnan(y);
 }
 
 template <typename T>
 bool Vector2<T>::is_inf(void) const
 {
-    return isinf(x) || isinf(y);
+    return std::isinf(x) || std::isinf(y);
 }
 
 template <typename T>

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -300,13 +300,13 @@ Vector3<T> &Vector3<T>::operator -=(const Vector3<T> &v)
 template <typename T>
 bool Vector3<T>::is_nan(void) const
 {
-    return isnan(x) || isnan(y) || isnan(z);
+    return std::isnan(x) || std::isnan(y) || std::isnan(z);
 }
 
 template <typename T>
 bool Vector3<T>::is_inf(void) const
 {
-    return isinf(x) || isinf(y) || isinf(z);
+    return std::isinf(x) || std::isinf(y) || std::isinf(z);
 }
 
 template <typename T>

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1622,7 +1622,7 @@ void AP_Param::convert_old_parameters(const struct ConversionInfo *conversion_ta
  */
 void AP_Param::set_float(float value, enum ap_var_type var_type)
 {
-    if (isnan(value) || isinf(value)) {
+    if (std::isnan(value) || std::isinf(value)) {
         return;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
@@ -107,7 +107,7 @@ void AP_RangeFinder_analog::update(void)
             dist_m = 0;
         }
         dist_m = scaling / (v - offset);
-        if (isinf(dist_m) || dist_m > max_distance_cm * 0.01f) {
+        if (std::isinf(dist_m) || dist_m > max_distance_cm * 0.01f) {
             dist_m = max_distance_cm * 0.01f;
         }
         break;

--- a/libraries/Filter/DerivativeFilter.cpp
+++ b/libraries/Filter/DerivativeFilter.cpp
@@ -102,7 +102,7 @@ float DerivativeFilter<T,FILTER_SIZE>::slope(void)
     }
 
     // cope with numerical errors
-    if (isnan(result) || isinf(result)) {
+    if (std::isnan(result) || std::isinf(result)) {
         result = 0;
     }
 

--- a/libraries/PID/PID.cpp
+++ b/libraries/PID/PID.cpp
@@ -63,7 +63,7 @@ float PID::get_pid(float error, float scaler)
     if ((fabsf(_kd) > 0) && (dt > 0)) {
         float derivative;
 
-		if (isnan(_last_derivative)) {
+		if (std::isnan(_last_derivative)) {
 			// we've just done a reset, suppress the first derivative
 			// term as we don't want a sudden change in input to cause
 			// a large D output change			


### PR DESCRIPTION
Building ArduPilot on Arch Linux failed with an error message like
>'isnan' was not declared in this scope

This is caused by a change in glibc >= 2.23

I replaced all calls to isinf and isnan with the C++ versions in the std namespace which fixed it.
Please see this glibc related bug for an explanation: https://sourceware.org/bugzilla/show_bug.cgi?id=19439

I tested the build of all projects under Linux, not on any embedded hardware, because I don't have any for testing right now, so please make sure it works on these targets as well before merging.