### PR TITLE
Copter: limit navigation attitude on landing

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -828,6 +828,7 @@ private:
     void land_run();
     void land_gps_run();
     void land_nogps_run();
+    int32_t land_get_alt_above_ground(void);
     void land_run_vertical_control(bool pause_descent = false);
     void land_run_horizontal_control();
     void land_do_not_use_GPS();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -963,12 +963,12 @@ const AP_Param::Info Copter::var_info[] = {
  */
 const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
-    // @Param: TKOFF_NAV_ALT
-    // @DisplayName: Takeoff navigation altitude
-    // @Description: This is the altitude in meters above the takeoff point that attitude changes for navigation can begin
+    // @Param: WP_NAVALT_MIN
+    // @DisplayName: Minimum navigation altitude
+    // @Description: This is the altitude in meters above which for navigation can begin. This applies in auto takeoff and auto landing.
     // @Range: 0 5
     // @User: Standard
-    AP_GROUPINFO("WP_TKOFF_NAV_ALT", 1, ParametersG2, takeoff_nav_alt, 0),
+    AP_GROUPINFO("WP_NAVALT_MIN", 1, ParametersG2, wp_navalt_min, 0),
 
     // @Group: BTN_
     // @Path: ../libraries/AP_Button/AP_Button.cpp

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -546,7 +546,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // altitude at which nav control can start in takeoff
-    AP_Float takeoff_nav_alt;
+    AP_Float wp_navalt_min;
 
     // button checking
     AP_Button button;

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -139,7 +139,7 @@ void Copter::auto_takeoff_start(const Location& dest_loc)
     // clear i term when we're taking off
     set_throttle_takeoff();
 
-    // get initial alt for TKOFF_NAV_ALT
+    // get initial alt for WP_NAVALT_MIN
     auto_takeoff_set_start_alt();
 }
 

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -74,7 +74,7 @@ bool Copter::guided_takeoff_start(float final_alt_above_home)
     // clear i term when we're taking off
     set_throttle_takeoff();
 
-    // get initial alt for WP_TKOFF_NAV_ALT
+    // get initial alt for WP_NAVALT_MIN
     auto_takeoff_set_start_alt();
     
     return true;

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -146,6 +146,23 @@ void Copter::land_nogps_run()
     land_run_vertical_control(land_pause);
 }
 
+/*
+  get a height above ground estimate for landing
+ */
+int32_t Copter::land_get_alt_above_ground(void)
+{
+    int32_t alt_above_ground;
+    if (rangefinder_alt_ok()) {
+        alt_above_ground = rangefinder_state.alt_cm_filt.get();
+    } else {
+        bool navigating = pos_control.is_active_xy();
+        if (!navigating || !current_loc.get_alt_cm(Location_Class::ALT_FRAME_ABOVE_TERRAIN, alt_above_ground)) {
+            alt_above_ground = current_loc.alt;
+        }
+    }
+    return alt_above_ground;
+}
+
 void Copter::land_run_vertical_control(bool pause_descent)
 {
     bool navigating = pos_control.is_active_xy();
@@ -159,15 +176,8 @@ void Copter::land_run_vertical_control(bool pause_descent)
     // compute desired velocity
     const float precland_acceptable_error = 25.0f;
     const float precland_min_descent_speed = -10.0f;
-    int32_t alt_above_ground;
-    if (rangefinder_alt_ok()) {
-        alt_above_ground = rangefinder_state.alt_cm_filt.get();
-    } else {
-        if (!navigating || !current_loc.get_alt_cm(Location_Class::ALT_FRAME_ABOVE_TERRAIN, alt_above_ground)) {
-            alt_above_ground = current_loc.alt;
-        }
-    }
-
+    int32_t alt_above_ground = land_get_alt_above_ground();
+    
     float cmb_rate = 0;
     if (!pause_descent) {
         float max_land_descent_velocity;
@@ -258,8 +268,33 @@ void Copter::land_run_horizontal_control()
     // run loiter controller
     wp_nav.update_loiter(ekfGndSpdLimit, ekfNavVelGainScaler);
 
+    int32_t nav_roll  = wp_nav.get_roll();
+    int32_t nav_pitch = wp_nav.get_pitch();
+
+    if (g2.wp_navalt_min > 0) {
+        // user has requested an altitude below which navigation
+        // attitude is limited. This is used to prevent commanded roll
+        // over on landing, which particularly affects helicopters if
+        // there is any position estimate drift after touchdown. We
+        // limit attitude to 7 degrees below this limit and linearly
+        // interpolate for 1m above that
+        int alt_above_ground = land_get_alt_above_ground();
+        float attitude_limit_cd = linear_interpolate(700, aparm.angle_max, alt_above_ground,
+                                                     g2.wp_navalt_min*100U, (g2.wp_navalt_min+1)*100U);
+        float total_angle_cd = norm(nav_roll, nav_pitch);
+        if (total_angle_cd > attitude_limit_cd) {
+            float ratio = attitude_limit_cd / total_angle_cd;
+            nav_roll *= ratio;
+            nav_pitch *= ratio;
+
+            // tell position controller we are applying an external limit
+            pos_control.set_limit_accel_xy();
+        }
+    }
+
+    
     // call attitude controller
-    attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), target_yaw_rate, get_smoothing_gain());
+    attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(nav_roll, nav_pitch, target_yaw_rate, get_smoothing_gain());
 }
 
 // land_do_not_use_GPS - forces land-mode to not use the GPS but instead rely on pilot input for roll and pitch

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -150,21 +150,21 @@ void Copter::auto_takeoff_set_start_alt(void)
     auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude();
     
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
-        // we are not flying, add the takeoff_nav_alt
-        auto_takeoff_no_nav_alt_cm += g2.takeoff_nav_alt * 100;
+        // we are not flying, add the wp_navalt_min
+        auto_takeoff_no_nav_alt_cm += g2.wp_navalt_min * 100;
     }
 }
 
 
 /*
   call attitude controller for automatic takeoff, limiting roll/pitch
-  if below takeoff_nav_alt
+  if below wp_navalt_min
  */
 void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
 {
     float nav_roll, nav_pitch;
     
-    if (g2.takeoff_nav_alt > 0 && inertial_nav.get_altitude() < auto_takeoff_no_nav_alt_cm) {
+    if (g2.wp_navalt_min > 0 && inertial_nav.get_altitude() < auto_takeoff_no_nav_alt_cm) {
         // we haven't reached the takeoff navigation altitude yet
         nav_roll = 0;
         nav_pitch = 0;


### PR DESCRIPTION
This prevents a commanded roll over while landing, particularly in helicopters.
When a helicopter touches down a combination of GPS drift and small changes in inertial position estimate due to vibration can cause it to try to reposition while it is in contact with the ground. That can lead to a large desired attitude from the navigation controller which can lead to blade strike.
This prevents that by limiting the commanded attitude close to the group when WP_NAVALT_MIN is set
