### PR TITLE
Return MAV_RESULT_FAILED rather then MAV_RESULT_UNSUPPORTED if home is not set

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1105,6 +1105,8 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             if (rover.home_is_set != HOME_UNSET) {
                 send_home(rover.ahrs.get_home());
                 result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
             }
             break;
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1425,6 +1425,8 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             if (copter.ap.home_state != HOME_UNSET) {
                 send_home(copter.ahrs.get_home());
                 result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
             }
             break;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1475,6 +1475,8 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             if (plane.home_is_set != HOME_UNSET) {
                 send_home(plane.ahrs.get_home());
                 result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
             }
             break;
 


### PR DESCRIPTION
We currently return MAV_RESULT_UNSUPPORTED if home is unset, which is rather misleading to a GCS, as the command is actually supported its just that home isn't set yet. Instead return MAV_RESULT_FAILED, which is more appropriate.

(Tagged as all vehicles, although this doesn't apply to Tracker as tracker will always return something)