### PR TITLE
Copter: polygon fence including stopping at the fence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ ArduCopter/terrain/*.DAT
 ArduCopter/test.ArduCopter/
 ArduCopter/test/*
 ArduCopter/way.txt
+ArduCopter/fence.txt
 ArduPlane/logs/
 ArduPlane/test/*
 ArduPlane/terrain/*.DAT

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1944,6 +1944,14 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
 #endif
 
+#if AC_FENCE == ENABLED
+    // send or receive fence points with GCS
+    case MAVLINK_MSG_ID_FENCE_POINT:            // MAV ID: 160
+    case MAVLINK_MSG_ID_FENCE_FETCH_POINT:
+        copter.fence.handle_msg(chan, msg);
+        break;
+#endif // AC_FENCE == ENABLED
+
 #if CAMERA == ENABLED
     //deprecated.  Use MAV_CMD_DO_DIGICAM_CONFIGURE
     case MAVLINK_MSG_ID_DIGICAM_CONFIGURE:      // MAV ID: 202

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -46,6 +46,11 @@ void AC_Avoid::adjust_velocity_circle(const float kP, const float accel_cmss, Ve
         return;
     }
 
+    // exit if the circular fence has already been breached
+    if ((_fence.get_breaches() & AC_FENCE_TYPE_CIRCLE) != 0) {
+        return;
+    }
+
     // get position as a 2D offset in cm from ahrs home
     const Vector2f position_xy = get_position();
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -33,6 +33,7 @@ void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f 
 
     if (_enabled == AC_AVOID_STOP_AT_FENCE) {
         adjust_velocity_circle(kP, accel_cmss_limited, desired_vel);
+        adjust_velocity_poly(kP, accel_cmss_limited, desired_vel);
     }
 }
 
@@ -78,6 +79,86 @@ void AC_Avoid::adjust_velocity_circle(const float kP, const float accel_cmss, Ve
 }
 
 /*
+ * Adjusts the desired velocity for the polygon fence.
+ */
+
+void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel)
+{
+    // exit if the polygon fence is not enabled
+    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
+        return;
+    }
+
+    // exit if the polygon fence has already been breached
+    if ((_fence.get_breaches() & AC_FENCE_TYPE_POLYGON) != 0) {
+        return;
+    }
+
+    // get polygon boundary
+    // Note: first point in list is the return-point (which copter does not use)
+    uint16_t num_points;
+    Vector2f* boundary = _fence.get_polygon_points(num_points);
+
+    // exit if there are no points
+    if (boundary == NULL || num_points == 0) {
+        return;
+    }
+
+    // do not adjust velocity if vehicle is outside the polygon fence
+    const Vector3f& position = _inav.get_position();
+    Vector2f position_xy(position.x, position.y);
+    if (_fence.boundary_breached(position_xy, num_points, boundary)) {
+        return;
+    }
+
+    // Safe_vel will be adjusted to remain within fence.
+    // We need a separate vector in case adjustment fails,
+    // e.g. if we are exactly on the boundary.
+    Vector2f safe_vel(desired_vel);
+
+    uint16_t i, j;
+    for (i = 1, j = num_points-1; i < num_points; j = i++) {
+        // end points of current edge
+        Vector2f start = boundary[j];
+        Vector2f end = boundary[i];
+        // vector from current position to closest point on current edge
+        Vector2f limit_direction = closest_point(position_xy, start, end) - position_xy;
+        // distance to closest point
+        const float limit_distance = limit_direction.length();
+        if (!is_zero(limit_distance)) {
+            // We are strictly inside the given edge.
+            // Adjust velocity to not violate this edge.
+            limit_direction /= limit_distance;
+            limit_velocity(kP, accel_cmss, safe_vel, limit_direction, limit_distance);
+        } else {
+            // We are exactly on the edge - treat this as a fence breach.
+            // i.e. do not adjust velocity.
+            return;
+        }
+    }
+
+    desired_vel = safe_vel;
+}
+
+/*
+ * Limits the component of desired_vel in the direction of the unit vector
+ * limit_direction to be at most the maximum speed permitted by the limit_distance.
+ *
+ * Uses velocity adjustment idea from Randy's second email on this thread:
+ * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
+ */
+void AC_Avoid::limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float limit_distance) const
+{
+    const float max_speed = get_max_speed(kP, accel_cmss, limit_distance - get_margin());
+    // project onto limit direction
+    const float speed = desired_vel * limit_direction;
+    if (speed > max_speed) {
+        // subtract difference between desired speed and maximum acceptable speed
+        desired_vel += limit_direction*(max_speed - speed);
+    }
+}
+
+/*
  * Gets the current xy-position, relative to home (not relative to EKF origin)
  */
 Vector2f AC_Avoid::get_position()
