### PR TITLE
Functor: Can contain a free function

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1602,9 +1602,9 @@ void Rover::gcs_update(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : NULL);
+            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -939,7 +939,7 @@ void Tracker::gcs_update(void)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
         }
     }
 }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2202,9 +2202,9 @@ void Copter::gcs_check_input(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):NULL);
+            gcs[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2367,9 +2367,9 @@ void Plane::gcs_update(void)
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
-            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):NULL);
+            gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Plane::run_cli, void, AP_HAL::UARTDriver *):nullptr);
 #else
-            gcs[i].update(NULL);
+            gcs[i].update(nullptr);
 #endif
         }
     }

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -19,11 +19,11 @@ AP_HAL::Proc Scheduler::_failsafe = NULL;
 volatile bool Scheduler::_timer_suspended = false;
 volatile bool Scheduler::_timer_event_missed = false;
 
-AP_HAL::MemberProc Scheduler::_timer_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {NULL};
+AP_HAL::MemberProc Scheduler::_timer_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {nullptr};
 uint8_t Scheduler::_num_timer_procs = 0;
 bool Scheduler::_in_timer_proc = false;
 
-AP_HAL::MemberProc Scheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {NULL};
+AP_HAL::MemberProc Scheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {nullptr};
 uint8_t Scheduler::_num_io_procs = 0;
 bool Scheduler::_in_io_proc = false;
 

--- a/libraries/AP_Menu/AP_Menu.h
+++ b/libraries/AP_Menu/AP_Menu.h
@@ -99,7 +99,7 @@ public:
     /// @param commands		An array of ::command structures in program memory.
     /// @param entries		The number of entries in the menu.
     ///
-    Menu(const char *prompt, const struct command *commands, uint8_t entries, preprompt ppfunc = 0);
+    Menu(const char *prompt, const struct command *commands, uint8_t entries, preprompt ppfunc = nullptr);
 
     /// set command line length limit
     void set_limits(uint8_t commandline_max, uint8_t args_max);

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -55,7 +55,7 @@ public:
     // constructor
     AP_Scheduler(void);
     
-    FUNCTOR_TYPEDEF(task_fn_t, void);
+    typedef Functor<void> task_fn_t;
 
     struct Task {
         task_fn_t function;

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -7,6 +7,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -46,6 +47,9 @@ const AP_Scheduler::Task SchedTest::scheduler_tasks[] = {
 
 void SchedTest::setup(void)
 {
+
+    AP_BoardConfig{}.init();
+
     ins.init(scheduler.get_loop_rate_hz());
 
     // initialise the scheduler

--- a/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
@@ -25,3 +25,4 @@ LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
 LIBRARIES += AP_OpticalFlow
+LIBRARIES += AP_BoardConfig

--- a/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/make.inc
@@ -1,28 +1,14 @@
-LIBRARIES += AP_ADC
-LIBRARIES += AP_AHRS
-LIBRARIES += AP_Airspeed
-LIBRARIES += AP_Baro
-LIBRARIES += AP_BattMonitor
-LIBRARIES += AP_Buffer
 LIBRARIES += AP_Common
-LIBRARIES += AP_Compass
-LIBRARIES += AP_Declination
-LIBRARIES += AP_GPS
 LIBRARIES += AP_InertialSensor
 LIBRARIES += AP_AccelCal
 LIBRARIES += AP_Math
-LIBRARIES += AP_Mission
-LIBRARIES += AP_NavEKF
 LIBRARIES += AP_Notify
 LIBRARIES += AP_Param
-LIBRARIES += AP_Rally
-LIBRARIES += AP_RangeFinder
 LIBRARIES += AP_Scheduler
-LIBRARIES += AP_Terrain
-LIBRARIES += AP_Vehicle
 LIBRARIES += DataFlash
 LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
-LIBRARIES += AP_OpticalFlow
 LIBRARIES += AP_BoardConfig
+
+


### PR DESCRIPTION
replaces : https://github.com/ArduPilot/ardupilot/pull/4805

 Functor: Add functionality so that Functor can contain a free function( or static member function) as well as an object pointer and a non-static member function. The size and performance of the functor is not affected. A list of functors , for example, can freely mix, object member functions, static member functions and free functions.
    
    A new constructor is added, that takes a pointer to free function argument.
    One consequence, when explicitly initialising an empty functor, you need to be explicit about constructing with a nullptr. Constructing with a 0 or NULL wont work since that is convertible to a function pointer as well as a nullptr
    
    There is also an overload of the bind static member for the free function pointer argument
