### PR TITLE
Copter: allow motor PWM range to be different from RC's throttle input range

### DIFF
--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -157,7 +157,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         read_radio();
         
         // pass through throttle to motors
-        motors.throttle_pass_through(channel_throttle->get_radio_in());
+        motors.set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() / 1000.0f);
         
         // read some compass values
         compass.read();

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -100,7 +100,7 @@ void Copter::esc_calibration_passthrough()
         delay(10);
 
         // pass through to motors
-        motors.throttle_pass_through(channel_throttle->get_radio_in());
+        motors.set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() / 1000.0f);
     }
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
@@ -126,7 +126,7 @@ void Copter::esc_calibration_auto()
 
     // raise throttle to maximum
     delay(10);
-    motors.throttle_pass_through(channel_throttle->get_radio_max());
+    motors.set_throttle_passthrough_for_esc_calibration(1.0f);
 
     // wait for safety switch to be pressed
     while (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
@@ -141,7 +141,7 @@ void Copter::esc_calibration_auto()
     delay(5000);
 
     // reduce throttle to minimum
-    motors.throttle_pass_through(channel_throttle->get_radio_min());
+    motors.set_throttle_passthrough_for_esc_calibration(0.0f);
 
     // clear esc parameter
     g.esc_calibrate.set_and_save(ESCCAL_NONE);

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -122,8 +122,8 @@ void AP_MotorsCoax::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_pitch_radio_passthrough, _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_roll_radio_passthrough, _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_pitch_radio_passthrough, _servo4));
-            rc_write(AP_MOTORS_MOT_5, get_pwm_min());
-            rc_write(AP_MOTORS_MOT_6, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_5, get_pwm_output_min());
+            rc_write(AP_MOTORS_MOT_6, get_pwm_output_min());
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
@@ -133,8 +133,8 @@ void AP_MotorsCoax::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[1], _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[2], _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[3], _servo4));
-            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
-            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
             hal.rcout->push();
             break;
         case SPOOL_UP:

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -122,8 +122,8 @@ void AP_MotorsCoax::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_pitch_radio_passthrough, _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_roll_radio_passthrough, _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_pitch_radio_passthrough, _servo4));
-            rc_write(AP_MOTORS_MOT_5, _throttle_radio_min);
-            rc_write(AP_MOTORS_MOT_6, _throttle_radio_min);
+            rc_write(AP_MOTORS_MOT_5, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_6, get_pwm_min());
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
@@ -133,8 +133,8 @@ void AP_MotorsCoax::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[1], _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[2], _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[3], _servo4));
-            rc_write(AP_MOTORS_MOT_5, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
-            rc_write(AP_MOTORS_MOT_6, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
+            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
             hal.rcout->push();
             break;
         case SPOOL_UP:

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -94,7 +94,7 @@ void AP_MotorsMatrix::output_to_motors()
             // set motor output based on thrust requests
             for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled[i]) {
-                    motor_out[i] = _throttle_radio_min;
+                    motor_out[i] = get_pwm_min();
                 }
             }
             break;
@@ -102,7 +102,7 @@ void AP_MotorsMatrix::output_to_motors()
             // sends output to motors when armed but not flying
             for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled[i]) {
-                    motor_out[i] = constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle);
+                    motor_out[i] = constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle);
                 }
             }
             break;

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -94,7 +94,7 @@ void AP_MotorsMatrix::output_to_motors()
             // set motor output based on thrust requests
             for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled[i]) {
-                    motor_out[i] = get_pwm_min();
+                    motor_out[i] = get_pwm_output_min();
                 }
             }
             break;
@@ -102,7 +102,7 @@ void AP_MotorsMatrix::output_to_motors()
             // sends output to motors when armed but not flying
             for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
                 if (motor_enabled[i]) {
-                    motor_out[i] = constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle);
+                    motor_out[i] = constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle);
                 }
             }
             break;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -105,7 +105,21 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Values: 0:Normal,1:OneShot,2:OneShot125
     // @User: Advanced
     AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, PWM_TYPE_NORMAL),
