### PR TITLE
MPU6000: raise accel to 16g

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -530,7 +530,6 @@ void AP_InertialSensor_MPU6000::_read_sample()
 
     if (!_block_read(MPUREG_INT_STATUS, (uint8_t *) &rx, sizeof(rx))) {
         if (++_error_count > 4) {
-            // TODO: set bus speed low for this (and only this) device
             hal.console->printf("MPU60x0: error reading sample\n");
             return;
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -9,9 +9,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-// MPU6000 accelerometer scaling
-#define MPU6000_ACCEL_SCALE_1G    (GRAVITY_MSS / 4096.0f)
-
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/GPIO.h>
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBOARD || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
@@ -338,8 +335,6 @@ void AP_InertialSensor_MPU6000::start()
     _product_id = _register_read(MPUREG_PRODUCT_ID);
     //Serial.printf("Product_ID= 0x%x\n", (unsigned) _mpu6000_product_id);
 
-    // TODO: should be changed to 16G once we have a way to override the
-    // previous offsets
     if ((_product_id == MPU6000ES_REV_C4) ||
         (_product_id == MPU6000ES_REV_C5) ||
         (_product_id == MPU6000_REV_C4)   ||
@@ -347,9 +342,11 @@ void AP_InertialSensor_MPU6000::start()
         // Accel scale 8g (4096 LSB/g)
         // Rev C has different scaling than rev D
         _register_write(MPUREG_ACCEL_CONFIG,1<<3);
+        _accel_scale = GRAVITY_MSS / 4096.f;
     } else {
-        // Accel scale 8g (4096 LSB/g)
-        _register_write(MPUREG_ACCEL_CONFIG,2<<3);
+        // Accel scale 16g (2048 LSB/g)
+        _register_write(MPUREG_ACCEL_CONFIG,3<<3);
+        _accel_scale = GRAVITY_MSS / 2048.f;
     }
     hal.scheduler->delay(1);
 
@@ -446,7 +443,7 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
         accel = Vector3f(int16_val(data, 1),
                          int16_val(data, 0),
                          -int16_val(data, 2));
-        accel *= MPU6000_ACCEL_SCALE_1G;
+        accel *= _accel_scale;
 
         gyro = Vector3f(int16_val(data, 5),
                         int16_val(data, 4),

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -97,6 +97,7 @@ private:
     uint16_t _error_count;
 
     float _temp_filtered;
+    float _accel_scale;
     LowPassFilter2pFloat _temp_filter;
 
     AP_HAL::DigitalSource *_drdy_pin;


### PR DESCRIPTION
MPU6000 was forgotten when we converted drivers to 16G and postponed forever to avoid re-doing accel calibrations.  Instead of postponing even more, just do it. Unfortunately we don't have a way to detect if the values for the accel are in the previous or current scale since product id is saved only for the first instance.