### PR TITLE
waf: allow to disable tests

### DIFF
--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -11,6 +11,10 @@ from waflib.Configure import conf
 import boards
 
 def configure(cfg):
+    cfg.env.HAS_GTEST = False
+    if cfg.options.disable_tests:
+        return
+
     board = cfg.get_board()
     if isinstance(board, boards.px4):
         # toolchain is currently broken for gtest
@@ -20,8 +24,6 @@ def configure(cfg):
             color='YELLOW',
         )
         return
-
-    cfg.env.HAS_GTEST = False
 
     if cfg.env.STATIC_LINKING:
         # gtest uses a function (getaddrinfo) that is supposed to be linked

--- a/wscript
+++ b/wscript
@@ -90,6 +90,10 @@ revisions.
         default=False,
         help="Don't use libiio even if supported by board and dependencies available")
 
+    g.add_option('--disable-tests', action='store_true',
+        default=False,
+        help="Disable compilation and test execution")
+
     g.add_option('--static',
         action='store_true',
         default=False,
@@ -235,7 +239,8 @@ def _build_common_taskgens(bld):
         use='mavlink',
     )
 
-    bld.libgtest(cxxflags=['-include', 'ap_config.h'])
+    if bld.env.HAS_GTEST:
+        bld.libgtest(cxxflags=['-include', 'ap_config.h'])
 
     if bld.env.HAS_GBENCHMARK:
         bld.libbenchmark()


### PR DESCRIPTION
This allows to completely disable the tests. Even the gtest submodule is
not checked out allowing integration on build servers without needing to
download one more submodule.

This is different from the --notests flag. The latter only disables
executing the tests, but always use the submodule.