### PR TITLE
Prevent takeoff using GPS before EKF has settled and fix height bug affecting alt_hold

### DIFF
--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -794,7 +794,8 @@ void Replay::loop()
         if (streq(type,"ATT")) {
             Vector3f ekf_euler;
             Vector3f velNED;
-            Vector3f posNED;
+            Vector2f posNE;
+            float posD;
             Vector3f gyroBias;
             float accelWeighting;
             float accelZBias1;
@@ -803,11 +804,10 @@ void Replay::loop()
             Vector3f magNED;
             Vector3f magXYZ;
             Vector3f DCM_attitude;
-            Vector3f ekf_relpos;
             Vector3f velInnov;
             Vector3f posInnov;
             Vector3f magInnov;
-            float    tasInnov;
+            float tasInnov;
             float velVar;
             float posVar;
             float hgtVar;
@@ -820,7 +820,8 @@ void Replay::loop()
             dcm_matrix.to_euler(&DCM_attitude.x, &DCM_attitude.y, &DCM_attitude.z);
             _vehicle.EKF.getEulerAngles(ekf_euler);
             _vehicle.EKF.getVelNED(velNED);
-            _vehicle.EKF.getPosNED(posNED);
+            _vehicle.EKF.getPosNE(posNE);
+            _vehicle.EKF.getPosD(posD);
             _vehicle.EKF.getGyroBias(gyroBias);
             _vehicle.EKF.getIMU1Weighting(accelWeighting);
             _vehicle.EKF.getAccelZBias(accelZBias1, accelZBias2);
@@ -830,7 +831,6 @@ void Replay::loop()
             _vehicle.EKF.getInnovations(velInnov, posInnov, magInnov, tasInnov);
             _vehicle.EKF.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
             _vehicle.EKF.getFilterFaults(faultStatus);
-            _vehicle.EKF.getPosNED(ekf_relpos);
             Vector3f inav_pos = _vehicle.inertial_nav.get_position() * 0.01f;
             float temp = degrees(ekf_euler.z);
 
@@ -858,9 +858,9 @@ void Replay::loop()
                     inav_pos.x,
                     inav_pos.y,
                     inav_pos.z,
-                    ekf_relpos.x,
-                    ekf_relpos.y,
-                    -ekf_relpos.z);
+                    posNE.x,
+                    posNE.y,
+                    -posD);
             fprintf(plotf2, "%.3f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\n",
                     AP_HAL::millis() * 0.001f,
                     degrees(ekf_euler.x),
@@ -869,17 +869,17 @@ void Replay::loop()
                     velNED.x, 
                     velNED.y, 
                     velNED.z, 
-                    posNED.x, 
-                    posNED.y, 
-                    posNED.z, 
+                    posNE.x,
+                    posNE.y,
+                    posD,
                     60*degrees(gyroBias.x), 
                     60*degrees(gyroBias.y), 
                     60*degrees(gyroBias.z), 
                     windVel.x, 
                     windVel.y, 
-                    magNED.x, 
-                    magNED.y, 
-                    magNED.z, 
+                    magNED.x,
+                    magNED.y,
+                    magNED.z,
                     magXYZ.x, 
                     magXYZ.y, 
                     magXYZ.z,
@@ -894,9 +894,8 @@ void Replay::loop()
             float       velN  = (float)(velNED.x); // velocity North (m/s)
             float       velE  = (float)(velNED.y); // velocity East (m/s)
             float       velD  = (float)(velNED.z); // velocity Down (m/s)
-            float       posN  = (float)(posNED.x); // metres North
-            float       posE  = (float)(posNED.y); // metres East
-            float       posD  = (float)(posNED.z); // metres Down
+            float       posN  = (float)(posNE.x); // metres North
+            float       posE  = (float)(posNE.y); // metres East
             float       gyrX  = (float)(6000*degrees(gyroBias.x)); // centi-deg/min
             float       gyrY  = (float)(6000*degrees(gyroBias.y)); // centi-deg/min
             float       gyrZ  = (float)(6000*degrees(gyroBias.z)); // centi-deg/min

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -14,8 +14,8 @@ HOME=mavutil.location(40.071374969556928,-105.22978898137808,1583.702759,246)
 homeloc = None
 
 def arm_rover(mavproxy, mav):
-    # wait for EKF to settle
-    wait_seconds(mav, 15)
+    # wait for EKF and GPS checks to pass
+    wait_seconds(mav, 30)
 
     mavproxy.send('arm throttle\n')
     mavproxy.expect('ARMED')

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -987,8 +987,8 @@ def fly_ArduCopter(binary, viewerip=None, map=False, valgrind=False, gdb=False):
         setup_rc(mavproxy)
         homeloc = mav.location()
 
-        # wait 10sec to allow EKF to settle
-        wait_seconds(mav, 10)
+        # wait for EKF and GPS checks to pass
+        wait_seconds(mav, 30)
 
         # Arm
         print("# Arm motors")
@@ -1340,8 +1340,8 @@ def fly_CopterAVC(binary, viewerip=None, map=False, valgrind=False, gdb=False):
         print("Lowering rotor speed")
         mavproxy.send('rc 8 1000\n')
 
-        # wait 20sec to allow EKF to settle
-        wait_seconds(mav, 20)
+        # wait for EKF and GPS checks to pass
+        wait_seconds(mav, 30)
 
         # Arm
         print("# Arm motors")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -21,7 +21,7 @@ AVCHOME=mavutil.location(40.072842,-105.230575,1586,0)
 
 homeloc = None
 num_wp = 0
-speedup_default = 5
+speedup_default = 10
 
 def hover(mavproxy, mav, hover_throttle=1500):
     mavproxy.send('rc 3 %u\n' % hover_throttle)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -17,8 +17,8 @@ homeloc = None
 def takeoff(mavproxy, mav):
     '''takeoff get to 30m altitude'''
 
-    # wait for EKF to settle
-    wait_seconds(mav, 15)
+    # wait for EKF and GPS checks to pass
+    wait_seconds(mav, 30)
 
     mavproxy.send('arm throttle\n')
     mavproxy.expect('ARMED')

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -101,8 +101,8 @@ def fly_QuadPlane(binary, viewerip=None, map=False, valgrind=False, gdb=False):
         homeloc = mav.location()
         print("Home location: %s" % homeloc)
 
-        # wait for EKF to settle
-        wait_seconds(mav, 15)
+        # wait for EKF and GPS checks to pass
+        wait_seconds(mav, 30)
 
         mavproxy.send('arm throttle\n')
         mavproxy.expect('ARMED')

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -293,6 +293,18 @@ public:
         return false;
     }
 
+    // return a position relative to home in meters, North/East
+    // order. Return true if estimate is valid
+    virtual bool get_relative_position_NE(Vector2f &vecNE) const {
+        return false;
+    }
+
+    // return a Down position relative to home in meters
+    // Return true if estimate is valid
+    virtual bool get_relative_position_D(float &posD) const {
+        return false;
+    }
+
     // return ground speed estimate in meters/second. Used by ground vehicles.
     float groundspeed(void) {
         return groundspeed_vector().length();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -713,8 +713,8 @@ bool AP_AHRS_NavEKF::get_relative_position_NED(Vector3f &vec) const
     }
 }
 
-// return a relative ground position in meters/second, North/East
-// order. return true if estimate is valid
+// write a relative ground position estimate in meters, North/East order
+// return true if estimate is valid
 bool AP_AHRS_NavEKF::get_relative_position_NE(Vector2f &posNE) const
 {
     switch (active_EKF_type()) {
@@ -745,7 +745,7 @@ bool AP_AHRS_NavEKF::get_relative_position_NE(Vector2f &posNE) const
     }
 }
 
-// return a relative ground position in meters/second, Down
+// write a relative ground position in meters, Down
 // return true if the estimate is valid
 bool AP_AHRS_NavEKF::get_relative_position_D(float &posD) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -140,6 +140,14 @@ public:
     bool get_velocity_NED(Vector3f &vec) const;
     bool get_relative_position_NED(Vector3f &vec) const;
 
