### PR TITLE
Fix compilation errors on gcc 6

### DIFF
--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -110,7 +110,7 @@ AP_GPS_ERB::read(void)
         case 5:
             _ck_b += (_ck_a += data);                   // checksum byte
             if (_payload_counter < sizeof(_buffer)) {
-                _buffer.bytes[_payload_counter] = data;
+                ((uint8_t *)&_buffer)[_payload_counter] = data;
             }
             if (++_payload_counter == _payload_length)
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -90,7 +90,6 @@ private:
         erb_stat stat;
         erb_dops dops;
         erb_vel vel;
-        uint8_t bytes[];
     } _buffer;
 
     enum erb_protocol_bytes {

--- a/libraries/AP_GPS/AP_GPS_MTK.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK.cpp
@@ -115,7 +115,7 @@ restart:
         // Receive message data
         //
         case 4:
-            _buffer.bytes[_payload_counter++] = data;
+            ((uint8_t *)&_buffer)[_payload_counter++] = data;
             _ck_b += (_ck_a += data);
             if (_payload_counter == sizeof(_buffer))
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_MTK.h
+++ b/libraries/AP_GPS/AP_GPS_MTK.h
@@ -72,7 +72,6 @@ private:
     // Receive buffer
     union PACKED {
         diyd_mtk_msg msg;
-        uint8_t bytes[];
     } _buffer;
 
     // Buffer parse & GPS state update

--- a/libraries/AP_GPS/AP_GPS_MTK19.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK19.cpp
@@ -105,7 +105,7 @@ restart:
         // Receive message data
         //
         case 3:
-            _buffer.bytes[_payload_counter++] = data;
+            ((uint8_t *)&_buffer)[_payload_counter++] = data;
             _ck_b += (_ck_a += data);
             if (_payload_counter == sizeof(_buffer)) {
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_MTK19.h
+++ b/libraries/AP_GPS/AP_GPS_MTK19.h
@@ -78,6 +78,5 @@ private:
     // Receive buffer
     union {
         diyd_mtk_msg msg;
-        uint8_t bytes[];
     } _buffer;
 };

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -138,7 +138,7 @@ AP_GPS_SIRF::read(void)
         case 5:
             if (_gather) {                                              // gather data if requested
                 _accumulate(data);
-                _buffer.bytes[_payload_counter] = data;
+                ((uint8_t *)&_buffer)[_payload_counter] = data;
                 if (++_payload_counter == _payload_length)
                     _step++;
             } else {

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -98,7 +98,6 @@ private:
     // Message buffer
     union {
         sirf_geonav nav;
-        uint8_t bytes[];
     } _buffer;
 
     bool        _parse_gps(void);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -431,7 +431,7 @@ AP_GPS_UBLOX::read(void)
         case 6:
             _ck_b += (_ck_a += data);                   // checksum byte
             if (_payload_counter < sizeof(_buffer)) {
-                _buffer.bytes[_payload_counter] = data;
+                ((uint8_t *)&_buffer)[_payload_counter] = data;
             }
             if (++_payload_counter == _payload_length)
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -384,7 +384,6 @@ private:
         ubx_rxm_rawx rxm_rawx;
 #endif
         ubx_ack_ack ack;
-        uint8_t bytes[];
     } _buffer;
 
     enum ubs_protocol_bytes {

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -36,6 +36,7 @@
 #ifndef I2C_SMBUS_BLOCK_MAX
 #include <linux/i2c.h>
 #endif
+#include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>

--- a/libraries/AP_HAL_SITL/sitl_barometer.cpp
+++ b/libraries/AP_HAL_SITL/sitl_barometer.cpp
@@ -76,7 +76,9 @@ void SITL_State::_update_barometer(float altitude)
 
     // find data corresponding to delayed time in buffer
     for (uint8_t i=0; i<=baro_buffer_length-1; i++) {
-        time_delta_baro = abs(delayed_time_baro - buffer_baro[i].time); // find difference between delayed time and time stamp in buffer
+        // find difference between delayed time and time stamp in buffer
+        time_delta_baro = abs(
+                (int32_t)(delayed_time_baro - buffer_baro[i].time));
         // if this difference is smaller than last delta, store this time
         if (time_delta_baro < best_time_delta_baro) {
             best_index_baro = i;

--- a/libraries/AP_HAL_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_SITL/sitl_compass.cpp
@@ -73,7 +73,8 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
     delayed_time_mag = now - _sitl->mag_delay; // get time corresponding to delay
     // find data corresponding to delayed time in buffer
     for (uint8_t i=0; i<=mag_buffer_length-1; i++) {
-        time_delta_mag = abs(delayed_time_mag - buffer_mag[i].time); // find difference between delayed time and time stamp in buffer
+        // find difference between delayed time and time stamp in buffer
+        time_delta_mag = abs((int32_t)(delayed_time_mag - buffer_mag[i].time));
         // if this difference is smaller than last delta, store this time
         if (time_delta_mag < best_time_delta_mag) {
             best_index_mag = i;

--- a/libraries/AP_HAL_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_SITL/sitl_ins.cpp
@@ -62,7 +62,9 @@ uint16_t SITL_State::_airspeed_sensor(float airspeed)
     delayed_time_wind = now - _sitl->wind_delay; // get time corresponding to delay
     // find data corresponding to delayed time in buffer
     for (uint8_t i=0; i<=wind_buffer_length-1; i++) {
-        time_delta_wind = abs(delayed_time_wind - buffer_wind[i].time); // find difference between delayed time and time stamp in buffer
+        // find difference between delayed time and time stamp in buffer
+        time_delta_wind = abs(
+                (int32_t)(delayed_time_wind - buffer_wind[i].time));
         // if this difference is smaller than last delta, store this time
         if (time_delta_wind < best_time_delta_wind) {
             best_index_wind = i;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -267,7 +267,7 @@ void AP_Mount_Alexmos::read_incoming()
             case 4: // parsing body
                 _checksum += data;
                 if (_payload_counter < sizeof(_buffer)) {
-                    _buffer.bytes[_payload_counter] = data;
+                    ((uint8_t *)&_buffer)[_payload_counter] = data;
                 }
                 if (++_payload_counter == _payload_length)
                     _step++;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -288,7 +288,6 @@ private:
         alexmos_angles angles;
         alexmos_params params;
         alexmos_angles_speed angle_speed;
-        uint8_t bytes[];
     } _buffer,_current_parameters;
 
     AP_HAL::UARTDriver *_port;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -236,7 +236,7 @@ void AP_Mount_SToRM32_serial::read_incoming() {
             continue;
         }
 
-        _buffer.bytes[_reply_counter++] = data;
+        ((uint8_t *)&_buffer)[_reply_counter++] = data;
         if (_reply_counter == _reply_length) {
             parse_reply();
 
@@ -266,7 +266,8 @@ void AP_Mount_SToRM32_serial::parse_reply() {
 
     switch (_reply_type) {
         case ReplyType_DATA:
-            crc = crc_calculate(_buffer.bytes, sizeof(_buffer.data)-3);
+            crc = crc_calculate(((uint8_t *)&_buffer),
+                                sizeof(_buffer.data) - 3);
             crc_ok = crc == _buffer.data.crc;
             if (!crc_ok) {
                 break;
@@ -277,7 +278,8 @@ void AP_Mount_SToRM32_serial::parse_reply() {
             _current_angle.z = _buffer.data.imu1_yaw;
             break;
         case ReplyType_ACK:
-            crc = crc_calculate(&_buffer.bytes[1], sizeof(SToRM32_reply_ack_struct)-3);
+            crc = crc_calculate(((uint8_t *)&_buffer) + 1,
+                                sizeof(SToRM32_reply_ack_struct) - 3);
             crc_ok = crc == _buffer.ack.crc;
             break;
         default:

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -145,7 +145,6 @@ private:
     union PACKED SToRM32_reply {
         SToRM32_reply_data_struct data;
         SToRM32_reply_ack_struct ack;
-        uint8_t bytes[];
     } _buffer;
 
     // keep the last _current_angle values


### PR DESCRIPTION
Hi all,

Arch Linux is already using gcc 6.1.1 and the build was failing when using that version.

This PR fixes the errors found when building boards that use native toolchain.

Useful information about porting to gcc 6 can be found here: https://gcc.gnu.org/gcc-6/porting_to.html.

Best regards,
Gustavo Sousa