### PR TITLE
AP_OpticalFlow: Changed short boundary the i2c_integral_frame.

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.h
@@ -54,6 +54,7 @@ private:
         uint16_t ground_distance;
         int16_t gyro_temperature;
         uint8_t qual;
+        uint8_t padding_not_used;
     } i2c_integral_frame;
 
     typedef struct {


### PR DESCRIPTION
Value of i2c_integral_frame does not change.
The value of i2c_frame changes.
I checked PX4Flow source.
i2c_integral_frame of PX4Flow does not packed specified.
For Linux has been packed.
For this reason, for 1 register worth less, the switching of the buffer is not performed.
However, the word boundary When you delete a packed specified.

So, it was padding to add a one byte.

This Information
this Structure is packed!!
i2c_integral_frame Structure:  https://pixhawk.org/modules/px4flow

But

PX4Flow source:  https://github.com/PX4/Flow
Oh no not Packed!!
i2c_integral_frame Structure: https://github.com/PX4/Flow/blob/master/src/include/i2c_frame.h

===
Changed short boundary

Debug Information:
f_integral=10 00 FB FF EB FF 00 00 04 00 00 00 E4 97 01 00 E8 94 05 00 00 00 D8 0E C3 00 
PX4FLOW id:0 qual:195 FlowRateX:-0.00 Y:-0.02 BodyRateX:0.00 y:0.00

===
11/9/2016 added  Log flie .BIN  data.
It is changing value

OF, 64857460879, 148, -0.008629989, 0.005393744, 0, -0.001078749
OF, 64857560911, 146, 0.001017708, 0, 0, 0
OF, 64857660799, 141, -0.0797546, 0.1042945, 0, 0
OF, 64857760967, 146, -0.003057169, 0.01019056, 0, 0.001019056