### PR TITLE
AP_AHRS: Use exact matrix for trim rotation

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -173,6 +173,14 @@ void AP_AHRS::add_trim(float roll_in_radians, float pitch_in_radians, bool save_
     }
 }
 
+Matrix3f AP_AHRS::get_rotation_autopilot_body_to_vehicle_body(void) const
+{
+
+    Matrix3f ret;
+    ret.from_euler(_trim.x, _trim.y, 0.0f);
+    return ret;
+}
+
 // return a ground speed estimate in m/s
 Vector2f AP_AHRS::groundspeed_vector(void)
 {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -173,14 +173,6 @@ void AP_AHRS::add_trim(float roll_in_radians, float pitch_in_radians, bool save_
     }
 }
 
-Matrix3f AP_AHRS::get_rotation_autopilot_body_to_vehicle_body(void) const
-{
-
-    Matrix3f ret;
-    ret.from_euler(_trim.x, _trim.y, 0.0f);
-    return ret;
-}
-
 // return a ground speed estimate in m/s
 Vector2f AP_AHRS::groundspeed_vector(void)
 {
@@ -238,6 +230,12 @@ Vector2f AP_AHRS::groundspeed_vector(void)
 //      should be called after _dcm_matrix is updated
 void AP_AHRS::update_trig(void)
 {
+    if (_last_trim != _trim.get()) {
+        _last_trim = _trim.get();
+        _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, 0.0f);
+        _rotation_vehicle_body_to_autopilot_body = _rotation_autopilot_body_to_vehicle_body.transposed();
+    }
+
     Vector2f yaw_vector;
     const Matrix3f &temp = get_rotation_body_to_ned();
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -240,6 +240,8 @@ public:
     // return a DCM rotation matrix representing our current
     // attitude
     virtual const Matrix3f &get_rotation_body_to_ned(void) const = 0;
+    Matrix3f get_rotation_autopilot_body_to_vehicle_body(void) const;
+    Matrix3f get_rotation_vehicle_body_to_autopilot_body(void) const { return get_rotation_autopilot_body_to_vehicle_body().transposed(); }
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -85,6 +85,10 @@ public:
         _home.alt        = 0;
         _home.lng        = 0;
         _home.lat        = 0;
+
+        _last_trim = _trim.get();
+        _rotation_autopilot_body_to_vehicle_body.from_euler(_last_trim.x, _last_trim.y, 0.0f);
+        _rotation_vehicle_body_to_autopilot_body = _rotation_autopilot_body_to_vehicle_body.transposed();
     }
 
     // empty virtual destructor
@@ -240,8 +244,8 @@ public:
     // return a DCM rotation matrix representing our current
     // attitude
     virtual const Matrix3f &get_rotation_body_to_ned(void) const = 0;
-    Matrix3f get_rotation_autopilot_body_to_vehicle_body(void) const;
-    Matrix3f get_rotation_vehicle_body_to_autopilot_body(void) const { return get_rotation_autopilot_body_to_vehicle_body().transposed(); }
+    const Matrix3f& get_rotation_autopilot_body_to_vehicle_body(void) const { return _rotation_autopilot_body_to_vehicle_body; }
+    const Matrix3f& get_rotation_vehicle_body_to_autopilot_body(void) const { return _rotation_vehicle_body_to_autopilot_body; }
 
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
@@ -504,6 +508,11 @@ protected:
 
     // a vector to capture the difference between the controller and body frames
     AP_Vector3f         _trim;
+
+    // cached trim rotations
+    Vector3f _last_trim;
+    Matrix3f _rotation_autopilot_body_to_vehicle_body;
+    Matrix3f _rotation_vehicle_body_to_autopilot_body;
 
     // the limit of the gyro drift claimed by the sensors, in
     // radians/s/s

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -944,8 +944,7 @@ void AP_AHRS_DCM::estimate_wind(void)
 void
 AP_AHRS_DCM::euler_angles(void)
 {
-    _body_dcm_matrix = _dcm_matrix;
-    _body_dcm_matrix.rotateXYinv(_trim);
+    _body_dcm_matrix = _dcm_matrix * get_rotation_vehicle_body_to_autopilot_body();
     _body_dcm_matrix.to_euler(&roll, &pitch, &yaw);
 
     update_cd_values();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -172,7 +172,7 @@ void AP_AHRS_NavEKF::update_EKF1(void)
                     accel.z -= abias2;
                 }
                 if (_ins.get_accel_health(i)) {
-                    _accel_ef_ekf[i] = _dcm_matrix * accel;
+                    _accel_ef_ekf[i] = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * accel;
                 }
             }
 
@@ -244,7 +244,7 @@ void AP_AHRS_NavEKF::update_EKF2(void)
                     accel.z -= abias;
                 }
                 if (_ins.get_accel_health(i)) {
-                    _accel_ef_ekf[i] = _dcm_matrix * accel;
+                    _accel_ef_ekf[i] = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * accel;
                 }
             }
             _accel_ef_ekf_blended = _accel_ef_ekf[primary_imu>=0?primary_imu:_ins.get_primary_accel()];

--- a/libraries/AP_Math/matrix3.cpp
+++ b/libraries/AP_Math/matrix3.cpp
@@ -116,44 +116,6 @@ void Matrix3<T>::rotate(const Vector3<T> &g)
     (*this) += temp_matrix;
 }
 
