### PR TITLE
Copter: ignore rally points outside the fence

### DIFF
--- a/ArduCopter/AP_Rally.cpp
+++ b/ArduCopter/AP_Rally.cpp
@@ -1,0 +1,32 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Common/Location.h>
+
+#include "Copter.h"
+
+#include "AP_Rally.h"
+
+bool AP_Rally_Copter::is_valid(const Location &rally_point) const
+{
+#if AC_FENCE == ENABLED
+    Location_Class rally_loc(rally_point);
+    if (!copter.fence.check_destination_within_fence(rally_loc)) {
+        return false;
+    }
+#endif
+    return true;
+}

--- a/ArduCopter/AP_Rally.h
+++ b/ArduCopter/AP_Rally.h
@@ -1,0 +1,32 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#pragma once
+
+#include <AP_Rally/AP_Rally.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+class AP_Rally_Copter : public AP_Rally
+{
+
+public:
+    // constructor
+    AP_Rally_Copter(AP_AHRS &ahrs) : AP_Rally(ahrs) {};
+
+private:
+    bool is_valid(const Location &rally_point) const override;
+
+};

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -923,7 +923,6 @@ private:
     void pre_arm_rc_checks();
     bool pre_arm_gps_checks(bool display_failure);
     bool pre_arm_ekf_attitude_check();
-    bool pre_arm_rallypoint_check();
     bool pre_arm_terrain_check(bool display_failure);
     bool arm_checks(bool display_failure, bool arming_from_gcs);
     void init_disarm_motors();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -50,7 +50,6 @@
 #include <AP_NavEKF/AP_NavEKF.h>
 #include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_Mission/AP_Mission.h>         // Mission command library
-#include <AP_Rally/AP_Rally.h>           // Rally point library
 #include <AC_PID/AC_PID.h>             // PID library
 #include <AC_PID/AC_PI_2D.h>           // PID library (2-axis)
 #include <AC_PID/AC_HELI_PID.h>        // Heli specific Rate PID library
@@ -95,6 +94,7 @@
 #include "config.h"
 
 #include "GCS_Mavlink.h"
+#include "AP_Rally.h"           // Rally point library
 
 // libraries which are dependent on #defines in defines.h and/or config.h
 #if SPRAYER == ENABLED
@@ -121,6 +121,7 @@
 class Copter : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Copter;
+    friend class AP_Rally_Copter;
     friend class Parameters;
 
     Copter(void);
@@ -508,7 +509,7 @@ private:
 
     // Rally library
 #if AC_RALLY == ENABLED
-    AP_Rally rally;
+    AP_Rally_Copter rally;
 #endif
 
     // RSSI 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -831,8 +831,8 @@ const AP_Param::Info Copter::var_info[] = {
 
 #if AC_RALLY == ENABLED
     // @Group: RALLY_
-    // @Path: ../libraries/AP_Rally/AP_Rally.cpp
-    GOBJECT(rally,      "RALLY_",   AP_Rally),
+    // @Path: AP_Rally.cpp,../libraries/AP_Rally/AP_Rally.cpp
+    GOBJECT(rally,      "RALLY_",   AP_Rally_Copter),
 #endif
 
 #if FRAME_CONFIG ==     HELI_FRAME

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -174,14 +174,6 @@ bool Copter::pre_arm_checks(bool display_failure)
     }
     #endif
 
-    // check rally points
-    if (!pre_arm_rallypoint_check()) {
-        if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: rallypoints outside fence");
-        }
-        return false;
-    }
-
     // check INS
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {
         // check accelerometers have been calibrated
@@ -499,25 +491,6 @@ bool Copter::pre_arm_ekf_attitude_check()
     return filt_status.flags.attitude;
 }
 
-// check rally points are within fences
-bool Copter::pre_arm_rallypoint_check()
-{
-#if AC_RALLY == ENABLED && AC_FENCE == ENABLED
-    for (uint8_t i=0; i<rally.get_rally_total(); i++) {
-        RallyLocation rally_loc;
-        if (rally.get_rally_point_with_index(i, rally_loc)) {
-            Location_Class rally_point(rally.rally_location_to_location(rally_loc));
-            if (!fence.check_destination_within_fence(rally_point)) {
-                return false;
-            }
-        }
-    }
-    return true;
-#else
-    return true;
-#endif
-}
-
 // check we have required terrain data
 bool Copter::pre_arm_terrain_check(bool display_failure)
 {
@@ -676,14 +649,6 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         return false;
     }
     #endif
-
-    // check rally points
-    if (!pre_arm_rallypoint_check()) {
-        if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: rallypoints outside fence");
-        }
-        return false;
-    }
 
     // check lean angle
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -132,7 +132,7 @@ bool AP_Rally::find_nearest_rally_point(const Location &current_loc, RallyLocati
         Location rally_loc = rally_location_to_location(next_rally);
         float dis = get_distance(current_loc, rally_loc);
 
-        if (dis < min_dis || min_dis < 0) {
+        if (is_valid(rally_loc) && (dis < min_dis || min_dis < 0)) {
             min_dis = dis;
             return_loc = next_rally;
         }

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -62,6 +62,8 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    virtual bool is_valid(const Location &rally_point) const { return true; }
+
     static StorageAccess _storage;
 
     // internal variables


### PR DESCRIPTION
As talked in the dev call two weeks ago, Copter will ignore rally points that are outside the fence instead of having a pre-arm check.

Tested in SITL.