### PR TITLE
AP_Airspeed: fix example

### DIFF
--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -22,6 +22,7 @@
 #include <AP_ADC/AP_ADC.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -33,9 +34,11 @@ void setup()
 {
     hal.console->println("ArduPilot Airspeed library test");
 
-    AP_Param::set_object_value(&airspeed, airspeed.var_info, "_PIN", 65);
-    AP_Param::set_object_value(&airspeed, airspeed.var_info, "_ENABLE", 1);
-    AP_Param::set_object_value(&airspeed, airspeed.var_info, "_USE", 1);
+    AP_Param::set_object_value(&airspeed, airspeed.var_info, "PIN", 65);
+    AP_Param::set_object_value(&airspeed, airspeed.var_info, "ENABLE", 1);
+    AP_Param::set_object_value(&airspeed, airspeed.var_info, "USE", 1);
+
+    AP_BoardConfig{}.init();
 
     airspeed.init();
     airspeed.calibrate(false);

--- a/libraries/AP_Airspeed/examples/Airspeed/make.inc
+++ b/libraries/AP_Airspeed/examples/Airspeed/make.inc
@@ -23,3 +23,4 @@ LIBRARIES += DataFlash
 LIBRARIES += Filter
 LIBRARIES += GCS_MAVLink
 LIBRARIES += StorageManager
+LIBRARIES += AP_BoardConfig


### PR DESCRIPTION
call board_config to load drivers  and correct ap_param save strings