### PR TITLE
Added support for controlling internal combustion engines

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -259,37 +259,6 @@ void Rover::send_servo_out(mavlink_channel_t chan)
 #endif
 }
 
-void Rover::send_radio_out(mavlink_channel_t chan)
-{
-#if HIL_MODE == HIL_MODE_DISABLED || HIL_SERVOS
-    mavlink_msg_servo_output_raw_send(
-        chan,
-        micros(),
-        0,     // port
-        hal.rcout->read(0),
-        hal.rcout->read(1),
-        hal.rcout->read(2),
-        hal.rcout->read(3),
-        hal.rcout->read(4),
-        hal.rcout->read(5),
-        hal.rcout->read(6),
-        hal.rcout->read(7));
-#else
-    mavlink_msg_servo_output_raw_send(
-        chan,
-        micros(),
-        0,     // port
-        RC_Channel::rc_channel(0)->get_radio_out(),
-        RC_Channel::rc_channel(1)->get_radio_out(),
-        RC_Channel::rc_channel(2)->get_radio_out(),
-        RC_Channel::rc_channel(3)->get_radio_out(),
-        RC_Channel::rc_channel(4)->get_radio_out(),
-        RC_Channel::rc_channel(5)->get_radio_out(),
-        RC_Channel::rc_channel(6)->get_radio_out(),
-        RC_Channel::rc_channel(7)->get_radio_out());
-#endif
-}
-
 void Rover::send_vfr_hud(mavlink_channel_t chan)
 {
     mavlink_msg_vfr_hud_send(
@@ -480,7 +449,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
 
     case MSG_RADIO_OUT:
         CHECK_PAYLOAD_SIZE(SERVO_OUTPUT_RAW);
-        rover.send_radio_out(chan);
+        send_servo_output_raw(false);
         break;
 
     case MSG_VFR_HUD:

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -396,7 +396,6 @@ private:
     void send_location(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
-    void send_radio_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
     void send_simstate(mavlink_channel_t chan);
     void send_hwstatus(mavlink_channel_t chan);

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -103,22 +103,6 @@ void Tracker::send_location(mavlink_channel_t chan)
         ahrs.yaw_sensor);
 }
 
-void Tracker::send_radio_out(mavlink_channel_t chan)
-{
-    mavlink_msg_servo_output_raw_send(
-        chan,
-        AP_HAL::micros(),
-        0,     // port
-        hal.rcout->read(0),
-        hal.rcout->read(1),
-        hal.rcout->read(2),
-        hal.rcout->read(3),
-        hal.rcout->read(4),
-        hal.rcout->read(5),
-        hal.rcout->read(6),
-        hal.rcout->read(7));
-}
-
 void Tracker::send_hwstatus(mavlink_channel_t chan)
 {
     mavlink_msg_hwstatus_send(
@@ -210,7 +194,7 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
 
     case MSG_RADIO_OUT:
         CHECK_PAYLOAD_SIZE(SERVO_OUTPUT_RAW);
-        tracker.send_radio_out(chan);
+        send_servo_output_raw(false);
         break;
 
     case MSG_RAW_IMU1:

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -189,7 +189,6 @@ private:
     void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);
-    void send_radio_out(mavlink_channel_t chan);
     void send_hwstatus(mavlink_channel_t chan);
     void send_waypoint_request(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -655,7 +655,6 @@ private:
     void send_simstate(mavlink_channel_t chan);
     void send_hwstatus(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
-    void send_radio_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -378,22 +378,6 @@ void NOINLINE Copter::send_servo_out(mavlink_channel_t chan)
 #endif // HIL_MODE
 }
 
-void NOINLINE Copter::send_radio_out(mavlink_channel_t chan)
-{
-    mavlink_msg_servo_output_raw_send(
-        chan,
-        micros(),
-        0,     // port
-        hal.rcout->read(0),
-        hal.rcout->read(1),
-        hal.rcout->read(2),
-        hal.rcout->read(3),
-        hal.rcout->read(4),
-        hal.rcout->read(5),
-        hal.rcout->read(6),
-        hal.rcout->read(7));
-}
-
 void NOINLINE Copter::send_vfr_hud(mavlink_channel_t chan)
 {
     mavlink_msg_vfr_hud_send(
@@ -584,7 +568,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 
     case MSG_RADIO_OUT:
         CHECK_PAYLOAD_SIZE(SERVO_OUTPUT_RAW);
-        copter.send_radio_out(chan);
+        send_servo_output_raw(false);
         break;
 
     case MSG_VFR_HUD:

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -60,6 +60,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(barometer_accumulate,   50,    150),
     SCHED_TASK(update_notify,          50,    300),
     SCHED_TASK(read_rangefinder,       50,    100),
+    SCHED_TASK(ice_update,             10,    100),
     SCHED_TASK(compass_cal_update,     50,    50),
     SCHED_TASK(accel_cal_update,       10,    50),
 #if OPTFLOW == ENABLED

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1256,6 +1256,13 @@ void Plane::set_servos(void)
         }
     }
 
+    uint8_t override_pct;
+    if (g2.ice_control.throttle_override(override_pct)) {
+        // the ICE controller wants to override the throttle for starting
+        channel_throttle->set_servo_out(override_pct);
+        channel_throttle->calc_pwm();
+    }
+    
     // send values to the PWM timers for output
     // ----------------------------------------
     if (g.rudder_only == 0) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -415,39 +415,6 @@ void Plane::send_servo_out(mavlink_channel_t chan)
         receiver_rssi);
 }
 
-void Plane::send_radio_out(mavlink_channel_t chan)
-{
-#if HIL_SUPPORT
-    if (g.hil_mode==1 && !g.hil_servos) {
-        mavlink_msg_servo_output_raw_send(
-            chan,
-            micros(),
-            0,     // port
-            RC_Channel::rc_channel(0)->get_radio_out(),
-            RC_Channel::rc_channel(1)->get_radio_out(),
-            RC_Channel::rc_channel(2)->get_radio_out(),
-            RC_Channel::rc_channel(3)->get_radio_out(),
-            RC_Channel::rc_channel(4)->get_radio_out(),
-            RC_Channel::rc_channel(5)->get_radio_out(),
-            RC_Channel::rc_channel(6)->get_radio_out(),
-            RC_Channel::rc_channel(7)->get_radio_out());
-        return;
-    }
-#endif
-    mavlink_msg_servo_output_raw_send(
-        chan,
-        micros(),
-        0,     // port
-        hal.rcout->read(0),
-        hal.rcout->read(1),
-        hal.rcout->read(2),
-        hal.rcout->read(3),
-        hal.rcout->read(4),
-        hal.rcout->read(5),
-        hal.rcout->read(6),
-        hal.rcout->read(7));
-}
-
 void Plane::send_vfr_hud(mavlink_channel_t chan)
 {
     float aspeed;
@@ -714,7 +681,11 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
 
     case MSG_RADIO_OUT:
         CHECK_PAYLOAD_SIZE(SERVO_OUTPUT_RAW);
-        plane.send_radio_out(chan);
+#if HIL_SUPPORT
+        send_servo_output_raw(plane.g.hil_mode);
+#else
+        send_servo_output_raw(false);
+#endif
         break;
 
     case MSG_VFR_HUD:

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1677,6 +1677,14 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
+
+        case MAV_CMD_DO_ENGINE_CONTROL:
+            if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3)) {
+                result = MAV_RESULT_FAILED;
+            } else {
+                result = MAV_RESULT_ACCEPTED;
+            }
+            break;
             
         default:
             break;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1373,8 +1373,18 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_Button/AP_Button.cpp
     AP_SUBGROUPINFO(button, "BTN_", 1, ParametersG2, AP_Button),
 
