### PR TITLE
Mavlink: On mission_set_current report the requested item if the set was a success

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -393,7 +393,7 @@ void GCS_MAVLINK::handle_mission_set_current(AP_Mission &mission, mavlink_messag
 
     // set current command
     if (mission.set_current_cmd(packet.seq)) {
-        mavlink_msg_mission_current_send(chan, mission.get_current_nav_cmd().index);
+        mavlink_msg_mission_current_send(chan, packet.seq);
     }
 }
 


### PR DESCRIPTION
The problem with reporting the mission index, is that the mission index will be walked
forward until its referring to a nav target, which means that if a DO_ command was
requested, the requesting mavlink device had no way to validate the command was
accepted, it would have to make a infrence from it's copy of the mission.

This was discussed on the 8/29 dev call