### PR TITLE
EKF2: miscellaneous bugfixes

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -23,7 +23,7 @@
 #define GYRO_P_NSE_DEFAULT      3.0E-02f
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
-#define GSCALE_P_NSE_DEFAULT    1.0E-05f
+#define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
 #define MAG_P_NSE_DEFAULT       2.5E-02f
 #define VEL_I_GATE_DEFAULT      500
@@ -47,7 +47,7 @@
 #define GYRO_P_NSE_DEFAULT      3.0E-02f
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
-#define GSCALE_P_NSE_DEFAULT    1.0E-05f
+#define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
 #define MAG_P_NSE_DEFAULT       2.5E-02f
 #define VEL_I_GATE_DEFAULT      500
@@ -71,7 +71,7 @@
 #define GYRO_P_NSE_DEFAULT      3.0E-02f
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
-#define GSCALE_P_NSE_DEFAULT    1.0E-05f
+#define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
 #define MAG_P_NSE_DEFAULT       2.5E-02f
 #define VEL_I_GATE_DEFAULT      500
@@ -95,7 +95,7 @@
 #define GYRO_P_NSE_DEFAULT      3.0E-02f
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
-#define GSCALE_P_NSE_DEFAULT    1.0E-05f
+#define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
 #define MAG_P_NSE_DEFAULT       2.5E-02f
 #define VEL_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -900,6 +900,9 @@ void NavEKF2_core::FuseDeclination()
     float t10 = t9-t14;
     float t15 = t23*t10;
     float t11 = R_DECL+t8-t15; // innovation variance
+    if (t11 < R_DECL) {
+        return;
+    }
     float t12 = 1.0f/t11;
 
     float H_MAG[24];

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -57,13 +57,6 @@ void NavEKF2_core::controlMagYawReset()
         }
     }
 
-    // In-Flight yaw alignment for vehicles that can use a zero sideslip assumption (Planes)
-    // and are not using a compass
-    if (!yawAlignComplete && assume_zero_sideslip() && inFlight) {
-        realignYawGPS();
-        firstMagYawInit = yawAlignComplete;
-    }
-
     // In-Flight reset for vehicles that can use a zero sideslip assumption (Planes)
     // this is done to protect against unrecoverable heading alignment errors due to compass faults
     if (!firstMagYawInit && assume_zero_sideslip() && inFlight) {
@@ -212,9 +205,12 @@ void NavEKF2_core::SelectMagFusion()
             magTestRatio.zero();
             yawTestRatio = 0.0f;
             lastSynthYawTime_ms = imuSampleTime_ms;
-        } else {
-            // Control reset of yaw and magnetic field states
-            controlMagYawReset();
+        }
+        // In-Flight yaw alignment for vehicles that can use a zero sideslip assumption (Planes)
+        // and are not using a compass
+        if (!yawAlignComplete && assume_zero_sideslip() && inFlight) {
+            realignYawGPS();
+            firstMagYawInit = yawAlignComplete;
         }
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -86,6 +86,8 @@ void NavEKF2_core::realignYawGPS()
             stateStruct.quat.from_euler(eulerAngles.x, eulerAngles.y, gpsYaw);
             yawAlignComplete = true;
 
+            // zero the attitude covariances becasue the corelations will now be invalid
+            zeroAttCovOnly();
         }
 
         // Check the yaw angles for consistency
@@ -100,13 +102,8 @@ void NavEKF2_core::realignYawGPS()
             // calculate new filter quaternion states from Euler angles
             stateStruct.quat.from_euler(eulerAngles.x, eulerAngles.y, gpsYaw);
 
-            // The correlations between attitude errors and position and velocity errors in the covariance matrix
-            // are invalid because of the changed yaw angle, so reset the corresponding row and columns
-            zeroCols(P,0,2);
-            zeroRows(P,0,2);
-
-            // Set the initial attitude error covariances
-            P[2][2] = P[1][1] = P[0][0] = sq(radians(5.0f));
+            // zero the attitude covariances becasue the corelations will now be invalid
+            zeroAttCovOnly();
 
             // reset tposition fusion timer to cause the states to be reset to the GPS on the next GPS fusion cycle
             lastPosPassTime_ms = 0;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1333,6 +1333,8 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
             lastYawReset_ms = imuSampleTime_ms;
             // calculate an initial quaternion using the new yaw value
             initQuat.from_euler(roll, pitch, yaw);
