### PR TITLE
ArduPlane: Only call init optflow when enabled by parameter

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -246,6 +246,10 @@ void Plane::init_ardupilot()
 
     // initialise sensor
 #if OPTFLOW == ENABLED
+    if (!optflow.enabled()) {
+        return;
+    }
+
     optflow.init();
 #endif
 


### PR DESCRIPTION
Regarding this: http://discuss.ardupilot.org/t/bbbmini-arduplane-error-at-startup/10170 and already done in ArduCopter (https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/sensors.cpp#L114), `optflow.init()` should only be called when `FLOW_ENABLE` parameter is set. BBBmini and some other LINUX boards are using an USB cam for optflow, now ArduPlane will exit always when there is no USB camera connected.