### PR TITLE
Rover: To add a judgment of 0 degrees longitude.

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -369,7 +369,7 @@ void Rover::update_GPS_10Hz(void)
             // We countdown N number of good GPS fixes
             // so that the altitude is more accurate
             // -------------------------------------
-            if (current_loc.lat == 0) {
+            if (current_loc.lat == 0 && current_loc.lng == 0) {
                 ground_start_count = 20;
             } else {
                 init_home();


### PR DESCRIPTION
It is determined only by latitude 0 degrees.
However, the latitude 0 degrees there is land.

Therefore,

To add a judgment of 0 degrees longitude.