+    // @Group: ICE_
+    // @Path: ../libraries/AP_ICEngine/AP_ICEngine.cpp
+    AP_SUBGROUPINFO(ice_control, "ICE_", 2, ParametersG2, AP_ICEngine),
+    
     AP_GROUPEND
 };
+
+ParametersG2::ParametersG2(void) :
+    ice_control(plane.rpm_sensor, plane.ahrs)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
 
 /*
   This is a conversion table from old parameter values to new

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -574,13 +574,16 @@ public:
  */
 class ParametersG2 {
 public:
-    ParametersG2(void) { AP_Param::setup_object_defaults(this, var_info); }
+    ParametersG2(void);
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
     // button reporting library
     AP_Button button;
+
+    // internal combustion engine control
+    AP_ICEngine ice_control;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -89,6 +89,7 @@
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_Button/AP_Button.h>
+#include <AP_ICEngine/AP_ICEngine.h>
 
 #include "GCS_Mavlink.h"
 #include "quadplane.h"
@@ -132,6 +133,7 @@ class Plane : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Plane;
     friend class Parameters;
+    friend class ParametersG2;
     friend class AP_Arming_Plane;
     friend class QuadPlane;
     friend class AP_Tuning_Plane;
@@ -956,6 +958,7 @@ private:
     void read_receiver_rssi(void);
     void rpm_update(void);
     void button_update(void);
+    void ice_update(void);
     void report_radio();
     void report_ins();
     void report_compass();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -801,7 +801,6 @@ private:
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_position_target_global_int(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
-    void send_radio_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
     void send_simstate(mavlink_channel_t chan);
     void send_hwstatus(mavlink_channel_t chan);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -225,6 +225,12 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_VTOL_TRANSITION:
         plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)cmd.content.do_vtol_transition.target_state);
         break;
