### PR TITLE
AP_HAL_Linux: I2CDriver: make sure we have hal constructed

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -18,7 +18,7 @@
 #include "I2CDriver.h"
 #include "Util.h"
 
-extern const AP_HAL::HAL &hal;
+static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
 using namespace Linux;
 


### PR DESCRIPTION
Fix segfault with gcc 5.3.0 - depending on the order the constructors
are in place we could have this code called without hal been
constructed.