### PR TITLE
PX4: safety button bypass to be async

### DIFF
--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -276,7 +276,6 @@ bool Plane::setup_failsafe_mixing(void)
     // it twice as there have been reports that this call can fail
     // with a small probability
     hal.rcout->force_safety_on();
-    hal.rcout->force_safety_on();
 
     /* reset any existing mixer in px4io. This shouldn't be needed,
      * but is good practice */
@@ -391,7 +390,6 @@ failed:
     }
     // restore safety state if it was previously armed
     if (old_state == AP_HAL::Util::SAFETY_ARMED) {
-        hal.rcout->force_safety_off();
         hal.rcout->force_safety_off();
     }
     return ret;

--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -276,6 +276,7 @@ bool Plane::setup_failsafe_mixing(void)
     // it twice as there have been reports that this call can fail
     // with a small probability
     hal.rcout->force_safety_on();
+    hal.rcout->force_safety_no_wait();
 
     /* reset any existing mixer in px4io. This shouldn't be needed,
      * but is good practice */

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -102,6 +102,11 @@ public:
     virtual void     force_safety_off(void) {}
 
     /*
+      If we support async sends (px4), this will force it to be serviced immediately
+     */
+    virtual void     force_safety_no_wait(void) {}
+
+    /*
       setup scaling of ESC output for ESCs that can output a
       percentage of power (such as UAVCAN ESCs). The values are in
       microseconds, and represent minimum and maximum PWM values which

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -264,15 +264,42 @@ void PX4RCOutput::set_failsafe_pwm(uint32_t chmask, uint16_t period_us)
 
 bool PX4RCOutput::force_safety_on(void)
 {
-    int ret = ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_ON, 0);
-    return (ret == OK);
+    _safety_state_request = AP_HAL::Util::SAFETY_DISARMED;
+    _safety_state_request_last_ms = AP_HAL::millis();
+    return true;
 }
 
 void PX4RCOutput::force_safety_off(void)
 {
-    int ret = ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0);
-    if (ret != OK) {
-        hal.console->printf("Failed to force safety off\n");
+    _safety_state_request = AP_HAL::Util::SAFETY_ARMED;
+    _safety_state_request_last_ms = AP_HAL::millis();
+}
+
+void PX4RCOutput::force_safety_pending_requests(void)
+{
+    // check if there is a pending saftey_state change. If so (timer != 0) then set it.
+    if (_safety_state_request_last_ms != 0 &&
+            AP_HAL::millis() - _safety_state_request_last_ms >= 100) {
+        if (hal.util->safety_switch_state() == _safety_state_request) {
+            // current switch state matches request, stop attempting
+            _safety_state_request_last_ms = 0;
+        } else if (_safety_state_request == AP_HAL::Util::SAFETY_DISARMED) {
+            // current != requested, set it
+            ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_ON, 0);
+            _safety_state_request_last_ms = AP_HAL::millis();
+        } else if (_safety_state_request == AP_HAL::Util::SAFETY_ARMED) {
+            // current != requested, set it
+            ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0);
+            _safety_state_request_last_ms = AP_HAL::millis();
+        }
+    }
+}
+
+void PX4RCOutput::force_safety_no_wait(void)
+{
+    if (_safety_state_request_last_ms != 0) {
+        _safety_state_request_last_ms = 1;
+        force_safety_pending_requests();
     }
 }
 
@@ -516,6 +543,8 @@ void PX4RCOutput::_timer_tick(void)
          * sent from push() */
         _send_outputs();
     }
+
+    force_safety_pending_requests();
 }
 
 /*

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -24,6 +24,7 @@ public:
     void     set_failsafe_pwm(uint32_t chmask, uint16_t period_us) override;
     bool     force_safety_on(void) override;
     void     force_safety_off(void) override;
+    void     force_safety_no_wait(void) override;
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override {
         _esc_pwm_min = min_pwm;
         _esc_pwm_max = max_pwm;
@@ -69,4 +70,7 @@ private:
     bool _corking;
     enum output_mode _output_mode = MODE_PWM_NORMAL;
     void _send_outputs(void);
+    enum AP_HAL::Util::safety_state _safety_state_request = AP_HAL::Util::SAFETY_NONE;
+    uint32_t _safety_state_request_last_ms = 0;
+    void force_safety_pending_requests(void);
 };


### PR DESCRIPTION
When overriding the safety button instead of writing immediately, once, queue it and retry until the intended state becomes the current state (armed or disarmed).