### PR TITLE
added SYSID_ENFORCE to plane and copter

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2259,3 +2259,17 @@ void Copter::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
     hal.util->vsnprintf((char *)str, sizeof(str), fmt, arg_list);
     GCS_MAVLINK::send_statustext(severity, 0xFF, str);
 }
+
+/*
+  return true if we will accept this packet. Used to implement SYSID_ENFORCE
+ */
+bool GCS_MAVLINK_Copter::accept_packet(const mavlink_status_t &status, mavlink_message_t &msg)
+{
+    if (!copter.g2.sysid_enforce) {
+        return true;
+    }
+    if (msg.msgid == MAVLINK_MSG_ID_RADIO || msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {
+        return true;
+    }
+    return (msg.sysid == copter.g.sysid_my_gcs);
+}

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -13,6 +13,8 @@ protected:
 
     uint32_t telem_delay() const override;
 
+    bool accept_packet(const mavlink_status_t &status, mavlink_message_t &msg) override;
+    
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1031,6 +1031,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ACRO_THR_MID", 10, ParametersG2, acro_thr_mid, ACRO_THR_MID_DEFAULT),
 
+    // @Group: SYSID_ENFORCE
+    // @DisplayName: GCS sysid enforcement
+    // @Description: This controls whether packets from other than the expected GCS system ID will be accepted
+    // @Values: 0:NotEnforced,1:Enforced
+    // @User: Advanced
+    AP_GROUPINFO("SYSID_ENFORCE", 11, ParametersG2, sysid_enforce, 0),
+    
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -563,6 +563,9 @@ public:
     AP_Proximity proximity;
 #endif
 
+    // whether to enforce acceptance of packets only from sysid_my_gcs
+    AP_Int8 sysid_enforce;
+    
 #if ADVANCED_FAILSAFE == ENABLED
     // advanced failsafe library
     AP_AdvancedFailsafe_Copter afs;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2432,3 +2432,17 @@ void Plane::gcs_retry_deferred(void)
     gcs_send_message(MSG_RETRY_DEFERRED);
     GCS_MAVLINK::service_statustext();
 }
+
+/*
+  return true if we will accept this packet. Used to implement SYSID_ENFORCE
+ */
+bool GCS_MAVLINK_Plane::accept_packet(const mavlink_status_t &status, mavlink_message_t &msg)
+{
+    if (!plane.g2.sysid_enforce) {
+        return true;
+    }
+    if (msg.msgid == MAVLINK_MSG_ID_RADIO || msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {
+        return true;
+    }
+    return (msg.sysid == plane.g.sysid_my_gcs);
+}

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -13,6 +13,8 @@ protected:
 
     uint32_t telem_delay() const override;
 
+    bool accept_packet(const mavlink_status_t &status, mavlink_message_t &msg) override;
+    
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1382,6 +1382,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Group: SERVO_
     // @Path: ../libraries/RC_Channel/SRV_Channel.cpp
     AP_SUBGROUPINFO(servo_channels, "SERVO", 3, ParametersG2, SRV_Channels),
+
+    // @Group: SYSID_ENFORCE
+    // @DisplayName: GCS sysid enforcement
+    // @Description: This controls whether packets from other than the expected GCS system ID will be accepted
+    // @Values: 0:NotEnforced,1:Enforced
+    // @User: Advanced
+    AP_GROUPINFO("SYSID_ENFORCE", 4, ParametersG2, sysid_enforce, 0),
     
     AP_GROUPEND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -588,6 +588,9 @@ public:
 
     // control over servo output ranges
     SRV_Channels servo_channels;
+
+    // whether to enforce acceptance of packets only from sysid_my_gcs
+    AP_Int8 sysid_enforce;
 };
 
 extern const AP_Param::Info var_info[];

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -225,6 +225,10 @@ public:
 
 protected:
 
+    // overridable method to check for packet acceptance. Allows for
+    // enforcement of GCS sysid
+    virtual bool accept_packet(const mavlink_status_t &status, mavlink_message_t &msg) { return true; }
+    
     bool            waypoint_receiving; // currently receiving
     // the following two variables are only here because of Tracker
     uint16_t        waypoint_request_i; // request index

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -985,7 +985,8 @@ void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
     if (msg_snoop != NULL) {
         msg_snoop(&msg);
     }
-    if (routing.check_and_forward(chan, &msg)) {
+    if (routing.check_and_forward(chan, &msg) &&
+        accept_packet(status, msg)) {
         handleMessage(&msg);
     }
 }


### PR DESCRIPTION
This adds a SYSID_ENFORCE parameter for plane and copter, defaulting to disabled.
This is needed when you have two ground stations sharing one telemetry link to two aircraft. This patch ensures that commands will not be interpreted by a vehicle from the wrong GCS.
Note due to parameter conflicts this also includes the advanced failsafe code for copter