### PR TITLE
Rover: handle new MAVLink rangefinder input

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1392,6 +1392,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         handle_gps_inject(msg, rover.gps);
         break;
 
+    case MAVLINK_MSG_ID_DISTANCE_SENSOR:
+        rover.sonar.handle_msg(msg);
+        break;
+
     case MAVLINK_MSG_ID_REMOTE_LOG_BLOCK_STATUS:
         rover.DataFlash.remote_log_block_status_msg(chan, msg);
         break;


### PR DESCRIPTION
Per @rmackay9's request from [this PR](https://github.com/ArduPilot/ardupilot/pull/4027), support the new MAVLink rangefinder type.