### PR TITLE
AP_Airspeed: reword calibrations start message

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -192,7 +192,7 @@ void AP_Airspeed::update_calibration(float raw_pressure)
 {
     if (AP_HAL::millis() - _cal.start_ms >= 1000) {
         if (_cal.count == 0) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Airspeed sensor unhealthy");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Airspeed sensor calibrating");
         } else {
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Airspeed sensor calibrated");
             _offset.set_and_save(_cal.sum / _cal.count);


### PR DESCRIPTION
Airspeed unhealthy sounds much scarier on the GCS then the actual situation is, and in many cases I don't ever recieve the "Airspeed sensor calibrated" message on the GCS causing the only message I have to be the unhealthy one which is alarming. (sensor health should also exclusively be reported via the sys_status health bits)