### PR TITLE
EKF2: micellaneous bug fixes and robustness and accuracy improvements

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -24,7 +24,7 @@
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
-#define ABIAS_P_NSE_DEFAULT     1.0E-03f
+#define ABIAS_P_NSE_DEFAULT     5.0E-03f
 #define MAGB_P_NSE_DEFAULT      5.0E-04f
 #define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -49,7 +49,7 @@
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
-#define ABIAS_P_NSE_DEFAULT     1.0E-03f
+#define ABIAS_P_NSE_DEFAULT     5.0E-03f
 #define MAGB_P_NSE_DEFAULT      5.0E-04f
 #define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -74,7 +74,7 @@
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
-#define ABIAS_P_NSE_DEFAULT     1.0E-03f
+#define ABIAS_P_NSE_DEFAULT     5.0E-03f
 #define MAGB_P_NSE_DEFAULT      5.0E-04f
 #define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -99,7 +99,7 @@
 #define ACC_P_NSE_DEFAULT       6.0E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
-#define ABIAS_P_NSE_DEFAULT     1.0E-03f
+#define ABIAS_P_NSE_DEFAULT     5.0E-03f
 #define MAGB_P_NSE_DEFAULT      5.0E-04f
 #define MAGE_P_NSE_DEFAULT      5.0E-03f
 #define VEL_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -940,6 +940,15 @@ void NavEKF2::getInnovations(int8_t instance, Vector3f &velInnov, Vector3f &posI
     }
 }
 
+// publish output observer angular, velocity and position tracking error
+void NavEKF2::getOutputTrackingError(int8_t instance, Vector3f &error) const
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (core) {
+        core[instance].getOutputTrackingError(error);
+    }
+}
+
 // return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
 void NavEKF2::getVariances(int8_t instance, float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset)
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -458,7 +458,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: -1 100
     // @Increment: 10
     // @User: Advanced
-    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 50),
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 10),
 
     // @Param: MAGE_P_NSE
     // @DisplayName: Earth magnetic field process noise (gauss/s)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -454,11 +454,11 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
 
     // @Param: TAU_OUTPUT
     // @DisplayName: Output complementary filter time constant (centi-sec)
-    // @Description: Sets the time constant of the output complementary filter/predictor in centi-seconds. Set to a negative number to use a computationally cheaper and less accurate method with an automatically calculated time constant.
-    // @Range: -1 100
-    // @Increment: 10
+    // @Description: Sets the time constant of the output complementary filter/predictor in centi-seconds.
+    // @Range: 5 30
+    // @Increment: 5
     // @User: Advanced
-    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 10),
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 20),
 
     // @Param: MAGE_P_NSE
     // @DisplayName: Earth magnetic field process noise (gauss/s)
@@ -475,7 +475,6 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     // @Units: gauss/s
     AP_GROUPINFO("MAGB_P_NSE", 41, NavEKF2, _magBodyProcessNoise, MAGB_P_NSE_DEFAULT),
-
 
     AP_GROUPEND
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -455,10 +455,10 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: TAU_OUTPUT
     // @DisplayName: Output complementary filter time constant (centi-sec)
     // @Description: Sets the time constant of the output complementary filter/predictor in centi-seconds.
-    // @Range: 5 30
+    // @Range: 10 50
     // @Increment: 5
     // @User: Advanced
-    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 20),
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 25),
 
     // @Param: MAGE_P_NSE
     // @DisplayName: Earth magnetic field process noise (gauss/s)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -174,6 +174,9 @@ public:
     // An out of range instance (eg -1) returns data for the the primary instance
     void  getInnovations(int8_t index, Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov);
 
+    // publish output observer angular, velocity and position tracking error
+    void getOutputTrackingError(int8_t instance, Vector3f &error) const;
+
     // return the innovation consistency test ratios for the specified instance
     // An out of range instance (eg -1) returns data for the the primary instance
     void  getVariances(int8_t instance, float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -346,7 +346,7 @@ void NavEKF2_core::FuseMagnetometer()
         }
 
         // scale magnetometer observation error with total angular rate to allow for timing errors
