### PR TITLE
Avoidance

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -129,6 +129,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if ADSB_ENABLED == ENABLED
     SCHED_TASK(adsb_update,            1,    100),
 #endif
+    SCHED_TASK(avoidance_update,       10,    400),
 #if FRSKY_TELEM_ENABLED == ENABLED
     SCHED_TASK(frsky_telemetry_send,   5,     75),
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -113,6 +113,7 @@
 
 // Local modules
 #include "Parameters.h"
+#include "avoidance.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
@@ -122,6 +123,11 @@ class Copter : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Copter;
     friend class Parameters;
+    friend class AP_Avoidance_Copter;
+    friend class AvoidanceHandler__AVOID;
+    friend class AvoidanceHandler__ModeChange;
+    friend class AvoidanceHandler_TCAS; // for access to wp_nav
+    friend class AvoidanceHandler_PERPENDICULAR; // for access to wp_nav
 
     Copter(void);
 
@@ -551,6 +557,9 @@ private:
 
     AP_ADSB adsb {ahrs};
 
+    // situational awareness and response:
+    AP_Avoidance_Copter avoidance{ahrs, adsb};
+
     // use this to prevent recursion during sensor init
     bool in_mavlink_delay;
 
@@ -778,6 +787,7 @@ private:
     void autotune_twitching_measure_acceleration(float &rate_of_change, float rate_measurement, float &rate_measurement_max);
     void adsb_update(void);
     void adsb_handle_vehicle_threats(void);
+    void avoidance_update(void);
     bool brake_init(bool ignore_checks);
     void brake_run();
     void brake_timeout_to_loiter_ms(uint32_t timeout_ms);
@@ -859,6 +869,12 @@ private:
     void parachute_check();
     void parachute_release();
     void parachute_manual_release();
+
+    // support for AP_Avoidance custom flight mode, AVOID
+    bool avoid_init(bool ignore_checks);
+    void avoid_run();
+    bool avoid_set_destination(const Vector3f& destination);
+
     void ekf_check();
     bool ekf_over_threshold();
     void failsafe_ekf_event();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -971,6 +971,13 @@ void GCS_MAVLINK_Copter::handle_change_alt_request(AP_Mission::Mission_Command &
     // To-Do: update target altitude for loiter or waypoint controller depending upon nav mode
 }
 
+void GCS_MAVLINK_Copter::packetReceived(const mavlink_status_t &status,
+                                        mavlink_message_t &msg)
+{
+    copter.avoidance.MAVLink_packetReceived(msg);
+    GCS_MAVLINK::packetReceived(status, msg);
+}
+
 void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 {
     uint8_t result = MAV_RESULT_FAILED;         // assume failure.  Each messages id is responsible for return ACK or NAK if required

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -20,4 +20,6 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     bool try_send_message(enum ap_message id) override;
 
+    void packetReceived(const mavlink_status_t &status,
+                        mavlink_message_t &msg) override;
 };

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -306,42 +306,42 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FLTMODE1
     // @DisplayName: Flight Mode 1
     // @Description: Flight mode when Channel 5 pwm is <= 1230
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode1, "FLTMODE1",               FLIGHT_MODE_1),
 
     // @Param: FLTMODE2
     // @DisplayName: Flight Mode 2
     // @Description: Flight mode when Channel 5 pwm is >1230, <= 1360
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode2, "FLTMODE2",               FLIGHT_MODE_2),
 
     // @Param: FLTMODE3
     // @DisplayName: Flight Mode 3
     // @Description: Flight mode when Channel 5 pwm is >1360, <= 1490
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode3, "FLTMODE3",               FLIGHT_MODE_3),
 
     // @Param: FLTMODE4
     // @DisplayName: Flight Mode 4
     // @Description: Flight mode when Channel 5 pwm is >1490, <= 1620
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode4, "FLTMODE4",               FLIGHT_MODE_4),
 
     // @Param: FLTMODE5
     // @DisplayName: Flight Mode 5
     // @Description: Flight mode when Channel 5 pwm is >1620, <= 1749
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode5, "FLTMODE5",               FLIGHT_MODE_5),
 
     // @Param: FLTMODE6
     // @DisplayName: Flight Mode 6
     // @Description: Flight mode when Channel 5 pwm is >=1750
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB
     // @User: Standard
     GSCALAR(flight_mode6, "FLTMODE6",               FLIGHT_MODE_6),
 
@@ -906,6 +906,10 @@ const AP_Param::Info Copter::var_info[] = {
     // @Group: ADSB_
     // @Path: ../libraries/AP_ADSB/AP_ADSB.cpp
     GOBJECT(adsb,                "ADSB_", AP_ADSB),
+
+    // @Group: AVD_
+    // @Path: ../libraries/AP_Avoidance/AP_Avoidance.cpp
+    GOBJECT(avoidance,                "AVD_", AP_Avoidance),
 
     // @Param: AUTOTUNE_AXES
     // @DisplayName: Autotune axis bitmask

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -397,42 +397,42 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: CH7_OPT
     // @DisplayName: Channel 7 option
     // @Description: Select which function if performed when CH7 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch7_option, "CH7_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH8_OPT
     // @DisplayName: Channel 8 option
     // @Description: Select which function if performed when CH8 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch8_option, "CH8_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH9_OPT
     // @DisplayName: Channel 9 option
     // @Description: Select which function if performed when CH9 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch9_option, "CH9_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH10_OPT
     // @DisplayName: Channel 10 option
     // @Description: Select which function if performed when CH10 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch10_option, "CH10_OPT",                AUXSW_DO_NOTHING),
 
     // @Param: CH11_OPT
     // @DisplayName: Channel 11 option
     // @Description: Select which function if performed when CH11 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch11_option, "CH11_OPT",                AUXSW_DO_NOTHING),
 
     // @Param: CH12_OPT
     // @DisplayName: Channel 12 option
     // @Description: Select which function if performed when CH12 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 12:ResetToArmedYaw, 13:Super Simple Mode, 14:Acro Trainer, 16:Auto, 17:AutoTune, 18:Land, 19:EPM, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance
     // @User: Standard
     GSCALAR(ch12_option, "CH12_OPT",                AUXSW_DO_NOTHING),
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -364,6 +364,11 @@ public:
         k_param_DataFlash = 253, // 253 - Logging Group
 
         // 254,255: reserved
+
+        k_param_avoidance = 256, // AP_Avoidance
+
+        // the k_param_* space is 9-bits in size
+        // 511: reserved
     };
 
     AP_Int16        format_version;

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -47,6 +47,13 @@ bool Copter::pre_arm_checks(bool display_failure)
         return false;
     }
 
+    if (avoidance.current_threat_level() != MAV_COLLISION_THREAT_LEVEL_NONE) {
+        if (display_failure) {
+            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Avoidance threat detected");
+        }
+        return false;
+    }
+
     // check if motor interlock aux switch is in use
     // if it is, switch needs to be in disabled position to arm
     // otherwise exit immediately.  This check to be repeated,

--- a/ArduCopter/avoidance.cpp
+++ b/ArduCopter/avoidance.cpp
@@ -9,10 +9,26 @@ void Copter::avoidance_update(void)
 
 #include <stdio.h>
 
