### PR TITLE
AP_Scheduler: fix example for px4

### DIFF
--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -7,6 +7,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -46,6 +47,9 @@ const AP_Scheduler::Task SchedTest::scheduler_tasks[] = {
 
 void SchedTest::setup(void)
 {
+
+    AP_BoardConfig{}.init();
+
     ins.init(scheduler.get_loop_rate_hz());
 
     // initialise the scheduler

--- a/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
@@ -25,3 +25,4 @@ LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
 LIBRARIES += AP_OpticalFlow
+LIBRARIES += AP_BoardConfig

--- a/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
@@ -1,28 +1,14 @@
-LIBRARIES += AP_ADC
-LIBRARIES += AP_AHRS
-LIBRARIES += AP_Airspeed
-LIBRARIES += AP_Baro
-LIBRARIES += AP_BattMonitor
-LIBRARIES += AP_Buffer
 LIBRARIES += AP_Common
-LIBRARIES += AP_Compass
-LIBRARIES += AP_Declination
-LIBRARIES += AP_GPS
 LIBRARIES += AP_InertialSensor
 LIBRARIES += AP_AccelCal
 LIBRARIES += AP_Math
-LIBRARIES += AP_Mission
-LIBRARIES += AP_NavEKF
 LIBRARIES += AP_Notify
 LIBRARIES += AP_Param
-LIBRARIES += AP_Rally
-LIBRARIES += AP_RangeFinder
 LIBRARIES += AP_Scheduler
-LIBRARIES += AP_Terrain
-LIBRARIES += AP_Vehicle
 LIBRARIES += DataFlash
 LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
-LIBRARIES += AP_OpticalFlow
 LIBRARIES += AP_BoardConfig
+
+


### PR DESCRIPTION
Now requires a call to AP_BoardConfig::init() for px4. Its a nop for other boards atm.