### PR TITLE
Copter: target_roll variable type float, Not set value int16_t.

### DIFF
--- a/ArduCopter/control_drift.cpp
+++ b/ArduCopter/control_drift.cpp
@@ -82,7 +82,7 @@ void Copter::drift_run()
 
     // Roll velocity is feed into roll acceleration to minimize slip
     target_roll = roll_vel_error * -DRIFT_SPEEDGAIN;
-    target_roll = constrain_int16(target_roll, -4500, 4500);
+    target_roll = constrain_float(target_roll, -4500.0f, 4500.0f);
 
     // If we let go of sticks, bring us to a stop
     if(is_zero(target_pitch)){


### PR DESCRIPTION
target_roll value set attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw method.
target_roll value is delicate value.
Therefore this value is not used constrain_int16, select constrain_float.

target_roll = constrain_int16(target_roll, -4500, 4500);
Change:
target_roll = constrain_float(target_roll, -4500.0f, 4500.0f);