### PR TITLE
AP_RangeFinder: The judgment of number_detections to previous CRC16.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -196,17 +196,17 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
     	return LEDDARONE_ERR_BAD_RESPONSE;
     }
 
-    // CRC16
-    if (!CRC16(data_buffer, len-2, true)) {
-        return LEDDARONE_ERR_BAD_CRC;
-    }
-
     // number of detections
     number_detections = data_buffer[10];
 
     // if the number of detection is over or zero , it is false
     if (number_detections > LEDDARONE_DETECTIONS_MAX || number_detections == 0) {
         return LEDDARONE_ERR_NUMBER_DETECTIONS;
+    }
+
+    // CRC16
+    if (!CRC16(data_buffer, len-2, true)) {
+        return LEDDARONE_ERR_BAD_CRC;
     }
 
     memset(detections, 0, sizeof(detections));


### PR DESCRIPTION
If the value of the number_detections is invalid value, not carried out long processing CRC16.
I think.
It is better to determine the incorrect value in a short time.