### PR TITLE
Set FlightGear socket, using instance number

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -99,7 +99,7 @@ void SITL_State::_sitl_setup(const char *home_str)
             gimbal = new SITL::Gimbal(_sitl->state);
         }
 
-        fg_socket.connect("127.0.0.1", 5503);
+        fg_socket.connect("127.0.0.1", 5503 + _instance*10);
     }
 
     if (_synthetic_clock_mode) {


### PR DESCRIPTION
This change permits ardupilot to set socket according to the number of the SITL instance (-I, default = 0), allowing multiple aircrafts in FlightGear using FGMS.
