### PR TITLE
Tracker: fixed calibration bug

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -112,8 +112,6 @@ void Tracker::init_tracker()
         prepare_servos();
     }
 
-    // calibrate pressure on startup by default
-    nav_status.need_altitude_calibration = true;
 }
 
 // updates the status of the notify objects

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -146,16 +146,16 @@ void Tracker::tracking_update_pressure(const mavlink_scaled_pressure_t &msg)
 
     // calculate altitude difference based on difference in barometric pressure
     float alt_diff = barometer.get_altitude_difference(local_pressure, aircraft_pressure);
-    if (!isnan(alt_diff)) {
+    if (!isnan(alt_diff) && !isinf(alt_diff)) {
         nav_status.alt_difference_baro = alt_diff + nav_status.altitude_offset;
-    }
 
-    if (nav_status.need_altitude_calibration) {
-        // we have done a baro calibration - zero the altitude
-        // difference to the aircraft
-        nav_status.altitude_offset = -nav_status.alt_difference_baro;
-        nav_status.alt_difference_baro = 0;
-        nav_status.need_altitude_calibration = false;
+		if (nav_status.need_altitude_calibration) {
+			// we have done a baro calibration - zero the altitude
+			// difference to the aircraft
+			nav_status.altitude_offset = -alt_diff;
+			nav_status.alt_difference_baro = 0;
+			nav_status.need_altitude_calibration = false;
+		}
     }
 
     // log altitude difference


### PR DESCRIPTION
Fixed bug where calibrating the altitude occurred too many times in Tracker::tracking_update_pressure. This caused the offset to be set to -infinity, causing problems with the antenna tracker's pitch.