### PR TITLE
Move time_utc functions from AP_HAL to AP_Common

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -31,6 +31,7 @@
 // Common dependencies
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
+#include <AP_Common/AP_Time.h>
 #include <AP_Menu/AP_Menu.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -531,7 +531,7 @@ void Copter::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max = cmd.content.nav_delay.seconds * 1000; // convert seconds to milliseconds
     } else {
         // absolute delay to utc time
-        nav_delay_time_max = hal.util->get_time_utc(cmd.content.nav_delay.hour_utc, cmd.content.nav_delay.min_utc, cmd.content.nav_delay.sec_utc, 0);
+        nav_delay_time_max = get_ms_until_time_utc(cmd.content.nav_delay.hour_utc, cmd.content.nav_delay.min_utc, cmd.content.nav_delay.sec_utc, 0);
     }
     gcs_send_text_fmt(MAV_SEVERITY_INFO, "Delaying %u sec",(unsigned int)(nav_delay_time_max/1000));
 }

--- a/libraries/AP_Common/AP_Time.cpp
+++ b/libraries/AP_Common/AP_Time.cpp
@@ -1,0 +1,84 @@
+/*
+ * AP_Time.cpp
+ */
+
+#include "AP_Time.h"
+#include <time.h>
+
+// get system time in UTC hours, minutes, seconds and milliseconds
+void get_time_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms)
+{
+     // get time of day in ms
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    uint64_t time_ms = ((uint64_t)(ts.tv_sec * 1000 + ts.tv_nsec/1000000));
+
+    // separate time into ms, sec, min, hour and days but all expressed in milliseconds
+    ms = time_ms % 1000;
+    uint32_t sec_ms = (time_ms % (60 * 1000)) - ms;
+    uint32_t min_ms = (time_ms % (60 * 60 * 1000)) - sec_ms - ms;
+    uint32_t hour_ms = (time_ms % (24 * 60 * 60 * 1000)) - min_ms - sec_ms - ms;
+
+    // convert times as milliseconds into appropriate units
+    sec = sec_ms / 1000;
+    min = min_ms / (60 * 1000);
+    hour = hour_ms / (60 * 60 * 1000);
+}
+
+// get milliseconds from now until a UTC time specified in hours, min, seconds and milliseconds
+// hour, minute and second values can be ignored by setting to -1
+// for example specifying hour=-1, minutes=10 will ignore the hour and return milliseconds until 10 minutes past the next hour
+uint32_t get_ms_until_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms)
+{
+    // determine highest value specified (0=none, 1=ms, 2=sec, 3=min, 4=hour)
+    int8_t largest_element = 0;
+    if (ms != -1) largest_element = 1;
+    if (sec != -1) largest_element = 2;
+    if (min != -1) largest_element = 3;
+    if (hour != -1) largest_element = 4;
+
+    // exit immediately if no time specified
+    if (largest_element == 0) {
+        return 0;
+    }
+
+    // get start_time_ms as h, m, s, ms
+    int32_t curr_hour, curr_min, curr_sec, curr_ms;
+    get_time_utc(curr_hour, curr_min, curr_sec, curr_ms);
+    int32_t total_delay_ms = 0;
+
+    // calculate ms to target
+    if (largest_element >= 1) {
+        total_delay_ms += ms - curr_ms;
+    }
+    if (largest_element == 1 && total_delay_ms < 0) {
+        total_delay_ms += 1000;
+    }
+
+    // calculate sec to target
+    if (largest_element >= 2) {
+        total_delay_ms += (sec - curr_sec)*1000;
+    }
+    if (largest_element == 2 && total_delay_ms < 0) {
+        total_delay_ms += (60*1000);
+    }
+
+    // calculate min to target
+    if (largest_element >= 3) {
+        total_delay_ms += (min - curr_min)*60*1000;
+    }
+    if (largest_element == 3 && total_delay_ms < 0) {
+        total_delay_ms += (60*60*1000);
+    }
+
+    // calculate hours to target
+    if (largest_element >= 4) {
+        total_delay_ms += (hour - curr_hour)*60*60*1000;
+    }
+    if (largest_element == 4 && total_delay_ms < 0) {
+        total_delay_ms += (24*60*60*1000);
+    }
+
+    // total delay in milliseconds
+    return (uint32_t)total_delay_ms;
+}

--- a/libraries/AP_Common/AP_Time.cpp
+++ b/libraries/AP_Common/AP_Time.cpp
@@ -3,7 +3,6 @@
  */
 
 #include "AP_Time.h"
-#include <time.h>
 
 // get system time in UTC hours, minutes, seconds and milliseconds
 void get_time_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms)

--- a/libraries/AP_Common/AP_Time.h
+++ b/libraries/AP_Common/AP_Time.h
@@ -2,10 +2,10 @@
  * AP_Time.h
  */
 
-#ifndef AP_TIME_H
-#define AP_TIME_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
+#include <time.h>
 
 // get system time in UTC hours, minutes, seconds and milliseconds
 void get_time_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms);
@@ -14,5 +14,3 @@ void get_time_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms);
 // hour, minute and second values can be ignored by setting to -1
 // for example specifying hour=-1, minutes=10 will ignore the hour and return milliseconds until 10 minutes past the next hour
 uint32_t get_ms_until_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
-
-#endif /* AP_TIME_H */