-    
+
+    // @Param: PWM_MIN
+    // @DisplayName: PWM output miniumum
+    // @Description: This sets the min PWM output value that will ever be output to the motors, 0 = use input RC3_MIN
+    // @Range: 0 2000
+    // @User: Advanced
+    AP_GROUPINFO("PWM_MIN", 16, AP_MotorsMulticopter, _pwm_min, 0),
+
+    // @Param: PWM_MAX
+    // @DisplayName: PWM output maximum
+    // @Description: This sets the max PWM value that will ever be output to the motors, 0 = use input RC3_MAX
+    // @Range: 0 2000
+    // @User: Advanced
+    AP_GROUPINFO("PWM_MAX", 17, AP_MotorsMulticopter, _pwm_max, 0),
+
     AP_GROUPEND
 };
 
@@ -114,10 +128,7 @@ AP_MotorsMulticopter::AP_MotorsMulticopter(uint16_t loop_rate, uint16_t speed_hz
     AP_Motors(loop_rate, speed_hz),
     _throttle_rpy_mix_desired(AP_MOTORS_THR_LOW_CMP_DEFAULT),
     _throttle_rpy_mix(AP_MOTORS_THR_LOW_CMP_DEFAULT),
-    _min_throttle(AP_MOTORS_DEFAULT_MIN_THROTTLE),
     _hover_out(AP_MOTORS_DEFAULT_MID_THROTTLE),
-    _throttle_radio_min(1100),
-    _throttle_radio_max(1900),
     _batt_voltage_resting(0.0f),
     _batt_current_resting(0.0f),
     _batt_resistance(0.0f),
@@ -133,6 +144,9 @@ AP_MotorsMulticopter::AP_MotorsMulticopter(uint16_t loop_rate, uint16_t speed_hz
     // setup battery voltage filtering
     _batt_voltage_filt.set_cutoff_frequency(AP_MOTORS_BATT_VOLT_FILT_HZ);
     _batt_voltage_filt.reset(1.0f);
+
+    // default throttle ranges (i.e. _min_throttle, _throttle_radio_min, _throttle_radio_max)
+    set_throttle_range(130, 1100, 1900);
 };
 
 // output - sends commands to the motors
@@ -314,17 +328,41 @@ float AP_MotorsMulticopter::get_compensation_gain() const
 
 int16_t AP_MotorsMulticopter::calc_thrust_to_pwm(float thrust_in) const
 {
-    return constrain_int16((_throttle_radio_min + _min_throttle + apply_thrust_curve_and_volt_scaling(thrust_in) *
-            ( _throttle_radio_max - (_throttle_radio_min + _min_throttle))), _throttle_radio_min + _min_throttle, _throttle_radio_max);
+    return constrain_int16((get_pwm_min() + _min_throttle + apply_thrust_curve_and_volt_scaling(thrust_in) *
+            ( get_pwm_max() - (get_pwm_min() + _min_throttle))), get_pwm_min() + _min_throttle, get_pwm_max());
+}
+
+// get minimum or maximum pwm value that can be output to motors
+int16_t AP_MotorsMulticopter::get_pwm_min() const
+{
+    // return _pwm_min if both PWM_MIN and PWM_MAX parmeters are defined and valid
+    if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
+        return _pwm_min;
+    }
+    return _throttle_radio_min;
+}
+
+// get maximum pwm value that can be output to motors
+int16_t AP_MotorsMulticopter::get_pwm_max() const
+{
+    // return _pwm_max if both PWM_MIN and PWM_MAX parmeters are defined and valid
+    if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
+        return _pwm_max;
+    }
+    return _throttle_radio_max;
 }
 
 // set_throttle_range - sets the minimum throttle that will be sent to the engines when they're not off (i.e. to prevents issues with some motors spinning and some not at very low throttle)
 // also sets throttle channel minimum and maximum pwm
 void AP_MotorsMulticopter::set_throttle_range(uint16_t min_throttle, int16_t radio_min, int16_t radio_max)
 {
-    _throttle_radio_min = radio_min;
-    _throttle_radio_max = radio_max;
-    _min_throttle = (float)min_throttle * ((_throttle_radio_max - _throttle_radio_min) / 1000.0f);
+    // sanity check
+    if ((radio_max > radio_min) && (min_throttle < (radio_max - radio_min))) {
+        _throttle_radio_min = radio_min;
+        _throttle_radio_max = radio_max;
+    }
+    // update _min_throttle
+    _min_throttle = (float)min_throttle * ((get_pwm_max() - get_pwm_min()) / 1000.0f);
 }
 
 void AP_MotorsMulticopter::output_logic()