+
+    case MAV_CMD_DO_ENGINE_CONTROL:
+        plane.ice_control.engine_control(cmd.content.do_engine_control.start_control,
+                                         cmd.content.do_engine_control.cold_start,
+                                         cmd.content.do_engine_control.height_delay_cm*0.01f);
+        break;
     }
 
     return true;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -227,9 +227,9 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         break;
 
     case MAV_CMD_DO_ENGINE_CONTROL:
-        plane.ice_control.engine_control(cmd.content.do_engine_control.start_control,
-                                         cmd.content.do_engine_control.cold_start,
-                                         cmd.content.do_engine_control.height_delay_cm*0.01f);
+        plane.g2.ice_control.engine_control(cmd.content.do_engine_control.start_control,
+                                            cmd.content.do_engine_control.cold_start,
+                                            cmd.content.do_engine_control.height_delay_cm*0.01f);
         break;
     }
 
@@ -316,6 +316,8 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
     case MAV_CMD_DO_LAND_START:
     case MAV_CMD_DO_FENCE_ENABLE:
     case MAV_CMD_DO_AUTOTUNE_ENABLE:
+    case MAV_CMD_DO_VTOL_TRANSITION:
+    case MAV_CMD_DO_ENGINE_CONTROL:
         return true;
 
     default:

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -164,3 +164,11 @@ void Plane::button_update(void)
 {
     g2.button.update();
 }
+
+/*
+  update AP_ICEngine
+ */
+void Plane::ice_update(void)
+{
+    g2.ice_control.update();
+}

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -57,6 +57,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Mount',
     'AP_Module',
     'AP_Button',
