### PR TITLE
Plane: fixed motor output on reboot in quadplanes

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1513,11 +1513,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-                // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(is_equal(packet.param1,3.0f));
-                result = MAV_RESULT_ACCEPTED;
-            }
+            result = handle_preflight_reboot(packet, plane.quadplane.enable != 0);
             break;
 
         case MAV_CMD_DO_LAND_START:

--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -355,7 +355,12 @@ bool Plane::setup_failsafe_mixing(void)
     }
 
     for (uint8_t i = 0; i < pwm_values.channel_count; i++) {
-        pwm_values.values[i] = 900;
+        if (RC_Channel_aux::channel_function(i) >= RC_Channel_aux::k_motor1 &&
+            RC_Channel_aux::channel_function(i) <= RC_Channel_aux::k_motor8) {
+            pwm_values.values[i] = quadplane.thr_min_pwm;
+        } else {
+            pwm_values.values[i] = 900;
+        }
     }
     if (ioctl(px4io_fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values) != 0) {
         hal.console->printf("SET_MIN_PWM failed\n");
@@ -363,7 +368,13 @@ bool Plane::setup_failsafe_mixing(void)
     }
 
     for (uint8_t i = 0; i < pwm_values.channel_count; i++) {
-        pwm_values.values[i] = 2100;
+        if (RC_Channel_aux::channel_function(i) >= RC_Channel_aux::k_motor1 &&
+            RC_Channel_aux::channel_function(i) <= RC_Channel_aux::k_motor8) {
+            hal.rcout->write(i, quadplane.thr_min_pwm);
+            pwm_values.values[i] = quadplane.thr_min_pwm;
+        } else {
+            pwm_values.values[i] = 2100;
+        }
     }
     if (ioctl(px4io_fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&pwm_values) != 0) {
         hal.console->printf("SET_MAX_PWM failed\n");
@@ -374,7 +385,6 @@ bool Plane::setup_failsafe_mixing(void)
         goto failed;
     }
 
-    // setup for immediate manual control if FMU dies
     if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_IMMEDIATE, 1) != 0) {
         hal.console->printf("SET_OVERRIDE_IMMEDIATE failed\n");
         goto failed;

--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -402,6 +402,7 @@ failed:
     // restore safety state if it was previously armed
     if (old_state == AP_HAL::Util::SAFETY_ARMED) {
         hal.rcout->force_safety_off();
+        hal.rcout->force_safety_no_wait();
     }
     if (!ret) {
         // clear out the mixer CRC so that we will attempt to send it again

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -444,8 +444,12 @@ bool QuadPlane::setup(void)
     // setup the trim of any motors used by AP_Motors so px4io
     // failsafe will disable motors
     for (uint8_t i=0; i<8; i++) {
-        RC_Channel_aux::set_servo_failsafe_pwm((RC_Channel_aux::Aux_servo_function_t)(RC_Channel_aux::k_motor1+i),
-                                               thr_min_pwm);
+        RC_Channel_aux::Aux_servo_function_t func = (RC_Channel_aux::Aux_servo_function_t)(RC_Channel_aux::k_motor1+i);
+        RC_Channel_aux::set_servo_failsafe_pwm(func, thr_min_pwm);
+        uint8_t chan;
+        if (RC_Channel_aux::find_channel(func, chan)) {
+            RC_Channel::rc_channel(chan)->set_radio_trim(thr_min_pwm);
+        }
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -35,6 +35,7 @@ class QuadPlane
 public:
     friend class Plane;
     friend class AP_Tuning_Plane;
+    friend class GCS_MAVLINK_Plane;
     
     QuadPlane(AP_AHRS_NavEKF &_ahrs);
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -103,13 +103,16 @@ void Plane::init_ardupilot()
     init_rc_out_main();
     
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
-    // this must be before BoardConfig.init() so if
-    // BRD_SAFETYENABLE==0 then we don't have safety off yet
-    for (uint8_t tries=0; tries<10; tries++) {
-        if (setup_failsafe_mixing()) {
-            break;
+    if (!quadplane.enable) {
+        // this must be before BoardConfig.init() so if
+        // BRD_SAFETYENABLE==0 then we don't have safety off yet. For
+        // quadplanes we wait till AP_Motors is initialised
+        for (uint8_t tries=0; tries<10; tries++) {
+            if (setup_failsafe_mixing()) {
+                break;
+            }
+            hal.scheduler->delay(10);
         }
-        hal.scheduler->delay(10);
     }
 #endif
 

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -146,6 +146,12 @@ void AP_BoardConfig::px4_setup_safety()
 
     if (px4.safety_enable.get() == 0) {
         hal.rcout->force_safety_off();
+        hal.rcout->force_safety_no_wait();
+        // wait until safety has been turned off
+        uint8_t count = 20;
+        while (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_ARMED && count--) {
+            hal.scheduler->delay(20);
+        }
     }
 }
 

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -278,19 +278,20 @@ void PX4RCOutput::force_safety_off(void)
 void PX4RCOutput::force_safety_pending_requests(void)
 {
     // check if there is a pending saftey_state change. If so (timer != 0) then set it.
+    uint32_t now = AP_HAL::millis();
     if (_safety_state_request_last_ms != 0 &&
-            AP_HAL::millis() - _safety_state_request_last_ms >= 100) {
-        if (hal.util->safety_switch_state() == _safety_state_request) {
-            // current switch state matches request, stop attempting
+        now - _safety_state_request_last_ms >= 100) {
+        if (hal.util->safety_switch_state() == _safety_state_request &&
+            _safety_state_request_last_ms != 1) {
             _safety_state_request_last_ms = 0;
         } else if (_safety_state_request == AP_HAL::Util::SAFETY_DISARMED) {
             // current != requested, set it
             ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_ON, 0);
-            _safety_state_request_last_ms = AP_HAL::millis();
+            _safety_state_request_last_ms = now;
         } else if (_safety_state_request == AP_HAL::Util::SAFETY_ARMED) {
             // current != requested, set it
             ioctl(_pwm_fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0);
-            _safety_state_request_last_ms = AP_HAL::millis();
+            _safety_state_request_last_ms = now;
         }
     }
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -264,6 +264,7 @@ protected:
 
     void handle_log_message(mavlink_message_t *msg, DataFlash_Class &dataflash);
     void handle_setup_signing(const mavlink_message_t *msg);
+    uint8_t handle_preflight_reboot(const mavlink_command_long_t &packet, bool disable_overrides);
 
 private:
 


### PR DESCRIPTION
This fixes a problem where the motors can start during a reboot of a quadplane. It was caused by the RC override behaviour when FMU fails, which causes IO to run the null mixer for the motors
It also fixes a race condition that could cause BRD_SAFETYENABLE not to operate correctly due to a race within the px4 mixer loading
