### PR TITLE
AntennaTracker: To add a judgment of 0 degrees longitude.

### DIFF
--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -108,7 +108,7 @@ void Tracker::update_GPS(void)
             // We countdown N number of good GPS fixes
             // so that the altitude is more accurate
             // -------------------------------------
-            if (current_loc.lat == 0) {
+            if (current_loc.lat == 0 && current_loc.lng == 0) {
                 ground_start_count = 5;
 
             } else {


### PR DESCRIPTION
It is determined only by latitude 0 degrees.
However, the latitude 0 degrees there is land.

Therefore,

To add a judgment of 0 degrees longitude.