@@ -118,5 +199,33 @@ float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, co
     } else {
         float linear_distance = accel_cmss/(2.0f*kP*kP);
         return linear_distance + (speed*speed)/(2.0f*accel_cmss);
+    }
+}
+
+/*
+ * Returns the point closest to p on the line segment (v,w).
+ *
+ * Comments and implementation taken from
+ * http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
+ */
+Vector2f AC_Avoid::closest_point(Vector2f p, Vector2f v, Vector2f w) const
+{
+    // length squared of line segment
+    const float l2 = (v - w).length_squared();
+    if (is_zero(l2)) {
+        // v == w case
+        return v;
+    }
+    // Consider the line extending the segment, parameterized as v + t (w - v).
+    // We find projection of point p onto the line.
+    // It falls where t = [(p-v) . (w-v)] / |w-v|^2
+    // We clamp t from [0,1] to handle points outside the segment vw.
+    const float t = ((p - v) * (w - v)) / l2;
+    if (t <= 0) {
+        return v;
+    } else if (t >= 1) {
+        return w;
+    } else {
+        return v + (w - v)*t;
     }
 }

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -87,7 +87,7 @@ Vector2f AC_Avoid::get_position()
  * Computes the speed such that the stopping distance
  * of the vehicle will be exactly the input distance.
  */
-float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const float distance)
+float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const float distance) const
 {
     return AC_AttitudeControl::sqrt_controller(distance, kP, accel_cmss);
 }
@@ -97,7 +97,7 @@ float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const floa
  *
  * Implementation copied from AC_PosControl.
  */
-float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, const float speed)
+float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, const float speed) const
 {
     // avoid divide by zero by using current position if the velocity is below 10cm/s, kP is very low or acceleration is zero
     if (kP <= 0.0f || accel_cmss <= 0.0f || is_zero(speed)) {

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -48,17 +48,17 @@ private:
      * Computes the speed such that the stopping distance
      * of the vehicle will be exactly the input distance.
      */
-    float get_max_speed(const float kP, const float accel_cmss, const float distance);
+    float get_max_speed(const float kP, const float accel_cmss, const float distance) const;
 
     /*
      * Computes distance required to stop, given current speed.
      */
-    float get_stopping_distance(const float kP, const float accel_cmss, const float speed);
+    float get_stopping_distance(const float kP, const float accel_cmss, const float speed) const;
 
     /*
      * Gets the fence margin in cm
      */
-    float get_margin() { return _fence.get_margin() * 100.0f; }
+    float get_margin() const { return _fence.get_margin() * 100.0f; }
 
     // external references
     const AP_AHRS& _ahrs;

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -40,6 +40,21 @@ private:
     void adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel);
 
     /*
+     * Adjusts the desired velocity for the polygon fence.
+     */
+    void adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel);
+
+
+    /*
+     * Limits the component of desired_vel in the direction of the unit vector
+     * limit_direction to be at most the maximum speed permitted by the limit_distance.
+     *
+     * Uses velocity adjustment idea from Randy's second email on this thread:
+     * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
+     */
+    void limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float limit_distance) const;
+
+    /*
      * Gets the current position, relative to home (not relative to EKF origin)
      */
     Vector2f get_position();
@@ -59,6 +74,11 @@ private:
      * Gets the fence margin in cm
      */
     float get_margin() const { return _fence.get_margin() * 100.0f; }
