### PR TITLE
Functor: Add functionality so that Functor can contain a free function

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1602,9 +1602,9 @@ void Rover::gcs_update(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : NULL);
+            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -939,7 +939,7 @@ void Tracker::gcs_update(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
         }
     }
 }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2199,9 +2199,9 @@ void Copter::gcs_check_input(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):NULL);
+            gcs[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2367,9 +2367,9 @@ void Plane::gcs_update(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):NULL);
+            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/libraries/AP_HAL/utility/functor.h
+++ b/libraries/AP_HAL/utility/functor.h
@@ -36,18 +36,6 @@ template <class RetType, class... Args>
 class Functor
 {
 public:
-    constexpr Functor(void *obj, RetType (*method)(void *obj, Args...))
-        : _obj(obj)
-        , _method(method)
-    {
-    }
-
-    // construct from a free function
-    constexpr Functor( RetType(* pfn)(Args...) )
-        : _obj{reinterpret_cast<void*>(pfn)}
-        , _method{free_wrapper}
-    {
-    }
 
     // Allow to construct an empty Functor
     constexpr Functor(decltype(nullptr))
@@ -87,6 +75,19 @@ public:
     }
 
 private:
+
+    constexpr Functor(void *obj, RetType (*method)(void *obj, Args...))
+        : _obj(obj)
+        , _method(method)
+    {
+    }
+
+    // construct from a free function
+    constexpr Functor( RetType(* pfn)(Args...) )
+        : _obj{reinterpret_cast<void*>(pfn)}
+        , _method{free_wrapper}
+    {
+    }
     void *_obj;
     RetType (*_method)(void *obj, Args...);
 

--- a/libraries/AP_HAL/utility/functor.h
+++ b/libraries/AP_HAL/utility/functor.h
@@ -42,6 +42,13 @@ public:
     {
     }
 
+    // construct from a free function
+    constexpr Functor( RetType(* pfn)(Args...) )
+        : _obj{reinterpret_cast<void*>(pfn)}
+        , _method{free_wrapper}
+    {
+    }
+
     // Allow to construct an empty Functor
     constexpr Functor(decltype(nullptr))
         : Functor(nullptr, nullptr) { }
@@ -74,6 +81,11 @@ public:
         return { obj, method_wrapper<T, method> };
     }
 
+    static constexpr Functor bind(RetType(*pfn)(Args...))
+    {
+        return {pfn};
+    }
+
 private:
     void *_obj;
     RetType (*_method)(void *obj, Args...);
@@ -83,5 +95,11 @@ private:
     {
         T *t = static_cast<T*>(obj);
         return (t->*method)(args...);
+    }
+
+    static RetType free_wrapper(void * obj, Args... args)
+    {
+        RetType(*pfn)(Args... ) = reinterpret_cast<RetType(*)(Args...)>(obj);
+        return pfn(args...);
     }
 };

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -19,11 +19,11 @@ AP_HAL::Proc Scheduler::_failsafe = NULL;
 volatile bool Scheduler::_timer_suspended = false;
 volatile bool Scheduler::_timer_event_missed = false;
 
-AP_HAL::MemberProc Scheduler::_timer_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {NULL};
+AP_HAL::MemberProc Scheduler::_timer_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {nullptr};
 uint8_t Scheduler::_num_timer_procs = 0;
 bool Scheduler::_in_timer_proc = false;
 
-AP_HAL::MemberProc Scheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {NULL};
+AP_HAL::MemberProc Scheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {nullptr};
 uint8_t Scheduler::_num_io_procs = 0;
 bool Scheduler::_in_io_proc = false;
 

--- a/libraries/AP_Menu/AP_Menu.h
+++ b/libraries/AP_Menu/AP_Menu.h
@@ -99,7 +99,7 @@ public:
     /// @param commands		An array of ::command structures in program memory.
     /// @param entries		The number of entries in the menu.
     ///
-    Menu(const char *prompt, const struct command *commands, uint8_t entries, preprompt ppfunc = 0);
+    Menu(const char *prompt, const struct command *commands, uint8_t entries, preprompt ppfunc = nullptr);
 
     /// set command line length limit
     void set_limits(uint8_t commandline_max, uint8_t args_max);

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -55,7 +55,7 @@ public:
     // constructor
     AP_Scheduler(void);
     
-    FUNCTOR_TYPEDEF(task_fn_t, void);
+    typedef Functor<void> task_fn_t;
 
     struct Task {
         task_fn_t function;

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -10,6 +10,8 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
+
+
 class SchedTest {
 public:
     void setup();
@@ -24,7 +26,6 @@ private:
     static const AP_Scheduler::Task scheduler_tasks[];
 
     void ins_update(void);
-    void one_hz_print(void);
     void five_second_call(void);
 };
 
@@ -32,6 +33,7 @@ static SchedTest schedtest;
 
 #define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(SchedTest, &schedtest, func, _interval_ticks, _max_time_micros)
 
+void one_hz_print(void);
 /*
   scheduler table - all regular tasks are listed here, along with how
   often they should be called (in 20ms units) and the maximum time
@@ -39,8 +41,14 @@ static SchedTest schedtest;
  */
 const AP_Scheduler::Task SchedTest::scheduler_tasks[] = {
     SCHED_TASK(ins_update,             50,   1000),
-    SCHED_TASK(one_hz_print,            1,   1000),
+    // here we install a global free function
+    {.function = AP_Scheduler::task_fn_t::bind(one_hz_print),
+     .name = "one_hz_print",
+     .rate_hz = 0.2f,
+     .max_time_micros = 1000
+    },
     SCHED_TASK(five_second_call,      0.2,   1800),
+
 };
 
 
@@ -76,7 +84,7 @@ void SchedTest::ins_update(void)
 /*
   print something once a second
  */
-void SchedTest::one_hz_print(void)
+void one_hz_print(void)
 {
     hal.console->printf("one_hz: t=%lu\n", (unsigned long)AP_HAL::millis());
 }

--- a/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
@@ -25,3 +25,4 @@ LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
 LIBRARIES += AP_OpticalFlow
+LIBRARIES += RC_Channel


### PR DESCRIPTION
 ( or static member function) as well as an object pointer and a non-static member function. The size and performance of the functor is not affected. A list of functors , for example, can freely mix, object member functions, static member functions and free functions.

A new constructor is added, that takes a pointer to free function argument.
One consequence, when explicitly initialising an empty functor, you need to be explicit about constructing with a nullptr. Constructing with a 0 or NULL wont work since that is convertible to a function pointer as well as a nullptr

There is also an overload of the bind static member for the free function pointer argument