### PR TITLE
Rover: Adding support for Rovers to go into Reverse

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -411,14 +411,12 @@ void Rover::update_current_mode(void)
     switch (control_mode){
     case AUTO:
     case RTL:
-        set_reverse(false);
         calc_lateral_acceleration();
         calc_nav_steer();
         calc_throttle(g.speed_cruise);
         break;
 
     case GUIDED:
-        set_reverse(false);
         if (rtl_complete || verify_RTL()) {
             // we have reached destination so stop where we are
             if (channel_throttle->get_servo_out() != g.throttle_min.get()) {
@@ -483,7 +481,6 @@ void Rover::update_current_mode(void)
         // hold position - stop motors and center steering
         channel_throttle->set_servo_out(0);
         channel_steer->set_servo_out(0);
-        set_reverse(false);
         break;
 
     case INITIALISING:

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -511,6 +511,7 @@ private:
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
     void do_digicam_control(const AP_Mission::Mission_Command& cmd);
+    void do_set_reverse(const AP_Mission::Mission_Command& cmd);
     void init_capabilities(void);
     void rudder_arm_disarm_check();
     void change_arm_state(void);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -203,7 +203,9 @@ void Rover::calc_nav_steer() {
     }
 
     // add in obstacle avoidance
-    lateral_acceleration += (obstacle.turn_angle/45.0f) * g.turn_max_g;
+    if (!in_reverse) {
+        lateral_acceleration += (obstacle.turn_angle/45.0f) * g.turn_max_g;
+    }
 
     // constrain to max G force
     lateral_acceleration = constrain_float(lateral_acceleration, -g.turn_max_g*GRAVITY_MSS, g.turn_max_g*GRAVITY_MSS);

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -107,6 +107,10 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
             break;
 #endif
 
+        case MAV_CMD_DO_SET_REVERSE:
+            do_set_reverse(cmd);
+            break;
+
 		default:
 		    // return false for unhandled commands
 		    return false;
@@ -403,5 +407,14 @@ void Rover::log_picture()
         if (should_log(MASK_LOG_CAMERA)) {
             DataFlash.Log_Write_Trigger(ahrs, gps, current_loc);
         }      
+    }
+}
+
+void Rover::do_set_reverse(const AP_Mission::Mission_Command& cmd)
+{
+	if (cmd.p1 == 1) {
+        set_reverse(true);
+	} else {
+        set_reverse(false);
     }
 }

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -250,6 +250,9 @@ void Rover::set_reverse(bool reverse)
         return;
     }
     g.pidSpeedThrottle.reset_I();
+    steerController.reset_I();
+    nav_controller->set_reverse(reverse);
+    steerController.set_reverse(reverse);
     in_reverse = reverse;
 }
 
@@ -269,7 +272,6 @@ void Rover::set_mode(enum mode mode)
     control_mode = mode;
     throttle_last = 0;
     throttle = 500;
-    set_reverse(false);
     g.pidSpeedThrottle.reset_I();
 
     if (control_mode != AUTO) {

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -115,7 +115,11 @@ int32_t AP_SteerController::get_steering_out_rate(float desired_rate)
 
 	// Calculate the steering rate error (deg/sec) and apply gain scaler
     // We do this in earth frame to allow for rover leaning over in hard corners
-	float rate_error = (desired_rate - ToDeg(_ahrs.get_yaw_rate_earth())) * scaler;
+    float yaw_rate_earth = ToDeg(_ahrs.get_yaw_rate_earth());
+    if (_reverse) {
+        yaw_rate_earth = wrap_180(180 + yaw_rate_earth);
+    }
+    float rate_error = (desired_rate - yaw_rate_earth) * scaler;
 	
 	// Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
     // No conversion is required for K_D
@@ -175,6 +179,9 @@ int32_t AP_SteerController::get_steering_out_lat_accel(float desired_accel)
 
 	// Calculate the desired steering rate given desired_accel and speed
     float desired_rate = ToDeg(desired_accel / speed);
+    if (_reverse) {
+        desired_rate *= -1;
+    }
     return get_steering_out_rate(desired_rate);
 }
 

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -45,6 +45,10 @@ public:
 
     const DataFlash_Class::PID_Info& get_pid_info(void) const { return _pid_info; }
 
+    void set_reverse(bool reverse) {
+        _reverse = reverse;
+    }
+
 private:
 	AP_Float _tau;
 	AP_Float _K_FF;
@@ -59,4 +63,6 @@ private:
     DataFlash_Class::PID_Info _pid_info {};
 
 	AP_AHRS &_ahrs;
+
+    bool _reverse;
 };

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -65,6 +65,10 @@ public:
     // this supports the NAVl1_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
+    void set_reverse(bool reverse) {
+        _reverse = reverse;
+    }
+
 private:
     // reference to the AHRS object
     AP_AHRS &_ahrs;
@@ -109,4 +113,8 @@ private:
     float _L1_xtrack_i_gain_prev = 0;
     uint32_t _last_update_waypoint_us;
     bool _data_is_stale = true;
+
+    bool _reverse = false;
+    float get_yaw();
+    float get_yaw_sensor();
 };

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -758,6 +758,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.do_vtol_transition.target_state = packet.param1;
         break;
         
+    case MAV_CMD_DO_SET_REVERSE:
+        cmd.p1 = packet.param1; // 0 = forward, 1 = reverse
+        break;
+
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1173,6 +1177,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     case MAV_CMD_DO_AUTOTUNE_ENABLE:
         packet.param1 = cmd.p1;                         // disable=0 enable=1
+        break;
+
+    case MAV_CMD_DO_SET_REVERSE:
+        packet.param1 = cmd.p1;   // 0 = forward, 1 = reverse
         break;
 
     case MAV_CMD_NAV_ALTITUDE_WAIT:                     // MAV ID: 83

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -113,6 +113,8 @@ public:
     // every update_XXXXXX() call.
     virtual bool data_is_stale(void) const = 0;
 
+    virtual void set_reverse(bool reverse) = 0;
+
 	// add new navigation controllers to this enum. Users can then
 	// select which navigation controller to use by setting the
 	// NAV_CONTROLLER parameter


### PR DESCRIPTION
This changes along with this change
https://github.com/ArduPilot/mavlink/pull/11
add's support for Rovers changing driving direction and driving in reverse by adding a MAV_CMD_DO_SET_REVERSE.  Param1=0 means forward and Param1=1 means reverse.
Thanks, Grant.