+    // return the relative position in North/East order
+    // return true if the estimate is valid
+    bool get_relative_position_NE(Vector2f &posNE) const;
+
+    // return the relative position in North/East order
+    // return true if the estimate is valid
+    bool get_relative_position_D(float &posD) const;
+
     // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
     // This is different to the vertical velocity from the EKF which is not always consistent with the verical position due to the various errors that are being corrected for.
     bool get_vert_pos_rate(float &velocity);

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -16,19 +16,27 @@
 */
 void AP_InertialNav_NavEKF::update(float dt)
 {
-    // get the position relative to the local earth frame origin
-    if (_ahrs_ekf.get_relative_position_NED(_relpos_cm)) {
-        _relpos_cm *= 100; // convert to cm
-        _relpos_cm.z = - _relpos_cm.z; // InertialNav is NEU
+    // get the NE position relative to the local earth frame origin
+    Vector2f posNE;
+    if (_ahrs_ekf.get_relative_position_NE(posNE)) {
+        _relpos_cm.x = posNE.x * 100; // convert from m to cm
+        _relpos_cm.y = posNE.y * 100; // convert from m to cm
+    }
+
+    // get the D position relative to the local earth frame origin
+    float posD;
+    if (_ahrs_ekf.get_relative_position_D(posD)) {
+        _relpos_cm.z = - posD * 100; // convert from m in NED to cm in NEU
     }
 
     // get the absolute WGS-84 position
     _haveabspos = _ahrs_ekf.get_position(_abspos);
 
     // get the velocity relative to the local earth frame
-    if (_ahrs_ekf.get_velocity_NED(_velocity_cm)) {
-        _velocity_cm *= 100; // convert to cm/s
-        _velocity_cm.z = -_velocity_cm.z; // InertialNav is NEU
+    Vector3f velNED;
+    if (_ahrs_ekf.get_velocity_NED(velNED)) {
+        _velocity_cm = velNED * 100; // convert to cm/s
+        _velocity_cm.z = -_velocity_cm.z; // convert from NED to NEU
     }
 
     // Get a derivative of the vertical position which is kinematically consistent with the vertical position is required by some control loops.

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -470,15 +470,26 @@ bool NavEKF::healthy(void) const
     return core->healthy();
 }
 
-// Return the last calculated NED position relative to the reference point (m).
+// Return the last calculated North East position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
-bool NavEKF::getPosNED(Vector3f &pos) const
+bool NavEKF::getPosNE(Vector2f &posNE) const
 {
     if (!core) {
         return false;
     }
-    return core->getPosNED(pos);
+    return core->getPosNE(posNE);
+}
+
+// Return the last calculated Down position relative to the reference point (m).
+// If a calculated solution is not available, use the best available data and return false
+// If false returned, do not use for flight control
+bool NavEKF::getPosD(float &posD) const
+{
+    if (!core) {
+        return false;
+    }
+    return core->getPosD(posD);
 }
 
 // return NED velocity in m/s

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -470,7 +470,7 @@ bool NavEKF::healthy(void) const
     return core->healthy();
 }
 
-// Return the last calculated North East position relative to the reference point (m).
+// Write the last calculated North East position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
 bool NavEKF::getPosNE(Vector2f &posNE) const
@@ -481,7 +481,7 @@ bool NavEKF::getPosNE(Vector2f &posNE) const
     return core->getPosNE(posNE);
 }
 
-// Return the last calculated Down position relative to the reference point (m).
+// Write the last calculated Down position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
 bool NavEKF::getPosD(float &posD) const

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -71,12 +71,12 @@ public:
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
-    // Return the last calculated North East position relative to the reference point (m).
+    // Write the last calculated North East position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosNE(Vector2f &posNE) const;
 
-    // Return the last calculated Down position relative to the reference point (m).
+    // Write the last calculated Down position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosD(float &posD) const;

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -71,10 +71,15 @@ public:
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
-    // Return the last calculated NED position relative to the reference point (m).
+    // Return the last calculated North East position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
-    bool getPosNED(Vector3f &pos) const;
+    bool getPosNE(Vector2f &posNE) const;
+
+    // Return the last calculated Down position relative to the reference point (m).
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosD(float &posD) const;
 
     // return NED velocity in m/s
     void getVelNED(Vector3f &vel) const;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -3358,8 +3358,8 @@ float NavEKF_core::getPosDownDerivative(void) const
     return posDownDerivative;
 }
 
-// Return the last calculated NE position relative to the reference point (m).
-// if a calculated solution is not available, use the best available data and return false
+// Write the last calculated NE position relative to the reference point (m).
+// Return true if the estimate is valid
 bool NavEKF_core::getPosNE(Vector2f &posNE) const
 {
     // There are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no position estimate available)
@@ -3394,8 +3394,8 @@ bool NavEKF_core::getPosNE(Vector2f &posNE) const
     return false;
 }
 
-// Return the last calculated D position relative to the reference point (m).
-// if a calculated solution is not available, use the best available data and return false
+// Write the last calculated D position relative to the reference point (m).
+// Return true if the estimate is valid
 bool NavEKF_core::getPosD(float &posD) const
 {
     // The EKF always has a height estimate regardless of mode of operation

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -445,6 +445,9 @@ void NavEKF_core::UpdateFilter()
     SelectTasFusion();
     SelectBetaFusion();
 
+    // Update the filter status
+    updateFilterStatus();
+
 end:
     // stop the timer used for load measurement
     hal.util->perf_end(_perf_UpdateFilter);
@@ -3355,19 +3358,15 @@ float NavEKF_core::getPosDownDerivative(void) const
     return posDownDerivative;
 }
 
-// Return the last calculated NED position relative to the reference point (m).
+// Return the last calculated NE position relative to the reference point (m).
 // if a calculated solution is not available, use the best available data and return false
-bool NavEKF_core::getPosNED(Vector3f &pos) const
+bool NavEKF_core::getPosNE(Vector2f &posNE) const
 {
-    // The EKF always has a height estimate regardless of mode of operation
-    pos.z = state.position.z;
     // There are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no position estimate available)
-    nav_filter_status status;
-    getFilterStatus(status);
-    if (status.flags.horiz_pos_abs || status.flags.horiz_pos_rel) {
+    if (filterStatus.flags.horiz_pos_abs || filterStatus.flags.horiz_pos_rel) {
         // This is the normal mode of operation where we can use the EKF position states
-        pos.x = state.position.x;
-        pos.y = state.position.y;
+        posNE.x = state.position.x;
+        posNE.y = state.position.y;
         return true;
     } else {
         // In constant position mode the EKF position states are at the origin, so we cannot use them as a position estimate
@@ -3376,23 +3375,32 @@ bool NavEKF_core::getPosNED(Vector3f &pos) const
                 // If the origin has been set and we have GPS, then return the GPS position relative to the origin
                 const struct Location &gpsloc = _ahrs->get_gps().location();
                 Vector2f tempPosNE = location_diff(EKF_origin, gpsloc);
-                pos.x = tempPosNE.x;
-                pos.y = tempPosNE.y;
+                posNE.x = tempPosNE.x;
+                posNE.y = tempPosNE.y;
                 return false;
             } else {
                 // If no GPS fix is available, all we can do is provide the last known position
-                pos.x = state.position.x + lastKnownPositionNE.x;
-                pos.y = state.position.y + lastKnownPositionNE.y;
+                posNE.x = state.position.x + lastKnownPositionNE.x;
+                posNE.y = state.position.y + lastKnownPositionNE.y;
                 return false;
             }
         } else {
             // If the origin has not been set, then we have no means of providing a relative position
-            pos.x = 0.0f;
-            pos.y = 0.0f;
+            posNE.x = 0.0f;
+            posNE.y = 0.0f;
             return false;
         }
     }
     return false;
