### PR TITLE
waf: ardupilotwaf: ap_get_all_libraries: ignore non-directory files

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -71,7 +71,7 @@ IGNORED_AP_LIBRARIES = [
 @conf
 def ap_get_all_libraries(bld):
     libraries = []
-    for lib_node in bld.srcnode.ant_glob('libraries/*', dir=True):
+    for lib_node in bld.srcnode.ant_glob('libraries/*', dir=True, src=False):
         name = lib_node.name
         if name in IGNORED_AP_LIBRARIES:
             continue


### PR DESCRIPTION
Hi guys,

Each library in ardupilot is a folder with the source in. That avoids build
failures when there are files in libraries/. That fixes #4099 ("waf doesn't
seem to like TAGS files") and #4093 ("sim_vehicle.py /w waf /w eclipse project
broken on Cygwin").

That problem can be reproduced by just creating a file in libraries/ and trying
to build with waf.

There should be a better way to confirm a path is an ardupilot library. That
can be done later.

Best regards,
Gustavo Sousa