### PR TITLE
AP_Param: change AP_Param::set_object_value to bool return type

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1168,20 +1168,24 @@ void AP_Param::setup_object_defaults(const void *object_pointer, const struct Gr
 
 // set a value directly in an object. This should only be used by
 // example code, not by mainline vehicle code
-void AP_Param::set_object_value(const void *object_pointer, 
+bool AP_Param::set_object_value(const void *object_pointer, 
                                 const struct GroupInfo *group_info, 
                                 const char *name, float value)
 {
     ptrdiff_t base = (ptrdiff_t)object_pointer;
     uint8_t type;
+    bool found = false;
     for (uint8_t i=0;
          (type=group_info[i].type) != AP_PARAM_NONE;
          i++) {
         if (strcmp(name, group_info[i].name) == 0 && type <= AP_PARAM_FLOAT) {
             void *ptr = (void *)(base + group_info[i].offset);
             set_value((enum ap_var_type)type, ptr, value);
+            // return true here ?
+            found = true;
         }
     }
+    return found;
 }
 
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -278,9 +278,10 @@ public:
     // load default values for scalars in a group
     static void         setup_object_defaults(const void *object_pointer, const struct GroupInfo *group_info);
 
-    // set a value directly in an object. This should only be used by
-    // example code, not by mainline vehicle code
-    static void set_object_value(const void *object_pointer, 
+    // set a value directly in an object.
+    // return true if the name was found and set, else false.
+    // This should only be used by example code, not by mainline vehicle code
+    static bool set_object_value(const void *object_pointer, 
                                  const struct GroupInfo *group_info, 
                                  const char *name, float value);
 


### PR DESCRIPTION
change AP_Param::set_object_value to bool return type so you can check if the set succceded or not

NOTE: In the function body I presume you could return once found, but that somewhat breaks existing functionality (if there are multiple objects with same name?) so I left it for now