### PR TITLE
Plane support for Frsky passthrough protocol

### DIFF
--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -155,6 +155,9 @@ void Plane::update_is_flying_5Hz(void)
     }
     previous_is_flying = new_is_flying;
     adsb.set_is_flying(new_is_flying);
+#if FRSKY_TELEM_ENABLED == ENABLED
+    frsky_telemetry.set_is_flying(is_flying());
+#endif
 
     crash_detection_update();
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -160,7 +160,9 @@ void Plane::init_ardupilot()
     // setup frsky
 #if FRSKY_TELEM_ENABLED == ENABLED
     // setup frsky, and pass a number of parameters to the library
-    frsky_telemetry.init(serial_manager);
+    frsky_telemetry.init(serial_manager, FIRMWARE_STRING,
+                         MAV_TYPE_FIXED_WING,
+                         &g.fs_batt_voltage, &g.fs_batt_mah);
 #endif
 
     mavlink_system.sysid = g.sysid_this_mav;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -118,6 +118,7 @@ public:
 
     // init - perform required initialisation
     void init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah, uint32_t *ap_value);
+    void init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage, AP_Float *fs_batt_mah);
     void init(const AP_SerialManager &serial_manager);
 
     // add statustext message to FrSky lib queue.
@@ -126,6 +127,9 @@ public:
     // update flight control mode. The control mode is vehicle type specific
     void update_control_mode(uint8_t mode) { _ap.control_mode = mode; }
 
+    // update whether we're flying (used for Plane)
+    void set_is_flying(bool is_flying) { *_ap.value == is_flying ? (*_ap.value | AP_ISFLYING_FLAG) : (*_ap.value & (~AP_ISFLYING_FLAG)); }
+ 
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not


### PR DESCRIPTION
Based on the work in #4762 and #4764, so some of the commits are in common...

Initial Plane support, tested on bench, but not in flight.