### PR TITLE
SIM_Calibration: Bring angular velocity controller back

### DIFF
--- a/Tools/mavproxy_modules/sitl_calibration.py
+++ b/Tools/mavproxy_modules/sitl_calibration.py
@@ -98,6 +98,9 @@ class CalController(object):
 
         self.general_state = 'angvel'
 
+    def autonomous_magcal(self):
+        self.mpstate.functions.process_stdin('servo set 5 1250')
+
     def handle_simstate(self, m):
         if self.general_state == 'attitude':
             q = quaternion.Quaternion((m.roll, m.pitch, m.yaw))
@@ -363,6 +366,13 @@ class SitlCalibrationModule(mp_module.MPModule):
             'actuate on the simulator vehicle for magnetometer calibration',
         )
         self.add_command(
+            'sitl_autonomous_magcal',
+            self.cmd_sitl_autonomous_magcal,
+            'let the simulating program do the rotations for magnetometer ' +
+            'calibration - basically, continuous rotations over six ' +
+            'calibration poses',
+        )
+        self.add_command(
             'sitl_stop',
             self.cmd_sitl_stop,
             'stop the current calibration control',
@@ -426,6 +436,10 @@ class SitlCalibrationModule(mp_module.MPModule):
 
     def cmd_sitl_magcal(self, args):
         self.set_controller('magcal_controller')
+
+    def cmd_sitl_autonomous_magcal(self, args):
+        self.set_controller('generic_controller')
+        self.current_controller.autonomous_magcal()
 
     def mavlink_packet(self, m):
         for c in self.controllers.values():

--- a/Tools/mavproxy_modules/sitl_calibration.py
+++ b/Tools/mavproxy_modules/sitl_calibration.py
@@ -89,7 +89,7 @@ class CalController(object):
             theta = 0
         elif theta > max_theta:
             theta = max_theta
-        theta_pwm = 1200 + round((theta / max_theta) * 800)
+        theta_pwm = 1300 + round((theta / max_theta) * 700)
 
         self.mpstate.functions.process_stdin('servo set 5 %d' % theta_pwm)
         self.mpstate.functions.process_stdin('servo set 6 %d' % x_pwm)

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -42,7 +42,7 @@ void SITL::Calibration::update(const struct sitl_input& input)
     } else if (switcher_pwm < 1300) {
         _calibration_poses(rot_accel);
     } else {
-        _attitude_control(input, rot_accel);
+        _angular_velocity_control(input, rot_accel);
     }
 
     accel_body(0, 0, 0);
@@ -108,7 +108,7 @@ void SITL::Calibration::_angular_velocity_control(const struct sitl_input& in,
     Vector3f axis{(float)(in.servos[5] - 1500),
                   (float)(in.servos[6] - 1500),
                   (float)(in.servos[7] - 1500)};
-    float theta = MAX_ANGULAR_SPEED * (in.servos[4] - 1200) / 800.f;
+    float theta = MAX_ANGULAR_SPEED * (in.servos[4] - 1300) / 700.f;
     float dt = frame_time_us * 1.0e-6f;
 
     if (axis.length() > 0) {

--- a/libraries/SITL/SIM_Calibration.h
+++ b/libraries/SITL/SIM_Calibration.h
@@ -30,7 +30,7 @@ namespace SITL {
  * values must be in [1000, 2000], otherwise that will cause undefined
  * behavior.
  *
- * There are three control modes, that are set with PWM[4]:
+ * There are four control modes, that are set with PWM[4]:
  *
  *  1) Stop (1000 <= PWM[4] < 1100):
  *    Stop the vehicle, i.e., stop the actuation of the other modes.
@@ -43,7 +43,11 @@ namespace SITL {
  *        pwm(theta) = 1500 + 500 * round(theta / pi)
  *        where -pi <= theta <= pi
  *
- *  3) Angular Velocity (1200 <= PWM[4] <= 2000):
+ *  3) Simple autonomous compass calibration (1200 <= PWM[4] < 1300):
+ *    Move continuously the vehicle through six calibration poses and do a
+ *    rotation about each pose over a short period of time.
+ *
+ *  4) Angular Velocity (1300 <= PWM[4] <= 2000):
  *    Rotate the vehicle at a desired angular velocity. The angular velocity is
  *    specified by a rotation axis and an angular speed.
  *
@@ -55,7 +59,7 @@ namespace SITL {
  *    The angular speed value is specified by PWM[4]. The PWM value for a
  *    desired angular speed in radians/s is given by:
  *
- *        pwm(theta) = 1200 + 800 * round(theta / (2 * pi)),
+ *        pwm(theta) = 1300 + 700 * round(theta / (2 * pi)),
  *        where 0 <= theta <= 2 * pi
  */
 class Calibration : public Aircraft {


### PR DESCRIPTION
Hi guys,

I also fix the sitl_calibration mavproxy module here.

The angular velocity controller has been very useful for my tests here, so I wanted it back, if possible :-)

Best regards,
Gustavo Sousa