### PR TITLE
Copter: Add FRAME_TYPE to distinguish multicopters and helicopters

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -118,7 +118,7 @@ void Copter::set_pre_arm_rc_check(bool b)
 
 void Copter::update_using_interlock()
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // helicopters are always using motor interlock
     ap.using_interlock = true;
 #else

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -16,8 +16,8 @@
  *  ArduCopter Version 3.0
  *  Creator:        Jason Short
  *  Lead Developer: Randy Mackay
- *  Lead Tester:    Marco Robustini 
- *  Based on code and ideas from the Arducopter team: Leonard Hall, Andrew Tridgell, Robert Lefebvre, Pat Hickey, Michael Oborne, Jani Hirvinen, 
+ *  Lead Tester:    Marco Robustini
+ *  Based on code and ideas from the Arducopter team: Leonard Hall, Andrew Tridgell, Robert Lefebvre, Pat Hickey, Michael Oborne, Jani Hirvinen,
                                                       Olivier Adler, Kevin Hester, Arthur Benemann, Jonathan Challinger, John Arne Birkeland,
                                                       Jean-Louis Naudin, Mike Smith, and more
  *  Thanks to:	Chris Anderson, Jordi Munoz, Jason Short, Doug Weibel, Jose Julio
@@ -104,7 +104,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if PRECISION_LANDING == ENABLED
     SCHED_TASK(update_precland,      400,     50),
 #endif
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     SCHED_TASK(check_dynamic_flight,  50,     75),
 #endif
     SCHED_TASK(update_notify,         50,     90),
@@ -156,7 +156,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 };
 
 
-void Copter::setup() 
+void Copter::setup()
 {
     cliSerial = hal.console;
 
@@ -261,10 +261,10 @@ void Copter::fast_loop()
 
     // run low level rate controllers that only require IMU data
     attitude_control.rate_controller_run();
-    
-#if FRAME_CONFIG == HELI_FRAME
+
+#if FRAME_TYPE == HELICOPTER
     update_heli_control_dynamics();
-#endif //HELI_FRAME
+#endif
 
     // send outputs to the motors library
     motors_output();
@@ -316,7 +316,7 @@ void Copter::throttle_loop()
     // check auto_armed status
     update_auto_armed();
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // update rotor speed
     heli_update_rotor_speed_targets();
 
@@ -348,7 +348,7 @@ void Copter::update_trigger(void)
         if (should_log(MASK_LOG_CAMERA)) {
             DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
         }
-    }    
+    }
 #endif
 }
 
@@ -408,7 +408,8 @@ void Copter::ten_hz_logging_loop()
         Log_Write_Proximity();
         Log_Write_Beacon();
     }
-#if FRAME_CONFIG == HELI_FRAME
+
+#if FRAME_TYPE == HELICOPTER
     Log_Write_Heli();
 #endif
 }
@@ -489,7 +490,7 @@ void Copter::one_hz_loop()
 
         update_using_interlock();
 
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
         // check the user hasn't updated the frame orientation
         motors.set_frame_orientation(g.frame_orientation);
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -105,7 +105,7 @@ float Copter::get_look_ahead_yaw()
 //  called at 100hz
 void Copter::update_throttle_hover()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // if not armed or landed exit
     if (!motors.armed() || ap.land_complete) {
         return;

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -23,7 +23,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 Copter::Copter(void) :
     DataFlash{FIRMWARE_STRING},
     flight_modes(&g.flight_mode1),
-    mission(ahrs, 
+    mission(ahrs,
             FUNCTOR_BIND_MEMBER(&Copter::start_command, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&Copter::verify_command_callback, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&Copter::exit_mission, void)),
@@ -107,7 +107,7 @@ Copter::Copter(void) :
 #if PRECISION_LANDING == ENABLED
     precland(ahrs, inertial_nav),
 #endif
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // ToDo: Input Manager is only used by Heli for 3.3, but will be used by all frames for 3.4
     input_manager(MAIN_LOOP_RATE),
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -293,7 +293,7 @@ private:
 
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
-    
+
     RCMapper rcmap;
 
     // board specific config
@@ -334,7 +334,7 @@ private:
  #define FRAME_MAV_TYPE MAV_TYPE_HEXAROTOR
 #elif (FRAME_CONFIG == OCTA_FRAME || FRAME_CONFIG == OCTA_QUAD_FRAME)
  #define FRAME_MAV_TYPE MAV_TYPE_OCTOROTOR
-#elif (FRAME_CONFIG == HELI_FRAME)
+#elif (FRAME_TYPE == HELICOPTER)
  #define FRAME_MAV_TYPE MAV_TYPE_HELICOPTER
 #elif (FRAME_CONFIG == SINGLE_FRAME || FRAME_CONFIG == COAX_FRAME)  //because mavlink did not define a singlecopter, we use a quad
  #define FRAME_MAV_TYPE MAV_TYPE_QUADROTOR
@@ -516,7 +516,7 @@ private:
 
     // Attitude, Position and Waypoint navigation objects
     // To-Do: move inertial nav up or other navigation variables down here
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     AC_AttitudeControl_Heli attitude_control;
 #else
     AC_AttitudeControl_Multi attitude_control;
@@ -570,8 +570,8 @@ private:
     AP_Rally_Copter rally;
 #endif
 
-    // RSSI 
-    AP_RSSI rssi;      
+    // RSSI
+    AP_RSSI rssi;
 
     // Crop Sprayer
 #if SPRAYER == ENABLED
@@ -599,7 +599,7 @@ private:
     // Pilot Input Management Library
     // Only used for Helicopter for AC3.3, to be expanded to include Multirotor
     // child class for AC3.4
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     AC_InputManager_Heli input_manager;
 #endif
 
@@ -616,12 +616,12 @@ private:
 
     // last valid RC input time
     uint32_t last_radio_update_ms;
-    
+
     // Top-level logic
     // setup the var_info table
     AP_Param param_loader;
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // Mode filter to reject RC Input glitches.  Filter size is 5, and it draws the 4th element, so it can reject 3 low glitches,
     // and 1 high glitch.  This is because any "off" glitches can be highly problematic for a helicopter running an ESC
     // governor.  Even a single "off" frame can cause the rotor to slow dramatically and take a long time to restart.
@@ -757,7 +757,7 @@ private:
     void Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, int16_t control_in, int16_t tune_low, int16_t tune_high);
     void Log_Write_Home_And_Origin();
     void Log_Sensor_Health();
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     void Log_Write_Heli(void);
 #endif
     void Log_Write_Precland();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -117,7 +117,7 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
     }
 
     update_sensor_status_flags();
