### PR TITLE
limit WPNAV_ACCEL by lean angle

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -205,7 +205,7 @@ public:
     // Return tilt angle limit for pilot input that prioritises altitude hold over lean angle
     virtual float get_althold_lean_angle_max() const = 0;
 
-    // Return configured tilt angle limit in centidegrees/s
+    // Return configured tilt angle limit in centidegrees
     float lean_angle_max() const { return _aparm.angle_max; }
 
     // Proportional controller with piecewise sqrt sections to constrain second derivative

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -393,6 +393,14 @@ void AC_WPNav::wp_and_spline_init()
         _wp_accel_cms.set_and_save(WPNAV_ACCELERATION);
     }
 
+    // also limit the accel using the maximum lean angle. This
+    // prevents the navigation controller from trying to move the
+    // target point at an unachievable rate
+    float accel_limit_cms = GRAVITY_MSS * 100 * tanf(radians(_attitude_control.lean_angle_max()*0.01f));
+    if (_wp_accel_cms > accel_limit_cms) {
+        _wp_accel_cms.set(accel_limit_cms);
+    }
+
     // initialise position controller
     _pos_control.init_xy_controller();
 


### PR DESCRIPTION
this prevents a backtracking problem in the nav controller if WPNAV_ACCEL is set too high
