### PR TITLE
Waf: autoconfig

### DIFF
--- a/wscript
+++ b/wscript
@@ -82,6 +82,23 @@ revisions.
         default=False,
         help='Configure as debug variant.')
 
+def _collect_autoconfig_files(cfg):
+    for m in sys.modules.values():
+        paths = []
+        if hasattr(m, '__file__'):
+            paths.append(m.__file__)
+        elif hasattr(m, '__path__'):
+            for p in m.__path__:
+                paths.append(p)
+
+        for p in paths:
+            if p in cfg.files or not os.path.isfile(p):
+                continue
+
+            with open(p, 'rb') as f:
+                cfg.hash = Utils.h_list((cfg.hash, f.read()))
+                cfg.files.append(p)
+
 def configure(cfg):
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
@@ -141,6 +158,8 @@ def configure(cfg):
     cfg.define('_GNU_SOURCE', 1)
 
     cfg.write_config_header(os.path.join(cfg.variant, 'ap_config.h'))
+
+    _collect_autoconfig_files(cfg)
 
 def collect_dirs_to_recurse(bld, globs, **kw):
     dirs = []

--- a/wscript
+++ b/wscript
@@ -10,7 +10,9 @@ sys.path.insert(0, 'Tools/ardupilotwaf/')
 import ardupilotwaf
 import boards
 
-from waflib import Build, ConfigSet, Context, Utils
+from waflib import Build, ConfigSet, Configure, Context, Utils
+
+Configure.autoconfig = 'clobber'
 
 # TODO: implement a command 'waf help' that shows the basic tasks a
 # developer might want to do: e.g. how to configure a board, compile a


### PR DESCRIPTION
Hi guys,

This PR is enabling the use of Waf's autoconfig feature and extends its functionality to look into all loaded modules instead of only modules loaded by the `recurse()` function.

For some reason, it seems that I've lost my rights to push to our Waf submodule, so this depends on applying the following branch in my fork to our submodule fork: https://github.com/guludo/waf/tree/ap-autoconfig

Best,
Gustavo Sousa