### PR TITLE
SITL: fix linkage issue

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -184,9 +184,13 @@ class sitl(Board):
                 '-O3',
             ]
 
+        cfg.check_librt()
+
         env.LIB += [
             'm',
         ]
+        env.LIB += cfg.env.LIB_RT
+
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES += [
             'AP_HAL_SITL',
@@ -212,10 +216,13 @@ class linux(Board):
                 '-O3',
             ]
 
+        cfg.check_librt()
+
         env.LIB += [
             'm',
-            'rt',
         ]
+        env.LIB += cfg.env.LIB_RT
+
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES = [
             'AP_HAL_Linux',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -31,6 +31,7 @@ class Board:
     def configure(self, cfg):
         cfg.env.TOOLCHAIN = self.toolchain
         cfg.load('toolchain')
+        cfg.load('cxx_checks')
 
         env = waflib.ConfigSet.ConfigSet()
         self.configure_env(cfg, env)
@@ -52,7 +53,7 @@ class Board:
             else:
                 cfg.env[k] = val
 
-        cfg.load('cxx_checks')
+        cfg.ap_common_checks()
 
     def configure_env(self, cfg, env):
         # Use a dictionary instead of the convetional list for definitions to

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -11,35 +11,44 @@ Example::
 """
 
 def configure(cfg):
-    cfg.check_cxx(fragment='''
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <cmath>
 
-                  int main() {
-                    return std::isfinite(1.0f);
-                  }''',
-                  define_name="HAVE_CMATH_ISFINITE",
-                  msg="Checking for HAVE_CMATH_ISFINITE",
-                  mandatory=False)
+        int main() {
+          return std::isfinite(1.0f);
+        }''',
+        define_name="HAVE_CMATH_ISFINITE",
+        msg="Checking for HAVE_CMATH_ISFINITE",
+        mandatory=False,
+    )
 
-    cfg.check_cxx(fragment='''
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <cmath>
 
-                  int main() {
-                    return std::isinf(1.0f);
-                  }''',
-                  define_name="HAVE_CMATH_ISINF",
-                  msg="Checking for HAVE_CMATH_ISINF",
-                  mandatory=False)
+        int main() {
+          return std::isinf(1.0f);
+        }''',
+        define_name="HAVE_CMATH_ISINF",
+        msg="Checking for HAVE_CMATH_ISINF",
+        mandatory=False,
+    )
 
-    cfg.check_cxx(fragment='''
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <cmath>
 
-                  int main() {
-                    return std::isnan(1.0f);
-                  }''',
-                  define_name="HAVE_CMATH_ISNAN",
-                  msg="Checking for HAVE_CMATH_ISNAN",
-                  mandatory=False)
+        int main() {
+          return std::isnan(1.0f);
+        }''',
+        define_name="HAVE_CMATH_ISNAN",
+        msg="Checking for HAVE_CMATH_ISNAN",
+        mandatory=False,
+    )
 
     # NEED_CMATH_FUNCTION_STD_NAMESPACE checks are needed due to
     # new gcc versions being more restrictive.
@@ -50,41 +59,50 @@ def configure(cfg):
     # Without these checks, in some cases, gcc points this as
     # overloads or function duplication in scope.
 
-    cfg.check_cxx(fragment='''
-                  #include <math.h>
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <math.h>
+        #include <cmath>
 
-                  using std::isfinite;
+        using std::isfinite;
 
-                  int main() {
-                    return isfinite((double)1);
-                  }''',
-                  define_name="NEED_CMATH_ISFINITE_STD_NAMESPACE",
-                  msg="Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE",
-                  mandatory=False)
+        int main() {
+          return isfinite((double)1);
+        }''',
+        define_name="NEED_CMATH_ISFINITE_STD_NAMESPACE",
+        msg="Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE",
+        mandatory=False,
+    )
 
-    cfg.check_cxx(fragment='''
-                  #include <math.h>
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <math.h>
+        #include <cmath>
 
-                  using std::isinf;
+        using std::isinf;
 
-                  int main() {
-                    return isinf((double)1);
-                  }''',
-                  define_name="NEED_CMATH_ISINF_STD_NAMESPACE",
-                  msg="Checking for NEED_CMATH_ISINF_STD_NAMESPACE",
-                  mandatory=False)
+        int main() {
+          return isinf((double)1);
+        }''',
+        define_name="NEED_CMATH_ISINF_STD_NAMESPACE",
+        msg="Checking for NEED_CMATH_ISINF_STD_NAMESPACE",
+        mandatory=False,
+    )
 
-    cfg.check_cxx(fragment='''
-                  #include <math.h>
-                  #include <cmath>
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <math.h>
+        #include <cmath>
 
-                  using std::isnan;
+        using std::isnan;
 
-                  int main() {
-                    return isnan((double)1);
-                  }''',
-                  define_name="NEED_CMATH_ISNAN_STD_NAMESPACE",
-                  msg="Checking for NEED_CMATH_ISNAN_STD_NAMESPACE",
-                  mandatory=False)
+        int main() {
+          return isnan((double)1);
+        }''',
+        define_name="NEED_CMATH_ISNAN_STD_NAMESPACE",
+        msg="Checking for NEED_CMATH_ISNAN_STD_NAMESPACE",
+        mandatory=False,
+    )

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -123,3 +123,27 @@ def ap_common_checks(cfg):
         msg="Checking for NEED_CMATH_ISNAN_STD_NAMESPACE",
         mandatory=False,
     )
+
+@conf
+def check_librt(cfg):
+    success = cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <time.h>
+
+        int main() {
+            clock_gettime(CLOCK_REALTIME, NULL);
+        }''',
+        msg='Checking for need to link with librt',
+        okmsg='not necessary',
+        errmsg='necessary',
+        mandatory=False,
+    )
+
+    if success:
+        return success
+
+    return cfg.check(
+        compiler='cxx',
+        lib='rt',
+    )

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -24,7 +24,10 @@ Example::
         cfg.load('cxx_checks')
 """
 
-def configure(cfg):
+from waflib.Configure import conf
+
+@conf
+def ap_common_checks(cfg):
     cfg.check(
         compiler='cxx',
         fragment='''

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 WAF Tool that checks cxx parameters, creating the ap_config.h
 header file.

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -62,7 +62,7 @@ ifneq ($(SYSTYPE),Darwin)
 LDFLAGS        +=   -Wl,--gc-sections -Wl,-Map -Wl,$(SKETCHMAP)
 endif
 
-LIBS ?= -lm -pthread
+LIBS ?= -lm -lrt -pthread
 ifneq ($(findstring CYGWIN, $(SYSTYPE)),)
 LIBS += -lwinmm
 endif


### PR DESCRIPTION
Hi all,

In some systems, there's the necessity to link against librt in order to use some functions. This PR is adding patches for that:
 - for makefiles: simply add `-lrt` to the `LIBS` for makefiles. I didn't spend to much time here, since the make build for linux and sitl will be removed in a near future.
 - the solution on Waf was to check for the necessity of linking against librt. Just try to find that library if there's the necessity.

Best regards,
Gustavo Sousa