### PR TITLE
Rover: Fixing up some of the outdated parameter comments/doco

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -12,6 +12,10 @@
 #define GOBJECTN(v, pname, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## pname, &rover.v, {group_info : class::var_info} }
 
 const AP_Param::Info Rover::var_info[] = {
+    // @Param: FORMAT_VERSION
+    // @DisplayName: Eeprom format version number
+    // @Description: This value is incremented when changes are made to the eeprom format
+    // @User: Advanced
 	GSCALAR(format_version,         "FORMAT_VERSION",   1),
     
     // @Param: SYSID_SW_TYPE
@@ -21,13 +25,18 @@ const AP_Param::Info Rover::var_info[] = {
     // @ReadOnly: True
 	GSCALAR(software_type,          "SYSID_SW_TYPE",    Parameters::k_software_type),
 
-	// misc
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
-    // @Description: Two byte bitmap of log types to enable in dataflash
-    // @Values: 0:Disabled,3950:Default,4078:Default+IMU
+    // @Description: Bitmap of what log types to enable in dataflash. This values is made up of the sum of each of the log types you want to be saved on dataflash. On a PX4 or Pixhawk the large storage size of a microSD card means it is usually best just to enable all log types by setting this to 65535. On APM2 the smaller 4 MByte dataflash means you need to be more selective in your logging or you may run out of log space while flying (in which case it will wrap and overwrite the start of the log). The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Sonar=16384, Arming=32768, LogWhenDisarmed=65536, FullLogsArmedOnly=65535, FullLogsWhenDisarmed=131071
+    // @Values: 0:Disabled,5190:APM2-Default,65535:PX4/Pixhawk-Default
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,16:WHEN_DISARMED,19:IMU_RAW
     // @User: Advanced
 	GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
+
+    // @Param: SYS_NUM_RESETS
+    // @DisplayName: Num Resets
+    // @Description: Number of APM board resets
+    // @User: Advanced
 	GSCALAR(num_resets,             "SYS_NUM_RESETS",   0),
 
     // @Param: RST_SWITCH_CH
@@ -52,7 +61,7 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: SYSID_MYGCS
     // @DisplayName: MAVLink ground station ID
-    // @Description: ID used in MAVLink protocol to identify the controlling ground station
+    // @Description: The identifier of the ground station in the MAVLink protocol. Don't change this unless you also modify the ground station to match.
     // @Range: 1 255
     // @User: Advanced
 	GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",      255),
@@ -84,8 +93,8 @@ const AP_Param::Info Rover::var_info[] = {
     GSCALAR(gcs_pid_mask,           "GCS_PID_MASK",     0),
 
     // @Param: MAG_ENABLED
-    // @DisplayName: Magnetometer (compass) enabled
-    // @Description: This should be set to 1 if a compass is installed
+    // @DisplayName: Enable Compass
+    // @Description: Setting this to Enabled(1) will enable the compass. Setting this to Disabled(0) will disable the compass. Note that this is separate from COMPASS_USE. This will enable the low level senor, and will enable logging of magnetometer data. To use the compass for navigation you must also set COMPASS_USE to 1.
     // @User: Standard
     // @Values: 0:Disabled,1:Enabled
 	GSCALAR(compass_enabled,        "MAG_ENABLE",       MAGNETOMETER),
@@ -296,7 +305,7 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: FS_THR_VALUE
     // @DisplayName: Throttle Failsafe Value
-    // @Description: The PWM level on channel 3 below which throttle failsafe triggers.
+    // @Description: The PWM level on the throttle channel below which throttle failsafe triggers.
     // @Range: 925 1100
     // @Increment: 1
     // @User: Standard


### PR DESCRIPTION
I noticed the doco on the Rover discourse page for LOG_BITMASK was
incorrect so I have fixed up a number of doco/comments so they
auto-generate the doco correctly for the wiki.  There is no actual
code changes in this commit.