### PR TITLE
Copter: Throw mode's NextMode and Drop feature

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -122,7 +122,7 @@ void Copter::update_using_interlock()
 #else
     // check if we are using motor interlock control on an aux switch or are in throw mode
     // which uses the interlock to stop motors while the copter is being thrown
-    ap.using_interlock = check_if_auxsw_mode_used(AUXSW_MOTOR_INTERLOCK) || (control_mode == THROW);
+    ap.using_interlock = check_if_auxsw_mode_used(AUXSW_MOTOR_INTERLOCK);
 #endif
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -277,7 +277,8 @@ private:
     // throw mode state
     struct {
         ThrowModeStage stage;
-    } throw_state = {Throw_Disarmed};
+        bool nextmode_attempted;
+    } throw_state = {Throw_Disarmed, false};
 
     uint32_t precland_last_update_ms;
 
@@ -850,6 +851,7 @@ private:
     bool throw_detected();
     bool throw_attitude_good();
     bool throw_height_good();
+    bool throw_position_good();
 
     bool rtl_init(bool ignore_checks);
     void rtl_restart_without_terrain();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -277,8 +277,10 @@ private:
     // throw mode state
     struct {
         ThrowModeStage stage;
+        ThrowModeStage prev_stage;
+        uint32_t last_log_ms;
         bool nextmode_attempted;
-    } throw_state = {Throw_Disarmed, false};
+    } throw_state = {Throw_Disarmed, Throw_Disarmed, 0, false};
 
     uint32_t precland_last_update_ms;
 
@@ -705,6 +707,7 @@ private:
 #endif
     void Log_Write_Precland();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_Throw(ThrowModeStage stage, float velocity, float velocity_z, float accel, float ef_accel_z, bool throw_detect, bool attitude_ok, bool height_ok, bool position_ok);
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void start_logging() ;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -274,6 +274,11 @@ private:
         uint32_t start_ms;
     } takeoff_state;
 
+    // throw mode state
+    struct {
+        ThrowModeStage stage;
+    } throw_state = {Throw_Disarmed};
+
     uint32_t precland_last_update_ms;
 
     // altitude below which we do no navigation in auto takeoff

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -274,14 +274,6 @@ private:
         uint32_t start_ms;
     } takeoff_state;
 
-    // throw mode state
-    struct {
-        ThrowModeStage stage;
-        ThrowModeStage prev_stage;
-        uint32_t last_log_ms;
-        bool nextmode_attempted;
-    } throw_state = {Throw_Disarmed, Throw_Disarmed, 0, false};
-
     uint32_t precland_last_update_ms;
 
     // altitude below which we do no navigation in auto takeoff
@@ -410,9 +402,15 @@ private:
     // Flip
     Vector3f flip_orig_attitude;         // original copter attitude before flip
 
-    // Throw
-    uint32_t throw_free_fall_start_ms = 0;  // system time free fall was detected
-    float throw_free_fall_start_velz = 0.0f;// vertical velocity when free fall was detected
+    // throw mode state
+    struct {
+        ThrowModeStage stage;
+        ThrowModeStage prev_stage;
+        uint32_t last_log_ms;
+        bool nextmode_attempted;
+        uint32_t free_fall_start_ms;    // system time free fall was detected
+        float free_fall_start_velz;     // vertical velocity when free fall was detected
+    } throw_state = {Throw_Disarmed, Throw_Disarmed, 0, false, 0, 0.0f};
 
     // Battery Sensors
     AP_BattMonitor battery;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -411,8 +411,6 @@ private:
     Vector3f flip_orig_attitude;         // original copter attitude before flip
 
     // Throw
-    bool throw_early_exit_interlock = true; // value of the throttle interlock that must be restored when exiting throw mode early
-    bool throw_flight_commenced = false;    // true when the throw has been detected and the motors and control loops are running
     uint32_t throw_free_fall_start_ms = 0;  // system time free fall was detected
     float throw_free_fall_start_velz = 0.0f;// vertical velocity when free fall was detected
 
@@ -849,7 +847,6 @@ private:
 
     // Throw to launch functionality
     bool throw_init(bool ignore_checks);
