### PR TITLE
BBBMini Leds A, B and C support

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -353,6 +353,11 @@
 #define HAL_FLOW_PX4_MAX_FLOW_PIXEL 4
 #define HAL_FLOW_PX4_BOTTOM_FLOW_FEATURE_THRESHOLD 30
 #define HAL_FLOW_PX4_BOTTOM_FLOW_VALUE_THRESHOLD 5000
+#define HAL_GPIO_A_LED_PIN        69
+#define HAL_GPIO_B_LED_PIN        68
+#define HAL_GPIO_C_LED_PIN        45
+#define HAL_GPIO_LED_ON           LOW
+#define HAL_GPIO_LED_OFF          HIGH
 /* ELP-USBFHD01M-L21
  * focal length 2.1 mm, pixel size 3 um
  * 240x240 crop rescaled to 64x64 */

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -106,9 +106,10 @@ struct AP_Notify::notify_events_type AP_Notify::events;
         ToshibaLED_I2C toshibaled;
         NotifyDevice *AP_Notify::_devices[] = {&navioled, &toshibaled};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
+        AP_BoardLED boardled;
         Buzzer buzzer;
         Display_SSD1306_I2C display;
-        NotifyDevice *AP_Notify::_devices[] = {&display, &buzzer};
+        NotifyDevice *AP_Notify::_devices[] = {&boardled, &display, &buzzer};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
         ToshibaLED_I2C toshibaled;
         ToneAlarm_Linux tonealarm;

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -106,10 +106,9 @@ struct AP_Notify::notify_events_type AP_Notify::events;
         ToshibaLED_I2C toshibaled;
         NotifyDevice *AP_Notify::_devices[] = {&navioled, &toshibaled};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
-        AP_BoardLED boardled;
         Buzzer buzzer;
         Display_SSD1306_I2C display;
-        NotifyDevice *AP_Notify::_devices[] = {&boardled, &display, &buzzer};
+        NotifyDevice *AP_Notify::_devices[] = {&display, &buzzer};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
         ToshibaLED_I2C toshibaled;
         ToneAlarm_Linux tonealarm;


### PR DESCRIPTION
AP_HAL_Boards: added BBBMini pins P8.9 for LED A, P8.10 for LED B and P8.11 for LED C
AP_Notify: added led support for BBBMini
