### PR TITLE
AP_InertialSensor: per-sensor ID

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -149,19 +149,6 @@ enum HomeState {
 ///
 //@{
 
-
-/*  Product IDs for all supported products follow */
-
-#define AP_PRODUCT_ID_NONE                      0x00    // Hardware in the loop
-#define AP_PRODUCT_ID_SITL              0x03    // Software in the loop
-#define AP_PRODUCT_ID_PX4               0x04    // PX4 on NuttX
-#define AP_PRODUCT_ID_PX4_V2            0x05    // PX4 FMU2 on NuttX
-#define AP_PRODUCT_ID_PX4_V4            0x06    // PX4 FMU4 on NuttX
-#define AP_PRODUCT_ID_L3G4200D          0x101   // Linux with L3G4200D and ADXL345
-#define AP_PRODUCT_ID_PIXHAWK_FIRE_CAPE 0x102   // Linux with the PixHawk Fire Cape
-#define AP_PRODUCT_ID_MPU9250           0x103   // MPU9250
-#define AP_PRODUCT_ID_VRBRAIN           0x150   // VRBRAIN on NuttX
-
 /*
   Return true if value is between lower and upper bound inclusive.
   False otherwise.

--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -150,6 +150,13 @@ public:
         _read_flag = flag;
     }
 
+    /*
+     * Unique identifier for this device on the system that shall be the same
+     * across reboots so device-specific values can be loaded from
+     * EEPROM/filesystem.
+     */
+    virtual uint16_t get_id() { return 0; }
+
 protected:
     uint8_t _read_flag = 0;
 };

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -263,6 +263,16 @@ bool I2CDevice::adjust_periodic_callback(
     return _bus.thread.adjust_timer(static_cast<TimerPollable*>(h), period_usec);
 }
 
