### PR TITLE
Tools: bump Vagrant Ubuntu to Wily

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/trusty32"
+  config.vm.box = "ubuntu/wily32"
   # push.app = "geeksville/ardupilot-sitl"
 
   # The following forwarding is not necessary (or possible), because our sim_vehicle.py is smart enough to send packets


### PR DESCRIPTION
This allows the Vagrant VM to build PX4 using waf.

The initvagrant script has been changed to run as much as possible
as the Vagrant user.

jsbsim is now compiled by the vagrant user, and run from the source directory.