### PR TITLE
Fix memory leaks in UARTDriver

### DIFF
--- a/libraries/AP_HAL_Linux/ConsoleDevice.cpp
+++ b/libraries/AP_HAL_Linux/ConsoleDevice.cpp
@@ -14,6 +14,7 @@ ConsoleDevice::ConsoleDevice()
 
 ConsoleDevice::~ConsoleDevice()
 {
+    close();
 }
 
 bool ConsoleDevice::close()

--- a/libraries/AP_HAL_Linux/SerialDevice.h
+++ b/libraries/AP_HAL_Linux/SerialDevice.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "AP_HAL_Linux.h"
+
 class SerialDevice {
 public: 
     virtual ~SerialDevice() {}
@@ -13,4 +15,9 @@ public:
     virtual ssize_t read(uint8_t *buf, uint16_t n) = 0;
     virtual void set_blocking(bool blocking) = 0;
     virtual void set_speed(uint32_t speed) = 0;
+    virtual AP_HAL::UARTDriver::flow_control get_flow_control(void) { return AP_HAL::UARTDriver::FLOW_CONTROL_ENABLE; }
+    virtual void set_flow_control(AP_HAL::UARTDriver::flow_control flow_control_setting)
+    {
+        /*most devices simply igmore this setting */
+    };
 };

--- a/libraries/AP_HAL_Linux/UARTDevice.cpp
+++ b/libraries/AP_HAL_Linux/UARTDevice.cpp
@@ -109,3 +109,23 @@ void UARTDevice::set_speed(uint32_t baudrate)
     cfsetspeed(&t, baudrate);
     tcsetattr(_fd, TCSANOW, &t);
 }
+
+void UARTDevice::set_flow_control(AP_HAL::UARTDriver::flow_control flow_control_setting)
+{
+    struct termios t;
+    tcgetattr(_fd, &t);
+
+    if (_flow_control == flow_control_setting) {
+        return;
+    }
+
+    if (flow_control_setting != AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE) {
+        t.c_cflag |= CRTSCTS;
+    } else {
+        t.c_cflag &= ~CRTSCTS;
+    }
+
+    tcsetattr(_fd, TCSANOW, &t);
+
+    _flow_control = flow_control_setting;
+}

--- a/libraries/AP_HAL_Linux/UARTDevice.h
+++ b/libraries/AP_HAL_Linux/UARTDevice.h
@@ -14,9 +14,15 @@ public:
     virtual ssize_t read(uint8_t *buf, uint16_t n) override;
     virtual void set_blocking(bool blocking) override;
     virtual void set_speed(uint32_t speed) override;
+    virtual void set_flow_control(enum AP_HAL::UARTDriver::flow_control flow_control_setting) override;
+    virtual AP_HAL::UARTDriver::flow_control get_flow_control(void) override
+    {
+        return _flow_control;
+    }
 
 private:
     void _disable_crlf();