-AvoidanceHandler &AP_Avoidance_Copter::handler_for_action(MAV_COLLISION_ACTION action)
+bool AP_Avoidance_Copter::active_actions_prohibited() const
 {
     if (copter.ap.land_complete) {
-        // do nothing if we are not flying
+        return true;
+    }
+
+    if (copter.control_mode == LAND ||
+        copter.control_mode == THROW ||
+        copter.control_mode == FLIP) {
+        return true;
+    }
+
+    return false;
+}
+
+
+AvoidanceHandler &AP_Avoidance_Copter::handler_for_action(MAV_COLLISION_ACTION action)
+{
+    if (active_actions_prohibited()) {
+        // do nothing except possibly report
         if (action == MAV_COLLISION_ACTION_REPORT) {
             return avoidance_handler_report;
         }

--- a/ArduCopter/avoidance.cpp
+++ b/ArduCopter/avoidance.cpp
@@ -1,0 +1,40 @@
+#include "Copter.h"
+#include "avoidance.h"
+#include <AP_Notify/AP_Notify.h>
+
+void Copter::avoidance_update(void)
+{
+    avoidance.update();
+}
+
+#include <stdio.h>
+
+AvoidanceHandler &AP_Avoidance_Copter::handler_for_action(MAV_COLLISION_ACTION action)
+{
+    if (copter.ap.land_complete) {
+        // do nothing if we are not flying
+        if (action == MAV_COLLISION_ACTION_REPORT) {
+            return avoidance_handler_report;
+        }
+        return avoidance_handler_none;
+    }
+
+    switch(action) {
+    case MAV_COLLISION_ACTION_NONE:
+        return avoidance_handler_none;
+    case MAV_COLLISION_ACTION_REPORT:
+        return avoidance_handler_report;
+    case MAV_COLLISION_ACTION_RTL:
+        return avoidance_handler_rtl;
+    case MAV_COLLISION_ACTION_HOVER:
+        return avoidance_handler_hover;
+    case MAV_COLLISION_ACTION_TCAS:
+        return avoidance_handler_tcas;
+    case MAV_COLLISION_ACTION_MOVE_PERPENDICULAR:
+        return avoidance_handler_perpendicular;
+    default:
+        ::fprintf(stderr, "Avoidance action %d not known\n", action);
+        internal_error();
+    };
+    return avoidance_handler_rtl;
+}

--- a/ArduCopter/avoidance.h
+++ b/ArduCopter/avoidance.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <AP_Avoidance/AP_Avoidance.h>
+
+#include "avoidance_handler.h"
+
+// Provide Copter-specific implementation of avoidance.  While most of
+// the logic for doing the actual avoidance is present in
+// AP_AvoidanceHandler, this class allows Copter to override base
+// functionality - for example, not doing anything while landed.
+class AP_Avoidance_Copter : public AP_Avoidance {
+
+public:
+
+    AP_Avoidance_Copter(AP_AHRS &ahrs, class AP_ADSB &adsb) :
+        AP_Avoidance(ahrs, adsb) { }
+
+protected:
+
+private:
+
+    // these objects are individually responsible for providing a
+    // specific avoidance behaviour
+    AvoidanceHandler_HOVER avoidance_handler_hover;
+    AvoidanceHandler_NONE avoidance_handler_none;
+    AvoidanceHandler_PERPENDICULAR avoidance_handler_perpendicular{_ahrs};
+    AvoidanceHandler_REPORT avoidance_handler_report;
+    AvoidanceHandler_RTL avoidance_handler_rtl;
+    AvoidanceHandler_TCAS avoidance_handler_tcas{_ahrs};
+
+    // returns an object which is responsible for getting the vehicle
+    // out of trouble
+    AvoidanceHandler &handler_for_action(MAV_COLLISION_ACTION action) override;
+
+};

--- a/ArduCopter/avoidance.h
+++ b/ArduCopter/avoidance.h
@@ -32,4 +32,7 @@ private:
     // out of trouble
     AvoidanceHandler &handler_for_action(MAV_COLLISION_ACTION action) override;
 
+    // returns true if taking control of the aircraft would be a bad idea
+    bool active_actions_prohibited() const;
+
 };

--- a/ArduCopter/avoidance_handler.h
+++ b/ArduCopter/avoidance_handler.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <AP_Avoidance/AvoidanceHandler.h>
+
+#include "avoidance_handler__modechange.h"
+#include "avoidance_handler__avoid.h"
+
+#include "avoidance_handler_hover.h"
+#include "avoidance_handler_perpendicular.h"
+#include "avoidance_handler_rtl.h"
+#include "avoidance_handler_tcas.h"

--- a/ArduCopter/avoidance_handler__avoid.cpp
+++ b/ArduCopter/avoidance_handler__avoid.cpp
@@ -1,0 +1,38 @@
+#include "avoidance_handler.h"
+
+#include <AP_Notify/AP_Notify.h>
+#include "Copter.h"
+
+bool AvoidanceHandler__AVOID::update()
+{
+    if (!AvoidanceHandler__ModeChange::update()) {
+        return false;
+    }
+
+    // only update our destination once per second
+    uint32_t now = AP_HAL::millis();
+    if (now - _last_wp_update > 1000) {
+        _last_wp_update = now;
+        if (!do_avoid_navigation()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+bool AvoidanceHandler__AVOID::do_avoid_navigation()
+{
+    Vector3f dest;
+    if (!new_destination(dest)) {
+        return false;
+    }
+
+    // avoid_set_destination takes NEU!
+    if (!copter.avoid_set_destination(dest)) {
+        return false;
+    }
+
+    return true;
+}

--- a/ArduCopter/avoidance_handler__avoid.h
+++ b/ArduCopter/avoidance_handler__avoid.h
@@ -1,0 +1,33 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h"
+
+class AvoidanceHandler__AVOID : public AvoidanceHandler__ModeChange {
+
+public:
+
+    AvoidanceHandler__AVOID(const AP_AHRS &ahrs) :
+        AvoidanceHandler__ModeChange(),
+        _ahrs(ahrs) { }
+
+    bool update() override;
+
+protected:
+
+    const AP_AHRS &_ahrs;
+
+    // new_destination - return new target destination
+    // (distance from home, in cm, NEU)
+    virtual bool new_destination(Vector3f &newdest_neu) = 0;
+
+    control_mode_t mode() const override { return AVOID; }
+
+    // lowest height avoidance will send the aircraft, in metres
+    static const uint8_t _minimum_avoid_height = 10;
+
+private:
+
+    uint32_t _last_wp_update;
+
+    bool do_avoid_navigation();
+};

--- a/ArduCopter/avoidance_handler__modechange.cpp
+++ b/ArduCopter/avoidance_handler__modechange.cpp
@@ -1,0 +1,66 @@
+#include "avoidance_handler.h"
+
+#include "Copter.h"
+
+bool AvoidanceHandler__ModeChange::enter(class AP_Avoidance::Obstacle &threat, class AvoidanceHandler *old_handler)
+{
+    if (!AvoidanceHandler::enter(threat, old_handler)) {
+        return false;
+    }
+    _old_flight_mode = copter.control_mode;
+
+    if (!copter.set_mode(mode(), MODE_REASON_AVOIDANCE)) {
+        return false;
+    }
+
+    return true;
+}
+
+// change mode every <n> seconds (this gives the pilot opportunity to
+// change modes and fly manually, for example)
+bool AvoidanceHandler__ModeChange::update()
+{
+    uint32_t now = AP_HAL::millis();
+    // if the copter has switched out of our mode switch back in:
+    if (copter.control_mode != mode()) {
+        // but give whatever decided to make the change time to
+        // resolve the situation:
+        if (now - _last_mode_change < _mode_change_hysteresis) {
+            return true;
+        }
+        if (!copter.set_mode(mode(), MODE_REASON_AVOIDANCE)) {
+            return false;
+        }
+        // question as to whether we should reset _old_flight_mode,
+        // but if it was us fighting e.g. Fence for control of the
+        // copter returning to the origin _old_flight_mode makes more
+        // sense
+        _last_mode_change = now;
+    }
+    return true;
+}
+
+void AvoidanceHandler__ModeChange::exit_revert_flight_mode()
+{
+    if (copter.control_mode_reason != MODE_REASON_AVOIDANCE) {
+        // we did not set the current flight mode (e.g. the user
+        // switched away from us to Stabilize and resolved the issue
+        // themselves).  Leave them in that mode:
+        return;
+    }
+
+    if (copter.set_mode(_old_flight_mode, MODE_REASON_AVOIDANCE)) { // should we revert the reason?
+        // All good, Copter returned to what it was doing.
+        return;
+    }
+
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: Failed to revert flight mode");
+
+    copter.set_mode_RTL_or_land_with_pause(MODE_REASON_AVOIDANCE);
+}
+
+void AvoidanceHandler__ModeChange::exit()
+{
+    exit_revert_flight_mode();
+    AvoidanceHandler::exit();
+}

--- a/ArduCopter/avoidance_handler__modechange.cpp
+++ b/ArduCopter/avoidance_handler__modechange.cpp
@@ -42,21 +42,22 @@ bool AvoidanceHandler__ModeChange::update()
 
 void AvoidanceHandler__ModeChange::exit_revert_flight_mode()
 {
-    if (copter.control_mode_reason != MODE_REASON_AVOIDANCE) {
+    if (copter.control_mode_reason != MODE_REASON_AVOIDANCE &&
+        copter.control_mode_reason != MODE_REASON_AVOIDANCE_RECOVERY) {
         // we did not set the current flight mode (e.g. the user
         // switched away from us to Stabilize and resolved the issue
         // themselves).  Leave them in that mode:
         return;
     }
 
-    if (copter.set_mode(_old_flight_mode, MODE_REASON_AVOIDANCE)) { // should we revert the reason?
+    if (copter.set_mode(_old_flight_mode, MODE_REASON_AVOIDANCE_RECOVERY)) {
         // All good, Copter returned to what it was doing.
         return;
     }
 
     GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: Failed to revert flight mode");
 
-    copter.set_mode_RTL_or_land_with_pause(MODE_REASON_AVOIDANCE);
+    copter.set_mode_RTL_or_land_with_pause(MODE_REASON_AVOIDANCE_RECOVERY);
 }
 
 void AvoidanceHandler__ModeChange::exit()

--- a/ArduCopter/avoidance_handler__modechange.h
+++ b/ArduCopter/avoidance_handler__modechange.h
@@ -1,0 +1,27 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h" // for control_mode_t
+
+class AvoidanceHandler__ModeChange : public AvoidanceHandler {
+
+public:
+
+    bool update() override;
+    virtual bool enter(class AP_Avoidance::Obstacle &threat, class AvoidanceHandler *old_handler) override;
+    void exit() override;
+
+protected:
+
+    virtual control_mode_t mode() const = 0;
+
+private:
+
+    control_mode_t _old_flight_mode;
+    uint32_t _last_mode_change; // timestamp
+
+    static const uint16_t _mode_change_hysteresis = 10000; // milliseconds
+
+    // change the flight mode back to what it was before entering AVOID
+    void exit_revert_flight_mode();
+
+};

--- a/ArduCopter/avoidance_handler_hover.h
+++ b/ArduCopter/avoidance_handler_hover.h
@@ -1,0 +1,21 @@
+// this file is #included in avoidance_handler.h
+
+// Avoid by standing very still and hoping the other aircraft avoids
+// us
+class AvoidanceHandler_HOVER : public AvoidanceHandler__ModeChange {
+
+public:
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_HOVER;
+    }
+
+    const char *name() const override { return "HOVER"; }
+
+protected:
+
+    control_mode_t mode() const override { return RTL; }
+
+private:
+
+};

--- a/ArduCopter/avoidance_handler_hover.h
+++ b/ArduCopter/avoidance_handler_hover.h
@@ -14,7 +14,7 @@ public:
 
 protected:
 
-    control_mode_t mode() const override { return RTL; }
+    control_mode_t mode() const override { return LOITER; }
 
 private:
 

--- a/ArduCopter/avoidance_handler_perpendicular.cpp
+++ b/ArduCopter/avoidance_handler_perpendicular.cpp
@@ -1,0 +1,11 @@
+#include "avoidance_handler.h"
+
+#include <stdio.h>
+#include <AP_Notify/AP_Notify.h>
+
+#include "Copter.h"
+
+bool AvoidanceHandler_PERPENDICULAR::new_destination(Vector3f &newdest_neu)
+{
+    return new_destination_perpendicular(newdest_neu, _ahrs, copter.wp_nav.get_speed_xy(), copter.wp_nav.get_speed_up(), _minimum_avoid_height);
+}

--- a/ArduCopter/avoidance_handler_perpendicular.h
+++ b/ArduCopter/avoidance_handler_perpendicular.h
@@ -1,0 +1,27 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h"
+
+// Avoid a collision by flying at right-angles to the other aircraft's
+// velocity
+class AvoidanceHandler_PERPENDICULAR : public AvoidanceHandler__AVOID {
+
+public:
+
+    AvoidanceHandler_PERPENDICULAR(const AP_AHRS &ahrs) :
+        AvoidanceHandler__AVOID(ahrs)
+        { }
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_MOVE_PERPENDICULAR;
+    }
+
+    const char *name() const override { return "PERPENDICULAR"; }
+
+protected:
+
+    bool new_destination(Vector3f &newdest_neu) override;
+
+private:
+
+};

--- a/ArduCopter/avoidance_handler_rtl.h
+++ b/ArduCopter/avoidance_handler_rtl.h
@@ -1,0 +1,20 @@
+// this file is #included in avoidance_handler.h
+
+// Avoid a collision by running for home
+class AvoidanceHandler_RTL : public AvoidanceHandler__ModeChange {
+
+public:
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_RTL;
+    }
+
+    const char *name() const override { return "RTL"; }
+
+protected:
+
+    control_mode_t mode() const override { return RTL; }
+
+private:
+
+};

--- a/ArduCopter/avoidance_handler_tcas.cpp
+++ b/ArduCopter/avoidance_handler_tcas.cpp
@@ -1,0 +1,89 @@
+#include "avoidance_handler.h"
+
+#include "Copter.h"
+
+uint32_t AvoidanceHandler_TCAS::my_src_id(const MAV_COLLISION_SRC src) const
+{
+    switch (src) {
+    case MAV_COLLISION_SRC_ADSB:
+        // if we are actively broadcasting ADSB then we should have an ID.  Return that here
+        return 0; // should we return MAX_UINT32/2 here?
+    case MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT:
+        return mavlink_system.sysid;
+    case MAV_COLLISION_SRC_ENUM_END:
+        break;
+    }
+    return 0;
+}
+
+AvoidanceHandler_TCAS::tcas_resolution_t AvoidanceHandler_TCAS::tcas_resolution()
+{
+    if (_threat == nullptr) {
+        // why where we called?!
+        return tcas_resolution_descend;
+    }
+
+    Location my_loc;
+    if (!_ahrs.get_position(my_loc)) {
+        // we should not get to here!  If we don't know our position
+        // we probably can't know if there are any threats, for starters!
+        internal_error();
+        return tcas_resolution_descend;
+    }
+    const uint32_t my_alt = my_loc.alt;
+    const uint32_t threat_alt = _threat->_location.alt;
+    // ::fprintf(stderr, "heights: me=%d threat=%d\n", my_alt, threat_alt);
+   if ((int)(my_alt/100) == (int)(threat_alt/100)) {
+       // the aircraft are within 1m of each other.  Treat this as
+       // equal
+
+       // we now compare src ids.  Note thatif these are coming from
+       // different sources (consider ADSB and MAVLink sources), then
+       // this comparison doesn't make a great deal of sense.
+       if (_threat->src_id < my_src_id(_threat->src)) {
+           return tcas_resolution_ascend;
+       } else if (_threat->src_id > my_src_id(_threat->src)) {
+           return tcas_resolution_descend;
+       }
+       // We have the same src id as the threat.  That's probably bad.
+       // Flip a coin as to whether to go up or down.
+       return ((my_alt % 2 == 0) ? tcas_resolution_descend : tcas_resolution_ascend);
+   }
+
+    if (my_loc.alt > _threat->_location.alt) {
+        return tcas_resolution_ascend;
+    }
+    return tcas_resolution_descend;
+}
+
+// execute TCAS avoidance
+// Traffic Collision Avoidance System, if you were wondering
+// Nice writeup: http://wiki.paparazziuav.org/wiki/MultiUAV
+bool AvoidanceHandler_TCAS::new_destination(Vector3f &newdest_neu)
+{
+    tcas_resolution_t rr = tcas_resolution();
+    // apparently we haven't gone up or down far enough yet...
+    // dest here is NEU!
+    const Vector3f dest = copter.wp_nav.get_wp_destination();
+    float delta_cm = 1000.00;
+    if (rr == tcas_resolution_descend) {
+        delta_cm = -delta_cm;
+    }
+    // ::fprintf(stderr, "tcas_resolution=%d delta_cm=%f\n", rr, delta_cm);
+    float new_alt_cm = 0;
+    Vector3f my_pos;
+    if (_ahrs.get_relative_position_NED(my_pos)) {
+        new_alt_cm = -my_pos[2]*100.0f + delta_cm;
+    } else {
+        // We don't know our current height.  How did we get here?!
+        internal_error();
+    }
+    if (new_alt_cm < _minimum_guided_height * 100) {
+        new_alt_cm = _minimum_guided_height * 100.0f;
+    }
+    newdest_neu[0] = dest[0];
+    newdest_neu[1] = dest[1];
+    newdest_neu[2] = new_alt_cm;
+
+    return true;
+}

--- a/ArduCopter/avoidance_handler_tcas.h
+++ b/ArduCopter/avoidance_handler_tcas.h
@@ -1,0 +1,41 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h"
+
+// Avoid a collision by following the TCAS protocol
+class AvoidanceHandler_TCAS : public AvoidanceHandler__AVOID {
+
+public:
+
+    AvoidanceHandler_TCAS(const AP_AHRS &ahrs) :
+        AvoidanceHandler__AVOID(ahrs)
+        { }
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_TCAS;
+    }
+
+    const char *name() const { return "TCAS"; }
+
+protected:
+
+    bool new_destination(Vector3f &newdest_neu) override;
+
+private:
+
+    // different types of TCAS resolution
+    typedef enum {
+        tcas_resolution_descend = 2,
+        tcas_resolution_ascend = 3,
+        tcas_resolution_neutral = 4, // not technically a TCAS resolution... FIXME
+    } tcas_resolution_t ;
+
+    // returns the action we should take based on the TCAS algorithm
+    tcas_resolution_t tcas_resolution();
+
+    // returns an identifier for this aircraft corresponding to
+    // supplied SRC.  For example, for if the source is mavlink then
+    // the identifier would be this aircraft's mavlink src id
+    uint32_t my_src_id(const MAV_COLLISION_SRC src) const;
+
+};

--- a/ArduCopter/control_avoid.cpp
+++ b/ArduCopter/control_avoid.cpp
@@ -1,0 +1,99 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include "Copter.h"
+
+/*
+ * control_avoid.cpp - init and run calls for AP_Avoidance's AVOID flight mode
+ *
+ * This is a heavily-cut-down version of GUIDED mode
+ */
+
+static Vector3f posvel_pos_target_cm;
+
+// avoid_init - initialise avoid controller
+bool Copter::avoid_init(const bool ignore_checks)
+{
+    if (!(position_ok() || ignore_checks)) {
+        return false;
+    }
+
+    // initialise waypoint and spline controller
+    wp_nav.wp_and_spline_init();
+
+    // initialise wpnav to stopping point at current altitude
+    // To-Do: set to current location if disarmed?
+    // To-Do: set to stopping point altitude?
+    Vector3f stopping_point;
+    stopping_point.z = inertial_nav.get_altitude();
+    wp_nav.get_wp_stopping_point_xy(stopping_point);
+
+    if (!wp_nav.set_wp_destination(stopping_point, false)) {
+        return false;
+    }
+
+    // initialise yaw
+    set_auto_yaw_mode(get_default_auto_yaw_mode(false));
+
+    return true;
+}
+
+// avoid_set_destination - sets AVOID mode's target destination
+// (distance from home, in cm)
+bool Copter::avoid_set_destination(const Vector3f& destination)
+{
+
+    if (!wp_nav.set_wp_destination(destination, false)) {
+        return false;
+    }
+
+    // log target
+    // Log_Write_GuidedTarget(guided_mode, destination, Vector3f());
+    return true;
+}
+
+// avoid_run - runs the AVOID controller
+// should be called at 100hz or more
+void Copter::avoid_run()
+{
+    // if not auto armed or motors not enabled set throttle to zero and exit immediately
+    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
+#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+        // call attitude controller
+        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(0, 0, 0, get_smoothing_gain());
+        attitude_control.set_throttle_out(0,false,g.throttle_filt);
+#else
+        motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
+        // multicopters do not stabilize roll/pitch/yaw when disarmed
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+#endif
+        return;
+    }
+
+    // process pilot's yaw input
+    float target_yaw_rate = 0;
+    if (!failsafe.radio) {
+        // get pilot's desired yaw rate
+        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+        if (!is_zero(target_yaw_rate)) {
+            set_auto_yaw_mode(AUTO_YAW_HOLD);
+        }
+    }
+
+    // set motors to full range
+    motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+
+    // run waypoint controller
+    failsafe_terrain_set_status(wp_nav.update_wpnav());
+
+    // call z-axis position controller (wpnav should have already updated it's alt target)
+    pos_control.update_z_controller();
+
+    // call attitude controller
+    if (auto_yaw_mode == AUTO_YAW_HOLD) {
+        // roll & pitch from waypoint controller, yaw rate from pilot
+        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), target_yaw_rate);
+    }else{
+        // roll, pitch from waypoint controller, yaw heading from auto_heading()
+        attitude_control.input_euler_angle_roll_pitch_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), get_auto_heading(), true);
+    }
+}

