### PR TITLE
SITL: Add calibration model and mavproxy helper

### DIFF
--- a/Tools/mavproxy_modules/README.md
+++ b/Tools/mavproxy_modules/README.md
@@ -1,0 +1,33 @@
+# MAVProxy modules #
+
+This folder contains modules for MAVProxy specifically for ArduPilot. Add the
+path to this folder to your `PYTHONPATH` in order to use it.
+
+# Modules #
+
+## `sitl_calibration` ##
+This module interfaces with the `calibration` model of SITL. It provides
+commands to actuate on the vehicle's rotation to simulate a calibration
+process.
+
+### Accelerometer Calibration ###
+The command `sitl_accelcal` listens to the accelerometer calibration status
+texts and set the vehicle in the desired attitude. Example:
+```
+accelcal
+sitl_accelcal
+```
+
+### Compass Calibration ###
+The command `sitl_magcal` applies angular velocity on the vehicle in order to
+get the compasses calibrated. Example:
+```
+magcal start
+sitl_magcal
+```
+
+### Other commands ###
+There are other commands you can use with this module:
+ - `sitl_attitude`: set vehicle at a desired attitude
+ - `sitl_angvel`: apply angular velocity on the vehicle
+ - `sitl_stop`: stop any of this module's currently active command

--- a/Tools/mavproxy_modules/sitl_calibration.py
+++ b/Tools/mavproxy_modules/sitl_calibration.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2015-2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+'''calibration simulation command handling'''
+
+from __future__ import division, print_function
+import math
+from pymavlink import quaternion
+
+from MAVProxy.modules.lib import mp_module
+
+class CalController(object):
+    def __init__(self, mpstate):
+        self.mpstate = mpstate
+        self.active = False
+        self.reset()
+
+    def reset(self):
+        self.desired_quaternion = None
+        self.general_state = 'idle'
+        self.attitude_callback = None
+        self.desired_quaternion_close_count = 0
+
+    def start(self):
+        self.active = True
+
+    def stop(self):
+        self.reset()
+        self.mpstate.functions.process_stdin('servo set 5 1000')
+        self.active = False
+
+    def normalize_attitude_angle(self, angle):
+        if angle < 0:
+            angle = 2 * math.pi + angle % (-2 * math.pi)
+        angle %= 2 * math.pi
+        if angle > math.pi:
+            return angle % -math.pi
+        return angle
+
+    def set_attitute(self, roll, pitch, yaw, callback=None):
+        roll = self.normalize_attitude_angle(roll)
+        pitch = self.normalize_attitude_angle(pitch)
+        yaw = self.normalize_attitude_angle(yaw)
+
+        self.desired_quaternion = quaternion.Quaternion((roll, pitch, yaw))
+        self.desired_quaternion.normalize()
+
+        scale = 500.0 / math.pi
+
+        roll_pwm = 1500 + int(roll * scale)
+        pitch_pwm = 1500 + int(pitch * scale)
+        yaw_pwm = 1500 + int(yaw * scale)
+
+        self.mpstate.functions.process_stdin('servo set 5 1150')
+        self.mpstate.functions.process_stdin('servo set 6 %d' % roll_pwm)
+        self.mpstate.functions.process_stdin('servo set 7 %d' % pitch_pwm)
+        self.mpstate.functions.process_stdin('servo set 8 %d' % yaw_pwm)
+
+        self.general_state = 'attitude'
+        self.desired_quaternion_close_count = 0
+
+        if callback:
+            self.attitude_callback = callback
+
+    def angvel(self, x, y, z, theta):
+        m = max(abs(x), abs(y), abs(z))
+        if not m:
+            x_pwm = y_pwm = z_pwm = 1500
+        else:
+            x_pwm = 1500 + round((x / m) * 500)
+            y_pwm = 1500 + round((y / m) * 500)
+            z_pwm = 1500 + round((z / m) * 500)
+
+        max_theta = 2 * math.pi
+        if theta < 0:
+            theta = 0
+        elif theta > max_theta:
+            theta = max_theta
+        theta_pwm = 1200 + round((theta / max_theta) * 800)
+
+        self.mpstate.functions.process_stdin('servo set 5 %d' % theta_pwm)
+        self.mpstate.functions.process_stdin('servo set 6 %d' % x_pwm)
+        self.mpstate.functions.process_stdin('servo set 7 %d' % y_pwm)
+        self.mpstate.functions.process_stdin('servo set 8 %d' % z_pwm)
+
+        self.general_state = 'angvel'
+
+    def handle_simstate(self, m):
+        if self.general_state == 'attitude':
+            q = quaternion.Quaternion((m.roll, m.pitch, m.yaw))
+            q.normalize()
+            d1 = abs(self.desired_quaternion.q - q.q)
+            d2 = abs(self.desired_quaternion.q + q.q)
+            if (d1 <= 1e-2).all() or (d2 <= 1e-2).all():
+                self.desired_quaternion_close_count += 1
+            else:
+                self.desired_quaternion_close_count = 0
+
+            if self.desired_quaternion_close_count == 5:
+                self.general_state = 'idle'
+                if callable(self.attitude_callback):
+                    self.attitude_callback()
+                    self.attitude_callback = None
+
+    def mavlink_packet(self, m):
+        if not self.active:
+            return
+        if m.get_type() == 'SIMSTATE':
+            self.handle_simstate(m)
+
+
+class SitlCalibrationModule(mp_module.MPModule):
+    def __init__(self, mpstate):
+        super(SitlCalibrationModule, self).__init__(mpstate, "sitl_calibration")
+        self.add_command(
+            'sitl_attitude',
+            self.cmd_sitl_attitude,
+            'set the vehicle at the inclination given by ROLL, PITCH and YAW' +
+            ' in degrees',
+        )
+        self.add_command(
+            'sitl_angvel',
+            self.cmd_angvel,
+            'apply angular velocity on the vehicle with a rotation axis and a '+
+            'magnitude in degrees/s',
+        )
+        self.add_command(
+            'sitl_stop',
+            self.cmd_sitl_stop,
+            'stop the current calibration control',
+        )
+
+        self.controllers = dict(
+            generic_controller=CalController(mpstate),
+        )
+
+        self.current_controller = None
+
+    def set_controller(self, controller):
+        if self.current_controller:
+            self.current_controller.stop()
+
+        controller = self.controllers.get(controller, None)
+        if controller:
+            controller.start()
+        self.current_controller = controller
+
+    def cmd_sitl_attitude(self, args):
+        if len(args) != 3:
+            print('Usage: sitl_attitude <ROLL> <PITCH> <YAW>')
+            return
+
+        try:
+            roll, pitch, yaw = args
+            roll = math.radians(float(roll))
+            pitch = math.radians(float(pitch))
+            yaw = math.radians(float(yaw))
+        except ValueError:
+            print('Invalid arguments')
+
+        self.set_controller('generic_controller')
+        self.current_controller.set_attitute(roll, pitch, yaw)
+
+    def cmd_angvel(self, args):
+        if len(args) != 4:
+            print('Usage: sitl_angvel <AXIS_X> <AXIS_Y> <AXIS_Z> <THETA>')
+            return
+
+        try:
+            x, y, z, theta = args
+            x = float(x)
+            y = float(y)
+            z = float(z)
+            theta = math.radians(float(theta))
+        except ValueError:
+            print('Invalid arguments')
+
+        self.set_controller('generic_controller')
+        self.current_controller.angvel(x, y, z, theta)
+
+    def cmd_sitl_stop(self, args):
+        self.set_controller('generic_controller')
+
+    def mavlink_packet(self, m):
+        for c in self.controllers.values():
+            c.mavlink_packet(m)
+
+def init(mpstate):
+    '''initialise module'''
+    return SitlCalibrationModule(mpstate)

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -25,6 +25,7 @@
 #include <SITL/SIM_Tracker.h>
 #include <SITL/SIM_Balloon.h>
 #include <SITL/SIM_FlightAxis.h>
