### PR TITLE
Tracker: add Vbar dataflash message

### DIFF
--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -26,8 +26,32 @@ void Tracker::Log_Write_Baro(void)
     DataFlash.Log_Write_Baro(barometer);
 }
 
+struct PACKED log_Vehicle_Baro {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float    press;
+    float    alt_diff;
+};
+
+// Write a vehicle baro packet
+void Tracker::Log_Write_Vehicle_Baro(float pressure, float altitude)
+{
+
+    struct log_Vehicle_Baro pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_V_BAR_MSG),
+        time_us         : AP_HAL::micros64(),
+        press           : pressure,
+        alt_diff        : altitude
+
+    };
+    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
+
 const struct LogStructure Tracker::log_structure[] = {
     LOG_COMMON_STRUCTURES,
+    {LOG_V_BAR_MSG, sizeof(log_Vehicle_Baro),
+    	      "VBAR", "Qff", "TimeUS,Press,AltDiff" },
 };
 
 void Tracker::Log_Write_Vehicle_Startup_Messages()

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -255,6 +255,7 @@ private:
     void compass_cal_update();
     void Log_Write_Attitude();
     void Log_Write_Baro(void);
+    void Log_Write_Vehicle_Baro(float pressure, float altitude);
     void Log_Write_Vehicle_Startup_Messages();
     void start_logging();
     void log_init(void);

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -32,3 +32,6 @@ enum ServoType {
 #define MASK_LOG_RCOUT                  (1<<4)
 #define MASK_LOG_COMPASS                (1<<5)
 #define MASK_LOG_ANY                    0xFFFF
+
+//  Logging messages
+#define LOG_V_BAR_MSG                   0x04

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -150,6 +150,9 @@ void Tracker::tracking_update_pressure(const mavlink_scaled_pressure_t &msg)
         nav_status.altitude_difference = 0;
         nav_status.need_altitude_calibration = false;
     }
+
+    // log altitude difference
+    Log_Write_Vehicle_Baro(local_pressure, alt_diff);
 }
 
 /**


### PR DESCRIPTION
This adds logging of the vehicle barometer info which should help identify why some users' trackers are always pointing down.