### PR TITLE
AP_Mission: Remove DO_SET_PARAMETER

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -600,11 +600,6 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
         cmd.p1 = packet.param1;                         // p1=0 means use current location, p=1 means use provided location
         break;
 
-    case MAV_CMD_DO_SET_PARAMETER:                      // MAV ID: 180
-        cmd.p1 = packet.param1;                         // parameter number
-        cmd.content.location.alt = packet.param2;       // parameter value
-        break;
-
     case MAV_CMD_DO_SET_RELAY:                          // MAV ID: 181
         cmd.content.relay.num = packet.param1;          // relay number
         cmd.content.relay.state = packet.param2;        // 0:off, 1:on
@@ -936,11 +931,6 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
     case MAV_CMD_DO_SET_HOME:                           // MAV ID: 179
         copy_location = true;
         packet.param1 = cmd.p1;                         // p1=0 means use current location, p=1 means use provided location
-        break;
-
-    case MAV_CMD_DO_SET_PARAMETER:                      // MAV ID: 180
-        packet.param1 = cmd.p1;                         // parameter number
-        packet.param2 = cmd.content.location.alt;       // parameter value
         break;
 
     case MAV_CMD_DO_SET_RELAY:                          // MAV ID: 181


### PR DESCRIPTION
DO_SET_PARAMETERS were accepted in the mission library even though they were never handled, and couldn't be executed. (They also represent a poor way to set parameters as they require knowledge of the param index which might not be available, or the same between boots). The current implementation also corrupted the param value as well so the storage and read back of the parameter wasn't correct anyway.