### PR TITLE
Ring buffer: remove 'old style' version

### DIFF
--- a/libraries/AP_HAL/utility/RingBuffer.cpp
+++ b/libraries/AP_HAL/utility/RingBuffer.cpp
@@ -37,6 +37,11 @@ uint32_t ByteBuffer::available(void) const
     return ((head > (_tail=tail))? (size - head) + _tail: _tail - head);
 }
 
+void ByteBuffer::clear(void)
+{
+    head = tail = 0;
+}
+
 uint32_t ByteBuffer::space(void) const
 {
     uint32_t _head = head;

--- a/libraries/AP_HAL/utility/RingBuffer.cpp
+++ b/libraries/AP_HAL/utility/RingBuffer.cpp
@@ -1,15 +1,13 @@
-#include "RingBuffer.h"
+#include <new>
 #include <stdlib.h>
 #include <string.h>
 
-/*
-  implement a simple ringbuffer of bytes
- */
+#include "RingBuffer.h"
 
 ByteBuffer::ByteBuffer(uint32_t _size)
 {
-    size = _size;
-    buf = new uint8_t[size];
+    buf = new(std::nothrow) uint8_t[_size];
+    size = buf ? _size : 0;
 }
 
 ByteBuffer::~ByteBuffer(void)
@@ -26,9 +24,9 @@ void ByteBuffer::set_size(uint32_t _size)
 
     head = tail = 0;
     if (_size != size) {
-        size = _size;
         oldbuf = buf;
-        buf = new uint8_t[size];
+        buf = new (std::nothrow) uint8_t[_size];
+        size = buf ? _size : 0;
         delete[] oldbuf;
     }
 }
@@ -41,8 +39,8 @@ uint32_t ByteBuffer::available(void) const
 
 uint32_t ByteBuffer::space(void) const
 {
-    uint32_t _head;
-    return (((_head=head) > tail)?(_head - tail) - 1:((size - tail) + _head) - 1);
+    uint32_t _head = head;
+    return size ? (_head > tail ? 0 : size) + _head - tail - 1 : 0;
 }
 
 bool ByteBuffer::empty(void) const

--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -35,6 +35,9 @@ public:
     // number of bytes available to be read
     uint32_t available(void) const;
 
+    // Discards the buffer content, emptying it.
+    void clear(void);
+
     // number of bytes space available to write
     uint32_t space(void) const;
 

--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -1,31 +1,11 @@
 #pragma once
 
 #include <atomic>
-#include <stdint.h>
 #include <stdbool.h>
-
-
-/*
-  old style ring buffer handling macros
-
-  These macros assume a ring buffer like this:
-
-    uint8_t *_buf;
-    uint16_t _buf_size;
-    volatile uint16_t _buf_head;
-    volatile uint16_t _buf_tail;
-
-  These should be converted to a class in future
- */
-#define BUF_AVAILABLE(buf) ((buf##_head > (_tail=buf##_tail))? (buf##_size - buf##_head) + _tail: _tail - buf##_head)
-#define BUF_SPACE(buf) (((_head=buf##_head) > buf##_tail)?(_head - buf##_tail) - 1:((buf##_size - buf##_tail) + _head) - 1)
-#define BUF_EMPTY(buf) (buf##_head == buf##_tail)
-#define BUF_ADVANCETAIL(buf, n) buf##_tail = (buf##_tail + n) % buf##_size
-#define BUF_ADVANCEHEAD(buf, n) buf##_head = (buf##_head + n) % buf##_size
-
+#include <stdint.h>
 
 /*
-  new style buffers
+ * Circular buffer of bytes.
  */
 class ByteBuffer {
 public:
@@ -105,10 +85,8 @@ private:
     uint8_t *buf;
     uint32_t size;
 
-    // head is where the next available data is. tail is where new
-    // data is written
-    std::atomic<uint32_t> head{0};
-    std::atomic<uint32_t> tail{0};
+    std::atomic<uint32_t> head{0}; // where to read data
+    std::atomic<uint32_t> tail{0}; // where to write data
 };
 
 /*

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/RingBuffer.h>
 
 #include "px4io_protocol.h"
 
@@ -34,8 +33,6 @@ RPIOUARTDriver::RPIOUARTDriver() :
     _need_set_baud(false),
     _baudrate(0)
 {
-    _readbuf = NULL;
-    _writebuf = NULL;
 }
 
 bool RPIOUARTDriver::sem_take_nonblocking()
@@ -75,31 +72,8 @@ void RPIOUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     _initialised = false;
     while (_in_timer) hal.scheduler->delay(1);
 
-   /*
-     allocate the read buffer
-   */
-   if (rxS != 0 && rxS != _readbuf_size) {
-       _readbuf_size = rxS;
-       if (_readbuf != NULL) {
-           free(_readbuf);
-       }
-       _readbuf = (uint8_t *)malloc(_readbuf_size);
-       _readbuf_head = 0;
-       _readbuf_tail = 0;
-   }
-
-   /*
-     allocate the write buffer
-   */
-   if (txS != 0 && txS != _writebuf_size) {
-       _writebuf_size = txS;
-       if (_writebuf != NULL) {
-           free(_writebuf);
-       }
-       _writebuf = (uint8_t *)malloc(_writebuf_size);
-       _writebuf_head = 0;
-       _writebuf_tail = 0;
-   }
+    _readbuf.set_size(rxS);
+    _writebuf.set_size(txS);
 
    _dev = hal.spi->get_device("raspio");
 
@@ -110,7 +84,7 @@ void RPIOUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         hal.scheduler->delay(1);
     }
 
-    if (_writebuf_size != 0 && _readbuf_size != 0) {
+    if (_writebuf.get_size() != 0 && _readbuf.get_size() != 0) {
         _initialised = true;
     }
 
@@ -189,8 +163,7 @@ void RPIOUARTDriver::_timer_tick(void)
     struct IOPacket _dma_packet_tx, _dma_packet_rx;
 
     /* get write_buf bytes */
-    uint16_t _tail;
-    uint16_t n = BUF_AVAILABLE(_writebuf);
+    uint16_t n = _writebuf.available();
 
     if (n > PKT_MAX_REGS * 2) {
         n = PKT_MAX_REGS * 2;
@@ -201,19 +174,7 @@ void RPIOUARTDriver::_timer_tick(void)
         n = _max_size;
     }
 
-    if (n > 0) {
-        uint16_t n1 = _writebuf_size - _writebuf_head;
-        if (n1 >= n) {
-            // do as a single write
-            memcpy( &((uint8_t *)_dma_packet_tx.regs)[0], &_writebuf[_writebuf_head], n );
-        } else {
-            // split into two writes
-            memcpy( &((uint8_t *)_dma_packet_tx.regs)[0], &_writebuf[_writebuf_head], n1 );
-            memcpy( &((uint8_t *)_dma_packet_tx.regs)[n1], &_writebuf[0], n-n1 );
-        }
-
-        BUF_ADVANCEHEAD(_writebuf, n);
-    }
+    _writebuf.read(&((uint8_t *)_dma_packet_tx.regs)[0], n);
 
     _dma_packet_tx.count_code = PKT_MAX_REGS | PKT_CODE_SPIUART;
     _dma_packet_tx.page = PX4IO_PAGE_UART_BUFFER;
@@ -244,8 +205,7 @@ void RPIOUARTDriver::_timer_tick(void)
     _dev->get_semaphore()->give();
 
     /* add bytes to read buf */
-    uint16_t _head;
-    n = BUF_SPACE(_readbuf);
+    n = _readbuf.space();
 
     if (_dma_packet_rx.page == PX4IO_PAGE_UART_BUFFER) {
 
@@ -257,19 +217,7 @@ void RPIOUARTDriver::_timer_tick(void)
             n = PKT_MAX_REGS * 2;
         }
 
-        if (n > 0) {
-            uint16_t n1 = _readbuf_size - _readbuf_tail;
-            if (n1 >= n) {
-                // one read will do
-                memcpy( &_readbuf[_readbuf_tail], &((uint8_t *)_dma_packet_rx.regs)[0], n );
-            } else {
-                memcpy( &_readbuf[_readbuf_tail], &((uint8_t *)_dma_packet_rx.regs)[0], n1 );
-                memcpy( &_readbuf[0], &((uint8_t *)_dma_packet_rx.regs)[n1], n-n1 );
-            }
-
-            BUF_ADVANCETAIL(_readbuf, n);
-        }
-
+        _readbuf.write(&((uint8_t *)_dma_packet_rx.regs)[0], n);
     }
 
     _in_timer = false;

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.h
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL/utility/RingBuffer.h>
+
 #include "AP_HAL_Linux.h"
 
 #include "UARTDriver.h"

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
@@ -5,7 +5,6 @@
 #include <cstdio>
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/RingBuffer.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -49,31 +48,8 @@ void SPIUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         txS = 2048;
     }
 
