### PR TITLE
Plane: Change loop_us variable type auto to static.

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -110,7 +110,7 @@ void Plane::setup()
 
 void Plane::loop()
 {
-    uint32_t loop_us = 1000000UL / scheduler.get_loop_rate_hz();
+    static uint32_t loop_us = 1000000UL / scheduler.get_loop_rate_hz();
 
     // wait for an INS sample
     ins.wait_for_sample();


### PR DESCRIPTION
**_loop_rate_hz** value is not active change value.
**loop_us** is cuclurated only first time .