### PR TITLE
Copter 3.3 gps NMEA fix

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -275,7 +275,7 @@ AP_GPS::detect_instance(uint8_t instance)
             new_gps = new AP_GPS_SBP(*this, state[instance], _port[instance]);
         }
 #endif // HAL_CPU_CLASS
-//#if !defined(GPS_SKIP_SIRF_NMEA)
+#if !defined(GPS_SKIP_SIRF_NMEA)
 		// save a bit of code space on a 1280
 		else if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_SIRF) &&
                  AP_GPS_SIRF::_detect(dstate->sirf_detect_state, data)) {
@@ -291,7 +291,7 @@ AP_GPS::detect_instance(uint8_t instance)
 				new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);                
 			}
 		}
-//#endif
+#endif
 	}
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -20,8 +20,6 @@
 #include <AP_Notify/AP_Notify.h>
 #include "AP_GPS.h"
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -20,6 +20,8 @@
 #include <AP_Notify/AP_Notify.h>
 #include "AP_GPS.h"
 
+#include <stdio.h>
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -221,7 +223,7 @@ AP_GPS::detect_instance(uint8_t instance)
     }
 
     if (now - dstate->last_baud_change_ms > GPS_BAUD_TIME_MS) {
-        // try the next baud rate
+        // try the next baud rate        
 		dstate->last_baud++;
 		if (dstate->last_baud == ARRAY_SIZE(_baudrates)) {
 			dstate->last_baud = 0;
@@ -254,7 +256,7 @@ AP_GPS::detect_instance(uint8_t instance)
             pgm_read_dword(&_baudrates[dstate->last_baud]) >= 38400 && 
             AP_GPS_UBLOX::_detect(dstate->ublox_detect_state, data)) {
             hal.console->print_P(PSTR(" ublox "));
-            new_gps = new AP_GPS_UBLOX(*this, state[instance], _port[instance]);
+            new_gps = new AP_GPS_UBLOX(*this, state[instance], _port[instance]);            
         } 
 		else if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_MTK19) &&
                  AP_GPS_MTK19::_detect(dstate->mtk19_detect_state, data)) {
@@ -273,7 +275,7 @@ AP_GPS::detect_instance(uint8_t instance)
             new_gps = new AP_GPS_SBP(*this, state[instance], _port[instance]);
         }
 #endif // HAL_CPU_CLASS
-#if !defined(GPS_SKIP_SIRF_NMEA)
+//#if !defined(GPS_SKIP_SIRF_NMEA)
 		// save a bit of code space on a 1280
 		else if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_SIRF) &&
                  AP_GPS_SIRF::_detect(dstate->sirf_detect_state, data)) {
@@ -286,10 +288,10 @@ AP_GPS::detect_instance(uint8_t instance)
 			if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_NMEA) &&
                 AP_GPS_NMEA::_detect(dstate->nmea_detect_state, data)) {
 				hal.console->print_P(PSTR(" NMEA "));
-				new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);
+				new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);                
 			}
 		}
-#endif
+//#endif
 	}
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -336,6 +336,38 @@ bool AP_GPS_NMEA::_term_complete()
 
     // the first term determines the sentence type
     if (_term_number == 0) {
+        /*
+          The first two letters of the NMEA term are the talker
+          ID. The most common is 'GP' but there are a bunch of others
+          that are valid. We accept any two characters here.
+         */
+        if (_term[0] < 'A' || _term[0] > 'Z' ||
+            _term[1] < 'A' || _term[1] > 'Z') {
+            _sentence_type = _GPS_SENTENCE_OTHER;
+            return false;
+        }
+        const char *term_type = &_term[2];
+        if (strcmp(term_type, "RMC") == 0) {
+            _sentence_type = _GPS_SENTENCE_GPRMC;
+            _last_GPRMC_ms = hal.scheduler->millis();
+        } else if (strcmp(term_type, "GGA") == 0) {
+            _sentence_type = _GPS_SENTENCE_GPGGA;
+            _last_GPGGA_ms = hal.scheduler->millis();
+        } else if (strcmp(term_type, "VTG") == 0) {
+            _sentence_type = _GPS_SENTENCE_GPVTG;
+            // VTG may not contain a data qualifier, presume the solution is good
+            // unless it tells us otherwise.
+            _last_GPVTG_ms = hal.scheduler->millis();
+            _gps_data_good = true;
+        } else {
+            _sentence_type = _GPS_SENTENCE_OTHER;
+        }
+        return false;
+    }
+
+    // the first term determines the sentence type
+    /*
+    if (_term_number == 0) {
         if (!strcmp_P(_term, _gprmc_string)) {
             _sentence_type = _GPS_SENTENCE_GPRMC;
             _last_GPRMC_ms = hal.scheduler->millis();
@@ -353,6 +385,7 @@ bool AP_GPS_NMEA::_term_complete()
         }
         return false;
     }
+    */
 
     // 32 = RMC, 64 = GGA, 96 = VTG
     if (_sentence_type != _GPS_SENTENCE_OTHER && _term[0]) {

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -365,28 +365,6 @@ bool AP_GPS_NMEA::_term_complete()
         return false;
     }
 
-    // the first term determines the sentence type
-    /*
-    if (_term_number == 0) {
-        if (!strcmp_P(_term, _gprmc_string)) {
-            _sentence_type = _GPS_SENTENCE_GPRMC;
-            _last_GPRMC_ms = hal.scheduler->millis();
-        } else if (!strcmp_P(_term, _gpgga_string)) {
-            _sentence_type = _GPS_SENTENCE_GPGGA;
-            _last_GPGGA_ms = hal.scheduler->millis();
-        } else if (!strcmp_P(_term, _gpvtg_string)) {
-            _sentence_type = _GPS_SENTENCE_GPVTG;
-            // VTG may not contain a data qualifier, presume the solution is good
-            // unless it tells us otherwise.
-            _last_GPVTG_ms = hal.scheduler->millis();
-            _gps_data_good = true;
-        } else {
-            _sentence_type = _GPS_SENTENCE_OTHER;
-        }
-        return false;
-    }
-    */
-
     // 32 = RMC, 64 = GGA, 96 = VTG
     if (_sentence_type != _GPS_SENTENCE_OTHER && _term[0]) {
         switch (_sentence_type + _term_number) {


### PR DESCRIPTION
Allow GPxxx, GNxxx, and GXxxx NMEA messages to be parsed by in Copter 3.3.3.
Code is copied from master branch.