### PR TITLE
AP_AHRS: provide interfaces for autopilot body frame rotations

### DIFF
--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -390,7 +390,7 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
         if(medium_loopCounter >= 5){
             if (compass.read()) {
                 // Calculate heading
-                Matrix3f m = ahrs.get_rotation_body_to_ned();
+                Matrix3f m = ahrs.get_rotation_autopilot_body_to_ned();
                 heading = compass.calculate_heading(m);
                 compass.learn_offsets();
             }

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -221,7 +221,7 @@ void Tracker::update_yaw_position_servo(float yaw)
     int8_t new_slew_dir = slew_dir;
 
     // get earth frame z-axis rotation rate in radians
-    Vector3f earth_rotation = ahrs.get_gyro() * ahrs.get_rotation_body_to_ned();
+    Vector3f earth_rotation = ahrs.get_gyro() * ahrs.get_rotation_autopilot_body_to_ned();
 
 
     bool making_progress;

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -216,7 +216,7 @@ bool Copter::throw_detected()
 bool Copter::throw_attitude_good()
 {
     // Check that we have uprighted the copter
-    const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+    const Matrix3f &rotMat = ahrs.get_rotation_vehicle_body_to_ned();
     bool is_upright = (rotMat.c.z > 0.866f);
     return is_upright;
 }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -47,7 +47,7 @@ void Copter::read_rangefinder(void)
 
  #if RANGEFINDER_TILT_CORRECTION == ENABLED
     // correct alt for angle of the rangefinder
-    temp_alt = (float)temp_alt * MAX(0.707f, ahrs.get_rotation_body_to_ned().c.z);
+    temp_alt = (float)temp_alt * MAX(0.707f, ahrs.get_rotation_vehicle_body_to_ned().c.z);
  #endif
 
     rangefinder_state.alt_cm = temp_alt;

--- a/ArduCopter/test.cpp
+++ b/ArduCopter/test.cpp
@@ -106,7 +106,7 @@ int8_t Copter::test_compass(uint8_t argc, const Menu::arg *argv)
             if(medium_loopCounter == 5) {
                 if (compass.read()) {
                     // Calculate heading
-                    const Matrix3f &m = ahrs.get_rotation_body_to_ned();
+                    const Matrix3f &m = ahrs.get_rotation_autopilot_body_to_ned();
                     heading = compass.calculate_heading(m);
                     compass.learn_offsets();
                 }

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -607,7 +607,7 @@ void Plane::rangefinder_height_update(void)
         }
         // correct the range for attitude (multiply by DCM.c.z, which
         // is cos(roll)*cos(pitch))
-        rangefinder_state.height_estimate = distance * ahrs.get_rotation_body_to_ned().c.z;
+        rangefinder_state.height_estimate = distance * ahrs.get_rotation_vehicle_body_to_ned().c.z;
 
         // we consider ourselves to be fully in range when we have 10
         // good samples (0.2s) that are different by 5% of the maximum

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -152,7 +152,7 @@ void Plane::calc_gndspeed_undershoot()
 	// This prevents flyaway if wind takes plane backwards
     if (gps.status() >= AP_GPS::GPS_OK_FIX_2D) {
 	    Vector2f gndVel = ahrs.groundspeed_vector();
-		const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+		const Matrix3f &rotMat = ahrs.get_rotation_vehicle_body_to_ned();
 		Vector2f yawVect = Vector2f(rotMat.a.x,rotMat.b.x);
 		yawVect.normalize();
 		float gndSpdFwd = yawVect * gndVel;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1754,7 +1754,7 @@ int8_t QuadPlane::forward_throttle_pct(void)
         vel_forward.integrator = 0;
         return 0;
     }
-    Vector3f vel_error_body = ahrs.get_rotation_body_to_ned().transposed() * ((desired_velocity_cms*0.01f) - vel_ned);
+    Vector3f vel_error_body = ahrs.get_rotation_vehicle_body_to_ned().transposed() * ((desired_velocity_cms*0.01f) - vel_ned);
 
     // find component of velocity error in fwd body frame direction
     float fwd_vel_error = vel_error_body * Vector3f(1,0,0);

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -431,7 +431,7 @@ int8_t Plane::test_mag(uint8_t argc, const Menu::arg *argv)
             if(counter % 5 == 0) {
                 if (compass.read()) {
                     // Calculate heading
-                    const Matrix3f &m = ahrs.get_rotation_body_to_ned();
+                    const Matrix3f &m = ahrs.get_rotation_autopilot_body_to_ned();
                     heading = compass.calculate_heading(m);
                     compass.learn_offsets();
                 }

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -816,7 +816,7 @@ void Replay::loop()
             Vector2f offset;
             uint16_t faultStatus;
 
-            const Matrix3f &dcm_matrix = _vehicle.ahrs.AP_AHRS_DCM::get_rotation_body_to_ned();
+            const Matrix3f &dcm_matrix = _vehicle.ahrs.AP_AHRS_DCM::get_rotation_autopilot_body_to_ned();
             dcm_matrix.to_euler(&DCM_attitude.x, &DCM_attitude.y, &DCM_attitude.z);
             _vehicle.EKF.getEulerAngles(ekf_euler);
             _vehicle.EKF.getVelNED(velNED);

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -136,7 +136,7 @@ bool AC_PrecLand::get_target_velocity_relative(Vector3f& ret)
 void AC_PrecLand::calc_angles_and_pos(const Vector3f& target_vec_unit_body, float alt_above_terrain_cm)
 {
     // rotate into NED frame
-    Vector3f target_vec_unit_ned = _ahrs.get_rotation_body_to_ned()*target_vec_unit_body;
+    Vector3f target_vec_unit_ned = _ahrs.get_rotation_vehicle_body_to_ned()*target_vec_unit_body;
 
     // extract the angles to target (logging only)
     _angle_to_target.x = atan2f(-target_vec_unit_body.y, target_vec_unit_body.z);

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -173,6 +173,14 @@ void AP_AHRS::add_trim(float roll_in_radians, float pitch_in_radians, bool save_
     }
 }
 
+Matrix3f AP_AHRS::get_rotation_vehicle_body_to_autopilot_body(void) const
+{
+    Matrix3f ret;
+    ret.identity();
+    ret.rotateXYinv(_trim);
+    return ret;
+}
+
 // return a ground speed estimate in m/s
 Vector2f AP_AHRS::groundspeed_vector(void)
 {
@@ -231,7 +239,7 @@ Vector2f AP_AHRS::groundspeed_vector(void)
 void AP_AHRS::update_trig(void)
 {
     Vector2f yaw_vector;
-    const Matrix3f &temp = get_rotation_body_to_ned();
+    const Matrix3f &temp = get_rotation_vehicle_body_to_ned();
 
     // sin_yaw, cos_yaw
     yaw_vector.x = temp.a.x;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -177,7 +177,7 @@ public:
 
     // get yaw rate in earth frame in radians/sec
     float get_yaw_rate_earth(void) const {
-        return get_gyro() * get_rotation_body_to_ned().c;
+        return get_gyro() * get_rotation_autopilot_body_to_ned().c;
     }
 
     // Methods
@@ -229,7 +229,9 @@ public:
 
     // return a DCM rotation matrix representing our current
     // attitude
-    virtual const Matrix3f &get_rotation_body_to_ned(void) const = 0;
+    virtual const Matrix3f &get_rotation_autopilot_body_to_ned(void) const = 0;
+    virtual const Matrix3f &get_rotation_vehicle_body_to_ned(void) const = 0;
+    Matrix3f get_rotation_vehicle_body_to_autopilot_body(void) const;
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -65,8 +65,13 @@ public:
     }
 
     // return rotation matrix representing rotaton from body to earth axes
-    const Matrix3f &get_rotation_body_to_ned(void) const {
+    const Matrix3f &get_rotation_vehicle_body_to_ned(void) const {
         return _body_dcm_matrix;
+    }
+
+    // return rotation matrix representing rotaton from body to earth axes
+    const Matrix3f &get_rotation_autopilot_body_to_ned(void) const {
+        return _dcm_matrix;
     }
 
     // return the current drift correction integrator value

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -62,7 +62,8 @@ public:
 
     // return the smoothed gyro vector corrected for drift
     const Vector3f &get_gyro(void) const;
-    const Matrix3f &get_rotation_body_to_ned(void) const;
+    const Matrix3f &get_rotation_autopilot_body_to_ned(void) const;
+    const Matrix3f &get_rotation_vehicle_body_to_ned(void) const;
 
     // return the current drift correction integrator value
     const Vector3f &get_gyro_drift(void) const;
@@ -255,6 +256,7 @@ private:
     bool ekf2_started:1;
     bool force_ekf:1;
     Matrix3f _dcm_matrix;
+    Matrix3f _body_dcm_matrix;
     Vector3f _dcm_attitude;
     Vector3f _gyro_bias;
     Vector3f _gyro_estimate;

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -57,7 +57,7 @@ void loop(void)
 
     if (now - last_compass > 100*1000UL &&
         compass.read()) {
-        heading = compass.calculate_heading(ahrs.get_rotation_body_to_ned());
+        heading = compass.calculate_heading(ahrs.get_rotation_autopilot_body_to_ned());
         // read compass at 10Hz
         last_compass = now;
     }

--- a/libraries/AP_Module/AP_Module.cpp
+++ b/libraries/AP_Module/AP_Module.cpp
@@ -152,7 +152,7 @@ void AP_Module::call_hook_AHRS_update(const AP_AHRS_NavEKF &ahrs)
     }
 
     Quaternion q;
-    q.from_rotation_matrix(ahrs.get_rotation_body_to_ned());
+    q.from_rotation_matrix(ahrs.get_rotation_vehicle_body_to_ned());
     state.quat[0] = q[0];
     state.quat[1] = q[1];
     state.quat[2] = q[2];

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -130,7 +130,7 @@ void AP_Mount_Servo::stabilize()
         Matrix3f m;                         ///< holds 3 x 3 matrix, var is used as temp in calcs
         Matrix3f cam;                       ///< Rotation matrix earth to camera. Desired camera from input.
         Matrix3f gimbal_target;             ///< Rotation matrix from plane to camera. Then Euler angles to the servos.
-        m = _frontend._ahrs.get_rotation_body_to_ned();
+        m = _frontend._ahrs.get_rotation_vehicle_body_to_ned();
         m.transpose();
         cam.from_euler(_angle_ef_target_rad.x, _angle_ef_target_rad.y, _angle_ef_target_rad.z);
         gimbal_target = m * cam;

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -29,7 +29,7 @@ bool SoloGimbal::aligned()
 
 gimbal_mode_t SoloGimbal::get_mode()
 {
-    if ((_gimbalParams.initialized() && is_zero(_gimbalParams.get_K_rate())) || (_ahrs.get_rotation_body_to_ned().c.z < 0 && !(_lockedToBody || _calibrator.running()))) {
+    if ((_gimbalParams.initialized() && is_zero(_gimbalParams.get_K_rate())) || (_ahrs.get_rotation_vehicle_body_to_ned().c.z < 0 && !(_lockedToBody || _calibrator.running()))) {
         return GIMBAL_MODE_IDLE;
     } else if (!_ekf.getStatus()) {
         return GIMBAL_MODE_POS_HOLD;
@@ -270,7 +270,7 @@ Vector3f SoloGimbal::get_ang_vel_dem_yaw(const Quaternion &quatEst)
     float dt = _measurement.delta_time;
     float alpha = dt/(dt+tc);
 
-    Matrix3f Tve = _ahrs.get_rotation_body_to_ned();
+    Matrix3f Tve = _ahrs.get_rotation_vehicle_body_to_ned();
     Matrix3f Teg;
     quatEst.inverse().rotation_matrix(Teg);
 

--- a/libraries/AP_Mount/SoloGimbalEKF.cpp
+++ b/libraries/AP_Mount/SoloGimbalEKF.cpp
@@ -92,7 +92,7 @@ void SoloGimbalEKF::RunEKF(float delta_time, const Vector3f &delta_angles, const
         }
 
         Quaternion ned_to_vehicle_quat;
-        ned_to_vehicle_quat.from_rotation_matrix(_ahrs.get_rotation_body_to_ned());
+        ned_to_vehicle_quat.from_rotation_matrix(_ahrs.get_rotation_vehicle_body_to_ned());
 
         Quaternion vehicle_to_gimbal_quat;
         vehicle_to_gimbal_quat.from_vector312(joint_angles.x,joint_angles.y,joint_angles.z);

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -3335,7 +3335,6 @@ void NavEKF_core::quat2Tbn(Matrix3f &Tbn, const Quaternion &quat) const
 void NavEKF_core::getEulerAngles(Vector3f &euler) const
 {
     state.quat.to_euler(euler.x, euler.y, euler.z);
-    euler = euler - _ahrs->get_trim();
 }
 
 // This returns the specific forces in the NED frame
@@ -4345,9 +4344,7 @@ void NavEKF_core::setWindVelStates()
 // return the transformation matrix from XYZ (body) to NED axes
 void NavEKF_core::getRotationBodyToNED(Matrix3f &mat) const
 {
-    Vector3f trim = _ahrs->get_trim();
     state.quat.rotation_matrix(mat);
-    mat.rotateXYinv(trim);
 }
 
 // return the innovations for the NED Pos, NED Vel, XYZ Mag and Vtas measurements

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -102,7 +102,6 @@ bool NavEKF2_core::getHeightControlLimit(float &height) const
 void NavEKF2_core::getEulerAngles(Vector3f &euler) const
 {
     outputDataNew.quat.to_euler(euler.x, euler.y, euler.z);
-    euler = euler - _ahrs->get_trim();
 }
 
 // return body axis gyro bias estimates in rad/sec
@@ -136,9 +135,7 @@ void NavEKF2_core::getTiltError(float &ang) const
 // return the transformation matrix from XYZ (body) to NED axes
 void NavEKF2_core::getRotationBodyToNED(Matrix3f &mat) const
 {
-    Vector3f trim = _ahrs->get_trim();
     outputDataNew.quat.rotation_matrix(mat);
-    mat.rotateXYinv(trim);
 }
 
 // return the quaternions defining the rotation from NED to XYZ (body) axes

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -321,7 +321,7 @@ void AP_TECS::update_50hz(void)
 
     // Update and average speed rate of change
     // Get DCM
-    const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
+    const Matrix3f &rotMat = _ahrs.get_rotation_autopilot_body_to_ned();
     // Calculate speed rate of change
     float temp = rotMat.c.x * GRAVITY_MSS + _ahrs.get_ins().get_accel().x;
     // take 5 point moving average
@@ -620,7 +620,7 @@ void AP_TECS::_update_throttle_with_airspeed(void)
         // Calculate feed-forward throttle
         float ff_throttle = 0;
         float nomThr = aparm.throttle_cruise * 0.01f;
-        const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
+        const Matrix3f &rotMat = _ahrs.get_rotation_vehicle_body_to_ned();
         // Use the demanded rate of change of total energy as the feed-forward demand, but add
         // additional component which scales with (1/cos(bank angle) - 1) to compensate for induced
         // drag increase during turns.
@@ -726,7 +726,7 @@ void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge)
     }
 
     // Calculate additional throttle for turn drag compensation including throttle nudging
-    const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
+    const Matrix3f &rotMat = _ahrs.get_rotation_vehicle_body_to_ned();
     // Use the demanded rate of change of total energy as the feed-forward demand, but add
     // additional component which scales with (1/cos(bank angle) - 1) to compensate for induced
     // drag increase during turns.


### PR DESCRIPTION
We have not been careful to maintain the distinction between autopilot body frame and vehicle body frame. These patches rectify that situation.