### PR TITLE
EKF2: Improvements and Solo Support

### DIFF
--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -399,9 +399,7 @@ bool Replay::find_log_info(struct log_information &info)
         if (streq(type, "PARM") && streq(reader.last_parm_name, "SCHED_LOOP_RATE")) {
             // get rate directly from parameters
             info.update_rate = reader.last_parm_value;
-            return true;
         }
-        
         if (strlen(clock_source) == 0) {
             // If you want to add a clock source, also add it to
             // handle_msg and handle_log_format_msg, above.  Note that

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -704,7 +704,9 @@ void NavEKF2::getTiltError(int8_t instance, float &ang)
 void NavEKF2::resetGyroBias(void)
 {
     if (core) {
-        core[primary].resetGyroBias();
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].resetGyroBias();
+        }
     }
 }
 
@@ -715,10 +717,17 @@ void NavEKF2::resetGyroBias(void)
 // If using a range finder for height no reset is performed and it returns false
 bool NavEKF2::resetHeightDatum(void)
 {
-    if (!core) {
-        return false;
+    bool status = true;
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            if (!core[i].resetHeightDatum()) {
+                status = false;
+            }
+        }
+    } else {
+        status = false;
     }
-    return core[primary].resetHeightDatum();
+    return status;
 }
 
 // Commands the EKF to not use GPS.

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -938,7 +938,9 @@ void NavEKF2::getFlowDebug(int8_t instance, float &varFlow, float &gndOffset, fl
 void NavEKF2::setTakeoffExpected(bool val)
 {
     if (core) {
-        core[primary].setTakeoffExpected(val);
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].setTakeoffExpected(val);
+        }
     }
 }
 
@@ -947,7 +949,9 @@ void NavEKF2::setTakeoffExpected(bool val)
 void NavEKF2::setTouchdownExpected(bool val)
 {
     if (core) {
-        core[primary].setTouchdownExpected(val);
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].setTouchdownExpected(val);
+        }
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -25,7 +25,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
-#define MAG_P_NSE_DEFAULT       2.5E-02f
+#define MAGB_P_NSE_DEFAULT      5.0E-04f
+#define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -49,7 +50,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
-#define MAG_P_NSE_DEFAULT       2.5E-02f
+#define MAGB_P_NSE_DEFAULT      5.0E-04f
+#define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -73,7 +75,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
-#define MAG_P_NSE_DEFAULT       2.5E-02f
+#define MAGB_P_NSE_DEFAULT      5.0E-04f
+#define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -97,7 +100,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     1.0E-03f
-#define MAG_P_NSE_DEFAULT       2.5E-02f
+#define MAGB_P_NSE_DEFAULT      5.0E-04f
+#define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -373,13 +377,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Units: m/s/s/s
     AP_GROUPINFO("ABIAS_P_NSE", 28, NavEKF2, _accelBiasProcessNoise, ABIAS_P_NSE_DEFAULT),
 
-    // @Param: MAG_P_NSE
-    // @DisplayName: Magnetic field process noise (gauss/s)
-    // @Description: This state process noise controls the growth of magnetic field state error estimates. Increasing it makes magnetic field bias estimation faster and noisier.
-    // @Range: 0.0001 0.01
-    // @User: Advanced
-    // @Units: gauss/s
-    AP_GROUPINFO("MAG_P_NSE", 29, NavEKF2, _magProcessNoise, MAG_P_NSE_DEFAULT),
+    // 29 previously used for EK2_MAG_P_NSE parameter that has been replaced with EK2_MAGE_P_NSE and EK2_MAGB_P_NSE
 
     // @Param: WIND_P_NSE
     // @DisplayName: Wind velocity process noise (m/s^2)
@@ -461,6 +459,22 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Increment: 10
     // @User: Advanced
     AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, -1),
+
+    // @Param: MAGE_P_NSE
+    // @DisplayName: Earth magnetic field process noise (gauss/s)
+    // @Description: This state process noise controls the growth of earth magnetic field state error estimates. Increasing it makes earth magnetic field estimation faster and noisier.
+    // @Range: 0.00001 0.01
+    // @User: Advanced
+    // @Units: gauss/s
+    AP_GROUPINFO("MAGE_P_NSE", 40, NavEKF2, _magEarthProcessNoise, MAGE_P_NSE_DEFAULT),
+
+    // @Param: MAGB_P_NSE
+    // @DisplayName: Body magnetic field process noise (gauss/s)
+    // @Description: This state process noise controls the growth of body magnetic field state error estimates. Increasing it makes magnetometer bias error estimation faster and noisier.
+    // @Range: 0.00001 0.01
+    // @User: Advanced
+    // @Units: gauss/s
+    AP_GROUPINFO("MAGB_P_NSE", 41, NavEKF2, _magBodyProcessNoise, MAGB_P_NSE_DEFAULT),
 
 
     AP_GROUPEND

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -454,7 +454,15 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("YAW_I_GATE", 38, NavEKF2, _yawInnovGate, 300),
 
