### PR TITLE
AP_Airspeed: Airspeed sensor failure detection and mitigation

### DIFF
--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -123,7 +123,13 @@ void Plane::read_airspeed(void)
                 const float error_threshold = target_airspeed_cm * 0.002f; // cmd to m conversion * 20% error.
                 airspeed_data_validity = fabsf(airspeed_error) < error_threshold;
             }
-            airspeed.self_check(airspeed_data_validity);
+
+            bool is_failure_detected = airspeed.self_check(airspeed_data_validity);
+            if (is_failure_detected &&
+                (airspeed.get_fail_action_mask() & AP_Airspeed::FAILURE_ACTION_RTL)) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Airspeed failure: setting mode to RTL");
+                set_mode(RTL);
+            }
         }
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -284,11 +284,11 @@ bool AP_Airspeed::self_check(bool airspeed_data_validity)
                 now - _self_check.hysteresis_timer_ms > 3000) { // require a few seconds of bad airspeed
 
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Airspeed sensor data invalid");
-            if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_DISABLE) {
+            if (_fail_action_mask & FAILURE_ACTION_BIT_DISABLE) {
                 // turn off airspeed sensor
                 _use = 0;
                 _self_check.hysteresis_timer_ms = now;
-                if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE) {
+                if (_fail_action_mask & FAILURE_ACTION_BIT_SAVE) {
                     // save param in non-volatile memory
                     _use.save(true);
                 }
@@ -299,16 +299,16 @@ bool AP_Airspeed::self_check(bool airspeed_data_validity)
             return true;
         }
     }
-#ifdef AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE // NOT SUPPORTED YET
+#ifdef FAILURE_ACTION_BIT_ALLOW_REENABLE // NOT SUPPORTED YET
     else if (_self_check.hysteresis_timer_ms > 0 && // if we've ever used it in the past
-            (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE) ) { // willing to turn it back on
+            (_fail_action_mask & FAILURE_ACTION_BIT_ALLOW_REENABLE) ) { // willing to turn it back on
 
         if (!_self_check.trustable) {
             _self_check.hysteresis_timer_ms = now;
         }  else if (now - _self_check.hysteresis_timer_ms > 20000) { // a few seconds of good airspeed
             _self_check.hysteresis_timer_ms = now;
             _use = 1;
-            if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE) {
+            if (_fail_action_mask & FAILURE_ACTION_BIT_SAVE) {
                 // save param in non-volatile memory
                 _use.save(true);
             }

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -22,6 +22,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -118,6 +119,13 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO("SKIP_CAL",  7, AP_Airspeed, _skip_cal, 0),
+
+    // @Param: FAIL_ACTN
+    // @DisplayName: Behavior for when a hardware failure is detected on a pitot tube
+    // @Description: When a pitot tube is determined to be generating untrustworthy data, various actions can occur which are set by a bitmask. 0 = do nothing, bit 1 allows auto-disable and reverts to using internal estimate by setting ARSPD_USE=0, bit 2 allows auto-reenable when airspeed sensor is determined to be trustworthy again (NOT SUPPORTED YET), bit 4 if ARSPD_USE value changes then save to non-volatile memory
+    // @Bitmask: 0:None,1:AutoTurnOffUse,2:AllowResumeUse,4:Save
+    // @User: Advanced
+    AP_GROUPINFO("FAIL_ACTN",  8, AP_Airspeed, _fail_action_mask, AP_AIRSPEED_FAILURE_ACTION_BIT_DEFAULT),
 
     AP_GROUPEND
 };
@@ -255,3 +263,61 @@ void AP_Airspeed::setHIL(float airspeed, float diff_pressure, float temperature)
     _hil_set = true;
     _healthy = true;
 }
+
+// check airspeed airspeed error and apply ARSPD_FAIL_ACTN behavior
+// return true if failure was just detected or if ARSPD_USE state changes
+bool AP_Airspeed::self_check(bool airspeed_data_validity)
+{
+    uint32_t now = AP_HAL::millis();
+    _self_check.trustable = airspeed_data_validity;
+
+    if (!_enable) {
+        _self_check.hysteresis_timer_ms = 0;
+        return false;
+    } else if (_use) {
+
+        if (_self_check.trustable) {
+            // Apply hysteresis to trust decision
+            _self_check.hysteresis_timer_ms = now;
+
+        } else if (_self_check.hysteresis_timer_ms > 0 &&
+                now - _self_check.hysteresis_timer_ms > 3000) { // require a few seconds of bad airspeed
+
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Airspeed sensor data invalid");
+            if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_DISABLE) {
+                // turn off airspeed sensor
+                _use = 0;
+                _self_check.hysteresis_timer_ms = now;
+                if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE) {
+                    // save param in non-volatile memory
+                    _use.save(true);
+                }
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Airspeed sensor disabled (ARSPD_USE=0)");
+            } else {
+                _self_check.hysteresis_timer_ms = 0;
+            }
+            return true;
+        }
+    }
+#ifdef AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE // NOT SUPPORTED YET
+    else if (_self_check.hysteresis_timer_ms > 0 && // if we've ever used it in the past
+            (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE) ) { // willing to turn it back on
+
+        if (!_self_check.trustable) {
+            _self_check.hysteresis_timer_ms = now;
+        }  else if (now - _self_check.hysteresis_timer_ms > 20000) { // a few seconds of good airspeed
+            _self_check.hysteresis_timer_ms = now;
+            _use = 1;
+            if (_fail_action_mask & AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE) {
+                // save param in non-volatile memory
+                _use.save(true);
+            }
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Airspeed sensor data valid again (ARSPD_USE=1)");
+            return true;
+        }
+    }
+#endif
+
+    return false;
+}
+

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -35,6 +35,12 @@ private:
     const AP_Vehicle::FixedWing &aparm;
 };
 
