### PR TITLE
Copter::pre_arm_rc_checks: fix throttle min and max set check logic

### DIFF
--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -373,7 +373,7 @@ void Copter::pre_arm_rc_checks()
     }
 
     // check if radio has been calibrated
-    if (!channel_throttle->radio_min.configured() && !channel_throttle->radio_max.configured()) {
+    if (!(channel_throttle->radio_min.configured() && channel_throttle->radio_max.configured())) {
         return;
     }
 


### PR DESCRIPTION
modify the logic so that both channel_throttle->radio_min and channel_throttle->radio_max must be configured in order to pass pre arm checks