### PR TITLE
Copter: Ahead to exclude the LAND.

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -129,7 +129,7 @@ void Copter::failsafe_ekf_event()
     }
 
     // do nothing if not in GPS flight mode and ekf-action is not land-even-stabilize
-    if (!mode_requires_GPS(control_mode) && (control_mode != LAND) && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE)) {
+    if ((control_mode != LAND) && !mode_requires_GPS(control_mode) && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE)) {
         return;
     }
 


### PR DESCRIPTION
mode_requires_GPS method in the case of LAND, return false.
The LAND from this result was added to exclude conditions.
Therefore,
Previously By excluding LAND, mode_requires_GPS method is not called.