### PR TITLE
Copter: fix RTL to rally point 

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -840,7 +840,7 @@ private:
     void rtl_land_start();
     void rtl_land_run();
     void rtl_build_path(bool terrain_following_allowed);
-    void rtl_compute_return_alt(const Location_Class &rtl_origin_point, Location_Class &rtl_return_target, bool terrain_following_allowed);
+    void rtl_compute_return_alt(bool terrain_following_allowed);
     bool sport_init(bool ignore_checks);
     void sport_run();
     bool stabilize_init(bool ignore_checks);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -840,7 +840,7 @@ private:
     void rtl_land_start();
     void rtl_land_run();
     void rtl_build_path(bool terrain_following_allowed);
-    void rtl_compute_return_alt(bool terrain_following_allowed);
+    void rtl_compute_return_target(bool terrain_following_allowed);
     bool sport_init(bool ignore_checks);
     void sport_run();
     bool stabilize_init(bool ignore_checks);


### PR DESCRIPTION
I looked at the logs in http://discuss.ardupilot.org/t/copter-3-4rc1-rtl-to-rally-point-issue/9659 and the issue is that when we go to a rally point we were adding an RTL altitude to the rally point instead of flying at the rally point altitude.

Although the AP_Rally library says the altitude is absolute it shouldn't be, since by looking at the _rally_location_to_location_ function we can see that the home altitude was added, so it is in fact an altitude above home. This fix retains that the altitude at the rally point will be above home. The travel between current location and rally point behaves the same as if going home: follow terrain if active, follow altitude above home if not.

@rmackay9 I tried to think of all scenarios (terrain/no terrain, home/rally point, fence/no fence, etc), but I might have missed something so this should be reviewed carefully.

This also fixes a bug where terrain was being checked for origin twice and not checked for the return target.