### PR TITLE
Singleton gcs function and method

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1567,7 +1567,7 @@ void Rover::gcs_update(void)
 
 void Rover::gcs_send_text(MAV_SEVERITY severity, const char *str)
 {
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -1583,7 +1583,7 @@ void Rover::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
     va_start(arg_list, fmt);
     hal.util->vsnprintf((char *)str, sizeof(str), fmt, arg_list);
     va_end(arg_list);
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -1594,7 +1594,7 @@ void Rover::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
 void Rover::gcs_retry_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
-    GCS_MAVLINK::service_statustext();
+    gcs().service_statustext();
 }
 
 /*

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -63,7 +63,7 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_GROUND_ROVER,
+    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_GROUND_ROVER,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -1485,7 +1485,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 void Rover::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs[0].initialised || in_mavlink_delay) {
+    if (!gcs_chan[0].initialised || in_mavlink_delay) {
         return;
     }
 
@@ -1518,8 +1518,8 @@ void Rover::mavlink_delay_cb()
 void Rover::gcs_send_message(enum ap_message id)
 {
     for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_message(id);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].send_message(id);
         }
     }
 }
@@ -1530,9 +1530,9 @@ void Rover::gcs_send_message(enum ap_message id)
 void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
     for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].mission_item_reached_index = mission_index;
-            gcs[i].send_message(MSG_MISSION_ITEM_REACHED);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].mission_item_reached_index = mission_index;
+            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
         }
     }
 }
@@ -1543,8 +1543,8 @@ void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
 void Rover::gcs_data_stream_send(void)
 {
     for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].data_stream_send();
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].data_stream_send();
         }
     }
 }
@@ -1555,11 +1555,11 @@ void Rover::gcs_data_stream_send(void)
 void Rover::gcs_update(void)
 {
     for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs[i].initialised) {
+        if (gcs_chan[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);
+            gcs_chan[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);
 #else
-            gcs[i].update(nullptr);
+            gcs_chan[i].update(nullptr);
 #endif
         }
     }

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -469,7 +469,7 @@ void Rover::log_init(void)
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i < num_gcs; i++) {
-            gcs[i].reset_cli_timeout();
+            gcs_chan[i].reset_cli_timeout();
         }
     }
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -408,19 +408,19 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -185,7 +185,7 @@ private:
     // GCS handling
     AP_SerialManager serial_manager;
     const uint8_t num_gcs;
-    GCS_MAVLINK_Rover gcs[MAVLINK_COMM_NUM_BUFFERS];
+    GCS_MAVLINK_Rover gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
 
     // relay support
     AP_Relay relay;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -186,6 +186,8 @@ private:
     AP_SerialManager serial_manager;
     const uint8_t num_gcs;
     GCS_MAVLINK_Rover gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
+    GCS _gcs; // avoid using this; use gcs()
+    GCS &gcs() { return _gcs; }
 
     // relay support
     AP_Relay relay;

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -92,7 +92,7 @@ void Rover::init_ardupilot()
     // initialise stats module
     g2.stats.init();
 
-    GCS_MAVLINK::set_dataflash(&DataFlash);
+    gcs().set_dataflash(&DataFlash);
 
     mavlink_system.sysid = g.sysid_this_mav;
 

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -100,7 +100,7 @@ void Rover::init_ardupilot()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -133,7 +133,7 @@ void Rover::init_ardupilot()
 
     // setup telem slots with serial ports
     for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
+        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
     }
 
     // setup frsky telemetry
@@ -193,11 +193,11 @@ void Rover::init_ardupilot()
     if (g.cli_enabled == 1) {
         const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
         cliSerial->printf("%s\n", msg);
-        if (gcs[1].initialised && (gcs[1].get_uart() != nullptr)) {
-            gcs[1].get_uart()->printf("%s\n", msg);
+        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
+            gcs_chan[1].get_uart()->printf("%s\n", msg);
         }
-        if (num_gcs > 2 && gcs[2].initialised && (gcs[2].get_uart() != nullptr)) {
-            gcs[2].get_uart()->printf("%s\n", msg);
+        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
+            gcs_chan[2].get_uart()->printf("%s\n", msg);
         }
     }
 #endif

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -58,7 +58,7 @@ void Tracker::send_heartbeat(mavlink_channel_t chan)
         base_mode |= MAV_MODE_FLAG_SAFETY_ARMED;
     }
 
-    gcs[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_ANTENNA_TRACKER,
+    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_ANTENNA_TRACKER,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -111,7 +111,7 @@ void Tracker::send_hwstatus(mavlink_channel_t chan)
 
 void Tracker::send_waypoint_request(mavlink_channel_t chan)
 {
-    gcs[chan-MAVLINK_COMM_0].queued_waypoint_send();
+    gcs_chan[chan-MAVLINK_COMM_0].queued_waypoint_send();
 }
 
 void Tracker::send_nav_controller_output(mavlink_channel_t chan)
@@ -486,7 +486,7 @@ void Tracker::mavlink_check_target(const mavlink_message_t* msg)
     // send data stream request to target on all channels
     //  Note: this doesn't check success for all sends meaning it's not guaranteed the vehicle's positions will be sent at 1hz
     for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs[i].initialised) {
+        if (gcs_chan[i].initialised) {
             // request position
             if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, DATA_STREAM)) {
                 mavlink_msg_request_data_stream_send(
@@ -889,7 +889,7 @@ mission_failed:
 void Tracker::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs[0].initialised) return;
+    if (!gcs_chan[0].initialised) return;
 
     tracker.in_mavlink_delay = true;
 
@@ -918,8 +918,8 @@ void Tracker::mavlink_delay_cb()
 void Tracker::gcs_send_message(enum ap_message id)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_message(id);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].send_message(id);
         }
     }
 }
@@ -930,8 +930,8 @@ void Tracker::gcs_send_message(enum ap_message id)
 void Tracker::gcs_data_stream_send(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].data_stream_send();
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].data_stream_send();
         }
     }
 }
@@ -942,8 +942,8 @@ void Tracker::gcs_data_stream_send(void)
 void Tracker::gcs_update(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].update(nullptr);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].update(nullptr);
         }
     }
 }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -950,7 +950,7 @@ void Tracker::gcs_update(void)
 
 void Tracker::gcs_send_text(MAV_SEVERITY severity, const char *str)
 {
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -966,7 +966,7 @@ void Tracker::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
     va_start(arg_list, fmt);
     hal.util->vsnprintf((char *)str, sizeof(str), fmt, arg_list);
     va_end(arg_list);
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -976,5 +976,5 @@ void Tracker::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
 void Tracker::gcs_retry_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
-    GCS_MAVLINK::service_statustext();
+    gcs().service_statustext();
 }

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -107,7 +107,7 @@ void Tracker::log_init(void)
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
-            gcs[i].reset_cli_timeout();
+            gcs_chan[i].reset_cli_timeout();
         }
     }
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -253,19 +253,19 @@ const AP_Param::Info Tracker::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -139,7 +139,7 @@ private:
 
     AP_SerialManager serial_manager;
     const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-    GCS_MAVLINK_Tracker gcs[MAVLINK_COMM_NUM_BUFFERS];
+    GCS_MAVLINK_Tracker gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
 
     AP_BoardConfig BoardConfig;
 

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -140,6 +140,8 @@ private:
     AP_SerialManager serial_manager;
     const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
     GCS_MAVLINK_Tracker gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
+    GCS _gcs; // avoid using this; use GCS::instance()
+    GCS &gcs() { return _gcs; }
 
     AP_BoardConfig BoardConfig;
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -26,7 +26,7 @@ void Tracker::init_tracker()
     // Check the EEPROM format version before loading any parameters from EEPROM
     load_parameters();
 
-    GCS_MAVLINK::set_dataflash(&DataFlash);
+    gcs().set_dataflash(&DataFlash);
 
     mavlink_system.sysid = g.sysid_this_mav;
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -34,7 +34,7 @@ void Tracker::init_tracker()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -58,8 +58,8 @@ void Tracker::init_tracker()
 
     // setup telem slots with serial ports
     for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-        gcs[i].set_snoop(mavlink_snoop_static);
+        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
+        gcs_chan[i].set_snoop(mavlink_snoop_static);
     }
 
 #if LOGGING_ENABLED == ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -238,7 +238,7 @@ private:
     AP_SerialManager serial_manager;
     static const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
 
-    GCS_MAVLINK_Copter gcs[MAVLINK_COMM_NUM_BUFFERS];
+    GCS_MAVLINK_Copter gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
 
     // User variables
 #ifdef USERHOOK_VARIABLES

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -239,6 +239,8 @@ private:
     static const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
 
     GCS_MAVLINK_Copter gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
+    GCS _gcs; // avoid using this; use gcs()
+    GCS &gcs() { return _gcs; }
 
     // User variables
 #ifdef USERHOOK_VARIABLES

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -78,7 +78,7 @@ NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs[chan-MAVLINK_COMM_0].send_heartbeat(get_frame_mav_type(),
+    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(get_frame_mav_type(),
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -1994,7 +1994,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 void Copter::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs[0].initialised || in_mavlink_delay) return;
+    if (!gcs_chan[0].initialised || in_mavlink_delay) return;
 
     in_mavlink_delay = true;
 
@@ -2026,8 +2026,8 @@ void Copter::mavlink_delay_cb()
 void Copter::gcs_send_message(enum ap_message id)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_message(id);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].send_message(id);
         }
     }
 }
@@ -2038,9 +2038,9 @@ void Copter::gcs_send_message(enum ap_message id)
 void Copter::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].mission_item_reached_index = mission_index;
-            gcs[i].send_message(MSG_MISSION_ITEM_REACHED);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].mission_item_reached_index = mission_index;
+            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
         }
     }
 }
@@ -2051,8 +2051,8 @@ void Copter::gcs_send_mission_item_reached_message(uint16_t mission_index)
 void Copter::gcs_data_stream_send(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].data_stream_send();
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].data_stream_send();
         }
     }
 }
@@ -2063,11 +2063,11 @@ void Copter::gcs_data_stream_send(void)
 void Copter::gcs_check_input(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
+        if (gcs_chan[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):nullptr);
+            gcs_chan[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(nullptr);
+            gcs_chan[i].update(nullptr);
 #endif
         }
     }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -11,7 +11,7 @@ void Copter::gcs_send_heartbeat(void)
 void Copter::gcs_send_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
-    GCS_MAVLINK::service_statustext();
+    gcs().service_statustext();
 }
 
 /*
@@ -2075,7 +2075,7 @@ void Copter::gcs_check_input(void)
 
 void Copter::gcs_send_text(MAV_SEVERITY severity, const char *str)
 {
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -2091,7 +2091,7 @@ void Copter::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
     va_start(arg_list, fmt);
     va_end(arg_list);
     hal.util->vsnprintf((char *)str, sizeof(str), fmt, arg_list);
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -958,7 +958,7 @@ void Copter::log_init(void)
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
-            gcs[i].reset_cli_timeout();
+            gcs_chan[i].reset_cli_timeout();
         }
     }
 }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -700,19 +700,19 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[0],  gcs0,       "SR0_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[0],  gcs0,       "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: AHRS_
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -40,7 +40,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
 
     // check compass is enabled
     if (!g.compass_enabled) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -49,7 +49,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     compass.read();
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (!compass.healthy(i)) {
-            gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Check compass");
+            gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Check compass");
             ap.compass_mot = false;
             return MAV_RESULT_TEMPORARILY_REJECTED;
         }
@@ -58,7 +58,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check if radio is calibrated
     arming.pre_arm_rc_checks(true);
     if (!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "RC not calibrated");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "RC not calibrated");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -66,14 +66,14 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check throttle is at zero
     read_radio();
     if (channel_throttle->get_control_in() != 0) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
 
     // check we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Not landed");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Not landed");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -98,13 +98,13 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     AP_Notify::flags.esc_calibration = true;
 
     // warn user we are starting calibration
-    gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Starting calibration");
+    gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Starting calibration");
 
     // inform what type of compensation we are attempting
     if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Current");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Current");
     } else{
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Throttle");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Throttle");
     }
 
     // disable throttle and battery failsafe
@@ -248,10 +248,10 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
         }
         compass.save_motor_compensation();
         // display success message
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Calibration successful");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Calibration successful");
     } else {
         // compensation vector never updated, report failure
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_NOTICE, "Failed");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_NOTICE, "Failed");
         compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
     }
 

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -75,19 +75,19 @@ bool Copter::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
     // check rc has been calibrated
     arming.pre_arm_rc_checks(true);
     if(check_rc && !ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: RC not calibrated");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: RC not calibrated");
         return false;
     }
 
     // ensure we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: vehicle not landed");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: vehicle not landed");
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Safety switch");
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Safety switch");
         return false;
     }
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -120,7 +120,7 @@ void Copter::init_ardupilot()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -152,7 +152,7 @@ void Copter::init_ardupilot()
 
     // setup telem slots with serial ports
     for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
+        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
     }
 
 #if FRSKY_TELEM_ENABLED == ENABLED
@@ -245,11 +245,11 @@ void Copter::init_ardupilot()
     if (g.cli_enabled) {
         const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
         cliSerial->printf("%s\n", msg);
-        if (gcs[1].initialised && (gcs[1].get_uart() != nullptr)) {
-            gcs[1].get_uart()->printf("%s\n", msg);
+        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
+            gcs_chan[1].get_uart()->printf("%s\n", msg);
         }
-        if (num_gcs > 2 && gcs[2].initialised && (gcs[2].get_uart() != nullptr)) {
-            gcs[2].get_uart()->printf("%s\n", msg);
+        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
+            gcs_chan[2].get_uart()->printf("%s\n", msg);
         }
     }
 #endif // CLI_ENABLED

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -111,7 +111,7 @@ void Copter::init_ardupilot()
     // initialise stats module
     g2.stats.init();
 
-    GCS_MAVLINK::set_dataflash(&DataFlash);
+    gcs().set_dataflash(&DataFlash);
 
     // identify ourselves correctly with the ground station
     mavlink_system.sysid = g.sysid_this_mav;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -91,7 +91,7 @@ void Plane::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_FIXED_WING,
+    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_FIXED_WING,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -2098,7 +2098,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 void Plane::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs[0].initialised || in_mavlink_delay) return;
+    if (!gcs_chan[0].initialised || in_mavlink_delay) return;
 
     in_mavlink_delay = true;
 
@@ -2129,8 +2129,8 @@ void Plane::mavlink_delay_cb()
 void Plane::gcs_send_message(enum ap_message id)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_message(id);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].send_message(id);
         }
     }
 }
@@ -2141,9 +2141,9 @@ void Plane::gcs_send_message(enum ap_message id)
 void Plane::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].mission_item_reached_index = mission_index;
-            gcs[i].send_message(MSG_MISSION_ITEM_REACHED);
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].mission_item_reached_index = mission_index;
+            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
         }
     }
 }
@@ -2154,8 +2154,8 @@ void Plane::gcs_send_mission_item_reached_message(uint16_t mission_index)
 void Plane::gcs_data_stream_send(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].data_stream_send();
+        if (gcs_chan[i].initialised) {
+            gcs_chan[i].data_stream_send();
         }
     }
 }
@@ -2166,11 +2166,11 @@ void Plane::gcs_data_stream_send(void)
 void Plane::gcs_update(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
+        if (gcs_chan[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):nullptr);
+            gcs_chan[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(nullptr);
+            gcs_chan[i].update(nullptr);
 #endif
         }
     }
@@ -2204,7 +2204,7 @@ void Plane::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
 void Plane::gcs_send_airspeed_calibration(const Vector3f &vg)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
+        if (gcs_chan[i].initialised) {
             if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, AIRSPEED_AUTOCAL)) {
                 airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
             }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2178,7 +2178,7 @@ void Plane::gcs_update(void)
 
 void Plane::gcs_send_text(MAV_SEVERITY severity, const char *str)
 {
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -2194,7 +2194,7 @@ void Plane::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
     va_start(arg_list, fmt);
     hal.util->vsnprintf((char *)str, sizeof(str), fmt, arg_list);
     va_end(arg_list);
-    GCS_MAVLINK::send_statustext(severity, 0xFF, str);
+    gcs().send_statustext(severity, 0xFF, str);
     notify.send_text(str);
 }
 
@@ -2218,7 +2218,7 @@ void Plane::gcs_send_airspeed_calibration(const Vector3f &vg)
 void Plane::gcs_retry_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
-    GCS_MAVLINK::service_statustext();
+    gcs().service_statustext();
 }
 
 /*

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -91,7 +91,7 @@ void Plane::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_FIXED_WING,
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(MAV_TYPE_FIXED_WING,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -2098,7 +2098,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 void Plane::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs_chan[0].initialised || in_mavlink_delay) return;
+    if (!gcs().chan(0).initialised || in_mavlink_delay) return;
 
     in_mavlink_delay = true;
 
@@ -2128,11 +2128,7 @@ void Plane::mavlink_delay_cb()
  */
 void Plane::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].send_message(id);
