### PR TITLE
This allows for measurement of low RPM values on PX4

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -38,13 +38,13 @@ const AP_Param::GroupInfo AP_RPM::var_info[] = {
     // @DisplayName: Maximum RPM
     // @Description: Maximum RPM to report
     // @Increment: 1
-    AP_GROUPINFO("_MAX", 2, AP_RPM, _maximum[0], 0),
+    AP_GROUPINFO("_MAX", 2, AP_RPM, _maximum[0], 100000),
 
     // @Param: _MIN
     // @DisplayName: Minimum RPM
     // @Description: Minimum RPM to report
     // @Increment: 1
-    AP_GROUPINFO("_MIN", 3, AP_RPM, _minimum[0], 0),
+    AP_GROUPINFO("_MIN", 3, AP_RPM, _minimum[0], 10),
 
     // @Param: _MIN_QUAL
     // @DisplayName: Minimum Quality

--- a/libraries/AP_RPM/RPM_PX4_PWM.cpp
+++ b/libraries/AP_RPM/RPM_PX4_PWM.cpp
@@ -56,6 +56,9 @@ AP_RPM_PX4_PWM::AP_RPM_PX4_PWM(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_St
         return;
     }
 
+    _resolution_usec = PWMIN_MINRPM_TO_RESOLUTION(((uint32_t)(ap_rpm._minimum[state.instance]+0.5f)));
+    ioctl(_fd, PWMINIOSRESOLUTION, _resolution_usec);
+    
 #if PWM_LOGGING
     _logfd = open("/fs/microsd/pwm.log", O_WRONLY|O_CREAT|O_TRUNC, 0644);
 #endif
@@ -78,6 +81,12 @@ void AP_RPM_PX4_PWM::update(void)
         return;
     }
 
+    uint32_t newres = PWMIN_MINRPM_TO_RESOLUTION(((uint32_t)(ap_rpm._minimum[state.instance]+0.5f)));
+    if (newres != _resolution_usec) {
+        ioctl(_fd, PWMINIOSRESOLUTION, newres);
+        _resolution_usec = newres;
+    }
+    
     struct pwm_input_s pwm;
     uint16_t count = 0;
     const float scaling = ap_rpm._scaling[state.instance];

--- a/libraries/AP_RPM/RPM_PX4_PWM.h
+++ b/libraries/AP_RPM/RPM_PX4_PWM.h
@@ -36,6 +36,7 @@ private:
     int _fd = -1;
     int _logfd = -1;
     uint64_t _last_timestamp = 0;
+    uint32_t _resolution_usec = 1;
 
     ModeFilterFloat_Size5 signal_quality_filter {3};
 };


### PR DESCRIPTION
by setting the timer resolution from the min and max RPM values we can go down to very low RPM values
