### PR TITLE
Git: add Koji Hosaka to Git_Success.txt

### DIFF
--- a/Tools/GIT_Test/GIT_Success.txt
+++ b/Tools/GIT_Test/GIT_Success.txt
@@ -36,3 +36,4 @@ Shinya Oda
 Kouichi Nakajima
 Yuki Yoshioka
 Takanobu Minoshima
+Koji Hosaka


### PR DESCRIPTION
This is for the preliminary check of github PR.