### PR TITLE
build: include ap_config.h in libgtest

### DIFF
--- a/wscript
+++ b/wscript
@@ -197,7 +197,7 @@ def _build_common_taskgens(bld):
         use='mavlink',
     )
 
-    bld.libgtest()
+    bld.libgtest(cxxflags=['-include', 'ap_config.h'])
 
     if bld.env.HAS_GBENCHMARK:
         bld.libbenchmark()


### PR DESCRIPTION
This is also needed while compiling libgtest because it's using our
cmath wrapper header. Otherwise it will end up entering the
"ifndef WAF_BUILD" part and fail to compile on gcc 5.3.1.