### PR TITLE
AP_Param: explicitly cast to float to avoid Clang warning

### DIFF
--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -539,7 +539,7 @@ public:
     /// Combined set and save
     ///
     bool set_and_save(const T &v) {
-        bool force = fabsf(_value - v) < FLT_EPSILON;
+        bool force = fabsf((float)(_value - v)) < FLT_EPSILON;
         set(v);
         return save(force);
     }


### PR DESCRIPTION
Clang gives the following warning multiple times:

```
/home/travis/build/ArduPilot/ardupilot/libraries/AP_Param/AP_Param.h:542:22: warning: using floating point absolute value function 'fabsf' when argument is of integer type [-Wabsolute-value]
        bool force = fabsf(_value - v) < FLT_EPSILON;
```

@rmackay9 I hope this helps your terrain PR to pass the Clang test