### PR TITLE
A neater method of constructing Backends

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -19,6 +19,7 @@
  *
  */
 #include "AP_Baro.h"
+#include "AP_Baro_Backend.h"
 
 #include <utility>
 
@@ -26,12 +27,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 
-#include "AP_Baro_BMP085.h"
-#include "AP_Baro_HIL.h"
-#include "AP_Baro_MS5611.h"
-#include "AP_Baro_PX4.h"
-#include "AP_Baro_qflight.h"
-#include "AP_Baro_QURT.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -282,10 +277,11 @@ float AP_Baro::get_calibration_temperature(uint8_t instance) const
 void AP_Baro::init(void)
 {
     if (_hil_mode) {
-        drivers[0] = new AP_Baro_HIL(*this);
+        drivers[0] = create_default_baro_backend<HAL_BARO_HIL>(*this);
         _num_drivers = 1;
         return;
     }
+
     drivers[0] = create_default_baro_backend<HAL_BARO_DEFAULT>(*this);
     _num_drivers = 1;
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -286,42 +286,10 @@ void AP_Baro::init(void)
         _num_drivers = 1;
         return;
     }
+    drivers[0] = create_default_baro_backend<HAL_BARO_DEFAULT>(*this);
+    _num_drivers = 1;
 
-#if HAL_BARO_DEFAULT == HAL_BARO_PX4 || HAL_BARO_DEFAULT == HAL_BARO_VRBRAIN
-    drivers[0] = new AP_Baro_PX4(*this);
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_HIL
-    drivers[0] = new AP_Baro_HIL(*this);
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_BMP085
-    drivers[0] = new AP_Baro_BMP085(*this,
-        std::move(hal.i2c_mgr->get_device(HAL_BARO_BMP085_BUS, HAL_BARO_BMP085_I2C_ADDR)));
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_MS5611_I2C
-    drivers[0] = new AP_Baro_MS5611(*this,
-        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5611_I2C_BUS, HAL_BARO_MS5611_I2C_ADDR)));
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_MS5611_SPI
-    drivers[0] = new AP_Baro_MS5611(*this,
-        std::move(hal.spi->get_device(HAL_BARO_MS5611_NAME)));
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_MS5607_I2C
-    drivers[0] = new AP_Baro_MS5607(*this,
-        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5607_I2C_BUS, HAL_BARO_MS5607_I2C_ADDR)));
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_MS5637_I2C
-    drivers[0] = new AP_Baro_MS5637(*this,
-        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5637_I2C_BUS, HAL_BARO_MS5637_I2C_ADDR)));
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_QFLIGHT
-    drivers[0] = new AP_Baro_QFLIGHT(*this);
-    _num_drivers = 1;
-#elif HAL_BARO_DEFAULT == HAL_BARO_QURT
-    drivers[0] = new AP_Baro_QURT(*this);
-    _num_drivers = 1;
-#endif
-
-    if (_num_drivers == 0 || _num_sensors == 0 || drivers[0] == NULL) {
+    if ( _num_sensors == 0 || drivers[0] == NULL) {
         AP_HAL::panic("Baro: unable to initialise driver");
     }
 }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -14,6 +14,11 @@
 #define BARO_MAX_DRIVERS 2
 
 class AP_Baro_Backend;
+class AP_Baro;
+
+// This function is specialised for each Baro backend
+template <uint32_t BackendId>
+AP_Baro_Backend* create_default_baro_backend(AP_Baro& baro);
 
 class AP_Baro
 {

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -19,6 +19,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/I2CDevice.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -82,6 +83,14 @@ AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> 
 
     sem->give();
 }
+
+#if defined(HAL_BARO_BMP085) && defined(HAL_BARO_BMP085_BUS) && defined(HAL_BARO_BMP085_I2C_ADDR)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_BMP085>(AP_Baro& baro)
+{
+    return new AP_Baro_BMP085(baro,
+        std::move(hal.i2c_mgr->get_device(HAL_BARO_BMP085_BUS, HAL_BARO_BMP085_I2C_ADDR)));
+}
+#endif
 
 /*
   This is a state machine. Acumulate a new sensor reading.

--- a/libraries/AP_Baro/AP_Baro_HIL.cpp
+++ b/libraries/AP_Baro/AP_Baro_HIL.cpp
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 #include "AP_Baro_HIL.h"
-
 #include <AP_HAL/AP_HAL.h>
 
 extern const AP_HAL::HAL& hal;
@@ -11,10 +10,18 @@ AP_Baro_HIL::AP_Baro_HIL(AP_Baro &baro) :
     _instance = _frontend.register_sensor();
 }
 
+#if defined (HAL_BARO_HIL)
+template <>
+AP_Baro_Backend* create_default_baro_backend<HAL_BARO_HIL>(AP_Baro& baro)
+{
+    return new AP_Baro_HIL(baro);
+}
+#endif
+
 // ==========================================================================
 // based on tables.cpp from http://www.pdas.com/atmosdownload.html
 
-/* 
+/*
    Compute the temperature, density, and pressure in the standard atmosphere
    Correct to 20 km.  Only approximate thereafter.
 */

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -18,6 +18,9 @@
 #include <utility>
 
 #include <AP_Math/AP_Math.h>
+#include <AP_HAL/I2CDevice.h>
+#include <AP_HAL/SPIDevice.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -63,6 +66,38 @@ AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev
     , _dev(std::move(dev))
 {
 }
