### PR TITLE
AC_Avoid: fix composition of fences

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -21,6 +21,10 @@ AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fen
     AP_Param::setup_object_defaults(this, var_info);
 }
 
+/*
+ * Adjusts the desired velocity so that the vehicle can stop
+ * before the fence/object.
+ */
 void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel)
 {
     // exit immediately if disabled
@@ -32,8 +36,49 @@ void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f 
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     if (_enabled == AC_AVOID_STOP_AT_FENCE) {
-        adjust_velocity_circle(kP, accel_cmss_limited, desired_vel);
-        adjust_velocity_poly(kP, accel_cmss_limited, desired_vel);
+
+        // get polygon boundary
+        // Note: first point in list is the return-point (which copter does not use)
+        uint16_t num_points_poly;
+        Vector2f* boundary = _fence.get_polygon_points(num_points_poly);
+        uint16_t num_points_reg_poly = get_num_points_reg_poly();
+
+        // Allocate an array to store all constraints
+        // Note: as new types of constraints are added (e.g. obstacles), this
+        // needs to be updated.
+        uint16_t num_constraints = 0;
+        if (can_adjust_reg_poly()) {
+            num_constraints += num_points_reg_poly;
+        }
+        if (can_adjust_poly()) {
+            // One of the points in the boundary is not part of the
+            // fence, so we don't need a constraint for that.
+            num_constraints += num_points_poly - 1;
+        }
+        if (num_constraints == 0) {
+            return;
+        }
+        // Two arrays giving constraints induced by the current position and fence
+        // The ith constraint is:
+        //    velocity * constraints[i].A <= constraints[i].c
+        constraint constraints[num_constraints];
+        // an index into the next free slot in constraints
+        uint16_t free_index = 0;
+        if (can_adjust_reg_poly()) {
+            velocity_constraints_reg_poly(kP, accel_cmss_limited, num_points_reg_poly, get_radius(),
+                                          constraints, free_index);
+        }
+        if (can_adjust_poly()) {
+            velocity_constraints_poly(kP, accel_cmss_limited, boundary, num_points_poly,
+                                      constraints, free_index);
+        }
+
+        // Adjust the velocity according to all constraints.
+        // The number of constraints is equal to free_index and not necessarily
+        // num_constraints. This is because we may not have filled the entire constraint
+        // array. This can happen, for example, if the polygon fence has already
+        // been breached.
+        adjust_velocity_constraints(kP, accel_cmss, constraints, free_index, desired_vel);
     }
 }
 
@@ -47,75 +92,90 @@ void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector3f 
 }
 
 /*
- * Adjusts the desired velocity for the circular fence.
+ * Returns true if the regular polygon fence (centered at home)
+ * adjustment should be run.
  */
-void AC_Avoid::adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel)
+bool AC_Avoid::can_adjust_reg_poly()
 {
-    // exit if circular fence is not enabled
-    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {
-        return;
-    }
+    return ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) != 0) &&
+           ((_fence.get_breaches() & AC_FENCE_TYPE_CIRCLE) == 0);
+}
 
