### PR TITLE
Copter: To delete a variable that has not been used.

### DIFF
--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -15,7 +15,6 @@ static union {
         uint8_t CH11_flag           : 2; // 10,11   // ch11 aux switch : 0 is low or false, 1 is center or true, 2 is high
         uint8_t CH12_flag           : 2; // 12,13   // ch12 aux switch : 0 is low or false, 1 is center or true, 2 is high
     };
-    uint32_t value;
 } aux_con;
 
 void Copter::read_control_switch()


### PR DESCRIPTION
This PR is re PR #4967.
**cppcheck** tool message is "(style) struct or union member 'Anonymous7::value' is never used.".
However,
To delete a variable that has not been used.

I failed to rebase.
Closed Original PR "Copter: Describing the comment to a variable that does not use the program. #4967"