### PR TITLE
added NTF_LED_OVERRIDE parameters

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2107,6 +2107,11 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         send_autopilot_version(FIRMWARE_VERSION);
         break;
 
+    case MAVLINK_MSG_ID_LED_CONTROL:
+        // send message to Notify
+        AP_Notify::handle_led_control(msg);
+        break;
+        
     case MAVLINK_MSG_ID_REMOTE_LOG_BLOCK_STATUS:
         plane.DataFlash.remote_log_block_status_msg(chan, msg);
         break;

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -49,6 +49,13 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("BUZZ_ENABLE", 1, AP_Notify, _buzzer_enable, BUZZER_ON),
 
+    // @Param: LED_OVERRIDE
+    // @DisplayName: Setup for MAVLink LED override
+    // @Description: This sets up the board RGB LED for override by MAVLink. Normal notify LED control is disabled
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("LED_OVERRIDE", 2, AP_Notify, _rgb_led_override, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -114,5 +114,6 @@ private:
     static NotifyDevice* _devices[];
 
     AP_Int8 _rgb_led_brightness;
+    AP_Int8 _rgb_led_override;
     AP_Int8 _buzzer_enable;
 };

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -39,11 +39,19 @@ public:
     // called at 50Hz
     virtual void update();
 
+    // handle LED control, only used when LED_OVERRIDE=1
+    virtual void handle_led_control(mavlink_message_t *msg) override;
+    
 protected:
     // methods implemented in hardware specific classes
     virtual bool hw_init(void) = 0;
     virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) = 0;
 
+    // set_rgb - set color as a combination of red, green and blue levels from 0 ~ 15
+    virtual void _set_rgb(uint8_t red, uint8_t green, uint8_t blue);
+
+    virtual void update_override();
+    
     // meta-data common to all hw devices
     uint8_t counter;
     uint8_t step;
@@ -54,6 +62,13 @@ protected:
     uint8_t _led_bright;
     uint8_t _led_medium;
     uint8_t _led_dim;
+
+    struct {
+        uint8_t r, g, b;
+        uint8_t rate_hz;
+        uint32_t start_ms;
+    } _led_override;
+    
 private:
     virtual void update_colours();
 };


### PR DESCRIPTION
when this is set the board RGB LED will be controlled by MAVLink
instead of internally. This is useful for cases where the LED patterns
and colours needed are specified by an external authority (such as the
OBC organisers)

