### PR TITLE
Use array subscript operators instead of zero-length array

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -44,6 +44,18 @@
 #define ToRad(x) radians(x)	// *pi/180
 #define ToDeg(x) degrees(x)	// *180/pi
 
+/* Declare and implement const and non-const versions of the array subscript
+ * operator. The object is treated as an array of type_ values. */
+#define ARRAY_SUBSCRIPT(type_) \
+inline type_ &operator[](size_t i) \
+{ \
+    return reinterpret_cast<type_ *>(this)[i]; \
+} \
+inline type_ operator[](size_t i) const \
+{ \
+    return reinterpret_cast<const type_ *>(this)[i]; \
+}
+
 #define LOCATION_ALT_MAX_M  83000   // maximum altitude (in meters) that can be fit into Location structure's alt field
 
 /*

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -110,7 +110,7 @@ AP_GPS_ERB::read(void)
         case 5:
             _ck_b += (_ck_a += data);                   // checksum byte
             if (_payload_counter < sizeof(_buffer)) {
-                _buffer.bytes[_payload_counter] = data;
+                _buffer[_payload_counter] = data;
             }
             if (++_payload_counter == _payload_length)
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -85,12 +85,12 @@ private:
 
     // Receive buffer
     union PACKED {
+        ARRAY_SUBSCRIPT(uint8_t)
         erb_ver ver;
         erb_pos pos;
         erb_stat stat;
         erb_dops dops;
         erb_vel vel;
-        uint8_t bytes[0];
     } _buffer;
 
     enum erb_protocol_bytes {

--- a/libraries/AP_GPS/AP_GPS_MTK.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK.cpp
@@ -115,7 +115,7 @@ restart:
         // Receive message data
         //
         case 4:
-            _buffer.bytes[_payload_counter++] = data;
+            _buffer[_payload_counter++] = data;
             _ck_b += (_ck_a += data);
             if (_payload_counter == sizeof(_buffer))
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_MTK.h
+++ b/libraries/AP_GPS/AP_GPS_MTK.h
@@ -71,8 +71,8 @@ private:
 
     // Receive buffer
     union PACKED {
+        ARRAY_SUBSCRIPT(uint8_t)
         diyd_mtk_msg msg;
-        uint8_t bytes[0];
     } _buffer;
 
     // Buffer parse & GPS state update

--- a/libraries/AP_GPS/AP_GPS_MTK19.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK19.cpp
@@ -105,7 +105,7 @@ restart:
         // Receive message data
         //
         case 3:
-            _buffer.bytes[_payload_counter++] = data;
+            _buffer[_payload_counter++] = data;
             _ck_b += (_ck_a += data);
             if (_payload_counter == sizeof(_buffer)) {
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_MTK19.h
+++ b/libraries/AP_GPS/AP_GPS_MTK19.h
@@ -77,7 +77,7 @@ private:
 
     // Receive buffer
     union {
+        ARRAY_SUBSCRIPT(uint8_t)
         diyd_mtk_msg msg;
-        uint8_t bytes[0];
     } _buffer;
 };

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -138,7 +138,7 @@ AP_GPS_SIRF::read(void)
         case 5:
             if (_gather) {                                              // gather data if requested
                 _accumulate(data);
-                _buffer.bytes[_payload_counter] = data;
+                _buffer[_payload_counter] = data;
                 if (++_payload_counter == _payload_length)
                     _step++;
             } else {

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -97,8 +97,8 @@ private:
 
     // Message buffer
     union {
+        ARRAY_SUBSCRIPT(uint8_t)
         sirf_geonav nav;
-        uint8_t bytes[0];
     } _buffer;
 
     bool        _parse_gps(void);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -431,7 +431,7 @@ AP_GPS_UBLOX::read(void)
         case 6:
             _ck_b += (_ck_a += data);                   // checksum byte
             if (_payload_counter < sizeof(_buffer)) {
-                _buffer.bytes[_payload_counter] = data;
+                _buffer[_payload_counter] = data;
             }
             if (++_payload_counter == _payload_length)
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -360,6 +360,7 @@ private:
 
     // Receive buffer
     union PACKED {
+        ARRAY_SUBSCRIPT(uint8_t)
         ubx_nav_posllh posllh;
         ubx_nav_status status;
         ubx_nav_dop dop;
@@ -384,7 +385,6 @@ private:
         ubx_rxm_rawx rxm_rawx;
 #endif
         ubx_ack_ack ack;
-        uint8_t bytes[0];
     } _buffer;
 
     enum ubs_protocol_bytes {

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -267,7 +267,7 @@ void AP_Mount_Alexmos::read_incoming()
             case 4: // parsing body
                 _checksum += data;
                 if (_payload_counter < sizeof(_buffer)) {
-                    _buffer.bytes[_payload_counter] = data;
+                    _buffer[_payload_counter] = data;
                 }
                 if (++_payload_counter == _payload_length)
                     _step++;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -284,11 +284,11 @@ private:
 
     };
     union PACKED alexmos_parameters {
+        ARRAY_SUBSCRIPT(uint8_t)
         alexmos_version version;
         alexmos_angles angles;
         alexmos_params params;
         alexmos_angles_speed angle_speed;
-        uint8_t bytes[0];
     } _buffer,_current_parameters;
 
     AP_HAL::UARTDriver *_port;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -236,7 +236,7 @@ void AP_Mount_SToRM32_serial::read_incoming() {
             continue;
         }
 
-        _buffer.bytes[_reply_counter++] = data;
+        _buffer[_reply_counter++] = data;
         if (_reply_counter == _reply_length) {
             parse_reply();
 
@@ -266,7 +266,7 @@ void AP_Mount_SToRM32_serial::parse_reply() {
 
     switch (_reply_type) {
         case ReplyType_DATA:
-            crc = crc_calculate(_buffer.bytes, sizeof(_buffer.data)-3);
+            crc = crc_calculate(&_buffer[0], sizeof(_buffer.data) - 3);
             crc_ok = crc == _buffer.data.crc;
             if (!crc_ok) {
                 break;
@@ -277,7 +277,8 @@ void AP_Mount_SToRM32_serial::parse_reply() {
             _current_angle.z = _buffer.data.imu1_yaw;
             break;
         case ReplyType_ACK:
-            crc = crc_calculate(&_buffer.bytes[1], sizeof(SToRM32_reply_ack_struct)-3);
+            crc = crc_calculate(&_buffer[1],
+                                sizeof(SToRM32_reply_ack_struct) - 3);
             crc_ok = crc == _buffer.ack.crc;
             break;
         default:

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -143,9 +143,9 @@ private:
 
 
     union PACKED SToRM32_reply {
+        ARRAY_SUBSCRIPT(uint8_t)
         SToRM32_reply_data_struct data;
         SToRM32_reply_ack_struct ack;
-        uint8_t bytes[0];
     } _buffer;
 
     // keep the last _current_angle values


### PR DESCRIPTION
Hi guys,

There were some different approaches on fixing compilation problems with GCC 6 regarding the `bytes` fields of some `union`s variables.

Apparently, using `uint8_t bytes[1]` wasn't very welcomed, which was replaced with zero-length array. However, the current approach fails compilation with GCC 6.1.1, as described at #4226.

Hopefully the approach of implementing array subscript operators makes people happy and fix compilation issues once and for all :-)

Best regards,
Gustavo Sousa