### PR TITLE
Copter: AC_Avoid library to stop at circular fence

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -76,6 +76,7 @@ Copter::Copter(void) :
     pos_control(ahrs, inertial_nav, motors, attitude_control,
                 g.p_alt_hold, g.p_vel_z, g.pid_accel_z,
                 g.p_pos_xy, g.pi_vel_xy),
+    avoid(ahrs, inertial_nav, fence),
     wp_nav(inertial_nav, ahrs, pos_control, attitude_control),
     circle_nav(inertial_nav, ahrs, pos_control),
     pmTest1(0),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -76,6 +76,7 @@
 #include <AC_WPNav/AC_Circle.h>          // circle navigation library
 #include <AP_Declination/AP_Declination.h>     // ArduPilot Mega Declination Helper Library
 #include <AC_Fence/AC_Fence.h>           // Arducopter Fence library
+#include <AC_Avoidance/AC_Avoid.h>           // Arducopter stop at fence library
 #include <AP_Scheduler/AP_Scheduler.h>       // main loop scheduler
 #include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library
 #include <AP_Notify/AP_Notify.h>          // Notify library
@@ -458,6 +459,7 @@ private:
     AC_AttitudeControl_Multi attitude_control;
 #endif
     AC_PosControl pos_control;
+    AC_Avoid avoid;
     AC_WPNav wp_nav;
     AC_Circle circle_nav;
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -825,6 +825,10 @@ const AP_Param::Info Copter::var_info[] = {
     GOBJECT(fence,      "FENCE_",   AC_Fence),
 #endif
 
+    // @Group: AVOID_
+    // @Path: ../libraries/AC_Avoidance/AC_Avoid.cpp
+    GOBJECT(avoid,      "AVOID_",   AC_Avoid),
+
 #if AC_RALLY == ENABLED
     // @Group: RALLY_
     // @Path: ../libraries/AP_Rally/AP_Rally.cpp

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -181,6 +181,7 @@ public:
         k_param_fs_crash_check,
         k_param_throw_motor_start,
         k_param_terrain_follow,    // 94
+        k_param_avoid,
 
         // 97: RSSI
         k_param_rssi = 97,

--- a/ArduCopter/make.inc
+++ b/ArduCopter/make.inc
@@ -43,6 +43,7 @@ LIBRARIES += AC_WPNav
 LIBRARIES += AC_Circle
 LIBRARIES += AP_Declination
 LIBRARIES += AC_Fence
+LIBRARIES += AC_Avoidance
 LIBRARIES += AP_Scheduler
 LIBRARIES += AP_RCMapper
 LIBRARIES += AP_Notify

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -200,6 +200,7 @@ void Copter::init_ardupilot()
     Location_Class::set_terrain(&terrain);
     wp_nav.set_terrain(&terrain);
 #endif
+    wp_nav.set_avoidance(&avoid);
 
     pos_control.set_dt(MAIN_LOOP_SECONDS);
 

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -11,6 +11,7 @@ def build(bld):
             'AC_AttitudeControl',
             'AC_InputManager',
             'AC_Fence',
+            'AC_Avoidance',
             'AC_PID',
             'AC_PrecLand',
             'AC_Sprayer',

--- a/ArduPlane/make.inc
+++ b/ArduPlane/make.inc
@@ -54,4 +54,6 @@ LIBRARIES += AC_AttitudeControl
 LIBRARIES += AC_PID
 LIBRARIES += AP_InertialNav
 LIBRARIES += AC_WPNav
+LIBRARIES += AC_Fence
+LIBRARIES += AC_Avoidance
 LIBRARIES += AP_Tuning

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -6,6 +6,8 @@
 #include <AP_InertialNav/AP_InertialNav.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AC_WPNav/AC_WPNav.h>
+#include <AC_Fence/AC_Fence.h>
+#include <AC_Avoidance/AC_Avoid.h>
 
 /*
   frame types for quadplane build. Most case be set with

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -26,7 +26,9 @@ def build(bld):
             'AC_WPNav',
             'AC_AttitudeControl',
             'AP_Motors',
-            'AC_PID'
+            'AC_PID',
+            'AC_Fence',
+            'AC_Avoidance'
         ],
         use='mavlink',
     )

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -396,8 +396,9 @@ def fly_fence_test(mavproxy, mav, timeout=180):
     mavproxy.send('switch 5\n') # loiter mode
     wait_mode(mav, 'LOITER')
 
-    # enable fence
+    # enable fence, disable avoidance
     mavproxy.send('param set FENCE_ENABLE 1\n')
+    mavproxy.send('param set AVOID_ENABLE 0\n')
 
     # first east
     print("turn east")
@@ -435,8 +436,11 @@ def fly_fence_test(mavproxy, mav, timeout=180):
             wait_mode(mav, 'STABILIZE')
             print("Reached home OK")
             return True
-    # disable fence
+
+    # disable fence, enable avoidance
     mavproxy.send('param set FENCE_ENABLE 0\n')
+    mavproxy.send('param set AVOID_ENABLE 1\n')
+
     # reduce throttle
     mavproxy.send('rc 3 1000\n')
     # switch mode to stabilize

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1,0 +1,117 @@
+#include "AC_Avoid.h"
+
+const AP_Param::GroupInfo AC_Avoid::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Avoidance control enable/disable
+    // @Description: Enabled/disable stopping at fence
+    // @Values: 0:None,1:StopAtFence
+    // @User: Standard
+    AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_STOP_AT_FENCE),
+
+    AP_GROUPEND
+};
+
+/// Constructor
+AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence)
+    : _ahrs(ahrs),
+      _inav(inav),
+      _fence(fence)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel)
+{
+    // exit immediately if disabled
+    if (_enabled == AC_AVOID_DISABLED) {
+        return;
+    }
+
+    // limit acceleration
+    float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
+
+    if (_enabled == AC_AVOID_STOP_AT_FENCE) {
+        adjust_velocity_circle(kP, accel_cmss_limited, desired_vel);
+    }
+}
+
+/*
+ * Adjusts the desired velocity for the circular fence.
+ */
+void AC_Avoid::adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel)
+{
+    // exit if circular fence is not enabled
+    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
+        return;
+    }
+
+    // get position as a 2D offset in cm from ahrs home
+    const Vector2f position_xy = get_position();
+
+    float speed = desired_vel.length();
+    // get the fence radius in cm
+    const float fence_radius = _fence.get_radius() * 100.0f;
+    // get the margin to the fence in cm
+    const float margin = get_margin();
+
+    if (!is_zero(speed) && position_xy.length() <= fence_radius) {
+        // Currently inside circular fence
+        Vector2f stopping_point = position_xy + desired_vel*(get_stopping_distance(kP, accel_cmss, speed)/speed);
+        float stopping_point_length = stopping_point.length();
+        if (stopping_point_length > fence_radius - margin) {
+            // Unsafe desired velocity - will not be able to stop before fence breach
+            // Project stopping point radially onto fence boundary
+            // Adjusted velocity will point towards this projected point at a safe speed
+            Vector2f target = stopping_point * ((fence_radius - margin) / stopping_point_length);
+            Vector2f target_direction = target - position_xy;
+            float distance_to_target = target_direction.length();
+            float max_speed = get_max_speed(kP, accel_cmss, distance_to_target);
+            desired_vel = target_direction * (MIN(speed,max_speed) / distance_to_target);
+        }
+    }
+}
+
+/*
+ * Gets the current xy-position, relative to home (not relative to EKF origin)
+ */
+Vector2f AC_Avoid::get_position()
+{
+    const Vector3f position_xyz = _inav.get_position();
+    const Vector2f position_xy(position_xyz.x,position_xyz.y);
+    const Vector2f diff = location_diff(_inav.get_origin(),_ahrs.get_home()) * 100.0f;
+    return position_xy - diff;
+}
+
+/*
+ * Computes the speed such that the stopping distance
+ * of the vehicle will be exactly the input distance.
+ */
+float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const float distance)
+{
+    return AC_AttitudeControl::sqrt_controller(distance, kP, accel_cmss);
+}
+
+/*
+ * Computes distance required to stop, given current speed.
+ *
+ * Implementation copied from AC_PosControl.
+ */
+float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, const float speed)
+{
+    // avoid divide by zero by using current position if the velocity is below 10cm/s, kP is very low or acceleration is zero
+    if (kP <= 0.0f || accel_cmss <= 0.0f || is_zero(speed)) {
+        return 0.0f;
+    }
+
+    // calculate point at which velocity switches from linear to sqrt
+    float linear_speed = accel_cmss/kP;
+
+    // calculate distance within which we can stop
+    if (speed < linear_speed) {
+        return speed/kP;
+    } else {
+        float linear_distance = accel_cmss/(2.0f*kP*kP);
+        return linear_distance + (speed*speed)/(2.0f*accel_cmss);
+    }
+}

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -8,7 +8,7 @@
 #include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude controller library for sqrt controller
 #include <AC_Fence/AC_Fence.h>         // Failsafe fence library
 