-        }
-    }
+    gcs().send_message(id);
 }
 
 /*
@@ -2140,12 +2136,7 @@ void Plane::gcs_send_message(enum ap_message id)
  */
 void Plane::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].mission_item_reached_index = mission_index;
-            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
-        }
-    }
+    gcs().send_mission_item_reached_message(mission_index);
 }
 
 /*
@@ -2153,11 +2144,7 @@ void Plane::gcs_send_mission_item_reached_message(uint16_t mission_index)
  */
 void Plane::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].data_stream_send();
-        }
-    }
+    gcs().data_stream_send();
 }
 
 /*
@@ -2165,15 +2152,7 @@ void Plane::gcs_data_stream_send(void)
  */
 void Plane::gcs_update(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-#if CLI_ENABLED == ENABLED
-            gcs_chan[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):nullptr);
-#else
-            gcs_chan[i].update(nullptr);
-#endif
-        }
-    }
+    gcs().update();
 }
 
 void Plane::gcs_send_text(MAV_SEVERITY severity, const char *str)
@@ -2203,13 +2182,7 @@ void Plane::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
  */
 void Plane::gcs_send_airspeed_calibration(const Vector3f &vg)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, AIRSPEED_AUTOCAL)) {
-                airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
-            }
-        }
-    }
+    gcs().send_airspeed_calibration(vg);
 }
 
 /**

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -1,0 +1,83 @@
+#include "GCS_Plane.h"
+#include "Plane.h"
+
+#define FOR_EACH_CHAN(fn)               \
+    do  {                                       \
+        for (uint8_t i=0; i<_num_gcs; i++) {     \
+            _chan[i].fn;                        \
+        }                                       \
+    } while (0)
+
+#define FOR_EACH_INITIALIZED_CHAN(fn)           \
+    do  {                                       \
+        for (uint8_t i=0; i<_num_gcs; i++) {     \
+            if (_chan[i].initialised) {         \
+                _chan[i].fn;                    \
+            }                                   \
+        }                                       \
+    } while (0)
+
+void GCS_Plane::reset_cli_timeout()
+{
+    FOR_EACH_CHAN(reset_cli_timeout());
+}
+
+void GCS_Plane::send_message(enum ap_message id)
+{
+    FOR_EACH_INITIALIZED_CHAN(send_message(id));
+}
+
+void GCS_Plane::data_stream_send()
+{
+    FOR_EACH_INITIALIZED_CHAN(data_stream_send());
+}
+
+void GCS_Plane::update(void)
+{
+    FOR_EACH_INITIALIZED_CHAN(update(_run_cli));
+}
+
+#undef FOR_EACH_CHAN
+#undef FOR_EACH_INITIALIZED_CHAN
+
+void GCS_Plane::send_mission_item_reached_message(uint16_t mission_index)
+{
+    for (uint8_t i=0; i<_num_gcs; i++) {
+        if (_chan[i].initialised) {
+            _chan[i].mission_item_reached_index = mission_index;
+            _chan[i].send_message(MSG_MISSION_ITEM_REACHED);
+        }
+    }
+}
+
+void GCS_Plane::send_airspeed_calibration(const Vector3f &vg)
+{
+    for (uint8_t i=0; i<_num_gcs; i++) {
+        if (_chan[i].initialised) {
+            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, AIRSPEED_AUTOCAL)) {
+                plane.airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
+            }
+        }
+    }
+}
+
+void GCS_Plane::setup_uarts(AP_SerialManager &serial_manager)
+{
+    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
+        _chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
+    }
+}
+
+void GCS_Plane::handle_interactive_setup()
+{
+    if (plane.g.cli_enabled == 1) {
+        const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
+        plane.cliSerial->printf("%s\n", msg);
+        if (_chan[1].initialised && (_chan[1].get_uart() != NULL)) {
+            _chan[1].get_uart()->printf("%s\n", msg);
+        }
+        if (num_gcs() > 2 && _chan[2].initialised && (_chan[2].get_uart() != NULL)) {
+            _chan[2].get_uart()->printf("%s\n", msg);
+        }
+    }
+}

--- a/ArduPlane/GCS_Plane.h
+++ b/ArduPlane/GCS_Plane.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include "GCS_Mavlink.h"
+
+class GCS_Plane : public GCS
+{
+    friend class Plane; // for temporary access to num_gcs and links
+
+public:
+
+    FUNCTOR_TYPEDEF(run_cli_fn, void, AP_HAL::UARTDriver*);
+
+    // return the number of valid GCS objects
+    uint8_t num_gcs() const { return _num_gcs; };
+
+    // return GCS link at offset ofs
+    GCS_MAVLINK_Plane &chan(const uint8_t ofs) { return _chan[ofs]; };
+
+    void reset_cli_timeout();
+    void send_message(enum ap_message id);
+    void send_mission_item_reached_message(uint16_t mission_index);
+    void data_stream_send();
+    void update();
+    void send_airspeed_calibration(const Vector3f &vg);
+
+    void set_run_cli_func(run_cli_fn run_cli) { _run_cli = run_cli; }
+    void setup_uarts(AP_SerialManager &serial_manager);
+    void handle_interactive_setup();
+
+private:
+
+    uint8_t _num_gcs = MAVLINK_COMM_NUM_BUFFERS;
+    GCS_MAVLINK_Plane _chan[MAVLINK_COMM_NUM_BUFFERS];
+    run_cli_fn _run_cli;
+
+};

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -543,7 +543,7 @@ void Plane::log_init(void)
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
-            gcs[i].reset_cli_timeout();
+            gcs_chan[i].reset_cli_timeout();
         }
     }
 }

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -542,9 +542,7 @@ void Plane::log_init(void)
         gcs_send_text(MAV_SEVERITY_INFO, "Preparing log system");
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
-        for (uint8_t i=0; i<num_gcs; i++) {
-            gcs_chan[i].reset_cli_timeout();
-        }
+        gcs().reset_cli_timeout();
     }
 }
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1079,19 +1079,19 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: INS_
     // @Path: ../libraries/AP_InertialSensor/AP_InertialSensor.cpp

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1079,19 +1079,19 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: INS_
     // @Path: ../libraries/AP_InertialSensor/AP_InertialSensor.cpp

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -27,6 +27,10 @@ Plane::Plane(void)
     auto_state.takeoff_complete = true;
     auto_state.next_wp_no_crosstrack = true;
     auto_state.no_crosstrack = true;
+
+    if (plane.g.cli_enabled) {
+        gcs().set_run_cli_func(FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *));
+    }
 }
 
 Plane plane;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -252,6 +252,8 @@ private:
     AP_SerialManager serial_manager;
     const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
     GCS_MAVLINK_Plane gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
+    GCS _gcs; // avoid using this; use gcs()
+    GCS &gcs() { return _gcs; }
 
     // selected navigation controller
     AP_Navigation *nav_controller = &L1_controller;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -251,7 +251,7 @@ private:
     // GCS selection
     AP_SerialManager serial_manager;
     const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-    GCS_MAVLINK_Plane gcs[MAVLINK_COMM_NUM_BUFFERS];
+    GCS_MAVLINK_Plane gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
 
     // selected navigation controller
     AP_Navigation *nav_controller = &L1_controller;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -95,6 +95,7 @@
 #include <AP_Landing/AP_Landing.h>
 
 #include "GCS_Mavlink.h"
+#include "GCS_Plane.h"
 #include "quadplane.h"
 #include "tuning.h"
 
@@ -144,6 +145,7 @@ public:
     friend class AP_Tuning_Plane;
     friend class AP_AdvancedFailsafe_Plane;
     friend class AP_Avoidance_Plane;
+    friend class GCS_Plane;
 
     Plane(void);
 
@@ -250,10 +252,8 @@ private:
 
     // GCS selection
     AP_SerialManager serial_manager;
-    const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-    GCS_MAVLINK_Plane gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
-    GCS _gcs; // avoid using this; use gcs()
-    GCS &gcs() { return _gcs; }
+    GCS_Plane _gcs; // avoid using this; use gcs()
+    GCS_Plane &gcs() { return _gcs; }
 
     // selected navigation controller
     AP_Navigation *nav_controller = &L1_controller;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -116,7 +116,7 @@ void Plane::init_ardupilot()
     }
 #endif
 
-    GCS_MAVLINK::set_dataflash(&DataFlash);
+    gcs().set_dataflash(&DataFlash);
 
     mavlink_system.sysid = g.sysid_this_mav;
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -122,7 +122,7 @@ void Plane::init_ardupilot()
 
     // initialise serial ports
     serial_manager.init();
-    gcs[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -162,7 +162,7 @@ void Plane::init_ardupilot()
 
     // setup telem slots with serial ports
     for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
+        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
     }
 
     // setup frsky
@@ -232,11 +232,11 @@ void Plane::init_ardupilot()
     if (g.cli_enabled == 1) {
         const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
         cliSerial->printf("%s\n", msg);
-        if (gcs[1].initialised && (gcs[1].get_uart() != nullptr)) {
-            gcs[1].get_uart()->printf("%s\n", msg);
+        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
+            gcs_chan[1].get_uart()->printf("%s\n", msg);
         }
-        if (num_gcs > 2 && gcs[2].initialised && (gcs[2].get_uart() != nullptr)) {
-            gcs[2].get_uart()->printf("%s\n", msg);
+        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
+            gcs_chan[2].get_uart()->printf("%s\n", msg);
         }
     }
 #endif // CLI_ENABLED
@@ -571,8 +571,8 @@ void Plane::check_long_failsafe()
                    (tnow - failsafe.last_heartbeat_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
-                   gcs[0].last_radio_status_remrssi_ms != 0 &&
-                   (tnow - gcs[0].last_radio_status_remrssi_ms) > g.long_fs_timeout*1000) {
+                   gcs_chan[0].last_radio_status_remrssi_ms != 0 &&
+                   (tnow - gcs_chan[0].last_radio_status_remrssi_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
         }
     } else {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -122,7 +122,7 @@ void Plane::init_ardupilot()
 
     // initialise serial ports
     serial_manager.init();
-    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -161,9 +161,7 @@ void Plane::init_ardupilot()
     check_usb_mux();
 
     // setup telem slots with serial ports
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-    }
+    gcs().setup_uarts(serial_manager);
 
     // setup frsky
 #if FRSKY_TELEM_ENABLED == ENABLED
@@ -229,16 +227,7 @@ void Plane::init_ardupilot()
     hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
 #if CLI_ENABLED == ENABLED
-    if (g.cli_enabled == 1) {
-        const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
-        cliSerial->printf("%s\n", msg);
-        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
-            gcs_chan[1].get_uart()->printf("%s\n", msg);
-        }
-        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
-            gcs_chan[2].get_uart()->printf("%s\n", msg);
-        }
-    }
+    gcs().handle_interactive_setup();
 #endif // CLI_ENABLED
 
     init_capabilities();
@@ -571,8 +560,8 @@ void Plane::check_long_failsafe()
                    (tnow - failsafe.last_heartbeat_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_RSSI && 
-                   gcs_chan[0].last_radio_status_remrssi_ms != 0 &&
-                   (tnow - gcs_chan[0].last_radio_status_remrssi_ms) > g.long_fs_timeout*1000) {
+                   gcs().chan(0).last_radio_status_remrssi_ms != 0 &&
+                   (tnow - gcs().chan(0).last_radio_status_remrssi_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_GCS, MODE_REASON_GCS_FAILSAFE);
         }
     } else {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -46,7 +46,7 @@ void AP_Frsky_Telem::init(const AP_SerialManager &serial_manager, const char *fi
     } else if ((_port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough, 0))) {
         _protocol = AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough; // FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
         // make frsky_telemetry available to GCS_MAVLINK (used to queue statustext messages from GCS_MAVLINK)
-        GCS_MAVLINK::register_frsky_telemetry_callback(this);
+        gcs().register_frsky_telemetry_callback(this);
         // add firmware and frame info to message queue
         queue_message(MAV_SEVERITY_INFO, firmware_str);
         // save main parameters locally

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -22,12 +22,6 @@
 #define CHECK_PAYLOAD_SIZE(id) if (comm_get_txspace(chan) < packet_overhead()+MAVLINK_MSG_ID_ ## id ## _LEN) return false
 #define CHECK_PAYLOAD_SIZE2(id) if (!HAVE_PAYLOAD_SPACE(chan, id)) return false
 
-#if HAL_CPU_CLASS <= HAL_CPU_CLASS_150 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    #define GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY          5
-#else
-    #define GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY          30
-#endif
-
 //  GCS Message ID's
 /// NOTE: to ensure we never block on sending MAVLink messages
 /// please keep each MSG_ to a single MAVLink message. If need be
@@ -79,7 +73,6 @@ enum ap_message {
     MSG_RETRY_DEFERRED // this must be last
 };
 
-
 ///
 /// @class	GCS_MAVLINK
 /// @brief	MAVLink transport control class
@@ -103,13 +96,6 @@ public:
     // packetReceived is called on any successful decode of a mavlink message
     virtual void packetReceived(const mavlink_status_t &status,
                                 mavlink_message_t &msg);
-
-    struct statustext_t {
-        uint8_t                 bitmask;
-        mavlink_statustext_t    msg;
-    };
-    static ObjectArray<statustext_t> _statustext_queue;
-
 
     // accessor for uart
     AP_HAL::UARTDriver *get_uart() { return _port; }
@@ -177,14 +163,15 @@ public:
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }
 
+    // return a bitmap of streaming channels
+    static uint8_t streaming_channel_mask(void) { return chan_is_streaming; }
+
     /*
     send a statustext message to active MAVLink connections, or a specific
     one. This function is static so it can be called from any library.
     */
     static void send_statustext_all(MAV_SEVERITY severity, const char *fmt, ...);
     static void send_statustext_chan(MAV_SEVERITY severity, uint8_t dest_chan, const char *fmt, ...);
