### PR TITLE
support 16 bit command IDs in missions

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -485,7 +485,7 @@ void Plane::update_GPS_10Hz(void)
  */
 void Plane::handle_auto_mode(void)
 {
-    uint8_t nav_cmd_id;
+    uint16_t nav_cmd_id;
 
     // we should be either running a mission or RTLing home
     if (mission.state() == AP_Mission::MISSION_RUNNING) {

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1176,7 +1176,7 @@ bool Plane::allow_reverse_thrust(void)
     switch (control_mode) {
     case AUTO:
         {
-        uint8_t nav_cmd = mission.get_current_nav_cmd().id;
+        uint16_t nav_cmd = mission.get_current_nav_cmd().id;
 
         // never allow reverse thrust during takeoff
         if (nav_cmd == MAV_CMD_NAV_TAKEOFF) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1625,7 +1625,11 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
             
         case MAV_CMD_DO_VTOL_TRANSITION:
-            result = plane.quadplane.handle_do_vtol_transition(packet);
+            if (!plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)packet.param1)) {
+                result = MAV_RESULT_FAILED;
+            } else {
+                result = MAV_RESULT_ACCEPTED;
+            }
             break;
             
         default:

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -218,6 +218,10 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
                                        cmd.content.mount_control.yaw);
         break;
 #endif
+
+    case MAV_CMD_DO_VTOL_TRANSITION:
+        plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)cmd.content.do_vtol_transition.target_state);
+        break;
     }
 
     return true;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -948,33 +948,38 @@ bool QuadPlane::init_mode(void)
 /*
   handle a MAVLink DO_VTOL_TRANSITION
  */
-bool QuadPlane::handle_do_vtol_transition(const mavlink_command_long_t &packet)
+bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state)
 {
     if (!available()) {
         plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "VTOL not available");
-        return MAV_RESULT_FAILED;
+        return false;
     }
     if (plane.control_mode != AUTO) {
         plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "VTOL transition only in AUTO");
-        return MAV_RESULT_FAILED;
+        return false;
     }
