### PR TITLE
waf: don't use hard-coded path for environment cache path

### DIFF
--- a/wscript
+++ b/wscript
@@ -26,7 +26,8 @@ from waflib import Build, ConfigSet, Context, Utils
 def init(ctx):
     env = ConfigSet.ConfigSet()
     try:
-        env.load('build/c4che/_cache.py')
+        p = os.path.join(Context.out_dir, Build.CACHE_DIR, Build.CACHE_SUFFIX)
+        env.load(p)
     except:
         return
 


### PR DESCRIPTION
The path for the "non-board" environment cache file was hard-coded, which was
causing the error below when the build was configured with the --out option
value different from the default path.

Traceback (most recent call last):
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Scripting.py", line 161, in waf_entry_point
    run_commands()
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Scripting.py", line 263, in run_commands
    ctx = run_command(cmd_name)
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Scripting.py", line 247, in run_command
    ctx.execute()
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Scripting.py", line 598, in execute
    return execute_method(self)
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Build.py", line 250, in execute
    self.execute_build()
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Build.py", line 263, in execute_build
    self.recurse([self.run_dir])
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Context.py", line 304, in recurse
    user_function(self)
  File "/home/gjsousa/ardupilot/wscript", line 246, in build
    config_header = Utils.h_file(bld.bldnode.make_node('ap_config.h').abspath())
  File "/home/gjsousa/ardupilot/modules/waf/waflib/Utils.py", line 208, in h_file
    f = open(fname, 'rb')
IOError: [Errno 2] No such file or directory: '/tmp/build/ap_config.h'