-    
+    // @Param: TAU_OUTPUT
+    // @DisplayName: Output complementary filter time constant (centi-sec)
+    // @Description: Sets the time constant of the output complementary filter/predictor in centi-seconds. Set to a negative number to use a computationally cheaper and less accurate method with an automatically calculated time constant.
+    // @Range: -1 100
+    // @Increment: 10
+    // @User: Advanced
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, -1),
+
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -434,6 +434,26 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Values: 0:Disabled,1:FirstIMU,3:FirstAndSecondIMU,7:AllIMUs
     // @User: Advanced
     AP_GROUPINFO("LOG_MASK", 36, NavEKF2, _logging_mask, 1),
+
+    // control of magentic yaw angle fusion
+
+    // @Param: YAW_M_NSE
+    // @DisplayName: Yaw measurement noise (rad)
+    // @Description: This is the RMS value of noise in yaw measurements from the magnetometer. Increasing it reduces the weighting on these measurements.
+    // @Range: 0.05 1.0
+    // @Increment: 0.05
+    // @User: Advanced
+    // @Units: gauss
+    AP_GROUPINFO("YAW_M_NSE", 37, NavEKF2, _yawNoise, 0.5f),
+
+    // @Param: YAW_I_GATE
+    // @DisplayName: Yaw measurement gate size
+    // @Description: This sets the percentage number of standard deviations applied to the magnetometer yaw measurement innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
+    // @Range: 100 1000
+    // @Increment: 25
+    // @User: Advanced
+    AP_GROUPINFO("YAW_I_GATE", 38, NavEKF2, _yawInnovGate, 300),
+
     
     AP_GROUPEND
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -458,7 +458,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: -1 100
     // @Increment: 10
     // @User: Advanced
-    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, -1),
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 50),
 
     // @Param: MAGE_P_NSE
     // @DisplayName: Earth magnetic field process noise (gauss/s)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -317,6 +317,8 @@ private:
     AP_Int16 _gpsCheckScaler;       // Percentage increase to be applied to GPS pre-flight accuracy and drift thresholds
     AP_Float _noaidHorizNoise;      // horizontal position measurement noise assumed when synthesised zero position measurements are used to constrain attitude drift : m
     AP_Int8 _logging_mask;          // mask of IMUs to log
+    AP_Float _yawNoise;             // magnetic yaw measurement noise : rad
+    AP_Int16 _yawInnovGate;         // Percentage number of standard deviations applied to magnetic yaw innovation consistency check
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -319,6 +319,7 @@ private:
     AP_Int8 _logging_mask;          // mask of IMUs to log
     AP_Float _yawNoise;             // magnetic yaw measurement noise : rad
     AP_Int16 _yawInnovGate;         // Percentage number of standard deviations applied to magnetic yaw innovation consistency check
+    AP_Int8 _tauVelPosOutput;       // Time constant of output complementary filter : csec (centi-seconds)
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -289,7 +289,8 @@ private:
     AP_Float _easNoise;             // equivalent airspeed measurement noise : m/s
     AP_Float _windVelProcessNoise;  // wind velocity state process noise : m/s^2
     AP_Float _wndVarHgtRateScale;   // scale factor applied to wind process noise due to height rate
-    AP_Float _magProcessNoise;      // magnetic field process noise : gauss/sec
+    AP_Float _magEarthProcessNoise; // Earth magnetic field process noise : gauss/sec
+    AP_Float _magBodyProcessNoise;  // Body magnetic field process noise : gauss/sec
     AP_Float _gyrNoise;             // gyro process noise : rad/s
     AP_Float _accNoise;             // accelerometer process noise : m/s^2
     AP_Float _gyroBiasProcessNoise; // gyro bias state process noise : rad/s

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -98,7 +98,7 @@ void NavEKF2_core::setWindMagStateLearningMode()
     bool magCalRequested =
             ((magCal == 0) && inFlight) || // when flying
             ((magCal == 1) && manoeuvring)  || // when manoeuvring
-            ((magCal == 3) && firstInflightYawInit && firstInflightMagInit) || // when initial in-air yaw and mag field reset is complete
+            ((magCal == 3) && finalInflightYawInit && finalInflightMagInit) || // when initial in-air yaw and mag field reset is complete
             (magCal == 4); // all the time
 
     // Deny mag calibration request if we aren't using the compass, it has been inhibited by the user,
@@ -116,7 +116,7 @@ void NavEKF2_core::setWindMagStateLearningMode()
             P[index][index] = sq(frontend->_magNoise);
         }
         // request a reset of the yaw and magnetic field states if not done before
