### PR TITLE
Perf counters improvements (v3)

### DIFF
--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -151,6 +151,10 @@ def check_librt(cfg, env):
 
 @conf
 def check_lttng(cfg, env):
+    if cfg.options.disable_lttng:
+        cfg.msg("Checking for 'lttng-ust':", 'disabled', color='YELLOW')
+        return False
+
     cfg.check_cfg(package='lttng-ust', mandatory=False, global_define=True,
                   args=['--libs', '--cflags'])
     env.LIB += cfg.env['LIB_LTTNG-UST']

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -162,6 +162,10 @@ def check_lttng(cfg, env):
 
 @conf
 def check_libiio(cfg, env):
+    if cfg.options.disable_libiio:
+        cfg.msg("Checking for 'libiio':", 'disabled', color='YELLOW')
+        return False
+
     cfg.check_cfg(package='libiio', mandatory=False, global_define=True,
                   args=['--libs', '--cflags'])
     env.LIB += cfg.env['LIB_LIBIIO']

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -55,5 +55,4 @@ namespace Linux {
     class VideoIn;
     class OpticalFlow_Onboard;
     class Flow_PX4;
-    class Perf_Lttng;
 }

--- a/libraries/AP_HAL_Linux/Perf.cpp
+++ b/libraries/AP_HAL_Linux/Perf.cpp
@@ -77,7 +77,7 @@ void Perf::_debug_counters()
                     "max: %llu\t"
                     "avg: %.4f\t"
                     "stddev: %.4f\n",
