### PR TITLE
Plane: reset baro drift when setting home while disarmed

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -472,6 +472,9 @@ void Plane::update_GPS_10Hz(void)
 
         if (!hal.util->get_soft_armed()) {
             update_home();
+
+            // zero out any baro drift
+            barometer.set_baro_drift_altitude(0);
         }
 
         // update wind estimate


### PR DESCRIPTION
When plane is disarmed it continually resets its home location, effectively resetting it's home.alt too. However, if you had a value in GND_ALT_OFFSET (baro drift) then it would persist onto another flight if you re-armed and launched again. Now when resetting home.alt it will also be resetting the baro drift to 0m.