### PR TITLE
Plane: fix min_gndspd

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -98,6 +98,31 @@ void Plane::calc_airspeed_errors()
                              ((int32_t)aparm.airspeed_min * 100);
     }
 
+    // Landing airspeed target
+    if (control_mode == AUTO && ahrs.airspeed_sensor_enabled()) {
+        float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+        switch (flight_stage) {
+        case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
+            if (land_airspeed >= 0) {
+                target_airspeed_cm = land_airspeed * 100;
+            }
+            break;
+
+        case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
+        case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
+            if (auto_state.land_pre_flare && aparm.land_pre_flare_airspeed > 0) {
+                // if we just preflared then continue using the pre-flare airspeed during final flare
+                target_airspeed_cm = aparm.land_pre_flare_airspeed * 100;
+            } else if (land_airspeed >= 0) {
+                target_airspeed_cm = land_airspeed * 100;
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
     // Set target to current airspeed + ground speed undershoot,
     // but only when this is faster than the target airspeed commanded
     // above.

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -68,8 +68,11 @@ public:
 	// return maximum climb rate
 	virtual float get_max_climbrate(void) const = 0;
 
-	// return landing sink rate
-	virtual float get_land_sinkrate(void) const = 0;
+    // return landing sink rate
+    virtual float get_land_sinkrate(void) const = 0;
+
+    // return landing airspeed
+    virtual float get_land_airspeed(void) const = 0;
 
 	// set path_proportion accessor
     virtual void set_path_proportion(float path_proportion) = 0;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -339,6 +339,7 @@ void AP_TECS::_update_speed(float load_factor)
     // Convert equivalent airspeeds to true airspeeds
 
     float EAS2TAS = _ahrs.get_EAS2TAS();
+    _TAS_dem = _EAS_dem * EAS2TAS;
     _TASmax   = aparm.airspeed_max * EAS2TAS;
     _TASmin   = aparm.airspeed_min * EAS2TAS;
 
@@ -348,19 +349,6 @@ void AP_TECS::_update_speed(float load_factor)
         _TASmin *= load_factor;
     }
 
-    float demanded_airspeed = _EAS_dem;
-    if (_ahrs.airspeed_sensor_enabled()) {
-        if ((_flight_stage == FLIGHT_LAND_APPROACH || _flight_stage == FLIGHT_LAND_FINAL) && _landAirspeed >= 0) {
-            demanded_airspeed = _landAirspeed;
-        } else if (_flight_stage == FLIGHT_LAND_PREFLARE) {
-            if (aparm.land_pre_flare_airspeed > 0) {
-                demanded_airspeed = aparm.land_pre_flare_airspeed;
-            } else if (_landAirspeed >= 0) {
-                demanded_airspeed = _landAirspeed;
-            }
-        }
-    }
-    _TAS_dem = demanded_airspeed * EAS2TAS;
     if (_TASmax < _TASmin) {
         _TASmax = _TASmin;
     }

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -87,6 +87,11 @@ public:
         return _land_sink;
     }
 
+    // return landing airspeed
+    float get_land_airspeed(void) const {
+        return _landAirspeed;
+    }
+
     // return height rate demand, in m/s
     float get_height_rate_demand(void) const {
         return _hgt_rate_dem;


### PR DESCRIPTION
Recent reverse-thrust changes had broken minimum groundspeed enforcement during landing by overriding the target airspeed in TECS which does not have any scope of min ground speed. This PR moves target-airspeed calculation from TECS up into Plane so that it can add groundspeed undershoot correctly.