--- a/ArduCopter/control_avoid.cpp
+++ b/ArduCopter/control_avoid.cpp
@@ -59,7 +59,7 @@ void Copter::avoid_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw_smooth(0, 0, 0, get_smoothing_gain());
+        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
 #else
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
@@ -91,9 +91,9 @@ void Copter::avoid_run()
     // call attitude controller
     if (auto_yaw_mode == AUTO_YAW_HOLD) {
         // roll & pitch from waypoint controller, yaw rate from pilot
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), target_yaw_rate);
+        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), target_yaw_rate, get_smoothing_gain());
     }else{
         // roll, pitch from waypoint controller, yaw heading from auto_heading()
-        attitude_control.input_euler_angle_roll_pitch_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), get_auto_heading(), true);
+        attitude_control.input_euler_angle_roll_pitch_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), get_auto_heading(), true, get_smoothing_gain());
     }
 }

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -67,7 +67,8 @@ enum aux_sw_func {
 	AUXSW_RELAY2 =              34, // Relay2 pin on/off (in Mission planner set CH8_OPT  = 34)
     AUXSW_RELAY3 =              35, // Relay3 pin on/off (in Mission planner set CH9_OPT  = 35)
     AUXSW_RELAY4 =              36, // Relay4 pin on/off (in Mission planner set CH10_OPT = 36)
-    AUXSW_THROW =               37  // change to THROW flight mode
+    AUXSW_THROW =               37,  // change to THROW flight mode
+    AUXSW_AVOID =               38,  // enable AP_Avoidance library
 };
 
 // Frame types
@@ -354,6 +355,8 @@ enum ThrowModeState {
 #define DATA_EKF_ALT_RESET                  60
 #define DATA_LAND_CANCELLED_BY_PILOT        61
 #define DATA_EKF_YAW_RESET                  62
+#define DATA_AVOIDANCE_ENABLE               63
+#define DATA_AVOIDANCE_DISABLE              64
 
 // Centi-degrees to radians
 #define DEGX100 5729.57795f

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -103,7 +103,8 @@ enum control_mode_t {
     AUTOTUNE =     15,  // automatically tune the vehicle's roll and pitch gains
     POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
     BRAKE =        17,  // full-brake using inertial/GPS system, no pilot input
-    THROW =        18   // throw to launch mode using inertial/GPS system, no pilot input
+    THROW =        18,  // throw to launch mode using inertial/GPS system, no pilot input
+    AVOID =        19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
 };
 
 enum mode_reason_t {
@@ -120,7 +121,8 @@ enum mode_reason_t {
     MODE_REASON_FENCE_BREACH,
     MODE_REASON_TERRAIN_FAILSAFE,
     MODE_REASON_BRAKE_TIMEOUT,
-    MODE_REASON_FLIP_COMPLETE
+    MODE_REASON_FLIP_COMPLETE,
+    MODE_REASON_AVOIDANCE,
 };
 
 // Tuning enumeration

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -123,6 +123,7 @@ enum mode_reason_t {
     MODE_REASON_BRAKE_TIMEOUT,
     MODE_REASON_FLIP_COMPLETE,
     MODE_REASON_AVOIDANCE,
+    MODE_REASON_AVOIDANCE_RECOVERY,
 };
 
 // Tuning enumeration

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -103,6 +103,10 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
             success = throw_init(ignore_checks);
             break;
 
+        case AVOID:
+            success = avoid_init(ignore_checks);
+            break;
+
         default:
             success = false;
             break;
@@ -224,6 +228,10 @@ void Copter::update_flight_mode()
             throw_run();
             break;
 
+        case AVOID:
+            avoid_run();
+            break;
+
         default:
             break;
     }
@@ -292,6 +300,7 @@ bool Copter::mode_requires_GPS(control_mode_t mode) {
         case DRIFT:
         case POSHOLD:
         case BRAKE:
+        case AVOID:
         case THROW:
             return true;
         default:
@@ -330,6 +339,7 @@ void Copter::notify_flight_mode(control_mode_t mode) {
         case GUIDED:
         case RTL:
         case CIRCLE:
+        case AVOID:
         case LAND:
             // autopilot modes
             AP_Notify::flags.autopilot_mode = true;
@@ -394,6 +404,9 @@ void Copter::print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode)
         break;
     case THROW:
         port->print("THROW");
+        break;
+    case AVOID:
+        port->print("AVOID");
         break;
     default:
         port->printf("Mode(%u)", (unsigned)mode);

--- a/ArduCopter/make.inc
+++ b/ArduCopter/make.inc
@@ -60,3 +60,4 @@ LIBRARIES += AC_PrecLand
 LIBRARIES += AP_IRLock
 LIBRARIES += AC_InputManager
 LIBRARIES += AP_ADSB
+LIBRARIES += AP_Avoidance

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -601,6 +601,17 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                 }
             }
             break;
+
+        case AUXSW_AVOID:
+            // enable or disable AP_Avoidance
+            if (ch_flag == AUX_SWITCH_HIGH) {
+                avoidance.enable();
+                Log_Write_Event(DATA_AVOIDANCE_ENABLE);
+            }else{
+                avoidance.disable();
+                Log_Write_Event(DATA_AVOIDANCE_DISABLE);
+            }
+            break;
     }
 }
 

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -28,6 +28,7 @@ def build(bld):
             'AP_RCMapper',
             'AP_Relay',
             'AP_ServoRelayEvents',
+            'AP_Avoidance',
         ],
         use='mavlink',
     )

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -85,6 +85,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(update_is_flying_5Hz,    5,    100),
     SCHED_TASK(dataflash_periodic,     50,    400),
     SCHED_TASK(adsb_update,             1,    400),
+    SCHED_TASK(avoidance_update,       10,    400),
 };
 
 void Plane::setup() 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1145,6 +1145,10 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_ADSB/AP_ADSB.cpp
     GOBJECT(adsb,                "ADSB_", AP_ADSB),
 
+    // @Group: AVD_
+    // @Path: ../libraries/AP_Avoidance/AP_Avoidance.cpp
+    GOBJECT(avoidance,                "AVD_", AP_Avoidance),
+
     // @Group: Q_
     // @Path: quadplane.cpp
     GOBJECT(quadplane,           "Q_", QuadPlane),

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -347,6 +347,11 @@ public:
         k_param_DataFlash = 253, // Logging Group
 
         // 254,255: reserved
+
+        k_param_avoidance = 256, // AP_Avoidance
+
+        // the k_param_* space is 9-bits in size
+        // 511: reserved
     };
 
     AP_Int16 format_version;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -92,6 +92,7 @@
 #include "GCS_Mavlink.h"
 #include "quadplane.h"
 #include "tuning.h"
+#include "avoidance.h"
 
 // Configuration
 #include "config.h"
@@ -134,6 +135,9 @@ public:
     friend class AP_Arming_Plane;
     friend class QuadPlane;
     friend class AP_Tuning_Plane;
+    friend class AP_Avoidance_Plane;
+    friend class AvoidanceHandler__ModeChange;
+    friend class AvoidanceHandler_PERPENDICULAR;
 
     Plane(void);
 
@@ -633,6 +637,9 @@ private:
     } adsb_state;
 
 
+    // situational awareness and response:
+    AP_Avoidance_Plane avoidance{ahrs, adsb};
+
     // Outback Challenge Failsafe Support
 #if OBC_FAILSAFE == ENABLED
     APM_OBC obc {mission, barometer, gps, rcmap};
@@ -1009,6 +1016,7 @@ private:
     bool adsb_evasion_start(void);
     void adsb_evasion_stop(void);
     void adsb_evasion_ongoing(void);
+    void avoidance_update();
     void update_flight_mode(void);
     void stabilize();
     void set_servos_idle(void);

--- a/ArduPlane/avoidance.cpp
+++ b/ArduPlane/avoidance.cpp
@@ -1,0 +1,34 @@
+#include "Plane.h"
+#include "avoidance.h"
+#include <AP_Notify/AP_Notify.h>
+
+void Plane::avoidance_update(void)
+{
+    avoidance.update();
+}
+
+#include <stdio.h>
+
+AvoidanceHandler &AP_Avoidance_Plane::handler_for_action(MAV_COLLISION_ACTION action)
+{
+    if (!plane.is_flying()) {
+        // do nothing if we are not flying
+        if (action == MAV_COLLISION_ACTION_REPORT) {
+            return avoidance_handler_report;
+        }
+        return avoidance_handler_none;
+    }
+
+    switch(action) {
+    case MAV_COLLISION_ACTION_NONE:
+        return avoidance_handler_none;
+    case MAV_COLLISION_ACTION_REPORT:
+        return avoidance_handler_report;
+    case MAV_COLLISION_ACTION_MOVE_PERPENDICULAR:
+        return avoidance_handler_perpendicular;
+    default:
+        ::fprintf(stderr, "Avoidance action %d not known\n", action);
+        internal_error();
+    };
+    return avoidance_handler_none;
+}

--- a/ArduPlane/avoidance.h
+++ b/ArduPlane/avoidance.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <AP_Avoidance/AP_Avoidance.h>
+
+#include "avoidance_handler.h"
+
+// Provide Plane-specific implementation of avoidance.  While most of
+// the logic for doing the actual avoidance is present in
+// AP_AvoidanceHandler, this class allows Plane to override base
+// functionality - for example, not doing anything while landed.
+class AP_Avoidance_Plane : public AP_Avoidance {
+
+public:
+
+    AP_Avoidance_Plane(AP_AHRS &ahrs, class AP_ADSB &adsb) :
+        AP_Avoidance(ahrs, adsb) { }
+
+protected:
+
+private:
+
+    // these objects are individually responsible for providing a
+    // specific avoidance behaviour
+    AvoidanceHandler_NONE avoidance_handler_none;
+    AvoidanceHandler_PERPENDICULAR avoidance_handler_perpendicular{_ahrs};
+    AvoidanceHandler_REPORT avoidance_handler_report;
+
+    // returns an object which is responsible for getting the vehicle
+    // out of trouble
+    AvoidanceHandler &handler_for_action(MAV_COLLISION_ACTION action) override;
+
+};

--- a/ArduPlane/avoidance_handler.h
+++ b/ArduPlane/avoidance_handler.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <AP_Avoidance/AvoidanceHandler.h>
+
+#include "avoidance_handler__modechange.h"
+#include "avoidance_handler_perpendicular.h"

--- a/ArduPlane/avoidance_handler__modechange.cpp
+++ b/ArduPlane/avoidance_handler__modechange.cpp
@@ -1,0 +1,97 @@
+#include "avoidance_handler.h"
+
+#include "Plane.h"
+
+bool AvoidanceHandler__ModeChange::set_mode(const FlightMode _mode)
+{
+    // make sure we don't auto trim the surfaces on this mode change
+    const int8_t saved_auto_trim = plane.g.auto_trim;
+    plane.g.auto_trim.set(0);
+    plane.set_mode(_mode);
+    plane.g.auto_trim.set(saved_auto_trim);
+
+    if (plane.control_mode != _mode) {
+        return false;
+    }
+    return true;
+}
+
+
+bool AvoidanceHandler__ModeChange::enter(class AP_Avoidance::Obstacle &threat, class AvoidanceHandler *old_handler)
+{
+    if (!AvoidanceHandler::enter(threat, old_handler)) {
+        return false;
+    }
+    _old_flight_mode = plane.control_mode;
+
+    old_switch_position = plane.oldSwitchPosition;
+    guided_WP_loc = plane.guided_WP_loc;
+
+    if (!set_mode(mode())) {
+        return false;
+    }
+
+    return true;
+}
+
+bool AvoidanceHandler__ModeChange::user_has_taken_control()
+{
+    if (plane.control_mode != mode()) {
+        // user has switched modes
+        return true;
+    }
+    if (plane.control_mode == GUIDED &&
+        !locations_are_same(guided_WP_loc, plane.guided_WP_loc)) {
+        // user has changed the guided destination
+        return true;
+    }
+
+    return false;
+}
+
+// change mode every <n> seconds (this gives the pilot opportunity to
+// change modes and fly manually, for example)
+bool AvoidanceHandler__ModeChange::update()
+{
+    uint32_t now = AP_HAL::millis();
+    // if something else has taken control, take it back again....
+    if (user_has_taken_control()) {
+        // but give whatever decided to make the change time to
+        // resolve the situation:
+        if (now - _last_mode_change < _mode_change_hysteresis) {
+            return true;
+        }
+        if (!set_mode(mode())) {
+            return false;
+        }
+        // question as to whether we should reset _old_flight_mode,
+        // but if it was us fighting e.g. Fence for control of the
+        // copter returning to the origin _old_flight_mode makes more
+        // sense
+        _last_mode_change = now;
+    }
+    return true;
+}
+
+void AvoidanceHandler__ModeChange::exit_revert_flight_mode()
+{
+    if (user_has_taken_control()) {
+        // something else has taken control.  Don't change things on them
+        return;
+    }
+
+    if (set_mode(_old_flight_mode)) {
+        // All good, Plane returned to what it was doing.
+        return;
+    }
+
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: Failed to revert flight mode");
+
+    plane.set_mode(RTL);
+}
+
+void AvoidanceHandler__ModeChange::exit()
+{
+    exit_revert_flight_mode();
+    AvoidanceHandler::exit();
+}

--- a/ArduPlane/avoidance_handler__modechange.h
+++ b/ArduPlane/avoidance_handler__modechange.h
@@ -1,0 +1,39 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h" // for control_mode_t
+
+class AvoidanceHandler__ModeChange : public AvoidanceHandler {
+
+public:
+
+    bool update() override;
+    virtual bool enter(class AP_Avoidance::Obstacle &threat, class AvoidanceHandler *old_handler) override;
+    void exit() override;
+
+protected:
+
+    virtual FlightMode mode() const = 0;
+    Location guided_WP_loc;
+
+private:
+
+    FlightMode _old_flight_mode;
+    uint32_t _last_mode_change; // timestamp
+
+    static const uint16_t _mode_change_hysteresis = 20000; // milliseconds
+
+    // change the flight mode back to what it was before entering AVOID
+    void exit_revert_flight_mode();
+
+    bool set_mode(const FlightMode _mode);
+
+    // keep track of various things to make sure we don't surprise the
+    // user with a mode change when they've taken control of the
+    // aircraft:
+    uint8_t old_switch_position;
+
+    // returns true if it looks like the user has decided they can
+    // resolve this situation better than we can
+    virtual bool user_has_taken_control();
+
+};

