### PR TITLE
AP_RangeFinder: Ahead to determine the upper limit of the method-exist value.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -136,13 +136,13 @@ int8_t AP_RangeFinder_LeddarOne::send_request(void)
     uint8_t i = 0;
 
     uint32_t nbytes = uart->available();
+    if(nbytes > 250) {
+        return LEDDARONE_ERR_SERIAL_PORT;
+    }
 
     // clear buffer
     while (nbytes-- > 0) {
         uart->read();
-        if (++i > 250) {
-            return LEDDARONE_ERR_SERIAL_PORT;
-        }
     }
 
     // Modbus read input register (function code 0x04)


### PR DESCRIPTION
The value of nbytes variable is acquired from the uart-> available methods.

Processing of the loop is as follows.
It decrements the value of nbytes variable, i variable increments.
If the value of the nbytes variable is 251, the value of the variable i is made to 251.
When the value of the variable i is 251, exit from the method.

Therefore, the value of the previously nbytes variable time of 250 or less, to the loop processing.