+
+    /*
+     * returns the point closest to p on the line segment (v,w)
+     */
+    Vector2f closest_point(Vector2f p, Vector2f v, Vector2f w) const;
 
     // external references
     const AP_AHRS& _ahrs;

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -5,12 +5,15 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
+#include <AP_Fence/AP_PolyFence_loader.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_NONE                          0       // fence disabled
 #define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
 #define AC_FENCE_TYPE_CIRCLE                        2       // circular horizontal fence (usually initiates an RTL)
+#define AC_FENCE_TYPE_POLYGON                       4       // polygon horizontal fence
 
 // valid actions should a fence be breached
 #define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
@@ -93,6 +96,19 @@ public:
     /// set_home_distance - update vehicle's distance from home in meters - required for circular horizontal fence monitoring
     void set_home_distance(float distance) { _home_distance = distance; }
 
+    ///
+    /// polygon related methods
+    ///
+
+    /// returns pointer to array of polygon points and num_points is filled in with the total number
+    Vector2f* get_polygon_points(uint16_t& num_points) const;
+
+    /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
+    bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const;
+
+    /// handler for polygon fence messages with GCS
+    void handle_msg(mavlink_channel_t chan, mavlink_message_t* msg);
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -102,6 +118,9 @@ private:
 
     /// clear_breach - update breach bitmask, time and count
     void clear_breach(uint8_t fence_type);
+
+    /// load polygon points stored in eeprom into boundary array and perform validation.  returns true if load successfully completed
+    bool load_polygon_from_eeprom(bool force_reload = false);
 
     // pointers to other objects we depend upon
     const AP_InertialNav& _inav;
@@ -113,6 +132,7 @@ private:
     AP_Float        _alt_max;               // altitude upper limit in meters
     AP_Float        _circle_radius;         // circle fence radius in meters
     AP_Float        _margin;                // distance in meters that autopilot's should maintain from the fence to avoid a breach
+    AP_Int8         _total;                 // number of polygon points saved in eeprom
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away
@@ -131,4 +151,13 @@ private:
     uint16_t        _breach_count;          // number of times we have breached the fence
 
     uint32_t        _manual_recovery_start_ms;  // system time in milliseconds that pilot re-took manual control
+
+    // polygon fence variables
+    AP_PolyFence_loader _poly_loader;               // helper for loading/saving polygon points
+    Vector2f        *_boundary = NULL;              // array of boundary points.  Note: point 0 is the return point
+    uint8_t         _boundary_num_points = 0;       // number of points in the boundary array (should equal _total parameter after load has completed)
+    bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
+    bool            _boundary_loaded = false;       // true if boundary array has been loaded from eeprom
+    bool            _boundary_valid = false;        // true if boundary forms a closed polygon
+    bool            _boundary_revalidate = false;   // set to true when we need to revalidate the boundary (required after a point is changed)
 };

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -7,7 +7,7 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
-#include <AP_Fence/AP_PolyFence_loader.h>
+#include <AC_Fence/AC_PolyFence_loader.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_NONE                          0       // fence disabled
@@ -153,7 +153,7 @@ private:
     uint32_t        _manual_recovery_start_ms;  // system time in milliseconds that pilot re-took manual control
 
     // polygon fence variables
-    AP_PolyFence_loader _poly_loader;               // helper for loading/saving polygon points
+    AC_PolyFence_loader _poly_loader;               // helper for loading/saving polygon points
     Vector2f        *_boundary = NULL;              // array of boundary points.  Note: point 0 is the return point
     uint8_t         _boundary_num_points = 0;       // number of points in the boundary array (should equal _total parameter after load has completed)
     bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -1,0 +1,144 @@
