### PR TITLE
Mag[i]cal graph

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -496,9 +496,9 @@ def progress_cmd(what, cmd):
     shell_text = "%s" % (" ".join([ '"%s"' % x for x in cmd ]))
     progress(shell_text)
 
-def run_cmd_blocking(what, cmd):
+def run_cmd_blocking(what, cmd, **kw):
     progress_cmd(what, cmd)
-    p = subprocess.Popen(cmd)
+    p = subprocess.Popen(cmd, **kw)
     return os.waitpid(p.pid,0)
 
 def run_in_terminal_window(autotest, name, cmd):

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -8,6 +8,7 @@ import optparse
 import sys
 import atexit
 import os
+import os.path
 import subprocess
 import tempfile
 import getpass
@@ -618,7 +619,12 @@ def start_mavproxy(opts, stuff):
     if len(extra_cmd):
         cmd.extend(['--cmd', extra_cmd])
 
-    run_cmd_blocking("Run MavProxy", cmd)
+    local_mp_modules_dir = os.path.abspath(
+            os.path.join(__file__, '..', '..', 'mavproxy_modules'))
+    env = dict(os.environ)
+    env['PYTHONPATH'] = local_mp_modules_dir + os.pathsep + env.get('PYTHONPATH', '')
+
+    run_cmd_blocking("Run MavProxy", cmd, env=env)
     progress("MAVProxy exitted")
 
 frame_options = options_for_frame(opts.frame, opts.vehicle, opts)

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -272,6 +272,9 @@ default_params_filename: filename of default parameters file.  Taken to be relat
 extra_mavlink_cmds: extra parameters that will be passed to mavproxy
 '''
 _options_for_frame = {
+    "calibration": {
+        "extra_mavlink_cmds": "module load sitl_calibration;",
+    },
     "+": {
         "waf_target": "bin/arducopter-quad",
         "default_params_filename": "copter_params.parm"

--- a/Tools/mavproxy_modules/README.md
+++ b/Tools/mavproxy_modules/README.md
@@ -35,3 +35,17 @@ There are other commands you can use with this module:
  - `sitl_attitude`: set vehicle at a desired attitude
  - `sitl_angvel`: apply angular velocity on the vehicle
  - `sitl_stop`: stop any of this module's currently active command
+
+## `magcal_graph` ##
+This module shows the geodesic sections hit by the samples collected during
+compass calibration, and also some status data. The objective of this module is
+to provide a reference on how to interpret the field `completion_mask` from the
+`MAG_CAL_PROGRESS` mavlink message. That information can be used in order to
+guide the vehicle user during calibration.
+
+The plot shown by this module isn't very helpful to the end user, but it might
+help developers during development of internal calibration support in ground
+control stations.
+
+The only command provided by this module is `magcal_graph`, which will open the
+graphical user interface.

--- a/Tools/mavproxy_modules/README.md
+++ b/Tools/mavproxy_modules/README.md
@@ -10,6 +10,10 @@ This module interfaces with the `calibration` model of SITL. It provides
 commands to actuate on the vehicle's rotation to simulate a calibration
 process.
 
+Make sure to pass `--model calibration` to the SITL binary in order to be able
+use this module's commands. You can also use
+`[sim_vehicle.py](../autotest/sim_vehicle.py)` with `--frame calibration`.
+
 ### Accelerometer Calibration ###
 The command `sitl_accelcal` listens to the accelerometer calibration status
 texts and set the vehicle in the desired attitude. Example:

--- a/Tools/mavproxy_modules/lib/geodesic_grid.py
+++ b/Tools/mavproxy_modules/lib/geodesic_grid.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+'''
+This module takes libraries/AP_Math/AP_GeodesicGrid.h reference for defining
+the geodesic sections.
+'''
+import math
+from scipy.constants import golden as g
+
+_first_half = (
+    ((-g, 1, 0), (-1, 0,-g), (-g,-1, 0)),
+    ((-1, 0,-g), (-g,-1, 0), ( 0,-g,-1)),
+    ((-g,-1, 0), ( 0,-g,-1), ( 0,-g, 1)),
+    ((-1, 0,-g), ( 0,-g,-1), ( 1, 0,-g)),
+    (( 0,-g,-1), ( 0,-g, 1), ( g,-1, 0)),
+    (( 0,-g,-1), ( 1, 0,-g), ( g,-1, 0)),
+    (( g,-1, 0), ( 1, 0,-g), ( g, 1, 0)),
+    (( 1, 0,-g), ( g, 1, 0), ( 0, g,-1)),
+    (( 1, 0,-g), ( 0, g,-1), (-1, 0,-g)),
+    (( 0, g,-1), (-g, 1, 0), (-1, 0,-g)),
+)
+_second_half = tuple(
+    ((-xa, -ya, -za), (-xb, -yb, -zb), (-xc, -yc, -zc))
+    for (xa, ya, za), (xb, yb, zb), (xc, yc, zc) in _first_half
+)
+
+triangles = _first_half + _second_half
+
+def _midpoint_projection(a, b):
+    xa, ya, za = a
+    xb, yb, zb = b
+    s = _midpoint_projection.scale
+    return s * (xa + xb), s * (ya + yb), s * (za + zb)
+
+radius = math.sqrt(1 + g**2)
+
+# radius / (length of two vertices of an icosahedron triangle)
+_midpoint_projection.scale = radius / (2 * g)
+
+sections_triangles = ()
+
+for a, b, c in triangles:
+    ma = _midpoint_projection(a, b)
+    mb = _midpoint_projection(b, c)
+    mc = _midpoint_projection(c, a)
+
+    sections_triangles += (
+        (ma, mb, mc),
+        ( a, ma, mc),
+        (ma,  b, mb),
+        (mc, mb,  c),
+    )

--- a/Tools/mavproxy_modules/lib/magcal_graph_ui.py
+++ b/Tools/mavproxy_modules/lib/magcal_graph_ui.py
@@ -1,0 +1,246 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_wxagg import FigureCanvas
+from mpl_toolkits.mplot3d import Axes3D
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+from pymavlink.mavutil import mavlink
+
+from MAVProxy.modules.lib import wx_processguard
+from MAVProxy.modules.lib.wx_loader import wx
+
+import geodesic_grid as grid
+
+class MagcalPanel(wx.Panel):
+    _status_markup_strings = {
+        mavlink.MAG_CAL_NOT_STARTED: 'Not started',
+        mavlink.MAG_CAL_WAITING_TO_START: 'Waiting to start',
+        mavlink.MAG_CAL_RUNNING_STEP_ONE: 'Step one',
+        mavlink.MAG_CAL_RUNNING_STEP_TWO: 'Step two',
+        mavlink.MAG_CAL_SUCCESS: '<span color="blue">Success</span>',
+        mavlink.MAG_CAL_FAILED: '<span  color="red">Failed</span>',
+    }
+
+    _empty_color = '#7ea6ce'
+    _filled_color = '#4680b9'
+
+    def __init__(self, *k, **kw):
+        super(MagcalPanel, self).__init__(*k, **kw)
+
+        facecolor = self.GetBackgroundColour().GetAsString(wx.C2S_HTML_SYNTAX)
+        fig = plt.figure(facecolor=facecolor, figsize=(1,1))
+
+        self._canvas = FigureCanvas(self, wx.ID_ANY, fig)
+        self._canvas.SetMinSize((300,300))
+
+        self._id_text = wx.StaticText(self, wx.ID_ANY)
+        self._status_text = wx.StaticText(self, wx.ID_ANY)
+        self._completion_pct_text = wx.StaticText(self, wx.ID_ANY)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self._id_text)
+        sizer.Add(self._status_text)
+        sizer.Add(self._completion_pct_text)
+        sizer.Add(self._canvas, proportion=1, flag=wx.EXPAND)
+        self.SetSizer(sizer)
+
+        ax = fig.add_subplot(111, axis_bgcolor=facecolor, projection='3d')
+        self.configure_plot(ax)
+
+    def configure_plot(self, ax):
+        extra = .5
+        lim = grid.radius + extra
+        ax.set_xlim3d(-lim, lim)
+        ax.set_ylim3d(-lim, lim)
+        ax.set_zlim3d(-lim, lim)
+
+        ax.set_xlabel('x')
+        ax.set_ylabel('y')
+        ax.set_zlabel('z')
+
+        ax.invert_zaxis()
+        ax.invert_xaxis()
+
+        ax.set_aspect('equal')
+
+        self._polygons_collection = Poly3DCollection(
+            grid.sections_triangles,
+            edgecolors='#386694',
+        )
+        ax.add_collection3d(self._polygons_collection)
+
+    def update_status_from_mavlink(self, m):
+        status_string = self._status_markup_strings.get(m.cal_status, '???')
+        self._status_text.SetLabelMarkup(
+            '<b>Status:</b> %s' % status_string,
+        )
+
+    def mavlink_magcal_report(self, m):
+        self.update_status_from_mavlink(m)
+        self._completion_pct_text.SetLabel('')
+
+    def mavlink_magcal_progress(self, m):
+        facecolors = []
+        for i, mask in enumerate(m.completion_mask):
+            for j in range(8):
+                section = i * 8 + j
+                if mask & 1 << j:
+                    facecolor = self._filled_color
+                else:
+                    facecolor = self._empty_color
+                facecolors.append(facecolor)
+        self._polygons_collection.set_facecolors(facecolors)
+        self._canvas.draw()
+
+        self._id_text.SetLabelMarkup(
+            '<b>Compass id:</b> %d' % m.compass_id
+        )
+
+        self._completion_pct_text.SetLabelMarkup(
+            '<b>Completion:</b> %d%%' % m.completion_pct
+        )
+
+        self.update_status_from_mavlink(m)
+
+    _legend_panel = None
+    @staticmethod
+    def legend_panel(*k, **kw):
+        if MagcalPanel._legend_panel:
+            return MagcalPanel._legend_panel
+
+        p = MagcalPanel._legend_panel = wx.Panel(*k, **kw)
+        sizer = wx.BoxSizer(wx.HORIZONTAL)
+        p.SetSizer(sizer)
+
+        marker = wx.Panel(p, wx.ID_ANY, size=(10, 10))
+        marker.SetBackgroundColour(MagcalPanel._empty_color)
+        sizer.Add(marker, flag=wx.ALIGN_CENTER)
+        text = wx.StaticText(p, wx.ID_ANY)
+        text.SetLabel('Sections not hit')
+        sizer.Add(text, border=4, flag=wx.ALIGN_CENTER | wx.LEFT)
+
+        marker = wx.Panel(p, wx.ID_ANY, size=(10, 10))
+        marker.SetBackgroundColour(MagcalPanel._filled_color)
+        sizer.Add(marker, border=10, flag=wx.ALIGN_CENTER | wx.LEFT)
+        text = wx.StaticText(p, wx.ID_ANY)
+        text.SetLabel('Sections hit')
+        sizer.Add(text, border=4, flag=wx.ALIGN_CENTER | wx.LEFT)
+        return p
+
+class MagcalFrame(wx.Frame):
+    def __init__(self, conn):
+        super(MagcalFrame, self).__init__(
+            None,
+            wx.ID_ANY,
+            title='Magcal Graph',
+        )
+
+        self.SetMinSize((300, 300))
+
+        self._conn = conn
+
+        self._main_panel = wx.ScrolledWindow(self, wx.ID_ANY)
+        self._main_panel.SetScrollbars(1, 1, 1, 1)
+
+        self._magcal_panels = {}
+
+        self._sizer = wx.BoxSizer(wx.VERTICAL)
+        self._main_panel.SetSizer(self._sizer)
+
+        idle_text = wx.StaticText(self._main_panel, wx.ID_ANY)
+        idle_text.SetLabelMarkup('<i>No calibration messages received yet...</i>')
+        idle_text.SetForegroundColour('#444444')
+
+        self._sizer.AddStretchSpacer()
+        self._sizer.Add(
+            idle_text,
+            proportion=0,
+            flag=wx.ALIGN_CENTER | wx.ALL,
+            border=10,
+        )
+        self._sizer.AddStretchSpacer()
+
+        self._timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.timer_callback, self._timer)
+        self._timer.Start(200)
+
+    def add_compass(self, id):
+        if not self._magcal_panels:
+            self._sizer.Clear(deleteWindows=True)
+            self._magcal_panels_sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+            self._sizer.Add(
+                self._magcal_panels_sizer,
+                proportion=1,
+                flag=wx.EXPAND,
+            )
+
+            legend = MagcalPanel.legend_panel(self._main_panel, wx.ID_ANY)
+            self._sizer.Add(
+                legend,
+                proportion=0,
+                flag=wx.ALIGN_CENTER,
+            )
+
+        self._magcal_panels[id] = MagcalPanel(self._main_panel, wx.ID_ANY)
+        self._magcal_panels_sizer.Add(
+            self._magcal_panels[id],
+            proportion=1,
+            border=10,
+            flag=wx.EXPAND | wx.ALL,
+        )
+
+    def timer_callback(self, evt):
+        close_requested = False
+        mavlink_msgs = {}
+        while self._conn.poll():
+            m = self._conn.recv()
+            if isinstance(m, str) and m == 'close':
+                close_requested = True
+                continue
+            if m.compass_id not in mavlink_msgs:
+                # Keep the last two messages so that we get the last progress
+                # if the last message is the calibration report.
+                mavlink_msgs[m.compass_id] = [None, m]
+            else:
+                l = mavlink_msgs[m.compass_id]
+                l[0] = l[1]
+                l[1] = m
+
+        if close_requested:
+            self._timer.Stop()
+            self.Destroy()
+            return
+
+        if not mavlink_msgs:
+            return
+
+        needs_fit = False
+        for k in mavlink_msgs:
+            if k not in self._magcal_panels:
+                self.add_compass(k)
+                needs_fit = True
+        if needs_fit:
+            self._sizer.Fit(self)
+
+        for k, l in mavlink_msgs.items():
+            for m in l:
+                if not m:
+                    continue
+                panel = self._magcal_panels[k]
+                if m.get_type() == 'MAG_CAL_PROGRESS':
+                    panel.mavlink_magcal_progress(m)
+                elif m.get_type() == 'MAG_CAL_REPORT':
+                    panel.mavlink_magcal_report(m)

--- a/Tools/mavproxy_modules/magcal_graph.py
+++ b/Tools/mavproxy_modules/magcal_graph.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+'''
+This module shows the geodesic sections hit by the samples collected during
+compass calibration, and also some status data. The objective of this module is
+to provide a reference on how to interpret the field `completion_mask` from the
+MAG_CAL_PROGRESS mavlink message. That information can be used in order to
+guide the vehicle user during calibration.
+
+The plot shown by this module isn't very helpful to the end user, but it might
+help developers during development of internal calibration support in ground
+control stations.
+'''
+from MAVProxy.modules.lib import mp_module, mp_util
+import multiprocessing
+
+class MagcalGraph():
+    def __init__(self):
+        self.parent_pipe, self.child_pipe = multiprocessing.Pipe()
+        self.ui_process = None
+        self._last_mavlink_msgs = {}
+
+    def start(self):
+        if self.is_active():
+            return
+        if self.ui_process:
+            self.ui_process.join()
+
+        for l in self._last_mavlink_msgs.values():
+            for m in l:
+                if not m:
+                    continue
+                self.parent_pipe.send(m)
+
+        self.ui_process = multiprocessing.Process(target=self.ui_task)
+        self.ui_process.start()
+
+    def stop(self):
+        if not self.is_active():
+            return
+
+        self.parent_pipe.send('close')
+        self.ui_process.join()
+
+    def ui_task(self):
+        mp_util.child_close_fds()
+
+        from MAVProxy.modules.lib import wx_processguard
+        from MAVProxy.modules.lib.wx_loader import wx
+        from lib.magcal_graph_ui import MagcalFrame
+
+        app = wx.App(False)
+        app.frame = MagcalFrame(self.child_pipe)
+        app.frame.Show()
+        app.MainLoop()
+
+    def is_active(self):
+        return self.ui_process is not None and self.ui_process.is_alive()
+
+    def mavlink_packet(self, m):
+        if m.compass_id not in self._last_mavlink_msgs:
+            # Keep the two last messages so that, if one is the calibration
+            # report message, the previous one is the last progress message.
+            self._last_mavlink_msgs[m.compass_id] = [None, m]
+        else:
+            l = self._last_mavlink_msgs[m.compass_id]
+            l[0] = l[1]
+            l[1] = m
+
+        if not self.is_active():
+            return
+        self.parent_pipe.send(m)
+
+class MagcalGraphModule(mp_module.MPModule):
+    def __init__(self, mpstate):
+        super(MagcalGraphModule, self).__init__(mpstate, 'magcal_graph')
+        self.add_command(
+            'magcal_graph',
+            self.cmd_magcal_graph,
+            'open a window to report magcal progress and plot geodesic ' +
+            'sections hit by the collected data in real time',
+        )
+
+        self.graph = MagcalGraph()
+
+    def cmd_magcal_graph(self, args):
+        self.graph.start()
+
+    def mavlink_packet(self, m):
+        if m.get_type() not in ('MAG_CAL_PROGRESS', 'MAG_CAL_REPORT'):
+            return
+        self.graph.mavlink_packet(m)
+
+    def unload(self):
+        self.graph.stop()
+
+def init(mpstate):
+    return MagcalGraphModule(mpstate)

--- a/libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py
+++ b/libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py
@@ -20,6 +20,7 @@ import numpy as np
 import sys
 
 import icosahedron as ico
+import grid
 
 def print_code_gen_notice():
     print("/* This was generated with")
@@ -59,7 +60,7 @@ Plot results when applicable.
 )
 
 parser.add_argument(
-    '-s', '--plot-subtriangles',
+    '-b', '--plot-subtriangles',
     action='store_true',
     help="""
 Plot subtriangles as well. This implies -p.
@@ -80,6 +81,17 @@ parser.add_argument(
     metavar='INDEX',
     help="""
 Get the icosahedron triangle at INDEX.
+""",
+)
+
+parser.add_argument(
+    '-s', '--section',
+    action='append',
+    type=int,
+    nargs='+',
+    help="""
+Get the grid section SECTION. If --plot is passed, then --plot-subtriangles is
+implied.
 """,
 )
 
@@ -151,6 +163,23 @@ if args.triangle:
         print(ico.triangles[i])
         if args.plot:
             plot.polygon(ico.triangles[i])
+
+if args.section:
+    sections = []
+    for l in args.section:
+        sections += l
+
+    for s in sections:
+        if 0 > s or s >= 4 * len(ico.triangles):
+            print(
+                'Section must be in the range [0,%d)' % 4 * len(ico.triangles),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(grid.section_triangle(s))
+    if args.plot:
+        args.plot_subtriangles = True
+        plot.sections(sections)
 
 if args.umbrella:
     for pivot in args.umbrella:

--- a/libraries/AP_Math/tools/geodesic_grid/grid.py
+++ b/libraries/AP_Math/tools/geodesic_grid/grid.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+import icosahedron as ico
+
+def section_triangle(s):
+    a, b, c = ico.triangles[s / 4]
+    # project the middle points to the sphere
+    alpha = a.length() / (2.0 * ico.g)
+    ma, mb, mc = alpha * (a + b), alpha * (b + c), alpha * (c + a)
+
+    sub = s % 4
+    if sub == 0:
+        return ico.Triangle(ma, mb, mc)
+    elif sub == 1:
+        return ico.Triangle(a, ma, mc)
+    elif sub == 2:
+        return ico.Triangle(ma, b, mb)
+    else:
+        return ico.Triangle(mc, mb, c)

--- a/libraries/AP_Math/tools/geodesic_grid/plot.py
+++ b/libraries/AP_Math/tools/geodesic_grid/plot.py
@@ -19,6 +19,7 @@ from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
 import icosahedron as ico
+import grid
 
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
@@ -36,18 +37,35 @@ ax.invert_xaxis()
 ax.set_aspect('equal')
 
 added_polygons = set()
+added_sections = set()
 
 def polygons(polygons):
     for p in polygons:
         polygon(p)
 
-
 def polygon(polygon):
     added_polygons.add(polygon)
+
+def section(s):
+    added_sections.add(s)
+
+def sections(sections):
+    for s in sections:
+        section(s)
 
 def show(subtriangles=False):
     polygons = []
     facecolors = []
+
+    subtriangle_facecolors = (
+        '#CCCCCC',
+        '#CCE5FF',
+        '#E5FFCC',
+        '#FFCCCC',
+    )
+
+    if added_sections:
+        subtriangles = True
 
     for p in added_polygons:
         try:
@@ -57,23 +75,7 @@ def show(subtriangles=False):
             continue
 
         if subtriangles:
-            a, b, c = p
-
-            # project the middle points to the sphere
-            alpha = a.length() / (2.0 * ico.g)
-            ma, mb, mc = alpha * (a + b), alpha * (b + c), alpha * (c + a)
-
-            polygons.append(ico.Triangle(ma, mb, mc))
-            facecolors.append('#CCCCCC')
-
-            polygons.append(ico.Triangle( a, ma, mc))
-            facecolors.append('#CCE5FF')
-
-            polygons.append(ico.Triangle(ma,  b, mb))
-            facecolors.append('#E5FFCC')
-
-            polygons.append(ico.Triangle(mc, mb,  c))
-            facecolors.append('#FFCCCC')
+            sections(range(i * 4, i * 4 + 4))
         else:
             polygons.append(p)
             facecolors.append('#DDDDDD')
@@ -85,6 +87,11 @@ def show(subtriangles=False):
             mz += z
         ax.text(mx / 2.6, my /2.6, mz / 2.6, i, color='#444444')
 
+    for s in added_sections:
+        subtriangle_index = s % 4
+        polygons.append(grid.section_triangle(s))
+        facecolors.append(subtriangle_facecolors[subtriangle_index])
+
     ax.add_collection3d(Poly3DCollection(
         polygons,
         facecolors=facecolors,
@@ -93,11 +100,9 @@ def show(subtriangles=False):
 
     if subtriangles:
         ax.legend(
-            handles=(
-                mpatches.Patch(color='#CCCCCC', label='Sub-triangle #0'),
-                mpatches.Patch(color='#CCE5FF', label='Sub-triangle #1'),
-                mpatches.Patch(color='#E5FFCC', label='Sub-triangle #2'),
-                mpatches.Patch(color='#FFCCCC', label='Sub-triangle #3'),
+            handles=tuple(
+                mpatches.Patch(color=c, label='Sub-triangle #%d' % i)
+                for i, c in enumerate(subtriangle_facecolors)
             ),
         )
 

--- a/libraries/AP_Math/tools/geodesic_grid/plot.py
+++ b/libraries/AP_Math/tools/geodesic_grid/plot.py
@@ -56,6 +56,7 @@ def sections(sections):
 def show(subtriangles=False):
     polygons = []
     facecolors = []
+    triangles_indexes = set()
 
     subtriangle_facecolors = (
         '#CCCCCC',
@@ -77,17 +78,12 @@ def show(subtriangles=False):
         if subtriangles:
             sections(range(i * 4, i * 4 + 4))
         else:
+            triangles_indexes.add(i)
             polygons.append(p)
             facecolors.append('#DDDDDD')
 
-        mx = my = mz = 0
-        for x, y, z in p:
-            mx += x
-            my += y
-            mz += z
-        ax.text(mx / 2.6, my /2.6, mz / 2.6, i, color='#444444')
-
     for s in added_sections:
+        triangles_indexes.add(int(s / 4))
         subtriangle_index = s % 4
         polygons.append(grid.section_triangle(s))
         facecolors.append(subtriangle_facecolors[subtriangle_index])
@@ -97,6 +93,15 @@ def show(subtriangles=False):
         facecolors=facecolors,
         edgecolors="#777777",
     ))
+
+    for i in triangles_indexes:
+        t = ico.triangles[i]
+        mx = my = mz = 0
+        for x, y, z in t:
+            mx += x
+            my += y
+            mz += z
+        ax.text(mx / 2.6, my / 2.6, mz / 2.6, i, color='#444444')
 
     if subtriangles:
         ax.legend(


### PR DESCRIPTION
Hi all,

**magcal_graph**
The main contribution of this PR is the addition of the local mavproxy module magcal_graph (a.k.a. magical_graph :P). 

That module shows the geodesic sections hit by the samples collected during compass calibration, and also some status data. The objective of this module is to provide a reference on how to interpret the field `completion_mask` from the `MAG_CAL_PROGRESS` mavlink message. That information can be used in order to guide the vehicle user during calibration.

The plot shown by this module isn't very helpful to the end user, but it might help developers during development of internal calibration support in ground control stations.

The only command provided by that module is `magcal_graph`, which will open the graphical user interface.

I've done a quick demo using it in combination with compass calibration simulation: https://youtu.be/HSrXM2ETjdI

Note: I've added a file `Tools/mavproxy_modules/lib/geodesic_grid.py`, which might be seen as a duplication of things in `libraries/AP_Math/tools/geodesic_grid/icosahedron.py` and `libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py`. However, I think the former is very simple and I thought that wasn't worth moving and editing files around just to make both `Tools/mavproxy_modules/lib/geodesic_grid.py` and `libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py` use the same module. Furthermore, @tridge showed interest on applying this to mavproxy's tree during the las devcall and this would make it simpler to do it.

**Previous commits**
This PR also does:
 - add a new option `--section` to `libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py`. That was helpful for me to check that the `magcal_module` was working properly.
 - enable the use of the "calibration" model in `sim_vehicle.py`.
 - and other minor enhancements.

Best regards,
Gustavo Sousa