--- a/ArduPlane/avoidance_handler_perpendicular.cpp
+++ b/ArduPlane/avoidance_handler_perpendicular.cpp
@@ -1,0 +1,57 @@
+#include "avoidance_handler.h"
+
+#include <stdio.h>
+#include <AP_Notify/AP_Notify.h>
+
+#include "Plane.h"
+
+bool AvoidanceHandler_PERPENDICULAR::new_destination(Location &newdest)
+{
+    if (! _ahrs.get_position(newdest)) {
+        return false;
+    }
+
+    Vector3f newdest_neu;
+    if (!new_destination_perpendicular(newdest_neu, _ahrs, plane.aparm.airspeed_max * 100, plane.aparm.airspeed_max * 100, _minimum_avoid_height * 100)) {
+        return false;
+    }
+
+    location_offset(newdest, newdest_neu[0]/100.0f, newdest_neu[1]/100.0f);
+    newdest.alt += newdest_neu[2];
+
+    return true;
+}
+
+
+bool AvoidanceHandler_PERPENDICULAR::update()
+{
+
+    if (!AvoidanceHandler__ModeChange::update()) {
+        return false;
+    }
+
+    // only update our destination once per second
+    uint32_t now = AP_HAL::millis();
+    if (now - _last_wp_update > 1000) {
+        _last_wp_update = now;
+        if (!do_avoid_navigation()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+bool AvoidanceHandler_PERPENDICULAR::do_avoid_navigation()
+{
+    if (!new_destination(guided_WP_loc)) {
+        return false;
+    }
+    plane.guided_WP_loc.lat = guided_WP_loc.lat;
+    plane.guided_WP_loc.lng = guided_WP_loc.lng;
+    plane.guided_WP_loc.alt = guided_WP_loc.alt;
+    plane.set_guided_WP();
+
+    return true;
+}

--- a/ArduPlane/avoidance_handler_perpendicular.h
+++ b/ArduPlane/avoidance_handler_perpendicular.h
@@ -1,0 +1,41 @@
+// this file is #included in avoidance_handler.h
+
+#include "defines.h"
+
+// Avoid a collision by flying at right-angles to the other aircraft's
+// velocity
+class AvoidanceHandler_PERPENDICULAR : public AvoidanceHandler__ModeChange {
+
+public:
+
+    AvoidanceHandler_PERPENDICULAR(const AP_AHRS &ahrs) :
+        AvoidanceHandler__ModeChange(),
+        _ahrs(ahrs)
+        { }
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_MOVE_PERPENDICULAR;
+    }
+
+    const char *name() const override { return "PERPENDICULAR"; }
+
+    bool update() override;
+
+protected:
+
+    FlightMode mode() const override { return GUIDED; };
+
+    bool new_destination(Location &newdest);
+
+private:
+
+    const AP_AHRS &_ahrs;
+
+    uint32_t _last_wp_update;
+
+    Location guided_wp_loc;
+
+    bool do_avoid_navigation();
+
+    const uint8_t _minimum_avoid_height = 20; // metres
+};

--- a/ArduPlane/make.inc
+++ b/ArduPlane/make.inc
@@ -57,3 +57,4 @@ LIBRARIES += AC_WPNav
 LIBRARIES += AC_Fence
 LIBRARIES += AC_Avoidance
 LIBRARIES += AP_Tuning
+LIBRARIES += AP_Avoidance

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -28,7 +28,8 @@ def build(bld):
             'AP_Motors',
             'AC_PID',
             'AC_Fence',
-            'AC_Avoidance'
+            'AC_Avoidance',
+            'AP_Avoidance'
         ],
         use='mavlink',
     )

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -1,0 +1,665 @@
+#include "AP_Avoidance.h"
+
+extern const AP_HAL::HAL& hal;
+
+#include <limits>
+#include <GCS_MAVLink/GCS.h>
+
+AP_Avoidance *AP_Avoidance::_instance;
+
+#include "AvoidanceHandler.h"
+
+#define AVOIDANCE_DEBUGGING 0
+
+#if AVOIDANCE_DEBUGGING
+#include <stdio.h>
+#define debug(fmt, args ...)  do {::fprintf(stderr,"%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
+#else
+#define debug(fmt, args ...)
+#endif
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable AVOIDANCE
+    // @Description: Enable Avoidance
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ENABLE",     0, AP_Avoidance, _enabled,    0),
+
+    // @Param: F_ACTION
+    // @DisplayName: Collision Avoidance Behavior
+    // @Description: Specifies aircraft behaviour when a collision is imminent
+    // The following values should come from the mavlink COLLISION_ACTION enum
+    // @Values: 0:None,1:Report,4:TCAS,5:Perpendicular,6:RTL,7:Hover
+    // @User: Advanced
+    AP_GROUPINFO("F_ACTION",   1, AP_Avoidance, _fail_action, MAV_COLLISION_ACTION_REPORT),
+
+    // @Param: W_ACTION
+    // @DisplayName: Collision Avoidance Behavior - Warn
+    // @Description: Specifies aircraft behaviour when a collision may occur
+    // The following values should come from the mavlink COLLISION_ACTION enum
+    // @Values: 0:None,1:Report,4:TCAS,5:Perpendicular,6:RTL,7:Hover
+    // @User: Advanced
+    AP_GROUPINFO("W_ACTION",   2, AP_Avoidance, _warn_action, MAV_COLLISION_ACTION_REPORT),
+
+    // @Param: W_RCVRY
+    // @DisplayName: Recovery behaviour after a warn event
+    // @Description: Determines what the aircraft will do after a warn event (which has not progressed to a fail event) has been resolved
+    // @Values: 0:Resume previous flight mode,1:Mode Loiter,2:Continue collision avoidance action
+    // @User: Advanced
+    AP_GROUPINFO("W_RCVRY",   3, AP_Avoidance, _warn_recovery, AVOIDANCE_RECOVERY_W_RESUME),
+
+    // @Param: F_RCVRY
+    // @DisplayName: Recovery behaviour after a fail event
+    // @Description: Determines what the aircraft will do after a fail event is resolved
+    // @Values: 0:Continue collision avoidance ACTION_F,1:Move to collision avoidance W_ACTION
+    // @User: Advanced
+    AP_GROUPINFO("F_RCVRY",   4, AP_Avoidance, _fail_recovery, AVOIDANCE_RECOVERY_F_MOVE_TO_WARN),
+
+    // @Param: OBS_MAX
+    // @DisplayName: Maximum number of obstacles to track
+    // @Description: Maximum number of obstacles to track
+    // @User: Advanced
+    AP_GROUPINFO("OBS_MAX",   5, AP_Avoidance, _obstacles_max, 20),
+
+    // @Param: W_TIME
+    // @DisplayName: Time Horizon Warn
+    // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than W_DIST_XY or W_DIST_Z then W_ACTION is undertaken (assuming F_ACTION is not undertaken)
+    // @User: Advanced
+    AP_GROUPINFO("W_TIME",     6, AP_Avoidance, _warn_time_horizon,    30),
+
+    // @Param: F_TIME
+    // @DisplayName: Time Horizon Fail
+    // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than F_DIST_XY or F_DIST_Z then F_ACTION is undertaken
+    // @User: Advanced
+    AP_GROUPINFO("F_TIME",     7, AP_Avoidance, _fail_time_horizon,    30),
+
+    // @Param: W_DIST_XY
+    // @DisplayName: Distance Warn XY
+    // @Description: Closest allowed projected distance before W_ACTION is undertaken
+    // @User: Advanced
+    AP_GROUPINFO("W_DIST_XY",     8, AP_Avoidance, _warn_distance_xy,    300),
+
+    // @Param: F_DIST_XY
+    // @DisplayName: Distance Fail XY
+    // @Description: Closest allowed projected distance before F_ACTION is undertaken
+    // @User: Advanced
+    AP_GROUPINFO("F_DIST_XY",     9, AP_Avoidance, _fail_distance_xy,    100),
+
+
+    // @Param: W_DIST_Z
+    // @DisplayName: Distance Warn Z
+    // @Description: Closest allowed projected distance before BEHAVIOUR_W is undertaken
+    // @User: Advanced
+    AP_GROUPINFO("W_DIST_Z",     10, AP_Avoidance, _warn_distance_z,    300),
+
+    // @Param: F_DIST_Z
+    // @DisplayName: Distance Fail Z
+    // @Description: Closest allowed projected distance before BEHAVIOUR_F is undertaken
+    // @User: Advanced
+    AP_GROUPINFO("F_DIST_Z",     11, AP_Avoidance, _fail_distance_z,    100),
+
+    AP_GROUPEND
+};
+
+const char *AP_Avoidance::_state_names[] = { "CLEAR", "WARN", "FAIL" };
+
+AP_Avoidance::AP_Avoidance(AP_AHRS &ahrs, AP_ADSB &adsb) :
+    _ahrs(ahrs),
+    _adsb(adsb)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    _instance = this;
+}
+
+/*
+ * Initialize variables and allocate memory for array
+ */
+void AP_Avoidance::init(void)
+{
+    debug("ADSB initialisation: %d obstacles", _obstacles_max.get());
+    if (_obstacles == NULL) {
+        _obstacles = new AP_Avoidance::Obstacle[_obstacles_max];
+
+        if (_obstacles == NULL) {
+            // dynamic RAM allocation of _obstacles[] failed, disable gracefully
+            hal.console->printf("Unable to initialize Avoidance obstacle list\n");
+            // disable ourselves to avoid repeated allocation attempts
+            _enabled.set(0);
+            return;
+        }
+        _obstacles_allocated = _obstacles_max;
+    }
+    _obstacle_count = 0;
+    _last_state_change_ms = 0;
+    _old_state = STATE_CLEAR;
+    _gcs_cleared_messages_first_sent = std::numeric_limits<uint32_t>::max();
+    _current_most_serious_threat = -1;
+}
+
+/*
+ * de-initialize and free up some memory
+ */
+void AP_Avoidance::deinit(void)
+{
+    if (_obstacles != nullptr) {
+        delete [] _obstacles;
+        _obstacles = nullptr;
+        _obstacles_allocated = 0;
+    }
+    _obstacle_count = 0;
+}
+
+bool AP_Avoidance::check_startup()
+{
+    if (!_enabled) {
+        if (_obstacles != nullptr) {
+            deinit();
+        }
+        // nothing to do
+        return false;
+    }
+    if (_obstacles == nullptr)  {
+        init();
+    }
+    return _obstacles != nullptr;
+}
+
+// vel is north/east/down!
+void AP_Avoidance::add_obstacle(const uint32_t obstacle_timestamp_ms,
+                                const MAV_COLLISION_SRC src,
+                                const uint32_t src_id,
+                                const Location &loc,
+                                const Vector3f &vel_ned)
+{
+    if (! check_startup()) {
+        return;
+    }
+    uint32_t oldest_timestamp = std::numeric_limits<uint32_t>::max();
+    uint8_t oldest_index = 255; // avoid compiler warning with initialisation
+    int16_t index = -1;
+    uint8_t i;
+    for (i=0; i<_obstacle_count; i++) {
+        if (_obstacles[i].src_id == src_id &&
+            _obstacles[i].src == src) {
+            // pre-existing obstacle found; we will update its information
+            index = i;
+            break;
+        }
+        if (_obstacles[i].timestamp_ms < oldest_timestamp) {
+            oldest_timestamp = _obstacles[i].timestamp_ms;
+            oldest_index = i;
+        }
+    }
+    if (index == -1) {
+        // existing obstacle not found.  See if we can store it anyway:
+        if (i <_obstacles_allocated) {
+            // have room to store more vehicles...
+            index = _obstacle_count++;
+        } else if (oldest_timestamp < obstacle_timestamp_ms) {
+            // replace this very old entry with this new data
+            index = oldest_index;
+        }
+        _obstacles[index].src = src;
+        _obstacles[index].src_id = src_id;
+    }
+
+    if (index == -1) {
+        // no room for this (old?!) data
+        return;
+    }
+    _obstacles[index]._location = loc;
+    _obstacles[index]._velocity = vel_ned;
+    _obstacles[index].timestamp_ms = obstacle_timestamp_ms;
+}
+
+void AP_Avoidance::add_obstacle(const uint32_t obstacle_timestamp_ms,
+                                const MAV_COLLISION_SRC src,
+                                const uint32_t src_id,
+                                const Location &loc,
+                                const float cog,
+                                const float hspeed,
+                                const float vspeed)
+{
+    Vector3f vel;
+    vel[0] = hspeed * cosf(radians(cog));
+    vel[1] = hspeed * sinf(radians(cog));
+    vel[2] = vspeed;
+    // debug("cog=%f hspeed=%f veln=%f vele=%f", cog, hspeed, vel[0], vel[1]);
+    return add_obstacle(obstacle_timestamp_ms, src, src_id, loc, vel);
+}
+
+uint32_t AP_Avoidance::src_id_for_adsb_vehicle(AP_ADSB::adsb_vehicle_t vehicle) const
+{
+    // TODO: need to include squawk code and callsign
+    return vehicle.info.ICAO_address;
+}
+
+void AP_Avoidance::get_adsb_samples()
+{
+    AP_ADSB::adsb_vehicle_t vehicle;
+    while (_adsb.next_sample(vehicle)) {
+        uint32_t src_id = src_id_for_adsb_vehicle(vehicle);
+        Location loc = vehicle.get_location();
+        add_obstacle(vehicle.last_update_ms,
+                   MAV_COLLISION_SRC_ADSB,
+                   src_id,
+                   loc,
+                   vehicle.info.heading/100.0f,
+                   vehicle.info.hor_velocity/100.0f,
+                   -vehicle.info.ver_velocity/1000.0f); // convert mm-up to m-down
+    }
+}
+
+float closest_approach_xy(const Location &my_loc,
+                          const Vector3f &my_vel,
+                          const Location &obstacle_loc,
+                          const Vector3f &obstacle_vel,
+                          const uint8_t time_horizon)
+{
+
+    Vector2f delta_vel_ne = Vector2f(obstacle_vel[0] - my_vel[0], obstacle_vel[1] - my_vel[1]);
+    Vector2f delta_pos_ne = location_diff(obstacle_loc, my_loc);
+
+    Vector2f line_segment_ne = delta_vel_ne * time_horizon;
+
+    float ret = Vector2<float>::closest_distance_between_radial_and_point
+        (line_segment_ne,
+         delta_pos_ne);
+
+    debug("   time_horizon: (%d)", time_horizon);
+    debug("   delta pos: (y=%f,x=%f)", delta_pos_ne[0], delta_pos_ne[1]);
+    debug("   delta vel: (y=%f,x=%f)", delta_vel_ne[0], delta_vel_ne[1]);
+    debug("   line segment: (y=%f,x=%f)", line_segment_ne[0], line_segment_ne[1]);
+    debug("   closest: (%f)", ret);
+
+    return ret;
+}
+
+// returns the closest these objects will get in the body z axis (in metres)
+float closest_approach_z(const Location &my_loc,
+                         const Vector3f &my_vel,
+                         const Location &obstacle_loc,
+                         const Vector3f &obstacle_vel,
+                         const uint8_t time_horizon)
+{
+
+    float delta_vel_d = obstacle_vel[2] - my_vel[2];
+    float delta_pos_d = obstacle_loc.alt - my_loc.alt;
+
+    float ret;
+    if (delta_pos_d >= 0 &&
+        delta_vel_d >= 0) {
+        ret = delta_pos_d;
+    } else if (delta_pos_d <= 0 &&
+        delta_vel_d <= 0) {
+        ret = fabs(delta_pos_d);
+    } else {
+        ret = fabs(delta_pos_d - delta_vel_d * time_horizon);
+    }
+
+    debug("   time_horizon: (%d)", time_horizon);
+    debug("   delta pos: (%f) metres", delta_pos_d/100.0f);
+    debug("   delta vel: (%f) m/s", delta_vel_d);
+    debug("   closest: (%f) metres", ret/100.0f);
+
+    return ret/100.0f;
+}
+
+void AP_Avoidance::update_threat_level(const Location &my_loc,
+                                       const Vector3f &my_vel,
+                                       AP_Avoidance::Obstacle &obstacle)
+{
+
+    Location &obstacle_loc = obstacle._location;
+    Vector3f &obstacle_vel = obstacle._velocity;
+
+    obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_NONE;
+
+    const uint32_t obstacle_age = AP_HAL::millis() - obstacle.timestamp_ms;
+    float closest_xy = closest_approach_xy(my_loc, my_vel, obstacle_loc, obstacle_vel, _fail_time_horizon + obstacle_age/1000);
+    if (closest_xy < _fail_distance_xy) {
+        obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_HIGH;
+    } else {
+        closest_xy = closest_approach_xy(my_loc, my_vel, obstacle_loc, obstacle_vel, _warn_time_horizon + obstacle_age/1000);
+        if (closest_xy < _warn_distance_xy) {
+            obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_LOW;
+        }
+    }
+
+    // check for vertical separation; our threat level is the minimum
+    // of vertical and horizontal threat levels
+    float closest_z = closest_approach_z(my_loc, my_vel, obstacle_loc, obstacle_vel, _warn_time_horizon + obstacle_age/1000);
+    if (obstacle.threat_level != MAV_COLLISION_THREAT_LEVEL_NONE) {
+        if (closest_z > _warn_distance_z) {
+            obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_NONE;
+        } else {
+            closest_z = closest_approach_z(my_loc, my_vel, obstacle_loc, obstacle_vel, _fail_time_horizon + obstacle_age/1000);
+            if (closest_z > _fail_distance_z) {
+                obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_LOW;
+            }
+        }
+    }
+
+    // If we haven't heard from a vehicle then assume it is no threat
+    if (obstacle_age > MAX_OBSTACLE_AGE_MS) {
+        obstacle.threat_level = MAV_COLLISION_THREAT_LEVEL_NONE;
+    }
+
+    // could optimise this to not calculate a lot of this if threat
+    // level is none - but only *once the GCS has been informed*!
+    obstacle.closest_approach_xy = closest_xy;
+    obstacle.closest_approach_z = closest_z;
+    float current_distance = get_distance(my_loc, obstacle_loc);
+    obstacle.distance_to_closest_approach = current_distance - closest_xy;
+    Vector2f net_velocity_ne = Vector2f(my_vel[0] - obstacle_vel[0], my_vel[1] - obstacle_vel[1]);
+    obstacle.time_to_closest_approach = 0.0f;
+    if (!is_zero(obstacle.distance_to_closest_approach) &&
+        ! is_zero(net_velocity_ne.length())) {
+        obstacle.time_to_closest_approach = obstacle.distance_to_closest_approach / net_velocity_ne.length();
+    }
+}
+
+MAV_COLLISION_THREAT_LEVEL AP_Avoidance::current_threat_level() const {
+    if (_obstacles == nullptr) {
+        return MAV_COLLISION_THREAT_LEVEL_NONE;
+    }
+    if (_current_most_serious_threat == -1) {
+        return MAV_COLLISION_THREAT_LEVEL_NONE;
+    }
+    return _obstacles[_current_most_serious_threat].threat_level;
+}
+
+void AP_Avoidance::handle_threat_gcs_notify(AP_Avoidance::Obstacle *threat)
+{
+    if (threat == nullptr) {
+        return;
+    }
+
+    uint32_t now = AP_HAL::millis();
+    if (threat->threat_level == MAV_COLLISION_THREAT_LEVEL_NONE) {
+        // only send cleared messages for a few seconds:
+        if (_gcs_cleared_messages_first_sent == 0) {
+            _gcs_cleared_messages_first_sent = now;
+        }
+        if (now - _gcs_cleared_messages_first_sent > _gcs_cleared_messages_duration * 1000) {
+            return;
+        }
+    } else {
+        _gcs_cleared_messages_first_sent = 0;
+    }
+    if (now - threat->last_gcs_report_time > _gcs_notify_interval * 1000) {
+        GCS_MAVLINK::send_collision_all(*threat, mav_avoidance_action());
+        threat->last_gcs_report_time = now;
+    }
+
+}
+
+bool AP_Avoidance::obstacle_is_more_serious_threat(const AP_Avoidance::Obstacle &obstacle) const
+{
+    if (_current_most_serious_threat == -1) {
+        // any threat is more of a threat than no threat
+        return true;
+    }
+    const AP_Avoidance::Obstacle &current = _obstacles[_current_most_serious_threat];
+    if (obstacle.threat_level > current.threat_level) {
+        // threat_level is updated by update_threat_level
+        return true;
+    }
+    if (obstacle.threat_level == current.threat_level &&
+        obstacle.time_to_closest_approach < current.time_to_closest_approach) {
+        return true;
+    }
+    return false;
+}
+
+void AP_Avoidance::check_for_threats()
+{
+    Location my_loc;
+    if (!_ahrs.get_position(my_loc)) {
+        // if we don't know our own location we can't determine any threat level
+        return;
+    }
+
+    Vector3f my_vel;
+    if (!_ahrs.get_velocity_NED(my_vel)) {
+        // assuming our own velocity to be zero here may cause us to
+        // fly into something.  Better not to attempt to avoid in this
+        // case.
+        return;
+    }
+
+    // we always check all obstacles to see if they are threats since it
+    // is most likely our own position and/or velocity have changed
+    // determine the current most-serious-threat
+    _current_most_serious_threat = -1;
+    for (uint8_t i=0; i<_obstacle_count; i++) {
+
+        AP_Avoidance::Obstacle &obstacle = _obstacles[i];
+        const uint32_t obstacle_age = AP_HAL::millis() - obstacle.timestamp_ms;
+        debug("i=%d src_id=%d timestamp=%u age=%d", i, obstacle.src_id, obstacle.timestamp_ms, obstacle_age);
+
+        update_threat_level(my_loc, my_vel, obstacle);
+        debug("   threat-level=%d", obstacle.threat_level);
+
+        // ignore any really old data:
+        if (obstacle_age > MAX_OBSTACLE_AGE_MS) {
+            // shrink list if this is the last entry:
+            if (i == _obstacle_count-1) {
+                _obstacle_count -= 1;
+            }
+            continue;
+        }
+
+        if (obstacle_is_more_serious_threat(obstacle)) {
+            _current_most_serious_threat = i;
+        }
+    }
+    if (_current_most_serious_threat != -1) {
+        debug("Current most serious threat: %d level=%d", _current_most_serious_threat, _obstacles[_current_most_serious_threat].threat_level);
+    }
+}
+
+void AP_Avoidance::internal_error()
+{
+    // internal_errors++;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    abort();
+#endif
+}
+
+AP_Avoidance::Obstacle *AP_Avoidance::most_serious_threat()
+{
+    if (_current_most_serious_threat < 0) {
+        // we *really_ should not have been called!
+        return nullptr;
+    }
+    return &_obstacles[_current_most_serious_threat];
+}
+
+
+void AP_Avoidance::update()
+{
+    if (!check_startup()) {
+        return;
+    }
+
+    if (_adsb.enabled()) {
+        get_adsb_samples();
+    }
+
+    check_for_threats();
+
+    handle_avoidance(most_serious_threat());
+}
+
+// returns an entry from the MAV_COLLISION_ACTION representative
+// of what the curent avoidance handler is up to.
+MAV_COLLISION_ACTION AP_Avoidance::mav_avoidance_action() {
+    if (_current_avoidance_handler == nullptr) {
+        return MAV_COLLISION_ACTION_NONE;
+    }
+    return _current_avoidance_handler->mav_avoidance_action();
+}
+
+void AP_Avoidance::handle_avoidance(AP_Avoidance::Obstacle *threat)
+{
+    handle_threat_gcs_notify(threat);
+
+    if (threat == nullptr) {
+        if (_current_avoidance_handler != nullptr) {
+            _current_avoidance_handler->exit();
+            _current_avoidance_handler = nullptr;
+        }
+        return;
+    }
+
+    int32_t action;
+    state_t new_state;
+    switch (threat->threat_level) {
+    case MAV_COLLISION_THREAT_LEVEL_NONE:
+        new_state = STATE_CLEAR;
+        action = MAV_COLLISION_ACTION_NONE;
+        break;
+    case MAV_COLLISION_THREAT_LEVEL_LOW:
+        new_state = STATE_WARN;
+        action = _warn_action;
+        break;
+    case MAV_COLLISION_THREAT_LEVEL_HIGH:
+        new_state = STATE_FAIL;
+        action = _fail_action;
+        break;
+    default:
+        internal_error();
+        new_state = STATE_CLEAR;
+        action = MAV_COLLISION_ACTION_NONE;
+        break;
+    }
+
+    uint32_t now = AP_HAL::millis();
+    bool should_change_state = false;
+    do {
+        if (new_state == _old_state) {
+            break;
+        }
+        // do not transition back from a fail or warn state too quickly:
+        if (now - _last_state_change_ms < _state_recovery_hysteresis*1000) {
+            if (new_state == STATE_CLEAR ||
+                (new_state == STATE_WARN && _old_state == STATE_FAIL)) {
+                break;
+            }
+        }
+        should_change_state = true;
+    } while(0);
+
+    if (should_change_state) {
+
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: State change: (%s)=>(%s)", _state_names[_old_state], _state_names[new_state]);
+
+        _last_state_change_ms = now;
+
+        // we can change state but not change handler - for example,
+        // the user has specified the recovery handler for Fail->Warn
+        // as "continue fail behaviour".
+
+        // Note that it is entirely possible to transition from
+        // Fail->Clear; in this case we honour both _recovery_f and
+        // _recovery_w
+
+        bool change_handler = true;
+
+        if (_old_state == STATE_FAIL) {
+            // transitioning from fail -> warn
+            switch(_fail_recovery) {
+            case AVOIDANCE_RECOVERY_F_CONTINUE_FAIL:
+                change_handler = false;
+                break;
+            case AVOIDANCE_RECOVERY_F_MOVE_TO_WARN:
+                change_handler = true;
+                break;
+            }
+        }
+        if (new_state == STATE_CLEAR) {
+            // transitioning from (fail or warn) to clear
+            switch(_warn_recovery) {
+            case AVOIDANCE_RECOVERY_W_CONTINUE_ACTION:
+                change_handler = true;
+                break;
+            case AVOIDANCE_RECOVERY_W_RESUME:
+                change_handler = true;
+                break;
+            }
+        }
+
+        if (change_handler) {
+            AvoidanceHandler *new_avoidance_handler;
+            if (new_state == STATE_CLEAR) {
+                new_avoidance_handler = nullptr;
+            } else {
+                AvoidanceHandler &tmp = handler_for_action((MAV_COLLISION_ACTION)action);
+                new_avoidance_handler = &tmp;
+            }
+
+            if (new_avoidance_handler != _current_avoidance_handler) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: Using handler (%s)", ((new_avoidance_handler != nullptr) ? new_avoidance_handler->name() : "NULL"));
+                if (new_avoidance_handler == nullptr) {
+                    if (_current_avoidance_handler != nullptr) {
+                        _current_avoidance_handler->exit();
+                        _current_avoidance_handler = nullptr;
+                    }
+                } else {
+                    if (new_avoidance_handler->enter(*threat, _current_avoidance_handler)) {
+                        _current_avoidance_handler = new_avoidance_handler;
+                    } else {
+                        // whinge. This may not be an internal error -
+                        // e.g. we may have lost GPS
+                    }
+                }
+            }
+        }
+        _old_state = new_state;
+    }
+
+    if (_current_avoidance_handler != nullptr) {
+        _current_avoidance_handler->update();
+    }
+}
+
+
+
+void AP_Avoidance::MAVLink_packetReceived(const mavlink_message_t &msg)
+{
+    if (!check_startup()) {
+        // avoidance is not active / allocated
+        return;
+    }
+
+    if (msg.msgid != MAVLINK_MSG_ID_GLOBAL_POSITION_INT) {
+        // we only take position from GLOBAL_POSITION_INT
+        return;
+    }
+
+    if (msg.sysid == mavlink_system.sysid) {
+        // we do not obstruct ourselves....
+        return;
+    }
+
+    // inform AP_Avoidance we have a new player
+    mavlink_global_position_int_t packet;
+    mavlink_msg_global_position_int_decode(&msg, &packet);
+    Location loc;
+    loc.lat = packet.lat;
+    loc.lng = packet.lon;
+    loc.alt = packet.alt / 10; // mm -> cm
+    loc.flags.relative_alt = false;
+    Vector3f vel = Vector3f(packet.vx/100.0f, // cm to m
+                            packet.vy/100.0f,
+                            packet.vz/100.0f);
+    add_obstacle(AP_HAL::millis(),
+                 MAV_COLLISION_SRC_ADSB,
+                 msg.sysid,
+                 loc,
+                 vel);
+}

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -77,6 +77,9 @@ public:
         return _instance;
     }
 
