### PR TITLE
Quadplane: inhibit fwd motor at low altitude

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -210,6 +210,7 @@ private:
     
     // alt to switch to QLAND_FINAL
     AP_Float land_final_alt;
+    AP_Float vel_forward_alt_cutoff;
     
     AP_Int8 enable;
     AP_Int8 transition_pitch_max;


### PR DESCRIPTION
When landing, or generally low altitude, disable Q_VFWD_GAIN function. Uses new param Q_VFWD_ALT

    // @Description: Controls altitude to disable forward velocity assit when below this altitude. This is useful to keep the forward velocity propeller from hitting the ground. Value of 0 disables feature, VFWD always available. Value of -1 will use Q_LAND_FINAL_ALT. Any other positive value is treated as a relative altitude. Rangefinder height data is incorporated when available.

