### PR TITLE
CI: remove make builds (and other improvements)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,25 +55,23 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 
+compiler:
+  - gcc
+  - clang
+
 env:
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "FjIwqZQV2FhNPWYITX5LZXTE38yYqBaQdbm3QmbEg/30wnPTm1ZOLIU7o/aSvX615ImR8kHoryvFPDQDWc6wWfqTEs3Ytq2kIvcIJS2Y5l/0PFfpWJoH5gRd6hDThnoi+1oVMLvj1+bhn4yFlCCQ2vT/jxoGfiQqqgvHtv4fLzI="
-
-# Note: while https://github.com/travis-ci/travis-ci/issues/4393 isn't solved we need to hack compiler name to have cache work properly
+  matrix:
+    - CI_BUILD_TARGET="sitl minlure raspilot"
+    - CI_BUILD_TARGET="linux navio2 bebop"
 
 matrix:
+  fast_finish: true
   include:
-    - compiler: "gcc PX4"
+    - compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v2 px4-v4"
-    - compiler: "gcc Native"
-      env: CI_BUILD_TARGET="sitl linux minlure"
-    - compiler: "gcc Linux"
-      env: CI_BUILD_TARGET="navio2 raspilot bebop"
-    - compiler: "gcc SITL Test"
+    - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
-    - compiler: "clang Native"
-      env: CI_BUILD_TARGET="sitl linux minlure"
-    - compiler: "clang Linux"
-      env: CI_BUILD_TARGET="navio2 raspilot bebop"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ addons:
 cache:
   ccache: true
   directories:
-    - $HOME/.cache/pip
     - $HOME/opt
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ cache:
 
 before_install:
   - Tools/scripts/configure-ci.sh
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
 script:
   - python Tools/autotest/param_metadata/param_parse.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ script:
   - python Tools/autotest/param_metadata/param_parse.py
   - Tools/scripts/build_ci.sh
 
+before_cache:
+  - ccache -z
+
 notifications:
   webhooks:
     urls:

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -55,6 +55,10 @@ waf=modules/waf/waf-light
 # get list of boards supported by the waf build
 for board in $($waf list_boards | head -n1); do waf_supported_boards[$board]=1; done
 
+function get_time {
+    date -u "+%s"
+}
+
 echo "Targets: $CI_BUILD_TARGET"
 for t in $CI_BUILD_TARGET; do
     # skip make-based build for clang
@@ -69,7 +73,10 @@ for t in $CI_BUILD_TARGET; do
                 make px4-cleandep
             fi
 
+            start_time=$(get_time)
             make $t -j2
+            diff_time=$(($(get_time)-$start_time))
+            echo -e "\033[32m'make' finished successfully (${diff_time}s)\033[0m"
             ccache -s && ccache -z
             popd
         done

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -28,6 +28,12 @@ if [ -z "$CI_BUILD_TARGET" ]; then
     CI_BUILD_TARGET="sitl linux px4-v2"
 fi
 
+if [[ "$CI_BUILD_TARGET" == *"px4"* ]]; then
+    export CCACHE_MAXSIZE="1500M"
+else
+    export CCACHE_MAXSIZE="500M"
+fi
+
 # special case for SITL testing in CI
 if [ "$CI_BUILD_TARGET" = "sitltest" ]; then
     echo "Installing pymavlink"
@@ -64,6 +70,7 @@ for t in $CI_BUILD_TARGET; do
             fi
 
             make $t -j2
+            ccache -s && ccache -z
             popd
         done
 
@@ -86,6 +93,8 @@ for t in $CI_BUILD_TARGET; do
         $waf configure --board $t --enable-benchmarks --check-c-compiler="$c_compiler" --check-cxx-compiler="$cxx_compiler"
         $waf clean
         $waf -j2 all
+        ccache -s && ccache -z
+
         if [[ $t == linux ]]; then
             $waf check
         fi

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -3,13 +3,16 @@
 
 set -ex
 
+# Disable ccache for the configure phase, it's not worth it
+export CCACHE_DISABLE="true"
+
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
 
 RPI_ROOT="master"
 RPI_TARBALL="$RPI_ROOT.tar.gz"
 
-CCACHE_ROOT="ccache-3.2.4"
+CCACHE_ROOT="ccache-3.2.5"
 CCACHE_TARBALL="$CCACHE_ROOT.tar.bz2"
 
 mkdir -p $HOME/opt
@@ -68,6 +71,7 @@ exportline="export PATH=$HOME/ccache"
 exportline="${exportline}:$HOME/bin"
 exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin"
 exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
+exportline="${exportline}:$HOME/opt/$CCACHE_ROOT"
 exportline="${exportline}:\$PATH"
 
 if grep -Fxq "$exportline" ~/.profile; then


### PR DESCRIPTION
Only use the make build system for PX4 (and SITL test). While the make system isn't removed we will run a scheduled job every day that just uses make.

I've changed the order and combination of boards in the jobs to try to have them more balanced and always using cache. I have done some tests with this, but a bigger test base is needed, so I will monitor the next days to see if this is appropriate or a change is needed.

Besides that, I updated a couple of things to improve cache support.

After this goes in, I will:
- reset the caches in Travis because they will be useless
- configure the scheduled jobs in Travis and SemaphoreCI