### PR TITLE
RC_Channel: major refactor.

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -421,11 +421,11 @@ void Rover::update_current_mode(void)
         set_reverse(false);
         if (rtl_complete || verify_RTL()) {
             // we have reached destination so stop where we are
-            if (channel_throttle->servo_out != g.throttle_min.get()) {
+            if (channel_throttle->get_servo_out() != g.throttle_min.get()) {
                 gcs_send_mission_item_reached_message(0);
             }
-            channel_throttle->servo_out = g.throttle_min.get();
-            channel_steer->servo_out = 0;
+            channel_throttle->set_servo_out(g.throttle_min.get());
+            channel_steer->set_servo_out(0);
             lateral_acceleration = 0;
         } else {
             calc_lateral_acceleration();
@@ -471,18 +471,18 @@ void Rover::update_current_mode(void)
           we set the exact value in set_servos(), but it helps for
           logging
          */
-        channel_throttle->servo_out = channel_throttle->control_in;
-        channel_steer->servo_out = channel_steer->pwm_to_angle();
+        channel_throttle->set_servo_out(channel_throttle->get_control_in());
+        channel_steer->set_servo_out(channel_steer->pwm_to_angle());
 
         // mark us as in_reverse when using a negative throttle to
         // stop AHRS getting off
-        set_reverse(channel_throttle->servo_out < 0);
+        set_reverse(channel_throttle->get_servo_out() < 0);
         break;
 
     case HOLD:
         // hold position - stop motors and center steering
-        channel_throttle->servo_out = 0;
-        channel_steer->servo_out = 0;
+        channel_throttle->set_servo_out(0);
+        channel_steer->set_servo_out(0);
         set_reverse(false);
         break;
 
@@ -510,7 +510,7 @@ void Rover::update_navigation()
         calc_lateral_acceleration();
         calc_nav_steer();
         if (verify_RTL()) {
-            channel_throttle->servo_out = g.throttle_min.get();
+            channel_throttle->set_servo_out(g.throttle_min.get());
             set_mode(HOLD);
         }
         break;
@@ -521,8 +521,8 @@ void Rover::update_navigation()
         calc_nav_steer();
         if (rtl_complete || verify_RTL()) {
             // we have reached destination so stop where we are
-            channel_throttle->servo_out = g.throttle_min.get();
-            channel_steer->servo_out = 0;
+            channel_throttle->set_servo_out(g.throttle_min.get());
+            channel_steer->set_servo_out(0);
             lateral_acceleration = 0;
         }
         break;

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -279,14 +279,14 @@ void Rover::send_radio_out(mavlink_channel_t chan)
         chan,
         micros(),
         0,     // port
-        RC_Channel::rc_channel(0)->radio_out,
-        RC_Channel::rc_channel(1)->radio_out,
-        RC_Channel::rc_channel(2)->radio_out,
-        RC_Channel::rc_channel(3)->radio_out,
-        RC_Channel::rc_channel(4)->radio_out,
-        RC_Channel::rc_channel(5)->radio_out,
-        RC_Channel::rc_channel(6)->radio_out,
-        RC_Channel::rc_channel(7)->radio_out);
+        RC_Channel::rc_channel(0)->get_radio_out(),
+        RC_Channel::rc_channel(1)->get_radio_out(),
+        RC_Channel::rc_channel(2)->get_radio_out(),
+        RC_Channel::rc_channel(3)->get_radio_out(),
+        RC_Channel::rc_channel(4)->get_radio_out(),
+        RC_Channel::rc_channel(5)->get_radio_out(),
+        RC_Channel::rc_channel(6)->get_radio_out(),
+        RC_Channel::rc_channel(7)->get_radio_out());
 #endif
 }
 

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -239,10 +239,10 @@ void Rover::Log_Write_Control_Tuning()
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CTUN_MSG),
         time_us         : AP_HAL::micros64(),
-        steer_out       : (int16_t)channel_steer->servo_out,
+        steer_out       : (int16_t)channel_steer->get_servo_out(),
         roll            : (int16_t)ahrs.roll_sensor,
         pitch           : (int16_t)ahrs.pitch_sensor,