@@ -488,16 +526,17 @@ void AP_MotorsMulticopter::output_logic()
     }
 }
 
-// throttle_pass_through - passes provided pwm directly to all motors - dangerous but used for initialising ESCs
-//  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
-void AP_MotorsMulticopter::throttle_pass_through(int16_t pwm)
+// passes throttle directly to all motors for ESC calibration.
+//   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_min() and 1 will send get_pwm_max()
+void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float throttle_input)
 {
     if (armed()) {
+        uint16_t pwm_out = get_pwm_min() + constrain_float(throttle_input, 0.0f, 1.0f) * (get_pwm_max() - get_pwm_min());
         // send the pilot's input directly to each enabled motor
         hal.rcout->cork();
         for (uint16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                rc_write(i, pwm);
+                rc_write(i, pwm_out);
             }
         }
         hal.rcout->push();
@@ -516,7 +555,7 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask)
             if (mask & (1U<<i)) {
                 motor_out = calc_thrust_to_pwm(thrust);
             } else {
-                motor_out = _throttle_radio_min;
+                motor_out = get_pwm_min();
             }
             rc_write(i, motor_out);
         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -54,36 +54,36 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("THST_EXPO", 8, AP_MotorsMulticopter, _thrust_curve_expo, AP_MOTORS_THST_EXPO_DEFAULT),
 
-    // @Param: THST_MAX
-    // @DisplayName: Thrust Curve Max
-    // @Description: Point at which the thrust saturates
-    // @Values: 0.9:Low, 1.0:High
+    // @Param: SPIN_MAX
+    // @DisplayName: Motor Spin maximum
+    // @Description: Point at which the thrust saturates expressed as a number from 0 to 1 in the entire output range
+    // @Values: 0.9:Low, 0.95:Default, 1.0:High
     // @User: Advanced
-    AP_GROUPINFO("THST_MAX", 9, AP_MotorsMulticopter, _thrust_curve_max, AP_MOTORS_THST_MAX_DEFAULT),
+    AP_GROUPINFO("SPIN_MAX", 9, AP_MotorsMulticopter, _thrust_curve_max, AP_MOTORS_SPIN_MAX_DEFAULT),
 
-    // @Param: THST_BAT_MAX
+    // @Param: BAT_VOLT_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.4 * cell count, 0 = Disabled
     // @Range: 6 35
     // @Units: Volts
     // @User: Advanced
-    AP_GROUPINFO("THST_BAT_MAX", 10, AP_MotorsMulticopter, _batt_voltage_max, AP_MOTORS_THST_BAT_MAX_DEFAULT),
+    AP_GROUPINFO("BAT_VOLT_MAX", 10, AP_MotorsMulticopter, _batt_voltage_max, AP_MOTORS_BAT_VOLT_MAX_DEFAULT),
 
-    // @Param: THST_BAT_MIN
+    // @Param: BAT_VOLT_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled
     // @Range: 6 35
     // @Units: Volts
     // @User: Advanced
-    AP_GROUPINFO("THST_BAT_MIN", 11, AP_MotorsMulticopter, _batt_voltage_min, AP_MOTORS_THST_BAT_MIN_DEFAULT),
+    AP_GROUPINFO("BAT_VOLT_MIN", 11, AP_MotorsMulticopter, _batt_voltage_min, AP_MOTORS_BAT_VOLT_MIN_DEFAULT),
 
