### PR TITLE
waf: shared objects

### DIFF
--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -21,7 +21,6 @@ def build(bld):
             'AP_ServoRelayEvents',
             'PID',
         ],
-        use='mavlink',
     )
 
     bld.ap_program(

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -9,7 +9,6 @@ def build(bld):
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AC_PID',
         ],
-        use='mavlink',
     )
 
     bld.ap_program(

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -30,7 +30,6 @@ def build(bld):
             'AP_ServoRelayEvents',
             'AP_Avoidance',
         ],
-        use='mavlink',
     )
 
     frames = (

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -31,7 +31,6 @@ def build(bld):
             'AC_Fence',
             'AC_Avoidance'
         ],
-        use='mavlink',
     )
 
     bld.ap_program(

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -15,7 +15,6 @@ def build(bld):
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_InertialNav',
         ],
-        use='mavlink',
     )
 
     bld.ap_program(

--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Waf tool for Ardupilot libraries. The function bld.ap_library() creates the
+necessary task generators for creating the objects of a library for a vehicle.
+That includes the common objects, which are shared among vehicles. That
+function is used by bld.ap_stlib() and shouldn't need to be called otherwise.
+
+The environment variable AP_LIBRARIES_OBJECTS_KW is a dictionary of keyword
+arguments to be passed to bld.objects() when during the creation of the task
+generators. You can use it to pass extra arguments to that function (although
+some of them will be rewritten, see the implementation for details).
+
+This tool also provides a feature to check if the headers used by the source
+files don't use vehicle-related headers. The task generators for performing the
+checks are created with bld.ap_library_check_headers(). They should be created
+in a build group that is processed after the compilation tasks, because they
+use the result of Waf's C preprocessor to know what headers should be checked.
+The results can be reported to the user by calling
+bld.ap_library_check_summary() to add the post build callback.
+"""
+import re
+
+from waflib import Errors, Logs, Task, Utils
+from waflib.Configure import conf
+from waflib.TaskGen import before_method, feature
+from waflib.Tools import c_preproc
+
+import ardupilotwaf as ap
+
+UTILITY_SOURCE_EXTS = ['utility/' + glob for glob in ap.SOURCE_EXTS]
+
+def _common_tgen_name(library):
+    return 'objs/%s' % library
+
+def _vehicle_tgen_name(library, vehicle):
+    return 'objs/%s/%s' % (library, vehicle)
+
+_vehicle_indexes = {}
+def _vehicle_index(vehicle):
+    """ Used for the objects taskgens idx parameter """
+    if vehicle not in _vehicle_indexes:
+        _vehicle_indexes[vehicle] = len(_vehicle_indexes) + 1
+    return _vehicle_indexes[vehicle]
+
+_vehicle_macros = ('SKETCHNAME', 'SKETCH', 'APM_BUILD_DIRECTORY',
+                   'APM_BUILD_TYPE')
+_macros_re = re.compile(r'\b(%s)\b' % '|'.join(_vehicle_macros))
+
+def _remove_comments(s):
+    return c_preproc.re_cpp.sub(c_preproc.repl, s)
+
+_depends_on_vehicle_cache = {}
+def _depends_on_vehicle(bld, source_node):
+    path = source_node.srcpath()
+
+    if path not in _depends_on_vehicle_cache:
+        s = _remove_comments(source_node.read())
+        _depends_on_vehicle_cache[path] = _macros_re.search(s) is not None
+
+    return _depends_on_vehicle_cache[path]
+
+@conf
+def ap_library(bld, library, vehicle):
+    try:
+        common_tg = bld.get_tgen_by_name(_common_tgen_name(library))
+    except Errors.WafError:
+        common_tg = None
+
+    try:
+        vehicle_tg = bld.get_tgen_by_name(_vehicle_tgen_name(library, vehicle))
+    except Errors.WafError:
+        vehicle_tg = None
+
+    if common_tg and vehicle_tg:
+        return
+
+    library_dir = bld.srcnode.find_dir('libraries/%s' % library)
+    if not library_dir:
+        bld.fatal('ap_library: %s not found' % library)
+
+    src = library_dir.ant_glob(ap.SOURCE_EXTS + UTILITY_SOURCE_EXTS)
+
+    if not common_tg:
+        kw = dict(bld.env.AP_LIBRARIES_OBJECTS_KW)
+        kw['features'] = kw.get('features', []) + ['ap_library_object']
+        kw.update(
+            name=_common_tgen_name(library),
+            source=[s for s in src if not _depends_on_vehicle(bld, s)],
+            idx=0,
+        )
+        bld.objects(**kw)
+
+    if not vehicle_tg:
+        source = [s for s in src if _depends_on_vehicle(bld, s)]
+
+        if not source:
+            return
+
+        kw = dict(bld.env.AP_LIBRARIES_OBJECTS_KW)
+        kw['features'] = kw.get('features', []) + ['ap_library_object']
+        kw.update(
+            name=_vehicle_tgen_name(library, vehicle),
+            source=source,
+            defines=ap.get_legacy_defines(vehicle),
+            idx=_vehicle_index(vehicle),
+        )
+        bld.objects(**kw)
+
+@before_method('process_use')
+@feature('cxxstlib')
+def process_ap_libraries(self):
+    self.use = Utils.to_list(getattr(self, 'use', []))
+    libraries = Utils.to_list(getattr(self, 'ap_libraries', []))
+    vehicle = getattr(self, 'ap_vehicle', None)
+
+    for l in libraries:
+        self.use.append(_common_tgen_name(l))
+        if vehicle:
+            self.use.append(_vehicle_tgen_name(l, vehicle))
+
+class ap_library_check_header(Task.Task):
+    color = 'PINK'
+    tasks = []
+
+    def run(self):
+        self.tasks.append(self)
+        n = self.inputs[0]
+        s = _remove_comments(n.read())
+        self.guilty = _macros_re.search(s) is not None
+
+    def post_run(self):
+        super(ap_library_check_header, self).post_run()
+        if self.guilty:
+            self.generator.bld.task_sigs[self.uid()] = None
+
+    def keyword(self):
+        return 'Checking header'
+
+_object_tgens = []
+@feature('ap_library_object')
+def ap_library_register_for_check(self):
+    _object_tgens.append(self)
+
+_headers_exceptions = (
+    'libraries/AP_Vehicle/AP_Vehicle_Type.h',
+)
+_headers = set()
+@feature('ap_library_check_headers')
+def ap_library_process_headers(self):
+    for o in _object_tgens:
+        if not hasattr(o, 'compiled_tasks'):
+            continue
+
+        for t in o.compiled_tasks:
+            for n in self.bld.node_deps[t.uid()]:
+                if not n.is_src():
+                    continue
+                if n.srcpath() in _headers_exceptions:
+                    continue
+                if n in _headers:
+                    continue
+                _headers.add(n)
+                self.create_task('ap_library_check_header', n)
+
+@conf
+def ap_library_check_headers(bld, name):
+    return bld(name=name, features='ap_library_check_headers')
+
+def _check_summary(bld):
+    if not ap_library_check_header.tasks:
+        return
+
+    guilty = [t.inputs[0].srcpath() for t in ap_library_check_header.tasks if t.guilty]
+    if guilty:
+        Logs.warn('ap_libraries: the following headers use vehicle-dependent macros:')
+        for path in guilty:
+            Logs.warn('    %s' % path)
+        bld.fatal('ap_libraries: there are headers using vehicle-dependent macros')
+    else:
+        Logs.info('ap_libraries: all headers okay')
+
+@conf
+def ap_library_check_summary(bld):
+    bld.add_post_fun(_check_summary)
+
+def configure(cfg):
+    cfg.env.AP_LIBRARIES_OBJECTS_KW = dict()

--- a/Tools/ardupilotwaf/ap_persistent.py
+++ b/Tools/ardupilotwaf/ap_persistent.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2016  Intel Corporation. All rights reserved.
+#
+# This file is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Module that changes Waf to keep persistent information across clean operations
+in for performance improvement.
+"""
+from waflib import Build, Task
+
+Build.SAVED_ATTRS.append('ap_persistent_task_sigs')
+Build.SAVED_ATTRS.append('ap_persistent_imp_sigs')
+Build.SAVED_ATTRS.append('ap_persistent_node_deps')
+
+_original_signature = Task.Task.signature
+
+_original_sig_implicit_deps = Task.Task.sig_implicit_deps
+if hasattr(_original_sig_implicit_deps, '__func__'):
+    _original_sig_implicit_deps = _original_sig_implicit_deps.__func__
+
+def _signature(self):
+    s = _original_signature(self)
+    real_fn = self.sig_implicit_deps.__func__
+    if not self.scan or _original_sig_implicit_deps != real_fn:
+        return s
+    bld = self.generator.bld
+    bld.ap_persistent_imp_sigs[self.uid()] = bld.imp_sigs[self.uid()]
+    bld.ap_persistent_node_deps[self.uid()] = bld.node_deps[self.uid()]
+    return s
+Task.Task.signature = _signature
+
+class CleanContext(Build.CleanContext):
+    def clean(self):
+        if not self.options.clean_all_sigs:
+            saved_task_sigs = dict(self.ap_persistent_task_sigs)
+            saved_imp_sigs = dict(self.ap_persistent_imp_sigs)
+            saved_node_deps = dict(self.ap_persistent_node_deps)
+
+        super(CleanContext, self).clean()
+
+        if not self.options.clean_all_sigs:
+            self.task_sigs.update(saved_task_sigs)
+            self.ap_persistent_task_sigs.update(saved_task_sigs)
+
+            self.imp_sigs.update(saved_imp_sigs)
+            self.ap_persistent_imp_sigs.update(saved_imp_sigs)
+
+            self.node_deps.update(saved_node_deps)
+            self.ap_persistent_node_deps.update(saved_node_deps)

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -2,8 +2,7 @@
 # encoding: utf-8
 
 from __future__ import print_function
-from waflib import Logs, Options, Utils
-from waflib.Build import BuildContext
+from waflib import Build, Logs, Options, Utils
 from waflib.Configure import conf
 from waflib.TaskGen import before_method, feature
 import os.path, os
@@ -317,7 +316,7 @@ def build_command(name,
         program_group_list=program_group_list,
     )
 
-    class context_class(BuildContext):
+    class context_class(Build.BuildContext):
         cmd = name
     context_class.__doc__ = doc
 
@@ -377,7 +376,17 @@ my board".
         action='store_true',
         help='Output all test programs.')
 
