### PR TITLE
Deprecate make for Linux boards

### DIFF
--- a/mk/mavgen.mk
+++ b/mk/mavgen.mk
@@ -5,7 +5,7 @@ MESSAGE_DEFINITIONS := $(SKETCHBOOK)/modules/mavlink/message_definitions/v1.0
 MAVLINK_HEADERS := $(BUILDROOT)/libraries/GCS_MAVLink/include/mavlink/v1.0/ardupilotmega/mavlink.h $(wildcard $(BUILDROOT)/libraries/GCS_MAVLink/include/mavlink/v1.0/,*.h) $(wildcard $(BUILDROOT)/libraries/GCS_MAVLink/include/mavlink/v1.0/ardupilotmega,*.h)
 MAVLINK_OUTPUT_DIR := $(BUILDROOT)/libraries/GCS_MAVLink/include/mavlink/v1.0
 
-$(MAVLINK_HEADERS): $(MESSAGE_DEFINITIONS)/ardupilotmega.xml $(MESSAGE_DEFINITIONS)/common.xml
+$(MAVLINK_HEADERS): CHECK_MODULES $(MESSAGE_DEFINITIONS)/ardupilotmega.xml $(MESSAGE_DEFINITIONS)/common.xml
 	echo "Generating MAVLink headers..."
 	#goto mavlink module directory and run the most recent generator script
 	echo "Generating C code using mavgen.py located at" $(SKETCHBOOK)/modules/mavlink/

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -1,11 +1,29 @@
 
 # git submodule support
 
-.PHONY: CHECK_MODULES
-all: CHECK_MODULES
+define echowarning
+@echo -e "\e[31mWARNING:\e[0m $1" >&2
+endef
+
+define echoallwarnings
+	$(call echowarning)
+	$(call echowarning)
+	$(call echowarning,make build system is deprecated for Linux boards)
+	$(call echowarning,new features are not going to be added anymore)
+	$(call echowarning,See README-WAF.md: https://github.com/ArduPilot/ardupilot/blob/master/README-WAF.md)
+	$(call echowarning)
+	$(call echowarning,The make build system will soon be removed)
+	$(call echowarning)
+	$(call echowarning)
+	@sleep 3
+endef
 
 CHECK_MODULES:
+	$(if $(BUILDSYS_DEPRECATED),$(call echoallwarnings))
 	$(v)$(MK_DIR)/check_modules.sh
+
+.PHONY: CHECK_MODULES
+all: CHECK_MODULES
 
 module-update:
 	git submodule update

--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -20,10 +20,12 @@ flymaple-hil: flymaple
 
 linux: HAL_BOARD = HAL_BOARD_LINUX
 linux: TOOLCHAIN = NATIVE
+linux: BUILDSYS_DEPRECATED = 1
 linux: all
 
 erleboard: HAL_BOARD = HAL_BOARD_LINUX
 erleboard: TOOLCHAIN = BBONE
+erleboard: BUILDSYS_DEPRECATED = 1
 erleboard: all
 
 zynq: HAL_BOARD = HAL_BOARD_LINUX
@@ -34,40 +36,54 @@ zynq-hil : zynq
 
 pxf: HAL_BOARD = HAL_BOARD_LINUX
 pxf: TOOLCHAIN = BBONE
+pxf: BUILDSYS_DEPRECATED = 1
 pxf: all
 
 bebop: HAL_BOARD = HAL_BOARD_LINUX
 bebop: TOOLCHAIN = BBONE
 bebop: LDFLAGS += "-static"
+bebop: BUILDSYS_DEPRECATED = 1
 bebop: all
 
 minlure: HAL_BOARD = HAL_BOARD_LINUX
 minlure: TOOLCHAIN = NATIVE
+minlure: BUILDSYS_DEPRECATED = 1
 minlure: all
 
 navio: HAL_BOARD = HAL_BOARD_LINUX
 navio: TOOLCHAIN = RPI
+navio: BUILDSYS_DEPRECATED = 1
 navio: all
 
 navio2: HAL_BOARD = HAL_BOARD_LINUX
 navio2: TOOLCHAIN = RPI
+navio2: BUILDSYS_DEPRECATED = 1
 navio2: all
 
 raspilot: HAL_BOARD = HAL_BOARD_LINUX
 raspilot: TOOLCHAIN = RPI
+raspilot: BUILDSYS_DEPRECATED = 1
 raspilot: all
 
 erlebrain2: HAL_BOARD = HAL_BOARD_LINUX
 erlebrain2: TOOLCHAIN = RPI
+erlebrain2: BUILDSYS_DEPRECATED  = 1
 erlebrain2: all
 
 bbbmini: HAL_BOARD = HAL_BOARD_LINUX
 bbbmini: TOOLCHAIN = BBONE
+bbbmini: BUILDSYS_DEPRECATED  = 1
 bbbmini: all
 
 bhat: HAL_BOARD = HAL_BOARD_LINUX
 bhat: TOOLCHAIN = RPI
+bhat: BUILDSYS_DEPRECATED  = 1
 bhat: all
+
+pxfmini: HAL_BOARD = HAL_BOARD_LINUX
+pxfmini: TOOLCHAIN = RPI
+pxfmini: BUILDSYS_DEPRECATED  = 1
+pxfmini: all
 
 qflight: HAL_BOARD = HAL_BOARD_LINUX
 qflight: TOOLCHAIN = QFLIGHT
@@ -80,10 +96,6 @@ empty: all
 qurt: HAL_BOARD = HAL_BOARD_QURT
 qurt: TOOLCHAIN = QURT
 qurt: all
-
-pxfmini: HAL_BOARD = HAL_BOARD_LINUX
-pxfmini: TOOLCHAIN = RPI
-pxfmini: all
 
 # cope with HIL targets
 %-hil: EXTRAFLAGS += "-DHIL_MODE=HIL_MODE_SENSORS "


### PR DESCRIPTION
This outputs a warning for people to notice the make build system is deprecated.

Besides that, it fixes the make build wrt to the generation of mavlink headers, that was not correctly ordered wrt submodule updates.