### PR TITLE
GCS_MAVLINK: Change deferred message queue size...

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -18,6 +18,8 @@
 #include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_HAL/utility/RingBuffer.h>
 
+#define MSG_QUEUE_SIZE 64
+
 // check if a message will fit in the payload space available
 #define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
 #define CHECK_PAYLOAD_SIZE(id) if (comm_get_txspace(chan) < packet_overhead()+MAVLINK_MSG_ID_ ## id ## _LEN) return false
@@ -348,7 +350,7 @@ private:
     uint16_t _log_data_page;
 
     // deferred message handling
-    enum ap_message deferred_messages[MSG_RETRY_DEFERRED];
+    enum ap_message deferred_messages[MSG_QUEUE_SIZE];
     uint8_t next_deferred_message;
     uint8_t num_deferred_messages;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -906,7 +906,7 @@ void GCS_MAVLINK::send_message(enum ap_message id)
             break;
         }
         next_deferred_message++;
-        if (next_deferred_message == MSG_RETRY_DEFERRED) {
+        if (next_deferred_message == MSG_QUEUE_SIZE) {
             next_deferred_message = 0;
         }
         num_deferred_messages--;
@@ -923,7 +923,7 @@ void GCS_MAVLINK::send_message(enum ap_message id)
             return;
         }
         nextid++;
-        if (nextid == MSG_RETRY_DEFERRED) {
+        if (nextid == MSG_QUEUE_SIZE) {
             nextid = 0;
         }
     }
@@ -931,13 +931,13 @@ void GCS_MAVLINK::send_message(enum ap_message id)
     if (num_deferred_messages != 0 ||
         !try_send_message(id)) {
         // can't send it now, so defer it
-        if (num_deferred_messages == MSG_RETRY_DEFERRED) {
+        if (num_deferred_messages == MSG_QUEUE_SIZE) {
             // the defer buffer is full, discard
             return;
         }
         nextid = next_deferred_message + num_deferred_messages;
-        if (nextid >= MSG_RETRY_DEFERRED) {
-            nextid -= MSG_RETRY_DEFERRED;
+        if (nextid >= MSG_QUEUE_SIZE) {
+            nextid -= MSG_QUEUE_SIZE;
         }
         deferred_messages[nextid] = id;
         num_deferred_messages++;


### PR DESCRIPTION
To remove the relationship between the array size and enum ap_message.

It looks like something that survived from an older version where the
vector was an id map.

But now the array represents a FIFO on a circular array, there is no
reason to keep it's size tied to the enum.

A priori this relationship brings no harm, but the enum can potentially
hold more items that the two auxiliary variables (uint8_t) can address.
It is far from being the case now, but with MAVLink 2.0 using 2 bytes
for IDS the enum can grow to a point that causes the bug.

And since it isn't obvious that growing the enum will grow an array, the
problem is likely to go undercover in the future.

-----------------------
I chose 64 because is the first aligned size bigger than the current size (43), but I think that 32 should do the job. What do you think?