### PR TITLE
Remove DO_CONDITION_CHANGE_ALT

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -699,7 +699,6 @@ private:
     bool verify_loiter_time();
     bool verify_RTL();
     bool verify_wait_delay();
-    bool verify_change_alt();
     bool verify_within_distance();
     bool verify_yaw();
     void do_take_picture();
@@ -1004,7 +1003,6 @@ private:
 #endif
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
-    void do_change_alt(const AP_Mission::Mission_Command& cmd);
     void do_yaw(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -64,10 +64,6 @@ bool Copter::start_command(const AP_Mission::Mission_Command& cmd)
         do_within_distance(cmd);
         break;
 
-    case MAV_CMD_CONDITION_CHANGE_ALT:             // 113
-        do_change_alt(cmd);
-        break;
-
     case MAV_CMD_CONDITION_YAW:             // 115
         do_yaw(cmd);
         break;
@@ -224,9 +220,6 @@ bool Copter::verify_command(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_CONDITION_DISTANCE:
         return verify_within_distance();
-
-    case MAV_CMD_CONDITION_CHANGE_ALT:
-        return verify_change_alt();
 
     case MAV_CMD_CONDITION_YAW:
         return verify_yaw();
@@ -724,11 +717,6 @@ void Copter::do_wait_delay(const AP_Mission::Mission_Command& cmd)
     condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
 }
 
-void Copter::do_change_alt(const AP_Mission::Mission_Command& cmd)
-{
-    // To-Do: store desired altitude in a variable so that it can be verified later
-}
-
 void Copter::do_within_distance(const AP_Mission::Mission_Command& cmd)
 {
     condition_value  = cmd.content.distance.meters * 100;
@@ -755,12 +743,6 @@ bool Copter::verify_wait_delay()
         return true;
     }
     return false;
-}
-
-bool Copter::verify_change_alt()
-{
-    // To-Do: use recorded target altitude to verify we have reached the target
-    return true;
 }
 
 bool Copter::verify_within_distance()

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -844,7 +844,6 @@ private:
     bool verify_RTL();
     bool verify_continue_and_change_alt();
     bool verify_wait_delay();
-    bool verify_change_alt();
     bool verify_within_distance();
     bool verify_altitude_wait(const AP_Mission::Mission_Command &cmd);
     bool verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd);
@@ -1031,7 +1030,6 @@ private:
     void do_vtol_land(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
-    void do_change_alt(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -48,7 +48,7 @@ void Plane::adjust_altitude_target()
 
         // stay within the range of the start and end locations in altitude
         constrain_target_altitude_location(next_WP_loc, prev_WP_loc);
-    } else if (mission.get_current_do_cmd().id != MAV_CMD_CONDITION_CHANGE_ALT) {
+    } else {
         set_target_altitude_location(next_WP_loc);
     }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -103,10 +103,6 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         do_within_distance(cmd);
         break;
 
-    case MAV_CMD_CONDITION_CHANGE_ALT:
-        do_change_alt(cmd);
-        break;
-
     // Do commands
 
     case MAV_CMD_DO_CHANGE_SPEED:
@@ -276,9 +272,6 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
 
     case MAV_CMD_CONDITION_DISTANCE:
         return verify_within_distance();
-
-    case MAV_CMD_CONDITION_CHANGE_ALT:
-        return verify_change_alt();
 
 #if PARACHUTE == ENABLED
     case MAV_CMD_DO_PARACHUTE:
@@ -795,23 +788,6 @@ void Plane::do_wait_delay(const AP_Mission::Mission_Command& cmd)
     condition_value  = cmd.content.delay.seconds * 1000;    // convert seconds to milliseconds
 }
 
-/*
-  process a DO_CHANGE_ALT request
- */
-void Plane::do_change_alt(const AP_Mission::Mission_Command& cmd)
-{
-    condition_rate = labs((int)cmd.content.location.lat);   // climb rate in cm/s
-    condition_value = cmd.content.location.alt;             // To-Do: ensure this altitude is an absolute altitude?
-    if (condition_value < adjusted_altitude_cm()) {
-        condition_rate = -condition_rate;
-    }
-    set_target_altitude_current_adjusted();
-    change_target_altitude(condition_rate/10);
-    next_WP_loc.alt = condition_value;                                      // For future nav calculations
-    reset_offset_altitude();
-    setup_glide_slope();
-}
-
 void Plane::do_within_distance(const AP_Mission::Mission_Command& cmd)
 {
     condition_value  = cmd.content.distance.meters;
@@ -827,19 +803,6 @@ bool Plane::verify_wait_delay()
         condition_value         = 0;
         return true;
     }
-    return false;
-}
-
-bool Plane::verify_change_alt()
-{
-    if( (condition_rate>=0 && adjusted_altitude_cm() >= condition_value) || 
-        (condition_rate<=0 && adjusted_altitude_cm() <= condition_value)) {
-        condition_value = 0;
-        return true;
-    }
-    // condition_rate is climb rate in cm/s.  
-    // We divide by 10 because this function is called at 10hz
-    change_target_altitude(condition_rate/10);
     return false;
 }
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -583,11 +583,6 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
         cmd.content.delay.seconds = packet.param1;      // delay in seconds
         break;
 
-    case MAV_CMD_CONDITION_CHANGE_ALT:                  // MAV ID: 113
-        copy_alt = true;                                // only altitude is used
-        cmd.content.location.lat = packet.param1 * 100; // climb/descent converted from m/s to cm/s.  To-Do: store in proper climb_rate structure
-        break;
-
     case MAV_CMD_CONDITION_DISTANCE:                    // MAV ID: 114
         cmd.content.distance.meters = packet.param1;    // distance in meters from next waypoint
         break;
@@ -921,11 +916,6 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     case MAV_CMD_CONDITION_DELAY:                       // MAV ID: 112
         packet.param1 = cmd.content.delay.seconds;      // delay in seconds
-        break;
-
-    case MAV_CMD_CONDITION_CHANGE_ALT:                  // MAV ID: 113
-        copy_alt = true;                                // only altitude is used
-        packet.param1 = cmd.content.location.lat / 100.0f;  // climb/descent rate converted from cm/s to m/s.  To-Do: store in proper climb_rate structure
         break;
 
     case MAV_CMD_CONDITION_DISTANCE:                    // MAV ID: 114


### PR DESCRIPTION
Per the dev call today removes support for the DO_CONDITION_CHANGE_ALT command. (Only plane supported it, and it required an absolute altitude, which was not well known or published).