### PR TITLE
AP_Frsky_Telem: updated sensor_status messages according to what is found in Mission Planner

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -520,6 +520,12 @@ void AP_Frsky_Telem::check_sensor_status_flags(void)
         } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_AHRS) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad AHRS");
             check_sensor_status_timer = now;
+        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_RC_RECEIVER) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "NO RC Receiver");
+            check_sensor_status_timer = now;
+        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_LOGGING) > 0) {
+            queue_message(MAV_SEVERITY_CRITICAL, "Bad Logging");
+            check_sensor_status_timer = now;
         }
     }
 }


### PR DESCRIPTION
Added "NO RC Receiver" and "Bad Logging."