### PR TITLE
AP_OpticalFlow: The first value of the register to the value of the definition.

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
@@ -91,14 +91,14 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
 
     // Perform the writing and reading in a single command
     if (PX4FLOW_REG == 0x00) {
-        if (!_dev->read_registers(0, val, I2C_FRAME_SIZE + I2C_INTEGRAL_FRAME_SIZE)) {
+        if (!_dev->read_registers(PX4FLOW_REG, val, I2C_FRAME_SIZE + I2C_INTEGRAL_FRAME_SIZE)) {
             goto fail_transfer;
         }
         memcpy(&f_integral, &(val[I2C_FRAME_SIZE]), I2C_INTEGRAL_FRAME_SIZE);
     }
 
     if (PX4FLOW_REG == 0x16) {
-        if (!_dev->read_registers(0, val, I2C_INTEGRAL_FRAME_SIZE)) {
+        if (!_dev->read_registers(PX4FLOW_REG, val, I2C_INTEGRAL_FRAME_SIZE)) {
             goto fail_transfer;
         }
         memcpy(&f_integral, val, I2C_INTEGRAL_FRAME_SIZE);


### PR DESCRIPTION
The first argument of **_dev-> read_register** method is adapted to set the number of the first register to obtain.
If the value of the **PX4FLOW_REG** is **0**, to get the _i2c_flame_ and _i2c_integral_frame_.
If the value of the **PX4FLOW_REG** is **0x16**(22), to get the _i2c_integral_frame_.
However, the value of **PX4FLOW_REG** cases of **0x16** (22), the first register is **0**.

Change

The value of the first register to be specified in the **PX4FLOW_REG**.

===
Debug information
(gdb) p f_integral
$1 = {frame_count_since_last_readout = 0, pixel_flow_x_integral = 0, pixel_flow_y_integral = 0, gyro_x_rate_integral = 0, gyro_y_rate_integral = 0, gyro_z_rate_integral = 0, integration_timespan = 0, sonar_timestamp = 24830, ground_distance = 1637, gyro_temperature = 3300, qual = 0 '\000'}
