### PR TITLE
Plane: if setting a mixer fails then clear the last crc so that it will be attempted again

### DIFF
--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -393,6 +393,8 @@ failed:
     if (old_state == AP_HAL::Util::SAFETY_ARMED) {
         hal.rcout->force_safety_off();
     }
+    // clear out the mixer CRC so that we will attempt to send it again
+    last_mixer_crc = -1;
     return ret;
 }
 


### PR DESCRIPTION
The bug was introduced by the changes to not reupload the mixer if it hasn't changed.