### PR TITLE
AP_GPS: ublox raise baud rate and allow user controlled baud rates

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -140,6 +140,20 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("AUTO_CONFIG", 13, AP_GPS, _auto_config, 1),
 
+    // @Param: RATE_MS
+    // @DisplayName: GPS update rate in milliseconds
+    // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
+    // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @User: Advanced
+    AP_GROUPINFO("RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
+
+    // @Param: RATE_MS2
+    // @DisplayName: GPS 2 update rate in milliseconds
+    // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
+    // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @User: Advanced
+    AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -161,7 +161,6 @@ const uint32_t AP_GPS::_baudrates[] = {4800U, 19200U, 38400U, 115200U, 57600U, 9
 // initialisation blobs to send to the GPS to try to get it into the
 // right mode
 const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY MTK_SET_BINARY SIRF_SET_BINARY;
-const char AP_GPS::_initialisation_raw_blob[] = UBLOX_SET_BINARY_RAW_BAUD MTK_SET_BINARY SIRF_SET_BINARY;
 
 /*
   send some more initialisation string bytes if there is room in the
@@ -268,11 +267,7 @@ AP_GPS::detect_instance(uint8_t instance)
         _port[instance]->begin(baudrate);
         _port[instance]->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
         dstate->last_baud_change_ms = now;
-#if UBLOX_RXM_RAW_LOGGING
-        if(_raw_data != 0)
-            send_blob_start(instance, _initialisation_raw_blob, sizeof(_initialisation_raw_blob));
-        else
-#endif
+
         if(_auto_config == 1){
             send_blob_start(instance, _initialisation_blob, sizeof(_initialisation_blob));
         }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -338,6 +338,7 @@ public:
     AP_Int8 _min_elevation;
     AP_Int8 _raw_data;
     AP_Int8 _gnss_mode[2];
+    AP_Int16 _rate_ms[2];
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
     

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -49,7 +49,7 @@
 #define UBX_MSG_TYPES 2
 
 #define UBLOX_MAX_PORTS 6
-#define MEASURE_RATE 200
+#define MINIMUM_MEASURE_RATE_MS 200
 
 #define RATE_POSLLH 1
 #define RATE_STATUS 1

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -38,8 +38,7 @@
  * modules are configured with all ubx binary messages off, which
  * would mean we would never detect it.
  */
-#define UBLOX_SET_BINARY "\265\142\006\001\003\000\001\006\001\022\117$PUBX,41,1,0003,0001,38400,0*26\r\n"
-#define UBLOX_SET_BINARY_RAW_BAUD "\265\142\006\001\003\000\001\006\001\022\117$PUBX,41,1,0003,0001,115200,0*1E\r\n"
+#define UBLOX_SET_BINARY "\265\142\006\001\003\000\001\006\001\022\117$PUBX,41,1,0003,0001,115200,0*1E\r\n"
 
 #define UBLOX_RXM_RAW_LOGGING 1
 #define UBLOX_MAX_RXM_RAW_SATS 22

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -506,8 +506,6 @@ private:
     // used to update fix between status and position packets
     AP_GPS::GPS_Status next_fix;
 
-    uint32_t _last_5hz_time;
-
     bool _cfg_needs_save;
 
     bool noReceivedHdop;
@@ -519,7 +517,6 @@ private:
     void        _send_message(uint8_t msg_class, uint8_t msg_id, void *msg, uint16_t size);
     void	send_next_rate_update(void);
     bool        _request_message_rate(uint8_t msg_class, uint8_t msg_id);
-    void        _request_navigation_rate(void);
     void        _request_next_config(void);
     void        _request_port(void);
     void        _request_version(void);


### PR DESCRIPTION
Raise the default baudrate to 115200 for all u-blox devices. This was tested primarily 6-8 series devices on the ground. I don't have a 4-5 series device to test with.

Also addresses seeing a 5Hz warning on initial gain of GPS fix if it took more then 20 seconds after detecting the GPS unit to have a fix.