+uint16_t I2CDevice::get_id()
+{
+    /*
+     * 7 MSb for the device address, followed by the bus number and then the
+     * bus type. When/if we support 10-bit addressing, this needs to be
+     * changed.
+     */
+    return (_address << 9) | (_bus.bus << 3) | bus_type;
+}
+
 I2CDeviceManager::I2CDeviceManager()
 {
     /* Reserve space up-front for 4 buses */

--- a/libraries/AP_HAL_Linux/I2CDevice.h
+++ b/libraries/AP_HAL_Linux/I2CDevice.h
@@ -75,6 +75,8 @@ public:
     bool adjust_periodic_callback(
         AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 
+    uint16_t get_id() override;
+
 protected:
     I2CBus &_bus;
     uint8_t _address;

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -412,6 +412,27 @@ bool SPIDevice::adjust_periodic_callback(
     return _bus.thread.adjust_timer(static_cast<TimerPollable*>(h), period_usec);
 }
 
+uint16_t SPIDevice::get_id()
+{
+    /*
+     * Instance number of this device on the device[] array: this is used in
+     * place of the gpio number because those may be too big to fit into the
+     * 16-bit we have for uniquely identifying the device.
+     *
+     * Since all of our SPIDevice's come from the _device[] array, this
+     * already uniquely identify a device, but we still use the bus number and
+     * kernel cs to be able to decode the ID.
+     */
+    unsigned n_desc = &_desc - SPIDeviceManager::from(hal.spi)->_device;
+    if (n_desc >= (1U << 5)) {
+        AP_HAL::panic("SPI: too many SPI devices or indexes wrong");
+    }
+
+    return (_desc.bus << 12) |
+           (_desc.subdev << 8 ) |
+           (n_desc << 3) |
+           bus_type;
+}
 
 AP_HAL::OwnPtr<AP_HAL::SPIDevice>
 SPIDeviceManager::get_device(const char *name)

--- a/libraries/AP_HAL_Linux/SPIDevice.h
+++ b/libraries/AP_HAL_Linux/SPIDevice.h
@@ -57,6 +57,8 @@ public:
     bool adjust_periodic_callback(
         AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 
+    uint16_t get_id() override;
+
 protected:
     SPIBus &_bus;
     SPIDesc &_desc;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -375,6 +375,48 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("POS3", 29, AP_InertialSensor, _accel_pos[2], 0.0f),
 
+    // @Param: GYR_ID
+    // @DisplayName: Gyro ID
+    // @Description: Gyro sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("GYR_ID", 30, AP_InertialSensor, _gyro_id[0], 0),
+
+    // @Param: GYR2_ID
+    // @DisplayName: Gyro2 ID
+    // @Description: Gyro2 sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("GYR2_ID", 31, AP_InertialSensor, _gyro_id[1], 0),
+
+    // @Param: GYR3_ID
+    // @DisplayName: Gyro3 ID
+    // @Description: Gyro3 sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("GYR3_ID", 32, AP_InertialSensor, _gyro_id[2], 0),
+
+    // @Param: ACC_ID
+    // @DisplayName: Accelerometer ID
+    // @Description: Accelerometer sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("ACC_ID", 33, AP_InertialSensor, _accel_id[0], 0),
+
+    // @Param: ACC2_ID
+    // @DisplayName: Accelerometer2 ID
+    // @Description: Accelerometer2 sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("ACC2_ID", 34, AP_InertialSensor, _accel_id[1], 0),
+
+    // @Param: ACC3_ID
+    // @DisplayName: Accelerometer3 ID
+    // @Description: Accelerometer3 sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO("ACC3_ID", 35, AP_InertialSensor, _accel_id[2], 0),
+
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully
@@ -456,24 +498,67 @@ AP_InertialSensor *AP_InertialSensor::get_instance()
 /*
   register a new gyro instance
  */
-uint8_t AP_InertialSensor::register_gyro(uint16_t raw_sample_rate_hz)
+uint8_t AP_InertialSensor::register_gyro(uint16_t raw_sample_rate_hz,
+                                         uint32_t id)
 {
     if (_gyro_count == INS_MAX_INSTANCES) {
         AP_HAL::panic("Too many gyros");
     }
+
     _gyro_raw_sample_rates[_gyro_count] = raw_sample_rate_hz;
+
+    bool saved = _gyro_id[_gyro_count].load();
+
+    if (saved && (uint32_t)_gyro_id[_gyro_count] != id) {
+        // inconsistent gyro id - mark it as needing calibration
+        _gyro_cal_ok[_gyro_count] = false;
+    }
+
+    _gyro_id[_gyro_count].set((int32_t) id);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (!saved) {
+        // assume this is the same sensor and save its ID to allow seamless
+        // transition from when we didn't have the IDs.
+        _gyro_id[_gyro_count].save();
+    }
+#endif
+
     return _gyro_count++;
 }
 
 /*
   register a new accel instance
  */
-uint8_t AP_InertialSensor::register_accel(uint16_t raw_sample_rate_hz)
+uint8_t AP_InertialSensor::register_accel(uint16_t raw_sample_rate_hz,
+                                          uint32_t id)
 {
     if (_accel_count == INS_MAX_INSTANCES) {
         AP_HAL::panic("Too many accels");
     }
+
     _accel_raw_sample_rates[_accel_count] = raw_sample_rate_hz;
+    bool saved = _accel_id[_accel_count].load();
+
+    if (!saved) {
+        // inconsistent accel id
+        _accel_id_ok[_accel_count] = false;
+    } else if ((uint32_t)_accel_id[_accel_count] != id) {
+        // inconsistent accel id
+        _accel_id_ok[_accel_count] = false;
+    } else {
+        _accel_id_ok[_accel_count] = true;
+    }
+
+    _accel_id[_accel_count].set((int32_t) id);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        // assume this is the same sensor and save its ID to allow seamless
+        // transition from when we didn't have the IDs.
+        _accel_id_ok[_accel_count] = true;
+        _accel_id[_accel_count].save();
+#endif
+
     return _accel_count++;
 }
 
@@ -787,6 +872,9 @@ bool AP_InertialSensor::accel_calibrated_ok_all() const
 
     // check each accelerometer has offsets saved
     for (uint8_t i=0; i<get_accel_count(); i++) {
+        if (!_accel_id_ok[i]) {
+            return false;
+        }
         // exactly 0.0 offset is extremely unlikely
         if (_accel_offset[i].get().is_zero()) {
             return false;
@@ -972,6 +1060,7 @@ void AP_InertialSensor::_save_gyro_calibration()
 {
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _gyro_offset[i].save();
+        _gyro_id[i].save();
     }
 }
 
@@ -1425,6 +1514,8 @@ void AP_InertialSensor::_acal_save_calibrations()
             _accel_calibrator[i].get_calibration(bias, gain);
             _accel_offset[i].set_and_save(bias);
             _accel_scale[i].set_and_save(gain);
+            _accel_id[i].save();
+            _accel_id_ok[i] = true;
         } else {
             _accel_offset[i].set_and_save(Vector3f(0,0,0));
             _accel_scale[i].set_and_save(Vector3f(0,0,0));

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -665,7 +665,7 @@ AP_InertialSensor::init_gyro()
     _init_gyro();
 
     // save calibration
-    _save_parameters();
+    _save_gyro_calibration();
 }
 
 // accelerometer clipping reporting
@@ -968,11 +968,9 @@ AP_InertialSensor::_init_gyro()
 }
 
 // save parameters to eeprom
-void AP_InertialSensor::_save_parameters()
+void AP_InertialSensor::_save_gyro_calibration()
 {
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-        _accel_scale[i].save();
-        _accel_offset[i].save();
         _gyro_offset[i].save();
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -54,10 +54,9 @@ extern const AP_HAL::HAL& hal;
 const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Param: PRODUCT_ID
     // @DisplayName: IMU Product ID
-    // @Description: Which type of IMU is installed (read-only).
+    // @Description: unused
     // @User: Advanced
-    // @Values: 0:Unknown,1:unused,2:unused,88:unused,3:SITL,4:PX4v1,5:PX4v2,256:unused,257:Linux
-    AP_GROUPINFO("PRODUCT_ID",  0, AP_InertialSensor, _product_id,   0),
+    AP_GROUPINFO("PRODUCT_ID",  0, AP_InertialSensor, _old_product_id,   0),
 
     /*
       The following parameter indexes and reserved from previous use
@@ -638,9 +637,6 @@ AP_InertialSensor::detect_backends(void)
     if (_backend_count == 0) {
         AP_HAL::panic("No INS backends available");
     }
-
-    // set the product ID to the ID of the first backend
-    _product_id.set(_backends[0]->product_id());
 }
 
 /*
@@ -974,7 +970,6 @@ AP_InertialSensor::_init_gyro()
 // save parameters to eeprom
 void AP_InertialSensor::_save_parameters()
 {
-    _product_id.save();
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _accel_scale[i].save();
         _accel_offset[i].save();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -272,8 +272,8 @@ private:
 
     bool _calculate_trim(const Vector3f &accel_sample, float& trim_roll, float& trim_pitch);
 
-    // save parameters to eeprom
-    void  _save_parameters();
+    // save gyro calibration values to eeprom
+    void _save_gyro_calibration();
 
     // backend objects
     AP_InertialSensor_Backend *_backends[INS_MAX_BACKENDS];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -319,7 +319,7 @@ private:
     Vector3f _last_raw_gyro[INS_MAX_INSTANCES];
 
     // product id
-    AP_Int16 _product_id;
+    AP_Int16 _old_product_id;
 
     // accelerometer scaling and offsets
     AP_Vector3f _accel_scale[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -66,8 +66,8 @@ public:
 
     /// Register a new gyro/accel driver, allocating an instance
     /// number
-    uint8_t register_gyro(uint16_t raw_sample_rate_hz);
-    uint8_t register_accel(uint16_t raw_sample_rate_hz);
+    uint8_t register_gyro(uint16_t raw_sample_rate_hz, uint32_t id);
+    uint8_t register_accel(uint16_t raw_sample_rate_hz, uint32_t id);
 
     bool calibrate_trim(float &trim_roll, float &trim_pitch);
 
@@ -321,6 +321,11 @@ private:
     // product id
     AP_Int16 _old_product_id;
 
+    // IDs to uniquely identify each sensor: shall remain
+    // the same across reboots
+    AP_Int32 _accel_id[INS_MAX_INSTANCES];
+    AP_Int32 _gyro_id[INS_MAX_INSTANCES];
+
     // accelerometer scaling and offsets
     AP_Vector3f _accel_scale[INS_MAX_INSTANCES];
     AP_Vector3f _accel_offset[INS_MAX_INSTANCES];
@@ -350,8 +355,9 @@ private:
     // board orientation from AHRS
     enum Rotation _board_orientation;
 
-    // calibrated_ok flags
+    // calibrated_ok/id_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];
+    bool _accel_id_ok[INS_MAX_INSTANCES];
 
     // primary accel and gyro
     uint8_t _primary_gyro;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -177,8 +177,10 @@ void AP_InertialSensor_BMI160::start()
 
     _dev->get_semaphore()->give();
 
-    _accel_instance = _imu.register_accel(BMI160_ODR_TO_HZ(BMI160_ODR));
-    _gyro_instance = _imu.register_gyro(BMI160_ODR_TO_HZ(BMI160_ODR));
+    _accel_instance = _imu.register_accel(BMI160_ODR_TO_HZ(BMI160_ODR),
+                                          _dev->get_id());
+    _gyro_instance = _imu.register_gyro(BMI160_ODR_TO_HZ(BMI160_ODR),
+                                        _dev->get_id());
 
     /* Call _poll_data() at 1kHz */
     _dev->register_periodic_callback(1000,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -6,10 +6,10 @@
 
 const extern AP_HAL::HAL& hal;
 
-AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
-    _imu(imu),
-    _product_id(AP_PRODUCT_ID_NONE)
-{}
+AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu)
+    : _imu(imu)
+{
+}
 
 void AP_InertialSensor_Backend::_rotate_and_correct_accel(uint8_t instance, Vector3f &accel) 
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -64,6 +64,10 @@ public:
      */
     virtual AuxiliaryBus *get_auxiliary_bus() { return nullptr; }
 
+    /*
+     * Return the unique identifier for this backend: it's the same for
+     * several sensors if the backend registers more gyros/accels
+     */
     int16_t get_id() const { return _id; }
 
 protected:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -64,11 +64,6 @@ public:
      */
     virtual AuxiliaryBus *get_auxiliary_bus() { return nullptr; }
 
-    /*
-      return the product ID
-     */
-    int16_t product_id(void) const { return _product_id; }
-
     int16_t get_id() const { return _id; }
 
 protected:
@@ -117,9 +112,6 @@ protected:
 
     // set gyro error_count
     void _set_gyro_error_count(uint8_t instance, uint32_t error_count);
-
-    // backend should fill in its product ID from AP_PRODUCT_ID_*
-    int16_t _product_id;
 
     // backend unique identifier or -1 if backend doesn't identify itself
     int16_t _id = -1;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
@@ -30,7 +30,6 @@ bool AP_InertialSensor_HIL::_init_sensor(void)
     _imu.register_gyro(1200);
     _imu.register_accel(1200);
 
-    _product_id = AP_PRODUCT_ID_NONE;
     _imu.set_hil_mode();
 
     return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
@@ -27,8 +27,8 @@ AP_InertialSensor_Backend *AP_InertialSensor_HIL::detect(AP_InertialSensor &_imu
 bool AP_InertialSensor_HIL::_init_sensor(void) 
 {
     // grab the used instances
-    _imu.register_gyro(1200);
-    _imu.register_accel(1200);
+    _imu.register_gyro(1200, 1);
+    _imu.register_accel(1200, 1);
 
     _imu.set_hil_mode();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -196,8 +196,8 @@ bool AP_InertialSensor_L3G4200D::_init_sensor(void)
 
     _dev->get_semaphore()->give();
 
-    _gyro_instance = _imu.register_gyro(800);
-    _accel_instance = _imu.register_accel(800);
+    _gyro_instance = _imu.register_gyro(800, _dev->get_id());
+    _accel_instance = _imu.register_accel(800, _dev->get_id());
 
     // start the timer process to read samples
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_L3G4200D::_accumulate, void));

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -198,7 +198,6 @@ bool AP_InertialSensor_L3G4200D::_init_sensor(void)
 
     _gyro_instance = _imu.register_gyro(800);
     _accel_instance = _imu.register_accel(800);
-    _product_id = AP_PRODUCT_ID_L3G4200D;
 
     // start the timer process to read samples
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_L3G4200D::_accumulate, void));

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -24,9 +24,6 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    // return product ID
-    int16_t product_id() const { return AP_PRODUCT_ID_L3G4200D; }
-
 private:
     bool _init_sensor();
     void _accumulate();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -490,8 +490,8 @@ bool AP_InertialSensor_LSM9DS0::_hardware_init()
 
     _spi_sem->give();
 
-    _gyro_instance = _imu.register_gyro(760);
-    _accel_instance = _imu.register_accel(800);
+    _gyro_instance = _imu.register_gyro(760, _dev_gyro->get_id());
+    _accel_instance = _imu.register_accel(800, _dev_accel->get_id());
 
     _set_accel_max_abs_offset(_accel_instance, 5.0f);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -389,7 +389,6 @@ AP_InertialSensor_LSM9DS0::AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,
     , _drdy_pin_num_a(drdy_pin_num_a)
     , _drdy_pin_num_g(drdy_pin_num_g)
 {
-    _product_id = AP_PRODUCT_ID_NONE;
 }
 
 AP_InertialSensor_Backend *AP_InertialSensor_LSM9DS0::probe(AP_InertialSensor &_imu,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -350,15 +350,15 @@ void AP_InertialSensor_MPU6000::start()
     hal.scheduler->delay(1);
 
     // read the product ID rev c has 1/2 the sensitivity of rev d
-    _product_id = _register_read(MPUREG_PRODUCT_ID);
+    uint8_t product_id = _register_read(MPUREG_PRODUCT_ID);
     //Serial.printf("Product_ID= 0x%x\n", (unsigned) _mpu6000_product_id);
 
     // TODO: should be changed to 16G once we have a way to override the
     // previous offsets
-    if ((_product_id == MPU6000ES_REV_C4) ||
-        (_product_id == MPU6000ES_REV_C5) ||
-        (_product_id == MPU6000_REV_C4)   ||
-        (_product_id == MPU6000_REV_C5)) {
+    if ((product_id == MPU6000ES_REV_C4) ||
+        (product_id == MPU6000ES_REV_C5) ||
+        (product_id == MPU6000_REV_C4)   ||
+        (product_id == MPU6000_REV_C5)) {
         // Accel scale 8g (4096 LSB/g)
         // Rev C has different scaling than rev D
         _register_write(MPUREG_ACCEL_CONFIG,1<<3);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -550,7 +550,6 @@ void AP_InertialSensor_MPU6000::_read_sample()
 
     if (!_block_read(MPUREG_INT_STATUS, (uint8_t *) &rx, sizeof(rx))) {
         if (++_error_count > 4) {
-            // TODO: set bus speed low for this (and only this) device
             hal.console->printf("MPU60x0: error reading sample\n");
             return;
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -7,9 +7,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-// MPU6000 accelerometer scaling
-#define MPU6000_ACCEL_SCALE_1G    (GRAVITY_MSS / 4096.0f)
-
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/GPIO.h>
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBOARD || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
@@ -213,7 +210,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 #define MAX_DATA_READ (MPU6000_MAX_FIFO_SAMPLES * MPU6000_SAMPLE_SIZE)
 
-#define MPU6000_DRIVER_VERSION_ACCEL 0U
+#define MPU6000_DRIVER_VERSION_ACCEL 1U
 #define MPU6000_DRIVER_VERSION_GYRO 0U
 
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
@@ -356,8 +353,6 @@ void AP_InertialSensor_MPU6000::start()
     uint8_t product_id = _register_read(MPUREG_PRODUCT_ID);
     //Serial.printf("Product_ID= 0x%x\n", (unsigned) _mpu6000_product_id);
 
-    // TODO: should be changed to 16G once we have a way to override the
-    // previous offsets
     if ((product_id == MPU6000ES_REV_C4) ||
         (product_id == MPU6000ES_REV_C5) ||
         (product_id == MPU6000_REV_C4)   ||
@@ -365,9 +360,11 @@ void AP_InertialSensor_MPU6000::start()
         // Accel scale 8g (4096 LSB/g)
         // Rev C has different scaling than rev D
         _register_write(MPUREG_ACCEL_CONFIG,1<<3);
+        _accel_scale = GRAVITY_MSS / 4096.f;
     } else {
-        // Accel scale 8g (4096 LSB/g)
-        _register_write(MPUREG_ACCEL_CONFIG,2<<3);
+        // Accel scale 16g (2048 LSB/g)
+        _register_write(MPUREG_ACCEL_CONFIG,3<<3);
+        _accel_scale = GRAVITY_MSS / 2048.f;
     }
     hal.scheduler->delay(1);
 
@@ -471,7 +468,7 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
         accel = Vector3f(int16_val(data, 1),
                          int16_val(data, 0),
                          -int16_val(data, 2));
-        accel *= MPU6000_ACCEL_SCALE_1G;
+        accel *= _accel_scale;
 
         gyro = Vector3f(int16_val(data, 5),
                         int16_val(data, 4),

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -213,6 +213,9 @@ extern const AP_HAL::HAL& hal;
 #endif
 #define MAX_DATA_READ (MPU6000_MAX_FIFO_SAMPLES * MPU6000_SAMPLE_SIZE)
 
+#define MPU6000_DRIVER_VERSION_ACCEL 0U
+#define MPU6000_DRIVER_VERSION_GYRO 0U
+
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 #define uint16_val(v, idx)(((uint16_t)v[2*idx] << 8) | v[2*idx+1])
 
@@ -382,8 +385,10 @@ void AP_InertialSensor_MPU6000::start()
     _dev->get_semaphore()->give();
 
     // grab the used instances
-    _gyro_instance = _imu.register_gyro(1000, _dev->get_id());
-    _accel_instance = _imu.register_accel(1000, _dev->get_id());
+    _gyro_instance = _imu.register_gyro(1000, _dev->get_id() |
+                                        (MPU6000_DRIVER_VERSION_GYRO << 16));
+    _accel_instance = _imu.register_accel(1000, _dev->get_id() |
+                                          (MPU6000_DRIVER_VERSION_ACCEL << 16));
 
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -382,8 +382,8 @@ void AP_InertialSensor_MPU6000::start()
     _dev->get_semaphore()->give();
 
     // grab the used instances
-    _gyro_instance = _imu.register_gyro(1000);
-    _accel_instance = _imu.register_accel(1000);
+    _gyro_instance = _imu.register_gyro(1000, _dev->get_id());
+    _accel_instance = _imu.register_accel(1000, _dev->get_id());
 
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -96,6 +96,7 @@ private:
     uint16_t _error_count;
 
     float _temp_filtered;
+    float _accel_scale;
     LowPassFilter2pFloat _temp_filter;
 
     AP_HAL::DigitalSource *_drdy_pin;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -325,8 +325,8 @@ void AP_InertialSensor_MPU9250::start()
     _dev->get_semaphore()->give();
 
     // grab the used instances
-    _gyro_instance = _imu.register_gyro(DEFAULT_SAMPLE_RATE);
-    _accel_instance = _imu.register_accel(DEFAULT_SAMPLE_RATE);
+    _gyro_instance = _imu.register_gyro(DEFAULT_SAMPLE_RATE, _dev->get_id());
+    _accel_instance = _imu.register_accel(DEFAULT_SAMPLE_RATE, _dev->get_id());
 
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -307,8 +307,6 @@ void AP_InertialSensor_MPU9250::start()
     _register_write(MPUREG_GYRO_CONFIG, BITS_GYRO_FS_2000DPS);
     hal.scheduler->delay(1);
 
-    _product_id = AP_PRODUCT_ID_MPU9250;
-
     // RM-MPU-9250A-00.pdf, pg. 15, select accel full scale 16g
     _register_write(MPUREG_ACCEL_CONFIG,3<<3);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -156,17 +156,6 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 
-#if  CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    _product_id = AP_PRODUCT_ID_VRBRAIN;
-#else
-#if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
-    _product_id = AP_PRODUCT_ID_PX4_V2;
-#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
-    _product_id = AP_PRODUCT_ID_PX4_V4;
-#else
-    _product_id = AP_PRODUCT_ID_PX4;
-#endif
-#endif
     return true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -112,7 +112,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             AP_HAL::panic("Invalid gyro sample rate");
         }
-        _gyro_instance[i] = _imu.register_gyro(samplerate);
+        _gyro_instance[i] = _imu.register_gyro(samplerate, i);
         _gyro_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -152,7 +152,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             AP_HAL::panic("Invalid accel sample rate");
         }
-        _accel_instance[i] = _imu.register_accel(samplerate);
+        _accel_instance[i] = _imu.register_accel(samplerate, i);
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -112,7 +112,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             AP_HAL::panic("Invalid gyro sample rate");
         }
-        _gyro_instance[i] = _imu.register_gyro(samplerate, i);
+        _gyro_instance[i] = _imu.register_gyro(samplerate, ioctl(fd, DEVIOCGDEVICEID, 0));
         _gyro_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -152,7 +152,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             AP_HAL::panic("Invalid accel sample rate");
         }
-        _accel_instance[i] = _imu.register_accel(samplerate, i);
+        _accel_instance[i] = _imu.register_accel(samplerate, ioctl(fd, DEVIOCGDEVICEID, 0));
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_QURT.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_QURT.cpp
@@ -36,8 +36,6 @@ bool AP_InertialSensor_QURT::init_sensor(void)
     mpu9250_mag_buffer = new ObjectBuffer<mpu9x50_data>(20);
     init_mpu9250();
 
-    _product_id = AP_PRODUCT_ID_MPU9250;
-
     return true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_QURT.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_QURT.cpp
@@ -28,10 +28,10 @@ AP_InertialSensor_Backend *AP_InertialSensor_QURT::detect(AP_InertialSensor &_im
     return sensor;
 }
 
-bool AP_InertialSensor_QURT::init_sensor(void) 
+bool AP_InertialSensor_QURT::init_sensor(void)
 {
-    gyro_instance = _imu.register_gyro(1000);
-    accel_instance = _imu.register_accel(1000);
+    gyro_instance = _imu.register_gyro(1000, 1);
+    accel_instance = _imu.register_accel(1000, 1);
 
     mpu9250_mag_buffer = new ObjectBuffer<mpu9x50_data>(20);
     init_mpu9250();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -36,8 +36,8 @@ bool AP_InertialSensor_SITL::init_sensor(void)
 
     // grab the used instances
     for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
-        gyro_instance[i] = _imu.register_gyro(sitl->update_rate_hz);
-        accel_instance[i] = _imu.register_accel(sitl->update_rate_hz);
+        gyro_instance[i] = _imu.register_gyro(sitl->update_rate_hz, i);
+        accel_instance[i] = _imu.register_accel(sitl->update_rate_hz, i);
     }
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -42,8 +42,6 @@ bool AP_InertialSensor_SITL::init_sensor(void)
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
 
-    _product_id = AP_PRODUCT_ID_NONE;
-
     return true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_qflight.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_qflight.cpp
@@ -31,8 +31,8 @@ AP_InertialSensor_Backend *AP_InertialSensor_QFLIGHT::detect(AP_InertialSensor &
 
 bool AP_InertialSensor_QFLIGHT::init_sensor(void) 
 {
-    gyro_instance = _imu.register_gyro(1000);
-    accel_instance = _imu.register_accel(1000);
+    gyro_instance = _imu.register_gyro(1000, 1);
+    accel_instance = _imu.register_accel(1000, 1);
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_QFLIGHT::timer_update, void));
     return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_qflight.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_qflight.cpp
@@ -35,7 +35,6 @@ bool AP_InertialSensor_QFLIGHT::init_sensor(void)
     accel_instance = _imu.register_accel(1000);
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_QFLIGHT::timer_update, void));
-    _product_id = AP_PRODUCT_ID_MPU9250;
     return true;
 }
 


### PR DESCRIPTION
This now contains #4635, which is the reason why I ended up doing this.  It's still WIP as the label says... it currently fails on sitl in pre-arm. I guess this is because when we set the accel params we save them directly instead of calling the method from AP_InertialSensor.

I had to do more things than I anticipated in order to reach this point, but it's still not working.  @tridge @rmackay9 could you take a look? I'm still not so familiar with the parameter part... I think this was the first time I'm adding a parameter and I probably did something wrong.