-    // @Param: CURR_MAX
+    // @Param: BAT_CURR_MAX
     // @DisplayName: Motor Current Max
     // @Description: Maximum current over which maximum throttle is limited (0 = Disabled)
     // @Range: 0 200
     // @Units: Amps
     // @User: Advanced
-    AP_GROUPINFO("CURR_MAX", 12, AP_MotorsMulticopter, _batt_current_max, AP_MOTORS_CURR_MAX_DEFAULT),
+    AP_GROUPINFO("BAT_CURR_MAX", 12, AP_MotorsMulticopter, _batt_current_max, AP_MOTORS_BAT_CURR_MAX_DEFAULT),
 
     // @Param: THR_MIX_MIN
     // @DisplayName: Throttle Mix Minimum

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -328,12 +328,12 @@ float AP_MotorsMulticopter::get_compensation_gain() const
 
 int16_t AP_MotorsMulticopter::calc_thrust_to_pwm(float thrust_in) const
 {
-    return constrain_int16((get_pwm_min() + _min_throttle + apply_thrust_curve_and_volt_scaling(thrust_in) *
-            ( get_pwm_max() - (get_pwm_min() + _min_throttle))), get_pwm_min() + _min_throttle, get_pwm_max());
+    return constrain_int16((get_pwm_output_min() + _min_throttle + apply_thrust_curve_and_volt_scaling(thrust_in) *
+            (get_pwm_output_max() - (get_pwm_output_min() + _min_throttle))), get_pwm_output_min() + _min_throttle, get_pwm_output_max());
 }
 
 // get minimum or maximum pwm value that can be output to motors
-int16_t AP_MotorsMulticopter::get_pwm_min() const
+int16_t AP_MotorsMulticopter::get_pwm_output_min() const
 {
     // return _pwm_min if both PWM_MIN and PWM_MAX parameters are defined and valid
     if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
@@ -343,7 +343,7 @@ int16_t AP_MotorsMulticopter::get_pwm_min() const
 }
 
 // get maximum pwm value that can be output to motors
-int16_t AP_MotorsMulticopter::get_pwm_max() const
+int16_t AP_MotorsMulticopter::get_pwm_output_max() const
 {
     // return _pwm_max if both PWM_MIN and PWM_MAX parameters are defined and valid
     if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
@@ -362,7 +362,7 @@ void AP_MotorsMulticopter::set_throttle_range(uint16_t min_throttle, int16_t rad
         _throttle_radio_max = radio_max;
     }
     // update _min_throttle
-    _min_throttle = (float)min_throttle * ((get_pwm_max() - get_pwm_min()) / 1000.0f);
+    _min_throttle = (float)min_throttle * ((get_pwm_output_max() - get_pwm_output_min()) / 1000.0f);
 }
 
 void AP_MotorsMulticopter::output_logic()
@@ -527,11 +527,11 @@ void AP_MotorsMulticopter::output_logic()
 }
 
 // passes throttle directly to all motors for ESC calibration.
