### PR TITLE
AP_HAL_Linux: fix bhat spi device driver build error

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -72,8 +72,9 @@ SPIDeviceDriver SPIDeviceManager::_device[] = {
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
 SPIDeviceDriver SPIDeviceManager::_device[] = {
-    SPIDeviceDriver("mpu9250", 0, 0, AP_HAL::SPIDevice_MPU9250, SPI_MODE_0, 8, RPI_GPIO_7, 1*MHZ, 20*MHZ),
-    SPIDeviceDriver("ublox", 0, 0, AP_HAL::SPIDevice_Ublox, SPI_MODE_0, 8, RPI_GPIO_8, 250*KHZ, 5*MHZ),
+    SPIDeviceDriver("mpu9250", 0, 0, AP_HAL::SPIDevice_MPU9250, SPI_MODE_0, 8, RPI_GPIO_7, 1*MHZ,   20*MHZ),
+    SPIDeviceDriver("ublox",   0, 0, AP_HAL::SPIDevice_Ublox,   SPI_MODE_0, 8, RPI_GPIO_8, 250*KHZ, 5*MHZ),
+};
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
 SPIDeviceDriver SPIDeviceManager::_device[] = {
     SPIDeviceDriver("bebop", 1, 0, AP_HAL::SPIDevice_Bebop, SPI_MODE_0, 8, SPI_CS_KERNEL,  320*KHZ, 320*KHZ),


### PR DESCRIPTION
Someone mistakenly removed the '};' for bhat build, add it back.
I would like to add bhat build to travis-ci later.