-        if (!magStateInitComplete || (!firstInflightMagInit && inFlight)) {
+        if (!magStateInitComplete || (!finalInflightMagInit && inFlight)) {
             magYawResetRequest = true;
         }
     }
@@ -124,8 +124,8 @@ void NavEKF2_core::setWindMagStateLearningMode()
     // If on ground we clear the flag indicating that the magnetic field in-flight initialisation has been completed
     // because we want it re-done for each takeoff
     if (onGround) {
-        firstInflightYawInit = false;
-        firstInflightMagInit = false;
+        finalInflightYawInit = false;
+        finalInflightMagInit = false;
     }
 
     // Adjust the indexing limits used to address the covariance, states and other EKF arrays to avoid unnecessary operations
@@ -304,7 +304,7 @@ void NavEKF2_core::recordYawReset()
 {
     yawAlignComplete = true;
     if (inFlight) {
-        firstInflightYawInit = true;
+        finalInflightYawInit = true;
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -717,7 +717,7 @@ void NavEKF2_core::fuseEulerYaw()
     float q3 = stateStruct.quat[3];
 
     // compass measurement error variance (rad^2)
-    const float R_YAW = 0.25f;
+    const float R_YAW = sq(frontend->_yawNoise);
 
     // calculate observation jacobian, predicted yaw and zero yaw body to earth rotation matrix
     // determine if a 321 or 312 Euler sequence is best
@@ -853,7 +853,7 @@ void NavEKF2_core::fuseEulerYaw()
     }
 
     // calculate the innovation test ratio
-    yawTestRatio = sq(innovation) / (sq(MAX(0.01f * (float)frontend->_magInnovGate, 1.0f)) * varInnov);
+    yawTestRatio = sq(innovation) / (sq(MAX(0.01f * (float)frontend->_yawInnovGate, 1.0f)) * varInnov);
 
     // Declare the magnetometer unhealthy if the innovation test fails
     if (yawTestRatio > 1.0f) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -20,42 +20,68 @@ extern const AP_HAL::HAL& hal;
 // Control reset of yaw and magnetic field states
 void NavEKF2_core::controlMagYawReset()
 {
-    // Use a quaternion division to calcualte the delta quaternion between the rotation at the current and last time
-    Quaternion deltaQuat = stateStruct.quat / prevQuatMagReset;
-    prevQuatMagReset = stateStruct.quat;
+    // Quaternion and delta rotation vector that are re-used for different calculations
+    Vector3f deltaRotVecTemp;
+    Quaternion deltaQuatTemp;
 
-    // convert the quaternion to a rotation vector and find its length
-    Vector3f deltaRotVec;
-    deltaQuat.to_axis_angle(deltaRotVec);
+    bool flightResetAllowed = false;
+    bool initialResetAllowed = false;
+    if (!finalInflightYawInit) {
+        // Use a quaternion division to calculate the delta quaternion between the rotation at the current and last time
+        deltaQuatTemp = stateStruct.quat / prevQuatMagReset;
+        prevQuatMagReset = stateStruct.quat;
 
-    // check if the spin rate is OK - high spin rates can cause angular alignment errors
-    bool angRateOK = deltaRotVec.length() < 0.1745f;
+        // convert the quaternion to a rotation vector and find its length
+        deltaQuatTemp.to_axis_angle(deltaRotVecTemp);
 
-    // a flight reset is allowed if we are not spinning too fast and are in flight
-    bool flightResetAllowed = angRateOK && inFlight;
+        // check if the spin rate is OK - high spin rates can cause angular alignment errors
+        bool angRateOK = deltaRotVecTemp.length() < 0.1745f;
+
+        initialResetAllowed = angRateOK;
+        flightResetAllowed = angRateOK && !onGround;
+
+    }
 
     // check that we have reached a height where ground magnetic interference effects are insignificant
-    bool hgtCheckPassed = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
+    // and can perform a final reset of the yaw and field states
+    bool finalResetRequest = false;
+    if (flightResetAllowed && !assume_zero_sideslip()) {
+        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
+    }
 
-    // check for 'toilet bowling' which is characterised by large yaw and velocity innovations and caused by bad yaw alignment
-    // this can occur if there is severe magnetic interference on the ground
-    bool toiletBowling = (yawTestRatio > 1.0f) && (velTestRatio > 1.0f);
+    // Check for bad yaw casued by ground based magnetic anomaly
+    bool interimResetRequest = false;
+    if (flightResetAllowed && !assume_zero_sideslip()) {
+        // check for increasing height
+        bool hgtIncreasing = (posDownAtLastMagReset-stateStruct.position.z) > 0.5f;
+        float yawInnovIncrease = fabsf(innovYaw) - fabsf(yawInnovAtLastMagReset);
 
-    // calculate if an in flight reset is required
-    bool flightResetRequired = (!firstInflightYawInit && (hgtCheckPassed || toiletBowling));
+        // check for increasing yaw innovations
+        bool yawInnovIncreasing = yawInnovIncrease > 0.25f;
+
+        // check that the yaw innovations haven't been caused by a large change in attitude
+        deltaQuatTemp = quatAtLastMagReset / stateStruct.quat;
+        deltaQuatTemp.to_axis_angle(deltaRotVecTemp);
+        bool largeAngleChange = deltaRotVecTemp.length() > yawInnovIncrease;
+
+        // if yaw innovations and height have increased and we haven't rotated much
+        // then we are climbing away from a ground based magnetic anomaly and need to reset
+        interimResetRequest = hgtIncreasing && yawInnovIncreasing && !largeAngleChange;
+    }
 
     // an initial reset is required if we have not yet aligned the yaw angle
-    bool initialResetRequired = !yawAlignComplete;
+    bool initialResetRequest = initialResetAllowed && !yawAlignComplete;
 
     // a combined yaw angle and magnetic field reset can be initiated by:
     magYawResetRequest = magYawResetRequest || // an external request
-            (initialResetRequired && angRateOK) || // we need to do an initial alignment and aren't rotating too fast
-            (flightResetRequired && flightResetAllowed && !assume_zero_sideslip()); // conditions are right to do the in-flight re-alignment
+            initialResetRequest || // an initial alignment performed by all vehicle types using magnetometer
+            interimResetRequest || // an interim alignment required to recover from ground based magnetic anomaly
+            finalResetRequest; // the final reset when we have acheived enough height to be in stable magnetic field environment
 
     // Perform a reset of magnetic field states and reset yaw to corrected magnetic heading
     if (magYawResetRequest || magStateResetRequest) {
 
-        // gett he eeruler angles from the current state estimate
+        // get the euler angles from the current state estimate
         Vector3f eulerAngles;
         stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
 
@@ -80,9 +106,11 @@ void NavEKF2_core::controlMagYawReset()
                 hal.console->printf("EKF2 IMU%u initial yaw alignment complete\n",(unsigned)imu_index);
             }
 
-            // send initial in-flight yaw alignment status to console
-            if (!firstInflightYawInit && inFlight) {
+            // send in-flight yaw alignment status to console
+            if (finalResetRequest) {
                 hal.console->printf("EKF2 IMU%u in-flight yaw alignment complete\n",(unsigned)imu_index);
+            } else if (interimResetRequest) {
+                hal.console->printf("EKF2 IMU%u ground mag anomaly, yaw re-aligned\n",(unsigned)imu_index);
             }
 
             // update the yaw reset completed status
@@ -90,13 +118,20 @@ void NavEKF2_core::controlMagYawReset()
 
             // clear the yaw reset request flag
             magYawResetRequest = false;
+
+            // clear the complete flags if an interim reset has been performed to allow subsequent
+            // and final reset to occur
+            if (interimResetRequest) {
+                finalInflightYawInit = false;
+                finalInflightMagInit = false;
+            }
         }
-}
+    }
 
     // Request an in-flight check of heading against GPS and reset if necessary
     // this can only be used by vehicles that can use a zero sideslip assumption (Planes)
     // this allows recovery for heading alignment errors due to compass faults
