### PR TITLE
waf: add --debug configuration option

### DIFF
--- a/README-WAF.md
+++ b/README-WAF.md
@@ -178,6 +178,13 @@ waf check --alltests
 waf check-all
 ```
 
+## Debugging ##
+
+It's possible to pass the option `--debug` to the `configure` command. That
+will set compiler flags to store debugging information in the binaries so that
+you can use them with `gdb`, for example. The build directory will be set to
+`build/<board>-debug/`. That option might come handy when using SITL.
+
 ## Make wrapper ##
 
 There's also a make wrapper called `Makefile.waf`. You can use

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -92,6 +92,12 @@ class Board:
                 '-Wno-c++11-narrowing'
             ]
 
+        if cfg.env.DEBUG:
+            env.CFLAGS += [
+                '-g',
+                '-O0',
+            ]
+
         env.CXXFLAGS += [
             '-std=gnu++11',
 
@@ -134,6 +140,12 @@ class Board:
                 '-Werror=unused-but-set-variable'
             ]
 
+        if cfg.env.DEBUG:
+            env.CXXFLAGS += [
+                '-g',
+                '-O0',
+            ]
+
         env.LINKFLAGS += [
             '-Wl,--gc-sections',
         ]
@@ -165,9 +177,12 @@ class sitl(Board):
             CONFIG_HAL_BOARD = 'HAL_BOARD_SITL',
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_NONE',
         )
-        env.CXXFLAGS += [
-            '-O3',
-        ]
+
+        if not cfg.env.DEBUG:
+            env.CXXFLAGS += [
+                '-O3',
+            ]
+
         env.LIB += [
             'm',
         ]
@@ -190,9 +205,12 @@ class linux(Board):
             CONFIG_HAL_BOARD = 'HAL_BOARD_LINUX',
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NONE',
         )
-        env.CXXFLAGS += [
-            '-O3',
-        ]
+
+        if not cfg.env.DEBUG:
+            env.CXXFLAGS += [
+                '-O3',
+            ]
+
         env.LIB += [
             'm',
             'rt',

--- a/wscript
+++ b/wscript
@@ -30,11 +30,14 @@ def init(ctx):
     except:
         return
 
+    if 'VARIANT' not in env:
+        return
+
     # define the variant build commands according to the board
     for c in Context.classes:
         if not issubclass(c, Build.BuildContext):
             continue
-        c.variant = env.BOARD
+        c.variant = env.VARIANT
 
 def options(opt):
     opt.load('compiler_cxx compiler_c waf_unit_test python')
@@ -67,13 +70,24 @@ def options(opt):
                  default=False,
                  help='Enable benchmarks')
 
+    g.add_option('--debug',
+                 action='store_true',
+                 default=False,
+                 help='Configure as debug variant')
+
 def configure(cfg):
     cfg.env.BOARD = cfg.options.board
-    # use a different variant for each board
-    cfg.setenv(cfg.env.BOARD)
+    cfg.env.DEBUG = cfg.options.debug
+
+    cfg.env.VARIANT = cfg.env.BOARD
+    if cfg.env.DEBUG:
+        cfg.env.VARIANT += '-debug'
+    cfg.setenv(cfg.env.VARIANT)
+
+    cfg.env.BOARD = cfg.options.board
+    cfg.env.DEBUG = cfg.options.debug
 
     cfg.msg('Setting board to', cfg.options.board)
-    cfg.env.BOARD = cfg.options.board
     boards.get_board(cfg.env.BOARD).configure(cfg)
 
     cfg.load('clang_compilation_database')


### PR DESCRIPTION
Hi all,

This PR is adding a `--debug` option to the `configure` command. That's useful when using SITL.

Best,
Gustavo Sousa