+#include <SITL/SIM_Calibration.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -86,6 +87,7 @@ static const struct {
     { "tracker",            Tracker::create },
     { "balloon",            Balloon::create },
     { "plane",              Plane::create },
+    { "calibration",        Calibration::create },
 };
 
 void SITL_State::_parse_command_line(int argc, char * const argv[])

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -242,7 +242,7 @@ bool inverse3x3(float m[], float invOut[])
     float  det = m[0] * (m[4] * m[8] - m[7] * m[5]) -
     m[1] * (m[3] * m[8] - m[5] * m[6]) +
     m[2] * (m[3] * m[7] - m[4] * m[6]);
-    if (is_zero(det)){
+    if (is_zero(det) || isinf(det)) {
         return false;
     }
 
@@ -393,7 +393,7 @@ bool inverse4x4(float m[],float invOut[])
 
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
 
-    if (is_zero(det)){
+    if (is_zero(det) || isinf(det)){
         return false;
     }
 

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -18,9 +18,15 @@
  */
 #pragma GCC optimize("O3")
 
-#include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
+
 #include <stdio.h>
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <fenv.h>
+#endif
+
+#include <AP_Math/AP_Math.h>
+
 extern const AP_HAL::HAL& hal;
 
 //TODO: use higher precision datatypes to achieve more accuracy for matrix algebra operations
@@ -279,6 +285,13 @@ bool inverse4x4(float m[],float invOut[])
     float inv[16], det;
     uint8_t i;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    int old = fedisableexcept(FE_OVERFLOW);
+    if (old < 0) {
+        hal.console->printf("inverse4x4(): warning: error on disabling FE_OVERFLOW floating point exception\n");
+    }
+#endif
+
     inv[0] = m[5]  * m[10] * m[15] -
     m[5]  * m[11] * m[14] -
     m[9]  * m[6]  * m[15] +
@@ -392,6 +405,12 @@ bool inverse4x4(float m[],float invOut[])
     m[8] * m[2] * m[5];
 
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (old >= 0 && feenableexcept(old) < 0) {
+        hal.console->printf("inverse4x4(): warning: error on restoring floating exception mask\n");
+    }
+#endif
 
     if (is_zero(det) || isinf(det)){
         return false;

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -70,21 +70,21 @@ void Quaternion::from_rotation_matrix(const Matrix3f &m)
         float S = sqrtf(tr+1) * 2;
         qw = 0.25f * S;
         qx = (m21 - m12) / S;
-        qy = (m02 - m20) / S; 
-        qz = (m10 - m01) / S; 
-    } else if ((m00 > m11) && (m00 > m22)) { 
+        qy = (m02 - m20) / S;
+        qz = (m10 - m01) / S;
+    } else if ((m00 > m11) && (m00 > m22)) {
         float S = sqrtf(1.0f + m00 - m11 - m22) * 2;
         qw = (m21 - m12) / S;
         qx = 0.25f * S;
-        qy = (m01 + m10) / S; 
-        qz = (m02 + m20) / S; 
-    } else if (m11 > m22) { 
+        qy = (m01 + m10) / S;
+        qz = (m02 + m20) / S;
+    } else if (m11 > m22) {
         float S = sqrtf(1.0f + m11 - m00 - m22) * 2;
         qw = (m02 - m20) / S;
-        qx = (m01 + m10) / S; 
+        qx = (m01 + m10) / S;
         qy = 0.25f * S;
-        qz = (m12 + m21) / S; 
-    } else { 
+        qz = (m12 + m21) / S;
+    } else {
         float S = sqrtf(1.0f + m22 - m00 - m11) * 2;
         qw = (m10 - m01) / S;
         qx = (m02 + m20) / S;
@@ -126,9 +126,10 @@ void Quaternion::from_vector312(float roll ,float pitch, float yaw)
     from_rotation_matrix(m);
 }
 
-void Quaternion::from_axis_angle(Vector3f v) {
+void Quaternion::from_axis_angle(Vector3f v)
+{
     float theta = v.length();
-    if(theta < 1.0e-12f) {
+    if (theta < 1.0e-12f) {
         q1 = 1.0f;
         q2=q3=q4=0.0f;
         return;
@@ -137,8 +138,9 @@ void Quaternion::from_axis_angle(Vector3f v) {
     from_axis_angle(v,theta);
 }
 
-void Quaternion::from_axis_angle(const Vector3f &axis, float theta) {
-    if(theta < 1.0e-12f) {
+void Quaternion::from_axis_angle(const Vector3f &axis, float theta)
+{
+    if (theta < 1.0e-12f) {
         q1 = 1.0f;
         q2=q3=q4=0.0f;
     }
@@ -150,24 +152,27 @@ void Quaternion::from_axis_angle(const Vector3f &axis, float theta) {
     q4 = axis.z * st2;
 }
 
-void Quaternion::rotate(const Vector3f &v) {
+void Quaternion::rotate(const Vector3f &v)
+{
     Quaternion r;
     r.from_axis_angle(v);
     (*this) *= r;
 }
 
-void Quaternion::to_axis_angle(Vector3f &v) {
+void Quaternion::to_axis_angle(Vector3f &v)
+{
     float l = sqrt(sq(q2)+sq(q3)+sq(q4));
     v = Vector3f(q2,q3,q4);
-    if(l >= 1.0e-12f) {
+    if (l >= 1.0e-12f) {
         v /= l;
         v *= wrap_PI(2.0f * atan2f(l,q1));
     }
 }
 
-void Quaternion::from_axis_angle_fast(Vector3f v) {
+void Quaternion::from_axis_angle_fast(Vector3f v)
+{
     float theta = v.length();
-    if(theta < 1.0e-12f) {
+    if (theta < 1.0e-12f) {
         q1 = 1.0f;
         q2=q3=q4=0.0f;
     }
@@ -175,7 +180,8 @@ void Quaternion::from_axis_angle_fast(Vector3f v) {
     from_axis_angle_fast(v,theta);
 }
 
-void Quaternion::from_axis_angle_fast(const Vector3f &axis, float theta) {
+void Quaternion::from_axis_angle_fast(const Vector3f &axis, float theta)
+{
     float t2 = theta/2.0f;
     float sqt2 = sq(t2);
     float st2 = t2-sqt2*t2/6.0f;
@@ -186,9 +192,12 @@ void Quaternion::from_axis_angle_fast(const Vector3f &axis, float theta) {
     q4 = axis.z * st2;
 }
 
-void Quaternion::rotate_fast(const Vector3f &v) {
+void Quaternion::rotate_fast(const Vector3f &v)
+{
     float theta = v.length();
-    if(theta < 1.0e-12f) return;
+    if (theta < 1.0e-12f) {
+        return;
+    }
     float t2 = theta/2.0f;
     float sqt2 = sq(t2);
     float st2 = t2-sqt2*t2/6.0f;
@@ -241,7 +250,7 @@ void Quaternion::to_euler(float &roll, float &pitch, float &yaw) const
 
 // create eulers from a quaternion
 Vector3f Quaternion::to_vector312(void) const
-{    
+{
     Matrix3f m;
     rotation_matrix(m);
     return m.to_euler312();
@@ -260,17 +269,17 @@ Quaternion Quaternion::inverse(void) const
 void Quaternion::normalize(void)
 {
     float quatMag = length();
-    if (quatMag > 1e-16f)
-    {
+    if (quatMag > 1e-16f) {
         float quatMagInv = 1.0f/quatMag;
         q1 *= quatMagInv;
         q2 *= quatMagInv;
         q3 *= quatMagInv;
         q4 *= quatMagInv;
-    }    
+    }
 }
 
-Quaternion Quaternion::operator*(const Quaternion &v) const {
+Quaternion Quaternion::operator*(const Quaternion &v) const
+{
     Quaternion ret;
     const float &w1 = q1;
     const float &x1 = q2;
@@ -290,7 +299,8 @@ Quaternion Quaternion::operator*(const Quaternion &v) const {
     return ret;
 }
 
-Quaternion &Quaternion::operator*=(const Quaternion &v) {
+Quaternion &Quaternion::operator*=(const Quaternion &v)
+{
     float w1 = q1;
     float x1 = q2;
     float y1 = q3;
@@ -309,7 +319,8 @@ Quaternion &Quaternion::operator*=(const Quaternion &v) {
     return *this;
 }
 
-Quaternion Quaternion::operator/(const Quaternion &v) const {
+Quaternion Quaternion::operator/(const Quaternion &v) const
+{
     Quaternion ret;
     const float &quat0 = q1;
     const float &quat1 = q2;

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -23,26 +23,31 @@
 #include <assert.h>
 #endif
 
-class Quaternion
-{
+class Quaternion {
 public:
     float        q1, q2, q3, q4;
 
     // constructor creates a quaternion equivalent
     // to roll=0, pitch=0, yaw=0
-    Quaternion() {
-        q1 = 1; q2 = q3 = q4 = 0;
+    Quaternion()
+    {
+        q1 = 1;
+        q2 = q3 = q4 = 0;
     }
 
     // setting constructor
     Quaternion(const float _q1, const float _q2, const float _q3, const float _q4) :
-        q1(_q1), q2(_q2), q3(_q3), q4(_q4) {
+        q1(_q1), q2(_q2), q3(_q3), q4(_q4)
+    {
     }
 
     // function call operator
-    void operator        ()(const float _q1, const float _q2, const float _q3, const float _q4)
+    void operator()(const float _q1, const float _q2, const float _q3, const float _q4)
     {
-        q1 = _q1; q2 = _q2; q3 = _q3; q4 = _q4;
+        q1 = _q1;
+        q2 = _q2;
+        q3 = _q3;
+        q4 = _q4;
     }
 
     // check if any elements are NAN
@@ -97,12 +102,17 @@ public:
     void normalize();
 
     // initialise the quaternion to no rotation
-    void initialise() { q1 = 1.0f; q2 = q3 = q4 = 0.0f; }
+    void initialise()
+    {
+        q1 = 1.0f;
+        q2 = q3 = q4 = 0.0f;
+    }
 
     Quaternion inverse(void) const;
 
     // allow a quaternion to be used as an array, 0 indexed
-    float & operator[](uint8_t i) {
+    float & operator[](uint8_t i)
+    {
         float *_v = &q1;
 #if MATH_CHECK_INDEXES
         assert(i < 4);
@@ -110,7 +120,8 @@ public:
         return _v[i];
     }
 
-    const float & operator[](uint8_t i) const {
+    const float & operator[](uint8_t i) const
+    {
         const float *_v = &q1;
 #if MATH_CHECK_INDEXES
         assert(i < 4);

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -142,18 +142,6 @@ void Aircraft::update_position(void)
     }
 }
 
-/*
-   rotate to the given yaw
-*/
-void Aircraft::set_yaw_degrees(float yaw_degrees)
-{
-    float roll, pitch, yaw;
-    dcm.to_euler(&roll, &pitch, &yaw);
-
-    yaw = radians(yaw_degrees);
-    dcm.from_euler(roll, pitch, yaw);
-}
-
 /* advance time by deltat in seconds */
 void Aircraft::time_advance(float deltat)
 {

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -142,9 +142,6 @@ protected:
     /* update location from position */
     void update_position(void);
 
-    /* rotate to the given yaw */
-    void set_yaw_degrees(float yaw_degrees);
-
     /* advance time by deltat in seconds */
     void time_advance(float deltat);
 

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015-2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+
+#include <AP_Math/AP_Math.h>
+
+#include "SIM_Calibration.h"
+
+#define MAX_ANGULAR_SPEED (2 * M_PI)
+
+#include <stdio.h>
+
+SITL::Calibration::Calibration(const char *home_str, const char *frame_str)
+    : Aircraft(home_str, frame_str)
+{
+    mass = 1.5f;
+}
+
+void SITL::Calibration::update(const struct sitl_input& input)
+{
+    Vector3f rot_accel{0, 0, 0};
+
+    float switcher_pwm = input.servos[4];
+    if (switcher_pwm < 1100) {
+        _stop_control(input, rot_accel);
+    } else if (switcher_pwm < 1200) {
+        _attitude_control(input, rot_accel);
+    } else {
+        _angular_velocity_control(input, rot_accel);
+    }
+
+    accel_body(0, 0, 0);
+    update_dynamics(rot_accel);
+    update_position();
+}
+
+void SITL::Calibration::_stop_control(const struct sitl_input& input,
+                                      Vector3f& rot_accel)
+{
+    Vector3f desired_angvel{0, 0, 0};
+    Vector3f error =  desired_angvel - gyro;
+    float dt = frame_time_us * 1.0e-6f;
+    rot_accel = error * (1.0f / dt);
+    /* Provide a somewhat "smooth" transition */
+    rot_accel *= 0.002f;
+}
+
+void SITL::Calibration::_attitude_control(const struct sitl_input& input,
+                                          Vector3f& rot_accel)
+{
+    float desired_roll = -M_PI + 2 * M_PI * (input.servos[5] - 1000) / 1000.f;
+    float desired_pitch = -M_PI + 2 * M_PI * (input.servos[6] - 1000) / 1000.f;
+    float desired_yaw = -M_PI + 2 * M_PI * (input.servos[7] - 1000) / 1000.f;
+    float dt = frame_time_us * 1.0e-6f;
+
+    Quaternion desired_q;
+    desired_q.from_euler(desired_roll, desired_pitch, desired_yaw);
+    desired_q.normalize();
+
+    Quaternion current_q;
+    current_q.from_rotation_matrix(dcm);
+    current_q.normalize();
+
+    Quaternion error_q = desired_q / current_q;
+
+    Vector3f angle_differential;
+    error_q.normalize();
+    error_q.to_axis_angle(angle_differential);
+
+    Vector3f desired_angvel = angle_differential * (1 / dt);
+    /* Provide a somewhat "smooth" transition */
+    desired_angvel *= .005f;
+
+    Vector3f error = desired_angvel - gyro;
+    rot_accel = error * (1.0f / dt);
+}
+
+void SITL::Calibration::_angular_velocity_control(const struct sitl_input& in,
+                                                  Vector3f& rot_accel)
+{
+    Vector3f axis{(float)(in.servos[5] - 1500),
+                  (float)(in.servos[6] - 1500),
+                  (float)(in.servos[7] - 1500)};
+    float theta = MAX_ANGULAR_SPEED * (in.servos[4] - 1200) / 800.f;
+    float dt = frame_time_us * 1.0e-6f;
+
+    axis.normalize();
+
+    Vector3f desired_angvel = axis * theta;
+    Vector3f error = desired_angvel - gyro;
+
+    rot_accel = error * (1.0f / dt);
+    /* Provide a somewhat "smooth" transition */
+    rot_accel *= .05f;
+}

--- a/libraries/SITL/SIM_Calibration.h
+++ b/libraries/SITL/SIM_Calibration.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015-2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "SIM_Aircraft.h"
+
+#include <AP_Math/AP_Math.h>
+
+namespace SITL {
+
+/**
+ * Simulation model to simulate calibration of accelerometers and compasses.
+ *
+ * The vehicle rotation can be controlled by sending PWM values to the servos
+ * input, denoted by PWM[i] for the i-th channel (starting by zero). All PWM
+ * values must be in [1000, 2000], otherwise that will cause undefined
+ * behavior.
+ *
+ * There are three control modes, that are set with PWM[4]:
+ *
+ *  1) Stop (1000 <= PWM[4] < 1100):
+ *    Stop the vehicle, i.e., stop the actuation of the other modes.
+ *
+ *  2) Attitude (1100 <= PWM[4] < 1200):
+ *    Rotate the vehicle to the specified attitude. The attitude is defined
+ *    with the PWM channels 5, 6 and 7 for roll, pitch and yaw angles,
+ *    respectively. The PWM value for a desired angle in radians is given by:
+ *
+ *        pwm(theta) = 1500 + 500 * round(theta / pi)
+ *        where -pi <= theta <= pi
+ *
+ *  3) Angular Velocity (1200 <= PWM[4] <= 2000):
+ *    Rotate the vehicle at a desired angular velocity. The angular velocity is
+ *    specified by a rotation axis and an angular speed.
+ *
+ *    The x, y and z components of the rotation axis is given, respectively, by
+ *    the PWM channels 5, 6 and 7 with an offset of 1500. The rotation axis is
+ *    normalized internally, so that PWM[5,6,7] = [1600, 1300, 0] and
+ *    PWM[5,6,7] = [1700, 1100, 0] means the same normalized rotation axis.
+ *
+ *    The angular speed value is specified by PWM[4]. The PWM value for a
+ *    desired angular speed in radians/s is given by:
+ *
+ *        pwm(theta) = 1200 + 800 * round(theta / (2 * pi)),
+ *        where 0 <= theta <= 2 * pi
+ */
+class Calibration : public Aircraft {
+public:
+    Calibration(const char *home_str, const char *frame_str);
+
+    void update(const struct sitl_input& input);
+
+    static Aircraft *create(const char *home_str, const char *frame_str) {
+        return new Calibration(home_str, frame_str);
+    }
+
+private:
+    void _stop_control(const struct sitl_input& input, Vector3f& rot_accel);
+
+    void _attitude_control(const struct sitl_input& input,
+                           Vector3f& rot_accel);
+
+    void _angular_velocity_control(const struct sitl_input& input,
+                                   Vector3f& rot_accel);
+};
+}

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -55,7 +55,6 @@ void MultiCopter::update(const struct sitl_input &input)
     // get wind vector setup
     update_wind(input);
 
-    // how much time has passed?
     Vector3f rot_accel;
 
     calculate_forces(input, rot_accel, accel_body);


### PR DESCRIPTION
Hi all,

This PR adds a new model in SITL for simulating sensors calibration (currently accelerometer and compass). It also adds a mavproxy module that interfaces with the model to trigger the simulations.

Best regards,
Gustavo Sousa