### PR TITLE
AP_Frsky_Telem: LANDCOMPLETE switched to ISFLYING flag

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -651,8 +651,8 @@ uint32_t AP_Frsky_Telem::calc_ap_status(void)
     ap_status = (uint8_t)(_ap.control_mode & AP_CONTROL_MODE_LIMIT);
     // simple/super simple modes flags
     ap_status |= (uint8_t)(*_ap.value & AP_SSIMPLE_FLAGS)<<AP_SSIMPLE_OFFSET;
-    // land complete flag
-    ap_status |= (uint8_t)(*_ap.value & AP_LANDCOMPLETE_FLAG);
+    // is_flying flag
+    ap_status |= (uint8_t)((*_ap.value & AP_ISFLYING_FLAG) ^ AP_ISFLYING_FLAG);
     // armed flag
     ap_status |= (uint8_t)(AP_Notify::flags.armed)<<AP_ARMED_OFFSET;
     // battery failsafe flag

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -90,7 +90,7 @@ for FrSky SPort Passthrough
 #define AP_CONTROL_MODE_LIMIT       0x1F
 #define AP_SSIMPLE_FLAGS            0x6
 #define AP_SSIMPLE_OFFSET           4
-#define AP_LANDCOMPLETE_FLAG        0x80
+#define AP_ISFLYING_FLAG            0x80
 #define AP_ARMED_OFFSET             8
 #define AP_BATT_FS_OFFSET           9
 #define AP_EKF_FS_OFFSET            10


### PR DESCRIPTION
This will make it consistent with is_flying() for when plane support rolls out.