+
+#if defined (HAL_BARO_MS5611_I2C) && defined(HAL_BARO_MS5611_I2C_BUS) && defined(HAL_BARO_MS5611_I2C_ADDR)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_MS5611_I2C>(AP_Baro& baro)
+{
+    return new AP_Baro_MS5611(baro,
+        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5611_I2C_BUS, HAL_BARO_MS5611_I2C_ADDR)));
+}
+#endif
+
+#if defined (HAL_BARO_MS5611_SPI) && defined(HAL_BARO_MS5611_NAME)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_MS5611_SPI>(AP_Baro& baro)
+{
+    return new AP_Baro_MS5611(baro,
+        std::move(hal.spi->get_device(HAL_BARO_MS5611_NAME)));
+}
+#endif
+
+#if defined(HAL_BARO_MS5607_I2C) && defined(HAL_BARO_MS5607_I2C_BUS) && defined(HAL_BARO_MS5607_I2C_ADDR)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_MS5607_I2C>(AP_Baro& baro)
+{
+    return new AP_Baro_MS5607(baro,
+        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5607_I2C_BUS, HAL_BARO_MS5607_I2C_ADDR)));
+}
+#endif
+
+#if defined (HAL_BARO_MS5637_I2C) && defined (HAL_BARO_MS5637_I2C_BUS) && defined(HAL_BARO_MS5637_I2C_ADDR)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_MS5637_I2C>(AP_Baro& baro)
+{
+    return new AP_Baro_MS5637(baro,
+        std::move(hal.i2c_mgr->get_device(HAL_BARO_MS5637_I2C_BUS, HAL_BARO_MS5637_I2C_ADDR)));
+}
+#endif
 
 void AP_Baro_MS56XX::_init()
 {

--- a/libraries/AP_Baro/AP_Baro_PX4.cpp
+++ b/libraries/AP_Baro/AP_Baro_PX4.cpp
@@ -14,6 +14,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+
+
 /*
   constructor - opens the PX4 drivers
  */
@@ -44,6 +46,19 @@ AP_Baro_PX4::AP_Baro_PX4(AP_Baro &baro) :
         ioctl(instances[i].fd, SENSORIOCSQUEUEDEPTH, 20);
     }
 }
+#if defined(HAL_BARO_PX4)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_PX4>(AP_Baro& baro)
+{
+    return new  AP_Baro_PX4(baro);
+}
+#endif
+
+#if defined(HAL_BARO_VRBRAIN)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_VRBRAIN>(AP_Baro& baro)
+{
+    return new  AP_Baro_PX4(baro);
+}
+#endif
 
 // Read the sensor
 void AP_Baro_PX4::update(void)

--- a/libraries/AP_Baro/AP_Baro_QURT.cpp
+++ b/libraries/AP_Baro/AP_Baro_QURT.cpp
@@ -29,6 +29,13 @@ AP_Baro_QURT::AP_Baro_QURT(AP_Baro &baro)
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Baro_QURT::timer, void));
 }
 
+#if defined(HAL_BARO_QURT)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_QURT>(AP_Baro& baro)
+{
+   return new AP_Baro_QURT(baro);
+}
+#endif
+
 /*
   transfer data to the frontend
  */
@@ -45,7 +52,7 @@ void AP_Baro_QURT::update(void)
         count = 0;
         temp_sum = 0;
         press_sum = 0;
-        
+
         _copy_to_frontend(instance, pressure, temperature);
         lock.give();
     }
@@ -54,7 +61,7 @@ void AP_Baro_QURT::update(void)
 void AP_Baro_QURT::timer(void)
 {
     if (handle == 0) {
-        int ret = bmp280_open("/dev/i2c-2", &handle);        
+        int ret = bmp280_open("/dev/i2c-2", &handle);
         if (ret != 0) {
             AP_HAL::panic("unable to open QURT baro");
             return;

--- a/libraries/AP_Baro/AP_Baro_qflight.cpp
+++ b/libraries/AP_Baro/AP_Baro_qflight.cpp
@@ -21,6 +21,13 @@ AP_Baro_QFLIGHT::AP_Baro_QFLIGHT(AP_Baro &baro) :
     hal.scheduler->delay(100);
 }
 
+#if defined(HAL_BARO_QFLIGHT)
+template<> AP_Baro_Backend* create_default_baro_backend<HAL_BARO_QFLIGHT>(AP_Baro& baro)
+{
+   return new AP_Baro_QFLIGHT(baro);
+}
+#endif
+
 // Read the sensor
 void AP_Baro_QFLIGHT::timer_update(void)
 {
@@ -29,7 +36,7 @@ void AP_Baro_QFLIGHT::timer_update(void)
         return;
     }
     last_check_ms = now;
-    
+
     if (barobuf == nullptr) {
         barobuf = QFLIGHT_RPC_ALLOCATE(DSPBuffer::BARO);
         if (barobuf == nullptr) {


### PR DESCRIPTION
A neater method of constructing sensor Backends.

I chose the AP_Baro as an example sensor, but the same applies to many other sensors

In this version a template function is declared in AP_Baro.h 

template \<uint32_t BackendID\>
AP_Baro_Backend* create_default_baro_backend(AP_Baro& baro);

Note there is no default function definition. It is up to each Backend to create a specialisation of the function.
The  BackendID is the value of the HAL_BARO_DEFAULT macro.

The resulting code reduction can be seen in the void AP_Baro::init(void) function in AP_Baro.cpp, which is now much cleaner and easier to read.

A more advanced version would use class tags and typedefs to provide the same functionality without the need for macros.