### PR TITLE
Support GPS_RTCM_DATA, with fragmenting

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1396,6 +1396,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+    case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
         {
             rover.gps.handle_msg(msg);

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -865,6 +865,11 @@ mission_failed:
         handle_gps_inject(msg, tracker.gps);
         break;
 
+    case MAVLINK_MSG_ID_GPS_RTCM_DATA:
+    case MAVLINK_MSG_ID_GPS_INPUT:
+        tracker.gps.handle_msg(msg);
+        break;
+
     case MAVLINK_MSG_ID_AUTOPILOT_VERSION_REQUEST:
         send_autopilot_version(FIRMWARE_VERSION);
         break;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1884,6 +1884,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
     {
       result = MAV_RESULT_ACCEPTED;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1976,6 +1976,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
     {
         plane.gps.handle_msg(msg);

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -484,8 +484,13 @@ AP_GPS::update(void)
   pass along a mavlink message (for MAV type)
  */
 void
-AP_GPS::handle_msg(mavlink_message_t *msg)
+AP_GPS::handle_msg(const mavlink_message_t *msg)
 {
+    if (msg->msgid == MAVLINK_MSG_ID_GPS_RTCM_DATA) {
+        // pass data to de-fragmenter
+        handle_gps_rtcm_data(msg);
+        return;
+    }
     uint8_t i;
     for (i=0; i<num_instances; i++) {
         if ((drivers[i] != NULL) && (_type[i] != GPS_TYPE_NONE)) {
@@ -699,4 +704,89 @@ AP_GPS::_broadcast_gps_type(const char *type, uint8_t instance, int8_t baud_inde
                  type);
     }
     GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, buffer);
+}
+
+
+/* 
+   re-assemble GPS_RTCM_DATA message
+ */
+void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
+{
+    mavlink_gps_rtcm_data_t packet;
+    mavlink_msg_gps_rtcm_data_decode(msg, &packet);
+
+    if (packet.len > MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
+        // invalid packet
+        return;
+    }
+    
+    if ((packet.flags & 1) == 0) {
+        // it is not fragmented, pass direct
+        inject_data_all(packet.data, packet.len);
+        return;
+    }
+
+    // see if we need to allocate re-assembly buffer
+    if (rtcm_buffer == nullptr) {
+        rtcm_buffer = (struct rtcm_buffer *)calloc(1, sizeof(*rtcm_buffer));
+        if (rtcm_buffer == nullptr) {
+            // nothing to do but discard the data
+            return;
+        }
+    }
+
+    uint8_t fragment = (packet.flags >> 1U) & 0x03;
+    uint8_t sequence = (packet.flags >> 3U) & 0x1F;
+
+    // see if this fragment is consistent with existing fragments
+    if (rtcm_buffer->fragments_received &&
+        (rtcm_buffer->sequence != sequence ||
+         rtcm_buffer->fragments_received & (1U<<fragment))) {
+        // we have one or more partial fragments already received
+        // which conflict with the new fragment, discard previous fragments
+        memset(rtcm_buffer, 0, sizeof(*rtcm_buffer));
+    }
+
+    // add this fragment
+    rtcm_buffer->sequence = sequence;
+    rtcm_buffer->fragments_received |= (1U << fragment);
+
+    // copy the data
+    memcpy(&rtcm_buffer->buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*(uint16_t)fragment], packet.data, packet.len);
+
+    // when we get a fragment of less than max size then we know the
+    // number of fragments. Note that this means if you want to send a
+    // block of RTCM data of an exact multiple of the buffer size you
+    // need to send a final packet of zero length
+    if (packet.len < MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
+        rtcm_buffer->fragment_count = fragment+1;
+        rtcm_buffer->total_length = (MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*fragment) + packet.len;
+    } else if (rtcm_buffer->fragments_received == 0x0F) {
+        // special case of 4 full fragments
+        rtcm_buffer->fragment_count = 4;
+        rtcm_buffer->total_length = MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*4;
+    }
+
+
+    // see if we have all fragments
+    if (rtcm_buffer->fragment_count != 0 &&
+        rtcm_buffer->fragments_received == (1U << rtcm_buffer->fragment_count) - 1) {
+        // we have them all, inject
+        inject_data_all(rtcm_buffer->buffer, rtcm_buffer->total_length);
+        memset(rtcm_buffer, 0, sizeof(*rtcm_buffer));
+    }
+}
+
+/*
+  inject data into all backends
+*/
+void AP_GPS::inject_data_all(const uint8_t *data, uint16_t len)
+{
+    uint8_t i;
+    for (i=0; i<num_instances; i++) {
+        if ((drivers[i] != NULL) && (_type[i] != GPS_TYPE_NONE)) {
+            drivers[i]->inject_data(data, len);
+        }
+    }
+    
 }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -130,7 +130,7 @@ public:
     };
 
     // Pass mavlink data to message handlers (for MAV type)
-    void handle_msg(mavlink_message_t *msg);
+    void handle_msg(const mavlink_message_t *msg);
 
     // Accessor functions
 
@@ -411,6 +411,32 @@ private:
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);
     void _broadcast_gps_type(const char *type, uint8_t instance, int8_t baud_index);
