### PR TITLE
waf: fix build for px4

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -18,13 +18,13 @@ void setup() {
 static void show_sizes(void)
 {
 	hal.console->println("Type sizes:");
-	hal.console->printf("char      : %lu\n", sizeof(char));
-	hal.console->printf("short     : %lu\n", sizeof(short));
-	hal.console->printf("int       : %lu\n", sizeof(int));
-	hal.console->printf("long      : %lu\n", sizeof(long));
-	hal.console->printf("long long : %lu\n", sizeof(long long));
-	hal.console->printf("bool      : %lu\n", sizeof(bool));
-	hal.console->printf("void*     : %lu\n", sizeof(void *));
+	hal.console->printf("char      : %lu\n", (unsigned long)sizeof(char));
+	hal.console->printf("short     : %lu\n", (unsigned long)sizeof(short));
+	hal.console->printf("int       : %lu\n", (unsigned long)sizeof(int));
+	hal.console->printf("long      : %lu\n", (unsigned long)sizeof(long));
+	hal.console->printf("long long : %lu\n", (unsigned long)sizeof(long long));
+	hal.console->printf("bool      : %lu\n", (unsigned long)sizeof(bool));
+	hal.console->printf("void*     : %lu\n", (unsigned long)sizeof(void *));
 
 	hal.console->printf("printing NaN: %f\n", sqrt(-1.0f));
 	hal.console->printf("printing +Inf: %f\n", 1.0f/0.0f);

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -260,6 +260,7 @@ def configure(cfg):
         NUTTX_SRC=env.PX4_NUTTX_ROOT,
         PX4_NUTTX_ROMFS=bldpath(env.PX4_ROMFS_BLD),
         APM_PROGRAM_LIB=bldpath(env.PX4_AP_PROGRAM_LIB),
+        ARDUPILOT_BUILD='YES',
         EXTRA_CXX_FLAGS=' '.join((
             # NOTE: these "-Wno-error=*" flags should be removed as we update
             # the submodule

--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
@@ -63,7 +63,6 @@ set(config_extra_builtin_cmds
 )
 
 set(config_extra_libs
-    ${CMAKE_SOURCE_DIR}/src/lib/mathlib/CMSIS/libarm_cortexM4lf_math.a
     ${APM_PROGRAM_LIB}
 )
 

--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v4_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v4_apm.cmake
@@ -6,6 +6,7 @@ list(APPEND config_module_list
     drivers/pwm_input
     modules/uavcan
     lib/mathlib
+    lib/rc
 )
 
 list(APPEND config_extra_libs

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -49,11 +49,6 @@ waf=modules/waf/waf-light
 # get list of boards supported by the waf build
 for board in $($waf list_boards | head -n1); do waf_supported_boards[$board]=1; done
 
-echo "Temporarily disabling px4 waf builds (broken in px4 merge)"
-waf_supported_boards[px4-v1]=""
-waf_supported_boards[px4-v2]=""
-waf_supported_boards[px4-v4]=""
-
 echo "Targets: $CI_BUILD_TARGET"
 for t in $CI_BUILD_TARGET; do
     # skip make-based build for clang


### PR DESCRIPTION
Hi all,

This PR is fixing the build for PX4 boards. I can't test it right now, I'll try doing that when I get the chance.

@OXINARF I cherry picked some of your commits. I changed the commit message of one of them, if that's alright to you.

This is just fixing the build for PX4. Enhancements requested at http://discuss.ardupilot.org/t/waf-build-for-px4/8396 are still to be done.

Best regards,
Gustavo Sousa