### PR TITLE
Allow surfaces to move regardless of safety switch

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -53,30 +53,35 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @DisplayName: Auxiliary pin config
     // @Description: Control assigning of FMU pins to PWM output, timer capture and GPIO. All unassigned pins can be used for GPIO
     // @Values: 0:No PWMs,2:Two PWMs,4:Four PWMs,6:Six PWMs,7:Three PWMs and One Capture
+    // @RebootRequired: True
     AP_GROUPINFO("PWM_COUNT",    0, AP_BoardConfig, _pwm_count, BOARD_PWM_COUNT_DEFAULT),
 
     // @Param: SER1_RTSCTS
     // @DisplayName: Serial 1 flow control
     // @Description: Enable flow control on serial 1 (telemetry 1) on Pixhawk. You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup. Note that the PX4v1 does not have hardware flow control pins on this port, so you should leave this disabled.
     // @Values: 0:Disabled,1:Enabled,2:Auto
+    // @RebootRequired: True
     AP_GROUPINFO("SER1_RTSCTS",    1, AP_BoardConfig, _ser1_rtscts, BOARD_SER1_RTSCTS_DEFAULT),
 
     // @Param: SER2_RTSCTS
     // @DisplayName: Serial 2 flow control
     // @Description: Enable flow control on serial 2 (telemetry 2) on Pixhawk and PX4. You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup.
     // @Values: 0:Disabled,1:Enabled,2:Auto
+    // @RebootRequired: True
     AP_GROUPINFO("SER2_RTSCTS",    2, AP_BoardConfig, _ser2_rtscts, 2),
 
     // @Param: SAFETYENABLE
     // @DisplayName:  Enable use of safety arming switch
     // @Description: Disabling this option will disable the use of the safety switch on PX4 for arming. Use of the safety switch is highly recommended, so you should leave this option set to 1 except in unusual circumstances.
     // @Values: 0:Disabled,1:Enabled
+    // @RebootRequired: True
     AP_GROUPINFO("SAFETYENABLE",   3, AP_BoardConfig, _safety_enable, 1),
 
     // @Param: SBUS_OUT
     // @DisplayName:  SBUS output rate
     // @Description: This sets the SBUS output frame rate in Hz
     // @Values: 0:Disabled,1:50Hz,2:75Hz,3:100Hz,4:150Hz,5:200Hz,6:250Hz,7:300Hz
+    // @RebootRequired: True
     AP_GROUPINFO("SBUS_OUT",   4, AP_BoardConfig, _sbus_out_rate, 0),
     
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
@@ -97,6 +102,16 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     AP_GROUPINFO("CAN_ENABLE", 6, AP_BoardConfig, _can_enable, 0),
 #endif
     
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+    // @Param: SAFETY_MASK
+    // @DisplayName: Channels to which ignore the safety switch state
+    // @Description: A bitmask which controls what channels can move while the safety witch has not been pressed
+    // @Values: 0:Disabled,1:Enabled
+    // @Bitmask: 0:Ch1,1:Ch2,2:Ch3,3:Ch4,4:Ch5,5:Ch6,6:Ch7,7:Ch8
+    // @RebootRequired: True
+    AP_GROUPINFO("SAFETY_MASK", 7, AP_BoardConfig, _ignore_safety_channels, 0),
+#endif
+
     AP_GROUPEND
 };
 
@@ -113,7 +128,7 @@ extern "C" int uavcan_main(int argc, const char *argv[]);
 void AP_BoardConfig::init()
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
-    /* configurre the FMU driver for the right number of PWMs */
+    /* configure the FMU driver for the right number of PWMs */
     static const struct {
         uint8_t mode_parm;
         uint8_t mode_value;
@@ -149,6 +164,15 @@ void AP_BoardConfig::init()
             AP_Param::set_default_by_name("RELAY_PIN", -1);
             AP_Param::set_default_by_name("RELAY_PIN2", -1);
         }
+    }
+
+    // setup channels to ignore the armed state
+    int px4io_fd = open("/dev/px4io", 0);
+    if (px4io_fd != -1) {
+        if (ioctl(px4io_fd, PWM_SERVO_IGNORE_ARMING, (uint16_t)(0x0000FFFF & _ignore_safety_channels)) != 0) {
+            hal.console->printf("IGNORE_ARMING failed\n");
+        }
+        close(px4io_fd);
     }
 
     hal.uartC->set_flow_control((AP_HAL::UARTDriver::flow_control)_ser1_rtscts.get());

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -27,6 +27,7 @@ private:
     AP_Int8 _ser2_rtscts;
     AP_Int8 _safety_enable;
     AP_Int8 _sbus_out_rate;
+    AP_Int32 _ignore_safety_channels;
 #ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
     AP_Int8 _can_enable;
 #endif


### PR DESCRIPTION
This allows a bitmask of channels to be passed to the io processor and move regardless of the safety switch state.

Also corrects a incorrect calculation on plane of the override PWM range.