+}
+
+// Return the last calculated D position relative to the reference point (m).
+// if a calculated solution is not available, use the best available data and return false
+bool NavEKF_core::getPosD(float &posD) const
+{
+    // The EKF always has a height estimate regardless of mode of operation
+    posD = state.position.z;
+    return filterStatus.flags.vert_pos;
 }
 
 // return body axis gyro bias estimates in rad/sec
@@ -3543,9 +3551,7 @@ bool NavEKF_core::getLLH(struct Location &loc) const
         loc.flags.terrain_alt = 0;
 
         // there are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no aiding)
-        nav_filter_status status;
-        getFilterStatus(status);
-        if (status.flags.horiz_pos_abs || status.flags.horiz_pos_rel) {
+        if (filterStatus.flags.horiz_pos_abs || filterStatus.flags.horiz_pos_rel) {
             loc.lat = EKF_origin.lat;
             loc.lng = EKF_origin.lng;
             location_offset(loc, state.position.x, state.position.y);
@@ -4515,6 +4521,7 @@ void NavEKF_core::InitialiseVariables()
     posResetNE.zero();
     velResetNE.zero();
     hgtInnovFiltState = 0.0f;
+    memset(&filterStatus, 0, sizeof(filterStatus));
 }
 
 // return true if we should use the airspeed sensor
@@ -4637,22 +4644,9 @@ void  NavEKF_core::getFilterGpsStatus(nav_gps_status &faults) const
     faults.flags.bad_horiz_vel      = gpsCheckStatus.bad_horiz_vel; // The GPS horizontal speed is excessive (check assumes the vehicle is static)
 }
 
-/*
-return filter function status as a bitmasked integer
- 0 = attitude estimate valid
- 1 = horizontal velocity estimate valid
- 2 = vertical velocity estimate valid
- 3 = relative horizontal position estimate valid
- 4 = absolute horizontal position estimate valid
- 5 = vertical position estimate valid
- 6 = terrain height estimate valid
- 7 = constant position mode
-*/
-void  NavEKF_core::getFilterStatus(nav_filter_status &status) const
+// Update the naigation filter status message
+void  NavEKF_core::updateFilterStatus(void)
 {
-    // init return value
-    status.value = 0;
-
     bool doingFlowNav = (PV_AidingMode == AID_RELATIVE) && flowDataValid;
     bool doingWindRelNav = !tasTimeout && assume_zero_sideslip();
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
@@ -4665,42 +4659,44 @@ void  NavEKF_core::getFilterStatus(nav_filter_status &status) const
     bool gyroHealthy = checkGyroHealthPreFlight();
 
     // set individual flags
-    status.flags.attitude = !state.quat.is_nan() && filterHealthy && gyroHealthy;   // attitude valid (we need a better check)
-    status.flags.horiz_vel = someHorizRefData && notDeadReckoning && filterHealthy;      // horizontal velocity estimate valid
-    status.flags.vert_vel = someVertRefData && filterHealthy;        // vertical velocity estimate valid
-    status.flags.horiz_pos_rel = ((doingFlowNav && gndOffsetValid) || doingWindRelNav || doingNormalGpsNav) && notDeadReckoning && filterHealthy;   // relative horizontal position estimate valid
-    status.flags.horiz_pos_abs = !gpsAidingBad && doingNormalGpsNav && notDeadReckoning && filterHealthy; // absolute horizontal position estimate valid
-    status.flags.vert_pos = !hgtTimeout && filterHealthy;            // vertical position estimate valid
-    status.flags.terrain_alt = gndOffsetValid && filterHealthy;		// terrain height estimate valid
-    status.flags.const_pos_mode = constPosMode && filterHealthy;     // constant position mode
-    status.flags.pred_horiz_pos_rel = (optFlowNavPossible || gpsNavPossible) && filterHealthy && gyroHealthy; // we should be able to estimate a relative position when we enter flight mode
-    status.flags.pred_horiz_pos_abs = gpsNavPossible && filterHealthy && gyroHealthy; // we should be able to estimate an absolute position when we enter flight mode
-    status.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
-    status.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
-    status.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
-    status.flags.using_gps = (imuSampleTime_ms - lastPosPassTime) < 4000;
-    status.flags.gps_glitching = !gpsAccuracyGood; // The GPS is glitching
+    filterStatus.flags.attitude = !state.quat.is_nan() && filterHealthy && gyroHealthy;   // attitude valid (we need a better check)
+    filterStatus.flags.horiz_vel = someHorizRefData && notDeadReckoning && filterHealthy;      // horizontal velocity estimate valid
+    filterStatus.flags.vert_vel = someVertRefData && filterHealthy;        // vertical velocity estimate valid
+    filterStatus.flags.horiz_pos_rel = ((doingFlowNav && gndOffsetValid) || doingWindRelNav || doingNormalGpsNav) && notDeadReckoning && filterHealthy;   // relative horizontal position estimate valid
+    filterStatus.flags.horiz_pos_abs = !gpsAidingBad && doingNormalGpsNav && notDeadReckoning && filterHealthy; // absolute horizontal position estimate valid
+    filterStatus.flags.vert_pos = !hgtTimeout && filterHealthy;            // vertical position estimate valid
+    filterStatus.flags.terrain_alt = gndOffsetValid && filterHealthy;		// terrain height estimate valid
+    filterStatus.flags.const_pos_mode = constPosMode && filterHealthy;     // constant position mode
+    filterStatus.flags.pred_horiz_pos_rel = (optFlowNavPossible || gpsNavPossible) && filterHealthy && gyroHealthy; // we should be able to estimate a relative position when we enter flight mode
+    filterStatus.flags.pred_horiz_pos_abs = gpsNavPossible && filterHealthy && gyroHealthy; // we should be able to estimate an absolute position when we enter flight mode
+    filterStatus.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
+    filterStatus.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
+    filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
+    filterStatus.flags.using_gps = (imuSampleTime_ms - lastPosPassTime) < 4000;
+    filterStatus.flags.gps_glitching = !gpsAccuracyGood; // The GPS is glitching
 }
 
