### PR TITLE
Rover: add support for SET_POSITION_TARGET_GLOBAL_INT

### DIFF
--- a/APMrover2/capabilities.cpp
+++ b/APMrover2/capabilities.cpp
@@ -6,5 +6,7 @@ void Rover::init_capabilities(void)
 {
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT |
                                MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT |
-                               MAV_PROTOCOL_CAPABILITY_MISSION_INT);
+                               MAV_PROTOCOL_CAPABILITY_MISSION_INT |
+                               MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED |
+                               MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT);
 }

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -68,3 +68,11 @@ enum mode {
 #define MASK_LOG_RC     		(1<<14)
 #define MASK_LOG_ARM_DISARM     (1<<15)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
+
+// for mavlink SET_POSITION_TARGET messages
+#define MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE      ((1<<0) | (1<<1) | (1<<2))
+#define MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE      ((1<<3) | (1<<4) | (1<<5))
+#define MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE      ((1<<6) | (1<<7) | (1<<8))
+#define MAVLINK_SET_POS_TYPE_MASK_FORCE           (1<<9)
+#define MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE      (1<<10)
+#define MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE (1<<11)


### PR DESCRIPTION
This change also adds support for the SET_POSITION_TARGET_LOCAL_NED message.

For both messages only the position fields are consumed (velocity, acceleration and yaw fields are ignored).

This has been tested in the simulator by me and it all seems to work.

The slightly confusing thing about these messages is knowing how to interpret the "coordinate_frame" fields (see MAV_FRAME enum: http://mavlink.org/messages/common).  I've interpreted the frames in the same way we do in Copter (which has supported these messages for quite a while).

For SET_POSITION_TARGET_GLOBAL_INT it's fairly simple, we accept 4 possible values (MAV_FRAME_GLOBAL_INT, MAV_FRAME_GLOBAL_RELATIVE_ALT, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT) but they all only affect only the altitude which we have no control over anyway so there's no functional difference depending upon what the call provides.

For SET_POSITION_TARGET_LOCAL_NED, we accept these four:
1. MAV_FRAME_LOCAL_NED = x,y interpreted as north, east offsets (in meters) from home.
7. MAV_FRAME_LOCAL_OFFSET_NED = x,y interpreted as north, east offsets (in meters) from vehicle's current position.
8. MAV_FRAME_BODY_NED = x,y interpreted as forward, right offsets (in meters) from vehicle's current position.
9. MAV_FRAME_BODY_OFFSET_NED = same as 8.

