### PR TITLE
Plane: ADSB-out support via uAvionix Ping2020 transceiver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = git://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/ArduPilot/mavlink
+	url = git://github.com/airphrame/mavlink
 [submodule "gtest"]
 	path = modules/gtest
 	url = git://github.com/ArduPilot/googletest

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -127,7 +127,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(compass_cal_update,   100,    100),
     SCHED_TASK(accel_cal_update,      10,    100),
 #if ADSB_ENABLED == ENABLED
-    SCHED_TASK(adsb_update,            1,    100),
+    SCHED_TASK(adsb_update,            5,    100),
 #endif
 #if FRSKY_TELEM_ENABLED == ENABLED
     SCHED_TASK(frsky_telemetry_send,   5,     75),
@@ -501,6 +501,8 @@ void Copter::one_hz_loop()
 
     // log terrain data
     terrain_logging();
+
+    adsb.set_is_flying(!ap.land_complete);
 }
 
 // called at 50hz

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2093,6 +2093,12 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 #endif
         break;
 
+    case MAVLINK_MSG_ID_ADSB_TRANSPONDER_DYNAMIC_OUTPUT:
+#if ADSB_ENABLED == ENABLED
+        copter.adsb.transceiver_report(chan, msg);
+#endif
+        break;
+
     case MAVLINK_MSG_ID_SETUP_SIGNING:
         handle_setup_signing(msg);
         break;

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -120,6 +120,8 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
         control_mode_reason = reason;
         DataFlash.Log_Write_Mode(control_mode, control_mode_reason);
 
+        adsb.set_is_auto_mode((mode == AUTO) || (mode == RTL) || (mode == GUIDED));
+
 #if AC_FENCE == ENABLED
         // pilot requested flight mode change during a fence breach indicates pilot is attempting to manually recover
         // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -321,6 +321,8 @@ void Plane::one_second_loop()
     // make it possible to change orientation at runtime
     ahrs.set_orientation();
 
+    adsb.set_stall_speed_cm(aparm.airspeed_min);
+
     // sync MAVLink system ID
     mavlink_system.sysid = g.sysid_this_mav;
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -84,7 +84,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(terrain_update,         10,    200),
     SCHED_TASK(update_is_flying_5Hz,    5,    100),
     SCHED_TASK(dataflash_periodic,     50,    400),
-    SCHED_TASK(adsb_update,             1,    400),
+    SCHED_TASK(adsb_update,             5,    400),
 };
 
 void Plane::setup() 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2265,6 +2265,10 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         plane.adsb.update_vehicle(msg);
         break;
 
+    case MAVLINK_MSG_ID_ADSB_TRANSPONDER_DYNAMIC_OUTPUT:
+        plane.adsb.transceiver_report(chan, msg);
+        break;
+
     case MAVLINK_MSG_ID_SETUP_SIGNING:
         handle_setup_signing(msg);
         break;

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -153,6 +153,7 @@ void Plane::update_is_flying_5Hz(void)
         }
     }
     previous_is_flying = new_is_flying;
+    adsb.set_is_flying(new_is_flying);
 
     crash_detection_update();
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -482,6 +482,8 @@ void Plane::set_mode(enum FlightMode mode)
     // start with throttle suppressed in auto_throttle modes
     throttle_suppressed = auto_throttle_mode;
 
+    adsb.set_is_auto_mode(auto_navigation_mode);
+
     if (should_log(MASK_LOG_MODE))
         DataFlash.Log_Write_Mode(control_mode);
 

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -203,13 +203,12 @@ void AP_ADSB::update(void)
         // if param changed then regenerate. This allows the param to be changed back to zero to trigger a re-generate
         if (out_state.cfg.ICAO_id_param == 0) {
             out_state.cfg.ICAO_id = genICAO(_my_loc);
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "ADSB: Generated ICAO_id: %d", out_state.cfg.ICAO_id);
         } else {
             out_state.cfg.ICAO_id = out_state.cfg.ICAO_id_param;
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id: %d", out_state.cfg.ICAO_id);
         }
         out_state.cfg.ICAO_id_param_prev = out_state.cfg.ICAO_id_param;
         set_callsign("PING", true);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "ADSB: Using ICAO_id %d and Callsign %s", out_state.cfg.ICAO_id, out_state.cfg.callsign);
         out_state.last_config_ms = 0; // send now
     }
 
