### PR TITLE
Copter: AP_Proximity and SF40c driver for object avoidance

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -25,6 +25,7 @@
 //#define AC_FENCE              DISABLED            // disable fence to save 2k of flash
 //#define CAMERA                DISABLED            // disable camera trigger to save 1k of flash
 //#define RANGEFINDER_ENABLED   DISABLED            // disable rangefinder to save 1k of flash
+//#define PROXIMITY_ENABLED     DISABLED            // disable proximity sensors
 //#define POSHOLD_ENABLED       DISABLED            // disable PosHold flight mode to save 4.5k of flash
 //#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
 //#define AC_TERRAIN            DISABLED            // disable terrain library

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -397,6 +397,7 @@ void Copter::ten_hz_logging_loop()
     }
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control.control_monitor_log();
+        Log_Write_Proximity();
     }
 #if FRAME_CONFIG == HELI_FRAME
     Log_Write_Heli();

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -95,6 +95,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(auto_disarm_check,     10,     50),
     SCHED_TASK(auto_trim,             10,     75),
     SCHED_TASK(read_rangefinder,      20,    100),
+    SCHED_TASK(update_proximity,     100,     50),
     SCHED_TASK(update_altitude,       10,    100),
     SCHED_TASK(run_nav_updates,       50,    100),
     SCHED_TASK(update_throttle_hover,100,     90),

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -76,7 +76,7 @@ Copter::Copter(void) :
     pos_control(ahrs, inertial_nav, motors, attitude_control,
                 g.p_alt_hold, g.p_vel_z, g.pid_accel_z,
                 g.p_pos_xy, g.pi_vel_xy),
-    avoid(ahrs, inertial_nav, fence),
+    avoid(ahrs, inertial_nav, fence, proximity),
     wp_nav(inertial_nav, ahrs, pos_control, attitude_control),
     circle_nav(inertial_nav, ahrs, pos_control),
     pmTest1(0),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -60,6 +60,7 @@
 #include <RC_Channel/RC_Channel.h>         // RC Channel Library
 #include <AP_Motors/AP_Motors.h>          // AP Motors library
 #include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
+#include <AP_Proximity/AP_Proximity.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>     // Optical Flow library
 #include <AP_RSSI/AP_RSSI.h>                   // RSSI Library
 #include <Filter/Filter.h>             // Filter library
@@ -195,6 +196,10 @@ private:
         uint32_t last_healthy_ms;
         LowPassFilterFloat alt_cm_filt; // altitude filter
     } rangefinder_state = { false, false, 0, 0 };
+
+#if PROXIMITY_ENABLED == ENABLED
+    AP_Proximity proximity {serial_manager};
+#endif
 
     AP_RPM rpm_sensor;
 
@@ -711,6 +716,8 @@ private:
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();
     void button_update();
+    void init_proximity();
+    void update_proximity();
     void send_pid_tuning(mavlink_channel_t chan);
     void gcs_send_message(enum ap_message id);
     void gcs_send_mission_item_reached_message(uint16_t mission_index);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -751,6 +751,7 @@ private:
     void Log_Write_Precland();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_Throw(ThrowModeStage stage, float velocity, float velocity_z, float accel, float ef_accel_z, bool throw_detect, bool attitude_ok, bool height_ok, bool position_ok);
+    void Log_Write_Proximity();
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void start_logging() ;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -143,6 +143,11 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
     if (copter.DataFlash.logging_present()) { // primary logging only (usually File)
         control_sensors_present |= MAV_SYS_STATUS_LOGGING;
     }
+#if PROXIMITY_ENABLED == ENABLED
+    if (copter.proximity.get_status() > AP_Proximity::Proximity_NotConnected) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
+    }
+#endif
 
     // all present sensors enabled by default except altitude and position control and motors which we will set individually
     control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL &
@@ -221,6 +226,12 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
     if (copter.DataFlash.logging_failed()) {
         control_sensors_health &= ~MAV_SYS_STATUS_LOGGING;
     }
