### PR TITLE
Copter: increase chance that parachute will deploy

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -101,7 +101,9 @@ void Copter::parachute_check()
     // check for angle error over 30 degrees
     const float angle_error = attitude_control.get_att_error_angle_deg();
     if (angle_error <= CRASH_CHECK_ANGLE_DEVIATION_DEG) {
-        control_loss_count = 0;
+        if (control_loss_count > 0) {
+            control_loss_count--;
+        }
         return;
     }
 


### PR DESCRIPTION
Previously a single moment where the vehicle was within 30deg of the target could cause the parachute release counter to reset to zero and thus delay the release for up to 1 second.  This change makes the parachute release if it is spending at least half it's time with more than a 30degree angle error.

This partially resolves this issue: https://github.com/ArduPilot/ardupilot/issues/4702

It's not a complete solution because the crash detector and the parachute deployment logic is still quite separate.  Still, it greatly reduces the chance that the crash detector could fire before the parachute is released.