### PR TITLE
make baro and airspeed calibration non-blocking

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -942,7 +942,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                         result = MAV_RESULT_FAILED;
                     }
                 } else if (is_equal(packet.param3,1.0f)) {
-                    rover.init_barometer();
+                    rover.init_barometer(false);
                     result = MAV_RESULT_ACCEPTED;
                 } else if (is_equal(packet.param4,1.0f)) {
                     rover.trim_radio();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -464,7 +464,7 @@ private:
     bool throttle_failsafe_active();
     void trim_control_surfaces();
     void trim_radio();
-    void init_barometer(void);
+    void init_barometer(bool full_calibration);
     void init_sonar(void);
     void read_battery(void);
     void read_receiver_rssi(void);

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -2,10 +2,14 @@
 
 #include "Rover.h"
 
-void Rover::init_barometer(void)
+void Rover::init_barometer(bool full_calibration)
 {
     gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
-    barometer.calibrate();
+    if (full_calibration) {
+        barometer.calibrate();
+    } else {
+        barometer.update_calibration();
+    }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -149,7 +149,7 @@ void Rover::init_ardupilot()
     init_sonar();
 
     // and baro for EKF
-    init_barometer();
+    init_barometer(true);
 
     // Do GPS init
     gps.init(&DataFlash, serial_manager);

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -592,7 +592,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     }
                 } 
                 if (is_equal(packet.param3,1.0f)) {
-                    tracker.init_barometer();
+                    tracker.init_barometer(false);
                     // zero the altitude difference on next baro update
                     tracker.nav_status.need_altitude_calibration = true;
                 }

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -214,7 +214,7 @@ private:
     void update_scan(void);
     bool servo_test_set_servo(uint8_t servo_num, uint16_t pwm);
     void read_radio();
-    void init_barometer(void);
+    void init_barometer(bool full_calibration);
     void update_barometer(void);
     void update_ahrs();
     void update_compass(void);

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -2,10 +2,14 @@
 
 #include "Tracker.h"
 
