### PR TITLE
AP_Motors: Fix conversion to 0~1 signalling in AP_MotorsHeli

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -68,10 +68,9 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: RSC_SETPOINT
     // @DisplayName: External Motor Governor Setpoint
-    // @Description: PWM passed to the external motor governor when external governor is enabled
-    // @Range: 0 1000
-    // @Units: PWM
-    // @Increment: 10
+    // @Description: Value passed to the external motor governor when external governor is enabled
+    // @Range: 0 1
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("RSC_SETPOINT", 7, AP_MotorsHeli, _rsc_setpoint, AP_MOTORS_HELI_RSC_SETPOINT),
 
@@ -110,32 +109,32 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Param: RSC_CRITICAL
     // @DisplayName: Critical Rotor Speed
     // @Description: Rotor speed below which flight is not possible
-    // @Range: 0 1000
-    // @Increment: 10
+    // @Range: 0 1
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("RSC_CRITICAL", 12, AP_MotorsHeli, _rsc_critical, AP_MOTORS_HELI_RSC_CRITICAL),
 
     // @Param: RSC_IDLE
     // @DisplayName: Rotor Speed Output at Idle
     // @Description: Rotor speed output while armed but rotor control speed is not engaged
-    // @Range: 0 500
-    // @Increment: 10
+    // @Range: 0 0.5
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("RSC_IDLE", 13, AP_MotorsHeli, _rsc_idle_output, AP_MOTORS_HELI_RSC_IDLE_DEFAULT),
 
     // @Param: RSC_POWER_LOW
     // @DisplayName: Throttle Servo Low Power Position
     // @Description: Throttle output at zero collective pitch.
-    // @Range: 0 1000
-    // @Increment: 10
+    // @Range: 0 1
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("RSC_POWER_LOW", 14, AP_MotorsHeli, _rsc_power_low, AP_MOTORS_HELI_RSC_POWER_LOW_DEFAULT),
-    
+
     // @Param: RSC_POWER_HIGH
     // @DisplayName: Throttle Servo High Power Position
     // @Description: Throttle output at max collective pitch.
-    // @Range: 0 1000
-    // @Increment: 10
+    // @Range: 0 1
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("RSC_POWER_HIGH", 15, AP_MotorsHeli, _rsc_power_high, AP_MOTORS_HELI_RSC_POWER_HIGH_DEFAULT),
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -27,16 +27,16 @@
 // swash min while landed or landing (as a number from 0 ~ 1000
 #define AP_MOTORS_HELI_LAND_COLLECTIVE_MIN      0
 
-// default main rotor speed (ch8 out) as a number from 0 ~ 1000
-#define AP_MOTORS_HELI_RSC_SETPOINT             700
+// default main rotor speed (ch8 out) as a number from 0 ~ 1
+#define AP_MOTORS_HELI_RSC_SETPOINT             0.7f
 
 // default main rotor critical speed
-#define AP_MOTORS_HELI_RSC_CRITICAL             500
+#define AP_MOTORS_HELI_RSC_CRITICAL             0.5f
 
 // RSC output defaults
-#define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
-#define AP_MOTORS_HELI_RSC_POWER_LOW_DEFAULT    200
-#define AP_MOTORS_HELI_RSC_POWER_HIGH_DEFAULT   700
+#define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0.0f
+#define AP_MOTORS_HELI_RSC_POWER_LOW_DEFAULT    0.2f
+#define AP_MOTORS_HELI_RSC_POWER_HIGH_DEFAULT   0.7f
 
 // default main rotor ramp up time in seconds
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to full power (most people use exterrnal govenors so we can ramp up quickly)
@@ -187,16 +187,16 @@ protected:
     AP_Int16        _collective_min;            // Lowest possible servo position for the swashplate
     AP_Int16        _collective_max;            // Highest possible servo position for the swashplate
     AP_Int16        _collective_mid;            // Swash servo position corresponding to zero collective pitch (or zero lift for Asymmetrical blades)
