### PR TITLE
Fixes in Linux I2C Driver

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -177,13 +177,13 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     i2c_data.msgs = msgs;
     i2c_data.nmsgs = nmsgs;
 
-    int r = -EINVAL;
+    int r;
     unsigned retries = _retries;
     do {
         r = ::ioctl(_bus.fd, I2C_RDWR, &i2c_data);
-    } while (r < 0 && retries-- > 0);
+    } while (r == -1 && retries-- > 0);
 
-    return r >= 0;
+    return r != -1;
 }
 
 bool I2CDevice::read_registers_multiple(uint8_t first_reg, uint8_t *recv,

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -178,7 +178,7 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     i2c_data.nmsgs = nmsgs;
 
     int r;
-    unsigned retries = _retries;
+    uint8_t retries = _retries;
     do {
         r = ::ioctl(_bus.fd, I2C_RDWR, &i2c_data);
     } while (r == -1 && retries-- > 0);
@@ -217,7 +217,7 @@ bool I2CDevice::read_registers_multiple(uint8_t first_reg, uint8_t *recv,
         };
 
         int r = -EINVAL;
-        unsigned retries = _retries;
+        uint8_t retries = _retries;
         do {
             r = ::ioctl(_bus.fd, I2C_RDWR, &i2c_data);
         } while (r < 0 && retries-- > 0);

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -169,7 +169,7 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     }
 
     if (!nmsgs) {
-        return false;
+        return true;
     }
 
     struct i2c_rdwr_ioctl_data i2c_data = { };


### PR DESCRIPTION
Hi,

this one perfects tiny parts of the Linux HAL I2C driver. There was especially one logical bug:
If the transfer() function of the I2C driver didn't send or receive anything, it returned false, which means that an error occured. In fact, it's not an error if nothing was sent or received.

Other C-functions, like read() behave in the same way.

Cheers
  Ralf