### PR TITLE
Rover: clean up defines

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -122,7 +122,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
-	GSCALAR(speed_cruise,        "CRUISE_SPEED",    5),
+	GSCALAR(speed_cruise,        "CRUISE_SPEED",    SPEED_CRUISE),
 
     // @Param: SPEED_TURN_GAIN
     // @DisplayName: Target speed reduction while turning

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -191,7 +191,7 @@
 // AIRSPEED_CRUISE
 //
 #ifndef SPEED_CRUISE
-# define SPEED_CRUISE		3 // 3 m/s
+# define SPEED_CRUISE		5 // in m/s
 #endif
 
 #ifndef GSBOOST

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -194,20 +194,6 @@
 # define SPEED_CRUISE		5 // in m/s
 #endif
 
-#ifndef GSBOOST
-# define GSBOOST		0
-#endif
-#ifndef GSBOOST
-# define GSBOOST		0
-#endif
-#ifndef NUDGE_OFFSET
-# define NUDGE_OFFSET		0
-#endif
-
-#ifndef E_GLIDER
-# define E_GLIDER		ENABLED
-#endif
-
 #ifndef TURN_GAIN
 # define TURN_GAIN		5
 #endif
@@ -244,18 +230,6 @@
 
 
 //////////////////////////////////////////////////////////////////////////////
-// Crosstrack compensation
-//
-#ifndef XTRACK_GAIN
-# define XTRACK_GAIN          1 // deg/m
-#endif
-#ifndef XTRACK_ENTRY_ANGLE
-# define XTRACK_ENTRY_ANGLE   50 // deg
-#endif
-# define XTRACK_GAIN_SCALED XTRACK_GAIN*100
-# define XTRACK_ENTRY_ANGLE_CENTIDEGREE XTRACK_ENTRY_ANGLE*100
-
-//////////////////////////////////////////////////////////////////////////////
 // Dataflash logging control
 //
 #ifndef LOGGING_ENABLED
@@ -268,12 +242,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Developer Items
 //
-
-#ifndef STANDARD_SPEED
-# define STANDARD_SPEED		3.0
-#define STANDARD_SPEED_SQUARED (STANDARD_SPEED * STANDARD_SPEED)
-#endif
-#define STANDARD_THROTTLE_SQUARED (THROTTLE_CRUISE * THROTTLE_CRUISE)
 
 // use this to enable servos in HIL mode
 #ifndef HIL_SERVOS
@@ -291,12 +259,4 @@
 // fence breach)
 #ifndef RESET_SWITCH_CHAN_PWM
 # define RESET_SWITCH_CHAN_PWM 1750
-#endif
-
-#ifndef BOOSTER
-# define BOOSTER              2    // booster factor x1 = 1 or x2 = 2
-#endif
-
-#ifndef SONAR_ENABLED
-# define SONAR_ENABLED       DISABLED
 #endif

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -10,18 +10,11 @@
 #define DEBUG 0
 #define SERVO_MAX 4500	// This value represents 45 degrees and is just an arbitrary representation of servo max travel.
 
-// active altitude sensor
-// ----------------------
-#define SONAR 0
-
 // CH 7 control
 enum ch7_option {
     CH7_DO_NOTHING=0,
     CH7_SAVE_WP=1
 };
-
-#define T6 1000000
-#define T7 10000000
 
 // HIL enumerations
 #define HIL_MODE_DISABLED			0
@@ -44,17 +37,6 @@ enum mode {
 #define FAILSAFE_EVENT_THROTTLE (1<<0)
 #define FAILSAFE_EVENT_GCS      (1<<1)
 #define FAILSAFE_EVENT_RC       (1<<2)
-
-//repeating events
-#define NO_REPEAT 0
-#define CH_5_TOGGLE 1
-#define CH_6_TOGGLE 2
-#define CH_7_TOGGLE 3
-#define CH_8_TOGGLE 4
-#define RELAY_TOGGLE 5
-#define STOP_REPEAT 10
-
-#define MAV_CMD_CONDITION_YAW 23
 
 //  Logging parameters
 #define LOG_CTUN_MSG	        0x01
@@ -86,37 +68,3 @@ enum mode {
 #define MASK_LOG_RC     		(1<<14)
 #define MASK_LOG_ARM_DISARM     (1<<15)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
-
-
-// Waypoint Modes
-// ----------------
-#define ABS_WP 0
-#define REL_WP 1
-
-// Command Queues
-// ---------------
-#define COMMAND_MUST 0
-#define COMMAND_MAY 1
-#define COMMAND_NOW 2
-
-// Events
-// ------
-#define EVENT_WILL_REACH_WAYPOINT 1
-#define EVENT_SET_NEW_COMMAND_INDEX 2
-#define EVENT_LOADED_WAYPOINT 3
-#define EVENT_LOOP 4
-
-// Climb rate calculations
-#define	ALTITUDE_HISTORY_LENGTH 8	//Number of (time,altitude) points to regress a climb rate from
-
-// sonar
-#define MAX_SONAR_XL 0
-#define MAX_SONAR_LV 1
-#define SonarToCm(x) (x*1.26)   // Sonar raw value to centimeters
-#define AN4			4
-#define AN5			5
-
-#define SPEEDFILT 400			// centimeters/second; the speed below which a groundstart will be triggered
-
-// convert a boolean (0 or 1) to a sign for multiplying (0 maps to 1, 1 maps to -1)
-#define BOOL_TO_SIGN(bvalue) ((bvalue)?-1:1)


### PR DESCRIPTION
Mostly remove unused defines, but start using SPEED_CRUISE which looks like it should have been.