-// apply an additional rotation from a body frame gyro vector
-// to a rotation matrix.
-template <typename T>
-void Matrix3<T>::rotateXY(const Vector3<T> &g)
-{
-    Matrix3<T> temp_matrix;
-    temp_matrix.a.x = -a.z * g.y;
-    temp_matrix.a.y = a.z * g.x;
-    temp_matrix.a.z = a.x * g.y - a.y * g.x;
-    temp_matrix.b.x = -b.z * g.y;
-    temp_matrix.b.y = b.z * g.x;
-    temp_matrix.b.z = b.x * g.y - b.y * g.x;
-    temp_matrix.c.x = -c.z * g.y;
-    temp_matrix.c.y = c.z * g.x;
-    temp_matrix.c.z = c.x * g.y - c.y * g.x;
-
-    (*this) += temp_matrix;
-}
-
-// apply an additional inverse rotation to a rotation matrix but 
-// only use X, Y elements from rotation vector
-template <typename T>
-void Matrix3<T>::rotateXYinv(const Vector3<T> &g)
-{
-    Matrix3<T> temp_matrix;
-    temp_matrix.a.x =   a.z * g.y;
-    temp_matrix.a.y = - a.z * g.x;
-    temp_matrix.a.z = - a.x * g.y + a.y * g.x;
-    temp_matrix.b.x =   b.z * g.y;
-    temp_matrix.b.y = - b.z * g.x;
-    temp_matrix.b.z = - b.x * g.y + b.y * g.x;
-    temp_matrix.c.x =   c.z * g.y;
-    temp_matrix.c.y = - c.z * g.x;
-    temp_matrix.c.z = - c.x * g.y + c.y * g.x;
-
-    (*this) += temp_matrix;
-}
-
 /*
   re-normalise a rotation matrix
 */
@@ -296,8 +258,6 @@ void Matrix3<T>::from_axis_angle(const Vector3<T> &v, float theta)
 // only define for float
 template void Matrix3<float>::zero(void);
 template void Matrix3<float>::rotate(const Vector3<float> &g);
-template void Matrix3<float>::rotateXY(const Vector3<float> &g);
-template void Matrix3<float>::rotateXYinv(const Vector3<float> &g);
 template void Matrix3<float>::normalize(void);
 template void Matrix3<float>::from_euler(float roll, float pitch, float yaw);
 template void Matrix3<float>::to_euler(float *roll, float *pitch, float *yaw) const;
@@ -315,8 +275,6 @@ template Vector2<float> Matrix3<float>::mulXY(const Vector3<float> &v) const;
 
 template void Matrix3<double>::zero(void);
 template void Matrix3<double>::rotate(const Vector3<double> &g);
-template void Matrix3<double>::rotateXY(const Vector3<double> &g);
-template void Matrix3<double>::rotateXYinv(const Vector3<double> &g);
 template void Matrix3<double>::from_euler(float roll, float pitch, float yaw);
 template void Matrix3<double>::to_euler(float *roll, float *pitch, float *yaw) const;
 template Vector3<double> Matrix3<double>::operator *(const Vector3<double> &v) const;

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -252,14 +252,6 @@ public:
     // to a rotation matrix.
     void        rotate(const Vector3<T> &g);
 
-    // apply an additional rotation from a body frame gyro vector
-    // to a rotation matrix but only use X, Y elements from gyro vector
-    void        rotateXY(const Vector3<T> &g);
-
-    // apply an additional inverse rotation to a rotation matrix but 
-    // only use X, Y elements from rotation vector
-    void        rotateXYinv(const Vector3<T> &g);
-
     // create rotation matrix for rotation about the vector v by angle theta
     // See: https://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
     // "Rotation matrix from axis and angle"

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -4345,9 +4345,8 @@ void NavEKF_core::setWindVelStates()
 // return the transformation matrix from XYZ (body) to NED axes
 void NavEKF_core::getRotationBodyToNED(Matrix3f &mat) const
 {
-    Vector3f trim = _ahrs->get_trim();
     state.quat.rotation_matrix(mat);
-    mat.rotateXYinv(trim);
+    mat = mat * _ahrs->get_rotation_vehicle_body_to_autopilot_body();
 }
 
 // return the innovations for the NED Pos, NED Vel, XYZ Mag and Vtas measurements

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -136,9 +136,8 @@ void NavEKF2_core::getTiltError(float &ang) const
 // return the transformation matrix from XYZ (body) to NED axes
 void NavEKF2_core::getRotationBodyToNED(Matrix3f &mat) const
 {
-    Vector3f trim = _ahrs->get_trim();
     outputDataNew.quat.rotation_matrix(mat);
-    mat.rotateXYinv(trim);
+    mat = mat * _ahrs->get_rotation_vehicle_body_to_autopilot_body();
 }
 
 // return the quaternions defining the rotation from NED to XYZ (body) axes


### PR DESCRIPTION
This PR:
- Fixes a bug in which the computation of accel_ef was incorrect
- Uses exact rotations to apply trim, where we were using a small-angle approximation - the result of which was not a rotation matrix.
- Caches the computation of the trim rotation matrix, initially computing it in the AP_AHRS ctor and updating it in update_trig() if necessary

Tested by comparing a couple different orientations and trim values against master on the bench.