### PR TITLE
EKF2: Prevent jumps in vehicle yaw due to core switching

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1134,14 +1134,58 @@ bool NavEKF2::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
-// return the amount of yaw angle change due to the last yaw angle reset in radians
+// return the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF2::getLastYawResetAngle(float &yawAng) const
+uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
 {
     if (!core) {
         return 0;
     }
-    return core[primary].getLastYawResetAngle(yawAng);
+
+    // check for an internal ekf yaw reset
+    float temp_yaw_delta;
+    uint32_t ekf_reset_ms = core[primary].getLastYawResetAngle(temp_yaw_delta);
+    if (ekf_reset_ms != last_ekf_reset_ms) {
+        // record the time of the ekf's internal yaw reset event
+        last_ekf_reset_ms = ekf_reset_ms;
+
+        // record the the ekf's internal yaw reset value
+        yaw_reset_delta = temp_yaw_delta;
+
+        // record the yaw reset event time
+        yaw_reset_time_ms = imuSampleTime_us/1000;
+
+    }
+
+    // check for a core switch and if a switch has occurred, set the yaw reset delta
+    // to the difference in yaw angle between the current and last yaw angle
+    Vector3f eulers_primary;
+    core[primary].getEulerAngles(eulers_primary);
+    if (primary != prev_instance) {
+        // the delta is the difference between the current and previous yaw
+        // This overwrites any yaw reset value recorded from an internal eff reset
+        yaw_reset_delta += wrap_PI(eulers_primary.z - prev_yaw);
+
+        // record the time of the yaw reset event
+        yaw_reset_time_ms = imuSampleTime_us/1000;
+
+        // update the time recorded for the last ekf internal yaw reset forthe primary core to
+        // prevent a yaw ekf reset event being published on the next frame due to the change in time
+        last_ekf_reset_ms = ekf_reset_ms;
+
+    }
+
+    // record the yaw angle from the primary core
+    prev_yaw = eulers_primary.z;
+
+    // record the primary core
+    prev_instance = primary;
+
+    // return the yaw delta from the last event
+    yawAngDelta = yaw_reset_delta;
+
+    // return the time of the last event
+    return yaw_reset_time_ms;
 }
 
 // return the amount of NE position change due to the last position reset in metres

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1145,15 +1145,15 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
     // check for an internal ekf yaw reset
     float temp_yaw_delta;
     uint32_t ekf_reset_ms = core[primary].getLastYawResetAngle(temp_yaw_delta);
