### PR TITLE
Ignore unused result warning

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -64,6 +64,27 @@ char (&_ARRAY_SIZE_HELPER(T (&_arr)[0]))[0];
 
 #define ARRAY_SIZE(_arr) sizeof(_ARRAY_SIZE_HELPER(_arr))
 
+/*
+ * See UNUSED_RESULT. The difference is that it receives @uniq_ as the name to
+ * be used for its internal variable.
+ *
+ * @uniq_: a unique name to use for variable name
+ * @expr_: the expression to be evaluated
+ */
+#define _UNUSED_RESULT(uniq_, expr_)                      \
+    do {                                                  \
+        decltype(expr_) uniq_ __attribute__((unused));    \
+        uniq_ = expr_;                                    \
+    } while (0)
+
+/*
+ * Allow to call a function annotated with warn_unused_result attribute
+ * without getting a warning, because sometimes this is what we want to do.
+ *
+ * @expr_: the expression to be evaluated
+ */
+#define UNUSED_RESULT(expr_) _UNUSED_RESULT(__unique_name_##__COUNTER__, expr_)
+
 // @}
 
 

--- a/libraries/AP_HAL_Linux/system.cpp
+++ b/libraries/AP_HAL_Linux/system.cpp
@@ -3,6 +3,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/system.h>
 #include <AP_HAL_Linux/Scheduler.h>
@@ -27,7 +28,7 @@ void panic(const char *errormsg, ...)
     va_start(ap, errormsg);
     vdprintf(1, errormsg, ap);
     va_end(ap);
-    write(1, "\n", 1);
+    UNUSED_RESULT(write(1, "\n", 1));
 
     hal.rcin->deinit();
     hal.scheduler->delay_microseconds(10000);


### PR DESCRIPTION
Implementation of what was discussed in #4277 - commit message of the first commit has more details about it. Tested on gcc and clang.