### PR TITLE
AP_HAL_SITL: ensure specified SITL model is found

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -243,6 +243,10 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             break;
         }
     }
+    if (sitl_model == nullptr) {
+        printf("Vehicle model (%s) not found\n", model_str);
+        exit(1);
+    }
 
     fprintf(stdout, "Starting sketch '%s'\n", SKETCH);
 


### PR DESCRIPTION
Without this check we get a null pointer exception the first time we attempt
to use the model object