-        R_MAG = sq(constrain_float(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / imuDataDelayed.delAngDT);
+        R_MAG = sq(constrain_float(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*delAngCorrected.length() / imuDataDelayed.delAngDT);
 
         // calculate common expressions used to calculate observation jacobians an innovation variance for each component
         SH_MAG[0] = sq(q0) - sq(q1) + sq(q2) - sq(q3);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -578,4 +578,10 @@ uint8_t NavEKF2_core::getFramesSincePredict(void) const
     return framesSincePredict;
 }
 
+// publish output observer angular, velocity and position tracking error
+void NavEKF2_core::getOutputTrackingError(Vector3f &error) const
+{
+    error = outputTrackError;
+}
+
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -642,16 +642,11 @@ void NavEKF2_core::calcOutputStates()
             // convert time constant from centi-seconds to seconds
             float tauPosVel = 0.01f*(float)frontend->_tauVelPosOutput;
 
-            // calculate a position correction that will be applied to the output state history
+            // calculate a position and velocity correction that will be applied to the output state history
             // to track the EKF position states with the specified time constant
             float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
             Vector3f posDelta = (stateStruct.position - outputDataDelayed.position) * velPosGain;
-
-            // calculate a velocity correction that will be applied to the output state history
-            // to track the EKF velocity states with the specified time constant
-            Vector3f velDelta;
-            float velGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
-            velDelta = (stateStruct.velocity - outputDataDelayed.velocity) * velGain;
+            Vector3f velDelta = (stateStruct.velocity - outputDataDelayed.velocity) * velPosGain;
 
             // loop through the output filter state history and apply the corrections to the velocity and position states
             // this method is too expensive to use for the attitude states due to the quaternion operations required

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -156,7 +156,7 @@ void NavEKF2_core::InitialiseVariables()
     finalInflightYawInit = false;
     finalInflightMagInit = false;
     dtIMUavg = 0.0025f;
-    dtEkfAvg = 0.01f;
+    dtEkfAvg = EKF_TARGET_DT;
     dt = 0;
     velDotNEDfilt.zero();
     lastKnownPositionNE.zero();
@@ -287,7 +287,6 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
 
     // Initialise IMU data
     dtIMUavg = _ahrs->get_ins().get_loop_delta_t();
-    dtEkfAvg = MIN(0.01f,dtIMUavg);
     readIMUData();
     storedIMU.reset_history(imuDataNew);
     imuDataDelayed = imuDataNew;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -652,8 +652,8 @@ void NavEKF2_core::calcOutputStates()
             float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
             // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * velPosGain; // I term
-            velCorrection += velDelta * velPosGain; //  I term
+            posCorrection += posDelta * velPosGain * 0.9f; // I term
+            velCorrection += velDelta * velPosGain * 0.9f; //  I term
             velDelta *= velPosGain; // P term
             posDelta *= velPosGain; // P term
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -652,8 +652,8 @@ void NavEKF2_core::calcOutputStates()
             float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
             // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * velPosGain * 0.9f; // I term
-            velCorrection += velDelta * velPosGain * 0.9f; //  I term
+            posCorrection += posDelta * sq(velPosGain) * 0.1f; // I term
+            velCorrection += velDelta * sq(velPosGain) * 0.1f; // I term
             velDelta *= velPosGain; // P term
             posDelta *= velPosGain; // P term
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -787,6 +787,8 @@ private:
     bool startPredictEnabled;       // boolean true when the frontend has given permission to start a new state prediciton cycele
     uint8_t localFilterTimeStep_ms; // average number of msec between filter updates
     float posDownObsNoise;          // observation noise variance on the vertical position used by the state and covariance update step (m^2)
+    Vector3f delAngCorrected;       // corrected IMU delta angle vector at the EKF time horizon (rad)
+    Vector3f delVelCorrected;       // corrected IMU delta velocity vector at the EKF time horizon (m/s)
 
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -761,8 +761,8 @@ private:
     output_elements outputDataNew;  // output state data at the current time step
     output_elements outputDataDelayed; // output state data at the current time step
     Vector3f delAngCorrection;      // correction applied to delta angles used by output observer to track the EKF
-    Vector3f delVelCorrection;      // correction applied to earth frame delta velocities used by output observer to track the EKF
     Vector3f velCorrection;         // correction applied to velocities used by the output observer to track the EKF
+    Vector3f posCorrection;         // correction applied to positions used by the output observer to track the EKF
     float innovYaw;                 // compass yaw angle innovation (rad)
     uint32_t timeTasReceived_ms;    // time last TAS data was received (msec)
     bool gpsGoodToAlign;            // true when the GPS quality can be used to initialise the navigation system

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -646,6 +646,8 @@ private:
     bool badMagYaw;                 // boolean true if the magnetometer is declared to be producing bad data
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
+    const float EKF_TARGET_DT = 0.01f;    // target EKF update time step
+
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
     Vector28 Kfusion;               // Kalman gain vector
     Matrix24 KH;                    // intermediate result used for covariance updates

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -258,6 +258,9 @@ public:
     // this is used by other instances to level load
     uint8_t getFramesSincePredict(void) const;
 
+    // publish output observer angular, velocity and position tracking error
+    void getOutputTrackingError(Vector3f &error) const;
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
@@ -789,6 +792,8 @@ private:
     float posDownObsNoise;          // observation noise variance on the vertical position used by the state and covariance update step (m^2)
     Vector3f delAngCorrected;       // corrected IMU delta angle vector at the EKF time horizon (rad)
     Vector3f delVelCorrected;       // corrected IMU delta velocity vector at the EKF time horizon (m/s)
+
+    Vector3f outputTrackError;
 
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1270,9 +1270,6 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
                 RI : (int16_t)(100*rngInnov),
                 meaRng : (uint16_t)(100*range),
                 errHAGL : (uint16_t)(100*gndOffsetErr),
-                angErr : 0.0f,
-                velErr : 0.0f,
-                posErr : 0.0f
             };
             WriteBlock(&pkt5, sizeof(pkt5));
         }
