### PR TITLE
CI: increase ccache size

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -30,8 +30,10 @@ fi
 
 if [[ "$CI_BUILD_TARGET" == *"px4"* ]]; then
     export CCACHE_MAXSIZE="1500M"
+elif [[ "$CI_BUILD_TARGET" == "sitltest" ]]; then
+    export CCACHE_MAXSIZE="300M"
 else
-    export CCACHE_MAXSIZE="500M"
+    export CCACHE_MAXSIZE="1000M"
 fi
 
 # special case for SITL testing in CI


### PR DESCRIPTION
Make based builds require more space, so, until we remove them, increase size.

SITL test job needs less space so make an exception for it.