-    if (ekf_reset_ms != last_ekf_reset_ms) {
+    if (ekf_reset_ms != yaw_step_data.last_ekf_reset_ms) {
         // record the time of the ekf's internal yaw reset event
-        last_ekf_reset_ms = ekf_reset_ms;
+        yaw_step_data.last_ekf_reset_ms = ekf_reset_ms;
 
         // record the the ekf's internal yaw reset value
-        yaw_reset_delta = temp_yaw_delta;
+        yaw_step_data.yaw_delta = temp_yaw_delta;
 
         // record the yaw reset event time
-        yaw_reset_time_ms = imuSampleTime_us/1000;
+        yaw_step_data.yaw_reset_time_ms = imuSampleTime_us/1000;
 
     }
 
@@ -1161,31 +1161,31 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
     // to the difference in yaw angle between the current and last yaw angle
     Vector3f eulers_primary;
     core[primary].getEulerAngles(eulers_primary);
-    if (primary != prev_instance) {
+    if (primary != yaw_step_data.prev_instance) {
         // the delta is the difference between the current and previous yaw
         // This overwrites any yaw reset value recorded from an internal eff reset
-        yaw_reset_delta += wrap_PI(eulers_primary.z - prev_yaw);
+        yaw_step_data.yaw_delta += wrap_PI(eulers_primary.z - yaw_step_data.prev_yaw);
 
         // record the time of the yaw reset event
-        yaw_reset_time_ms = imuSampleTime_us/1000;
+        yaw_step_data.yaw_reset_time_ms = imuSampleTime_us/1000;
 
         // update the time recorded for the last ekf internal yaw reset forthe primary core to
         // prevent a yaw ekf reset event being published on the next frame due to the change in time
-        last_ekf_reset_ms = ekf_reset_ms;
+        yaw_step_data.last_ekf_reset_ms = ekf_reset_ms;
 
     }
 
     // record the yaw angle from the primary core
-    prev_yaw = eulers_primary.z;
+    yaw_step_data.prev_yaw = eulers_primary.z;
 
     // record the primary core
-    prev_instance = primary;
+    yaw_step_data.prev_instance = primary;
 
     // return the yaw delta from the last event
-    yawAngDelta = yaw_reset_delta;
+    yawAngDelta = yaw_step_data.yaw_delta;
 
     // return the time of the last event
-    return yaw_reset_time_ms;
+    return yaw_step_data.yaw_reset_time_ms;
 }
 
 // return the amount of NE position change due to the last position reset in metres

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1163,8 +1163,9 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
     core[primary].getEulerAngles(eulers_primary);
     if (primary != yaw_step_data.prev_instance) {
         // the delta is the difference between the current and previous yaw
-        // This overwrites any yaw reset value recorded from an internal eff reset
-        yaw_step_data.yaw_delta += wrap_PI(eulers_primary.z - yaw_step_data.prev_yaw);
+        // This overwrites any yaw reset value recorded from an internal ekf reset
+        // that has occured on the same time-step
+        yaw_step_data.yaw_delta = wrap_PI(eulers_primary.z - yaw_step_data.prev_yaw);
 
         // record the time of the yaw reset event
         yaw_step_data.yaw_reset_time_ms = imuSampleTime_us/1000;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -376,11 +376,13 @@ private:
     // time at start of current filter update
     uint64_t imuSampleTime_us;
 
-    // used to keep track of yaw angle changes due to change of primary instance
-    uint8_t prev_instance = 0;          // active core number from the previous time step
-    uint32_t last_ekf_reset_ms= 0;      // last time the active ekf performed a yaw reset (msec)
-    uint32_t last_lane_switch_ms = 0;   // last time there was a lane switch (msec)
-    uint32_t yaw_reset_time_ms = 0;     // last time a yaw reset event was published
-    float yaw_reset_delta = 0.0f;       // the amount of yaw change due to the last published yaw reset (rad)
-    float prev_yaw = 0.0f;              // yaw angle published by the active core from the previous time step (rad)
+    // used to keep track of yaw angle steps due to change of primary instance or internal ekf yaw resets
+    struct {
+        uint8_t prev_instance;          // active core number from the previous time step
+        uint32_t last_ekf_reset_ms;     // last time the active ekf performed a yaw reset (msec)
+        uint32_t last_lane_switch_ms;   // last time there was a lane switch (msec)
+        uint32_t yaw_reset_time_ms;     // last time a yaw reset event was published
+        float yaw_delta;                // the amount of yaw change due to the last published yaw step (rad)
+        float prev_yaw;                 // yaw angle published by the active core from the previous time step (rad)
+    } yaw_step_data;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -266,7 +266,7 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng) const;
+    uint32_t getLastYawResetAngle(float &yawAngDelta);
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
@@ -375,4 +375,12 @@ private:
 
     // time at start of current filter update
     uint64_t imuSampleTime_us;
+
+    // used to keep track of yaw angle changes due to change of primary instance
+    uint8_t prev_instance = 0;          // active core number from the previous time step
+    uint32_t last_ekf_reset_ms= 0;      // last time the active ekf performed a yaw reset (msec)
+    uint32_t last_lane_switch_ms = 0;   // last time there was a lane switch (msec)
+    uint32_t yaw_reset_time_ms = 0;     // last time a yaw reset event was published
+    float yaw_reset_delta = 0.0f;       // the amount of yaw change due to the last published yaw reset (rad)
+    float prev_yaw = 0.0f;              // yaw angle published by the active core from the previous time step (rad)
 };


### PR DESCRIPTION
Addresses https://github.com/ArduPilot/ardupilot/issues/4679

The EKF2 publishes the amount of any yaw angle reset and the time of the reset so that the yaw controller can adjust its set-point to avoid jumps in yaw angle when the EKF performs an in-flight reset of yaw angle such as can occur when taking off out of a ground based magnetic anomaly.

The publishing of the yaw change and the time did not take into account changes in yaw angle due to a switch between EKF cores caused by IMU or other errors.

These patches ensure that a core switch also results in a the yaw step being published.

*SITL Testing*

For the first test a core switch in LOITER mode was induced by setting a very large Z gyro bias for IMU1. The yaw slews due to the fault, but when the core switch occurs, the yaw set-point jumps to match the current yaw angle and the yawing stops.

<img width="857" alt="screen shot 2016-08-30 at 10 42 54 pm" src="https://cloud.githubusercontent.com/assets/3596952/18089603/14b34588-6f04-11e6-801c-a7db2947c17d.png">

For the second test the SIM_MAG_ALY_X  and SIM_MAG_ALY_Y parameters were set to -200 and 200 respectively to simulate a large ground based magnetic anomaly. This affected both cores which performed two yaw resets as the copter climbed away from the anomaly, the first being triggered by the anomaly detector, and the second the normal reset that happens at 5m when the copter switches from simple heading to 3D magnetometer fusion.

<img width="862" alt="screen shot 2016-08-30 at 10 56 56 pm" src="https://cloud.githubusercontent.com/assets/3596952/18089912/838e7878-6f05-11e6-8fe9-991cd63950c6.png">