### PR TITLE
Plane: add support for guided via command int

### DIFF
--- a/ArduPlane/capabilities.cpp
+++ b/ArduPlane/capabilities.cpp
@@ -6,4 +6,5 @@ void Plane::init_capabilities(void)
 {
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_COMMAND_INT);
 }

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -71,7 +71,7 @@ void Plane::set_next_WP(const struct Location &loc)
 
 void Plane::set_guided_WP(void)
 {
-    if (g.loiter_radius < 0) {
+    if (g.loiter_radius < 0 || guided_WP_loc.flags.loiter_ccw) {
         loiter.direction = -1;
     } else {
         loiter.direction = 1;

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -140,7 +140,11 @@ void Plane::update_loiter(uint16_t radius)
     if (radius <= 1) {
         // if radius is <=1 then use the general loiter radius. if it's small, use default
         radius = (abs(g.loiter_radius) <= 1) ? LOITER_RADIUS_DEFAULT : abs(g.loiter_radius);
-        loiter.direction = (g.loiter_radius < 0) ? -1 : 1;
+        if (next_WP_loc.flags.loiter_ccw == 1) {
+            loiter.direction = -1;
+        } else {
+            loiter.direction = (g.loiter_radius < 0) ? -1 : 1;
+        }
     }
 
     if (loiter.start_time_ms == 0 &&

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -259,6 +259,14 @@ bool location_sanitize(const struct Location &defaultLoc, struct Location &loc)
         loc.alt = defaultLoc.alt;
         has_changed = true;
     }
+
+    // limit lat/lng to appropriate ranges
+    if (abs(loc.lat) > 90 * 1e7 || abs(loc.lng) > 180 * 1e7) {
+        loc.lat = defaultLoc.lat;
+        loc.lng = defaultLoc.lng;
+        has_changed = true;
+    }
+
     return has_changed;
 }
 


### PR DESCRIPTION
Allows plane to transition into guided and a point with a single packet, the mode change behavior is dependent on the mavlink command requesting it. Also allows guided waypoints to loiter ccw if requested.

I will be flight testing this tommorow.