### PR TITLE
Buzzer: change pin 11(P8_31) to pin 12(P8_32) to avoid boot conflict

### DIFF
--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -22,7 +22,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
  # define BUZZER_PIN    32
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX && CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
- # define BUZZER_PIN     10 // GPIO P8_31
+ # define BUZZER_PIN     11 // GPIO P8_32
 #else
  # define BUZZER_PIN     0 // pin undefined on other boards
 #endif


### PR DESCRIPTION
During power on, pin P8.31 is used for boot selection, and using this pin with the transistor + buzzer circuit cause an unexpected behavior(BBB is not boot). 