### PR TITLE
AP_GPS: improve GPS switching

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -99,6 +99,13 @@ public:
        GPS_ALL_CONFIGURED = 255
    };
 
+   // GPS auto-switching modes
+   enum GPS_Auto_Switch {
+       GPS_AUTO_SWITCH_DISABLED = 0,
+       GPS_AUTO_SWITCH_MORE_SATS = 1,
+       GPS_AUTO_SWITCH_VZ = 2
+   };
+
     /*
       The GPS_State structure is filled in by the backend driver as it
       parses each message from the GPS.
@@ -335,6 +342,7 @@ public:
     AP_Int8 _gnss_mode[2];
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
+    AP_Float _vz_switch_threshold;
     
     // handle sending of initialisation strings to the GPS
     void send_blob_start(uint8_t instance, const char *_blob, uint16_t size);
@@ -373,6 +381,8 @@ private:
 
     /// primary GPS instance
     uint8_t primary_instance:2;
+    uint8_t primary_instance_change_request:2;
+    uint32_t primary_instance_change_debounce_ms;
 
     /// number of GPS instances present
     uint8_t num_instances:2;


### PR DESCRIPTION
current GPS_AUTO_SWITCH scheme is horrible, this replaces option 1 with something better and adds a second one:
0) disabled (no switching)

1)   swap if (state[secondary].status > state[primary].status || (state[secondary].num_sats >= state[primary].num_sats + 2))

2) monitor the vertical velocity and check if it is above a param threshold but the other GPS is not. I have found that this is a reliable pre-cursor to a GPS losing sats/lock.

@Description: When GPS_AUTO_SWITCH=2 this value sets the vertical velocity switching threshold. Vertical velocity is indicitive of a GPS signal that is about to lose lock. If the primary GPS's VZ is above this value, and the other GPS is under it, then switch.