-    static void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
-    static void service_statustext(void);
 
     // send a PARAM_VALUE message to all active MAVLink connections.
     static void send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value);
@@ -205,20 +192,6 @@ public:
       returns if a matching component is found
      */
     static bool find_by_mavtype(uint8_t mav_type, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel) { return routing.find_by_mavtype(mav_type, sysid, compid, channel); }
-
-    /*
-      set a dataflash pointer for logging
-     */
-    static void set_dataflash(DataFlash_Class *dataflash) {
-        dataflash_p = dataflash;
-    }
-
-    /*
-      set a frsky_telem pointer for queueing
-     */
-    static void register_frsky_telemetry_callback(AP_Frsky_Telem *frsky_telemetry) {
-        frsky_telemetry_p = frsky_telemetry;
-    }
 
     // update signing timestamp on GPS lock
     static void update_signing_timestamp(uint64_t timestamp_usec);
@@ -381,9 +354,6 @@ private:
     // mavlink routing object
     static MAVLink_routing routing;
 
-    // pointer to static dataflash for logging of text messages
-    static DataFlash_Class *dataflash_p;
-
     // pointer to static frsky_telem for queueing of text messages
     static AP_Frsky_Telem *frsky_telemetry_p;
  
@@ -422,3 +392,71 @@ private:
     bool signing_enabled(void) const;
     static void save_signing_timestamp(bool force_save_now);
 };
