### PR TITLE
GCS_MAVLink: fix race condition when recieving last waypoint

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1010,17 +1010,15 @@ GCS_MAVLINK::update(run_cli_fn run_cli)
     uint32_t tnow = AP_HAL::millis();
     uint32_t wp_recv_time = 1000U + (stream_slowdown*20);
 
-    if (waypoint_receiving &&
-        waypoint_request_i <= waypoint_request_last &&
-        tnow - waypoint_timelast_request > wp_recv_time) {
+    // stop waypoint receiving if timeout
+    if (waypoint_receiving && (tnow - waypoint_timelast_receive) > wp_recv_time+waypoint_receive_timeout) {
+        waypoint_receiving = false;
+    } else if (waypoint_receiving &&
+               (tnow - waypoint_timelast_request) > wp_recv_time) {
         waypoint_timelast_request = tnow;
         send_message(MSG_NEXT_WAYPOINT);
     }
 
-    // stop waypoint receiving if timeout
-    if (waypoint_receiving && (tnow - waypoint_timelast_receive) > wp_recv_time+waypoint_receive_timeout) {
-        waypoint_receiving = false;
-    }
 }
 
 


### PR DESCRIPTION
This only shows up when the waypoint is about to time out, as when the aircraft isn't in receiving mode we will nack the last packet if it gets uploaded, but GCS will drop this as it is not uncommon to see a nack on upload, and lack of prompting by the autopilot on the last items will indicate success.

The removal of the waypoint_request_i <= waypoint_request_last is fine, as when we increment waypoint_request_i we already check that against the last request and exit the revceiving mode.

Tagged as safety critical as this can convince a GCS that it succeeded on uploading the last waypoint when it failed to, which could surprise users. (This is a rare occurrence).