### PR TITLE
add SRx_ADSB for packet throttling

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -596,6 +596,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         break;
 
     case MSG_RETRY_DEFERRED:
+    case MSG_ADSB_VEHICLE:
     case MSG_TERRAIN:
     case MSG_OPTICAL_FLOW:
     case MSG_GIMBAL_REPORT:

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -265,6 +265,7 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
     case MSG_EXTENDED_STATUS1:
     case MSG_EXTENDED_STATUS2:
     case MSG_RETRY_DEFERRED:
+    case MSG_ADSB_VEHICLE:
     case MSG_CURRENT_WAYPOINT:
     case MSG_VFR_HUD:
     case MSG_SYSTEM_TIME:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -740,6 +740,11 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     case MSG_MAG_CAL_REPORT:
         copter.compass.send_mag_cal_report(chan);
         break;
+
+    case MSG_ADSB_VEHICLE:
+        CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
+        copter.adsb.send_adsb_vehicle(chan);
+        break;
     }
 
     return true;
@@ -827,7 +832,16 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("PARAMS",   8, GCS_MAVLINK, streamRates[8],  0),
-    AP_GROUPEND
+
+    // @Param: ADSB
+    // @DisplayName: ADSB stream rate to ground station
+    // @Description: ADSB stream rate to ground station
+    // @Units: Hz
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("ADSB",   9, GCS_MAVLINK, streamRates[9],  5),
+AP_GROUPEND
 };
 
 void
@@ -932,6 +946,12 @@ GCS_MAVLINK_Copter::data_stream_send(void)
         send_message(MSG_EKF_STATUS_REPORT);
         send_message(MSG_VIBRATION);
         send_message(MSG_RPM);
+    }
+
+    if (copter.gcs_out_of_time) return;
+
+    if (stream_trigger(STREAM_ADSB)) {
+        send_message(MSG_ADSB_VEHICLE);
     }
 }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -873,6 +873,11 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(MAG_CAL_REPORT);
         plane.compass.send_mag_cal_report(chan);
         break;
+
+    case MSG_ADSB_VEHICLE:
+        CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
+        plane.adsb.send_adsb_vehicle(chan);
+        break;
     }
     return true;
 }
@@ -962,6 +967,15 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("PARAMS",   8, GCS_MAVLINK, streamRates[8],  10),
+
+    // @Param: ADSB
+    // @DisplayName: ADSB stream rate to ground station
+    // @Description: ADSB stream rate to ground station
+    // @Units: Hz
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("ADSB",   9, GCS_MAVLINK, streamRates[9],  5),
     AP_GROUPEND
 };
 
@@ -1080,6 +1094,12 @@ GCS_MAVLINK_Plane::data_stream_send(void)
         send_message(MSG_EKF_STATUS_REPORT);
         send_message(MSG_GIMBAL_REPORT);
         send_message(MSG_VIBRATION);
+    }
+
+    if (plane.gcs_out_of_time) return;
+
+    if (stream_trigger(STREAM_ADSB)) {
+        send_message(MSG_ADSB_VEHICLE);
     }
 }
 

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -24,7 +24,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_ADSB.h"
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLINK/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -23,6 +23,8 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_ADSB.h"
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLINK/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -287,6 +289,47 @@ void AP_ADSB::set_vehicle(uint16_t index, const adsb_vehicle_t &vehicle)
     if (index < VEHICLE_LIST_LENGTH) {
         _vehicle_list[index] = vehicle;
         _vehicle_list[index].last_update_ms = AP_HAL::millis();
+    }
+}
+
+void AP_ADSB::send_adsb_vehicle(mavlink_channel_t chan)
+{
+    if (_vehicle_list == NULL || !_enabled || _vehicle_count == 0) {
+        return;
+    }
+
+    uint32_t now = AP_HAL::millis();
+
+    if (send_index[chan] >= _vehicle_count) {
+        // we've finished a list
+        if (now - send_start_ms[chan] < 1000) {
+            // too soon to start a new one
+            return;
+        } else {
+            // start new list
+            send_start_ms[chan] = now;
+            send_index[chan] = 0;
+        }
+    }
+
+    if (send_index[chan] < _vehicle_count) {
+        mavlink_adsb_vehicle_t vehicle = _vehicle_list[send_index[chan]].info;
+        send_index[chan]++;
+
+        mavlink_msg_adsb_vehicle_send(chan,
+            vehicle.ICAO_address,
+            vehicle.lat,
+            vehicle.lon,
+            vehicle.altitude_type,
+            vehicle.altitude,
+            vehicle.heading,
+            vehicle.hor_velocity,
+            vehicle.ver_velocity,
+            vehicle.callsign,
+            vehicle.emitter_type,
+            vehicle.tslc,
+            vehicle.flags,
+            vehicle.squawk);
     }
 }
 

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -75,6 +75,9 @@ public:
     void set_is_evading_threat(bool is_evading) { if (_enabled) { _is_evading_threat = is_evading; } }
     uint16_t get_vehicle_count() { return _vehicle_count; }
 
