### PR TITLE
AP_HAL_Linux: Fix RCInput::read from stopping at any zero channel

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -58,14 +58,9 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
 {
     uint8_t i;
     for (i=0; i<len; i++) {
-        if((periods[i] = read(i))){
-            continue;
-        }
-        else{
-            break;
-        }
+        periods[i] = read(i);
     }
-    return (i+1);
+    return len;
 }
 
 bool RCInput::set_overrides(int16_t *overrides, uint8_t len) 


### PR DESCRIPTION
This bug led to issues for us so it may help others to resolve it. Currently, the AP_HAL_Linux RCInput::read(uint16_t*,uint8_t) function only returns the first x nonzero channels. Once it hits a channel that is set to zero, it stops and all remaining channels are returned as zero, even if they are set. This causes discrepancies between the raw RC input sent to the GCS and the RC input that is actually used on the vehicle.

The PR fixes this issue and makes it behave exactly as it does on the PX4_HAL code.

We ran into this issue when sending rc_override messages in which there were some channels set to zero.