+
+/// @class GCS
+/// @brief global GCS object
+class GCS
+{
+
+public:
+
+    GCS() {
+        if (_singleton  == nullptr) {
+            _singleton = this;
+        } else {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            // this is a serious problem, but we don't need to kill a
+            // real vehicle
+            AP_HAL::panic("GCS must be singleton");
+#endif
+        }
+    };
+
+    static class GCS *instance() {
+        return _singleton;
+    }
+
+    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
+    void service_statustext(void);
+
+    /*
+      set a dataflash pointer for logging
+     */
+    void set_dataflash(DataFlash_Class *dataflash) {
+        dataflash_p = dataflash;
+    }
+
+    // pointer to static dataflash for logging of text messages
+    DataFlash_Class *dataflash_p;
+
+
+    /*
+      set a frsky_telem pointer for queueing
+     */
+    void register_frsky_telemetry_callback(AP_Frsky_Telem *frsky_telemetry) {
+        frsky_telemetry_p = frsky_telemetry;
+    }
+
+    // static frsky_telem pointer to support queueing text messages
+    AP_Frsky_Telem *frsky_telemetry_p;
+
+private:
+
+    static GCS *_singleton;
+
+    struct statustext_t {
+        uint8_t                 bitmask;
+        mavlink_statustext_t    msg;
+    };
+
+#if HAL_CPU_CLASS <= HAL_CPU_CLASS_150 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    static const uint8_t _status_capacity = 5;
+#else
+    static const uint8_t _status_capacity = 30;
+#endif
+
+    ObjectArray<statustext_t> _statustext_queue{_status_capacity};
+
+};
+
+GCS &gcs();

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -46,12 +46,6 @@ static uint8_t mavlink_locked_mask;
 // routing table
 MAVLink_routing GCS_MAVLINK::routing;
 
