### PR TITLE
PR for #932 -- Copter:heading turns towards next WP before vehicle reaches waypoint

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -90,6 +90,17 @@ float Copter::get_look_ahead_yaw()
     return yaw_look_ahead_bearing;
 }
 
+float Copter::get_look_at_target_yaw()
+{
+    const Vector3f& vel = pos_control.get_vel_target();
+    float speed = norm(vel.x,vel.y);
+    // Commanded Yaw to automatically look ahead.
+    if (position_ok() && (speed > YAW_LOOK_AHEAD_MIN_SPEED)) {
+        yaw_look_at_target_bearing = degrees(atan2f(vel.y,vel.x))*100.0f;
+    }
+    return yaw_look_at_target_bearing;
+}
+
 /*************************************************************
  *  throttle control
  ****************************************************************/

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -439,6 +439,9 @@ private:
     // heading when in yaw_look_ahead_bearing
     float yaw_look_ahead_bearing;
 
+    // heading when in yaw_look_at_target_bearing
+    float yaw_look_at_target_bearing;
+
     // Delay Mission Scripting Command
     int32_t condition_value;  // used in condition commands (eg delay, change alt, etc.)
     uint32_t condition_start;
@@ -620,6 +623,7 @@ private:
     void check_ekf_yaw_reset();
     float get_roi_yaw();
     float get_look_ahead_yaw();
+    float get_look_at_target_yaw();
     void update_thr_average();
     void set_throttle_takeoff();
     float get_pilot_desired_throttle(int16_t throttle_control);

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -626,7 +626,9 @@ uint8_t Copter::get_default_auto_yaw_mode(bool rtl)
         case WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL:
             if (rtl) {
                 return AUTO_YAW_HOLD;
-            }else{
+            } else if (control_mode == AUTO) {
+                return AUTO_YAW_LOOK_AT_TARGET;
+            } else {
                 return AUTO_YAW_LOOK_AT_NEXT_WP;
             }
             break;
@@ -637,6 +639,9 @@ uint8_t Copter::get_default_auto_yaw_mode(bool rtl)
 
         case WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP:
         default:
+            if (control_mode == AUTO) {
+                return AUTO_YAW_LOOK_AT_TARGET;
+            }
             return AUTO_YAW_LOOK_AT_NEXT_WP;
             break;
     }
@@ -655,6 +660,10 @@ void Copter::set_auto_yaw_mode(uint8_t yaw_mode)
     switch (auto_yaw_mode) {
 
     case AUTO_YAW_LOOK_AT_NEXT_WP:
+        // wpnav will initialise heading when wpnav's set_destination method is called
+        break;
+
+    case AUTO_YAW_LOOK_AT_TARGET:
         // wpnav will initialise heading when wpnav's set_destination method is called
         break;
 
@@ -773,6 +782,10 @@ float Copter::get_auto_heading(void)
     case AUTO_YAW_RESETTOARMEDYAW:
         // changes yaw to be same as when quad was armed
         return initial_armed_bearing;
+        break;
+
+    case AUTO_YAW_LOOK_AT_TARGET:
+        return get_look_at_target_yaw();
         break;
 
     case AUTO_YAW_LOOK_AT_NEXT_WP:

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -19,6 +19,7 @@ enum autopilot_yaw_mode {
     AUTO_YAW_LOOK_AT_HEADING =  3,  // point towards a particular angle (not pilot input accepted)
     AUTO_YAW_LOOK_AHEAD =       4,  // point in the direction the copter is moving
     AUTO_YAW_RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
+    AUTO_YAW_LOOK_AT_TARGET  =  6,  // point towards target point
 };
 
 // Ch6... Ch12 aux switch control


### PR DESCRIPTION
This commit fix the error of vehicle in an automated mission to turn towards the next waypoint far before it reaches the current one and solves the issue #932
