### PR TITLE
AP_TECS: ensure we use full throttle in initial takeoff

### DIFF
--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -241,6 +241,9 @@ private:
 
         // true when plane is in auto mode and executing a land mission item
         bool is_doing_auto_land:1;
+
+        // true when we have reached target speed in takeoff
+        bool reached_speed_takeoff:1;
     };
     union {
         struct flags _flags;
@@ -316,10 +319,10 @@ private:
     void _update_energies(void);
 
     // Update Demanded Throttle
-    void _update_throttle(void);
+    void _update_throttle_with_airspeed(void);
 
     // Update Demanded Throttle Non-Airspeed
-    void _update_throttle_option(int16_t throttle_nudge);
+    void _update_throttle_without_airspeed(int16_t throttle_nudge);
 
     // get integral gain which is flight_stage dependent
     float _get_i_gain(void);

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -36,6 +36,9 @@ Plane::Plane(const char *home_str, const char *frame_str) :
     thrust_scale = (mass * GRAVITY_MSS) / hover_throttle;
     frame_height = 0.1f;
 
+    if (strstr(frame_str, "-heavy")) {
+        mass = 8;
+    }
     if (strstr(frame_str, "-revthrust")) {
         reverse_thrust = true;
     }


### PR DESCRIPTION
when we have not yet reached the target airspeed we force full throttle. This prevents a situation where TECS may drop the throttle on takeoff too early, leading to a stall.
