### PR TITLE
waf: build sitl on windows

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -177,6 +177,11 @@ class sitl(Board):
             'SITL',
         ]
 
+	if sys.platform == 'cygwin':
+            env.LIB += [
+                'winmm',
+            ]
+
 class linux(Board):
     def configure_env(self, cfg, env):
         super(linux, self).configure_env(cfg, env)

--- a/wscript
+++ b/wscript
@@ -114,6 +114,9 @@ def configure(cfg):
     if cfg.options.submodule_update:
         cfg.env.SUBMODULE_UPDATE = True
 
+    # Always use system extensions
+    cfg.define('_GNU_SOURCE', 1)
+
     cfg.write_config_header(os.path.join(cfg.variant, 'ap_config.h'))
 
 def collect_dirs_to_recurse(bld, globs, **kw):


### PR DESCRIPTION
Tested on cygwin - only things that need to be installed are gcc, g++ and python.