### PR TITLE
AP_HAL: move definition of callbacks structure out of C linkage

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Main.h
+++ b/libraries/AP_HAL/AP_HAL_Main.h
@@ -37,10 +37,11 @@
 
 #else
 
-#define AP_HAL_MAIN() extern "C" { \
+#define AP_HAL_MAIN() \
+    AP_HAL::HAL::FunCallbacks callbacks(setup, loop); \
+    extern "C" {                               \
     int AP_MAIN(int argc, char* const argv[]); \
     int AP_MAIN(int argc, char* const argv[]) { \
-        AP_HAL::HAL::FunCallbacks callbacks(setup, loop); \
         hal.run(argc, argv, &callbacks); \
         return 0; \
     } \


### PR DESCRIPTION
This fixes all the examples which use the AP_HAL_MAIN macro.