### PR TITLE
Parameters.h

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -176,7 +176,7 @@ public:
         //
         // 90: misc2
         //
-        k_param_motors = 90,
+        k_param_motors = 0,
         k_param_disarm_delay,
         k_param_fs_crash_check,
         k_param_throw_motor_start,


### PR DESCRIPTION
when we armed the ardupilot with throttle , at initial motor speed should be 0 instead of 90. so that when we armed by throttle we can move some safe distance from quadcopter.
i am using 3.1.5 firmware