### PR TITLE
Have all status_text messages sent to the Frsky lib message queue

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -120,8 +120,8 @@ public:
     // init - perform required initialisation
     void init(const AP_SerialManager &serial_manager, const char *firmware_str, const uint8_t mav_type, AP_Float *fs_batt_voltage = nullptr, AP_Float *fs_batt_mah = nullptr, uint32_t *ap_valuep = nullptr);
 
-    // add statustext message to FrSky lib message queue
-    void queue_message(MAV_SEVERITY severity, const char *text);
+    // add statustext message to FrSky lib queue
+    static void queue_message(MAV_SEVERITY severity, const char *text);
 
     // update flight control mode. The control mode is vehicle type specific
     void update_control_mode(uint8_t mode) { _ap.control_mode = mode; }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -17,6 +17,7 @@
 #include <AP_Mount/AP_Mount.h>
 #include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 
 // check if a message will fit in the payload space available
 #define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1358,6 +1358,9 @@ void GCS_MAVLINK::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, c
     // block but not until the buffer fills up.
     _statustext_queue.push_force(statustext);
 
+    // add statustext message to FrSky lib queue
+    AP_Frsky_Telem::queue_message(severity, text);
+    
     // try and send immediately if possible
     service_statustext();
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1360,7 +1360,7 @@ void GCS_MAVLINK::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, c
 
     // add statustext message to FrSky lib queue
     AP_Frsky_Telem::queue_message(severity, text);
-    
+
     // try and send immediately if possible
     service_statustext();
 }


### PR DESCRIPTION
This passes the status_text messages to the Frsky lib so that they can be downstreamed using the FrSky link.