### PR TITLE
EKF2: Fix bugs causing height drift on ground when using range height without GPS

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -82,6 +82,9 @@ void NavEKF2_core::readRangeFinder(void)
                 // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
                 storedRange.push(rangeDataNew);
 
+                // indicate we have updated the measurement
+                rngValidMeaTime_ms = imuSampleTime_ms;
+
             } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
@@ -96,10 +99,10 @@ void NavEKF2_core::readRangeFinder(void)
                 // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
                 storedRange.push(rangeDataNew);
 
+                // indicate we have updated the measurement
+                rngValidMeaTime_ms = imuSampleTime_ms;
+
             }
-
-            rngValidMeaTime_ms = imuSampleTime_ms;
-
         }
     }
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1336,10 +1336,8 @@ void NavEKF2_core::ConstrainStates()
     for (uint8_t i=19; i<=21; i++) statesArray[i] = constrain_float(statesArray[i],-0.5f,0.5f);
     // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
     for (uint8_t i=22; i<=23; i++) statesArray[i] = constrain_float(statesArray[i],-100.0f,100.0f);
-    // constrain the terrain or vertical position state state depending on whether we are using the ground as the height reference
-    if (inhibitGndState) {
-        stateStruct.position.z = MIN(stateStruct.position.z, terrainState - rngOnGnd);
-    } else {
+    // constrain the terrain state to be below the vehicle height unless we are using terrain as the height datum
+    if (!inhibitGndState) {
         terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
     }
 }


### PR DESCRIPTION
Depending on the sign of the vertical accel bias these bugs could cause the height estimate to to drop when on the ground before achieving GPS lock if EK2_RNG_USE_HGT was set to a positive number to enable range finder as the primary height source for low altitude operation. They could also cause an unconstrained height error if starting on ground with a range finder that was reporting below the minimum valid range.

Before - note the slow downwards drift in height estimate which climbs back up to the range finder estimate when GPS lock is gained:

![before](https://cloud.githubusercontent.com/assets/3596952/17829742/0420a86a-66fc-11e6-942d-0ac1e0fd7b16.png)

After - the height estimate tracks the range finder from startup:

![after](https://cloud.githubusercontent.com/assets/3596952/17829747/0c6246f0-66fc-11e6-8d88-ee71f73833be.png)

It has been flight tested with range finder enabled and transitioning from range finder fusion to baro fusion and back again. 

Here are the different height estimates - note that because baro alt is used as the height reference at altitude, that the height datum has changed by a few metres by the time it drops below the range finder use height.
![screen shot 2016-08-20 at 5 36 39 pm](https://cloud.githubusercontent.com/assets/3596952/17829769/ac6040bc-66fc-11e6-9254-194db4f4a415.png)

Here is the height innovation - note the increase in innovation noise when it switches to baro
![screen shot 2016-08-20 at 5 40 32 pm](https://cloud.githubusercontent.com/assets/3596952/17829803/36a383b0-66fd-11e6-92f1-e436f41bf484.png)