-#define AC_AVOID_ACCEL_CMSS_MAX         250.0f  // maximum acceleration/deceleration in cm/s/s used to avoid hitting fence
+#define AC_AVOID_ACCEL_CMSS_MAX         100.0f  // maximum acceleration/deceleration in cm/s/s used to avoid hitting fence
 
 // bit masks for enabled fence types.
 #define AC_AVOID_DISABLED               0       // avoidance disabled

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_AHRS/AP_AHRS.h>     // AHRS library
+#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
+#include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude controller library for sqrt controller
+#include <AC_Fence/AC_Fence.h>         // Failsafe fence library
+
+#define AC_AVOID_ACCEL_CMSS_MAX         250.0f  // maximum acceleration/deceleration in cm/s/s used to avoid hitting fence
+
+// bit masks for enabled fence types.
+#define AC_AVOID_DISABLED               0       // avoidance disabled
+#define AC_AVOID_STOP_AT_FENCE          1       // stop at fence
+
+/*
+ * This class prevents the vehicle from leaving a polygon fence in
+ * 2 dimensions by limiting velocity (adjust_velocity).
+ */
+class AC_Avoid {
+public:
+
+    /// Constructor
+    AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence);
+
+    /*
+     * Adjusts the desired velocity so that the vehicle can stop
+     * before the fence/object.
+     */
+    void adjust_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel);
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+
+    /*
+     * Adjusts the desired velocity for the circular fence.
+     */
+    void adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel);
+
+    /*
+     * Gets the current position, relative to home (not relative to EKF origin)
+     */
+    Vector2f get_position();
+
+    /*
+     * Computes the speed such that the stopping distance
+     * of the vehicle will be exactly the input distance.
+     */
+    float get_max_speed(const float kP, const float accel_cmss, const float distance);
+
+    /*
+     * Computes distance required to stop, given current speed.
+     */
+    float get_stopping_distance(const float kP, const float accel_cmss, const float speed);
+
+    /*
+     * Gets the fence margin in cm
+     */
+    float get_margin() { return _fence.get_margin() * 100.0f; }
+
+    // external references
+    const AP_AHRS& _ahrs;
+    const AP_InertialNav& _inav;
+    const AC_Fence& _fence;
+
+    // parameters
+    AP_Int8 _enabled;
+};

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -75,6 +75,12 @@ public:
     /// get_safe_alt - returns maximum safe altitude (i.e. alt_max - margin)
     float get_safe_alt() const { return _alt_max - _margin; }
 
