### PR TITLE
Convert drivers to use I2CDevice interface (v3)

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -175,7 +175,8 @@ AP_BattMonitor::init()
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
                 drivers[instance] = new AP_BattMonitor_SMBus_PX4(*this, instance, state[instance]);
 #else
-                drivers[instance] = new AP_BattMonitor_SMBus_I2C(*this, instance, state[instance]);
+                drivers[instance] = new AP_BattMonitor_SMBus_I2C(*this, instance, state[instance],
+                                                                 hal.i2c_mgr->get_device(0, BATTMONITOR_SMBUS_I2C_ADDR));
 #endif
                 _num_instances++;
                 break;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -176,7 +176,7 @@ AP_BattMonitor::init()
                 drivers[instance] = new AP_BattMonitor_SMBus_PX4(*this, instance, state[instance]);
 #else
                 drivers[instance] = new AP_BattMonitor_SMBus_I2C(*this, instance, state[instance],
-                                                                 hal.i2c_mgr->get_device(0, BATTMONITOR_SMBUS_I2C_ADDR));
+                                                                 hal.i2c_mgr->get_device(BATTMONITOR_SBUS_I2C_BUS, BATTMONITOR_SMBUS_I2C_ADDR));
 #endif
                 _num_instances++;
                 break;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
@@ -4,14 +4,13 @@
 #include <AP_Math/AP_Math.h>
 #include "AP_BattMonitor.h"
 #include "AP_BattMonitor_SMBus_I2C.h"
+#include <utility>
 
 extern const AP_HAL::HAL& hal;
 
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD != HAL_BOARD_PX4
-
-#define BATTMONITOR_SMBUS_I2C_ADDR  0x0B    // default I2C bus address
 
 #define BATTMONITOR_SMBUS_TEMP      0x08    // temperature register
 #define BATTMONITOR_SMBUS_VOLTAGE   0x09    // voltage register
@@ -28,8 +27,11 @@ extern const AP_HAL::HAL& hal;
 #define BATTMONITOR_SMBUS_CURRENT               0x2a    // current register
 
 // Constructor
-AP_BattMonitor_SMBus_I2C::AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state) :
-    AP_BattMonitor_SMBus(mon, instance, mon_state)
+AP_BattMonitor_SMBus_I2C::AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance,
+                                                   AP_BattMonitor::BattMonitor_State &mon_state,
+                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev) :
+    AP_BattMonitor_SMBus(mon, instance, mon_state),
+    _dev(std::move(dev))
 {}
 
 /// Read the battery voltage and current.  Should be called at 10hz
