### PR TITLE
EKF2: Improve vehicle yaw report due to core switching

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1159,52 +1159,7 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
     if (!core) {
         return 0;
     }
-
-    // check for an internal ekf yaw reset
-    float temp_yaw_delta;
-    uint32_t ekf_reset_ms = core[primary].getLastYawResetAngle(temp_yaw_delta);
-    if (ekf_reset_ms != yaw_step_data.last_ekf_reset_ms) {
-        // record the time of the ekf's internal yaw reset event
-        yaw_step_data.last_ekf_reset_ms = ekf_reset_ms;
-
-        // record the the ekf's internal yaw reset value
-        yaw_step_data.yaw_delta = temp_yaw_delta;
-
-        // record the yaw reset event time
-        yaw_step_data.yaw_reset_time_ms = imuSampleTime_us/1000;
-
-    }
-
-    // check for a core switch and if a switch has occurred, set the yaw reset delta
-    // to the difference in yaw angle between the current and last yaw angle
-    Vector3f eulers_primary;
-    core[primary].getEulerAngles(eulers_primary);
-    if (primary != yaw_step_data.prev_instance) {
-        // the delta is the difference between the current and previous yaw
-        // This overwrites any yaw reset value recorded from an internal ekf reset
-        // that has occured on the same time-step
-        yaw_step_data.yaw_delta = wrap_PI(eulers_primary.z - yaw_step_data.prev_yaw);
-
-        // record the time of the yaw reset event
-        yaw_step_data.yaw_reset_time_ms = imuSampleTime_us/1000;
-
-        // update the time recorded for the last ekf internal yaw reset forthe primary core to
-        // prevent a yaw ekf reset event being published on the next frame due to the change in time
-        yaw_step_data.last_ekf_reset_ms = ekf_reset_ms;
-
-    }
-
-    // record the yaw angle from the primary core
-    yaw_step_data.prev_yaw = eulers_primary.z;
-
-    // record the primary core
-    yaw_step_data.prev_instance = primary;
-
-    // return the yaw delta from the last event
-    yawAngDelta = yaw_step_data.yaw_delta;
-
-    // return the time of the last event
-    return yaw_step_data.yaw_reset_time_ms;
+    return core[primary].getLastYawResetAngle(yawAng);
 }
 
 // return the amount of NE position change due to the last position reset in metres

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -268,7 +268,7 @@ public:
     // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
     bool getHeightControlLimit(float &height) const;
 
-    // return the amount of yaw angle change due to the last yaw angle reset in radians
+    // return the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAngDelta);
 
@@ -380,4 +380,11 @@ private:
 
     // time at start of current filter update
     uint64_t imuSampleTime_us;
+    
+    struct {
+        uint32_t last_function_call;  // last time getLastYawYawResetAngle was called
+        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
+        uint32_t last_primary_change; // last time a primary has changed
+        float core_delta;             // the ammount of yaw change between cores when a change happened
+    } yaw_reset_data;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -380,14 +380,4 @@ private:
 
     // time at start of current filter update
     uint64_t imuSampleTime_us;
-
-    // used to keep track of yaw angle steps due to change of primary instance or internal ekf yaw resets
-    struct {
-        uint8_t prev_instance;          // active core number from the previous time step
-        uint32_t last_ekf_reset_ms;     // last time the active ekf performed a yaw reset (msec)
-        uint32_t last_lane_switch_ms;   // last time there was a lane switch (msec)
-        uint32_t yaw_reset_time_ms;     // last time a yaw reset event was published
-        float yaw_delta;                // the amount of yaw change due to the last published yaw step (rad)
-        float prev_yaw;                 // yaw angle published by the active core from the previous time step (rad)
-    } yaw_step_data;
 };


### PR DESCRIPTION
As talked in #4757 here is my version for correctly reporting yaw reset even when core switching happens.

@priseborough I've found a new bug in my implementation that I have now corrected. If there were 3 cores, we could switch primary two times in the same filter update and it could keep adding the internal core yaw reset.

I've added comments in code, but I'm not the best at that, so please tell me if you think it needs to be improved.