### PR TITLE
AntennaTracker: Delete (wrong) filename out of header V2

### DIFF
--- a/AntennaTracker/control_auto.cpp
+++ b/AntennaTracker/control_auto.cpp
@@ -3,7 +3,7 @@
 #include "Tracker.h"
 
 /*
- * control_auto.pde - auto control mode
+ * Auto control mode
  */
 
 /*

--- a/AntennaTracker/control_manual.cpp
+++ b/AntennaTracker/control_manual.cpp
@@ -3,7 +3,7 @@
 #include "Tracker.h"
 
 /*
- * control_manual.pde - manual control mode
+ * Manual control mode
  */
 
 /*

--- a/AntennaTracker/control_scan.cpp
+++ b/AntennaTracker/control_scan.cpp
@@ -3,7 +3,7 @@
 #include "Tracker.h"
 
 /*
- * control_scan.pde - scan control mode
+ * Scan control mode
  */
 
 /*

--- a/AntennaTracker/control_servo_test.cpp
+++ b/AntennaTracker/control_servo_test.cpp
@@ -3,7 +3,7 @@
 #include "Tracker.h"
 
 /*
- * control_servo_test.pde - GCS controlled servo test mode
+ * GCS controlled servo test mode
  */
 
 /*

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -3,7 +3,7 @@
 #include "Tracker.h"
 
 /*
- * servos.pde - code to move pitch and yaw servos to attain a target heading or pitch
+ * Code to move pitch and yaw servos to attain a target heading or pitch
  */
 
 // init_servos - initialises the servos


### PR DESCRIPTION
AntennaTracker: Delete (wrong) filename out of header #4523 