### PR TITLE
AP_Motors: fixed motor load calculation

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -432,7 +432,11 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     // feed power estimate into main rotor controller
     // ToDo: include tail rotor power?
     // ToDo: add main rotor cyclic power?
-    _main_rotor.set_motor_load(fabsf(collective_out - _collective_mid_pct));
+    if (collective_out > _collective_mid_pct) {
+        _main_rotor.set_motor_load((collective_out - _collective_mid_pct) / (1.0f - _collective_mid_pct));
+    } else {
+        _main_rotor.set_motor_load((_collective_mid_pct - collective_out) / _collective_mid_pct);
+    }
 
     // swashplate servos
     float collective_scalar = ((float)(_collective_max-_collective_min))/1000.0f;


### PR DESCRIPTION
scale to 1.0 for max collective. Otherwise you need a H_RSC_POWER_HIGH greater than 1000 to get the full range specified in the H_RSC_PWM_MIN/H_RSC_PWM_MAX
