### PR TITLE
implement cork() and push() in all AP_HAL RCOutput classes

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -52,20 +52,14 @@ public:
      * Delay subsequent calls to write() going to the underlying hardware in
      * order to group related writes together. When all the needed writes are
      * done, call push() to commit the changes.
-     *
-     * This method is optional: if the subclass doesn't implement it all calls
-     * to write() are synchronous.
      */
-    virtual void     cork() { }
+    virtual void     cork() = 0;
 
     /*
      * Push pending changes to the underlying hardware. All changes between a
      * call to cork() and push() are pushed together in a single transaction.
-     *
-     * This method is optional: if the subclass doesn't implement it all calls
-     * to write() are synchronous.
      */
-    virtual void     push() { }
+    virtual void     push() = 0;
 
     /* Read back current output state, as either single channel or
      * array of channels. On boards that have a separate IO controller,

--- a/libraries/AP_HAL_Empty/RCOutput.h
+++ b/libraries/AP_HAL_Empty/RCOutput.h
@@ -11,4 +11,6 @@ class Empty::RCOutput : public AP_HAL::RCOutput {
     void     write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
+    void     cork(void) override {}
+    void     push(void) override {}
 };

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
@@ -27,6 +27,8 @@ class RCOutput_AioPRU : public AP_HAL::RCOutput {
     void     write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
+    void     cork(void) override;
+    void     push(void) override;
 
 private:
    static const uint32_t TICK_PER_US = 200;
@@ -41,6 +43,9 @@ private:
     };
 
     volatile struct pwm *pwm;
+    uint16_t pending[PWM_CHAN_COUNT];
+    uint32_t pending_mask;
+    bool corked;
 };
 
 }

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.h
@@ -24,6 +24,8 @@ class RCOutput_PRU : public AP_HAL::RCOutput {
     void     write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
+    void     cork(void) override;
+    void     push(void) override;
 
 private:
     static const int TICK_PER_US=200;
@@ -38,6 +40,8 @@ private:
     };
     volatile struct pwm_cmd *sharedMem_cmd;
 
+    uint16_t pending[MAX_PWMS];
+    bool corked;
+    uint32_t pending_mask;    
 };
-
 }

--- a/libraries/AP_HAL_Linux/RCOutput_Raspilot.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Raspilot.cpp
@@ -95,7 +95,7 @@ void RCOutput_Raspilot::_update(void)
 {
     int i;
 
-    if (AP_HAL::micros() - _last_update_timestamp < 10000) {
+    if (_corked || AP_HAL::micros() - _last_update_timestamp < 10000) {
         return;
     }
 
@@ -139,6 +139,16 @@ void RCOutput_Raspilot::_update(void)
                    (uint8_t *)&_dma_packet_rx, sizeof(_dma_packet_rx));
 
     _dev->get_semaphore()->give();
+}
+
+void RCOutput_Raspilot::cork(void)
+{
+    _corked = true;
+}
+
+void RCOutput_Raspilot::push(void)
+{
+    _corked = false;
 }
 
 #endif // CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT

--- a/libraries/AP_HAL_Linux/RCOutput_Raspilot.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Raspilot.h
@@ -15,6 +15,8 @@ public:
     void     write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
+    void     cork(void) override;
+    void     push(void) override;
 
 private:
     void reset();
@@ -25,6 +27,7 @@ private:
     uint32_t _last_update_timestamp;
     uint16_t _frequency;
     uint16_t _period_us[8];
+    bool _corked;
 };
 
 }

--- a/libraries/AP_HAL_Linux/RCOutput_Sysfs.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Sysfs.h
@@ -23,12 +23,19 @@ public:
     void write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void read(uint16_t *period_us, uint8_t len);
+    void cork(void) override;
+    void push(void) override;
 
 private:
     const uint8_t _chip;
     const uint8_t _channel_base;
     const uint8_t _channel_count;
     PWM_Sysfs_Base **_pwm_channels;
+
+    // for handling cork()/push()
+    bool _corked;
+    uint16_t *_pending;
+    uint32_t _pending_mask;
 };
 
 }

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
@@ -16,6 +16,8 @@ public:
     void     write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
+    void     cork(void) override;
+    void     push(void) override;
 
 private:
     static const int TICK_PER_US=100;
@@ -30,6 +32,10 @@ private:
         struct s_period_hi periodhi[MAX_ZYNQ_PWMS];
     };
     volatile struct pwm_cmd *sharedMem_cmd;
+
+    uint16_t pending[MAX_ZYNQ_PWMS];
+    bool corked;
+    uint32_t pending_mask;
 };
 
 }

--- a/libraries/AP_HAL_Linux/RCOutput_qflight.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_qflight.cpp
@@ -76,7 +76,9 @@ void RCOutput_QFLIGHT::write(uint8_t ch, uint16_t period_us)
         return;
     }
     period[ch] = period_us;
-    need_write = true;
+    if (!corked) {
+        need_write = true;
+    }
 }
 
 uint16_t RCOutput_QFLIGHT::read(uint8_t ch)
@@ -170,6 +172,17 @@ void RCOutput_QFLIGHT::check_rc_in(void)
         }
         nrcin_bytes = 0;
     }
+}
+
+void RCOutput_QFLIGHT::cork(void)
+{
+    corked = true;
+}
+
+void RCOutput_QFLIGHT::push(void)
+{
+    corked = false;
+    need_write = true;
 }
 
 #endif // CONFIG_HAL_BOARD_SUBTYPE

--- a/libraries/AP_HAL_Linux/RCOutput_qflight.h
+++ b/libraries/AP_HAL_Linux/RCOutput_qflight.h
@@ -18,6 +18,8 @@ public:
     uint16_t read(uint8_t ch);
     void read(uint16_t *period_us, uint8_t len);
     void set_device_path(const char *device);
+    void cork(void) override;
+    void push(void) override;
 
 private:
     const char *device = nullptr;
@@ -44,6 +46,7 @@ private:
         uint8_t bytes[19];
     } rcu;
     uint8_t nrcin_bytes;
+    bool corked;
 };
 
 }

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -539,7 +539,7 @@ void PX4RCOutput::push()
 
 void PX4RCOutput::_timer_tick(void)
 {
-    if (_output_mode != MODE_PWM_ONESHOT) {
+    if (_output_mode != MODE_PWM_ONESHOT && !_corking) {
         /* in oneshot mode the timer does nothing as the outputs are
          * sent from push() */
         _send_outputs();

