### PR TITLE
Fence breaches can now go to RTL mode in addtion to GUIDED Mode

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -410,8 +410,8 @@ const AP_Param::Info Plane::var_info[] = {
 #if GEOFENCE_ENABLED == ENABLED
     // @Param: FENCE_ACTION
     // @DisplayName: Action on geofence breach
-    // @Description: What to do on fence breach. If this is set to 0 then no action is taken, and geofencing is disabled. If this is set to 1 then the plane will enter GUIDED mode, with the target waypoint as the fence return point. If this is set to 2 then the fence breach is reported to the ground station, but no other action is taken. If set to 3 then the plane enters guided mode but the pilot retains manual throttle control.
-    // @Values: 0:None,1:GuidedMode,2:ReportOnly,3:GuidedModeThrPass
+    // @Description: What to do on fence breach. If this is set to 0 then no action is taken, and geofencing is disabled. If this is set to 1 then the plane will enter GUIDED mode, with the target waypoint as the fence return point. If this is set to 2 then the fence breach is reported to the ground station, but no other action is taken. If set to 3 then the plane enters guided mode but the pilot retains manual throttle control. If set to 4 the plane enters RTL mode, with the target waypoint as the closest rally point (or home point if there are no rally points).
+    // @Values: 0:None,1:GuidedMode,2:ReportOnly,3:GuidedModeThrPass,4:RTL_Mode
     // @User: Standard
     GSCALAR(fence_action,           "FENCE_ACTION",   0),
 


### PR DESCRIPTION
NOTE that this PR will very likely fail Travis checks due to a dependency on a modification to mavlink.  This modification is in the PR here:

https://github.com/ArduPilot/mavlink/pull/7

The reason for this PR is because after discussion here:
https://github.com/ArduPilot/ardupilot/pull/4070

there is some motivation for switching to RTL mode on a fence breach vice GUIDED mode.  This PR makes that possible by implemented fence behavior based on a new value for the FENCE_ACTION parameter, FENCE_ACTION_RTL.

This patch does NOT subsume previous behavior, it is still possible to use all previous FENCE_ACTION values (GUIDED, REPORT, GUIDED_PASSTHR).