### PR TITLE
AC_Avoid: Delete the only use variable once a simple calculation.

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -199,14 +199,11 @@ float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, co
         return 0.0f;
     }
 
-    // calculate point at which velocity switches from linear to sqrt
-    float linear_speed = accel_cmss/kP;
-
+    // accel_cmss/kP: calculate point at which velocity switches from linear to sqrt
     // calculate distance within which we can stop
-    if (speed < linear_speed) {
+    if (speed < accel_cmss/kP) {
         return speed/kP;
     } else {
-        float linear_distance = accel_cmss/(2.0f*kP*kP);
-        return linear_distance + (speed*speed)/(2.0f*accel_cmss);
+        return accel_cmss/(2.0f*kP*kP) + (speed*speed)/(2.0f*accel_cmss);
     }
 }


### PR DESCRIPTION
linear_speed variable is used only the following equation.
linear_distance variable is used only the following equation.
Both are simple equation.

Therefore,

Without the use of variable, describing the expression directly.