### PR TITLE
waf: let wrapper exit with error

### DIFF
--- a/waf
+++ b/waf
@@ -12,7 +12,7 @@ try:
     subprocess.check_call(['python', waf_light] + sys.argv[1:])
 except subprocess.CalledProcessError as e:
     if e.returncode != 2 or p.isfile(waf_light):
-        raise e
+        sys.exit(1)
 
     print('Missing waf submodule. Trying to get it')
 


### PR DESCRIPTION
It's not useful to raise an excpetion because it will only report the
command called exit with an error. Just return an error code instead of
rasing an exception. This way we get nicer error messages:

    ./waf unknowncommand
    No function unknowncommand defined in /home/lucas/p/dronecode/ardupilot/wscript

vs

    ./waf unknowncommand
    No function unknowncommand defined in /home/lucas/p/dronecode/ardupilot/wscript
    Traceback (most recent call last):
      File "./waf", line 15, in <module>
        raise e
    subprocess.CalledProcessError: Command '['python', '/home/lucas/p/dronecode/ardupilot/modules/waf/waf-light', 'unknowncommand']' returned non-zero exit status 1