### PR TITLE
ArduCopter: Delete (wrong) filename out of header V2

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -52,7 +52,7 @@
 // User Hooks : For User Developed code that you wish to run
 // Put your variable definitions into the UserVariables.h file (or another file name and then change the #define below).
 //#define USERHOOK_VARIABLES "UserVariables.h"
-// Put your custom code into the UserCode.pde with function names matching those listed below and ensure the appropriate #define below is uncommented below
+// Put your custom code into the UserCode.cpp with function names matching those listed below and ensure the appropriate #define below is uncommented below
 //#define USERHOOK_INIT userhook_init();                      // for code to be run once at startup
 //#define USERHOOK_FASTLOOP userhook_FastLoop();            // for code to be run at 100hz
 //#define USERHOOK_50HZLOOP userhook_50Hz();                  // for code to be run at 50hz

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -3,7 +3,7 @@
 
 
 /*
- * control_acro.pde - init and run calls for acro flight mode
+ * Init and run calls for acro flight mode
  */
 
 // acro_init - initialise acro controller

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -3,7 +3,7 @@
 
 
 /*
- * control_althold.pde - init and run calls for althold, flight mode
+ * Init and run calls for althold, flight mode
  */
 
 // althold_init - initialise althold controller

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_auto.pde - init and run calls for auto flight mode
+ * Init and run calls for auto flight mode
  *
  * This file contains the implementation for Land, Waypoint navigation and Takeoff from Auto mode
  * Command execution code (i.e. command_logic.pde) should:

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -5,7 +5,7 @@
 #if AUTOTUNE_ENABLED == ENABLED
 
 /*
- * control_autotune.pde - init and run calls for autotune flight mode
+ * Init and run calls for autotune flight mode
  *
  * Instructions:
  *      1) Set up one flight mode switch position to be AltHold.

--- a/ArduCopter/control_brake.cpp
+++ b/ArduCopter/control_brake.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_brake.pde - init and run calls for brake flight mode
+ * Init and run calls for brake flight mode
  */
 
 // brake_init - initialise brake controller

--- a/ArduCopter/control_circle.cpp
+++ b/ArduCopter/control_circle.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_circle.pde - init and run calls for circle flight mode
+ * Init and run calls for circle flight mode
  */
 
 // circle_init - initialise circle controller flight mode

--- a/ArduCopter/control_drift.cpp
+++ b/ArduCopter/control_drift.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_drift.pde - init and run calls for drift flight mode
+ * Init and run calls for drift flight mode
  */
 
 #ifndef DRIFT_SPEEDGAIN

--- a/ArduCopter/control_flip.cpp
+++ b/ArduCopter/control_flip.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_flip.pde - init and run calls for flip flight mode
+ * Init and run calls for flip flight mode
  *      original implementation in 2010 by Jose Julio
  *      Adapted and updated for AC2 in 2011 by Jason Short
  *

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_guided.pde - init and run calls for guided flight mode
+ * Init and run calls for guided flight mode
  */
 
 #ifndef GUIDED_LOOK_AT_TARGET_MIN_DISTANCE_CM

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_loiter.pde - init and run calls for loiter flight mode
+ * Init and run calls for loiter flight mode
  */
 
 // loiter_init - initialise loiter controller

--- a/ArduCopter/control_poshold.cpp
+++ b/ArduCopter/control_poshold.cpp
@@ -5,7 +5,7 @@
 #if POSHOLD_ENABLED == ENABLED
 
 /*
- * control_poshold.pde - init and run calls for PosHold flight mode
+ * Init and run calls for PosHold flight mode
  *     PosHold tries to improve upon regular loiter by mixing the pilot input with the loiter controller
  */
 

--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_rtl.pde - init and run calls for RTL flight mode
+ * Init and run calls for RTL flight mode
  *
  * There are two parts to RTL, the high level decision making which controls which state we are in
  * and the lower implementation of the waypoint or landing controllers within those states

--- a/ArduCopter/control_sport.cpp
+++ b/ArduCopter/control_sport.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_sport.pde - init and run calls for sport flight mode
+ * Init and run calls for sport flight mode
  */
 
 // sport_init - initialise sport controller

--- a/ArduCopter/control_stabilize.cpp
+++ b/ArduCopter/control_stabilize.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*
- * control_stabilize.pde - init and run calls for stabilize flight mode
+ * Init and run calls for stabilize flight mode
  */
 
 // stabilize_init - initialise stabilize controller

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -4,8 +4,8 @@
 
 /**
  *
- * ekf_check.pde - detects failures of the ekf or inertial nav system
- *                 triggers an alert to the pilot and helps take countermeasures
+ * Detects failures of the ekf or inertial nav system triggers an alert
+ * to the pilot and helps take countermeasures
  *
  */
 

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -3,7 +3,7 @@
 #include "Copter.h"
 
 /*****************************************************************************
-*  esc_calibration.pde : functions to check and perform ESC calibration
+* Functions to check and perform ESC calibration
 *****************************************************************************/
 
 #define ESC_CALIBRATION_HIGH_THROTTLE   950

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -3,8 +3,8 @@
 #include "Copter.h"
 
 /*
- * flight.pde - high level calls to set and update flight modes
- *      logic for individual flight modes is in control_acro.pde, control_stabilize.pde, etc
+ * High level calls to set and update flight modes logic for individual
+ * flight modes is in control_acro.cpp, control_stabilize.cpp, etc
  */
 
 // set_mode - change flight mode and perform any necessary initialisation

--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -4,7 +4,7 @@
 
 #if FRAME_CONFIG == HELI_FRAME
 /*
- * heli_control_acro.pde - init and run calls for acro flight mode for trad heli
+ * Init and run calls for acro flight mode for trad heli
  */
 
 // heli_acro_init - initialise acro controller

--- a/ArduCopter/heli_control_stabilize.cpp
+++ b/ArduCopter/heli_control_stabilize.cpp
@@ -4,7 +4,7 @@
 
 #if FRAME_CONFIG == HELI_FRAME
 /*
- * heli_control_stabilize.pde - init and run calls for stabilize flight mode for trad heli
+ * Init and run calls for stabilize flight mode for trad heli
  */
 
 // stabilize_init - initialise stabilize controller

--- a/ArduCopter/position_vector.cpp
+++ b/ArduCopter/position_vector.cpp
@@ -2,7 +2,7 @@
 
 #include "Copter.h"
 
-// position_vector.pde related utility functions
+// Position vectors related utility functions
 
 // position vectors are Vector3f
 //    .x = latitude from home in cm

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -3,8 +3,8 @@
 #include "Copter.h"
 
 /*
- * tuning.pde - function to update various parameters in flight using the ch6 tuning knob
- *      This should not be confused with the AutoTune feature which can bve found in control_autotune.pde
+ * Function to update various parameters in flight using the ch6 tuning knob
+ * This should not be confused with the AutoTune feature which can bve found in control_autotune.cpp
  */
 
 // tuning - updates parameters based on the ch6 tuning knob's position


### PR DESCRIPTION
ArduCopter: Delete (wrong) filename out of header #4520 

We may should think about a generic ArduPilot file header.