### PR TITLE
waf: be compatible with git < 1.8.5

### DIFF
--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -40,12 +40,12 @@ import os.path
 
 class update_submodule(Task.Task):
     color = 'BLUE'
-    run_str = '${GIT} -C ${SRC_ROOT} submodule update --recursive --init -- ${SUBMODULE_PATH}'
+    run_str = '${GIT} submodule update --recursive --init -- ${SUBMODULE_PATH}'
 
     def runnable_status(self):
         e = self.env.get_flat
-        cmd = e('GIT'), '-C', e('SRC_ROOT'), 'submodule', 'status', '--recursive', '--', e('SUBMODULE_PATH')
-        out = self.generator.bld.cmd_and_log(cmd, quiet=Context.BOTH)
+        cmd = e('GIT'), 'submodule', 'status', '--recursive', '--', e('SUBMODULE_PATH')
+        out = self.generator.bld.cmd_and_log(cmd, quiet=Context.BOTH, cwd=self.cwd)
 
         # git submodule status uses a blank prefix for submodules that are up
         # to date
@@ -80,7 +80,7 @@ def git_submodule_update(self, name):
         module_node = self.bld.srcnode.make_node(os.path.join('modules', name))
 
         tsk = self.create_task('update_submodule', submodule=name)
-        tsk.env.SRC_ROOT = self.bld.srcnode.abspath()
+        tsk.cwd = self.bld.srcnode.abspath()
         tsk.env.SUBMODULE_PATH = module_node.abspath()
 
         _submodules_tasks[name] = tsk
@@ -107,6 +107,6 @@ def git_submodule(bld, git_submodule, **kw):
 @conf
 def git_submodule_head_hash(self, name):
     module_node = self.srcnode.make_node(os.path.join('modules', name))
-    cmd = self.env.get_flat('GIT'), '-C', module_node.abspath(), 'rev-parse', 'HEAD'
-    out = self.cmd_and_log(cmd, quiet=Context.BOTH)
+    cmd = self.env.get_flat('GIT'), 'rev-parse', 'HEAD'
+    out = self.cmd_and_log(cmd, quiet=Context.BOTH, cwd=module_node.abspath())
     return out.strip()


### PR DESCRIPTION
The -C option was added to git in version 1.8.5 which is not available
in Ubuntu 12.04.

Fix #4023

@kwikius could you test this in your machine?