+    void enable() { _enabled = true; };
+    void disable() { _enabled = false; };
+
     // add obstacles into the Avoidance system from MAVLink messages
     void MAVLink_packetReceived(const mavlink_message_t &msg);
 

--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -1,0 +1,210 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#pragma once
+
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Situational awareness for ArduPilot
+
+ - record a series of moving points in space which should be avoided
+ - produce messages for GCS if a collision risk is detected
+
+  Peter Barker, May 2016
+
+  based on AP_ADSB,  Tom Pittenger, November 2015
+*/
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_ADSB/AP_ADSB.h>
+
+class AP_Avoidance {
+
+public:
+
+    class Obstacle {
+    public:
+        MAV_COLLISION_SRC src;
+        uint32_t src_id;
+        uint32_t timestamp_ms;
+
+        Location _location;
+        Vector3f _velocity;
+
+        // fields relating to this being a threat.  These would be the reason to have a separate list of threats:
+        MAV_COLLISION_THREAT_LEVEL threat_level;
+        float closest_approach_xy; // metres
+        float closest_approach_z; // metres
+        float time_to_closest_approach; // seconds, 3D approach
+        float distance_to_closest_approach; // metres, 3D
+        uint32_t last_gcs_report_time; // millis
+    };
+
+    AP_Avoidance(AP_AHRS &ahrs, class AP_ADSB &adsb);
+
+    // for holding parameters
+    static const struct AP_Param::GroupInfo var_info[];
+
+    void add_obstacle(uint32_t obstacle_timestamp_ms,
+                      const MAV_COLLISION_SRC src,
+                      uint32_t src_id,
+                      const Location &loc,
+                      const Vector3f &vel_ned);
+
+    void add_obstacle(uint32_t obstacle_timestamp_ms,
+                      const MAV_COLLISION_SRC src,
+                      uint32_t src_id,
+                      const Location &loc,
+                      float cog,
+                      float hspeed,
+                      float vspeed);
+
+    void update();
+
+    static AP_Avoidance *instance(void) {
+        return _instance;
+    }
+
+    // add obstacles into the Avoidance system from MAVLink messages
+    void MAVLink_packetReceived(const mavlink_message_t &msg);
+
+    AP_Int8     _enabled;
+    AP_Int8     _obstacles_max;
+
+    AP_Int8     _fail_action;
+    AP_Int8     _fail_recovery;
+    AP_Int8     _fail_time_horizon;
+    AP_Int16    _fail_distance_xy;
+    AP_Int16    _fail_distance_z;
+
+    AP_Int8     _warn_action;
+    AP_Int8     _warn_recovery;
+    AP_Int8     _warn_time_horizon;
+    AP_Float    _warn_distance_xy;
+    AP_Float    _warn_distance_z;
+
+    MAV_COLLISION_THREAT_LEVEL current_threat_level() const;
+
+protected:
+
+    enum state_t {
+        STATE_CLEAR = 0,
+        STATE_WARN = 1,
+        STATE_FAIL = 2,
+    };
+    // contains English names corresponding to state_t entries
+    static const char *_state_names[];
+
+    uint32_t _last_state_change_ms;
+    // we will not recover from a state any faster than this
+    static const uint8_t _state_recovery_hysteresis = 20; // seconds
+    state_t _old_state = STATE_CLEAR;
+
+    enum avoidance_recovery_f_t {
+        AVOIDANCE_RECOVERY_F_CONTINUE_FAIL,
+        AVOIDANCE_RECOVERY_F_MOVE_TO_WARN,
+    };
+    enum avoidance_recovery_w_t {
+        AVOIDANCE_RECOVERY_W_RESUME,
+        AVOIDANCE_RECOVERY_W_CONTINUE_ACTION
+    };
+
+    uint32_t _gcs_cleared_messages_first_sent;
+    // specifies how long we should continue sending messages about a threat after it has cleared
+    static const uint8_t _gcs_cleared_messages_duration = 5; // seconds
+
+
+    void handle_threat_gcs_notify(AP_Avoidance::Obstacle *threat);
+
+    AP_Avoidance::Obstacle *most_serious_threat();
+
+    // reference to AHRS, so we can ask for our position, heading and
+    // speed
+    const AP_AHRS &_ahrs;
+
+    void internal_error();
+
+    // Deal with the most significant threat
+    virtual void handle_avoidance(AP_Avoidance::Obstacle *threat);
+
+    // returns an entry from the MAV_COLLISION_ACTION representative
+    // of what the curent avoidance handler is up to.
+    MAV_COLLISION_ACTION mav_avoidance_action();
+
+    // returns an object which is responsible for avoiding the most significant threat
+    virtual class AvoidanceHandler &handler_for_action(MAV_COLLISION_ACTION action) = 0;
+
+private:
+
+    class AP_ADSB &_adsb;
+
+    static AP_Avoidance *_instance;
+
+    uint8_t _obstacles_allocated;
+    uint8_t _obstacle_count;
+    AP_Avoidance::Obstacle *_obstacles;
+
+    // check to see if we are initialised (and possibly do initialisation)
+    bool check_startup();
+
+    // initialize _obstacle_list
+    void init();
+
+    // free _obstacle_list
+    void deinit();
+
+    const uint32_t MAX_OBSTACLE_AGE_MS = 60000;
+//    const uint32_t MAX_OBSTACLE_AGE_MS = 1000; 
+
+    uint32_t src_id_for_adsb_vehicle(AP_ADSB::adsb_vehicle_t vehicle) const;
+
+    void check_for_threats();
+    void update_threat_level(const Location &my_loc,
+                             const Vector3f &my_vel,
+                             AP_Avoidance::Obstacle &obstacle);
+
+    // calls into the AP_ADSB library to retrieve vehicle data
+    void get_adsb_samples();
+
+    const static uint8_t _gcs_notify_interval = 1; // seconds
+
+    // in SITL, at least, the threat level never remains higher for
+    // more than a fraction of a second.  This could potentially lead
+    // to an aircraft switching rapidly between its avoidance
+    // action and its recovery action.
+    const static uint8_t _minimum_handler_duration = 1; // seconds
+
+    int8_t _current_most_serious_threat;
+
+    class AvoidanceHandler *_current_avoidance_handler = nullptr;
+
+    // returns true if the obstacle should be considered more of a
+    // threat than the current most serious threat
+    bool obstacle_is_more_serious_threat(const AP_Avoidance::Obstacle &obstacle) const;
+};
+
+float closest_distance_between_radial_and_point(const Vector2f &w,
+                                                const Vector2f &p);
+float closest_approach_xy(const Location &my_loc,
+                          const Vector3f &my_vel,
+                          const Location &obstacle_loc,
+                          const Vector3f &obstacle_vel,
+                          uint8_t time_horizon);
+
+float closest_approach_z(const Location &my_loc,
+                         const Vector3f &my_vel,
+                         const Location &obstacle_loc,
+                         const Vector3f &obstacle_vel,
+                         uint8_t time_horizon);

