### PR TITLE
Plane: Fixed bug with landing flare for high values of LAND_FLARE_SEC

### DIFF
--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -58,8 +58,12 @@ bool Plane::verify_land()
 #else
     bool rangefinder_in_range = false;
 #endif
+
+    // Below we check for wp_proportion being greater then 50%.  In otherwords ensure that the vehicle
+    // has covered 50% of the distance to the landing point before it can flare
     if (height <= g.land_flare_alt ||
-        (aparm.land_flare_sec > 0 && height <= auto_state.sink_rate * aparm.land_flare_sec) ||
+        ((aparm.land_flare_sec > 0 && height <= auto_state.sink_rate * aparm.land_flare_sec) &&
+         (auto_state.wp_proportion > 0.5)) ||
         (!rangefinder_in_range && location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) ||
         (fabsf(auto_state.sink_rate) < 0.2f && !is_flying())) {
 


### PR DESCRIPTION
I had an issue in SITL where my plane would round the last WP staring
its landing approach and immediately limit the roll to 5degress even
before the plane had finished turning the corner so it would go WAY
off course.  For a high value of LAND_FLARE_SEC (mine was 5) the math
works out the plane has landed if
    height <= sink_rate * land_flare_sec
During the banking of the last corner the plane started to decend and
quickly set itself up for a 6.1m/s sink rate which is normal.  It was
at 30 meters altitude.  As you can see at this point the math thinks
the plane has landed so limits the roll.  The solution was to ensure
the plane had covered at least 50% of the distance toward the final
waypoint before allowing a flare to happen.  Note that LAND_FLARE_SEC
above 2 is considered very high and this normally wouldn't occur.