### PR TITLE
Enable automatic use of range finder height at low altitude

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -201,7 +201,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
 
     // @Param: ALT_SOURCE
     // @DisplayName: Primary height source
-    // @Description: This parameter controls which height sensor is used by the EKF. If the selected optionn cannot be used, it will default to Baro as the primary height source. Setting 0 will use the baro altitude at all times. Setting 1 uses the range finder and is only available in combination with optical flow navigation (EK2_GPS_TYPE = 3). Setting 2 uses GPS.
+    // @Description: This parameter controls the primary height sensor used by the EKF. If the selected option cannot be used, it will default to Baro as the primary height source. Setting 0 will use the baro altitude at all times. Setting 1 uses the range finder and is only available in combination with optical flow navigation (EK2_GPS_TYPE = 3). Setting 2 uses GPS. NOTE - the EK2_RNG_USE_HGT parameter can be used to switch to range-finder when close to the ground.
     // @Values: 0:Use Baro, 1:Use Range Finder, 2:Use GPS
     // @User: Advanced
     AP_GROUPINFO("ALT_SOURCE", 9, NavEKF2, _altSource, 0),
@@ -475,6 +475,15 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     // @Units: gauss/s
     AP_GROUPINFO("MAGB_P_NSE", 41, NavEKF2, _magBodyProcessNoise, MAGB_P_NSE_DEFAULT),
+
+    // @Param: RNG_USE_HGT
+    // @DisplayName: Range finder switch height percentage
+    // @Description: The range finder will be used as the primary height source when below a specified percentage of the sensor maximum as set by the RNGFND_MAX_CM parameter. Set to -1 to prevent range finder use.
+    // @Range: -1 70
+    // @Increment: 1
+    // @User: Advanced
+    // @Units: %
+    AP_GROUPINFO("RNG_USE_HGT", 42, NavEKF2, _useRngSwHgt, -1),
 
     AP_GROUPEND
 };
@@ -1023,6 +1032,19 @@ void NavEKF2::setTouchdownExpected(bool val)
             core[i].setTouchdownExpected(val);
         }
     }