-    switch ((uint8_t)packet.param1) {
+    switch (state) {
     case MAV_VTOL_STATE_MC:
         if (!plane.auto_state.vtol_mode) {
             plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Entered VTOL mode");
         }
         plane.auto_state.vtol_mode = true;
-        return MAV_RESULT_ACCEPTED;
+        return true;
+        
     case MAV_VTOL_STATE_FW:
         if (plane.auto_state.vtol_mode) {
             plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
         }
         plane.auto_state.vtol_mode = false;
-        return MAV_RESULT_ACCEPTED;
+
+        return true;
+
+    default:
+        break;
     }
 
     plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Invalid VTOL mode");
-    return MAV_RESULT_FAILED;
+    return false;
 }
 
 /*

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -42,7 +42,7 @@ public:
         return available() && assisted_flight;
     }
     
-    bool handle_do_vtol_transition(const mavlink_command_long_t &packet);
+    bool handle_do_vtol_transition(enum MAV_VTOL_STATE state);
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
     bool do_vtol_land(const AP_Mission::Mission_Command& cmd);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -726,6 +726,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
     case MAV_CMD_NAV_VTOL_LAND:
         copy_location = true;
         break;
+
+    case MAV_CMD_DO_VTOL_TRANSITION:
+        cmd.content.do_vtol_transition.target_state = packet.param1;
+        break;
         
     default:
         // unrecognised command
@@ -1066,6 +1070,10 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     case MAV_CMD_NAV_VTOL_LAND:
         copy_location = true;
+        break;
+
+    case MAV_CMD_DO_VTOL_TRANSITION:
+        packet.param1 = cmd.content.do_vtol_transition.target_state;
         break;
         
     default:

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -424,9 +424,16 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
         // read WP position
         uint16_t pos_in_storage = 4 + (index * AP_MISSION_EEPROM_COMMAND_SIZE);
 
-        cmd.id = _storage.read_byte(pos_in_storage);
-        cmd.p1 = _storage.read_uint16(pos_in_storage+1);
-        _storage.read_block(cmd.content.bytes, pos_in_storage+3, 12);
+        uint8_t b1 = _storage.read_byte(pos_in_storage);
+        if (b1 == 0) {
+            cmd.id = _storage.read_uint16(pos_in_storage+1);
+            cmd.p1 = _storage.read_uint16(pos_in_storage+3);
+            _storage.read_block(cmd.content.bytes, pos_in_storage+5, 10);
+        } else {
+            cmd.id = b1;
+            cmd.p1 = _storage.read_uint16(pos_in_storage+1);
+            _storage.read_block(cmd.content.bytes, pos_in_storage+3, 12);
+        }
 
         // set command's index to it's position in eeprom
         cmd.index = index;
@@ -449,9 +456,17 @@ bool AP_Mission::write_cmd_to_storage(uint16_t index, Mission_Command& cmd)
     // calculate where in storage the command should be placed
     uint16_t pos_in_storage = 4 + (index * AP_MISSION_EEPROM_COMMAND_SIZE);
 
-    _storage.write_byte(pos_in_storage, cmd.id);
-    _storage.write_uint16(pos_in_storage+1, cmd.p1);
-    _storage.write_block(pos_in_storage+3, cmd.content.bytes, 12);
+    if (cmd.id < 256) {
+        _storage.write_byte(pos_in_storage, cmd.id);
+        _storage.write_uint16(pos_in_storage+1, cmd.p1);
+        _storage.write_block(pos_in_storage+3, cmd.content.bytes, 12);
+    } else {
+        // if the command ID is above 256 we store a 0 followed by the 16 bit command ID
+        _storage.write_byte(pos_in_storage, 0);
+        _storage.write_uint16(pos_in_storage+1, cmd.id);
+        _storage.write_uint16(pos_in_storage+3, cmd.p1);
+        _storage.write_block(pos_in_storage+5, cmd.content.bytes, 10);
+    }
 
     // remember when the mission last changed
     _last_change_time_ms = AP_HAL::millis();
@@ -485,6 +500,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
     // command specific conversions from mavlink packet to mission command
     switch (cmd.id) {
 
+    case 0:
+        // this is reserved for storing 16 bit command IDs
+        return MAV_MISSION_INVALID;
+        
     case MAV_CMD_NAV_WAYPOINT:                          // MAV ID: 16
         copy_location = true;
         /*
@@ -819,7 +838,10 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     // command specific conversions from mission command to mavlink packet
     switch (cmd.id) {
-
+    case 0:
+        // this is reserved for 16 bit command IDs
+        return false;
+        
     case MAV_CMD_NAV_WAYPOINT:                          // MAV ID: 16
         copy_location = true;
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -208,14 +208,15 @@ public:
         // location
         Location location;      // Waypoint location
 
-        // raw bytes, for reading/writing to eeprom
+        // raw bytes, for reading/writing to eeprom. Note that only 12 bytes are available
+        // if a 16 bit command ID is used
         uint8_t bytes[12];
     };
 
     // command structure
-    struct PACKED Mission_Command {
+    struct Mission_Command {
         uint16_t index;             // this commands position in the command list
-        uint8_t id;                 // mavlink command id
+        uint16_t id;                // mavlink command id
         uint16_t p1;                // general purpose parameter 1
         Content content;
     };

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -156,6 +156,11 @@ public:
         float horiz_max;        // max horizontal distance the vehicle can move before the command will be aborted.  0 for no horizontal limit
     };
 
+    // do VTOL transition
+    struct PACKED Do_VTOL_Transition {
+        uint8_t target_state;
+    };
+
     union PACKED Content {
         // jump structure
         Jump_Command jump;
@@ -205,6 +210,9 @@ public:
         // cam trigg distance
         Altitude_Wait altitude_wait;
 
+        // do vtol transition
+        Do_VTOL_Transition do_vtol_transition;
+        
         // location
         Location location;      // Waypoint location
 


### PR DESCRIPTION
this allows us to support 16 bit command IDs in missions. It reserves command ID 0 and uses 0 as a marker to indicate that the next 2 bytes in FRAM are the 16 bit ID. Commands are then limited to 10 bytes