+            // zero the attitude covariances becasue the corelations will now be invalid
+            zeroAttCovOnly();
         } else {
             initQuat = stateStruct.quat;
         }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -240,7 +240,6 @@ void NavEKF2_core::InitialiseVariables()
     optFlowFusionDelayed = false;
     airSpdFusionDelayed = false;
     sideSlipFusionDelayed = false;
-    magFuseTiltInhibit = false;
     posResetNE.zero();
     velResetNE.zero();
     hgtInnovFiltState = 0.0f;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1291,7 +1291,6 @@ void NavEKF2_core::calcEarthRateNED(Vector3f &omega, int32_t latitude) const
 
 // initialise the earth magnetic field states using declination, suppled roll/pitch
 // and magnetometer measurements and return initial attitude quaternion
-// if no magnetometer data, do not update magnetic field states and assume zero yaw angle
 Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
 {
     // declare local variables required to calculate initial orientation and magnetic field
@@ -1362,8 +1361,8 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
         // clear bad magnetic yaw status
         badMagYaw = false;
     } else {
-        initQuat.from_euler(roll, pitch, 0.0f);
-        yawAlignComplete = false;
+        // no magnetoemter data so there is nothing we can do
+        initQuat = stateStruct.quat;
     }
 
     // return attitude quaternion

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1350,11 +1350,11 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
         zeroRows(P,16,21);
         zeroCols(P,16,21);
         // set initial earth magnetic field variances
-        P[16][16] = sq(0.05f);
+        P[16][16] = sq(frontend->_magNoise);
         P[17][17] = P[16][16];
         P[18][18] = P[16][16];
         // set initial body magnetic field variances
-        P[19][19] = sq(0.05f);
+        P[19][19] = sq(frontend->_magNoise);
         P[20][20] = P[19][19];
         P[21][21] = P[19][19];
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1368,4 +1368,18 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
     return initQuat;
 }
 
+// zero the attitude covariances, but preserve the variances
+void NavEKF2_core::zeroAttCovOnly()
+{
+    float varTemp[3];
+    for (uint8_t index=0; index<=2; index++) {
+        varTemp[index] = P[index][index];
+    }
+    zeroCols(P,0,2);
+    zeroRows(P,0,2);
+    for (uint8_t index=0; index<=2; index++) {
+        P[index][index] = varTemp[index];
+    }
+}
+
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -758,8 +758,6 @@ private:
     bool optFlowFusionDelayed;      // true when the optical flow fusion has been delayed
     bool airSpdFusionDelayed;       // true when the air speed fusion has been delayed
     bool sideSlipFusionDelayed;     // true when the sideslip fusion has been delayed
-    bool magFuseTiltInhibit;        // true when the 3-axis magnetoemter fusion is prevented from changing tilt angle
-    uint32_t magFuseTiltInhibit_ms; // time in msec that the condition indicated by magFuseTiltInhibit was commenced
     Vector3f lastMagOffsets;        // Last magnetometer offsets from COMPASS_ parameters. Used to detect parameter changes.
     bool lastMagOffsetsValid;       // True when lastMagOffsets has been initialized
     Vector2f posResetNE;            // Change in North/East position due to last in-flight reset in metres. Returned by getLastPosNorthEastReset

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -608,6 +608,9 @@ private:
     // Select height data to be fused from the available baro, range finder and GPS sources
     void selectHeightForFusion();
 
+    // zero attitude state covariances, but preserve variances
+    void zeroAttCovOnly();
+
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH
     static const uint32_t OBS_BUFFER_LENGTH = 5;


### PR DESCRIPTION
Addresses the following issues:

1) Slow learning of gyro scale factors resulting last retune
2) Roll disturbances on commencement of 3-axis mag fusion with a large pitch angle
3) Inconsistent handling of attitude error covariances after yaw resets
4) Pitch angle disturbances associated with commencing airspeed fusion from rapid launches (bungee or catapult) in combination with wind or airspeed errors.
5) missing arithmetic error trap in declination fusion

Has been tested on replay with the --no-params option using all logs from http://uav.tridgell.net/ReplayLogs/

Has also been tested on the plane logs (eaglet and ranger) with all compasses disabled.