-                    c.name, c.count, c.least, c.most, c.mean, sqrt(c.m2));
+                    c.name, c.count, c.min, c.max, c.avg, sqrt(c.m2));
         } else {
             fprintf(stderr, "%-30s\t"
                     "count: %llu\n",
@@ -161,22 +161,22 @@ void Perf::end(Util::perf_counter_t pc)
     perf.count++;
     perf.total += elapsed;
 
-    if (perf.least > elapsed) {
-        perf.least = elapsed;
+    if (perf.min > elapsed) {
+        perf.min = elapsed;
     }
 
-    if (perf.most < elapsed) {
-        perf.most = elapsed;
+    if (perf.max < elapsed) {
+        perf.max = elapsed;
     }
 
     /*
-     * Maintain mean and variance of interval in nanoseconds
-     * Knuth/Welford recursive mean and variance of update intervals (via Wikipedia)
+     * Maintain avg and variance of interval in nanoseconds
+     * Knuth/Welford recursive avg and variance of update intervals (via Wikipedia)
      * Same implementation of PX4.
      */
-    const double delta_intvl = elapsed - perf.mean;
-    perf.mean += (delta_intvl / perf.count);
-    perf.m2 += (delta_intvl * (elapsed - perf.mean));
+    const double delta_intvl = elapsed - perf.avg;
+    perf.avg += (delta_intvl / perf.count);
+    perf.m2 += (delta_intvl * (elapsed - perf.avg));
     perf.start = 0;
 
     perf.lttng.end(perf.name);

--- a/libraries/AP_HAL_Linux/Perf.cpp
+++ b/libraries/AP_HAL_Linux/Perf.cpp
@@ -86,9 +86,7 @@ void Perf::begin(Util::perf_counter_t pc)
 
     perf.start = now_nsec();
 
-#ifdef HAVE_LTTNG_UST
-    perf.lttng.begin();
-#endif
+    perf.lttng.begin(perf.name);
 }
 
 void Perf::end(Util::perf_counter_t pc)
@@ -137,9 +135,7 @@ void Perf::end(Util::perf_counter_t pc)
     perf.m2 += (delta_intvl * (elapsed - perf.mean));
     perf.start = 0;
 
-#ifdef HAVE_LTTNG_UST
-    perf.lttng.end();
-#endif
+    perf.lttng.end(perf.name);
 }
 
 void Perf::count(Util::perf_counter_t pc)
@@ -161,10 +157,7 @@ void Perf::count(Util::perf_counter_t pc)
     _update_count++;
     perf.count++;
 
-#ifdef HAVE_LTTNG_UST
-    perf.lttng.count();
-#endif
-
+    perf.lttng.count(perf.name, perf.count);
 }
 
 Util::perf_counter_t Perf::add(Util::perf_counter_type type, const char *name)

--- a/libraries/AP_HAL_Linux/Perf.h
+++ b/libraries/AP_HAL_Linux/Perf.h
@@ -37,17 +37,12 @@ public:
     Perf_Counter(perf_counter_type type_, const char *name_)
         : name{name_}
         , type{type_}
-#ifdef HAVE_LTTNG_UST
-        , lttng{name_}
-#endif
         , least{ULONG_MAX}
     {
     }
 
     const char *name;
-#ifdef HAVE_LTTNG_UST
     Perf_Lttng lttng;
-#endif
 
     perf_counter_type type;
 

--- a/libraries/AP_HAL_Linux/Perf.h
+++ b/libraries/AP_HAL_Linux/Perf.h
@@ -1,0 +1,97 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+ * Copyright (C) 2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <atomic>
+#include <limits.h>
+#include <pthread.h>
+#include <vector>
+
+#include "AP_HAL_Linux.h"
+#include "Perf_Lttng.h"
+#include "Thread.h"
+#include "Util.h"
+
+namespace Linux {
+
+class Perf_Counter {
+    using perf_counter_type = AP_HAL::Util::perf_counter_type;
+    using perf_counter_t = AP_HAL::Util::perf_counter_t;
+
+public:
+    Perf_Counter(perf_counter_type type_, const char *name_)
+        : name{name_}
+        , type{type_}
+#ifdef HAVE_LTTNG_UST
+        , lttng{name_}
+#endif
+        , least{ULONG_MAX}
+    {
+    }
+
+    const char *name;
+#ifdef HAVE_LTTNG_UST
+    Perf_Lttng lttng;
+#endif
+
+    perf_counter_type type;
+
+    uint64_t count;
+
+    /* Everything below is in nanoseconds */
+    uint64_t start;
+    uint64_t total;
+    uint64_t least;
+    uint64_t most;
+
+    double mean;
+    double m2;
+};
+
+class Perf {
+    using perf_counter_type = AP_HAL::Util::perf_counter_type;
+    using perf_counter_t = AP_HAL::Util::perf_counter_t;
+
+public:
+    ~Perf();
+
+    static Perf *get_instance();
+
+    perf_counter_t add(perf_counter_type type, const char *name);
+
+    void begin(perf_counter_t pc);
+    void end(perf_counter_t pc);
+    void count(perf_counter_t pc);
+
+    unsigned int get_update_count() { return _update_count; }
+
+private:
+    static Perf *_instance;
+
+    Perf();
+
+    std::vector<Perf_Counter> _perf_counters;
+
+    /* synchronize addition of new perf counters */
+    pthread_rwlock_t _perf_counters_lock;
+
+    /* allow to check if memory pool has changed */
+    std::atomic<unsigned int> _update_count;
+};
+
+}

--- a/libraries/AP_HAL_Linux/Perf.h
+++ b/libraries/AP_HAL_Linux/Perf.h
@@ -80,6 +80,10 @@ private:
 
     Perf();
 
+    void _debug_counters();
+
+    uint64_t _last_debug_msec;
+
     std::vector<Perf_Counter> _perf_counters;
 
     /* synchronize addition of new perf counters */

--- a/libraries/AP_HAL_Linux/Perf.h
+++ b/libraries/AP_HAL_Linux/Perf.h
@@ -37,7 +37,7 @@ public:
     Perf_Counter(perf_counter_type type_, const char *name_)
         : name{name_}
         , type{type_}
-        , least{ULONG_MAX}
+        , min{ULONG_MAX}
     {
     }
 
@@ -51,10 +51,10 @@ public:
     /* Everything below is in nanoseconds */
     uint64_t start;
     uint64_t total;
-    uint64_t least;
-    uint64_t most;
+    uint64_t min;
+    uint64_t max;
 
-    double mean;
+    double avg;
     double m2;
 };
 

