### PR TITLE
Don't report range finder variance on mavlink if not required

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -520,8 +520,17 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
     Vector2f offset;
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
 
+    // Only report range finder normalised innovation levels if the EKF needs the data.
+    // This prevents false alarms at the GCS if a range finder is fitted for other applications
+    float temp;
+    if ((frontend->_useRngSwHgt > 0) || PV_AidingMode == AID_RELATIVE) {
+        temp = sqrtf(auxRngTestRatio);
+    } else {
+        temp = 0.0f;
+    }
+
     // send message
-    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), sqrtf(auxRngTestRatio));
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), temp);
 
 }
 


### PR DESCRIPTION
Fixes the issue where fitment of a range finder for non EKF functions (plane landing etc) can cause large range finder innovations to be reported over MAVLink which shows up as warning messages that are not relevant to flight vehicle health. these range finder innovations come from a single state auxiliary filter that does not affect the main EKF unless range finder is being used for height or optical flow is being used.