### PR TITLE
Copter: loosen accelerometer consistency check in z-axis

### DIFF
--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -216,6 +216,10 @@ bool Copter::pre_arm_checks(bool display_failure)
                      */
                     threshold *= 2;
                 }
+
+                // EKF is less sensitive to Z-axis error
+                vec_diff.z *= 0.5f;
+
                 if (vec_diff.length() > threshold) {
                     if (display_failure) {
                         gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent Accelerometers");


### PR DESCRIPTION
This is consistent with the pre-arm checks in both ArduPlane and Solo.

It *drastically* reduces the incidence of "inconsistent accelerometers," for two reasons:
1. As stated in the comment, EKF is far less sensitive to Z-axis accelerometer bias
2. The most commonly-used accelerometers, MPU-6000 and LSM-303D, tend to have far more temperature drift in the Z axis in my experiments (N = 3)