### PR TITLE
Plane: remove throttle suppressed message

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -646,8 +646,6 @@ bool Plane::suppress_throttle(void)
     if (relative_altitude_abs_cm() >= 1000) {
         // we're more than 10m from the home altitude
         throttle_suppressed = false;
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled. Altitude %.2f",
-                          (double)(relative_altitude_abs_cm()*0.01f));
         return false;
     }
 
@@ -657,16 +655,12 @@ bool Plane::suppress_throttle(void)
         // groundspeed with bad GPS reception
         if ((!ahrs.airspeed_sensor_enabled()) || airspeed.get_airspeed() >= 5) {
             // we're moving at more than 5 m/s
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled. Speed %.2f airspeed %.2f",
-                              (double)gps.ground_speed(),
-                              (double)airspeed.get_airspeed());
             throttle_suppressed = false;
             return false;        
         }
     }
 
     if (quadplane.is_flying()) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled VTOL");
         throttle_suppressed = false;
     }
 


### PR DESCRIPTION
More of a debug print then anything else. If there are objections to just removing it I think in order we should either:

 1. Log it to the DF (so it's available for review)
 2. Have an VERBOSITY param that controls whether more debug type prints come out (kinda a severity thing, the goal is to just keep the message off the wire if the user doesn't care about it)
 3. Only print it when the throttle is initially unsuppressed

In general though prints like this have no guarantee of making it to the GCS, and if someone is dependent on seeing this come down it needs to be fit into the MAVLink protocol somehow as a periodic message, because you have a very real chance of loosing this message.