### PR TITLE
Revert "Global: workaround toolchain problem on windows"

### DIFF
--- a/libraries/AP_ADC/AP_ADC_ADS1115.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.cpp
@@ -1,7 +1,4 @@
 #include <AP_HAL/AP_HAL.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-
 #include <AP_HAL/utility/sparse-endian.h>
 
 #include "AP_ADC_ADS1115.h"
@@ -239,5 +236,3 @@ void AP_ADC_ADS1115::_update()
 
     _last_update_timestamp = AP_HAL::micros();
 }
-
-#endif

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -24,8 +24,6 @@
  */
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-
 #ifdef HAL_COMPASS_HMC5843_I2C_ADDR
 
 #include <assert.h>
@@ -591,7 +589,5 @@ bool AP_HMC5843_BusDriver_Auxiliary::start_measurements()
 
     return true;
 }
-
-#endif
 
 #endif


### PR DESCRIPTION
This reverts commit 4e2b30b413a62faa7dd8e7a8efc61bfd95fe0531.

The toolchain for windows is now updated, we can remove this workaround.