+    'AP_ICEngine',
 ]
 
 def _get_legacy_defines(sketch_name):

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -1,0 +1,289 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <RC_Channel/RC_Channel_aux.h>
+#include <GCS_MAVLink/GCS.h>
+#include "AP_ICEngine.h"
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable ICEngine control
+    // @Description: This enables internal combusion engine control
+    // @Values: 0:Disabled, 1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_ICEngine, enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: START_CHAN
+    // @DisplayName: Input channel for engine start
+    // @Description: This is an RC input channel for requesting engine start. Engine will try to start when channel is at or above 1700. Engine will stop when channel is at or below 1300. Between 1301 and 1699 the engine will not change state unless a MAVLink command or mission item commands a state change, or the vehicle is disamed.
+    // @User: Standard
+    // @Values: 0:None,1:Chan1,2:Chan2,3:Chan3,4:Chan4,5:Chan5,6:Chan6,7:Chan7,8:Chan8,9:Chan9,10:Chan10,11:Chan11,12:Chan12,13:Chan13,14:Chan14,15:Chan15,16:Chan16
+    AP_GROUPINFO("START_CHAN", 1, AP_ICEngine, start_chan, 0),
+
+    // @Param: STARTER_TIME
+    // @DisplayName: Time to run starter
+    // @Description: This is the number of seconds to run the starter when trying to start the engine
+    // @User: Standard
+    // @Units: Seconds
+    // @Range: 0.1 5
+    AP_GROUPINFO("STARTER_TIME", 2, AP_ICEngine, starter_time, 3),
+
+    // @Param: START_DELAY
+    // @DisplayName: Time to wait between starts
+    // @Description: Delay between start attempts
+    // @User: Standard
+    // @Units: Seconds
+    // @Range: 1 10
+    AP_GROUPINFO("START_DELAY", 3, AP_ICEngine, starter_delay, 2),
+    
+    // @Param: RPM_THRESH
+    // @DisplayName: RPM threshold
+    // @Description: This is the measured RPM above which tne engine is considered to be running
+    // @User: Standard
+    // @Range: 100 100000
+    AP_GROUPINFO("RPM_THRESH", 4, AP_ICEngine, rpm_threshold, 100),
+
+    // @Param: PWM_IGN_ON
+    // @DisplayName: PWM value for ignition on
+    // @Description: This is the value sent to the ignition channel when on
+    // @User: Standard
+    // @Range: 1000 2000
+    AP_GROUPINFO("PWM_IGN_ON", 5, AP_ICEngine, pwm_ignition_on, 2000),
+
+    // @Param: PWM_IGN_OFF
+    // @DisplayName: PWM value for ignition off
+    // @Description: This is the value sent to the ignition channel when off
+    // @User: Standard
+    // @Range: 1000 2000
+    AP_GROUPINFO("PWM_IGN_OFF", 6, AP_ICEngine, pwm_ignition_off, 1000),
+
+    // @Param: PWM_STRT_ON
+    // @DisplayName: PWM value for starter on
+    // @Description: This is the value sent to the starter channel when on
+    // @User: Standard
+    // @Range: 1000 2000
+    AP_GROUPINFO("PWM_STRT_ON", 7, AP_ICEngine, pwm_starter_on, 2000),
+
+    // @Param: PWM_STRT_OFF
+    // @DisplayName: PWM value for starter off
+    // @Description: This is the value sent to the starter channel when off
+    // @User: Standard
+    // @Range: 1000 2000
+    AP_GROUPINFO("PWM_STRT_OFF", 8, AP_ICEngine, pwm_starter_off, 1000),
+
+    // @Param: RPM_CHAN
+    // @DisplayName: RPM instance channel to use
+    // @Description: This is which of the RPM instances to use for detecting the RPM of the engine
+    // @User: Standard
+    // @Values: 0:None,1:RPM1,2:RPM2
+    AP_GROUPINFO("RPM_CHAN",  9, AP_ICEngine, rpm_instance, 0),
+
+    // @Param: START_PCT
+    // @DisplayName: Throttle percentage for engine start
+    // @Description: This is the percentage throttle output for engine start
+    // @User: Standard
+    // @Range: 0 100
+    AP_GROUPINFO("START_PCT", 10, AP_ICEngine, start_percent, 5),
+    
+    AP_GROUPEND    
+};
+
+
+// constructor
+AP_ICEngine::AP_ICEngine(const AP_RPM &_rpm, const AP_AHRS &_ahrs) :
+    rpm(_rpm),
+    ahrs(_ahrs),
+    state(ICE_OFF)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+/*
+  update engine state
+ */
+void AP_ICEngine::update(void)
+{
+    if (!enable) {
+        return;
+    }
+
+    uint16_t cvalue = 1500;
+    if (start_chan != 0) {
+        // get starter control channel
+        cvalue = hal.rcin->read(start_chan-1);
+    }
+
+    bool should_run = false;
+    uint32_t now = AP_HAL::millis();
+
+    if (state == ICE_OFF && cvalue >= 1700) {
+        should_run = true;
+    } else if (cvalue <= 1300) {
+        should_run = false;
+    } else if (state != ICE_OFF) {
+        should_run = true;
+    }
+
+    // switch on current state to work out new state
+    switch (state) {
+    case ICE_OFF:
+        if (should_run) {
+            state = ICE_START_DELAY;
+        }
+        break;
+
+    case ICE_START_HEIGHT_DELAY: {
+        Vector3f pos;
+        if (!should_run) {
+            state = ICE_OFF;
+        } else if (ahrs.get_relative_position_NED(pos)) {
+            if (height_pending) {
+                height_pending = false;
+                initial_height = -pos.z;
+            } else if ((-pos.z) >= initial_height + height_required) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Starting height reached %.1f",
+                                                 (double)(-pos.z) - initial_height);
+                state = ICE_STARTING;
+            }
+        }
+        break;
+    }
+
+    case ICE_START_DELAY:
+        if (!should_run) {
+            state = ICE_OFF;
+        } else if (now - starter_last_run_ms >= starter_delay*1000) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Starting engine");
+            state = ICE_STARTING;
+        }
+        break;
+
+    case ICE_STARTING:
+        if (!should_run) {
+            state = ICE_OFF;
+        } else if (now - starter_start_time_ms >= starter_time*1000) {
+            state = ICE_RUNNING;
+        }
+        break;
+
+    case ICE_RUNNING:
+        if (!should_run) {
+            state = ICE_OFF;
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Stopped engine");
+        } else if (rpm_instance > 0) {
+            // check RPM to see if still running
+            if (!rpm.healthy(rpm_instance-1) ||
+                rpm.get_rpm(rpm_instance-1) < rpm_threshold) {
+                // engine has stopped when it should be running
+                state = ICE_START_DELAY;
+            }
+        }
+        break;
+    }
+
+    if (!hal.util->get_soft_armed()) {
+        if (state == ICE_START_HEIGHT_DELAY) {
+            // when disarmed we can be waiting for takeoff
+            Vector3f pos;
+            if (ahrs.get_relative_position_NED(pos)) {
+                // reset initial height while disarmed
+                initial_height = -pos.z;
+            }
+        } else {
+            // force ignition off when disarmed
+            state = ICE_OFF;
+        }
+    }
+    
+    /* now set output channels */
+    switch (state) {
+    case ICE_OFF:
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_ignition, pwm_ignition_off);
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_starter,  pwm_starter_off);
+        starter_start_time_ms = 0;
+        break;
+
+    case ICE_START_HEIGHT_DELAY:
+    case ICE_START_DELAY:
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_ignition, pwm_ignition_on);
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_starter,  pwm_starter_off);
+        break;
+        
+    case ICE_STARTING:
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_ignition, pwm_ignition_on);
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_starter,  pwm_starter_on);
+        if (starter_start_time_ms == 0) {
+            starter_start_time_ms = now;
+        }
+        starter_last_run_ms = now;
+        break;
+
+    case ICE_RUNNING:
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_ignition, pwm_ignition_on);
+        RC_Channel_aux::set_radio(RC_Channel_aux::k_starter,  pwm_starter_off);
+        starter_start_time_ms = 0;
+        break;
+    }
+}
+
+
+/*
+  check for throttle override. This allows the ICE controller to force
+  the correct starting throttle when starting the engine
+ */
+bool AP_ICEngine::throttle_override(uint8_t &percentage)
+{
+    if (!enable) {
+        return false;
+    }
+    if (state == ICE_STARTING || state == ICE_START_DELAY) {
+        percentage = (uint8_t)start_percent.get();
+        return true;
+    }
+    return false;
+}
+
+
+/*
+  handle DO_ENGINE_CONTROL messages via MAVLink or mission
+*/
+bool AP_ICEngine::engine_control(float start_control, float cold_start, float height_delay)
+{
+    if (start_control <= 0) {
+        state = ICE_OFF;
+        return true;
+    }
+    if (start_chan != 0) {
+        // get starter control channel
+        if (hal.rcin->read(start_chan-1) <= 1300) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Engine: start control disabled");
+            return false;
+        }
+    }
+    if (height_delay > 0) {
+        height_pending = true;
+        initial_height = 0;
+        height_required = height_delay;
+        state = ICE_START_HEIGHT_DELAY;
+        return true;
+    }
+    state = ICE_STARTING;
+    return true;
+}

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -1,0 +1,100 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  control of internal combustion engines (starter, ignition and choke)
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_RPM/AP_RPM.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+class AP_ICEngine {
+public:
+    // constructor
+    AP_ICEngine(const AP_RPM &_rpm, const AP_AHRS &_ahrs);
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    // update engine state. Should be called at 10Hz or more
+    void update(void);
+
+    // check for throttle override
+    bool throttle_override(uint8_t &percent);
+
+    enum ICE_State {
+        ICE_OFF=0,
+        ICE_START_HEIGHT_DELAY=1,
+        ICE_START_DELAY=2,
+        ICE_STARTING=3,
+        ICE_RUNNING=4
+    };
+
+    // get current engine control state
+    ICE_State get_state(void) const { return state; }
+
+    // handle DO_ENGINE_CONTROL messages via MAVLink or mission
+    bool engine_control(float start_control, float cold_start, float height_delay);
+    
+private:
+    const AP_RPM &rpm;
+    const AP_AHRS &ahrs;
+
+    enum ICE_State state;
+
+    // enable library
+    AP_Int8 enable;
+
+    // channel for pilot to command engine start, 0 for none
+    AP_Int8 start_chan;
+
+    // which RPM instance to use
+    AP_Int8 rpm_instance;
+    
+    // time to run starter for (seconds)
+    AP_Float starter_time;
+
+    // delay between start attempts (seconds)
+    AP_Float starter_delay;
+    
+    // pwm values 
+    AP_Int16 pwm_ignition_on;
+    AP_Int16 pwm_ignition_off;
+    AP_Int16 pwm_starter_on;
+    AP_Int16 pwm_starter_off;
+    
+    // RPM above which engine is considered to be running
+    AP_Int32 rpm_threshold;
+    
+    // time when we started the starter
+    uint32_t starter_start_time_ms;
+
+    // time when we last ran the starter
+    uint32_t starter_last_run_ms;
+
+    // throttle percentage for engine start
+    AP_Int8 start_percent;
+
+    // height when we enter ICE_START_HEIGHT_DELAY
+    float initial_height;
+
+    // height change required to start engine
+    float height_required;
+
+    // we are waiting for valid height data
+    bool height_pending:1;
+};
+

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -757,11 +757,17 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_DO_VTOL_TRANSITION:
         cmd.content.do_vtol_transition.target_state = packet.param1;
         break;