-    if (!firstInflightYawInit && inFlight && assume_zero_sideslip()) {
+    if (!finalInflightYawInit && inFlight && assume_zero_sideslip()) {
         gpsYawResetRequest = true;
     }
 
@@ -1044,8 +1079,13 @@ void NavEKF2_core::recordMagReset()
 {
     magStateInitComplete = true;
     if (inFlight) {
-        firstInflightMagInit = true;
+        finalInflightMagInit = true;
     }
+    // take a snap-shot of the vertical position, quaternion  and yaw innovation to use as a reference
+    // for post alignment checks
+    posDownAtLastMagReset = stateStruct.position.z;
+    quatAtLastMagReset = stateStruct.quat;
+    yawInnovAtLastMagReset = innovYaw;
 }
 
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -42,16 +42,14 @@ void NavEKF2_core::controlMagYawReset()
 
     }
 
-    // check that we have reached a height where ground magnetic interference effects are insignificant
-    // and can perform a final reset of the yaw and field states
+    // Check if conditions for a interim or final yaw/mag reset are met
     bool finalResetRequest = false;
-    if (flightResetAllowed && !assume_zero_sideslip()) {
-        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
-    }
-
-    // Check for bad yaw casued by ground based magnetic anomaly
     bool interimResetRequest = false;
     if (flightResetAllowed && !assume_zero_sideslip()) {
+        // check that we have reached a height where ground magnetic interference effects are insignificant
+        // and can perform a final reset of the yaw and field states
+        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
+
         // check for increasing height
         bool hgtIncreasing = (posDownAtLastMagReset-stateStruct.position.z) > 0.5f;
         float yawInnovIncrease = fabsf(innovYaw) - fabsf(yawInnovAtLastMagReset);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -269,10 +269,11 @@ void NavEKF2_core::readIMUData()
     imuQuatDownSampleNew.rotate(imuDataNew.delAng);
     imuQuatDownSampleNew.normalize();
 
-    // Rotate the latest delta velocity into the frame of reference at the start of
-    // accumulate the latest delta velocity and apply it to the delta velocity accumulator
+    // Rotate the latest delta velocity into body frame at the start of accumulation
     Matrix3f deltaRotMat;
     imuQuatDownSampleNew.rotation_matrix(deltaRotMat);
+
+    // Apply the delta velocity to the delta velocity accumulator
     imuDataDownSampledNew.delVel += deltaRotMat*imuDataNew.delVel;
 
     // Keep track of the number of IMU frames since the last state prediction

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -411,10 +411,10 @@ void NavEKF2_core::readGpsData()
             if (PV_AidingMode != AID_ABSOLUTE) {
                 // Pre-alignment checks
                 gpsGoodToAlign = calcGpsGoodToAlign();
-            } else {
-                // Post-alignment checks
-                calcGpsGoodForFlight();
             }
+
+            // Post-alignment checks
+            calcGpsGoodForFlight();
 
             // Read the GPS locaton in WGS-84 lat,long,height coordinates
             const struct Location &gpsloc = _ahrs->get_gps().location();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -299,17 +299,18 @@ void NavEKF2_core::readIMUData()
         framesSincePredict = 0;
         // set the flag to let the filter know it has new IMU data nad needs to run
         runUpdates = true;
+        // extract the oldest available data from the FIFO buffer
+        imuDataDelayed = storedIMU.pop_oldest_element();
+        float minDT = 0.1f*dtEkfAvg;
+        imuDataDelayed.delAngDT = MAX(imuDataDelayed.delAngDT,minDT);
+        imuDataDelayed.delVelDT = MAX(imuDataDelayed.delVelDT,minDT);
+        // correct the extracted IMU data for sensor errors
+        correctDeltaAngle(imuDataDelayed.delAng, imuDataDelayed.delAngDT);
+        correctDeltaVelocity(imuDataDelayed.delVel, imuDataDelayed.delVelDT);
     } else {
         // we don't have new IMU data in the buffer so don't run filter updates on this time step
         runUpdates = false;
     }