+#define AP_AIRSPEED_FAILURE_ACTION_BIT_DISABLE               0x01
+//#define AP_AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE      0x02 // NOT SUPPORTED YET
+#define AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE                  0x04
+
+#define AP_AIRSPEED_FAILURE_ACTION_BIT_DEFAULT               0
+
 class AP_Airspeed
 {
 public:
@@ -152,6 +158,14 @@ public:
                             PITOT_TUBE_ORDER_NEGATIVE = 1,
                             PITOT_TUBE_ORDER_AUTO     = 2 };
 
+    // apply fail actions on hardware failure detection. Return true if failure was just detected or _use state changes
+    bool self_check(bool airspeed_data_validity);
+
+    struct {
+        uint32_t    hysteresis_timer_ms;
+        bool        trustable;
+    } _self_check;
+
 private:
     AP_Float        _offset;
     AP_Float        _ratio;
@@ -161,6 +175,7 @@ private:
     AP_Int8         _autocal;
     AP_Int8         _tube_order;
     AP_Int8         _skip_cal;
+    AP_Int8         _fail_action_mask;
     float           _raw_airspeed;
     float           _airspeed;
     float			_last_pressure;

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -35,11 +35,7 @@ private:
     const AP_Vehicle::FixedWing &aparm;
 };
 
-#define AP_AIRSPEED_FAILURE_ACTION_BIT_DISABLE               0x01
-//#define AP_AIRSPEED_FAILURE_ACTION_BIT_ALLOW_REENABLE      0x02 // NOT SUPPORTED YET
-#define AP_AIRSPEED_FAILURE_ACTION_BIT_SAVE                  0x04
-
-#define AP_AIRSPEED_FAILURE_ACTION_BIT_DEFAULT               0
+#define AP_AIRSPEED_FAILURE_ACTION_BIT_DEFAULT               (AP_Airspeed::FAILURE_ACTION_NONE)
 
 class AP_Airspeed
 {
@@ -165,6 +161,16 @@ public:
         uint32_t    hysteresis_timer_ms;
         bool        trustable;
     } _self_check;
+
+    int8_t get_fail_action_mask() { return _fail_action_mask; }
+
+    enum failure_action {
+        FAILURE_ACTION_NONE                  = 0,
+        FAILURE_ACTION_BIT_DISABLE           = 0x01,
+        //FAILURE_ACTION_BIT_ALLOW_REENABLE  = 0x02, // NOT SUPPORTED YET
+        FAILURE_ACTION_BIT_SAVE              = 0x04,
+        FAILURE_ACTION_RTL                   = 0x08,
+    };
 
 private:
     AP_Float        _offset;


### PR DESCRIPTION
I've added some sanity checking to the airspeed and it can now disable itself automatically. A boolean check is made to determine if the airspeed sensor is trustworthy. If EKF1 or EKF2 is used then it looks at the:
airspeed innovation <1 otherwise it reverts to:
abs(target_airspeed - measured_airspeed) < (20% of ARSPD_TRIM)

When in AUTO mode, the new airspeed sanity checking is bypassed during TAKEOFF, PreFlare, Flare, and VTOL stages. In addition, the aircraft must be flying for at least 10 seconds. If failing this test for 3 continuous seconds then the ARSPD_FAIL_ACTN will kick in.

new param: ARSPD_FAIL_ACTN:
// @Description: When a pitot tube is determined to be generating untrustworthy data, various actions can occur which are set by a bitmask. 0 = do nothing, bit 1 allows auto-disable and reverts to using internal estimate by setting ARSPD_USE=0, bit 2 allows auto-reenable when airspeed sensor is determined to be trustworthy again (NOT SUPPORTED YET), bit 4 if ARSPD_USE value changes then save to non-volatile memory
// @Bitmask: 0:None,1:AutoTurnOffUse,2:AllowResumeUse,4:Save