-    AP_Int8         _servo_mode;              // Pass radio inputs directly to servos during set-up through mission planner
-    AP_Int16        _rsc_setpoint;              // rotor speed when RSC mode is set to is enabledv
+    AP_Int8         _servo_mode;                // Pass radio inputs directly to servos during set-up through mission planner
+    AP_Float        _rsc_setpoint;              // rotor speed when RSC mode is set to is enabledv
     AP_Int8         _rsc_mode;                  // Which main rotor ESC control mode is active
     AP_Int8         _rsc_ramp_time;             // Time in seconds for the output to the main rotor's ESC to reach full speed
     AP_Int8         _rsc_runup_time;            // Time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
     AP_Int16        _land_collective_min;       // Minimum collective when landed or landing
-    AP_Int16        _rsc_critical;              // Rotor speed below which flight is not possible
-    AP_Int16        _rsc_idle_output;           // Rotor control output while at idle
-    AP_Int16        _rsc_power_low;             // throttle value sent to throttle servo at zero collective pitch
-    AP_Int16        _rsc_power_high;            // throttle value sent to throttle servo at maximum collective pitch
+    AP_Float        _rsc_critical;              // Rotor speed below which flight is not possible
+    AP_Float        _rsc_idle_output;           // Rotor control output while at idle
+    AP_Float        _rsc_power_low;             // throttle value sent to throttle servo at zero collective pitch
+    AP_Float        _rsc_power_high;            // throttle value sent to throttle servo at maximum collective pitch
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
 
     // internal variables

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -24,7 +24,7 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     AP_NESTEDGROUPINFO(AP_MotorsHeli, 0),
-    
+
     // @Param: SV1_POS
     // @DisplayName: Servo 1 Position
     // @Description: Angular location of swash servo #1
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV3_POS", 3, AP_MotorsHeli_Single, _servo3_pos, AP_MOTORS_HELI_SINGLE_SERVO3_POS),
-  
+
     // @Param: TAIL_TYPE
     // @DisplayName: Tail Type
     // @Description: Tail type selection.  Simpler yaw controller used if external gyro is selected
@@ -97,13 +97,12 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Values: 0:NoFlybar,1:Flybar
     // @User: Standard
     AP_GROUPINFO("FLYBAR_MODE", 9, AP_MotorsHeli_Single, _flybar_mode, AP_MOTORS_HELI_NOFLYBAR),
-  
+
     // @Param: TAIL_SPEED
     // @DisplayName: Direct Drive VarPitch Tail ESC speed
     // @Description: Direct Drive VarPitch Tail ESC speed.  Only used when TailType is DirectDrive VarPitch
-    // @Range: 0 1000
-    // @Units: PWM
-    // @Increment: 1
+    // @Range: 0 1
+    // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("TAIL_SPEED", 10, AP_MotorsHeli_Single, _direct_drive_tailspeed, AP_MOTORS_HELI_SINGLE_DDVPT_SPEED_DEFAULT),
 
@@ -144,7 +143,7 @@ void AP_MotorsHeli_Single::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    uint32_t mask = 
+    uint32_t mask =
         1U << AP_MOTORS_MOT_1 |
         1U << AP_MOTORS_MOT_2 |
         1U << AP_MOTORS_MOT_3 |
@@ -230,7 +229,7 @@ void AP_MotorsHeli_Single::set_desired_rotor_speed(float desired_speed)
     _main_rotor.set_desired_speed(desired_speed);
 
     // always send desired speed to tail rotor control, will do nothing if not DDVPT not enabled
-    _tail_rotor.set_desired_speed(_direct_drive_tailspeed/1000.0f);
+    _tail_rotor.set_desired_speed(_direct_drive_tailspeed);
 }
 
 // calculate_scalars - recalculates various scalers used.
@@ -238,9 +237,9 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
 {
     _main_rotor.set_ramp_time(_rsc_ramp_time);
     _main_rotor.set_runup_time(_rsc_runup_time);
-    _main_rotor.set_critical_speed(_rsc_critical/1000.0f);
-    _main_rotor.set_idle_output(_rsc_idle_output/1000.0f);
-    _main_rotor.set_power_output_range(_rsc_power_low/1000.0f, _rsc_power_high/1000.0f);
+    _main_rotor.set_critical_speed(_rsc_critical);
+    _main_rotor.set_idle_output(_rsc_idle_output);
+    _main_rotor.set_power_output_range(_rsc_power_low, _rsc_power_high);
 }
 
 