--- a/libraries/AP_HAL_Linux/Perf_Lttng.cpp
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.cpp
@@ -24,66 +24,27 @@
 #include "AP_HAL_Linux.h"
 #include "Perf_Lttng_TracePoints.h"
 #include "Perf_Lttng.h"
-#include "Util.h"
-
-#pragma GCC diagnostic ignored "-Wcast-align"
 
 using namespace Linux;
 
-Perf_Lttng::Perf_Lttng(AP_HAL::Util::perf_counter_type type, const char *name)
-    : _type(type)
+Perf_Lttng::Perf_Lttng(const char *name)
 {
     strncpy(_name, name, MAX_TRACEPOINT_NAME_LEN);
 }
 
 void Perf_Lttng::begin()
 {
-    if (_type != AP_HAL::Util::PC_ELAPSED) {
-        return;
-    }
     tracepoint(ardupilot, begin, _name);
 }
 
 void Perf_Lttng::end()
 {
-    if (_type != AP_HAL::Util::PC_ELAPSED) {
-        return;
-    }
     tracepoint(ardupilot, end, _name);
 }
 
 void Perf_Lttng::count()
 {
-    if (_type != AP_HAL::Util::PC_COUNT) {
-        return;
-    }
     tracepoint(ardupilot, count, _name, ++_count);
-}
-
-Util::perf_counter_t Util::perf_alloc(perf_counter_type type, const char *name)
-{
-    return new Linux::Perf_Lttng(type, name);
-}
-
-void Util::perf_begin(perf_counter_t perf)
-{
-    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
-
-    perf_lttng->begin();
-}
-
-void Util::perf_end(perf_counter_t perf)
-{
-    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
-
-    perf_lttng->end();
-}
-
-void Util::perf_count(perf_counter_t perf)
-{
-    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
-
-    perf_lttng->count();
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/Perf_Lttng.cpp
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.cpp
@@ -19,32 +19,35 @@
 
 #include <string.h>
 
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_HAL_Linux.h"
 #include "Perf_Lttng_TracePoints.h"
 #include "Perf_Lttng.h"
 
 using namespace Linux;
 
-Perf_Lttng::Perf_Lttng(const char *name)
+void Perf_Lttng::begin(const char *name)
 {
-    strncpy(_name, name, MAX_TRACEPOINT_NAME_LEN);
+    tracepoint(ardupilot, begin, name);
 }
 
-void Perf_Lttng::begin()
+void Perf_Lttng::end(const char *name)
 {
-    tracepoint(ardupilot, begin, _name);
+    tracepoint(ardupilot, end, name);
 }
 
-void Perf_Lttng::end()
+void Perf_Lttng::count(const char *name, uint64_t val)
 {
-    tracepoint(ardupilot, end, _name);
+    tracepoint(ardupilot, count, name, val);
 }
 
-void Perf_Lttng::count()
-{
-    tracepoint(ardupilot, count, _name, ++_count);
-}
+#else
+
+#include "Perf_Lttng.h"
+
+using namespace Linux;
+
+void Perf_Lttng::begin(const char *name) { }
+void Perf_Lttng::end(const char *name) { }
+void Perf_Lttng::count(const char *name, uint64_t val) { }
 
 #endif

--- a/libraries/AP_HAL_Linux/Perf_Lttng.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.h
@@ -14,23 +14,17 @@
  */
 #pragma once
 
-#include <AP_HAL/Util.h>
+#include <inttypes.h>
 
 #include "AP_HAL_Linux.h"
-
-#define MAX_TRACEPOINT_NAME_LEN 128
 
 namespace Linux {
 
 class Perf_Lttng {
 public:
-    Perf_Lttng(const char *name);
-    void begin();
-    void end();
-    void count();
-private:
-    char _name[MAX_TRACEPOINT_NAME_LEN];
-    uint64_t _count;
+    void begin(const char *name);
+    void end(const char *name);
+    void count(const char *name, uint64_t val);
 };
 
 }

--- a/libraries/AP_HAL_Linux/Perf_Lttng.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.h
@@ -12,21 +12,25 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #pragma once
-#include "AP_HAL_Linux.h"
+
 #include <AP_HAL/Util.h>
+
+#include "AP_HAL_Linux.h"
 
 #define MAX_TRACEPOINT_NAME_LEN 128
 
-class Linux::Perf_Lttng {
+namespace Linux {
+
+class Perf_Lttng {
 public:
-    Perf_Lttng(enum AP_HAL::Util::perf_counter_type type, const char *name);
+    Perf_Lttng(const char *name);
     void begin();
     void end();
     void count();
 private:
     char _name[MAX_TRACEPOINT_NAME_LEN];
     uint64_t _count;
-    enum AP_HAL::Util::perf_counter_type _type;
 };
+
+}

--- a/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
@@ -28,7 +28,7 @@ TRACEPOINT_EVENT(
     ardupilot,
     begin,
     TP_ARGS(
-        char*, name_arg
+        const char*, name_arg
     ),
     TP_FIELDS(
         ctf_string(name_field, name_arg)
@@ -39,7 +39,7 @@ TRACEPOINT_EVENT(
     ardupilot,
     end,
     TP_ARGS(
-        char*, name_arg
+        const char*, name_arg
     ),
     TP_FIELDS(
         ctf_string(name_field, name_arg)
@@ -50,7 +50,7 @@ TRACEPOINT_EVENT(
     ardupilot,
     count,
     TP_ARGS(
-        char*, name_arg,
+        const char*, name_arg,
         int, count_arg
     ),
     TP_FIELDS(

--- a/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
@@ -62,4 +62,3 @@ TRACEPOINT_EVENT(
 #endif
 
 #include <lttng/tracepoint-event.h>
-

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -4,6 +4,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_HAL_Linux_Namespace.h"
+#include "Perf.h"
 #include "ToneAlarm.h"
 #include "Semaphores.h"
 
@@ -63,10 +64,25 @@ public:
      */
     int read_file(const char *path, const char *fmt, ...) FMT_SCANF(3, 4);
 
-    perf_counter_t perf_alloc(perf_counter_type t, const char *name) override;
-    void perf_begin(perf_counter_t perf) override;
-    void perf_end(perf_counter_t perf) override;
-    void perf_count(perf_counter_t perf) override;
+    perf_counter_t perf_alloc(enum perf_counter_type t, const char *name) override
+    {
+        return Perf::get_instance()->add(t, name);
+    }
+
+    void perf_begin(perf_counter_t perf) override
+    {
+        return Perf::get_instance()->begin(perf);
+    }
+
+    void perf_end(perf_counter_t perf) override
+    {
+        return Perf::get_instance()->end(perf);
+    }
+
+    void perf_count(perf_counter_t perf) override
+    {
+        return Perf::get_instance()->count(perf);
+    }
 
     // create a new semaphore
     AP_HAL::Semaphore *new_semaphore(void) override { return new Linux::Semaphore; }

--- a/wscript
+++ b/wscript
@@ -80,6 +80,10 @@ revisions.
         default=False,
         help='Configure as debug variant.')
 
+    g.add_option('--disable-lttng', action='store_true',
+        default=False,
+        help="Don't use lttng even if supported by board and dependencies available")
+
 def configure(cfg):
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug

--- a/wscript
+++ b/wscript
@@ -84,6 +84,10 @@ revisions.
         default=False,
         help="Don't use lttng even if supported by board and dependencies available")
 
+    g.add_option('--disable-libiio', action='store_true',
+        default=False,
+        help="Don't use libiio even if supported by board and dependencies available")
+
 def configure(cfg):
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug


### PR DESCRIPTION
v3 of #4224. Changes:

  - First 2 commits already applied
  - Remove commit avoiding div by 0 since I hope we don't have batteries on drones lasting for million years
  - Clarify comment about implemented counters
  - Move call to `_perf_counters.size()` to be inside the locked region since otherwise we could have a race between any 2 places adding a counter
  - Rebase

I hoped after this time we could already have the d-bus part, but I prefer to postpone this to when we have #4024 working since it will use the same infra.