-
-    // extract the oldest available data from the FIFO buffer
-    imuDataDelayed = storedIMU.pop_oldest_element();
-    float minDT = 0.1f*dtEkfAvg;
-    imuDataDelayed.delAngDT = MAX(imuDataDelayed.delAngDT,minDT);
-    imuDataDelayed.delVelDT = MAX(imuDataDelayed.delVelDT,minDT);
-
 }
 
 // read the delta velocity and corresponding time interval from the IMU

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -473,8 +473,8 @@ void  NavEKF2_core::getFilterStatus(nav_filter_status &status) const
     status.flags.vert_pos = !hgtTimeout && filterHealthy && !hgtNotAccurate; // vertical position estimate valid
     status.flags.terrain_alt = gndOffsetValid && filterHealthy;		// terrain height estimate valid
     status.flags.const_pos_mode = (PV_AidingMode == AID_NONE) && filterHealthy;     // constant position mode
-    status.flags.pred_horiz_pos_rel = (optFlowNavPossible || gpsNavPossible) && filterHealthy; // we should be able to estimate a relative position when we enter flight mode
-    status.flags.pred_horiz_pos_abs = gpsNavPossible && filterHealthy; // we should be able to estimate an absolute position when we enter flight mode
+    status.flags.pred_horiz_pos_rel = ((optFlowNavPossible || gpsNavPossible) && filterHealthy) || status.flags.horiz_pos_rel; // we should be able to estimate a relative position when we enter flight mode
+    status.flags.pred_horiz_pos_abs = (gpsNavPossible && filterHealthy) || status.flags.horiz_pos_abs; // we should be able to estimate an absolute position when we enter flight mode
     status.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
     status.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
     status.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -350,7 +350,7 @@ void NavEKF2_core::getMagXYZ(Vector3f &magXYZ) const
 bool NavEKF2_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 {
     // compass offsets are valid if we have finalised magnetic field initialisation and magnetic field learning is not prohibited and primary compass is valid
-    if (mag_idx == magSelectIndex && firstInflightMagInit && (effective_magCal() != 2) && _ahrs->get_compass()->healthy(magSelectIndex)) {
+    if (mag_idx == magSelectIndex && finalInflightMagInit && (effective_magCal() != 2) && _ahrs->get_compass()->healthy(magSelectIndex)) {
         magOffsets = _ahrs->get_compass()->get_offsets(magSelectIndex) - stateStruct.body_magfield*1000.0f;
         return true;
     } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -349,8 +349,15 @@ void NavEKF2_core::getMagXYZ(Vector3f &magXYZ) const
 // return true if offsets are valid
 bool NavEKF2_core::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 {
-    // compass offsets are valid if we have finalised magnetic field initialisation and magnetic field learning is not prohibited and primary compass is valid
-    if (mag_idx == magSelectIndex && finalInflightMagInit && (effective_magCal() != 2) && _ahrs->get_compass()->healthy(magSelectIndex)) {
+    // compass offsets are valid if we have finalised magnetic field initialisation, magnetic field learning is not prohibited,
+    // primary compass is valid and state variances have converged
+    const float maxMagVar = 5E-6f;
+    bool variancesConverged = (P[19][19] < maxMagVar) && (P[20][20] < maxMagVar) && (P[21][21] < maxMagVar);
+    if ((mag_idx == magSelectIndex) &&
+            finalInflightMagInit &&
+            !inhibitMagStates &&
+            _ahrs->get_compass()->healthy(magSelectIndex) &&
+            variancesConverged) {
         magOffsets = _ahrs->get_compass()->get_offsets(magSelectIndex) - stateStruct.body_magfield*1000.0f;
         return true;
     } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -684,6 +684,11 @@ void NavEKF2_core::selectHeightForFusion()
         if (getTakeoffExpected() || getTouchdownExpected()) {
             posDownObsNoise *= frontend->gndEffectBaroScaler;
         }
+        // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
+        // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
+        if (motorsArmed && getTakeoffExpected()) {
+            hgtMea = MAX(hgtMea, meaHgtAtTakeOff);
+        }
     } else {
         fuseHgtData = false;
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -184,7 +184,7 @@ bool NavEKF2_core::calcGpsGoodToAlign(void)
     // fail if magnetometer innovations are outside limits indicating bad yaw
     // with bad yaw we are unable to use GPS
     bool yawFail;
-    if ((magTestRatio.x > 1.0f || magTestRatio.y > 1.0f) && (frontend->_gpsCheck & MASK_GPS_YAW_ERR)) {
+    if ((magTestRatio.x > 1.0f || magTestRatio.y > 1.0f || yawTestRatio > 1.0f) && (frontend->_gpsCheck & MASK_GPS_YAW_ERR)) {
         yawFail = true;
     } else {
         yawFail = false;
@@ -365,6 +365,13 @@ void NavEKF2_core::detectFlight()
         posDownAtTakeoff = stateStruct.position.z;
         // store the range finder measurement which will be used as a reference to detect when we have taken off
         rngAtStartOfFlight = rangeDataNew.rng;
+        // if the magnetic field states have been set, then continue to update the vertical position
+        // quaternion and yaw innovation snapshots to use as a reference when we start to fly.
+        if (magStateInitComplete) {
+            posDownAtLastMagReset = stateStruct.position.z;
+            quatAtLastMagReset = stateStruct.quat;
+            yawInnovAtLastMagReset = innovYaw;
+        }
     }
 
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -360,7 +360,7 @@ void NavEKF2_core::detectFlight()
     prevInFlight = inFlight;
 
     // Store vehicle height and range prior to takeoff for use in post takeoff checks
-    if (onGround && prevOnGround) {
+    if (onGround) {
         // store vertical position at start of flight to use as a reference for ground relative checks
         posDownAtTakeoff = stateStruct.position.z;
         // store the range finder measurement which will be used as a reference to detect when we have taken off

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -153,8 +153,8 @@ void NavEKF2_core::InitialiseVariables()
     tasTimeout = true;
     badMagYaw = false;
     badIMUdata = false;
-    firstInflightYawInit = false;
-    firstInflightMagInit = false;
+    finalInflightYawInit = false;
+    finalInflightMagInit = false;
     dtIMUavg = 0.0025f;
     dtEkfAvg = 0.01f;
     dt = 0;
@@ -258,6 +258,9 @@ void NavEKF2_core::InitialiseVariables()
     magStateInitComplete = false;
     magYawResetRequest = false;
     gpsYawResetRequest = false;
+    posDownAtLastMagReset = stateStruct.position.z;
+    yawInnovAtLastMagReset = 0.0f;
+    quatAtLastMagReset = stateStruct.quat;
 
     // zero data buffers
     storedIMU.reset();
@@ -1387,6 +1390,7 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
 
         // record the fact we have initialised the magnetic field states
         recordMagReset();
+
     } else {
         // this function should not be called if there is no compass data but if is is, return the
         // current attitude

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -23,7 +23,7 @@ extern const AP_HAL::HAL& hal;
 #define INIT_ACCEL_BIAS_UNCERTAINTY 0.5f
 
 // maximum allowed gyro bias (rad/sec)
-#define GYRO_BIAS_LIMIT 0.349066f
+#define GYRO_BIAS_LIMIT 0.5f
 
 // constructor
 NavEKF2_core::NavEKF2_core(void) :

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -628,7 +628,7 @@ void NavEKF2_core::calcOutputStates()
         // adjust for changes in time delay to maintain consistent damping ratio of ~0.7
         float timeDelay = 1e-3f * (float)(imuDataNew.time_ms - imuDataDelayed.time_ms);
         timeDelay = fmaxf(timeDelay, dtIMUavg);
-        float errorGain = 0.5f / timeDelay;
+        float errorGain = 0.45f / timeDelay;
 
         // calculate a corrrection to the delta angle
         // that will cause the INS to track the EKF quaternions

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -493,10 +493,6 @@ void NavEKF2_core::correctDeltaVelocity(Vector3f &delVel, float delVelDT)
 */
 void NavEKF2_core::UpdateStrapdownEquationsNED()
 {
-    // apply corrections to the IMU data
-    correctDeltaAngle(imuDataDelayed.delAng, imuDataDelayed.delAngDT);
-    correctDeltaVelocity(imuDataDelayed.delVel, imuDataDelayed.delVelDT);
-
     // apply correction for earth's rotation rate
     // % * - and + operators have been overloaded
     imuDataDelayed.delAng -= prevTnb * earthRateNED*imuDataDelayed.delAngDT;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -741,8 +741,8 @@ void NavEKF2_core::CovariancePrediction()
     dAngBiasSigma = sq(dt) * constrain_float(frontend->_gyroBiasProcessNoise, 0.0f, 1.0f);
     dVelBiasSigma = sq(dt) * constrain_float(frontend->_accelBiasProcessNoise, 0.0f, 1.0f);
     dAngScaleSigma = dt * constrain_float(frontend->_gyroScaleProcessNoise, 0.0f, 1.0f);
-    magEarthSigma = dt * constrain_float(frontend->_magProcessNoise, 0.0f, 1.0f);
-    magBodySigma  = dt * constrain_float(frontend->_magProcessNoise, 0.0f, 1.0f);
+    magEarthSigma = dt * constrain_float(frontend->_magEarthProcessNoise, 0.0f, 1.0f);
+    magBodySigma  = dt * constrain_float(frontend->_magBodyProcessNoise, 0.0f, 1.0f);
     for (uint8_t i= 0; i<=8;  i++) processNoise[i] = 0.0f;
     for (uint8_t i=9; i<=11; i++) processNoise[i] = dAngBiasSigma;
     for (uint8_t i=12; i<=14; i++) processNoise[i] = dAngScaleSigma;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -726,7 +726,7 @@ private:
     float gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
     uint32_t lastGpsVelFail_ms;     // time of last GPS vertical velocity consistency check fail
     uint32_t lastGpsAidBadTime_ms;  // time in msec gps aiding was last detected to be bad
-    float posDownAtTakeoff;         // flight vehicle vertical position at arming used as a reference point
+    float posDownAtTakeoff;         // flight vehicle vertical position sampled at transition from on-ground to in-air and used as a reference (m)
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
     float yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
     uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -651,9 +651,6 @@ private:
     obs_ring_buffer_t<tas_elements> storedTAS;      // TAS data buffer
     obs_ring_buffer_t<range_elements> storedRange;
     imu_ring_buffer_t<output_elements> storedOutput;// output state buffer
-    Vector3f correctedDelAng;       // delta angles about the xyz body axes corrected for errors (rad)
-    Quaternion correctedDelAngQuat; // quaternion representation of correctedDelAng
-    Vector3f correctedDelVel;       // delta velocities along the XYZ body axes for weighted average of IMU1 and IMU2 corrected for errors (m/s)
     Matrix3f prevTnb;               // previous nav to body transformation used for INS earth rotation compensation
     ftype accNavMag;                // magnitude of navigation accel - used to adjust GPS obs variance (m/s^2)
     ftype accNavMagHoriz;           // magnitude of navigation accel in horizontal plane (m/s^2)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -715,8 +715,6 @@ private:
     float tasTestRatio;             // sum of squares of true airspeed innovation divided by fail threshold
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
-    bool firstInflightYawInit;      // true when the first post takeoff initialisation of yaw angle has been performed
-    bool firstInflightMagInit;      // true when the first post takeoff initialisation of magnetic field states been performed
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     bool isAiding;                  // true when the filter is fusing position, velocity or flow measurements
     bool prevIsAiding;              // isAiding from previous frame
@@ -789,9 +787,6 @@ private:
     bool startPredictEnabled;       // boolean true when the frontend has given permission to start a new state prediciton cycele
     uint8_t localFilterTimeStep_ms; // average number of msec between filter updates
     float posDownObsNoise;          // observation noise variance on the vertical position used by the state and covariance update step (m^2)
-    bool magStateResetRequest;      // true if magnetic field states need to be reset using the magneteomter measurements
-    bool magYawResetRequest;        // true if the vehicle yaw and magnetic field states need to be reset using the magnetometer measurements
-    bool gpsYawResetRequest;        // true if the vehicle yaw needs to be reset to the GPS course
 
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.
@@ -886,6 +881,16 @@ private:
     bool expectGndEffectTouchdown;    // external state from ArduCopter - touchdown expected
     uint32_t touchdownExpectedSet_ms; // system time at which expectGndEffectTouchdown was set
     float meaHgtAtTakeOff;            // height measured at commencement of takeoff
+
+    // control of post takeoff magentic field and heading resets
+    bool finalInflightYawInit;      // true when the final post takeoff initialisation of yaw angle has been performed
+    bool finalInflightMagInit;      // true when the final post takeoff initialisation of magnetic field states been performed
+    bool magStateResetRequest;      // true if magnetic field states need to be reset using the magneteomter measurements
+    bool magYawResetRequest;        // true if the vehicle yaw and magnetic field states need to be reset using the magnetometer measurements
+    bool gpsYawResetRequest;        // true if the vehicle yaw needs to be reset to the GPS course
+    float posDownAtLastMagReset;    // vertical position last time the mag states were reset (m)
+    float yawInnovAtLastMagReset;   // magnetic yaw innovation last time the yaw and mag field states were reset (rad)
+    Quaternion quatAtLastMagReset;  // quaternion states last time the mag states were reset
 
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -474,6 +474,10 @@ private:
     bool readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt);
     bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng);
 
+    // helper functions for correcting IMU data
+    void correctDeltaAngle(Vector3f &delAng, float delAngDT);
+    void correctDeltaVelocity(Vector3f &delVel, float delVelDT);
+
     // update IMU delta angle and delta velocity measurements
     void readIMUData();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -604,7 +604,7 @@ private:
 
     // Propagate PVA solution forward from the fusion time horizon to the current time horizon
     // using a simple observer
-    void calcOutputStatesFast();
+    void calcOutputStates();
 
     // calculate a filtered offset between baro height measurement and EKF height estimate
     void calcFiltBaroOffset();


### PR DESCRIPTION
This replaces https://github.com/ArduPilot/ardupilot/pull/4239 and https://github.com/ArduPilot/ardupilot/pull/4237

**Testing**

Replay testing on the following logs:

http://uav.tridgell.net/ReplayLogs/
https://drive.google.com/open?id=0B0cCriOUIHS0eGNxTTYtcWxXN3c
https://drive.google.com/open?id=0B0cCriOUIHS0c3dHMWFvaUtxbDg

SITL testing using SiM_MAG_ALY_X,Y,Z  in the range +-300 to create up to  90 degrees of yaw error on ground.

SITL testing on plane with magnetometer disabled to verify that changes have not affected this capability. 

**Flight Testing**

Tests before recent rebase using 3DR Solo hardware:

https://drive.google.com/open?id=0B0cCriOUIHS0eGNxTTYtcWxXN3c
https://drive.google.com/open?id=0B0cCriOUIHS0c3dHMWFvaUtxbDg

Tests after rebase using  3DR Solo hardware. Iron bar placed adjacent to compass leg to induce a magnetic anomaly. 

https://drive.google.com/open?id=0B0cCriOUIHS0MnY0YzZ3QzlERlU

Initial and final field resets confirmed in data
![screen shot 2016-06-20 at 1 50 36 pm](https://cloud.githubusercontent.com/assets/3596952/16182859/0351b106-36ee-11e6-8bd4-3854d7bdac98.png)

Seconds test with bar placed at a different orientation:

https://drive.google.com/open?id=0B0cCriOUIHS0WXE0SkJRdlBNTlU

No 'toilet bowling' observed and innovations were low after reset.

Landings next to the iron bar and taking off again showed expected switch to heading fusion when disarmed and re-initialisation of field states when airborne.

![screen shot 2016-06-20 at 1 44 22 pm](https://cloud.githubusercontent.com/assets/3596952/16182910/86134d8e-36ee-11e6-89fd-1a2ef50bac41.png)
