### PR TITLE
AP_Math: use inline wrappers for constrain_* functions

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -111,9 +111,20 @@ float wrap_2PI(const T radian);
 template <class T>
 T constrain_value(const T amt, const T low, const T high);
 
-auto const constrain_float = &constrain_value<float>;
-auto const constrain_int16 = &constrain_value<int16_t>;
-auto const constrain_int32 = &constrain_value<int32_t>;
+inline float constrain_float(const float amt, const float low, const float high)
+{
+    return constrain_value(amt, low, high);
+}
+
+inline int16_t constrain_int16(const int16_t amt, const int16_t low, const int16_t high)
+{
+    return constrain_value(amt, low, high);
+}
+
+inline int32_t constrain_int32(const int32_t amt, const int32_t low, const int32_t high)
+{
+    return constrain_value(amt, low, high);
+}
 
 // degrees -> radians
 static inline float radians(float deg)


### PR DESCRIPTION
This avoids some warnings about "constrain_float defined but not used"
in some compilers.


I couldn't reproduce the warnings since it's likely related to compiler version. But here is the fix.

@rmackay9 @kwikius 