### PR TITLE
APM_Control: Get steer rate using earth frame.

### DIFF
--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -114,7 +114,8 @@ int32_t AP_SteerController::get_steering_out_rate(float desired_rate)
     _pid_info.desired = desired_rate;
 
 	// Calculate the steering rate error (deg/sec) and apply gain scaler
-	float rate_error = (desired_rate - ToDeg(_ahrs.get_gyro().z)) * scaler;
+    // We do this in earth frame to allow for rover leaning over in hard corners
+	float rate_error = (desired_rate - ToDeg(_ahrs.get_yaw_rate_earth())) * scaler;
 	
 	// Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
     // No conversion is required for K_D


### PR DESCRIPTION
Rather then just using the standard z gyro by using the earth frame it
takes into account when a rover leans over in hard corners.  My rover
leans 15 degrees no problem which is why this is needed.