### PR TITLE
Copter: log change to primary EKF

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -264,8 +264,8 @@ void Copter::fast_loop()
     // --------------------
     read_inertia();
 
-    // check if ekf has reset target heading
-    check_ekf_yaw_reset();
+    // check if ekf has reset target heading or position
+    check_ekf_reset();
 
     // run the attitude controllers
     update_flight_mode();

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -49,18 +49,6 @@ float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
     return stick_angle * g.acro_yaw_p;
 }
 
-// check for ekf yaw reset and adjust target heading
-void Copter::check_ekf_yaw_reset()
-{
-    float yaw_angle_change_rad = 0.0f;
-    uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
-    if (new_ekfYawReset_ms != ekfYawReset_ms) {
-        attitude_control.shift_ef_yaw_target(ToDeg(yaw_angle_change_rad) * 100.0f);
-        ekfYawReset_ms = new_ekfYawReset_ms;
-        Log_Write_Event(DATA_EKF_YAW_RESET);
-    }
-}
-
 /*************************************************************
  * yaw controllers
  *************************************************************/

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -223,6 +223,7 @@ private:
 
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms = 0;
+    uint8_t ekf_primary_core;
 
     // GCS selection
     AP_SerialManager serial_manager;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -680,7 +680,7 @@ private:
     float get_smoothing_gain();
     void get_pilot_desired_lean_angles(float roll_in, float pitch_in, float &roll_out, float &pitch_out, float angle_max);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
-    void check_ekf_yaw_reset();
+    void check_ekf_reset();
     float get_roi_yaw();
     float get_look_ahead_yaw();
     void update_throttle_hover();

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -407,6 +407,7 @@ enum DevOptions {
 #define ERROR_SUBSYSTEM_TERRAIN             21
 #define ERROR_SUBSYSTEM_NAVIGATION          22
 #define ERROR_SUBSYSTEM_FAILSAFE_TERRAIN    23
+#define ERROR_SUBSYSTEM_EKF_PRIMARY         24
 // general error codes
 #define ERROR_CODE_ERROR_RESOLVED           0
 #define ERROR_CODE_FAILED_TO_INITIALISE     1

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -168,3 +168,17 @@ void Copter::failsafe_ekf_off_event(void)
     failsafe.ekf = false;
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_EKFINAV, ERROR_CODE_FAILSAFE_RESOLVED);
 }
+
+// check for ekf yaw reset and adjust target heading, also log position reset
+void Copter::check_ekf_reset()
+{
+    // check for yaw reset
+    float yaw_angle_change_rad = 0.0f;
+    uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
+    if (new_ekfYawReset_ms != ekfYawReset_ms) {
+        attitude_control.shift_ef_yaw_target(ToDeg(yaw_angle_change_rad) * 100.0f);
+        ekfYawReset_ms = new_ekfYawReset_ms;
+        Log_Write_Event(DATA_EKF_YAW_RESET);
+    }
+
+}

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -181,4 +181,12 @@ void Copter::check_ekf_reset()
         Log_Write_Event(DATA_EKF_YAW_RESET);
     }
 
+#if AP_AHRS_NAVEKF_AVAILABLE
+    // check for change in primary EKF (log only, AC_WPNav handles position target adjustment)
+    if (EKF2.getPrimaryCoreIndex() != ekf_primary_core) {
+        ekf_primary_core = EKF2.getPrimaryCoreIndex();
+        Log_Write_Error(ERROR_SUBSYSTEM_EKF_PRIMARY, ekf_primary_core);
+        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "EKF primary changed:%u\n", (unsigned)ekf_primary_core);
+    }
+#endif
 }


### PR DESCRIPTION
This is a follow-up change to Paul's PR: https://github.com/ArduPilot/ardupilot/pull/4903

This logs the change in the primary EKF as an error and also sends a warning to the ground station.

