### PR TITLE
AP_Airspeed library standalone from APM:Plane

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -323,7 +323,7 @@ void Plane::one_second_loop()
     // make it possible to change orientation at runtime
     ahrs.set_orientation();
 
-    adsb.set_stall_speed_cm(aparm.airspeed_min);
+    adsb.set_stall_speed_cm(airspeed.get_airspeed_min());
 
     // sync MAVLink system ID
     mavlink_system.sysid = g.sysid_this_mav;
@@ -398,8 +398,8 @@ void Plane::airspeed_ratio_update(void)
         // don't calibrate when not moving
         return;        
     }
-    if (airspeed.get_airspeed() < aparm.airspeed_min && 
-        gps.ground_speed() < (uint32_t)aparm.airspeed_min) {
+    if (airspeed.get_airspeed() < airspeed.get_airspeed_min() &&
+        gps.ground_speed() < (uint32_t)airspeed.get_airspeed_min()) {
         // don't calibrate when flying below the minimum airspeed. We
         // check both airspeed and ground speed to catch cases where
         // the airspeed ratio is way too low, which could lead to it

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1388,7 +1388,7 @@ void Plane::update_load_factor(void)
         return;
     }
 
-    float max_load_factor = smoothed_airspeed / aparm.airspeed_min;
+    float max_load_factor = smoothed_airspeed / airspeed.get_airspeed_min();
     if (max_load_factor <= 1) {
         // our airspeed is below the minimum airspeed. Limit roll to
         // 25 degrees

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -476,24 +476,6 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     ASCALAR(stall_prevention, "STALL_PREVENTION",  1),
 
-    // @Param: ARSPD_FBW_MIN
-    // @DisplayName: Minimum Airspeed
-    // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
-    // @Units: m/s
-    // @Range: 5 100
-    // @Increment: 1
-    // @User: Standard
-    ASCALAR(airspeed_min, "ARSPD_FBW_MIN",  AIRSPEED_FBW_MIN),
-
-    // @Param: ARSPD_FBW_MAX
-    // @DisplayName: Maximum Airspeed
-    // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_FBW_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_FBW_MIN is recommended.
-    // @Units: m/s
-    // @Range: 5 100
-    // @Increment: 1
-    // @User: Standard
-    ASCALAR(airspeed_max, "ARSPD_FBW_MAX",  AIRSPEED_FBW_MAX),
-
     // @Param: FBWB_ELEV_REV
     // @DisplayName: Fly By Wire elevator reverse
     // @Description: Reverse sense of elevator in FBWB and CRUISE modes. When set to 0 up elevator (pulling back on the stick) means to lower altitude. When set to 1, up elevator means to raise altitude.
@@ -1423,6 +1405,9 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_serial0_baud,       0,      AP_PARAM_INT16, "SERIAL0_BAUD" },
     { Parameters::k_param_serial1_baud,       0,      AP_PARAM_INT16, "SERIAL1_BAUD" },
     { Parameters::k_param_serial2_baud,       0,      AP_PARAM_INT16, "SERIAL2_BAUD" },
+
+    { Parameters::k_param_airspeed_min,       0,      AP_PARAM_INT16, "ARSPD_FBW_MIN" },
+    { Parameters::k_param_airspeed_max,       0,      AP_PARAM_INT16, "ARSPD_FBW_MAX" },
 
     // these are needed to cope with the change to treat nested index 0 as index 63
     { Parameters::k_param_quadplane,          3,      AP_PARAM_FLOAT, "Q_RT_RLL_P" },

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -172,8 +172,8 @@ public:
 
         // 120: Fly-by-wire control
         //
-        k_param_airspeed_min = 120,
-        k_param_airspeed_max,
+        k_param_airspeed_min = 120,     // unused
+        k_param_airspeed_max,           // unused
         k_param_FBWB_min_altitude_cm,  // 0=disabled, minimum value for altitude in cm (for first time try 30 meters = 3000 cm)
         k_param_flybywire_elev_reverse,
         k_param_alt_control_algorithm,

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -394,7 +394,7 @@ private:
 #endif
 
     // Airspeed Sensors
-    AP_Airspeed airspeed {aparm};
+    AP_Airspeed airspeed;
 
     // ACRO controller state
     struct {

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -275,13 +275,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // FLY_BY_WIRE_B airspeed control
 //
-#ifndef AIRSPEED_FBW_MIN
- # define AIRSPEED_FBW_MIN               9
-#endif
-#ifndef AIRSPEED_FBW_MAX
- # define AIRSPEED_FBW_MAX               22
-#endif
-
 #ifndef ALT_HOLD_FBW
  # define ALT_HOLD_FBW 0
 #endif

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -24,7 +24,7 @@ void Plane::update_is_flying_5Hz(void)
                                     (gps.ground_speed_cm() >= ground_speed_thresh_cm);
 
     // airspeed at least 75% of stall speed?
-    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (aparm.airspeed_min*0.75f));
+    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (airspeed.get_airspeed_min()*0.75f));
 
 
     if (quadplane.is_flying()) {

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -92,10 +92,10 @@ void Plane::calc_airspeed_errors()
     // FBW_B airspeed target
     if (control_mode == FLY_BY_WIRE_B || 
         control_mode == CRUISE) {
-        target_airspeed_cm = ((int32_t)(aparm.airspeed_max -
-                                        aparm.airspeed_min) *
+        target_airspeed_cm = ((int32_t)(airspeed.get_airspeed_max() -
+                                        airspeed.get_airspeed_min()) *
                               channel_throttle->get_control_in()) +
-                             ((int32_t)aparm.airspeed_min * 100);
+                             ((int32_t)airspeed.get_airspeed_min() * 100);
     }
 
     // Landing airspeed target
@@ -138,8 +138,9 @@ void Plane::calc_airspeed_errors()
     }
 
     // Apply airspeed limit
-    if (target_airspeed_cm > (aparm.airspeed_max * 100))
-        target_airspeed_cm = (aparm.airspeed_max * 100);
+    if (target_airspeed_cm > ((int32_t)airspeed.get_airspeed_max() * 100)) {
+        target_airspeed_cm = ((int32_t)airspeed.get_airspeed_max() * 100);
+    }
 
     // use the TECS view of the target airspeed for reporting, to take
     // account of the landing speed

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -856,8 +856,8 @@ float QuadPlane::assist_climb_rate_cms(void)
 float QuadPlane::desired_auto_yaw_rate_cds(void)
 {
     float aspeed;
-    if (!ahrs.airspeed_estimate(&aspeed) || aspeed < plane.aparm.airspeed_min) {
-        aspeed = plane.aparm.airspeed_min;
+    if (!ahrs.airspeed_estimate(&aspeed) || aspeed < plane.airspeed.get_airspeed_min()) {
+        aspeed = plane.airspeed.get_airspeed_min();
     }
     if (aspeed < 1) {
         aspeed = 1;
@@ -925,7 +925,7 @@ void QuadPlane::update_transition(void)
             transition_start_ms = millis();
         }
 
-        if (have_airspeed && aspeed > plane.aparm.airspeed_min && !assisted_flight) {
+        if (have_airspeed && aspeed > plane.airspeed.get_airspeed_min() && !assisted_flight) {
             transition_start_ms = millis();
             transition_state = TRANSITION_TIMER;
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Transition airspeed reached %.1f", (double)aspeed);
@@ -1763,7 +1763,7 @@ int8_t QuadPlane::forward_throttle_pct(void)
     float fwd_vel_error = vel_error_body * Vector3f(1,0,0);
 
     // scale forward velocity error by maximum airspeed
-    fwd_vel_error /= MAX(plane.aparm.airspeed_max, 5);
+    fwd_vel_error /= MAX(plane.airspeed.get_airspeed_max(), 5.0f);
 
     // add in a component from our current pitch demand. This tends to
     // move us to zero pitch. Assume that LIM_PITCH would give us the

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -216,7 +216,7 @@ void Plane::read_radio()
     if (g.throttle_nudge && channel_throttle->get_servo_out() > 50 && geofence_stickmixing()) {
         float nudge = (channel_throttle->get_servo_out() - 50) * 0.02f;
         if (ahrs.airspeed_sensor_enabled()) {
-            airspeed_nudge_cm = (aparm.airspeed_max * 100 - g.airspeed_cruise_cm) * nudge;
+            airspeed_nudge_cm = ((int16_t)airspeed.get_airspeed_max()*100 - g.airspeed_cruise_cm) * nudge;
         } else {
             throttle_nudge = (aparm.throttle_max - aparm.throttle_cruise) * nudge;
         }

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -70,7 +70,7 @@ public:
     AP_AHRS_NavEKF ahrs {ins, barometer, gps, rng, EKF, EKF2};
     AP_InertialNav_NavEKF inertial_nav{ahrs};
     AP_Vehicle::FixedWing aparm;
-    AP_Airspeed airspeed{aparm};
+    AP_Airspeed airspeed;
     DataFlash_Class dataflash{"Replay v0.1"};
 
 private:

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -152,7 +152,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
         }
         float ki_rate = k_I * gains.tau;
 		//only integrate if gain and time step are positive and airspeed above min value.
-		if (dt > 0 && aspeed > 0.5f*float(aparm.airspeed_min)) {
+		if (dt > 0 && aspeed > 0.5f*airspeed.get_airspeed_min()) {
 		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
 			if (_last_out < -45) {
 				// prevent the integrator from increasing if surface defln demand is above the upper limit
@@ -189,7 +189,7 @@ int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool
 	_last_out = _pid_info.D + _pid_info.FF + _pid_info.P;
     _pid_info.desired = desired_rate;
 
-    if (autotune.running && aspeed > aparm.airspeed_min) {
+    if (autotune.running && aspeed > airspeed.get_airspeed_min()) {
         // let autotune have a go at the values 
         // Note that we don't pass the integrator component so we get
         // a better idea of how much the base PD controller
@@ -241,7 +241,7 @@ int32_t AP_PitchController::get_rate_out(float desired_rate, float scaler)
     float aspeed;
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(airspeed.get_airspeed_min() + airspeed.get_airspeed_max());
 	}
     return _get_rate_out(desired_rate, scaler, false, aspeed);
 }
@@ -272,13 +272,13 @@ float AP_PitchController::_get_coordination_rate_offset(float &aspeed, bool &inv
 	}
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(airspeed.get_airspeed_min() + airspeed.get_airspeed_max());
 	}
     if (abs(_ahrs.pitch_sensor) > 7000) {
         // don't do turn coordination handling when at very high pitch angles
         rate_offset = 0;
     } else {
-        rate_offset = cosf(_ahrs.pitch)*fabsf(ToDeg((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()) , float(aparm.airspeed_min))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
+        rate_offset = cosf(_ahrs.pitch)*fabsf(ToDeg((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()) , airspeed.get_airspeed_min())) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
     }
 	if (inverted) {
 		rate_offset = -rate_offset;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -37,6 +37,7 @@ public:
     
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;
 	AP_Int16 _max_rate_neg;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -133,7 +133,7 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 	// Don't integrate if in stabilise mode as the integrator will wind up against the pilots inputs
 	if (!disable_integrator && ki_rate > 0) {
 		//only integrate if gain and time step are positive and airspeed above min value.
-		if (dt > 0 && aspeed > float(aparm.airspeed_min)) {
+		if (dt > 0 && aspeed > airspeed.get_airspeed_min()) {
 		    float integrator_delta = rate_error * ki_rate * delta_time * scaler;
 			// prevent the integrator from increasing if surface defln demand is above the upper limit
 			if (_last_out < -45) {
@@ -165,7 +165,7 @@ int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool 
 
 	_last_out = _pid_info.FF + _pid_info.P + _pid_info.D;
 
-    if (autotune.running && aspeed > aparm.airspeed_min) {
+    if (autotune.running && aspeed > airspeed.get_airspeed_min()) {
         // let autotune have a go at the values 
         // Note that we don't pass the integrator component so we get
         // a better idea of how much the base PD controller

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -44,6 +44,7 @@ public:
     
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;
 	uint32_t _last_t;

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -79,11 +79,7 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 	}
 	_last_t = tnow;
 	
-
-    int16_t aspd_min = aparm.airspeed_min;
-    if (aspd_min < 1) {
-        aspd_min = 1;
-    }
+    float aspd_min = MAX(airspeed.get_airspeed_min(),1.0f);
 	
 	float delta_time = (float) dt / 1000.0f;
 	
@@ -97,9 +93,9 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 	}
 	if (!_ahrs.airspeed_estimate(&aspeed)) {
 	    // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aspd_min) + float(aparm.airspeed_max));
+        aspeed = 0.5f*(aspd_min + airspeed.get_airspeed_max());
 	}
-    rate_offset = (GRAVITY_MSS / MAX(aspeed , float(aspd_min))) * tanf(bank_angle) * cosf(bank_angle) * _K_FF;
+    rate_offset = (GRAVITY_MSS / MAX(aspeed , aspd_min)) * tanf(bank_angle) * cosf(bank_angle) * _K_FF;
 
     // Get body rate vector (radians/sec)
 	float omega_z = _ahrs.get_gyro().z;
@@ -127,7 +123,7 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 	// Don't integrate if _K_D is zero as integrator will keep winding up
 	if (!disable_integrator && _K_D > 0) {
 		//only integrate if airspeed above min value
-		if (aspeed > float(aspd_min))
+		if (aspeed > aspd_min)
 		{
 			// prevent the integrator from increasing if surface defln demand is above the upper limit
 			if (_last_out < -45) {

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -29,6 +29,7 @@ public:
 
 private:
 	const AP_Vehicle::FixedWing &aparm;
+	AP_Airspeed airspeed;
 	AP_Float _K_A;
 	AP_Float _K_I;
 	AP_Float _K_D;

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -132,17 +132,37 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Description: This parameter allows you to to set the PSI (pounds per square inch) range for your sensor. You should not change this unless you examine the datasheet for your device
     // @User: Advanced
     AP_GROUPINFO("PSI_RANGE",  8, AP_Airspeed, _psi_range, PSI_RANGE_DEFAULT),
-    
+
+    // @Param: ARSPD_FBW_MIN
+    // @DisplayName: Minimum Airspeed
+    // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
+    // @Units: m/s
+    // @Range: 5 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("FBW_MIN", 9, AP_Airspeed, _airspeed_min, 9),
+
+    // @Param: ARSPD_FBW_MAX
+    // @DisplayName: Maximum Airspeed
+    // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_MIN is recommended.
+    // @Units: m/s
+    // @Range: 5 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("FBW_MAX", 10, AP_Airspeed, _airspeed_max, 22),
+
     AP_GROUPEND
 };
 
 
-AP_Airspeed::AP_Airspeed(const AP_Vehicle::FixedWing &parms)
+AP_Airspeed::AP_Airspeed()
     : _EAS2TAS(1.0f)
-    , _calibration(parms)
+    , _calibration()
+    , analog(_pin, _psi_range)
+    , digital(_psi_range)
 {
     AP_Param::setup_object_defaults(this, var_info);
-}
+};
 
 
 /*

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -16,7 +16,7 @@ class Airspeed_Calibration {
 public:
     friend class AP_Airspeed;
     // constructor
-    Airspeed_Calibration(const AP_Vehicle::FixedWing &parms);
+    Airspeed_Calibration(void);
 
     // initialise the calibration
     void init(float initial_ratio);
@@ -32,14 +32,13 @@ private:
     const float Q1; // process noise matrix bottom right element
     Vector3f state; // state vector
     const float DT; // time delta
-    const AP_Vehicle::FixedWing &aparm;
 };
 
 class AP_Airspeed
 {
 public:
     // constructor
-    AP_Airspeed(const AP_Vehicle::FixedWing &parms);
+    AP_Airspeed();
 
     void init(void);
 
@@ -124,6 +123,16 @@ public:
         return _EAS2TAS;
     }
 
+    // get the min set airspeed
+    float get_airspeed_min(void) const {
+        return (float)(_airspeed_min);
+    }
+
+    // get the max set airspeed
+    float get_airspeed_max(void) const {
+        return (float)(_airspeed_max);
+    }
+
     // update airspeed ratio calibration
     void update_calibration(const Vector3f &vground);
 
@@ -156,6 +165,8 @@ private:
     AP_Int8         _autocal;
     AP_Int8         _tube_order;
     AP_Int8         _skip_cal;
+    AP_Int16        _airspeed_min;
+    AP_Int16        _airspeed_max;
     float           _raw_airspeed;
     float           _airspeed;
     float			_last_pressure;

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -25,11 +25,9 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_Vehicle::FixedWing aparm;
-
 float temperature;
 
-AP_Airspeed airspeed(aparm);
+AP_Airspeed airspeed;
 
 void setup()
 {

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -340,8 +340,8 @@ void AP_TECS::_update_speed(float load_factor)
 
     float EAS2TAS = _ahrs.get_EAS2TAS();
     _TAS_dem = _EAS_dem * EAS2TAS;
-    _TASmax   = aparm.airspeed_max * EAS2TAS;
-    _TASmin   = aparm.airspeed_min * EAS2TAS;
+    _TASmax   = airspeed.get_airspeed_max() * EAS2TAS;
+    _TASmin   = airspeed.get_airspeed_min() * EAS2TAS;
 
     if (aparm.stall_prevention) {
         // when stall prevention is active we raise the mimimum
@@ -368,7 +368,7 @@ void AP_TECS::_update_speed(float load_factor)
     // airspeed is not being used and set speed rate to zero
     if (!_ahrs.airspeed_sensor_enabled() || !_ahrs.airspeed_estimate(&_EAS)) {
         // If no airspeed available use average of min and max
-        _EAS = 0.5f * (aparm.airspeed_min.get() + (float)aparm.airspeed_max.get());
+        _EAS = 0.5f * (airspeed.get_airspeed_min() + airspeed.get_airspeed_max());
     }
 
     // Implement a second order complementary filter to obtain a

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -121,6 +121,7 @@ private:
     AP_AHRS &_ahrs;
 
     const AP_Vehicle::FixedWing &aparm;
+    AP_Airspeed airspeed;
 
     // TECS tuning parameters
     AP_Float _hgtCompFiltOmega;

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -33,8 +33,6 @@ public:
         AP_Int8 throttle_slewrate;
         AP_Int8 throttle_cruise;
         AP_Int8 takeoff_throttle_max;
-        AP_Int16 airspeed_min;
-        AP_Int16 airspeed_max;
         AP_Int16 roll_limit_cd;
         AP_Int16 pitch_limit_max_cd;
         AP_Int16 pitch_limit_min_cd;        


### PR DESCRIPTION
An updated version of #4229, fixing a couple of things that failed the test.

This series of commits makes the AP_Airspeed library standalone from the APM:Plane library. Currently the airspeed sensor can't be used on Copter (even for logging purposes) due to the reliance on airspeed_min and airspeed_max which are part of AP_Vehicle::Plane. This moves airspeed_min and airspeed_max to the AP_Airspeed library and updates all the references.

Additional notes
- airspeed_min and airspeed_max are now accessed through get_airspeed_min() and get_airspeed_max() (were previously accessed via globals).
- Although it was previously discussed about renaming ARSPD_FBW_MIN and ARSPD_FBW_MAX to ARSPD_MIN and ARSPD_MAX, I have reverted to the old names of ARSPD_FBW_MIN and ARSPD_FBW_MAX.  Changing the names breaks the autotest functions (loading parameters from a file).  If desired, I can make the changes requried so that things don't break in autotest, but I figured I'd leave that up for discussion.  Changing the names may also confuse users, and given the fundamental use of the parameters hasn't changed, I thought it better to keep with the old.
- ARSPD_FBW_MIN and ARSPD_FBW_MAX are kept as AP_Int16, however the function calls get_airspeed_min() and get_airspeed_max() return floats.  This is to facilitate an easier transition in the future if it is desired to change the parameters to floats.  I don't think it's really necessary to define ARSPD_FBW_MIN and ARSPD_FBW_MAX as floats - the aircraft can't hold airspeed to that degree of prescision accurately enough to justify needing decimal points to bound the flight envelope.


