### PR TITLE
waf: make build a little bit smarter about submodules

### DIFF
--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -32,7 +32,7 @@ post_mode should be set to POST_LAZY. Example::
         ...
 """
 
-from waflib import Context, Task, Utils
+from waflib import Context, Logs, Task, Utils
 from waflib.Configure import conf
 from waflib.TaskGen import before_method, feature, taskgen_method
 
@@ -146,6 +146,16 @@ def git_submodule(bld, git_submodule, **kw):
 
     return bld(**kw)
 
+def _post_fun(bld):
+    Logs.info('')
+    for name, t in _submodules_tasks.items():
+        if not t.non_fast_forward:
+            continue
+        Logs.warn("Submodule %s not updated: non-fastforward" % name)
+
+@conf
+def git_submodule_post_fun(bld):
+    bld.add_post_fun(_post_fun)
 
 def _git_head_hash(ctx, path, short=False):
     cmd = [ctx.env.get_flat('GIT'), 'rev-parse']

--- a/wscript
+++ b/wscript
@@ -141,7 +141,23 @@ def configure(cfg):
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')
     cfg.load('mavgen')
-    cfg.load('git_submodule')
+
+    cfg.env.SUBMODULE_UPDATE = cfg.options.submodule_update
+
+    cfg.start_msg('Source is git repository')
+    if cfg.srcnode.find_node('.git'):
+        cfg.end_msg('yes')
+    else:
+        cfg.end_msg('no')
+        cfg.env.SUBMODULE_UPDATE = False
+
+    cfg.start_msg('Update submodules')
+    if cfg.env.SUBMODULE_UPDATE:
+        cfg.end_msg('yes')
+        cfg.load('git_submodule')
+    else:
+        cfg.end_msg('no')
+
     if cfg.options.enable_benchmarks:
         cfg.load('gbenchmark')
     cfg.load('gtest')
@@ -171,9 +187,6 @@ def configure(cfg):
     cfg.env.prepend_value('DEFINES', [
         'SKETCHBOOK="' + cfg.srcnode.abspath() + '"',
     ])
-
-    if cfg.options.submodule_update:
-        cfg.env.SUBMODULE_UPDATE = True
 
     # Always use system extensions
     cfg.define('_GNU_SOURCE', 1)

--- a/wscript
+++ b/wscript
@@ -341,6 +341,8 @@ def build(bld):
     )
 
     bld.load('build_summary')
+    if bld.env.SUBMODULE_UPDATE:
+        bld.git_submodule_post_fun()
 
 ardupilotwaf.build_command('check',
     program_group_list='all',


### PR DESCRIPTION
Hi all,

This PR adds two fixes in order to make the build system a little bit smarter with respect to submodules:

1. Don't try to load 'git_submodules' and consequently don't update submodules if the source directory isn't a git repository. That's useful for release tarballs.
2. Don't cause trouble to developers working on submodules by updating submodules if the update isn't recursively fast-forward (with respect to the submodule's current HEAD).

Best regards,
Gustavo Sousa