### PR TITLE
AP_Compass: add non-primary compass cal fitness parameter

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -354,12 +354,20 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     AP_GROUPINFO("ODI3",    29, Compass, _state[2].offdiagonals, 0),
 
     // @Param: CAL_FIT
-    // @DisplayName: Compass calibration fitness
-    // @Description: This controls the fitness level required for a successful compass calibration. A lower value makes for a stricter fit (less likely to pass). This is the value used for the primary magnetometer. Other magnetometers get double the value.
-    // @Range: 4 20
+    // @DisplayName: External Compass calibration fitness
+    // @Description: This controls the fitness level required for a successful compass calibration. A lower value makes for a stricter fit (less likely to pass). This is the value used for the external magnetometer. Internal magnetometers get max(double the value, COMPASS_ICAL_FIT).
+    // @Range: 4 25
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("CAL_FIT", 30, Compass, _calibration_threshold, 8.0f),
+
+    // @Param: ICAL_FIT
+    // @DisplayName: Non-Primary Compass calibration fitness
+    // @Description: This controls the fitness level required for a successful compass calibration of internal compasses. The chosen fitness is equal to max(2*COMPASS_CAL_FIT, COMPASS_ICAL_FIT)
+    // @Range: 8 50
+    // @Increment: 0.1
+    // @User: Advanced    
+    AP_GROUPINFO("ICAL_FIT", 31, Compass, _int_calibration_threshold, 16.0f),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -56,7 +56,8 @@
 #define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(50.0f)
 #define AP_COMPASS_MAX_XY_ANG_DIFF radians(30.0f)
 #define AP_COMPASS_MAX_XY_LENGTH_DIFF 100.0f
-
+#define AP_COMPASS_MAX_FITNESS_EXT  25.0f
+#define AP_COMPASS_MAX_FITNESS_INT  50.0f
 class Compass
 {
 friend class AP_Compass_Backend;
@@ -398,4 +399,5 @@ private:
     bool _hil_mode:1;
 
     AP_Float _calibration_threshold;
+    AP_Float _int_calibration_threshold;
 };


### PR DESCRIPTION
Selects the max of 2*primary cal fitness and non-primary compass cal fitness parameter to be fitness setting for non primary compasses. The reasoning behind this change is to give greater flexibility for non primary compass's calibration fitness while having stricter value for primary compass. Primary compass should not have tolerance greater than 10 milligauss, as such a calibration could lead to imprecise primary compass measurement. @OXINARF and @tridge can you review and pull this PR if it makes sense.