-        throttle_out    : (int16_t)channel_throttle->servo_out,
+        throttle_out    : (int16_t)channel_throttle->get_servo_out(),
         accel_y         : accel.y
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -332,7 +332,7 @@ void Rover::Log_Write_Sonar()
 
 void Rover::Log_Write_Current()
 {
-    DataFlash.Log_Write_Current(battery, channel_throttle->control_in);
+    DataFlash.Log_Write_Current(battery, channel_throttle->get_control_in());
 
     // also write power status
     DataFlash.Log_Write_Power();

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -75,7 +75,7 @@ void Rover::read_trim_switch()
     case CH7_DO_NOTHING:
         break;
     case CH7_SAVE_WP:
-		if (channel_learn->radio_in > CH_7_PWM_TRIGGER) {
+		if (channel_learn->get_radio_in() > CH_7_PWM_TRIGGER) {
             // switch is engaged
 			ch7_flag = true;
 		} else { // switch is disengaged
@@ -86,7 +86,7 @@ void Rover::read_trim_switch()
                     hal.console->println("Erasing waypoints");
                     // if SW7 is ON in MANUAL = Erase the Flight Plan
 					mission.clear();
-                    if (channel_steer->control_in > 3000) {
+                    if (channel_steer->get_control_in() > 3000) {
 						// if roll is full right store the current location as home
                         init_home();
                     }

--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -57,14 +57,14 @@ int8_t Rover::test_radio_pwm(uint8_t argc, const Menu::arg *argv)
 		read_radio();
 
 		cliSerial->printf("IN:\t1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-							channel_steer->radio_in,
-							g.rc_2.radio_in,
-							channel_throttle->radio_in,
-							g.rc_4.radio_in,
-							g.rc_5.radio_in,
-							g.rc_6.radio_in,
-							g.rc_7.radio_in,
-							g.rc_8.radio_in);
+							channel_steer->get_radio_in(),
+							g.rc_2.get_radio_in(),
+							channel_throttle->get_radio_in(),
+							g.rc_4.get_radio_in(),
+							g.rc_5.get_radio_in(),
+							g.rc_6.get_radio_in(),
+							g.rc_7.get_radio_in(),
+							g.rc_8.get_radio_in());
 
 		if(cliSerial->available() > 0){
 			return (0);
@@ -119,14 +119,14 @@ int8_t Rover::test_radio(uint8_t argc, const Menu::arg *argv)
 		set_servos();
 
 		cliSerial->printf("IN 1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-							channel_steer->control_in,
-							g.rc_2.control_in,
-							channel_throttle->control_in,
-							g.rc_4.control_in,
-							g.rc_5.control_in,
-							g.rc_6.control_in,
-							g.rc_7.control_in,
-							g.rc_8.control_in);
+							channel_steer->get_control_in(),
+							g.rc_2.get_control_in(),
+							channel_throttle->get_control_in(),
+							g.rc_4.get_control_in(),
+							g.rc_5.get_control_in(),
+							g.rc_6.get_control_in(),
+							g.rc_7.get_control_in(),
+							g.rc_8.get_control_in());
 
 		if(cliSerial->available() > 0){
 			return (0);
@@ -150,7 +150,7 @@ int8_t Rover::test_failsafe(uint8_t argc, const Menu::arg *argv)
 	oldSwitchPosition = readSwitch();
 
 	cliSerial->printf("Unplug battery, throttle in neutral, turn off radio.\n");
-	while(channel_throttle->control_in > 0){
+	while(channel_throttle->get_control_in() > 0){
 		delay(20);
 		read_radio();
 	}
@@ -159,8 +159,8 @@ int8_t Rover::test_failsafe(uint8_t argc, const Menu::arg *argv)
 		delay(20);
 		read_radio();
 
-		if(channel_throttle->control_in > 0){
-			cliSerial->printf("THROTTLE CHANGED %d \n", channel_throttle->control_in);
+		if(channel_throttle->get_control_in() > 0){
+			cliSerial->printf("THROTTLE CHANGED %d \n", channel_throttle->get_control_in());
 			fail_test++;
 		}
 
@@ -172,7 +172,7 @@ int8_t Rover::test_failsafe(uint8_t argc, const Menu::arg *argv)
 		}
 
         if(throttle_failsafe_active()) {
-			cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", channel_throttle->radio_in);
+			cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", channel_throttle->get_radio_in());
             print_mode(cliSerial, readSwitch());
             cliSerial->println();
 			fail_test++;

--- a/AntennaTracker/control_manual.cpp
+++ b/AntennaTracker/control_manual.cpp
@@ -13,8 +13,8 @@
 void Tracker::update_manual(void)
 {
     // copy yaw and pitch input to output
-    channel_yaw.radio_out = constrain_int16(channel_yaw.radio_in, channel_yaw.radio_min, channel_yaw.radio_max);
-    channel_pitch.radio_out = constrain_int16(channel_pitch.radio_in, channel_pitch.radio_min, channel_pitch.radio_max);
+    channel_yaw.set_radio_out(constrain_int16(channel_yaw.get_radio_in(), channel_yaw.get_radio_min(), channel_yaw.get_radio_max()));
+    channel_pitch.set_radio_out(constrain_int16(channel_pitch.get_radio_in(), channel_pitch.get_radio_min(), channel_pitch.get_radio_max()));
 
     // send output to servos
     channel_yaw.output();

--- a/AntennaTracker/control_servo_test.cpp
+++ b/AntennaTracker/control_servo_test.cpp
@@ -27,13 +27,13 @@ bool Tracker::servo_test_set_servo(uint8_t servo_num, uint16_t pwm)
 
     // set yaw servo pwm and send output to servo
     if (servo_num == CH_YAW) {
-        channel_yaw.radio_out = constrain_int16(pwm, channel_yaw.radio_min, channel_yaw.radio_max);
+        channel_yaw.set_radio_out(constrain_int16(pwm, channel_yaw.get_radio_min(), channel_yaw.get_radio_max()));
         channel_yaw.output();
     }
 
     // set pitch servo pwm and send output to servo
     if (servo_num == CH_PITCH) {
-        channel_pitch.radio_out = constrain_int16(pwm, channel_pitch.radio_min, channel_pitch.radio_max);
+        channel_pitch.set_radio_out(constrain_int16(pwm, channel_pitch.get_radio_min(), channel_pitch.get_radio_max()));
         channel_pitch.output();
     }
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -188,8 +188,8 @@ void Tracker::disarm_servos()
 void Tracker::prepare_servos()
 {
     start_time_ms = AP_HAL::millis();
-    channel_yaw.radio_out = channel_yaw.radio_trim;
-    channel_pitch.radio_out = channel_pitch.radio_trim;
+    channel_yaw.set_radio_out(channel_yaw.get_radio_trim());
+    channel_pitch.set_radio_out(channel_pitch.get_radio_trim());
     channel_yaw.output();
     channel_pitch.output();
 }

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -488,7 +488,7 @@ void Copter::one_hz_loop()
         motors.set_frame_orientation(g.frame_orientation);
 
         // set all throttle channel settings
-        motors.set_throttle_range(g.throttle_min, channel_throttle->radio_min, channel_throttle->radio_max);
+        motors.set_throttle_range(g.throttle_min, channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
         // set hover throttle
         motors.set_hover_throttle(g.throttle_mid);
 #endif
@@ -579,17 +579,17 @@ void Copter::update_simple_mode(void)
 
     if (ap.simple_mode == 1) {
         // rotate roll, pitch input by -initial simple heading (i.e. north facing)
-        rollx = channel_roll->control_in*simple_cos_yaw - channel_pitch->control_in*simple_sin_yaw;
-        pitchx = channel_roll->control_in*simple_sin_yaw + channel_pitch->control_in*simple_cos_yaw;
+        rollx = channel_roll->get_control_in()*simple_cos_yaw - channel_pitch->get_control_in()*simple_sin_yaw;
+        pitchx = channel_roll->get_control_in()*simple_sin_yaw + channel_pitch->get_control_in()*simple_cos_yaw;
     }else{
         // rotate roll, pitch input by -super simple heading (reverse of heading to home)
-        rollx = channel_roll->control_in*super_simple_cos_yaw - channel_pitch->control_in*super_simple_sin_yaw;
-        pitchx = channel_roll->control_in*super_simple_sin_yaw + channel_pitch->control_in*super_simple_cos_yaw;
+        rollx = channel_roll->get_control_in()*super_simple_cos_yaw - channel_pitch->get_control_in()*super_simple_sin_yaw;
+        pitchx = channel_roll->get_control_in()*super_simple_sin_yaw + channel_pitch->get_control_in()*super_simple_cos_yaw;
     }
 
     // rotate roll, pitch input from north facing to vehicle's perspective
-    channel_roll->control_in = rollx*ahrs.cos_yaw() + pitchx*ahrs.sin_yaw();
-    channel_pitch->control_in = -rollx*ahrs.sin_yaw() + pitchx*ahrs.cos_yaw();
+    channel_roll->set_control_in(rollx*ahrs.cos_yaw() + pitchx*ahrs.sin_yaw());
+    channel_pitch->set_control_in(-rollx*ahrs.sin_yaw() + pitchx*ahrs.cos_yaw());
 }
 
 // update_super_simple_bearing - adjusts simple bearing based on location

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -293,7 +293,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // failsafe parameter checks
         if (g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
-            if (channel_throttle->radio_min <= g.failsafe_throttle_value+10 || g.failsafe_throttle_value < 910) {
+            if (channel_throttle->get_radio_min() <= g.failsafe_throttle_value+10 || g.failsafe_throttle_value < 910) {
                 if (display_failure) {
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check FS_THR_VALUE");
                 }
@@ -343,7 +343,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     // check throttle is above failsafe throttle
     // this is near the bottom to allow other failures to be displayed before checking pilot throttle
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
-        if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->radio_in < g.failsafe_throttle_value) {
+        if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->get_radio_in() < g.failsafe_throttle_value) {
             if (display_failure) {
                 #if FRAME_CONFIG == HELI_FRAME
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Collective below Failsafe");
@@ -373,27 +373,27 @@ void Copter::pre_arm_rc_checks()
     }
 
     // check if radio has been calibrated
-    if (!channel_throttle->radio_min.configured() && !channel_throttle->radio_max.configured()) {
+    if (!channel_throttle->min_max_configured()) {
         return;
     }
 
     // check channels 1 & 2 have min <= 1300 and max >= 1700
-    if (channel_roll->radio_min > 1300 || channel_roll->radio_max < 1700 || channel_pitch->radio_min > 1300 || channel_pitch->radio_max < 1700) {
+    if (channel_roll->get_radio_min() > 1300 || channel_roll->get_radio_max() < 1700 || channel_pitch->get_radio_min() > 1300 || channel_pitch->get_radio_max() < 1700) {
         return;
     }
 
     // check channels 3 & 4 have min <= 1300 and max >= 1700
-    if (channel_throttle->radio_min > 1300 || channel_throttle->radio_max < 1700 || channel_yaw->radio_min > 1300 || channel_yaw->radio_max < 1700) {
+    if (channel_throttle->get_radio_min() > 1300 || channel_throttle->get_radio_max() < 1700 || channel_yaw->get_radio_min() > 1300 || channel_yaw->get_radio_max() < 1700) {
         return;
     }
 
     // check channels 1 & 2 have trim >= 1300 and <= 1700
-    if (channel_roll->radio_trim < 1300 || channel_roll->radio_trim > 1700 || channel_pitch->radio_trim < 1300 || channel_pitch->radio_trim > 1700) {
+    if (channel_roll->get_radio_trim() < 1300 || channel_roll->get_radio_trim() > 1700 || channel_pitch->get_radio_trim() < 1300 || channel_pitch->get_radio_trim() > 1700) {
         return;
     }
 
     // check channel 4 has trim >= 1300 and <= 1700
-    if (channel_yaw->radio_trim < 1300 || channel_yaw->radio_trim > 1700) {
+    if (channel_yaw->get_radio_trim() < 1300 || channel_yaw->get_radio_trim() > 1700) {
         return;
     }
 
@@ -671,7 +671,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     // check throttle
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
         // check throttle is not too low - must be above failsafe throttle
-        if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->radio_in < g.failsafe_throttle_value) {
+        if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->get_radio_in() < g.failsafe_throttle_value) {
             if (display_failure) {
                 #if FRAME_CONFIG == HELI_FRAME
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective below Failsafe");
@@ -685,7 +685,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         // check throttle is not too high - skips checks if arming from GCS in Guided
         if (!(arming_from_gcs && control_mode == GUIDED)) {
             // above top of deadband is too always high
-            if (channel_throttle->control_in > get_takeoff_trigger_throttle()) {
+            if (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()) {
                 if (display_failure) {
                     #if FRAME_CONFIG == HELI_FRAME
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
@@ -696,7 +696,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
                 return false;
             }
             // in manual modes throttle must be at zero
-            if ((mode_has_manual_throttle(control_mode) || control_mode == DRIFT) && channel_throttle->control_in > 0) {
+            if ((mode_has_manual_throttle(control_mode) || control_mode == DRIFT) && channel_throttle->get_control_in() > 0) {
                 if (display_failure) {
                     #if FRAME_CONFIG == HELI_FRAME
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -67,7 +67,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
 
     // check throttle is at zero
     read_radio();
-    if (channel_throttle->control_in != 0) {
+    if (channel_throttle->get_control_in() != 0) {
         gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
         ap.compass_mot = false;
         return 1;
@@ -157,7 +157,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         read_radio();
         
         // pass through throttle to motors
-        motors.throttle_pass_through(channel_throttle->radio_in);
+        motors.throttle_pass_through(channel_throttle->get_radio_in());
         
         // read some compass values
         compass.read();
@@ -166,7 +166,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         read_battery();
         
         // calculate scaling for throttle
-        throttle_pct = (float)channel_throttle->control_in / 1000.0f;
+        throttle_pct = (float)channel_throttle->get_control_in() / 1000.0f;
         throttle_pct = constrain_float(throttle_pct,0.0f,1.0f);
 
         // if throttle is near zero, update base x,y,z values
@@ -229,7 +229,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         if (AP_HAL::millis() - last_send_time > 500) {
             last_send_time = AP_HAL::millis();
             mavlink_msg_compassmot_status_send(chan, 
-                                               channel_throttle->control_in,
+                                               channel_throttle->get_control_in(),
                                                battery.current_amps(),
                                                interference_pct[compass.get_primary()],
                                                motor_compensation[compass.get_primary()].x,

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -10,7 +10,7 @@
 bool Copter::acro_init(bool ignore_checks)
 {
    // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
-   if (motors.armed() && ap.land_complete && !mode_has_manual_throttle(control_mode) && (get_pilot_desired_throttle(channel_throttle->control_in) > get_non_takeoff_throttle())) {
+   if (motors.armed() && ap.land_complete && !mode_has_manual_throttle(control_mode) && (get_pilot_desired_throttle(channel_throttle->get_control_in()) > get_non_takeoff_throttle())) {
        return false;
    }
    // set target altitude to zero for reporting
@@ -36,10 +36,10 @@ void Copter::acro_run()
     motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // convert the input to the desired body frame rate
-    get_pilot_desired_angle_rates(channel_roll->control_in, channel_pitch->control_in, channel_yaw->control_in, target_roll, target_pitch, target_yaw);
+    get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
 
     // get pilot's desired throttle
-    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->control_in);
+    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->get_control_in());
 
     // run attitude controller
     attitude_control.input_rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -46,20 +46,20 @@ void Copter::althold_run()
 
     // get pilot desired lean angles
     float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, attitude_control.get_althold_lean_angle_max());
+    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, attitude_control.get_althold_lean_angle_max());
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot desired climb rate
-    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
     target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
 
 #if FRAME_CONFIG == HELI_FRAME
     // helicopters are held on the ground until rotor speed runup has finished
-    bool takeoff_triggered = (ap.land_complete && (channel_throttle->control_in > get_takeoff_trigger_throttle()) && motors.rotor_runup_complete());
+    bool takeoff_triggered = (ap.land_complete && (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()) && motors.rotor_runup_complete());
 #else
-    bool takeoff_triggered = (ap.land_complete && (channel_throttle->control_in > get_takeoff_trigger_throttle()) && motors.spool_up_complete());
+    bool takeoff_triggered = (ap.land_complete && (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()) && motors.spool_up_complete());
 #endif
 
     // Alt Hold State Machine Determination
@@ -90,7 +90,7 @@ void Copter::althold_run()
         // Multicopter do not stabilize roll/pitch/yaw when disarmed
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
 #endif  // HELI_FRAME
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         break;
 
     case AltHold_MotorStop:
@@ -106,7 +106,7 @@ void Copter::althold_run()
 #else   // Multicopter do not stabilize roll/pitch/yaw when motor are stopped
         motors.set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
 #endif  // HELI_FRAME
         break;
 
@@ -129,7 +129,7 @@ void Copter::althold_run()
         if (ap.throttle_zero) {
             motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
             attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-            pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+            pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
             return;
         }
 
@@ -151,9 +151,9 @@ void Copter::althold_run()
         attitude_control.set_yaw_target_to_current_heading();
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
 #else   // Multicopter stabilize roll/pitch/yaw when landed
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
         // if throttle zero reset attitude and exit immediately
         if (ap.throttle_zero) {
             motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
@@ -161,7 +161,7 @@ void Copter::althold_run()
             motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
 #endif
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         break;
 
     case AltHold_Flying:

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -160,7 +160,7 @@ void Copter::auto_takeoff_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range
@@ -234,7 +234,7 @@ void Copter::auto_wp_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -306,7 +306,7 @@ void Copter::auto_spline_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rat
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -400,12 +400,12 @@ void Copter::auto_land_run()
             update_simple_mode();
 
             // process pilot's roll and pitch input
-            roll_control = channel_roll->control_in;
-            pitch_control = channel_pitch->control_in;
+            roll_control = channel_roll->get_control_in();
+            pitch_control = channel_pitch->get_control_in();
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range
@@ -593,7 +593,7 @@ void Copter::auto_loiter_run()
     // accept pilot input of yaw
     float target_yaw_rate = 0;
     if(!failsafe.radio) {
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -271,7 +271,7 @@ void Copter::autotune_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         return;
     }
 
@@ -279,13 +279,13 @@ void Copter::autotune_run()
     update_simple_mode();
 
     // get pilot desired lean angles
-    get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot desired climb rate
-    target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+    target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
 
     // check for pilot requested take-off - this should not actually be possible because of autotune_init() checks
     if (ap.land_complete && target_climb_rate > 0) {
@@ -303,8 +303,8 @@ void Copter::autotune_run()
             motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
     }else{
         // check if pilot is overriding the controls
         if (!is_zero(target_roll) || !is_zero(target_pitch) || !is_zero(target_yaw_rate) || !is_zero(target_climb_rate)) {

--- a/ArduCopter/control_circle.cpp
+++ b/ArduCopter/control_circle.cpp
@@ -60,13 +60,13 @@ void Copter::circle_run()
     // process pilot inputs
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             circle_pilot_yaw_override = true;
         }
 
         // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
 
         // check for pilot requested take-off
         if (ap.land_complete && target_climb_rate > 0) {

--- a/ArduCopter/control_drift.cpp
+++ b/ArduCopter/control_drift.cpp
@@ -56,10 +56,10 @@ void Copter::drift_run()
     }
 
     // convert pilot input to lean angles
-    get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired throttle
-    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->control_in);
+    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->get_control_in());
 
     // Grab inertial velocity
     const Vector3f& vel = inertial_nav.get_velocity();
@@ -75,7 +75,7 @@ void Copter::drift_run()
     roll_vel = constrain_float(roll_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
     pitch_vel = constrain_float(pitch_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
     
-    roll_input = roll_input * .96f + (float)channel_yaw->control_in * .04f;
+    roll_input = roll_input * .96f + (float)channel_yaw->get_control_in() * .04f;
 
     //convert user input into desired roll velocity
     float roll_vel_error = roll_vel - (roll_input / DRIFT_SPEEDGAIN);

--- a/ArduCopter/control_flip.cpp
+++ b/ArduCopter/control_flip.cpp
@@ -53,7 +53,7 @@ bool Copter::flip_init(bool ignore_checks)
     }
 
     // ensure roll input is less than 40deg
-    if (abs(channel_roll->control_in) >= 4000) {
+    if (abs(channel_roll->get_control_in()) >= 4000) {
         return false;
     }
 
@@ -73,11 +73,11 @@ bool Copter::flip_init(bool ignore_checks)
     flip_roll_dir = flip_pitch_dir = 0;
 
     // choose direction based on pilot's roll and pitch sticks
-    if (channel_pitch->control_in > 300) {
+    if (channel_pitch->get_control_in() > 300) {
         flip_pitch_dir = FLIP_PITCH_BACK;
-    }else if(channel_pitch->control_in < -300) {
+    }else if(channel_pitch->get_control_in() < -300) {
         flip_pitch_dir = FLIP_PITCH_FORWARD;
-    }else if (channel_roll->control_in >= 0) {
+    }else if (channel_roll->get_control_in() >= 0) {
         flip_roll_dir = FLIP_ROLL_RIGHT;
     }else{
         flip_roll_dir = FLIP_ROLL_LEFT;
@@ -102,12 +102,12 @@ void Copter::flip_run()
     float recovery_angle;
 
     // if pilot inputs roll > 40deg or timeout occurs abandon flip
-    if (!motors.armed() || (abs(channel_roll->control_in) >= 4000) || (abs(channel_pitch->control_in) >= 4000) || ((millis() - flip_start_time) > FLIP_TIMEOUT_MS)) {
+    if (!motors.armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - flip_start_time) > FLIP_TIMEOUT_MS)) {
         flip_state = Flip_Abandon;
     }
 
     // get pilot's desired throttle
-    throttle_out = get_pilot_desired_throttle(channel_throttle->control_in);
+    throttle_out = get_pilot_desired_throttle(channel_throttle->get_control_in());
 
     // get corrected angle based on direction and axis of rotation
     // we flip the sign of flip_angle to minimize the code repetition

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -314,7 +314,7 @@ void Copter::guided_takeoff_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range
@@ -352,7 +352,7 @@ void Copter::guided_pos_control_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -401,7 +401,7 @@ void Copter::guided_vel_control_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -455,7 +455,7 @@ void Copter::guided_posvel_control_run()
 
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -102,8 +102,8 @@ void Copter::land_gps_run()
             update_simple_mode();
 
             // process pilot's roll and pitch input
-            roll_control = channel_roll->control_in;
-            pitch_control = channel_pitch->control_in;
+            roll_control = channel_roll->get_control_in();
+            pitch_control = channel_pitch->get_control_in();
 
             // record if pilot has overriden roll or pitch
             if (roll_control != 0 || pitch_control != 0) {
@@ -112,7 +112,7 @@ void Copter::land_gps_run()
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range
@@ -172,11 +172,11 @@ void Copter::land_nogps_run()
             update_simple_mode();
 
             // get pilot desired lean angles
-            get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+            get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -54,13 +54,13 @@ void Copter::loiter_run()
         update_simple_mode();
 
         // process pilot's roll and pitch input
-        wp_nav.set_pilot_desired_acceleration(channel_roll->control_in, channel_pitch->control_in);
+        wp_nav.set_pilot_desired_acceleration(channel_roll->get_control_in(), channel_pitch->get_control_in());
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
         // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
         target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
     } else {
         // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
@@ -77,7 +77,7 @@ void Copter::loiter_run()
         loiter_state = Loiter_Disarmed;
     } else if (!motors.get_interlock()){
         loiter_state = Loiter_MotorStop;
-    } else if (takeoff_state.running || (ap.land_complete && (channel_throttle->control_in > get_takeoff_trigger_throttle()))){
+    } else if (takeoff_state.running || (ap.land_complete && (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()))){
         loiter_state = Loiter_Takeoff;
     } else if (ap.land_complete){
         loiter_state = Loiter_Landed;
@@ -100,7 +100,7 @@ void Copter::loiter_run()
         // multicopters do not stabilize roll/pitch/yaw when disarmed
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
 #endif  // HELI_FRAME
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         break;
 
     case Loiter_MotorStop:
@@ -121,7 +121,7 @@ void Copter::loiter_run()
         wp_nav.init_loiter_target();
         // multicopters do not stabilize roll/pitch/yaw when motors are stopped
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
 #endif  // HELI_FRAME
         break;
 
@@ -159,7 +159,7 @@ void Copter::loiter_run()
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(0, 0, 0, get_smoothing_gain());
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
 #else
         // if throttle zero reset attitude and exit immediately
         if (ap.throttle_zero) {
@@ -169,9 +169,9 @@ void Copter::loiter_run()
         }
         // multicopters do not stabilize roll/pitch/yaw when disarmed
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
 #endif
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         break;
 
     case Loiter_Flying:

--- a/ArduCopter/control_poshold.cpp
+++ b/ArduCopter/control_poshold.cpp
@@ -145,7 +145,7 @@ void Copter::poshold_run()
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         wp_nav.init_loiter_target();
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         return;
     }
 
@@ -155,17 +155,17 @@ void Copter::poshold_run()
         update_simple_mode();
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
         // get pilot desired climb rate (for alt-hold mode and take-off)
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
         target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
 
         // get takeoff adjusted pilot and takeoff climb rates
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // check for take-off
-        if (ap.land_complete && (takeoff_state.running || channel_throttle->control_in > get_takeoff_trigger_throttle())) {
+        if (ap.land_complete && (takeoff_state.running || channel_throttle->get_control_in() > get_takeoff_trigger_throttle())) {
             if (!takeoff_state.running) {
                 takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             }
@@ -192,12 +192,12 @@ void Copter::poshold_run()
         }
         wp_nav.init_loiter_target();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         return;
     }else{
         // convert pilot input to lean angles
-        get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+        get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
         // convert inertial nav earth-frame velocities to body-frame
         // To-Do: move this to AP_Math (or perhaps we already have a function to do this)

--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -153,7 +153,7 @@ void Copter::rtl_climb_return_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -220,7 +220,7 @@ void Copter::rtl_loiterathome_run()
     float target_yaw_rate = 0;
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         if (!is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
@@ -312,12 +312,12 @@ void Copter::rtl_descent_run()
             update_simple_mode();
 
             // process pilot's roll and pitch input
-            roll_control = channel_roll->control_in;
-            pitch_control = channel_pitch->control_in;
+            roll_control = channel_roll->get_control_in();
+            pitch_control = channel_pitch->get_control_in();
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range
@@ -413,12 +413,12 @@ void Copter::rtl_land_run()
             update_simple_mode();
 
             // process pilot's roll and pitch input
-            roll_control = channel_roll->control_in;
-            pitch_control = channel_pitch->control_in;
+            roll_control = channel_roll->get_control_in();
+            pitch_control = channel_pitch->get_control_in();
         }
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
     // set motors to full range

--- a/ArduCopter/control_sport.cpp
+++ b/ArduCopter/control_sport.cpp
@@ -36,7 +36,7 @@ void Copter::sport_run()
     if (!motors.armed() || ap.throttle_zero || !motors.get_interlock()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
         return;
     }
 
@@ -46,8 +46,8 @@ void Copter::sport_run()
     // get pilot's desired roll and pitch rates
 
     // calculate rate requests
-    target_roll_rate = channel_roll->control_in * g.acro_rp_p;
-    target_pitch_rate = channel_pitch->control_in * g.acro_rp_p;
+    target_roll_rate = channel_roll->get_control_in() * g.acro_rp_p;
+    target_pitch_rate = channel_pitch->get_control_in() * g.acro_rp_p;
 
     int32_t roll_angle = wrap_180_cd(ahrs.roll_sensor);
     target_roll_rate -= constrain_int32(roll_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_roll;
@@ -69,17 +69,17 @@ void Copter::sport_run()
     }
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot desired climb rate
-    target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->control_in);
+    target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
     target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
 
     // get takeoff adjusted pilot and takeoff climb rates
     takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
     // check for take-off
-    if (ap.land_complete && (takeoff_state.running || (channel_throttle->control_in > get_takeoff_trigger_throttle()))) {
+    if (ap.land_complete && (takeoff_state.running || (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()))) {
         if (!takeoff_state.running) {
             takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
         }
@@ -98,8 +98,8 @@ void Copter::sport_run()
             motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->control_in),false,g.throttle_filt);
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->control_in)-throttle_average);
+        attitude_control.set_throttle_out(get_throttle_pre_takeoff(channel_throttle->get_control_in()),false,g.throttle_filt);
+        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-throttle_average);
     }else{
         // set motors to full range
         motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);

--- a/ArduCopter/control_stabilize.cpp
+++ b/ArduCopter/control_stabilize.cpp
@@ -10,7 +10,7 @@
 bool Copter::stabilize_init(bool ignore_checks)
 {
     // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
-    if (motors.armed() && ap.land_complete && !mode_has_manual_throttle(control_mode) && (get_pilot_desired_throttle(channel_throttle->control_in) > get_non_takeoff_throttle())) {
+    if (motors.armed() && ap.land_complete && !mode_has_manual_throttle(control_mode) && (get_pilot_desired_throttle(channel_throttle->get_control_in()) > get_non_takeoff_throttle())) {
         return false;
     }
     // set target altitude to zero for reporting
@@ -41,13 +41,13 @@ void Copter::stabilize_run()
 
     // convert pilot input to lean angles
     // To-Do: convert get_pilot_desired_lean_angles to return angles as floats
-    get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot's desired throttle
-    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->control_in);
+    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->get_control_in());
 
     // call attitude controller
     attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -35,7 +35,7 @@ void Copter::esc_calibration_startup_check()
     switch (g.esc_calibrate) {
         case ESCCAL_NONE:
             // check if throttle is high
-            if (channel_throttle->control_in >= ESC_CALIBRATION_HIGH_THROTTLE) {
+            if (channel_throttle->get_control_in() >= ESC_CALIBRATION_HIGH_THROTTLE) {
                 // we will enter esc_calibrate mode on next reboot
                 g.esc_calibrate.set_and_save(ESCCAL_PASSTHROUGH_IF_THROTTLE_HIGH);
                 // send message to gcs
@@ -48,7 +48,7 @@ void Copter::esc_calibration_startup_check()
             break;
         case ESCCAL_PASSTHROUGH_IF_THROTTLE_HIGH:
             // check if throttle is high
-            if (channel_throttle->control_in >= ESC_CALIBRATION_HIGH_THROTTLE) {
+            if (channel_throttle->get_control_in() >= ESC_CALIBRATION_HIGH_THROTTLE) {
                 // pass through pilot throttle to escs
                 esc_calibration_passthrough();
             }
@@ -100,7 +100,7 @@ void Copter::esc_calibration_passthrough()
         delay(10);
 
         // pass through to motors
-        motors.throttle_pass_through(channel_throttle->radio_in);
+        motors.throttle_pass_through(channel_throttle->get_radio_in());
     }
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
@@ -126,7 +126,7 @@ void Copter::esc_calibration_auto()
 
     // raise throttle to maximum
     delay(10);
-    motors.throttle_pass_through(channel_throttle->radio_max);
+    motors.throttle_pass_through(channel_throttle->get_radio_max());
 
     // wait for safety switch to be pressed
     while (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
@@ -141,7 +141,7 @@ void Copter::esc_calibration_auto()
     delay(5000);
 
     // reduce throttle to minimum
-    motors.throttle_pass_through(channel_throttle->radio_min);
+    motors.throttle_pass_through(channel_throttle->get_radio_min());
 
     // clear esc parameter
     g.esc_calibrate.set_and_save(ESCCAL_NONE);

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -255,7 +255,7 @@ void Copter::exit_mode(control_mode_t old_control_mode, control_mode_t new_contr
     // smooth throttle transition when switching from manual to automatic flight modes
     if (mode_has_manual_throttle(old_control_mode) && !mode_has_manual_throttle(new_control_mode) && motors.armed() && !ap.land_complete) {
         // this assumes all manual flight modes use get_pilot_desired_throttle to translate pilot input to output throttle
-        set_accel_throttle_I_from_pilot_throttle(get_pilot_desired_throttle(channel_throttle->control_in));
+        set_accel_throttle_I_from_pilot_throttle(get_pilot_desired_throttle(channel_throttle->get_control_in()));
     }
 
     // cancel any takeoffs in progress

--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -49,7 +49,7 @@ void Copter::heli_acro_run()
 
     if (!motors.has_flybar()){
         // convert the input to the desired body frame rate
-        get_pilot_desired_angle_rates(channel_roll->control_in, channel_pitch->control_in, channel_yaw->control_in, target_roll, target_pitch, target_yaw);
+        get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
 
         if (motors.supports_yaw_passthrough()) {
             // if the tail on a flybar heli has an external gyro then
@@ -78,7 +78,7 @@ void Copter::heli_acro_run()
             // if there is no external gyro then run the usual
             // ACRO_YAW_P gain on the input control, including
             // deadzone
-            yaw_in = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+            yaw_in = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
         }
 
         // run attitude controller
@@ -86,7 +86,7 @@ void Copter::heli_acro_run()
     }
 
     // get pilot's desired throttle
-    pilot_throttle_scaled = input_manager.get_pilot_desired_collective(channel_throttle->control_in);
+    pilot_throttle_scaled = input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());
 
     // output pilot's throttle without angle boost
     attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);

--- a/ArduCopter/heli_control_stabilize.cpp
+++ b/ArduCopter/heli_control_stabilize.cpp
@@ -51,13 +51,13 @@ void Copter::heli_stabilize_run()
 
     // convert pilot input to lean angles
     // To-Do: convert get_pilot_desired_lean_angles to return angles as floats
-    get_pilot_desired_lean_angles(channel_roll->control_in, channel_pitch->control_in, target_roll, target_pitch, aparm.angle_max);
+    get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->control_in);
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
 
     // get pilot's desired throttle
-    pilot_throttle_scaled = input_manager.get_pilot_desired_collective(channel_throttle->control_in);
+    pilot_throttle_scaled = input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());
 
     // call attitude controller
     attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -122,7 +122,7 @@ void Copter::update_throttle_thr_mix()
 
     if (mode_has_manual_throttle(control_mode)) {
         // manual throttle
-        if(channel_throttle->control_in <= 0) {
+        if(channel_throttle->get_control_in() <= 0) {
             motors.set_throttle_mix_min();
         } else {
             motors.set_throttle_mix_mid();

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -39,7 +39,9 @@ void Copter::motor_test_output()
             case MOTOR_TEST_THROTTLE_PERCENT:
                 // sanity check motor_test_throttle value
                 if (motor_test_throttle_value <= 100) {
-                    pwm = channel_throttle->radio_min + (channel_throttle->radio_max - channel_throttle->radio_min) * (float)motor_test_throttle_value/100.0f;
+                    pwm = channel_throttle->get_radio_min()
+                        + (channel_throttle->get_radio_max() - channel_throttle->get_radio_min()) 
+                           * (float)motor_test_throttle_value/100.0f;
                 }
                 break;
 
@@ -48,7 +50,7 @@ void Copter::motor_test_output()
                 break;
 
             case MOTOR_TEST_THROTTLE_PILOT:
-                pwm = channel_throttle->radio_in;
+                pwm = channel_throttle->get_radio_in();
                 break;
 
             default:

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -16,12 +16,12 @@ void Copter::arm_motors_check()
     static int16_t arming_counter;
 
     // ensure throttle is down
-    if (channel_throttle->control_in > 0) {
+    if (channel_throttle->get_control_in() > 0) {
         arming_counter = 0;
         return;
     }
 
-    int16_t tmp = channel_yaw->control_in;
+    int16_t tmp = channel_yaw->get_control_in();
 
     // full right
     if (tmp > 4000) {
@@ -104,7 +104,7 @@ void Copter::auto_disarm_check()
             thr_low = ap.throttle_zero;
         } else {
             float deadband_top = g.rc_3.get_control_mid() + g.throttle_deadzone;
-            thr_low = g.rc_3.control_in <= deadband_top;
+            thr_low = g.rc_3.get_control_in() <= deadband_top;
         }
 
         if (!thr_low || !ap.land_complete) {
@@ -288,7 +288,7 @@ void Copter::lost_vehicle_check()
     }
 
     // ensure throttle is down, motors not armed, pitch and roll rc at max. Note: rc1=roll rc2=pitch
-    if (ap.throttle_zero && !motors.armed() && (channel_roll->control_in > 4000) && (channel_pitch->control_in > 4000)) {
+    if (ap.throttle_zero && !motors.armed() && (channel_roll->get_control_in() > 4000) && (channel_pitch->get_control_in() > 4000)) {
         if (soundalarm_counter >= LOST_VEHICLE_DELAY) {
             if (AP_Notify::flags.vehicle_lost == false) {
                 AP_Notify::flags.vehicle_lost = true;

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -58,7 +58,7 @@ void Copter::init_rc_out()
     motors.set_frame_orientation(g.frame_orientation);
     motors.Init();                                              // motor initialisation
 #if FRAME_CONFIG != HELI_FRAME
-    motors.set_throttle_range(g.throttle_min, channel_throttle->radio_min, channel_throttle->radio_max);
+    motors.set_throttle_range(g.throttle_min, channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
     motors.set_hover_throttle(g.throttle_mid);
 #endif
 
@@ -84,7 +84,7 @@ void Copter::init_rc_out()
 
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
     // take a proportion of speed. 
-    hal.rcout->set_esc_scaling(channel_throttle->radio_min, channel_throttle->radio_max);
+    hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 }
 
 // enable_motor_output() - enable and output lowest possible value to motors
@@ -104,8 +104,8 @@ void Copter::read_radio()
         ap.new_radio_frame = true;
         RC_Channel::set_pwm_all();
 
-        set_throttle_and_failsafe(channel_throttle->radio_in);
-        set_throttle_zero_flag(channel_throttle->control_in);
+        set_throttle_and_failsafe(channel_throttle->get_radio_in());
+        set_throttle_zero_flag(channel_throttle->get_control_in());
 
         // flag we must have an rc receiver attached
         if (!failsafe.rc_override_active) {
@@ -119,7 +119,7 @@ void Copter::read_radio()
         radio_passthrough_to_motors();
 
         float dt = (tnow_ms - last_update_ms)*1.0e-3f;
-        rc_throttle_control_in_filter.apply(g.rc_3.control_in, dt);
+        rc_throttle_control_in_filter.apply(g.rc_3.get_control_in(), dt);
         last_update_ms = tnow_ms;
     }else{
         uint32_t elapsed = tnow_ms - last_update_ms;
@@ -198,5 +198,5 @@ void Copter::set_throttle_zero_flag(int16_t throttle_control)
 // pass pilot's inputs to motors library (used to allow wiggling servos while disarmed on heli, single, coax copters)
 void Copter::radio_passthrough_to_motors()
 {
-    motors.set_radio_passthrough(channel_roll->control_in/1000.0f, channel_pitch->control_in/1000.0f, channel_throttle->control_in/1000.0f, channel_yaw->control_in/1000.0f);
+    motors.set_radio_passthrough(channel_roll->get_control_in()/1000.0f, channel_pitch->get_control_in()/1000.0f, channel_throttle->get_control_in()/1000.0f, channel_yaw->get_control_in()/1000.0f);
 }

--- a/ArduCopter/setup.cpp
+++ b/ArduCopter/setup.cpp
@@ -382,14 +382,14 @@ void Copter::report_optflow()
 
 void Copter::print_radio_values()
 {
-    cliSerial->printf("CH1: %d | %d\n", (int)channel_roll->radio_min, (int)channel_roll->radio_max);
-    cliSerial->printf("CH2: %d | %d\n", (int)channel_pitch->radio_min, (int)channel_pitch->radio_max);
-    cliSerial->printf("CH3: %d | %d\n", (int)channel_throttle->radio_min, (int)channel_throttle->radio_max);
-    cliSerial->printf("CH4: %d | %d\n", (int)channel_yaw->radio_min, (int)channel_yaw->radio_max);
-    cliSerial->printf("CH5: %d | %d\n", (int)g.rc_5.radio_min, (int)g.rc_5.radio_max);
-    cliSerial->printf("CH6: %d | %d\n", (int)g.rc_6.radio_min, (int)g.rc_6.radio_max);
-    cliSerial->printf("CH7: %d | %d\n", (int)g.rc_7.radio_min, (int)g.rc_7.radio_max);
-    cliSerial->printf("CH8: %d | %d\n", (int)g.rc_8.radio_min, (int)g.rc_8.radio_max);
+    cliSerial->printf("CH1: %d | %d\n", (int)channel_roll->get_radio_min(), (int)channel_roll->get_radio_max());
+    cliSerial->printf("CH2: %d | %d\n", (int)channel_pitch->get_radio_min(), (int)channel_pitch->get_radio_max());
+    cliSerial->printf("CH3: %d | %d\n", (int)channel_throttle->get_radio_min(), (int)channel_throttle->get_radio_max());
+    cliSerial->printf("CH4: %d | %d\n", (int)channel_yaw->get_radio_min(), (int)channel_yaw->get_radio_max());
+    cliSerial->printf("CH5: %d | %d\n", (int)g.rc_5.get_radio_min(), (int)g.rc_5.get_radio_max());
+    cliSerial->printf("CH6: %d | %d\n", (int)g.rc_6.get_radio_min(), (int)g.rc_6.get_radio_max());
+    cliSerial->printf("CH7: %d | %d\n", (int)g.rc_7.get_radio_min(), (int)g.rc_7.get_radio_max());
+    cliSerial->printf("CH8: %d | %d\n", (int)g.rc_8.get_radio_min(), (int)g.rc_8.get_radio_max());
 }
 
 void Copter::print_switch(uint8_t p, uint8_t m, bool b)

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -24,11 +24,11 @@ void Copter::read_control_switch()
 
     // calculate position of flight mode switch
     int8_t switch_position;
-    if      (g.rc_5.radio_in < 1231) switch_position = 0;
-    else if (g.rc_5.radio_in < 1361) switch_position = 1;
-    else if (g.rc_5.radio_in < 1491) switch_position = 2;
-    else if (g.rc_5.radio_in < 1621) switch_position = 3;
-    else if (g.rc_5.radio_in < 1750) switch_position = 4;
+    if      (g.rc_5.get_radio_in() < 1231) switch_position = 0;
+    else if (g.rc_5.get_radio_in() < 1361) switch_position = 1;
+    else if (g.rc_5.get_radio_in() < 1491) switch_position = 2;
+    else if (g.rc_5.get_radio_in() < 1621) switch_position = 3;
+    else if (g.rc_5.get_radio_in() < 1750) switch_position = 4;
     else switch_position = 5;
 
     // store time that switch last moved
@@ -130,7 +130,7 @@ void Copter::read_aux_switches()
     }
 
     // check if ch7 switch has changed position
-    switch_position = read_3pos_switch(g.rc_7.radio_in);
+    switch_position = read_3pos_switch(g.rc_7.get_radio_in());
     if (aux_con.CH7_flag != switch_position) {
         // set the CH7 flag
         aux_con.CH7_flag = switch_position;
@@ -140,7 +140,7 @@ void Copter::read_aux_switches()
     }
 
     // check if Ch8 switch has changed position
-    switch_position = read_3pos_switch(g.rc_8.radio_in);
+    switch_position = read_3pos_switch(g.rc_8.get_radio_in());
     if (aux_con.CH8_flag != switch_position) {
         // set the CH8 flag
         aux_con.CH8_flag = switch_position;
@@ -150,7 +150,7 @@ void Copter::read_aux_switches()
     }
 
     // check if Ch9 switch has changed position
-    switch_position = read_3pos_switch(g.rc_9.radio_in);
+    switch_position = read_3pos_switch(g.rc_9.get_radio_in());
     if (aux_con.CH9_flag != switch_position) {
         // set the CH9 flag
         aux_con.CH9_flag = switch_position;
@@ -160,7 +160,7 @@ void Copter::read_aux_switches()
     }
 
     // check if Ch10 switch has changed position
-    switch_position = read_3pos_switch(g.rc_10.radio_in);
+    switch_position = read_3pos_switch(g.rc_10.get_radio_in());
     if (aux_con.CH10_flag != switch_position) {
         // set the CH10 flag
         aux_con.CH10_flag = switch_position;
@@ -170,7 +170,7 @@ void Copter::read_aux_switches()
     }
 
     // check if Ch11 switch has changed position
-    switch_position = read_3pos_switch(g.rc_11.radio_in);
+    switch_position = read_3pos_switch(g.rc_11.get_radio_in());
     if (aux_con.CH11_flag != switch_position) {
         // set the CH11 flag
         aux_con.CH11_flag = switch_position;
@@ -181,7 +181,7 @@ void Copter::read_aux_switches()
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     // check if Ch12 switch has changed position
-    switch_position = read_3pos_switch(g.rc_12.radio_in);
+    switch_position = read_3pos_switch(g.rc_12.get_radio_in());
     if (aux_con.CH12_flag != switch_position) {
         // set the CH12 flag
         aux_con.CH12_flag = switch_position;
@@ -196,14 +196,14 @@ void Copter::read_aux_switches()
 void Copter::init_aux_switches()
 {
     // set the CH7 ~ CH12 flags
-    aux_con.CH7_flag = read_3pos_switch(g.rc_7.radio_in);
-    aux_con.CH8_flag = read_3pos_switch(g.rc_8.radio_in);
-    aux_con.CH10_flag = read_3pos_switch(g.rc_10.radio_in);
-    aux_con.CH11_flag = read_3pos_switch(g.rc_11.radio_in);
+    aux_con.CH7_flag = read_3pos_switch(g.rc_7.get_radio_in());
+    aux_con.CH8_flag = read_3pos_switch(g.rc_8.get_radio_in());
+    aux_con.CH10_flag = read_3pos_switch(g.rc_10.get_radio_in());
+    aux_con.CH11_flag = read_3pos_switch(g.rc_11.get_radio_in());
 
     // ch9, ch12 only supported on some boards
-    aux_con.CH9_flag = read_3pos_switch(g.rc_9.radio_in);
-    aux_con.CH12_flag = read_3pos_switch(g.rc_12.radio_in);
+    aux_con.CH9_flag = read_3pos_switch(g.rc_9.get_radio_in());
+    aux_con.CH12_flag = read_3pos_switch(g.rc_12.get_radio_in());
 
     // initialise functions assigned to switches
     init_aux_switch_function(g.ch7_option, aux_con.CH7_flag);
@@ -278,7 +278,7 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             break;
 
         case AUXSW_SAVE_TRIM:
-            if ((ch_flag == AUX_SWITCH_HIGH) && (control_mode <= ACRO) && (channel_throttle->control_in == 0)) {
+            if ((ch_flag == AUX_SWITCH_HIGH) && (control_mode <= ACRO) && (channel_throttle->get_control_in() == 0)) {
                 save_trim();
             }
             break;
@@ -293,7 +293,7 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                 }
 
                 // do not allow saving the first waypoint with zero throttle
-                if((mission.num_commands() == 0) && (channel_throttle->control_in == 0)){
+                if((mission.num_commands() == 0) && (channel_throttle->get_control_in() == 0)){
                     return;
                 }
 
@@ -322,7 +322,7 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                 cmd.content.location = current_loc;
 
                 // if throttle is above zero, create waypoint command
-                if(channel_throttle->control_in > 0) {
+                if(channel_throttle->get_control_in() > 0) {
                     cmd.id = MAV_CMD_NAV_WAYPOINT;
                 }else{
                     // with zero throttle, create LAND command
@@ -608,8 +608,8 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
 void Copter::save_trim()
 {
     // save roll and pitch trim
-    float roll_trim = ToRad((float)channel_roll->control_in/100.0f);
-    float pitch_trim = ToRad((float)channel_pitch->control_in/100.0f);
+    float roll_trim = ToRad((float)channel_roll->get_control_in()/100.0f);
+    float pitch_trim = ToRad((float)channel_pitch->get_control_in()/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     Log_Write_Event(DATA_SAVE_TRIM);
     gcs_send_text(MAV_SEVERITY_INFO, "Trim saved");
@@ -626,10 +626,10 @@ void Copter::auto_trim()
         AP_Notify::flags.save_trim = true;
 
         // calculate roll trim adjustment
-        float roll_trim_adjustment = ToRad((float)channel_roll->control_in / 4000.0f);
+        float roll_trim_adjustment = ToRad((float)channel_roll->get_control_in() / 4000.0f);
 
         // calculate pitch trim adjustment
-        float pitch_trim_adjustment = ToRad((float)channel_pitch->control_in / 4000.0f);
+        float pitch_trim_adjustment = ToRad((float)channel_pitch->get_control_in() / 4000.0f);
 
         // add trim to ahrs object
         // save to eeprom on last iteration

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -12,17 +12,17 @@
 void Copter::tuning() {
 
     // exit immediately if not using tuning function, or when radio failsafe is invoked, so tuning values are not set to zero
-    if ((g.radio_tuning <= 0) || failsafe.radio || failsafe.radio_counter != 0 || g.rc_6.radio_in == 0) {
+    if ((g.radio_tuning <= 0) || failsafe.radio || failsafe.radio_counter != 0 || g.rc_6.get_radio_in() == 0) {
         return;
     }
 
     // set tuning range and then get new value
     g.rc_6.set_range_in(g.radio_tuning_low,g.radio_tuning_high);
-    float tuning_value = (float)g.rc_6.control_in / 1000.0f;
+    float tuning_value = (float)g.rc_6.get_control_in() / 1000.0f;
     // Tuning Value should never be outside the bounds of the specified low and high value
     tuning_value = constrain_float(tuning_value, g.radio_tuning_low/1000.0f, g.radio_tuning_high/1000.0f);
 
-    Log_Write_Parameter_Tuning(g.radio_tuning, tuning_value, g.rc_6.control_in, g.radio_tuning_low, g.radio_tuning_high);
+    Log_Write_Parameter_Tuning(g.radio_tuning, tuning_value, g.rc_6.get_control_in(), g.radio_tuning_low, g.radio_tuning_high);
 
     switch(g.radio_tuning) {
 
@@ -96,7 +96,7 @@ void Copter::tuning() {
 
     case TUNING_WP_SPEED:
         // set waypoint navigation horizontal speed to 0 ~ 1000 cm/s
-        wp_nav.set_speed_xy(g.rc_6.control_in);
+        wp_nav.set_speed_xy(g.rc_6.get_control_in());
         break;
 
     // Acro roll pitch gain
@@ -111,7 +111,7 @@ void Copter::tuning() {
 
 #if FRAME_CONFIG == HELI_FRAME
     case TUNING_HELI_EXTERNAL_GYRO:
-        motors.ext_gyro_gain((float)g.rc_6.control_in / 1000.0f);
+        motors.ext_gyro_gain((float)g.rc_6.get_control_in() / 1000.0f);
         break;
 
     case TUNING_RATE_PITCH_FF:
@@ -129,12 +129,12 @@ void Copter::tuning() {
 
     case TUNING_DECLINATION:
         // set declination to +-20degrees
-        compass.set_declination(ToRad((2.0f * g.rc_6.control_in - g.radio_tuning_high)/100.0f), false);     // 2nd parameter is false because we do not want to save to eeprom because this would have a performance impact
+        compass.set_declination(ToRad((2.0f * g.rc_6.get_control_in() - g.radio_tuning_high)/100.0f), false);     // 2nd parameter is false because we do not want to save to eeprom because this would have a performance impact
         break;
 
     case TUNING_CIRCLE_RATE:
         // set circle rate up to approximately 45 deg/sec in either direction
-        circle_nav.set_rate((float)g.rc_6.control_in/25.0f-20.0f);
+        circle_nav.set_rate((float)g.rc_6.get_control_in()/25.0f-20.0f);
         break;
 
     case TUNING_SONAR_GAIN:
@@ -175,7 +175,7 @@ void Copter::tuning() {
 
     case TUNING_RC_FEEL_RP:
         // roll-pitch input smoothing
-        g.rc_feel_rp = g.rc_6.control_in / 10;
+        g.rc_feel_rp = g.rc_6.get_control_in() / 10;
         break;
 
     case TUNING_RATE_PITCH_KP:

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -519,7 +519,7 @@ void Plane::handle_auto_mode(void)
         if (auto_state.land_complete) {
             // we are in the final stage of a landing - force
             // zero throttle
-            channel_throttle->servo_out = 0;
+            channel_throttle->set_servo_out(0);
         }
     } else {
         // we are doing normal AUTO flight, the special cases
@@ -639,7 +639,7 @@ void Plane::update_flight_mode(void)
             // FBWA failsafe glide
             nav_roll_cd = 0;
             nav_pitch_cd = 0;
-            channel_throttle->servo_out = 0;
+            channel_throttle->set_servo_out(0);
         }
         if (g.fbwa_tdrag_chan > 0) {
             // check for the user enabling FBWA taildrag takeoff mode
@@ -668,7 +668,7 @@ void Plane::update_flight_mode(void)
           roll when heading is locked. Heading becomes unlocked on
           any aileron or rudder input
         */
-        if ((channel_roll->control_in != 0 ||
+        if ((channel_roll->get_control_in() != 0 ||
              rudder_input != 0)) {                
             cruise_state.locked_heading = false;
             cruise_state.lock_timer_ms = 0;
@@ -704,8 +704,8 @@ void Plane::update_flight_mode(void)
     case MANUAL:
         // servo_out is for Sim control only
         // ---------------------------------
-        channel_roll->servo_out = channel_roll->pwm_to_angle();
-        channel_pitch->servo_out = channel_pitch->pwm_to_angle();
+        channel_roll->set_servo_out(channel_roll->pwm_to_angle());
+        channel_pitch->set_servo_out(channel_pitch->pwm_to_angle());
         steering_control.steering = steering_control.rudder = channel_rudder->pwm_to_angle();
         break;
         //roll: -13788.000,  pitch: -13698.000,   thr: 0.000, rud: -13742.000
@@ -929,7 +929,7 @@ void Plane::update_flight_stage(void)
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_TAKEOFF);
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
 
-                if ((g.land_abort_throttle_enable && channel_throttle->control_in >= 90) ||
+                if ((g.land_abort_throttle_enable && channel_throttle->get_control_in() >= 90) ||
                         auto_state.commanded_go_around ||
                         flight_stage == AP_SpdHgtControl::FLIGHT_LAND_ABORT){
                     // abort mode is sticky, it must complete while executing NAV_LAND

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -21,8 +21,8 @@ float Plane::get_speed_scaler(void)
         }
         speed_scaler = constrain_float(speed_scaler, 0.5f, 2.0f);
     } else {
-        if (channel_throttle->servo_out > 0) {
-            speed_scaler = 0.5f + ((float)THROTTLE_CRUISE / channel_throttle->servo_out / 2.0f);                 // First order taylor expansion of square root
+        if (channel_throttle->get_servo_out() > 0) {
+            speed_scaler = 0.5f + ((float)THROTTLE_CRUISE / channel_throttle->get_servo_out() / 2.0f);                 // First order taylor expansion of square root
             // Should maybe be to the 2/7 power, but we aren't going to implement that...
         }else{
             speed_scaler = 1.67f;
@@ -79,12 +79,12 @@ void Plane::stabilize_roll(float speed_scaler)
     }
 
     bool disable_integrator = false;
-    if (control_mode == STABILIZE && channel_roll->control_in != 0) {
+    if (control_mode == STABILIZE && channel_roll->get_control_in() != 0) {
         disable_integrator = true;
     }
-    channel_roll->servo_out = rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, 
+    channel_roll->set_servo_out(rollController.get_servo_out(nav_roll_cd - ahrs.roll_sensor, 
                                                            speed_scaler, 
-                                                           disable_integrator);
+                                                           disable_integrator));
 }
 
 /*
@@ -98,17 +98,17 @@ void Plane::stabilize_pitch(float speed_scaler)
     if (force_elevator != 0) {
         // we are holding the tail down during takeoff. Just convert
         // from a percentage to a -4500..4500 centidegree angle
-        channel_pitch->servo_out = 45*force_elevator;
+        channel_pitch->set_servo_out(45*force_elevator);
         return;
     }
-    int32_t demanded_pitch = nav_pitch_cd + g.pitch_trim_cd + channel_throttle->servo_out * g.kff_throttle_to_pitch;
+    int32_t demanded_pitch = nav_pitch_cd + g.pitch_trim_cd + channel_throttle->get_servo_out() * g.kff_throttle_to_pitch;
     bool disable_integrator = false;
-    if (control_mode == STABILIZE && channel_pitch->control_in != 0) {
+    if (control_mode == STABILIZE && channel_pitch->get_control_in() != 0) {
         disable_integrator = true;
     }
-    channel_pitch->servo_out = pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, 
+    channel_pitch->set_servo_out (pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, 
                                                              speed_scaler, 
-                                                             disable_integrator);
+                                                             disable_integrator) );
 }
 
 /*
@@ -121,12 +121,24 @@ void Plane::stick_mix_channel(RC_Channel *channel, int16_t &servo_out)
 {
     float ch_inf;
         
-    ch_inf = (float)channel->radio_in - (float)channel->radio_trim;
+    ch_inf = (float)channel->get_radio_in() - (float)channel->get_radio_trim();
     ch_inf = fabsf(ch_inf);
     ch_inf = MIN(ch_inf, 400.0f);
     ch_inf = ((400.0f - ch_inf) / 400.0f);
     servo_out *= ch_inf;
     servo_out += channel->pwm_to_angle();
+}
+
+// one argument version when 
+void Plane::stick_mix_channel(RC_Channel *channel)
+{
+    float ch_inf;
+        
+    ch_inf = (float)channel->get_radio_in() - (float)channel->get_radio_trim();
+    ch_inf = fabsf(ch_inf);
+    ch_inf = MIN(ch_inf, 400.0f);
+    ch_inf = ((400.0f - ch_inf) / 400.0f);
+    channel->set_servo_out(channel->get_servo_out() * ch_inf + channel->pwm_to_angle());
 }
 
 /*
@@ -148,8 +160,8 @@ void Plane::stabilize_stick_mixing_direct()
         control_mode == TRAINING) {
         return;
     }
-    stick_mix_channel(channel_roll, channel_roll->servo_out);
-    stick_mix_channel(channel_pitch, channel_pitch->servo_out);
+    stick_mix_channel(channel_roll);
+    stick_mix_channel(channel_pitch);
 }
 
 /*
@@ -219,7 +231,7 @@ void Plane::stabilize_yaw(float speed_scaler)
     } else {
         // otherwise use ground steering when no input control and we
         // are below the GROUND_STEER_ALT
-        steering_control.ground_steering = (channel_roll->control_in == 0 && 
+        steering_control.ground_steering = (channel_roll->get_control_in() == 0 && 
                                             fabsf(relative_altitude()) < g.ground_steer_alt);
         if (control_mode == AUTO &&
                 (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
@@ -257,25 +269,25 @@ void Plane::stabilize_yaw(float speed_scaler)
 void Plane::stabilize_training(float speed_scaler)
 {
     if (training_manual_roll) {
-        channel_roll->servo_out = channel_roll->control_in;
+        channel_roll->set_servo_out(channel_roll->get_control_in());
     } else {
         // calculate what is needed to hold
         stabilize_roll(speed_scaler);
-        if ((nav_roll_cd > 0 && channel_roll->control_in < channel_roll->servo_out) ||
-            (nav_roll_cd < 0 && channel_roll->control_in > channel_roll->servo_out)) {
+        if ((nav_roll_cd > 0 && channel_roll->get_control_in() < channel_roll->get_servo_out()) ||
+            (nav_roll_cd < 0 && channel_roll->get_control_in() > channel_roll->get_servo_out())) {
             // allow user to get out of the roll
-            channel_roll->servo_out = channel_roll->control_in;            
+            channel_roll->set_servo_out(channel_roll->get_control_in());            
         }
     }
 
     if (training_manual_pitch) {
-        channel_pitch->servo_out = channel_pitch->control_in;
+        channel_pitch->set_servo_out(channel_pitch->get_control_in());
     } else {
         stabilize_pitch(speed_scaler);
-        if ((nav_pitch_cd > 0 && channel_pitch->control_in < channel_pitch->servo_out) ||
-            (nav_pitch_cd < 0 && channel_pitch->control_in > channel_pitch->servo_out)) {
+        if ((nav_pitch_cd > 0 && channel_pitch->get_control_in() < channel_pitch->get_servo_out()) ||
+            (nav_pitch_cd < 0 && channel_pitch->get_control_in() > channel_pitch->get_servo_out())) {
             // allow user to get back to level
-            channel_pitch->servo_out = channel_pitch->control_in;            
+            channel_pitch->set_servo_out(channel_pitch->get_control_in());            
         }
     }
 
@@ -289,8 +301,8 @@ void Plane::stabilize_training(float speed_scaler)
  */
 void Plane::stabilize_acro(float speed_scaler)
 {
-    float roll_rate = (channel_roll->control_in/4500.0f) * g.acro_roll_rate;
-    float pitch_rate = (channel_pitch->control_in/4500.0f) * g.acro_pitch_rate;
+    float roll_rate = (channel_roll->get_control_in()/4500.0f) * g.acro_roll_rate;
+    float pitch_rate = (channel_pitch->get_control_in()/4500.0f) * g.acro_pitch_rate;
 
     /*
       check for special roll handling near the pitch poles
@@ -310,16 +322,16 @@ void Plane::stabilize_acro(float speed_scaler)
         nav_roll_cd = ahrs.roll_sensor + roll_error_cd;
         // try to reduce the integrated angular error to zero. We set
         // 'stabilze' to true, which disables the roll integrator
-        channel_roll->servo_out  = rollController.get_servo_out(roll_error_cd,
+        channel_roll->set_servo_out(rollController.get_servo_out(roll_error_cd,
                                                                 speed_scaler,
-                                                                true);
+                                                                true));
     } else {
         /*
           aileron stick is non-zero, use pure rate control until the
           user releases the stick
          */
         acro_state.locked_roll = false;
-        channel_roll->servo_out  = rollController.get_rate_out(roll_rate,  speed_scaler);
+        channel_roll->set_servo_out(rollController.get_rate_out(roll_rate,  speed_scaler));
     }
 
     if (g.acro_locking && is_zero(pitch_rate)) {
@@ -334,15 +346,15 @@ void Plane::stabilize_acro(float speed_scaler)
         // try to hold the locked pitch. Note that we have the pitch
         // integrator enabled, which helps with inverted flight
         nav_pitch_cd = acro_state.locked_pitch_cd;
-        channel_pitch->servo_out  = pitchController.get_servo_out(nav_pitch_cd - ahrs.pitch_sensor,
+        channel_pitch->set_servo_out(pitchController.get_servo_out(nav_pitch_cd - ahrs.pitch_sensor,
                                                                   speed_scaler,
-                                                                  false);
+                                                                  false));
     } else {
         /*
           user has non-zero pitch input, use a pure rate controller
          */
         acro_state.locked_pitch = false;
-        channel_pitch->servo_out = pitchController.get_rate_out(pitch_rate, speed_scaler);
+        channel_pitch->set_servo_out( pitchController.get_rate_out(pitch_rate, speed_scaler));
     }
 
     /*
@@ -387,7 +399,7 @@ void Plane::stabilize()
     /*
       see if we should zero the attitude controller integrators. 
      */
-    if (channel_throttle->control_in == 0 &&
+    if (channel_throttle->get_control_in() == 0 &&
         relative_altitude_abs_cm() < 500 && 
         fabsf(barometer.get_climb_rate()) < 0.5f &&
         gps.ground_speed() < 3) {
@@ -412,11 +424,11 @@ void Plane::calc_throttle()
         // user has asked for zero throttle - this may be done by a
         // mission which wants to turn off the engine for a parachute
         // landing
-        channel_throttle->servo_out = 0;
+        channel_throttle->set_servo_out(0);
         return;
     }
 
-    channel_throttle->servo_out = SpdHgt_Controller->get_throttle_demand();
+    channel_throttle->set_servo_out(SpdHgt_Controller->get_throttle_demand());
 }
 
 /*****************************************
@@ -435,7 +447,7 @@ void Plane::calc_nav_yaw_coordinated(float speed_scaler)
     steering_control.rudder = yawController.get_servo_out(speed_scaler, disable_integrator);
 
     // add in rudder mixing from roll
-    steering_control.rudder += channel_roll->servo_out * g.kff_rudder_mix;
+    steering_control.rudder += channel_roll->get_servo_out() * g.kff_rudder_mix;
     steering_control.rudder += rudder_input;
     steering_control.rudder = constrain_int16(steering_control.rudder, -4500, 4500);
 }
@@ -461,7 +473,7 @@ void Plane::calc_nav_yaw_course(void)
 void Plane::calc_nav_yaw_ground(void)
 {
     if (gps.ground_speed() < 1 && 
-        channel_throttle->control_in == 0 &&
+        channel_throttle->get_control_in() == 0 &&
         flight_stage != AP_SpdHgtControl::FLIGHT_TAKEOFF &&
         flight_stage != AP_SpdHgtControl::FLIGHT_LAND_ABORT) {
         // manual rudder control while still
@@ -538,12 +550,12 @@ void Plane::throttle_slew_limit(int16_t last_throttle)
     // if slew limit rate is set to zero then do not slew limit
     if (slewrate) {                   
         // limit throttle change by the given percentage per second
-        float temp = slewrate * G_Dt * 0.01f * fabsf(channel_throttle->radio_max - channel_throttle->radio_min);
+        float temp = slewrate * G_Dt * 0.01f * fabsf(channel_throttle->get_radio_max() - channel_throttle->get_radio_min());
         // allow a minimum change of 1 PWM per cycle
         if (temp < 1) {
             temp = 1;
         }
-        channel_throttle->radio_out = constrain_int16(channel_throttle->radio_out, last_throttle - temp, last_throttle + temp);
+        channel_throttle->set_radio_out(constrain_int16(channel_throttle->get_radio_out(), last_throttle - temp, last_throttle + temp));
     }
 }
 
@@ -662,7 +674,7 @@ bool Plane::suppress_throttle(void)
 /*
   implement a software VTail or elevon mixer. There are 4 different mixing modes
  */
-void Plane::channel_output_mixer(uint8_t mixing_type, int16_t &chan1_out, int16_t &chan2_out)
+void Plane::channel_output_mixer(uint8_t mixing_type, int16_t & chan1_out, int16_t & chan2_out)const
 {
     int16_t c1, c2;
     int16_t v1, v2;
@@ -704,6 +716,17 @@ void Plane::channel_output_mixer(uint8_t mixing_type, int16_t &chan1_out, int16_
     chan2_out = 1500 + v2;
 }
 
+void Plane::channel_output_mixer(uint8_t mixing_type, RC_Channel* chan1, RC_Channel* chan2)const
+{
+   int16_t ch1 = chan1->get_radio_out();
+   int16_t ch2 = chan2->get_radio_out();
+
+   channel_output_mixer(mixing_type,ch1,ch2);
+
+   chan1->set_radio_out(ch1);
+   chan2->set_radio_out(ch2);
+}
+
 /*
   setup flaperon output channels
  */
@@ -724,7 +747,7 @@ void Plane::flaperon_update(int8_t flap_percent)
       by mixing gain). flapin_channel's trim is not used.
      */
      
-    ch1 = channel_roll->radio_out;
+    ch1 = channel_roll->get_radio_out();
     // The *5 is to take a percentage to a value from -500 to 500 for the mixer
     ch2 = 1500 - flap_percent * 5;
     channel_output_mixer(g.flaperon_output, ch1, ch2);
@@ -758,9 +781,9 @@ void Plane::set_servos_idle(void)
     } else {
         auto_state.idle_wiggle_stage = 0;
     }
-    channel_roll->servo_out = servo_value;
-    channel_pitch->servo_out = servo_value;
-    channel_rudder->servo_out = servo_value;
+    channel_roll->set_servo_out(servo_value);
+    channel_pitch->set_servo_out(servo_value);
+    channel_rudder->set_servo_out(servo_value);
     channel_roll->calc_pwm();
     channel_pitch->calc_pwm();
     channel_rudder->calc_pwm();
@@ -777,9 +800,9 @@ void Plane::set_servos_idle(void)
 uint16_t Plane::throttle_min(void) const
 {
     if (aparm.throttle_min < 0) {
-        return channel_throttle->radio_trim;
+        return channel_throttle->get_radio_trim();
     }
-    return channel_throttle->get_reverse() ? channel_throttle->radio_max : channel_throttle->radio_min;
+    return channel_throttle->get_reverse() ? channel_throttle->get_radio_max() : channel_throttle->get_radio_min();
 };
 
 
@@ -788,7 +811,7 @@ uint16_t Plane::throttle_min(void) const
 *****************************************/
 void Plane::set_servos(void)
 {
-    int16_t last_throttle = channel_throttle->radio_out;
+    int16_t last_throttle = channel_throttle->get_radio_out();
 
     // do any transition updates for quadplane
     quadplane.update();    
@@ -813,25 +836,25 @@ void Plane::set_servos(void)
         // steering output
         steering_control.rudder = steering_control.steering;
     }
-    channel_rudder->servo_out = steering_control.rudder;
+    channel_rudder->set_servo_out(steering_control.rudder);
 
     // clear ground_steering to ensure manual control if the yaw stabilizer doesn't run
     steering_control.ground_steering = false;
 
-    RC_Channel_aux::set_servo_out(RC_Channel_aux::k_rudder, steering_control.rudder);
-    RC_Channel_aux::set_servo_out(RC_Channel_aux::k_steering, steering_control.steering);
+    RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_rudder, steering_control.rudder);
+    RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_steering, steering_control.steering);
 
     if (control_mode == MANUAL) {
         // do a direct pass through of radio values
         if (g.mix_mode == 0 || g.elevon_output != MIXING_DISABLED) {
-            channel_roll->radio_out                = channel_roll->radio_in;
-            channel_pitch->radio_out               = channel_pitch->radio_in;
+            channel_roll->set_radio_out(channel_roll->get_radio_in());
+            channel_pitch->set_radio_out(channel_pitch->get_radio_in());
         } else {
-            channel_roll->radio_out                = channel_roll->read();
-            channel_pitch->radio_out               = channel_pitch->read();
+            channel_roll->set_radio_out(channel_roll->read());
+            channel_pitch->set_radio_out(channel_pitch->read());
         }
-        channel_throttle->radio_out    = channel_throttle->radio_in;
-        channel_rudder->radio_out              = channel_rudder->radio_in;
+        channel_throttle->set_radio_out(channel_throttle->get_radio_in());
+        channel_rudder->set_radio_out(channel_rudder->get_radio_in());
 
         // setup extra channels. We want this to come from the
         // main input channel, but using the 2nd channels dead
@@ -839,8 +862,8 @@ void Plane::set_servos(void)
         // pwm_to_angle_dz() to ensure we don't trim the value for the
         // deadzone of the main aileron channel, otherwise the 2nd
         // aileron won't quite follow the first one
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_aileron, channel_roll->pwm_to_angle_dz(0));
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_elevator, channel_pitch->pwm_to_angle_dz(0));
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_aileron, channel_roll->pwm_to_angle_dz(0));
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_elevator, channel_pitch->pwm_to_angle_dz(0));
 
         // this variant assumes you have the corresponding
         // input channel setup in your transmitter for manual control
@@ -851,24 +874,24 @@ void Plane::set_servos(void)
         if (g.mix_mode == 0 && g.elevon_output == MIXING_DISABLED) {
             // set any differential spoilers to follow the elevons in
             // manual mode. 
-            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler1, channel_roll->radio_out);
-            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler2, channel_pitch->radio_out);
+            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler1, channel_roll->get_radio_out());
+            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler2, channel_pitch->get_radio_out());
         }
     } else {
         if (g.mix_mode == 0) {
             // both types of secondary aileron are slaved to the roll servo out
-            RC_Channel_aux::set_servo_out(RC_Channel_aux::k_aileron, channel_roll->servo_out);
-            RC_Channel_aux::set_servo_out(RC_Channel_aux::k_aileron_with_input, channel_roll->servo_out);
+            RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_aileron, channel_roll->get_servo_out());
+            RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_aileron_with_input, channel_roll->get_servo_out());
 
             // both types of secondary elevator are slaved to the pitch servo out
-            RC_Channel_aux::set_servo_out(RC_Channel_aux::k_elevator, channel_pitch->servo_out);
-            RC_Channel_aux::set_servo_out(RC_Channel_aux::k_elevator_with_input, channel_pitch->servo_out);
+            RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_elevator, channel_pitch->get_servo_out());
+            RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_elevator_with_input, channel_pitch->get_servo_out());
         }else{
             /*Elevon mode*/
             float ch1;
             float ch2;
-            ch1 = channel_pitch->servo_out - (BOOL_TO_SIGN(g.reverse_elevons) * channel_roll->servo_out);
-            ch2 = channel_pitch->servo_out + (BOOL_TO_SIGN(g.reverse_elevons) * channel_roll->servo_out);
+            ch1 = channel_pitch->get_servo_out() - (BOOL_TO_SIGN(g.reverse_elevons) * channel_roll->get_servo_out());
+            ch2 = channel_pitch->get_servo_out() + (BOOL_TO_SIGN(g.reverse_elevons) * channel_roll->get_servo_out());
 
 			/* Differential Spoilers
                If differential spoilers are setup, then we translate
@@ -879,20 +902,20 @@ void Plane::set_servos(void)
 			if (RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler1) && RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler2)) {
 				float ch3 = ch1;
 				float ch4 = ch2;
-				if ( BOOL_TO_SIGN(g.reverse_elevons) * channel_rudder->servo_out < 0) {
-				    ch1 += abs(channel_rudder->servo_out);
-				    ch3 -= abs(channel_rudder->servo_out);
+				if ( BOOL_TO_SIGN(g.reverse_elevons) * channel_rudder->get_servo_out() < 0) {
+				    ch1 += abs(channel_rudder->get_servo_out());
+				    ch3 -= abs(channel_rudder->get_servo_out());
 				} else {
-					ch2 += abs(channel_rudder->servo_out);
-				    ch4 -= abs(channel_rudder->servo_out);
+					ch2 += abs(channel_rudder->get_servo_out());
+				    ch4 -= abs(channel_rudder->get_servo_out());
 				}
-				RC_Channel_aux::set_servo_out(RC_Channel_aux::k_dspoiler1, ch3);
-				RC_Channel_aux::set_servo_out(RC_Channel_aux::k_dspoiler2, ch4);
+				RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_dspoiler1, ch3);
+				RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_dspoiler2, ch4);
 			}
 
             // directly set the radio_out values for elevon mode
-            channel_roll->radio_out  =     elevon.trim1 + (BOOL_TO_SIGN(g.reverse_ch1_elevon) * (ch1 * 500.0f/ SERVO_MAX));
-            channel_pitch->radio_out =     elevon.trim2 + (BOOL_TO_SIGN(g.reverse_ch2_elevon) * (ch2 * 500.0f/ SERVO_MAX));
+            channel_roll->set_radio_out(elevon.trim1 + (BOOL_TO_SIGN(g.reverse_ch1_elevon) * (ch1 * 500.0f/ SERVO_MAX)));
+            channel_pitch->set_radio_out(elevon.trim2 + (BOOL_TO_SIGN(g.reverse_ch2_elevon) * (ch2 * 500.0f/ SERVO_MAX)));
         }
 
         // push out the PWM values
@@ -903,7 +926,7 @@ void Plane::set_servos(void)
         channel_rudder->calc_pwm();
 
 #if THROTTLE_OUT == 0
-        channel_throttle->servo_out = 0;
+        channel_throttle->set_servo_out(0);
 #else
         // convert 0 to 100% (or -100 to +100) into PWM
         int8_t min_throttle = aparm.throttle_min.get();
@@ -933,14 +956,14 @@ void Plane::set_servos(void)
             // overpower detected, cut back on the throttle if we're maxing it out by calculating a limiter value
             // throttle limit will attack by 10% per second
 
-            if (channel_throttle->servo_out > 0 && // demanding too much positive thrust
+            if (channel_throttle->get_servo_out() > 0 && // demanding too much positive thrust
                 throttle_watt_limit_max < max_throttle - 25 &&
                 now - throttle_watt_limit_timer_ms >= 1) {
                 // always allow for 25% throttle available regardless of battery status
                 throttle_watt_limit_timer_ms = now;
                 throttle_watt_limit_max++;
 
-            } else if (channel_throttle->servo_out < 0 &&
+            } else if (channel_throttle->get_servo_out() < 0 &&
                 min_throttle < 0 && // reverse thrust is available
                 throttle_watt_limit_min < -(min_throttle) - 25 &&
                 now - throttle_watt_limit_timer_ms >= 1) {
@@ -953,12 +976,12 @@ void Plane::set_servos(void)
             // it has been 1 second since last over-current, check if we can resume higher throttle.
             // this throttle release is needed to allow raising the max_throttle as the battery voltage drains down
             // throttle limit will release by 1% per second
-            if (channel_throttle->servo_out > throttle_watt_limit_max && // demanding max forward thrust
+            if (channel_throttle->get_servo_out() > throttle_watt_limit_max && // demanding max forward thrust
                 throttle_watt_limit_max > 0) { // and we're currently limiting it
                 throttle_watt_limit_timer_ms = now;
                 throttle_watt_limit_max--;
 
-            } else if (channel_throttle->servo_out < throttle_watt_limit_min && // demanding max negative thrust
+            } else if (channel_throttle->get_servo_out() < throttle_watt_limit_min && // demanding max negative thrust
                 throttle_watt_limit_min > 0) { // and we're limiting it
                 throttle_watt_limit_timer_ms = now;
                 throttle_watt_limit_min--;
@@ -970,19 +993,19 @@ void Plane::set_servos(void)
             min_throttle = constrain_int16(min_throttle, min_throttle + throttle_watt_limit_min, 0);
         }
 
-        channel_throttle->servo_out = constrain_int16(channel_throttle->servo_out, 
+        channel_throttle->set_servo_out(constrain_int16(channel_throttle->get_servo_out(), 
                                                       min_throttle,
-                                                      max_throttle);
+                                                      max_throttle));
 
         if (!hal.util->get_soft_armed()) {
-            channel_throttle->servo_out = 0;
+            channel_throttle->set_servo_out(0);
             channel_throttle->calc_pwm();                
         } else if (suppress_throttle()) {
             // throttle is suppressed in auto mode
-            channel_throttle->servo_out = 0;
+            channel_throttle->set_servo_out(0);
             if (g.throttle_suppress_manual) {
                 // manual pass through of throttle while throttle is suppressed
-                channel_throttle->radio_out = channel_throttle->radio_in;
+                channel_throttle->set_radio_out(channel_throttle->get_radio_in());
             } else {
                 channel_throttle->calc_pwm();                
             }
@@ -994,14 +1017,14 @@ void Plane::set_servos(void)
                     control_mode == AUTOTUNE)) {
             // manual pass through of throttle while in FBWA or
             // STABILIZE mode with THR_PASS_STAB set
-            channel_throttle->radio_out = channel_throttle->radio_in;
+            channel_throttle->set_radio_out(channel_throttle->get_radio_in());
         } else if (control_mode == GUIDED && 
                    guided_throttle_passthru) {
             // manual pass through of throttle while in GUIDED
-            channel_throttle->radio_out = channel_throttle->radio_in;
+            channel_throttle->set_radio_out(channel_throttle->get_radio_in());
         } else if (quadplane.in_vtol_mode()) {
             // ask quadplane code for forward throttle
-            channel_throttle->servo_out = quadplane.forward_throttle_pct();
+            channel_throttle->set_servo_out(quadplane.forward_throttle_pct());
             channel_throttle->calc_pwm();
         } else {
             // normal throttle calculation based on servo_out
@@ -1070,8 +1093,8 @@ void Plane::set_servos(void)
     flap_slew_limit(last_auto_flap, auto_flap_percent);
     flap_slew_limit(last_manual_flap, manual_flap_percent);
 
-    RC_Channel_aux::set_servo_out(RC_Channel_aux::k_flap_auto, auto_flap_percent);
-    RC_Channel_aux::set_servo_out(RC_Channel_aux::k_flap, manual_flap_percent);
+    RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_flap_auto, auto_flap_percent);
+    RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_flap, manual_flap_percent);
 
     if (control_mode >= FLY_BY_WIRE_B ||
         quadplane.in_assisted_flight() ||
@@ -1083,16 +1106,16 @@ void Plane::set_servos(void)
 
     if (control_mode == TRAINING) {
         // copy rudder in training mode
-        channel_rudder->radio_out   = channel_rudder->radio_in;
+        channel_rudder->set_radio_out(channel_rudder->get_radio_in());
     }
 
     if (g.flaperon_output != MIXING_DISABLED && g.elevon_output == MIXING_DISABLED && g.mix_mode == 0) {
         flaperon_update(auto_flap_percent);
     }
     if (g.vtail_output != MIXING_DISABLED) {
-        channel_output_mixer(g.vtail_output, channel_pitch->radio_out, channel_rudder->radio_out);
+        channel_output_mixer(g.vtail_output, channel_pitch, channel_rudder);
     } else if (g.elevon_output != MIXING_DISABLED) {
-        channel_output_mixer(g.elevon_output, channel_pitch->radio_out, channel_roll->radio_out);
+        channel_output_mixer(g.elevon_output, channel_pitch, channel_roll);
     }
 
     if (!arming.is_armed()) {
@@ -1105,12 +1128,12 @@ void Plane::set_servos(void)
             break;
 
         case AP_Arming::YES_ZERO_PWM:
-            channel_throttle->radio_out = 0;
+            channel_throttle->set_radio_out(0);
             break;
 
         case AP_Arming::YES_MIN_PWM:
         default:
-            channel_throttle->radio_out = throttle_min();
+            channel_throttle->set_radio_out(throttle_min());
             break;
         }
     }
@@ -1143,9 +1166,9 @@ void Plane::set_servos(void)
         // after an auto land and auto disarm, set the servos to be neutral just
         // in case we're upside down or some crazy angle and straining the servos.
         if (g.land_then_servos_neutral == 1) {
-            channel_roll->radio_out = channel_roll->radio_trim;
-            channel_pitch->radio_out = channel_pitch->radio_trim;
-            channel_rudder->radio_out = channel_rudder->radio_trim;
+            channel_roll->set_radio_out(channel_roll->get_radio_trim());
+            channel_pitch->set_radio_out(channel_pitch->get_radio_trim());
+            channel_rudder->set_radio_out(channel_rudder->get_radio_trim());
         } else if (g.land_then_servos_neutral == 2) {
             channel_roll->disable_out();
             channel_pitch->disable_out();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -308,7 +308,7 @@ void Plane::send_extended_status1(mavlink_channel_t chan)
     }
 #endif
 
-    if (aparm.throttle_min < 0 && channel_throttle->servo_out < 0) {
+    if (aparm.throttle_min < 0 && channel_throttle->get_servo_out() < 0) {
         control_sensors_enabled |= MAV_SYS_STATUS_REVERSE_MOTOR;
         control_sensors_health |= MAV_SYS_STATUS_REVERSE_MOTOR;
     }
@@ -423,14 +423,14 @@ void Plane::send_radio_out(mavlink_channel_t chan)
             chan,
             micros(),
             0,     // port
-            RC_Channel::rc_channel(0)->radio_out,
-            RC_Channel::rc_channel(1)->radio_out,
-            RC_Channel::rc_channel(2)->radio_out,
-            RC_Channel::rc_channel(3)->radio_out,
-            RC_Channel::rc_channel(4)->radio_out,
-            RC_Channel::rc_channel(5)->radio_out,
-            RC_Channel::rc_channel(6)->radio_out,
-            RC_Channel::rc_channel(7)->radio_out);
+            RC_Channel::rc_channel(0)->get_radio_out(),
+            RC_Channel::rc_channel(1)->get_radio_out(),
+            RC_Channel::rc_channel(2)->get_radio_out(),
+            RC_Channel::rc_channel(3)->get_radio_out(),
+            RC_Channel::rc_channel(4)->get_radio_out(),
+            RC_Channel::rc_channel(5)->get_radio_out(),
+            RC_Channel::rc_channel(6)->get_radio_out(),
+            RC_Channel::rc_channel(7)->get_radio_out());
         return;
     }
 #endif

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -259,8 +259,8 @@ void Plane::Log_Write_Control_Tuning()
         roll            : (int16_t)ahrs.roll_sensor,
         nav_pitch_cd    : (int16_t)nav_pitch_cd,
         pitch           : (int16_t)ahrs.pitch_sensor,
-        throttle_out    : (int16_t)channel_throttle->servo_out,
-        rudder_out      : (int16_t)channel_rudder->servo_out,
+        throttle_out    : (int16_t)channel_throttle->get_servo_out(),
+        rudder_out      : (int16_t)channel_rudder->get_servo_out(),
         throttle_dem    : (int16_t)SpdHgt_Controller->get_throttle_demand()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -416,7 +416,7 @@ struct PACKED log_Arm_Disarm {
 
 void Plane::Log_Write_Current()
 {
-    DataFlash.Log_Write_Current(battery, channel_throttle->control_in);
+    DataFlash.Log_Write_Current(battery, channel_throttle->get_control_in());
 
     // also write power status
     DataFlash.Log_Write_Power();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -997,7 +997,8 @@ private:
     bool stick_mixing_enabled(void);
     void stabilize_roll(float speed_scaler);
     void stabilize_pitch(float speed_scaler);
-    void stick_mix_channel(RC_Channel *channel, int16_t &servo_out);
+    static void stick_mix_channel(RC_Channel *channel);
+    static void stick_mix_channel(RC_Channel *channel, int16_t &servo_out);
     void stabilize_stick_mixing_direct();
     void stabilize_stick_mixing_fbw();
     void stabilize_yaw(float speed_scaler);
@@ -1009,7 +1010,8 @@ private:
     void throttle_slew_limit(int16_t last_throttle);
     void flap_slew_limit(int8_t &last_value, int8_t &new_value);
     bool suppress_throttle(void);
-    void channel_output_mixer(uint8_t mixing_type, int16_t &chan1_out, int16_t &chan2_out);
+    void channel_output_mixer(uint8_t mixing_type, int16_t & chan1, int16_t & chan2)const;
+    void channel_output_mixer(uint8_t mixing_type, RC_Channel* chan1, RC_Channel* chan2)const;
     void flaperon_update(int8_t flap_percent);
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/arming_checks.cpp
+++ b/ArduPlane/arming_checks.cpp
@@ -54,7 +54,7 @@ bool AP_Arming_Plane::pre_arm_checks(bool report)
     if (plane.channel_throttle->get_reverse() && 
         plane.g.throttle_fs_enabled &&
         plane.g.throttle_fs_value < 
-        plane.channel_throttle->radio_max) {
+        plane.channel_throttle->get_radio_max()) {
         if (report) {
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Invalid THR_FS_VALUE for rev throttle");
         }

--- a/ArduPlane/failsafe.cpp
+++ b/ArduPlane/failsafe.cpp
@@ -57,12 +57,12 @@ void Plane::failsafe_check(void)
 
         // pass RC inputs to outputs every 20ms
         hal.rcin->clear_overrides();
-        channel_roll->radio_out     = channel_roll->read();
-        channel_pitch->radio_out    = channel_pitch->read();
+        channel_roll->set_radio_out(channel_roll->read());
+        channel_pitch->set_radio_out(channel_pitch->read());
         if (hal.util->get_soft_armed()) {
-            channel_throttle->radio_out = channel_throttle->read();
+            channel_throttle->set_radio_out(channel_throttle->read());
         }
-        channel_rudder->radio_out   = channel_rudder->read();
+        channel_rudder->set_radio_out(channel_rudder->read());
 
         int16_t roll = channel_roll->pwm_to_angle_dz(0);
         int16_t pitch = channel_pitch->pwm_to_angle_dz(0);
@@ -70,15 +70,15 @@ void Plane::failsafe_check(void)
 
         // setup secondary output channels that don't have
         // corresponding input channels
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_aileron, roll);
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_elevator, pitch);
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_rudder, rudder);
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_steering, rudder);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_aileron, roll);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_elevator, pitch);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_rudder, rudder);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_steering, rudder);
 
         if (g.vtail_output != MIXING_DISABLED) {
-            channel_output_mixer(g.vtail_output, channel_pitch->radio_out, channel_rudder->radio_out);
+            channel_output_mixer(g.vtail_output, channel_pitch, channel_rudder);
         } else if (g.elevon_output != MIXING_DISABLED) {
-            channel_output_mixer(g.elevon_output, channel_pitch->radio_out, channel_roll->radio_out);
+            channel_output_mixer(g.elevon_output, channel_pitch, channel_roll);
         }
 
 #if OBC_FAILSAFE == ENABLED
@@ -102,8 +102,8 @@ void Plane::failsafe_check(void)
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_manual, true);
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_aileron_with_input, true);
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_elevator_with_input, true);
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_flap, 0);
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_flap_auto, 0);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_flap, 0);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_flap_auto, 0);
 
         // setup flaperons
         flaperon_update(0);

--- a/ArduPlane/motor_test.cpp
+++ b/ArduPlane/motor_test.cpp
@@ -48,7 +48,7 @@ void QuadPlane::motor_test_output()
     case MOTOR_TEST_THROTTLE_PERCENT:
         // sanity check motor_test.throttle value
         if (motor_test.throttle_value <= 100) {
-            pwm = plane.channel_throttle->radio_min + (plane.channel_throttle->radio_max - plane.channel_throttle->radio_min) * (float)motor_test.throttle_value/100.0f;
+            pwm = plane.channel_throttle->get_radio_min() + (plane.channel_throttle->get_radio_max()  - plane.channel_throttle->get_radio_min()) * (float)motor_test.throttle_value/100.0f;
         }
         break;
 
@@ -57,7 +57,7 @@ void QuadPlane::motor_test_output()
         break;
 
     case MOTOR_TEST_THROTTLE_PILOT:
-        pwm = plane.channel_throttle->radio_in;
+        pwm = plane.channel_throttle->get_radio_in();
         break;
 
     default:

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -94,7 +94,7 @@ void Plane::calc_airspeed_errors()
         control_mode == CRUISE) {
         target_airspeed_cm = ((int32_t)(aparm.airspeed_max -
                                         aparm.airspeed_min) *
-                              channel_throttle->control_in) +
+                              channel_throttle->get_control_in()) +
                              ((int32_t)aparm.airspeed_min * 100);
     }
 
@@ -203,7 +203,7 @@ void Plane::update_loiter(uint16_t radius)
 void Plane::update_cruise()
 {
     if (!cruise_state.locked_heading &&
-        channel_roll->control_in == 0 &&
+        channel_roll->get_control_in() == 0 &&
         rudder_input == 0 &&
         gps.status() >= AP_GPS::GPS_OK_FIX_2D &&
         gps.ground_speed() >= 3 &&
@@ -240,7 +240,7 @@ void Plane::update_fbwb_speed_height(void)
 {
     static float last_elevator_input;
     float elevator_input;
-    elevator_input = channel_pitch->control_in / 4500.0f;
+    elevator_input = channel_pitch->get_control_in() / 4500.0f;
     
     if (g.flybywire_elev_reverse) {
         elevator_input = -elevator_input;

--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -136,24 +136,24 @@ uint16_t Plane::create_mixer(char *buf, uint16_t buf_size, const char *filename)
             // channels and adjust for trims
             const RC_Channel *chan1 = RC_Channel::rc_channel(i);
             const RC_Channel *chan2 = RC_Channel::rc_channel(c1);
-            int16_t chan1_trim = (i==rcmap.throttle()-1?1500:chan1->radio_trim);
-            int16_t chan2_trim = (c1==rcmap.throttle()-1?1500:chan2->radio_trim);
+            int16_t chan1_trim = (i==rcmap.throttle()-1?1500:chan1->get_radio_trim());
+            int16_t chan2_trim = (c1==rcmap.throttle()-1?1500:chan2->get_radio_trim());
             chan1_trim = constrain_int16(chan1_trim, PX4_LIM_RC_MIN+1, PX4_LIM_RC_MAX-1);
             chan2_trim = constrain_int16(chan2_trim, PX4_LIM_RC_MIN+1, PX4_LIM_RC_MAX-1);
             // if the input and output channels are the same then we
             // apply clipping. This allows for direct pass-thru
             int32_t limit = (c1==i?scale_max2:scale_max1);
             int32_t in_scale_low;
-            if (chan2_trim <= chan2->radio_min) {
+            if (chan2_trim <= chan2->get_radio_min()) {
                 in_scale_low = scale_max1;
             } else {
-                in_scale_low = scale_max1*(chan2_trim - pwm_min)/(float)(chan2_trim - chan2->radio_min);
+                in_scale_low = scale_max1*(chan2_trim - pwm_min)/(float)(chan2_trim - chan2->get_radio_min());
             }
             int32_t in_scale_high;
-            if (chan2->radio_max <= chan2_trim) {
+            if (chan2->get_radio_max() <= chan2_trim) {
                 in_scale_high = scale_max1;
             } else {
-                in_scale_high = scale_max1*(pwm_max - chan2_trim)/(float)(chan2->radio_max - chan2_trim);
+                in_scale_high = scale_max1*(pwm_max - chan2_trim)/(float)(chan2->get_radio_max() - chan2_trim);
             }
             if (chan1->get_reverse() != chan2->get_reverse()) {
                 in_scale_low = -in_scale_low;
@@ -161,8 +161,8 @@ uint16_t Plane::create_mixer(char *buf, uint16_t buf_size, const char *filename)
             }
             if (!print_buffer(buf, buf_size, "M: 1\n") ||
                 !print_buffer(buf, buf_size, "O: %d %d %d %d %d\n",
-                              (int)(pwm_scale*(chan1_trim - chan1->radio_min)),
-                              (int)(pwm_scale*(chan1->radio_max - chan1_trim)),
+                              (int)(pwm_scale*(chan1_trim - chan1->get_radio_min())),
+                              (int)(pwm_scale*(chan1->get_radio_max() - chan1_trim)),
                               (int)(pwm_scale*(chan1_trim - 1500)),
                               (int)-scale_max2, (int)scale_max2) ||
                 !print_buffer(buf, buf_size, "S: 0 %u %d %d %d %d %d\n", c1,
@@ -175,8 +175,8 @@ uint16_t Plane::create_mixer(char *buf, uint16_t buf_size, const char *filename)
         } else {
             const RC_Channel *chan1 = RC_Channel::rc_channel(c1);
             const RC_Channel *chan2 = RC_Channel::rc_channel(c2);
-            int16_t chan1_trim = (c1==rcmap.throttle()-1?1500:chan1->radio_trim);
-            int16_t chan2_trim = (c2==rcmap.throttle()-1?1500:chan2->radio_trim);
+            int16_t chan1_trim = (c1==rcmap.throttle()-1?1500:chan1->get_radio_trim());
+            int16_t chan2_trim = (c2==rcmap.throttle()-1?1500:chan2->get_radio_trim());
             chan1_trim = constrain_int16(chan1_trim, PX4_LIM_RC_MIN+1, PX4_LIM_RC_MAX-1);
             chan2_trim = constrain_int16(chan2_trim, PX4_LIM_RC_MIN+1, PX4_LIM_RC_MAX-1);
             // mix of two input channels to give an output channel. To
@@ -315,7 +315,7 @@ bool Plane::setup_failsafe_mixing(void)
             // by small numbers near RC3_MIN
             config.rc_trim = 1500;
         } else {
-            config.rc_trim = constrain_int16(ch->radio_trim, config.rc_min+1, config.rc_max-1);
+            config.rc_trim = constrain_int16(ch->get_radio_trim(), config.rc_min+1, config.rc_max-1);
         }
         config.rc_dz = 0; // zero for the purposes of manual takeover
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -400,7 +400,7 @@ bool QuadPlane::setup(void)
         if (mask & 1U<<i) {
             RC_Channel *ch = RC_Channel::rc_channel(i);
             if (ch != nullptr) {
-                ch->radio_trim = thr_min_pwm;
+                ch->set_radio_trim(thr_min_pwm);
             }
         }
     }
@@ -466,7 +466,7 @@ void QuadPlane::hold_stabilize(float throttle_in)
 // quadplane stabilize mode
 void QuadPlane::control_stabilize(void)
 {
-    float pilot_throttle_scaled = plane.channel_throttle->control_in / 100.0f;
+    float pilot_throttle_scaled = plane.channel_throttle->get_control_in() / 100.0f;
     hold_stabilize(pilot_throttle_scaled);
 
 }
@@ -628,8 +628,8 @@ void QuadPlane::control_loiter()
     pos_control->set_accel_z(pilot_accel_z);
 
     // process pilot's roll and pitch input
-    wp_nav->set_pilot_desired_acceleration(plane.channel_roll->control_in,
-                                           plane.channel_pitch->control_in);
+    wp_nav->set_pilot_desired_acceleration(plane.channel_roll->get_control_in(),
+                                           plane.channel_pitch->get_control_in());
 
     // Update EKF speed limit - used to limit speed when we are using optical flow
     float ekfGndSpdLimit, ekfNavVelGainScaler;    
@@ -672,7 +672,7 @@ void QuadPlane::control_loiter()
  */
 float QuadPlane::get_pilot_input_yaw_rate_cds(void)
 {
-    if (plane.channel_throttle->control_in <= 0 && !plane.auto_throttle_mode) {
+    if (plane.channel_throttle->get_control_in() <= 0 && !plane.auto_throttle_mode) {
         // the user may be trying to disarm
         return 0;
     }
@@ -691,7 +691,7 @@ float QuadPlane::get_desired_yaw_rate_cds(void)
         // use bank angle to get desired yaw rate
         yaw_cds += desired_auto_yaw_rate_cds();
     }
-    if (plane.channel_throttle->control_in <= 0 && !plane.auto_throttle_mode) {
+    if (plane.channel_throttle->get_control_in() <= 0 && !plane.auto_throttle_mode) {
         // the user may be trying to disarm
         return 0;
     }
@@ -712,7 +712,7 @@ float QuadPlane::get_pilot_desired_climb_rate_cms(void)
         return -50;
     }
     uint16_t dead_zone = plane.channel_throttle->get_dead_zone();
-    uint16_t trim = (plane.channel_throttle->radio_max + plane.channel_throttle->radio_min)/2;
+    uint16_t trim = (plane.channel_throttle->get_radio_max() + plane.channel_throttle->get_radio_min())/2;
     return pilot_velocity_z_max * plane.channel_throttle->pwm_to_angle_dz_trim(dead_zone, trim) / 100.0f;
 }
 
@@ -722,7 +722,7 @@ float QuadPlane::get_pilot_desired_climb_rate_cms(void)
  */
 void QuadPlane::init_throttle_wait(void)
 {
-    if (plane.channel_throttle->control_in >= 10 ||
+    if (plane.channel_throttle->get_control_in() >= 10 ||
         plane.is_flying()) {
         throttle_wait = false;
     } else {
@@ -755,7 +755,7 @@ float QuadPlane::assist_climb_rate_cms(void)
     } else {
         // otherwise estimate from pilot input
         climb_rate = plane.g.flybywire_climb_rate * (plane.nav_pitch_cd/(float)plane.aparm.pitch_limit_max_cd);
-        climb_rate *= plane.channel_throttle->control_in;
+        climb_rate *= plane.channel_throttle->get_control_in();
     }
     climb_rate = constrain_float(climb_rate, -wp_nav->get_speed_down(), wp_nav->get_speed_up());
     return climb_rate;
@@ -800,7 +800,7 @@ void QuadPlane::update_transition(void)
      */
     if (have_airspeed && aspeed < assist_speed &&
         (plane.auto_throttle_mode ||
-         plane.channel_throttle->control_in>0 ||
+         plane.channel_throttle->get_control_in()>0 ||
          plane.is_flying())) {
         // the quad should provide some assistance to the plane
         transition_state = TRANSITION_AIRSPEED_WAIT;
@@ -900,7 +900,7 @@ void QuadPlane::update(void)
 
     // disable throttle_wait when throttle rises above 10%
     if (throttle_wait &&
-        (plane.channel_throttle->control_in > 10 ||
+        (plane.channel_throttle->get_control_in() > 10 ||
          plane.failsafe.ch3_failsafe ||
          plane.failsafe.ch3_counter>0)) {
         throttle_wait = false;
@@ -1626,7 +1626,7 @@ float QuadPlane::get_weathervane_yaw_rate_cds(void)
         weathervane.last_output = 0;
         return 0;
     }
-    if (plane.channel_rudder->control_in != 0) {
+    if (plane.channel_rudder->get_control_in() != 0) {
         weathervane.last_pilot_input_ms = AP_HAL::millis();
         weathervane.last_output = 0;
         return 0;

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -39,7 +39,7 @@ void Plane::set_control_channels(void)
 
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
     // take a proportion of speed
-    hal.rcout->set_esc_scaling(channel_throttle->radio_min, channel_throttle->radio_max);
+    hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 }
 
 /*
@@ -67,7 +67,7 @@ void Plane::init_rc_out()
       configuration error where the user sets CH3_TRIM incorrectly and
       the motor may start on power up
      */
-    channel_throttle->radio_trim = throttle_min();
+    channel_throttle->set_radio_trim (throttle_min());
     
     if (arming.arming_required() != AP_Arming::YES_ZERO_PWM) {
         channel_throttle->enable_out();
@@ -102,7 +102,7 @@ void Plane::rudder_arm_disarm_check()
     }
 
     // if throttle is not down, then pilot cannot rudder arm/disarm
-    if (channel_throttle->control_in != 0){
+    if (channel_throttle->get_control_in() != 0){
         rudder_arm_timer = 0;
         return;
     }
@@ -115,7 +115,7 @@ void Plane::rudder_arm_disarm_check()
 
 	if (!arming.is_armed()) {
 		// when not armed, full right rudder starts arming counter
-		if (channel_rudder->control_in > 4000) {
+		if (channel_rudder->get_control_in() > 4000) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||
@@ -135,7 +135,7 @@ void Plane::rudder_arm_disarm_check()
 		}
 	} else if (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM && !is_flying()) {
 		// when armed and not flying, full left rudder starts disarming counter
-		if (channel_rudder->control_in < -4000) {
+		if (channel_rudder->get_control_in() < -4000) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||
@@ -158,7 +158,7 @@ void Plane::rudder_arm_disarm_check()
 void Plane::read_radio()
 {
     if (!hal.rcin->new_input()) {
-        control_failsafe(channel_throttle->radio_in);
+        control_failsafe(channel_throttle->get_radio_in());
         return;
     }
 
@@ -177,8 +177,10 @@ void Plane::read_radio()
         pwm_roll = elevon.ch1_temp;
         pwm_pitch = elevon.ch2_temp;
     }else{
-        pwm_roll = BOOL_TO_SIGN(g.reverse_elevons) * (BOOL_TO_SIGN(g.reverse_ch2_elevon) * int16_t(elevon.ch2_temp - elevon.trim2) - BOOL_TO_SIGN(g.reverse_ch1_elevon) * int16_t(elevon.ch1_temp - elevon.trim1)) / 2 + 1500;
-        pwm_pitch = (BOOL_TO_SIGN(g.reverse_ch2_elevon) * int16_t(elevon.ch2_temp - elevon.trim2) + BOOL_TO_SIGN(g.reverse_ch1_elevon) * int16_t(elevon.ch1_temp - elevon.trim1)) / 2 + 1500;
+        pwm_roll = BOOL_TO_SIGN(g.reverse_elevons) * (BOOL_TO_SIGN(g.reverse_ch2_elevon) * int16_t(elevon.ch2_temp - elevon.trim2) 
+         - BOOL_TO_SIGN(g.reverse_ch1_elevon) * int16_t(elevon.ch1_temp - elevon.trim1)) / 2 + 1500;
+        pwm_pitch = (BOOL_TO_SIGN(g.reverse_ch2_elevon) * int16_t(elevon.ch2_temp - elevon.trim2) 
+         + BOOL_TO_SIGN(g.reverse_ch1_elevon) * int16_t(elevon.ch1_temp - elevon.trim1)) / 2 + 1500;
     }
 
     RC_Channel::set_pwm_all();
@@ -195,12 +197,12 @@ void Plane::read_radio()
         channel_pitch->set_pwm(pwm_pitch);
     }
 
-    control_failsafe(channel_throttle->radio_in);
+    control_failsafe(channel_throttle->get_radio_in());
 
-    channel_throttle->servo_out = channel_throttle->control_in;
+    channel_throttle->set_servo_out(channel_throttle->get_control_in());
 
-    if (g.throttle_nudge && channel_throttle->servo_out > 50 && geofence_stickmixing()) {
-        float nudge = (channel_throttle->servo_out - 50) * 0.02f;
+    if (g.throttle_nudge && channel_throttle->get_servo_out() > 50 && geofence_stickmixing()) {
+        float nudge = (channel_throttle->get_servo_out() - 50) * 0.02f;
         if (ahrs.airspeed_sensor_enabled()) {
             airspeed_nudge_cm = (aparm.airspeed_max * 100 - g.airspeed_cruise_cm) * nudge;
         } else {
@@ -218,7 +220,7 @@ void Plane::read_radio()
         // attitude from the roll channel.
         rudder_input = 0;
     } else {
-        rudder_input = channel_rudder->control_in;
+        rudder_input = channel_rudder->get_control_in();
     }
 
     tuning.check_input();
@@ -229,17 +231,16 @@ void Plane::control_failsafe(uint16_t pwm)
     if (millis() - failsafe.last_valid_rc_ms > 1000 || rc_failsafe_active()) {
         // we do not have valid RC input. Set all primary channel
         // control inputs to the trim value and throttle to min
-        channel_roll->radio_in     = channel_roll->radio_trim;
-        channel_pitch->radio_in    = channel_pitch->radio_trim;
-        channel_rudder->radio_in   = channel_rudder->radio_trim;
+        channel_roll->set_radio_in(channel_roll->get_radio_trim());
+        channel_pitch->set_radio_in(channel_pitch->get_radio_trim());
+        channel_rudder->set_radio_in(channel_rudder->get_radio_trim());
 
         // note that we don't set channel_throttle->radio_in to radio_trim,
         // as that would cause throttle failsafe to not activate
-
-        channel_roll->control_in     = 0;
-        channel_pitch->control_in    = 0;
-        channel_rudder->control_in   = 0;
-        channel_throttle->control_in = 0;
+        channel_roll->set_control_in(0);
+        channel_pitch->set_control_in(0);
+        channel_rudder->set_control_in(0);
+        channel_throttle->set_control_in(0);
     }
 
     if(g.throttle_fs_enabled == 0)
@@ -279,12 +280,12 @@ void Plane::control_failsafe(uint16_t pwm)
 void Plane::trim_control_surfaces()
 {
     read_radio();
-    int16_t trim_roll_range = (channel_roll->radio_max - channel_roll->radio_min)/5;
-    int16_t trim_pitch_range = (channel_pitch->radio_max - channel_pitch->radio_min)/5;
-    if (channel_roll->radio_in < channel_roll->radio_min+trim_roll_range ||
-        channel_roll->radio_in > channel_roll->radio_max-trim_roll_range ||
-        channel_pitch->radio_in < channel_pitch->radio_min+trim_pitch_range ||
-        channel_pitch->radio_in > channel_pitch->radio_max-trim_pitch_range) {
+    int16_t trim_roll_range = (channel_roll->get_radio_max() - channel_roll->get_radio_min())/5;
+    int16_t trim_pitch_range = (channel_pitch->get_radio_max() - channel_pitch->get_radio_min())/5;
+    if (channel_roll->get_radio_in() < channel_roll->get_radio_min()+trim_roll_range ||
+        channel_roll->get_radio_in() > channel_roll->get_radio_max()-trim_roll_range ||
+        channel_pitch->get_radio_in() < channel_pitch->get_radio_min()+trim_pitch_range ||
+        channel_pitch->get_radio_in() > channel_pitch->get_radio_max()-trim_pitch_range) {
         // don't trim for extreme values - if we attempt to trim so
         // there is less than 20 percent range left then assume the
         // sticks are not properly centered. This also prevents
@@ -295,18 +296,18 @@ void Plane::trim_control_surfaces()
     // Store control surface trim values
     // ---------------------------------
     if(g.mix_mode == 0) {
-        if (channel_roll->radio_in != 0) {
-            channel_roll->radio_trim = channel_roll->radio_in;
+        if (channel_roll->get_radio_in() != 0) {
+            channel_roll->set_radio_trim(channel_roll->get_radio_in());
         }
-        if (channel_pitch->radio_in != 0) {
-            channel_pitch->radio_trim = channel_pitch->radio_in;
+        if (channel_pitch->get_radio_in() != 0) {
+            channel_pitch->set_radio_trim(channel_pitch->get_radio_in());
         }
 
         // the secondary aileron/elevator is trimmed only if it has a
         // corresponding transmitter input channel, which k_aileron
         // doesn't have
-        RC_Channel_aux::set_radio_trim(RC_Channel_aux::k_aileron_with_input);
-        RC_Channel_aux::set_radio_trim(RC_Channel_aux::k_elevator_with_input);
+        RC_Channel_aux::set_trim_to_radio_in_for(RC_Channel_aux::k_aileron_with_input);
+        RC_Channel_aux::set_trim_to_radio_in_for(RC_Channel_aux::k_elevator_with_input);
     } else{
         if (elevon.ch1_temp != 0) {
             elevon.trim1 = elevon.ch1_temp;
@@ -317,11 +318,11 @@ void Plane::trim_control_surfaces()
         //Recompute values here using new values for elevon1_trim and elevon2_trim
         //We cannot use radio_in[CH_ROLL] and radio_in[CH_PITCH] values from read_radio() because the elevon trim values have changed
         uint16_t center                         = 1500;
-        channel_roll->radio_trim       = center;
-        channel_pitch->radio_trim      = center;
+        channel_roll->set_radio_trim(center);
+        channel_pitch->set_radio_trim(center);
     }
-    if (channel_rudder->radio_in != 0) {
-        channel_rudder->radio_trim = channel_rudder->radio_in;
+    if (channel_rudder->get_radio_in() != 0) {
+        channel_rudder->set_radio_trim(channel_rudder->get_radio_in());
     }
 
     // save to eeprom
@@ -353,7 +354,7 @@ bool Plane::rc_failsafe_active(void)
         return true;
     }
     if (channel_throttle->get_reverse()) {
-        return channel_throttle->radio_in >= g.throttle_fs_value;
+        return channel_throttle->get_radio_in() >= g.throttle_fs_value;
     }
-    return channel_throttle->radio_in <= g.throttle_fs_value;
+    return channel_throttle->get_radio_in() <= g.throttle_fs_value;
 }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -737,7 +737,7 @@ void Plane::servo_write(uint8_t ch, uint16_t pwm)
 #if HIL_SUPPORT
     if (g.hil_mode==1 && !g.hil_servos) {
         if (ch < 8) {
-            RC_Channel::rc_channel(ch)->radio_out = pwm;
+            RC_Channel::rc_channel(ch)->set_radio_out(pwm);
         }
         return;
     }

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -60,14 +60,14 @@ int8_t Plane::test_radio_pwm(uint8_t argc, const Menu::arg *argv)
         read_radio();
 
         cliSerial->printf("IN:\t1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-                        (int)channel_roll->radio_in,
-                        (int)channel_pitch->radio_in,
-                        (int)channel_throttle->radio_in,
-                        (int)channel_rudder->radio_in,
-                        (int)g.rc_5.radio_in,
-                        (int)g.rc_6.radio_in,
-                        (int)g.rc_7.radio_in,
-                        (int)g.rc_8.radio_in);
+                        (int)channel_roll->get_radio_in(),
+                        (int)channel_pitch->get_radio_in(),
+                        (int)channel_throttle->get_radio_in(),
+                        (int)channel_rudder->get_radio_in(),
+                        (int)g.rc_5.get_radio_in(),
+                        (int)g.rc_6.get_radio_in(),
+                        (int)g.rc_7.get_radio_in(),
+                        (int)g.rc_8.get_radio_in());
 
         if(cliSerial->available() > 0) {
             return (0);
@@ -124,14 +124,14 @@ int8_t Plane::test_radio(uint8_t argc, const Menu::arg *argv)
         set_servos();
 
         cliSerial->printf("IN 1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-                        (int)channel_roll->control_in,
-                        (int)channel_pitch->control_in,
-                        (int)channel_throttle->control_in,
-                        (int)channel_rudder->control_in,
-                        (int)g.rc_5.control_in,
-                        (int)g.rc_6.control_in,
-                        (int)g.rc_7.control_in,
-                        (int)g.rc_8.control_in);
+                        (int)channel_roll->get_control_in(),
+                        (int)channel_pitch->get_control_in(),
+                        (int)channel_throttle->get_control_in(),
+                        (int)channel_rudder->get_control_in(),
+                        (int)g.rc_5.get_control_in(),
+                        (int)g.rc_6.get_control_in(),
+                        (int)g.rc_7.get_control_in(),
+                        (int)g.rc_8.get_control_in() );
 
         if(cliSerial->available() > 0) {
             return (0);
@@ -155,7 +155,7 @@ int8_t Plane::test_failsafe(uint8_t argc, const Menu::arg *argv)
     oldSwitchPosition = readSwitch();
 
     cliSerial->printf("Unplug battery, throttle in neutral, turn off radio.\n");
-    while(channel_throttle->control_in > 0) {
+    while(channel_throttle->get_control_in() > 0) {
         hal.scheduler->delay(20);
         read_radio();
     }
@@ -164,8 +164,8 @@ int8_t Plane::test_failsafe(uint8_t argc, const Menu::arg *argv)
         hal.scheduler->delay(20);
         read_radio();
 
-        if(channel_throttle->control_in > 0) {
-            cliSerial->printf("THROTTLE CHANGED %d \n", (int)channel_throttle->control_in);
+        if(channel_throttle->get_control_in() > 0) {
+            cliSerial->printf("THROTTLE CHANGED %d \n", (int)channel_throttle->get_control_in());
             fail_test++;
         }
 
@@ -177,7 +177,7 @@ int8_t Plane::test_failsafe(uint8_t argc, const Menu::arg *argv)
         }
 
         if(rc_failsafe_active()) {
-            cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", (int)channel_throttle->radio_in);
+            cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", (int)channel_throttle->get_radio_in());
             print_flight_mode(cliSerial, readSwitch());
             cliSerial->println();
             fail_test++;

--- a/libraries/APM_OBC/APM_OBC.cpp
+++ b/libraries/APM_OBC/APM_OBC.cpp
@@ -399,10 +399,10 @@ void APM_OBC::check_crash_plane(void)
     RC_Channel *ch_yaw      = RC_Channel::rc_channel(rcmap.yaw()-1);
     RC_Channel *ch_throttle = RC_Channel::rc_channel(rcmap.throttle()-1);
 
-    ch_roll->radio_out     = ch_roll->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MIN);
-    ch_pitch->radio_out    = ch_pitch->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MAX);
-    ch_yaw->radio_out      = ch_yaw->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MAX);
-    ch_throttle->radio_out = ch_throttle->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MIN);
+    ch_roll->set_radio_out(ch_roll->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MIN));
+    ch_pitch->set_radio_out(ch_pitch->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MAX));
+    ch_yaw->set_radio_out(ch_yaw->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MAX));
+    ch_throttle->set_radio_out(ch_throttle->get_limit_pwm(RC_Channel::RC_CHANNEL_LIMIT_MIN));
 
     // and all aux channels
     RC_Channel_aux::set_servo_limit(RC_Channel_aux::k_flap_auto, RC_Channel::RC_CHANNEL_LIMIT_MAX);

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -348,8 +348,8 @@ void AP_MotorsHeli::reset_swash_servo(RC_Channel& servo)
     servo.set_range_out(0, 1000);
 
     // swash servos always use full endpoints as restricting them would lead to scaling errors
-    servo.radio_min = 1000;
-    servo.radio_max = 2000;
+    servo.set_radio_min(1000);
+    servo.set_radio_max(2000);
 }
 
 // update the throttle input filter

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -162,6 +162,6 @@ void AP_MotorsHeli_RSC::write_rsc(float servo_out)
         // ToDo: We should probably use RC_Channel_Aux to avoid this problem
         return;
     } else {
-        RC_Channel_aux::set_servo_out(RC_Channel_aux::k_heli_rsc, servo_out * 1000.0f);
+        RC_Channel_aux::set_servo_out_for(RC_Channel_aux::k_heli_rsc, servo_out * 1000.0f);
     }
 }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -155,12 +155,12 @@ int16_t AP_Motors::calc_pwm_output_1to1(float input, const RC_Channel& servo)
     }
 
     if (input >= 0.0f) {
-        ret = ((input * (servo.radio_max - servo.radio_trim)) + servo.radio_trim);
+        ret = ((input * (servo.get_radio_max() - servo.get_radio_trim())) + servo.get_radio_trim());
     } else {
-        ret = ((input * (servo.radio_trim - servo.radio_min)) + servo.radio_trim);
+        ret = ((input * (servo.get_radio_trim() - servo.get_radio_min())) + servo.get_radio_trim());
     }
 
-    return constrain_int16(ret, servo.radio_min, servo.radio_max);
+    return constrain_int16(ret, servo.get_radio_min(), servo.get_radio_max());
 }
 
 // convert input in 0 to +1 range to pwm output
@@ -174,9 +174,9 @@ int16_t AP_Motors::calc_pwm_output_0to1(float input, const RC_Channel& servo)
         input = 1.0f-input;
     }
 
-    ret = input * (servo.radio_max - servo.radio_min) + servo.radio_min;
+    ret = input * (servo.get_radio_max() - servo.get_radio_min()) + servo.get_radio_min();
 
-    return constrain_int16(ret, servo.radio_min, servo.radio_max);
+    return constrain_int16(ret, servo.get_radio_min(), servo.get_radio_max());
 }
 
 /*

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -123,7 +123,8 @@ void AP_Mount_Backend::update_targets_from_rc()
 // returns the angle (degrees*100) that the RC_Channel input is receiving
 int32_t AP_Mount_Backend::angle_input(RC_Channel* rc, int16_t angle_min, int16_t angle_max)
 {
-    return (rc->get_reverse() ? -1 : 1) * (rc->radio_in - rc->radio_min) * (int32_t)(angle_max - angle_min) / (rc->radio_max - rc->radio_min) + (rc->get_reverse() ? angle_max : angle_min);
+    return (rc->get_reverse() ? -1 : 1) * (rc->get_radio_in() - rc->get_radio_min()) 
+      * (int32_t)(angle_max - angle_min) / (rc->get_radio_max() - rc->get_radio_min()) + (rc->get_reverse() ? angle_max : angle_min);
 }
 
 // returns the angle (radians) that the RC_Channel input is receiving

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -109,7 +109,7 @@ void AP_ServoRelayEvents::update_events(void)
     case EVENT_TYPE_SERVO:
         hal.rcout->enable_ch(channel-1);
         if (repeat & 1) {
-            hal.rcout->write(channel-1, RC_Channel::rc_channel(channel-1)->radio_trim);
+            hal.rcout->write(channel-1, RC_Channel::rc_channel(channel-1)->get_radio_trim());
         } else {
             hal.rcout->write(channel-1, servo_value);
         }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -24,10 +24,11 @@ public:
     ///
     RC_Channel(uint8_t ch_out) :
         _high_in(1),
-        _ch_out(ch_out) {
-		AP_Param::setup_object_defaults(this, var_info);
+        _ch_out(ch_out) 
+    {
+		  AP_Param::setup_object_defaults(this, var_info);
         if (ch_out < RC_MAX_CHANNELS) {
-            rc_ch[ch_out] = this;
+            _rc_ch[ch_out] = this;
         }
     }
 
@@ -76,90 +77,112 @@ public:
     // return a limit PWM value
     uint16_t    get_limit_pwm(LimitValue limit) const;
 
-    // pwm is stored here
-    int16_t        radio_in;
-
     // call after first set_pwm
     void        trim();
-
-    // value generated from PWM
-    int16_t         control_in;
-
-    int16_t         control_mix(float value);
-
-    // current values to the servos - degrees * 100 (approx assuming servo is -45 to 45 degrees except [3] is 0 to 100
-    int16_t        servo_out;
 
     // generate PWM from servo_out value
     void        calc_pwm(void);
 
-    // PWM is without the offset from radio_min
-    int16_t         pwm_out;
-    int16_t         radio_out;
-
-    AP_Int16        radio_min;
-    AP_Int16        radio_trim;
-    AP_Int16        radio_max;
-
-    // includes offset from PWM
-    //int16_t   get_radio_out(void);
-
-    int16_t                                         pwm_to_angle_dz_trim(uint16_t dead_zone, uint16_t trim);
-    int16_t                                         pwm_to_angle_dz(uint16_t dead_zone);
-    int16_t                                         pwm_to_angle();
+    int16_t     pwm_to_angle_dz_trim(uint16_t dead_zone, uint16_t trim);
+    int16_t     pwm_to_angle_dz(uint16_t dead_zone);
+    int16_t     pwm_to_angle();
 
     /*
       return a normalised input for a channel, in range -1 to 1,
       centered around the channel trim. Ignore deadzone.
      */
-    float                                           norm_input();
+    float       norm_input();
 
     /*
       return a normalised input for a channel, in range -1 to 1,
       centered around the channel trim. Take into account the deadzone
     */
-    float                                           norm_input_dz();
+    float       norm_input_dz();
 
-    uint8_t                                         percent_input();
-    float                                           norm_output();
-    int16_t                                         angle_to_pwm();
-    int16_t                                         pwm_to_range();
-    int16_t                                         pwm_to_range_dz(uint16_t dead_zone);
-    int16_t                                         range_to_pwm();
-
-    void                                            output() const;
-    void                                            output_trim() const;
-    static void                                     output_trim_all();
-    static void                                     setup_failsafe_trim_all();
-    uint16_t                                        read() const;
-    void                                            input();
-    void                                            enable_out();
-    void                                            disable_out();
+    uint8_t     percent_input();
+    float       norm_output();
+    int16_t     angle_to_pwm();
+    int16_t     pwm_to_range();
+    int16_t     pwm_to_range_dz(uint16_t dead_zone);
+    int16_t     range_to_pwm();
+    void        output() const;
+    void        output_trim() const;
+    static void output_trim_all();
+    static void setup_failsafe_trim_all();
+    uint16_t    read() const;
+    void        input();
+    void        enable_out();
+    void        disable_out();
 
     static const struct AP_Param::GroupInfo         var_info[];
 
     static RC_Channel *rc_channel(uint8_t i);
 
-    static RC_Channel **rc_channel_array(void) {
-        return rc_ch;
+    static RC_Channel **rc_channel_array(void) 
+    {
+        return _rc_ch;
     }
     
-    bool in_trim_dz();
+    bool       in_trim_dz();
 
+    int16_t    get_radio_in() const { return _radio_in;}
+    void       set_radio_in(int16_t val){_radio_in = val;}
+
+    int16_t    get_control_in() const { return _control_in;}
+    void       set_control_in(int16_t val) { _control_in = val;}
+
+    int16_t    get_servo_out() const {return _servo_out;}
+    void       set_servo_out(int16_t val){_servo_out = val;}
+
+    int16_t    get_pwm_out() const { return _pwm_out;}
+
+    int16_t    get_radio_out() const { return _radio_out;}
+    void       set_radio_out(int16_t val){ _radio_out = val;}
+
+    int16_t    get_radio_min() const {return _radio_min.get();}
+    void       set_radio_min(int16_t val){_radio_min = val;}
+
+    int16_t    get_radio_max() const {return _radio_max.get();}
+    void       set_radio_max(int16_t val){_radio_max = val;}
+
+    int16_t    get_radio_trim() const { return _radio_trim.get();}
+    void       set_radio_trim(int16_t val) { _radio_trim.set(val);}
+    void       save_radio_trim() { _radio_trim.save();}
+    
+    bool min_max_configured()
+    {
+        return _radio_min.configured() && _radio_max.configured();
+    }
+    
 private:
-    AP_Int8         _reverse;
-    AP_Int16        _dead_zone;
-    uint8_t         _type_in;
-    int16_t         _high_in;
-    int16_t         _low_in;
-    uint8_t         _type_out;
-    int16_t         _high_out;
-    int16_t         _low_out;
 
-    static RC_Channel *rc_ch[RC_MAX_CHANNELS];
+    // pwm is stored here
+    int16_t     _radio_in;
+    // value generated from PWM
+    int16_t     _control_in;
+    // current values to the servos - degrees * 100 (approx assuming servo is -45 to 45 degrees except [3] is 0 to 100
+    int16_t     _servo_out;
+    // PWM is without the offset from radio_min
+    int16_t     _pwm_out;
+    int16_t     _radio_out;
+
+    AP_Int16    _radio_min;
+    AP_Int16    _radio_trim;
+    AP_Int16    _radio_max;
+
+    AP_Int8     _reverse;
+    AP_Int16    _dead_zone;
+    uint8_t     _type_in;
+    int16_t     _high_in;
+    int16_t     _low_in;
+    uint8_t     _type_out;
+    int16_t     _high_out;
+    int16_t     _low_out;
+
+    static RC_Channel *_rc_ch[RC_MAX_CHANNELS];
 
 protected:
-    uint8_t         _ch_out;
+    uint8_t     _ch_out;
 };
 
 // This is ugly, but it fixes poorly architected library

--- a/libraries/RC_Channel/RC_Channel_aux.cpp
+++ b/libraries/RC_Channel/RC_Channel_aux.cpp
@@ -33,16 +33,16 @@ RC_Channel_aux::output_ch(void)
     case k_none:                // disabled
         return;
     case k_manual:              // manual
-        radio_out = radio_in;
+        set_radio_out(get_radio_in());
         break;
     case k_rcin1 ... k_rcin16: // rc pass-thru
-        radio_out = hal.rcin->read(function-k_rcin1);
+        set_radio_out(hal.rcin->read(function-k_rcin1));
         break;
     case k_motor1 ... k_motor8:
         // handled by AP_Motors::rc_write()
         return;
     }
-    hal.rcout->write(_ch_out, radio_out);
+    hal.rcout->write(_ch_out, get_radio_out());
 }
 
 /*
@@ -153,13 +153,13 @@ void RC_Channel_aux::enable_aux_servos()
     // trim value on startup
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i]) {
-			RC_Channel_aux::Aux_servo_function_t function = (RC_Channel_aux::Aux_servo_function_t)_aux_channels[i]->function.get();
-			// see if it is a valid function
-			if (function < RC_Channel_aux::k_nr_aux_servo_functions) {
-				_aux_channels[i]->enable_out();
-			}
-		}
-	}
+			   RC_Channel_aux::Aux_servo_function_t function = (RC_Channel_aux::Aux_servo_function_t)_aux_channels[i]->function.get();
+			   // see if it is a valid function
+			   if (function < RC_Channel_aux::k_nr_aux_servo_functions) {
+				    _aux_channels[i]->enable_out();
+			   }
+		  }
+	 }
 }
 
 /*
@@ -173,9 +173,9 @@ RC_Channel_aux::set_radio(RC_Channel_aux::Aux_servo_function_t function, int16_t
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			_aux_channels[i]->radio_out = constrain_int16(value,_aux_channels[i]->radio_min,_aux_channels[i]->radio_max);
+			   _aux_channels[i]->set_radio_out(constrain_int16(value,_aux_channels[i]->get_radio_min(),_aux_channels[i]->get_radio_max()));
             _aux_channels[i]->output();
-		}
+		  }
     }
 }
 
@@ -190,10 +190,10 @@ RC_Channel_aux::set_radio_trimmed(RC_Channel_aux::Aux_servo_function_t function,
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-        	int16_t value2 = value - 1500 + _aux_channels[i]->radio_trim;
-			_aux_channels[i]->radio_out = constrain_int16(value2,_aux_channels[i]->radio_min,_aux_channels[i]->radio_max);
+        	   int16_t value2 = value - 1500 + _aux_channels[i]->get_radio_trim();
+			   _aux_channels[i]->set_radio_out(constrain_int16(value2,_aux_channels[i]->get_radio_min(),_aux_channels[i]->get_radio_max()));
             _aux_channels[i]->output();
-		}
+		  }
     }
 }
 
@@ -202,18 +202,18 @@ RC_Channel_aux::set_radio_trimmed(RC_Channel_aux::Aux_servo_function_t function,
   the given function type
  */
 void
-RC_Channel_aux::set_radio_trim(RC_Channel_aux::Aux_servo_function_t function)
+RC_Channel_aux::set_trim_to_radio_in_for(RC_Channel_aux::Aux_servo_function_t function)
 {
     if (!function_assigned(function)) {
         return;
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			if (_aux_channels[i]->radio_in != 0) {
-				_aux_channels[i]->radio_trim = _aux_channels[i]->radio_in;
-				_aux_channels[i]->radio_trim.save();
-			}
-		}
+			   if (_aux_channels[i]->get_radio_in() != 0) {
+				    _aux_channels[i]->set_radio_trim( _aux_channels[i]->get_radio_in());
+				    _aux_channels[i]->save_radio_trim();
+			   }
+		  }
     }
 }
 
@@ -228,9 +228,9 @@ RC_Channel_aux::set_radio_to_min(RC_Channel_aux::Aux_servo_function_t function)
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-            _aux_channels[i]->radio_out = _aux_channels[i]->radio_min;
+            _aux_channels[i]->set_radio_out( _aux_channels[i]->get_radio_min());
             _aux_channels[i]->output();
-		}
+		  }
     }
 }
 
@@ -245,7 +245,7 @@ RC_Channel_aux::set_radio_to_max(RC_Channel_aux::Aux_servo_function_t function)
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-            _aux_channels[i]->radio_out = _aux_channels[i]->radio_max;
+            _aux_channels[i]->set_radio_out(_aux_channels[i]->get_radio_max());
             _aux_channels[i]->output();
 		}
     }
@@ -262,9 +262,9 @@ RC_Channel_aux::set_radio_to_trim(RC_Channel_aux::Aux_servo_function_t function)
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			_aux_channels[i]->radio_out = _aux_channels[i]->radio_trim;
+			   _aux_channels[i]->set_radio_out( _aux_channels[i]->get_radio_trim());
             _aux_channels[i]->output();
-		}
+		  }
     }
 }
 
@@ -279,14 +279,14 @@ RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::Aux_servo_function_t function,
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			if (do_input_output) {
-				_aux_channels[i]->input();
-			}
-			_aux_channels[i]->radio_out = _aux_channels[i]->radio_in;
-			if (do_input_output) {
-				_aux_channels[i]->output();
-			}
-		}
+			   if (do_input_output) {
+				    _aux_channels[i]->input();
+			   }
+			   _aux_channels[i]->set_radio_out(_aux_channels[i]->get_radio_in());
+			   if (do_input_output) {
+				    _aux_channels[i]->output();
+			   }
+		  }
     }
 }
 
@@ -294,17 +294,17 @@ RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::Aux_servo_function_t function,
   set servo_out and call calc_pwm() for a given function
  */
 void
-RC_Channel_aux::set_servo_out(RC_Channel_aux::Aux_servo_function_t function, int16_t value)
+RC_Channel_aux::set_servo_out_for(RC_Channel_aux::Aux_servo_function_t function, int16_t value)
 {
     if (!function_assigned(function)) {
         return;
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			_aux_channels[i]->servo_out = value;
-			_aux_channels[i]->calc_pwm();
+			   _aux_channels[i]->set_servo_out(value);
+			   _aux_channels[i]->calc_pwm();
             _aux_channels[i]->output();
-		}
+		  }
     }
 }
 
@@ -339,15 +339,15 @@ RC_Channel_aux::set_servo_limit(RC_Channel_aux::Aux_servo_function_t function, R
         RC_Channel_aux *ch = _aux_channels[i];
         if (ch && ch->function.get() == function) {
             uint16_t pwm = ch->get_limit_pwm(limit);
-            ch->radio_out = pwm;
+            ch->set_radio_out(pwm);
             if (ch->function.get() == k_manual) {
                 // in order for output_ch() to work for k_manual we
                 // also have to override radio_in
-                ch->radio_in = pwm;
+                ch->set_radio_in(pwm);
             }
             if (ch->function.get() >= k_rcin1 && ch->function.get() <= k_rcin16) {
                 // save for k_rcin*
-                ch->radio_in = pwm;
+                ch->set_radio_in(pwm);
             }
         }
     }
@@ -362,7 +362,7 @@ RC_Channel_aux::function_assigned(RC_Channel_aux::Aux_servo_function_t function)
     if (function < k_nr_aux_servo_functions) {
         return (_function_mask & (1ULL<<function)) != 0;
     }
-	return false;
+	 return false;
 }
 
 /*
@@ -378,7 +378,7 @@ RC_Channel_aux::move_servo(RC_Channel_aux::Aux_servo_function_t function,
     }
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i] && _aux_channels[i]->function.get() == function) {
-			_aux_channels[i]->servo_out = value;
+			_aux_channels[i]->set_servo_out(value);
 			_aux_channels[i]->set_range(angle_min, angle_max);
 			_aux_channels[i]->calc_pwm();
 			_aux_channels[i]->output();

--- a/libraries/RC_Channel/RC_Channel_aux.h
+++ b/libraries/RC_Channel/RC_Channel_aux.h
@@ -108,7 +108,7 @@ public:
 	static void set_radio_trimmed(Aux_servo_function_t function, int16_t value);
 
 	// set and save the trim for a function channel to radio_in
-	static void set_radio_trim(Aux_servo_function_t function);
+	static void set_trim_to_radio_in_for(Aux_servo_function_t function);
 
 	// set radio_out to radio_min
 	static void set_radio_to_min(Aux_servo_function_t function);
@@ -123,7 +123,7 @@ public:
 	static void copy_radio_in_out(Aux_servo_function_t function, bool do_input_output=false);
 
 	// set servo_out
-	static void set_servo_out(Aux_servo_function_t function, int16_t value);
+	static void set_servo_out_for(Aux_servo_function_t function, int16_t value);
 
 	// setup failsafe for an auxillary channel function
 	static void set_servo_failsafe(Aux_servo_function_t function, RC_Channel::LimitValue limit);


### PR DESCRIPTION
Rationale:

	RC_Channel is a complicated class, which combines several functionalities 
        dealing with stick inputs in pwm and logical units, logical and actual actuator outputs,
        unit conversion etc, etc
	The intent of this PR is to clarify existing use of the class. At the basic level 
        it should now be possible to grep all places where private variable is set 
        by searching for the set_xx function.

	(The wider purpose is to provide a more generic and logically simpler method of output mixing. 
        This is a small step)

1) make data members of RC_Channnels private.
2) rename all data members of RC_Channnels with leadng underscore .
3) Provide get_xx and set_xx methods.
4) Fix up the RC_Channel_aux class where the names (but not signatures) shadow 
   the base class names.
4) Fix up all uses for ArduPlane, ArduCopter, APMRover2, AntennaTracker.
5) Note: Examples and tests have not been tackled.

Issues:

1) To provide a common name convention for the RC_Channel members using get_xx set_xx , some RC_Channel_aux static member functions were renamed:
RC_Channel_aux::set_radio_trim was renamed to RC_Channel_aux::set_trim_to_radio_in_for
RC_Channel_aux::set_servo_out was renamed to to RC_Channel_aux::set_servo_out_for

2) Because data members are now private, some overloads were required to keep functionality where non const references were modified previously

new overload Plane::stick_mix_channel(RC_Channel *channel) to complement stick_mix_channel(RC_Channel *channel, int16_t &servo_out)
new overload void Plane::channel_output_mixer(Rc_Channel* , RC_Channel*) 
to complement  void channel_output_mixer(uint8_t mixing_type, int16_t & chan1, int16_t & chan2)
(The functions were made const also)

-----------------------------------