### PR TITLE
Copter: pre-arm check that rally points are within fence

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -92,7 +92,7 @@ Copter::Copter(void) :
     camera_mount(ahrs, current_loc),
 #endif
 #if AC_FENCE == ENABLED
-    fence(inertial_nav),
+    fence(ahrs, inertial_nav),
 #endif
 #if AC_RALLY == ENABLED
     rally(ahrs),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -913,6 +913,7 @@ private:
     void pre_arm_rc_checks();
     bool pre_arm_gps_checks(bool display_failure);
     bool pre_arm_ekf_attitude_check();
+    bool pre_arm_rallypoint_check();
     bool pre_arm_terrain_check(bool display_failure);
     bool arm_checks(bool display_failure, bool arming_from_gcs);
     void init_disarm_motors();

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -177,7 +177,8 @@ bool Copter::guided_set_destination(const Vector3f& destination)
 
 #if AC_FENCE == ENABLED
     // reject destination if outside the fence
-    if (!fence.check_destination_within_fence(pv_alt_above_home(destination.z)*0.01f, pv_distance_to_home_cm(destination)*0.01f)) {
+    Location_Class dest_loc(destination);
+    if (!fence.check_destination_within_fence(dest_loc)) {
         Log_Write_Error(ERROR_SUBSYSTEM_NAVIGATION, ERROR_CODE_DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
         return false;
@@ -205,13 +206,10 @@ bool Copter::guided_set_destination(const Location_Class& dest_loc)
 #if AC_FENCE == ENABLED
     // reject destination outside the fence.
     // Note: there is a danger that a target specified as a terrain altitude might not be checked if the conversion to alt-above-home fails
-    int32_t alt_target_cm;
-    if (dest_loc.get_alt_cm(Location_Class::ALT_FRAME_ABOVE_HOME, alt_target_cm)) {
-        if (!fence.check_destination_within_fence(alt_target_cm*0.01f, get_distance_cm(ahrs.get_home(), dest_loc)*0.01f)) {
-            Log_Write_Error(ERROR_SUBSYSTEM_NAVIGATION, ERROR_CODE_DEST_OUTSIDE_FENCE);
-            // failure is propagated to GCS with NAK
-            return false;
-        }
+    if (!fence.check_destination_within_fence(dest_loc)) {
+        Log_Write_Error(ERROR_SUBSYSTEM_NAVIGATION, ERROR_CODE_DEST_OUTSIDE_FENCE);
+        // failure is propagated to GCS with NAK
+        return false;
     }
 #endif
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -202,6 +202,10 @@ uint8_t AC_Fence::check_fence(float curr_alt)
 
     // polygon fence check
     if ((_enabled_fences & AC_FENCE_TYPE_POLYGON) != 0 ) {
+        // check consistency of number of points
+        if (_boundary_num_points != _total) {
+            _boundary_loaded = false;
+        }
         // load fence if necessary
         if (!_boundary_loaded) {
             load_polygon_from_eeprom();
@@ -338,6 +342,9 @@ void AC_Fence::handle_msg(mavlink_channel_t chan, mavlink_message_t* msg)
                 point.y = packet.lng*1.0e7f;
                 if (!_poly_loader.save_point_to_eeprom(packet.idx, point)) {
                     GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_WARNING, chan, "Failed to save polygon point, too many points?");
+                } else {
+                    // trigger reload of points
+                    _boundary_loaded = false;
                 }
             }
             break;

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -6,8 +6,10 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_Fence/AC_PolyFence_loader.h>
+#include <AP_Common/Location.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_NONE                          0       // fence disabled
@@ -35,7 +37,7 @@ class AC_Fence
 public:
 
     /// Constructor
-    AC_Fence(const AP_InertialNav& inav);
+    AC_Fence(const AP_AHRS& ahrs, const AP_InertialNav& inav);
 
     /// enable - allows fence to be enabled/disabled.  Note: this does not update the eeprom saved value
     void enable(bool true_false) { _enabled = true_false; }
@@ -58,7 +60,7 @@ public:
     uint8_t check_fence(float curr_alt);
 
     // returns true if the destination is within fence (used to reject waypoints outside the fence)
-    bool check_destination_within_fence(float dest_alt, float dest_distance_to_home);
+    bool check_destination_within_fence(const Location_Class& loc);
 
     /// get_breaches - returns bit mask of the fence types that have been breached
     uint8_t get_breaches() const { return _breached_fences; }
@@ -123,6 +125,7 @@ private:
     bool load_polygon_from_eeprom(bool force_reload = false);
 
     // pointers to other objects we depend upon
+    const AP_AHRS& _ahrs;
     const AP_InertialNav& _inav;
 
     // parameters


### PR DESCRIPTION
During Copter-3.4 beta testing we found that the vehicle would attempt to fly to a Rally point even if it was outside the fence.  Worse yet, if it was 100m outside the circular fence the vehicle would switch to land before reaching the rally point.  This pre-arm check stops the vehicle from arming if the rally points are outside the circular and/or pollygon fences (if the fences are enabled).