-    // exit if the circular fence has already been breached
-    if ((_fence.get_breaches() & AC_FENCE_TYPE_CIRCLE) != 0) {
+/*
+ * Returns true if the polygon fence adjustment should be run.
+ */
+bool AC_Avoid::can_adjust_poly()
+{
+    return ((_fence.get_enabled_fences() & AC_FENCE_TYPE_POLYGON) != 0) &&
+           ((_fence.get_breaches() & AC_FENCE_TYPE_POLYGON) == 0);
+}
+
+/*
+ * Computes velocity constraints for the regular polygon fence centered at home.
+ *
+ * In particular, for each edge:
+ * Let P be the closest point to the current position of the vehicle.
+ * Let U be the unit vector in the direction of P from the current position.
+ * Let D be the distance from the current position to P.
+ * safe_vel must satisfy
+ *
+ *       safe_vel * U <= max_speed(D)
+ */
+void AC_Avoid::velocity_constraints_reg_poly(const float kP, const float accel_cmss, const uint16_t num_points,
+        const float radius, constraint* constraints, uint16_t& free_index)
+{
+    if (num_points < 3) {
         return;
     }
 
     // get position as a 2D offset in cm from ahrs home
     const Vector2f position_xy = get_position();
 
-    float speed = desired_vel.length();
-    // get the fence radius in cm
-    const float fence_radius = _fence.get_radius() * 100.0f;
-    // get the margin to the fence in cm
-    const float margin = get_margin();
+    // the angle between vertices
+    const float angle_step_size = M_2PI/num_points;
 
-    if (!is_zero(speed) && position_xy.length() <= fence_radius) {
-        // Currently inside circular fence
-        Vector2f stopping_point = position_xy + desired_vel*(get_stopping_distance(kP, accel_cmss, speed)/speed);
-        float stopping_point_length = stopping_point.length();
-        if (stopping_point_length > fence_radius - margin) {
-            // Unsafe desired velocity - will not be able to stop before fence breach
-            // Project stopping point radially onto fence boundary
-            // Adjusted velocity will point towards this projected point at a safe speed
-            Vector2f target = stopping_point * ((fence_radius - margin) / stopping_point_length);
-            Vector2f target_direction = target - position_xy;
-            float distance_to_target = target_direction.length();
-            float max_speed = get_max_speed(kP, accel_cmss, distance_to_target);
-            desired_vel = target_direction * (MIN(speed,max_speed) / distance_to_target);
+    // Compute constraints for a regular polygon with num_points vertices
+    // whose center is the origin and whose vertices are radius
+    // distance from the origin.
+    // The first vertex is on the positive x-axis.
+    Vector2f start = Vector2f(radius, 0);
+    uint16_t index = free_index;
+    for (uint8_t i = 1; i <= num_points; i++) {
+        const float angle = angle_step_size * i;
+        Vector2f end = Vector2f(cosf(angle), sinf(angle)) * radius;
+
+        // Check containment within the current edge
+        // Should we move this containment check to AC_Fence?
+        if ((end - start) % (position_xy - start) > 0) {
+            // contained within current edge
+            constraints[index] = velocity_constraint_edge(kP, accel_cmss, start, end, position_xy);
+            start = end;
+            index++;
+        } else {
+            // outside polygon - abort
+            // we haven't changed free_index, so it
+            // doesn't matter what values have been written to constraints
+            return;
         }
     }
+
+    free_index = index;
 }
 
 /*
- * Adjusts the desired velocity for the polygon fence.
+ * Computes velocity constraints for the polygon fence.
  *
- * This function is supposed to solve the following optimization problem.
- * Find the vector safe_vel that is closest to desired_vel,
- * subject to the following constraints for each edge:
+ * In particular, for each edge:
  * Let P be the closest point to the current position of the vehicle.
  * Let U be the unit vector in the direction of P from the current position.
  * Let D be the distance from the current position to P.
+ * safe_vel must satisfy
  *
- *    safe_vel must satisfy safe_vel * P <= max_speed(D)
+ *       safe_vel * U <= max_speed(D)
  */
-void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel)
+void AC_Avoid::velocity_constraints_poly(const float kP, const float accel_cmss, const Vector2f* boundary,
+        const uint16_t num_points, constraint* constraints, uint16_t& free_index)
 {
-    // exit if the polygon fence is not enabled
-    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {
-        return;
-    }
-
-    // exit if the polygon fence has already been breached
-    if ((_fence.get_breaches() & AC_FENCE_TYPE_POLYGON) != 0) {
-        return;
-    }
-
-    // get polygon boundary
-    // Note: first point in list is the return-point (which copter does not use)
-    uint16_t num_points;
-    Vector2f* boundary = _fence.get_polygon_points(num_points);
-
     // exit if there are no points
     if (boundary == NULL || num_points == 0) {
         return;
@@ -128,55 +188,67 @@ void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vect
         return;
     }
 
-    // Two arrays giving constraints induced by the current position and fence
-    // The ith constraint is:
-    //    velocity * constraint_directions[i] <= max_speeds[i]
-    Vector2f constraint_directions[num_points - 1];
-    float max_speeds[num_points - 1];
-
     uint16_t i, j;
     for (i = 1, j = num_points-1; i < num_points; j = i++) {
         // end points of current edge
         Vector2f start = boundary[j];
         Vector2f end = boundary[i];
-        // vector from current position to closest point on current edge
-        Vector2f limit_direction = Vector2f::closest_point(position_xy, start, end) - position_xy;
-        // distance to closest point
-        const float limit_distance = limit_direction.length();
-        if (!is_zero(limit_distance)) {
-            // We are strictly inside the given edge.
-            // Adjust velocity to not violate this edge.
-            limit_direction /= limit_distance;
-            constraint_directions[i - 1] = limit_direction;
-            max_speeds[i - 1] = get_max_speed(kP, accel_cmss, limit_distance - get_margin());
-        } else {
-            // We are exactly on the edge - treat this as a fence breach.
-            // i.e. do not adjust velocity.
-            return;
-        }
+        constraints[free_index] = velocity_constraint_edge(kP, accel_cmss, start, end, position_xy);;
+        free_index++;
     }
 
-    adjust_velocity_constraints(kP, accel_cmss, constraint_directions, max_speeds, num_points - 1, desired_vel);
+}
+
+/*
+ * Computes the velocity constraint for the given edge. In particular,
+ * Let P be the closest point to the current position of the vehicle.
+ * Let U be the unit vector in the direction of P from the current position.
+ * Let D be the distance from the current position to P.
+ * The velocity must satisfy
+ *
+ *       velocity * U <= max_speed(D)
+ */
+constraint AC_Avoid::velocity_constraint_edge(const float kP, const float accel_cmss, const Vector2f start, const Vector2f end,
+        const Vector2f position_xy)
+{
+    // vector from current position to closest point on current edge
+    Vector2f limit_direction = Vector2f::closest_point(position_xy, start, end) - position_xy;
+    // distance to closest point
+    const float limit_distance = limit_direction.length();
+    constraint res;
+    if (!is_zero(limit_distance)) {
+        // We are strictly inside the given edge.
+        // Set constraint for this edge.
+        limit_direction /= limit_distance;
+        res.A = limit_direction;
+        res.c = get_max_speed(kP, accel_cmss, limit_distance - get_margin());
+    }
+
+    // TODO: figure out what to do when the limit_distance is zero.
+    // It's not a big deal since that means the vehicle is directly on
+    // the fence boundary and should probably be considered a fence breach.
+    return res;
 }
 
 /*
  * Adjusts the velocity to satisfy the given set of constraints. The ith constraint is
- *    desired_vel * constraint_directions[i] <= max_speeds[i]
+ *    desired_vel * constraints[i].A <= constraints[i].c
  */
-void AC_Avoid::adjust_velocity_constraints(const float kP, const float accel_cmss, const Vector2f* constraint_directions, const float* max_speeds, const uint16_t num_constraints, Vector2f& desired_vel)
+void AC_Avoid::adjust_velocity_constraints(const float kP, const float accel_cmss, const constraint* constraints,
+        const uint16_t num_constraints, Vector2f& desired_vel)
 {
     for (uint16_t i = 0; i < num_constraints; i++) {
-        if (limit_velocity(kP, accel_cmss, desired_vel, constraint_directions[i], max_speeds[i])) {
+        if (limit_velocity(kP, accel_cmss, desired_vel, constraints[i].A, constraints[i].c)) {
             // If velocity was adjusted, iterate through all prior constraints to check for
             // violations
             for (uint16_t j = 0; j < i; j++) {
-                if (desired_vel * constraint_directions[j] > max_speeds[j]) {
+                if (desired_vel * constraints[j].A > constraints[j].c) {
                     // New velocity violates previous constraint
                     // Adjust velocity to intersection of the two constraints.
                     // This should be the closest point that satisfies both constraints.
                     // The following will do nothing if there is no intersection,
                     // but this should never happen.
-                    intersection(constraint_directions[j], max_speeds[j], constraint_directions[i], max_speeds[i], desired_vel);
+                    intersection(constraints[j].A, constraints[j].c, constraints[i].A, constraints[i].c, desired_vel);
                 }
             }
         }
@@ -202,14 +274,15 @@ void AC_Avoid::intersection(const Vector2f vec1, const float c1, const Vector2f 
 
 /*
  * Limits the component of desired_vel in the direction of the unit vector
- * limit_direction to be at most the maximum speed permitted by the limit_distance.
+ * limit_direction to be at most the maximum speed.
  *
  * Return true iff the velocity was actually changed.
  *
  * Uses velocity adjustment idea from Randy's second email on this thread:
  * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
  */
-bool AC_Avoid::limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float max_speed) const
+bool AC_Avoid::limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction,
+                              const float max_speed) const
 {
     // project onto limit direction
     const float speed = desired_vel * limit_direction;

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -61,6 +61,13 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("TOTAL",       6,  AC_Fence,   _total, 0),
 
+    // @Param: PTS_CIRC
+    // @DisplayName: Number of vertices on circle
+    // @Description: Number of vertices of the regular polygon inside the circular fence
+    // @Range: 1 20
+    // @User: Standard
+    AP_GROUPINFO("PTS_CIRC",    7,  AC_Fence,   _num_pts_circle, AC_FENCE_NUM_PTS_CIRCLE_DEFAULT),
+
     AP_GROUPEND
 };
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -27,6 +27,7 @@
 #define AC_FENCE_ALT_MAX_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further up
 #define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE      20.0f   // after fence is broken we recreate the fence 20m further out
 #define AC_FENCE_MARGIN_DEFAULT                     2.0f    // default distance in meters that autopilot's should maintain from the fence to avoid a breach
+#define AC_FENCE_NUM_PTS_CIRCLE_DEFAULT             8       // default number of points of the polygon fence inscribed in the circular fence
 
 // give up distance
 #define AC_FENCE_GIVE_UP_DISTANCE                   100.0f  // distance outside the fence at which we should give up and just land.  Note: this is not used by library directly but is intended to be used by the main code
@@ -83,6 +84,10 @@ public:
     /// get_radius - returns the fence radius in meters
     float get_radius() const { return _circle_radius.get(); }
 
+    /// get_num_pts_circle - returns number of points of the polygon fence
+    ///    inscribed in the circular fence
+    float get_num_pts_circle() const { return _num_pts_circle.get(); }
+
     /// get_margin - returns the fence margin in meters
     float get_margin() const { return _margin.get(); }
 
@@ -136,6 +141,7 @@ private:
     AP_Float        _circle_radius;         // circle fence radius in meters
     AP_Float        _margin;                // distance in meters that autopilot's should maintain from the fence to avoid a breach
     AP_Int8         _total;                 // number of polygon points saved in eeprom
+    AP_Int8         _num_pts_circle;        // number of polygon points on the circular fence
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away


### PR DESCRIPTION
This fixes two related issues: https://github.com/ArduPilot/ardupilot/issues/4807 and https://github.com/ArduPilot/ardupilot/issues/4429. Both issues had the same root cause. In particular, the previous implementation would adjust the velocity for the first edge in the polygon, use this new velocity when adjusting for the second edge, and so on. However, the adjustment for the second edge could produce a new velocity that violates the first edge. Similarly, if the polygon fence code was run after the circular fence code, it could produce a velocity that violated the circular fence.

My solution involves two components:
1. Implement a function that computes the closest velocity to the desired velocity, subject to _linear_ constraints.
2. Compute linear constraints on velocity for all fences that are sufficient to keep the vehicle inside these fences. Pass these linear constraints to the function from (1).

(2) requires re-phrasing the circular fence in terms of linear constraints. I think the simplest approach is to just embed a regular polygon inside the circular fence. I think that this is a sufficient solution since the circular fence is very coarse to begin with.

The main downside to this patch is that the runtime is now quadratic in the number of edges (previously it was linear). However, this is only in the worst case. A more precise runtime is O(k*n) where k is the number of fence edges that must be adjusted for. In most cases, I expect k <= 1. If there is concern about the runtime, we can parameterize this code by a maximum value of k. After the velocity has been adjusted k times, the code will only adjust the magnitude of velocity, not the direction. This will not be optimal, but will at least have a guaranteed linear runtime.

I think that this new approach will make the avoidance code easily extensible. The idea is that there are many different sources of velocity constraints (polygon fence, no-fly zones, obstacles, etc.). In the future, we can generate all such constraints and then pass them to adjust_velocity_constraints. This guarantees that the velocity satisfies all constraints, without having to worry about weird interactions between, e.g. the polygon fence and obstacle avoidance.

Finally, this pull request builds on a previous one: https://github.com/ArduPilot/ardupilot/pull/4813. I'm not sure whether I should close the previous one, or do one after another. I think it would probably be easier to ignore the previous pull request.
