### PR TITLE
waf: git_submodule: fix for Waf 1.9

### DIFF
--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -80,7 +80,7 @@ def git_submodule_update(self, name):
         module_node = self.bld.srcnode.make_node(os.path.join('modules', name))
 
         tsk = self.create_task('update_submodule', submodule=name)
-        tsk.cwd = self.bld.srcnode.abspath()
+        tsk.cwd = self.bld.srcnode
         tsk.env.SUBMODULE_PATH = module_node.abspath()
 
         _submodules_tasks[name] = tsk


### PR DESCRIPTION
Tasks cwd must be Node objects in Waf 1.9