+
+#if PROXIMITY_ENABLED == ENABLED
+    if (copter.proximity.get_status() < AP_Proximity::Proximity_Good) {
+        control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_LASER_POSITION;
+    }
+#endif
 
     int16_t battery_current = -1;
     int8_t battery_remaining = -1;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -156,7 +156,6 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
                                                          ~MAV_SYS_STATUS_LOGGING);
 
     switch (control_mode) {
-    case ALT_HOLD:
     case AUTO:
     case AVOID_ADSB:
     case GUIDED:
@@ -166,13 +165,18 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
     case LAND:
     case POSHOLD:
     case BRAKE:
+    case THROW:
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
         break;
+    case ALT_HOLD:
+    case GUIDED_NOGPS:
     case SPORT:
+    case AUTOTUNE:
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
         break;
     default:
+        // stabilize, acro, drift, and flip have no automatic x,y or z control (i.e. all manual)
         break;
     }
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -750,6 +750,52 @@ void Copter::Log_Write_Throw(ThrowModeStage stage, float velocity, float velocit
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
+// proximity sensor logging
+struct PACKED log_Proximity {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t health;
+    float dist0;
+    float dist45;
+    float dist90;
+    float dist135;
+    float dist180;
+    float dist225;
+    float dist270;
+    float dist315;
+};
+
+// Write proximity sensor distances
+void Copter::Log_Write_Proximity()
+{
+#if PROXIMITY_ENABLED == ENABLED
+    float sector_distance[8] = {0,0,0,0,0,0,0,0};
+    proximity.get_horizontal_distance(0, sector_distance[0]);
+    proximity.get_horizontal_distance(45, sector_distance[1]);
+    proximity.get_horizontal_distance(90, sector_distance[2]);
+    proximity.get_horizontal_distance(135, sector_distance[3]);
+    proximity.get_horizontal_distance(180, sector_distance[4]);
+    proximity.get_horizontal_distance(225, sector_distance[5]);
+    proximity.get_horizontal_distance(270, sector_distance[6]);
+    proximity.get_horizontal_distance(315, sector_distance[7]);
+
+    struct log_Proximity pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
+        time_us         : AP_HAL::micros64(),
+        health          : (uint8_t)proximity.get_status(),
+        dist0           : sector_distance[0],
+        dist45          : sector_distance[1],
+        dist90          : sector_distance[2],
+        dist135         : sector_distance[3],
+        dist180         : sector_distance[4],
+        dist225         : sector_distance[5],
+        dist270         : sector_distance[6],
+        dist315         : sector_distance[7]
+    };
+    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+#endif
+}
+
 const struct LogStructure Copter::log_structure[] = {
     LOG_COMMON_STRUCTURES,
 #if AUTOTUNE_ENABLED == ENABLED
@@ -792,6 +838,8 @@ const struct LogStructure Copter::log_structure[] = {
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
     { LOG_THROW_MSG, sizeof(log_Throw),
       "THRO",  "QBffffbbbb",  "TimeUS,Stage,Vel,VelZ,Acc,AccEfZ,Throw,AttOk,HgtOk,PosOk" },
+    { LOG_PROXIMITY_MSG, sizeof(log_Proximity),
+      "PRX",   "QBffffffff",  "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315" },
 };
 
 #if CLI_ENABLED == ENABLED

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -911,6 +911,12 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_Avoidance/AP_Avoidance.cpp
     GOBJECT(avoidance_adsb, "AVD_", AP_Avoidance_Copter),
 
+#if PROXIMITY_ENABLED == ENABLED
+    // @Group: PRX_
+    // @Path: ../libraries/AP_Proximity/AP_Proximity.cpp
+    GOBJECT(proximity, "PRX_", AP_Proximity),
+#endif
+
     // @Param: AUTOTUNE_AXES
     // @DisplayName: Autotune axis bitmask
     // @Description: 1-byte bitmap of axes to autotune

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -362,6 +362,7 @@ public:
         k_param_rtl_climb_min,
         k_param_rpm_sensor,
         k_param_autotune_min_d, // 251
+        k_param_proximity,
         k_param_DataFlash = 253, // 253 - Logging Group
 
         // 254,255: reserved

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -380,6 +380,17 @@ bool Copter::parameter_checks(bool display_failure)
             return false;
         }
         #endif
+
+        #if PROXIMITY_ENABLED == ENABLED
+        // check proximity sensor if enabled
+        if (copter.proximity.get_status() == AP_Proximity::Proximity_NoData) {
+            if (display_failure) {
+                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: check proximity sensor");
+            }
+            return false;
+        }
+        #endif
+
         #if FRAME_CONFIG == HELI_FRAME
         // check helicopter parameters
         if (!motors.parameter_check(display_failure)) {

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -152,6 +152,12 @@
  # define RANGEFINDER_TILT_CORRECTION ENABLED
 #endif
 
+//////////////////////////////////////////////////////////////////////////////
+// Proximity sensor
+//
+#ifndef PROXIMITY_ENABLED
+ # define PROXIMITY_ENABLED ENABLED
+#endif
 
 #ifndef MAV_SYSTEM_ID
  # define MAV_SYSTEM_ID          1

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -307,6 +307,7 @@ enum DevOptions {
 #define LOG_PRECLAND_MSG                0x21
 #define LOG_GUIDEDTARGET_MSG            0x22
 #define LOG_THROW_MSG                   0x23
+#define LOG_PROXIMITY_MSG               0x24
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)

--- a/ArduCopter/make.inc
+++ b/ArduCopter/make.inc
@@ -61,3 +61,4 @@ LIBRARIES += AP_IRLock
 LIBRARIES += AC_InputManager
 LIBRARIES += AP_ADSB
 LIBRARIES += AP_Avoidance
+LIBRARIES += AP_Proximity

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -234,3 +234,20 @@ void Copter::button_update(void)
 {
     g2.button.update();
 }
+
+// initialise proximity sensor
+void Copter::init_proximity(void)
+{
+#if PROXIMITY_ENABLED == ENABLED
+    proximity.init();
+#endif
+}
+
+// update proximity sensor
+void Copter::update_proximity(void)
+{
+#if PROXIMITY_ENABLED == ENABLED
+    proximity.update();
+#endif
+}
+

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -258,6 +258,9 @@ void Copter::init_ardupilot()
     // initialise rangefinder
     init_rangefinder();
 
+    // init proximity sensor
+    init_proximity();
+
     // initialise AP_RPM library
     rpm_sensor.init();
 

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -29,7 +29,8 @@ def build(bld):
             'AP_Relay',
             'AP_ServoRelayEvents',
             'AP_Avoidance',
-            'AP_AdvancedFailsafe'
+            'AP_AdvancedFailsafe',
+            'AP_Proximity'
         ],
     )
 

--- a/ArduPlane/make.inc
+++ b/ArduPlane/make.inc
@@ -57,4 +57,5 @@ LIBRARIES += AP_InertialNav
 LIBRARIES += AC_WPNav
 LIBRARIES += AC_Fence
 LIBRARIES += AC_Avoidance
