### PR TITLE
ArduPlane: return false when throttle is not suppressed

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -699,6 +699,7 @@ bool Plane::suppress_throttle(void)
 
     if (quadplane.is_flying()) {
         throttle_suppressed = false;
+        return false;
     }
 
     // throttle remains suppressed


### PR DESCRIPTION
suppress_throttle() should return false when throttle is not suppressed