-    /*
-     allocate the read buffer
-   */
-    if (rxS != 0 && rxS != _readbuf_size) {
-        _readbuf_size = rxS;
-        if (_readbuf != NULL) {
-            free(_readbuf);
-        }
-        _readbuf = (uint8_t *)malloc(_readbuf_size);
-        _readbuf_head = 0;
-        _readbuf_tail = 0;
-    }
-
-    /*
-     allocate the write buffer
-   */
-    if (txS != 0 && txS != _writebuf_size) {
-        _writebuf_size = txS;
-        if (_writebuf != NULL) {
-            free(_writebuf);
-        }
-        _writebuf = (uint8_t *)malloc(_writebuf_size);
-        _writebuf_head = 0;
-        _writebuf_tail = 0;
-    }
+    _readbuf.set_size(rxS);
+    _writebuf.set_size(txS);
 
     if (_buffer == NULL) {
         /* Do not allocate new buffer, if we're just changing speed */
@@ -122,7 +98,7 @@ int SPIUARTDriver::_write_fd(const uint8_t *buf, uint16_t size)
 
     _dev->get_semaphore()->give();
 
-    BUF_ADVANCEHEAD(_writebuf, size);
+    _writebuf.advance(size);
 
     uint16_t ret = size;
 
@@ -131,41 +107,7 @@ int SPIUARTDriver::_write_fd(const uint8_t *buf, uint16_t size)
      * this operation since it's the same as in the
      * UARTDriver::write().
      */
-
-    uint8_t *buffer = _buffer;
-
-    uint16_t _head, space;
-    space = BUF_SPACE(_readbuf);
-
-    if (space == 0) {
-        return ret;
-    }
-
-    if (size > space) {
-        size = space;
-    }
-
-    if (_readbuf_tail < _head) {
-        // perform as single memcpy
-        assert(_readbuf_tail+size <= _readbuf_size);
-        memcpy(&_readbuf[_readbuf_tail], buffer, size);
-        BUF_ADVANCETAIL(_readbuf, size);
-        return ret;
-    }
-
-    // perform as two memcpy calls
-    uint16_t n = _readbuf_size - _readbuf_tail;
-    if (n > size) n = size;
-    assert(_readbuf_tail+n <= _readbuf_size);
-    memcpy(&_readbuf[_readbuf_tail], buffer, n);
-    BUF_ADVANCETAIL(_readbuf, n);
-    buffer += n;
-    n = size - n;
-    if (n > 0) {
-        assert(_readbuf_tail+n <= _readbuf_size);
-        memcpy(&_readbuf[_readbuf_tail], buffer, n);
-        BUF_ADVANCETAIL(_readbuf, n);
-    }
+    _readbuf.write(_buffer, size);
 
     return ret;
 }
@@ -194,7 +136,7 @@ int SPIUARTDriver::_read_fd(uint8_t *buf, uint16_t n)
     _dev->transfer_fullduplex(ff_stub, buf, n);
     _dev->get_semaphore()->give();
 
-    BUF_ADVANCETAIL(_readbuf, n);
+    _readbuf.commit(n);
 
     return n;
 }

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.h
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL/utility/RingBuffer.h>
+
 #include "AP_HAL_Linux.h"
 
 #include "UARTDriver.h"

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -19,7 +19,6 @@
 #include <unistd.h>
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/RingBuffer.h>
 
 #include "ConsoleDevice.h"
 #include "TCPServerDevice.h"
@@ -106,54 +105,18 @@ void UARTDriver::_allocate_buffers(uint16_t rxS, uint16_t txS)
         txS = 32000;
     }
 
-    /*
-      allocate the read buffer
-    */
-    if (rxS != 0 && rxS != _readbuf_size) {
-        _readbuf_size = rxS;
-        if (_readbuf != NULL) {
-            free(_readbuf);
-        }
-        _readbuf = (uint8_t *)malloc(_readbuf_size);
-        _readbuf_head = 0;
-        _readbuf_tail = 0;
-    }
+    _readbuf.set_size(rxS);
+    _writebuf.set_size(txS);
 
