### PR TITLE
Gps configuration validiation messages

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -340,8 +340,9 @@ bool AP_Arming::gps_checks(bool report)
         if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,
-                                                 "PreArm: GPS %d has not been fully configured",
-                                                  first_unconfigured);
+                                                 "PreArm: GPS %d failing configuration checks",
+                                                  first_unconfigured + 1);
+                gps.broadcast_first_configuration_failure_reason();
             }
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
             return false;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -610,6 +610,16 @@ AP_GPS::first_unconfigured_gps(void) const
 }
 
 void
+AP_GPS::broadcast_first_configuration_failure_reason(void) const {
+    uint8_t unconfigured = first_unconfigured_gps();
+    if (drivers[unconfigured] == NULL) {
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "GPS %d: was not found", unconfigured + 1);
+    } else {
+        drivers[unconfigured]->broadcast_configuration_failure_reason();
+    }
+}
+
+void
 AP_GPS::_broadcast_gps_type(const char *type, uint8_t instance, int8_t baud_index)
 {
     char buffer[64];

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -344,6 +344,7 @@ public:
 
     // Returns the index of the first unconfigured GPS (returns GPS_ALL_CONFIGURED if all instances report as being configured)
     uint8_t first_unconfigured_gps(void) const;
+    void broadcast_first_configuration_failure_reason(void) const;
 
 private:
     struct GPS_timing {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1187,3 +1187,30 @@ AP_GPS_UBLOX::inject_data(uint8_t *data, uint8_t len)
         Debug("UBX: Not enough TXSPACE");
     }
 }
+
+
+static const char *reasons[] = {"navigation rate",
+                                "posllh rate",
+                                "status rate",
+                                "solution rate",
+                                "velned rate",
+                                "dop rate",
+                                "hw monitor rate",
+                                "hw2 monitor rate",
+                                "raw rate",
+                                "version",
+                                "navigation settings",
+                                "GNSS settings",
+                                "SBAS settings"};
+
+
+void
+AP_GPS_UBLOX::broadcast_configuration_failure_reason(void) const {
+    for (uint8_t i = 0; i < ARRAY_SIZE(reasons); i++) {
+        if (_unconfigured_messages & (1 << i)) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "GPS %d: u-blox %s configuration 0x%02x",
+                state.instance +1, reasons[i], _unconfigured_messages);
+            break;
+        }
+    }
+}

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -108,6 +108,7 @@ public:
         }
     }
 
+    void broadcast_configuration_failure_reason(void) const;
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -49,6 +49,8 @@ public:
 
     virtual void send_mavlink_gps2_rtk(mavlink_channel_t chan) { return ; }
 
+    virtual void broadcast_configuration_failure_reason(void) const { return ; }
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
Prints out if the configuration check is failing due to not finding the a device, or what internal part is failing. Requires an addition to the wiki to document the meanings of the u-blox bits, but this was selected as being superior to adding a message for each bit. Addresses issue #3879 