-// send an EKF_STATUS message to GCS
+// Return the navigation filter status message
+void  NavEKF_core::getFilterStatus(nav_filter_status &status) const
+{
+    status = filterStatus;
+}
+
+    // send an EKF_STATUS message to GCS
 void NavEKF_core::send_status_report(mavlink_channel_t chan)
 {
-    // get filter status
-    nav_filter_status filt_state;
-    getFilterStatus(filt_state);
-
     // prepare flags
     uint16_t flags = 0;
-    if (filt_state.flags.attitude) { flags |= EKF_ATTITUDE; }
-    if (filt_state.flags.horiz_vel) { flags |= EKF_VELOCITY_HORIZ; }
-    if (filt_state.flags.vert_vel) { flags |= EKF_VELOCITY_VERT; }
-    if (filt_state.flags.horiz_pos_rel) { flags |= EKF_POS_HORIZ_REL; }
-    if (filt_state.flags.horiz_pos_abs) { flags |= EKF_POS_HORIZ_ABS; }
-    if (filt_state.flags.vert_pos) { flags |= EKF_POS_VERT_ABS; }
-    if (filt_state.flags.terrain_alt) { flags |= EKF_POS_VERT_AGL; }
-    if (filt_state.flags.const_pos_mode) { flags |= EKF_CONST_POS_MODE; }
-    if (filt_state.flags.pred_horiz_pos_rel) { flags |= EKF_PRED_POS_HORIZ_REL; }
-    if (filt_state.flags.pred_horiz_pos_abs) { flags |= EKF_PRED_POS_HORIZ_ABS; }
+    if (filterStatus.flags.attitude) { flags |= EKF_ATTITUDE; }
+    if (filterStatus.flags.horiz_vel) { flags |= EKF_VELOCITY_HORIZ; }
+    if (filterStatus.flags.vert_vel) { flags |= EKF_VELOCITY_VERT; }
+    if (filterStatus.flags.horiz_pos_rel) { flags |= EKF_POS_HORIZ_REL; }
+    if (filterStatus.flags.horiz_pos_abs) { flags |= EKF_POS_HORIZ_ABS; }
+    if (filterStatus.flags.vert_pos) { flags |= EKF_POS_VERT_ABS; }
+    if (filterStatus.flags.terrain_alt) { flags |= EKF_POS_VERT_AGL; }
+    if (filterStatus.flags.const_pos_mode) { flags |= EKF_CONST_POS_MODE; }
+    if (filterStatus.flags.pred_horiz_pos_rel) { flags |= EKF_PRED_POS_HORIZ_REL; }
+    if (filterStatus.flags.pred_horiz_pos_abs) { flags |= EKF_PRED_POS_HORIZ_ABS; }
 
     // get variances
     float velVar, posVar, hgtVar, tasVar;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.h
@@ -114,12 +114,12 @@ public:
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
-    // Return the last calculated NE position relative to the reference point (m).
+    // Write the last calculated NE position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosNE(Vector2f &posNE) const;
 
-    // Return the last calculated D position relative to the reference point (m).
+    // Write the last calculated D position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosD(float &posD) const;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.h
@@ -114,10 +114,15 @@ public:
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
-    // Return the last calculated NED position relative to the reference point (m).
+    // Return the last calculated NE position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
-    bool getPosNED(Vector3f &pos) const;
+    bool getPosNE(Vector2f &posNE) const;
+
+    // Return the last calculated D position relative to the reference point (m).
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosD(float &posD) const;
 
     // return NED velocity in m/s
     void getVelNED(Vector3f &vel) const;
@@ -259,9 +264,7 @@ public:
     */
     void  getFilterTimeouts(uint8_t &timeouts) const;
 
-    /*
-    return filter status flags
-    */
+    // return filter status flags
     void  getFilterStatus(nav_filter_status &status) const;
 
     /*
@@ -323,6 +326,9 @@ private:
         float       posD2;          // 30
         Vector3f    omega;          // 31 .. 33
     } &state;
+
+    // update the navigation filter status
+    void  updateFilterStatus(void);
 
     // update the quaternion, velocity and position states using IMU measurements
     void UpdateStrapdownEquationsNED();
@@ -697,6 +703,7 @@ private:
     Vector3f delAngBiasAtArming;    // value of the gyro delta angle bias at arming
     float hgtInnovFiltState;        // state used for fitering of the height innovations used for pre-flight checks
     Quaternion prevQuatMagReset;    // Quaternion from the previous frame that the magnetic field state reset condition test was performed
+    nav_filter_status filterStatus; // contains the status of various filter outputs
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -686,6 +686,30 @@ bool NavEKF2::getPosNED(int8_t instance, Vector3f &pos)
     return core[instance].getPosNED(pos);
 }
 
+// Return the last calculated NE position relative to the reference point (m).
+// If a calculated solution is not available, use the best available data and return false
+// If false returned, do not use for flight control
+bool NavEKF2::getPosNE(int8_t instance, Vector2f &posNE)
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (!core) {
+        return false;
+    }
+    return core[instance].getPosNE(posNE);
+}
+
+// Return the last calculated D position relative to the reference point (m).
+// If a calculated solution is not available, use the best available data and return false
+// If false returned, do not use for flight control
+bool NavEKF2::getPosD(int8_t instance, float &posD)
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (!core) {
+        return false;
+    }
+    return core[instance].getPosD(posD);
+}
+
 // return NED velocity in m/s
 void NavEKF2::getVelNED(int8_t instance, Vector3f &vel)
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -673,19 +673,6 @@ int8_t NavEKF2::getPrimaryCoreIndex(void) const
     return primary;
 }
 
-
-// Return the last calculated NED position relative to the reference point (m).
-// If a calculated solution is not available, use the best available data and return false
-// If false returned, do not use for flight control
-bool NavEKF2::getPosNED(int8_t instance, Vector3f &pos)
-{
-    if (instance < 0 || instance >= num_cores) instance = primary;
-    if (!core) {
-        return false;
-    }
-    return core[instance].getPosNED(pos);
-}
-
 // Return the last calculated NE position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -673,7 +673,7 @@ int8_t NavEKF2::getPrimaryCoreIndex(void) const
     return primary;
 }
 
-// Return the last calculated NE position relative to the reference point (m).
+// Write the last calculated NE position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
 bool NavEKF2::getPosNE(int8_t instance, Vector2f &posNE)
@@ -685,7 +685,7 @@ bool NavEKF2::getPosNE(int8_t instance, Vector2f &posNE)
     return core[instance].getPosNE(posNE);
 }
 
-// Return the last calculated D position relative to the reference point (m).
+// Write the last calculated D position relative to the reference point (m).
 // If a calculated solution is not available, use the best available data and return false
 // If false returned, do not use for flight control
 bool NavEKF2::getPosD(int8_t instance, float &posD)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -68,6 +68,18 @@ public:
     // If false returned, do not use for flight control
     bool getPosNED(int8_t instance, Vector3f &pos);
 
+    // Return the last calculated NE position relative to the reference point (m) for the specified instance.
+    // An out of range instance (eg -1) returns data for the the primary instance
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosNE(int8_t instance, Vector2f &posNE);
+
+    // Return the last calculated D position relative to the reference point (m) for the specified instance.
+    // An out of range instance (eg -1) returns data for the the primary instance
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosD(int8_t instance, float &posD);
+
     // return NED velocity in m/s for the specified instance
     // An out of range instance (eg -1) returns data for the the primary instance
     void getVelNED(int8_t instance, Vector3f &vel);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -62,12 +62,6 @@ public:
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIndex(void) const;
 
-    // Return the last calculated NED position relative to the reference point (m) for the specified instance.
-    // An out of range instance (eg -1) returns data for the the primary instance
-    // If a calculated solution is not available, use the best available data and return false
-    // If false returned, do not use for flight control
-    bool getPosNED(int8_t instance, Vector3f &pos);
-
     // Return the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the the primary instance
     // If a calculated solution is not available, use the best available data and return false

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -62,13 +62,13 @@ public:
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIndex(void) const;
 
-    // Return the last calculated NE position relative to the reference point (m) for the specified instance.
+    // Write the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the the primary instance
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosNE(int8_t instance, Vector2f &posNE);
 
-    // Return the last calculated D position relative to the reference point (m) for the specified instance.
+    // Write the last calculated D position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the the primary instance
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -313,7 +313,7 @@ bool NavEKF2_core::optFlowDataPresent(void) const
 // return true if the filter to be ready to use gps
 bool NavEKF2_core::readyToUseGPS(void) const
 {
-    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsGoodToAlign && (frontend->_fusionModeGPS != 3);
+    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsGoodToAlign && (frontend->_fusionModeGPS != 3) && gpsDataToFuse;
 }
 
 // return true if we should use the compass

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -227,6 +227,7 @@ void NavEKF2_core::setAidingMode()
         // set various  usage modes based on the condition when we start aiding. These are then held until aiding is stopped.
         if (PV_AidingMode == AID_NONE) {
             // We have ceased aiding
+            hal.console->printf("EKF2 IMU%u has stopped aiding\n",(unsigned)imu_index);
             // When not aiding, estimate orientation & height fusing synthetic constant position and zero velocity measurement to constrain tilt errors
             posTimeout = true;
             velTimeout = true;            
@@ -388,7 +389,7 @@ bool NavEKF2_core::checkGyroCalStatus(void)
 // Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
 uint8_t NavEKF2_core::setInhibitGPS(void)
 {
-    if(PV_AidingMode == AID_ABSOLUTE && motorsArmed) {
+    if((PV_AidingMode == AID_ABSOLUTE) && motorsArmed) {
         return 0;
     } else {
         gpsInhibit = true;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -164,7 +164,7 @@ void NavEKF2_core::setAidingMode()
      if (!isAiding) {
         // Don't allow filter to start position or velocity aiding until the tilt and yaw alignment is complete
         // and IMU gyro bias estimates have stabilised
-        bool filterIsStable = tiltAlignComplete && yawAlignComplete && imuCalCompleted();
+        bool filterIsStable = tiltAlignComplete && yawAlignComplete && checkGyroCalStatus();
         // If GPS usage has been prohiited then we use flow aiding provided optical flow data is present
         bool useFlowAiding = (frontend->_fusionModeGPS == 3) && optFlowDataPresent();
         // Start aiding if we have a source of aiding data and the filter attitude algnment is complete
@@ -327,17 +327,15 @@ void NavEKF2_core::recordYawReset()
     }
 }
 
-// return true when IMU calibration completed
-bool NavEKF2_core::imuCalCompleted(void)
+// return true and set the class variable true if the delta angle bias has been learned
+bool NavEKF2_core::checkGyroCalStatus(void)
 {
     // check delta angle bias variances
     const float delAngBiasVarMax = sq(radians(0.1f * dtEkfAvg));
-    bool gyroCalComplete =  (P[9][9] <= delAngBiasVarMax) &&
+    delAngBiasLearned =  (P[9][9] <= delAngBiasVarMax) &&
                             (P[10][10] <= delAngBiasVarMax) &&
                             (P[11][11] <= delAngBiasVarMax);
-
-    return gyroCalComplete;
-
+    return delAngBiasLearned;
 }
 
 // Commands the EKF to not use GPS.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -331,7 +331,7 @@ void NavEKF2_core::recordYawReset()
 bool NavEKF2_core::checkGyroCalStatus(void)
 {
     // check delta angle bias variances
-    const float delAngBiasVarMax = sq(radians(0.1f * dtEkfAvg));
+    const float delAngBiasVarMax = sq(radians(0.15f * dtEkfAvg));
     delAngBiasLearned =  (P[9][9] <= delAngBiasVarMax) &&
                             (P[10][10] <= delAngBiasVarMax) &&
                             (P[11][11] <= delAngBiasVarMax);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -160,7 +160,7 @@ void NavEKF2_core::setAidingMode()
     // Save the previous status so we can detect when it has changed
     PV_AidingModePrev = PV_AidingMode;
 
-    // Determine if we should start aiding
+    // Determine if we should change aiding mode
      if (PV_AidingMode == AID_NONE) {
         // Don't allow filter to start position or velocity aiding until the tilt and yaw alignment is complete
         // and IMU gyro bias estimates have stabilised
@@ -172,10 +172,7 @@ void NavEKF2_core::setAidingMode()
         } else if ((frontend->_fusionModeGPS == 3) && optFlowDataPresent()) {
             PV_AidingMode = AID_RELATIVE;
         }
-    }
-
-     // Determine if we should exit optical flow aiding
-     if (PV_AidingMode == AID_RELATIVE) {
+    } else if (PV_AidingMode == AID_RELATIVE) {
          // Check if the optical flow sensor has timed out
          bool flowSensorTimeout = ((imuSampleTime_ms - flowValidMeaTime_ms) > 5000);
          // Check if the fusion has timed out (flow measurements have been rejected for too long)
@@ -183,10 +180,7 @@ void NavEKF2_core::setAidingMode()
          if (flowSensorTimeout || flowFusionTimeout) {
              PV_AidingMode = AID_NONE;
          }
-     }
-
-     // Determine if we should exit GPS aiding
-     if (PV_AidingMode == AID_ABSOLUTE) {
+     } else if (PV_AidingMode == AID_ABSOLUTE) {
          // check if we can use opticalflow as a backup
          bool optFlowBackupAvailable = (flowDataValid && !hgtTimeout);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -185,7 +185,13 @@ void NavEKF2_core::readMagData()
                     stateStruct.body_magfield.zero();
                     // clear the measurement buffer
                     storedMag.reset();
-                    }
+                    // clear the data waiting flag so that we do not use any data pending from the previous sensor
+                    magDataToFuse = false;
+                    // request a reset of the magnetic field states
+                    magStateResetRequest = true;
+                    // declare the field unlearned so that the reset request will be obeyed
+                    magFieldLearned = false;
+                }
             }
         }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -417,6 +417,8 @@ void NavEKF2_core::readGpsData()
             if (PV_AidingMode != AID_ABSOLUTE) {
                 // Pre-alignment checks
                 gpsGoodToAlign = calcGpsGoodToAlign();
+            } else {
+                gpsGoodToAlign = false;
             }
 
             // Post-alignment checks

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -454,54 +454,6 @@ void NavEKF2_core::readGpsData()
             gpsCheckStatus.bad_fix = true;
         }
     }
-
-    // We need to handle the case where GPS is lost for a period of time that is too long to dead-reckon
-    // If that happens we need to put the filter into a constant position mode, reset the velocity states to zero
-    // and use the last estimated position as a synthetic GPS position
-
-    // check if we can use opticalflow as a backup
-    bool optFlowBackupAvailable = (flowDataValid && !hgtTimeout);
-
-    // Set GPS time-out threshold depending on whether we have an airspeed sensor to constrain drift
-    uint16_t gpsRetryTimeout_ms = useAirspeed() ? frontend->gpsRetryTimeUseTAS_ms : frontend->gpsRetryTimeNoTAS_ms;
-
-    // Set the time that copters will fly without a GPS lock before failing the GPS and switching to a non GPS mode
-    uint16_t gpsFailTimeout_ms = optFlowBackupAvailable ? frontend->gpsFailTimeWithFlow_ms : gpsRetryTimeout_ms;
-
-    // If we haven't received GPS data for a while and we are using it for aiding, then declare the position and velocity data as being timed out
-    if (imuSampleTime_ms - lastTimeGpsReceived_ms > gpsFailTimeout_ms) {
-
-        // Let other processes know that GPS is not available and that a timeout has occurred
-        posTimeout = true;
-        velTimeout = true;
-        gpsNotAvailable = true;
-
-        // If we are totally reliant on GPS for navigation, then we need to switch to a non-GPS mode of operation
-        // If we don't have airspeed or sideslip assumption or optical flow to constrain drift, then go into constant position mode.
-        // If we can do optical flow nav (valid flow data and height above ground estimate), then go into flow nav mode.
-        if (PV_AidingMode == AID_ABSOLUTE && !useAirspeed() && !assume_zero_sideslip()) {
-            if (optFlowBackupAvailable) {
-                // we can do optical flow only nav
-                frontend->_fusionModeGPS = 3;
-                PV_AidingMode = AID_RELATIVE;
-            } else {
-                // store the current position
-                lastKnownPositionNE.x = stateStruct.position.x;
-                lastKnownPositionNE.y = stateStruct.position.y;
-
-                // put the filter into constant position mode
-                PV_AidingMode = AID_NONE;
-
-                // Reset the velocity and position states
-                ResetVelocity();
-                ResetPosition();
-
-                // Reset the normalised innovation to avoid false failing bad fusion tests
-                velTestRatio = 0.0f;
-                posTestRatio = 0.0f;
-            }
-        }
-    }
 }
 
 // read the delta angle and corresponding time interval from the IMU
@@ -534,7 +486,7 @@ void NavEKF2_core::readBaroData()
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
-        if (isAiding && getTakeoffExpected()) {
+        if (getTakeoffExpected()) {
             baroDataNew.hgt = MAX(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -209,46 +209,6 @@ void NavEKF2_core::getAccelZBias(float &zbias) const {
     }
 }
 
-// Return the last calculated NED position relative to the reference point (m).
-// if a calculated solution is not available, use the best available data and return false
-bool NavEKF2_core::getPosNED(Vector3f &pos) const
-{
-    // The EKF always has a height estimate regardless of mode of operation
-    pos.z = outputDataNew.position.z;
-    // There are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no position estimate available)
-    nav_filter_status status;
-    getFilterStatus(status);
-    if (PV_AidingMode != AID_NONE) {
-        // This is the normal mode of operation where we can use the EKF position states
-        pos.x = outputDataNew.position.x;
-        pos.y = outputDataNew.position.y;
-        return true;
-    } else {
-        // In constant position mode the EKF position states are at the origin, so we cannot use them as a position estimate
-        if(validOrigin) {
-            if ((_ahrs->get_gps().status() >= AP_GPS::GPS_OK_FIX_2D)) {
-                // If the origin has been set and we have GPS, then return the GPS position relative to the origin
-                const struct Location &gpsloc = _ahrs->get_gps().location();
-                Vector2f tempPosNE = location_diff(EKF_origin, gpsloc);
-                pos.x = tempPosNE.x;
-                pos.y = tempPosNE.y;
-                return false;
-            } else {
-                // If no GPS fix is available, all we can do is provide the last known position
-                pos.x = outputDataNew.position.x;
-                pos.y = outputDataNew.position.y;
-                return false;
-            }
-        } else {
-            // If the origin has not been set, then we have no means of providing a relative position
-            pos.x = 0.0f;
-            pos.y = 0.0f;
-            return false;
-        }
-    }
-    return false;
-}
-
 // Return the last estimated NE position relative to the reference point (m).
 // Return true if the estimate is valid
 bool NavEKF2_core::getPosNE(Vector2f &posNE) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -249,7 +249,57 @@ bool NavEKF2_core::getPosNED(Vector3f &pos) const
     return false;
 }
 
+// Return the last estimated NE position relative to the reference point (m).
+// Return true if the estimate is valid
+bool NavEKF2_core::getPosNE(Vector2f &posNE) const
+{
+    // There are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no position estimate available)
+    nav_filter_status status;
+    getFilterStatus(status);
+    if (PV_AidingMode != AID_NONE) {
+        // This is the normal mode of operation where we can use the EKF position states
+        posNE.x = outputDataNew.position.x;
+        posNE.y = outputDataNew.position.y;
+        return true;
+    } else {
+        // In constant position mode the EKF position states are at the origin, so we cannot use them as a position estimate
+        if(validOrigin) {
+            if ((_ahrs->get_gps().status() >= AP_GPS::GPS_OK_FIX_2D)) {
+                // If the origin has been set and we have GPS, then return the GPS position relative to the origin
+                const struct Location &gpsloc = _ahrs->get_gps().location();
+                Vector2f tempPosNE = location_diff(EKF_origin, gpsloc);
+                posNE.x = tempPosNE.x;
+                posNE.y = tempPosNE.y;
+                return false;
+            } else {
+                // If no GPS fix is available, all we can do is provide the last known position
+                posNE.x = outputDataNew.position.x;
+                posNE.y = outputDataNew.position.y;
+                return false;
+            }
+        } else {
+            // If the origin has not been set, then we have no means of providing a relative position
+            posNE.x = 0.0f;
+            posNE.y = 0.0f;
+            return false;
+        }
+    }
+    return false;
+}
 
+// Return the last calculated D position relative to the reference point (m).
+// Return true if the estimte is valid
+bool NavEKF2_core::getPosD(float &posD) const
+{
+    // The EKF always has a height estimate regardless of mode of operation
+    posD = outputDataNew.position.z;
+
+    // Return the current height solution status
+    nav_filter_status status;
+    getFilterStatus(status);
+    return status.flags.vert_pos;
+
+}
 // return the estimated height above ground level
 bool NavEKF2_core::getHAGL(float &HAGL) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -209,7 +209,7 @@ void NavEKF2_core::getAccelZBias(float &zbias) const {
     }
 }
 
-// Return the last estimated NE position relative to the reference point (m).
+// Write the last estimated NE position relative to the reference point (m).
 // Return true if the estimate is valid
 bool NavEKF2_core::getPosNE(Vector2f &posNE) const
 {
@@ -245,7 +245,7 @@ bool NavEKF2_core::getPosNE(Vector2f &posNE) const
     return false;
 }
 
-// Return the last calculated D position relative to the reference point (m).
+// Write the last calculated D position relative to the reference point (m).
 // Return true if the estimte is valid
 bool NavEKF2_core::getPosD(float &posD) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -459,14 +459,13 @@ void  NavEKF2_core::getFilterStatus(nav_filter_status &status) const
 {
     // init return value
     status.value = 0;
-
     bool doingFlowNav = (PV_AidingMode == AID_RELATIVE) && flowDataValid;
     bool doingWindRelNav = !tasTimeout && assume_zero_sideslip();
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
     bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
-    bool optFlowNavPossible = flowDataValid && (frontend->_fusionModeGPS == 3);
-    bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign;
+    bool optFlowNavPossible = flowDataValid && (frontend->_fusionModeGPS == 3) && delAngBiasLearned;
+    bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign && delAngBiasLearned;
     bool filterHealthy = healthy() && tiltAlignComplete && (yawAlignComplete || (!use_compass() && (PV_AidingMode == AID_NONE)));
     // If GPS height usage is specified, height is considered to be inaccurate until the GPS passes all checks
     bool hgtNotAccurate = (frontend->_altSource == 2) && !validOrigin;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -27,7 +27,7 @@ void NavEKF2_core::ResetVelocity(void)
 
     if (PV_AidingMode != AID_ABSOLUTE) {
         stateStruct.velocity.zero();
-    } else if (!gpsNotAvailable) {
+    } else {
         // reset horizontal velocity states to the GPS velocity
         stateStruct.velocity.x  = gpsDataNew.vel.x; // north velocity from blended accel data
         stateStruct.velocity.y  = gpsDataNew.vel.y; // east velocity from blended accel data
@@ -68,7 +68,7 @@ void NavEKF2_core::ResetPosition(void)
         // reset all position state history to the last known position
         stateStruct.position.x = lastKnownPositionNE.x;
         stateStruct.position.y = lastKnownPositionNE.y;
-    } else if (!gpsNotAvailable) {
+    } else  {
         // write to state vector and compensate for offset  between last GPs measurement and the EKF time horizon
         stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
         stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -38,7 +38,7 @@ bool NavEKF2_core::calcGpsGoodToAlign(void)
     if ((magTestRatio.x <= 1.0f && magTestRatio.y <= 1.0f && yawTestRatio <= 1.0f) || !consistentMagData) {
         magYawResetTimer_ms = imuSampleTime_ms;
     }
-    if (imuSampleTime_ms - magYawResetTimer_ms > 5000) {
+    if ((imuSampleTime_ms - magYawResetTimer_ms > 5000) && !motorsArmed) {
         // request reset of heading and magnetic field states
         magYawResetRequest = true;
         // reset timer to ensure that bad magnetometer data cannot cause a heading reset more often than every 5 seconds

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -213,8 +213,8 @@ void NavEKF2_core::InitialiseVariables()
     tasStoreIndex = 0;
     ofStoreIndex = 0;
     delAngCorrection.zero();
-    velCorrection.zero();
-    posCorrection.zero();
+    velErrintegral.zero();
+    posErrintegral.zero();
     gpsGoodToAlign = false;
     gpsNotAvailable = true;
     motorsArmed = false;
@@ -633,54 +633,47 @@ void NavEKF2_core::calcOutputStates()
         delAngCorrection = deltaAngErr * errorGain * dtIMUavg;
 
         // calculate velocity and position tracking errors
-        Vector3f velDelta = (stateStruct.velocity - outputDataDelayed.velocity);
-        Vector3f posDelta = (stateStruct.position - outputDataDelayed.position);
+        Vector3f velErr = (stateStruct.velocity - outputDataDelayed.velocity);
+        Vector3f posErr = (stateStruct.position - outputDataDelayed.position);
 
         // collect magnitude tracking error for diagnostics
         outputTrackError.x = deltaAngErr.length();
-        outputTrackError.y = velDelta.length();
-        outputTrackError.z = posDelta.length();
+        outputTrackError.y = velErr.length();
+        outputTrackError.z = posErr.length();
 
-        // If the user specifes a time constant for the position and velocity states then calculate and apply the position
-        // and velocity corrections immediately to the whole output history which takes longer to process but enables smaller
-        // time constants to be used. Else apply the corrections to the current state only using the same time constant
-        // used for the quaternion corrections.
-        if (frontend->_tauVelPosOutput > 0) {
-            // convert time constant from centi-seconds to seconds
-            float tauPosVel = constrain_float(0.01f*(float)frontend->_tauVelPosOutput, 0.1f, 0.5f);
+        // convert user specified time constant from centi-seconds to seconds
+        float tauPosVel = constrain_float(0.01f*(float)frontend->_tauVelPosOutput, 0.1f, 0.5f);
 
-            // calculate a gain to track the EKF position states with the specified time constant
-            float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
+        // calculate a gain to track the EKF position states with the specified time constant
+        float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
-            // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * sq(velPosGain) * 0.1f; // I term
-            velCorrection += velDelta * sq(velPosGain) * 0.1f; // I term
-            velDelta *= velPosGain; // P term
-            posDelta *= velPosGain; // P term
+        // use a PI feedback to calculate a correction that will be applied to the output state history
+        posErrintegral += posErr;
+        velErrintegral += velErr;
+        Vector3f velCorrection = velErr * velPosGain + velErrintegral * sq(velPosGain) * 0.1f;
+        Vector3f posCorrection = posErr * velPosGain + posErrintegral * sq(velPosGain) * 0.1f;
 
-            // loop through the output filter state history and apply the corrections to the velocity and position states
-            // this method is too expensive to use for the attitude states due to the quaternion operations required
-            // but does not introduce a time delay in the 'correction loop' and allows smaller tracking time constants
-            // to be used
-            output_elements outputStates;
-            for (unsigned index=0; index < imu_buffer_length; index++) {
-                outputStates = storedOutput[index];
+        // loop through the output filter state history and apply the corrections to the velocity and position states
+        // this method is too expensive to use for the attitude states due to the quaternion operations required
+        // but does not introduce a time delay in the 'correction loop' and allows smaller tracking time constants
+        // to be used
+        output_elements outputStates;
+        for (unsigned index=0; index < imu_buffer_length; index++) {
+            outputStates = storedOutput[index];
 
-                // a constant  velocity correction is applied
-                outputStates.velocity += velDelta + velCorrection;
+            // a constant  velocity correction is applied
+            outputStates.velocity += velCorrection;
 
-                // a constant position correction is applied
-                outputStates.position += posDelta + posCorrection;
+            // a constant position correction is applied
+            outputStates.position += posCorrection;
 
-                // push the updated data to the buffer
-                storedOutput[index] = outputStates;
-            }
-
-            // update output state to corrected values
-            //outputDataDelayed = storedOutput[storedIMU.get_oldest_index()];
-            outputDataNew = storedOutput[storedIMU.get_youngest_index()];
-
+            // push the updated data to the buffer
+            storedOutput[index] = outputStates;
         }
+
+        // update output state to corrected values
+        outputDataNew = storedOutput[storedIMU.get_youngest_index()];
+
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -262,6 +262,7 @@ void NavEKF2_core::InitialiseVariables()
     yawInnovAtLastMagReset = 0.0f;
     quatAtLastMagReset = stateStruct.quat;
     magFieldLearned = false;
+    delAngBiasLearned = false;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -176,10 +176,9 @@ void NavEKF2_core::InitialiseVariables()
     flowGyroBias.y = 0;
     heldVelNE.zero();
     PV_AidingMode = AID_NONE;
+    PV_AidingModePrev = AID_NONE;
     posTimeout = true;
     velTimeout = true;
-    isAiding = false;
-    prevIsAiding = false;
     memset(&faultStatus, 0, sizeof(faultStatus));
     hgtRate = 0.0f;
     mag_state.q0 = 1;
@@ -264,6 +263,7 @@ void NavEKF2_core::InitialiseVariables()
     magFieldLearned = false;
     delAngBiasLearned = false;
     memset(&filterStatus, 0, sizeof(filterStatus));
+    gpsInhibit = false;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -263,6 +263,7 @@ void NavEKF2_core::InitialiseVariables()
     quatAtLastMagReset = stateStruct.quat;
     magFieldLearned = false;
     delAngBiasLearned = false;
+    memset(&filterStatus, 0, sizeof(filterStatus));
 
     // zero data buffers
     storedIMU.reset();
@@ -460,6 +461,9 @@ void NavEKF2_core::UpdateFilter(bool predict)
 
         // Update states using sideslip constraint assumption for fly-forward vehicles
         SelectBetaFusion();
+
+        // Update the filter status
+        updateFilterStatus();
     }
 
     // Wind output forward from the fusion to output time horizon

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -71,6 +71,16 @@ public:
     // If false returned, do not use for flight control
     bool getPosNED(Vector3f &pos) const;
 
+    // Return the last calculated NE position relative to the reference point (m).
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosNE(Vector2f &posNE) const;
+
+    // Return the last calculated D position relative to the reference point (m).
+    // If a calculated solution is not available, use the best available data and return false
+    // If false returned, do not use for flight control
+    bool getPosD(float &posD) const;
+
     // return NED velocity in m/s
     void getVelNED(Vector3f &vel) const;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -733,8 +733,6 @@ private:
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
-    bool isAiding;                  // true when the filter is fusing position, velocity or flow measurements
-    bool prevIsAiding;              // isAiding from previous frame
     struct Location EKF_origin;     // LLH origin of the NED axis system - do not change unless filter is reset
     bool validOrigin;               // true when the EKF origin is valid
     float gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
@@ -883,7 +881,9 @@ private:
                      AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
                      AID_RELATIVE=2    // only optical flow aiding is being used so position estimates will be relative
                     };
-    AidingMode PV_AidingMode;           // Defines the preferred mode for aiding of velocity and position estimates from the INS
+    AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
+    AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions
+    bool gpsInhibit;                // externally set flag informing the EKF not to use the GPS
     bool gndOffsetValid;            // true when the ground offset state can still be considered valid
     Vector3f delAngBodyOF;          // bias corrected delta angle of the vehicle IMU measured summed across the time since the last OF measurement
     float delTimeOF;                // time that delAngBodyOF is summed across

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -66,12 +66,12 @@ public:
     // Intended to be used by the front-end to determine which is the primary EKF
     float faultScore(void) const;
 
-    // Return the last calculated NE position relative to the reference point (m).
+    // Write the last calculated NE position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosNE(Vector2f &posNE) const;
 
-    // Return the last calculated D position relative to the reference point (m).
+    // Write the last calculated D position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control
     bool getPosD(float &posD) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -586,6 +586,9 @@ private:
     // Assess GPS data quality and return true if good enough to align the EKF
     bool calcGpsGoodToAlign(void);
 
+    // return true when IMU calibration completed
+    bool imuCalCompleted(void);
+
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -66,11 +66,6 @@ public:
     // Intended to be used by the front-end to determine which is the primary EKF
     float faultScore(void) const;
 
-    // Return the last calculated NED position relative to the reference point (m).
-    // If a calculated solution is not available, use the best available data and return false
-    // If false returned, do not use for flight control
-    bool getPosNED(Vector3f &pos) const;
-
     // Return the last calculated NE position relative to the reference point (m).
     // If a calculated solution is not available, use the best available data and return false
     // If false returned, do not use for flight control

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -767,8 +767,8 @@ private:
     output_elements outputDataNew;  // output state data at the current time step
     output_elements outputDataDelayed; // output state data at the current time step
     Vector3f delAngCorrection;      // correction applied to delta angles used by output observer to track the EKF
-    Vector3f velCorrection;         // correction applied to velocities used by the output observer to track the EKF
-    Vector3f posCorrection;         // correction applied to positions used by the output observer to track the EKF
+    Vector3f velErrintegral;        // integral of output predictor NED velocity tracking error (m)
+    Vector3f posErrintegral;        // integral of output predictor NED position tracking error (m.sec)
     float innovYaw;                 // compass yaw angle innovation (rad)
     uint32_t timeTasReceived_ms;    // time last TAS data was received (msec)
     bool gpsGoodToAlign;            // true when the GPS quality can be used to initialise the navigation system

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -586,8 +586,8 @@ private:
     // Assess GPS data quality and return true if good enough to align the EKF
     bool calcGpsGoodToAlign(void);
 
-    // return true when IMU calibration completed
-    bool imuCalCompleted(void);
+    // return true and set the class variable true if the delta angle bias has been learned
+    bool checkGyroCalStatus(void);
 
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
@@ -801,6 +801,7 @@ private:
     bool magFieldLearned;           // true when the magnetic field has been learned
     Vector3f earthMagFieldVar;      // NED earth mag field variances for last learned field (mGauss^2)
     Vector3f bodyMagFieldVar;       // XYZ body mag field variances for last learned field (mGauss^2)
+    bool delAngBiasLearned;         // true when the gyro bias has been learned
 
     Vector3f outputTrackError;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -389,6 +389,9 @@ private:
         uint32_t    time_ms;        // 4
     };
 
+    // update the navigation filter status
+    void  updateFilterStatus(void);
+
     // update the quaternion, velocity and position states using IMU measurements
     void UpdateStrapdownEquationsNED();
 
@@ -807,6 +810,7 @@ private:
     Vector3f earthMagFieldVar;      // NED earth mag field variances for last learned field (mGauss^2)
     Vector3f bodyMagFieldVar;       // XYZ body mag field variances for last learned field (mGauss^2)
     bool delAngBiasLearned;         // true when the gyro bias has been learned
+    nav_filter_status filterStatus; // contains the status of various filter outputs
 
     Vector3f outputTrackError;
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1131,7 +1131,8 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     if (ahrs.get_NavEKF().enabled()) {
         // Write first EKF packet
         Vector3f euler;
-        Vector3f posNED;
+        Vector2f posNE;
+        float posD;
         Vector3f velNED;
         Vector3f dAngBias;
         Vector3f dVelBias;
@@ -1139,7 +1140,8 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         float posDownDeriv;
         ahrs.get_NavEKF().getEulerAngles(euler);
         ahrs.get_NavEKF().getVelNED(velNED);
-        ahrs.get_NavEKF().getPosNED(posNED);
+        ahrs.get_NavEKF().getPosNE(posNE);
+        ahrs.get_NavEKF().getPosD(posD);
         ahrs.get_NavEKF().getGyroBias(gyroBias);
         posDownDeriv = ahrs.get_NavEKF().getPosDownDerivative();
         struct log_EKF1 pkt = {
@@ -1152,9 +1154,9 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
             velE    : (float)(velNED.y), // velocity East (m/s)
             velD    : (float)(velNED.z), // velocity Down (m/s)
             posD_dot : (float)(posDownDeriv), // first derivative of down position
-            posN    : (float)(posNED.x), // metres North
-            posE    : (float)(posNED.y), // metres East
-            posD    : (float)(posNED.z), // metres Down
+            posN    : (float)(posNE.x), // metres North
+            posE    : (float)(posNE.y), // metres East
+            posD    : (float)(posD), // metres Down
             gyrX    : (int16_t)(100*degrees(gyroBias.x)), // cd/sec, displayed as deg/sec due to format string
             gyrY    : (int16_t)(100*degrees(gyroBias.y)), // cd/sec, displayed as deg/sec due to format string
             gyrZ    : (int16_t)(100*degrees(gyroBias.z)) // cd/sec, displayed as deg/sec due to format string
@@ -1286,7 +1288,8 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     uint64_t time_us = AP_HAL::micros64();
 	// Write first EKF packet
     Vector3f euler;
-    Vector3f posNED;
+    Vector2f posNE;
+    float posD;
     Vector3f velNED;
     Vector3f dAngBias;
     Vector3f dVelBias;
@@ -1294,7 +1297,8 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     float posDownDeriv;
     ahrs.get_NavEKF2().getEulerAngles(0,euler);
     ahrs.get_NavEKF2().getVelNED(0,velNED);
-    ahrs.get_NavEKF2().getPosNED(0,posNED);
+    ahrs.get_NavEKF2().getPosNE(0,posNE);
+    ahrs.get_NavEKF2().getPosD(0,posD);
     ahrs.get_NavEKF2().getGyroBias(0,gyroBias);
     posDownDeriv = ahrs.get_NavEKF2().getPosDownDerivative(0);
     struct log_EKF1 pkt = {
@@ -1307,9 +1311,9 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         velE    : (float)(velNED.y), // velocity East (m/s)
         velD    : (float)(velNED.z), // velocity Down (m/s)
         posD_dot : (float)(posDownDeriv), // first derivative of down position
-        posN    : (float)(posNED.x), // metres North
-        posE    : (float)(posNED.y), // metres East
-        posD    : (float)(posNED.z), // metres Down
+        posN    : (float)(posNE.x), // metres North
+        posE    : (float)(posNE.y), // metres East
+        posD    : (float)(posD), // metres Down
         gyrX    : (int16_t)(100*degrees(gyroBias.x)), // cd/sec, displayed as deg/sec due to format string
         gyrY    : (int16_t)(100*degrees(gyroBias.y)), // cd/sec, displayed as deg/sec due to format string
         gyrZ    : (int16_t)(100*degrees(gyroBias.z)) // cd/sec, displayed as deg/sec due to format string
@@ -1445,7 +1449,8 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         // Write 6th EKF packet
         ahrs.get_NavEKF2().getEulerAngles(1,euler);
         ahrs.get_NavEKF2().getVelNED(1,velNED);
-        ahrs.get_NavEKF2().getPosNED(1,posNED);
+        ahrs.get_NavEKF2().getPosNE(1,posNE);
+        ahrs.get_NavEKF2().getPosD(1,posD);
         ahrs.get_NavEKF2().getGyroBias(1,gyroBias);
         posDownDeriv = ahrs.get_NavEKF2().getPosDownDerivative(1);
         struct log_EKF1 pkt6 = {
@@ -1458,9 +1463,9 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
             velE    : (float)(velNED.y), // velocity East (m/s)
             velD    : (float)(velNED.z), // velocity Down (m/s)
             posD_dot : (float)(posDownDeriv), // first derivative of down position
-            posN    : (float)(posNED.x), // metres North
-            posE    : (float)(posNED.y), // metres East
-            posD    : (float)(posNED.z), // metres Down
+            posN    : (float)(posNE.x), // metres North
+            posE    : (float)(posNE.y), // metres East
+            posD    : (float)(posD), // metres Down
             gyrX    : (int16_t)(100*degrees(gyroBias.x)), // cd/sec, displayed as deg/sec due to format string
             gyrY    : (int16_t)(100*degrees(gyroBias.y)), // cd/sec, displayed as deg/sec due to format string
             gyrZ    : (int16_t)(100*degrees(gyroBias.z)) // cd/sec, displayed as deg/sec due to format string


### PR DESCRIPTION
Prevents a situation whereby an early GPS lock can result in the EKF switching to GPS aiding before gyro bias value have settled. This can result in some position drifting immediately after takeoff. Note that up to 30 seconds can be required from EKF start for gyro bias values to stabilise.

Fixes a bug in AP_InertialNav whereby the height output from the EKF was not being scaled to cm if the EKF was not operating in GPS mode. This would cause large height transients if GPS aiding was gained in-flight and caused very poor height control if taking off in alt_hold without GPS.

Fixes a bug that would prevent reversion back to non-GPS aiding if GPs was lost for an extended period and cleans up the aiding selection logic.