### PR TITLE
New parameter LOG_FILE_DSRMROT rotates dataflash logfile on disarm

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -135,11 +135,17 @@ void Rover::loop()
     scheduler.run(remaining);
 }
 
+void Rover::update_soft_armed()
+{
+    hal.util->set_soft_armed(arming.is_armed() &&
+                             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    DataFlash.set_vehicle_armed(hal.util->get_soft_armed());
+}
+
 // update AHRS system
 void Rover::ahrs_update()
 {
-    hal.util->set_soft_armed(arming.is_armed() &&
-                   hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    update_soft_armed();
 
 #if HIL_MODE != HIL_MODE_DISABLED
     // update hil before AHRS update

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -553,6 +553,7 @@ public:
 #endif
 
     void dataflash_periodic(void);
+    void update_soft_armed();
 };
 
 #define MENU_FUNC(func) FUNCTOR_BIND(&rover, &Rover::func, int8_t, uint8_t, const Menu::arg *)

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -497,8 +497,7 @@ bool Rover::should_log(uint32_t mask)
 void Rover::change_arm_state(void)
 {
     Log_Arm_Disarm();
-    hal.util->set_soft_armed(arming.is_armed() &&
-                             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    update_soft_armed();
 }
 
 /*

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -139,6 +139,9 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
         return false;
     }
 
+    // let dataflash know that we're armed (it may open logs e.g.)
+    DataFlash_Class::instance()->set_vehicle_armed(true);
+
     // disable cpu failsafe because initialising everything takes a while
     failsafe_disable();
 
@@ -256,6 +259,7 @@ void Copter::init_disarm_motors()
     if (!DataFlash.log_while_disarmed()) {
         DataFlash.EnableWrites(false);
     }
+    DataFlash_Class::instance()->set_vehicle_armed(false);
 
     // disable gps velocity based centrefugal force compensation
     ahrs.set_correct_centrifugal(false);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -143,11 +143,17 @@ void Plane::loop()
     scheduler.run(loop_us);
 }
 
+void Plane::update_soft_armed()
+{
+    hal.util->set_soft_armed(arming.is_armed() &&
+                             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    DataFlash.set_vehicle_armed(hal.util->get_soft_armed());
+}
+
 // update AHRS system
 void Plane::ahrs_update()
 {
-    hal.util->set_soft_armed(arming.is_armed() &&
-                   hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    update_soft_armed();
 
 #if HIL_SUPPORT
     if (g.hil_mode == 1) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1108,6 +1108,7 @@ private:
     void parachute_release();
     bool parachute_manual_release();
     void accel_cal_update(void);
+    void update_soft_armed();
 
     // support for AP_Avoidance custom flight mode, AVOID_ADSB
     bool avoid_adsb_init(bool ignore_checks);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -813,8 +813,7 @@ int8_t Plane::throttle_percentage(void)
 void Plane::change_arm_state(void)
 {
     Log_Arm_Disarm();
-    hal.util->set_soft_armed(arming.is_armed() &&
-                             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    update_soft_armed();
     quadplane.set_armed(hal.util->get_soft_armed());
 }
 

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -72,6 +72,17 @@ void DataFlash_Class::setVehicle_Startup_Log_Writer(vehicle_startup_message_Log_
     _vehicle_messages = writer;
 }
 
+void DataFlash_Class::set_vehicle_armed(const bool armed_state)
+{
+    if (armed_state == _armed) {
+        // no change in status
+        return;
+    }
+
+    _armed = armed_state;
+}
+
+
 void DataFlash_Class::set_mission(const AP_Mission *mission) {
     FOR_EACH_BACKEND(set_mission(mission));
 }

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -31,7 +31,14 @@ const AP_Param::GroupInfo DataFlash_Class::var_info[] = {
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
     AP_GROUPINFO("_REPLAY",  3, DataFlash_Class, _params.log_replay,       0),
-    
+
+    // @Param: _FILE_DSRMROT
+    // @DisplayName: Stop logging to current file on disarm
+    // @Description: When set, the current log file is closed when the vehicle is disarmed.  If LOG_DISARMED is set then a fresh log will be opened.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("_FILE_DSRMROT",  4, DataFlash_Class, _params.file_disarm_rot,       0),
+
     AP_GROUPEND
 };
 
@@ -78,8 +85,13 @@ void DataFlash_Class::set_vehicle_armed(const bool armed_state)
         // no change in status
         return;
     }
-
     _armed = armed_state;
+
+    if (!_armed) {
+        // went from armed to disarmed
+        FOR_EACH_BACKEND(vehicle_was_disarmed());
+    }
+
 }
 
 

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -194,6 +194,7 @@ public:
     struct {
         AP_Int8 backend_types;
         AP_Int8 file_bufsize; // in kilobytes
+        AP_Int8 file_disarm_rot;
         AP_Int8 log_disarmed;
         AP_Int8 log_replay;
     } _params;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -207,6 +207,8 @@ public:
     bool logging_enabled() const;
     bool logging_failed() const;
 
+    void set_vehicle_armed(bool armed_state);
+
 protected:
 
     const struct LogStructure *_structures;
@@ -259,6 +261,8 @@ private:
     // calculate the length of a message using fields specified in
     // fmt; includes the message header
     int16_t Log_Write_calc_msg_len(const char *fmt) const;
+
+    bool _armed;
 
 private:
     static DataFlash_Class *_instance;

--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -121,6 +121,8 @@ public:
     virtual bool logging_enabled() const = 0;
     virtual bool logging_failed() const = 0;
 
+    virtual void vehicle_was_disarmed() { };
+
 protected:
     uint32_t dropped;
     uint8_t internal_errors; // uint8_t - wishful thinking?

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -1152,5 +1152,15 @@ bool DataFlash_File::logging_failed() const
 }
 
 
+void DataFlash_File::vehicle_was_disarmed()
+{
+    if (_front._params.file_disarm_rot) {
+        // rotate our log.  Closing the current one and letting the
+        // logging restart naturally based on log_disarmed should do
+        // the trick:
+        stop_logging();
+    }
+}
+
 #endif // HAL_OS_POSIX_IO
 

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -71,6 +71,8 @@ public:
     bool logging_enabled() const;
     bool logging_failed() const;
 
+    void vehicle_was_disarmed() override;
+
 private:
     int _write_fd;
     int _read_fd;


### PR DESCRIPTION
This parameter, when set, will break your flights (or drives...) up into separate dataflash logs, assuming you disarm between flights.