+#include "AC_PolyFence_loader.h"
+
+extern const AP_HAL::HAL& hal;
+
+static const StorageAccess fence_storage(StorageManager::StorageFence);
+
+/*
+  maximum number of fencepoints
+ */
+uint8_t AC_PolyFence_loader::max_points() const
+{
+    return MIN(255U, fence_storage.size() / sizeof(Vector2l));
+}
+
+// create buffer to hold copy of eeprom points in RAM
+// returns NULL if not enough memory can be allocated
+void* AC_PolyFence_loader::create_point_array(uint8_t element_size)
+{
+    uint32_t array_size = max_points() * element_size;
+    if (hal.util->available_memory() < 100U + array_size) {
+        // too risky to enable as we could run out of stack
+        return NULL;
+    }
+
+    return calloc(1, array_size);
+}
+
+// load boundary point from eeprom, returns true on successful load
+bool AC_PolyFence_loader::load_point_from_eeprom(uint16_t i, Vector2l& point)
+{
+    // sanity check index
+    if (i >= max_points()) {
+        return false;
+    }
+
+    // read fence point
+    point.x = fence_storage.read_uint32(i * sizeof(Vector2l));
+    point.y = fence_storage.read_uint32(i * sizeof(Vector2l) + 4);
+    return true;
+}
+
+// save a fence point to eeprom, returns true on successful save
+bool AC_PolyFence_loader::save_point_to_eeprom(uint16_t i, const Vector2l& point)
+{
+    // sanity check index
+    if (i >= max_points()) {
+        return false;
+    }
+
+    // write point to eeprom
+    fence_storage.write_uint32(i * sizeof(Vector2l), point.x);
+    fence_storage.write_uint32(i * sizeof(Vector2l)+4, point.y);
+    return true;
+}
+
+// validate array of boundary points (expressed as either floats or long ints)
+//   contains_return_point should be true for plane which stores the return point as the first point in the array
+//   returns true if boundary is valid
+bool AC_PolyFence_loader::boundary_valid(uint16_t num_points, const Vector2l* points, bool contains_return_point) const
+{
+    // exit immediate if no points
+    if (points == NULL) {
+        return false;
+    }
+
+    // start from 2nd point if boundary contains return point (as first point)
+    uint8_t start_num = contains_return_point ? 1 : 0;
+
+    // a boundary requires at least 4 point (a triangle and last point equals first)
+    if (num_points < start_num + 4) {
+        return false;
+    }
+
+    // point 1 and last point must be the same.  Note: 0th point is reserved as the return point
+    if (!Polygon_complete(&points[start_num], num_points-start_num)) {
+        return false;
+    }
+
+    // check return point is within the fence
+    if (contains_return_point && Polygon_outside(points[0], &points[1], num_points-start_num)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool AC_PolyFence_loader::boundary_valid(uint16_t num_points, const Vector2f* points, bool contains_return_point) const
+{
+    // exit immediate if no points
+    if (points == NULL) {
+        return false;
+    }
+
+    // start from 2nd point if boundary contains return point (as first point)
+    uint8_t start_num = contains_return_point ? 1 : 0;
+
+    // a boundary requires at least 4 point (a triangle and last point equals first)
+    if (num_points < start_num + 4) {
+        return false;
+    }
+
+    // point 1 and last point must be the same.  Note: 0th point is reserved as the return point
+    if (!Polygon_complete(&points[start_num], num_points-start_num)) {
+        return false;
+    }
+
+    // check return point is within the fence
+    if (contains_return_point && Polygon_outside(points[0], &points[1], num_points-start_num)) {
+        return false;
+    }
+
+    return true;
+}
+
+// check if a location (expressed as either floats or long ints) is within the boundary
+//   contains_return_point should be true for plane which stores the return point as the first point in the array
+//   returns true if location is outside the boundary
+bool AC_PolyFence_loader::boundary_breached(const Vector2l& location, uint16_t num_points, const Vector2l* points, bool contains_return_point) const
+{
+    // exit immediate if no points
+    if (points == NULL) {
+        return false;
+    }
+
+    // start from 2nd point if boundary contains return point (as first point)
+    uint8_t start_num = contains_return_point ? 1 : 0;
+
+    // check location is within the fence
+    return Polygon_outside(location, &points[start_num], num_points-start_num);
+}
+
+bool AC_PolyFence_loader::boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points, bool contains_return_point) const
+{
+    // exit immediate if no points
+    if (points == NULL) {
+        return false;
+    }
+
+    // start from 2nd point if boundary contains return point (as first point)
+    uint8_t start_num = contains_return_point ? 1 : 0;
+
+    // check location is within the fence
+    return Polygon_outside(location, &points[start_num], num_points-start_num);
+}

--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+
+class AC_PolyFence_loader
+{
+
+public:
+
+    // maximum number of fence points we can store in eeprom
+    uint8_t max_points() const;
+
+    // create buffer to hold copy of eeprom points in RAM
+    // returns NULL if not enough memory can be allocated
+    void* create_point_array(uint8_t element_size);
+
+    // load boundary point from eeprom, returns true on successful load
+    bool load_point_from_eeprom(uint16_t i, Vector2l& point);
+
+    // save a fence point to eeprom, returns true on successful save
+    bool save_point_to_eeprom(uint16_t i, const Vector2l& point);
+
+    // validate array of boundary points (expressed as either floats or long ints)
+    //   contains_return_point should be true for plane which stores the return point as the first point in the array
+    //   returns true if boundary is valid
+    bool boundary_valid(uint16_t num_points, const Vector2l* points, bool contains_return_point) const;
+    bool boundary_valid(uint16_t num_points, const Vector2f* points, bool contains_return_point) const;
+
+    // check if a location (expressed as either floats or long ints) is within the boundary
+    //   contains_return_point should be true for plane which stores the return point as the first point in the array
+    //   returns true if location is outside the boundary
+    bool boundary_breached(const Vector2l& location, uint16_t num_points, const Vector2l* points, bool contains_return_point) const;
+    bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points, bool contains_return_point) const;
+
+};
+