-    /*
-      allocate the write buffer
-    */
-    if (txS != 0 && txS != _writebuf_size) {
-        _writebuf_size = txS;
-        if (_writebuf != NULL) {
-            free(_writebuf);
-        }
-        _writebuf = (uint8_t *)malloc(_writebuf_size);
-        _writebuf_head = 0;
-        _writebuf_tail = 0;
-    }
-
-    if (_writebuf_size != 0 && _readbuf_size != 0) {
+    if (_writebuf.get_size() && _readbuf.get_size()) {
         _initialised = true;
     }
 }
 
 void UARTDriver::_deallocate_buffers()
 {
-    if (_readbuf) {
-        free(_readbuf);
-        _readbuf = NULL;
-    }
-
-    if (_writebuf) {
-        free(_writebuf);
-        _writebuf = NULL;
-    }
-
-    _readbuf_size = _writebuf_size = 0;
-    _writebuf_head = 0;
-    _writebuf_tail = 0;
-    _readbuf_head = 0;
-    _readbuf_tail = 0;
+    _readbuf.set_size(0);
+    _writebuf.set_size(0);
 }
 
 /*
@@ -284,7 +247,7 @@ void UARTDriver::set_blocking_writes(bool blocking)
  */
 bool UARTDriver::tx_pending()
 {
-    return !BUF_EMPTY(_writebuf);
+    return _writebuf.available();
 }
 
 /*
@@ -292,11 +255,7 @@ bool UARTDriver::tx_pending()
  */
 int16_t UARTDriver::available()
 {
-    if (!_initialised) {
-        return 0;
-    }
-    uint16_t _tail;
-    return BUF_AVAILABLE(_readbuf);
+    return _readbuf.available();
 }
 
 /*
@@ -304,24 +263,17 @@ int16_t UARTDriver::available()
  */
 int16_t UARTDriver::txspace()
 {
-    if (!_initialised) {
-        return 0;
-    }
-    uint16_t _head;
-    return BUF_SPACE(_writebuf);
+    return _writebuf.space();
 }
 
 int16_t UARTDriver::read()
 {
     uint8_t c;
-    if (!_initialised || _readbuf == NULL) {
+    if (!_initialised) {
         return -1;
     }
-    if (BUF_EMPTY(_readbuf)) {
-        return -1;
-    }
-    c = _readbuf[_readbuf_head];
-    BUF_ADVANCEHEAD(_readbuf, 1);
+    c = _readbuf.peek(0);
+    _readbuf.advance(1);
     return c;
 }
 
@@ -331,17 +283,14 @@ size_t UARTDriver::write(uint8_t c)
     if (!_initialised) {
         return 0;
     }
-    uint16_t _head;
 
-    while (BUF_SPACE(_writebuf) == 0) {
+    while (_writebuf.space() == 0) {
         if (_nonblocking_writes) {
             return 0;
         }
         hal.scheduler->delay(1);
     }
-    _writebuf[_writebuf_tail] = c;
-    BUF_ADVANCETAIL(_writebuf, 1);
-    return 1;
+    return _writebuf.write(&c, 1);
 }
 
 /*
@@ -364,36 +313,7 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    uint16_t _head, space;
-    space = BUF_SPACE(_writebuf);
-    if (space == 0) {
-        return 0;
-    }
-    if (size > space) {
-        size = space;
-    }
-    if (_writebuf_tail < _head) {
-        // perform as single memcpy
-        assert(_writebuf_tail+size <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, size);
-        BUF_ADVANCETAIL(_writebuf, size);
-        return size;
-    }
-
-    // perform as two memcpy calls
-    uint16_t n = _writebuf_size - _writebuf_tail;
-    if (n > size) n = size;
-    assert(_writebuf_tail+n <= _writebuf_size);
-    memcpy(&_writebuf[_writebuf_tail], buffer, n);
-    BUF_ADVANCETAIL(_writebuf, n);
-    buffer += n;
-    n = size - n;
-    if (n > 0) {
-        assert(_writebuf_tail+n <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, n);
-        BUF_ADVANCETAIL(_writebuf, n);
-    }
-    return size;
+    return _writebuf.write(buffer, size);
 }
 
 /*
@@ -417,7 +337,7 @@ int UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
     ret = _device->write(buf, n);
 
     if (ret > 0) {
-        BUF_ADVANCEHEAD(_writebuf, ret);
+        _writebuf.advance(ret);
         return ret;
     }
 
@@ -429,15 +349,7 @@ int UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
  */
 int UARTDriver::_read_fd(uint8_t *buf, uint16_t n)
 {
-    int ret;
-
-    ret = _device->read(buf, n);
-
-    if (ret > 0) {
-        BUF_ADVANCETAIL(_readbuf, ret);
-    }
-
-    return ret;
+    return _device->read(buf, n);
 }
 
 
@@ -450,12 +362,11 @@ bool UARTDriver::_write_pending_bytes(void)
     uint16_t n;
 
     // write any pending bytes
-    uint16_t _tail;
-    uint16_t available_bytes = BUF_AVAILABLE(_writebuf);
+    uint16_t available_bytes = _writebuf.available();
     n = available_bytes;
     if (_packetise && n > 0 &&
-        (_writebuf[_writebuf_head] != MAVLINK_STX_MAVLINK1 &&
-         _writebuf[_writebuf_head] != MAVLINK_STX)) {
+        (_writebuf.peek(0) != MAVLINK_STX_MAVLINK1 &&
+         _writebuf.peek(0) != MAVLINK_STX)) {
         /*
           we have a non-mavlink packet at the start of the
           buffer. Look ahead for a MAVLink start byte, up to 256 bytes
@@ -464,7 +375,7 @@ bool UARTDriver::_write_pending_bytes(void)
         uint16_t limit = n>256?256:n;
         uint16_t i;
         for (i=0; i<limit; i++) {
-            uint8_t b = _writebuf[(_writebuf_head + i) % _writebuf_size];
+            uint8_t b = _writebuf.peek(i);
             if (b == MAVLINK_STX_MAVLINK1 || b == MAVLINK_STX) {
                 n = i;
                 break;
@@ -475,7 +386,7 @@ bool UARTDriver::_write_pending_bytes(void)
             n = limit;
         }
     }
-    const uint8_t b = _writebuf[_writebuf_head];
+    const uint8_t b = _writebuf.peek(0);
     if (_packetise && n > 0 &&
         (b == MAVLINK_STX_MAVLINK1 || b == MAVLINK_STX)) {
         uint8_t min_length = (b == MAVLINK_STX_MAVLINK1)?8:12;
@@ -488,10 +399,10 @@ bool UARTDriver::_write_pending_bytes(void)
             // the length of the packet is the 2nd byte, and mavlink
             // packets have a 6 byte header plus 2 byte checksum,
             // giving len+8 bytes
-            uint8_t len = _writebuf[(_writebuf_head + 1) % _writebuf_size];
+            uint8_t len = _writebuf.peek(1);
             if (b == MAVLINK_STX) {
                 // check for signed packet with extra 13 bytes
-                uint8_t incompat_flags = _writebuf[(_writebuf_head + 2) % _writebuf_size];
+                uint8_t incompat_flags = _writebuf.peek(2);
                 if (incompat_flags & MAVLINK_IFLAG_SIGNED) {
                     min_length += MAVLINK_SIGNATURE_BLOCK_LEN;
                 }
@@ -508,30 +419,21 @@ bool UARTDriver::_write_pending_bytes(void)
     }
 
     if (n > 0) {
-        uint16_t n1 = _writebuf_size - _writebuf_head;
-        if (n1 >= n) {
-            // do as a single write
-            _write_fd(&_writebuf[_writebuf_head], n);
+        if (_packetise) {
+            // keep as a single UDP packet
+            uint8_t tmpbuf[n];
+            _writebuf.peekbytes(tmpbuf, n);
+            _write_fd(tmpbuf, n);
         } else {
-            // split into two writes
-            if (_packetise) {
-                // keep as a single UDP packet
-                uint8_t tmpbuf[n];
-                memcpy(tmpbuf, &_writebuf[_writebuf_head], n1);
-                if (n > n1) {
-                    memcpy(&tmpbuf[n1], &_writebuf[0], n-n1);
-                }
-                _write_fd(tmpbuf, n);
-            } else {
-                int ret = _write_fd(&_writebuf[_writebuf_head], n1);
-                if (ret == n1 && n > n1) {
-                    _write_fd(&_writebuf[_writebuf_head], n - n1);
-                }
+            ByteBuffer::IoVec vec[2];
+            const auto n_vec = _writebuf.peekiovec(vec, n);
+            for (int i = 0; i < n_vec; i++) {
+                _write_fd(vec[i].data, (uint16_t)vec[i].len);
             }
         }
     }
 
-    return BUF_AVAILABLE(_writebuf) != available_bytes;
+    return _writebuf.available() != available_bytes;
 }
 
 /*
@@ -541,8 +443,6 @@ bool UARTDriver::_write_pending_bytes(void)
  */
 void UARTDriver::_timer_tick(void)
 {
-    uint16_t n;
-
     if (!_initialised) return;
 
     _in_timer = true;
@@ -553,22 +453,16 @@ void UARTDriver::_timer_tick(void)
     }
 
     // try to fill the read buffer
-    uint16_t _head;
-    n = BUF_SPACE(_readbuf);
-    if (n > 0) {
-        uint16_t n1 = _readbuf_size - _readbuf_tail;
-        if (n1 >= n) {
-            // one read will do
-            assert(_readbuf_tail+n <= _readbuf_size);
-            _read_fd(&_readbuf[_readbuf_tail], n);
-        } else {
-            assert(_readbuf_tail+n1 <= _readbuf_size);
-            int ret = _read_fd(&_readbuf[_readbuf_tail], n1);
-            if (ret == n1 && n > n1) {
-                assert(_readbuf_tail+(n-n1) <= _readbuf_size);
-                _read_fd(&_readbuf[_readbuf_tail], n - n1);
-            }
-        }
+    int ret;
+    ByteBuffer::IoVec vec[2];
+
+    const auto n_vec = _readbuf.reserve(vec, _readbuf.space());
+    for (int i = 0; i < n_vec; i++) {
+        ret = _read_fd(vec[i].data, vec[i].len);
+        assert(ret < 0);
+        _readbuf.commit((unsigned)ret);
+        if ((unsigned)ret < vec[i].len)
+            break;
     }
 
     _in_timer = false;

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_HAL/utility/OwnPtr.h>
+#include <AP_HAL/utility/RingBuffer.h>
 
 #include "AP_HAL_Linux.h"
 #include "SerialDevice.h"
@@ -68,24 +69,14 @@ private:
 protected:
     const char *device_path;
     volatile bool _initialised;
+
     // we use in-task ring buffers to reduce the system call cost
     // of ::read() and ::write() in the main loop
-    uint8_t *_readbuf;
-    uint16_t _readbuf_size;
-
-    // _head is where the next available data is. _tail is where new
-    // data is put
-    volatile uint16_t _readbuf_head;
-    volatile uint16_t _readbuf_tail;
-
-    uint8_t *_writebuf;
-    uint16_t _writebuf_size;
-    volatile uint16_t _writebuf_head;
-    volatile uint16_t _writebuf_tail;
+    ByteBuffer _readbuf{0};
+    ByteBuffer _writebuf{0};
 
     virtual int _write_fd(const uint8_t *buf, uint16_t n);
     virtual int _read_fd(uint8_t *buf, uint16_t n);
-
 };
 
 }

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -16,7 +16,6 @@
 #include <termios.h>
 #include <drivers/drv_hrt.h>
 #include <assert.h>
-#include <AP_HAL/utility/RingBuffer.h>
 #include "GPIO.h"
 
 using namespace PX4;
@@ -72,19 +71,14 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       thrashing of the heap once we are up. The ttyACM0 driver may not
       connect for some time after boot
      */
-	if (rxS != 0 && rxS != _readbuf_size) {
+    if (rxS != 0 && rxS != _readbuf.get_size()) {
         _initialised = false;
         while (_in_timer) {
             hal.scheduler->delay(1);
         }
-		_readbuf_size = rxS;
-		if (_readbuf != NULL) {
-			free(_readbuf);
-		}
-		_readbuf = (uint8_t *)malloc(_readbuf_size);
-		_readbuf_head = 0;
-		_readbuf_tail = 0;
-	}
+
+        _readbuf.set_size(rxS);
+    }
 
     if (b != 0) {
         _baudrate = b;
@@ -93,19 +87,13 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     /*
       allocate the write buffer
      */
-	if (txS != 0 && txS != _writebuf_size) {
+    if (txS != 0 && txS != _writebuf.get_size()) {
         _initialised = false;
         while (_in_timer) {
             hal.scheduler->delay(1);
         }
-		_writebuf_size = txS;
-		if (_writebuf != NULL) {
-			free(_writebuf);
-		}
-		_writebuf = (uint8_t *)malloc(_writebuf_size+16);
-		_writebuf_head = 0;
-		_writebuf_tail = 0;
-	}
+        _writebuf.set_size(txS+16);
+    }
 
 	if (_fd == -1) {
         _fd = open(_devpath, O_RDWR);
@@ -132,18 +120,17 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 		tcsetattr(_fd, TCSANOW, &t);
 	}
 
-    if (_writebuf_size != 0 && _readbuf_size != 0 && _fd != -1) {
+    if (_writebuf.get_size() && _readbuf.get_size() && _fd != -1) {
         if (!_initialised) {
             if (strcmp(_devpath, "/dev/ttyACM0") == 0) {
                 ((PX4GPIO *)hal.gpio)->set_usb_connected();
             }
             ::printf("initialised %s OK %u %u\n", _devpath, 
-                     (unsigned)_writebuf_size, (unsigned)_readbuf_size);
+                     (unsigned)_writebuf.get_size(), (unsigned)_readbuf.get_size());
         }
         _initialised = true;
     }
     _uart_owner_pid = getpid();
-
 }
 
 void PX4UARTDriver::set_flow_control(enum flow_control fcontrol)
@@ -203,19 +190,9 @@ void PX4UARTDriver::end()
         close(_fd);
         _fd = -1;
     }