--- a/libraries/AP_Avoidance/AvoidanceHandler.cpp
+++ b/libraries/AP_Avoidance/AvoidanceHandler.cpp
@@ -1,0 +1,83 @@
+#include "AvoidanceHandler.h"
+
+bool AvoidanceHandler::enter(AP_Avoidance::Obstacle &threat, AvoidanceHandler *_old_handler) {
+    if (_old_handler != nullptr) {
+        // check here whether we should change modes or not
+        _old_handler->exit();
+    }
+    _threat = &threat;
+    return true;
+}
+
+void AvoidanceHandler::internal_error()
+{
+    // internal_errors++;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    abort();
+#endif
+}
+
+
+
+// returns XYZ
+Vector3f AvoidanceHandler::perpendicular_xyz(const Location &p1, const Vector3f &v1, const Location &p2)
+{
+    Vector2f delta_p_2d = location_diff(p1, p2);
+    Vector3f delta_p_xyz = Vector3f(delta_p_2d[1],delta_p_2d[0],(p2.alt-p1.alt)/100.0f); //check this line
+    Vector3f v1_xyz = Vector3f(v1[1], v1[0], -v1[2]);
+    Vector3f ret = Vector3f::perpendicular(delta_p_xyz, v1_xyz);
+    return ret;
+}
+
+// return XY
+Vector2f AvoidanceHandler::perpendicular_xy(const Location &p1, const Vector3f &v1, const Location &p2)
+{
+    Vector2f delta_p = location_diff(p1, p2);
+    Vector2f delta_p_n = Vector2f(delta_p[1],delta_p[0]);
+    Vector2f v1n(v1[1],v1[0]);
+    Vector2f ret_xy = Vector2f::perpendicular(delta_p_n, v1n);
+    return ret_xy;
+}
+
+// wp_speeds in cm/s
+bool AvoidanceHandler::new_destination_perpendicular(Vector3f &newdest_neu, const AP_AHRS &_ahrs, const uint8_t _minimum_avoid_height, const float wp_speed_xy, const float wp_speed_z)
+{
+    if (_threat == nullptr) {
+        // why where we called?!
+        return false;
+    }
+
+    Location my_abs_pos;
+    if (! _ahrs.get_position(my_abs_pos)) {
+        // we should not get to here!  If we don't know our position
+        // we can't know if there are any threats, for starters!
+        return false;
+    }
+
+    Vector3f my_pos_ned;
+    if (! _ahrs.get_relative_position_NED(my_pos_ned)) {
+        // we should not get to here!  If we don't know our position
+        // we know if there are any threats, for starters!
+        return false;
+    }
+
+    {
+        Vector3f perp_xyz = perpendicular_xyz(_threat->_location, _threat->_velocity, my_abs_pos);
+        perp_xyz.normalize();
+        newdest_neu[0] = my_pos_ned[0]*100 + perp_xyz[1] * wp_speed_xy * 10; // ten seconds
+        newdest_neu[1] = my_pos_ned[1]*100 + perp_xyz[0] * wp_speed_xy * 10; // ten seconds
+        newdest_neu[2] =  -my_pos_ned[2]*100 + perp_xyz[2] * wp_speed_z * 10; // ten seconds
+    }
+
+    if (newdest_neu[2] < _minimum_avoid_height*100) {
+        // too close to the ground to do 3D avoidance
+        // GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AVOID: PERPENDICULAR: 2D");
+        Vector2f perp_xy = perpendicular_xy(_threat->_location, _threat->_velocity, my_abs_pos);
+        perp_xy.normalize();
+        newdest_neu[0] = my_pos_ned[0]*100 + perp_xy[1] * wp_speed_xy * 10; // ten seconds
+        newdest_neu[1] = my_pos_ned[1]*100 + perp_xy[0] * wp_speed_xy * 10; // ten seconds
+        newdest_neu[2] = -my_pos_ned[2]*100;
+    }
+
+    return true;
+}

--- a/libraries/AP_Avoidance/AvoidanceHandler.h
+++ b/libraries/AP_Avoidance/AvoidanceHandler.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <AP_Avoidance/AP_Avoidance.h>
+
+class AP_Avoidance;
+
+class AvoidanceHandler {
+public:
+
+    // enter is called once when starting this avoidance action
+    virtual bool enter(class AP_Avoidance::Obstacle &threat, class AvoidanceHandler *old_handler);
+    // update is called perdiodically while undertaking this avoidance
+    // action
+    virtual bool update() { return true; };
+    // exit is called when the problem is either resolved or being
+    // handed off to a different handler
+    virtual void exit() { }
+
+    // mav_avoidance_action returns the closest entry in the MAV
+    // enumeration MAV_COLLISION_ACTION that this avoidance handler
+    // corresponds to
+    virtual MAV_COLLISION_ACTION mav_avoidance_action() const = 0;
+
+    // name returns a human-readable string for this avoidance handler
+    virtual const char * name() const = 0;
+
+    // v1 is NED
+    static Vector3f perpendicular_xyz(const Location &p1, const Vector3f &v1, const Location &p2);
+    static Vector2f perpendicular_xy(const Location &p1, const Vector3f &v1, const Location &p2);
+
+protected:
+
+    AP_Avoidance::Obstacle *_threat;
+    virtual void internal_error();
+
+    // lowest height guided avoidance will send the aircraft, in metres
+    const uint8_t _minimum_guided_height = 10;
+
+    bool new_destination_perpendicular(Vector3f &newdest_neu, const AP_AHRS &_ahrs, const uint8_t _minimum_avoid_height, const float wp_speed_xy, const float wp_speed_z);
+};
+
+// Ignore any collision threat
+class AvoidanceHandler_NONE : public AvoidanceHandler {
+
+public:
+
+    bool update() { return true; };
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_NONE;
+    }
+
+    const char *name() const { return "NONE"; }
+
+private:
+
+};
+
+// Report any collision threat
+class AvoidanceHandler_REPORT : public AvoidanceHandler {
+
+public:
+
+    bool update() { return true; };
+
+    MAV_COLLISION_ACTION mav_avoidance_action() const override {
+        return MAV_COLLISION_ACTION_REPORT;
+    }
+
+    const char *name() const { return "REPORT"; }
+
+private:
+
+};

--- a/libraries/AP_Avoidance/AvoidanceHandler.h
+++ b/libraries/AP_Avoidance/AvoidanceHandler.h
@@ -36,7 +36,7 @@ protected:
     // lowest height guided avoidance will send the aircraft, in metres
     const uint8_t _minimum_guided_height = 10;
 
-    bool new_destination_perpendicular(Vector3f &newdest_neu, const AP_AHRS &_ahrs, const uint8_t _minimum_avoid_height, const float wp_speed_xy, const float wp_speed_z);
+    bool new_destination_perpendicular(Vector3f &newdest_neu, const AP_AHRS &_ahrs, const float wp_speed_xy, const float wp_speed_z, const uint8_t _minimum_avoid_height);
 
 private:
 