--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -35,7 +35,8 @@
  *  expect that to be very small over the distances involved in the
  *  fence boundary
  */
-bool Polygon_outside(const Vector2l &P, const Vector2l *V, unsigned n)
+template <typename T>
+bool Polygon_outside(const Vector2<T> &P, const Vector2<T> *V, unsigned n)
 {
     unsigned i, j;
     bool outside = true;
@@ -85,7 +86,14 @@ bool Polygon_outside(const Vector2l &P, const Vector2l *V, unsigned n)
  *  and the first point is the same as the last point. That is the
  *  minimum requirement for the Polygon_outside function to work
  */
-bool Polygon_complete(const Vector2l *V, unsigned n)
+template <typename T>
+bool Polygon_complete(const Vector2<T> *V, unsigned n)
 {
     return (n >= 4 && V[n-1].x == V[0].x && V[n-1].y == V[0].y);
 }
+
+// Necessary to avoid linker errors
+template bool Polygon_outside<int32_t>(const Vector2l &P, const Vector2l *V, unsigned n);
+template bool Polygon_complete<int32_t>(const Vector2l *V, unsigned n);
+template bool Polygon_outside<float>(const Vector2f &P, const Vector2f *V, unsigned n);
+template bool Polygon_complete<float>(const Vector2f *V, unsigned n);

--- a/libraries/AP_Math/polygon.h
+++ b/libraries/AP_Math/polygon.h
@@ -20,6 +20,8 @@
 
 #include "vector2.h"
 
-bool        Polygon_outside(const Vector2l &P, const Vector2l *V, unsigned n);
-bool        Polygon_complete(const Vector2l *V, unsigned n);
+template <typename T>
+bool        Polygon_outside(const Vector2<T> &P, const Vector2<T> *V, unsigned n);
+template <typename T>
+bool        Polygon_complete(const Vector2<T> *V, unsigned n);
 


### PR DESCRIPTION
This feature adds support for Polygon fences in the same style and format as Plane.  It also includes extra code from Daniel Ricketts to allow the vehicle to stop at the fence in Loiter mode.

I've created a new class in the AP_Fence library called AP_Polygon_loader.  This is based on work from Peter Barker to generalize Plane's geofence feature into a library (see PR: https://github.com/ArduPilot/ardupilot/pull/4251)

All feedback welcome!