### PR TITLE
AP_RangeFinder: change error and ok status defines to LeddarOne_Status enum

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -69,8 +69,9 @@ bool AP_RangeFinder_LeddarOne::get_reading(uint16_t &reading_cm)
 
     // parse a response message, set number_detections, detections and sum_distance
     // must be signed to handle errors
-    if (parse_response() != LEDDARONE_OK) {
-        // TODO: when (number_detections < 0) handle LEDDARONE_ERR_
+    uint8_t number_detections;
+    if (parse_response(number_detections) != LEDDARONE_OK) {
+        // TODO: when (not LEDDARONE_OK) handle LEDDARONE_ERR_
         return false;
     }
 
@@ -166,7 +167,7 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
  /*
     parse a response message from Modbus
   */
-LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(void)
+LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detections)
 {
     uint8_t data_buffer[25] = {0};
     uint32_t start_ms = AP_HAL::millis();
@@ -204,7 +205,7 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(void)
     number_detections = data_buffer[10];
 
     // if the number of detection is over or zero , it is false
-    if (number_detections > LEDDARONE_DETECTIONS_MAX || number_detections <= 0) {
+    if (number_detections > LEDDARONE_DETECTIONS_MAX || number_detections == 0) {
         return LEDDARONE_ERR_NUMBER_DETECTIONS;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -67,7 +67,7 @@ bool AP_RangeFinder_LeddarOne::get_reading(uint16_t &reading_cm)
         }
     }
 
-    // parse a response message, set number_detectins, detections and sum_distance
+    // parse a response message, set number_detections, detections and sum_distance
     // must be signed to handle errors
     if (parse_response() != LEDDARONE_OK) {
         // TODO: when (number_detections < 0) handle LEDDARONE_ERR_
@@ -212,7 +212,7 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(void)
     sum_distance = 0;
     for (i=0; i<number_detections; i++) {
         // construct data word from two bytes and convert mm to cm
-        detections[i] =  (((uint16_t)data_buffer[index_offset])*256 + data_buffer[index_offset+1]) / 10;
+        detections[i] =  (static_cast<uint16_t>(data_buffer[index_offset])*256 + data_buffer[index_offset+1]) / 10;
         sum_distance += detections[i];
         index_offset += 4;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -46,12 +46,11 @@ private:
     LeddarOne_Status send_request(void);
 
     // parse a response message from ModBus
-    LeddarOne_Status parse_response(void);
+    LeddarOne_Status parse_response(uint8_t &number_detections);
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms;
 
     uint16_t detections[LEDDARONE_DETECTIONS_MAX];
     uint32_t sum_distance;
-    uint8_t number_detections;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -10,14 +10,16 @@
 // default slave address
 #define LEDDARONE_DEFAULT_ADDRESS 0x01
 
-// error codes
-#define LEDDARONE_OK 0
-#define LEDDARONE_ERR_BAD_CRC -1
-#define LEDDARONE_ERR_NO_RESPONSES -2
-#define LEDDARONE_ERR_BAD_RESPONSE -3
-#define LEDDARONE_ERR_SHORT_RESPONSE -4
-#define LEDDARONE_ERR_SERIAL_PORT -5
-#define LEDDARONE_ERR_NUMBER_DETECTIONS -6
+// LeddarOne status
+enum LeddarOne_Status {
+    LEDDARONE_OK = 0,
+    LEDDARONE_ERR_BAD_CRC = -1,
+    LEDDARONE_ERR_NO_RESPONSES = -2,
+    LEDDARONE_ERR_BAD_RESPONSE = -3,
+    LEDDARONE_ERR_SHORT_RESPONSE = -4,
+    LEDDARONE_ERR_SERIAL_PORT = -5,
+    LEDDARONE_ERR_NUMBER_DETECTIONS = -6
+};
 
 class AP_RangeFinder_LeddarOne : public AP_RangeFinder_Backend
 {
@@ -41,14 +43,15 @@ private:
     bool CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCheck);
 
     // send a request message to execute ModBus function
-    int8_t send_request(void);
+    LeddarOne_Status send_request(void);
 
     // parse a response message from ModBus
-    int8_t parse_response(void);
+    LeddarOne_Status parse_response(void);
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms;
 
     uint16_t detections[LEDDARONE_DETECTIONS_MAX];
     uint32_t sum_distance;
+    uint8_t number_detections;
 };


### PR DESCRIPTION
change error and ok status defines to LeddarOne_Status enum. And change send_request, parse_response function's return value from int8_t to LeddarOne_Status.  