### PR TITLE
Copter: added RTL_TYPE

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -899,6 +899,7 @@ private:
     bool throw_position_good();
 
     bool rtl_init(bool ignore_checks);
+    control_mode_t check_do_land_start(void);
     void rtl_restart_without_terrain();
     void rtl_run();
     void rtl_climb_start();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1007,6 +1007,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 0:ADSBMavlinkProcessing
     // @User: Advanced
     AP_GROUPINFO("DEV_OPTIONS", 7, ParametersG2, dev_options, 0),
+
+    // @Param: RTL_TYPE
+    // @DisplayName: RTL handling type
+    // @Description: This controls how RTL is handled. A value of zero means a conventional RTL. A value of 1 uses the closest DO_LAND_START marker in the mission waypoints to fly a pre-planned path. If no DO_LAND_START markers a found a conventional RTL is used.
+    // @Values: 0:Normal,1:MissionDoLandStart
+    // @User: Advanced
+    AP_GROUPINFO("RTL_TYPE", 8, ParametersG2, rtl_type, RTLType_Normal),
     
     AP_GROUPEND
 };

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -565,6 +565,9 @@ public:
 
     // developer options
     AP_Int32 dev_options;
+
+    // type of RTL
+    AP_Int8 rtl_type;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -21,6 +21,22 @@ bool Copter::rtl_init(bool ignore_checks)
     }
 }
 
+/*
+  check if an RTL should be done as AUTO starting at DO_LAND_START
+ */
+control_mode_t Copter::check_do_land_start(void)
+{
+    uint16_t land_start_idx = mission.get_landing_sequence_start();
+    if (land_start_idx == 0) {
+        // keep doing RTL
+        return RTL;
+    }
+    mission.set_current_cmd(land_start_idx);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Starting RTL mission at %u", (unsigned)land_start_idx);
+    return AUTO;
+}
+
+
 // re-start RTL with terrain following disabled
 void Copter::rtl_restart_without_terrain()
 {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -128,6 +128,7 @@ enum mode_reason_t {
     MODE_REASON_AVOIDANCE,
     MODE_REASON_AVOIDANCE_RECOVERY,
     MODE_REASON_THROW_COMPLETE,
+    MODE_REASON_DO_LAND_START,
 };
 
 // Tuning enumeration
@@ -280,6 +281,12 @@ enum LandStateType {
 // bit options for DEV_OPTIONS parameter
 enum DevOptions {
     DevOptionADSBMAVLink = 1,
+};
+
+// values for RTL_TYPE
+enum RTLType {
+    RTLType_Normal = 0,
+    RTLType_MissionDoLandStart = 1
 };
 
 //  Logging parameters

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -26,6 +26,11 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
         return true;
     }
 
+    // check if an RTL needs to be converted to an AUTO
+    if (mode == RTL && g2.rtl_type == RTLType_MissionDoLandStart) {
+        mode = check_do_land_start();
+    }
+    
     switch (mode) {
         case ACRO:
             #if FRAME_CONFIG == HELI_FRAME
@@ -262,7 +267,7 @@ void Copter::exit_mode(control_mode_t old_control_mode, control_mode_t new_contr
 #endif
 
     // stop mission when we leave auto mode
-    if (old_control_mode == AUTO) {
+    if (old_control_mode == AUTO && control_mode != AUTO) {
         if (mission.state() == AP_Mission::MISSION_RUNNING) {
             mission.stop();
         }


### PR DESCRIPTION
this adds support for RTL_TYPE=1 to use DO_LAND_START markers in
mission to give the path home on RTL
