### PR TITLE
waf: rename config_header variable to config_hash

### DIFF
--- a/wscript
+++ b/wscript
@@ -247,10 +247,9 @@ def _write_version_header(tsk):
 
 
 def build(bld):
-    config_header = Utils.h_file(bld.bldnode.make_node('ap_config.h').abspath())
-
-    bld.env.CCDEPS = config_header
-    bld.env.CXXDEPS = config_header
+    config_hash = Utils.h_file(bld.bldnode.make_node('ap_config.h').abspath())
+    bld.env.CCDEPS = config_hash
+    bld.env.CXXDEPS = config_hash
 
     bld.post_mode = Build.POST_LAZY
 


### PR DESCRIPTION
Hi all,

That's a better name. The other name would give the wrong idea that that
variable would store a path to the header.

Best,
Gustavo Sousa