### PR TITLE
SpdHgt_Control: Remove hgt_afe from the 50hz update

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -188,7 +188,7 @@ void Plane::update_speed_height(void)
 	    // Call TECS 50Hz update. Note that we call this regardless of
 	    // throttle suppressed, as this needs to be running for
 	    // takeoff detection
-        SpdHgt_Controller->update_50hz(tecs_hgt_afe());
+        SpdHgt_Controller->update_50hz();
     }
 }
 

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -20,7 +20,7 @@ public:
 	// Update the internal state of the height and height rate estimator
 	// Update of the inertial speed rate estimate internal state
 	// Should be called at 50Hz or faster
-	virtual void update_50hz(float height_above_field) = 0;
+	virtual void update_50hz(void) = 0;
 
 	/**
 	   stages of flight so the altitude controller can choose to

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -252,7 +252,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
  *
  */
 
-void AP_TECS::update_50hz(float hgt_afe)
+void AP_TECS::update_50hz(void)
 {
     // Implement third order complementary filter for height and height rate
     // estimted height rate = _climb_rate

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -39,7 +39,7 @@ public:
     // Update of the estimated height and height rate internal state
     // Update of the inertial speed rate internal state
     // Should be called at 50Hz or greater
-    void update_50hz(float hgt_afe);
+    void update_50hz(void);
 
     // Update the control loop calculations
     void update_pitch_throttle(int32_t hgt_dem_cm,


### PR DESCRIPTION
No speed height controller uses the passed in value, so calculating it every time is wasted processing power, as well as being dependent upon a minimum of 1 loop of stale data (for the update_speed_height task)