@@ -62,26 +64,23 @@ void AP_BattMonitor_SMBus_I2C::read()
 // returns true if read was successful, false if failed
 bool AP_BattMonitor_SMBus_I2C::read_word(uint8_t reg, uint16_t& data) const
 {
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
     // take i2c bus semaphore
-    if (!i2c_sem->take_nonblocking()) {
+    if (!_dev->get_semaphore()->take_nonblocking()) {
         return false;
     }
 
     uint8_t buff[3];    // buffer to hold results
 
     // read three bytes and place in last three bytes of buffer
-    if (hal.i2c->readRegisters(BATTMONITOR_SMBUS_I2C_ADDR, reg, 3, buff) != 0) {
-        i2c_sem->give();
+    if (!_dev->read_registers(reg, buff, sizeof(buff))) {
+        _dev->get_semaphore()->give();
         return false;
     }
 
     // check PEC
     uint8_t pec = get_PEC(BATTMONITOR_SMBUS_I2C_ADDR, reg, true, buff, 2);
     if (pec != buff[2]) {
-        i2c_sem->give();
+        _dev->get_semaphore()->give();
         return false;
     }
 
@@ -89,7 +88,7 @@ bool AP_BattMonitor_SMBus_I2C::read_word(uint8_t reg, uint16_t& data) const
     data = (uint16_t)buff[1]<<8 | (uint16_t)buff[0];
 
     // give back i2c semaphore
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     // return success
     return true;
@@ -100,22 +99,19 @@ uint8_t AP_BattMonitor_SMBus_I2C::read_block(uint8_t reg, uint8_t* data, uint8_t
 {
     uint8_t buff[max_len+2];    // buffer to hold results (2 extra byte returned holding length and PEC)
 
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
     // take i2c bus semaphore
-    if (!i2c_sem->take_nonblocking()) {
+    if (!_dev->get_semaphore()->take_nonblocking()) {
         return 0;
     }
 
     // read bytes
-    if (hal.i2c->readRegisters(BATTMONITOR_SMBUS_I2C_ADDR, reg, max_len+2, buff) != 0) {
-        i2c_sem->give();
+    if (!_dev->read_registers(reg, buff, sizeof(buff))) {
+        _dev->get_semaphore()->give();
         return 0;
     }
 
     // give back i2c semaphore
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     // get length
     uint8_t bufflen = buff[0];

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
@@ -29,9 +29,9 @@ extern const AP_HAL::HAL& hal;
 // Constructor
 AP_BattMonitor_SMBus_I2C::AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
-                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev) :
-    AP_BattMonitor_SMBus(mon, instance, mon_state),
-    _dev(std::move(dev))
+                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+    : AP_BattMonitor_SMBus(mon, instance, mon_state)
+    , _dev(std::move(dev))
 {}
 
 /// Read the battery voltage and current.  Should be called at 10hz

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.h
@@ -5,13 +5,18 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include "AP_BattMonitor_SMBus.h"
+#include <AP_HAL/I2CDevice.h>
+
+#define BATTMONITOR_SMBUS_I2C_ADDR 0x0B    // default I2C bus address
 
 class AP_BattMonitor_SMBus_I2C : public AP_BattMonitor_SMBus
 {
 public:
 
     // Constructor
-    AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state);
+    AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance,
+                             AP_BattMonitor::BattMonitor_State &mon_state,
+                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // Read the battery voltage and current.  Should be called at 10hz
     void read();
@@ -28,4 +33,6 @@ private:
     // get_PEC - calculate PEC for a read or write from the battery
     //  buff is the data that was read or will be written
     uint8_t get_PEC(const uint8_t i2c_addr, uint8_t cmd, bool reading, const uint8_t buff[], uint8_t len) const;
+
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.h
@@ -7,6 +7,7 @@
 #include "AP_BattMonitor_SMBus.h"
 #include <AP_HAL/I2CDevice.h>
 
+#define BATTMONITOR_SBUS_I2C_BUS 1
 #define BATTMONITOR_SMBUS_I2C_ADDR 0x0B    // default I2C bus address
 
 class AP_BattMonitor_SMBus_I2C : public AP_BattMonitor_SMBus

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -63,7 +63,7 @@ bool AP_RangeFinder_LightWareI2C::get_reading(uint16_t &reading_cm)
     }
 
     // exit immediately if we can't take the semaphore
-    if (!_dev->get_semaphore()->take(1)) {
+    if (!_dev || _dev->get_semaphore()->take(1)) {
         return false;
     }
 
@@ -75,6 +75,7 @@ bool AP_RangeFinder_LightWareI2C::get_reading(uint16_t &reading_cm)
     }
 
     _dev->get_semaphore()->give();
+
     return ret;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -21,7 +21,7 @@
 extern const AP_HAL::HAL& hal;
 
 /* 
-   The constructor also initialises the rangefinder. Note that this
+   The constructor also initializes the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
 */
@@ -54,29 +54,26 @@ AP_RangeFinder_Backend *AP_RangeFinder_LightWareI2C::detect(RangeFinder &_ranger
 // read - return last value measured by sensor
 bool AP_RangeFinder_LightWareI2C::get_reading(uint16_t &reading_cm)
 {
+    uint8_t buff[2];
+
+    if (ranger._address[state.instance] == 0) {
+        return false;
+    }
+
     // exit immediately if we can't take the semaphore
     if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
     
-    if (ranger._address[state.instance] == 0) {
-        return false;
-    }
-
-    uint8_t buff[2];
     // read the high and low byte distance registers
-    if (!_dev->read(buff, sizeof(buff))) {
-        _dev->get_semaphore()->give();
-        return false;
+    bool ret = _dev->read(buff, sizeof(buff));
+    if (ret) {
+        // combine results into distance
+        reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
     }
 
-    // combine results into distance
-    reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
-
-    // return semaphore
     _dev->get_semaphore()->give();
-
-    return true;
+    return ret;
 }
 
 /* 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -13,25 +13,27 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #include "AP_RangeFinder_LightWareI2C.h"
-#include <AP_HAL/AP_HAL.h>
+
 #include <utility>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/sparse-endian.h>
 
 extern const AP_HAL::HAL& hal;
 
-/* 
+/*
    The constructor also initializes the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
 */
-AP_RangeFinder_LightWareI2C::AP_RangeFinder_LightWareI2C(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev) :
-    AP_RangeFinder_Backend(_ranger, instance, _state),
-    _dev(std::move(dev))
+AP_RangeFinder_LightWareI2C::AP_RangeFinder_LightWareI2C(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+    : AP_RangeFinder_Backend(_ranger, instance, _state)
+    , _dev(std::move(dev))
 {
 }
 
-/* 
+/*
    detect if a Lightware rangefinder is connected. We'll detect by
    trying to take a reading on I2C. If we get a result the sensor is
    there.
@@ -54,7 +56,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_LightWareI2C::detect(RangeFinder &_ranger
 // read - return last value measured by sensor
 bool AP_RangeFinder_LightWareI2C::get_reading(uint16_t &reading_cm)
 {
-    uint8_t buff[2];
+    be16_t val;
 
     if (ranger._address[state.instance] == 0) {
         return false;
@@ -64,19 +66,19 @@ bool AP_RangeFinder_LightWareI2C::get_reading(uint16_t &reading_cm)
     if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
-    
+
     // read the high and low byte distance registers
-    bool ret = _dev->read(buff, sizeof(buff));
+    bool ret = _dev->read((uint8_t *) &val, sizeof(val));
     if (ret) {
         // combine results into distance
-        reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
+        reading_cm = be16toh(val);
     }
 
     _dev->get_semaphore()->give();
     return ret;
 }
 
-/* 
+/*
    update the state of the sensor
 */
 void AP_RangeFinder_LightWareI2C::update(void)

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -3,21 +3,23 @@
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
+#include <AP_HAL/I2CDevice.h>
 
 class AP_RangeFinder_LightWareI2C : public AP_RangeFinder_Backend
 {
 
 public:
-    // constructor
-    AP_RangeFinder_LightWareI2C(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state);
-
     // static detection function
-    static bool detect(RangeFinder &ranger, uint8_t instance);
+    static AP_RangeFinder_Backend *detect(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // update state
     void update(void);
 
 private:
+    // constructor
+    AP_RangeFinder_LightWareI2C(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
     // get a reading
     bool get_reading(uint16_t &reading_cm);
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -25,6 +25,7 @@
 
 #include "AP_RangeFinder_MaxsonarI2CXL.h"
 #include <AP_HAL/AP_HAL.h>
+#include <utility>
 
 extern const AP_HAL::HAL& hal;
 
@@ -34,7 +35,8 @@ extern const AP_HAL::HAL& hal;
    already know that we should setup the rangefinder
 */
 AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state) :
-    AP_RangeFinder_Backend(_ranger, instance, _state)
+    AP_RangeFinder_Backend(_ranger, instance, _state),
+    _dev(hal.i2c_mgr->get_device(0, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR))
 {
 }
 
@@ -43,40 +45,44 @@ AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder &_ranger,
    trying to take a reading on I2C. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder &_ranger, uint8_t instance)
+AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder &_ranger, uint8_t instance,
+                                                             RangeFinder::RangeFinder_State &_state)
 {
-    if (!start_reading()) {
-        return false;
+    AP_RangeFinder_MaxsonarI2CXL *sensor
+        = new AP_RangeFinder_MaxsonarI2CXL(_ranger, instance, _state);
+
+    if (!sensor->start_reading()) {
+        delete sensor;
+        return nullptr;
     }
     // give time for the sensor to process the request
     hal.scheduler->delay(50);
     uint16_t reading_cm;
-    return get_reading(reading_cm);
+    if (!sensor->get_reading(reading_cm)) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
 }
 
 // start_reading() - ask sensor to make a range reading
 bool AP_RangeFinder_MaxsonarI2CXL::start_reading()
 {
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
-    // exit immediately if we can't take the semaphore
-    if (i2c_sem == NULL || !i2c_sem->take(1)) {
+    if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
 
-    uint8_t tosend[1] = 
-        { AP_RANGE_FINDER_MAXSONARI2CXL_COMMAND_TAKE_RANGE_READING };
+    uint8_t tosend[] = {AP_RANGE_FINDER_MAXSONARI2CXL_COMMAND_TAKE_RANGE_READING};
 
     // send command to take reading
-    if (hal.i2c->write(AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR,
-                       1, tosend) != 0) {
-        i2c_sem->give();
+    if (!_dev->transfer(tosend, sizeof(tosend), nullptr, 0)) {
+        _dev->get_semaphore()->give();
         return false;
     }
 
     // return semaphore
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     return true;
 }
@@ -84,22 +90,18 @@ bool AP_RangeFinder_MaxsonarI2CXL::start_reading()
 // read - return last value measured by sensor
 bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 {
-    uint8_t buff[2];
-
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
     // exit immediately if we can't take the semaphore
-    if (i2c_sem == NULL || !i2c_sem->take(1)) {
+    if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
 
+    uint8_t buff[2];
     // take range reading and read back results
-    if (hal.i2c->read(AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR, 2, buff) != 0) {
-        i2c_sem->give();
+    if (!_dev->transfer(nullptr, 0, buff, sizeof(buff))) {
+        _dev->get_semaphore()->give();
         return false;
     }
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     // combine results into distance
     reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -22,25 +22,27 @@
  *
  *       Sensor should be connected to the I2C port
  */
-
 #include "AP_RangeFinder_MaxsonarI2CXL.h"
-#include <AP_HAL/AP_HAL.h>
+
 #include <utility>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/sparse-endian.h>
 
 extern const AP_HAL::HAL& hal;
 
-/* 
+/*
    The constructor also initializes the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
 */
-AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state) :
-    AP_RangeFinder_Backend(_ranger, instance, _state),
-    _dev(hal.i2c_mgr->get_device(0, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR))
+AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state)
+    : AP_RangeFinder_Backend(_ranger, instance, _state)
+    , _dev(hal.i2c_mgr->get_device(1, AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR))
 {
 }
 
-/* 
+/*
    detect if a Maxbotix rangefinder is connected. We'll detect by
    trying to take a reading on I2C. If we get a result the sensor is
    there.
@@ -55,8 +57,10 @@ AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder &_range
         delete sensor;
         return nullptr;
     }
+
     // give time for the sensor to process the request
     hal.scheduler->delay(50);
+
     uint16_t reading_cm;
     if (!sensor->get_reading(reading_cm)) {
         delete sensor;
@@ -69,22 +73,24 @@ AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder &_range
 // start_reading() - ask sensor to make a range reading
 bool AP_RangeFinder_MaxsonarI2CXL::start_reading()
 {
-    if (!_dev->get_semaphore()->take(1)) {
+    if (!_dev || !_dev->get_semaphore()->take(1)) {
         return false;
     }
 
-    uint8_t tosend[] = {AP_RANGE_FINDER_MAXSONARI2CXL_COMMAND_TAKE_RANGE_READING};
+    uint8_t cmd = AP_RANGE_FINDER_MAXSONARI2CXL_COMMAND_TAKE_RANGE_READING;
 
     // send command to take reading
-    bool ret = _dev->transfer(tosend, sizeof(tosend), nullptr, 0);
+    bool ret = _dev->transfer(&cmd, sizeof(cmd), nullptr, 0);
+
     _dev->get_semaphore()->give();
+
     return ret;
 }
 
 // read - return last value measured by sensor
 bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 {
-    uint8_t buff[2];
+    be16_t val;
 
     // exit immediately if we can't take the semaphore
     if (!_dev->get_semaphore()->take(1)) {
@@ -92,12 +98,12 @@ bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
     }
 
     // take range reading and read back results
-    bool ret = _dev->transfer(nullptr, 0, buff, sizeof(buff));
+    bool ret = _dev->transfer(nullptr, 0, (uint8_t *) &val, sizeof(val));
     _dev->get_semaphore()->give();
 
     if (ret) {
         // combine results into distance
-        reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
+        reading_cm = be16toh(val);
 
         // trigger a new reading
         start_reading();
@@ -107,7 +113,7 @@ bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 }
 
 
-/* 
+/*
    update the state of the sensor
 */
 void AP_RangeFinder_MaxsonarI2CXL::update(void)

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -30,7 +30,7 @@
 extern const AP_HAL::HAL& hal;
 
 /* 
-   The constructor also initialises the rangefinder. Note that this
+   The constructor also initializes the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
 */
@@ -76,40 +76,34 @@ bool AP_RangeFinder_MaxsonarI2CXL::start_reading()
     uint8_t tosend[] = {AP_RANGE_FINDER_MAXSONARI2CXL_COMMAND_TAKE_RANGE_READING};
 
     // send command to take reading
-    if (!_dev->transfer(tosend, sizeof(tosend), nullptr, 0)) {
-        _dev->get_semaphore()->give();
-        return false;
-    }
-
-    // return semaphore
+    bool ret = _dev->transfer(tosend, sizeof(tosend), nullptr, 0);
     _dev->get_semaphore()->give();
-
-    return true;
+    return ret;
 }
 
 // read - return last value measured by sensor
 bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 {
+    uint8_t buff[2];
+
     // exit immediately if we can't take the semaphore
     if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
 
-    uint8_t buff[2];
     // take range reading and read back results
-    if (!_dev->transfer(nullptr, 0, buff, sizeof(buff))) {
-        _dev->get_semaphore()->give();
-        return false;
-    }
+    bool ret = _dev->transfer(nullptr, 0, buff, sizeof(buff));
     _dev->get_semaphore()->give();
 
-    // combine results into distance
-    reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
+    if (ret) {
+        // combine results into distance
+        reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
 
-    // trigger a new reading
-    start_reading();
+        // trigger a new reading
+        start_reading();
+    }
 
-    return true;
+    return ret;
 }
 
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
@@ -3,6 +3,7 @@
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
+#include <AP_HAL/I2CDevice.h>
 
 #define AP_RANGE_FINDER_MAXSONARI2CXL_DEFAULT_ADDR   0x70
 
@@ -16,17 +17,20 @@
 class AP_RangeFinder_MaxsonarI2CXL : public AP_RangeFinder_Backend
 {
 public:
-    // constructor
-    AP_RangeFinder_MaxsonarI2CXL(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state);
-
     // static detection function
-    static bool detect(RangeFinder &ranger, uint8_t instance);
+    static AP_RangeFinder_Backend *detect(RangeFinder &ranger, uint8_t instance,
+                                          RangeFinder::RangeFinder_State &_state);
 
     // update state
     void update(void);
 
 private:
+    // constructor
+    AP_RangeFinder_MaxsonarI2CXL(RangeFinder &ranger, uint8_t instance,
+                                 RangeFinder::RangeFinder_State &_state);
+
     // start a reading
-    static bool start_reading(void);
-    static bool get_reading(uint16_t &reading_cm);
+    bool start_reading(void);
+    bool get_reading(uint16_t &reading_cm);
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -16,6 +16,7 @@
 
 #include "AP_RangeFinder_PulsedLightLRF.h"
 #include <AP_HAL/AP_HAL.h>
+#include <utility>
 
 extern const AP_HAL::HAL& hal;
 
@@ -24,8 +25,10 @@ extern const AP_HAL::HAL& hal;
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
 */
-AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state) :
-    AP_RangeFinder_Backend(_ranger, instance, _state)
+AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_ranger, uint8_t instance,
+                                                             RangeFinder::RangeFinder_State &_state) :
+    AP_RangeFinder_Backend(_ranger, instance, _state),
+    _dev(hal.i2c_mgr->get_device(0, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
 {
 }
 
@@ -34,38 +37,44 @@ AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_range
    trying to take a reading on I2C. If we get a result the sensor is
    there.
 */
-bool AP_RangeFinder_PulsedLightLRF::detect(RangeFinder &_ranger, uint8_t instance)
+AP_RangeFinder_Backend *AP_RangeFinder_PulsedLightLRF::detect(RangeFinder &_ranger, uint8_t instance,
+                                                              RangeFinder::RangeFinder_State &_state)
 {
-    if (!start_reading()) {
-        return false;
+    AP_RangeFinder_PulsedLightLRF *sensor
+        = new AP_RangeFinder_PulsedLightLRF(_ranger, instance, _state);
+
+    if (!sensor->start_reading()) {
+        delete sensor;
+        return nullptr;
     }
     // give time for the sensor to process the request
     hal.scheduler->delay(50);
     uint16_t reading_cm;
-    return get_reading(reading_cm);
+
+    if (!sensor->get_reading(reading_cm)) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
 }
 
 // start_reading() - ask sensor to make a range reading
 bool AP_RangeFinder_PulsedLightLRF::start_reading()
 {
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
-    // exit immediately if we can't take the semaphore
-    if (i2c_sem == NULL || !i2c_sem->take(1)) {
+    if (!_dev->get_semaphore()->take(1)) {
         return false;
     }
 
     // send command to take reading
-    if (hal.i2c->writeRegister(AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR, 
-                               AP_RANGEFINDER_PULSEDLIGHTLRF_MEASURE_REG, 
-                               AP_RANGEFINDER_PULSEDLIGHTLRF_MSRREG_ACQUIRE) != 0) {
-        i2c_sem->give();
+    if (!_dev->write_register(AP_RANGEFINDER_PULSEDLIGHTLRF_MEASURE_REG,
+                              AP_RANGEFINDER_PULSEDLIGHTLRF_MSRREG_ACQUIRE)) {
+        _dev->get_semaphore()->give();
         return false;
     }
 
     // return semaphore
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     return true;
 }
@@ -73,20 +82,14 @@ bool AP_RangeFinder_PulsedLightLRF::start_reading()
 // read - return last value measured by sensor
 bool AP_RangeFinder_PulsedLightLRF::get_reading(uint16_t &reading_cm)
 {
-    uint8_t buff[2];
-
-    // get pointer to i2c bus semaphore
-    AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();
-
-    // exit immediately if we can't take the semaphore
-    if (i2c_sem == NULL || !i2c_sem->take(1)) {
+    if (_dev->get_semaphore()->take(1)) {
         return false;
     }
 
+    uint8_t buff[2];
     // read the high and low byte distance registers
-    if (hal.i2c->readRegisters(AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR, 
-                               AP_RANGEFINDER_PULSEDLIGHTLRF_DISTHIGH_REG, 2, &buff[0]) != 0) {
-        i2c_sem->give();
+    if (!_dev->read_registers(AP_RANGEFINDER_PULSEDLIGHTLRF_DISTHIGH_REG, buff, sizeof(buff))) {
+        _dev->get_semaphore()->give();
         return false;
     }
 
@@ -94,7 +97,7 @@ bool AP_RangeFinder_PulsedLightLRF::get_reading(uint16_t &reading_cm)
     reading_cm = ((uint16_t)buff[0]) << 8 | buff[1];
 
     // return semaphore
-    i2c_sem->give();
+    _dev->get_semaphore()->give();
 
     // kick off another reading for next time
     // To-Do: replace this with continuous mode

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -30,7 +30,7 @@ extern const AP_HAL::HAL& hal;
 AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_ranger, uint8_t instance,
                                                              RangeFinder::RangeFinder_State &_state)
     : AP_RangeFinder_Backend(_ranger, instance, _state)
-    , _dev(hal.i2c_mgr->get_device(0, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
+    , _dev(hal.i2c_mgr->get_device(1, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
 {
 }
 
@@ -64,7 +64,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_PulsedLightLRF::detect(RangeFinder &_rang
 // start_reading() - ask sensor to make a range reading
 bool AP_RangeFinder_PulsedLightLRF::start_reading()
 {
-    if (!_dev->get_semaphore()->take(1)) {
+    if (!_dev || !_dev->get_semaphore()->take(1)) {
         return false;
     }
 
@@ -72,6 +72,7 @@ bool AP_RangeFinder_PulsedLightLRF::start_reading()
     bool ret = _dev->write_register(AP_RANGEFINDER_PULSEDLIGHTLRF_MEASURE_REG,
                                     AP_RANGEFINDER_PULSEDLIGHTLRF_MSRREG_ACQUIRE);
     _dev->get_semaphore()->give();
+
     return ret;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -13,10 +13,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #include "AP_RangeFinder_PulsedLightLRF.h"
-#include <AP_HAL/AP_HAL.h>
+
 #include <utility>
+
+#include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -26,9 +27,9 @@ extern const AP_HAL::HAL& hal;
    already know that we should setup the rangefinder
 */
 AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_ranger, uint8_t instance,
-                                                             RangeFinder::RangeFinder_State &_state) :
-    AP_RangeFinder_Backend(_ranger, instance, _state),
-    _dev(hal.i2c_mgr->get_device(0, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
+                                                             RangeFinder::RangeFinder_State &_state)
+    : AP_RangeFinder_Backend(_ranger, instance, _state)
+    , _dev(hal.i2c_mgr->get_device(0, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
 {
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
@@ -3,6 +3,7 @@
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
+#include <AP_HAL/I2CDevice.h>
 
 /* Connection diagram
  *
@@ -32,18 +33,21 @@ class AP_RangeFinder_PulsedLightLRF : public AP_RangeFinder_Backend
 {
 
 public:
-    // constructor
-    AP_RangeFinder_PulsedLightLRF(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state);
-
     // static detection function
-    static bool detect(RangeFinder &ranger, uint8_t instance);
+    static AP_RangeFinder_Backend *detect(RangeFinder &ranger, uint8_t instance,
+                                          RangeFinder::RangeFinder_State &_state);
 
     // update state
     void update(void);
 
 
 private:
+    // constructor
+    AP_RangeFinder_PulsedLightLRF(RangeFinder &ranger, uint8_t instance,
+                                  RangeFinder::RangeFinder_State &_state);
+
     // start a reading
-    static bool start_reading(void);
-    static bool get_reading(uint16_t &reading_cm);
+    bool start_reading(void);
+    bool get_reading(uint16_t &reading_cm);
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 };

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -463,6 +463,18 @@ void RangeFinder::update(void)
         }
     }
 }
+
+void RangeFinder::_add_backend(AP_RangeFinder_Backend *backend)
+{
+    if (!backend) {
+        return;
+    }
+    if (num_instances == RANGEFINDER_MAX_INSTANCES) {
+        AP_HAL::panic("Too many RANGERS backends");
+    }
+
+    drivers[num_instances++] = backend;
+}
     
 /*
   detect if an instance of a rangefinder is connected. 

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -26,7 +26,7 @@
 #include "AP_RangeFinder_Bebop.h"
 #include "AP_RangeFinder_MAVLink.h"
 
-extern const AP_HAL::HAL& hal;
+extern const AP_HAL::HAL &hal;
 
 // table of user settable parameters
 const AP_Param::GroupInfo RangeFinder::var_info[] = {
@@ -495,18 +495,14 @@ void RangeFinder::detect_instance(uint8_t instance)
         _add_backend(AP_RangeFinder_PulsedLightLRF::detect(*this, instance, state[instance]));
     }
     if (type == RangeFinder_TYPE_MBI2C) {
-        if (AP_RangeFinder_MaxsonarI2CXL::detect(*this, instance)) {
-            state[instance].instance = instance;
-            drivers[instance] = new AP_RangeFinder_MaxsonarI2CXL(*this, instance, state[instance]);
-            return;
-        }
+        _add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(*this, instance, state[instance]));
     }
     if (type == RangeFinder_TYPE_LWI2C) {
         if (_address[instance]) {
             _add_backend(AP_RangeFinder_LightWareI2C::detect(*this, instance, state[instance],
                 hal.i2c_mgr->get_device(0, _address[instance])));
         }
-    } 
+    }
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4  || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     if (type == RangeFinder_TYPE_PX4) {
         if (AP_RangeFinder_PX4::detect(*this, instance)) {

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -26,6 +26,8 @@
 #include "AP_RangeFinder_Bebop.h"
 #include "AP_RangeFinder_MAVLink.h"
 
+extern const AP_HAL::HAL& hal;
+
 // table of user settable parameters
 const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _TYPE
@@ -490,12 +492,8 @@ void RangeFinder::detect_instance(uint8_t instance)
     }
 #endif
     if (type == RangeFinder_TYPE_PLI2C) {
-        if (AP_RangeFinder_PulsedLightLRF::detect(*this, instance)) {
-            state[instance].instance = instance;
-            drivers[instance] = new AP_RangeFinder_PulsedLightLRF(*this, instance, state[instance]);
-            return;
-        }
-    } 
+        _add_backend(AP_RangeFinder_PulsedLightLRF::detect(*this, instance, state[instance]));
+    }
     if (type == RangeFinder_TYPE_MBI2C) {
         if (AP_RangeFinder_MaxsonarI2CXL::detect(*this, instance)) {
             state[instance].instance = instance;

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -502,10 +502,9 @@ void RangeFinder::detect_instance(uint8_t instance)
         }
     }
     if (type == RangeFinder_TYPE_LWI2C) {
-        if (AP_RangeFinder_LightWareI2C::detect(*this, instance)) {
-            state[instance].instance = instance;
-            drivers[instance] = new AP_RangeFinder_LightWareI2C(*this, instance, state[instance]);
-            return;
+        if (_address[instance]) {
+            _add_backend(AP_RangeFinder_LightWareI2C::detect(*this, instance, state[instance],
+                hal.i2c_mgr->get_device(0, _address[instance])));
         }
     } 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4  || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -193,4 +193,5 @@ private:
     void update_instance(uint8_t instance);  
 
     void update_pre_arm_check(uint8_t instance);
+    void _add_backend(AP_RangeFinder_Backend *driver);
 };


### PR DESCRIPTION
All I2C drivers are now converted. Tested:

  - ToshibaLED
  - Airspeed_I2C is tested by @tridge and probably with a pending fix on his branch
  - RCOutput_PCA9685
  - NavioLED

Would be nice if someone could test:

  - Changes to AP_RangeFinder
  - RCOutput_Bebop
  - AP_BattMonitor_SMBus
  - Display_SSD1306_I2C