-    
+
     mavlink_msg_sys_status_send(
         chan,
         control_sensors_present,
@@ -196,7 +196,7 @@ void NOINLINE Copter::send_servo_out(mavlink_channel_t chan)
     // normalized values scaled to -10000 to 10000
     // This is used for HIL.  Do not change without discussing with HIL maintainers
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     mavlink_msg_rc_channels_scaled_send(
         chan,
         millis(),
@@ -318,7 +318,7 @@ void Copter::send_pid_tuning(mavlink_channel_t chan)
     const Vector3f &gyro = ahrs.get_gyro();
     if (g.gcs_pid_mask & 1) {
         const DataFlash_Class::PID_Info &pid_info = attitude_control.get_rate_roll_pid().get_pid_info();
-        mavlink_msg_pid_tuning_send(chan, PID_TUNING_ROLL, 
+        mavlink_msg_pid_tuning_send(chan, PID_TUNING_ROLL,
                                     pid_info.desired*0.01f,
                                     degrees(gyro.x),
                                     pid_info.FF*0.01f,
@@ -331,7 +331,7 @@ void Copter::send_pid_tuning(mavlink_channel_t chan)
     }
     if (g.gcs_pid_mask & 2) {
         const DataFlash_Class::PID_Info &pid_info = attitude_control.get_rate_pitch_pid().get_pid_info();
-        mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH, 
+        mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH,
                                     pid_info.desired*0.01f,
                                     degrees(gyro.y),
                                     pid_info.FF*0.01f,
@@ -344,7 +344,7 @@ void Copter::send_pid_tuning(mavlink_channel_t chan)
     }
     if (g.gcs_pid_mask & 4) {
         const DataFlash_Class::PID_Info &pid_info = attitude_control.get_rate_yaw_pid().get_pid_info();
-        mavlink_msg_pid_tuning_send(chan, PID_TUNING_YAW, 
+        mavlink_msg_pid_tuning_send(chan, PID_TUNING_YAW,
                                     pid_info.desired*0.01f,
                                     degrees(gyro.z),
                                     pid_info.FF*0.01f,
@@ -357,7 +357,7 @@ void Copter::send_pid_tuning(mavlink_channel_t chan)
     }
     if (g.gcs_pid_mask & 8) {
         const DataFlash_Class::PID_Info &pid_info = g.pid_accel_z.get_pid_info();
-        mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ, 
+        mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info.desired*0.01f,
                                     -(ahrs.get_accel_ef_blended().z + GRAVITY_MSS),
                                     pid_info.FF*0.01f,
@@ -553,7 +553,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 
     case MSG_MOUNT_STATUS:
 #if MOUNT == ENABLED
-        CHECK_PAYLOAD_SIZE(MOUNT_STATUS);    
+        CHECK_PAYLOAD_SIZE(MOUNT_STATUS);
         copter.camera_mount.status_msg(chan);
 #endif // MOUNT == ENABLED
         break;
@@ -925,7 +925,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         }
         break;
     }
-    
+
     case MAVLINK_MSG_ID_MISSION_ITEM_INT:
     {
         if (handle_mission_item(msg, copter.mission)) {
@@ -1260,7 +1260,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 }
                 copter.ins.acal_init();
                 copter.ins.get_acal()->start(this);
-                
+
             } else if (is_equal(packet.param5,2.0f)) {
                 // calibrate gyros
                 if (!copter.calibrate_gyros()) {
@@ -1980,7 +1980,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         // send message to Notify
         AP_Notify::handle_play_tune(msg);
         break;
-                
+
     case MAVLINK_MSG_ID_SET_HOME_POSITION:
     {
         mavlink_set_home_position_t packet;

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -401,7 +401,7 @@ struct PACKED log_MotBatt {
 // Write an rate packet
 void Copter::Log_Write_MotBatt()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     struct log_MotBatt pkt_mot = {
         LOG_PACKET_HEADER_INIT(LOG_MOTBATT_MSG),
         time_us         : AP_HAL::micros64(),
@@ -630,7 +630,7 @@ struct PACKED log_Heli {
     float    main_rotor_speed;
 };
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
 // Write an helicopter packet
 void Copter::Log_Write_Heli()
 {
@@ -993,7 +993,7 @@ void Copter::Log_Write_Home_And_Origin() {}
 void Copter::Log_Sensor_Health() {}
 void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
 void Copter::Log_Write_Heli() {}
 #endif
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -257,7 +257,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Increment: 10
     // @User: Standard
     GSCALAR(land_speed_high,        "LAND_SPEED_HIGH",   0),
-    
+
     // @Param: PILOT_VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
@@ -449,7 +449,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Range: 0 127
     // @User: Advanced
     GSCALAR(disarm_delay, "DISARM_DELAY",           AUTO_DISARMING_DELAY),
-    
+
     // @Param: ANGLE_MAX
     // @DisplayName: Angle Max
     // @Description: Maximum lean angle in all flight modes
@@ -717,7 +717,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_LandingGear/AP_LandingGear.cpp
     GOBJECT(landinggear,    "LGR_", AP_LandingGear),
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // @Group: IM_
     // @Path: ../libraries/AC_InputManager/AC_InputManager_Heli.cpp
     GOBJECT(input_manager, "IM_", AC_InputManager_Heli),
@@ -739,7 +739,9 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AC_WPNav/AC_Circle.cpp
     GOBJECT(circle_nav, "CIRCLE_",  AC_Circle),
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
+    // @Group: ATC_
+    // @Path: ../libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
     GOBJECT(attitude_control, "ATC_", AC_AttitudeControl_Heli),
 #else
     // @Group: ATC_
@@ -855,7 +857,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Group: EK2_
     // @Path: ../libraries/AP_NavEKF2/AP_NavEKF2.cpp
     GOBJECTN(EKF2, NavEKF2, "EK2_", NavEKF2),
-    
+
     // @Group: EK3_
     // @Path: ../libraries/AP_NavEKF3/AP_NavEKF3.cpp
     GOBJECTN(EKF3, NavEKF3, "EK3_", NavEKF3),
@@ -866,8 +868,8 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Group: RSSI_
     // @Path: ../libraries/AP_RSSI/AP_RSSI.cpp
-    GOBJECT(rssi, "RSSI_",  AP_RSSI),      
-    
+    GOBJECT(rssi, "RSSI_",  AP_RSSI),
+
 #if RANGEFINDER_ENABLED == ENABLED
     // @Group: RNGFND
     // @Path: ../libraries/AP_RangeFinder/RangeFinder.cpp
@@ -944,10 +946,10 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(terrain_follow, "TERRAIN_FOLLOW", 0),
 
-    // @Group: 
+    // @Group:
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),
-    
+
     AP_VAREND
 };
 
@@ -1133,7 +1135,7 @@ void Copter::convert_pid_parameters(void)
         { Parameters::k_param_pid_rate_yaw, 0, AP_PARAM_FLOAT, "ATC_RAT_YAW_P" },
         { Parameters::k_param_pid_rate_yaw, 1, AP_PARAM_FLOAT, "ATC_RAT_YAW_I" },
         { Parameters::k_param_pid_rate_yaw, 2, AP_PARAM_FLOAT, "ATC_RAT_YAW_D" },
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         { Parameters::k_param_pid_rate_roll,  4, AP_PARAM_FLOAT, "ATC_RAT_RLL_VFF" },
         { Parameters::k_param_pid_rate_pitch, 4, AP_PARAM_FLOAT, "ATC_RAT_PIT_VFF" },
         { Parameters::k_param_pid_rate_yaw  , 4, AP_PARAM_FLOAT, "ATC_RAT_YAW_VFF" },
@@ -1143,7 +1145,7 @@ void Copter::convert_pid_parameters(void)
         { Parameters::k_param_pid_rate_roll,  5, AP_PARAM_FLOAT, "ATC_RAT_RLL_IMAX" },
         { Parameters::k_param_pid_rate_pitch, 5, AP_PARAM_FLOAT, "ATC_RAT_PIT_IMAX" },
         { Parameters::k_param_pid_rate_yaw,   5, AP_PARAM_FLOAT, "ATC_RAT_YAW_IMAX" },
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         { Parameters::k_param_pid_rate_roll,  7, AP_PARAM_FLOAT, "ATC_RAT_RLL_ILMI" },
         { Parameters::k_param_pid_rate_pitch, 7, AP_PARAM_FLOAT, "ATC_RAT_PIT_ILMI" },
         { Parameters::k_param_pid_rate_yaw,   7, AP_PARAM_FLOAT, "ATC_RAT_YAW_ILMI" },
@@ -1166,7 +1168,7 @@ void Copter::convert_pid_parameters(void)
     // and motor libraries switch to accept inputs in -1 to +1 range instead of -4500 ~ +4500
     float pid_scaler = 1.27f;
 
-#if FRAME_CONFIG == QUAD_FRAME || FRAME_CONFIG == HEXA_FRAME || FRAME_CONFIG == Y6_FRAME  || FRAME_CONFIG == OCTA_FRAME || FRAME_CONFIG == OCTA_QUAD_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // Multicopter x-frame gains are 40% lower because -1 or +1 input to motors now results in maximum rotation
     if (g.frame_orientation == AP_MOTORS_X_FRAME || g.frame_orientation == AP_MOTORS_V_FRAME || g.frame_orientation == AP_MOTORS_H_FRAME) {
         pid_scaler = 0.9f;

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -187,7 +187,7 @@ public:
 
         // 97: RSSI
         k_param_rssi = 97,
-                
+
         //
         // 100: Inertial Nav
         //
@@ -409,7 +409,7 @@ public:
 
     AP_Int16        poshold_brake_rate;         // PosHold flight mode's rotation rate during braking in deg/sec
     AP_Int16        poshold_brake_angle_max;    // PosHold flight mode's max lean angle during braking in centi-degrees
-    
+
     // Waypoints
     //
     AP_Int32        rtl_loiter_time;

--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -23,7 +23,7 @@ void AP_AdvancedFailsafe_Copter::terminate_vehicle(void)
 
     // disarm as well
     copter.init_disarm_motors();
-    
+
     // and set all aux channels
     RC_Channel_aux::set_servo_limit(RC_Channel_aux::k_heli_rsc, RC_Channel::RC_CHANNEL_LIMIT_TRIM);
     RC_Channel_aux::set_servo_limit(RC_Channel_aux::k_heli_tail_rsc, RC_Channel::RC_CHANNEL_LIMIT_TRIM);
@@ -45,7 +45,7 @@ void AP_AdvancedFailsafe_Copter::setup_IO_failsafe(void)
     RC_Channel_aux::set_servo_failsafe(RC_Channel_aux::k_none, RC_Channel::RC_CHANNEL_LIMIT_TRIM);
     RC_Channel_aux::set_servo_failsafe(RC_Channel_aux::k_manual, RC_Channel::RC_CHANNEL_LIMIT_TRIM);
 
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // setup AP_Motors outputs for failsafe
     uint16_t mask = copter.motors.get_motor_mask();
     hal.rcout->set_failsafe_pwm(mask, copter.motors.get_pwm_output_min());

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -376,12 +376,12 @@ bool Copter::parameter_checks(bool display_failure)
         }
         #endif
 
-        #if FRAME_CONFIG == HELI_FRAME
+        #if FRAME_TYPE == HELICOPTER
         // check helicopter parameters
         if (!motors.parameter_check(display_failure)) {
             return false;
         }
-        #endif // HELI_FRAME
+        #endif
 
         // check for missing terrain data
         if (!pre_arm_terrain_check(display_failure)) {
@@ -412,7 +412,7 @@ bool Copter::pilot_throttle_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
         if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->get_radio_in() < g.failsafe_throttle_value) {
             if (display_failure) {
-                #if FRAME_CONFIG == HELI_FRAME
+                #if FRAME_TYPE == HELICOPTER
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Collective below Failsafe");
                 #else
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Throttle below Failsafe");
@@ -819,7 +819,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         // check throttle is not too low - must be above failsafe throttle
         if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->get_radio_in() < g.failsafe_throttle_value) {
             if (display_failure) {
-                #if FRAME_CONFIG == HELI_FRAME
+                #if FRAME_TYPE == HELICOPTER
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective below Failsafe");
                 #else
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle below Failsafe");
@@ -833,7 +833,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
             // above top of deadband is too always high
             if (get_pilot_desired_climb_rate(channel_throttle->get_control_in()) > 0.0f) {
                 if (display_failure) {
-                    #if FRAME_CONFIG == HELI_FRAME
+                    #if FRAME_TYPE == HELICOPTER
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
                     #else
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");
@@ -844,7 +844,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
             // in manual modes throttle must be at zero
             if ((mode_has_manual_throttle(control_mode) || control_mode == DRIFT) && channel_throttle->get_control_in() > 0) {
                 if (display_failure) {
-                    #if FRAME_CONFIG == HELI_FRAME
+                    #if FRAME_TYPE == HELICOPTER
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
                     #else
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -7,7 +7,7 @@
 // setup_compassmot - sets compass's motor interference parameters
 MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // compassmot not implemented for tradheli
     return MAV_RESULT_TEMPORARILY_REJECTED;
 #else
@@ -153,16 +153,16 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
 
         // read radio input
         read_radio();
-        
+
         // pass through throttle to motors
         motors.set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() / 1000.0f);
-        
+
         // read some compass values
         compass.read();
-        
+
         // read current
         read_battery();
-        
+
         // calculate scaling for throttle
         throttle_pct = (float)channel_throttle->get_control_in() / 1000.0f;
         throttle_pct = constrain_float(throttle_pct,0.0f,1.0f);
@@ -197,7 +197,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
                 for (uint8_t i=0; i<compass.get_count(); i++) {
                     // current based compensation if more than 3amps being drawn
                     motor_impact_scaled[i] = motor_impact[i] / battery.current_amps();
-                
+
                     // adjust the motor compensation to negate the impact if drawing over 3amps
                     if (battery.current_amps() >= 3.0f) {
                         motor_compensation[i] = motor_compensation[i] * 0.99f - motor_impact_scaled[i] * 0.01f;
@@ -226,7 +226,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
         }
         if (AP_HAL::millis() - last_send_time > 500) {
             last_send_time = AP_HAL::millis();
-            mavlink_msg_compassmot_status_send(chan, 
+            mavlink_msg_compassmot_status_send(chan,
                                                channel_throttle->get_control_in(),
                                                battery.current_amps(),
                                                interference_pct[compass.get_primary()],
@@ -272,6 +272,5 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     ap.compass_mot = false;
 
     return MAV_RESULT_ACCEPTED;
-#endif  // FRAME_CONFIG != HELI_FRAME
+#endif
 }
-

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -86,9 +86,19 @@
  # define FRAME_CONFIG_STRING "UNKNOWN"
 #endif
 
+// FRAME_TYPE
+
+#ifndef FRAME_TYPE
+ #if FRAME_CONFIG == HELI_FRAME
+  # define FRAME_TYPE HELICOPTER
+ #else
+  # define FRAME_TYPE MULTICOPTER
+ #endif
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////
 // TradHeli defaults
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
   # define RC_FAST_SPEED                        125
   # define WP_YAW_BEHAVIOR_DEFAULT              WP_YAW_BEHAVIOR_LOOK_AHEAD
   # define THR_MIN_DEFAULT                      0

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -8,7 +8,7 @@
 // althold_init - initialise althold controller
 bool Copter::althold_init(bool ignore_checks)
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // do not allow helis to enter Alt Hold if the Rotor Runup is not complete
     if (!ignore_checks && !motors.rotor_runup_complete()){
         return false;
@@ -56,7 +56,7 @@ void Copter::althold_run()
     float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
     target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // helicopters are held on the ground until rotor speed runup has finished
     bool takeoff_triggered = (ap.land_complete && (target_climb_rate > 0.0f) && motors.rotor_runup_complete());
 #else
@@ -81,7 +81,7 @@ void Copter::althold_run()
 
         motors.set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
-#if FRAME_CONFIG == HELI_FRAME    
+#if FRAME_TYPE == HELICOPTER
         // force descent rate and call position controller
         pos_control.set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
 #else

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -153,7 +153,7 @@ void Copter::auto_takeoff_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -174,7 +174,7 @@ void Copter::auto_takeoff_run()
         target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
     }
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // helicopters stay in landed state until rotor speed runup has finished
     if (motors.rotor_runup_complete()) {
         set_land_complete(false);
@@ -241,7 +241,7 @@ void Copter::auto_wp_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -286,7 +286,7 @@ void Copter::auto_wp_run()
 // auto_spline_start - initialises waypoint controller to implement flying to a particular destination using the spline controller
 //  seg_end_type can be SEGMENT_END_STOP, SEGMENT_END_STRAIGHT or SEGMENT_END_SPLINE.  If Straight or Spline the next_destination should be provided
 void Copter::auto_spline_start(const Location_Class& destination, bool stopped_at_start,
-                               AC_WPNav::spline_segment_end_type seg_end_type, 
+                               AC_WPNav::spline_segment_end_type seg_end_type,
                                const Location_Class& next_destination)
 {
     auto_mode = Auto_Spline;
@@ -313,7 +313,7 @@ void Copter::auto_spline_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -390,7 +390,7 @@ void Copter::auto_land_run()
 {
     // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -406,7 +406,7 @@ void Copter::auto_land_run()
 
     // set motors to full range
     motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-    
+
     land_run_horizontal_control();
     land_run_vertical_control();
 }
@@ -560,7 +560,7 @@ void Copter::auto_loiter_run()
 {
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -808,7 +808,7 @@ bool Copter::auto_payload_place_run_should_run()
 void Copter::auto_payload_place_run()
 {
     if (!auto_payload_place_run_should_run()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER  // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);

--- a/ArduCopter/control_brake.cpp
+++ b/ArduCopter/control_brake.cpp
@@ -40,7 +40,7 @@ void Copter::brake_run()
     // if not auto armed set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
         wp_nav.init_brake_target(BRAKE_MODE_DECEL_RATE);
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);

--- a/ArduCopter/control_circle.cpp
+++ b/ArduCopter/control_circle.cpp
@@ -42,7 +42,7 @@ void Copter::circle_run()
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
         // To-Do: add some initialisation of position controllers
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -74,7 +74,7 @@ bool Copter::guided_takeoff_start(float final_alt_above_home)
 
     // get initial alt for WP_NAVALT_MIN
     auto_takeoff_set_start_alt();
-    
+
     return true;
 }
 
@@ -335,7 +335,7 @@ void Copter::guided_takeoff_run()
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -373,7 +373,7 @@ void Copter::guided_pos_control_run()
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -422,7 +422,8 @@ void Copter::guided_vel_control_run()
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
         // initialise velocity controller
         pos_control.init_vel_controller_xyz();
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER
+        // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -477,7 +478,8 @@ void Copter::guided_posvel_control_run()
         // set target position and velocity to current position and velocity
         pos_control.set_pos_target(inertial_nav.get_position());
         pos_control.set_desired_velocity(Vector3f(0,0,0));
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER
+        // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -548,7 +550,7 @@ void Copter::guided_angle_control_run()
 {
     // if not auto armed or motors not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || (ap.land_complete && guided_angle_state.climb_rate_cms <= 0.0f)) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.set_yaw_target_to_current_heading();
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f, get_smoothing_gain());

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -55,7 +55,7 @@ void Copter::land_gps_run()
 {
     // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -115,7 +115,7 @@ void Copter::land_nogps_run()
 
     // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -7,7 +7,7 @@
 // loiter_init - initialise loiter controller
 bool Copter::loiter_init(bool ignore_checks)
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // do not allow helis to enter Loiter if the Rotor Runup is not complete
     if (!ignore_checks && !motors.rotor_runup_complete()){
         return false;
@@ -108,7 +108,7 @@ void Copter::loiter_run()
         wp_nav.loiter_soften_for_landing();
     }
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // helicopters are held on the ground until rotor speed runup has finished
     bool takeoff_triggered = (ap.land_complete && (target_climb_rate > 0.0f) && motors.rotor_runup_complete());
 #else
@@ -132,7 +132,7 @@ void Copter::loiter_run()
     case Loiter_MotorStopped:
 
         motors.set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // force descent rate and call position controller
         pos_control.set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
 #else

--- a/ArduCopter/control_poshold.cpp
+++ b/ArduCopter/control_poshold.cpp
@@ -75,7 +75,7 @@ static struct {
 // poshold_init - initialise PosHold controller
 bool Copter::poshold_init(bool ignore_checks)
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // do not allow helis to enter Pos Hold if the Rotor Runup is not complete
     if (!ignore_checks && !motors.rotor_runup_complete()){
         return false;
@@ -86,7 +86,7 @@ bool Copter::poshold_init(bool ignore_checks)
     if (!position_ok() && !ignore_checks) {
         return false;
     }
-    
+
     // initialize vertical speeds and acceleration
     pos_control.set_speed_z(-g.pilot_velocity_z_max, g.pilot_velocity_z_max);
     pos_control.set_accel_z(g.pilot_accel_z);
@@ -172,7 +172,7 @@ void Copter::poshold_run()
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // check for take-off
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // helicopters are held on the ground until rotor speed runup has finished
         if (ap.land_complete && (takeoff_state.running || (target_climb_rate > 0.0f && motors.rotor_runup_complete()))) {
 #else
@@ -217,7 +217,7 @@ void Copter::poshold_run()
         // To-Do: move this to AP_Math (or perhaps we already have a function to do this)
         vel_fw = vel.x*ahrs.cos_yaw() + vel.y*ahrs.sin_yaw();
         vel_right = -vel.x*ahrs.sin_yaw() + vel.y*ahrs.cos_yaw();
-        
+
         // If not in LOITER, retrieve latest wind compensation lean angles related to current yaw
         if (poshold.roll_mode != POSHOLD_LOITER || poshold.pitch_mode != POSHOLD_LOITER)
         poshold_get_wind_comp_lean_angles(poshold.wind_comp_roll, poshold.wind_comp_pitch);
@@ -525,7 +525,7 @@ void Copter::poshold_run()
                     break;
             }
         }
-        
+
         // constrain target pitch/roll angles
         poshold.roll = constrain_int16(poshold.roll, -aparm.angle_max, aparm.angle_max);
         poshold.pitch = constrain_int16(poshold.pitch, -aparm.angle_max, aparm.angle_max);

--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -133,7 +133,7 @@ void Copter::rtl_climb_return_run()
 {
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -200,7 +200,7 @@ void Copter::rtl_loiterathome_run()
 {
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -281,7 +281,7 @@ void Copter::rtl_descent_run()
 
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);
@@ -363,7 +363,7 @@ void Copter::rtl_land_run()
 {
     // if not auto armed or landing completed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors.armed() || !ap.auto_armed || ap.land_complete || !motors.get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+#if FRAME_TYPE == HELICOPTER // Helicopters always stabilize roll/pitch/yaw
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
         attitude_control.set_throttle_out(0,false,g.throttle_filt);

--- a/ArduCopter/control_sport.cpp
+++ b/ArduCopter/control_sport.cpp
@@ -66,7 +66,7 @@ void Copter::sport_run()
     float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
     target_climb_rate = constrain_float(target_climb_rate, -g.pilot_velocity_z_max, g.pilot_velocity_z_max);
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // helicopters are held on the ground until rotor speed runup has finished
     bool takeoff_triggered = (ap.land_complete && (target_climb_rate > 0.0f) && motors.rotor_runup_complete());
 #else
@@ -91,7 +91,7 @@ void Copter::sport_run()
 
         motors.set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
         attitude_control.input_euler_rate_roll_pitch_yaw(target_roll_rate, target_pitch_rate, target_yaw_rate);
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // force descent rate and call position controller
         pos_control.set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
 #else

--- a/ArduCopter/control_throw.cpp
+++ b/ArduCopter/control_throw.cpp
@@ -4,7 +4,7 @@
 // throw_init - initialise throw controller
 bool Copter::throw_init(bool ignore_checks)
 {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // do not allow helis to use throw to start
     return false;
 #endif

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -85,6 +85,11 @@ enum aux_sw_func {
 #define SINGLE_FRAME 8
 #define COAX_FRAME 9
 
+// Frame types
+
+#define MULTICOPTER 0
+#define HELICOPTER 1
+
 // HIL enumerations
 #define HIL_MODE_DISABLED               0
 #define HIL_MODE_SENSORS                1

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -18,7 +18,7 @@ enum ESCCalibrationModes {
 // check if we should enter esc calibration mode
 void Copter::esc_calibration_startup_check()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // exit immediately if pre-arm rc checks fail
     pre_arm_rc_checks();
     if (!ap.pre_arm_rc_check) {
@@ -69,13 +69,13 @@ void Copter::esc_calibration_startup_check()
     if (g.esc_calibrate != ESCCAL_DISABLED) {
         g.esc_calibrate.set_and_save(ESCCAL_NONE);
     }
-#endif  // FRAME_CONFIG != HELI_FRAME
+#endif
 }
 
 // esc_calibration_passthrough - pass through pilot throttle to escs
 void Copter::esc_calibration_passthrough()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // clear esc flag for next time
     g.esc_calibrate.set_and_save(ESCCAL_NONE);
 
@@ -93,7 +93,7 @@ void Copter::esc_calibration_passthrough()
     // arm motors
     motors.armed(true);
     motors.enable();
-    
+
     while(1) {
         // flash LEDS
         AP_Notify::flags.esc_calibration = true;
@@ -108,13 +108,13 @@ void Copter::esc_calibration_passthrough()
         // pass through to motors
         motors.set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() / 1000.0f);
     }
-#endif  // FRAME_CONFIG != HELI_FRAME
+#endif
 }
 
 // esc_calibration_auto - calibrate the ESCs automatically using a timer and no pilot input
 void Copter::esc_calibration_auto()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     bool printed_msg = false;
 
     if (motors.get_pwm_type() >= AP_Motors::PWM_TYPE_ONESHOT) {
@@ -166,5 +166,5 @@ void Copter::esc_calibration_auto()
         delay(3);
         motors.set_throttle_passthrough_for_esc_calibration(0.0f);
     }
-#endif // FRAME_CONFIG != HELI_FRAME
+#endif
 }

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -26,7 +26,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
 
     switch (mode) {
         case ACRO:
-            #if FRAME_CONFIG == HELI_FRAME
+            #if FRAME_TYPE == HELICOPTER
                 success = heli_acro_init(ignore_checks);
             #else
                 success = acro_init(ignore_checks);
@@ -34,7 +34,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
             break;
 
         case STABILIZE:
-            #if FRAME_CONFIG == HELI_FRAME
+            #if FRAME_TYPE == HELICOPTER
                 success = heli_stabilize_init(ignore_checks);
             #else
                 success = stabilize_init(ignore_checks);
@@ -118,7 +118,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     if (success) {
         // perform any cleanup required by previous flight mode
         exit_mode(control_mode, mode);
-        
+
         prev_control_mode = control_mode;
         prev_control_mode_reason = control_mode_reason;
 
@@ -162,7 +162,7 @@ void Copter::update_flight_mode()
 
     switch (control_mode) {
         case ACRO:
-            #if FRAME_CONFIG == HELI_FRAME
+            #if FRAME_TYPE == HELICOPTER
                 heli_acro_run();
             #else
                 acro_run();
@@ -170,7 +170,7 @@ void Copter::update_flight_mode()
             break;
 
         case STABILIZE:
-            #if FRAME_CONFIG == HELI_FRAME
+            #if FRAME_TYPE == HELICOPTER
                 heli_stabilize_run();
             #else
                 stabilize_run();
@@ -278,11 +278,13 @@ void Copter::exit_mode(control_mode_t old_control_mode, control_mode_t new_contr
     // cancel any takeoffs in progress
     takeoff_stop();
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // firmly reset the flybar passthrough to false when exiting acro mode.
     if (old_control_mode == ACRO) {
         attitude_control.use_flybar_passthrough(false, false);
+#if FRAME_CONFIG == HELI_FRAME
         motors.set_acro_tail(false);
+#endif
     }
 
     // if we are changing from a mode that did not use manual throttle,
@@ -295,7 +297,7 @@ void Copter::exit_mode(control_mode_t old_control_mode, control_mode_t new_contr
             input_manager.set_stab_col_ramp(0.0);
         }
     }
-#endif //HELI_FRAME
+#endif
 }
 
 // returns true or false whether mode requires GPS
@@ -426,4 +428,3 @@ void Copter::print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode)
         break;
     }
 }
-

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -2,7 +2,7 @@
 
 // Traditional helicopter variables and functions
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
 
 #ifndef HELI_DYNAMIC_FLIGHT_SPEED_MIN
  #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      500     // we are in "dynamic flight" when the speed is over 1m/s for 2 seconds
@@ -47,7 +47,7 @@ void Copter::check_dynamic_flight(void)
         // rangefinder lock consider it to be dynamic flight
         moving = (rangefinder.distance_cm() > 200);
     }
-    
+
     if (moving) {
         // if moving for 2 seconds, set the dynamic flight flag
         if (!heli_flags.dynamic_flight) {
@@ -78,7 +78,7 @@ void Copter::update_heli_control_dynamics(void)
 
     if (ap.land_complete || (is_zero(motors.get_desired_rotor_speed()))){
         // if we are landed or there is no rotor power demanded, decrement slew scalar
-        hover_roll_trim_scalar_slew--;        
+        hover_roll_trim_scalar_slew--;
     } else {
         // if we are not landed and motor power is demanded, increment slew scalar
         hover_roll_trim_scalar_slew++;
@@ -176,4 +176,4 @@ void Copter::heli_update_rotor_speed_targets()
     rotor_runup_complete_last = motors.rotor_runup_complete();
 }
 
-#endif  // FRAME_CONFIG == HELI_FRAME
+#endif

--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -1,6 +1,6 @@
 #include "Copter.h"
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
 /*
  * Init and run calls for acro flight mode for trad heli
  */
@@ -11,8 +11,10 @@ bool Copter::heli_acro_init(bool ignore_checks)
     // if heli is equipped with a flybar, then tell the attitude controller to pass through controls directly to servos
     attitude_control.use_flybar_passthrough(motors.has_flybar(), motors.supports_yaw_passthrough());
 
+#if FRAME_CONFIG == HELI_FRAME
     motors.set_acro_tail(true);
-    
+#endif
+
     // set stab collective false to use full collective pitch range
     input_manager.set_use_stab_col(false);
 
@@ -26,24 +28,24 @@ void Copter::heli_acro_run()
 {
     float target_roll, target_pitch, target_yaw;
     float pilot_throttle_scaled;
-    
+
     // Tradheli should not reset roll, pitch, yaw targets when motors are not runup, because
     // we may be in autorotation flight.  These should be reset only when transitioning from disarmed
     // to armed, because the pilot will have placed the helicopter down on the landing pad.  This is so
     // that the servos move in a realistic fashion while disarmed for operational checks.
     // Also, unlike multicopters we do not set throttle (i.e. collective pitch) to zero so the swash servos move
-    
+
     if(!motors.armed()) {
         heli_flags.init_targets_on_arming=true;
         attitude_control.set_yaw_target_to_current_heading();
     }
-    
+
     if(motors.armed() && heli_flags.init_targets_on_arming) {
         attitude_control.set_yaw_target_to_current_heading();
         if (motors.rotor_speed_above_critical()) {
             heli_flags.init_targets_on_arming=false;
         }
-    }   
+    }
 
     // clear landing flag above zero throttle
     if (motors.armed() && motors.get_interlock() && motors.rotor_runup_complete() && !ap.throttle_zero) {
@@ -71,7 +73,7 @@ void Copter::heli_acro_run()
         float roll_in = channel_roll->pwm_to_angle_dz(0);
         float pitch_in = channel_pitch->pwm_to_angle_dz(0);
         float yaw_in;
-        
+
         if (motors.supports_yaw_passthrough()) {
             // if the tail on a flybar heli has an external gyro then
             // also use no deadzone for the yaw control and
@@ -95,4 +97,4 @@ void Copter::heli_acro_run()
     attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);
 }
 
-#endif  //HELI_FRAME
+#endif

--- a/ArduCopter/heli_control_stabilize.cpp
+++ b/ArduCopter/heli_control_stabilize.cpp
@@ -1,6 +1,6 @@
 #include "Copter.h"
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
 /*
  * Init and run calls for stabilize flight mode for trad heli
  */
@@ -69,4 +69,4 @@ void Copter::heli_stabilize_run()
     attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);
 }
 
-#endif  //HELI_FRAME
+#endif

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -44,7 +44,7 @@ void Copter::update_land_detector()
         // if disarmed, always landed.
         set_land_complete(true);
     } else if (ap.land_complete) {
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // if rotor speed and collective pitch are high then clear landing flag
         if (motors.get_throttle() > get_non_takeoff_throttle() && !motors.limit.throttle_lower && motors.rotor_runup_complete()) {
 #else
@@ -55,7 +55,7 @@ void Copter::update_land_detector()
         }
     } else {
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // check that collective pitch is on lower limit (should be constrained by LAND_COL_MIN)
         bool motor_at_lower_limit = motors.limit.throttle_lower;
 #else
@@ -133,7 +133,7 @@ void Copter::set_land_complete_maybe(bool b)
 //  has no effect when throttle is above hover throttle
 void Copter::update_throttle_thr_mix()
 {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     // if disarmed or landed prioritise throttle
     if(!motors.armed() || ap.land_complete) {
         attitude_control.set_throttle_mix_min();

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -36,7 +36,7 @@ void Copter::motor_test_output()
 
             case MOTOR_TEST_THROTTLE_PERCENT:
                 // sanity check motor_test_throttle value
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
                 if (motor_test_throttle_value <= 100) {
                     int16_t pwm_min = motors.get_pwm_output_min();
                     int16_t pwm_max = motors.get_pwm_output_max();

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -80,7 +80,7 @@ void Copter::auto_disarm_check()
         return;
     }
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // if the rotor is still spinning, don't initiate auto disarm
     if (motors.rotor_speed_above_critical()) {
         auto_disarm_begin = tnow_ms;
@@ -90,7 +90,7 @@ void Copter::auto_disarm_check()
 
     // always allow auto disarm if using interlock switch or motors are Emergency Stopped
     if ((ap.using_interlock && !motors.get_interlock()) || ap.motor_emergency_stop) {
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
         // use a shorter delay if using throttle interlock switch or Emergency Stop, because it is less
         // obvious the copter is armed as the motors will not be spinning
         disarm_delay_ms /= 2;

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -8,7 +8,7 @@ void Copter::default_dead_zones()
 {
     channel_roll->set_default_dead_zone(10);
     channel_pitch->set_default_dead_zone(10);
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     channel_throttle->set_default_dead_zone(10);
     channel_yaw->set_default_dead_zone(15);
     g.rc_8.set_default_dead_zone(10);
@@ -56,7 +56,8 @@ void Copter::init_rc_out()
     motors.set_frame_orientation(g.frame_orientation);
     motors.set_loop_rate(scheduler.get_loop_rate_hz());
     motors.Init();                                              // motor initialisation
-#if FRAME_CONFIG != HELI_FRAME
+
+#if FRAME_TYPE == MULTICOPTER
     motors.set_throttle_range(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #endif
 
@@ -69,7 +70,7 @@ void Copter::init_rc_out()
     channel_throttle->set_range_out(0,1000);
 
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
-    // take a proportion of speed. 
+    // take a proportion of speed.
     hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 
     // check if we should enter esc calibration mode
@@ -84,7 +85,7 @@ void Copter::init_rc_out()
     // refresh auxiliary channel to function map
     RC_Channel_aux::update_aux_servo_function();
 
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     /*
       setup a default safety ignore mask, so that servo gimbals can be active while safety is on
      */
@@ -191,7 +192,7 @@ void Copter::set_throttle_zero_flag(int16_t throttle_control)
     uint32_t tnow_ms = millis();
 
     // if not using throttle interlock and non-zero throttle and not E-stopped,
-    // or using motor interlock and it's enabled, then motors are running, 
+    // or using motor interlock and it's enabled, then motors are running,
     // and we are flying. Immediately set as non-zero
     if ((!ap.using_interlock && (throttle_control > 0) && !ap.motor_emergency_stop) || (ap.using_interlock && motors.get_interlock())) {
         last_nonzero_throttle_ms = tnow_ms;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -169,7 +169,7 @@ void Copter::init_ardupilot()
     // update motor interlock state
     update_using_interlock();
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
     // trad heli specific initialisation
     heli_init();
 #endif
@@ -403,17 +403,17 @@ void Copter::update_auto_armed()
         if(mode_has_manual_throttle(control_mode) && ap.throttle_zero && !failsafe.radio) {
             set_auto_armed(false);
         }
-#if FRAME_CONFIG == HELI_FRAME 
+#if FRAME_TYPE == HELICOPTER 
         // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
         // so that rotor runup is checked again before attempting to take-off
         if(ap.land_complete && !motors.rotor_runup_complete()) {
             set_auto_armed(false);
         }
-#endif // HELI_FRAME
+#endif
     }else{
         // arm checks
         
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // for tradheli if motors are armed and throttle is above zero and the motor is started, auto_armed should be true
         if(motors.armed() && !ap.throttle_zero && motors.rotor_runup_complete()) {
             set_auto_armed(true);
@@ -424,7 +424,7 @@ void Copter::update_auto_armed()
         if(motors.armed() && (!ap.throttle_zero || control_mode == THROW)) {
             set_auto_armed(true);
         }
-#endif // HELI_FRAME
+#endif
     }
 }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -27,7 +27,7 @@ bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
 {
     if (motors.armed() && ap.land_complete && current_mode_has_user_takeoff(must_navigate) && takeoff_alt_cm > current_loc.alt) {
 
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning
         if (!motors.rotor_runup_complete()) {
             return false;
@@ -146,7 +146,7 @@ void Copter::auto_takeoff_set_start_alt(void)
 {
     // start with our current altitude
     auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude();
-    
+
     if (!motors.armed() || !ap.auto_armed || !motors.get_interlock() || ap.land_complete) {
         // we are not flying, add the wp_navalt_min
         auto_takeoff_no_nav_alt_cm += g2.wp_navalt_min * 100;
@@ -166,9 +166,9 @@ void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
         // we haven't reached the takeoff navigation altitude yet
         nav_roll = 0;
         nav_pitch = 0;
-#if FRAME_CONFIG == HELI_FRAME
+#if FRAME_TYPE == HELICOPTER
         // prevent hover roll starting till past specified altitude
-        hover_roll_trim_scalar_slew = 0;        
+        hover_roll_trim_scalar_slew = 0;
 #endif
         // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
         pos_control.set_limit_accel_xy();
@@ -176,7 +176,7 @@ void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
         nav_roll = wp_nav.get_roll();
         nav_pitch = wp_nav.get_pitch();
     }
-    
+
     // roll & pitch from waypoint controller, yaw rate from pilot
     attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(nav_roll, nav_pitch, target_yaw_rate, get_smoothing_gain());
 }

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -111,7 +111,9 @@ void Copter::tuning() {
     case TUNING_HELI_EXTERNAL_GYRO:
         motors.ext_gyro_gain((float)g.rc_6.get_control_in() / 1000.0f);
         break;
+#endif
 
+#if FRAME_TYPE == HELICOPTER
     case TUNING_RATE_PITCH_FF:
         attitude_control.get_heli_rate_pitch_pid().ff(tuning_value);
         break;
@@ -200,7 +202,7 @@ void Copter::tuning() {
         attitude_control.get_rate_roll_pid().kD(tuning_value);
         break;
 
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_TYPE == MULTICOPTER
     case TUNING_RATE_MOT_YAW_HEADROOM:
         motors.set_yaw_headroom(tuning_value*1000);
         break;


### PR DESCRIPTION
Add FRAME_TYPE to distinguish multicopters and helicopters. This makes it easier to maintain other helicopter frames out of master (see #1860, #3245, etc.).
