### PR TITLE
Plane: Only allow commanded speed changes in GUIDED and AUTO modes.

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1226,6 +1226,15 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         switch(packet.command) {
 
         case MAV_CMD_DO_CHANGE_SPEED:
+            //if we're in failsafe modes (e.g., RTL, LOITER) or in pilot
+            //controlled modes (e.g., MANUAL, TRAINING) 
+            //this comand should be ignored since it comes in from GCS
+            //or a companion computer:
+            if (plane.control_mode != GUIDED && plane.control_mode != AUTO) {
+                result = MAV_RESULT_FAILED;
+                break;
+            }
+
             result = MAV_RESULT_FAILED;
             AP_Mission::Mission_Command cmd;
             if (AP_Mission::mavlink_cmd_long_to_mission_cmd(packet, cmd)


### PR DESCRIPTION
After discussion here:

https://github.com/ArduPilot/ardupilot/pull/4070

it is proposed that some commands/messages NOT be allowable when in failsafe modes. The command to change speed is one.  Also, it doesn't make sense to send a GCS/companion computer command a change to speed with a pilot at the sticks. My earlier PR:

https://github.com/ArduPilot/ardupilot/pull/4063

did not consider that and this PR is a patch that addresses that.