-
 def build(bld):
     bld.add_pre_fun(_process_build_command)
     bld.add_pre_fun(_select_programs_from_group)
+
+class CleanContext(Build.CleanContext):
+    Build.SAVED_ATTRS.append('ap_persistent_task_sigs')
+
+    def clean(self):
+        saved_sigs = dict(self.ap_persistent_task_sigs)
+
+        super(CleanContext, self).clean()
+
+        self.task_sigs.update(saved_sigs)
+        self.ap_persistent_task_sigs.update(saved_sigs)

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -346,6 +346,12 @@ def _select_programs_from_group(bld):
             bld.targets += ',' + tg.name
 
 def options(opt):
+    opt.ap_groups = {
+        'configure': opt.add_option_group('Ardupilot configure options'),
+        'build': opt.add_option_group('Ardupilot build options'),
+        'check': opt.add_option_group('Ardupilot check options'),
+    }
+
     g = opt.ap_groups['build']
 
     g.add_option('--program-group',

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -17,7 +17,7 @@ def _load_dynamic_env_data(bld):
     for name in ('cxx_flags', 'include_dirs', 'definitions'):
         _dynamic_env_data[name] = bldnode.find_node(name).read().split(';')
 
-@feature('px4_ap_stlib', 'px4_ap_program')
+@feature('px4_ap_library', 'px4_ap_program')
 @before_method('process_source')
 def px4_dynamic_env(self):
     # The generated files from configuration possibly don't exist if it's just
@@ -216,7 +216,9 @@ def configure(cfg):
     env = cfg.env
 
     env.AP_PROGRAM_FEATURES += ['px4_ap_program']
-    env.AP_STLIB_FEATURES += ['px4_ap_stlib']
+
+    kw = env.AP_LIBRARIES_OBJECTS_KW
+    kw['features'] = Utils.to_list(kw.get('features', [])) + ['px4_ap_library']
 
     def srcpath(path):
         return cfg.srcnode.make_node(path).abspath()

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -5,7 +5,7 @@
 Waf tool for PX4 build
 """
 
-from waflib import Logs, Task, Utils
+from waflib import Errors, Logs, Task, Utils
 from waflib.TaskGen import after_method, before_method, feature
 
 import os

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -123,6 +123,7 @@ def px4_firmware(self):
         'px4',
         'build_firmware_px4fmu-v%s' % version,
     )
+    fw_task.set_run_after(self.link_task)
 
     # we need to synchronize in order to avoid the output expected by the
     # previous ap_program being overwritten before used

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -39,7 +39,7 @@ def px4_dynamic_env(self):
 @after_method('apply_link')
 @before_method('process_use')
 def px4_import_objects_from_use(self):
-    queue = Utils.to_list(getattr(self, 'use', []))
+    queue = list(Utils.to_list(getattr(self, 'use', [])))
     names = set()
 
     while queue:

--- a/wscript
+++ b/wscript
@@ -47,13 +47,6 @@ def init(ctx):
 
 def options(opt):
     opt.load('compiler_cxx compiler_c waf_unit_test python')
-
-    opt.ap_groups = {
-        'configure': opt.add_option_group('Ardupilot configure options'),
-        'build': opt.add_option_group('Ardupilot build options'),
-        'check': opt.add_option_group('Ardupilot check options'),
-    }
-
     opt.load('ardupilotwaf')
     opt.load('build_summary')
 

--- a/wscript
+++ b/wscript
@@ -152,6 +152,8 @@ def configure(cfg):
         cfg.msg('Using static linking', 'yes', color='YELLOW')
         cfg.env.STATIC_LINKING = True
 
+    cfg.load('ap_library')
+
     cfg.msg('Setting board to', cfg.options.board)
     cfg.get_board().configure(cfg)
 
@@ -276,7 +278,6 @@ def _build_common_taskgens(bld):
         name='ap',
         ap_vehicle='UNKNOWN',
         ap_libraries=bld.ap_get_all_libraries(),
-        use='mavlink',
     )
 
     if bld.env.HAS_GTEST:
@@ -347,6 +348,11 @@ def build(bld):
     bld.post_mode = Build.POST_LAZY
 
     bld.load('ardupilotwaf')
+
+    bld.env.AP_LIBRARIES_OBJECTS_KW.update(
+        use='mavlink',
+        cxxflags=['-include', 'ap_config.h'],
+    )
 
     _build_cmd_tweaks(bld)
 


### PR DESCRIPTION
Hi all,

This PR adds a new Waf tool to handle Ardupilot libraries object files generation, so that non-vehicle-dependent sources don't get compiled multiple times unnecessarily.

This is a followup of #4544. Thanks for everyone's feedback!

Best regards,
Gustavo Sousa