### PR TITLE
AP_NavEKF2: optical flow fixups

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -113,7 +113,7 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
     stateStruct.quat.rotation_matrix(Tbn_flow);
     Tnb_flow = Tbn_flow.transposed();
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)
-    if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {
+    if ((rawFlowQuality > 0) && rawFlowRates.length() < MIN(4.2f, frontend->_maxFlowRate) && rawGyroRates.length() < MIN(4.2f, frontend->_maxFlowRate)) {
         // correct flow sensor rates for bias
         omegaAcrossFlowTime.x = rawGyroRates.x - flowGyroBias.x;
         omegaAcrossFlowTime.y = rawGyroRates.y - flowGyroBias.y;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -52,9 +52,12 @@ void NavEKF2_core::ResetVelocity(void)
     zeroRows(P,3,4);
     zeroCols(P,3,4);
 
-    // set the variances to the measurement variance
-    P[4][4] = P[3][3] = sq(frontend->_gpsHorizVelNoise);
-
+    if (PV_AidingMode == AID_RELATIVE) {
+        P[4][4] = P[3][3] = sq(10.0f);
+    } else {
+        // set the variances to the measurement variance
+        P[4][4] = P[3][3] = sq(frontend->_gpsHorizVelNoise);
+    }
 }
 
 // resets position states to last GPS measurement or to zero if in constant position mode

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -151,6 +151,7 @@ void NavEKF2_core::InitialiseVariables()
     magTimeout = false;
     allMagSensorsFailed = false;
     tasTimeout = true;
+    flowTimeout = true;
     badMagYaw = false;
     badIMUdata = false;
     finalInflightYawInit = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -655,6 +655,7 @@ private:
     bool hgtTimeout;                // boolean true if height measurements have failed innovation consistency check and timed out
     bool magTimeout;                // boolean true if magnetometer measurements have failed for too long and have timed out
     bool tasTimeout;                // boolean true if true airspeed measurements have failed for too long and have timed out
+    bool flowTimeout;
     bool badMagYaw;                 // boolean true if the magnetometer is declared to be producing bad data
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -812,7 +812,7 @@ Format characters in the format string for binary log messages
     { LOG_EKF4_MSG, sizeof(log_EKF4), \
       "EKF4","QcccccccbbHBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
-      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr" }, \
+      "EKF5","QBhhhcccCC","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \


### PR DESCRIPTION
- Corrects poor aiding mode logic that causes filter to operate without any position or velocity fusion when flow data is invalid or is failing innovation consistency checks
- Modifies initial velocity variance in relative aiding mode, giving flow measurements a better chance of passing innovation consistency checks
- Adds flow timeout flag, anticipating further logic improvements
