### PR TITLE
waf: Fix build on windows

### DIFF
--- a/libraries/AP_Common/missing/cmath
+++ b/libraries/AP_Common/missing/cmath
@@ -2,21 +2,26 @@
 
 #include_next <cmath>
 
-#ifdef __CYGWIN__
-// hack to get SITL on windows working
-#ifndef HAVE_CMATH_ISFINITE
-#define HAVE_CMATH_ISFINITE
-#define NEED_CMATH_ISFINITE_STD_NAMESPACE
+#ifndef WAF_BUILD
+#  ifdef __GNUG__
+#    define _GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#    if _GCC_VERSION >= 50300
+#      ifndef HAVE_CMATH_ISFINITE
+#        define HAVE_CMATH_ISFINITE
+#        define NEED_CMATH_ISFINITE_STD_NAMESPACE
+#      endif
+#      ifndef HAVE_CMATH_ISINF
+#        define HAVE_CMATH_ISINF
+#        define NEED_CMATH_ISINF_STD_NAMESPACE
+#      endif
+#      ifndef HAVE_CMATH_ISNAN
+#        define HAVE_CMATH_ISNAN
+#        define NEED_CMATH_ISNAN_STD_NAMESPACE
+#      endif
+#    endif
+#    undef _GCC_VERSION
+#  endif
 #endif
-#ifndef HAVE_CMATH_ISINF
-#define HAVE_CMATH_ISINF
-#define NEED_CMATH_ISINF_STD_NAMESPACE
-#endif
-#ifndef HAVE_CMATH_ISNAN
-#define HAVE_CMATH_ISNAN
-#define NEED_CMATH_ISNAN_STD_NAMESPACE
-#endif
-#endif // __CYGWIN__
 
 #if defined(HAVE_CMATH_ISFINITE) && defined(NEED_CMATH_ISFINITE_STD_NAMESPACE)
 using std::isfinite;

--- a/wscript
+++ b/wscript
@@ -130,6 +130,9 @@ def configure(cfg):
     # Always use system extensions
     cfg.define('_GNU_SOURCE', 1)
 
+    # Allow to differentiate our build from the make build
+    cfg.define('WAF_BUILD', 1)
+
     cfg.write_config_header(os.path.join(cfg.variant, 'ap_config.h'))
 
 def collect_dirs_to_recurse(bld, globs, **kw):


### PR DESCRIPTION
Revert "AP_Common: workaround for SITL on windows"

This reverts commit 7b47d54d6b55cef863fbca742b4e9d95f84f3e9e.

This breaks the build on windows with old compiler versions. Waf
properly checks if the compiler needs/supports these macros, so let's
move the workaround to the makefile.