### PR TITLE
Replay: build: use separate library

### DIFF
--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -7,7 +7,18 @@ def build(bld):
     if not isinstance(bld.get_board(), boards.linux):
         return
 
+    vehicle = bld.path.name
+
+    bld.ap_stlib(
+        name=vehicle + '_libs',
+        vehicle=vehicle,
+        libraries=bld.ap_common_vehicle_libraries() + [
+            'AP_InertialNav',
+        ],
+        use='mavlink',
+    )
+
     bld.ap_program(
-        use='ap',
         program_groups='tools',
+        use=vehicle + '_libs',
     )


### PR DESCRIPTION
There are checks for APM_BUILD_Replay in the source code, so Replay tools needs
a separate static library.

This should fix #4281 .

Best,
Gustavo Sousa