### PR TITLE
Fix zero-based bug in RCInput example.

### DIFF
--- a/libraries/AP_HAL/examples/RCInput/RCInput.cpp
+++ b/libraries/AP_HAL/examples/RCInput/RCInput.cpp
@@ -34,7 +34,7 @@ void loop(void)
         }
     }
     if (changed) {
-        for (uint8_t i=0; i<max_channels; i++) {
+        for (uint8_t i=0; i<=max_channels; i++) {
             hal.console->printf("%2u:%04u ", (unsigned)i+1, (unsigned)last_value[i]);
         }
         hal.console->println();


### PR DESCRIPTION
RCInput example code uses the variable “max_channels” to display the PWM signals to the console. In a previous for loop (Line 26), “nchannels” was compared to “i”. However, “nchannels” is one-based, whereas max_channels is zero-based. Tested and working on a HK32Pilot (Pixhawk clone) with an Orange R616xn PPM receiver.