### PR TITLE
DataFlash: Avoid null pointer dereference

### DIFF
--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -351,6 +351,11 @@ bool DataFlash_Class::fill_log_write_logstructure(struct LogStructure &logstruct
             break;
         }
     }
+
+    if (!f) {
+        return false;
+    }
+
     logstruct.msg_type = msg_type;
     strncpy((char*)logstruct.name, f->name, sizeof(logstruct.name)); /* cast away the "const" (*gulp*) */
     strncpy((char*)logstruct.format, f->fmt, sizeof(logstruct.format));


### PR DESCRIPTION
Confirms that the loop successfully found a log structure before using it.

Should fix CID 126742