### PR TITLE
Plane: reduce elevator input when rolled past LIM_ROLL_CD

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -164,7 +164,7 @@ void Plane::ahrs_update()
     }
 
     // calculate a scaled roll limit based on current pitch
-    roll_limit_cd = g.roll_limit_cd * cosf(ahrs.pitch);
+    roll_limit_cd = aparm.roll_limit_cd * cosf(ahrs.pitch);
     pitch_limit_min_cd = aparm.pitch_limit_min_cd * fabsf(cosf(ahrs.roll));
 
     // updated the summed gyro used for ground steering and

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -736,7 +736,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Range: 0 9000
     // @Increment: 1
     // @User: Standard
-    GSCALAR(roll_limit_cd,          "LIM_ROLL_CD",    HEAD_MAX_CENTIDEGREE),
+    ASCALAR(roll_limit_cd,          "LIM_ROLL_CD",    HEAD_MAX_CENTIDEGREE),
 
     // @Param: LIM_PITCH_MAX
     // @DisplayName: Maximum Pitch Angle

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -449,7 +449,6 @@ public:
 
     // Navigational maneuvering limits
     //
-    AP_Int16 roll_limit_cd;
     AP_Int16 alt_offset;
     AP_Int16 acro_roll_rate;
     AP_Int16 acro_pitch_rate;

--- a/ArduPlane/arming_checks.cpp
+++ b/ArduPlane/arming_checks.cpp
@@ -30,9 +30,9 @@ bool AP_Arming_Plane::pre_arm_checks(bool report)
     // Check airspeed sensor
     ret &= AP_Arming::airspeed_checks(report);
 
-    if (plane.g.roll_limit_cd < 300) {
+    if (plane.aparm.roll_limit_cd < 300) {
         if (report) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: LIM_ROLL_CD too small (%u)", plane.g.roll_limit_cd);
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: LIM_ROLL_CD too small (%u)", plane.aparm.roll_limit_cd);
         }
         ret = false;        
     }

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -201,7 +201,27 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
     }
 
 	_last_out += _pid_info.I;
-	
+
+    /*
+      when we are past the users defined roll limit for the
+      aircraft our priority should be to bring the aircraft back
+      within the roll limit. Using elevator for pitch control at
+      large roll angles is ineffective, and can be counter
+      productive as it induces earth-frame yaw which can reduce
+      the ability to roll. We linearly reduce elevator input when
+      beyond the configured roll limit, reducing to zero at 90
+      degrees
+    */
+    float roll_wrapped = fabsf(_ahrs.roll_sensor);
+    if (roll_wrapped > 9000) {
+        roll_wrapped = 18000 - roll_wrapped;
+    }
+    if (roll_wrapped > aparm.roll_limit_cd + 500 && aparm.roll_limit_cd < 8500 &&
+        labs(_ahrs.pitch_sensor) < 7000) {
+        float roll_prop = (roll_wrapped - (aparm.roll_limit_cd+500)) / (float)(9000 - aparm.roll_limit_cd);
+        _last_out *= (1 - roll_prop);
+    }
+    
 	// Convert to centi-degrees and constrain
 	return constrain_float(_last_out * 100, -4500, 4500);
 }

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -35,6 +35,7 @@ public:
         AP_Int8 takeoff_throttle_max;
         AP_Int16 airspeed_min;
         AP_Int16 airspeed_max;
+        AP_Int16 roll_limit_cd;
         AP_Int16 pitch_limit_max_cd;
         AP_Int16 pitch_limit_min_cd;        
         AP_Int8  autotune_level;


### PR DESCRIPTION
this reduces elevator input when rolled well past the roll limit of the aircraft. This helps with recovery from inverted flight and produces a much neater horizontal roll.