--- a/libraries/AP_Common/AP_Time.h
+++ b/libraries/AP_Common/AP_Time.h
@@ -1,0 +1,18 @@
+/*
+ * AP_Time.h
+ */
+
+#ifndef AP_TIME_H
+#define AP_TIME_H
+
+#include <AP_Common/AP_Common.h>
+
+// get system time in UTC hours, minutes, seconds and milliseconds
+void get_time_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms);
+
+// get milliseconds from now until a UTC time specified in hours, min, seconds and milliseconds
+// hour, minute and second values can be ignored by setting to -1
+// for example specifying hour=-1, minutes=10 will ignore the hour and return milliseconds until 10 minutes past the next hour
+uint32_t get_ms_until_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms);
+
+#endif /* AP_TIME_H */

--- a/libraries/AP_HAL/Util.cpp
+++ b/libraries/AP_HAL/Util.cpp
@@ -1,7 +1,6 @@
 #include "AP_HAL.h"
 #include "Util.h"
 #include "utility/print_vprintf.h"
-#include <time.h>
 
 /* Helper class implements AP_HAL::Print so we can use utility/vprintf */
 class BufferPrinter : public AP_HAL::Print {
@@ -46,85 +45,4 @@ int AP_HAL::Util::vsnprintf(char* str, size_t size, const char *format, va_list 
     int ret = buf._offs;
     buf.write(0);
     return ret;
-}
-
-uint64_t AP_HAL::Util::get_system_clock_ms() const
-{
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    return ((long long)(ts.tv_sec * 1000 + ts.tv_nsec/1000000));
-}
-
-void AP_HAL::Util::get_system_clock_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms) const
-{
-     // get time of day in ms
-    uint64_t time_ms = get_system_clock_ms();
-
-    // separate time into ms, sec, min, hour and days but all expressed in milliseconds
-    ms = time_ms % 1000;
-    uint32_t sec_ms = (time_ms % (60 * 1000)) - ms;
-    uint32_t min_ms = (time_ms % (60 * 60 * 1000)) - sec_ms - ms;
-    uint32_t hour_ms = (time_ms % (24 * 60 * 60 * 1000)) - min_ms - sec_ms - ms;
-
-    // convert times as milliseconds into appropriate units
-    sec = sec_ms / 1000;
-    min = min_ms / (60 * 1000);
-    hour = hour_ms / (60 * 60 * 1000);
-}
-
-// get milliseconds from now to a target time of day expressed as hour, min, sec, ms
-// match starts from first value that is not -1. I.e. specifying hour=-1, minutes=10 will ignore the hour and return time until 10 minutes past 12am (utc)
-uint32_t AP_HAL::Util::get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms) const
-{
-    // determine highest value specified (0=none, 1=ms, 2=sec, 3=min, 4=hour)
-    int8_t largest_element = 0;
-    if (ms != -1) largest_element = 1;
-    if (sec != -1) largest_element = 2;
-    if (min != -1) largest_element = 3;
-    if (hour != -1) largest_element = 4;
-
-    // exit immediately if no time specified
-    if (largest_element == 0) {
-        return 0;
-    }
-
-    // get start_time_ms as h, m, s, ms
-    int32_t curr_hour, curr_min, curr_sec, curr_ms;
-    get_system_clock_utc(curr_hour, curr_min, curr_sec, curr_ms);
-    int32_t total_delay_ms = 0;
-
-    // calculate ms to target
-    if (largest_element >= 1) {
-        total_delay_ms += ms - curr_ms;
-    }
-    if (largest_element == 1 && total_delay_ms < 0) {
-        total_delay_ms += 1000;
-    }
-
-    // calculate sec to target
-    if (largest_element >= 2) {
-        total_delay_ms += (sec - curr_sec)*1000;
-    }
-    if (largest_element == 2 && total_delay_ms < 0) {
-        total_delay_ms += (60*1000);
-    }
-
-    // calculate min to target
-    if (largest_element >= 3) {
-        total_delay_ms += (min - curr_min)*60*1000;
-    }
-    if (largest_element == 3 && total_delay_ms < 0) {
-        total_delay_ms += (60*60*1000);
-    }
-
-    // calculate hours to target
-    if (largest_element >= 4) {
-        total_delay_ms += (hour - curr_hour)*60*60*1000;
-    }
-    if (largest_element == 4 && total_delay_ms < 0) {
-        total_delay_ms += (24*60*60*1000);
-    }
-
-    // total delay in milliseconds
-    return (uint32_t)total_delay_ms;
 }

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -46,18 +46,6 @@ public:
     virtual void set_system_clock(uint64_t time_utc_usec) {}
 
     /*
-      get system clock in UTC milliseconds
-     */
-    uint64_t get_system_clock_ms() const;
-
-    /*
-      get system time in UTC hours, minutes, seconds and milliseconds
-     */
-    void get_system_clock_utc(int32_t &hour, int32_t &min, int32_t &sec, int32_t &ms) const;
-
-    uint32_t get_time_utc(int32_t hour, int32_t min, int32_t sec, int32_t ms) const;
-
-    /*
       get system identifier (eg. serial number)
       return false if a system identifier is not available
 


### PR DESCRIPTION
Moves the newly added get_ms_until_time_utc functions from AP_HAL to AP_Common/AP_Time.

This doesn't yet resolve the compile issue for Linux boards that has something to do with a missing library (-lrt ?)