-        
+
     case MAV_CMD_DO_SET_REVERSE:
         cmd.p1 = packet.param1; // 0 = forward, 1 = reverse
         break;
 
+    case MAV_CMD_DO_ENGINE_CONTROL:
+        cmd.content.do_engine_control.start_control = (packet.param1>0);
+        cmd.content.do_engine_control.cold_start = (packet.param2>0);
+        cmd.content.do_engine_control.height_delay_cm = packet.param3*100;
+        break;        
+        
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1200,7 +1206,13 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_DO_VTOL_TRANSITION:
         packet.param1 = cmd.content.do_vtol_transition.target_state;
         break;
-        
+
+    case MAV_CMD_DO_ENGINE_CONTROL:
+        packet.param1 = cmd.content.do_engine_control.start_control?1:0;
+        packet.param2 = cmd.content.do_engine_control.cold_start?1:0;
+        packet.param3 = cmd.content.do_engine_control.height_delay_cm*0.01f;
+        break;        
+                
     default:
         // unrecognised command
         return false;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -169,6 +169,13 @@ public:
         int8_t sec_utc; // absolute time's sec (utc)
     };
 
+    // DO_ENGINE_CONTROL support
+    struct PACKED Do_Engine_Control {
+        bool start_control; // start or stop engine
+        bool cold_start; // use cold start procedure
+        uint16_t height_delay_cm; // height delay for start
+    };
+    
     union PACKED Content {
         // jump structure
         Jump_Command jump;
@@ -220,6 +227,9 @@ public:
 
         // do vtol transition
         Do_VTOL_Transition do_vtol_transition;
+
+        // DO_ENGINE_CONTROL
+        Do_Engine_Control do_engine_control;
         
         // location
         Location location;      // Waypoint location

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -166,6 +166,7 @@ public:
     void send_home(const Location &home) const;
     static void send_home_all(const Location &home);
     void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
+    void send_servo_output_raw(bool hil);
 
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1667,3 +1667,30 @@ bool GCS_MAVLINK::telemetry_delayed(mavlink_channel_t _chan)
 }
 
 
