### PR TITLE
AP_HAL_Linux: Fix compiler warning (unused hal) in GPIO_BBB

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_BBB.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.cpp
@@ -17,7 +17,6 @@
 
 using namespace Linux;
 
-static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 GPIO_BBB::GPIO_BBB()
 {}
 


### PR DESCRIPTION
Fix compiler warning (unused `hal`) in `GPIO_BBB.cpp`.