### PR TITLE
Copter: Delete a comparison that does not become a true forever.

### DIFF
--- a/ArduCopter/setup.cpp
+++ b/ArduCopter/setup.cpp
@@ -246,7 +246,7 @@ int8_t Copter::esc_calib(uint8_t argc,const Menu::arg *argv)
 		if (c == 'c') {
             break;
 
-		} else if (c == 0x03 || c == 0x63 || c == 'q') {
+		} else if (c == 0x03 || c == 'q') {
 			cliSerial->printf("ESC calibration exited\n");
 			return(0);
 		}
@@ -274,7 +274,7 @@ int8_t Copter::esc_calib(uint8_t argc,const Menu::arg *argv)
 
 			break;
 
-		} else if (c == 0x03 || c == 0x63 || c == 'q') {
+		} else if (c == 0x03 || c == 'q') {
 			cliSerial->printf("ESC calibration exited\n");
 			return(0);
 		}


### PR DESCRIPTION
Already against Checked code, again, it is checked.