### PR TITLE
AC_PrecLand: add target velocity estimation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/PX4Firmware"]
 	path = modules/PX4Firmware
-	url = git://github.com/ArduPilot/PX4Firmware.git
+	url = git://github.com/jschall/PX4Firmware.git
 [submodule "modules/PX4NuttX"]
 	path = modules/PX4NuttX
 	url = git://github.com/ArduPilot/PX4NuttX.git

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -293,8 +293,6 @@ private:
         uint32_t start_ms;
     } takeoff_state;
 
-    uint32_t precland_last_update_ms;
-
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
     

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -651,12 +651,11 @@ struct PACKED log_Precland {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint8_t healthy;
-    float bf_angle_x;
-    float bf_angle_y;
-    float ef_angle_x;
-    float ef_angle_y;
+    uint8_t target_acquired;
     float pos_x;
     float pos_y;
+    float vel_x;
+    float vel_y;
 };
 
 // Write an optical flow packet
@@ -668,19 +667,20 @@ void Copter::Log_Write_Precland()
         return;
     }
 
-    const Vector2f &bf_angle = precland.last_bf_angle_to_target();
-    const Vector2f &ef_angle = precland.last_ef_angle_to_target();
-    const Vector3f &target_pos_ofs = precland.last_target_pos_offset();
+    Vector2f target_pos_rel = Vector2f(0.0f,0.0f);
+    Vector2f target_vel_rel = Vector2f(0.0f,0.0f);
+    precland.get_target_position_relative_cm(target_pos_rel);
+    precland.get_target_velocity_relative_cms(target_vel_rel);
+
     struct log_Precland pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PRECLAND_MSG),
         time_us         : AP_HAL::micros64(),
         healthy         : precland.healthy(),
-        bf_angle_x      : degrees(bf_angle.x),
-        bf_angle_y      : degrees(bf_angle.y),
-        ef_angle_x      : degrees(ef_angle.x),
-        ef_angle_y      : degrees(ef_angle.y),
-        pos_x           : target_pos_ofs.x,
-        pos_y           : target_pos_ofs.y
+        target_acquired : precland.target_acquired(),
+        pos_x           : target_pos_rel.x,
+        pos_y           : target_pos_rel.y,
+        vel_x           : target_vel_rel.x,
+        vel_y           : target_vel_rel.y
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
  #endif     // PRECISION_LANDING == ENABLED
