### PR TITLE
EKF2 - Improve use of range finder data

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -485,6 +485,14 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Units: %
     AP_GROUPINFO("RNG_USE_HGT", 42, NavEKF2, _useRngSwHgt, -1),
 
+    // @Param: TERR_GRAD
+    // @DisplayName: Maximum terrain gradient
+    // @Description: Specifies the maxium gradient of the terrain below the vehicle when it is using range finder as a height reference
+    // @Range: 0 0.2
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("TERR_GRAD", 43, NavEKF2, _terrGradMax, 0.1f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -340,6 +340,7 @@ private:
     AP_Int16 _yawInnovGate;         // Percentage number of standard deviations applied to magnetic yaw innovation consistency check
     AP_Int8 _tauVelPosOutput;       // Time constant of output complementary filter : csec (centi-seconds)
     AP_Int8 _useRngSwHgt;           // Maximum valid range of the range finder in metres
+    AP_Float _terrGradMax;          // Maximum terrain gradient below the vehicle
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -82,6 +82,9 @@ void NavEKF2_core::readRangeFinder(void)
                 // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
                 storedRange.push(rangeDataNew);
 
+                // indicate we have updated the measurement
+                rngValidMeaTime_ms = imuSampleTime_ms;
+
             } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
@@ -96,10 +99,10 @@ void NavEKF2_core::readRangeFinder(void)
                 // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
                 storedRange.push(rangeDataNew);
 
+                // indicate we have updated the measurement
+                rngValidMeaTime_ms = imuSampleTime_ms;
+
             }
-
-            rngValidMeaTime_ms = imuSampleTime_ms;
-
         }
     }
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -719,6 +719,8 @@ void NavEKF2_core::selectHeightForFusion()
             fuseHgtData = true;
             // set the observation noise
             posDownObsNoise = sq(constrain_float(frontend->_rngNoise, 0.1f, 10.0f));
+            // add uncertainty created by terrain gradient and vehicle tilt
+            posDownObsNoise += sq(rangeDataDelayed.rng * frontend->_terrGradMax) * MAX(0.0f , (1.0f - sq(prevTnb.c.z)));
         } else {
             // disable fusion if tilted too far
             fuseHgtData = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1336,10 +1336,8 @@ void NavEKF2_core::ConstrainStates()
     for (uint8_t i=19; i<=21; i++) statesArray[i] = constrain_float(statesArray[i],-0.5f,0.5f);
     // wind velocity limit 100 m/s (could be based on some multiple of max airspeed * EAS2TAS) - TODO apply circular limit
     for (uint8_t i=22; i<=23; i++) statesArray[i] = constrain_float(statesArray[i],-100.0f,100.0f);
-    // constrain the terrain or vertical position state state depending on whether we are using the ground as the height reference
-    if (inhibitGndState) {
-        stateStruct.position.z = MIN(stateStruct.position.z, terrainState - rngOnGnd);
-    } else {
+    // constrain the terrain state to be below the vehicle height unless we are using terrain as the height datum
+    if (!inhibitGndState) {
         terrainState = MAX(terrainState, stateStruct.position.z + rngOnGnd);
     }
 }


### PR DESCRIPTION
Addresses the following:

1) Fixes bugs allowing continuous out of range data to cause indefinite height drift and problems with EKF output - refer to http://discuss.ardupilot.org/t/bug-using-ek2-rng-use-hgt-on-rc3/11268
2) Improves height keeping at larger heights over uneven surfaces by allowing for the errors produced by combined terrain gradient and vehicle tilt when setting range finder observation noise.

Has been bench and flight tested. The following plots hows the height estimates , height measurements, height innovation and vehicle speed for a test flown using a SF10/B range finder over a range of speeds and height. The following parameter settings were used:

RNGFND_MAX_CM  = 4000
RNGFND_MIN_CM = 8
EK2_ALT_SOURCE = 0 (use baro height as the primary reference when not using range finder)
EK2_RNG_USE_HGT = 50 (allow use of range finder blow 50% of the value set by RNGFND_MAX_CM)
EK2_TERR_GRAD = 0.1 (allow for a 1:10 terrain gradient below the vehicle - the test was flown over a sporting field with small trees around the perimeter)

![screen shot 2016-09-10 at 11 04 10 am](https://cloud.githubusercontent.com/assets/3596952/18406853/583379aa-7746-11e6-88ed-99773c9844cf.png)

The copter switched seamlessly between range finder and baro height. Range finder height use is indicated where the noise in the height innovations (NKF3.IPD) is low and corresponds to height below 20m and low speed/hover condition.