@@ -263,14 +262,14 @@ void AP_MotorsHeli_Single::calculate_scalars()
     // send setpoints to main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
     calculate_armed_scalars();
-    
+
     // send setpoints to tail rotor controller and trigger recalculation of scalars
     if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPITCH) {
         _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_SPEED_SETPOINT);
         _tail_rotor.set_ramp_time(AP_MOTORS_HELI_SINGLE_DDVPT_RAMP_TIME);
         _tail_rotor.set_runup_time(AP_MOTORS_HELI_SINGLE_DDVPT_RUNUP_TIME);
-        _tail_rotor.set_critical_speed(_rsc_critical/1000.0f);
-        _tail_rotor.set_idle_output(_rsc_idle_output/1000.0f);
+        _tail_rotor.set_critical_speed(_rsc_critical);
+        _tail_rotor.set_idle_output(_rsc_idle_output);
     } else {
         _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_DISABLED);
         _tail_rotor.set_ramp_time(0);
@@ -524,7 +523,7 @@ void AP_MotorsHeli_Single::servo_test()
 // parameter_check - check if helicopter specific parameters are sensible
 bool AP_MotorsHeli_Single::parameter_check(bool display_msg) const
 {
-    // returns false if Phase Angle is outside of range 
+    // returns false if Phase Angle is outside of range
     if ((_phase_angle > 90) || (_phase_angle < -90)){
         if (display_msg) {
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: H_PHANG out of range");

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -30,7 +30,7 @@
 #define AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_FIXEDPITCH  3
 
 // default direct-drive variable pitch tail defaults
-#define AP_MOTORS_HELI_SINGLE_DDVPT_SPEED_DEFAULT              500
+#define AP_MOTORS_HELI_SINGLE_DDVPT_SPEED_DEFAULT              0.5
 #define AP_MOTORS_HELI_SINGLE_DDVPT_RAMP_TIME                  2
 #define AP_MOTORS_HELI_SINGLE_DDVPT_RUNUP_TIME                 3
 
@@ -85,7 +85,7 @@ public:
 
     // calculate_armed_scalars - recalculates scalars that can change while armed
     void calculate_armed_scalars();
-    
+
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t get_motor_mask();
@@ -103,7 +103,7 @@ public:
 
     // parameter_check - returns true if helicopter specific parameters are sensible, used for pre-arm check
     bool parameter_check(bool display_msg) const;
-    
+
     // var_info
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -146,7 +146,7 @@ protected:
     // parameters
     AP_Int16        _servo1_pos;                // Angular location of swash servo #1
     AP_Int16        _servo2_pos;                // Angular location of swash servo #2
-    AP_Int16        _servo3_pos;                // Angular location of swash servo #3    
+    AP_Int16        _servo3_pos;                // Angular location of swash servo #3
     AP_Int16        _tail_type;                 // Tail type used: Servo, Servo with external gyro, direct drive variable pitch or direct drive fixed pitch
     AP_Int8         _swash_type;                // Swash Type Setting - either 3-servo CCPM or H1 Mechanical Mixing
     AP_Int16        _ext_gyro_gain_std;         // PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro
@@ -154,7 +154,7 @@ protected:
     AP_Int16        _phase_angle;               // Phase angle correction for rotor head.  If pitching the swash forward induces a roll, this can be correct the problem
     AP_Float        _collective_yaw_effect;     // Feed-forward compensation to automatically add rudder input when collective pitch is increased. Can be positive or negative depending on mechanics.
     AP_Int8         _flybar_mode;               // Flybar present or not.  Affects attitude controller used during ACRO flight mode
-    AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed (0 ~ 1000)
+    AP_Float        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed
     RC_Channel      _swash_servo_1;             // swash plate servo #1
     RC_Channel      _swash_servo_2;             // swash plate servo #2
     RC_Channel      _swash_servo_3;             // swash plate servo #3


### PR DESCRIPTION
This fixes the conversion to 0~1 signalling in AP_MotorsHeli which makes RSC mode 2 (set-point) work again.