### PR TITLE
Plane: Parachute ALT_MIN should be not above home, but above ground

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -810,6 +810,7 @@ private:
     int32_t get_RTL_altitude();
     float relative_altitude(void);
     int32_t relative_altitude_abs_cm(void);
+    float relative_ground_altitude(void);
     void set_target_altitude_current(void);
     void set_target_altitude_current_adjusted(void);
     void set_target_altitude_location(const Location &loc);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -115,7 +115,6 @@ int32_t Plane::get_RTL_altitude()
     return g.RTL_altitude_cm + home.alt;
 }
 
-
 /*
   return relative altitude in meters (relative to home)
  */
@@ -132,6 +131,20 @@ int32_t Plane::relative_altitude_abs_cm(void)
     return labs(current_loc.alt - home.alt);
 }
 
+/*
+  return relative altitude in meters (relative to terrain, if available,
+  or home otherwise)
+ */
+float Plane::relative_ground_altitude(void)
+{
+#if AP_TERRAIN_AVAILABLE
+    float altitude;
+    if (terrain.status() == AP_Terrain::TerrainStatusOK && terrain.height_above_terrain(altitude, true)) {
+        return altitude;
+    }
+#endif
+    return relative_altitude();
+}
 
 /*
   set the target altitude to the current altitude. This is used when 

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -46,7 +46,7 @@ bool Plane::parachute_manual_release()
         return false;
     }
 
-    if (relative_altitude() < parachute.alt_min()) {
+    if (relative_ground_altitude() < parachute.alt_min()) {
         gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Parachute: Too low");
         return false;
     }


### PR DESCRIPTION
Added a method `Plane::relative_ground_altitude` that returns altitude above terrain (if terrain data available) or home (otherwise).

Use this method for checking parachute deployment altitude.