--- a/libraries/AP_Avoidance/AvoidanceHandler.h
+++ b/libraries/AP_Avoidance/AvoidanceHandler.h
@@ -37,6 +37,13 @@ protected:
     const uint8_t _minimum_guided_height = 10;
 
     bool new_destination_perpendicular(Vector3f &newdest_neu, const AP_AHRS &_ahrs, const uint8_t _minimum_avoid_height, const float wp_speed_xy, const float wp_speed_z);
+
+private:
+
+    // speed below which we will fly directly away from a threat
+    // rather than perpendicular to its velocity:
+    const uint8_t _low_velocity_threshold = 1; // metres/second
+
 };
 
 // Ignore any collision threat

--- a/libraries/AP_Avoidance/tests/test_avoidance_perpendicular.cpp
+++ b/libraries/AP_Avoidance/tests/test_avoidance_perpendicular.cpp
@@ -1,0 +1,85 @@
+#include <AP_gtest.h>
+
+#include <AP_Avoidance/AvoidanceHandler.h>
+
+#define SQRT_2 0.70710677
+
+#define EXPECT_VECTOR3F_EQ(v1, v2)              \
+    do {                                        \
+        EXPECT_FLOAT_EQ(v1[0], v2[0]);          \
+        EXPECT_FLOAT_EQ(v1[1], v2[1]);          \
+        EXPECT_FLOAT_EQ(v1[2], v2[2]);          \
+    } while (false);
+
+// note this function translates the velocity from XYZ to NED!
+#define TEST_PERPENDICULAR_XYZ(loc1_lat,loc1_lon,loc1_alt, vel1_x,vel1_y,vel1_z, loc2_lat,loc2_lon,loc2_alt, expected_x,expected_y,expected_z) \
+    do {                                                                \
+        Location loc1;                                                  \
+        loc1.lat = loc1_lat *1e7;                                       \
+        loc1.lng = loc1_lon *1e7;                                       \
+        loc1.alt = loc1_alt;                                                   \
+        Vector3f vel1;                                                  \
+        vel1.x = vel1_y;                                                \
+        vel1.y = vel1_x;                                                \
+        vel1.z = -vel1_z;                                               \
+        Location loc2;                                                  \
+        loc2.lat = loc2_lat *1e7;                                       \
+        loc2.lng = loc2_lon *1e7;                                       \
+        loc2.alt = loc2_alt;                                                   \
+        Vector3f expected=Vector3f(expected_x,expected_y,expected_z);   \
+        Vector3f result;                                                \
+        result = AvoidanceHandler::perpendicular_xyz(loc1, vel1, loc2); \
+        result.normalize();                                             \
+        EXPECT_VECTOR3F_EQ(expected, result);                           \
+    } while (0)
+
+
+TEST(ThreatTests, Distance)
+{
+
+    // nb: 0.0001f degrees lat/lon is ~15 metres
+    //                    Loc1(LatLonAlt)        Vel1(XYZ)       Loc2              expected(XYZ)
+
+    TEST_PERPENDICULAR_XYZ(0,0,0, 0,0,0,  0.0001f,0.0001f,0, SQRT_2,SQRT_2,0.0); // no velocity means we get garbage back
+    TEST_PERPENDICULAR_XYZ(0,0,0, -10.0,0,0,  0.0001f,0.0001f,0,  0,1.0,0.0);
+    TEST_PERPENDICULAR_XYZ(0.0001f,0.0001f,0,    -10.0,0,0,  0,0,0,  0,-1,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,    10.0,0,0,  0.0001f,0.0001f,0,  0,1.0,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,    1.0,0,0,  0.0001f,0.0001f,0,  0,1.0,0.0);
+    TEST_PERPENDICULAR_XYZ(0,-0.1,0,  1.0,0,0,  0.0001f,0.0001f,0,  0,1.0,0.0);
+    TEST_PERPENDICULAR_XYZ(0.1,0.10001f,0,  1.0,0,0,  0.1001f,0.1001f,0,  0,1.0,0.0);
+
+    TEST_PERPENDICULAR_XYZ(0,0,0,  0,1.0,0,  0.0001f,0.0001f,0,  1.0,0,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  1.0,1.0,0,  0.0000f,0.0001f,0,  SQRT_2,-SQRT_2,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  2.0,2.0,0,  0.0000f,0.0001f,0,  SQRT_2,-SQRT_2,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  1.0,1.0,0,  0.0000f,-0.0001f,0,  -SQRT_2,SQRT_2,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  2.0,2.0,0,  0.0000f,-0.0001f,0,  -SQRT_2,SQRT_2,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  1.0,2.0,0,  0.0000f,0.0001f,0,  0.89442718,-0.44721359,0.0);
+    TEST_PERPENDICULAR_XYZ(0,0,0,  2.0,1.0,0,  0.0000f,0.0001f,0,  0.44721365,-0.89442718,0.0);
+    TEST_PERPENDICULAR_XYZ(0,-0.0001,0,  2.0,1.0,0,  0,0,0,  0.44721365,-0.89442718,0.0);
+
+// TEST_PERPENDICULAR_XYZ(0.1,0.10002f,  1.0,0.0,0.0,  0.1001f,0.1001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(0.1,0.10004f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(0.1,0.10008f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(0.1,0.10010f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(0.1,0.10011f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,0.0);
+
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00001f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00002f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00004f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00008f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00010f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(1.0,1.00011f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,0.0);
+
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00001f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00002f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00004f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00008f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00010f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+    // TEST_PERPENDICULAR_XYZ(45.0,45.00011f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,0.0);
+}
+
+
+AP_GTEST_MAIN()
+
+
+int hal = 0; // bizarrely, this fixes an undefined-symbol error but doesn't raise a type exception.  Yay.