@@ -645,7 +644,7 @@ void AP_ADSB::set_callsign(const char* str, bool append_icao)
 
     if (append_icao) {
         char str_icao[5];
-        sprintf(str_icao, "%4d", out_state.cfg.ICAO_id % 10000);
+        sprintf(str_icao, "%04X", out_state.cfg.ICAO_id % 0x10000);
         out_state.cfg.callsign[4] = str_icao[0];
         out_state.cfg.callsign[5] = str_icao[1];
         out_state.cfg.callsign[6] = str_icao[2];

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -219,13 +219,13 @@ void AP_ADSB::update(void)
             // haven't gotten a heartbeat health status packet in a while, assume hardware failure
             out_state.chan = -1;
         } else {
-        if (now - out_state.last_config_ms >= 10000) {
+            if (now - out_state.last_config_ms >= 5000) {
             out_state.last_config_ms = now;
             send_configure((mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan));
         } // last_config_ms
 
-        // send dynamic data to transceiver, every 1s
-        if (now - out_state.last_report_ms >= 1000) {
+            // send dynamic data to transceiver at 5Hz
+            if (now - out_state.last_report_ms >= 200) {
             out_state.last_report_ms = now;
             send_dynamic_out((mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan));
         } // last_report_ms

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -41,14 +41,15 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Description: ADSB based Collision Avoidance Behavior selector
     // @Values: 0:None,1:Loiter,2:LoiterAndDescend
     // @User: Advanced
-    AP_GROUPINFO("BEHAVIOR",   1, AP_ADSB, _behavior, ADSB_BEHAVIOR_NONE),
+    AP_GROUPINFO("BEHAVIOR",   1, AP_ADSB, avoid_state.behavior, ADSB_BEHAVIOR_NONE),
 
     // @Param: LIST_MAX
     // @DisplayName: ADSB vehicle list size
     // @Description: ADSB list size of nearest vehicles. Longer lists take longer to refresh with lower SRx_ADSB values.
     // @Range: 1 100
     // @User: Advanced
-    AP_GROUPINFO("LIST_MAX",   2, AP_ADSB, _list_size_param, ADSB_VEHICLE_LIST_SIZE_DEFAULT),
+    AP_GROUPINFO("LIST_MAX",   2, AP_ADSB, in_state.list_size_param, ADSB_VEHICLE_LIST_SIZE_DEFAULT),
+
 
     AP_GROUPEND
 };
@@ -58,25 +59,28 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
  */
 void AP_ADSB::init(void)
 {
-    _vehicle_count = 0;
-    if (_vehicle_list == nullptr) {
-        if (_list_size_param != constrain_int16(_list_size_param, 1, ADSB_VEHICLE_LIST_SIZE_MAX)) {
-            _list_size_param.set_and_notify(ADSB_VEHICLE_LIST_SIZE_DEFAULT);
-            _list_size_param.save();
+    // in_state
+    in_state.vehicle_count = 0;
+    if (in_state.vehicle_list == nullptr) {
+        if (in_state.list_size_param != constrain_int16(in_state.list_size_param, 1, ADSB_VEHICLE_LIST_SIZE_MAX)) {
+            in_state.list_size_param.set_and_notify(ADSB_VEHICLE_LIST_SIZE_DEFAULT);
+            in_state.list_size_param.save();
         }
-        _list_size = _list_size_param;
-        _vehicle_list = new adsb_vehicle_t[_list_size];
+        in_state.list_size = in_state.list_size_param;
+        in_state.vehicle_list = new adsb_vehicle_t[in_state.list_size];
 
-        if (_vehicle_list == nullptr) {
+        if (in_state.vehicle_list == nullptr) {
             // dynamic RAM allocation of _vehicle_list[] failed, disable gracefully
             hal.console->printf("Unable to initialize ADS-B vehicle list\n");
             _enabled.set_and_notify(0);
         }
     }
-    _lowest_threat_distance = 0;
-    _highest_threat_distance = 0;
-    _another_vehicle_within_radius = false;
-    _is_evading_threat = false;
+
+    // avoid_state
+    avoid_state.lowest_threat_distance = 0;
+    avoid_state.highest_threat_distance = 0;
+    avoid_state.another_vehicle_within_radius = false;
+    avoid_state.is_evading_threat = false;
 }
 
 /*
@@ -84,10 +88,10 @@ void AP_ADSB::init(void)
  */
 void AP_ADSB::deinit(void)
 {
-    _vehicle_count = 0;
-    if (_vehicle_list != nullptr) {
-        delete [] _vehicle_list;
-        _vehicle_list = nullptr;
+    in_state.vehicle_count = 0;
+    if (in_state.vehicle_list != nullptr) {
+        delete [] in_state.vehicle_list;
+        in_state.vehicle_list = nullptr;
     }
 }
 
@@ -96,24 +100,32 @@ void AP_ADSB::deinit(void)
  */
 void AP_ADSB::update(void)
 {
+    // update _my_loc
+    if (!_ahrs.get_position(_my_loc)) {
+        _my_loc.zero();
+    }
+
     if (!_enabled) {
-        if (_vehicle_list != nullptr) {
+        if (in_state.vehicle_list != nullptr) {
             deinit();
         }
         // nothing to do
         return;
-    } else if (_vehicle_list == nullptr)  {
+    } else if (in_state.vehicle_list == nullptr)  {
         init();
         return;
-    } else if (_list_size != _list_size_param) {
+    } else if (in_state.list_size != in_state.list_size_param) {
         deinit();
         return;
     }
 
+    uint32_t now = AP_HAL::millis();
+
+    // check current list for vehicles that time out
     uint16_t index = 0;
-    while (index < _vehicle_count) {
+    while (index < in_state.vehicle_count) {
         // check list and drop stale vehicles. When disabled, the list will get flushed
-        if (AP_HAL::millis() - _vehicle_list[index].last_update_ms > VEHICLE_TIMEOUT_MS) {
+        if (now - in_state.vehicle_list[index].last_update_ms > VEHICLE_TIMEOUT_MS) {
             // don't increment index, we want to check this same index again because the contents changed
             // also, if we're disabled then clear the list
             delete_vehicle(index);
@@ -123,7 +135,6 @@ void AP_ADSB::update(void)
     }
 
     perform_threat_detection();
-    //hal.console->printf("ADSB: cnt %u, lowT %.0f, highT %.0f\r", _vehicle_count, _lowest_threat_distance, _highest_threat_distance);
 }
 
 /*
@@ -131,13 +142,11 @@ void AP_ADSB::update(void)
  */
 void AP_ADSB::perform_threat_detection(void)
 {
-    Location my_loc;
-    if (_vehicle_count == 0 ||
-        _ahrs.get_position(my_loc) == false) {
+    if (in_state.vehicle_count == 0 || _my_loc.is_zero()) {
         // nothing to do or current location is unknown so we can't calculate any collisions
-        _another_vehicle_within_radius = false;
-        _lowest_threat_distance = 0; // 0 means invalid
-        _highest_threat_distance = 0; // 0 means invalid
+        avoid_state.another_vehicle_within_radius = false;
+        avoid_state.lowest_threat_distance = 0; // 0 means invalid
+        avoid_state.highest_threat_distance = 0; // 0 means invalid
         return;
     }
 
@@ -152,8 +161,8 @@ void AP_ADSB::perform_threat_detection(void)
     uint16_t min_distance_index = 0;
     uint16_t max_distance_index = 0;
 
-    for (uint16_t index = 0; index < _vehicle_count; index++) {
-        float distance = get_distance(my_loc, get_location(_vehicle_list[index]));
+    for (uint16_t index = 0; index < in_state.vehicle_count; index++) {
+        float distance = _my_loc.get_distance(get_location(in_state.vehicle_list[index]));
         if (min_distance > distance || index == 0) {
             min_distance = distance;
             min_distance_index = index;
@@ -164,24 +173,24 @@ void AP_ADSB::perform_threat_detection(void)
         }
 
         if (distance <= VEHICLE_THREAT_RADIUS_M) {
-            _vehicle_list[index].threat_level = ADSB_THREAT_HIGH;
+            in_state.vehicle_list[index].threat_level = ADSB_THREAT_HIGH;
         } else {
-            _vehicle_list[index].threat_level = ADSB_THREAT_LOW;
+            in_state.vehicle_list[index].threat_level = ADSB_THREAT_LOW;
         }
     } // for index
 
-    _highest_threat_index = min_distance_index;
-    _highest_threat_distance = min_distance;
+    avoid_state.highest_threat_index = min_distance_index;
+    avoid_state.highest_threat_distance = min_distance;
 
-    _lowest_threat_index = max_distance_index;
-    _lowest_threat_distance = max_distance;
+    avoid_state.lowest_threat_index = max_distance_index;
+    avoid_state.lowest_threat_distance = max_distance;
 
     // if within radius, set flag and enforce a double radius to clear flag
-    if (is_zero(_highest_threat_distance) ||  // 0 means invalid
-            _highest_threat_distance > 2*VEHICLE_THREAT_RADIUS_M) {
-        _another_vehicle_within_radius = false;
-    } else if (_highest_threat_distance <= VEHICLE_THREAT_RADIUS_M) {
-        _another_vehicle_within_radius = true;
+    if (is_zero(avoid_state.highest_threat_distance) ||  // 0 means invalid
+            avoid_state.highest_threat_distance > 2*VEHICLE_THREAT_RADIUS_M) {
+        avoid_state.another_vehicle_within_radius = false;
+    } else if (avoid_state.highest_threat_distance <= VEHICLE_THREAT_RADIUS_M) {
+        avoid_state.another_vehicle_within_radius = true;
     }
 }
 
@@ -204,21 +213,21 @@ Location AP_ADSB::get_location(const adsb_vehicle_t &vehicle) const
  */
 void AP_ADSB::delete_vehicle(uint16_t index)
 {
-    if (index < _vehicle_count) {
+    if (index < in_state.vehicle_count) {
         // if the vehicle is the lowest/highest threat, invalidate it
-        if (index == _lowest_threat_index) {
-            _lowest_threat_distance = 0;
+        if (index == avoid_state.lowest_threat_index) {
+            avoid_state.lowest_threat_distance = 0;
         }
-        if (index == _highest_threat_index) {
-            _highest_threat_distance = 0;
+        if (index == avoid_state.highest_threat_index) {
+            avoid_state.highest_threat_distance = 0;
         }
 
-        if (index != (_vehicle_count-1)) {
-            _vehicle_list[index] = _vehicle_list[_vehicle_count-1];
+        if (index != (in_state.vehicle_count-1)) {
+            in_state.vehicle_list[index] = in_state.vehicle_list[in_state.vehicle_count-1];
         }
         // TODO: is memset needed? When we decrement the index we essentially forget about it
-        memset(&_vehicle_list[_vehicle_count-1], 0, sizeof(adsb_vehicle_t));
-        _vehicle_count--;
+        memset(&in_state.vehicle_list[in_state.vehicle_count-1], 0, sizeof(adsb_vehicle_t));
+        in_state.vehicle_count--;
     }
 }
 
@@ -229,8 +238,8 @@ void AP_ADSB::delete_vehicle(uint16_t index)
  */
 bool AP_ADSB::find_index(const adsb_vehicle_t &vehicle, uint16_t *index) const
 {
-    for (uint16_t i = 0; i < _vehicle_count; i++) {
-        if (_vehicle_list[i].info.ICAO_address == vehicle.info.ICAO_address) {
+    for (uint16_t i = 0; i < in_state.vehicle_count; i++) {
+        if (in_state.vehicle_list[i].info.ICAO_address == vehicle.info.ICAO_address) {
             *index = i;
             return true;
         }
@@ -244,7 +253,7 @@ bool AP_ADSB::find_index(const adsb_vehicle_t &vehicle, uint16_t *index) const
  */
 void AP_ADSB::update_vehicle(const mavlink_message_t* packet)
 {
-    if (_vehicle_list == nullptr) {
+    if (in_state.vehicle_list == nullptr) {
         // We are only null when disabled. Updating is inhibited.
         return;
     }
@@ -258,36 +267,34 @@ void AP_ADSB::update_vehicle(const mavlink_message_t* packet)
         // found, update it
         set_vehicle(index, vehicle);
 
-    } else if (_vehicle_count < _list_size) {
+    } else if (in_state.vehicle_count < in_state.list_size) {
 
         // not found and there's room, add it to the end of the list
-        set_vehicle(_vehicle_count, vehicle);
-        _vehicle_count++;
+        set_vehicle(in_state.vehicle_count, vehicle);
+        in_state.vehicle_count++;
 
     } else {
 
         // buffer is full, replace the vehicle with lowest threat as long as it's not further away
-        Location my_loc;
-        if (!is_zero(_lowest_threat_distance) && // nonzero means it is valid
-            _ahrs.get_position(my_loc)) {       // true means my_loc is valid
+        if (!is_zero(avoid_state.lowest_threat_distance) && !_my_loc.is_zero()) { // nonzero means it is valid
 
-            float distance = get_distance(my_loc, get_location(vehicle));
-            if (distance < _lowest_threat_distance) { // is closer than the furthest
+            float distance = _my_loc.get_distance(get_location(vehicle));
+            if (distance < avoid_state.lowest_threat_distance) { // is closer than the furthest
 
                  // overwrite the lowest_threat/furthest
-                index = _lowest_threat_index;
+                index = avoid_state.lowest_threat_index;
                 set_vehicle(index, vehicle);
 
                 // this is now invalid because the vehicle was overwritten, need
                 // to run perform_threat_detection() to determine new one because
                 // we aren't keeping track of the second-furthest vehicle.
-                _lowest_threat_distance = 0;
+                avoid_state.lowest_threat_distance = 0;
 
                 // is it the nearest? Then it's the highest threat. That's an easy check
                 // that we don't need to run perform_threat_detection() to determine
-                if (_highest_threat_distance > distance) {
-                    _highest_threat_distance = distance;
-                    _highest_threat_index = index;
+                if (avoid_state.highest_threat_distance > distance) {
+                    avoid_state.highest_threat_distance = distance;
+                    avoid_state.highest_threat_index = index;
                 }
             } // if distance
 
@@ -300,35 +307,35 @@ void AP_ADSB::update_vehicle(const mavlink_message_t* packet)
  */
 void AP_ADSB::set_vehicle(uint16_t index, const adsb_vehicle_t &vehicle)
 {
-    if (index < _list_size) {
-        _vehicle_list[index] = vehicle;
-        _vehicle_list[index].last_update_ms = AP_HAL::millis();
+    if (index < in_state.list_size) {
+        in_state.vehicle_list[index] = vehicle;
+        in_state.vehicle_list[index].last_update_ms = AP_HAL::millis();
     }
 }
 
 void AP_ADSB::send_adsb_vehicle(mavlink_channel_t chan)
 {
-    if (_vehicle_list == nullptr || _vehicle_count == 0) {
+    if (in_state.vehicle_list == nullptr || in_state.vehicle_count == 0) {
         return;
     }
 
     uint32_t now = AP_HAL::millis();
 
-    if (send_index[chan] >= _vehicle_count) {
+    if (in_state.send_index[chan] >= in_state.vehicle_count) {
         // we've finished a list
-        if (now - send_start_ms[chan] < 1000) {
+        if (now - in_state.send_start_ms[chan] < 1000) {
             // too soon to start a new one
             return;
         } else {
             // start new list
-            send_start_ms[chan] = now;
-            send_index[chan] = 0;
+            in_state.send_start_ms[chan] = now;
+            in_state.send_index[chan] = 0;
         }
     }
 
-    if (send_index[chan] < _vehicle_count) {
-        mavlink_adsb_vehicle_t vehicle = _vehicle_list[send_index[chan]].info;
-        send_index[chan]++;
+    if (in_state.send_index[chan] < in_state.vehicle_count) {
+        mavlink_adsb_vehicle_t vehicle = in_state.vehicle_list[in_state.send_index[chan]].info;
+        in_state.send_index[chan]++;
 
         mavlink_msg_adsb_vehicle_send(chan,
             vehicle.ICAO_address,

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -219,16 +219,17 @@ void AP_ADSB::update(void)
             // haven't gotten a heartbeat health status packet in a while, assume hardware failure
             out_state.chan = -1;
         } else {
-            if (now - out_state.last_config_ms >= 5000) {
-            out_state.last_config_ms = now;
-            send_configure((mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan));
-        } // last_config_ms
+            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan);
+            if (now - out_state.last_config_ms >= 5000 && HAVE_PAYLOAD_SPACE(chan, ADSB_TRANSPONDER_STATIC_INPUT)) {
+                out_state.last_config_ms = now;
+                send_configure(chan);
+            } // last_config_ms
 
             // send dynamic data to transceiver at 5Hz
-            if (now - out_state.last_report_ms >= 200) {
-            out_state.last_report_ms = now;
-            send_dynamic_out((mavlink_channel_t)(MAVLINK_COMM_0 + out_state.chan));
-        } // last_report_ms
+            if (now - out_state.last_report_ms >= 200 && HAVE_PAYLOAD_SPACE(chan, ADSB_TRANSPONDER_DYNAMIC_INPUT)) {
+                out_state.last_report_ms = now;
+                send_dynamic_out(chan);
+            } // last_report_ms
         } // chan_last_ms
     }
 }

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -145,7 +145,7 @@ private:
         AP_Int16    list_size_param;
         uint16_t    list_size = 1; // start with tiny list, then change to param-defined size. This ensures it doesn't fail on start
         adsb_vehicle_t *vehicle_list = nullptr;
-        uint16_t    vehicle_count = 0;
+        uint16_t    vehicle_count;
         AP_Int32    list_radius;
 
         // streamrate stuff
@@ -183,16 +183,16 @@ private:
     struct {
         AP_Int8     behavior;
 
-        bool        another_vehicle_within_radius = false;
-        bool        is_evading_threat = false;
+        bool        another_vehicle_within_radius;
+        bool        is_evading_threat;
 
         // index of and distance to vehicle with lowest threat
-        uint16_t    lowest_threat_index = 0;
-        float       lowest_threat_distance = 0;
+        uint16_t    lowest_threat_index;
+        float       lowest_threat_distance;
 
         // index of and distance to vehicle with highest threat
-        uint16_t    highest_threat_index = 0;
-        float       highest_threat_distance = 0;
+        uint16_t    highest_threat_index;
+        float       highest_threat_distance;
     } avoid_state;
 
 };

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -85,16 +85,16 @@ public:
 
     ADSB_BEHAVIOR get_behavior()  { return (ADSB_BEHAVIOR)(avoid_state.behavior.get()); }
     bool get_is_evading_threat()  { return _enabled && avoid_state.is_evading_threat; }
-    void set_is_evading_threat(bool is_evading) { if (_enabled) { avoid_state.is_evading_threat = is_evading; } }
+    void set_is_evading_threat(const bool is_evading) { if (_enabled) { avoid_state.is_evading_threat = is_evading; } }
     uint16_t get_vehicle_count() { return in_state.vehicle_count; }
 
     // send ADSB_VEHICLE mavlink message, usually as a StreamRate
     void send_adsb_vehicle(mavlink_channel_t chan);
 
-    void set_stall_speed_cm(uint16_t stall_speed_cm) { out_state.cfg.stall_speed_cm = stall_speed_cm; }
+    void set_stall_speed_cm(const uint16_t stall_speed_cm) { out_state.cfg.stall_speed_cm = stall_speed_cm; }
 
-    void set_is_auto_mode(bool is_in_auto_mode) { _is_in_auto_mode = is_in_auto_mode; }
-    void set_is_flying(bool is_flying) { out_state.is_flying = is_flying; }
+    void set_is_auto_mode(const bool is_in_auto_mode) { _is_in_auto_mode = is_in_auto_mode; }
+    void set_is_flying(const bool is_flying) { out_state.is_flying = is_flying; }
 
 private:
 
@@ -108,25 +108,25 @@ private:
     void perform_threat_detection(void);
 
     // extract a location out of a vehicle item
-    Location get_location(const adsb_vehicle_t &vehicle) const;
+    Location_Class get_location(const adsb_vehicle_t &vehicle) const;
 
     // return index of given vehicle if ICAO_ADDRESS matches. return -1 if no match
     bool find_index(const adsb_vehicle_t &vehicle, uint16_t *index) const;
 
     // remove a vehicle from the list
-    void delete_vehicle(uint16_t index);
+    void delete_vehicle(const uint16_t index);
 
-    void set_vehicle(uint16_t index, const adsb_vehicle_t &vehicle);
+    void set_vehicle(const uint16_t index, const adsb_vehicle_t &vehicle);
 
     // Generates pseudorandom ICAO from gps time, lat, and lon
-    uint32_t genICAO(const Location &loc);
+    uint32_t genICAO(const Location_Class &loc);
 
     // set callsign: 8char string (plus null termination) then optionally append last 4 digits of icao
-    void set_callsign(const char* str, bool append_icao);
+    void set_callsign(const char* str, const bool append_icao);
 
     // send static and dynamic data to ADSB transceiver
-    void send_configure(mavlink_channel_t chan);
-    void send_dynamic_out(mavlink_channel_t chan);
+    void send_configure(const mavlink_channel_t chan);
+    void send_dynamic_out(const mavlink_channel_t chan);
 
 
     // reference to AHRS, so we can ask for our position,

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -25,11 +25,20 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_Common/Location.h>
 
 #define VEHICLE_THREAT_RADIUS_M         1000
 #define VEHICLE_TIMEOUT_MS              10000   // if no updates in this time, drop it from the list
 #define ADSB_VEHICLE_LIST_SIZE_DEFAULT  25
 #define ADSB_VEHICLE_LIST_SIZE_MAX      100
+
+
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+    #define ADSB_LIST_RADIUS_DEFAULT        10000 // in meters
+#else // APM_BUILD_TYPE(APM_BUILD_ArduCopter), Rover, Boat
+    #define ADSB_LIST_RADIUS_DEFAULT        2000 // in meters
+#endif
 
 class AP_ADSB
 {
@@ -117,6 +126,7 @@ private:
         uint16_t    list_size = 1; // start with tiny list, then change to param-defined size. This ensures it doesn't fail on start
         adsb_vehicle_t *vehicle_list = nullptr;
         uint16_t    vehicle_count = 0;
+        AP_Int32    list_radius;
 
     // streamrate stuff
     uint32_t    send_start_ms[MAVLINK_COMM_NUM_BUFFERS];

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -32,7 +32,7 @@
 #define VEHICLE_TIMEOUT_MS              10000   // if no updates in this time, drop it from the list
 #define ADSB_VEHICLE_LIST_SIZE_DEFAULT  25
 #define ADSB_VEHICLE_LIST_SIZE_MAX      100
-
+#define ADSB_CHAN_TIMEOUT_MS            15000
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     #define ADSB_LIST_RADIUS_DEFAULT        10000 // in meters
@@ -63,7 +63,7 @@ public:
 
 
     // Constructor
-    AP_ADSB(AP_AHRS &ahrs) :
+    AP_ADSB(const AP_AHRS &ahrs) :
         _ahrs(ahrs)
     {
         AP_Param::setup_object_defaults(this, var_info);
@@ -131,7 +131,7 @@ private:
 
     // reference to AHRS, so we can ask for our position,
     // heading and speed
-    AP_AHRS &_ahrs;
+    const AP_AHRS &_ahrs;
 
     AP_Int8     _enabled;
 
@@ -159,6 +159,7 @@ private:
         uint32_t    last_config_ms; // send once every 10s
         uint32_t    last_report_ms; // send at 5Hz
         int8_t      chan = -1; // channel that contains an ADS-b Transceiver. -1 means broadcast to all
+        uint32_t    chan_last_ms;
         ADSB_TRANSPONDER_DYNAMIC_OUTPUT_STATUS_FLAGS status;     // transceiver status
         bool        is_flying;
 

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -234,7 +234,8 @@ float Location_Class::get_distance(const struct Location &loc2) const
 // extrapolate latitude/longitude given distances (in meters) north and east
 void Location_Class::offset(float ofs_north, float ofs_east)
 {
-    if (!is_zero(ofs_north) || !is_zero(ofs_east)) {
+    // use is_equal() because is_zero() is a local class conflict and is_zero() in AP_Math does not belong to a class
+    if (!is_equal(ofs_north, 0.0f) || !is_equal(ofs_east, 0.0f)) {
         int32_t dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
         int32_t dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale(*this);
         lat += dlat;

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -20,8 +20,7 @@ AP_Terrain *Location_Class::_terrain = NULL;
 /// constructors
 Location_Class::Location_Class()
 {
-    lat = lng = alt = 0;
-    options = 0;
+    zero();
 }
 
 Location_Class::Location_Class(int32_t latitude, int32_t longitude, int32_t alt_in_cm, ALT_FRAME frame)

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -67,6 +67,10 @@ public:
     // extrapolate latitude/longitude given distances (in meters) north and east
     void offset(float ofs_north, float ofs_east);
 
+    bool is_zero(void) { return (lat == 0 && lng == 0 && alt == 0 && options == 0); }
+
+    void zero(void) { lat = lng = alt = 0; options = 0; }
+
 private:
     static const AP_AHRS_NavEKF *_ahrs;
     static AP_Terrain *_terrain;


### PR DESCRIPTION
This is a request for comment for the ADSB-out feature using the [uAvionix PING2020](http://www.uavionix.com/products/ping2020/) transceiver. The [mavlink packet is here](https://github.com/Airphrame/mavlink/commit/5ed82f17e27df43b8f0ceaf52d65d38bf9c63eb9) but will be changing so I didn't bother including it as a commit so Travis will be failing. The packets will be moving up to 10000 range via MAVLink 2 24bit msg id addressing.

This adds support to Plane only. Once this gets in I'll add it to Copter too. It's just a couple lines, very trivial.

Main feature is you can set an ICAO number, or leave it as 0 and it auto-generates, and yo will broadcast your position to other aircraft (and the local air traffic controller!). If you're lucky you'll show up on [flightradar24](http://www.flightradar24.com).

new params:
ADSB_LIST_RADIUS - limits your range, ignore distant aircraft
ADSB_ICAO_ID
ADSB_EMIT_TYPE - declare your aircraft type. Default is "UAV"
ADSB_LEN_WIDTH
ADSB_OFFSET_LAT
ADSB_OFFSET_LON