-//   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_min() and 1 will send get_pwm_max()
+//   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_output_min() and 1 will send get_pwm_output_max()
 void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float throttle_input)
 {
     if (armed()) {
-        uint16_t pwm_out = get_pwm_min() + constrain_float(throttle_input, 0.0f, 1.0f) * (get_pwm_max() - get_pwm_min());
+        uint16_t pwm_out = get_pwm_output_min() + constrain_float(throttle_input, 0.0f, 1.0f) * (get_pwm_output_max() - get_pwm_output_min());
         // send the pilot's input directly to each enabled motor
         hal.rcout->cork();
         for (uint16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
@@ -555,7 +555,7 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask)
             if (mask & (1U<<i)) {
                 motor_out = calc_thrust_to_pwm(thrust);
             } else {
-                motor_out = get_pwm_min();
+                motor_out = get_pwm_output_min();
             }
             rc_write(i, motor_out);
         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -335,7 +335,7 @@ int16_t AP_MotorsMulticopter::calc_thrust_to_pwm(float thrust_in) const
 // get minimum or maximum pwm value that can be output to motors
 int16_t AP_MotorsMulticopter::get_pwm_min() const
 {
-    // return _pwm_min if both PWM_MIN and PWM_MAX parmeters are defined and valid
+    // return _pwm_min if both PWM_MIN and PWM_MAX parameters are defined and valid
     if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
         return _pwm_min;
     }
@@ -345,7 +345,7 @@ int16_t AP_MotorsMulticopter::get_pwm_min() const
 // get maximum pwm value that can be output to motors
 int16_t AP_MotorsMulticopter::get_pwm_max() const
 {
-    // return _pwm_max if both PWM_MIN and PWM_MAX parmeters are defined and valid
+    // return _pwm_max if both PWM_MIN and PWM_MAX parameters are defined and valid
     if ((_pwm_min > 0) && (_pwm_max > 0) && (_pwm_max > _pwm_min)) {
         return _pwm_max;
     }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -78,7 +78,7 @@ public:
     void                output_logic();
 
     // passes throttle directly to all motors for ESC calibration.
-    //   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_min() and 1 will send get_pwm_max()
+    //   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_output_min() and 1 will send get_pwm_output_max()
     void                set_throttle_passthrough_for_esc_calibration(float throttle_input);
 
     // get_lift_max - get maximum lift ratio - for logging purposes only
@@ -143,8 +143,8 @@ protected:
     int16_t             calc_thrust_to_pwm(float thrust_in) const;
 
     // get minimum or maximum pwm value that can be output to motors
-    int16_t             get_pwm_min() const;
-    int16_t             get_pwm_max() const;
+    int16_t             get_pwm_output_min() const;
+    int16_t             get_pwm_output_max() const;
 
     // apply any thrust compensation for the frame
     virtual void        thrust_compensation(void) {}

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -10,7 +10,6 @@
 #define AP_MOTORS_DENSITY_COMP 1
 #endif
 
-#define AP_MOTORS_DEFAULT_MIN_THROTTLE  130
 #define AP_MOTORS_DEFAULT_MID_THROTTLE  500
 
 #define AP_MOTORS_SPIN_WHEN_ARMED       70      // spin motors at this PWM value when armed
@@ -78,9 +77,9 @@ public:
 
     void                output_logic();
 
-    // throttle_pass_through - passes provided pwm directly to all motors - dangerous but used for initialising ESCs
-    //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
-    void                throttle_pass_through(int16_t pwm);
+    // passes throttle directly to all motors for ESC calibration.
+    //   throttle_input is in the range of 0 ~ 1 where 0 will send get_pwm_min() and 1 will send get_pwm_max()
+    void                set_throttle_passthrough_for_esc_calibration(float throttle_input);
 
     // get_lift_max - get maximum lift ratio - for logging purposes only
     float               get_lift_max() { return _lift_max; }
@@ -143,6 +142,10 @@ protected:
     // convert thrust (0~1) range back to pwm range
     int16_t             calc_thrust_to_pwm(float thrust_in) const;
 
+    // get minimum or maximum pwm value that can be output to motors
+    int16_t             get_pwm_min() const;
+    int16_t             get_pwm_max() const;
+
     // apply any thrust compensation for the frame
     virtual void        thrust_compensation(void) {}
     
@@ -162,6 +165,8 @@ protected:
     AP_Float            _batt_current_max;      // current over which maximum throttle is limited
     AP_Float            _thr_mix_min;           // throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)
     AP_Float            _thr_mix_max;           // throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)
+    AP_Int16            _pwm_min;               // minimum PWM value that will ever be output to the motors (if 0, vehicle's throttle input channel's min pwm used)
+    AP_Int16            _pwm_max;               // maximum PWM value that will ever be output to the motors (if 0, vehicle's throttle input channel's max pwm used)
 
     // internal variables
     bool                motor_enabled[AP_MOTORS_MAX_NUM_MOTORS];    // true if motor is enabled

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -59,7 +59,7 @@ public:
     bool                is_throttle_mix_min() const { return (_throttle_rpy_mix < 1.25f*_thr_mix_min); }
 
     // set_throttle_range - sets the minimum throttle that will be sent to the engines when they're not off (i.e. to prevents issues with some motors spinning and some not at very low throttle)
-    // also sets throttle channel minimum and maximum pwm
+    // also sets minimum and maximum pwm values that will be sent to the motors
     void                set_throttle_range(uint16_t min_throttle, int16_t radio_min, int16_t radio_max);
 
     // set_hover_throttle - sets the mid throttle which is close to the hover throttle of the copter
@@ -174,8 +174,8 @@ protected:
     float               _throttle_rpy_mix;          // mix between throttle and hover throttle for 0 to 1 and ratio above hover throttle for >1
     int16_t             _min_throttle;              // the minimum throttle to be sent to the motors when they're on (prevents motors stalling while flying)
     int16_t             _hover_out;                 // the estimated hover throttle as pct * 10 (i.e. 0 ~ 1000)
-    int16_t             _throttle_radio_min;        // minimum radio channel pwm
-    int16_t             _throttle_radio_max;        // maximum radio channel pwm
+    int16_t             _throttle_radio_min;        // minimum PWM from RC input's throttle channel (i.e. minimum PWM input from receiver, RC3_MIN)
+    int16_t             _throttle_radio_max;        // maximum PWM from RC input's throttle channel (i.e. maximum PWM input from receiver, RC3_MAX)
     float               _throttle_thrust_max;       // the maximum allowed throttle thrust 0.0 to 1.0 in the range throttle_min to throttle_max
 
     // spool variables

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -16,10 +16,10 @@
 #define AP_MOTORS_YAW_HEADROOM_DEFAULT  200
 #define AP_MOTORS_THR_LOW_CMP_DEFAULT   0.5f    // ratio controlling the max throttle output during competing requests of low throttle from the pilot (or autopilot) and higher throttle for attitude control.  Higher favours Attitude over pilot input
 #define AP_MOTORS_THST_EXPO_DEFAULT     0.65f   // set to 0 for linear and 1 for second order approximation
-#define AP_MOTORS_THST_MAX_DEFAULT      0.95f   // throttle which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
-#define AP_MOTORS_THST_BAT_MAX_DEFAULT  0.0f
-#define AP_MOTORS_THST_BAT_MIN_DEFAULT  0.0f
-#define AP_MOTORS_CURR_MAX_DEFAULT      0.0f    // current limiting max default
+#define AP_MOTORS_SPIN_MAX_DEFAULT      0.95f   // throttle which produces the maximum thrust.  (i.e. 0 ~ 1 ) of the full throttle range
+#define AP_MOTORS_BAT_VOLT_MAX_DEFAULT  0.0f    // voltage limiting max default
+#define AP_MOTORS_BAT_VOLT_MIN_DEFAULT  0.0f    // voltage limiting min default (voltage dropping below this level will have no effect)
+#define AP_MOTORS_BAT_CURR_MAX_DEFAULT  0.0f    // current limiting max default
 #define AP_MOTORS_CURRENT_LIMIT_P       0.2f    // replace with parameter - Sets the current limit P term
 #define AP_MOTORS_BATT_VOLT_FILT_HZ     0.5f    // battery voltage filtered at 0.5hz
 #define AP_MOTORS_THR_MIX_MIN_DEFAULT   0.1f    // minimum throttle mix

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -125,8 +125,8 @@ void AP_MotorsSingle::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_pitch_radio_passthrough+_yaw_radio_passthrough, _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(-_roll_radio_passthrough+_yaw_radio_passthrough, _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(-_pitch_radio_passthrough+_yaw_radio_passthrough, _servo4));
-            rc_write(AP_MOTORS_MOT_5, _throttle_radio_min);
-            rc_write(AP_MOTORS_MOT_6, _throttle_radio_min);
+            rc_write(AP_MOTORS_MOT_5, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_6, get_pwm_min());
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
@@ -136,8 +136,8 @@ void AP_MotorsSingle::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[1], _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[2], _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[3], _servo4));
-            rc_write(AP_MOTORS_MOT_5, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
-            rc_write(AP_MOTORS_MOT_6, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
+            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
             hal.rcout->push();
             break;
         case SPOOL_UP:

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -125,8 +125,8 @@ void AP_MotorsSingle::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_pitch_radio_passthrough+_yaw_radio_passthrough, _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(-_roll_radio_passthrough+_yaw_radio_passthrough, _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(-_pitch_radio_passthrough+_yaw_radio_passthrough, _servo4));
-            rc_write(AP_MOTORS_MOT_5, get_pwm_min());
-            rc_write(AP_MOTORS_MOT_6, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_5, get_pwm_output_min());
+            rc_write(AP_MOTORS_MOT_6, get_pwm_output_min());
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
@@ -136,8 +136,8 @@ void AP_MotorsSingle::output_to_motors()
             rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[1], _servo2));
             rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[2], _servo3));
             rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(_throttle_low_end_pct * _actuator_out[3], _servo4));
