### PR TITLE
Fix argument 'valgrind' issue about fly.CopterAVC test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1258,7 +1258,7 @@ def fly_ArduCopter(viewerip=None, map=False, valgrind=False):
     return True
 
 
-def fly_CopterAVC(viewerip=None, map=False):
+def fly_CopterAVC(viewerip=None, map=False, valgrind=False):
     '''fly ArduCopter in SIL for AVC2013 mission
     '''
     global homeloc
@@ -1279,7 +1279,7 @@ def fly_CopterAVC(viewerip=None, map=False):
     util.pexpect_close(mavproxy)
     util.pexpect_close(sil)
 
-    sil = util.start_SIL('ArduCopter', model='heli', home=home, speedup=speedup_default)
+    sil = util.start_SIL('ArduCopter', model='heli', home=home, speedup=speedup_default, valgrind=valgrind)
     options = '--sitl=127.0.0.1:5501 --out=127.0.0.1:19550 --streamrate=5'
     if viewerip:
         options += ' --out=%s:14550' % viewerip


### PR DESCRIPTION
Commit 8774f15 causes fly.CopterAVC test failure.
Here is the failure info below:
>>>> FAILED STEP: fly.CopterAVC at Tue May 17 13:21:56 2016 (fly_CopterAVC() got an unexpected keyword argument 'valgrind')
Traceback (most recent call last):
  File "./Tools/autotest/autotest.py", line 406, in run_tests
    if not run_step(step):
  File "./Tools/autotest/autotest.py", line 232, in run_step
    return arducopter.fly_CopterAVC(viewerip=opts.viewerip, map=opts.map, valgrind=opts.valgrind)
TypeError: fly_CopterAVC() got an unexpected keyword argument 'valgrind'
('check step: ', 'fly.CopterAVC')
FAILED 1 tests: ['fly.CopterAVC']