-    if (_readbuf) {
-        free(_readbuf);
-        _readbuf = NULL;
-    }
-    if (_writebuf) {
-        free(_writebuf);
-        _writebuf = NULL;
-    }
-    _readbuf_size = _writebuf_size = 0;
-    _writebuf_head = 0;
-    _writebuf_tail = 0;
-    _readbuf_head = 0;
-    _readbuf_tail = 0;
+
+    _readbuf.set_size(0);
+    _writebuf.set_size(0);
 }
 
 void PX4UARTDriver::flush() {}
@@ -238,12 +215,12 @@ bool PX4UARTDriver::tx_pending() { return false; }
  */
 int16_t PX4UARTDriver::available() 
 { 
-	if (!_initialised) {
+    if (!_initialised) {
         try_initialise();
-		return 0;
-	}
-    uint16_t _tail;
-    return BUF_AVAILABLE(_readbuf);
+        return 0;
+    }
+
+    return _readbuf.available();
 }
 
 /*
@@ -251,12 +228,12 @@ int16_t PX4UARTDriver::available()
  */
 int16_t PX4UARTDriver::txspace() 
 { 
-	if (!_initialised) {
+    if (!_initialised) {
         try_initialise();
-		return 0;
-	}
-    uint16_t _head;
-    return BUF_SPACE(_writebuf);
+        return 0;
+    }
+
+    return _writebuf.space();
 }
 
 /*
@@ -264,7 +241,6 @@ int16_t PX4UARTDriver::txspace()
  */
 int16_t PX4UARTDriver::read() 
 { 
-	uint8_t c;
     if (_uart_owner_pid != getpid()){
         return -1;
     }
@@ -272,15 +248,14 @@ int16_t PX4UARTDriver::read()
         try_initialise();
         return -1;
     }
