### PR TITLE
Copter: stabilize when landed in AltHold and Loiter

### DIFF
--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -138,20 +138,18 @@ void Copter::althold_run()
 
     case AltHold_Landed:
 
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_CONFIG == HELI_FRAME
         attitude_control.set_yaw_target_to_current_heading();
+#endif
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
         attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-#else   // Multicopter stabilize roll/pitch/yaw when landed
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-        // if throttle zero reset attitude and exit immediately
+        // set motors to spin-when-armed if throttle at zero, otherwise full range
         if (ap.throttle_zero) {
             motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-        }else{
+        } else {
             motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
-#endif
         pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
         break;
 

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -124,15 +124,6 @@ void Copter::althold_run()
         // get take-off adjusted pilot and takeoff climb rates
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
-
-        // if throttle zero reset attitude and exit immediately
-        if (ap.throttle_zero) {
-            motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-            attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-            pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
-            return;
-        }
-
         // set motors to full range
         motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -156,21 +156,16 @@ void Copter::loiter_run()
     case Loiter_Landed:
 
         wp_nav.init_loiter_target();
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(0, 0, 0, get_smoothing_gain());
+        // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
         attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-#else
         // if throttle zero reset attitude and exit immediately
         if (ap.throttle_zero) {
             motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-        }else{
+        } else {
             motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
-        // multicopters do not stabilize roll/pitch/yaw when disarmed
-        // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-#endif
         pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
         break;
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -225,8 +225,8 @@ enum AltHoldModeState {
 
 // Loiter states
 enum LoiterModeState {
-    Loiter_Disarmed,
-    Loiter_MotorStop,
+    Loiter_MotorStopped,
+    Loiter_NotAutoArmed,
     Loiter_Takeoff,
     Loiter_Flying,
     Loiter_Landed

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -216,8 +216,8 @@ enum RTLState {
 
 // Alt_Hold states
 enum AltHoldModeState {
-    AltHold_Disarmed,
-    AltHold_MotorStop,
+    AltHold_MotorStopped,
+    AltHold_NotAutoArmed,
     AltHold_Takeoff,
     AltHold_Flying,
     AltHold_Landed

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -603,7 +603,6 @@ void AC_AttitudeControl::set_throttle_out(float throttle_in, bool apply_angle_bo
 {
     _throttle_in = throttle_in;
     _throttle_in_filt.apply(throttle_in, _dt);
-    _motors.set_stabilizing(true);
     _motors.set_throttle_filter_cutoff(filter_cutoff);
     if (apply_angle_boost) {
         _motors.set_throttle(get_boosted_throttle(throttle_in));
@@ -618,12 +617,11 @@ void AC_AttitudeControl::set_throttle_out_unstabilized(float throttle_in, bool r
 {
     _throttle_in = throttle_in;
     _throttle_in_filt.apply(throttle_in, _dt);
+    _motors.set_throttle_filter_cutoff(filter_cutoff);
     if (reset_attitude_control) {
         relax_bf_rate_controller();
         set_yaw_target_to_current_heading();
     }
-    _motors.set_throttle_filter_cutoff(filter_cutoff);
-    _motors.set_stabilizing(false);
     _motors.set_throttle(throttle_in);
     _angle_boost = 0.0f;
 }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -40,7 +40,6 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
 {
     // init other flags
     _flags.armed = false;
-    _flags.stabilizing = false;
     _flags.frame_orientation = AP_MOTORS_X_FRAME;
     _flags.interlock = false;
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -65,8 +65,6 @@ public:
     void                set_throttle(float throttle_in) { _throttle_in = throttle_in; };   // range 0 ~ 1
     void                set_throttle_filter_cutoff(float filt_hz) { _throttle_filter.set_cutoff_frequency(filt_hz); }
 
-    void                set_stabilizing(bool stabilizing) { _flags.stabilizing = stabilizing; }
-
     // accessors for roll, pitch, yaw and throttle inputs to motors
     float               get_roll() const { return _roll_in; }
     float               get_pitch() const { return _pitch_in; }


### PR DESCRIPTION
Tridge, PeterBarker and some users on the pixracer testing thread have found an issue in which the vehicle can end up bumping along the ground while taking off in AltHold mode.

This is at least a partial solution in that the vehicles roll and pitch will be controlled while the vehicle is landed.

There may be another issue though in which the vehicle is taking off at below 25% throttle.  This issue needs further investigation.