### PR TITLE
Plane: Add POSITION_TARGET_GLOBAL_INT to the EXTENDED_STATUS stream

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -598,6 +598,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
     case MSG_OPTICAL_FLOW:
     case MSG_GIMBAL_REPORT:
     case MSG_RPM:
+    case MSG_POSITION_TARGET_GLOBAL_INT:
         break; // just here to prevent a warning
 
     }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -280,6 +280,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
     case MSG_VIBRATION:
     case MSG_RPM:
     case MSG_MISSION_ITEM_REACHED:
+    case MSG_POSITION_TARGET_GLOBAL_INT:
         break; // just here to prevent a warning
     }
     return true;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -720,6 +720,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
 
     case MSG_FENCE_STATUS:
     case MSG_WIND:
+    case MSG_POSITION_TARGET_GLOBAL_INT:
         // unused
         break;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -372,6 +372,26 @@ void Plane::send_nav_controller_output(mavlink_channel_t chan)
         nav_controller->crosstrack_error());
 }
 
+void Plane::send_position_target_global_int(mavlink_channel_t chan)
+{
+    mavlink_msg_position_target_global_int_send(
+        chan,
+        AP_HAL::millis(), // time_boot_ms
+        MAV_FRAME_GLOBAL_INT, // targets are always global altitude
+        0xFFF8, // ignore everything except the x/y/z components
+        next_WP_loc.lat, // latitude as 1e7
+        next_WP_loc.lng, // longitude as 1e7
+        next_WP_loc.alt * 0.01f, // altitude is sent as a float
+        0.0f, // vx
+        0.0f, // vy
+        0.0f, // vz
+        0.0f, // afx
+        0.0f, // afy
+        0.0f, // afz
+        0.0f, // yaw
+        0.0f); // yaw_rate
+}
+
 
 void Plane::send_servo_out(mavlink_channel_t chan)
 {
@@ -668,6 +688,13 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
         if (plane.control_mode != MANUAL) {
             CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
             plane.send_nav_controller_output(chan);
+        }
+        break;
+
+    case MSG_POSITION_TARGET_GLOBAL_INT:
+        if (plane.control_mode != MANUAL) {
+            CHECK_PAYLOAD_SIZE(POSITION_TARGET_GLOBAL_INT);
+            plane.send_position_target_global_int(chan);
         }
         break;
 
@@ -1037,6 +1064,7 @@ GCS_MAVLINK::data_stream_send(void)
         send_message(MSG_GPS_RAW);
         send_message(MSG_NAV_CONTROLLER_OUTPUT);
         send_message(MSG_FENCE_STATUS);
+        send_message(MSG_POSITION_TARGET_GLOBAL_INT);
     }
 
     if (plane.gcs_out_of_time) return;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -740,6 +740,7 @@ private:
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
+    void send_position_target_global_int(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
     void send_radio_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -74,6 +74,7 @@ enum ap_message {
     MSG_VIBRATION,
     MSG_RPM,
     MSG_MISSION_ITEM_REACHED,
+    MSG_POSITION_TARGET_GLOBAL_INT,
     MSG_RETRY_DEFERRED // this must be last
 };
 


### PR DESCRIPTION
I think this belongs on the other vehicles as well, although I didn't add that yet, as I believe copter implements more of the fields (and should maybe send the NED version as well). I'm not sure if rover offers the others as well.

Motivation: When one GCS sends a guided or target (or a companion computer does) none of the other GCS's know where the current target is, as well as offering feedback on what the vehicle is trying to accomplish, without needing a current copy of the flight plan. PX4 also uses this so this brings the two closer for GCS's.