-	if (_readbuf == NULL) {
-		return -1;
-	}
-    if (BUF_EMPTY(_readbuf)) {
+    if (_readbuf.empty()) {
         return -1;
     }
-    c = _readbuf[_readbuf_head];
-    BUF_ADVANCEHEAD(_readbuf, 1);
-	return c;
+
+    uint8_t c = _readbuf.peek(0);
+    _readbuf.advance(1);
+
+    return c;
 }
 
 /* 
@@ -295,17 +270,14 @@ size_t PX4UARTDriver::write(uint8_t c)
         try_initialise();
         return 0;
     }
-    uint16_t _head;
 
-    while (BUF_SPACE(_writebuf) == 0) {
+    while (_writebuf.space() == 0) {
         if (_nonblocking_writes) {
             return 0;
         }
         hal.scheduler->delay(1);
     }
-    _writebuf[_writebuf_tail] = c;
-    BUF_ADVANCETAIL(_writebuf, 1);
-    return 1;
+    return _writebuf.write(&c, 1);
 }
 
 /*
@@ -333,36 +305,7 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    uint16_t _head, space;
-    space = BUF_SPACE(_writebuf);
-    if (space == 0) {
-        return 0;
-    }
-    if (size > space) {
-        size = space;
-    }
-    if (_writebuf_tail < _head) {
-        // perform as single memcpy
-        assert(_writebuf_tail+size <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, size);
-        BUF_ADVANCETAIL(_writebuf, size);
-        return size;
-    }
-
-    // perform as two memcpy calls
-    uint16_t n = _writebuf_size - _writebuf_tail;
-    if (n > size) n = size;
-    assert(_writebuf_tail+n <= _writebuf_size);
-    memcpy(&_writebuf[_writebuf_tail], buffer, n);
-    BUF_ADVANCETAIL(_writebuf, n);
-    buffer += n;
-    n = size - n;
-    if (n > 0) {
-        assert(_writebuf_tail+n <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, n);
-        BUF_ADVANCETAIL(_writebuf, n);
-    }        
-    return size;
+    return _writebuf.write(buffer, size);
 }
 
 /*
@@ -411,7 +354,7 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
     }
 
     if (ret > 0) {
-        BUF_ADVANCEHEAD(_writebuf, ret);
+        _writebuf.advance(ret);
         _last_write_time = AP_HAL::micros64();
         _total_written += ret;
         if (! _first_write_time && _total_written > 5) {
@@ -449,7 +392,7 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
         // discarding bytes, even if this is a blocking port. This
         // prevents the ttyACM0 port blocking startup if the endpoint
         // is not connected
-        BUF_ADVANCEHEAD(_writebuf, n);
+        _writebuf.advance(n);
         return n;
     }
     return ret;
@@ -474,7 +417,6 @@ int PX4UARTDriver::_read_fd(uint8_t *buf, uint16_t n)
         }
     }
     if (ret > 0) {
-        BUF_ADVANCETAIL(_readbuf, ret);
         _total_read += ret;
     }
     return ret;
@@ -500,44 +442,31 @@ void PX4UARTDriver::_timer_tick(void)
     _in_timer = true;
 
     // write any pending bytes
-    uint16_t _tail;
-    n = BUF_AVAILABLE(_writebuf);
+    n = _writebuf.available();
     if (n > 0) {
-        uint16_t n1 = _writebuf_size - _writebuf_head;
+        ByteBuffer::IoVec vec[2];
         perf_begin(_perf_uart);
-        if (n1 >= n) {
-            // do as a single write
-            _write_fd(&_writebuf[_writebuf_head], n);
-        } else {
-            // split into two writes
-            int ret = _write_fd(&_writebuf[_writebuf_head], n1);
-            if (ret == n1 && n > n1) {
-                _write_fd(&_writebuf[_writebuf_head], n - n1);                
-            }
+        const auto n_vec = _writebuf.peekiovec(vec, n);
+        for (int i = 0; i < n_vec; i++) {
+            _write_fd(vec[i].data, (uint16_t)vec[i].len);
         }
         perf_end(_perf_uart);
     }
 
     // try to fill the read buffer
-    uint16_t _head;
-    n = BUF_SPACE(_readbuf);
-    if (n > 0) {
-        uint16_t n1 = _readbuf_size - _readbuf_tail;
-        perf_begin(_perf_uart);
-        if (n1 >= n) {
-            // one read will do
-            assert(_readbuf_tail+n <= _readbuf_size);
-            _read_fd(&_readbuf[_readbuf_tail], n);
-        } else {
-            assert(_readbuf_tail+n1 <= _readbuf_size);
-            int ret = _read_fd(&_readbuf[_readbuf_tail], n1);
-            if (ret == n1 && n > n1) {
-                assert(_readbuf_tail+(n-n1) <= _readbuf_size);
-                _read_fd(&_readbuf[_readbuf_tail], n - n1);                
-            }
-        }
-        perf_end(_perf_uart);
+    int ret;
+    ByteBuffer::IoVec vec[2];
+
+    perf_begin(_perf_uart);
+    const auto n_vec = _readbuf.reserve(vec, _readbuf.space());
+    for (int i = 0; i < n_vec; i++) {
+        ret = _read_fd(vec[i].data, vec[i].len);
+        assert(ret < 0);
+        _readbuf.commit((unsigned)ret);
+        if ((unsigned)ret < vec[i].len)
+            break;
     }
+    perf_end(_perf_uart);
 
     _in_timer = false;
 }

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL/utility/RingBuffer.h>
+
 #include "AP_HAL_PX4.h"
 #include <systemlib/perf_counter.h>
 
@@ -48,18 +50,8 @@ private:
 
     // we use in-task ring buffers to reduce the system call cost
     // of ::read() and ::write() in the main loop
-    uint8_t *_readbuf;
-    uint16_t _readbuf_size;
-
-    // _head is where the next available data is. _tail is where new
-    // data is put
-    volatile uint16_t _readbuf_head;
-    volatile uint16_t _readbuf_tail;
-
-    uint8_t *_writebuf;
-    uint16_t _writebuf_size;
-    volatile uint16_t _writebuf_head;
-    volatile uint16_t _writebuf_tail;
+    ByteBuffer _readbuf{0};
+    ByteBuffer _writebuf{0};
     perf_counter_t  _perf_uart;
 
     int _write_fd(const uint8_t *buf, uint16_t n);

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
@@ -16,7 +16,6 @@
 #include <termios.h>
 #include <drivers/drv_hrt.h>
 #include <assert.h>
-#include <AP_HAL/utility/RingBuffer.h>
 
 using namespace VRBRAIN;
 
@@ -71,19 +70,14 @@ void VRBRAINUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       thrashing of the heap once we are up. The ttyACM0 driver may not
       connect for some time after boot
      */
-	if (rxS != 0 && rxS != _readbuf_size) {
+    if (rxS != 0 && rxS != _readbuf.get_size()) {
         _initialised = false;
         while (_in_timer) {
             hal.scheduler->delay(1);
         }
-		_readbuf_size = rxS;
-		if (_readbuf != NULL) {
-			free(_readbuf);
-		}
-		_readbuf = (uint8_t *)malloc(_readbuf_size);
-		_readbuf_head = 0;
-		_readbuf_tail = 0;
-	}
+
+        _readbuf.set_size(rxS);
+    }
 
     if (b != 0) {
         _baudrate = b;
@@ -92,19 +86,13 @@ void VRBRAINUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     /*
       allocate the write buffer
      */
-	if (txS != 0 && txS != _writebuf_size) {
+    if (txS != 0 && txS != _writebuf.get_size()) {
         _initialised = false;
         while (_in_timer) {
             hal.scheduler->delay(1);
         }
-		_writebuf_size = txS;
-		if (_writebuf != NULL) {
-			free(_writebuf);
-		}
-		_writebuf = (uint8_t *)malloc(_writebuf_size+16);
-		_writebuf_head = 0;
-		_writebuf_tail = 0;
-	}
+        _writebuf.set_size(txS+16);
+    }
 
 	if (_fd == -1) {
         _fd = open(_devpath, O_RDWR);
@@ -131,10 +119,10 @@ void VRBRAINUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 		tcsetattr(_fd, TCSANOW, &t);
 	}
 
-    if (_writebuf_size != 0 && _readbuf_size != 0 && _fd != -1) {
+    if (_writebuf.get_size() && _readbuf.get_size() && _fd != -1) {
         if (!_initialised) {
             ::printf("initialised %s OK %u %u\n", _devpath, 
-                     (unsigned)_writebuf_size, (unsigned)_readbuf_size);
+                     (unsigned)_writebuf.get_size(), (unsigned)_readbuf.get_size());
         }
         _initialised = true;
     }
@@ -197,19 +185,9 @@ void VRBRAINUARTDriver::end()
         close(_fd);
         _fd = -1;
     }
