### PR TITLE
AP_ADSB: allow param based VEHICLE list sizes, 1 to 100.

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -27,8 +27,9 @@
 #include <GCS_MAVLink/GCS.h>
 
 #define VEHICLE_THREAT_RADIUS_M         1000
-#define VEHICLE_LIST_LENGTH             25      // # of ADS-B vehicles to remember at any given time
 #define VEHICLE_TIMEOUT_MS              10000   // if no updates in this time, drop it from the list
+#define ADSB_VEHICLE_LIST_SIZE_DEFAULT  25
+#define ADSB_VEHICLE_LIST_SIZE_MAX      100
 
 class AP_ADSB
 {
@@ -106,6 +107,8 @@ private:
 
     AP_Int8     _enabled;
     AP_Int8     _behavior;
+    AP_Int16    _list_size_param;
+    uint16_t    _list_size = 1; // start with tiny list, then change to param-defined size. This ensures it doesn't fail on start
     adsb_vehicle_t *_vehicle_list;
     uint16_t    _vehicle_count = 0;
     bool        _another_vehicle_within_radius = false;


### PR DESCRIPTION
Instead of a fixed 25, allow flexible ADSB_VEHICLE list length. Shorter lists can loop faster with slower links via stream rate SRx_ADSB. The list always contains the nearest vehicles by distance.

Example: list of 25 aircraft and SRx_ADSB=5 means it takes 2.5s to loop through. List can loop faster by either raising SR (increasing bandwidth) or with this PR by reducing list length (ignore further vehicles). For applications where the GCS and bandwidth doesn't matter, you can raise the list count to be very high. List size can go up to 100 but still limited by ADSB hardware limitations.

@rmackay9 would be nice if we can get this into copter v3.4.