### PR TITLE
EKF2: Critical Bug Fix

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -101,8 +101,6 @@ void NavEKF2_core::setWindMagStateLearningMode()
         for (uint8_t index=16; index<=21; index++) {
             P[index][index] = sq(frontend->_magNoise);
         }
-        // let the magnetometer fusion know it needs to reset the yaw and field states
-        firstMagYawInit = false;
     }
 
     // If on ground we clear the flag indicating that the magnetic field in-flight initialisation has been completed


### PR DESCRIPTION
Fixes critical bug introduced with recent changes to allow use without a magnetometer. The bug causes repeated heading resets for copters above 5m altitude when the default EK2_MAG_CAL=3 was used. This can result in poor attitude accuracy and loss of navigation.

This bug was observed during SITL testing.

The patch has been replay tested on a copter and plane logs and on SITL. It  has not yet been flight tested