### PR TITLE
waf: ap_library: make headers whitelist portable

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -134,6 +134,7 @@ class ap_library_check_headers(Task.Task):
     whitelist = (
         'libraries/AP_Vehicle/AP_Vehicle_Type.h',
     )
+    whitelist = tuple(os.path.join(*p.split('/')) for p in whitelist)
 
     def run(self):
         for n in self.headers:


### PR DESCRIPTION
Otherwise it won't work for platforms that don't use Unix style paths.