--- a/libraries/AP_HAL_QURT/RCOutput.cpp
+++ b/libraries/AP_HAL_QURT/RCOutput.cpp
@@ -51,7 +51,9 @@ void RCOutput::write(uint8_t ch, uint16_t period_us)
         return;
     }
     period[ch] = period_us;
-    need_write = true;
+    if (!corked) {
+        need_write = true;
+    }
 }
 
 uint16_t RCOutput::read(uint8_t ch)
@@ -108,6 +110,16 @@ void RCOutput::timer_update(void)
     ::write(fd, (uint8_t *)&frame, sizeof(frame));
 }
 
+void RCOutput::cork(void)
+{
+    corked = true;
+}
+
+void RCOutput::push(void)
+{
+    need_write = true;
+    corked = false;
+}
 
 #endif // CONFIG_HAL_BOARD_SUBTYPE
 

--- a/libraries/AP_HAL_QURT/RCOutput.h
+++ b/libraries/AP_HAL_QURT/RCOutput.h
@@ -24,6 +24,8 @@ public:
     void write(uint8_t ch, uint16_t period_us);
     uint16_t read(uint8_t ch);
     void read(uint16_t *period_us, uint8_t len);
+    void cork(void) override;
+    void push(void) override;
 
     void timer_update(void);
     
@@ -36,6 +38,7 @@ private:
     uint16_t enable_mask;
     uint16_t period[channel_count];
     volatile bool need_write;
+    bool corked;
 };
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -18,11 +18,15 @@ public:
     void     write(uint8_t ch, uint16_t period_us) override;
     uint16_t read(uint8_t ch) override;
     void     read(uint16_t* period_us, uint8_t len) override;
+    void     cork(void);
+    void     push(void);
 
 private:
     SITL_State *_sitlState;
     uint16_t _freq_hz;
     uint16_t _enable_mask;
+    bool _corked;
+    uint16_t _pending[SITL_NUM_CHANNELS];
 };
 
 #endif

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -546,7 +546,7 @@ void VRBRAINRCOutput::push()
 
 void VRBRAINRCOutput::_timer_tick(void)
 {
-    if (_output_mode != MODE_PWM_ONESHOT) {
+    if (_output_mode != MODE_PWM_ONESHOT && !_corking) {
         /* in oneshot mode the timer does nothing as the outputs are
          * sent from push() */
         _send_outputs();


### PR DESCRIPTION
this implements cork() and push() for RCOutput on all HALs, and makes it mandatory
It also fixes the implementation of cork/push for PX4 and VRBrain, where it didn't actually do anything unless oneshot was enabled.
