### PR TITLE
EKF2 bug fixes

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -143,10 +143,9 @@ void NavEKF2_core::setAidingMode()
             // reset the last valid position fix time to prevent unwanted activation of GPS glitch logic
             lastPosPassTime_ms = imuSampleTime_ms;
         }
-        // Reset all position, velocity and covariance
+        // Reset all position and velocity states
         ResetVelocity();
         ResetPosition();
-        CovarianceInit();
 
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -845,15 +845,14 @@ void NavEKF2_core::FuseDeclination()
     float magN = stateStruct.earth_magfield.x;
     float magE = stateStruct.earth_magfield.y;
 
-    // prevent bad earth field states from causing numerical errors or exceptions
-    if (magN < 1e-3f) {
-        return;
-    }
-
     // Calculate observation Jacobian and Kalman gains
     float t2 = magE*magE;
     float t3 = magN*magN;
     float t4 = t2+t3;
+    if (t4 < 0.001f) {
+        // prevent bad earth field states from causing numerical errors or exceptions
+        return;
+    }
     float t5 = 1.0f/t4;
     float t22 = magE*t5;
     float t23 = magN*t5;
@@ -885,7 +884,7 @@ void NavEKF2_core::FuseDeclination()
     float magDecAng = use_compass() ? _ahrs->get_compass()->get_declination() : 0;
 
     // Calculate the innovation
-    float innovation = atanf(t4) - magDecAng;
+    float innovation = atan2f(magE , magN) - magDecAng;
 
     // limit the innovation to protect against data errors
     if (innovation > 0.5f) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -178,7 +178,6 @@ void NavEKF2_core::SelectMagFusion()
 
             // if we are spinning rapidly, then the declination observaton used is the last learned value before the spin started
             bool useLearnedDecl = fabsf(filtYawRate) > 1.0f;
-            printf("%e\n",fabsf(filtYawRate));
             if (!useLearnedDecl) {
                 lastLearnedDecl = atan2f(stateStruct.earth_magfield.y,stateStruct.earth_magfield.x);
             }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -774,7 +774,11 @@ private:
     uint32_t framesSincePredict;    // number of frames lapsed since EKF instance did a state prediction
     bool startPredictEnabled;       // boolean true when the frontend has given permission to start a new state prediciton cycele
     uint8_t localFilterTimeStep_ms; // average number of msec between filter updates
-    float posDownObsNoise;          // observationn noise on the vertical position used by the state and covariance update step (m)
+    float posDownObsNoise;          // observation noise on the vertical position used by the state and covariance update step (m)
+    float magDecAng;                // Magnetic declination angle used by the filter (rad)
+    float filtYawRate;              // filtered yaw rate used to activate rapid yaw protection (rad/sec)
+    float lastLearnedDecl;          // last value of declination learned (rad)
+    float declObsVar;               // variance of the magentic declination observation (rad)^2
 
     // variables used to calulate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.


### PR DESCRIPTION
The following bugs have been fixed:

The filter covariance matrix as being reset when switching to GPS mode. If this occurred in-flight, and 3-axis magnetometer fusion was being used or commenced shortly after it could lead to loss of attitude reference under some circumstances. The first patch eliminates the reset of the covariance matrix and replaces it with a reset of the covariances associated with the horizontal position and velocity only.

The fusion of  synthetic declination angle used when using 3-axis fusion without GPS data to constrain drift in the declination had an error in the calculation of the predicted declination. This has been replaced wth the correct calculation.

Rapid continuous yaw spins in loiter in combination with gyro scale factor errors and 3-axis magnetometer fusion could result in rotation of the earth field states and large yaw errors. Rotation of earth field states has been eliminated by fusing in the last estimated declination angle when yaw rates are high.

This has had  testing on Copter, but requires testing on Rovers and Planes. Further Copter flight testing with full stick continual yaw rotations is required. When testing it would be appreciated if with the following parameters settings are used and links to the logs posted here so that a back to back comparison between the two observers can be made.

AHRS_EKF_TYPE = 1 (use EKF1 to de-risk flight testing for prolonged high rate yaw inputs)
EKF_ENABLE = 1
EK2_ENABLE = 1
EK2_IMU_MASK = 1
INS_USE = 1
INS_USE2 = 0
INS_USE3 = 0