@@ -1425,7 +1422,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     Vector3f predictorErrors; // output predictor angle, velocity and position tracking error
     ahrs.get_NavEKF2().getFlowDebug(-1,normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
     ahrs.get_NavEKF2().getOutputTrackingError(-1,predictorErrors);
-    struct log_EKF5 pkt5 = {
+    struct log_NKF5 pkt5 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF5_MSG),
         time_us : time_us,
         normInnov : (uint8_t)(MIN(100*normInnov,255)),

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1424,7 +1424,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     float gndOffsetErr=0; // filter ground offset state error
     Vector3f predictorErrors; // output predictor angle, velocity and position tracking error
     ahrs.get_NavEKF2().getFlowDebug(-1,normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
-    ahrs.get_NavEKF2().getOutputTrackingError(0,predictorErrors);
+    ahrs.get_NavEKF2().getOutputTrackingError(-1,predictorErrors);
     struct log_EKF5 pkt5 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF5_MSG),
         time_us : time_us,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -352,6 +352,20 @@ struct PACKED log_EKF5 {
     int16_t RI;
     uint16_t meaRng;
     uint16_t errHAGL;
+};
+
+struct PACKED log_NKF5 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t normInnov;
+    int16_t FIX;
+    int16_t FIY;
+    int16_t AFI;
+    int16_t HAGL;
+    int16_t offset;
+    int16_t RI;
+    uint16_t meaRng;
+    uint16_t errHAGL;
     float angErr;
     float velErr;
     float posErr;
@@ -788,7 +802,7 @@ Format characters in the format string for binary log messages
     { LOG_EKF4_MSG, sizeof(log_EKF4), \
       "EKF4","QcccccccbbHBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
-      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,_,_,_" }, \
+      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \
@@ -797,7 +811,7 @@ Format characters in the format string for binary log messages
       "NKF3","Qcccccchhhcc","TimeUS,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT" }, \
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
       "NKF4","QcccccfbbHBHHb","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI" }, \