+/*
+  send SERVO_OUTPUT_RAW
+ */
+void GCS_MAVLINK::send_servo_output_raw(bool hil)
+{
+    uint16_t values[16] {};
+    if (hil) {
+        for (uint8_t i=0; i<16; i++) {
+            values[i] = RC_Channel::rc_channel(i)->get_radio_out();
+        }
+    } else {
+        hal.rcout->read(values, 16);
+    }
+    for (uint8_t i=0; i<16; i++) {
+        if (values[i] == 65535) {
+            values[i] = 0;
+        }
+    }    
+    mavlink_msg_servo_output_raw_send(
+            chan,
+            AP_HAL::micros(),
+            0,     // port
+            values[0],  values[1],  values[2],  values[3],
+            values[4],  values[5],  values[6],  values[7],
+            values[8],  values[9],  values[10], values[11],
+            values[12], values[13], values[14], values[15]);
+}

--- a/libraries/RC_Channel/RC_Channel_aux.h
+++ b/libraries/RC_Channel/RC_Channel_aux.h
@@ -91,6 +91,9 @@ public:
         k_rcin14                = 64,
         k_rcin15                = 65,
         k_rcin16                = 66,
+        k_ignition              = 67,
+        k_choke                 = 68,
+        k_starter               = 69,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 

