### PR TITLE
Travis: temporarily remove clang builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
       - george-edison55-precise-backports
-      - llvm-toolchain-precise-3.7
+#      - llvm-toolchain-precise-3.7
     packages:
       - build-essential
       - gawk
@@ -29,8 +29,8 @@ addons:
       - g++-4.9
       - cmake
       - cmake-data
-      - clang-3.7
-      - llvm-3.7
+#      - clang-3.7
+#      - llvm-3.7
 
 cache:
   ccache: true
@@ -58,7 +58,7 @@ notifications:
 
 compiler:
   - gcc
-  - clang
+#  - clang
 
 env:
   global:

--- a/Tools/scripts/install-apt-ci.sh
+++ b/Tools/scripts/install-apt-ci.sh
@@ -4,7 +4,7 @@
 set -ex
 
 PKGS="build-essential gawk ccache genromfs libc6-i386 \
-      python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9 cmake cmake-data clang-3.7 llvm-3.7"
+      python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9 cmake cmake-data" # clang-3.7 llvm-3.7"
 
 read -r UBUNTU_CODENAME <<<$(lsb_release -c -s)
 
@@ -16,8 +16,8 @@ elif [ "$UBUNTU_CODENAME" = "trusty" ]; then
     sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
 fi
 
-wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
+#wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+#sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
 sudo apt-get -qq -y --force-yes update
 sudo apt-get -qq -y --force-yes remove clang llvm
 sudo apt-get -y --force-yes install $PKGS


### PR DESCRIPTION
The LLVM APT repo has been temporarily switched off, so remove clang builds until it is back on