### PR TITLE
Copter: fixed heli criterion for unsetting land_complete

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -48,7 +48,7 @@ void Copter::update_land_detector()
     } else if (ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME
         // if rotor speed and collective pitch are high then clear landing flag
-        if (motors.get_throttle() > get_non_takeoff_throttle() && motors.rotor_runup_complete()) {
+        if (motors.get_throttle() > get_non_takeoff_throttle() && !motors.limit.throttle_lower && motors.rotor_runup_complete()) {
 #else
         // if throttle output is high then clear landing flag
         if (motors.get_throttle() > get_non_takeoff_throttle()) {


### PR DESCRIPTION
in order to honor H_LAND_COL_MIN we need to check if we have reached
the throttle lower limit
This fixes a problem in helicopter landing where we set LAND_COMPLETE when we reach the landing collective and then unset it almost immediately as we are still above the non_takeoff_throttle. 