### PR TITLE
Copter: fix logging after log download

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -785,11 +785,15 @@ void Copter::Log_Write_Vehicle_Startup_Messages()
 // start a new log
 void Copter::start_logging() 
 {
-    if (g.log_bitmask != 0) {
+    if (g.log_bitmask != 0 && !in_log_download) {
         if (!ap.logging_started) {
             ap.logging_started = true;
             DataFlash.set_mission(&mission);
             DataFlash.setVehicle_Startup_Log_Writer(FUNCTOR_BIND(&copter, &Copter::Log_Write_Vehicle_Startup_Messages, void));
+            DataFlash.StartNewLog();
+        } else if (!DataFlash.logging_started()) {
+            // dataflash may have stopped logging - when we get_log_data,
+            // for example.  Try to restart:
             DataFlash.StartNewLog();
         }
         // enable writes


### PR DESCRIPTION
Downloading a log causes DataFlash to stop logging (and not start again before a reboot)

Restart logging when we are not downloading and start_logging is called.