+}
+
+// Set to true if the terrain underneath is stable enough to be used as a height reference
+// in combination with a range finder. Set to false if the terrain underneath the vehicle
+// cannot be used as a height reference
+void NavEKF2::setTerrainHgtStable(bool val)
+{
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].setTerrainHgtStable(val);
+        }
+    }
+
 }
 
 /*

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -211,6 +211,11 @@ public:
     // causes the EKF to compensate for expected barometer errors due to ground effect
     void setTouchdownExpected(bool val);
 
+    // Set to true if the terrain underneath is stable enough to be used as a height reference
+    // in combination with a range finder. Set to false if the terrain underneath the vehicle
+    // cannot be used as a height reference
+    void setTerrainHgtStable(bool val);
+
     /*
     return the filter fault status as a bitmasked integer for the specified instance
     An out of range instance (eg -1) returns data for the the primary instance
@@ -330,6 +335,7 @@ private:
     AP_Float _yawNoise;             // magnetic yaw measurement noise : rad
     AP_Int16 _yawInnovGate;         // Percentage number of standard deviations applied to magnetic yaw innovation consistency check
     AP_Int8 _tauVelPosOutput;       // Time constant of output complementary filter : csec (centi-seconds)
+    AP_Int8 _useRngSwHgt;           // Maximum valid range of the range finder in metres
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -36,50 +36,70 @@ void NavEKF2_core::readRangeFinder(void)
         lastRngMeasTime_ms =  imuSampleTime_ms;
 
         // store samples and sample time into a ring buffer if valid
-        if (frontend->_rng.status() == RangeFinder::RangeFinder_Good) {
-            rngMeasIndex ++;
-            if (rngMeasIndex > 2) {
-                rngMeasIndex = 0;
-            }
-            storedRngMeasTime_ms[rngMeasIndex] = imuSampleTime_ms - 25;
-            storedRngMeas[rngMeasIndex] = frontend->_rng.distance_cm() * 0.01f;
-        }
+        // use data from two range finders if available
 
-        // check for three fresh samples
-        bool sampleFresh[3];
-        for (uint8_t index = 0; index <= 2; index++) {
-            sampleFresh[index] = (imuSampleTime_ms - storedRngMeasTime_ms[index]) < 500;
-        }
+        for (uint8_t sensorIndex = 0; sensorIndex <= 1; sensorIndex++) {
+            if (frontend->_rng.status(sensorIndex) == RangeFinder::RangeFinder_Good) {
+                rngMeasIndex[sensorIndex] ++;
+                if (rngMeasIndex[sensorIndex] > 2) {
+                    rngMeasIndex[sensorIndex] = 0;
+                }
+                storedRngMeasTime_ms[sensorIndex][rngMeasIndex[sensorIndex]] = imuSampleTime_ms - 25;
+                storedRngMeas[sensorIndex][rngMeasIndex[sensorIndex]] = frontend->_rng.distance_cm(sensorIndex) * 0.01f;
+            }
 
-        // find the median value if we have three fresh samples
-        if (sampleFresh[0] && sampleFresh[1] && sampleFresh[2]) {
-            if (storedRngMeas[0] > storedRngMeas[1]) {
-                minIndex = 1;
-                maxIndex = 0;
-            } else {
-                maxIndex = 0;
-                minIndex = 1;
+            // check for three fresh samples
+            bool sampleFresh[2][3] = {};
+            for (uint8_t index = 0; index <= 2; index++) {
+                sampleFresh[sensorIndex][index] = (imuSampleTime_ms - storedRngMeasTime_ms[sensorIndex][index]) < 500;
             }
-            if (storedRngMeas[2] > storedRngMeas[maxIndex]) {
-                midIndex = maxIndex;
-            } else if (storedRngMeas[2] < storedRngMeas[minIndex]) {
-                midIndex = minIndex;
-            } else {
-                midIndex = 2;
+
+            // find the median value if we have three fresh samples
+            if (sampleFresh[sensorIndex][0] && sampleFresh[sensorIndex][1] && sampleFresh[sensorIndex][2]) {
+                if (storedRngMeas[sensorIndex][0] > storedRngMeas[sensorIndex][1]) {
+                    minIndex = 1;
+                    maxIndex = 0;
+                } else {
+                    maxIndex = 0;
+                    minIndex = 1;
+                }
+                if (storedRngMeas[sensorIndex][2] > storedRngMeas[sensorIndex][maxIndex]) {
+                    midIndex = maxIndex;
+                } else if (storedRngMeas[sensorIndex][2] < storedRngMeas[sensorIndex][minIndex]) {
+                    midIndex = minIndex;
+                } else {
+                    midIndex = 2;
+                }
+
+                // don't allow time to go backwards
+                if (storedRngMeasTime_ms[sensorIndex][midIndex] > rangeDataNew.time_ms) {
+                    rangeDataNew.time_ms = storedRngMeasTime_ms[sensorIndex][midIndex];
+                }
+
+                // limit the measured range to be no less than the on-ground range
+                rangeDataNew.rng = MAX(storedRngMeas[sensorIndex][midIndex],rngOnGnd);
+
+                // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
+                storedRange.push(rangeDataNew);
+
+            } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+                // before takeoff we assume on-ground range value if there is no data
+                rangeDataNew.time_ms = imuSampleTime_ms;
+                rangeDataNew.rng = rngOnGnd;
+                rangeDataNew.time_ms = imuSampleTime_ms;
+
+                // don't allow time to go backwards
+                if (imuSampleTime_ms > rangeDataNew.time_ms) {
+                    rangeDataNew.time_ms = imuSampleTime_ms;
+                }
+
+                // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
+                storedRange.push(rangeDataNew);
+
             }
-            rangeDataNew.time_ms = storedRngMeasTime_ms[midIndex];
-            // limit the measured range to be no less than the on-ground range
-            rangeDataNew.rng = MAX(storedRngMeas[midIndex],rngOnGnd);
+
             rngValidMeaTime_ms = imuSampleTime_ms;
-            // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
-            storedRange.push(rangeDataNew);
-        } else if (!takeOffDetected) {
-            // before takeoff we assume on-ground range value if there is no data
-            rangeDataNew.time_ms = imuSampleTime_ms;
-            rangeDataNew.rng = rngOnGnd;
-            rngValidMeaTime_ms = imuSampleTime_ms;
-            // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
-            storedRange.push(rangeDataNew);
+
         }
     }
 }
@@ -111,7 +131,6 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
     }
     // calculate rotation matrices at mid sample time for flow observations
     stateStruct.quat.rotation_matrix(Tbn_flow);
-    Tnb_flow = Tbn_flow.transposed();
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)
     if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {
         // correct flow sensor rates for bias
@@ -403,6 +422,14 @@ void NavEKF2_core::readGpsData()
                 gpsPosAccuracy = MAX(gpsPosAccuracy,gpsPosAccRaw);
                 gpsPosAccuracy = MIN(gpsPosAccuracy,100.0f);
             }
+            gpsHgtAccuracy *= (1.0f - alpha);
+            float gpsHgtAccRaw;
+            if (!_ahrs->get_gps().vertical_accuracy(gpsHgtAccRaw)) {
+                gpsHgtAccuracy = 0.0f;
+            } else {
+                gpsHgtAccuracy = MAX(gpsHgtAccuracy,gpsHgtAccRaw);
+                gpsHgtAccuracy = MIN(gpsHgtAccuracy,100.0f);
+            }
 
             // check if we have enough GPS satellites and increase the gps noise scaler if we don't
             if (_ahrs->get_gps().num_sats() >= 6 && (PV_AidingMode == AID_ABSOLUTE)) {
@@ -444,6 +471,9 @@ void NavEKF2_core::readGpsData()
 
                 // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
                 EKF_origin.alt = gpsloc.alt - baroDataNew.hgt;
+
+                // Set the uncertinty of the GPS origin height
+                ekfOriginHgtVar = sq(gpsHgtAccuracy);
 
             }
 
@@ -518,11 +548,55 @@ void NavEKF2_core::readBaroData()
 
 // calculate filtered offset between baro height measurement and EKF height estimate
 // offset should be subtracted from baro measurement to match filter estimate
-// offset is used to enable reversion to baro if alternate height data sources fail
+// offset is used to enable reversion to baro from alternate height data source
 void NavEKF2_core::calcFiltBaroOffset()
 {
     // Apply a first order LPF with spike protection
     baroHgtOffset += 0.1f * constrain_float(baroDataDelayed.hgt + stateStruct.position.z - baroHgtOffset, -5.0f, 5.0f);
+}
+
+// calculate filtered offset between GPS height measurement and EKF height estimate
+// offset should be subtracted from GPS measurement to match filter estimate
+// offset is used to switch reversion to GPS from alternate height data source
+void NavEKF2_core::calcFiltGpsHgtOffset()
+{
+    // Estimate the WGS-84 height of the EKF's origin using a Bayes filter
+
+    // calculate the variance of our a-priori estimate of the ekf origin height
+    float deltaTime = constrain_float(0.001f * (imuDataDelayed.time_ms - lastOriginHgtTime_ms), 0.0f, 1.0f);
+    if (activeHgtSource == HGT_SOURCE_BARO) {
+        // Use the baro drift rate
+        const float baroDriftRate = 0.05f;
+        ekfOriginHgtVar += sq(baroDriftRate * deltaTime);
+    } else if (activeHgtSource == HGT_SOURCE_RNG) {
+        // use the worse case expected terrain gradient and vehicle horizontal speed
+        const float maxTerrGrad = 0.25f;
+        ekfOriginHgtVar += sq(maxTerrGrad * norm(stateStruct.velocity.x , stateStruct.velocity.y) * deltaTime);
+    } else if (activeHgtSource == HGT_SOURCE_GPS) {
+        // by definition we are using GPS height as the EKF datum in this mode
+        // so cannot run this filter
+        return;
+    }
+    lastOriginHgtTime_ms = imuDataDelayed.time_ms;
+
+    // calculate the observation variance assuming EKF error relative to datum is independant of GPS observation error
+    // when not using GPS as height source
+    float originHgtObsVar = sq(gpsHgtAccuracy) + P[8][8];
+
+    // calculate the correction gain
+    float gain = ekfOriginHgtVar / (ekfOriginHgtVar + originHgtObsVar);
+
+    // calculate the innovation
+    float innovation = - stateStruct.position.z - gpsDataDelayed.hgt;
+
+    // check the innovation variance ratio
+    float ratio = sq(innovation) / (ekfOriginHgtVar + originHgtObsVar);
+
+    // correct the EKF origin and variance estimate if the innovation variance ratio is < 5-sigma
+    if (ratio < 5.0f) {
+        EKF_origin.alt -= (int)(100.0f * gain * innovation);
+        ekfOriginHgtVar -= fmaxf(gain * ekfOriginHgtVar , 0.0f);
+    }
 }
 
 /********************************************************

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -414,6 +414,15 @@ void NavEKF2_core::setTouchdownExpected(bool val)
     expectGndEffectTouchdown = val;
 }
 
+// Set to true if the terrain underneath is stable enough to be used as a height reference
+// in combination with a range finder. Set to false if the terrain underneath the vehicle
+// cannot be used as a height reference
+void NavEKF2_core::setTerrainHgtStable(bool val)
+{
+    terrainHgtStableSet_ms = imuSampleTime_ms;
+    terrainHgtStable = val;
+}
+
 // Detect takeoff for optical flow navigation
 void NavEKF2_core::detectOptFlowTakeoff(void)
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -29,10 +29,6 @@ extern const AP_HAL::HAL& hal;
 NavEKF2_core::NavEKF2_core(void) :
     stateStruct(*reinterpret_cast<struct state_elements *>(&statesArray)),
 
-    //variables
-    lastRngMeasTime_ms(0),          // time in msec that the last range measurement was taken
-    rngMeasIndex(0),                // index into ringbuffer of current range measurement
-
     _perf_UpdateFilter(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_UpdateFilter")),
     _perf_CovariancePrediction(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_CovariancePrediction")),
     _perf_FuseVelPosNED(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseVelPosNED")),
@@ -89,7 +85,7 @@ bool NavEKF2_core::setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOF.init(OBS_BUFFER_LENGTH)) {
         return false;
     }
-    if(!storedRange.init(OBS_BUFFER_LENGTH)) {
+    if(!storedRange.init(2*OBS_BUFFER_LENGTH)) {
         return false;
     }
     if(!storedIMU.init(imu_buffer_length)) {
@@ -144,6 +140,8 @@ void NavEKF2_core::InitialiseVariables()
     lastPreAlignGpsCheckTime_ms = imuSampleTime_ms;
     lastPosReset_ms = 0;
     lastVelReset_ms = 0;
+    lastRngMeasTime_ms = 0;
+    terrainHgtStableSet_ms = 0;
 
     // initialise other variables
     gpsNoiseScaler = 1.0f;
@@ -171,7 +169,7 @@ void NavEKF2_core::InitialiseVariables()
     terrainState = 0.0f;
     prevPosN = stateStruct.position.x;
     prevPosE = stateStruct.position.y;
-    inhibitGndState = true;
+    inhibitGndState = false;
     flowGyroBias.x = 0;
     flowGyroBias.y = 0;
     heldVelNE.zero();
@@ -198,6 +196,7 @@ void NavEKF2_core::InitialiseVariables()
     expectGndEffectTouchdown = false;
     gpsSpdAccuracy = 0.0f;
     gpsPosAccuracy = 0.0f;
+    gpsHgtAccuracy = 0.0f;
     baroHgtOffset = 0.0f;
     yawResetAngle = 0.0f;
     lastYawReset_ms = 0;
@@ -264,6 +263,12 @@ void NavEKF2_core::InitialiseVariables()
     delAngBiasLearned = false;
     memset(&filterStatus, 0, sizeof(filterStatus));
     gpsInhibit = false;
+    activeHgtSource = 0;
+    memset(&rngMeasIndex, 0, sizeof(rngMeasIndex));
+    memset(&storedRngMeasTime_ms, 0, sizeof(storedRngMeasTime_ms));
+    memset(&storedRngMeas, 0, sizeof(storedRngMeas));
+    terrainHgtStable = true;
+    ekfOriginHgtVar = 0.0f;
 
     // zero data buffers
     storedIMU.reset();
@@ -1331,8 +1336,12 @@ void NavEKF2_core::ConstrainStates()
     for (uint8_t i=19; i<=21; i++) statesArray[i] = constrain_float(statesArray[i],-0.5f,0.5f);
     // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
     for (uint8_t i=22; i<=23; i++) statesArray[i] = constrain_float(statesArray[i],-100.0f,100.0f);
-    // constrain the terrain offset state
-    terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
+    // constrain the terrain or vertical position state state depending on whether we are using the ground as the height reference
+    if (inhibitGndState) {
+        stateStruct.position.z = MIN(stateStruct.position.z, terrainState - rngOnGnd);
+    } else {
+        terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
+    }
 }
 
 // calculate the NED earth spin vector in rad/sec


### PR DESCRIPTION
The EK2_RNG_USE_HGT parameter sets the height (expressed as a percentage of the maximum range of the range finder as set by the RNGFND_MAX_CM parameter) below which the range finder will be used as the primary height source when the vehicle is moving slowly.

When using a height reference other than GPS, the height datum can drift due to air pressure changes if using baro, or due to terrain height changes if using range finder as the primary height source. To ensure that a consistent height datum is available when switching between altitude sources, the WGS-84 height estimate of the EKF's local positi norigin is updated using a
single state Bayes estimator,

If rngfinder or gps height data is lost whilst being used, there is  a fall-back to baro data.

TODO - need to add logging of range finder data to Copter  and get range finder data working in EKF replay.