### PR TITLE
AP_HAL_Linux: Change the way to calculate pwm bitmask in ToneAlarm

### DIFF
--- a/libraries/AP_HAL_Linux/ToneAlarm_Raspilot.cpp
+++ b/libraries/AP_HAL_Linux/ToneAlarm_Raspilot.cpp
@@ -181,16 +181,9 @@ void ToneAlarm_Raspilot::_set_pwm0_period(uint32_t time_us)
 void ToneAlarm_Raspilot::_set_pwm0_duty(uint8_t percent)
 {
     int bit_count = constrain_int32(320 * percent / 100, 320, 0);
-    unsigned int bits = 0;
 
     // FIXME: bits overflows for any bit_count > 32
-    while (bit_count) {
-      bits <<= 1;
-      bits |= 1;
-      bit_count--;
-    }
-
-    *(_pwm + RPI_PWM_DAT1) = bits;
+    *(_pwm + RPI_PWM_DAT1) = (1U << bit_count) - 1;
 }
 
 #endif


### PR DESCRIPTION
Simple change.