-    { LOG_NKF5_MSG, sizeof(log_EKF5), \
+    { LOG_NKF5_MSG, sizeof(log_NKF5), \
       "NKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos" }, \
     { LOG_NKF6_MSG, sizeof(log_EKF1), \
       "NKF6","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -352,6 +352,9 @@ struct PACKED log_EKF5 {
     int16_t RI;
     uint16_t meaRng;
     uint16_t errHAGL;
+    float angErr;
+    float velErr;
+    float posErr;
 };
 
 struct PACKED log_Cmd {
@@ -785,7 +788,7 @@ Format characters in the format string for binary log messages
     { LOG_EKF4_MSG, sizeof(log_EKF4), \
       "EKF4","QcccccccbbHBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
-      "EKF5","QBhhhcccCC","TimeUS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
+      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,_,_,_" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \
@@ -795,7 +798,7 @@ Format characters in the format string for binary log messages
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
       "NKF4","QcccccfbbHBHHb","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI" }, \
     { LOG_NKF5_MSG, sizeof(log_EKF5), \
-      "NKF5","QBhhhcccCC","TimeUS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
+      "NKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos" }, \
     { LOG_NKF6_MSG, sizeof(log_EKF1), \
       "NKF6","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_NKF7_MSG, sizeof(log_NKF2), \


### PR DESCRIPTION
Improves accuracy of covariance prediction and output observer tracking. Has been tested on replay and flight on 4 different 3DR Solo airframes. Has not been tested on other vehicles, but the changes are vehicle type agnostic.

The EK2_TAU_OUTPUT tuning parameter change improves the accuracy of copter position hold when the IMU data is noisy or has significant bias errors as the position and velocity output to the control loops nor more closely tracks the EKF states at the fusion time horizon.

The EK2_ABIAS_P_NSE parameter change addresses a vulnerability observed in a developer log where a pixhawk experienced a large and rapid temperature change in flight that resulted in the accel bias estimation not keeping up. This caused offsets in height and vertical velocity that made height control difficult. There is a small increase in noise of the bias estimate - see before and after plots from a 3DR Solo flight replay - units are cm/s/s

before:
![before](https://cloud.githubusercontent.com/assets/3596952/16486805/583896a2-3f0a-11e6-85be-5ef3fa199ca9.png)

after:
![after](https://cloud.githubusercontent.com/assets/3596952/16486809/5fd38a5c-3f0a-11e6-9fbd-a70b54298ca4.png)

Here is the temperature and Z accel of the IMU from the pixhawk that exhibited poor height control. It can be seen that a temperature swing of only 15degrees can produce a 0.5 m/s/s bias change.  This can happen over ~100 seconds which is how the updated parameter was obtained at 0.5/100 = 0.005 m/s/s/s
![screen shot 2016-06-30 at 9 39 10 pm](https://cloud.githubusercontent.com/assets/3596952/16486965/338a16e0-3f0b-11e6-9ac4-402078019161.png)

The output predictor (predicts attitude, velocity and position forward from the delayed fusion time horizon) was vulnerable to high vibration levels, aliasing and rapid bias changes in the accelerometers. This may have contributed to reports of poor flying qualities from some setups. Here is a plot of the attitude, velocity and position tracking error for a high vibration poor IMU data setup:

![tracking errors - before](https://cloud.githubusercontent.com/assets/3596952/16514681/cc573330-3fb0-11e6-9de0-173cef86e5c7.png)

This PR adds logging of the tracking errors and also implements a revised PI gain structure in the output predictor that significantly reduces these errors. Here are the tracking errors after the update:

![tracking errors - after](https://cloud.githubusercontent.com/assets/3596952/16514703/ec916e7c-3fb0-11e6-9435-c946f6a91c8e.png)

The new output observer structure has been flight tested here:

https://drive.google.com/open?id=0B0cCriOUIHS0cnh0SUZUSXRBSEk

The average filter time-step used to convert delta angles and velocities to equivalent angular rates and specific forces was not being updated, resulting in incorrect IMU bias calculation. Here is the difference to gyro bias estimates.

before
<img width="839" alt="gyro bias - before" src="https://cloud.githubusercontent.com/assets/3596952/16554948/6966e466-4215-11e6-9b15-e77ac1d4e789.png">

after
<img width="827" alt="gyro bias - after" src="https://cloud.githubusercontent.com/assets/3596952/16554958/73fb254a-4215-11e6-8518-c5a18503e7cb.png">

This has also reduced GPs innovations:

before
<img width="814" alt="vel innov - before" src="https://cloud.githubusercontent.com/assets/3596952/16554972/8f2806a8-4215-11e6-8c5b-12437734b956.png">

after
<img width="821" alt="vel innov - after" src="https://cloud.githubusercontent.com/assets/3596952/16554983/977b44dc-4215-11e6-915d-7b8ec88a51da.png">

