### PR TITLE
can't trust HAVE_ for bytewap and endian under osx

### DIFF
--- a/libraries/AP_Common/missing/byteswap.h
+++ b/libraries/AP_Common/missing/byteswap.h
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#undef HAVE_BYTESWAP_H
+#endif
+
 #if defined(HAVE_BYTESWAP_H) && HAVE_BYTESWAP_H
 #include_next <byteswap.h>
 #else

--- a/libraries/AP_Common/missing/endian.h
+++ b/libraries/AP_Common/missing/endian.h
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#undef HAVE_ENDIAN_H
+#endif
+
 #if defined(HAVE_ENDIAN_H) && HAVE_ENDIAN_H
 #include_next <endian.h>
 #else


### PR DESCRIPTION
this is probably not the right fix, i would like to know why XXX.h isn't found under macOS if HAVE_XXX_H is defined

configure:
```
☁  ardupilot [rroche/missing_libs_under_osx] ./waf configure --board=sitl
Setting top to                           : /Users/rroche/Work/ArduPilot/ardupilot
Setting out to                           : /Users/rroche/Work/ArduPilot/ardupilot/build
Autoconfiguration                        : enabled
Setting board to                         : sitl
Checking for 'clang++' (C++ compiler)    : /usr/bin/clang++
Checking for 'clang' (C compiler)        : /usr/bin/clang
Checking for HAVE_CMATH_ISFINITE         : yes
Checking for HAVE_CMATH_ISINF            : yes
Checking for HAVE_CMATH_ISNAN            : yes
Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE : yes
Checking for NEED_CMATH_ISINF_STD_NAMESPACE    : yes
Checking for NEED_CMATH_ISNAN_STD_NAMESPACE    : yes
Checking for header endian.h                   : yes
Checking for header byteswap.h                 : yes
Checking for program 'python'                  : /Users/rroche/.pyenv/versions/2.7.12/bin/python
Checking for python version >= 2.7.0           : 2.7.12
Source is git repository                       : yes
Update submodules                              : yes
Checking for program 'git'                     : /usr/local/bin/git
Checking for program 'size'                    : /usr/bin/size
Benchmarks                                     : disabled
Unit tests                                     : enabled
'configure' finished successfully (1.144s)
```

error before patch on byteswap:

```
In file included from ../../libraries/AP_ADC/AP_ADC_ADS1115.cpp:2:
In file included from ../../libraries/AP_HAL/utility/sparse-endian.h:23:
../../libraries/AP_Common/missing/byteswap.h:6:15: fatal error: 'byteswap.h' file not found
#include_next <byteswap.h>
              ^
1 error generated.
.... (more from other files, but same error)...
```

error before patch on endian:

```
In file included from ../../libraries/AP_ADC/AP_ADC_ADS1115.cpp:2:
In file included from ../../libraries/AP_HAL/utility/sparse-endian.h:24:
../../libraries/AP_Common/missing/endian.h:6:15: fatal error: 'endian.h' file not found
#include_next <endian.h>
              ^
1 error generated.
.... (more from other files, but same error)...
```

Build completes successfully with patch

```
657/657] Linking build/sitl/bin/arducopter-quad
clang: warning: argument unused during compilation: '-pthread'

Waf: Leaving directory `/Users/rroche/Work/ArduPilot/ardupilot/build/sitl'

BUILD SUMMARY
Build directory: /Users/rroche/Work/ArduPilot/ardupilot/build/sitl
Target               Text    Data   BSS  Total
---------------------------------------------------
bin/arducopter-quad  913408  81920    0  4295270400

Build commands will be stored in build/sitl/compile_commands.json
'build' finished successfully (2.902s)
```