### PR TITLE
Copter: removed 30ms delay on arming

### DIFF
--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -181,9 +181,6 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
     sprayer.test_pump(false);
 #endif
 
-    // short delay to allow reading of rc inputs
-    delay(30);
-
     // enable output to motors
     enable_motor_output();
 


### PR DESCRIPTION
this is the last of the delays that can cause the EKF to get unhappy
on arming in copter. The comment says it is waiting for RC input, but
I don't think that makes any sense any more.