### PR TITLE
Global: workaround toolchain problem on windows

### DIFF
--- a/libraries/AP_ADC/AP_ADC_ADS1115.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.cpp
@@ -1,4 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
 #include <AP_HAL/utility/sparse-endian.h>
 
 #include "AP_ADC_ADS1115.h"
@@ -236,3 +239,5 @@ void AP_ADC_ADS1115::_update()
 
     _last_update_timestamp = AP_HAL::micros();
 }
+
+#endif

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -24,6 +24,8 @@
  */
 #include <AP_HAL/AP_HAL.h>
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
 #ifdef HAL_COMPASS_HMC5843_I2C_ADDR
 
 #include <assert.h>
@@ -589,5 +591,7 @@ bool AP_HMC5843_BusDriver_Auxiliary::start_measurements()
 
     return true;
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
The minimum version for gcc was supposed to be 4.9 for any platform.
However our build instructions are outdated. Remove the problematic
parts that use the sparse-endian.h header while we don't fix the setup
for windows.