--- a/libraries/SITL/SIM_ICEngine.cpp
+++ b/libraries/SITL/SIM_ICEngine.cpp
@@ -84,9 +84,12 @@ float ICEngine::update(const Aircraft::sitl_input &input)
     }
     if (start_time_us != 0 && state.starter) {
         uint32_t starter_time_us = (now - start_time_us);
-        if (starter_time_us > 3000*1000UL) {
+        if (starter_time_us > 3000*1000UL && !overheat) {
+            overheat = true;
             printf("Starter overheat\n");            
         }
+    } else {
+        overheat = false;
     }
 
 output:

--- a/libraries/SITL/SIM_ICEngine.cpp
+++ b/libraries/SITL/SIM_ICEngine.cpp
@@ -1,0 +1,115 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple internal combustion engine simulator class
+*/
+
+#include "SIM_ICEngine.h"
+#include <stdio.h>
+
+using namespace SITL;
+
+/*
+  update engine state, returning power output from 0 to 1
+ */
+float ICEngine::update(const Aircraft::sitl_input &input)
+{
+    bool have_ignition = ignition_servo>=0;
+    bool have_choke = choke_servo>=0;
+    bool have_starter = starter_servo>=0;
+    float throttle_demand = (input.servos[throttle_servo]-1000) * 0.001f;
+
+    state.ignition = have_ignition?input.servos[ignition_servo]>1700:true;
+    state.choke = have_choke?input.servos[choke_servo]>1700:false;
+    state.starter = have_starter?input.servos[starter_servo]>1700:false;
+
+    uint64_t now = AP_HAL::micros64();
+    float dt = (now - last_update_us) * 1.0e-6f;
+    float max_change = slew_rate * 0.01f * dt;
+    
+    if (!have_starter) {
+        // always on
+        last_output = throttle_demand;
+        return last_output;
+    }
+
+    if (state.value != last_state.value) {
+        printf("choke:%u starter:%u ignition:%u\n",
+               (unsigned)state.choke,
+               (unsigned)state.starter,
+               (unsigned)state.ignition);
+    }
+    
+    if (have_ignition && !state.ignition) {
+        // engine is off
+        if (!state.starter) {
+            goto engine_off;
+        }
+        // give 10% when on starter alone without ignition
+        last_update_us = now;
+        throttle_demand = 0.1;
+        goto output;
+    }
+    if (have_choke && state.choke && now - start_time_us > 1000*1000UL) {
+        // engine is choked, only run for 1s
+        goto engine_off;
+    }
+    if (last_output <= 0 && !state.starter) {
+        // not started
+        goto engine_off;
+    }
+    if (start_time_us == 0 && state.starter) {
+        if (throttle_demand > 0.2) {
+            printf("too much throttle to start: %.2f\n", throttle_demand);
+        } else {
+            // start the motor
+            if (start_time_us == 0) {
+                printf("Engine started\n");
+            }
+            start_time_us = now;
+        }
+    }
+    if (start_time_us != 0 && state.starter) {
+        uint32_t starter_time_us = (now - start_time_us);
+        if (starter_time_us > 3000*1000UL) {
+            printf("Starter overheat\n");            
+        }
+    }
+
+output:
+    if (start_time_us != 0 && throttle_demand < 0.01) {
+        // even idling it gives some thrust
+        throttle_demand = 0.01;
+    }
+
+    last_output = constrain_float(throttle_demand, last_output-max_change, last_output+max_change);
+    last_output = constrain_float(last_output, 0, 1);
+    
+    last_update_us = now;
+    last_state = state;
+    return last_output;
+
+engine_off:
+    if (start_time_us != 0) {
+        printf("Engine stopped\n");
+    }
+    last_update_us = AP_HAL::micros64();
+    start_time_us = 0;
+    last_output = 0;
+    last_state = state;
+    start_time_us = 0;
+    return 0;
+}

--- a/libraries/SITL/SIM_ICEngine.h
+++ b/libraries/SITL/SIM_ICEngine.h
@@ -1,0 +1,58 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple internal combustion motor simulation class
+*/
+
+#pragma once
+
+#include "SIM_Aircraft.h"
+
+namespace SITL {
+
+class ICEngine {
+public:
+    const uint8_t throttle_servo;
+    const int8_t choke_servo;
+    const int8_t ignition_servo;
+    const int8_t starter_servo;
+    const float slew_rate; // percent-per-second
+
+    ICEngine(uint8_t _throttle, int8_t _choke, int8_t _ignition, int8_t _starter, float _slew_rate) :
+        throttle_servo(_throttle),
+        choke_servo(_choke),
+        ignition_servo(_ignition),
+        starter_servo(_starter),
+        slew_rate(_slew_rate)
+    {}
+
+    // update motor state
+    float update(const struct Aircraft::sitl_input &input);
+
+private:
+    float last_output;
+    uint64_t start_time_us;
+    uint64_t last_update_us;
+    union state {
+        struct {
+            bool choke:1;
+            bool ignition:1;
+            bool starter:1;
+        };
+        uint8_t value;
+    } state, last_state;
+};
+}

--- a/libraries/SITL/SIM_ICEngine.h
+++ b/libraries/SITL/SIM_ICEngine.h
@@ -54,5 +54,6 @@ private:
         };
         uint8_t value;
     } state, last_state;
