### PR TITLE
Copter: To remove a return after the Switch statement.

### DIFF
--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -315,10 +315,8 @@ bool Copter::mode_requires_GPS(control_mode_t mode) {
         case THROW:
             return true;
         default:
-            break;
+            return false;
     }
-
-    return false;
 }
 
 // mode_has_manual_throttle - returns true if the flight mode has a manual throttle (i.e. pilot directly controls throttle)
@@ -328,10 +326,8 @@ bool Copter::mode_has_manual_throttle(control_mode_t mode) {
         case STABILIZE:
             return true;
         default:
-            break;
+            return false;
     }
-
-    return false;
 }
 
 // mode_allows_arming - returns true if vehicle can be armed in the specified mode

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -315,7 +315,7 @@ bool Copter::mode_requires_GPS(control_mode_t mode) {
         case THROW:
             return true;
         default:
-            return false;
+            break;
     }
 
     return false;
@@ -328,7 +328,7 @@ bool Copter::mode_has_manual_throttle(control_mode_t mode) {
         case STABILIZE:
             return true;
         default:
-            return false;
+            break;
     }
 
     return false;


### PR DESCRIPTION
To return in the default of a switch statement.
In this return, the next process is meaningless.

Therefore,

To change the return to break.