+LIBRARIES += AP_Proximity
 LIBRARIES += AP_Tuning

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -8,6 +8,7 @@
 #include <AC_WPNav/AC_WPNav.h>
 #include <AC_Fence/AC_Fence.h>
 #include <AC_Avoidance/AC_Avoid.h>
+#include <AP_Proximity/AP_Proximity.h>
 
 /*
   frame types for quadplane build. Most case be set with

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -29,7 +29,8 @@ def build(bld):
             'AP_Motors',
             'AC_PID',
             'AC_Fence',
-            'AC_Avoidance'
+            'AC_Avoidance',
+            'AP_Proximity'
         ],
     )
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -5,18 +5,20 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Param: ENABLE
     // @DisplayName: Avoidance control enable/disable
     // @Description: Enabled/disable stopping at fence
-    // @Values: 0:None,1:StopAtFence
+    // @Values: 0:None,1:StopAtFence,2:UseProximitySensor,3:All
+    // @Bitmask: 0:StopAtFence,1:UseProximitySensor
     // @User: Standard
-    AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_STOP_AT_FENCE),
+    AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_ALL),
 
     AP_GROUPEND
 };
 
 /// Constructor
-AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence)
+AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence, const AP_Proximity& proximity)
     : _ahrs(ahrs),
       _inav(inav),
-      _fence(fence)
+      _fence(fence),
+      _proximity(proximity)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -31,9 +33,13 @@ void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f 
     // limit acceleration
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
-    if (_enabled == AC_AVOID_STOP_AT_FENCE) {
+    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
         adjust_velocity_circle(kP, accel_cmss_limited, desired_vel);
         adjust_velocity_poly(kP, accel_cmss_limited, desired_vel);
+    }
+
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0) {
+        adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel);
     }
 }
 
@@ -138,7 +144,7 @@ void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vect
             // We are strictly inside the given edge.
             // Adjust velocity to not violate this edge.
             limit_direction /= limit_distance;
-            limit_velocity(kP, accel_cmss, safe_vel, limit_direction, limit_distance);
+            limit_velocity(kP, accel_cmss, safe_vel, limit_direction, MAX(limit_distance - get_margin(),0.0f));
         } else {
             // We are exactly on the edge - treat this as a fence breach.
             // i.e. do not adjust velocity.
@@ -150,6 +156,32 @@ void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vect
 }
 
 /*
+ * Adjusts the desired velocity based on output from the proximity sensor
+ */
+void AC_Avoid::adjust_velocity_proximity(const float kP, const float accel_cmss, Vector2f &desired_vel)
+{
+    // exit immediately if no desired velocity
+    if (desired_vel.is_zero()) {
+        return;
+    }
+
+    // normalise desired velocity vector
+    Vector2f vel_dir = desired_vel.normalized();
+
+    // get angle of desired velocity
+    float heading_rad = atan2f(vel_dir.y, vel_dir.x);
+
+    // rotate desired velocity angle into body-frame angle
+    float heading_bf_rad = wrap_PI(heading_rad - _ahrs.yaw);
+
+    // get nearest object using body-frame angle and shorten desired velocity (which must remain in earth-frame)
+    float distance_m;
+    if (_proximity.get_horizontal_distance(degrees(heading_bf_rad), distance_m)) {
+        limit_velocity(kP, accel_cmss, desired_vel, vel_dir, MAX(distance_m*100.0f - 200.0f, 0.0f));
+    }
+}
+
+/*
  * Limits the component of desired_vel in the direction of the unit vector
  * limit_direction to be at most the maximum speed permitted by the limit_distance.
  *
@@ -158,7 +190,7 @@ void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vect
  */
 void AC_Avoid::limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float limit_distance) const
 {
-    const float max_speed = get_max_speed(kP, accel_cmss, limit_distance - get_margin());
+    const float max_speed = get_max_speed(kP, accel_cmss, limit_distance);
     // project onto limit direction
     const float speed = desired_vel * limit_direction;
     if (speed > max_speed) {

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -7,12 +7,15 @@
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude controller library for sqrt controller
 #include <AC_Fence/AC_Fence.h>         // Failsafe fence library
+#include <AP_Proximity/AP_Proximity.h>
 
 #define AC_AVOID_ACCEL_CMSS_MAX         100.0f  // maximum acceleration/deceleration in cm/s/s used to avoid hitting fence
 
 // bit masks for enabled fence types.
 #define AC_AVOID_DISABLED               0       // avoidance disabled
 #define AC_AVOID_STOP_AT_FENCE          1       // stop at fence
+#define AC_AVOID_USE_PROXIMITY_SENSOR   2       // stop based on proximity sensor output
+#define AC_AVOID_ALL                    3       // use fence and promiximity sensor
 
 /*
  * This class prevents the vehicle from leaving a polygon fence in
@@ -22,7 +25,7 @@ class AC_Avoid {
 public:
 
     /// Constructor
-    AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence);
+    AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence, const AP_Proximity& proximity);
 
     /*
      * Adjusts the desired velocity so that the vehicle can stop
@@ -46,6 +49,10 @@ private:
      */
     void adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel);
 
+    /*
+     * Adjusts the desired velocity based on output from the proximity sensor
+     */
+    void adjust_velocity_proximity(const float kP, const float accel_cmss, Vector2f &desired_vel);
 
     /*
      * Limits the component of desired_vel in the direction of the unit vector
@@ -81,6 +88,7 @@ private:
     const AP_AHRS& _ahrs;
     const AP_InertialNav& _inav;
     const AC_Fence& _fence;
+    const AP_Proximity& _proximity;
 
     // parameters
     AP_Int8 _enabled;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -1,0 +1,189 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Proximity.h"
+#include "AP_Proximity_LightWareSF40C.h"
+
+extern const AP_HAL::HAL &hal;
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Proximity::var_info[] = {
+    // 0 is reserved for possible addition of an ENABLED parameter
+
+    // @Param: _TYPE
+    // @DisplayName: Proximity type
+    // @Description: What type of proximity sensor is connected
+    // @Values: 0:None,1:LightWareSF40C
+    // @User: Standard
+    AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
+
+    // @Param: _ORIENT
+    // @DisplayName: Proximity sensor orientation
+    // @Description: Proximity sensor orientation
+    // @Values: 0:Default,1:Upside Down
+    // @User: Standard
+    AP_GROUPINFO("_ORIENT", 2, AP_Proximity, _orientation[0], 0),
+
+    // @Param: _YAW_CORR
+    // @DisplayName: Proximity sensor yaw correction
+    // @Description: Proximity sensor yaw correction
+    // @Range: -180 180
+    // @User: Standard
+    AP_GROUPINFO("_YAW_CORR", 3, AP_Proximity, _yaw_correction[0], PROXIMITY_YAW_CORRECTION_DEFAULT),
+
+#if PROXIMITY_MAX_INSTANCES > 1
+    // @Param: 2_TYPE
+    // @DisplayName: Second Proximity type
+    // @Description: What type of proximity sensor is connected
+    // @Values: 0:None,1:LightWareSF40C
+    // @User: Advanced
+    AP_GROUPINFO("2_TYPE", 4, AP_Proximity, _type[1], 0),
+
+    // @Param: _ORIENT
+    // @DisplayName: Second Proximity sensor orientation
+    // @Description: Second Proximity sensor orientation
+    // @Values: 0:Default,1:Upside Down
+    // @User: Standard
+    AP_GROUPINFO("2_ORIENT", 5, AP_Proximity, _orientation[1], 0),
+
+    // @Param: _YAW_CORR
+    // @DisplayName: Second Proximity sensor yaw correction
+    // @Description: Second Proximity sensor yaw correction
+    // @Range: -180 180
+    // @User: Standard
+    AP_GROUPINFO("2_YAW_CORR", 6, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
+#endif
+
+    AP_GROUPEND
+};
+
+AP_Proximity::AP_Proximity(AP_SerialManager &_serial_manager) :
+    primary_instance(0),
+    num_instances(0),
+    serial_manager(_serial_manager)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+// initialise the Proximity class. We do detection of attached sensors here
+// we don't allow for hot-plugging of sensors (i.e. reboot required)
+void AP_Proximity::init(void)
+{
+    if (num_instances != 0) {
+        // init called a 2nd time?
+        return;
+    }
+    for (uint8_t i=0; i<PROXIMITY_MAX_INSTANCES; i++) {
+        detect_instance(i);
+        if (drivers[i] != NULL) {
+            // we loaded a driver for this instance, so it must be
+            // present (although it may not be healthy)
+            num_instances = i+1;
+        }
+
+        // initialise status
+        state[i].status = Proximity_NotConnected;
+    }
+}
+
+// update Proximity state for all instances. This should be called at a high rate by the main loop
+void AP_Proximity::update(void)
+{
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (drivers[i] != NULL) {
+            if (_type[i] == Proximity_Type_None) {
+                // allow user to disable a proximity sensor at runtime
+                state[i].status = Proximity_NotConnected;
+                continue;
+            }
+            drivers[i]->update();
+        }
+    }
+
+    // work out primary instance - first sensor returning good data
+    for (int8_t i=num_instances-1; i>=0; i--) {
+        if (drivers[i] != NULL && (state[i].status == Proximity_Good)) {
+            primary_instance = i;
+        }
+    }
+}
+
+// return sensor orientation
+uint8_t AP_Proximity::get_orientation(uint8_t instance) const
+{
+    if (instance >= PROXIMITY_MAX_INSTANCES) {
+        return 0;
+    }
+
+    return _orientation[instance].get();
+}
+
+// return sensor yaw correction
+int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
+{
+    if (instance >= PROXIMITY_MAX_INSTANCES) {
+        return 0;
+    }
+
+    return _yaw_correction[instance].get();
+}
+
+// return sensor health
+AP_Proximity::Proximity_Status AP_Proximity::get_status(uint8_t instance) const
+{
+    // sanity check instance number
+    if (instance >= num_instances) {
+        return Proximity_NotConnected;
+    }
+
+    return state[instance].status;
+}
+
+AP_Proximity::Proximity_Status AP_Proximity::AP_Proximity::get_status() const
+{
+    return get_status(primary_instance);
+}
+
+//  detect if an instance of a proximity sensor is connected.
+void AP_Proximity::detect_instance(uint8_t instance)
+{
+    uint8_t type = _type[instance];
+    if (type == Proximity_Type_SF40C) {
+        if (AP_Proximity_LightWareSF40C::detect(serial_manager)) {
+            state[instance].instance = instance;
+            drivers[instance] = new AP_Proximity_LightWareSF40C(*this, state[instance], serial_manager);
+            return;
+        }
+    }
+}
+
+// get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+// returns true on successful read and places distance in distance
+bool AP_Proximity::get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const
+{
+    if ((drivers[instance] == NULL) || (_type[instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get distance from backend
+    return drivers[instance]->get_horizontal_distance(angle_deg, distance);
+}
+
+// get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+// returns true on successful read and places distance in distance
+bool AP_Proximity::get_horizontal_distance(float angle_deg, float &distance) const
+{
+    return get_horizontal_distance(primary_instance, angle_deg, distance);
+}

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -1,0 +1,96 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+
+
+#define PROXIMITY_MAX_INSTANCES             1   // Maximum number of proximity sensor instances available on this platform
+#define PROXIMITY_YAW_CORRECTION_DEFAULT    22  // default correction for sensor error in yaw
+
+class AP_Proximity_Backend;
+
+class AP_Proximity
+{
+public:
+    friend class AP_Proximity_Backend;
+
+    AP_Proximity(AP_SerialManager &_serial_manager);
+
+    // Proximity driver types
+    enum Proximity_Type {
+        Proximity_Type_None  = 0,
+        Proximity_Type_SF40C = 1,
+    };
+
+    enum Proximity_Status {
+        Proximity_NotConnected = 0,
+        Proximity_NoData,
+        Proximity_Good
+    };
+
+    // detect and initialise any available rangefinders
+    void init(void);
+
+    // update state of all rangefinders. Should be called at high rate from main loop
+    void update(void);
+
+    // return sensor orientation and yaw correction
+    uint8_t get_orientation(uint8_t instance) const;
+    int16_t get_yaw_correction(uint8_t instance) const;
+
+    // return sensor health
+    Proximity_Status get_status(uint8_t instance) const;
+    Proximity_Status get_status() const;
+
+    // Return the number of range finder instances
+    uint8_t num_sensors(void) const {
+        return num_instances;
+    }
+
+    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+    // returns true on successful read and places distance in distance
+    bool get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const;
+    bool get_horizontal_distance(float angle_deg, float &distance) const;
+
+    // The Proximity_State structure is filled in by the backend driver
+    struct Proximity_State {
+        uint8_t                 instance;   // the instance number of this proximity sensor
+        enum Proximity_Status   status;     // sensor status
+    };
+
+    // parameter list
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+    Proximity_State state[PROXIMITY_MAX_INSTANCES];
+    AP_Proximity_Backend *drivers[PROXIMITY_MAX_INSTANCES];
+    uint8_t primary_instance:3;
+    uint8_t num_instances:3;
+    AP_SerialManager &serial_manager;
+
+    // parameters for all instances
+    AP_Int8  _type[PROXIMITY_MAX_INSTANCES];
+    AP_Int8  _orientation[PROXIMITY_MAX_INSTANCES];
+    AP_Int16 _yaw_correction[PROXIMITY_MAX_INSTANCES];
+
+    void detect_instance(uint8_t instance);
+    void update_instance(uint8_t instance);  
+};

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -1,0 +1,36 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Proximity.h"
+#include "AP_Proximity_Backend.h"
+
+/*
+  base class constructor. 
+  This incorporates initialisation as well.
+*/
+AP_Proximity_Backend::AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state) :
+        frontend(_frontend),
+        state(_state)
+{
+}
+
+// set status and update valid count
+void AP_Proximity_Backend::set_status(AP_Proximity::Proximity_Status status)
+{
+    state.status = status;
+}

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -1,0 +1,46 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Proximity.h"
+
+class AP_Proximity_Backend
+{
+public:
+    // constructor. This incorporates initialisation as well.
+	AP_Proximity_Backend(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
+
+    // we declare a virtual destructor so that Proximity drivers can
+    // override with a custom destructor if need be
+    virtual ~AP_Proximity_Backend(void) {}
+
+    // update the state structure
+    virtual void update() = 0;
+
+    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+    // returns true on successful read and places distance in distance
+    virtual bool get_horizontal_distance(float angle_deg, float &distance) const = 0;
+
+protected:
+
+    // set status and update valid_count
+    void set_status(AP_Proximity::Proximity_Status status);
+
+    AP_Proximity &frontend;
+    AP_Proximity::Proximity_State &state;   // reference to this instances state
+};

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -1,0 +1,421 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Proximity_LightWareSF40C.h"
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <ctype.h>
+#include <stdio.h>
+
+extern const AP_HAL::HAL& hal;
+
+/* 
+   The constructor also initialises the proximity sensor. Note that this
+   constructor is not called until detect() returns true, so we
+   already know that we should setup the proximity sensor
+*/
+AP_Proximity_LightWareSF40C::AP_Proximity_LightWareSF40C(AP_Proximity &_frontend,
+                                                         AP_Proximity::Proximity_State &_state,
+                                                         AP_SerialManager &serial_manager) :
+    AP_Proximity_Backend(_frontend, _state)
+{
+    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0);
+    if (uart != nullptr) {
+        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
+    }
+}
+
+// detect if a Lightware proximity sensor is connected by looking for a configured serial port
+bool AP_Proximity_LightWareSF40C::detect(AP_SerialManager &serial_manager)
+{
+    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
+}
+
+// get distance in meters in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
+bool AP_Proximity_LightWareSF40C::get_horizontal_distance(float angle_deg, float &distance) const
+{
+    uint8_t sector;
+    if (convert_angle_to_sector(angle_deg, sector)) {
+        if (_distance_valid[sector]) {
+            distance = _distance[sector];
+            return true;
+        }
+    }
+    return false;
+}
+
+// update the state of the sensor
+void AP_Proximity_LightWareSF40C::update(void)
+{
+    if (uart == nullptr) {
+        return;
+    }
+
+    // initialise sensor if necessary
+    bool initialised = initialise();
+
+    // process incoming messages
+    check_for_reply();
+
+    // request new data from sensor
+    if (initialised) {
+        request_new_data();
+    }
+
+    // check for timeout and set health status
+    if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > PROXIMITY_SF40C_TIMEOUT_MS)) {
+        set_status(AP_Proximity::Proximity_NoData);
+    } else {
+        set_status(AP_Proximity::Proximity_Good);
+    }
+}
+
+// initialise sensor (returns true if sensor is succesfully initialised)
+bool AP_Proximity_LightWareSF40C::initialise()
+{
+    // set motor direction once per second
+    if (_motor_direction > 1) {
+        if ((_last_request_ms == 0) || AP_HAL::millis() - _last_request_ms > 1000) {
+            set_motor_direction();
+        }
+    }
+    // set forward direction once per second
+    if (_forward_direction != frontend.get_yaw_correction(state.instance)) {
+        if ((_last_request_ms == 0) || AP_HAL::millis() - _last_request_ms > 1000) {
+            set_forward_direction();
+        }
+    }
+    // request motors turn on once per second
+    if (_motor_speed == 0) {
+        if ((_last_request_ms == 0) || AP_HAL::millis() - _last_request_ms > 1000) {
+            set_motor_speed(true);
+        }
+        return false;
+    }
+    return true;
+}
+
+// set speed of rotating motor
+void AP_Proximity_LightWareSF40C::set_motor_speed(bool on_off)
+{
+    // exit immediately if no uart
+    if (uart == nullptr) {
+        return;
+    }
+
+    // set motor update speed
+    if (on_off) {
+        uart->write("#MBS,3\r\n");  // send request to spin motor at 4.5hz
+    } else {
+        uart->write("#MBS,0\r\n");  // send request to stop motor
+    }
+
+    // request update motor speed
+    uart->write("?MBS\r\n");
+    _last_request_type = RequestType_MotorSpeed;
+    _last_request_ms = AP_HAL::millis();
+}
+
+// set spin direction of motor
+void AP_Proximity_LightWareSF40C::set_motor_direction()
+{
+    // exit immediately if no uart
+    if (uart == nullptr) {
+        return;
+    }
+
+    // set motor update speed
+    if (frontend.get_orientation(state.instance) == 0) {
+        uart->write("#MBD,0\r\n");  // spin clockwise
+    } else {
+        uart->write("#MBD,1\r\n");  // spin counter clockwise
+    }
+
+    // request update on motor direction
+    uart->write("?MBD\r\n");
+    _last_request_type = RequestType_MotorDirection;
+    _last_request_ms = AP_HAL::millis();
+}
+
+// set forward direction (to allow rotating lidar)
+void AP_Proximity_LightWareSF40C::set_forward_direction()
+{
+    // exit immediately if no uart
+    if (uart == nullptr) {
+        return;
+    }
+
+    // set forward direction
+    char request_str[15];
+    int16_t yaw_corr = frontend.get_yaw_correction(state.instance);
+    sprintf(request_str, "#MBF,%d\r\n", (int)yaw_corr);
+    uart->write(request_str);
+
+    // request update on motor direction
+    uart->write("?MBF\r\n");
+    _last_request_type = RequestType_ForwardDirection;
+    _last_request_ms = AP_HAL::millis();
+}
+
+// request new data if required
+void AP_Proximity_LightWareSF40C::request_new_data()
+{
+    if (uart == nullptr) {
+        return;
+    }
+
+    // after timeout assume no reply will ever come
+    uint32_t now = AP_HAL::millis();
+    if ((_last_request_type != RequestType_None) && ((now - _last_request_ms) > PROXIMITY_SF40C_TIMEOUT_MS)) {
+        _last_request_type = RequestType_None;
+        _last_request_ms = 0;
+    }
+
+    // if we are not waiting for a reply, ask for something
+    if (_last_request_type == RequestType_None) {
+        _request_count++;
+        if (_request_count >= 5) {
+            send_request_for_health();
+            _request_count = 0;
+        } else {
+            // request new distance measurement
+            send_request_for_distance();
+        }
+        _last_request_ms = now;
+    }
+}
+
+// send request for sensor health
+void AP_Proximity_LightWareSF40C::send_request_for_health()
+{
+    if (uart == nullptr) {
+        return;
+    }
+
+    uart->write("?GS\r\n");
+    _last_request_type = RequestType_Health;
+    _last_request_ms = AP_HAL::millis();
+}
+
+// send request for distance from the next sector
+bool AP_Proximity_LightWareSF40C::send_request_for_distance()
+{
+    if (uart == nullptr) {
+        return false;
+    }
+
+    // increment sector
+    _last_sector++;
+    if (_last_sector >= _num_sectors) {
+        _last_sector = 0;
+    }
+
+    // prepare request
+    char request_str[15];
+    sprintf(request_str, "?TS,%d,%d\r\n", (int)(_sector_width_deg[_last_sector]), (int)(_sector_middle_deg[_last_sector]));
+    uart->write(request_str);
+
+
+    // record request for distance
+    _last_request_type = RequestType_DistanceMeasurement;
+    _last_request_ms = AP_HAL::millis();
+
+    return true;
+}
+
+// check for replies from sensor, returns true if at least one message was processed
+bool AP_Proximity_LightWareSF40C::check_for_reply()
+{
+    if (uart == nullptr) {
+        return false;
+    }
+
+    // read any available lines from the lidar
+    //    if CR (i.e. \r), LF (\n) it means we have received a full packet so send for processing
+    //    lines starting with # are ignored because this is the echo of a set-motor request which has no reply
+    //    lines starting with ? are the echo back of our distance request followed by the sensed distance
+    //        distance data appears after a <space>
+    //    distance data is comma separated so we put into separate elements (i.e. <space>angle,distance)
+    uint16_t count = 0;
+    int16_t nbytes = uart->available();
+    while (nbytes-- > 0) {
+        char c = uart->read();
+        // check for end of packet
+        if (c == '\r' || c == '\n') {
+            if ((element_len[0] > 0)) {
+                if (process_reply()) {
+                    count++;
+                }
+            }
+            // clear buffers after processing
+            clear_buffers();
+            ignore_reply = false;
+            wait_for_space = false;
+
+        // if message starts with # ignore it
+        } else if (c == '#' || ignore_reply) {
+            ignore_reply = true;
+
+        // if waiting for <space>
+        } else if (c == '?') {
+            wait_for_space = true;
+
+        } else if (wait_for_space) {
+            if (c == ' ') {
+                wait_for_space = false;
+            }
+
+        // if comma, move onto filling in 2nd element
+        } else if (c == ',') {
+            if ((element_num == 0) && (element_len[0] > 0)) {
+                element_num++;
+            } else {
+                // don't support 3rd element so clear buffers
+                clear_buffers();
+                ignore_reply = true;
+            }
+
+        // if part of a number, add to element buffer
+        } else if (isdigit(c) || c == '.' || c == '-') {
+            element_buf[element_num][element_len[element_num]] = c;
+            element_len[element_num]++;
+            if (element_len[element_num] >= sizeof(element_buf[element_num])-1) {
+                // too long, discard the line
+                clear_buffers();
+                ignore_reply = true;
+            }
+        }
+    }
+
+    return (count > 0);
+}
+
+// process reply
+bool AP_Proximity_LightWareSF40C::process_reply()
+{
+    if (uart == nullptr) {
+        return false;
+    }
+
+    bool success = false;
+
+    switch (_last_request_type) {
+        case RequestType_None:
+            break;
+
+        case RequestType_Health:
+            // expect result in the form "0xhhhh"
+            if (element_len[0] > 0) {
+                int result;
+                if (sscanf(element_buf[0], "%x", &result) > 0) {
+                    _sensor_status.value = result;
+                    success = true;
+                }
+            }
+            break;
+
+        case RequestType_MotorSpeed:
+            _motor_speed = atoi(element_buf[0]);
+            success = true;
+            break;
+
+        case RequestType_MotorDirection:
+            _motor_direction = atoi(element_buf[0]);
+            success = true;
+            break;
+
+        case RequestType_ForwardDirection:
+            _forward_direction = atoi(element_buf[0]);
+            success = true;
+            break;
+
+        case RequestType_DistanceMeasurement:
+        {
+            float angle_deg = (float)atof(element_buf[0]);
+            float distance_m = (float)atof(element_buf[1]);
+            uint8_t sector;
+            if (convert_angle_to_sector(angle_deg, sector)) {
+                _angle[sector] = angle_deg;
+                _distance[sector] = distance_m;
+                _distance_valid[sector] = true;
+                _last_distance_received_ms = AP_HAL::millis();
+                success = true;
+            }
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    // mark request as cleared
+    if (success) {
+        _last_request_type = RequestType_None;
+    }
+
+    return success;
+}
+
+// clear buffers ahead of processing next message
+void AP_Proximity_LightWareSF40C::clear_buffers()
+{
+    element_len[0] = 0;
+    element_len[1] = 0;
+    element_num = 0;
+    memset(element_buf, 0, sizeof(element_buf));
+}
+
+bool AP_Proximity_LightWareSF40C::convert_angle_to_sector(float angle_degrees, uint8_t &sector) const
+{
+    // sanity check angle
+    if (angle_degrees > 360.0f || angle_degrees < -180.0f) {
+        return false;
+    }
+
+    // convert to 0 ~ 360
+    if (angle_degrees < 0.0f) {
+        angle_degrees += 360.0f;
+    }
+
+    bool closest_found = false;
+    uint8_t closest_sector;
+    float closest_angle;
+
+    // search for which sector angle_degrees falls into
+    for (uint8_t i = 0; i < _num_sectors; i++) {
+        float angle_diff = fabsf(wrap_180(_sector_middle_deg[i] - angle_degrees));
+
+        // record if closest
+        if (!closest_found || angle_diff < closest_angle) {
+            closest_found = true;
+            closest_sector = i;
+            closest_angle = angle_diff;
+        }
+
+        if (fabsf(angle_diff) <= _sector_width_deg[i] / 2.0f) {
+            sector = i;
+            return true;
+        }
+    }
+
+    // angle_degrees might have been within a gap between sectors
+    if (closest_found) {
+        sector = closest_sector;
+        return true;
+    }
+
+    return false;
+}

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -1,0 +1,104 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
+
+#include "AP_Proximity.h"
+#include "AP_Proximity_Backend.h"
+
+#define PROXIMITY_SF40C_SECTORS_MAX           8                                 // maximum number of sectors
+#define PROXIMITY_SF40C_SECTOR_WIDTH_DEG      (360/PROXIMITY_SF40C_SECTORS_MAX) // angular width of each sector
+#define PROXIMITY_SF40C_TIMEOUT_MS            200                               // requests timeout after 0.2 seconds
+
+class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend
+{
+
+public:
+    // constructor
+    AP_Proximity_LightWareSF40C(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+
+    // static detection function
+    static bool detect(AP_SerialManager &serial_manager);
+
+    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+    // returns true on successful read and places distance in distance
+    bool get_horizontal_distance(float angle_deg, float &distance) const;
+
+    // update state
+    void update(void);
+
+private:
+
+    enum RequestType {
+        RequestType_None = 0,
+        RequestType_Health,
+        RequestType_MotorSpeed,
+        RequestType_MotorDirection,
+        RequestType_ForwardDirection,
+        RequestType_DistanceMeasurement
+    };
+
+    // initialise sensor (returns true if sensor is succesfully initialised)
+    bool initialise();
+    void set_motor_speed(bool on_off);
+    void set_motor_direction();
+    void set_forward_direction();
+
+    // send request for something from sensor
+    void request_new_data();
+    void send_request_for_health();
+    bool send_request_for_distance();
+
+    // check and process replies from sensor
+    bool check_for_reply();
+    bool process_reply();
+    void clear_buffers();
+    bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
+
+    // reply related variables
+    AP_HAL::UARTDriver *uart = nullptr;
+    char element_buf[2][10];
+    uint8_t element_len[2];
+    uint8_t element_num;
+    bool ignore_reply;                      // true if we should ignore the incoming message (because it is just echoing our command)
+    bool wait_for_space;                    // space marks the start of returned data
+
+    // request related variables
+    enum RequestType _last_request_type;    // last request made to sensor
+    uint8_t  _last_sector;                  // last sector requested
+    uint32_t _last_request_ms;              // system time of last request
+    uint32_t _last_distance_received_ms;    // system time of last distance measurement received from sensor
+    uint8_t _request_count;                 // counter used to interleave requests for distance with health requests
+
+    // sensor health register
+    union {
+        struct PACKED {
+            uint16_t motor_stopped : 1;
+            uint16_t motor_dir : 1;          // 0 = clockwise, 1 = counter-clockwise
+            uint16_t motor_fault : 1;
+            uint16_t torque_control : 1;     // 0 = automatic, 1 = manual
+            uint16_t laser_fault : 1;
+            uint16_t low_battery : 1;
+            uint16_t flat_battery : 1;
+            uint16_t system_restarting : 1;
+            uint16_t no_results_available : 1;
+            uint16_t power_saving : 1;
+            uint16_t user_flag1 : 1;
+            uint16_t user_flag2 : 1;
+            uint16_t unused1 : 1;
+            uint16_t unused2 : 1;
+            uint16_t spare_input : 1;
+            uint16_t major_system_abnormal : 1;
+        } _flags;
+        uint16_t value;
+    } _sensor_status;
+
+    // sensor data
+    uint8_t _motor_speed;               // motor speed as reported by lidar
+    uint8_t _motor_direction = 99;      // motor direction as reported by lidar
+    int16_t _forward_direction = 999;   // forward direction as reported by lidar
+    uint8_t _num_sectors = PROXIMITY_SF40C_SECTORS_MAX;     // number of sectors we will search
+    uint16_t _sector_middle_deg[PROXIMITY_SF40C_SECTORS_MAX] = {0, 45, 90, 135, 180, 225, 270, 315};    // middle angle of each sector
+    uint8_t _sector_width_deg[PROXIMITY_SF40C_SECTORS_MAX] = {45, 45, 45, 45, 45, 45, 45, 45};          // width (in degrees) of each sector
+    float _angle[PROXIMITY_SF40C_SECTORS_MAX];              // angle to closest object within each sector
+    float _distance[PROXIMITY_SF40C_SECTORS_MAX];           // distance to closest object within each sector
+    bool _distance_valid[PROXIMITY_SF40C_SECTORS_MAX];      // true if a valid distance received for each sector
+};

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -53,7 +53,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX)
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
     // @User: Standard
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
 
@@ -67,8 +67,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX)
-    // @User: Standard
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360    // @User: Standard
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SerialProtocol_MAVLink),
 
     // @Param: 2_BAUD
