### PR TITLE
waf: make it more "platform independent"

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -218,6 +218,8 @@ class linux(Board):
     def configure_env(self, cfg, env):
         super(linux, self).configure_env(cfg, env)
 
+        cfg.find_toolchain_program('pkg-config', var='PKGCONFIG')
+
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_LINUX',
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NONE',

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -9,6 +9,7 @@ from waflib import Logs, Task, Utils
 from waflib.TaskGen import after_method, before_method, feature
 
 import os
+import shutil
 import sys
 
 _dynamic_env_data = {}
@@ -60,8 +61,10 @@ def px4_import_objects_from_use(self):
         queue.extend(Utils.to_list(getattr(tg, 'use', [])))
 
 class px4_copy(Task.Task):
-    run_str = '${CP} ${SRC} ${TGT}'
     color = 'CYAN'
+
+    def run(self):
+        shutil.copy2(self.inputs[0].abspath(), self.outputs[0].abspath())
 
     def keyword(self):
         return "PX4: Copying %s to" % self.inputs[0].name
@@ -209,7 +212,6 @@ def _process_romfs(self):
 def configure(cfg):
     cfg.env.CMAKE_MIN_VERSION = '3.2'
     cfg.load('cmake')
-    cfg.find_program('cp')
 
     bldnode = cfg.bldnode.make_node(cfg.variant)
     env = cfg.env

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -133,8 +133,8 @@ def configure(cfg):
     _filter_supported_c_compilers('gcc', 'clang')
     _filter_supported_cxx_compilers('g++', 'clang++')
 
-    cfg.env.AR = cfg.env.TOOLCHAIN + '-ar'
-    cfg.env.PKGCONFIG = cfg.env.TOOLCHAIN + '-pkg-config'
+    cfg.find_toolchain_program('ar')
+
     cfg.msg('Using toolchain', cfg.env.TOOLCHAIN)
     cfg.load('compiler_cxx compiler_c')
 


### PR DESCRIPTION
Hi all,

This is part of an effort on making the build system work on Windows platforms. This PR makes some changes in our build system in order to be more platform independent.

In order to build natively on Windows, some changes in the submodules are also required. I'm working on that. I've actually been able to build natively with Ninja as the build generated by cmake with the my local changes to the submodules, but a little more work is required to make it work with generated Makefiles as well.

Nevertheless, I believe this is good to go in, since it is an overall improvement.

By the way, with these patches, I can build for px4-v2 on cygwin. We can upload the arm-none-eabi toolchain for cygwin somewhere if there's interest on using that. The "official" source doesn't support building the toolchain for cygwin, so I had to change their script a little bit in order to get it for cygwin.

Best regards,
Gustavo Sousa