-    if (_readbuf) {
-        free(_readbuf);
-        _readbuf = NULL;
-    }
-    if (_writebuf) {
-        free(_writebuf);
-        _writebuf = NULL;
-    }
-    _readbuf_size = _writebuf_size = 0;
-    _writebuf_head = 0;
-    _writebuf_tail = 0;
-    _readbuf_head = 0;
-    _readbuf_tail = 0;
+
+    _readbuf.set_size(0);
+    _writebuf.set_size(0);
 }
 
 void VRBRAINUARTDriver::flush() {}
@@ -232,12 +210,12 @@ bool VRBRAINUARTDriver::tx_pending() { return false; }
  */
 int16_t VRBRAINUARTDriver::available()
 { 
-	if (!_initialised) {
+    if (!_initialised) {
         try_initialise();
-		return 0;
-	}
-    uint16_t _tail;
-    return BUF_AVAILABLE(_readbuf);
+        return 0;
+    }
+
+    return _readbuf.available();
 }
 
 /*
@@ -245,12 +223,12 @@ int16_t VRBRAINUARTDriver::available()
  */
 int16_t VRBRAINUARTDriver::txspace()
 { 
-	if (!_initialised) {
+    if (!_initialised) {
         try_initialise();
-		return 0;
-	}
-    uint16_t _head;
-    return BUF_SPACE(_writebuf);
+        return 0;
+    }
+
+    return _writebuf.space();
 }
 
 /*
@@ -258,20 +236,18 @@ int16_t VRBRAINUARTDriver::txspace()
  */
 int16_t VRBRAINUARTDriver::read()
 { 
-	uint8_t c;
     if (!_initialised) {
         try_initialise();
         return -1;
     }
-	if (_readbuf == NULL) {
-		return -1;
-	}
-    if (BUF_EMPTY(_readbuf)) {
+    if (_readbuf.empty()) {
         return -1;
     }
-    c = _readbuf[_readbuf_head];
-    BUF_ADVANCEHEAD(_readbuf, 1);
-	return c;
+
+    uint8_t c = _readbuf.peek(0);
+    _readbuf.advance(1);
+
+    return c;
 }
 
 /* 
@@ -287,17 +263,14 @@ size_t VRBRAINUARTDriver::write(uint8_t c)
         // not allowed from timers
         return 0;
     }
-    uint16_t _head;
 
-    while (BUF_SPACE(_writebuf) == 0) {
+    while (_writebuf.space() == 0) {
         if (_nonblocking_writes) {
             return 0;
         }
         hal.scheduler->delay(1);
     }
-    _writebuf[_writebuf_tail] = c;
-    BUF_ADVANCETAIL(_writebuf, 1);
-    return 1;
+    return _writebuf.write(&c, 1);
 }
 
 /*
@@ -326,36 +299,7 @@ size_t VRBRAINUARTDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    uint16_t _head, space;
-    space = BUF_SPACE(_writebuf);
-    if (space == 0) {
-        return 0;
-    }
-    if (size > space) {
-        size = space;
-    }
-    if (_writebuf_tail < _head) {
-        // perform as single memcpy
-        assert(_writebuf_tail+size <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, size);
-        BUF_ADVANCETAIL(_writebuf, size);
-        return size;
-    }
-
-    // perform as two memcpy calls
-    uint16_t n = _writebuf_size - _writebuf_tail;
-    if (n > size) n = size;
-    assert(_writebuf_tail+n <= _writebuf_size);
-    memcpy(&_writebuf[_writebuf_tail], buffer, n);
-    BUF_ADVANCETAIL(_writebuf, n);
-    buffer += n;
-    n = size - n;
-    if (n > 0) {
-        assert(_writebuf_tail+n <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], buffer, n);
-        BUF_ADVANCETAIL(_writebuf, n);
-    }        
-    return size;
+    return _writebuf.write(buffer, size);
 }
 
 /*
@@ -404,7 +348,7 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
     }
 
     if (ret > 0) {
-        BUF_ADVANCEHEAD(_writebuf, ret);
+        _writebuf.advance(ret);
         _last_write_time = AP_HAL::micros64();
         _total_written += ret;
         if (! _first_write_time && _total_written > 5) {
@@ -442,7 +386,7 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
         // discarding bytes, even if this is a blocking port. This
         // prevents the ttyACM0 port blocking startup if the endpoint
         // is not connected
-        BUF_ADVANCEHEAD(_writebuf, n);
+        _writebuf.advance(n);
         return n;
     }
     return ret;
@@ -467,7 +411,6 @@ int VRBRAINUARTDriver::_read_fd(uint8_t *buf, uint16_t n)
         }
     }
     if (ret > 0) {
-        BUF_ADVANCETAIL(_readbuf, ret);
         _total_read += ret;
     }
     return ret;
@@ -493,44 +436,31 @@ void VRBRAINUARTDriver::_timer_tick(void)
     _in_timer = true;
 
     // write any pending bytes
-    uint16_t _tail;
-    n = BUF_AVAILABLE(_writebuf);
+    n = _writebuf.available();
     if (n > 0) {
-        uint16_t n1 = _writebuf_size - _writebuf_head;
+        ByteBuffer::IoVec vec[2];
         perf_begin(_perf_uart);
-        if (n1 >= n) {
-            // do as a single write
-            _write_fd(&_writebuf[_writebuf_head], n);
-        } else {
-            // split into two writes
-            int ret = _write_fd(&_writebuf[_writebuf_head], n1);
-            if (ret == n1 && n > n1) {
-                _write_fd(&_writebuf[_writebuf_head], n - n1);                
-            }
+        const auto n_vec = _writebuf.peekiovec(vec, n);
+        for (int i = 0; i < n_vec; i++) {
+            _write_fd(vec[i].data, (uint16_t)vec[i].len);
         }
         perf_end(_perf_uart);
     }
 
     // try to fill the read buffer
-    uint16_t _head;
-    n = BUF_SPACE(_readbuf);
-    if (n > 0) {
-        uint16_t n1 = _readbuf_size - _readbuf_tail;
-        perf_begin(_perf_uart);
-        if (n1 >= n) {
-            // one read will do
-            assert(_readbuf_tail+n <= _readbuf_size);
-            _read_fd(&_readbuf[_readbuf_tail], n);
-        } else {
-            assert(_readbuf_tail+n1 <= _readbuf_size);
-            int ret = _read_fd(&_readbuf[_readbuf_tail], n1);
-            if (ret == n1 && n > n1) {
-                assert(_readbuf_tail+(n-n1) <= _readbuf_size);
-                _read_fd(&_readbuf[_readbuf_tail], n - n1);                
-            }
-        }
-        perf_end(_perf_uart);
+    int ret;
+    ByteBuffer::IoVec vec[2];
+
+    perf_begin(_perf_uart);
+    const auto n_vec = _readbuf.reserve(vec, _readbuf.space());
+    for (int i = 0; i < n_vec; i++) {
+        ret = _read_fd(vec[i].data, vec[i].len);
+        assert(ret < 0);
+        _readbuf.commit((unsigned)ret);
+        if ((unsigned)ret < vec[i].len)
+            break;
     }
+    perf_end(_perf_uart);
 
     _in_timer = false;
 }

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.h
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "AP_HAL_VRBRAIN.h"
+#include <AP_HAL/utility/RingBuffer.h>
 #include <systemlib/perf_counter.h>
+
+#include "AP_HAL_VRBRAIN.h"
 
 class VRBRAIN::VRBRAINUARTDriver : public AP_HAL::UARTDriver {
 public:
@@ -48,18 +50,9 @@ private:
 
     // we use in-task ring buffers to reduce the system call cost
     // of ::read() and ::write() in the main loop
-    uint8_t *_readbuf;
-    uint16_t _readbuf_size;
+    ByteBuffer _readbuf;
+    ByteBuffer _writebuf;
 
-    // _head is where the next available data is. _tail is where new
-    // data is put
-    volatile uint16_t _readbuf_head;
-    volatile uint16_t _readbuf_tail;
-
-    uint8_t *_writebuf;
-    uint16_t _writebuf_size;
-    volatile uint16_t _writebuf_head;
-    volatile uint16_t _writebuf_tail;
     perf_counter_t  _perf_uart;
 
     int _write_fd(const uint8_t *buf, uint16_t n);

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -31,14 +31,12 @@
 #include <stdio.h>
 #include <time.h>
 #include <dirent.h>
-#include <AP_HAL/utility/RingBuffer.h>
 #if defined(__APPLE__) && defined(__MACH__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #elif !DATAFLASH_FILE_MINIMAL
 #include <sys/statfs.h>
 #endif
-
 extern const AP_HAL::HAL& hal;
 
 #define MAX_LOG_FILES 500U
@@ -56,11 +54,11 @@ DataFlash_File::DataFlash_File(DataFlash_Class &front,
     _read_fd_log_num(0),
     _read_offset(0),
     _write_offset(0),
-    _initialised(false),
+    _initialized(false),
     _open_error(false),
     _log_directory(log_directory),
     _cached_oldest_log(0),
-    _writebuf(NULL),
+    _writebuf(0),
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
     // V1 gets IO errors with larger than 512 byte writes
     _writebuf_chunk(512),
@@ -79,8 +77,6 @@ DataFlash_File::DataFlash_File(DataFlash_Class &front,
 #else
     _writebuf_chunk(4096),
 #endif
-    _writebuf_head(0),
-    _writebuf_tail(0),
     _last_write_time(0),
     _perf_write(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "DF_write")),
     _perf_fsync(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "DF_fsync")),
@@ -89,7 +85,6 @@ DataFlash_File::DataFlash_File(DataFlash_Class &front,
 {}
 
 
-// initialisation
 void DataFlash_File::Init()
 {
     DataFlash_Backend::Init();
@@ -102,7 +97,7 @@ void DataFlash_File::Init()
         AP_HAL::panic("Failed to create DataFlash_File semaphore");
         return;
     }
-    
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     // try to cope with an existing lowercase log directory
     // name. NuttX does not handle case insensitive VFAT well
@@ -133,38 +128,27 @@ void DataFlash_File::Init()
         return;
     }
 #endif
-    
-    if (_writebuf != NULL) {
-        free(_writebuf);
-        _writebuf = NULL;
-    }
 
     // determine and limit file backend buffersize
-    uint8_t bufsize = _front._params.file_bufsize;
+    uint32_t bufsize = _front._params.file_bufsize;
     if (bufsize > 64) {
-        // we currently use uint16_t for the ringbuffer.  Also,
-        // PixHawk has DMA limitaitons.
-        bufsize = 64;
+        bufsize = 64; // Also, PixHawk has DMA limitaitons.
     }
-    _writebuf_size = bufsize * 1024;
+    bufsize *= 1024;
 
-    /*
-      if we can't allocate the full writebuf then try reducing it
-      until we can allocate it
-     */
-    while (_writebuf == NULL && _writebuf_size >= _writebuf_chunk) {
-        hal.console->printf("DataFlash_File: buffer size=%u\n", (unsigned)_writebuf_size);
-        _writebuf = (uint8_t *)malloc(_writebuf_size);
-        if (_writebuf == NULL) {
-            _writebuf_size /= 2;
-        }
-    }
-    if (_writebuf == NULL) {
+    // If we can't allocate the full size, try to reduce it until we can allocate it
+    do {
+        hal.console->printf("DataFlash_File: buffer size=%u\n", (unsigned)bufsize);
+        _writebuf.set_size(bufsize);
+        bufsize >>= 1;
+    } while(!_writebuf.get_size() && bufsize >= _writebuf_chunk);
+
+    if (!_writebuf.get_size()) {
         hal.console->printf("Out of memory for logging\n");
         return;        
     }
-    _writebuf_head = _writebuf_tail = 0;
-    _initialised = true;
+
+    _initialized = true;
     hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&DataFlash_File::_io_timer, void));
 }
 
