### PR TITLE
AP_HAL_Linux: Compile fix for I2CDevice

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -155,7 +155,7 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     if (send && send_len != 0) {
         msgs[nmsgs].addr = _address;
         msgs[nmsgs].flags = 0;
-        msgs[nmsgs].buf = const_cast<uint8_t*>(send);
+        msgs[nmsgs].buf = reinterpret_cast<decltype(msgs[nmsgs].buf)>(const_cast<uint8_t*>(send));
         msgs[nmsgs].len = send_len;
         nmsgs++;
     }
@@ -163,7 +163,7 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
     if (recv && recv_len != 0) {
         msgs[nmsgs].addr = _address;
         msgs[nmsgs].flags = I2C_M_RD;
-        msgs[nmsgs].buf = recv;
+        msgs[nmsgs].buf = reinterpret_cast<decltype(msgs[nmsgs].buf)>(recv);
         msgs[nmsgs].len = recv_len;
         nmsgs++;
     }
@@ -207,11 +207,11 @@ bool I2CDevice::read_registers_multiple(uint8_t first_reg, uint8_t *recv,
         for (uint8_t i = 0; i < i2c_data.nmsgs; i += 2) {
             msgs[i].addr = _address;
             msgs[i].flags = 0;
-            msgs[i].buf = &first_reg;
+            msgs[i].buf = reinterpret_cast<decltype(msgs[i].buf)>(&first_reg);
             msgs[i].len = 1;
             msgs[i + 1].addr = _address;
             msgs[i + 1].flags = I2C_M_RD;
-            msgs[i + 1].buf = recv;
+            msgs[i + 1].buf = reinterpret_cast<decltype(msgs[i + 1].buf)>(recv);
             msgs[i + 1].len = recv_len;
 
             recv += recv_len;


### PR DESCRIPTION
This commit fixes the build error:
         "error: invalid conversion from ‘uint8_t\* {aka unsigned char_}’ to ‘char_’ [-fpermissive]"
         "msgs[nmsgs].buf = const_cast<uint8_t*>(send);"
The cast does not work on any platform, because __u8 is not guaranteed to be unsigned.
