### PR TITLE
EKF2: Enable simultaneous optical flow and GPS use

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -131,8 +131,8 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
 
     // @Param: GPS_TYPE
     // @DisplayName: GPS mode control
-    // @Description: This controls use of GPS measurements : 0 = use 3D velocity & 2D position, 1 = use 2D velocity and 2D position, 2 = use 2D position, 3 = use no GPS (optical flow will be used if available)
-    // @Values: 0:GPS 3D Vel and 2D Pos, 1:GPS 2D vel and 2D pos, 2:GPS 2D pos, 3:No GPS use optical flow
+    // @Description: This controls use of GPS measurements : 0 = use 3D velocity & 2D position, 1 = use 2D velocity and 2D position, 2 = use 2D position, 3 = Inhibit GPS use - this can be useful when flying with an optical flow sensor in an environment where GPS quality is poor and subject to large multipath errors.
+    // @Values: 0:GPS 3D Vel and 2D Pos, 1:GPS 2D vel and 2D pos, 2:GPS 2D pos, 3:No GPS
     // @User: Advanced
     AP_GROUPINFO("GPS_TYPE", 1, NavEKF2, _fusionModeGPS, 0),
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -170,7 +170,7 @@ void NavEKF2_core::setAidingMode()
         // GPS aiding is the perferred option unless excluded by the user
         if((frontend->_fusionModeGPS) != 3 && readyToUseGPS() && filterIsStable && !gpsInhibit) {
             PV_AidingMode = AID_ABSOLUTE;
-        } else if ((frontend->_fusionModeGPS == 3) && optFlowDataPresent()) {
+        } else if (optFlowDataPresent() && filterIsStable) {
             PV_AidingMode = AID_RELATIVE;
         }
     } else if (PV_AidingMode == AID_RELATIVE) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -407,7 +407,7 @@ void  NavEKF2_core::updateFilterStatus(void)
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
     bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
-    bool optFlowNavPossible = flowDataValid && (frontend->_fusionModeGPS == 3) && delAngBiasLearned;
+    bool optFlowNavPossible = flowDataValid && delAngBiasLearned;
     bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign && delAngBiasLearned;
     bool filterHealthy = healthy() && tiltAlignComplete && (yawAlignComplete || (!use_compass() && (PV_AidingMode == AID_NONE)));
     // If GPS height usage is specified, height is considered to be inaccurate until the GPS passes all checks

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -178,7 +178,11 @@ void NavEKF2_core::setAidingMode()
          bool flowSensorTimeout = ((imuSampleTime_ms - flowValidMeaTime_ms) > 5000);
          // Check if the fusion has timed out (flow measurements have been rejected for too long)
          bool flowFusionTimeout = ((imuSampleTime_ms - prevFlowFuseTime_ms) > 5000);
-         if (flowSensorTimeout || flowFusionTimeout) {
+         // Enable switch to absolute position mode if GPS is available
+         // If GPS is not available and flow fusion has timed out, then fall-back to no-aiding
+         if((frontend->_fusionModeGPS) != 3 && readyToUseGPS() && !gpsInhibit) {
+             PV_AidingMode = AID_ABSOLUTE;
+         } else if (flowSensorTimeout || flowFusionTimeout) {
              PV_AidingMode = AID_NONE;
          }
      } else if (PV_AidingMode == AID_ABSOLUTE) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -127,11 +127,10 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
         delAngBodyOF.zero();
         delTimeOF = 0.0f;
     }
-    // check for takeoff if relying on optical flow and zero measurements until takeoff detected
-    // if we haven't taken off - constrain position and velocity states
-    if (frontend->_fusionModeGPS == 3) {
-        detectOptFlowTakeoff();
-    }
+    // by definition if this function is called, then flow measurements have been provided so we
+    // need to run the optical flow takeoff detection
+    detectOptFlowTakeoff();
+
     // calculate rotation matrices at mid sample time for flow observations
     stateStruct.quat.rotation_matrix(Tbn_flow);
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -43,8 +43,10 @@ void NavEKF2_core::SelectFlowFusion()
     gndOffsetValid = ((imuSampleTime_ms - gndHgtValidTime_ms) < 5000);
     // Perform tilt check
     bool tiltOK = (prevTnb.c.z > frontend->DCM33FlowMin);
