### PR TITLE
AP_HAL_Linux:SPIDevice: Added functions for spi device table reference manipulation

### DIFF
--- a/libraries/AP_HAL/SPIDevice.h
+++ b/libraries/AP_HAL/SPIDevice.h
@@ -66,6 +66,12 @@ public:
     {
         return nullptr;
     }
+
+    /* Return possible spi device count number. */
+    virtual uint8_t get_count() { return 0; }
+
+    /* Get spi device name with @ref */
+    virtual const char* get_device_name(uint8_t n) { return 0; }
 };
 
 }

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -426,6 +426,15 @@ SPIDeviceManager::get_device(const char *name)
     return dev;
 }
 
+uint8_t SPIDeviceManager::get_count() {
+   return _n_device_desc;
+}
+
+const char* SPIDeviceManager::get_device_name(uint8_t n)
+{
+    return _device[n].name;
+}
+
 /* Create a new device increasing the bus reference */
 AP_HAL::OwnPtr<AP_HAL::SPIDevice>
 SPIDeviceManager::_create_device(SPIBus &b, SPIDesc &desc) const

--- a/libraries/AP_HAL_Linux/SPIDevice.h
+++ b/libraries/AP_HAL_Linux/SPIDevice.h
@@ -95,6 +95,12 @@ public:
 
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name);
 
+    /* See AP_HAL::SPIDeviceManager::get_count() */
+    uint8_t get_count();
+
+    /* See AP_HAL::SPIDeviceManager::get_device_name() */
+    const char* get_device_name(uint8_t n);
+
 protected:
     void _unregister(SPIBus &b);
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _create_device(SPIBus &b, SPIDesc &device_desc) const;

--- a/libraries/AP_HAL_Linux/examples/BusTest/BusTest.cpp
+++ b/libraries/AP_HAL_Linux/examples/BusTest/BusTest.cpp
@@ -1,0 +1,101 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+//
+// scan I2C and SPI buses for expected devices
+//
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+static struct {
+    const char *name;
+    uint8_t whoami_reg;
+} whoami_list[] = {
+    { "ms5611",     0x00 | 0x80 },
+    { "mpu9250",    0x75 | 0x80 },
+    { "mpu6000",    0x75 | 0x80 },
+    { "lsm9ds0_am", 0x0F | 0x80 },
+    { "lsm9ds0_g",  0x0F | 0x80 },
+};
+
+AP_HAL::OwnPtr<AP_HAL::Device>
+get_device(const char *name)
+{
+    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+
+    const char *spi_name = new char;
+    spi_name = hal.spi->get_device_name(0);
+    /* Dummy is the default device at index 0 
+       if there isn't registered device for the target board.
+    */
+    const char *dummy = {"**dummy**"};
+    if (!strcmp(dummy, spi_name)) {
+        hal.console->printf("No devices, nothing to do.\n");
+        while(1) { hal.scheduler->delay(500); };
+    }
+
+    /* We get possible registered device count on the target board */
+    uint8_t spicount = hal.spi->get_count();
+    for (uint8_t ref = 0; ref < spicount; ref++) {
+        /* We get the name from the index and we compare
+           with our possible devices list.
+        */
+        spi_name = hal.spi->get_device_name(ref);
+        if (!strcmp(name, spi_name)) {
+            dev = hal.spi->get_device(spi_name);
+            break;
+        }
+    }
+
+    return dev;
+}
+
+void setup(void)
+{
+    hal.console->println("BusTest startup...\n");
+}
+
+void loop(void)
+{
+    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Semaphore *spi_sem;
+    const char *bus_type = new char;
+
+    hal.console->printf("Scanning SPI and I2C bus devices\n");
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(whoami_list); i++) {
+        dev = get_device(whoami_list[i].name);
+        if (dev) {
+
+            if (dev->bus_type == AP_HAL::Device::BusType::BUS_TYPE_SPI) {
+                bus_type = "SPI";
+            } else {
+                bus_type = "I2C";
+            }
+
+            hal.console->printf("Device %s registered on %s bus\n", whoami_list[i].name, bus_type);
+            hal.console->printf("Trying to send data...\n");
+
+            spi_sem = dev->get_semaphore();
+            if (!spi_sem->take(1000)) {
+                hal.console->printf("Failed to get SPI semaphore for %s\n", whoami_list[i].name);
+                break;
+            }
+            uint8_t tx[2] = { whoami_list[i].whoami_reg, 0 };
+            uint8_t rx[2] = { 0, 0 };
+            dev->transfer(tx, sizeof(tx), rx, sizeof(rx));
+            if (rx[1] != 0) {
+                hal.console->printf("WHO_AM_I for %s: 0x%02x\n\n", whoami_list[i].name, (unsigned)rx[1]);
+            } else {
+                hal.console->printf("No response %s!\n\n", whoami_list[i].name);
+                break;
+            }
+            spi_sem->give();
+        }
+    }
+    hal.scheduler->delay(1000);
+}
+
+AP_HAL_MAIN();

--- a/libraries/AP_HAL_Linux/examples/BusTest/Makefile
+++ b/libraries/AP_HAL_Linux/examples/BusTest/Makefile
@@ -1,0 +1,1 @@
+include ../../../../mk/apm.mk

--- a/libraries/AP_HAL_Linux/examples/BusTest/make.inc
+++ b/libraries/AP_HAL_Linux/examples/BusTest/make.inc
@@ -1,0 +1,5 @@
+LIBRARIES += AP_Common
+LIBRARIES += AP_Math
+LIBRARIES += AP_Param
+LIBRARIES += StorageManager
+LIBRARIES += AP_ADC

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )


### PR DESCRIPTION
Two functions added, tested with URUS.

/\* Return possible spi device count number. */
uint8_t get_count();

/\* Get spi device name with @n _/
const char_ get_device_name(uint8_t n);

Added to this PR an example to scan spi and i2c bus.
This example use the new interface APM API.

Example check our list devices with the possible devices registered on the target board, if it exist then we send data verification if hardware is present physically.
