### PR TITLE
AP_HAL_Linux: Standard RPi version change and simplifications

### DIFF
--- a/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
@@ -99,6 +99,7 @@ float AnalogIn_Navio2::board_voltage(void)
 {
     return _board_voltage_pin->voltage_average();
 }
+
 float AnalogIn_Navio2::servorail_voltage(void)
 {
     return _servorail_pin->voltage_average();

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -169,19 +169,13 @@ void GPIO_RPI::setPWM0Period(uint32_t time_us)
     *(pwm + PWM_CTL) = 3;
 }
 
-void GPIO_RPI::setPWM0Duty(uint8_t percent)
-{
-    int bitCount;
-    unsigned int bits = 0;
-
-    bitCount = 320 * percent / 100;
-    if (bitCount > 320) bitCount = 320;
-    if (bitCount < 0) bitCount = 0;
-    bits = 0;
-    while (bitCount) {
+void setPWM0Duty(uint8_t percent) {
+    // Check whether percent is valid
+    percent = percent > 100 ? 100 : percent;
+    uint32_t bits = 0;
+    for (int bitCount = sizeof(uint32_t) * percent / 100; bitCount != 0; bitCount--) {
       bits <<= 1;
       bits |= 1;
-      bitCount--;
     }
     *(pwm + PWM_DAT1) = bits;
 }

--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -33,15 +33,15 @@ int UtilRPI::_check_rpi_version()
     hw = Util::from(hal.util)->get_hw_arm32();
 
     if (hw == UTIL_HARDWARE_RPI2) {
-        printf("Raspberry Pi 2 with BCM2709!\n");
+        printf("Raspberry Pi 2/3 with BCM2709!\n");
         _rpi_version = 2;
     } else if (hw == UTIL_HARDWARE_RPI1) {
         printf("Raspberry Pi 1 with BCM2708!\n");
         _rpi_version = 1;
     } else {
-        /* defaults to 1 */
-        fprintf(stderr, "Could not detect RPi version, defaulting to 1\n");
-        _rpi_version = 1;
+        /* defaults to RPi version 2/3 */
+        fprintf(stderr, "Could not detect RPi version, defaulting to 2/3\n");
+        _rpi_version = 2;
     }
     return _rpi_version;
 }


### PR DESCRIPTION
Just minor changes, which should enhance readability. I followed @lucasdemarchi  suggestions (hopefully).
Another change was the standard version detection is currently RPi1. RPi1 is not really supported anymore, because ArduPilot wouldn't run on this platform sufficiently fast enough. I set standard to 2/3 now. 
I also noticed that the cpuinfo detection mechanism is prone for future problems. The RPi3 is actually giving out the same cpuinfo as the RPi2. It might break, if the distributor would correct cpuinfo output for RPi3, so the new standard RPI version would circumvent this as well.. 
