### PR TITLE
Copter: remove ap.auto_armed

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -25,19 +25,6 @@ bool Copter::home_is_set()
 }
 
 // ---------------------------------------------
-void Copter::set_auto_armed(bool b)
-{
-    // if no change, exit immediately
-    if( ap.auto_armed == b )
-        return;
-
-    ap.auto_armed = b;
-    if(b){
-        Log_Write_Event(DATA_AUTO_ARMED);
-    }
-}
-
-// ---------------------------------------------
 void Copter::set_simple_mode(uint8_t b)
 {
     if(ap.simple_mode != b){

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -304,9 +304,6 @@ void Copter::throttle_loop()
     // update throttle_low_comp value (controls priority of throttle vs attitude control)
     update_throttle_thr_mix();
 
-    // check auto_armed status
-    update_auto_armed();
-
 #if FRAME_CONFIG == HELI_FRAME
     // update rotor speed
     heli_update_rotor_speed_targets();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -231,7 +231,7 @@ private:
             uint8_t simple_mode             : 2; // 1,2     // This is the state of simple mode : 0 = disabled ; 1 = SIMPLE ; 2 = SUPERSIMPLE
             uint8_t pre_arm_rc_check        : 1; // 3       // true if rc input pre-arm checks have been completed successfully
             uint8_t pre_arm_check           : 1; // 4       // true if all pre-arm checks (rc, accel calibration, gps lock) have been performed
-            uint8_t auto_armed              : 1; // 5       // stops auto missions from beginning until throttle is raised
+            uint8_t unused2                 : 1; // 5       // formerly auto_armed
             uint8_t logging_started         : 1; // 6       // true if dataflash logging has started
             uint8_t land_complete           : 1; // 7       // true if we have detected a landing
             uint8_t new_radio_frame         : 1; // 8       // Set true if we have new PWM data to act on from the Radio
@@ -628,7 +628,6 @@ private:
     void update_altitude();
     void set_home_state(enum HomeState new_home_state);
     bool home_is_set();
-    void set_auto_armed(bool b);
     void set_simple_mode(uint8_t b);
     void set_failsafe_radio(bool b);
     void set_failsafe_battery(bool b);
@@ -1028,7 +1027,6 @@ private:
     bool position_ok();
     bool ekf_position_ok();
     bool optflow_position_ok();
-    void update_auto_armed();
     void check_usb_mux(void);
     void frsky_telemetry_send(void);
     bool should_log(uint32_t mask);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1330,7 +1330,8 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_MISSION_START:
             if (copter.motors.armed() && copter.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
-                copter.set_auto_armed(true);
+                // TODO: check if mission begins with takeoff
+                copter.set_land_complete(false);
                 if (copter.mission.state() != AP_Mission::MISSION_RUNNING) {
                     copter.mission.start_or_resume();
                 }

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -65,8 +65,6 @@ void Copter::althold_run()
     // Alt Hold State Machine Determination
     if (!motors.armed() || !motors.get_interlock()) {
         althold_state = AltHold_MotorStopped;
-    } else if (!ap.auto_armed){
-        althold_state = AltHold_NotAutoArmed;
     } else if (takeoff_state.running || takeoff_triggered){
         althold_state = AltHold_Takeoff;
     } else if (ap.land_complete){
@@ -94,21 +92,6 @@ void Copter::althold_run()
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-motors.get_throttle_hover());
 #endif
-        break;
-
-    case AltHold_NotAutoArmed:
-
-        motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-#if FRAME_CONFIG == HELI_FRAME
-        // Helicopters always stabilize roll/pitch/yaw
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
-        attitude_control.set_throttle_out(0,false,g.throttle_filt);
-#else
-        // Multicopters do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-#endif
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-motors.get_throttle_hover());
         break;
 
     case AltHold_Takeoff:

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -147,8 +147,13 @@ void Copter::auto_takeoff_start(const Location& dest_loc)
 //      called by auto_run at 100hz or more
 void Copter::auto_takeoff_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // trigger takeoff if throttle has been raised
+    if (motors.armed() && motors.get_interlock() && ap.land_complete && channel_throttle->get_control_in() > get_takeoff_trigger_throttle()) {
+        set_land_complete(false);
+    }
+
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
@@ -223,8 +228,8 @@ void Copter::auto_wp_start(const Location_Class& dest_loc)
 //      called by auto_run at 100hz or more
 void Copter::auto_wp_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
@@ -295,8 +300,8 @@ void Copter::auto_spline_start(const Location_Class& destination, bool stopped_a
 //      called by auto_run at 100hz or more
 void Copter::auto_spline_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
@@ -372,8 +377,8 @@ void Copter::auto_land_start(const Vector3f& destination)
 //      called by auto_run at 100hz or more
 void Copter::auto_land_run()
 {
-    // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -542,8 +547,8 @@ bool Copter::auto_loiter_start()
 //      called by auto_run at 100hz or more
 void Copter::auto_loiter_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -239,7 +239,7 @@ bool Copter::autotune_start(bool ignore_checks)
     }
 
     // ensure we are flying
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete) {
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         return false;
     }
 
@@ -266,9 +266,9 @@ void Copter::autotune_run()
     pos_control.set_speed_z(-g.pilot_velocity_z_max, g.pilot_velocity_z_max);
     pos_control.set_accel_z(g.pilot_accel_z);
 
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    // this should not actually be possible because of the autotune_init() checks
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed or motor interlock not enabled set throttle to zero and exit immediately
+    // NOTE: land_complete is handled below
+    if (!motors.armed() || !motors.get_interlock()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-motors.get_throttle_hover());

--- a/ArduCopter/control_brake.cpp
+++ b/ArduCopter/control_brake.cpp
@@ -37,8 +37,14 @@ bool Copter::brake_init(bool ignore_checks)
 // should be called at 100hz or more
 void Copter::brake_run()
 {
-    // if not auto armed set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if landed immediately disarm
+    if (ap.land_complete) {
+        init_disarm_motors();
+        return;
+    }
+
+    // if not disarmed or interlock not enabled set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock()) {
         wp_nav.init_brake_target(BRAKE_MODE_DECEL_RATE);
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
@@ -56,11 +62,6 @@ void Copter::brake_run()
     // relax stop target if we might be landed
     if (ap.land_complete_maybe) {
         wp_nav.loiter_soften_for_landing();
-    }
-
-    // if landed immediately disarm
-    if (ap.land_complete) {
-        init_disarm_motors();
     }
 
     // set motors to full range

--- a/ArduCopter/control_circle.cpp
+++ b/ArduCopter/control_circle.cpp
@@ -41,8 +41,9 @@ void Copter::circle_run()
     pos_control.set_speed_z(-g.pilot_velocity_z_max, g.pilot_velocity_z_max);
     pos_control.set_accel_z(g.pilot_accel_z);
     
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, motor interlock disabled, or landed, set throttle to zero and exit immediately
+    // takeoff is not intended to be possible in this mode
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // To-Do: add some initialisation of position controllers
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
@@ -67,14 +68,6 @@ void Copter::circle_run()
 
         // get pilot desired climb rate
         target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
-
-        // check for pilot requested take-off
-        if (ap.land_complete && target_climb_rate > 0) {
-            // indicate we are taking off
-            set_land_complete(false);
-            // clear i term when we're taking off
-            set_throttle_takeoff();
-        }
     }
 
     // set motors to full range

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -279,8 +279,8 @@ void Copter::guided_set_angle(const Quaternion &q, float climb_rate_cms)
     guided_angle_state.update_time_ms = millis();
 
     // interpret positive climb rate as triggering take-off
-    if (motors.armed() && !ap.auto_armed && (guided_angle_state.climb_rate_cms > 0.0f)) {
-        set_auto_armed(true);
+    if (motors.armed() && ap.land_complete && (guided_angle_state.climb_rate_cms > 0.0f)) {
+        set_land_complete(false);
     }
 
     // log target
@@ -327,8 +327,8 @@ void Copter::guided_run()
 //      called by guided_run at 100hz or more
 void Copter::guided_takeoff_run()
 {
-    // if not auto armed or motors not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -365,8 +365,8 @@ void Copter::guided_takeoff_run()
 // called from guided_run
 void Copter::guided_pos_control_run()
 {
-    // if not auto armed or motors not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
+    // if disarmed or motors not enabled or landed, set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -413,7 +413,7 @@ void Copter::guided_pos_control_run()
 void Copter::guided_vel_control_run()
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // initialise velocity controller
         pos_control.init_vel_controller_xyz();
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
@@ -467,7 +467,7 @@ void Copter::guided_vel_control_run()
 void Copter::guided_posvel_control_run()
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // set target position and velocity to current position and velocity
         pos_control.set_pos_target(inertial_nav.get_position());
         pos_control.set_desired_velocity(Vector3f(0,0,0));
@@ -540,8 +540,8 @@ void Copter::guided_posvel_control_run()
 // called from guided_run
 void Copter::guided_angle_control_run()
 {
-    // if not auto armed or motors not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || (ap.land_complete && guided_angle_state.climb_rate_cms <= 0.0f)) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.set_yaw_target_to_current_heading();

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -53,8 +53,8 @@ void Copter::land_run()
 //      should be called at 100hz or more
 void Copter::land_gps_run()
 {
-    // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -120,8 +120,8 @@ void Copter::land_nogps_run()
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
-    // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -75,8 +75,6 @@ void Copter::loiter_run()
     // Loiter State Machine Determination
     if (!motors.armed() || !motors.get_interlock()) {
         loiter_state = Loiter_MotorStopped;
-    } else if (!ap.auto_armed) {
-        loiter_state = Loiter_NotAutoArmed;
     } else if (takeoff_state.running || (ap.land_complete && (channel_throttle->get_control_in() > get_takeoff_trigger_throttle()))){
         loiter_state = Loiter_Takeoff;
     } else if (ap.land_complete){
@@ -108,21 +106,6 @@ void Copter::loiter_run()
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-motors.get_throttle_hover());
 #endif
-        break;
-
-    case Loiter_NotAutoArmed:
-
-        motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-        wp_nav.init_loiter_target();
-#if FRAME_CONFIG == HELI_FRAME
-        // Helicopters always stabilize roll/pitch/yaw
-        attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
-        attitude_control.set_throttle_out(0,false,g.throttle_filt);
-#else
-        // Multicopters do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-#endif
-        pos_control.relax_alt_hold_controllers(get_throttle_pre_takeoff(channel_throttle->get_control_in())-motors.get_throttle_hover());
         break;
 
     case Loiter_Takeoff:

--- a/ArduCopter/control_poshold.cpp
+++ b/ArduCopter/control_poshold.cpp
@@ -140,8 +140,8 @@ void Copter::poshold_run()
     pos_control.set_speed_z(-g.pilot_velocity_z_max, g.pilot_velocity_z_max);
     pos_control.set_accel_z(g.pilot_accel_z);
 
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         wp_nav.init_loiter_target();
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);

--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -133,8 +133,8 @@ void Copter::rtl_return_start()
 //      called by rtl_run at 100hz or more
 void Copter::rtl_climb_return_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -200,8 +200,8 @@ void Copter::rtl_loiterathome_start()
 //      called by rtl_run at 100hz or more
 void Copter::rtl_loiterathome_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -281,8 +281,8 @@ void Copter::rtl_descent_run()
     int16_t roll_control = 0, pitch_control = 0;
     float target_yaw_rate = 0;
 
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
@@ -361,8 +361,8 @@ void Copter::rtl_land_start()
 //      called by rtl_run at 100hz or more
 void Copter::rtl_land_run()
 {
-    // if not auto armed or landing completed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
+    // if disarmed, interlock disabled or landed set throttle to zero and exit immediately
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -71,19 +71,12 @@ void Copter::throw_run()
         // set the initial velocity of the height controller demand to the measured velocity if it is going up
         // if it is going down, set it to zero to enforce a very hard stop
         pos_control.set_desired_velocity_z(fmaxf(inertial_nav.get_velocity_z(),0.0f));
-
-        // Set the auto_arm status to true to avoid a possible automatic disarm caused by selection of an auto mode with throttle at minimum
-        set_auto_armed(true);
-
     } else if (throw_state.stage == Throw_HgtStabilise && throw_height_good()) {
         gcs_send_text(MAV_SEVERITY_INFO,"height achieved - controlling position");
         throw_state.stage = Throw_PosHold;
 
         // initialise the loiter target to the curent position and velocity
         wp_nav.init_loiter_target();
-
-        // Set the auto_arm status to true to avoid a possible automatic disarm caused by selection of an auto mode with throttle at minimum
-        set_auto_armed(true);
     } else if (throw_state.stage == Throw_PosHold && throw_position_good()) {
         if (!throw_state.nextmode_attempted) {
             switch (g2.throw_nextmode) {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -225,7 +225,6 @@ enum RTLState {
 // Alt_Hold states
 enum AltHoldModeState {
     AltHold_MotorStopped,
-    AltHold_NotAutoArmed,
     AltHold_Takeoff,
     AltHold_Flying,
     AltHold_Landed
@@ -234,7 +233,6 @@ enum AltHoldModeState {
 // Loiter states
 enum LoiterModeState {
     Loiter_MotorStopped,
-    Loiter_NotAutoArmed,
     Loiter_Takeoff,
     Loiter_Flying,
     Loiter_Landed
@@ -322,7 +320,6 @@ enum ThrowModeType {
 #define DATA_INIT_SIMPLE_BEARING            9
 #define DATA_ARMED                          10
 #define DATA_DISARMED                       11
-#define DATA_AUTO_ARMED                     15
 #define DATA_LAND_COMPLETE_MAYBE            17
 #define DATA_LAND_COMPLETE                  18
 #define DATA_NOT_LANDED                     28

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -211,12 +211,8 @@ bool Copter::should_disarm_on_failsafe() {
             // if throttle is zero OR vehicle is landed disarm motors
             return ap.throttle_zero || ap.land_complete;
             break;
-        case AUTO:
-            // if mission has not started AND vehicle is landed, disarm motors
-            return !ap.auto_armed && ap.land_complete;
-            break;
         default:
-            // used for AltHold, Guided, Loiter, RTL, Circle, Drift, Sport, Flip, Autotune, PosHold
+            // used for Auto, AltHold, Guided, Loiter, RTL, Circle, Drift, Sport, Flip, Autotune, PosHold
             // if landed disarm
             return ap.land_complete;
             break;

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -113,7 +113,7 @@ void Copter::heli_update_landing_swash()
             if (rtl_state == RTL_Land) {
                 motors.set_collective_for_landing(true);
             }else{
-                motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete || !ap.auto_armed);
+                motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete);
             }
             break;
 
@@ -121,13 +121,13 @@ void Copter::heli_update_landing_swash()
             if (auto_mode == Auto_Land) {
                 motors.set_collective_for_landing(true);
             }else{
-                motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete || !ap.auto_armed);
+                motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete);
             }
             break;
 
         default:
             // auto and hold use limited swash when landed
-            motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete || !ap.auto_armed);
+            motors.set_collective_for_landing(!heli_flags.dynamic_flight || ap.land_complete);
             break;
     }
 }

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -374,45 +374,6 @@ bool Copter::optflow_position_ok()
 #endif
 }
 
-// update_auto_armed - update status of auto_armed flag
-void Copter::update_auto_armed()
-{
-    // disarm checks
-    if(ap.auto_armed){
-        // if motors are disarmed, auto_armed should also be false
-        if(!motors.armed()) {
-            set_auto_armed(false);
-            return;
-        }
-        // if in stabilize or acro flight mode and throttle is zero, auto-armed should become false
-        if(mode_has_manual_throttle(control_mode) && ap.throttle_zero && !failsafe.radio) {
-            set_auto_armed(false);
-        }
-#if FRAME_CONFIG == HELI_FRAME 
-        // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
-        // so that rotor runup is checked again before attempting to take-off
-        if(ap.land_complete && !motors.rotor_runup_complete()) {
-            set_auto_armed(false);
-        }
-#endif // HELI_FRAME
-    }else{
-        // arm checks
-        
-#if FRAME_CONFIG == HELI_FRAME
-        // for tradheli if motors are armed and throttle is above zero and the motor is started, auto_armed should be true
-        if(motors.armed() && !ap.throttle_zero && motors.rotor_runup_complete()) {
-            set_auto_armed(true);
-        }
-#else
-        // if motors are armed and throttle is above zero auto_armed should be true
-        // if motors are armed and we are in throw mode, then auto_ermed should be true
-        if(motors.armed() && (!ap.throttle_zero || control_mode == THROW)) {
-            set_auto_armed(true);
-        }
-#endif // HELI_FRAME
-    }
-}
-
 void Copter::check_usb_mux(void)
 {
     bool usb_check = hal.gpio->usb_connected();

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -39,7 +39,6 @@ bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
         switch(control_mode) {
             case GUIDED:
                 if (guided_takeoff_start(takeoff_alt_cm)) {
-                    set_auto_armed(true);
                     return true;
                 }
                 return false;
@@ -47,7 +46,6 @@ bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
             case POSHOLD:
             case ALT_HOLD:
             case SPORT:
-                set_auto_armed(true);
                 takeoff_timer_start(takeoff_alt_cm);
                 return true;
             default:
@@ -149,7 +147,7 @@ void Copter::auto_takeoff_set_start_alt(void)
     // start with our current altitude
     auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude();
     
-    if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
+    if (!motors.armed() || !motors.get_interlock() || ap.land_complete) {
         // we are not flying, add the takeoff_nav_alt
         auto_takeoff_no_nav_alt_cm += g2.takeoff_nav_alt * 100;
     }


### PR DESCRIPTION
ap.auto_armed was completely redundant with ap.land_complete, was not consistently checked, and occasionally (at least 2 occasions) this complexity has resulted in bugs that have caused crashes.

This PR removes ap.auto_armed entirely. Safety is provided by land_complete. Takeoff is triggered by setting land_complete to false.