+    bool overheat:1;
 };
 }

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -250,6 +250,9 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     Vector3f force = getForce(aileron, elevator, rudder);
     rot_accel = getTorque(aileron, elevator, rudder, force);
 
+    // simulate engine RPM
+    rpm1 = thrust * 7000;
+    
     // scale thrust to newtons
     thrust *= thrust_scale;
 

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -52,6 +52,9 @@ Plane::Plane(const char *home_str, const char *frame_str) :
     }
 
     ground_behavior = GROUND_BEHAVIOR_FWD_ONLY;
+    if (strstr(frame_str, "-ice")) {
+        ice_engine = true;
+    }
 }
 
 /*
@@ -235,6 +238,10 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     }
     
     float thrust     = throttle;
+
+    if (ice_engine) {
+        thrust = icengine.update(input);
+    }
 
     // calculate angle of attack
     angle_of_attack = atan2f(velocity_air_bf.z, velocity_air_bf.x);

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "SIM_Aircraft.h"
+#include "SIM_ICEngine.h"
 
 namespace SITL {
 
@@ -95,6 +96,9 @@ protected:
     bool elevons;
     bool vtail;
     bool reverse_elevator_rudder;
+    bool ice_engine;
+
+    ICEngine icengine{2, 4, 5, 6, 100};
 
     float liftCoeff(float alpha) const;
     float dragCoeff(float alpha) const;

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -98,7 +98,7 @@ protected:
     bool reverse_elevator_rudder;
     bool ice_engine;
 
-    ICEngine icengine{2, 4, 5, 6, 100};
+    ICEngine icengine{2, 14, 12, 13, 100};
 
     float liftCoeff(float alpha) const;
     float dragCoeff(float alpha) const;

--- a/mk/make.inc
+++ b/mk/make.inc
@@ -1,3 +1,5 @@
 # libraries linked into every program
 LIBRARIES += AP_Module
 LIBRARIES += AP_Button
+LIBRARIES += AP_ICEngine
+


### PR DESCRIPTION
This adds support for controlling IC engines via RC input, MAVLink and mission commands. It allows for control of ignition and starter motors, and includes support for delayed engine start by height for quadplane takeoffs.
It also can monitor the engine in flight and automatically restart the engine if required.
The patches include improvments to the ICEngine SITL simulation for fixed wing and quadplanes for testing the ICEngine support.
In the future it is planner to add support for this library for gas helicopters
The PR also expands SERVO_OUTPUT_RAW to 16 channels for MAVLink2, which makes testing IC engine support much easier