-            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
-            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_5, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_6, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
             hal.rcout->push();
             break;
         case SPOOL_UP:

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -128,18 +128,18 @@ void AP_MotorsTri::output_to_motors()
         case SHUT_DOWN:
             // sends minimum values out to the motors
             hal.rcout->cork();
-            rc_write(AP_MOTORS_MOT_1, _throttle_radio_min);
-            rc_write(AP_MOTORS_MOT_2, _throttle_radio_min);
-            rc_write(AP_MOTORS_MOT_4, _throttle_radio_min);
+            rc_write(AP_MOTORS_MOT_1, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_2, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_4, get_pwm_min());
             rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
             // sends output to motors when armed but not flying
             hal.rcout->cork();
-            rc_write(AP_MOTORS_MOT_1, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
-            rc_write(AP_MOTORS_MOT_2, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
-            rc_write(AP_MOTORS_MOT_4, constrain_int16(_throttle_radio_min + _throttle_low_end_pct * _min_throttle, _throttle_radio_min, _throttle_radio_min + _min_throttle));
+            rc_write(AP_MOTORS_MOT_1, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_2, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_4, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
             rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
             hal.rcout->push();
             break;

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -128,18 +128,18 @@ void AP_MotorsTri::output_to_motors()
         case SHUT_DOWN:
             // sends minimum values out to the motors
             hal.rcout->cork();
-            rc_write(AP_MOTORS_MOT_1, get_pwm_min());
-            rc_write(AP_MOTORS_MOT_2, get_pwm_min());
-            rc_write(AP_MOTORS_MOT_4, get_pwm_min());
+            rc_write(AP_MOTORS_MOT_1, get_pwm_output_min());
+            rc_write(AP_MOTORS_MOT_2, get_pwm_output_min());
+            rc_write(AP_MOTORS_MOT_4, get_pwm_output_min());
             rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
             hal.rcout->push();
             break;
         case SPIN_WHEN_ARMED:
             // sends output to motors when armed but not flying
             hal.rcout->cork();
-            rc_write(AP_MOTORS_MOT_1, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
-            rc_write(AP_MOTORS_MOT_2, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
-            rc_write(AP_MOTORS_MOT_4, constrain_int16(get_pwm_min() + _throttle_low_end_pct * _min_throttle, get_pwm_min(), get_pwm_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_1, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_2, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
+            rc_write(AP_MOTORS_MOT_4, constrain_int16(get_pwm_output_min() + _throttle_low_end_pct * _min_throttle, get_pwm_output_min(), get_pwm_output_min() + _min_throttle));
             rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
             hal.rcout->push();
             break;


### PR DESCRIPTION
This adds two new parameters, MOT_PWM_MIN and MOT_PWM_MAX that can be used to set the motor output pwm range to something different than the RC receiver's throttle input range (i.e. RC3_MIN, RC3_MAX).

The parameters are zero by default meaning no change from master's current behaviour which is to use the RC receivers throttle input range for output as well.

Also included in this PR is a slightly unrelated change to rename a few motor library parameters