### PR TITLE
readme: fix link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ### Maintainers ###
 >> Ardupilot is comprised of several parts, vehicles and boards. The list below
 >> contains the people that regularly contribute to the project and are responsible
->> for reviewing patches on their specific area. See [CONTRIBUTING.md](CONTRIBUTING.md)
+>> for reviewing patches on their specific area. See [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 >> for more information.
 >>
 >> - [Andrew Tridgell](https://github.com/tridge)


### PR DESCRIPTION
fixes a 404 when opening the CONTRIBUTING.md link