+    /// get_radius - returns the fence radius in meters
+    float get_radius() const { return _circle_radius.get(); }
+
+    /// get_margin - returns the fence margin in meters
+    float get_margin() const { return _margin.get(); }
+
     /// manual_recovery_start - caller indicates that pilot is re-taking manual control so fence should be disabled for 10 seconds
     ///     should be called whenever the pilot changes the flight mode
     ///     has no effect if no breaches have occurred

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -304,6 +304,11 @@ void AC_WPNav::calc_loiter_desired_velocity(float nav_dt, float ekfGndSpdLimit)
         desired_vel.y = desired_vel.y * gnd_speed_limit_cms / horizSpdDem;
     }
 
+    // Limit the velocity to prevent fence violations
+    if (_avoid != NULL) {
+        _avoid->adjust_velocity(_pos_control.get_pos_xy_kP(), _loiter_accel_cmss, desired_vel);
+    }
+
     // send adjusted feed forward velocity back to position controller
     _pos_control.set_desired_velocity_xy(desired_vel.x,desired_vel.y);
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -9,6 +9,7 @@
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
 #include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude control library
 #include <AP_Terrain/AP_Terrain.h>
+#include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
 // loiter maximum velocities and accelerations
 #define WPNAV_ACCELERATION              100.0f      // defines the default velocity vs distant curve.  maximum acceleration in cm/s/s that position controller asks for from acceleration controller
@@ -58,6 +59,9 @@ public:
 
     /// provide pointer to terrain database
     void set_terrain(AP_Terrain* terrain_ptr) { _terrain = terrain_ptr; }
+
+    /// provide pointer to avoidance library
+    void set_avoidance(AC_Avoid* avoid_ptr) { _avoid = avoid_ptr; }
 
     /// provide rangefinder altitude
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_use = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
@@ -315,6 +319,7 @@ protected:
     AC_PosControl&          _pos_control;
     const AC_AttitudeControl& _attitude_control;
     AP_Terrain              *_terrain = NULL;
+    AC_Avoid                *_avoid = NULL;
 
     // parameters
     AP_Float    _loiter_speed_cms;      // maximum horizontal speed in cm/s while in loiter


### PR DESCRIPTION
This is a PR from Dan Ricketts (with design input from Leonard and implementation input from Randy) which causes the vehicle to stop at the circular fence.