### PR TITLE
Removed reliance in Frsky lib on home_distance and home_bearing which are only in copter

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -155,7 +155,7 @@ void Copter::init_ardupilot()
     // setup frsky, and pass a number of parameters to the library
     frsky_telemetry.init(serial_manager, FIRMWARE_STRING " " FRAME_CONFIG_STRING,
                          FRAME_MAV_TYPE,
-                         &g.fs_batt_voltage, &g.fs_batt_mah, &ap.value, &home_distance, &home_bearing);
+                         &g.fs_batt_voltage, &g.fs_batt_mah, &ap.value);
 #endif
 
     // identify ourselves correctly with the ground station

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -47,7 +47,7 @@ AP_Frsky_Telem::AP_Frsky_Telem(AP_AHRS &ahrs, const AP_BattMonitor &battery, con
  * init - perform required initialisation
  * for Copter
  */
-void AP_Frsky_Telem::init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah, uint32_t *ap_value, int32_t *home_distance, int32_t *home_bearing)
+void AP_Frsky_Telem::init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah, uint32_t *ap_value)
 {
     // check for protocol configured for a serial port - only the first serial port with one of these protocols will then run (cannot have FrSky on multiple serial ports)
     if ((_port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FrSky_D, 0))) {
@@ -63,8 +63,6 @@ void AP_Frsky_Telem::init(const AP_SerialManager &serial_manager, const char *fi
         _params.fs_batt_voltage = fs_batt_voltage; // failsafe battery voltage in volts
         _params.fs_batt_mah = fs_batt_mah; // failsafe reserve capacity in mAh
         _ap.value = ap_value; // ap bit-field
-        _ap.home_distance = home_distance;
-        _ap.home_bearing = home_bearing;
     }
     
     if (_port != NULL) {
@@ -668,13 +666,18 @@ uint32_t AP_Frsky_Telem::calc_ap_status(void)
  */
 uint32_t AP_Frsky_Telem::calc_home(void)
 {
-    uint32_t home;
-
-    // distance between vehicle and home location in meters
-    home = prep_number(roundf(*_ap.home_distance * 0.01f), 3, 2);
-    // altitude between vehicle and home location in decimeters
+    uint32_t home = 0;
     Location loc;
-    if (_ahrs.get_position(loc)) {
+    if (_ahrs.get_position(loc)) {            
+        // check home_loc is valid
+        Location home_loc = _ahrs.get_home();
+        if (home_loc.lat != 0 || home_loc.lng != 0) {
+            // distance between vehicle and home_loc in meters
+            home = prep_number(roundf(get_distance(home_loc, loc)), 3, 2);
+            // angle from front of vehicle to the direction of home_loc in 3 degree increments (just in case, limit to 127 (0x7F) since the value is stored on 7 bits)
+            home |= (((uint8_t)roundf(get_bearing_cd(loc,home_loc) * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
+        }
+        // altitude between vehicle and home_loc
         _relative_home_altitude = loc.alt;
         if (!loc.flags.relative_alt) {
             // loc.alt has home altitude added, remove it
@@ -684,8 +687,6 @@ uint32_t AP_Frsky_Telem::calc_home(void)
         _relative_home_altitude = 0;
     }
     home |= prep_number(roundf(_relative_home_altitude * 0.1f), 3, 2)<<HOME_ALT_OFFSET;
-    // angle between vehicle and home loc (relative to North) in 3 degree increments (just in case, limit to 127 (0x7F) since the value is stored on 7 bits)
-    home |= (((uint8_t)roundf(*_ap.home_bearing * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
     return home;
 }
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -117,7 +117,7 @@ public:
     AP_Frsky_Telem(AP_AHRS &ahrs, const AP_BattMonitor &battery, const RangeFinder &rng);
 
     // init - perform required initialisation
-    void init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah, uint32_t *ap_value, int32_t *home_distance, int32_t *home_bearing);
+    void init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah, uint32_t *ap_value);
     void init(const AP_SerialManager &serial_manager);
 
     // add statustext message to FrSky lib queue.
@@ -163,8 +163,6 @@ private:
         uint8_t control_mode;
         uint32_t *value;
         uint32_t sensor_status_error_flags;
-        int32_t *home_distance;
-        int32_t *home_bearing;
     } _ap;
     
     float _relative_home_altitude; // altitude in centimeters above home


### PR DESCRIPTION
To provide Plane and Rover support and use as generic of functions in the Frsky lib, it would be good to remove reliance on the Copter specific home_distance and home_bearing variables.

From testing on my end, ahrs.get_home() seems to take some time to return a valid location, whereas the variables used before (loc.alt, home_distance and home_bearing) have values right away. Suggestions would be appreciated on this issue...