### PR TITLE
waf: cmake min version

### DIFF
--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -207,6 +207,7 @@ def _process_romfs(self):
         self.create_task('px4_copy', src, dst)
 
 def configure(cfg):
+    cfg.env.CMAKE_MIN_VERSION = '3.2'
     cfg.load('cmake')
     cfg.find_program('cp')
 


### PR DESCRIPTION
Hi all,

I'm adding support for requiring a minimum version for cmake and using that for PX4. That way we can avoid errors like the one reported in #4254 .

Regards,
Gustavo Sousa