### PR TITLE
AP_Frsky_Telem: airspeed scaling factor fix

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -742,7 +742,7 @@ uint32_t AP_Frsky_Telem::calc_velandyaw(void)
     // horizontal velocity in dm/s (use airspeed if available, otherwise use groundspeed)
     float airspeed;
     if (_ahrs.airspeed_estimate_true(&airspeed)) {
-        velandyaw |= prep_number(roundf(airspeed * 0.1f), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
+        velandyaw |= prep_number(roundf(airspeed * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
     } else {
         velandyaw |= prep_number(roundf(_ahrs.groundspeed_vector().length() * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
     }


### PR DESCRIPTION
I thought I got this right, but testers on plane have reported that the scaling factor was off by x100, so this is the proposed fix. The fix has been tested in flight, and now the proper airspeed is being reported.