### PR TITLE
Fix a couple bugs contributing to "flyaway"/fly-up in ALT_HOLD with no GPS.

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -233,19 +233,24 @@ void AP_AHRS_NavEKF::update_EKF2(void)
             float abias;
             EKF2.getAccelZBias(-1,abias);
 
-            // This EKF uses the primary IMU
+            int8_t imu_index = EKF2.getIMUIndex();
+            if (imu_index == -1) {
+                imu_index = _ins.get_primary_accel();
+            }
+
             // Eventually we will run a separate instance of the EKF for each IMU and do the selection and blending of EKF outputs upstream
             // update _accel_ef_ekf
             for (uint8_t i=0; i<_ins.get_accel_count(); i++) {
                 Vector3f accel = _ins.get_accel(i);
-                if (i==_ins.get_primary_accel()) {
+                if (i==imu_index) {
                     accel.z -= abias;
                 }
                 if (_ins.get_accel_health(i)) {
                     _accel_ef_ekf[i] = _dcm_matrix * accel;
                 }
             }
-            _accel_ef_ekf_blended = _accel_ef_ekf[_ins.get_primary_accel()];
+
+            _accel_ef_ekf_blended = _accel_ef_ekf[imu_index];
         }
     }
 }

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -17,26 +17,25 @@
 void AP_InertialNav_NavEKF::update(float dt)
 {
     // get the position relative to the local earth frame origin
-    if (_ahrs_ekf.get_relative_position_NED(_relpos_cm)) {
-        _relpos_cm *= 100; // convert to cm
-        _relpos_cm.z = - _relpos_cm.z; // InertialNav is NEU
-    }
+    Vector3f relpos_m = Vector3f(0.0f,0.0f,0.0f);
+    _ahrs_ekf.get_relative_position_NED(relpos_m);
+    _relpos_cm = relpos_m*100;
+    _relpos_cm.z = - _relpos_cm.z; // InertialNav is NEU
 
     // get the absolute WGS-84 position
-    _haveabspos = _ahrs_ekf.get_position(_abspos);
+    _ahrs_ekf.get_position(_abspos);
 
     // get the velocity relative to the local earth frame
-    if (_ahrs_ekf.get_velocity_NED(_velocity_cm)) {
-        _velocity_cm *= 100; // convert to cm/s
-        _velocity_cm.z = -_velocity_cm.z; // InertialNav is NEU
-    }
+    Vector3f velocity_m = Vector3f(0.0f,0.0f,0.0f);
+    _ahrs_ekf.get_velocity_NED(velocity_m);
+    _velocity_cm = velocity_m*100;
+    _velocity_cm.z = - _velocity_cm.z; // InertialNav is NEU
 
     // Get a derivative of the vertical position which is kinematically consistent with the vertical position is required by some control loops.
     // This is different to the vertical velocity from the EKF which is not always consistent with the verical position due to the various errors that are being corrected for.
-    if (_ahrs_ekf.get_vert_pos_rate(_pos_z_rate)) {
-        _pos_z_rate *= 100; // convert to cm/s
-        _pos_z_rate = - _pos_z_rate; // InertialNav is NEU
-    }
+    float pos_z_rate_m;
+    _ahrs_ekf.get_vert_pos_rate(pos_z_rate_m);
+    _pos_z_rate_cm = -pos_z_rate_m*100; // convert from meters down to centimeters up
 }
 
 /**
@@ -126,7 +125,7 @@ float AP_InertialNav_NavEKF::get_velocity_xy() const
 */
 float AP_InertialNav_NavEKF::get_pos_z_derivative() const
 {
-    return _pos_z_rate;
+    return _pos_z_rate_cm;
 }
 
 /**

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -15,7 +15,6 @@ public:
     // Constructor
     AP_InertialNav_NavEKF(AP_AHRS_NavEKF &ahrs) :
         AP_InertialNav(),
-        _haveabspos(false),
         _ahrs_ekf(ahrs)
         {}
 
@@ -116,8 +115,7 @@ public:
 private:
     Vector3f _relpos_cm;   // NEU
     Vector3f _velocity_cm; // NEU
-    float _pos_z_rate;
+    float _pos_z_rate_cm;
     struct Location _abspos;
-    bool _haveabspos;
     AP_AHRS_NavEKF &_ahrs_ekf;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -673,6 +673,14 @@ int8_t NavEKF2::getPrimaryCoreIndex(void) const
     return primary;
 }
 
+int8_t NavEKF2::getIMUIndex(void) const
+{
+    if (!core) {
+        return -1;
+    }
+    return core[primary].getIMUIndex();
+}
+
 
 // Return the last calculated NED position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -271,6 +271,8 @@ public:
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set(enable); }
 
+    int8_t getIMUIndex(void) const;
+
     // are we doing sensor logging inside the EKF?
     bool have_ekf_logging(void) const { return logging.enabled && _logging_mask != 0; }
     

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -261,6 +261,8 @@ public:
     // publish output observer angular, velocity and position tracking error
     void getOutputTrackingError(Vector3f &error) const;
 
+    uint8_t getIMUIndex(void) const { return imu_index; }
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;


### PR DESCRIPTION
The scaling code in AP_InertialNav was not being run when it should have been, due to the EKF getPosNED function returning false but still modifying the reference to provide a height.

Further, AP_AHRS_NavEKF was not correcting _accel_ef properly, potentially resulting in land detector failures, crash detector failures, steady-state error on height. It still isn't perfect - it should loop through the available EKFs and apply corrections from each one. This is a stopgap for now.