@@ -833,7 +833,7 @@ const struct LogStructure Copter::log_structure[] = {
     { LOG_HELI_MSG, sizeof(log_Heli),
       "HELI",  "Qff",         "TimeUS,DRRPM,ERRPM" },
     { LOG_PRECLAND_MSG, sizeof(log_Precland),
-      "PL",    "QBffffff",    "TimeUS,Heal,bX,bY,eX,eY,pX,pY" },
+      "PL",    "QBBffff",    "TimeUS,Heal,TAcq,pX,pY,vX,vY" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
     { LOG_THROW_MSG, sizeof(log_Throw),

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -196,7 +196,7 @@ void Copter::land_run_vertical_control(bool pause_descent)
         // Constrain the demanded vertical velocity so that it is between the configured maximum descent speed and the configured minimum descent speed.
         cmb_rate = constrain_float(cmb_rate, max_land_descent_velocity, -abs(g.land_speed));
 
-        if (doing_precision_landing && alt_above_ground < 200.0f) {
+        if (doing_precision_landing && rangefinder_alt_ok() && rangefinder_state.alt_cm > 35.0f && rangefinder_state.alt_cm < 200.0f) {
             float max_descent_speed = abs(g.land_speed)/2.0f;
             float land_slowdown = MAX(0.0f, pos_control.get_horizontal_error()*(max_descent_speed/precland_acceptable_error));
             cmb_rate = MIN(-precland_min_descent_speed, -max_descent_speed+land_slowdown);

--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -26,6 +26,6 @@ void Copter::update_precland()
         }
     }
 
-    copter.precland.update(height_above_ground_cm);
+    copter.precland.update(height_above_ground_cm, rangefinder_alt_ok());
 }
 #endif

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -237,7 +237,7 @@ void AC_PosControl::relax_alt_hold_controllers(float throttle_setting)
     _pos_target.z = _inav.get_altitude();
     _vel_desired.z = 0.0f;
     _flags.use_desvel_ff_z = false;
-    _vel_target.z= _inav.get_velocity_z();
+    _vel_target.z = _inav.get_velocity_z();
     _vel_last.z = _inav.get_velocity_z();
     _accel_feedforward.z = 0.0f;
     _accel_last_z_cms = 0.0f;
@@ -568,8 +568,8 @@ void AC_PosControl::set_target_to_stopping_point_xy()
 ///     set_leash_length() should have been called before this method
 void AC_PosControl::get_stopping_point_xy(Vector3f &stopping_point) const
 {
-	const Vector3f curr_pos = _inav.get_position();
-	Vector3f curr_vel = _inav.get_velocity();
+    const Vector3f curr_pos = _inav.get_position();
+    Vector3f curr_vel = _inav.get_velocity();
     float linear_distance;      // the distance at which we swap from a linear to sqrt response
     float linear_velocity;      // the velocity above which we swap from a linear to sqrt response
     float stopping_dist;		// the distance within the vehicle can stop
@@ -866,7 +866,6 @@ void AC_PosControl::pos_to_rate_xy(xy_mode mode, float dt, float ekfNavVelGainSc
 ///    converts desired velocities in lat/lon directions to accelerations in lat/lon frame
 void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
 {
-    const Vector3f &vel_curr = _inav.get_velocity();  // current velocity in cm/s
     Vector2f vel_xy_p, vel_xy_i;
 
     // reset last velocity target to current target
@@ -874,6 +873,14 @@ void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
         _vel_last.x = _vel_target.x;
         _vel_last.y = _vel_target.y;
         _flags.reset_rate_to_accel_xy = false;
+    }
+
+    // check if vehicle velocity is being overridden
+    if (_flags.vehicle_horiz_vel_override) {
+        _flags.vehicle_horiz_vel_override = false;
+    } else {
+        _vehicle_horiz_vel.x = _inav.get_velocity().x;
+        _vehicle_horiz_vel.y = _inav.get_velocity().y;
     }
 
     // feed forward desired acceleration calculation
@@ -895,8 +902,8 @@ void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
     _vel_last.y = _vel_target.y;
 
     // calculate velocity error
-    _vel_error.x = _vel_target.x - vel_curr.x;
-    _vel_error.y = _vel_target.y - vel_curr.y;
+    _vel_error.x = _vel_target.x - _vehicle_horiz_vel.x;
+    _vel_error.y = _vel_target.y - _vehicle_horiz_vel.y;
 
     // call pi controller
     _pi_vel_xy.set_input(_vel_error);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -229,6 +229,9 @@ public:
     ///     when update_vel_controller_xyz is next called the position target is moved based on the desired velocity
     void set_desired_velocity(const Vector3f &des_vel) { _vel_desired = des_vel; freeze_ff_xy(); }
 
+    // overrides the velocity process variable for one timestep
+    void override_vehicle_velocity_xy(const Vector2f& vel_xy) { _vehicle_horiz_vel = vel_xy; _flags.vehicle_horiz_vel_override = true; }
+
     /// freeze_ff_z - used to stop the feed forward being calculated during a known discontinuity
     void freeze_ff_z() { _flags.freeze_ff_z = true; }
 
@@ -302,6 +305,7 @@ private:
             uint16_t freeze_ff_xy       : 1;    // 1 use to freeze feed forward during step updates
             uint16_t freeze_ff_z        : 1;    // 1 used to freeze velocity to accel feed forward for one iteration
             uint16_t use_desvel_ff_z    : 1;    // 1 to use z-axis desired velocity as feed forward into velocity step
+            uint16_t vehicle_horiz_vel_override : 1; // 1 if we should use _vehicle_horiz_vel as our velocity process variable for one timestep
     } _flags;
 
     // limit flags structure
@@ -401,6 +405,7 @@ private:
     Vector3f    _accel_target;          // desired acceleration in cm/s/s  // To-Do: are xy actually required?
     Vector3f    _accel_error;           // desired acceleration in cm/s/s  // To-Do: are xy actually required?
     Vector3f    _accel_feedforward;     // feedforward acceleration in cm/s/s
+    Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
     float       _alt_max;               // max altitude - should be updated from the main code with altitude limit from fence
     float       _distance_to_target;    // distance to position target - for reporting only
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -160,8 +160,8 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
                 if (!target_acquired()) {
                     // reset filter state
                     if (_inav.get_filter_status().flags.horiz_pos_rel) {
-                        _ekf_x.init(targetPosRelMeasNED.x, xy_pos_var, -vehicleVelocityNED.x, sq(1.0f));
-                        _ekf_y.init(targetPosRelMeasNED.y, xy_pos_var, -vehicleVelocityNED.y, sq(1.0f));
+                        _ekf_x.init(targetPosRelMeasNED.x, xy_pos_var, -vehicleVelocityNED.x, sq(2.0f));
+                        _ekf_y.init(targetPosRelMeasNED.y, xy_pos_var, -vehicleVelocityNED.y, sq(2.0f));
                     } else {
                         _ekf_x.init(targetPosRelMeasNED.x, xy_pos_var, 0.0f, sq(10.0f));
                         _ekf_y.init(targetPosRelMeasNED.y, xy_pos_var, 0.0f, sq(10.0f));

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -22,6 +22,33 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("TYPE",    1, AC_PrecLand, _type, 0),
 
+    // @Param: YAW_ALIGN
+    // @DisplayName: Sensor yaw alignment
+    // @Description: Yaw angle from body x-axis to sensor x-axis.
+    // @Range: 0 360
+    // @Increment: 1
+    // @User: Advanced
+    // @Units: Centi-degrees
+    AP_GROUPINFO("YAW_ALIGN",    2, AC_PrecLand, _yaw_align, 0),
+
+    // @Param: LAND_OFS_X
+    // @DisplayName: Land offset forward
+    // @Description: Desired landing position of the camera forward of the target in vehicle body frame
+    // @Range: -20 20
+    // @Increment: 1
+    // @User: Advanced
+    // @Units: Centimeters
+    AP_GROUPINFO("LAND_OFS_X",    3, AC_PrecLand, _land_ofs_cm_x, 0),
+
+    // @Param: LAND_OFS_Y
+    // @DisplayName: Land offset right
+    // @Description: desired landing position of the camera right of the target in vehicle body frame
+    // @Range: -20 20
+    // @Increment: 1
+    // @User: Advanced
+    // @Units: Centimeters
+    AP_GROUPINFO("LAND_OFS_Y",    4, AC_PrecLand, _land_ofs_cm_y, 0),
+
     AP_GROUPEND
 };
 
@@ -81,81 +108,126 @@ void AC_PrecLand::init()
 }
 
 // update - give chance to driver to get updates from sensor
-void AC_PrecLand::update(float alt_above_terrain_cm)
+void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
 {
+    _attitude_history.push_back(_ahrs.get_rotation_body_to_ned());
+    
     // run backend update
     if (_backend != NULL && _enabled) {
         // read from sensor
         _backend->update();
-        
+
+        Vector3f vehicleVelocityNED = _inav.get_velocity()*0.01f;
+        vehicleVelocityNED.z = -vehicleVelocityNED.z;
+
+        if (target_acquired()) {
+            // EKF prediction step
+            float dt;
+            Vector3f targetDelVel;
+            _ahrs.getCorrectedDeltaVelocityNED(targetDelVel, dt);
+            targetDelVel = -targetDelVel;
+
+            _ekf_x.predict(dt, targetDelVel.x, 0.5f*dt);
+            _ekf_y.predict(dt, targetDelVel.y, 0.5f*dt);
+
+            if (_inav.get_filter_status().flags.horiz_pos_rel) {
+                _ekf_x.fuseVel(-vehicleVelocityNED.x, sq(1.0f));
+                _ekf_y.fuseVel(-vehicleVelocityNED.y, sq(1.0f));
+            }
+        }
+
         if (_backend->have_los_meas() && _backend->los_meas_time_ms() != _last_backend_los_meas_ms) {
             // we have a new, unique los measurement
             _last_backend_los_meas_ms = _backend->los_meas_time_ms();
 
             Vector3f target_vec_unit_body;
             _backend->get_los_body(target_vec_unit_body);
-            
-            calc_angles_and_pos(target_vec_unit_body, alt_above_terrain_cm);
+
+            // Apply sensor yaw alignment rotation
+            float sin_yaw_align = sinf(radians(_yaw_align*0.01f));
+            float cos_yaw_align = cosf(radians(_yaw_align*0.01f));
+            Matrix3f Rz = Matrix3f(
+                cos_yaw_align, -sin_yaw_align, 0,
+                sin_yaw_align, cos_yaw_align, 0,
+                0, 0, 1
+            );
+
+            Vector3f target_vec_unit_ned = _attitude_history.front() * Rz * target_vec_unit_body;
+
+            bool target_vec_valid = target_vec_unit_ned.z > 0.0f;
+
+            if (target_vec_valid && rangefinder_alt_valid && rangefinder_alt_cm > 0.0f) {
+                float alt = MAX(rangefinder_alt_cm*0.01f, 0.0f);
+                float dist = alt/target_vec_unit_ned.z;
+                Vector3f targetPosRelMeasNED = Vector3f(target_vec_unit_ned.x*dist, target_vec_unit_ned.y*dist, alt);
+
+                float xy_pos_var = sq(targetPosRelMeasNED.z*(0.01f + 0.01f*_ahrs.get_gyro().length()) + 0.02f);
+                if (!target_acquired()) {
+                    // reset filter state
+                    if (_inav.get_filter_status().flags.horiz_pos_rel) {
+                        _ekf_x.init(targetPosRelMeasNED.x, xy_pos_var, -vehicleVelocityNED.x, sq(1.0f));
+                        _ekf_y.init(targetPosRelMeasNED.y, xy_pos_var, -vehicleVelocityNED.y, sq(1.0f));
+                    } else {
+                        _ekf_x.init(targetPosRelMeasNED.x, xy_pos_var, 0.0f, sq(10.0f));
+                        _ekf_y.init(targetPosRelMeasNED.y, xy_pos_var, 0.0f, sq(10.0f));
+                    }
+                    _last_update_ms = AP_HAL::millis();
+                } else {
+                    float NIS_x = _ekf_x.getPosNIS(targetPosRelMeasNED.x, xy_pos_var);
+                    float NIS_y = _ekf_y.getPosNIS(targetPosRelMeasNED.y, xy_pos_var);
+                    if (MAX(NIS_x, NIS_y) < 3.0f || _outlier_reject_count >= 3) {
+                        _outlier_reject_count = 0;
+                        _ekf_x.fusePos(targetPosRelMeasNED.x, xy_pos_var);
+                        _ekf_y.fusePos(targetPosRelMeasNED.y, xy_pos_var);
+                        _last_update_ms = AP_HAL::millis();
+                    } else {
+                        _outlier_reject_count++;
+                    }
+                }
+            }
         }
     }
 }
 
-bool AC_PrecLand::target_acquired()
+bool AC_PrecLand::target_acquired() const
 {
-    return (AP_HAL::millis()-_last_update_ms) < 1000;
+    return (AP_HAL::millis()-_last_update_ms) < 2000;
 }
 
-bool AC_PrecLand::get_target_position(Vector3f& ret)
+bool AC_PrecLand::get_target_position_cm(Vector2f& ret) const
 {
     if (!target_acquired()) {
         return false;
     }
 
-    ret = _target_pos;
+    Vector3f land_ofs_ned_cm = _ahrs.get_rotation_body_to_ned() * Vector3f(_land_ofs_cm_x,_land_ofs_cm_y,0);
+
+    ret.x = _ekf_x.getPos()*100.0f + _inav.get_position().x + land_ofs_ned_cm.x;
+    ret.y = _ekf_y.getPos()*100.0f + _inav.get_position().y + land_ofs_ned_cm.y;
     return true;
 }
 
-bool AC_PrecLand::get_target_position_relative(Vector3f& ret)
+bool AC_PrecLand::get_target_position_relative_cm(Vector2f& ret) const
 {
     if (!target_acquired()) {
         return false;
     }
 
-    ret = _target_pos_rel;
+    Vector3f land_ofs_ned_cm = _ahrs.get_rotation_body_to_ned() * Vector3f(_land_ofs_cm_x,_land_ofs_cm_y,0);
+
+    ret.x = _ekf_x.getPos()*100.0f + land_ofs_ned_cm.x;
+    ret.y = _ekf_y.getPos()*100.0f + land_ofs_ned_cm.y;
     return true;
 }
 
-bool AC_PrecLand::get_target_velocity_relative(Vector3f& ret)
+bool AC_PrecLand::get_target_velocity_relative_cms(Vector2f& ret) const
 {
-    return false;
-}
-
-// converts sensor's body-frame angles to earth-frame angles and position estimate
-//  raw sensor angles stored in _angle_to_target (might be in earth frame, or maybe body frame)
-//  earth-frame angles stored in _ef_angle_to_target
-//  position estimate is stored in _target_pos
-void AC_PrecLand::calc_angles_and_pos(const Vector3f& target_vec_unit_body, float alt_above_terrain_cm)
-{
-    // rotate into NED frame
-    Vector3f target_vec_unit_ned = _ahrs.get_rotation_body_to_ned()*target_vec_unit_body;
-
-    // extract the angles to target (logging only)
-    _angle_to_target.x = atan2f(-target_vec_unit_body.y, target_vec_unit_body.z);
-    _angle_to_target.y = atan2f( target_vec_unit_body.x, target_vec_unit_body.z);
-    _ef_angle_to_target.x = atan2f(-target_vec_unit_ned.y, target_vec_unit_ned.z);
-    _ef_angle_to_target.y = atan2f( target_vec_unit_ned.x, target_vec_unit_ned.z);
-
-    if (target_vec_unit_ned.z > 0.0f) {
-        // get current altitude (constrained to be positive)
-        float alt = MAX(alt_above_terrain_cm, 0.0f);
-        float dist = alt/target_vec_unit_ned.z;
-        _target_pos_rel.x = target_vec_unit_ned.x*dist;
-        _target_pos_rel.y = target_vec_unit_ned.y*dist;
-        _target_pos_rel.z = alt;  // not used
-        _target_pos = _inav.get_position()+_target_pos_rel;
-
-        _last_update_ms = AP_HAL::millis();
+    if (!target_acquired()) {
+        return false;
     }
+    ret.x = _ekf_x.getVel()*100.0f;
+    ret.y = _ekf_y.getVel()*100.0f;
+    return true;
 }
 
 // handle_msg - Process a LANDING_TARGET mavlink message

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -129,11 +129,6 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
 
             _ekf_x.predict(dt, targetDelVel.x, 0.5f*dt);
             _ekf_y.predict(dt, targetDelVel.y, 0.5f*dt);
-
-            if (_inav.get_filter_status().flags.horiz_pos_rel) {
-                _ekf_x.fuseVel(-vehicleVelocityNED.x, sq(1.0f));
-                _ekf_y.fuseVel(-vehicleVelocityNED.y, sq(1.0f));
-            }
         }
 
         if (_backend->have_los_meas() && _backend->los_meas_time_ms() != _last_backend_los_meas_ms) {

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -6,6 +6,8 @@
 #include <AP_InertialNav/AP_InertialNav.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <stdint.h>
+#include "PosVelEKF.h"
+#include <AP_Buffer/AP_Buffer.h>
 
 // declare backend classes
 class AC_PrecLand_Backend;
@@ -42,49 +44,36 @@ public:
     void init();
 
     // returns true if precision landing is healthy
-    bool healthy() { return _backend_state.healthy; }
+    bool healthy() const { return _backend_state.healthy; }
 
     // returns time of last update
-    uint32_t last_update_ms() { return _last_update_ms; }
+    uint32_t last_update_ms() const { return _last_update_ms; }
 
     // give chance to driver to get updates from sensor
-    void update(float alt_above_terrain_cm);
-
-    // returns 3D vector of earth-frame position adjustments to target
-    Vector3f get_target_shift(const Vector3f& orig_target);
+    void update(float rangefinder_alt_cm, bool rangefinder_alt_valid);
 
     // returns target position relative to origin
-    bool get_target_position(Vector3f& ret);
+    bool get_target_position_cm(Vector2f& ret) const;
 
     // returns target position relative to vehicle
-    bool get_target_position_relative(Vector3f& ret);
+    bool get_target_position_relative_cm(Vector2f& ret) const;
 
     // returns target velocity relative to vehicle
-    bool get_target_velocity_relative(Vector3f& ret);
+    bool get_target_velocity_relative_cms(Vector2f& ret) const;
 
     // returns true when the landing target has been detected
-    bool target_acquired();
+    bool target_acquired() const;
 
     // process a LANDING_TARGET mavlink message
     void handle_msg(mavlink_message_t* msg);
 
     // accessors for logging
     bool enabled() const { return _enabled; }
-    const Vector2f& last_bf_angle_to_target() const { return _angle_to_target; }
-    const Vector2f& last_ef_angle_to_target() const { return _ef_angle_to_target; }
-    const Vector3f& last_target_pos_offset() const { return _target_pos_rel; }
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-
-    // converts sensor's body-frame angles to earth-frame angles and position estimate
-    //  angles stored in _angle_to_target
-    //  earth-frame angles stored in _ef_angle_to_target
-    //  position estimate is stored in _target_pos
-    void calc_angles_and_pos(const Vector3f& target_vec_unit_body, float alt_above_terrain_cm);
-
     // returns enabled parameter as an behaviour
     enum PrecLandBehaviour get_behaviour() const { return (enum PrecLandBehaviour)(_enabled.get()); }
 
@@ -95,17 +84,17 @@ private:
     // parameters
     AP_Int8                     _enabled;           // enabled/disabled and behaviour
     AP_Int8                     _type;              // precision landing controller type
+    AP_Float                    _yaw_align;         // Yaw angle from body x-axis to sensor x-axis.
+    AP_Float                    _land_ofs_cm_x;     // Desired landing position of the camera forward of the target in vehicle body frame
+    AP_Float                    _land_ofs_cm_y;     // Desired landing position of the camera right of the target in vehicle body frame
 
     uint32_t                    _last_update_ms;      // epoch time in millisecond when update is called
     uint32_t                    _last_backend_los_meas_ms;
 
-    // output from sensor (stored for logging)
-    Vector2f                    _angle_to_target;   // last raw sensor angle to target
-    Vector2f                    _ef_angle_to_target;// last earth-frame angle to target
-
-    // estimator output
-    Vector3f                    _target_pos_rel;    // estimate target position relative to vehicle in NEU cm
-    Vector3f                    _target_pos;        // estimate target position in NEU cm
+    PosVelEKF                   _ekf_x, _ekf_y;
+    uint32_t                    _outlier_reject_count;
+    
+    AP_Buffer<Matrix3f,8>       _attitude_history;
 
     // backend state
     struct precland_state {

--- a/libraries/AC_PrecLand/PosVelEKF.cpp
+++ b/libraries/AC_PrecLand/PosVelEKF.cpp
@@ -1,0 +1,93 @@
+#include "PosVelEKF.h"
+#include <math.h>
+#include <string.h>
+
+#define POSVELEKF_POS_CALC_NIS(__P, __R, __X, __Z, __RET_NIS) \
+__RET_NIS = ((-__X[0] + __Z)*(-__X[0] + __Z))/(__P[0] + __R);
+
+#define POSVELEKF_POS_CALC_STATE(__P, __R, __X, __Z, __RET_STATE) \
+__RET_STATE[0] = __P[0]*(-__X[0] + __Z)/(__P[0] + __R) + __X[0]; __RET_STATE[1] = __P[1]*(-__X[0] + \
+__Z)/(__P[0] + __R) + __X[1];
+
+#define POSVELEKF_POS_CALC_COV(__P, __R, __X, __Z, __RET_COV) \
+__RET_COV[0] = ((__P[0])*(__P[0]))*__R/((__P[0] + __R)*(__P[0] + __R)) + __P[0]*((-__P[0]/(__P[0] + \
+__R) + 1)*(-__P[0]/(__P[0] + __R) + 1)); __RET_COV[1] = __P[0]*__P[1]*__R/((__P[0] + __R)*(__P[0] + \
+__R)) - __P[0]*__P[1]*(-__P[0]/(__P[0] + __R) + 1)/(__P[0] + __R) + __P[1]*(-__P[0]/(__P[0] + __R) + \
+1); __RET_COV[2] = ((__P[1])*(__P[1]))*__R/((__P[0] + __R)*(__P[0] + __R)) - \
+((__P[1])*(__P[1]))/(__P[0] + __R) - __P[1]*(-__P[0]*__P[1]/(__P[0] + __R) + __P[1])/(__P[0] + __R) + \
+__P[2];
+
+#define POSVELEKF_PREDICTION_CALC_STATE(__P, __DT, __DV, __DV_NOISE, __X, __RET_STATE) \
+__RET_STATE[0] = __DT*__X[1] + __X[0]; __RET_STATE[1] = __DV + __X[1];
+
+#define POSVELEKF_PREDICTION_CALC_COV(__P, __DT, __DV, __DV_NOISE, __X, __RET_COV) \
+__RET_COV[0] = __DT*__P[1] + __DT*(__DT*__P[2] + __P[1]) + __P[0]; __RET_COV[1] = __DT*__P[2] + \
+__P[1]; __RET_COV[2] = ((__DV_NOISE)*(__DV_NOISE)) + __P[2];
+
+#define POSVELEKF_VEL_CALC_NIS(__P, __R, __X, __Z, __RET_NIS) \
+__RET_NIS = ((-__X[1] + __Z)*(-__X[1] + __Z))/(__P[2] + __R);
+
+#define POSVELEKF_VEL_CALC_STATE(__P, __R, __X, __Z, __RET_STATE) \
+__RET_STATE[0] = __P[1]*(-__X[1] + __Z)/(__P[2] + __R) + __X[0]; __RET_STATE[1] = __P[2]*(-__X[1] + \
+__Z)/(__P[2] + __R) + __X[1];
+
+#define POSVELEKF_VEL_CALC_COV(__P, __R, __X, __Z, __RET_COV) \
+__RET_COV[0] = __P[0] + ((__P[1])*(__P[1]))*__R/((__P[2] + __R)*(__P[2] + __R)) - \
+((__P[1])*(__P[1]))/(__P[2] + __R) - __P[1]*(-__P[1]*__P[2]/(__P[2] + __R) + __P[1])/(__P[2] + __R); \
+__RET_COV[1] = __P[1]*__P[2]*__R/((__P[2] + __R)*(__P[2] + __R)) + (-__P[2]/(__P[2] + __R) + \
+1)*(-__P[1]*__P[2]/(__P[2] + __R) + __P[1]); __RET_COV[2] = ((__P[2])*(__P[2]))*__R/((__P[2] + \
+__R)*(__P[2] + __R)) + __P[2]*((-__P[2]/(__P[2] + __R) + 1)*(-__P[2]/(__P[2] + __R) + 1));
+
+void PosVelEKF::init(float pos, float posVar, float vel, float velVar)
+{
+    _state[0] = pos;
+    _state[1] = vel;
+    _cov[0] = posVar;
+    _cov[1] = 0.0f;
+    _cov[2] = velVar;
+}
+
+void PosVelEKF::predict(float dt, float dVel, float dVelNoise)
+{
+    float newState[2];
+    float newCov[3];
+
+    POSVELEKF_PREDICTION_CALC_STATE(_cov, dt, dVel, dVelNoise, _state, newState)
+    POSVELEKF_PREDICTION_CALC_COV(_cov, dt, dVel, dVelNoise, _state, newCov)
+
+    memcpy(_state,newState,sizeof(_state));
+    memcpy(_cov,newCov,sizeof(_cov));
+}
+
+void PosVelEKF::fusePos(float pos, float posVar)
+{
+    float newState[2];
+    float newCov[3];
+
+    POSVELEKF_POS_CALC_STATE(_cov, posVar, _state, pos, newState)
+    POSVELEKF_POS_CALC_COV(_cov, posVar, _state, pos, newCov)
+
+    memcpy(_state,newState,sizeof(_state));
+    memcpy(_cov,newCov,sizeof(_cov));
+}
+
+void PosVelEKF::fuseVel(float vel, float velVar)
+{
+    float newState[2];
+    float newCov[3];
+
+    POSVELEKF_VEL_CALC_STATE(_cov, velVar, _state, vel, newState)
+    POSVELEKF_VEL_CALC_COV(_cov, velVar, _state, vel, newCov)
+
+    memcpy(_state,newState,sizeof(_state));
+    memcpy(_cov,newCov,sizeof(_cov));
+}
+
+float PosVelEKF::getPosNIS(float pos, float posVar)
+{
+    float ret;
+
+    POSVELEKF_POS_CALC_NIS(_cov, posVar, _state, pos, ret)
+
+    return ret;
+}

--- a/libraries/AC_PrecLand/PosVelEKF.h
+++ b/libraries/AC_PrecLand/PosVelEKF.h
@@ -1,0 +1,19 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
+
+class PosVelEKF {
+public:
+    void init(float pos, float posVar, float vel, float velVar);
+    void predict(float dt, float dVel, float dVelNoise);
+    void fusePos(float pos, float posVar);
+    void fuseVel(float vel, float velVar);
+
+    float getPos() const { return _state[0]; }
+    float getVel() const { return _state[1]; }
+
+    float getPosNIS(float pos, float posVar);
+
+private:
+    float _state[2];
+    float _cov[3];
+};

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -463,6 +463,9 @@ public:
     int8_t get_ekf_type(void) const {
         return _ekf_type;
     }
+
+    // Retrieves the corrected NED delta velocity in use by the inertial navigation
+    virtual void getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const { ret.zero(); _ins.get_delta_velocity(ret); dt = _ins.get_delta_velocity_dt(); }
     
 protected:
     AHRS_VehicleClass _vehicle_class;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1109,6 +1109,24 @@ bool AP_AHRS_NavEKF::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets)
     }
 }
 
+// Retrieves the NED delta velocity corrected
+void AP_AHRS_NavEKF::getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const
+{
+    if (ekf_type() == 2) {
+        uint8_t imu_idx = EKF2.getPrimaryCoreIMUIndex();
+        float accel_z_bias;
+        EKF2.getAccelZBias(-1,accel_z_bias);
+        ret.zero();
+        _ins.get_delta_velocity(imu_idx, ret);
+        dt = _ins.get_delta_velocity_dt(imu_idx);
+        ret.z -= accel_z_bias*dt;
+        ret = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
+        ret.z += GRAVITY_MSS*dt;
+    } else {
+        AP_AHRS::getCorrectedDeltaVelocityNED(ret, dt);
+    }
+}
+
 // report any reason for why the backend is refusing to initialise
 const char *AP_AHRS_NavEKF::prearm_failure_reason(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -126,6 +126,9 @@ public:
     const Vector3f &get_accel_ef(uint8_t i) const override;
     const Vector3f &get_accel_ef() const override;
 
+    // Retrieves the corrected NED delta velocity in use by the inertial navigation
+    void getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const;
+
     // blended accelerometer values in the earth frame in m/s/s
     const Vector3f &get_accel_ef_blended(void) const;
 


### PR DESCRIPTION
These changes:
- Largely decouple precision landing performance from GPS accuracy.
- Disable precision landing without a rangefinder (for the time being - until an estimator capable of depth-from-motion is introduced)
- Are a step towards precision landing with no GPS (just need some logic to switch AC_PosControl over to a different position input)
- Correct for distortion in the IR-LOCK lens (PX4Firmware patch)