### PR TITLE
Mission item int (extension of #3688)

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1175,6 +1175,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
 
 	// XXX read a WP from EEPROM and send it to the GCS
+    case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
     case MAVLINK_MSG_ID_MISSION_REQUEST:
     {
         handle_mission_request(rover.mission, msg);
@@ -1232,19 +1233,26 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     // GCS has sent us a mission item, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
-        {
-            if (handle_mission_item(msg, rover.mission)) {
-                rover.DataFlash.Log_Write_EntireMission(rover.mission);
-            }
-            break;
+    {
+        if (handle_mission_item(msg, rover.mission)) {
+            rover.DataFlash.Log_Write_EntireMission(rover.mission);
         }
+        break;
+    }
 
+    case MAVLINK_MSG_ID_MISSION_ITEM_INT:
+    {
+        if (handle_mission_item(msg, rover.mission)) {
+            rover.DataFlash.Log_Write_EntireMission(rover.mission);
+        }
+        break;
+    }
 
     case MAVLINK_MSG_ID_PARAM_SET:
-        {
-            handle_param_set(msg, &rover.DataFlash);
-            break;
-        }
+    {
+        handle_param_set(msg, &rover.DataFlash);
+        break;
+    }
 
     case MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE:
     {

--- a/APMrover2/capabilities.cpp
+++ b/APMrover2/capabilities.cpp
@@ -6,4 +6,5 @@ void Rover::init_capabilities(void)
 {
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_INT);
 }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1070,9 +1070,18 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         }
         break;
     }
+    
+    case MAVLINK_MSG_ID_MISSION_ITEM_INT:
+    {
+        if (handle_mission_item(msg, copter.mission)) {
+            copter.DataFlash.Log_Write_EntireMission(copter.mission);
+        }
+        break;
+    }
 
     // read an individual command from EEPROM and send it to the GCS
-    case MAVLINK_MSG_ID_MISSION_REQUEST:     // MAV ID: 40
+    case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
+    case MAVLINK_MSG_ID_MISSION_REQUEST:     // MAV ID: 40, 51
     {
         handle_mission_request(copter.mission, msg);
         break;

--- a/ArduCopter/capabilities.cpp
+++ b/ArduCopter/capabilities.cpp
@@ -6,6 +6,7 @@ void Copter::init_capabilities(void)
 {
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_INT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1662,8 +1662,8 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         break;
     }
 
-
     // XXX read a WP from EEPROM and send it to the GCS
+    case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
     case MAVLINK_MSG_ID_MISSION_REQUEST:
     {
         handle_mission_request(plane.mission, msg);
@@ -1729,6 +1729,15 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     // GCS has sent us a mission item, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
+    {
+        if (handle_mission_item(msg, plane.mission)) {
+            plane.DataFlash.Log_Write_EntireMission(plane.mission);
+        }
+        break;
+    }
+    
+    // GCS has sent us a mission item, store to EEPROM
+    case MAVLINK_MSG_ID_MISSION_ITEM_INT:
     {
         if (handle_mission_item(msg, plane.mission)) {
             plane.DataFlash.Log_Write_EntireMission(plane.mission);

--- a/ArduPlane/capabilities.cpp
+++ b/ArduPlane/capabilities.cpp
@@ -7,4 +7,5 @@ void Plane::init_capabilities(void)
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_COMMAND_INT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_INT);
 }

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -375,10 +375,12 @@ public:
     // mavlink_to_mission_cmd - converts mavlink message to an AP_Mission::Mission_Command object which can be stored to eeprom
     //  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
     static MAV_MISSION_RESULT mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd);
+    static MAV_MISSION_RESULT mavlink_int_to_mission_cmd(const mavlink_mission_item_int_t& packet, AP_Mission::Mission_Command& cmd);
 
     // mission_cmd_to_mavlink - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
     //  return true on success, false on failure
     static bool mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_t& packet);
+    static bool mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_int_t& packet);
 
     // return the last time the mission changed in milliseconds
     uint32_t last_change_time_ms(void) const { return _last_change_time_ms; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -253,47 +253,91 @@ void GCS_MAVLINK::handle_mission_request_list(AP_Mission &mission, mavlink_messa
 void GCS_MAVLINK::handle_mission_request(AP_Mission &mission, mavlink_message_t *msg)
 {
     AP_Mission::Mission_Command cmd;
-    // decode
-    mavlink_mission_request_t packet;
-    mavlink_msg_mission_request_decode(msg, &packet);
 
-    // retrieve mission from eeprom
-    if (!mission.read_cmd_from_storage(packet.seq, cmd)) {
-        goto mission_item_send_failed;
-    }
+    if (msg->msgid == MAVLINK_MSG_ID_MISSION_REQUEST_INT) {  
+        // decode
+        mavlink_mission_request_int_t packet;
+        mavlink_msg_mission_request_int_decode(msg, &packet);
 
-    // convert mission command to mavlink mission item packet
-    mavlink_mission_item_t ret_packet;
-    memset(&ret_packet, 0, sizeof(ret_packet));
-    if (!AP_Mission::mission_cmd_to_mavlink(cmd, ret_packet)) {
-        goto mission_item_send_failed;
-    }
+        // retrieve mission from eeprom
+        if (!mission.read_cmd_from_storage(packet.seq, cmd)) {
+            goto mission_item_send_failed;
+        }
 
-    // set packet's current field to 1 if this is the command being executed
-    if (cmd.id == (uint16_t)mission.get_current_nav_cmd().index) {
-        ret_packet.current = 1;
+        mavlink_mission_item_int_t ret_packet;
+        memset(&ret_packet, 0, sizeof(ret_packet));
+        if (!AP_Mission::mission_cmd_to_mavlink_int(cmd, ret_packet)) {
+            goto mission_item_send_failed;
+        }
+
+        // set packet's current field to 1 if this is the command being executed
+        if (cmd.id == (uint16_t)mission.get_current_nav_cmd().index) {
+            ret_packet.current = 1;
+        } else {
+            ret_packet.current = 0;
+        }
+
+        // set auto continue to 1
+        ret_packet.autocontinue = 1;     // 1 (true), 0 (false)
+
+        /*
+          avoid the _send() function to save memory, as it avoids
+          the stack usage of the _send() function by using the already
+          declared ret_packet above
+         */
+        ret_packet.target_system = msg->sysid;
+        ret_packet.target_component = msg->compid;
+        ret_packet.seq = packet.seq;
+        ret_packet.command = cmd.id;
+
+        _mav_finalize_message_chan_send(chan, 
+                                        MAVLINK_MSG_ID_MISSION_ITEM_INT,
+                                        (const char *)&ret_packet,
+                                        MAVLINK_MSG_ID_MISSION_ITEM_INT_LEN,
+                                        MAVLINK_MSG_ID_MISSION_ITEM_INT_CRC);
     } else {
-        ret_packet.current = 0;
+        // decode
+        mavlink_mission_request_t packet;
+        mavlink_msg_mission_request_decode(msg, &packet);
+
+        // retrieve mission from eeprom
+        if (!mission.read_cmd_from_storage(packet.seq, cmd)) {
+            goto mission_item_send_failed;
+        }
+
+        mavlink_mission_item_t ret_packet;
+        memset(&ret_packet, 0, sizeof(ret_packet));
+        if (!AP_Mission::mission_cmd_to_mavlink(cmd, ret_packet)) {
+            goto mission_item_send_failed;
+        }
+            
+        // set packet's current field to 1 if this is the command being executed
+        if (cmd.id == (uint16_t)mission.get_current_nav_cmd().index) {
+            ret_packet.current = 1;
+        } else {
+            ret_packet.current = 0;
+        }
+
+        // set auto continue to 1
+        ret_packet.autocontinue = 1;     // 1 (true), 0 (false)
+
+        /*
+          avoid the _send() function to save memory, as it avoids
+          the stack usage of the _send() function by using the already
+          declared ret_packet above
+         */
+        ret_packet.target_system = msg->sysid;
+        ret_packet.target_component = msg->compid;
+        ret_packet.seq = packet.seq;
+        ret_packet.command = cmd.id;
+
+        _mav_finalize_message_chan_send(chan, 
+                                        MAVLINK_MSG_ID_MISSION_ITEM,
+                                        (const char *)&ret_packet,
+                                        MAVLINK_MSG_ID_MISSION_ITEM_LEN,
+                                        MAVLINK_MSG_ID_MISSION_ITEM_CRC);
     }
 
-    // set auto continue to 1
-    ret_packet.autocontinue = 1;     // 1 (true), 0 (false)
-
-    /*
-      avoid the _send() function to save memory, as it avoids
-      the stack usage of the _send() function by using the already
-      declared ret_packet above
-     */
-    ret_packet.target_system = msg->sysid;
-    ret_packet.target_component = msg->compid;
-    ret_packet.seq = packet.seq;
-    ret_packet.command = cmd.id;
-
-    _mav_finalize_message_chan_send(chan, 
-                                    MAVLINK_MSG_ID_MISSION_ITEM,
-                                    (const char *)&ret_packet,
-                                    MAVLINK_MSG_ID_MISSION_ITEM_LEN,
-                                    MAVLINK_MSG_ID_MISSION_ITEM_CRC);
     return;
 
 mission_item_send_failed:
@@ -625,20 +669,39 @@ void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &d
  */
 bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &mission)
 {
-    mavlink_mission_item_t packet;
     MAV_MISSION_RESULT result = MAV_MISSION_ACCEPTED;
     struct AP_Mission::Mission_Command cmd = {};
     bool mission_is_complete = false;
-
-    mavlink_msg_mission_item_decode(msg, &packet);
-
-    // convert mavlink packet to mission command
-    result = AP_Mission::mavlink_to_mission_cmd(packet, cmd);
-    if (result != MAV_MISSION_ACCEPTED) {
-        goto mission_ack;
+    uint16_t seq=0;
+    uint16_t current = 0;
+    
+    if (msg->msgid == MAVLINK_MSG_ID_MISSION_ITEM) {      
+        mavlink_mission_item_t packet;    
+        mavlink_msg_mission_item_decode(msg, &packet);
+        
+        // convert mavlink packet to mission command
+        result = AP_Mission::mavlink_to_mission_cmd(packet, cmd);
+        if (result != MAV_MISSION_ACCEPTED) {
+            goto mission_ack;
+        }
+        
+        seq = packet.seq;
+        current = packet.current;
+    } else {
+        mavlink_mission_item_int_t packet;
+        mavlink_msg_mission_item_int_decode(msg, &packet);
+        
+        // convert mavlink packet to mission command
+        result = AP_Mission::mavlink_int_to_mission_cmd(packet, cmd);
+        if (result != MAV_MISSION_ACCEPTED) {
+            goto mission_ack;
+        }
+        
+        seq = packet.seq;
+        current = packet.current;
     }
 
-    if (packet.current == 2) {                                               
+    if (current == 2) {                                               
         // current = 2 is a flag to tell us this is a "guided mode"
         // waypoint and not for the mission
         result = (handle_guided_request(cmd) ? MAV_MISSION_ACCEPTED
@@ -648,7 +711,7 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         goto mission_ack;
     }
 
-    if (packet.current == 3) {
+    if (current == 3) {
         //current = 3 is a flag to tell us this is a alt change only
         // add home alt if needed
         handle_change_alt_request(cmd);
@@ -665,21 +728,21 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
     }
 
     // check if this is the requested waypoint
-    if (packet.seq != waypoint_request_i) {
+    if (seq != waypoint_request_i) {
         result = MAV_MISSION_INVALID_SEQUENCE;
         goto mission_ack;
     }
     
     // if command index is within the existing list, replace the command
-    if (packet.seq < mission.num_commands()) {
-        if (mission.replace_cmd(packet.seq,cmd)) {
+    if (seq < mission.num_commands()) {
+        if (mission.replace_cmd(seq,cmd)) {
             result = MAV_MISSION_ACCEPTED;
         }else{
             result = MAV_MISSION_ERROR;
             goto mission_ack;
         }
         // if command is at the end of command list, add the command
-    } else if (packet.seq == mission.num_commands()) {
+    } else if (seq == mission.num_commands()) {
         if (mission.add_cmd(cmd)) {
             result = MAV_MISSION_ACCEPTED;
         }else{


### PR DESCRIPTION
Adds a commit on top of #3688 to address the problems with digicams, and NED/local frames.

I haven't finished a full implementation test here, but this addresses all the issues I found while reviewing the original PR, and were brought up on the dev call. I will be finishing my implementation tests shortly.

NED/local frames were removed as we don't ever define them, and the scaling that was present was not correct for NED coordinates once in mission item int. If this is strongly objectionable they can come back in, but will need some extra conversions to handle the correct units. (As well as the existing support didn't allow for reading back the NED frame and would only come back as a global relative).