### PR TITLE
build: fix configure check for headers

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -56,14 +56,15 @@ class Board:
 
         cfg.ap_common_checks()
 
+        cfg.env.prepend_value('INCLUDES', [
+            cfg.srcnode.find_dir('libraries/AP_Common/missing').abspath()
+        ])
+
+
     def configure_env(self, cfg, env):
         # Use a dictionary instead of the convetional list for definitions to
         # make easy to override them. Convert back to list before consumption.
         env.DEFINES = {}
-
-        env.prepend_value('INCLUDES', [
-            cfg.srcnode.find_dir('libraries/AP_Common/missing').abspath()
-        ])
 
         env.CFLAGS += [
             '-ffunction-sections',


### PR DESCRIPTION
When we are checking if a header is available we can't pass -I argument
to our missing/ directory. Otherwise we would end up telling the build
that a header is available when it actually isn't.

This fixes the build of sitl in MacOS with clang.