### PR TITLE
RFC: waf: shared objects (wip)

### DIFF
--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -5,8 +5,8 @@ def build(bld):
     vehicle = bld.path.name
     bld.ap_stlib(
         name=vehicle + '_libs',
-        vehicle=vehicle,
-        libraries=bld.ap_common_vehicle_libraries() + [
+        ap_vehicle=vehicle,
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
             'APM_Control',
             'AP_Arming',
             'AP_Camera',

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -5,8 +5,8 @@ def build(bld):
     vehicle = bld.path.name
     bld.ap_stlib(
         name=vehicle + '_libs',
-        vehicle=vehicle,
-        libraries=bld.ap_common_vehicle_libraries() + [
+        ap_vehicle=vehicle,
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AC_PID',
         ],
         use='mavlink',

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -5,8 +5,8 @@ def build(bld):
     vehicle = bld.path.name
     bld.ap_stlib(
         name=vehicle + '_libs',
-        vehicle=vehicle,
-        libraries=bld.ap_common_vehicle_libraries() + [
+        ap_vehicle=vehicle,
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_ADSB',
             'AC_AttitudeControl',
             'AC_InputManager',

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -5,8 +5,8 @@ def build(bld):
     vehicle = bld.path.name
     bld.ap_stlib(
         name=vehicle + '_libs',
-        vehicle=vehicle,
-        libraries=bld.ap_common_vehicle_libraries() + [
+        ap_vehicle=vehicle,
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
             'APM_Control',
             'APM_OBC',
             'AP_ADSB',

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -11,8 +11,8 @@ def build(bld):
 
     bld.ap_stlib(
         name=vehicle + '_libs',
-        vehicle=vehicle,
-        libraries=bld.ap_common_vehicle_libraries() + [
+        ap_vehicle=vehicle,
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_InertialNav',
         ],
         use='mavlink',

--- a/Tools/ardupilotwaf/ap_libraries.py
+++ b/Tools/ardupilotwaf/ap_libraries.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Waf tool for Ardupilot libraries. The function bld.ap_library() creates the
+necessary task generators for creating the objects of a library for a vehicle.
+That includes the common objects, which are shared among vehicles. That
+function is used by bld.ap_stlib() and shouldn't need to be called otherwise.
+
+The environment variable AP_LIBRARIES_OBJECTS_KW is a dictionary of keyword
+arguments to be passed to bld.objects() when during the creation of the task
+generators. You can use it to pass extra arguments to that function (although
+some of them will be rewritten, see the implementation for details).
+
+NOTE: This tool is provisional, it shouldn't be necessary when all libraries
+become independent of vehicle. Thus, this tool should contain the only
+*minimal* functionality required and addition of features should be avoided.
+"""
+from waflib import Utils
+from waflib.Configure import conf
+from waflib.TaskGen import before_method, feature
+
+import ardupilotwaf as ap
+
+UTILITY_SOURCE_EXTS = ['utility/' + glob for glob in ap.SOURCE_EXTS]
+
+AP_LIBRARIES_VEHICLE_DEPENDENT_SRC = [
+    'libraries/AP_AccelCal/AP_AccelCal.cpp',
+    'libraries/AP_BattMonitor/AP_BattMonitor.cpp',
+    'libraries/AP_Compass/AP_Compass.cpp',
+    'libraries/AP_HAL_Linux/Storage.cpp',
+    'libraries/AP_HAL_PX4/HAL_PX4_Class.cpp',
+    'libraries/AP_HAL_PX4/Storage.cpp',
+    'libraries/AP_HAL_QURT/mainapp/mainapp.cpp',
+    'libraries/AP_HAL_SITL/SITL_cmdline.cpp',
+    'libraries/AP_HAL_VRBRAIN/HAL_VRBRAIN_Class.cpp',
+    'libraries/AP_HAL_VRBRAIN/Storage.cpp',
+    'libraries/AP_InertialSensor/AP_InertialSensor.cpp',
+    'libraries/AP_Mission/AP_Mission.cpp',
+    'libraries/AP_NavEKF2/AP_NavEKF2.cpp',
+    'libraries/AP_NavEKF/AP_NavEKF_core.cpp',
+    'libraries/AP_NavEKF/AP_NavEKF.cpp',
+    'libraries/AP_Rally/AP_Rally.cpp',
+    'libraries/AP_Scheduler/AP_Scheduler.cpp',
+]
+
+_common_objects_tgens = {}
+""" Mapped by library """
+_vehicle_objects_tgens = {}
+""" Mapped by (library, vehicle) """
+
+def _common_tgen_name(library):
+    return 'objs/%s' % library
+
+def _vehicle_tgen_name(library, vehicle):
+    return 'objs/%s/%s' % (library, vehicle)
+
+_vehicle_indexes = {}
+def _vehicle_index(vehicle):
+    """ Used for the objects taskgens idx parameter """
+    if vehicle not in _vehicle_indexes:
+        _vehicle_indexes[vehicle] = len(_vehicle_indexes) + 1
+    return _vehicle_indexes[vehicle]
+
+@conf
+def ap_library(bld, library, vehicle):
+    if library in _common_objects_tgens and \
+       (library, vehicle) in _vehicle_objects_tgens:
+        return
+
+    library_dir = bld.srcnode.find_dir('libraries/%s' % library)
+    if not library_dir:
+        bld.fatal('ap_libraries: %s not found' % library)
+
+    vehicle_dependent = AP_LIBRARIES_VEHICLE_DEPENDENT_SRC
+    sources = library_dir.ant_glob(ap.SOURCE_EXTS + UTILITY_SOURCE_EXTS)
+
+    if library not in _common_objects_tgens:
+        kw = dict(bld.env.AP_LIBRARIES_OBJECTS_KW)
+        kw['features'] = kw.get('features', []) + bld.env.AP_LIBRARY_FEATURES
+        kw.update(
+            name=_common_tgen_name(library),
+            source=[
+                s for s in sources
+                if s.path_from(bld.srcnode) not in vehicle_dependent
+            ],
+            idx=0,
+        )
+        _common_objects_tgens[library] = bld.objects(**kw)
+
+    if (library, vehicle) not in _vehicle_objects_tgens:
+        source = [
+            s for s in sources
+            if s.path_from(bld.srcnode) in vehicle_dependent
+        ]
+
+        if not source:
+            return
+
+        kw = dict(bld.env.AP_LIBRARIES_OBJECTS_KW)
+        kw['features'] = kw.get('features', []) + bld.env.AP_LIBRARY_FEATURES
+        kw.update(
+            name=_vehicle_tgen_name(library, vehicle),
+            source=source,
+            defines=ap.get_legacy_defines(vehicle),
+            idx=_vehicle_index(vehicle),
+        )
+        _vehicle_objects_tgens[(library, vehicle)] = bld.objects(**kw)
+
+@before_method('process_use')
+@feature('cxxstlib')
+def process_ap_libraries(self):
+    self.use = Utils.to_list(getattr(self, 'use', []))
+    libraries = Utils.to_list(getattr(self, 'ap_libraries', []))
+    vehicle = getattr(self, 'ap_vehicle', None)
+
+    for l in libraries:
+        if l not in _common_objects_tgens:
+            self.bld.fatal('ap_libraries: common objects for %s not declared' % l)
+
+        self.use.append(_common_tgen_name(l))
+
+        if not vehicle or (l, vehicle) not in _vehicle_objects_tgens:
+            continue
+
+        self.use.append(_vehicle_tgen_name(l, vehicle))
+
+def configure(cfg):
+    cfg.env.AP_LIBRARIES_OBJECTS_KW = dict()

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -166,13 +166,13 @@ def unique_list(items):
 def ap_stlib(bld, **kw):
     if 'name' not in kw:
         bld.fatal('Missing name for ap_stlib')
-    if 'vehicle' not in kw:
-        bld.fatal('Missing vehicle for ap_stlib')
-    if 'libraries' not in kw:
-        bld.fatal('Missing libraries for ap_stlib')
+    if 'ap_vehicle' not in kw:
+        bld.fatal('Missing ap_vehicle for ap_stlib')
+    if 'ap_libraries' not in kw:
+        bld.fatal('Missing ap_libraries for ap_stlib')
 
     sources = []
-    libraries = unique_list(kw['libraries'] + bld.env.AP_LIBRARIES)
+    libraries = unique_list(kw['ap_libraries'] + bld.env.AP_LIBRARIES)
 
     for lib_name in libraries:
         lib_node = bld.srcnode.find_dir('libraries/' + lib_name)
@@ -185,7 +185,7 @@ def ap_stlib(bld, **kw):
     kw['features'] = kw.get('features', []) + bld.env.AP_STLIB_FEATURES
     kw['source'] = sources
     kw['target'] = kw['name']
-    kw['defines'] = _get_legacy_defines(kw['vehicle'])
+    kw['defines'] = _get_legacy_defines(kw['ap_vehicle'])
     kw['idx'] = _get_next_idx()
 
     bld.stlib(**kw)

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -60,7 +60,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_ICEngine',
 ]
 
-def _get_legacy_defines(sketch_name):
+def get_legacy_defines(sketch_name):
     return [
         'APM_BUILD_DIRECTORY=APM_BUILD_' + sketch_name,
         'SKETCH="' + sketch_name + '"',
@@ -111,7 +111,7 @@ def ap_program(bld,
         program_name = bld.path.name
 
     if use_legacy_defines:
-        kw['defines'].extend(_get_legacy_defines(bld.path.name))
+        kw['defines'].extend(get_legacy_defines(bld.path.name))
 
     kw['cxxflags'] = kw.get('cxxflags', []) + ['-include', 'ap_config.h']
     kw['features'] = kw.get('features', []) + bld.env.AP_PROGRAM_FEATURES
@@ -185,7 +185,7 @@ def ap_stlib(bld, **kw):
     kw['features'] = kw.get('features', []) + bld.env.AP_STLIB_FEATURES
     kw['source'] = sources
     kw['target'] = kw['name']
-    kw['defines'] = _get_legacy_defines(kw['ap_vehicle'])
+    kw['defines'] = get_legacy_defines(kw['ap_vehicle'])
     kw['idx'] = _get_next_idx()
 
     bld.stlib(**kw)

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -17,7 +17,7 @@ def _load_dynamic_env_data(bld):
     for name in ('cxx_flags', 'include_dirs', 'definitions'):
         _dynamic_env_data[name] = bldnode.find_node(name).read().split(';')
 
-@feature('px4_ap_stlib', 'px4_ap_program')
+@feature('px4_ap_library', 'px4_ap_program')
 @before_method('process_source')
 def px4_dynamic_env(self):
     # The generated files from configuration possibly don't exist if it's just
@@ -215,7 +215,9 @@ def configure(cfg):
     env = cfg.env
 
     env.AP_PROGRAM_FEATURES += ['px4_ap_program']
-    env.AP_STLIB_FEATURES += ['px4_ap_stlib']
+
+    kw = env.AP_LIBRARIES_OBJECTS_KW
+    kw['features'] = Utils.to_list(kw.get('features', []) + ['px4_ap_library']
 
     def srcpath(path):
         return cfg.srcnode.make_node(path).abspath()

--- a/wscript
+++ b/wscript
@@ -247,8 +247,8 @@ def _build_common_taskgens(bld):
     # split into smaller pieces with well defined boundaries.
     bld.ap_stlib(
         name='ap',
-        vehicle='UNKNOWN',
-        libraries=bld.ap_get_all_libraries(),
+        ap_vehicle='UNKNOWN',
+        ap_libraries=bld.ap_get_all_libraries(),
         use='mavlink',
     )
 

--- a/wscript
+++ b/wscript
@@ -135,6 +135,8 @@ def configure(cfg):
         cfg.msg('Using static linking', 'yes', color='YELLOW')
         cfg.env.STATIC_LINKING = True
 
+    cfg.load('ap_libraries')
+
     cfg.msg('Setting board to', cfg.options.board)
     cfg.get_board().configure(cfg)
 
@@ -316,6 +318,11 @@ def build(bld):
     bld.post_mode = Build.POST_LAZY
 
     bld.load('ardupilotwaf')
+
+    bld.env.AP_LIBRARIES_OBJECTS_KW.update(
+        use='mavlink',
+        cxxflags=['-include', 'ap_config.h'],
+    )
 
     _build_cmd_tweaks(bld)
 


### PR DESCRIPTION
Hi all,

This is a **work in progress** of an effort to recompile only source files that are really dependent on the vehicle type.

There's still a pending issue that is the use of vehicle-dependent macros in header, whose only case is with `AP_BattMonitor`. Using preprocesssor directives dependent on vehicle type on headers is bad because it becomes cumbersome to keep track of of source files that depend on the vehicle type, and also increase the list (probably) unnecessarily. This is probably a matter to be discussed with @magicrub and other maintainers. I just added a revert commit in order to my changes.

Best regards,
Gustavo Sousa