### PR TITLE
Prevent motor movement while programming

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1040,6 +1040,10 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
             if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
+                // disarm motors so ensure they are off during bootloader upload
+                hal.rcout->force_safety_on();
+                hal.rcout->force_safety_no_wait();
+
                 // when packet.param1 == 3 we reboot to hold in bootloader
                 hal.scheduler->reboot(is_equal(packet.param1,3.0f));
                 result = MAV_RESULT_ACCEPTED;

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -678,6 +678,10 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
             case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
             {
                 if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
+                    // disarm motors so ensure they are off during bootloader upload
+                    hal.rcout->force_safety_on();
+                    hal.rcout->force_safety_no_wait();
+
                     // when packet.param1 == 3 we reboot to hold in bootloader
                     hal.scheduler->reboot(is_equal(packet.param1,3.0f));
                     result = MAV_RESULT_ACCEPTED;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1444,6 +1444,11 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 AP_Notify::flags.firmware_update = 1;
                 copter.update_notify();
                 hal.scheduler->delay(200);
+
+                // disarm motors so ensure they are off during bootloader upload
+                hal.rcout->force_safety_on();
+                hal.rcout->force_safety_no_wait();
+
                 // when packet.param1 == 3 we reboot to hold in bootloader
                 hal.scheduler->reboot(is_equal(packet.param1,3.0f));
                 result = MAV_RESULT_ACCEPTED;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1501,6 +1501,10 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
             if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
+                // disarm motors so ensure they are off during bootloader upload
+                hal.rcout->force_safety_on();
+                hal.rcout->force_safety_no_wait();
+
                 // when packet.param1 == 3 we reboot to hold in bootloader
                 hal.scheduler->reboot(is_equal(packet.param1,3.0f));
                 result = MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
When uploading a firmware image to the px4fmu (the main cpu) the motors have occasionally spun up on me using a pixhawk. I have BRD_SAFETYENABLE=0 so the px4io is always armed and I suspect that is allowing random data from the px4fmu during it's firmware upload to trigger my ESCs. Admittedly i haven't had this problem in a while but used to in the past a lot. This patch will ensure it is impossible by setting the safety button to disarmed just before a mavlink-triggered reboot so that px4io is disarmed.

This won't help when the px4io is being bootloaded/upgraded, but that is a much rarer event.