--- a/libraries/AP_Avoidance/tests/test_threat_calculations.cpp
+++ b/libraries/AP_Avoidance/tests/test_threat_calculations.cpp
@@ -1,0 +1,68 @@
+#include <AP_gtest.h>
+
+#include <AP_Avoidance/AP_Avoidance.h>
+
+#define TEST_CLOSEST_APPROACH(loc1_lat,loc1_lon, vel1_x,vel1_y, loc2_lat,loc2_lon, vel2_x,vel2_y, time, expected_distance) \
+    do {                                                                \
+        Location loc1;                                                  \
+        loc1.lat = loc1_lat *1e7;                                       \
+        loc1.lng = loc1_lon *1e7;                                       \
+        loc1.alt = 0;                                                   \
+        Vector3f vel1;                                                  \
+        vel1.x = vel1_x;                                                \
+        vel1.y = vel1_y;                                                \
+        vel1.z = 0;                                                     \
+        Location loc2;                                                  \
+        loc2.lat = loc2_lat *1e7;                                       \
+        loc2.lng = loc2_lon *1e7;                                       \
+        loc2.alt = 0;                                                   \
+        Vector3f vel2;                                                  \
+        vel2.x = vel2_x;                                                \
+        vel2.y = vel2_y;                                                \
+        vel2.z = 0;                                                     \
+        float result = closest_approach_xy(loc1, vel1, loc2, vel2, time); \
+        EXPECT_FLOAT_EQ(result, expected_distance);                     \
+    } while (0)
+
+
+TEST(ThreatTests, Distance)
+{
+
+    // nb: 0.0001f degrees lat/lon is ~15 metres
+    //                    Loc1        Vel1       Loc2              Vel2          dT    result
+    TEST_CLOSEST_APPROACH(0.0,0.0,    0.0,0.0,  0.0001f,0.0001f,  0.0,0.0,      30,   15.727118);
+
+    TEST_CLOSEST_APPROACH(0.0,0.0,    0.0,-10.0,  0.0001f,0.0001f,  0.0,0.0,      30,   15.727118);
+    TEST_CLOSEST_APPROACH(0.0,0.0,    0.0,10.0,  0.0001f,0.0001f,  0.0,0.0,      30,   11.120752);
+
+    TEST_CLOSEST_APPROACH(0.0,0.0,    0.0,1.0,  0.0001f,0.0001f,  0.0,0.0,      30,   11.120752);
+
+    TEST_CLOSEST_APPROACH(0.0,-0.1,  0.0,1.0,  0.0001f,0.0001f,  0.0,0.0,      30,   11113.011);
+
+    TEST_CLOSEST_APPROACH(0.1,0.10001f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(0.1,0.10002f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(0.1,0.10004f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(0.1,0.10008f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(0.1,0.10010f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(0.1,0.10011f,  0.0,1.0,  0.1001f,0.1001f,  0.0,0.0,      30,   11.187406);
+
+    TEST_CLOSEST_APPROACH(1.0,1.00001f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(1.0,1.00002f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(1.0,1.00004f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(1.0,1.00008f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(1.0,1.00010f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.131885);
+    TEST_CLOSEST_APPROACH(1.0,1.00011f,  0.0,1.0,  1.0001f,1.0001f,  0.0,0.0,      30,   11.187388);
+
+    TEST_CLOSEST_APPROACH(45.0,45.00001f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.031697);
+    TEST_CLOSEST_APPROACH(45.0,45.00002f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.031697);
+    TEST_CLOSEST_APPROACH(45.0,45.00004f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.031697);
+    TEST_CLOSEST_APPROACH(45.0,45.00008f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.031697);
+    TEST_CLOSEST_APPROACH(45.0,45.00010f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.031697);
+    TEST_CLOSEST_APPROACH(45.0,45.00011f,  0.0,1.0,  45.0001f,45.0001f,  0.0,0.0,      30,   11.068774);
+}
+
+
+AP_GTEST_MAIN()
+
+
+int hal = 0; // bizarrely, this fixes an undefined-symbol error but doesn't raise a type exception.  Yay.

--- a/libraries/AP_Avoidance/tests/wscript
+++ b/libraries/AP_Avoidance/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_Math/tests/test_closest_distance_between_radial_and_point.cpp
+++ b/libraries/AP_Math/tests/test_closest_distance_between_radial_and_point.cpp
@@ -1,0 +1,49 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/vector2.h>
+
+#define TEST_DISTANCE_BOTH(line_segment_x,line_segment_y, point_x, point_y, expected_length) \
+    do {                                                                \
+        {                                                               \
+            Vector2f line_segment = Vector2f(line_segment_x, line_segment_y); \
+            Vector2f point = Vector2f(point_x, point_y);                \
+            float result = Vector2<float>::closest_distance_between_radial_and_point( \
+                line_segment,                                           \
+                point                                                   \
+                );                                                      \
+            EXPECT_FLOAT_EQ(result, expected_length);                   \
+        }                                                               \
+    } while (false)
+
+
+TEST(ThreatTests, Distance)
+{
+
+    TEST_DISTANCE_BOTH( 0, 0,  0, 0, 0);
+    TEST_DISTANCE_BOTH( 0, 0,  0, 1, 1);
+
+    TEST_DISTANCE_BOTH( 1, 1,  1, 0, sqrt(0.5));
+    TEST_DISTANCE_BOTH(-1,-1, -1, 0, sqrt(0.5));
+
+    TEST_DISTANCE_BOTH( 3, 1,  3, 0, 0.94868332);
+    TEST_DISTANCE_BOTH( 1, 3,  0, 3, 0.94868332);
+    TEST_DISTANCE_BOTH(-1, 3,  0, 3, 0.94868332);
+    TEST_DISTANCE_BOTH( 1,-3,  0,-3, 0.94868332);
+    TEST_DISTANCE_BOTH(-1,-3,  0,-3, 0.94868332);
+
+    TEST_DISTANCE_BOTH( 2, 2,  1, 1, 0.0);
+    TEST_DISTANCE_BOTH( 2, 2,  3, 3, sqrt(2));
+    TEST_DISTANCE_BOTH( 2, 2,  2, 2, 0);
+    TEST_DISTANCE_BOTH( 0, 0,  1, 1, sqrt(2));
+    TEST_DISTANCE_BOTH( 0, 0,  1, 1, sqrt(2));
+
+    TEST_DISTANCE_BOTH( 0, 0,  1, 1, sqrt(2));
+    TEST_DISTANCE_BOTH( 1, 1,  0, 3, sqrt(5));
+}
+
+AP_GTEST_MAIN()
+
+
+int hal = 0; // bizarrely, this fixes an undefined-symbol error but doesn't raise a type exception.  Yay.
+
+

--- a/libraries/AP_Math/tests/test_perpendicular.cpp
+++ b/libraries/AP_Math/tests/test_perpendicular.cpp
@@ -1,6 +1,7 @@
 #include <AP_gtest.h>
 
 #include <AP_Math/vector2.h>
+#include <AP_Math/vector3.h>
 
 #define EXPECT_VECTOR2F_EQ(v1, v2)              \
     do {                                        \
@@ -8,26 +9,63 @@
         EXPECT_FLOAT_EQ(v1[1], v2[1]);          \
     } while (false);
 
-#define PERP_TEST(px,py, vx,vy, ex,ey)              \
+#define EXPECT_VECTOR3F_EQ(v1, v2)              \
+    do {                                        \
+        EXPECT_FLOAT_EQ(v1[0], v2[0]);          \
+        EXPECT_FLOAT_EQ(v1[1], v2[1]);          \
+        EXPECT_FLOAT_EQ(v1[2], v2[2]);          \
+    } while (false);
+
+
+#define PERP_TEST_2D(px,py, vx,vy, ex,ey)               \
     do {                                                \
-        Vector2f p(px,py);                           \
-        Vector2f v(vx,vy);                           \
+        Vector2f p(px,py);                              \
+        Vector2f v(vx,vy);                              \
         Vector2f expected(ex,ey);                       \
         Vector2f result;                                \
-        result = Vector2f::perpendicular(p, v);   \
-        EXPECT_VECTOR2F_EQ(result, expected);           \
+        result = Vector2f::perpendicular(p, v);         \
+        EXPECT_VECTOR2F_EQ(expected, result);           \
     } while (false)
 
+#define PERP_TEST_3D(px,py,pz, vx,vy,vz, ex,ey,ez)      \
+    do {                                                \
+        Vector3f p(px,py,pz);                           \
+        Vector3f v(vx,vy,vz);                           \
+        Vector3f expected(ex,ey,ez);                    \
+        Vector3f result;                                \
+        result = Vector3f::perpendicular(p, v);         \
+        EXPECT_VECTOR3F_EQ(expected, result);           \
+    } while (false)
+
+void foo() { } 
 TEST(ThreatTests, Distance)
 {
 
-    PERP_TEST( 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f);
-    PERP_TEST( 0.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
-    PERP_TEST( 2.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
-    PERP_TEST( 0.0f,2.0f, 1.0f,0.0f, 0.0f,1.0f);
+    PERP_TEST_2D( 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f);
+    PERP_TEST_2D( 0.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
+    PERP_TEST_2D( 2.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
+    PERP_TEST_2D( 0.0f,2.0f, 1.0f,0.0f, 0.0f,1.0f);
+    PERP_TEST_2D( 0.0f,2.0f, 1.0f,2.0f, -2.0f,1.0f);
+    PERP_TEST_2D( 2.0f,0.0f, 1.0f,2.0f, 2.0f,-1.0f);
 
-    PERP_TEST( 0.0f,2.0f, 1.0f,2.0f, -2.0f,1.0f);
-    PERP_TEST( 2.0f,0.0f, 1.0f,2.0f, 2.0f,-1.0f);
+    // 2D cases for the 3D code:
+    PERP_TEST_3D( 0.0f,0.0f,0.0f, 0.0f,0.0f,0.0f, 0.0f,0.0f,0.0f);
+    PERP_TEST_3D( 0.0f,0.0f,0.0f, 1.0f,0.0f,0.0f, 0.0f,0.0f,0.0f);
+    PERP_TEST_3D( 2.0f,0.0f,0.0f, 1.0f,0.0f,0.0f, 0.0f,0.0f,0.0f);
+    foo();
+    PERP_TEST_3D( 0.0f,2.0f,0.0f, 1.0f,0.0f,0.0f, 0.0f,2.0f,0.0f);
+    PERP_TEST_3D( 0.0f,2.0f,0.0f, 1.0f,2.0f,0.0f, -0.8f,0.4f,0.0f);
+    PERP_TEST_3D( 2.0f,0.0f,0.0f, 1.0f,2.0f,0.0f, 1.6f,-0.8f,0.0f);
+
+
+    // 3D-specific tests
+    PERP_TEST_3D( 1.0f,1.0f,1.0f, 1.0f,0.0f,0.0f, 0.0f,1.0f,1.0f);
+    PERP_TEST_3D( -1.0f,-1.0f,-1.0f, -1.0f,0.0f,0.0f, 0.0f,-1.0f,-1.0f);
+    PERP_TEST_3D(1.0f,1.0f,0.0f, 1.0f,0.0f,0.0f, 0.0f,1.0f,0.0f);
+
+    PERP_TEST_3D(1.0f,1.0f,1.0f, 1.0f,-1.0f,0.0f, 1.0f,1.0f,1.0f);
+
+    PERP_TEST_3D(1.0f,1.0f,1.0f, 1.0f,-1.0f,1.0f, 0.66666666f,1.33333333f,0.66666666f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/tests/test_perpendicular.cpp
+++ b/libraries/AP_Math/tests/test_perpendicular.cpp
@@ -1,0 +1,36 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/vector2.h>
+
+#define EXPECT_VECTOR2F_EQ(v1, v2)              \
+    do {                                        \
+        EXPECT_FLOAT_EQ(v1[0], v2[0]);          \
+        EXPECT_FLOAT_EQ(v1[1], v2[1]);          \
+    } while (false);
+
+#define PERP_TEST(px,py, vx,vy, ex,ey)              \
+    do {                                                \
+        Vector2f p(px,py);                           \
+        Vector2f v(vx,vy);                           \
+        Vector2f expected(ex,ey);                       \
+        Vector2f result;                                \
+        result = Vector2f::perpendicular(p, v);   \
+        EXPECT_VECTOR2F_EQ(result, expected);           \
+    } while (false)
+
+TEST(ThreatTests, Distance)
+{
+
+    PERP_TEST( 0.0f,0.0f, 0.0f,0.0f, 0.0f,0.0f);
+    PERP_TEST( 0.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
+    PERP_TEST( 2.0f,0.0f, 1.0f,0.0f, 0.0f,-1.0f);
+    PERP_TEST( 0.0f,2.0f, 1.0f,0.0f, 0.0f,1.0f);
+
+    PERP_TEST( 0.0f,2.0f, 1.0f,2.0f, -2.0f,1.0f);
+    PERP_TEST( 2.0f,0.0f, 1.0f,2.0f, 2.0f,-1.0f);
+}
+
+AP_GTEST_MAIN()
+
+
+int hal = 0; // bizarrely, this fixes an undefined-symbol error but doesn't raise a type exception.  Yay.

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -161,7 +161,37 @@ struct Vector2
     {
         return v * (*this * v)/(v*v);
     }
+
+    // given a position p1 and a velocity v1 produce a vector
+    // perpendicular to v1 maximising distance from p1
+    static Vector2<T> perpendicular(const Vector2<T> &pos_delta, const Vector2<T> &v1)
+    {
+        Vector2<T> perpendicular1 = Vector2<T>(-v1[1], v1[0]);
+        Vector2<T> perpendicular2 = Vector2<T>(v1[1], -v1[0]);
+        T d1 = perpendicular1 * pos_delta;
+        T d2 = perpendicular2 * pos_delta;
+        if (d1 > d2) {
+            return perpendicular1;
+        }
+        return perpendicular2;
+    }
+
+    // thanks to grumdrig (http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment)
+    // w defines a line segment from the origin
+    // p is a point
+    // returns the closest distance between the radial and the point
+    static float closest_distance_between_radial_and_point(const Vector2<T> &w,
+                                                           const Vector2<T> &p)
+    {
+        const float len = w.length_squared();
+        if (len < FLT_EPSILON) return p.length();
+        const float t = fmax(0, fmin(1, (p*w) / len));
+        const Vector2<T> projection = w * t;
+        return (p-projection).length();
+    }
+
 };
+
 
 typedef Vector2<int16_t>        Vector2i;
 typedef Vector2<uint16_t>       Vector2ui;

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -107,6 +107,14 @@ struct Vector2
     // check if all elements are zero
     bool is_zero(void) const { return (fabsf(x) < FLT_EPSILON) && (fabsf(y) < FLT_EPSILON); }
 
+    const T & operator[](uint8_t i) const {
+        const T *_v = &x;
+#if MATH_CHECK_INDEXES
+        assert(i >= 0 && i < 2);
+#endif
+        return _v[i];
+    }
+
     // zero the vector
     void zero()
     {

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -211,6 +211,21 @@ public:
         return v * (*this * v)/(v*v);
     }
 
+    // given a position p1 and a velocity v1 produce a vector
+    // perpendicular to v1 maximising distance from p1.  If p1 is the
+    // zero vector the return from the function will always be the
+    // zero vector - that should be checked for.
+    static Vector3<T> perpendicular(const Vector3<T> &p1, const Vector3<T> &v1)
+    {
+        T d = p1 * v1;
+        if (fabsf(d) < FLT_EPSILON) {
+            return p1;
+        }
+        Vector3<T> parallel = (v1 * d) / v1.length_squared();
+        Vector3<T> perpendicular = p1 - parallel;
+
+        return perpendicular;
+    }
 
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -100,6 +100,9 @@ public:
     void        set_snoop(void (*_msg_snoop)(const mavlink_message_t* msg)) {
         msg_snoop = _msg_snoop;
     }
+    // packetReceived is called on any successful decode of a mavlink message
+    virtual void packetReceived(const mavlink_status_t &status,
+                                mavlink_message_t &msg);
 
     struct statustext_t {
         uint8_t                 bitmask;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -15,6 +15,7 @@
 #include "MAVLink_routing.h"
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Mount/AP_Mount.h>
+#include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_HAL/utility/RingBuffer.h>
 
 // check if a message will fit in the payload space available
@@ -169,6 +170,7 @@ public:
     void send_home(const Location &home) const;
     static void send_home_all(const Location &home);
     void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
+    static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
 
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -415,6 +415,9 @@ void GCS_MAVLINK::handle_mission_count(AP_Mission &mission, mavlink_message_t *m
     waypoint_request_i = 0;                 // reset the next expected command number to zero
     waypoint_request_last = packet.count;   // record how many commands we expect to receive
     waypoint_timelast_request = 0;          // set time we last requested commands to zero
+
+    waypoint_dest_sysid = msg->sysid;       // record system id of GCS who has requested the commands
+    waypoint_dest_compid = msg->compid;     // record component id of GCS who has requested the commands
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -944,6 +944,35 @@ void GCS_MAVLINK::send_message(enum ap_message id)
     }
 }
 
+void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
+                                 mavlink_message_t &msg)
+{
+    // we exclude radio packets to make it possible to use the
+    // CLI over the radio
+    if (msg.msgid != MAVLINK_MSG_ID_RADIO && msg.msgid != MAVLINK_MSG_ID_RADIO_STATUS) {
+        mavlink_active |= (1U<<(chan-MAVLINK_COMM_0));
+    }
+    if (!(status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) &&
+        (status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) &&
+        serialmanager_p &&
+        serialmanager_p->get_mavlink_protocol(chan) == AP_SerialManager::SerialProtocol_MAVLink2) {
+        // if we receive any MAVLink2 packets on a connection
+        // currently sending MAVLink1 then switch to sending
+        // MAVLink2
+        mavlink_status_t *cstatus = mavlink_get_channel_status(chan);
+        if (cstatus != NULL) {
+            cstatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+        }
+    }
+    // if a snoop handler has been setup then use it
+    if (msg_snoop != NULL) {
+        msg_snoop(&msg);
+    }
+    if (routing.check_and_forward(chan, &msg)) {
+        handleMessage(&msg);
+    }
+}
+
 void
 GCS_MAVLINK::update(run_cli_fn run_cli)
 {
@@ -976,30 +1005,7 @@ GCS_MAVLINK::update(run_cli_fn run_cli)
 
         // Try to get a new message
         if (mavlink_parse_char(chan, c, &msg, &status)) {
-            // we exclude radio packets to make it possible to use the
-            // CLI over the radio
-            if (msg.msgid != MAVLINK_MSG_ID_RADIO && msg.msgid != MAVLINK_MSG_ID_RADIO_STATUS) {
-                mavlink_active |= (1U<<(chan-MAVLINK_COMM_0));
-            }
-            if (!(status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) &&
-                (status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) &&
-                serialmanager_p &&
-                serialmanager_p->get_mavlink_protocol(chan) == AP_SerialManager::SerialProtocol_MAVLink2) {
-                // if we receive any MAVLink2 packets on a connection
-                // currently sending MAVLink1 then switch to sending
-                // MAVLink2
-                mavlink_status_t *cstatus = mavlink_get_channel_status(chan);
-                if (cstatus != NULL) {
-                    cstatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-                }
-            }
-            // if a snoop handler has been setup then use it
-            if (msg_snoop != NULL) {
-                msg_snoop(&msg);
-            }
-            if (routing.check_and_forward(chan, &msg)) {
-                handleMessage(&msg);
-            }
+            packetReceived(status, msg);
         }
     }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1673,3 +1673,23 @@ bool GCS_MAVLINK::telemetry_delayed(mavlink_channel_t _chan)
 }
 
 
+void GCS_MAVLINK::send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour)
+{
+    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+        if ((1U<<i) & mavlink_active) {
+            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
+            if (comm_get_txspace(chan) >= MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_COLLISION) {
+                mavlink_msg_collision_send(
+                    chan,
+                    MAV_COLLISION_SRC_ADSB,
+                    threat.src_id,
+                    behaviour,
+                    threat.threat_level,
+                    threat.time_to_closest_approach,
+                    threat.closest_approach_z,
+                    threat.closest_approach_xy
+                    );
+            }
+        }
+    }
+}

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -416,8 +416,8 @@ void GCS_MAVLINK::handle_mission_count(AP_Mission &mission, mavlink_message_t *m
     waypoint_request_last = packet.count;   // record how many commands we expect to receive
     waypoint_timelast_request = 0;          // set time we last requested commands to zero
 
-    waypoint_dest_sysid = msg->sysid;       // record system id of GCS who has requested the commands
-    waypoint_dest_compid = msg->compid;     // record component id of GCS who has requested the commands
+    waypoint_dest_sysid = msg->sysid;       // record system id of GCS who wants to upload
+    waypoint_dest_compid = msg->compid;     // record component id of GCS who wants to upload
 }
 
 /*
@@ -461,6 +461,9 @@ void GCS_MAVLINK::handle_mission_write_partial_list(AP_Mission &mission, mavlink
     waypoint_receiving   = true;
     waypoint_request_i   = packet.start_index;
     waypoint_request_last= packet.end_index;
+
+    waypoint_dest_sysid = msg->sysid;       // record system id of GCS who wants to upload
+    waypoint_dest_compid = msg->compid;     // record component id of GCS who wants to upload
 }
 
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1023,10 +1023,9 @@ GCS_MAVLINK::update(run_cli_fn run_cli)
     uint32_t wp_recv_time = 1000U + (stream_slowdown*20);
 
     // stop waypoint receiving if timeout
-    if (waypoint_receiving && (tnow - waypoint_timelast_receive) > wp_recv_time+waypoint_receive_timeout) {
+    if ((tnow - waypoint_timelast_receive) > wp_recv_time+waypoint_receive_timeout) {
         waypoint_receiving = false;
-    } else if (waypoint_receiving &&
-               (tnow - waypoint_timelast_request) > wp_recv_time) {
+    } else if ((tnow - waypoint_timelast_request) > wp_recv_time) {
         waypoint_timelast_request = tnow;
         send_message(MSG_NEXT_WAYPOINT);
     }


### PR DESCRIPTION
Looking for comments on this code.

Functions as is.

This dronekit-python example exercises this avoidance code: https://github.com/peterbarker/dronekit-python/tree/source-system-filtering/examples/avoidance

Outstanding TODO:
 - determine whether a threat object should contain a sample object (as opposed to having all the fields in the same all the time).
 - implement the minimum-vertical-avoidance option.  To what radius out do we care (noting that ADSB can give us samples from many tens-of-kilometres away)
 - determine what should be entered into the dataflash log
 - restore guided mode parameters when recovering to CLEAR
  - alternatively, create a simple single-waypoint-based control mode we can switch into
- determine if there is enough information in the mavlink COLLISION packets for the GCS to work with
