### PR TITLE
Fix compilation errors with gcc 6 (v2)

### DIFF
--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -90,7 +90,7 @@ private:
         erb_stat stat;
         erb_dops dops;
         erb_vel vel;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 
     enum erb_protocol_bytes {

--- a/libraries/AP_GPS/AP_GPS_MTK.h
+++ b/libraries/AP_GPS/AP_GPS_MTK.h
@@ -72,7 +72,7 @@ private:
     // Receive buffer
     union PACKED {
         diyd_mtk_msg msg;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 
     // Buffer parse & GPS state update

--- a/libraries/AP_GPS/AP_GPS_MTK19.h
+++ b/libraries/AP_GPS/AP_GPS_MTK19.h
@@ -78,6 +78,6 @@ private:
     // Receive buffer
     union {
         diyd_mtk_msg msg;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 };

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -98,7 +98,7 @@ private:
     // Message buffer
     union {
         sirf_geonav nav;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 
     bool        _parse_gps(void);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -384,7 +384,7 @@ private:
         ubx_rxm_rawx rxm_rawx;
 #endif
         ubx_ack_ack ack;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 
     enum ubs_protocol_bytes {

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -288,7 +288,7 @@ private:
         alexmos_angles angles;
         alexmos_params params;
         alexmos_angles_speed angle_speed;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer,_current_parameters;
 
     AP_HAL::UARTDriver *_port;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -145,7 +145,7 @@ private:
     union PACKED SToRM32_reply {
         SToRM32_reply_data_struct data;
         SToRM32_reply_ack_struct ack;
-        uint8_t bytes[];
+        uint8_t bytes[1];
     } _buffer;
 
     // keep the last _current_angle values


### PR DESCRIPTION
Alternative fixes to #4098 

@guludo please take a look. I didn't need the other patches to build with gcc 6.1.1 in archlinux.