### PR TITLE
Copter: check attitude control's thr mix parameters

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -206,6 +206,7 @@ void Copter::init_ardupilot()
 #endif
     wp_nav.set_avoidance(&avoid);
 
+    attitude_control.parameter_sanity_check();
     pos_control.set_dt(MAIN_LOOP_SECONDS);
 
     // init the optical flow sensor

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -449,6 +449,7 @@ bool QuadPlane::setup(void)
     motors->set_interlock(true);
     pid_accel_z.set_dt(loop_delta_t);
     pos_control->set_dt(loop_delta_t);
+    attitude_control->parameter_sanity_check();
 
     // setup the trim of any motors used by AP_Motors so px4io
     // failsafe will disable motors

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -234,6 +234,9 @@ public:
     // Calculates the body frame angular velocities to follow the target attitude
     void attitude_controller_run_quat();
 
+    // sanity check parameters.  should be called once before take-off
+    virtual void parameter_sanity_check() {}
+
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -217,9 +217,6 @@ public:
     // Inverse proportional controller with piecewise sqrt sections to constrain second derivative
     static float stopping_point(float first_ord_mag, float p, float second_ord_lim);
 
-    // User settable parameters
-    static const struct AP_Param::GroupInfo var_info[];
-
     // calculates the velocity correction from an angle error. The angular velocity has acceleration and
     // deceleration limits including basic jerk limiting using smoothing_gain
     float input_shaping_angle(float error_angle, float smoothing_gain, float accel_max, float target_ang_vel);
@@ -237,6 +234,8 @@ public:
     // Calculates the body frame angular velocities to follow the target attitude
     void attitude_controller_run_quat();
 
+    // User settable parameters
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -232,3 +232,19 @@ void AC_AttitudeControl_Multi::rate_controller_run()
 
     control_monitor_update();
 }
+
+// sanity check parameters.  should be called once before takeoff
+void AC_AttitudeControl_Multi::parameter_sanity_check()
+{
+    // sanity check throttle mix parameters
+    if (_thr_mix_min < 0.1f || _thr_mix_min > 0.25f) {
+        _thr_mix_min = AC_ATTITUDE_CONTROL_MIN_DEFAULT;
+    }
+    if (_thr_mix_max < 0.5f || _thr_mix_max > 0.9f) {
+        _thr_mix_max = AC_ATTITUDE_CONTROL_MAX_DEFAULT;
+    }
+    if (_thr_mix_min > _thr_mix_max) {
+        _thr_mix_min = AC_ATTITUDE_CONTROL_MIN_DEFAULT;
+        _thr_mix_max = AC_ATTITUDE_CONTROL_MAX_DEFAULT;
+    }
+}

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -74,6 +74,9 @@ public:
     // run lowest level body-frame rate controller and send outputs to the motors
     void rate_controller_run();
 
+    // sanity check parameters.  should be called once before take-off
+    void parameter_sanity_check();
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
There was a crash on the Copter-3.4 beta testing thread in which somehow (and it's not clear how) the ATC_THR_MIX_MIN parameter was set to 10575.15.  http://discuss.ardupilot.org/t/large-hex-crash-been-working-perfectly-on-3-4rc1-and-rc2/11101

This is quite worrying as it appears to be parameter corruption.  We certainly had a problem with corruption in Copter-3.4-dev before beta testing began which occurred as part of the automatic upgrade of parameters (the scaling has changed since AC3.3) but I thought those were all resolved.

Another suspect is there was a time when the handling of parameters between multicopters and traditional helicopters was not perfect.

For now, this PR adds a sanity check on the parameters and resets them to the defaults if they're out of range.