@@ -81,8 +80,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX)
-    // @User: Standard
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360    // @User: Standard
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SerialProtocol_GPS),
 
     // @Param: 3_BAUD
@@ -95,8 +93,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX)
-    // @User: Standard
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360    // @User: Standard
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SerialProtocol_GPS),
 
     // @Param: 4_BAUD
@@ -109,8 +106,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX)
-    // @User: Standard
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360    // @User: Standard
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
 
     // @Param: 5_BAUD

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -82,6 +82,7 @@ public:
         SerialProtocol_SToRM32 = 8,
         SerialProtocol_Lidar = 9,
         SerialProtocol_FrSky_SPort_Passthrough = 10, // FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
+        SerialProtocol_Lidar360 = 11,
     };
 
     // Constructor


### PR DESCRIPTION
This PR adds support for the Lightware SF40c 360 degree range finder including a simple (GPS based) object avoidance by re-using the AC_Avoidance library (which is also used by the polygon fence).

This PR replaces: https://github.com/ArduPilot/ardupilot/pull/4712

Other various bits of information:

- The datasheet for the range finder can be found here: http://www.lightware.co.za/shop/en/scanning-and-obstacle-detection/45-sf40c-100-m.html
- We use the sensor's "Search Light" feature to find the closest object within 8 sectors (each sector is 45degrees with the 0th sector being straight forward of the copter).
- Each time the AP_Proximity::update function is called (which happens at 100hz) it asks for the closest object in the next sector. On the next iteration it will start looking for a reply and parse it and stick the result into a buffer.  This achieves about a 10hz update rate for a full rotation which is twice the sensor's actual update rate (it spins at 4.5hz)
- AC_Avoidance indirectly accesses the appropriate buffer for the direction the vehicle is flying in and shortens the vector so that the vehicle doesn't hit anything.  This could be improved by instead building a small polygon fence using the closest object (and angle to that object) in each sector.

This has been test flown and the video is here:
https://www.youtube.com/watch?v=BDBSpR1Dw_8

