### PR TITLE
GCS_Mavlink: Correctly check if a channel is streaming

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -681,7 +681,7 @@ bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
     rate *= adjust_rate_for_stream_trigger(stream_num);
 
     if (rate <= 0) {
-        if (chan_is_streaming | (1U<<(chan-MAVLINK_COMM_0))) {
+        if (chan_is_streaming & (1U<<(chan-MAVLINK_COMM_0))) {
             // if currently streaming then check if all streams are disabled
             // to allow runtime detection of user disabling streaming
             bool is_streaming = false;


### PR DESCRIPTION
In GCS_MAVLINK::stream_trigger(), chan_is_streaming would be checked with a bitwise OR, instead of a bitwise AND.  This way, the condition would always be true.