### PR TITLE
AP_Airspeed library standalone from APM:Plane

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -387,8 +387,8 @@ void Plane::airspeed_ratio_update(void)
         // don't calibrate when not moving
         return;        
     }
-    if (airspeed.get_airspeed() < aparm.airspeed_min && 
-        gps.ground_speed() < (uint32_t)aparm.airspeed_min) {
+    if (airspeed.get_airspeed() < airspeed._airspeed_min &&
+        gps.ground_speed() < (uint32_t)airspeed._airspeed_min) {
         // don't calibrate when flying below the minimum airspeed. We
         // check both airspeed and ground speed to catch cases where
         // the airspeed ratio is way too low, which could lead to it

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1317,7 +1317,7 @@ void Plane::update_load_factor(void)
         return;
     }
 
-    float max_load_factor = smoothed_airspeed / aparm.airspeed_min;
+    float max_load_factor = smoothed_airspeed / airspeed._airspeed_min;
     if (max_load_factor <= 1) {
         // our airspeed is below the minimum airspeed. Limit roll to
         // 25 degrees

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -476,24 +476,6 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     ASCALAR(stall_prevention, "STALL_PREVENTION",  1),
 
-    // @Param: ARSPD_FBW_MIN
-    // @DisplayName: Minimum Airspeed
-    // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
-    // @Units: m/s
-    // @Range: 5 100
-    // @Increment: 1
-    // @User: Standard
-    ASCALAR(airspeed_min, "ARSPD_FBW_MIN",  AIRSPEED_FBW_MIN),
-
-    // @Param: ARSPD_FBW_MAX
-    // @DisplayName: Maximum Airspeed
-    // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_FBW_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_FBW_MIN is recommended.
-    // @Units: m/s
-    // @Range: 5 100
-    // @Increment: 1
-    // @User: Standard
-    ASCALAR(airspeed_max, "ARSPD_FBW_MAX",  AIRSPEED_FBW_MAX),
-
     // @Param: FBWB_ELEV_REV
     // @DisplayName: Fly By Wire elevator reverse
     // @Description: Reverse sense of elevator in FBWB and CRUISE modes. When set to 0 up elevator (pulling back on the stick) means to lower altitude. When set to 1, up elevator means to raise altitude.

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -390,7 +390,7 @@ private:
 #endif
 
     // Airspeed Sensors
-    AP_Airspeed airspeed {aparm};
+    AP_Airspeed airspeed;
 
     // ACRO controller state
     struct {

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -271,13 +271,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // FLY_BY_WIRE_B airspeed control
 //
-#ifndef AIRSPEED_FBW_MIN
- # define AIRSPEED_FBW_MIN               9
-#endif
-#ifndef AIRSPEED_FBW_MAX
- # define AIRSPEED_FBW_MAX               22
-#endif
-
 #ifndef ALT_HOLD_FBW
  # define ALT_HOLD_FBW 0
 #endif

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -24,7 +24,7 @@ void Plane::update_is_flying_5Hz(void)
                                     (gps.ground_speed_cm() >= ground_speed_thresh_cm);
 
     // airspeed at least 75% of stall speed?
-    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (aparm.airspeed_min*0.75f));
+    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (airspeed._airspeed_min*0.75f));
 
     if(arming.is_armed()) {
         // when armed assuming flying and we need overwhelming evidence that we ARE NOT flying

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -92,10 +92,10 @@ void Plane::calc_airspeed_errors()
     // FBW_B airspeed target
     if (control_mode == FLY_BY_WIRE_B || 
         control_mode == CRUISE) {
-        target_airspeed_cm = ((int32_t)(aparm.airspeed_max -
-                                        aparm.airspeed_min) *
+        target_airspeed_cm = ((int32_t)(airspeed._airspeed_max -
+                                        airspeed._airspeed_min) *
                               channel_throttle->get_control_in()) +
-                             ((int32_t)aparm.airspeed_min * 100);
+                             ((int32_t)airspeed._airspeed_min * 100);
     }
 
     // Landing airspeed target
@@ -138,8 +138,8 @@ void Plane::calc_airspeed_errors()
     }
 
     // Apply airspeed limit
-    if (target_airspeed_cm > (aparm.airspeed_max * 100))
-        target_airspeed_cm = (aparm.airspeed_max * 100);
+    if (target_airspeed_cm > (airspeed._airspeed_max * 100))
+        target_airspeed_cm = (airspeed._airspeed_max * 100);
 
     // use the TECS view of the target airspeed for reporting, to take
     // account of the landing speed

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -803,8 +803,8 @@ float QuadPlane::assist_climb_rate_cms(void)
 float QuadPlane::desired_auto_yaw_rate_cds(void)
 {
     float aspeed;
-    if (!ahrs.airspeed_estimate(&aspeed) || aspeed < plane.aparm.airspeed_min) {
-        aspeed = plane.aparm.airspeed_min;
+    if (!ahrs.airspeed_estimate(&aspeed) || aspeed < plane.airspeed._airspeed_min) {
+        aspeed = plane.airspeed._airspeed_min;
     }
     if (aspeed < 1) {
         aspeed = 1;
@@ -864,7 +864,7 @@ void QuadPlane::update_transition(void)
             transition_start_ms = millis();
         }
 
-        if (have_airspeed && aspeed > plane.aparm.airspeed_min && !assisted_flight) {
+        if (have_airspeed && aspeed > plane.airspeed._airspeed_min && !assisted_flight) {
             transition_start_ms = millis();
             transition_state = TRANSITION_TIMER;
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Transition airspeed reached %.1f", (double)aspeed);
@@ -1643,7 +1643,7 @@ int8_t QuadPlane::forward_throttle_pct(void)
     float fwd_vel_error = vel_error_body * Vector3f(1,0,0);
 
     // scale forward velocity error by maximum airspeed
-    fwd_vel_error /= MAX(plane.aparm.airspeed_max, 5);
+    fwd_vel_error /= MAX(plane.airspeed._airspeed_max, 5);
 
     // add in a component from our current pitch demand. This tends to
     // move us to zero pitch. Assume that LIM_PITCH would give us the

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -204,7 +204,7 @@ void Plane::read_radio()
     if (g.throttle_nudge && channel_throttle->get_servo_out() > 50 && geofence_stickmixing()) {
         float nudge = (channel_throttle->get_servo_out() - 50) * 0.02f;
         if (ahrs.airspeed_sensor_enabled()) {
-            airspeed_nudge_cm = (aparm.airspeed_max * 100 - g.airspeed_cruise_cm) * nudge;
+            airspeed_nudge_cm = (airspeed._airspeed_max * 100 - g.airspeed_cruise_cm) * nudge;
         } else {
             throttle_nudge = (aparm.throttle_max - aparm.throttle_cruise) * nudge;
         }

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -88,7 +88,7 @@ public:
     AP_AHRS_NavEKF ahrs {ins, barometer, gps, rng, EKF, EKF2};
     AP_InertialNav_NavEKF inertial_nav{ahrs};
     AP_Vehicle::FixedWing aparm;
-    AP_Airspeed airspeed{aparm};
+    AP_Airspeed airspeed;
     DataFlash_Class dataflash{"Replay v0.1"};
 
 private:

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -152,7 +152,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
         }
         float ki_rate = k_I * gains.tau;
 		//only integrate if gain and time step are positive and airspeed above min value.
-		if (dt > 0 && aspeed > 0.5f*float(aparm.airspeed_min)) {
+		if (dt > 0 && aspeed > 0.5f*float(airspeed._airspeed_min)) {
 		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
 			if (_last_out < -45) {
 				// prevent the integrator from increasing if surface defln demand is above the upper limit
@@ -189,7 +189,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
 	_last_out = _pid_info.D + _pid_info.FF + _pid_info.P;
     _pid_info.desired = desired_rate;
 
-    if (autotune.running && aspeed > aparm.airspeed_min) {
+    if (autotune.running && aspeed > airspeed._airspeed_min) {
         // let autotune have a go at the values 
         // Note that we don't pass the integrator component so we get
         // a better idea of how much the base PD controller
@@ -221,7 +221,7 @@ int32_t AP_PitchController::get_rate_out(float desired_rate, float scaler)
     float aspeed;
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(float(airspeed._airspeed_min) + float(airspeed._airspeed_max));
 	}
     return _get_rate_out(desired_rate, scaler, false, aspeed);
 }
@@ -252,13 +252,13 @@ float AP_PitchController::_get_coordination_rate_offset(float &aspeed, bool &inv
 	}
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(float(airspeed._airspeed_min) + float(airspeed._airspeed_max));
 	}
     if (abs(_ahrs.pitch_sensor) > 7000) {
         // don't do turn coordination handling when at very high pitch angles
         rate_offset = 0;
     } else {
-        rate_offset = cosf(_ahrs.pitch)*fabsf(ToDeg((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()) , float(aparm.airspeed_min))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
+        rate_offset = cosf(_ahrs.pitch)*fabsf(ToDeg((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()) , float(airspeed._airspeed_min))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
     }
 	if (inverted) {
 		rate_offset = -rate_offset;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -37,6 +37,7 @@ public:
     
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;
 	AP_Int16 _max_rate_neg;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -133,7 +133,7 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 	// Don't integrate if in stabilise mode as the integrator will wind up against the pilots inputs
 	if (!disable_integrator && ki_rate > 0) {
 		//only integrate if gain and time step are positive and airspeed above min value.
-		if (dt > 0 && aspeed > float(aparm.airspeed_min)) {
+		if (dt > 0 && aspeed > float(airspeed._airspeed_min)) {
 		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
 			// prevent the integrator from increasing if surface defln demand is above the upper limit
 			if (_last_out < -45) {
@@ -165,7 +165,7 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 
 	_last_out = _pid_info.FF + _pid_info.P + _pid_info.D;
 
-    if (autotune.running && aspeed > aparm.airspeed_min) {
+    if (autotune.running && aspeed > airspeed._airspeed_min) {
         // let autotune have a go at the values 
         // Note that we don't pass the integrator component so we get
         // a better idea of how much the base PD controller

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -44,6 +44,7 @@ public:
     
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;
 	uint32_t _last_t;

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -80,7 +80,7 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 	_last_t = tnow;
 	
 
-    int16_t aspd_min = aparm.airspeed_min;
+    int16_t aspd_min = airspeed._airspeed_min;
     if (aspd_min < 1) {
         aspd_min = 1;
     }
@@ -97,7 +97,7 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 	}
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aspd_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(float(aspd_min) + float(airspeed._airspeed_max));
 	}
     rate_offset = (GRAVITY_MSS / MAX(aspeed , float(aspd_min))) * tanf(bank_angle) * cosf(bank_angle) * _K_FF;
 

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -29,6 +29,7 @@ public:
 
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
 	AP_Float _K_A;
 	AP_Float _K_I;
 	AP_Float _K_D;

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -119,6 +119,24 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SKIP_CAL",  7, AP_Airspeed, _skip_cal, 0),
 
+    // @Param: MIN (previously ARSPD_FBW_MIN)
+    // @DisplayName: Minimum Airspeed
+    // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
+    // @Units: m/s
+    // @Range: 5 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("MIN", 8, AP_Airspeed, _airspeed_min, 5),
+
+    // @Param: MAX (previously ARSPD_FBW_MAX)
+    // @DisplayName: Maximum Airspeed
+    // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_FBW_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_FBW_MIN is recommended.
+    // @Units: m/s
+    // @Range: 5 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("MAX", 9, AP_Airspeed, _airspeed_max, 20),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Range: 5 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MIN", 8, AP_Airspeed, _airspeed_min, 5),
+    AP_GROUPINFO("MIN", 8, AP_Airspeed, _airspeed_min, 9),
 
     // @Param: MAX (previously ARSPD_FBW_MAX)
     // @DisplayName: Maximum Airspeed
@@ -135,7 +135,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Range: 5 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MAX", 9, AP_Airspeed, _airspeed_max, 20),
+    AP_GROUPINFO("MAX", 9, AP_Airspeed, _airspeed_max, 22),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -119,23 +119,23 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("SKIP_CAL",  7, AP_Airspeed, _skip_cal, 0),
 
-    // @Param: MIN (previously ARSPD_FBW_MIN)
+    // @Param: FBW_MIN
     // @DisplayName: Minimum Airspeed
     // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
     // @Units: m/s
     // @Range: 5 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MIN", 8, AP_Airspeed, _airspeed_min, 9),
+    AP_GROUPINFO("FBW_MIN", 8, AP_Airspeed, _airspeed_min, 9),
 
-    // @Param: MAX (previously ARSPD_FBW_MAX)
+    // @Param: FBW_MAX
     // @DisplayName: Maximum Airspeed
     // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_FBW_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_FBW_MIN is recommended.
     // @Units: m/s
     // @Range: 5 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("MAX", 9, AP_Airspeed, _airspeed_max, 22),
+    AP_GROUPINFO("FBW_MAX", 9, AP_Airspeed, _airspeed_max, 22),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -16,7 +16,7 @@ class Airspeed_Calibration {
 public:
     friend class AP_Airspeed;
     // constructor
-    Airspeed_Calibration(const AP_Vehicle::FixedWing &parms);
+    Airspeed_Calibration(void);
 
     // initialise the calibration
     void init(float initial_ratio);
@@ -32,16 +32,15 @@ private:
     const float Q1; // process noise matrix bottom right element
     Vector3f state; // state vector
     const float DT; // time delta
-    const AP_Vehicle::FixedWing &aparm;
 };
 
 class AP_Airspeed
 {
 public:
     // constructor
-    AP_Airspeed(const AP_Vehicle::FixedWing &parms)
+    AP_Airspeed()
         : _EAS2TAS(1.0f)
-        , _calibration(parms)
+        , _calibration()
         , analog(_pin)
     {
 		AP_Param::setup_object_defaults(this, var_info);
@@ -151,6 +150,9 @@ public:
     enum pitot_tube_order { PITOT_TUBE_ORDER_POSITIVE = 0,
                             PITOT_TUBE_ORDER_NEGATIVE = 1,
                             PITOT_TUBE_ORDER_AUTO     = 2 };
+
+    AP_Int16       _airspeed_min;
+    AP_Int16       _airspeed_max;
 
 private:
     AP_Float        _offset;

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -13,9 +13,10 @@
 #include "AP_Airspeed.h"
 
 extern const AP_HAL::HAL& hal;
+AP_Airspeed arspd;
 
 // constructor - fill in all the initial values
-Airspeed_Calibration::Airspeed_Calibration(const AP_Vehicle::FixedWing &parms)
+Airspeed_Calibration::Airspeed_Calibration()
     : P(100,   0,         0,
         0,   100,         0,
         0,     0,  0.000001f)
@@ -23,7 +24,6 @@ Airspeed_Calibration::Airspeed_Calibration(const AP_Vehicle::FixedWing &parms)
     , Q1(0.0000005f)
     , state(0, 0, 0)
     , DT(1)
-    , aparm(parms)
 {
 }
 
@@ -39,7 +39,7 @@ void Airspeed_Calibration::init(float initial_ratio)
   update the state of the airspeed calibration - needs to be called
   once a second
  */
-float Airspeed_Calibration::update(float airspeed, const Vector3f &vg)
+float Airspeed_Calibration::update(float aspeed, const Vector3f &vg)
 {
     // Perform the covariance prediction
     // Q is a diagonal matrix so only need to add three terms in
@@ -54,7 +54,7 @@ float Airspeed_Calibration::update(float airspeed, const Vector3f &vg)
     // invariant plus process noise
     // Ignore vertical wind component
     float TAS_pred = state.z * norm(vg.x - state.x, vg.y - state.y, vg.z);
-    float TAS_mea  = airspeed;
+    float TAS_mea  = aspeed;
 
     // Calculate the observation Jacobian H_TAS
     float SH1 = sq(vg.y - state.y) + sq(vg.x - state.x);
@@ -101,8 +101,8 @@ float Airspeed_Calibration::update(float airspeed, const Vector3f &vg)
     P.b.y = MAX(P.b.y, 0.0f);
     P.c.z = MAX(P.c.z, 0.0f);
 
-    state.x = constrain_float(state.x, -aparm.airspeed_max, aparm.airspeed_max);
-    state.y = constrain_float(state.y, -aparm.airspeed_max, aparm.airspeed_max);
+    state.x = constrain_float(state.x, -arspd._airspeed_max, arspd._airspeed_max);
+    state.y = constrain_float(state.y, -arspd._airspeed_max, arspd._airspeed_max);
     state.z = constrain_float(state.z, 0.5f, 1.0f);
 
     return state.z;

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -25,11 +25,9 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_Vehicle::FixedWing aparm;
-
 float temperature;
 
-AP_Airspeed airspeed(aparm);
+AP_Airspeed airspeed;
 
 void setup()
 {

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -340,8 +340,8 @@ void AP_TECS::_update_speed(float load_factor)
 
     float EAS2TAS = _ahrs.get_EAS2TAS();
     _TAS_dem = _EAS_dem * EAS2TAS;
-    _TASmax   = aparm.airspeed_max * EAS2TAS;
-    _TASmin   = aparm.airspeed_min * EAS2TAS;
+    _TASmax   = airspeed._airspeed_max * EAS2TAS;
+    _TASmin   = airspeed._airspeed_min * EAS2TAS;
 
     if (aparm.stall_prevention) {
         // when stall prevention is active we raise the mimimum
@@ -368,7 +368,7 @@ void AP_TECS::_update_speed(float load_factor)
     // airspeed is not being used and set speed rate to zero
     if (!_ahrs.airspeed_sensor_enabled() || !_ahrs.airspeed_estimate(&_EAS)) {
         // If no airspeed available use average of min and max
-        _EAS = 0.5f * (aparm.airspeed_min.get() + (float)aparm.airspeed_max.get());
+        _EAS = 0.5f * ((float)airspeed._airspeed_min + (float)airspeed._airspeed_max);
     }
 
     // Implement a second order complementary filter to obtain a

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -121,6 +121,7 @@ private:
     AP_AHRS &_ahrs;
 
     const AP_Vehicle::FixedWing &aparm;
+    AP_Airspeed airspeed;
 
     // TECS tuning parameters
     AP_Float _hgtCompFiltOmega;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -33,8 +33,6 @@ public:
         AP_Int8 throttle_slewrate;
         AP_Int8 throttle_cruise;
         AP_Int8 takeoff_throttle_max;
-        AP_Int16 airspeed_min;
-        AP_Int16 airspeed_max;
         AP_Int16 pitch_limit_max_cd;
         AP_Int16 pitch_limit_min_cd;        
         AP_Int8  autotune_level;


### PR DESCRIPTION
This series of commits makes the AP_Airspeed library standalone from the APM:Plane library.  Currently the airspeed sensor can't be used on Copter (even for logging purposes) due to the reliance on _airspeed_min_ and _airspeed_max_ which are part of AP_Vehicle::Plane.  This moves _airspeed_min_ and _airspeed_max_ to the AP_Airspeed library and updates all the references.

Updating will (most likely) require users to reset _ARSPD_MIN_ and _ARSPD_MAX_ to their previous _ARSPD_FBW_MIN_ and _ARSPD_FBW_MAX_ values.