+    AP_HAL::UARTDriver::flow_control _flow_control = AP_HAL::UARTDriver::flow_control::FLOW_CONTROL_DISABLE;
 
     int _fd = -1;
     const char *_device_path;

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -61,7 +61,7 @@ void UARTDriver::begin(uint32_t b)
 
 void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 {
-    if (device_path == NULL && _console) {
+    if (device_path == NULL && _console && !_initialised) {
         _device = new ConsoleDevice();
     } else if (!_initialised) {
         if (device_path == NULL) {

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -39,8 +39,6 @@ UARTDriver::UARTDriver(bool default_console) :
     _flow_control(FLOW_CONTROL_DISABLE)
 {
     if (default_console) {
-        _device = new ConsoleDevice();
-        _device->open();
         _console = true;
     }
 }

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -35,8 +35,7 @@ using namespace Linux;
 
 UARTDriver::UARTDriver(bool default_console) :
     device_path(NULL),
-    _packetise(false),
-    _flow_control(FLOW_CONTROL_DISABLE)
+    _packetise(false)
 {
     if (default_console) {
         _console = true;
@@ -74,21 +73,18 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         case DEVICE_TCP:
         {
             _tcp_start_connection();
-            _flow_control = FLOW_CONTROL_ENABLE;
             break;
         }
 
         case DEVICE_UDP:
         {
             _udp_start_connection();
-            _flow_control = FLOW_CONTROL_ENABLE;
             break;
         }
 
         case DEVICE_UDPIN:
         {
             _udpin_start_connection();
-            _flow_control = FLOW_CONTROL_ENABLE;
             break;
         }
         
@@ -96,7 +92,6 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         case DEVICE_QFLIGHT:
         {
             _qflight_start_connection();
-            _flow_control = FLOW_CONTROL_DISABLE;
             break;
         }
 #endif
@@ -275,7 +270,6 @@ bool UARTDriver::_serial_start_connection()
     _device = new UARTDevice(device_path);
     _connected = _device->open();
     _device->set_blocking(false);
-    _flow_control = FLOW_CONTROL_DISABLE;
 
     return true;
 }
@@ -285,7 +279,6 @@ bool UARTDriver::_qflight_start_connection()
 {
     _device = new QFLIGHTDevice(device_path);
     _connected = _device->open();
-    _flow_control = FLOW_CONTROL_DISABLE;
 
     return true;
 }

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -36,7 +36,15 @@ public:
     bool _write_pending_bytes(void);
     virtual void _timer_tick(void);
 
-    enum flow_control get_flow_control(void) { return _flow_control; }
+    virtual enum flow_control get_flow_control(void) override
+    {
+        return _device->get_flow_control();
+    }
+
+    virtual void set_flow_control(enum flow_control flow_control_setting) override
+   {
+       _device->set_flow_control(flow_control_setting);
+   }
 
 private:
     AP_HAL::OwnPtr<SerialDevice> _device = nullptr;
@@ -48,7 +56,6 @@ private:
     char *_flag;
     bool _connected; // true if a client has connected         
     bool _packetise; // true if writes should try to be on mavlink boundaries
-    enum flow_control _flow_control;
 
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _deallocate_buffers();

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -3,6 +3,7 @@
 #include "AP_HAL_Linux.h"
 
 #include "SerialDevice.h"
+#include <AP_HAL/utility/OwnPtr.h>
 
 class Linux::UARTDriver : public AP_HAL::UARTDriver {
 public:
@@ -38,7 +39,7 @@ public:
     enum flow_control get_flow_control(void) { return _flow_control; }
 
 private:
-    SerialDevice *_device = nullptr;
+    AP_HAL::OwnPtr<SerialDevice> _device = nullptr;
     bool _nonblocking_writes;
     bool _console;
     volatile bool _in_timer;

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -47,7 +47,7 @@ public:
    }
 
 private:
-    AP_HAL::OwnPtr<SerialDevice> _device = nullptr;
+    AP_HAL::OwnPtr<SerialDevice> _device;
     bool _nonblocking_writes;
     bool _console;
     volatile bool _in_timer;
@@ -59,24 +59,8 @@ private:
 
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _deallocate_buffers();
-    void _udp_start_connection(void);
-    void _udpin_start_connection(void);
-    void _tcp_start_connection(void);
-    bool _serial_start_connection(void);
-    bool _qflight_start_connection(void);
 
-    enum device_type {
-        DEVICE_TCP,
-        DEVICE_UDP,
-        DEVICE_UDPIN,
-        DEVICE_SERIAL,
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
-        DEVICE_QFLIGHT,
-#endif
-        DEVICE_UNKNOWN
-    };
-
-    enum device_type _parseDevicePath(const char *arg);
+    AP_HAL::OwnPtr<SerialDevice> _parseDevicePath(const char *arg);
     uint64_t _last_write_time;    
 
 protected:


### PR DESCRIPTION
I observed that multiple instances of ConsoleDevice were getting created and none of the unneeded ones were destroyed. There's also a couple of refactorings that I added along the way.