+
+    /*
+      buffer for re-assembling RTCM data for GPS injection. 
+      The 8 bit flags field in GPS_RTCM_DATA is interpreted as:
+              1 bit for "is fragmented"
+              2 bits for fragment number
+              5 bits for sequence number
+
+      The rtcm_buffer is allocated on first use. Once a block of data
+      is successfully reassembled it is injected into all active GPS
+      backends. This assumes we don't want more than 4*180=720 bytes
+      in a RTCM data block
+     */
+    struct rtcm_buffer {
+        uint8_t fragments_received:4;
+        uint8_t sequence:5;
+        uint8_t fragment_count;
+        uint16_t total_length;
+        uint8_t buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*4];
+    } *rtcm_buffer;
+
+    // re-assemble GPS_RTCM_DATA message
+    void handle_gps_rtcm_data(const mavlink_message_t *msg);
+
+    // ibject data into all backends
+    void inject_data_all(const uint8_t *data, uint16_t len);
 };
 
 #define GPS_BAUD_TIME_MS 1200

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -225,7 +225,7 @@ AP_GPS_ERB::_parse_gps(void)
 }
 
 void
-AP_GPS_ERB::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_ERB::inject_data(const uint8_t *data, uint16_t len)
 {
 
     if (port->txspace() > len) {

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -134,7 +134,7 @@ private:
     // Buffer parse & GPS state update
     bool _parse_gps();
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
 
     // used to update fix between status and position packets
     AP_GPS::GPS_Status next_fix;

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -345,7 +345,7 @@ AP_GPS_GSOF::process_message(void)
 }
 
 void
-AP_GPS_GSOF::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_GSOF::inject_data(const uint8_t *data, uint16_t len)
 {
 
     if (port->txspace() > len) {

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -35,7 +35,7 @@ public:
     // Methods
     bool read();
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
 
 private:
 

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -41,7 +41,7 @@ bool AP_GPS_MAV::read(void)
 
 // handles an incoming mavlink message (HIL_GPS) and sets
 // corresponding gps data appropriately;
-void AP_GPS_MAV::handle_msg(mavlink_message_t *msg)
+void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
 {
     mavlink_gps_input_t packet;
     mavlink_msg_gps_input_decode(msg, &packet);

--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -34,7 +34,7 @@ public:
 
     static bool _detect(struct MAV_detect_state &state, uint8_t data);
 
-    void handle_msg(mavlink_message_t *msg);
+    void handle_msg(const mavlink_message_t *msg);
 
 private:
     bool _new_data;

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -279,7 +279,7 @@ AP_GPS_NOVA::process_message(void)
 }
 
 void
-AP_GPS_NOVA::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_NOVA::inject_data(const uint8_t *data, uint16_t len)
 {
     if (port->txspace() > len) {
         last_injected_data_ms = AP_HAL::millis();

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -33,7 +33,7 @@ public:
     // Methods
     bool read();
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
 
 private:
 

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -296,7 +296,7 @@ AP_GPS_SBF::process_message(void)
 }
 
 void
-AP_GPS_SBF::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_SBF::inject_data(const uint8_t *data, uint16_t len)
 {
 
     if (port->txspace() > len) {

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -35,7 +35,7 @@ public:
     // Methods
     bool read();
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
 
 private:
 

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -85,7 +85,7 @@ AP_GPS_SBP::read(void)
 }
 
 void 
-AP_GPS_SBP::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_SBP::inject_data(const uint8_t *data, uint16_t len)
 {
 
     if (port->txspace() > len) {

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -35,7 +35,7 @@ public:
     // Methods
     bool read();
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
 
     static bool _detect(struct SBP_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1181,7 +1181,7 @@ AP_GPS_UBLOX::_configure_rate(void)
 }
 
 void
-AP_GPS_UBLOX::inject_data(uint8_t *data, uint8_t len)
+AP_GPS_UBLOX::inject_data(const uint8_t *data, uint16_t len)
 {
     if (port->txspace() > len) {
         port->write(data, len);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -100,7 +100,7 @@ public:
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
 
-    void inject_data(uint8_t *data, uint8_t len);
+    void inject_data(const uint8_t *data, uint16_t len) override;
     
     bool is_configured(void) {
         if (!gps._auto_config) {

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -42,7 +42,7 @@ public:
 
     virtual bool is_configured(void) { return true; }
 
-    virtual void inject_data(uint8_t *data, uint8_t len) { return; }
+    virtual void inject_data(const uint8_t *data, uint16_t len) { return; }
 
     //MAVLink methods
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan) { return ; }
@@ -51,7 +51,7 @@ public:
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }
 
-    virtual void handle_msg(mavlink_message_t *msg) { return ; }
+    virtual void handle_msg(const mavlink_message_t *msg) { return ; }
 
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to


### PR DESCRIPTION
Support GPS_RTCM_DATA for injecting to all GPS drivers. The previous GPS_INJECT_DATA should be considered deprecated, but is still supported. This is primarily used to supply correction data to a GPS, although it can be used to transmit any other data to a GPS unit.

We are using the GPS_RTCM_DATA.flags field to allow fragmenting correction data so that it is sent to the GPS as a single packet. The structure is:
0xF8 - Sequnce number
0x06 - Fragment index
0x01 - Packet is fragmented.

We assemble the incoming packet into a internal buffer and support the packets arriving out of sequence. If the sequence number doesn't match the current sequence we are assembling we dump the current progress and start over.

Fragment index is which slot of the buffer the packet should drop into.

If the packet is fragmented the fragment bit shall be set. Failure to set the fragment bit means to just flush the current packet's data out to the GPS.

The buffer is flushed when it hits a packet in order that has a length less then the maximum amount that fits into a single GPS_RTCM_DATA. IE a packet with length <180 bytes. If you send a message that happens to be exactly 180 bytes long an additional 0 byte packet is required to actually transmit to the GPS.

Tested with Plane firmware, generating random data from a GCS, and validating that the data was dumped out of a Pixhawk on the Tx line without any fragmenting or collision with the normal u-blox driver activities.

Extra thanks to @tridge for implementing the packet reassembly really quickly!