### PR TITLE
Change stack size

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -96,6 +96,7 @@ void Scheduler::init()
         const struct sched_table *t = &sched_table[i];
 
         t->thread->set_rate(t->rate);
+        t->thread->set_stack_size(256 * 1024);
         t->thread->start(t->name, t->policy, t->prio);
     }
 

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -98,6 +98,30 @@ void Scheduler::init()
         t->thread->set_rate(t->rate);
         t->thread->start(t->name, t->policy, t->prio);
     }
+
+#if defined(DEBUG_STACK) && DEBUG_STACK
+    register_timer_process(FUNCTOR_BIND_MEMBER(&Scheduler::_debug_stack, void));
+#endif
+}
+
+void Scheduler::_debug_stack()
+{
+    uint64_t now = AP_HAL::millis64();
+
+    if (now - _last_stack_debug_msec > 5000) {
+        fprintf(stderr, "Stack Usage:\n"
+                "\ttimer = %zu\n"
+                "\tio    = %zu\n"
+                "\trcin  = %zu\n"
+                "\tuart  = %zu\n"
+                "\ttone  = %zu\n",
+                _timer_thread.get_stack_usage(),
+                _io_thread.get_stack_usage(),
+                _rcin_thread.get_stack_usage(),
+                _uart_thread.get_stack_usage(),
+                _tonealarm_thread.get_stack_usage());
+        _last_stack_debug_msec = now;
+    }
 }
 
 void Scheduler::microsleep(uint32_t usec)

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -60,6 +60,8 @@ private:
 
     void _wait_all_threads();
 
+    void     _debug_stack();
+
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
 
@@ -102,6 +104,7 @@ private:
     bool _register_timesliced_proc(AP_HAL::MemberProc, uint8_t);
 
     uint64_t _stopped_clock_usec;
+    uint64_t _last_stack_debug_msec;
 
     Semaphore _timer_semaphore;
     Semaphore _io_semaphore;

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -154,6 +154,12 @@ bool Thread::start(const char *name, int policy, int prio)
         }
     }
 
+    if (_stack_size) {
+        if (pthread_attr_setstacksize(&attr, _stack_size) != 0) {
+            return false;
+        }
+    }
+
     r = pthread_create(&_ctx, &attr, &Thread::_run_trampoline, this);
     if (r != 0) {
         AP_HAL::panic("Failed to create thread '%s': %s",
@@ -182,6 +188,17 @@ bool PeriodicThread::set_rate(uint32_t rate_hz)
     }
 
     _period_usec = hz_to_usec(rate_hz);
+
+    return true;
+}
+
+bool Thread::set_stack_size(size_t stack_size)
+{
+    if (_started) {
+        return false;
+    }
+
+    _stack_size = stack_size;
 
     return true;
 }

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -17,13 +17,18 @@
  */
 #include "Thread.h"
 
+#include <alloca.h>
 #include <sys/types.h>
+#include <stdio.h>
 #include <unistd.h>
+#include <utility>
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 
 #include "Scheduler.h"
+
+#define STACK_POISON 0xBEBACAFE
 
 extern const AP_HAL::HAL &hal;
 
@@ -33,6 +38,7 @@ namespace Linux {
 void *Thread::_run_trampoline(void *arg)
 {
     Thread *thread = static_cast<Thread *>(arg);
+    thread->_poison_stack();
     thread->_run();
 
     return nullptr;
@@ -47,6 +53,79 @@ bool Thread::_run()
     _task();
 
     return true;
+}
+
+void Thread::_poison_stack()
+{
+    pthread_attr_t attr;
+    size_t stack_size, guard_size;
+    void *stackp;
+    uint8_t *end, *start, *curr;
+    uint32_t *p;
+
+    if (pthread_getattr_np(_ctx, &attr) != 0 ||
+        pthread_attr_getstack(&attr, &stackp, &stack_size) != 0 ||
+        pthread_attr_getguardsize(&attr, &guard_size) != 0) {
+        return;
+    }
+
+    /* The stack either grows upward or downard. The guard part always
+     * protects the end */
+    end = (uint8_t *) stackp;
+    start = end + stack_size;
+    curr = (uint8_t *) alloca(sizeof(uint32_t));
+
+    /* if curr is closer to @end, the stack actually grows from low to high
+     * virtual address: this is because this function should be executing very
+     * early in the thread's life and close to the thread creation, assuming
+     * the actual stack size is greater than the guard size and the stack
+     * until now is resonably small */
+    if (abs(curr - start) > abs(curr - end)) {
+        std::swap(end, start);
+        end -= guard_size;
+
+        for (p = (uint32_t *) end; p > (uint32_t *) curr; p--) {
+            *p = STACK_POISON;
+        }
+    } else {
+        end += guard_size;
+
+        for (p = (uint32_t *) end; p < (uint32_t *) curr; p++) {
+            *p = STACK_POISON;
+        }
+    }
+
+    _stack_debug.start = (uint32_t *) start;
+    _stack_debug.end = (uint32_t *) end;
+}
+
+size_t Thread::get_stack_usage()
+{
+    uint32_t *p;
+    size_t result = 0;
+
+    /* Make sure we are tracking usage for this thread */
+    if (_stack_debug.start == 0 || _stack_debug.end == 0) {
+        return 0;
+    }
+
+    if (_stack_debug.start < _stack_debug.end) {
+        for (p = _stack_debug.end; p > _stack_debug.start; p--) {
+            if (*p != STACK_POISON) {
+                break;
+            }
+        }
+        result = p - _stack_debug.start;
+    } else {
+        for (p = _stack_debug.end; p < _stack_debug.start; p++) {
+            if (*p != STACK_POISON) {
+                break;
+            }
+        }
+        result = _stack_debug.start - p;
+    }
+
+    return result;
 }
 
 bool Thread::start(const char *name, int policy, int prio)

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -44,6 +44,8 @@ public:
 
     size_t get_stack_usage();
 
+    bool set_stack_size(size_t stack_size);
+
 protected:
     static void *_run_trampoline(void *arg);
 
@@ -64,6 +66,8 @@ protected:
         uint32_t *start;
         uint32_t *end;
     } _stack_debug;
+
+    size_t _stack_size;
 };
 
 class PeriodicThread : public Thread {

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -42,6 +42,8 @@ public:
 
     bool is_current_thread();
 
+    size_t get_stack_usage();
+
 protected:
     static void *_run_trampoline(void *arg);
 
@@ -52,9 +54,16 @@ protected:
      */
     virtual bool _run();
 
+    void _poison_stack();
+
     task_t _task;
     bool _started;
     pthread_t _ctx;
+
+    struct stack_debug {
+        uint32_t *start;
+        uint32_t *end;
+    } _stack_debug;
 };
 
 class PeriodicThread : public Thread {


### PR DESCRIPTION
This is a long overdue task and is necessary in order to enable one thread per bus. We can't use the default stack size for these threads (neither for the current ones) since we would end up using a lot of memory.

This PR adds some hacks^Winfrastructure to allow debugging the stack size. This needs more test to check if we don't use more stack space in other parts of the code. It would probably be good to test more on other boards. This was mainly tested on minlure with 64bits distro. There's also some magic with alloca() and pthread calls to be able to poison the stack memory. There's probably a better way to do it, but it seems to work. It has code in place to deal with the stack growing in each direction, but it was only tested with stack growing from high to low virtual addresses.

I don't like the ifdef to debug the stack but it looks ok for now. This is a potential user of the interface being added #3195.

Since the tests showed that the stack is around 4k, leave a little bit of room and safety: set the scheduler threads to use 256k. See last commit about memory reduction in this PR.