### PR TITLE
Adding custom addons to startup

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -506,3 +506,11 @@ fi
 
 echo "rc.APM finished"
 
+# Start any custom addons
+	set FEXTRAS /fs/microsd/etc/extras.txt
+	if [ -f $FEXTRAS ]
+	then
+		echo "INFO  [init] Addons script: $FEXTRAS"
+		sh $FEXTRAS
+	fi
+	unset FEXTRAS


### PR DESCRIPTION
This part of code allow users to custom their startup as it is possible with PX4 autopilot.