### PR TITLE
Force arm

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -837,7 +837,7 @@ private:
     // motors.cpp
     void arm_motors_check();
     void auto_disarm_check();
-    bool init_arm_motors(bool arming_from_gcs);
+    bool init_arm_motors(bool arming_from_gcs, bool do_arming_checks=true);
     void init_disarm_motors();
     void motors_output();
     void lost_vehicle_check();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -964,10 +964,14 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 if (copter.init_arm_motors(true)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
-            } else if (is_zero(packet.param1) && (copter.ap.land_complete || is_equal(packet.param2,21196.0f)))  {
-                // force disarming by setting param2 = 21196 is deprecated
-                copter.init_disarm_motors();
-                result = MAV_RESULT_ACCEPTED;
+            } else if (is_zero(packet.param1))  {
+                if (copter.ap.land_complete || is_equal(packet.param2,21196.0f)) {
+                    // force disarming by setting param2 = 21196 is deprecated
+                    copter.init_disarm_motors();
+                    result = MAV_RESULT_ACCEPTED;
+                } else {
+                    result = MAV_RESULT_FAILED;
+                }
             } else {
                 result = MAV_RESULT_UNSUPPORTED;
             }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -961,7 +961,8 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_COMPONENT_ARM_DISARM:
             if (is_equal(packet.param1,1.0f)) {
                 // attempt to arm and return success or failure
-                if (copter.init_arm_motors(true)) {
+                const bool do_arming_checks = !is_equal(packet.param2,2989.0f);
+                if (copter.init_arm_motors(true, do_arming_checks)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
             } else if (is_zero(packet.param1))  {

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -961,12 +961,12 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_COMPONENT_ARM_DISARM:
             if (is_equal(packet.param1,1.0f)) {
                 // attempt to arm and return success or failure
-                const bool do_arming_checks = !is_equal(packet.param2,2989.0f);
+                const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
                 if (copter.init_arm_motors(true, do_arming_checks)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
             } else if (is_zero(packet.param1))  {
-                if (copter.ap.land_complete || is_equal(packet.param2,21196.0f)) {
+                if (copter.ap.land_complete || is_equal(packet.param2,magic_force_disarm_value)) {
                     // force disarming by setting param2 = 21196 is deprecated
                     copter.init_disarm_motors();
                     result = MAV_RESULT_ACCEPTED;

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -127,7 +127,7 @@ void Copter::auto_disarm_check()
 
 // init_arm_motors - performs arming process including initialisation of barometer and gyros
 //  returns false if arming failed because of pre-arm checks, arming checks or a gyro calibration failure
-bool Copter::init_arm_motors(bool arming_from_gcs)
+bool Copter::init_arm_motors(const bool arming_from_gcs, const bool do_arming_checks)
 {
     static bool in_arm_motors = false;
 
@@ -144,7 +144,7 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
     }
 
     // run pre-arm-checks and display failures
-    if (!arming.all_checks_passing(arming_from_gcs)) {
+    if (do_arming_checks && !arming.all_checks_passing(arming_from_gcs)) {
         AP_Notify::events.arming_failed = true;
         in_arm_motors = false;
         return false;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -975,7 +975,8 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_COMPONENT_ARM_DISARM:
             if (is_equal(packet.param1,1.0f)) {
                 // run pre_arm_checks and arm_checks and display failures
-                if (plane.arm_motors(AP_Arming::MAVLINK)) {
+                const bool do_arming_checks = !is_equal(packet.param2,2989.0f);
+                if (plane.arm_motors(AP_Arming::MAVLINK, do_arming_checks)) {
                     result = MAV_RESULT_ACCEPTED;
                 } else {
                     result = MAV_RESULT_FAILED;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -975,7 +975,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_COMPONENT_ARM_DISARM:
             if (is_equal(packet.param1,1.0f)) {
                 // run pre_arm_checks and arm_checks and display failures
-                const bool do_arming_checks = !is_equal(packet.param2,2989.0f);
+                const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
                 if (plane.arm_motors(AP_Arming::MAVLINK, do_arming_checks)) {
                     result = MAV_RESULT_ACCEPTED;
                 } else {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -928,7 +928,7 @@ private:
     int8_t throttle_percentage(void);
     void change_arm_state(void);
     bool disarm_motors(void);
-    bool arm_motors(AP_Arming::ArmingMethod method);
+    bool arm_motors(AP_Arming::ArmingMethod method, bool do_arming_checks=true);
     bool auto_takeoff_check(void);
     void takeoff_calc_roll(void);
     void takeoff_calc_pitch(void);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -729,9 +729,9 @@ void Plane::change_arm_state(void)
 /*
   arm motors
  */
-bool Plane::arm_motors(AP_Arming::ArmingMethod method)
+bool Plane::arm_motors(const AP_Arming::ArmingMethod method, const bool do_arming_checks)
 {
-    if (!arming.arm(method)) {
+    if (!arming.arm(method, do_arming_checks)) {
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -590,7 +590,7 @@ bool AP_Arming::arm_checks(uint8_t method)
 }
 
 //returns true if arming occurred successfully
-bool AP_Arming::arm(uint8_t method)
+bool AP_Arming::arm(uint8_t method, const bool do_arming_checks)
 {
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
     // Copter should never use this function
@@ -601,7 +601,7 @@ bool AP_Arming::arm(uint8_t method)
     }
 
     //are arming checks disabled?
-    if (checks_to_perform == ARMING_CHECK_NONE) {
+    if (!do_arming_checks || checks_to_perform == ARMING_CHECK_NONE) {
         armed = true;
         arming_method = NONE;
         gcs().send_text(MAV_SEVERITY_INFO, "Throttle armed");

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -40,7 +40,7 @@ public:
 
     // these functions should not be used by Copter which holds the armed state in the motors library
     ArmingRequired arming_required();
-    virtual bool arm(uint8_t method);
+    virtual bool arm(uint8_t method, bool do_arming_checks=true);
     bool disarm();
     bool is_armed();
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -373,6 +373,9 @@ protected:
     virtual int16_t vfr_hud_throttle() const { return 0; }
     Vector3f vfr_hud_velned;
 
+    static constexpr const float magic_force_arm_value = 2989.0f;
+    static constexpr const float magic_force_disarm_value = 21196.0f;
+
 private:
 
     float       adjust_rate_for_stream_trigger(enum streams stream_num);


### PR DESCRIPTION
Passing a parameter value of 2989 through as the second parameter to the long command used to arm a vehicle will bypass the arming checks.