-    void throw_exit();
     void throw_run();
     bool throw_detected();
     bool throw_attitude_good();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -714,6 +714,40 @@ void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_tar
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
+// precision landing logging
+struct PACKED log_Throw {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t stage;
+    float velocity;
+    float velocity_z;
+    float accel;
+    float ef_accel_z;
+    uint8_t throw_detect;
+    uint8_t attitude_ok;
+    uint8_t height_ok;
+    uint8_t pos_ok;
+};
+
+// Write a Throw mode details
+void Copter::Log_Write_Throw(ThrowModeStage stage, float velocity, float velocity_z, float accel, float ef_accel_z, bool throw_detect, bool attitude_ok, bool height_ok, bool pos_ok)
+{
+    struct log_Throw pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_THROW_MSG),
+        time_us         : AP_HAL::micros64(),
+        stage           : (uint8_t)stage,
+        velocity        : velocity,
+        velocity_z      : velocity_z,
+        accel           : accel,
+        ef_accel_z      : ef_accel_z,
+        throw_detect    : throw_detect,
+        attitude_ok     : attitude_ok,
+        height_ok       : height_ok,
+        pos_ok          : pos_ok
+    };
+    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
 const struct LogStructure Copter::log_structure[] = {
     LOG_COMMON_STRUCTURES,
 #if AUTOTUNE_ENABLED == ENABLED
@@ -754,6 +788,8 @@ const struct LogStructure Copter::log_structure[] = {
       "PL",    "QBffffff",    "TimeUS,Heal,bX,bY,eX,eY,pX,pY" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
+    { LOG_THROW_MSG, sizeof(log_Throw),
+      "THRO",  "QBffffbbbb",  "TimeUS,Stage,Vel,VelZ,Acc,AccEfZ,Throw,AttOk,HgtOk,PosOk" },
 };
 
 #if CLI_ENABLED == ENABLED

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -981,6 +981,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("THROW_NEXTMODE", 3, ParametersG2, throw_nextmode, 18),
 
+    // @Param: THROW_TYPE
+    // @DisplayName: Type of Type
+    // @Description: Used by THROW mode. Specifies whether Copter is thrown upward or dropped.
+    // @Values: 0:Upward Throw,1:Drop
+    // @User: Standard
+    AP_GROUPINFO("THROW_TYPE", 4, ParametersG2, throw_type, ThrowType_Upward),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -973,7 +973,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Group: BTN_
     // @Path: ../libraries/AP_Button/AP_Button.cpp
     AP_SUBGROUPINFO(button, "BTN_", 2, ParametersG2, AP_Button),
-    
+
+    // @Param: THROW_NEXTMODE
+    // @DisplayName: Throw mode's follow up mode
+    // @Description: Vehicle will switch to this mode after the throw is successfully completed.  Default is to stay in throw mode (18)
+    // @Values: 3:Auto,4:Guided,6:RTL,9:Land,17:Brake,18:Throw
+    // @User: Standard
+    AP_GROUPINFO("THROW_NEXTMODE", 3, ParametersG2, throw_nextmode, 18),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -550,6 +550,9 @@ public:
 
     // button checking
     AP_Button button;
+
+    // Throw mode state
+    AP_Int8 throw_nextmode;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -551,8 +551,9 @@ public:
     // button checking
     AP_Button button;
 
-    // Throw mode state
+    // Throw mode parameters
     AP_Int8 throw_nextmode;
+    AP_Int8 throw_type;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -51,7 +51,8 @@ bool Copter::pre_arm_checks(bool display_failure)
     // if it is, switch needs to be in disabled position to arm
     // otherwise exit immediately.  This check to be repeated,
     // as state can change at any time.
-    if (ap.using_interlock && motors.get_interlock()){
+    // skip check in Throw mode which takes control of the motor interlock
+    if (ap.using_interlock && motors.get_interlock()) {
         if (display_failure) {
             gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Motor Interlock Enabled");
         }
@@ -610,7 +611,8 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     }
 
     // if we are using motor interlock switch and it's enabled, fail to arm
-    if (ap.using_interlock && motors.get_interlock()){
+    // skip check in Throw mode which takes control of the motor interlock
+    if (ap.using_interlock && motors.get_interlock()) {
         gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Interlock Enabled");
         return false;
     }

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -600,6 +600,16 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// Throw mode configuration
+//
+#ifndef THROW_HIGH_SPEED
+# define THROW_HIGH_SPEED       500.0f  // vehicle much reach this total 3D speed in cm/s (or be free falling)
+#endif
+#ifndef THROW_VERTICAL_SPEED
+# define THROW_VERTICAL_SPEED   50.0f   // motors start when vehicle reaches this total 3D speed in cm/s
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Dataflash logging control
 //
 #ifndef LOGGING_ENABLED

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -218,7 +218,7 @@ bool Copter::throw_detected()
     // Check if the accel length is < 1.0g indicating that any throw action is complete and the copter has been released
     bool no_throw_action = ins.get_accel().length() < 1.0f * GRAVITY_MSS;
 
-    // High velocity or free-fall combined with incresing height indicate a possible air-drop or throw release
+    // High velocity or free-fall combined with increasing height indicate a possible air-drop or throw release
     bool possible_throw_detected = (free_falling || high_speed) && changing_height && no_throw_action;
 
     // Record time and vertical velocity when we detect the possible throw

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -17,6 +17,7 @@ bool Copter::throw_init(bool ignore_checks)
     }
 
     // init state
+    throw_state.stage = Throw_Disarmed;
     throw_state.nextmode_attempted = false;
 
     return true;

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -234,13 +234,13 @@ bool Copter::throw_detected()
     bool possible_throw_detected = (free_falling || high_speed) && changing_height && no_throw_action;
 
     // Record time and vertical velocity when we detect the possible throw
-    if (possible_throw_detected && ((AP_HAL::millis() - throw_free_fall_start_ms) > 500)) {
-        throw_free_fall_start_ms = AP_HAL::millis();
-        throw_free_fall_start_velz = inertial_nav.get_velocity().z;
+    if (possible_throw_detected && ((AP_HAL::millis() - throw_state.free_fall_start_ms) > 500)) {
+        throw_state.free_fall_start_ms = AP_HAL::millis();
+        throw_state.free_fall_start_velz = inertial_nav.get_velocity().z;
     }
 
     // Once a possible throw condition has been detected, we check for 2.5 m/s of downwards velocity change in less than 0.5 seconds to confirm
-    bool throw_condition_confirmed = ((AP_HAL::millis() - throw_free_fall_start_ms < 500) && ((inertial_nav.get_velocity().z - throw_free_fall_start_velz) < -250.0f));
+    bool throw_condition_confirmed = ((AP_HAL::millis() - throw_state.free_fall_start_ms < 500) && ((inertial_nav.get_velocity().z - throw_state.free_fall_start_velz) < -250.0f));
 
     // start motors and enter the control mode if we are in continuous freefall
     if (throw_condition_confirmed) {

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -191,6 +191,30 @@ void Copter::throw_run()
 
         break;
     }
+
+    // log at 10hz or if stage changes
+    uint32_t now = AP_HAL::millis();
+    if ((throw_state.stage != throw_state.prev_stage) || (now - throw_state.last_log_ms) > 100) {
+        throw_state.prev_stage = throw_state.stage;
+        throw_state.last_log_ms = now;
+        float velocity = inertial_nav.get_velocity().length();
+        float velocity_z = inertial_nav.get_velocity().z;
+        float accel = ins.get_accel().length();
+        float ef_accel_z = ahrs.get_accel_ef().z;
+        bool throw_detect = (throw_state.stage > Throw_Detecting) || throw_detected();
+        bool attitude_ok = (throw_state.stage > Throw_Uprighting) || throw_attitude_good();
+        bool height_ok = (throw_state.stage > Throw_HgtStabilise) || throw_height_good();
+        bool pos_ok = (throw_state.stage > Throw_PosHold) || throw_position_good();
+        Log_Write_Throw(throw_state.stage,
+                        velocity,
+                        velocity_z,
+                        accel,
+                        ef_accel_z,
+                        throw_detect,
+                        attitude_ok,
+                        height_ok,
+                        pos_ok);
+    }
 }
 
 bool Copter::throw_detected()

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -201,15 +201,15 @@ bool Copter::throw_detected()
         return false;
     }
 
-    // Check for high speed (note get_inertial_nav methods use a cm length scale)
-    bool high_speed = inertial_nav.get_velocity().length() > 500.0f;
+    // Check for high speed (>500 cm/s)
+    bool high_speed = inertial_nav.get_velocity().length() > THROW_HIGH_SPEED;
 
-    // check for upwards or downwards trajectory (airdrop)
+    // check for upwards or downwards trajectory (airdrop) of 50cm/s
     bool changing_height;
     if (g2.throw_type == ThrowType_Drop) {
-        changing_height = inertial_nav.get_velocity().z < -50.0f;
+        changing_height = inertial_nav.get_velocity().z < -THROW_VERTICAL_SPEED;
     } else {
-        changing_height = inertial_nav.get_velocity().z > 50.0f;
+        changing_height = inertial_nav.get_velocity().z > THROW_VERTICAL_SPEED;
     }
 
     // Check the vertical acceleraton is greater than 0.25g

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -125,6 +125,7 @@ enum mode_reason_t {
     MODE_REASON_FLIP_COMPLETE,
     MODE_REASON_AVOIDANCE,
     MODE_REASON_AVOIDANCE_RECOVERY,
+    MODE_REASON_THROW_COMPLETE,
 };
 
 // Tuning enumeration

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -248,8 +248,8 @@ enum FlipState {
     Flip_Abandon
 };
 
-// Throw states
-enum ThrowModeState {
+// Throw stages
+enum ThrowModeStage {
     Throw_Disarmed,
     Throw_Detecting,
     Throw_Uprighting,

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -292,6 +292,7 @@ enum ThrowModeType {
 #define LOG_HELI_MSG                    0x20
 #define LOG_PRECLAND_MSG                0x21
 #define LOG_GUIDEDTARGET_MSG            0x22
+#define LOG_THROW_MSG                   0x23
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -258,6 +258,12 @@ enum ThrowModeStage {
     Throw_PosHold
 };
 
+// Throw types
+enum ThrowModeType {
+    ThrowType_Upward = 0,
+    ThrowType_Drop = 1
+};
+
 // LAND state
 #define LAND_STATE_FLY_TO_LOCATION  0
 #define LAND_STATE_DESCENDING       1

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -258,10 +258,6 @@ void Copter::exit_mode(control_mode_t old_control_mode, control_mode_t new_contr
 #endif  // MOUNT == ENABLED
     }
 
-    if (old_control_mode == THROW) {
-        throw_exit();
-    }
-
     // smooth throttle transition when switching from manual to automatic flight modes
     if (mode_has_manual_throttle(old_control_mode) && !mode_has_manual_throttle(new_control_mode) && motors.armed() && !ap.land_complete) {
         // this assumes all manual flight modes use get_pilot_desired_throttle to translate pilot input to output throttle

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -567,9 +567,6 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             // control signal in tradheli
             motors.set_interlock(ch_flag == AUX_SWITCH_HIGH || ch_flag == AUX_SWITCH_MIDDLE);
 
-            // remember the current value of the motor interlock so that this condition can be restored if we exit the throw mode early
-            throw_early_exit_interlock = motors.get_interlock();
-
             // Log new status
             if (motors.get_interlock()){
                 Log_Write_Event(DATA_MOTORS_INTERLOCK_ENABLED);


### PR DESCRIPTION
This PR adds two new features to Throw mode:
1. a new parameter THROW_NEXTMODE allows the vehicle to switch into a specified mode (like AUTO) after the throw is completed.
2. new parameter THROW_TYPE allows detecting a throw by looking for the vehicle being dropped (as opposed to being thrown up in the air).

This PR also removes the use of the interlock and instead uses the motor spool logic.  This resolves a problem with being unable to arm if the THROW_MOT_SPIN was set to "1" (the arming checks complained that the motor interlock was on) and it generally simplifies (I think) how the motors are turned on/off without interfering with the interlock.

This PR includes the changes from these two (now closed) PRs:
https://github.com/ArduPilot/ardupilot/pull/4410
https://github.com/ArduPilot/ardupilot/issues/4585