### PR TITLE
Rover: To add a judgment of 0 degrees longitude.

### DIFF
--- a/APMrover2/navigation.cpp
+++ b/APMrover2/navigation.cpp
@@ -13,7 +13,7 @@ void Rover::navigate()
 		return;
 	}
 
-	if ((next_WP.lat == 0) || (home_is_set==HOME_UNSET)){
+	if ((next_WP.lat == 0 && next_WP.lng == 0) || (home_is_set==HOME_UNSET)){
 		return;
 	}
 


### PR DESCRIPTION
It is determined only by latitude 0 degrees.
However, the latitude 0 degrees there is land.

Therefore,

To add a judgment of 0 degrees longitude.