### PR TITLE
Bug#2384: In guided mode Copter should not fly above the fence

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -779,8 +779,8 @@ private:
     void guided_vel_control_start();
     void guided_posvel_control_start();
     void guided_angle_control_start();
-    void guided_set_destination(const Vector3f& destination);
     bool guided_set_destination(const Location_Class& dest_loc);
+    bool guided_set_destination(const Vector3f& destination);
     void guided_set_velocity(const Vector3f& velocity);
     void guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity);
     void guided_set_angle(const Quaternion &q, float climb_rate_cms);
@@ -931,6 +931,7 @@ private:
     float pv_alt_above_home(float alt_above_origin_cm);
     float pv_get_bearing_cd(const Vector3f &origin, const Vector3f &destination);
     float pv_get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destination);
+    float pv_get_home_destination_distance_cm(const Vector3f &destination);
     void default_dead_zones();
     void init_rc_in();
     void init_rc_out();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1711,7 +1711,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             copter.guided_set_velocity(vel_vector);
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            copter.guided_set_destination(pos_vector);
+            if (!copter.guided_set_destination(pos_vector)) {
+                result = MAV_RESULT_FAILED;
+            }
         } else {
             result = MAV_RESULT_FAILED;
         }
@@ -1783,7 +1785,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             copter.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            copter.guided_set_destination(pos_ned);
+            if (!copter.guided_set_destination(pos_ned)) {
+                result = MAV_RESULT_FAILED;
+            }
         } else {
             result = MAV_RESULT_FAILED;
         }

--- a/ArduCopter/position_vector.cpp
+++ b/ArduCopter/position_vector.cpp
@@ -66,3 +66,10 @@ float Copter::pv_get_horizontal_distance_cm(const Vector3f &origin, const Vector
 {
     return pythagorous2(destination.x-origin.x,destination.y-origin.y);
 }
+
+// pv_get_home_destination_distance_cm - return distance between destination and home in cm
+float Copter::pv_get_home_destination_distance_cm(const Vector3f &destination)
+{
+    Vector3f home = pv_location_to_vector(ahrs.get_home());
+    return pv_get_horizontal_distance_cm(home, destination);
+}

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -197,6 +197,23 @@ uint8_t AC_Fence::check_fence(float curr_alt)
     //outside = Polygon_outside(location, &geofence_state->boundary[1], geofence_state->num_points-1);
 }
 
+/// check_fence_guided - returns false if the destination waypoint is outside the fence
+// returns true if the guided waypoint is within the fence
+bool AC_Fence::check_fence_location(float destination_alt, float home_destination_distance)
+{
+    // Altitude fence check
+    if ((get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) && (round(destination_alt*0.01f) >= _alt_max)) {
+        return false;
+    }
+
+    // Circular fence check
+    if ((get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) && (home_destination_distance*0.01f >= _circle_radius)) {
+        return false;
+    }
+
+    return true;
+}
+
 /// record_breach - update breach bitmask, time and count
 void AC_Fence::record_breach(uint8_t fence_type)
 {

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -54,6 +54,9 @@ public:
     ///     curr_alt is the altitude above home in meters
     uint8_t check_fence(float curr_alt);
 
+    // check_fence_location - returns true if the destination waypoint is within fence
+    bool check_fence_location(float destination_alt, float home_destination_distance);
+
     /// get_breaches - returns bit mask of the fence types that have been breached
     uint8_t get_breaches() const { return _breached_fences; }
 


### PR DESCRIPTION
This PR solves the issue #2384. 

This PR always rejects the request from the GCS (or companion computer) that directs the vehicle to go outside the fence.

The changes for reporting the failure status to GCS (or CC) has been done in PR #3985 and hence not updated here.