-void Tracker::init_barometer(void)
+void Tracker::init_barometer(bool full_calibration)
 {
     gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
-    barometer.calibrate();
+    if (full_calibration) {
+        barometer.calibrate();
+    } else {
+        barometer.update_calibration();
+    }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -77,7 +77,7 @@ void Tracker::init_tracker()
     ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
-    init_barometer();
+    init_barometer(true);
 
     // set serial ports non-blocking
     serial_manager.set_blocking_writes_all(false);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1347,7 +1347,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                 }
             } else if (is_equal(packet.param3,1.0f)) {
-                plane.init_barometer();
+                plane.init_barometer(false);
                 if (plane.airspeed.enabled()) {
                     plane.zero_airspeed(false);
                 }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1333,12 +1333,16 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_PREFLIGHT_CALIBRATION:
-            if(hal.util->get_soft_armed()) {
-                result = MAV_RESULT_FAILED;
-                break;
-            }
             plane.in_calibration = true;
             if (is_equal(packet.param1,1.0f)) {
+                /*
+                  gyro calibration
+                 */
+                if(hal.util->get_soft_armed()) {
+                    send_text(MAV_SEVERITY_WARNING, "No calibration while armed");
+                    result = MAV_RESULT_FAILED;
+                    break;
+                }
                 plane.ins.init_gyro();
                 if (plane.ins.gyro_calibrated_ok_all()) {
                     plane.ahrs.reset_gyro_drift();
@@ -1347,15 +1351,34 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                 }
             } else if (is_equal(packet.param3,1.0f)) {
+                /*
+                  baro and airspeed calibration
+                 */
                 plane.init_barometer(false);
                 if (plane.airspeed.enabled()) {
                     plane.zero_airspeed(false);
                 }
                 result = MAV_RESULT_ACCEPTED;
             } else if (is_equal(packet.param4,1.0f)) {
+                /*
+                  radio trim
+                 */
+                if(hal.util->get_soft_armed()) {
+                    send_text(MAV_SEVERITY_WARNING, "No calibration while armed");
+                    result = MAV_RESULT_FAILED;
+                    break;
+                }
                 plane.trim_radio();
                 result = MAV_RESULT_ACCEPTED;
             } else if (is_equal(packet.param5,1.0f)) {
+                /*
+                  accel calibration
+                 */
+                if(hal.util->get_soft_armed()) {
+                    send_text(MAV_SEVERITY_WARNING, "No calibration while armed");
+                    result = MAV_RESULT_FAILED;
+                    break;
+                }
                 result = MAV_RESULT_ACCEPTED;
                 // start with gyro calibration
                 plane.ins.init_gyro();
@@ -1369,6 +1392,14 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 plane.ins.get_acal()->start(this);
 
             } else if (is_equal(packet.param5,2.0f)) {
+                /*
+                  ahrs trim
+                 */
+                if(hal.util->get_soft_armed()) {
+                    send_text(MAV_SEVERITY_WARNING, "No calibration while armed");
+                    result = MAV_RESULT_FAILED;
+                    break;
+                }
                 // start with gyro calibration
                 plane.ins.init_gyro();
                 // accel trim

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -922,7 +922,7 @@ private:
     void trim_control_surfaces();
     void trim_radio();
     bool rc_failsafe_active(void);
-    void init_barometer(void);
+    void init_barometer(bool full_calibration);
     void init_rangefinder(void);
     void read_rangefinder(void);
     void read_airspeed(void);

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -116,7 +116,7 @@ void Plane::zero_airspeed(bool in_startup)
     read_airspeed();
     // update barometric calibration with new airspeed supplied temperature
     barometer.update_calibration();
-    gcs_send_text(MAV_SEVERITY_INFO,"Zero airspeed calibrated");
+    gcs_send_text(MAV_SEVERITY_INFO,"Airspeed calibration started");
 }
 
 // read_battery - reads battery voltage and current and invokes failsafe

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -3,11 +3,14 @@
 #include "Plane.h"
 #include <AP_RSSI/AP_RSSI.h>
 
-void Plane::init_barometer(void)
+void Plane::init_barometer(bool full_calibration)
 {
     gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
-    barometer.calibrate();
-
+    if (full_calibration) {
+        barometer.calibrate();
+    } else {
+        barometer.update_calibration();
+    }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -617,7 +617,7 @@ void Plane::startup_INS_ground(void)
 
     // read Baro pressure at ground
     //-----------------------------
-    init_barometer();
+    init_barometer(true);
 
     if (airspeed.enabled()) {
         // initialize airspeed sensor

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -497,7 +497,7 @@ int8_t Plane::test_pressure(uint8_t argc, const Menu::arg *argv)
     cliSerial->printf("Uncalibrated relative airpressure\n");
     print_hit_enter();
 
-    init_barometer();
+    init_barometer(true);
 
     while(1) {
         hal.scheduler->delay(100);

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -22,6 +22,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -174,8 +175,6 @@ bool AP_Airspeed::get_temperature(float &temperature)
 // the get_airspeed() interface can be used
 void AP_Airspeed::calibrate(bool in_startup)
 {
-    float sum = 0;
-    uint8_t count = 0;
     if (!_enable) {
         return;
     }
@@ -184,24 +183,27 @@ void AP_Airspeed::calibrate(bool in_startup)
     }
     // discard first reading
     get_pressure();
-    for (uint8_t i = 0; i < 10; i++) {
-        hal.scheduler->delay(100);
-        float p = get_pressure();
-        if (_healthy) {
-            sum += p;
-            count++;
+    _cal.start_ms = AP_HAL::millis();
+    _cal.count = 0;
+    _cal.sum = 0;
+}
+
+void AP_Airspeed::update_calibration(float raw_pressure)
+{
+    if (AP_HAL::millis() - _cal.start_ms >= 1000) {
+        if (_cal.count == 0) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Airspeed sensor unhealthy");
+        } else {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Airspeed sensor calibrated");
+            _offset.set_and_save(_cal.sum / _cal.count);
         }
-    }
-    if (count == 0) {
-        // unhealthy sensor
-        hal.console->println("Airspeed sensor unhealthy");
-        _offset.set(0);
+        _cal.start_ms = 0;
         return;
     }
-    float raw = sum/count;
-    _offset.set_and_save(raw);
-    _airspeed = 0;
-    _raw_airspeed = 0;
+    if (_healthy) {
+        _cal.sum += raw_pressure;
+        _cal.count++;
+    }
 }
 
 // read the airspeed sensor
@@ -211,10 +213,15 @@ void AP_Airspeed::read(void)
     if (!_enable) {
         return;
     }
-    airspeed_pressure = get_pressure() - _offset;
+    float raw_pressure = get_pressure();
+    if (_cal.start_ms != 0) {
+        update_calibration(raw_pressure);
+    }
+    
+    airspeed_pressure = raw_pressure - _offset;
 
     // remember raw pressure for logging
-    _raw_pressure     = airspeed_pressure;
+    _corrected_pressure = airspeed_pressure;
 
     /*
       we support different pitot tube setups so used can choose if

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -115,9 +115,9 @@ public:
         return _offset;
     }
 
-    // return the current raw pressure
-    float get_raw_pressure(void) const {
-        return _raw_pressure;
+    // return the current corrected pressure
+    float get_corrected_pressure(void) const {
+        return _corrected_pressure;
     }
 
     // set the apparent to true airspeed ratio
@@ -164,18 +164,26 @@ private:
     float           _raw_airspeed;
     float           _airspeed;
     float			_last_pressure;
-    float			_raw_pressure;
+    float			_corrected_pressure;
     float           _EAS2TAS;
     bool		    _healthy:1;
     bool		    _hil_set:1;
     float           _hil_pressure;
     uint32_t        _last_update_ms;
 
+    // state of runtime calibration
+    struct {
+        uint32_t        start_ms;
+        uint16_t        count;
+        float           sum;
+    } _cal;
+
     Airspeed_Calibration _calibration;
     float _last_saved_ratio;
     uint8_t _counter;
 
     float get_pressure(void);
+    void update_calibration(float raw_pressure);
 
     AP_Airspeed_Analog analog;
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1792,7 +1792,7 @@ void DataFlash_Class::Log_Write_Airspeed(AP_Airspeed &airspeed)
         airspeed      : airspeed.get_raw_airspeed(),
         diffpressure  : airspeed.get_differential_pressure(),
         temperature   : (int16_t)(temperature * 100.0f),
-        rawpressure   : airspeed.get_raw_pressure(),
+        rawpressure   : airspeed.get_corrected_pressure(),
         offset        : airspeed.get_offset(),
         use           : airspeed.use()
     };


### PR DESCRIPTION
This prevents a time jump for the EKF which can make it upset. An upset EKF is bad :-)
