### PR TITLE
Waf cxx checks

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -221,6 +221,7 @@ class linux(Board):
 
         cfg.check_librt(env)
         cfg.check_lttng(env)
+        cfg.check_libiio(env)
 
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES = [
@@ -301,11 +302,6 @@ class bebop(linux):
 
     def configure_env(self, cfg, env):
         super(bebop, self).configure_env(cfg, env)
-
-        cfg.check_cfg(package='libiio', mandatory=False, global_define=True,
-                args = ['--libs', '--cflags'])
-
-        env.LIB += cfg.env.LIB_LIBIIO
 
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BEBOP',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -184,12 +184,11 @@ class sitl(Board):
                 '-O3',
             ]
 
-        cfg.check_librt()
-
         env.LIB += [
             'm',
         ]
-        env.LIB += cfg.env.LIB_RT
+
+        cfg.check_librt(env)
 
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES += [
@@ -216,12 +215,11 @@ class linux(Board):
                 '-O3',
             ]
 
-        cfg.check_librt()
-
         env.LIB += [
             'm',
         ]
-        env.LIB += cfg.env.LIB_RT
+
+        cfg.check_librt(env)
 
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES = [

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -220,6 +220,7 @@ class linux(Board):
         ]
 
         cfg.check_librt(env)
+        cfg.check_lttng(env)
 
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES = [

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -148,3 +148,10 @@ def check_librt(cfg, env):
         env.LIB += cfg.env['LIB_RT']
 
     return ret
+
+@conf
+def check_lttng(cfg, env):
+    cfg.check_cfg(package='lttng-ust', mandatory=False, global_define=True,
+                  args = ['--libs', '--cflags'])
+    env.LIB += cfg.env['LIB_LTTNG-UST']
+    return True

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -125,8 +125,8 @@ def ap_common_checks(cfg):
     )
 
 @conf
-def check_librt(cfg):
-    success = cfg.check(
+def check_librt(cfg, env):
+    ret = cfg.check(
         compiler='cxx',
         fragment='''
         #include <time.h>
@@ -140,10 +140,11 @@ def check_librt(cfg):
         mandatory=False,
     )
 
-    if success:
-        return success
+    if ret:
+        return ret
 
-    return cfg.check(
-        compiler='cxx',
-        lib='rt',
-    )
+    ret = cfg.check(compiler='cxx', lib='rt', mandatory=True)
+    if ret:
+        env.LIB += cfg.env['LIB_RT']
+
+    return ret

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -155,3 +155,13 @@ def check_lttng(cfg, env):
                   args = ['--libs', '--cflags'])
     env.LIB += cfg.env['LIB_LTTNG-UST']
     return True
+
+@conf
+def check_libiio(cfg, env):
+    cfg.check_cfg(package='libiio', mandatory=False, global_define=True,
+                  args = ['--libs', '--cflags'])
+    env.LIB += cfg.env['LIB_LIBIIO']
+    # workaround bug in libiio 0.6 not including -ldl
+    if cfg.env['LIB_LIBIIO']:
+        env.LIB += ['dl']
+    return True

--- a/libraries/AP_HAL_Linux/Perf.cpp
+++ b/libraries/AP_HAL_Linux/Perf.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#if !defined(PERF_LTTNG)
+#ifndef HAVE_LTTNG_UST
 
 #include <limits.h>
 #include <time.h>

--- a/libraries/AP_HAL_Linux/Perf_Lttng.cpp
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.cpp
@@ -12,7 +12,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#if defined(PERF_LTTNG)
+#ifdef HAVE_LTTNG_UST
 
 #define TRACEPOINT_CREATE_PROBES
 #define TRACEPOINT_DEFINE

--- a/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
@@ -59,7 +59,7 @@ TRACEPOINT_EVENT(
     )
 )
 
-#endif /* _HELLO_TP_H */
+#endif
 
 #include <lttng/tracepoint-event.h>
 

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -34,10 +34,10 @@ COPTS           =   -ffunction-sections -fdata-sections -fsigned-char
 ASOPTS          =   -x assembler-with-cpp 
 
 # features: TODO detect dependecy and make them optional
-HAVE_LTTNG=
+HAVE_LTTNG_UST=
 
-ifeq ($(HAVE_LTTNG),1)
-DEFINES        += -DPERF_LTTNG=1
+ifeq ($(HAVE_LTTNG_UST),1)
+DEFINES        += -DHAVE_LTTNG_UST=1
 LIBS           += -llttng-ust -ldl
 endif
 


### PR DESCRIPTION
I cherry-picked the relevant commits from #4187 and did some changes as requested by @OXINARF and @jberaud 

This fixes the case in which librt is required but not available, move every check to be inside cxx_checks.py and allow to enable libiio and lttng integration for all linux boards.