-// static dataflash pointer to support logging text messages
-DataFlash_Class *GCS_MAVLINK::dataflash_p;
-
-// static frsky_telem pointer to support queueing text messages
-AP_Frsky_Telem *GCS_MAVLINK::frsky_telemetry_p;
- 
 // static AP_SerialManager pointer
 const AP_SerialManager *GCS_MAVLINK::serialmanager_p;
 

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -30,7 +30,7 @@ private:
 
 
 static const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-static GCS_MAVLINK_routing gcs[MAVLINK_COMM_NUM_BUFFERS];
+static GCS_MAVLINK_routing gcs_link[MAVLINK_COMM_NUM_BUFFERS];
 
 extern mavlink_system_t mavlink_system;
 
@@ -42,8 +42,8 @@ static MAVLink_routing routing;
 
 void setup(void)
 {
-    hal.console->printf("routing test startup...\n");
-    gcs[0].init(hal.uartA, MAVLINK_COMM_0);
+    hal.console->printf("routing test startup...");
+    gcs_link[0].init(hal.uartA, MAVLINK_COMM_0);
 }
 
 void loop(void)


### PR DESCRIPTION
This GCS singleton implementation has anybody that wants to use the GCS singleton call their method on the result of gcs().

So, for example, gcs()->send_statustext(...)

gcs() is a method on each vehicle; in vehicle code it will return a subclass of GCS:: - for example, GCS_Rover.  gcs() is also a function defined by GCS.h - it is in the top-level namespace.  library code calling gcs() will thus get a generic GCS:: object, so can only call methods available on the top-level object.

This is in contrast to https://github.com/ArduPilot/ardupilot/pull/4241; calling GCS:instance() to get the singleton.  Vehicle code which wanted to call a e.g. ->send_rover_specific_message() would need to use _gcs to call that method.  Using gcs() avoids having to change code as it is moved around.
