### PR TITLE
Tracker: Pitch range and altitude calculation update

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -207,8 +207,8 @@ const AP_Param::Info Tracker::var_info[] = {
 
     // @Param: ALT_SOURCE
     // @DisplayName: Altitude Source
-    // @Description: What provides altitude information for vehicle
-    // @Values: 0:Barometer,1:GPS
+    // @Description: What provides altitude information for vehicle. Vehicle only assumes tracker has same altitude as vehicle's home
+    // @Values: 0:Barometer,1:GPS ,2:GPS vehicle only
     // @User: Standard
     GSCALAR(alt_source,				"ALT_SOURCE",	0),
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -196,15 +196,6 @@ const AP_Param::Info Tracker::var_info[] = {
     // @User: Standard
     GSCALAR(yaw_range,              "YAW_RANGE", YAW_RANGE_DEFAULT),
 
-    // @Param: PITCH_RANGE
-    // @DisplayName: Pitch Range
-    // @Description: Pitch axis total range of motion in degrees
-    // @Units: degrees
-    // @Increment: 0.1
-    // @Range: 0 180
-    // @User: Standard
-    GSCALAR(pitch_range,            "PITCH_RANGE", PITCH_RANGE_DEFAULT),
-
     // @Param: DISTANCE_MIN
     // @DisplayName: Distance minimum to target
     // @Description: Tracker will track targets at least this distance away
@@ -229,6 +220,24 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Range: 1 10
     // @User: Standard
     GSCALAR(mavlink_update_rate,	"MAV_UPDATE_RATE",	1),
+
+    // @Param: PITCH_MIN
+    // @DisplayName: Minimum Pitch Angle
+    // @Description: The lowest angle the pitch can reach
+    // @Units: Degrees
+    // @Increment: 1
+    // @Range: 0 -90
+    // @User: Standard
+    GSCALAR(pitch_min,               "PITCH_MIN",	PITCH_MIN_DEFAULT),
+
+    // @Param: PITCH_MAX
+    // @DisplayName: Maximum Pitch Angle
+    // @Description: The highest angle the pitch can reach
+    // @Units: Degrees
+    // @Increment: 1
+    // @Range: 0 90
+    // @User: Standard
+    GSCALAR(pitch_max,               "PITCH_MAX",	PITCH_MAX_DEFAULT),
 
     // barometer ground calibration. The GND_ prefix is chosen for
     // compatibility with previous releases of ArduPlane

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -87,7 +87,7 @@ public:
         k_param_yaw_trim,
         k_param_pitch_trim,
         k_param_yaw_range,
-        k_param_pitch_range,
+        k_param_pitch_range,	//deprecated
         k_param_distance_min,
         k_param_sysid_target,       // 138
         k_param_gcs3,               // stream rates for fourth MAVLink port
@@ -101,6 +101,8 @@ public:
         k_param_servo_yaw_type,
         k_param_alt_source,
         k_param_mavlink_update_rate,
+        k_param_pitch_min,
+        k_param_pitch_max,
 
         //
         // 200 : Radio settings
@@ -149,8 +151,9 @@ public:
     AP_Float yaw_trim;
     AP_Float pitch_trim;
     AP_Int16 yaw_range;             // yaw axis total range of motion in degrees
-    AP_Int16 pitch_range;           // pitch axis total range of motion in degrees
     AP_Int16 distance_min;          // target's must be at least this distance from tracker to be tracked
+    AP_Int16 pitch_min;
+    AP_Int16 pitch_max;
 
     // Waypoints
     //

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -150,6 +150,7 @@ private:
         uint32_t last_update_us;    // last position update in microseconds
         uint32_t last_update_ms;    // last position update in milliseconds
         Vector3f vel;           // the vehicle's velocity in m/s
+        int32_t relative_alt;	// the vehicle's relative altitude in meters * 100
     } vehicle;
 
     // Navigation controller state

--- a/AntennaTracker/config.h
+++ b/AntennaTracker/config.h
@@ -44,6 +44,7 @@
 #endif
 #ifndef PITCH_MIN_DEFAULT
  # define PITCH_MIN_DEFAULT -90
+#endif
 #ifndef PITCH_MAX_DEFAULT
  # define PITCH_MAX_DEFAULT 90
 #endif

--- a/AntennaTracker/config.h
+++ b/AntennaTracker/config.h
@@ -42,8 +42,10 @@
 #ifndef YAW_RANGE_DEFAULT
  # define YAW_RANGE_DEFAULT 360
 #endif
-#ifndef PITCH_RANGE_DEFAULT
- # define PITCH_RANGE_DEFAULT 180
+#ifndef PITCH_MIN_DEFAULT
+ # define PITCH_MIN_DEFAULT -90
+#ifndef PITCH_MAX_DEFAULT
+ # define PITCH_MAX_DEFAULT 90
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -26,7 +26,8 @@ enum ServoType {
 
 enum AltSource {
 	ALT_SOURCE_BARO=0,
-	ALT_SOURCE_GPS=1
+	ALT_SOURCE_GPS=1,
+	ALT_SOURCE_GPS_VEH_ONLY=2
 };
 
 //  Logging parameters

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -11,7 +11,7 @@ void Tracker::init_servos()
 {
     // setup antenna control PWM channels
     channel_yaw.set_angle(g.yaw_range * 100/2);        // yaw range is +/- (YAW_RANGE parameter/2) converted to centi-degrees
-    channel_pitch.set_angle(g.pitch_range * 100/2);    // pitch range is +/- (PITCH_RANGE parameter/2) converted to centi-degrees
+    channel_pitch.set_angle((-g.pitch_min+g.pitch_max) * 100/2);    // pitch range is +/- (PITCH_MIN/MAX parameters/2) converted to centi-degrees
 
     // move servos to mid position
     channel_yaw.output_trim();
@@ -59,7 +59,8 @@ void Tracker::update_pitch_position_servo(float pitch)
     // servo_out is in 100ths of a degree
     float ahrs_pitch = ahrs.pitch_sensor*0.01f;
     int32_t angle_err = -(ahrs_pitch - pitch) * 100.0f;
-    int32_t pitch_limit_cd = g.pitch_range*100/2;
+    int32_t pitch_min_cd = g.pitch_min*100;
+    int32_t pitch_max_cd = g.pitch_max*100;
     // Need to configure your servo so that increasing servo_out causes increase in pitch/elevation (ie pointing higher into the sky,
     // above the horizon. On my antenna tracker this requires the pitch/elevation servo to be reversed
     // param set RC2_REV -1
@@ -83,7 +84,7 @@ void Tracker::update_pitch_position_servo(float pitch)
 
     // rate limit pitch servo
     if (g.pitch_slew_time > 0.02f) {
-        uint16_t max_change = 0.02f * (pitch_limit_cd) / g.pitch_slew_time;
+        uint16_t max_change = 0.02f * ((-pitch_min_cd+pitch_max_cd)/2) / g.pitch_slew_time;
         if (max_change < 1) {
             max_change = 1;
         }
@@ -97,12 +98,12 @@ void Tracker::update_pitch_position_servo(float pitch)
     channel_pitch.set_servo_out(new_servo_out);
 
     // position limit pitch servo
-    if (channel_pitch.get_servo_out() <= -pitch_limit_cd) {
-        channel_pitch.set_servo_out(-pitch_limit_cd);
+    if (channel_pitch.get_servo_out() <= pitch_min_cd) {
+        channel_pitch.set_servo_out(pitch_min_cd);
         g.pidPitch2Srv.reset_I();
     }
-    if (channel_pitch.get_servo_out() >= pitch_limit_cd) {
-        channel_pitch.set_servo_out(pitch_limit_cd);
+    if (channel_pitch.get_servo_out() >= pitch_max_cd) {
+        channel_pitch.set_servo_out(pitch_max_cd);
         g.pidPitch2Srv.reset_I();
     }
 }
@@ -119,15 +120,17 @@ void Tracker::update_pitch_onoff_servo(float pitch)
     // get_servo_out() is in 100ths of a degree
     float ahrs_pitch = degrees(ahrs.pitch);
     float err = ahrs_pitch - pitch;
+    int32_t pitch_min_cd = g.pitch_min*100;
+    int32_t pitch_max_cd = g.pitch_max*100;
 
     float acceptable_error = g.onoff_pitch_rate * g.onoff_pitch_mintime;
     if (fabsf(err) < acceptable_error) {
         channel_pitch.set_servo_out(0);
-    } else if (err > 0) {
+    } else if ((err > 0) && (pitch*100>pitch_min_cd)) {
         // positive error means we are pointing too high, so push the
         // servo down
         channel_pitch.set_servo_out(-9000);
-    } else {
+    } else if (pitch*100<pitch_max_cd){
         // negative error means we are pointing too low, so push the
         // servo up
         channel_pitch.set_servo_out(9000);
@@ -141,8 +144,12 @@ void Tracker::update_pitch_cr_servo(float pitch)
 {
     float ahrs_pitch = degrees(ahrs.pitch);
     float err_cd = (pitch - ahrs_pitch) * 100.0f;
-    g.pidPitch2Srv.set_input_filter_all(err_cd);
-    channel_pitch.set_servo_out(g.pidPitch2Srv.get_pid());
+    int32_t pitch_min_cd = g.pitch_min*100;
+    int32_t pitch_max_cd = g.pitch_max*100;
+    if ((pitch>pitch_min_cd) && (pitch<pitch_max_cd)){
+        g.pidPitch2Srv.set_input_filter_all(err_cd);
+        channel_pitch.set_servo_out(g.pidPitch2Srv.get_pid());
+    }
 }
 
 /**

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -187,7 +187,7 @@ void Tracker::update_yaw_position_servo(float yaw)
     int32_t ahrs_yaw_cd = wrap_180_cd(ahrs.yaw_sensor);
     int32_t yaw_cd   = wrap_180_cd(yaw*100);
     int32_t yaw_limit_cd = g.yaw_range*100/2;
-    const int16_t margin = max(500, wrap_360_cd(36000-yaw_limit_cd)/2);
+    const int16_t margin = MAX(500, wrap_360_cd(36000-yaw_limit_cd)/2);
 
     // Antenna as Ballerina. Use with antenna that do not have continuously rotating servos, ie at some point in rotation
     // the servo limits are reached and the servo has to slew 360 degrees to the 'other side' to keep tracking.

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -180,7 +180,7 @@ void Tracker::update_yaw_position_servo(float yaw)
     int32_t ahrs_yaw_cd = wrap_180_cd(ahrs.yaw_sensor);
     int32_t yaw_cd   = wrap_180_cd(yaw*100);
     int32_t yaw_limit_cd = g.yaw_range*100/2;
-    const int16_t margin = 500; // 5 degrees slop
+    const int16_t margin = max(500, wrap_360_cd(36000-yaw_limit_cd)/2);
 
     // Antenna as Ballerina. Use with antenna that do not have continuously rotating servos, ie at some point in rotation
     // the servo limits are reached and the servo has to slew 360 degrees to the 'other side' to keep tracking.

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -61,7 +61,12 @@ void Tracker::update_bearing_and_distance()
     nav_status.distance = get_distance(current_loc, vehicle.location_estimate);
 
     // calculate altitude difference to vehicle using gps
-    nav_status.alt_difference_gps = (vehicle.location_estimate.alt - current_loc.alt) / 100.0f;
+    if (g.alt_source == ALT_SOURCE_GPS){
+        nav_status.alt_difference_gps = (vehicle.location_estimate.alt - current_loc.alt) / 100.0f;
+    } else {
+    	// g.alt_source == ALT_SOURCE_GPS_VEH_ONLY
+    	nav_status.alt_difference_gps = vehicle.relative_alt / 100.0f;
+    }
 
     // calculate pitch to vehicle
     // To-Do: remove need for check of control_mode
@@ -127,6 +132,7 @@ void Tracker::tracking_update_position(const mavlink_global_position_int_t &msg)
     vehicle.location.lat = msg.lat;
     vehicle.location.lng = msg.lon;
     vehicle.location.alt = msg.alt/10;
+    vehicle.relative_alt = msg.relative_alt/10;
     vehicle.vel = Vector3f(msg.vx/100.0f, msg.vy/100.0f, msg.vz/100.0f);
     vehicle.last_update_us = AP_HAL::micros();
     vehicle.last_update_ms = AP_HAL::millis();


### PR DESCRIPTION
Changing the yaw slew margin to be based on the Antenna Tracker's range. Changing pitch_range to pitch_min and pitch_max. Adding alt_source option which calculates altitude difference based off of relative altitude.