-    // Constrain measurements to zero if we are on the ground
-    if (frontend->_fusionModeGPS == 3 && !takeOffDetected) {
+    // Constrain measurements to zero if takeoff is not detected and the height above ground
+    // is insuffient to achieve acceptable focus. This allows the vehicle to be picked up
+    // and carried to test optical flow operation
+    if (!takeOffDetected && ((terrainState - stateStruct.position.z) < 0.5f)) {
         ofDataDelayed.flowRadXYcomp.zero();
         ofDataDelayed.flowRadXY.zero();
         flowDataValid = true;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -59,8 +59,8 @@ void NavEKF2_core::SelectFlowFusion()
         EstimateTerrainOffset();
     }
 
-    // Fuse optical flow data into the main filter if not excessively tilted and we are in the correct mode
-    if (flowDataToFuse && tiltOK && PV_AidingMode == AID_RELATIVE)
+    // Fuse optical flow data into the main filter
+    if (flowDataToFuse && tiltOK)
     {
         // Set the flow noise used by the fusion processes
         R_LOS = sq(MAX(frontend->_flowNoise, 0.05f));

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -520,10 +520,11 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
     Vector2f offset;
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
 
-    // Only report range finder normalised innovation levels if the EKF needs the data.
-    // This prevents false alarms at the GCS if a range finder is fitted for other applications
+    // Only report range finder normalised innovation levels if the EKF needs the data for primary
+    // height estimation or optical flow operation. This prevents false alarms at the GCS if a
+    // range finder is fitted for other applications
     float temp;
-    if ((frontend->_useRngSwHgt > 0) || PV_AidingMode == AID_RELATIVE) {
+    if ((frontend->_useRngSwHgt > 0) || PV_AidingMode == AID_RELATIVE || flowDataValid) {
         temp = sqrtf(auxRngTestRatio);
     } else {
         temp = 0.0f;


### PR DESCRIPTION
Enables simultaneous use of GPS and optical flow data with automatic fallback to relative position mode if GPS is lost and automatic switch-up to absolute position status if GPS gained/re-gained.

**Parameter Settings**

The  EK2_RNG_USE_HGT was set to 50 so that below 50% of the range finders max range of 40m and when the vehicle is stationary, the range finder height is used as the primary EKF height reference. This is the preferred option for combined GPS and optical flow operation.
The EK2_GPS_TYPE was set to 0. Previously this would mean that optical flow data would be ignored, but now optical flow data will be used if a sensor is fitted and enabled by the FLOW_ENABLE parameter. Setting EK2_GPS_TYPE = 3 will still have the same effect as before, putting the EKF into an optical flow only mode that ignores GPS

**Ground Testing**

The ability to lose and regain GPS has been tested on the ground. The was conducted inside to provide a very marginal GPS signal. Placing a hand over the antenna was able to induce complete loss of GPS satellite tracking resulting in a switch to optical flow/relative position mode. When the GPS blockage was removed and the 3D lock recovered, the EKF reset its position to the GPS and switched to GPS mode. This was repeated twice.

GPS position accuracy - very poor and rises rapidly when 3D lock is lost
![screen shot 2016-10-05 at 11 18 29 am](https://cloud.githubusercontent.com/assets/3596952/19097070/75d171aa-8aed-11e6-8255-38609c3a5b01.png)

GPS position innovations - flat-lining indicates GPS is not being fused
![screen shot 2016-10-05 at 11 18 44 am](https://cloud.githubusercontent.com/assets/3596952/19097076/8216e1d4-8aed-11e6-90f7-82195d8f22c0.png)

Optical flow innovations - flow data was fused throughout
![screen shot 2016-10-05 at 11 20 56 am](https://cloud.githubusercontent.com/assets/3596952/19097117/ce751fc8-8aed-11e6-823f-be95c65f6f3b.png)

NE Position - note the position resets when GPS lock is regained.
![screen shot 2016-10-05 at 11 21 49 am](https://cloud.githubusercontent.com/assets/3596952/19097139/f1efc156-8aed-11e6-8f54-0bf071a9a8b5.png)

**Flight Testing**

This branch has been flight tested on a 3DR Iris airframe with a PX4Flow v1.3 optical flow sensor and a Lightware SF10B range finder over flat terrain (sports field). The GPS was getting interference from the optical flow sensor with high levels of noise. The flight log can be found here: https://drive.google.com/file/d/0By4v2BuLAaCfeWtyd2xQTWxXZEE/view?usp=sharing

GPS reported speed error (m/s)
![screen shot 2016-10-05 at 9 30 23 am](https://cloud.githubusercontent.com/assets/3596952/19094895/6b41b56a-8ade-11e6-8ade-6d5ff108a9c0.png)

GPS reported position error (m)
![screen shot 2016-10-05 at 9 36 34 am](https://cloud.githubusercontent.com/assets/3596952/19095029/3a145488-8adf-11e6-9d0b-03c89e372727.png)

Despite this, the copters position hold was steady throughout. The flight went through a range of speeds up to 5 m/s and altitudes up to 39m.

Optical flow innovations remained good throughout.

Optical flow innovations (mrad/sec)
![screen shot 2016-10-05 at 9 33 25 am](https://cloud.githubusercontent.com/assets/3596952/19094943/c7f74fe0-8ade-11e6-835d-aede95c5a9b5.png)

GPS position and velocity innovations were high, reflecting the amount of interference. Normally GPS innovations this high would result in an unsteady position hold, but the optical flow fusion reduced the effect of the GPs errors on position and velocity output.

GPS position innovations (m)
![screen shot 2016-10-05 at 9 34 51 am](https://cloud.githubusercontent.com/assets/3596952/19094978/fc9305e6-8ade-11e6-9f56-27956851cd99.png)

GPS velocity innovations (m/s)
![screen shot 2016-10-05 at 9 38 10 am](https://cloud.githubusercontent.com/assets/3596952/19095075/74772164-8adf-11e6-9e7b-53c21977e247.png)

The automatic switching between range finder and Baro height can be seen in the height innovations. The periods of increased noise correspond to use of the Baro.
![screen shot 2016-10-05 at 10 12 04 am](https://cloud.githubusercontent.com/assets/3596952/19095908/71dd3cf4-8ae4-11e6-86f9-80cba89eed37.png)

