### PR TITLE
Fix implementation of _parse_decimal_100() (v2)

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -185,17 +185,29 @@ int16_t AP_GPS_NMEA::_from_hex(char a)
         return a - '0';
 }
 
-uint32_t AP_GPS_NMEA::_parse_decimal_100()
+int32_t AP_GPS_NMEA::_parse_decimal_100()
 {
     char *p = _term;
-    uint32_t ret = 100UL * atol(p);
-    while (isdigit(*p))
+    int32_t ret = 100UL * atol(p);
+    int32_t sign = 1;
+    if (*p == '+') {
         ++p;
+    } else if (*p == '-') {
+        ++p;
+        sign = -1;
+    }
+    while (isdigit(*p)) {
+        ++p;
+    }
     if (*p == '.') {
         if (isdigit(p[1])) {
-            ret += 10 * DIGIT_TO_VAL(p[1]);
-            if (isdigit(p[2]))
-                ret += DIGIT_TO_VAL(p[2]);
+            ret += sign * 10 * DIGIT_TO_VAL(p[1]);
+            if (isdigit(p[2])) {
+                ret += sign * DIGIT_TO_VAL(p[2]);
+                if (isdigit(p[3])) {
+                    ret += sign * (DIGIT_TO_VAL(p[3]) >= 5);
+                }
+            }
         }
     }
     return ret;

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -187,32 +187,29 @@ int16_t AP_GPS_NMEA::_from_hex(char a)
 
 int32_t AP_GPS_NMEA::_parse_decimal_100(const char *p)
 {
-    int32_t ret = 100UL * atol(p);
-    int32_t sign = 1;
+    char *endptr = nullptr;
+    long ret = 100 * strtol(p, &endptr, 10);
+    int sign = ret < 0 ? -1 : 1;
 
-    if (*p == '+') {
-        ++p;
-    } else if (*p == '-') {
-        ++p;
-        sign = -1;
+    if (ret >= (long)INT32_MAX) {
+        return INT32_MAX;
+    }
+    if (ret <= (long)INT32_MIN) {
+        return INT32_MIN;
+    }
+    if (endptr == nullptr || *endptr != '.') {
+        return ret;
     }
 
-    while (isdigit(*p)) {
-        ++p;
-    }
-
-    if (*p == '.') {
-        if (isdigit(p[1])) {
-            ret += sign * 10 * DIGIT_TO_VAL(p[1]);
-            if (isdigit(p[2])) {
-                ret += sign * DIGIT_TO_VAL(p[2]);
-                if (isdigit(p[3])) {
-                    ret += sign * (DIGIT_TO_VAL(p[3]) >= 5);
-                }
+    if (isdigit(endptr[1])) {
+        ret += sign * 10 * DIGIT_TO_VAL(endptr[1]);
+        if (isdigit(endptr[2])) {
+            ret += sign * DIGIT_TO_VAL(endptr[2]);
+            if (isdigit(endptr[3])) {
+                ret += sign * (DIGIT_TO_VAL(endptr[3]) >= 5);
             }
         }
     }
-
     return ret;
 }
 

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -185,20 +185,22 @@ int16_t AP_GPS_NMEA::_from_hex(char a)
         return a - '0';
 }
 
-int32_t AP_GPS_NMEA::_parse_decimal_100()
+int32_t AP_GPS_NMEA::_parse_decimal_100(const char *p)
 {
-    char *p = _term;
     int32_t ret = 100UL * atol(p);
     int32_t sign = 1;
+
     if (*p == '+') {
         ++p;
     } else if (*p == '-') {
         ++p;
         sign = -1;
     }
+
     while (isdigit(*p)) {
         ++p;
     }
+
     if (*p == '.') {
         if (isdigit(p[1])) {
             ret += sign * 10 * DIGIT_TO_VAL(p[1]);
@@ -210,6 +212,7 @@ int32_t AP_GPS_NMEA::_parse_decimal_100()
             }
         }
     }
+
     return ret;
 }
 
@@ -390,14 +393,14 @@ bool AP_GPS_NMEA::_term_complete()
             _new_satellite_count = atol(_term);
             break;
         case _GPS_SENTENCE_GGA + 8: // HDOP (GGA)
-            _new_hdop = _parse_decimal_100();
+            _new_hdop = (uint16_t)_parse_decimal_100(_term);
             break;
 
         // time and date
         //
         case _GPS_SENTENCE_RMC + 1: // Time (RMC)
         case _GPS_SENTENCE_GGA + 1: // Time (GGA)
-            _new_time = _parse_decimal_100();
+            _new_time = _parse_decimal_100(_term);
             break;
         case _GPS_SENTENCE_RMC + 9: // Date (GPRMC)
             _new_date = atol(_term);
@@ -424,18 +427,18 @@ bool AP_GPS_NMEA::_term_complete()
                 _new_longitude = -_new_longitude;
             break;
         case _GPS_SENTENCE_GGA + 9: // Altitude (GPGGA)
-            _new_altitude = _parse_decimal_100();
+            _new_altitude = _parse_decimal_100(_term);
             break;
 
         // course and speed
         //
         case _GPS_SENTENCE_RMC + 7: // Speed (GPRMC)
         case _GPS_SENTENCE_VTG + 5: // Speed (VTG)
-            _new_speed = (_parse_decimal_100() * 514) / 1000;       // knots-> m/sec, approximiates * 0.514
+            _new_speed = (_parse_decimal_100(_term) * 514) / 1000;       // knots-> m/sec, approximiates * 0.514
             break;
         case _GPS_SENTENCE_RMC + 8: // Course (GPRMC)
         case _GPS_SENTENCE_VTG + 1: // Course (VTG)
-            _new_course = _parse_decimal_100();
+            _new_course = _parse_decimal_100(_term);
             break;
         }
     }

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -91,7 +91,7 @@ private:
     /// @returns		The value expressed by the string in _term,
     ///					multiplied by 100.
     ///
-    uint32_t    _parse_decimal_100();
+    int32_t    _parse_decimal_100();
 
     /// Parses the current term as a NMEA-style degrees + minutes
     /// value with up to four decimal digits.

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -85,13 +85,13 @@ private:
     ///
     int16_t                     _from_hex(char a);
 
-    /// Parses the current term as a NMEA-style decimal number with
-    /// up to two decimal digits.
+    /// Parses the @p as a NMEA-style decimal number with
+    /// up to 3 decimal digits.
     ///
-    /// @returns		The value expressed by the string in _term,
+    /// @returns		The value expressed by the string in @p,
     ///					multiplied by 100.
     ///
-    int32_t    _parse_decimal_100();
+    static int32_t _parse_decimal_100(const char *p);
 
     /// Parses the current term as a NMEA-style degrees + minutes
     /// value with up to four decimal digits.

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -51,6 +51,8 @@
 ///
 class AP_GPS_NMEA : public AP_GPS_Backend
 {
+    friend class AP_GPS_NMEA_Test;
+
 public:
 	AP_GPS_NMEA(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 

--- a/libraries/AP_GPS/tests/test_gps.cpp
+++ b/libraries/AP_GPS/tests/test_gps.cpp
@@ -1,0 +1,66 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+ * Copyright (C) 2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <AP_GPS/AP_GPS_NMEA.h>
+
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+class AP_GPS_NMEA_Test
+{
+public:
+    int32_t parse_decimal_100(const char *p) const
+    {
+        return AP_GPS_NMEA::_parse_decimal_100(p);
+    }
+};
+
+TEST(AP_GPS_NMEA, parse_decimal_100)
+{
+    AP_GPS_NMEA_Test test;
+
+    /* Positive numbers with possible round/truncate */
+    ASSERT_EQ(100, test.parse_decimal_100("1.0"));
+    ASSERT_EQ(100, test.parse_decimal_100("1.00"));
+    ASSERT_EQ(100, test.parse_decimal_100("1.001"));
+    ASSERT_EQ(101, test.parse_decimal_100("1.006"));
+
+    /* Positive numbers with possible round/truncate with + signal */
+    ASSERT_EQ(100, test.parse_decimal_100("+1.0"));
+    ASSERT_EQ(100, test.parse_decimal_100("+1.00"));
+    ASSERT_EQ(100, test.parse_decimal_100("+1.001"));
+    ASSERT_EQ(101, test.parse_decimal_100("+1.006"));
+
+    /* Positive numbers in (0, 1) range, with possible round/truncate */
+    ASSERT_EQ(0, test.parse_decimal_100("0.0"));
+    ASSERT_EQ(0, test.parse_decimal_100("0.00"));
+    ASSERT_EQ(0, test.parse_decimal_100("0.001"));
+    ASSERT_EQ(1, test.parse_decimal_100("0.006"));
+
+    /* Negative numbers with possible round/truncate */
+    ASSERT_EQ(-100, test.parse_decimal_100("-1.0"));
+    ASSERT_EQ(-100, test.parse_decimal_100("-1.00"));
+    ASSERT_EQ(-100, test.parse_decimal_100("-1.001"));
+    ASSERT_EQ(-101, test.parse_decimal_100("-1.006"));
+
+    /* Integer numbers */
+    ASSERT_EQ(100, test.parse_decimal_100("1"));
+    ASSERT_EQ(-100, test.parse_decimal_100("-1"));
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_GPS/tests/wscript
+++ b/libraries/AP_GPS/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )


### PR DESCRIPTION
v2 of #3602

This implements _parse_decimal_100() a little bit differently, add some safety checks and add a unit test for this function.

It could be much simpler if NuttX had strtof() - which btw is posix:
```
return MIN(INT32_MAX, lround(strtof(p, nullptr) * 100U));
```

Since it doesn't have, the implementation in this PR was the best I could come up with.

@jaluna @regelink @WickedShell 