+    // send ADSB_VEHICLE mavlink message, usually as a StreamRate
+    void send_adsb_vehicle(mavlink_channel_t chan);
+
 private:
 
     // initialize _vehicle_list
@@ -115,4 +118,9 @@ private:
     // index of and distance to vehicle with highest threat
     uint16_t    _highest_threat_index = 0;
     float       _highest_threat_distance = 0;
+
+    // streamrate stuff
+    uint32_t    send_start_ms[MAVLINK_COMM_NUM_BUFFERS];
+    uint16_t    send_index[MAVLINK_COMM_NUM_BUFFERS];
+
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -75,6 +75,7 @@ enum ap_message {
     MSG_RPM,
     MSG_MISSION_ITEM_REACHED,
     MSG_POSITION_TARGET_GLOBAL_INT,
+    MSG_ADSB_VEHICLE,
     MSG_RETRY_DEFERRED // this must be last
 };
 
@@ -127,6 +128,7 @@ public:
                   STREAM_EXTRA2,
                   STREAM_EXTRA3,
                   STREAM_PARAMS,
+                  STREAM_ADSB,
                   NUM_STREAMS};
 
     // see if we should send a stream now. Called at 50Hz

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -114,6 +114,11 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
         return true;
     }
 
+    if (msg->msgid == MAVLINK_MSG_ID_ADSB_VEHICLE) {
+        // ADSB packets are not forwarded, they have their own stream rate
+        return true;
+    }
+
     // extract the targets for this packet
     int16_t target_system = -1;
     int16_t target_component = -1;


### PR DESCRIPTION
Master is suffering from a bug so it's hard to test this but it works fine on another fork of mine.

Fixes https://github.com/ArduPilot/ardupilot/issues/4292

Add SRx_ADSB for controlled packet throttling. Packets that arrive from an ADSB are no longer forwarded, only the 25 nearest targets are retained. Then, at this rate interval we iterate through sending the list. The start of sending a list is never sent faster than 1 second.

Examples:
list contains 1 aircraft, SRx_ADSB=1. List obtained immediately, repeated @ 1Hz
list contains 1 aircraft, SRx_ADSB=5. List obtained immediately, repeated @ 1Hz
list contains 1 aircraft, SRx_ADSB=50.  List obtained immediately, repeated @ 1Hz
list contains 5 aircraft, SRx_ADSB=1.  List obtained in 5 sec then repeated
list contains 5 aircraft, SRx_ADSB=5. List obtained in 1 sec then repeated
list contains 5 aircraft, SRx_ADSB=50. List obtained in 100ms repeated @ 1Hz
list contains 25 aircraft, SRx_ADSB=1. List obtained in 25 sec then repeated
list contains 25 aircraft, SRx_ADSB=5. List obtained in 5 sec then repeated
list contains 25 aircraft, SRx_ADSB=50. List obtained in 500ms, repeated @ 1Hz