@@ -206,14 +190,13 @@ void DataFlash_File::periodic_fullrate(const uint32_t now)
 
 uint16_t DataFlash_File::bufferspace_available()
 {
-    uint16_t _head;
-    return (BUF_SPACE(_writebuf)) - critical_message_reserved_space();
+    return _writebuf.space() - critical_message_reserved_space();
 }
 
-// return true for CardInserted() if we successfully initialised
+// return true for CardInserted() if we successfully initialized
 bool DataFlash_File::CardInserted(void)
 {
-    return _initialised && !_open_error;
+    return _initialized && !_open_error;
 }
 
 // returns the amount of disk space available in _log_directory (in bytes)
@@ -470,7 +453,7 @@ void DataFlash_File::EraseAll()
 /* Write a block of data at current offset */
 bool DataFlash_File::WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical)
 {
-    if (_write_fd == -1 || !_initialised || _open_error || !_writes_enabled) {
+    if (_write_fd == -1 || !_initialized || _open_error || !_writes_enabled) {
         return false;
     }
 
@@ -483,8 +466,7 @@ bool DataFlash_File::WritePrioritisedBlock(const void *pBuffer, uint16_t size, b
         return false;
     }
         
-    uint16_t _head;
-    uint16_t space = BUF_SPACE(_writebuf);
+    uint16_t space = _writebuf.space();
 
     if (_writing_startup_messages &&
         _startup_messagewriter->fmt_done()) {
@@ -514,26 +496,7 @@ bool DataFlash_File::WritePrioritisedBlock(const void *pBuffer, uint16_t size, b
         return false;
     }
 
-    if (_writebuf_tail < _head) {
-        // perform as single memcpy
-        assert(((uint32_t)_writebuf_tail)+size <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], pBuffer, size);
-        BUF_ADVANCETAIL(_writebuf, size);
-    } else {
-        // perform as two memcpy calls
-        uint32_t n = _writebuf_size - _writebuf_tail;
-        if (n > size) n = size;
-        assert(((uint32_t)_writebuf_tail)+n <= _writebuf_size);
-        memcpy(&_writebuf[_writebuf_tail], pBuffer, n);
-        BUF_ADVANCETAIL(_writebuf, n);
-        pBuffer = (const void *)(((const uint8_t *)pBuffer) + n);
-        n = size - n;
-        if (n > 0) {
-            assert(((uint32_t)_writebuf_tail)+n <= _writebuf_size);
-            memcpy(&_writebuf[_writebuf_tail], pBuffer, n);
-            BUF_ADVANCETAIL(_writebuf, n);
-        }
-    }
+    _writebuf.write((uint8_t*)pBuffer, size);
     semaphore->give();
     return true;
 }
@@ -543,7 +506,7 @@ bool DataFlash_File::WritePrioritisedBlock(const void *pBuffer, uint16_t size, b
 */
 bool DataFlash_File::ReadBlock(void *pkt, uint16_t size)
 {
-    if (_read_fd == -1 || !_initialised || _open_error) {
+    if (_read_fd == -1 || !_initialized || _open_error) {
         return false;
     }
 
@@ -661,7 +624,7 @@ void DataFlash_File::get_log_boundaries(const uint16_t list_entry, uint16_t & st
  */
 int16_t DataFlash_File::get_log_data(const uint16_t list_entry, const uint16_t page, const uint32_t offset, const uint16_t len, uint8_t *data)
 {
-    if (!_initialised || _open_error) {
+    if (!_initialized || _open_error) {
         return -1;
     }
 
@@ -832,7 +795,7 @@ uint16_t DataFlash_File::start_new_log(void)
     _cached_oldest_log = 0;
 
     if (_write_fd == -1) {
-        _initialised = false;
+        _initialized = false;
         _open_error = true;
         int saved_errno = errno;
         ::printf("Log open fail for %s - %s\n",
@@ -844,8 +807,7 @@ uint16_t DataFlash_File::start_new_log(void)
     }
     free(fname);
     _write_offset = 0;
-    _writebuf_head = 0;
-    _writebuf_tail = 0;
+    _writebuf.clear();
     log_write_started = true;
 
     // now update lastlog.txt with the new log number
@@ -876,7 +838,7 @@ void DataFlash_File::LogReadProcess(const uint16_t list_entry,
                                     AP_HAL::BetterStream *port)
 {
     uint8_t log_step = 0;
-    if (!_initialised || _open_error) {
+    if (!_initialized || _open_error) {
         return;
     }
 
@@ -1018,11 +980,9 @@ void DataFlash_File::ListAvailableLogs(AP_HAL::BetterStream *port)
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 void DataFlash_File::flush(void)
 {
-    uint16_t _tail;
     uint32_t tnow = AP_HAL::micros();
     hal.scheduler->suspend_timer_procs();
-    while (_write_fd != -1 && _initialised && !_open_error &&
-           BUF_AVAILABLE(_writebuf)) {
+    while (_write_fd != -1 && _initialized && !_open_error && _writebuf.available()) {
         // convince the IO timer that it really is OK to write out
         // less than _writebuf_chunk bytes:
         if (tnow > 2000001) { // avoid resetting _last_write_time to 0
@@ -1039,12 +999,11 @@ void DataFlash_File::flush(void)
 
 void DataFlash_File::_io_timer(void)
 {
-    uint16_t _tail;
-    if (_write_fd == -1 || !_initialised || _open_error) {
+    if (_write_fd == -1 || !_initialized || _open_error) {
         return;
     }
 
-    uint16_t nbytes = BUF_AVAILABLE(_writebuf);
+    uint32_t nbytes = _writebuf.available();
     if (nbytes == 0) {
         return;
     }
@@ -1063,13 +1022,12 @@ void DataFlash_File::_io_timer(void)
         // be kind to the FAT PX4 filesystem
         nbytes = _writebuf_chunk;
     }
-    if (_writebuf_head > _tail) {
-        // only write to the end of the buffer
-        nbytes = MIN(nbytes, _writebuf_size - _writebuf_head);
-    }
 
-    // try to align writes on a 512 byte boundary to avoid filesystem
-    // reads
+    uint32_t size;
+    const uint8_t *head = _writebuf.readptr(size);
+    nbytes = MIN(nbytes, size);
+
+    // try to align writes on a 512 byte boundary to avoid filesystem reads
     if ((nbytes + _write_offset) % 512 != 0) {
         uint32_t ofs = (nbytes + _write_offset) % 512;
         if (ofs < nbytes) {
@@ -1077,22 +1035,21 @@ void DataFlash_File::_io_timer(void)
         }
     }
 
-    assert(((uint32_t)_writebuf_head)+nbytes <= _writebuf_size);
-    ssize_t nwritten = ::write(_write_fd, &_writebuf[_writebuf_head], nbytes);
+    ssize_t nwritten = ::write(_write_fd, &head, nbytes);
     if (nwritten <= 0) {
         hal.util->perf_count(_perf_errors);
         close(_write_fd);
         _write_fd = -1;
-        _initialised = false;
+        _initialized = false;
     } else {
         _write_offset += nwritten;
+        _writebuf.advance(nwritten);
         /*
-          the best strategy for minimising corruption on microSD cards
+          the best strategy for minimizing corruption on microSD cards
           seems to be to write in 4k chunks and fsync the file on each
           chunk, ensuring the directory entry is updated after each
           write.
          */
-        BUF_ADVANCEHEAD(_writebuf, nwritten);
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL && CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_NONE && CONFIG_HAL_BOARD != HAL_BOARD_QURT
         ::fsync(_write_fd);
 #endif
@@ -1101,4 +1058,3 @@ void DataFlash_File::_io_timer(void)
 }
 
 #endif // HAL_OS_POSIX_IO
-

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -10,6 +10,7 @@
 
 #if HAL_OS_POSIX_IO
 
+#include <AP_HAL/utility/RingBuffer.h>
 #include "DataFlash_Backend.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_QURT
@@ -32,7 +33,7 @@ public:
                    DFMessageWriter_DFLogStart *,
                    const char *log_directory);
 
-    // initialisation
+    // initialization
     void Init() override;
     bool CardInserted(void);
 
@@ -73,7 +74,7 @@ private:
     uint16_t _read_fd_log_num;
     uint32_t _read_offset;
     uint32_t _write_offset;
-    volatile bool _initialised;
+    volatile bool _initialized;
     volatile bool _open_error;
     const char *_log_directory;
 
@@ -103,11 +104,8 @@ private:
     const float min_avail_space_percent = 10.0f;
 #endif
     // write buffer
-    uint8_t *_writebuf;
-    uint32_t _writebuf_size; // in bytes; may be == 65536, thus 32-bits
+    ByteBuffer _writebuf;
     const uint16_t _writebuf_chunk;
-    volatile uint16_t _writebuf_head;
-    volatile uint16_t _writebuf_tail;
     uint32_t _last_write_time;
 
     /* construct a file name given a log number. Caller must free. */
@@ -123,16 +121,16 @@ private:
     uint16_t critical_message_reserved_space() const {
         // possibly make this a proportional to buffer size?
         uint16_t ret = 1024;
-        if (ret > _writebuf_size) {
+        if (ret > _writebuf.get_size()) {
             // in this case you will only get critical messages
-            ret = _writebuf_size;
+            ret = _writebuf.get_size();
         }
         return ret;
     };
     uint16_t non_messagewriter_message_reserved_space() const {
         // possibly make this a proportional to buffer size?
         uint16_t ret = 1024;
-        if (ret >= _writebuf_size) {
+        if (ret >= _writebuf.get_size()) {
             // need to allow messages out from the messagewriters.  In
             // this case while you have a messagewriter you won't get
             // any other messages.  This should be a corner case!


### PR DESCRIPTION
Now all the code should be using ByteBuffer class instead of RingBuffer macros.