### PR TITLE
Correct for sensor  position offsets 

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -140,7 +140,8 @@ void Copter::update_optical_flow(void)
         uint8_t flowQuality = optflow.quality();
         Vector2f flowRate = optflow.flowRate();
         Vector2f bodyRate = optflow.bodyRate();
-        ahrs.writeOptFlowMeas(flowQuality, flowRate, bodyRate, last_of_update);
+        Vector3f posOffset = optflow.get_pos_offset();
+        ahrs.writeOptFlowMeas(flowQuality, flowRate, bodyRate, last_of_update, posOffset);
         if (g.log_bitmask & MASK_LOG_OPTFLOW) {
             Log_Write_Optflow();
         }

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -1013,7 +1013,8 @@ void Plane::update_optical_flow(void)
         uint8_t flowQuality = optflow.quality();
         Vector2f flowRate = optflow.flowRate();
         Vector2f bodyRate = optflow.bodyRate();
-        ahrs.writeOptFlowMeas(flowQuality, flowRate, bodyRate, last_of_update);
+        Vector3f posOffset = optflow.get_pos_offset();
+        ahrs.writeOptFlowMeas(flowQuality, flowRate, bodyRate, last_of_update, posOffset);
         Log_Write_Optflow();
     }
 }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1039,10 +1039,10 @@ bool AP_AHRS_NavEKF::get_filter_status(nav_filter_status &status) const
 }
 
 // write optical flow data to EKF
-void  AP_AHRS_NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas)
+void  AP_AHRS_NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset)
 {
-    EKF1.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);
-    EKF2.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);
+    EKF1.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
+    EKF2.writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
 }
 
 // inhibit GPS usage

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -153,7 +153,7 @@ public:
     bool get_vert_pos_rate(float &velocity);
 
     // write optical flow measurements to EKF
-    void writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas);
+    void writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset);
 
     // inibit GPS usage
     uint8_t setInhibitGPS(void);

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -156,38 +156,38 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 
     // @Param: POS1_X
     // @DisplayName: Antenna X position offset
-    // @Description: X position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: X position of the first GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Y
     // @DisplayName: Antenna Y position offset
-    // @Description: Y position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: Y position of the first GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Z
     // @DisplayName: Antenna Z position offset
-    // @Description: Z position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: Z position of the first GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS1", 16, AP_GPS, _antenna_offset[0], 0.0f),
 
     // @Param: POS2_X
     // @DisplayName: Antenna X position offset
-    // @Description: X position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: X position of the second GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Y
     // @DisplayName: Antenna Y position offset
-    // @Description: Y position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: Y position of the second GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Z
     // @DisplayName: Antenna Z position offset
-    // @Description: Z position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Description: Z position of the second GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS2", 17, AP_GPS, _antenna_offset[1], 0.0f),

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -154,6 +154,44 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
 
+    // @Param: POS1_X
+    // @DisplayName: Antenna X position offset
+    // @Description: X position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS1_Y
+    // @DisplayName: Antenna Y position offset
+    // @Description: Y position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS1_Z
+    // @DisplayName: Antenna Z position offset
+    // @Description: Z position of the first GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("POS1", 16, AP_GPS, _antenna_offset[0], 0.0f),
+
+    // @Param: POS2_X
+    // @DisplayName: Antenna X position offset
+    // @Description: X position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS2_Y
+    // @DisplayName: Antenna Y position offset
+    // @Description: Y position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS2_Z
+    // @DisplayName: Antenna Z position offset
+    // @Description: Z position of the second GPS antenna in body frame. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("POS2", 17, AP_GPS, _antenna_offset[1], 0.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -313,6 +313,14 @@ public:
     // the expected lag (in seconds) in the position and velocity readings from the gps
     float get_lag() const { return 0.2f; }
 
+    // return a 3D vector defining the offset of the GPS antenna in metres relative to the body frame origin
+    const Vector3f get_antenna_offset(uint8_t instance) const {
+        return _antenna_offset[instance];
+    }
+    const Vector3f get_antenna_offset(void) const {
+        return _antenna_offset[primary_instance];
+    }
+
     // set position for HIL
     void setHIL(uint8_t instance, GPS_Status status, uint64_t time_epoch_ms, 
                 const Location &location, const Vector3f &velocity, uint8_t num_sats,
@@ -341,7 +349,8 @@ public:
     AP_Int16 _rate_ms[2];
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
-    
+    AP_Vector3f _antenna_offset[2];
+
     // handle sending of initialisation strings to the GPS
     void send_blob_start(uint8_t instance, const char *_blob, uint16_t size);
     void send_blob_update(uint8_t instance);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -964,15 +964,50 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
     d.longitude = longitude + glitch_offsets.y;
     d.altitude = altitude + glitch_offsets.z;
 
-    if (_sitl->gps_drift_alt > 0) {
-        // slow altitude drift
-        d.altitude += _sitl->gps_drift_alt*sinf(AP_HAL::millis()*0.001f*0.02f);
-    }
-
+    // Add offet to c.g. velocity to get velocity at antenna
     d.speedN = speedN;
     d.speedE = speedE;
     d.speedD = speedD;
     d.have_lock = have_lock;
+
+    // correct the latitude, longitude, hiehgt and NED velocity for the offset between
+    // the vehicle c.g. and GPs antenna
+    Vector3f posRelOffsetBF = _sitl->gps_pos_offset;
+    if (!posRelOffsetBF.is_zero()) {
+        // get a rotation matrix following DCM conventions (body to earth)
+        Matrix3f rotmat;
+        rotmat.from_euler(radians(_sitl->state.rollDeg),
+                          radians(_sitl->state.pitchDeg),
+                          radians(_sitl->state.yawDeg));
+
+        // rotate the antenna offset into the earth frame
+        Vector3f posRelOffsetEF = rotmat * posRelOffsetBF;
+
+        // Add the offset to the latitude, longitude and height using a spherical earth approximation
+        double const earth_rad_inv = 1.569612305760477e-7; // use Authalic/Volumetric radius
+        double lng_scale_factor = earth_rad_inv / cos(radians(d.latitude));
+        d.latitude += degrees(posRelOffsetEF.x * earth_rad_inv);
+        d.longitude += degrees(posRelOffsetEF.y * lng_scale_factor);
+        d.altitude -= posRelOffsetEF.z;
+
+        // calculate a velocity offset due to the antenna position offset and body rotation rate
+        // note: % operator is overloaded for cross product
+        Vector3f gyro(radians(_sitl->state.rollRate),
+             radians(_sitl->state.pitchRate),
+             radians(_sitl->state.yawRate));
+        Vector3f velRelOffsetBF = gyro % posRelOffsetBF;
+
+        // rotate the velocity offset into earth frame and add to the c.g. velocity
+        Vector3f velRelOffsetEF = rotmat * velRelOffsetBF;
+        d.speedN += velRelOffsetEF.x;
+        d.speedE += velRelOffsetEF.y;
+        d.speedD += velRelOffsetEF.z;
+    }
+
+    if (_sitl->gps_drift_alt > 0) {
+        // slow altitude drift
+        d.altitude += _sitl->gps_drift_alt*sinf(AP_HAL::millis()*0.001f*0.02f);
+    }
 
     // add in some GPS lag
     _gps_data[next_gps_index++] = d;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -323,57 +323,57 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
 
     // @Param: POS1_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the first IMU Accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the first IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the first IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS1", 27, AP_InertialSensor, _accel_pos[0], 0.0f),
 
     // @Param: POS2_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: X position of the second IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Y position of the second IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Z position of the second IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS2", 28, AP_InertialSensor, _accel_pos[1], 0.0f),
 
     // @Param: POS3_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: X position of the third IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS3_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Y position of the third IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS3_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
+    // @Description: Z position of the third IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS3", 29, AP_InertialSensor, _accel_pos[2], 0.0f),

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -320,6 +320,64 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @User: Advanced
     // @Values: 1:IMU 1,2:IMU 2,3:IMU 3
     AP_GROUPINFO("ACC_BODYFIX", 26, AP_InertialSensor, _acc_body_aligned, 2),
+
+    // @Param: POS1_X
+    // @DisplayName: IMU accelerometer X position
+    // @Description: X position of the first IMU Accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS1_Y
+    // @DisplayName: IMU accelerometer Y position
+    // @Description: Y position of the first IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS1_Z
+    // @DisplayName: IMU accelerometer Z position
+    // @Description: Z position of the first IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("POS1", 27, AP_InertialSensor, _accel_pos[0], 0.0f),
+
+    // @Param: POS2_X
+    // @DisplayName: IMU accelerometer X position
+    // @Description: X position of the second IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS2_Y
+    // @DisplayName: IMU accelerometer Y position
+    // @Description: Y position of the second IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS2_Z
+    // @DisplayName: IMU accelerometer Z position
+    // @Description: Z position of the second IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("POS2", 28, AP_InertialSensor, _accel_pos[1], 0.0f),
+
+    // @Param: POS3_X
+    // @DisplayName: IMU accelerometer X position
+    // @Description: X position of the third IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS3_Y
+    // @DisplayName: IMU accelerometer Y position
+    // @Description: Y position of the third IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: POS3_Z
+    // @DisplayName: IMU accelerometer Z position
+    // @Description: Z position of the third IMU accelerometer in body frame.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("POS3", 29, AP_InertialSensor, _accel_pos[2], 0.0f),
+
     /*
       NOTE: parameter indexes have gaps above. When adding new
       parameters check for conflicts carefully

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -323,57 +323,57 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
 
     // @Param: POS1_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the first IMU Accelerometer in body frame.
+    // @Description: X position of the first IMU Accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the first IMU accelerometer in body frame.
+    // @Description: Y position of the first IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS1_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the first IMU accelerometer in body frame.
+    // @Description: Z position of the first IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS1", 27, AP_InertialSensor, _accel_pos[0], 0.0f),
 
     // @Param: POS2_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the second IMU accelerometer in body frame.
+    // @Description: X position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the second IMU accelerometer in body frame.
+    // @Description: Y position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS2_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the second IMU accelerometer in body frame.
+    // @Description: Z position of the second IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS2", 28, AP_InertialSensor, _accel_pos[1], 0.0f),
 
     // @Param: POS3_X
     // @DisplayName: IMU accelerometer X position
-    // @Description: X position of the third IMU accelerometer in body frame.
+    // @Description: X position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS3_Y
     // @DisplayName: IMU accelerometer Y position
-    // @Description: Y position of the third IMU accelerometer in body frame.
+    // @Description: Y position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: POS3_Z
     // @DisplayName: IMU accelerometer Z position
-    // @Description: Z position of the third IMU accelerometer in body frame.
+    // @Description: Z position of the third IMU accelerometer in body frame. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("POS3", 29, AP_InertialSensor, _accel_pos[2], 0.0f),

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -142,6 +142,14 @@ public:
     const Vector3f &get_accel_scale(uint8_t i) const { return _accel_scale[i]; }
     const Vector3f &get_accel_scale(void) const { return get_accel_scale(_primary_accel); }
 
+    // return a 3D vector defining the position offset of the IMU accelerometer in metres relative to the body frame origin
+    const Vector3f get_imu_pos_offset(uint8_t instance) const {
+        return _accel_pos[instance];
+    }
+    const Vector3f get_imu_pos_offset(void) const {
+        return _accel_pos[_primary_accel];
+    }
+
     // return the temperature if supported. Zero is returned if no
     // temperature is available
     float get_temperature(uint8_t instance) const { return _temperature[instance]; }
@@ -318,6 +326,9 @@ private:
     AP_Vector3f _accel_scale[INS_MAX_INSTANCES];
     AP_Vector3f _accel_offset[INS_MAX_INSTANCES];
     AP_Vector3f _gyro_offset[INS_MAX_INSTANCES];
+
+    // accelerometer position offset in body frame
+    AP_Vector3f _accel_pos[INS_MAX_INSTANCES];
 
     // accelerometer max absolute offsets to be used for calibration
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -75,6 +75,26 @@ void AP_InertialSensor_SITL::timer_update(void)
     float yAccel2 = sitl->state.yAccel + accel2_noise * rand_float();
     float zAccel2 = sitl->state.zAccel + accel2_noise * rand_float();
 
+    // correct for the acceleration due to the IMU position offset and angular acceleration
+    // correct for the centripetal acceleration
+    // only apply corrections to first accelerometer
+    Vector3f pos_offset = sitl->imu_pos_offset;
+    if (!pos_offset.is_zero()) {
+        // calculate sensed acceleration due to lever arm effect
+        // Note: the % operator has been overloaded to provide a cross product
+        Vector3f angular_accel = Vector3f(radians(sitl->state.angAccel.x) , radians(sitl->state.angAccel.y) , radians(sitl->state.angAccel.z));
+        Vector3f lever_arm_accel = angular_accel % pos_offset;
+
+        // calculate sensed acceleration due to centripetal acceleration
+        Vector3f angular_rate = Vector3f(radians(sitl->state.rollRate), radians(sitl->state.pitchRate), radians(sitl->state.yawRate));
+        Vector3f centripetal_accel = angular_rate % (angular_rate % pos_offset);
+
+        // apply corrections
+        xAccel1 += lever_arm_accel.x + centripetal_accel.x;
+        yAccel1 += lever_arm_accel.y + centripetal_accel.y;
+        zAccel1 += lever_arm_accel.z + centripetal_accel.z;
+    }
+
     if (fabsf(sitl->accel_fail) > 1.0e-6f) {
         xAccel1 = sitl->accel_fail;
         yAccel1 = sitl->accel_fail;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -729,7 +729,7 @@ bool NavEKF::use_compass(void) const
 // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
 // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
 // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
-void NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas)
+void NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset)
 {
     if (core) {
         core->writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -729,6 +729,7 @@ bool NavEKF::use_compass(void) const
 // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
 // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
 // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
+// NOTE: AP_NavEKF does not use the posOffset data
 void NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset)
 {
     if (core) {

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -182,7 +182,7 @@ public:
     // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
     // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
     // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
-    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas);
+    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset);
 
     // return data for debugging optical flow fusion
     void getFlowDebug(float &varFlow, float &gndOffset, float &flowInnovX, float &flowInnovY, float &auxInnov, float &HAGL, float &rngInnov, float &range, float &gndOffsetErr) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1017,11 +1017,12 @@ bool NavEKF2::use_compass(void) const
 // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
 // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
 // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
-void NavEKF2::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas)
+// posOffset is the XYZ flow sensor position in the body frame in m
+void NavEKF2::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset)
 {
     if (core) {
         for (uint8_t i=0; i<num_cores; i++) {
-            core[i].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);
+            core[i].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas, posOffset);
         }
     }
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -201,7 +201,8 @@ public:
     // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
     // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
     // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
-    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas);
+    // posOffset is the XYZ flow sensor position in the body frame in m
+    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset);
 
     // return data for debugging optical flow fusion for the specified instance
     // An out of range instance (eg -1) returns data for the the primary instance

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -278,8 +278,10 @@ void NavEKF2_core::readIMUData()
     // use the nominated imu or primary if not available
     if (ins.use_accel(imu_index)) {
         readDeltaVelocity(imu_index, imuDataNew.delVel, imuDataNew.delVelDT);
+        accelPosOffset = ins.get_imu_pos_offset(imu_index);
     } else {
         readDeltaVelocity(ins.get_primary_accel(), imuDataNew.delVel, imuDataNew.delVelDT);
+        accelPosOffset = ins.get_imu_pos_offset(ins.get_primary_accel());
     }
 
     // Get delta angle data from primary gyro or primary if not available

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -138,17 +138,28 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
     stateStruct.quat.rotation_matrix(Tbn_flow);
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)
     if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {
-        // correct flow sensor rates for bias
-        omegaAcrossFlowTime.x = rawGyroRates.x - flowGyroBias.x;
-        omegaAcrossFlowTime.y = rawGyroRates.y - flowGyroBias.y;
-        // write uncorrected flow rate measurements that will be used by the focal length scale factor estimator
+        // correct flow sensor body rates for bias and write
+        ofDataNew.bodyRadXYZ.x = rawGyroRates.x - flowGyroBias.x;
+        ofDataNew.bodyRadXYZ.y = rawGyroRates.y - flowGyroBias.y;
+        // the sensor interface doesn't provide a z axis rate so use the rate from the nav sensor instead
+        if (delTimeOF > 0.001f) {
+            // first preference is to use the rate averaged over the same sampling period as the flow sensor
+            ofDataNew.bodyRadXYZ.z = delAngBodyOF.z / delTimeOF;
+        } else if (imuDataNew.delAngDT > 0.001f){
+            // second preference is to use most recent IMU data
+            ofDataNew.bodyRadXYZ.z = imuDataNew.delAng.z / imuDataNew.delAngDT;
+        } else {
+            // third preference is use zero
+            ofDataNew.bodyRadXYZ.z =  0.0f;
+        }
+        // write uncorrected flow rate measurements
         // note correction for different axis and sign conventions used by the px4flow sensor
         ofDataNew.flowRadXY = - rawFlowRates; // raw (non motion compensated) optical flow angular rate about the X axis (rad/sec)
         // write the flow sensor position in body frame
         ofDataNew.body_offset = posOffset;
         // write flow rate measurements corrected for body rates
-        ofDataNew.flowRadXYcomp.x = ofDataNew.flowRadXY.x + omegaAcrossFlowTime.x;
-        ofDataNew.flowRadXYcomp.y = ofDataNew.flowRadXY.y + omegaAcrossFlowTime.y;
+        ofDataNew.flowRadXYcomp.x = ofDataNew.flowRadXY.x + ofDataNew.bodyRadXYZ.x;
+        ofDataNew.flowRadXYcomp.y = ofDataNew.flowRadXY.y + ofDataNew.bodyRadXYZ.y;
         // record time last observation was received so we can detect loss of data elsewhere
         flowValidMeaTime_ms = imuSampleTime_ms;
         // estimate sample time of the measurement

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -402,6 +402,9 @@ void NavEKF2_core::readGpsData()
             // Prevent time delay exceeding age of oldest IMU data in the buffer
             gpsDataNew.time_ms = MAX(gpsDataNew.time_ms,imuDataDelayed.time_ms);
 
+            // Get the GPS position offset in body frame
+            gpsDataNew.body_offset = _ahrs->get_gps().get_antenna_offset();
+
             // read the NED velocity from the GPS
             gpsDataNew.vel = _ahrs->get_gps().velocity();
 
@@ -480,6 +483,7 @@ void NavEKF2_core::readGpsData()
             }
 
             // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin
+            // correct for position offset of antenna in body frame
             if (validOrigin) {
                 gpsDataNew.pos = location_diff(EKF_origin, gpsloc);
                 gpsDataNew.hgt = 0.01f * (gpsloc.alt - EKF_origin.alt);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -109,7 +109,7 @@ void NavEKF2_core::readRangeFinder(void)
 
 // write the raw optical flow measurements
 // this needs to be called externally.
-void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas)
+void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset)
 {
     // The raw measurements need to be optical flow rates in radians/second averaged across the time since the last update
     // The PX4Flow sensor outputs flow rates with the following axis and sign conventions:

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -144,6 +144,8 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
         // write uncorrected flow rate measurements that will be used by the focal length scale factor estimator
         // note correction for different axis and sign conventions used by the px4flow sensor
         ofDataNew.flowRadXY = - rawFlowRates; // raw (non motion compensated) optical flow angular rate about the X axis (rad/sec)
+        // write the flow sensor position in body frame
+        ofDataNew.body_offset = posOffset;
         // write flow rate measurements corrected for body rates
         ofDataNew.flowRadXYcomp.x = ofDataNew.flowRadXY.x + omegaAcrossFlowTime.x;
         ofDataNew.flowRadXYcomp.y = ofDataNew.flowRadXY.y + omegaAcrossFlowTime.y;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -501,7 +501,6 @@ void NavEKF2_core::readGpsData()
             }
 
             // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin
-            // correct for position offset of antenna in body frame
             if (validOrigin) {
                 gpsDataNew.pos = location_diff(EKF_origin, gpsloc);
                 gpsDataNew.hgt = 0.01f * (gpsloc.alt - EKF_origin.alt);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -79,6 +79,9 @@ void NavEKF2_core::readRangeFinder(void)
                 // limit the measured range to be no less than the on-ground range
                 rangeDataNew.rng = MAX(storedRngMeas[sensorIndex][midIndex],rngOnGnd);
 
+                // get position in body frame for the current sensor
+                rangeDataNew.body_offset = frontend->_rng.get_pos_offset(sensorIndex);
+
                 // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
                 storedRange.push(rangeDataNew);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -305,8 +305,15 @@ void NavEKF2_core::FuseOptFlow()
         // calculate range from ground plain to centre of sensor fov assuming flat earth
         float range = constrain_float((heightAboveGndEst/prevTnb.c.z),rngOnGnd,1000.0f);
 
-        // calculate relative velocity in sensor frame
-        relVelSensor = prevTnb*stateStruct.velocity;
+        // correct range for flow sensor offset body frame position offset
+        // the corrected value is the predicted range from the sensor focal point to the
+        // centre of the image on the ground assuming flat terrain
+        Vector3f posOffsetBody = ofDataDelayed.body_offset - accelPosOffset;
+        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+        range -= posOffsetEarth.z / prevTnb.c.z;
+
+        // calculate relative velocity in sensor frame including the relative motion due to rotation
+        relVelSensor = prevTnb*stateStruct.velocity + ofDataDelayed.bodyRadXYZ % posOffsetBody;
 
         // divide velocity by range  to get predicted angular LOS rates relative to X and Y axes
         losPred[0] =  relVelSensor.y/range;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -309,8 +309,10 @@ void NavEKF2_core::FuseOptFlow()
         // the corrected value is the predicted range from the sensor focal point to the
         // centre of the image on the ground assuming flat terrain
         Vector3f posOffsetBody = ofDataDelayed.body_offset - accelPosOffset;
-        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
-        range -= posOffsetEarth.z / prevTnb.c.z;
+        if (!posOffsetBody.is_zero()) {
+            Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+            range -= posOffsetEarth.z / prevTnb.c.z;
+        }
 
         // calculate relative velocity in sensor frame including the relative motion due to rotation
         relVelSensor = prevTnb*stateStruct.velocity + ofDataDelayed.bodyRadXYZ % posOffsetBody;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -179,18 +179,20 @@ void NavEKF2_core::getWind(Vector3f &wind) const
 }
 
 
-// return NED velocity in m/s
+// return the NED velocity of the body frame origin in m/s
 //
 void NavEKF2_core::getVelNED(Vector3f &vel) const
 {
-    vel = outputDataNew.velocity;
+    // correct for the IMU position offset (EKF calculations are at the IMU)
+    vel = outputDataNew.velocity + velOffsetNED;
 }
 
-// Return the rate of change of vertical position in the down diection (dPosD/dt) in m/s
+// Return the rate of change of vertical position in the down diection (dPosD/dt) of the body frame origin in m/s
 float NavEKF2_core::getPosDownDerivative(void) const
 {
-    // return the value calculated from a complmentary filer applied to the EKF height and vertical acceleration
-    return posDownDerivative;
+    // return the value calculated from a complementary filter applied to the EKF height and vertical acceleration
+    // correct for the IMU offset (EKF calculations are at the IMU)
+    return posDownDerivative + velOffsetNED.z;
 }
 
 // This returns the specific forces in the NED frame
@@ -208,16 +210,18 @@ void NavEKF2_core::getAccelZBias(float &zbias) const {
     }
 }
 
-// Write the last estimated NE position relative to the reference point (m).
+// Write the last estimated NE position of the body frame origin relative to the reference point (m).
 // Return true if the estimate is valid
 bool NavEKF2_core::getPosNE(Vector2f &posNE) const
 {
     // There are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no position estimate available)
     if (PV_AidingMode != AID_NONE) {
         // This is the normal mode of operation where we can use the EKF position states
-        posNE.x = outputDataNew.position.x;
-        posNE.y = outputDataNew.position.y;
+        // correct for the IMU offset (EKF calculations are at the IMU)
+        posNE.x = outputDataNew.position.x + posOffsetNED.x;
+        posNE.y = outputDataNew.position.y + posOffsetNED.y;
         return true;
+
     } else {
         // In constant position mode the EKF position states are at the origin, so we cannot use them as a position estimate
         if(validOrigin) {
@@ -244,27 +248,28 @@ bool NavEKF2_core::getPosNE(Vector2f &posNE) const
     return false;
 }
 
-// Write the last calculated D position relative to the reference point (m).
-// Return true if the estimte is valid
+// Write the last calculated D position of the body frame origin relative to the reference point (m).
+// Return true if the estimate is valid
 bool NavEKF2_core::getPosD(float &posD) const
 {
     // The EKF always has a height estimate regardless of mode of operation
-    posD = outputDataNew.position.z;
+    // correct for the IMU offset (EKF calculations are at the IMU)
+    posD = outputDataNew.position.z + posOffsetNED.z;
 
     // Return the current height solution status
     return filterStatus.flags.vert_pos;
 
 }
-// return the estimated height above ground level
+// return the estimated height of body frame origin above ground level
 bool NavEKF2_core::getHAGL(float &HAGL) const
 {
-    HAGL = terrainState - outputDataNew.position.z;
+    HAGL = terrainState - outputDataNew.position.z - posOffsetNED.z;
     // If we know the terrain offset and altitude, then we have a valid height above ground estimate
     return !hgtTimeout && gndOffsetValid && healthy();
 }
 
 
-// Return the last calculated latitude, longitude and height in WGS-84
+// Return the last calculated latitude, longitude and height of the body frame origin in WGS-84
 // If a calculated location isn't available, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
@@ -280,7 +285,8 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
         if (filterStatus.flags.horiz_pos_abs || filterStatus.flags.horiz_pos_rel) {
             loc.lat = EKF_origin.lat;
             loc.lng = EKF_origin.lng;
-            location_offset(loc, outputDataNew.position.x, outputDataNew.position.y);
+            // correct for IMU offset (EKF calculations are at the IMU position)
+            location_offset(loc, (outputDataNew.position.x + posOffsetNED.x), (outputDataNew.position.y + posOffsetNED.y));
             return true;
         } else {
             // we could be in constant position mode  because the vehicle has taken off without GPS, or has lost GPS
@@ -293,7 +299,8 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
                 return true;
             } else {
                 // if no GPS fix, provide last known position before entering the mode
-                location_offset(loc, lastKnownPositionNE.x, lastKnownPositionNE.y);
+                // correct for IMU offset (EKF calculations are at the IMU position)
+                location_offset(loc, (lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
                 return false;
             }
         }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -657,8 +657,10 @@ void NavEKF2_core::selectHeightForFusion()
     // co-located with the IMU
     if (rangeDataToFuse) {
         Vector3f posOffsetBody = rangeDataDelayed.body_offset - accelPosOffset;
-        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
-        rangeDataDelayed.rng += posOffsetEarth.z / prevTnb.c.z;
+        if (!posOffsetBody.is_zero()) {
+            Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+            rangeDataDelayed.rng += posOffsetEarth.z / prevTnb.c.z;
+        }
     }
 
     // read baro height data from the sensor and check for new data in the buffer

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -652,6 +652,15 @@ void NavEKF2_core::selectHeightForFusion()
     readRangeFinder();
     rangeDataToFuse = storedRange.recall(rangeDataDelayed,imuDataDelayed.time_ms);
 
+    // correct range data for the body frame position offset relative to the IMU
+    // the corrected reading is the reading that would have been taken if the sensor was
+    // co-located with the IMU
+    if (rangeDataToFuse) {
+        Vector3f posOffsetBody = rangeDataDelayed.body_offset - accelPosOffset;
+        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+        rangeDataDelayed.rng += posOffsetEarth.z / prevTnb.c.z;
+    }
+
     // read baro height data from the sensor and check for new data in the buffer
     readBaroData();
     baroDataToFuse = storedBaro.recall(baroDataDelayed, imuDataDelayed.time_ms);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -194,10 +194,28 @@ void NavEKF2_core::SelectVelPosFusion()
         // Don't fuse velocity data if GPS doesn't support it
         if (frontend->_fusionModeGPS <= 1) {
             fuseVelData = true;
+
         } else {
             fuseVelData = false;
         }
         fusePosData = true;
+
+        // correct GPS velocity data for position offset relative to the IMU
+        // TOTO use a filtered angular rate with a group delay that matches the GPS delay
+        Vector3f posOffsetBody = gpsDataDelayed.body_offset - accelPosOffset;
+        if (fuseVelData) {
+            Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
+            Vector3f velOffsetBody = angRate % posOffsetBody;
+            Vector3f velOffsetEarth = prevTnb.mul_transpose(velOffsetBody);
+            gpsDataDelayed.vel -= velOffsetEarth;
+        }
+
+        // correct GPS position data for position offset relative to the IMU
+        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+        gpsDataDelayed.pos.x -= posOffsetEarth.x;
+        gpsDataDelayed.pos.y -= posOffsetEarth.y;
+        gpsDataDelayed.hgt += posOffsetEarth.z;
+
     } else {
         fuseVelData = false;
         fusePosData = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -194,28 +194,26 @@ void NavEKF2_core::SelectVelPosFusion()
         // Don't fuse velocity data if GPS doesn't support it
         if (frontend->_fusionModeGPS <= 1) {
             fuseVelData = true;
-
         } else {
             fuseVelData = false;
         }
         fusePosData = true;
 
-        // correct GPS velocity data for position offset relative to the IMU
-        // TOTO use a filtered angular rate with a group delay that matches the GPS delay
+        // correct GPS data for position offset of antenna phase centre relative to the IMU
         Vector3f posOffsetBody = gpsDataDelayed.body_offset - accelPosOffset;
-        if (fuseVelData) {
-            Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
-            Vector3f velOffsetBody = angRate % posOffsetBody;
-            Vector3f velOffsetEarth = prevTnb.mul_transpose(velOffsetBody);
-            gpsDataDelayed.vel -= velOffsetEarth;
+        if (!posOffsetBody.is_zero()) {
+            if (fuseVelData) {
+                // TODO use a filtered angular rate with a group delay that matches the GPS delay
+                Vector3f angRate = imuDataDelayed.delAng * (1.0f/imuDataDelayed.delAngDT);
+                Vector3f velOffsetBody = angRate % posOffsetBody;
+                Vector3f velOffsetEarth = prevTnb.mul_transpose(velOffsetBody);
+                gpsDataDelayed.vel -= velOffsetEarth;
+            }
+            Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
+            gpsDataDelayed.pos.x -= posOffsetEarth.x;
+            gpsDataDelayed.pos.y -= posOffsetEarth.y;
+            gpsDataDelayed.hgt += posOffsetEarth.z;
         }
-
-        // correct GPS position data for position offset relative to the IMU
-        Vector3f posOffsetEarth = prevTnb.mul_transpose(posOffsetBody);
-        gpsDataDelayed.pos.x -= posOffsetEarth.x;
-        gpsDataDelayed.pos.y -= posOffsetEarth.y;
-        gpsDataDelayed.hgt += posOffsetEarth.z;
-
     } else {
         fuseVelData = false;
         fusePosData = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -608,17 +608,26 @@ void NavEKF2_core::calcOutputStates()
     // apply a trapezoidal integration to velocities to calculate position
     outputDataNew.position += (outputDataNew.velocity + lastVelocity) * (imuDataNew.delVelDT*0.5f);
 
-    // calculate the average angular rate across the last IMU update
-    // note delAngDT is prevented from being zero in readIMUData()
-    Vector3f angRate = imuDataNew.delAng * (1.0f/imuDataNew.delAngDT);
+    // If the IMU accelerometer is offset from the body frame origin, then calculate corrections
+    // that can be added to the EKF velocity and position outputs so that they represent the velocity
+    // and position of the body frame origin.
+    // Note the * operator has been overloaded to operate as a dot product
+    if (!accelPosOffset.is_zero()) {
+        // calculate the average angular rate across the last IMU update
+        // note delAngDT is prevented from being zero in readIMUData()
+        Vector3f angRate = imuDataNew.delAng * (1.0f/imuDataNew.delAngDT);
 
-    // Calculate the velocity of the body frame origin relative to the IMU in body frame
-    // and rotate into earth frame. Note % operator has been overloaded to perform a cross product
-    Vector3f velBodyRelIMU = angRate % (- accelPosOffset);
-    velOffsetNED = Tbn_temp * velBodyRelIMU;
+        // Calculate the velocity of the body frame origin relative to the IMU in body frame
+        // and rotate into earth frame. Note % operator has been overloaded to perform a cross product
+        Vector3f velBodyRelIMU = angRate % (- accelPosOffset);
+        velOffsetNED = Tbn_temp * velBodyRelIMU;
 
-    // calculate the earth frame position of the body frame origin relative to the IMU
-    posOffsetNED = Tbn_temp * (- accelPosOffset);
+        // calculate the earth frame position of the body frame origin relative to the IMU
+        posOffsetNED = Tbn_temp * (- accelPosOffset);
+    } else {
+        velOffsetNED.zero();
+        posOffsetNED.zero();
+    }
 
     // store INS states in a ring buffer that with the same length and time coordinates as the IMU data buffer
     if (runUpdates) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -269,6 +269,8 @@ void NavEKF2_core::InitialiseVariables()
     memset(&storedRngMeas, 0, sizeof(storedRngMeas));
     terrainHgtStable = true;
     ekfOriginHgtVar = 0.0f;
+    velOffsetNED.zero();
+    posOffsetNED.zero();
 
     // zero data buffers
     storedIMU.reset();
@@ -605,6 +607,18 @@ void NavEKF2_core::calcOutputStates()
 
     // apply a trapezoidal integration to velocities to calculate position
     outputDataNew.position += (outputDataNew.velocity + lastVelocity) * (imuDataNew.delVelDT*0.5f);
+
+    // calculate the average angular rate across the last IMU update
+    // note delAngDT is prevented from being zero in readIMUData()
+    Vector3f angRate = imuDataNew.delAng * (1.0f/imuDataNew.delAngDT);
+
+    // Calculate the velocity of the body frame origin relative to the IMU in body frame
+    // and rotate into earth frame. Note % operator has been overloaded to perform a cross product
+    Vector3f velBodyRelIMU = angRate % (- accelPosOffset);
+    velOffsetNED = Tbn_temp * velBodyRelIMU;
+
+    // calculate the earth frame position of the body frame origin relative to the IMU
+    posOffsetNED = Tbn_temp * (- accelPosOffset);
 
     // store INS states in a ring buffer that with the same length and time coordinates as the IMU data buffer
     if (runUpdates) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -909,6 +909,8 @@ private:
     bool gndOffsetValid;            // true when the ground offset state can still be considered valid
     Vector3f delAngBodyOF;          // bias corrected delta angle of the vehicle IMU measured summed across the time since the last OF measurement
     float delTimeOF;                // time that delAngBodyOF is summed across
+    Vector3f accelPosOffset;        // position of IMU accelerometer unit in body frame (m)
+
 
     // Range finder
     float baroHgtOffset;                    // offset applied when when switching to use of Baro height

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -188,7 +188,8 @@ public:
     // rawGyroRates are the sensor rotation rates in rad/sec measured by the sensors internal gyro
     // The sign convention is that a RH physical rotation of the sensor about an axis produces both a positive flow and gyro rate
     // msecFlowMeas is the scheduler time in msec when the optical flow data was received from the sensor.
-    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas);
+    // posOffset is the XYZ flow sensor position in the body frame in m
+    void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, Vector3f &posOffset);
 
     // return data for debugging optical flow fusion
     void getFlowDebug(float &varFlow, float &gndOffset, float &flowInnovX, float &flowInnovY, float &auxInnov, float &HAGL, float &rngInnov, float &range, float &gndOffsetErr) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -833,8 +833,7 @@ private:
     nav_filter_status filterStatus; // contains the status of various filter outputs
     float ekfOriginHgtVar;          // Variance of the the EKF WGS-84 origin height estimate (m^2)
     uint32_t lastOriginHgtTime_ms;  // last time the ekf's WGS-84 origin height was corrected
-
-    Vector3f outputTrackError;
+    Vector3f outputTrackError;      // attitude (rad), velocity (m/s) and position (m) tracking error magnitudes from the output observer
 
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -391,6 +391,7 @@ private:
     struct range_elements {
         float       rng;         // 0
         uint32_t    time_ms;     // 1
+        Vector3f    body_offset; // 2..4
     };
 
     struct tas_elements {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -403,6 +403,7 @@ private:
         Vector2f    flowRadXY;      // 0..1
         Vector2f    flowRadXYcomp;  // 2..3
         uint32_t    time_ms;        // 4
+        Vector3f    body_offset;    // 5..7
     };
 
     // update the navigation filter status

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -404,6 +404,7 @@ private:
         Vector2f    flowRadXYcomp;  // 2..3
         uint32_t    time_ms;        // 4
         Vector3f    body_offset;    // 5..7
+        Vector3f    bodyRadXYZ;     //8..10
     };
 
     // update the navigation filter status
@@ -876,7 +877,6 @@ private:
     uint32_t rngValidMeaTime_ms;    // time stamp from latest valid range measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
     uint32_t gndHgtValidTime_ms;    // time stamp from last terrain offset state update (msec)
-    Vector3f omegaAcrossFlowTime;   // body angular rates averaged across the optical flow sample period
     Matrix3f Tbn_flow;              // transformation matrix from body to nav axes at the middle of the optical flow sample period
     Vector2 varInnovOptFlow;        // optical flow innovations variances (rad/sec)^2
     Vector2 innovOptFlow;           // optical flow LOS innovations (rad/sec)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -834,6 +834,8 @@ private:
     float ekfOriginHgtVar;          // Variance of the the EKF WGS-84 origin height estimate (m^2)
     uint32_t lastOriginHgtTime_ms;  // last time the ekf's WGS-84 origin height was corrected
     Vector3f outputTrackError;      // attitude (rad), velocity (m/s) and position (m) tracking error magnitudes from the output observer
+    Vector3f velOffsetNED;          // This adds to the earth frame velocity estimate at the IMU to give the velocity at the body origin (m/s)
+    Vector3f posOffsetNED;          // This adds to the earth frame position estimate at the IMU to give the position at the body origin (m)
 
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -375,6 +375,7 @@ private:
         float       hgt;         // 2
         Vector3f    vel;         // 3..5
         uint32_t    time_ms;     // 6
+        Vector3f    body_offset; // 7..9
     };
 
     struct mag_elements {

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -37,6 +37,25 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_ORIENT_YAW", 3,  OpticalFlow,    _yawAngle_cd,   0),
 
+    // @Param: _POS_X
+    // @DisplayName:  X position offset
+    // @Description: X position of the optical flow sensor focal point in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: _POS_Y
+    // @DisplayName: Y position offset
+    // @Description: Y position of the optical flow sensor focal point in body frame.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: _POS_Z
+    // @DisplayName: Z position offset
+    // @Description: Z position of the optical flow sensor focal point in body frame.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("_POS", 4, OpticalFlow, _pos_offset, 0.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -39,19 +39,19 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
 
     // @Param: _POS_X
     // @DisplayName:  X position offset
-    // @Description: X position of the optical flow sensor focal point in body frame.
+    // @Description: X position of the optical flow sensor focal point in body frame. Positive X is forward of the origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: _POS_Y
     // @DisplayName: Y position offset
-    // @Description: Y position of the optical flow sensor focal point in body frame.
+    // @Description: Y position of the optical flow sensor focal point in body frame. Positive Y is to the right of the origin.
     // @Units: m
     // @User: Advanced
 
     // @Param: _POS_Z
     // @DisplayName: Z position offset
-    // @Description: Z position of the optical flow sensor focal point in body frame.
+    // @Description: Z position of the optical flow sensor focal point in body frame. Positive Z is down from the origin.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("_POS", 4, OpticalFlow, _pos_offset, 0.0f),

--- a/libraries/AP_OpticalFlow/OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow.h
@@ -73,6 +73,11 @@ public:
     // support for HIL/SITL
     void setHIL(const struct OpticalFlow_state &state);
 
+    // return a 3D vector defining the position offset of the sensors focal point in metres relative to the body frame origin
+    const Vector3f get_pos_offset(void) const {
+        return _pos_offset;
+    }
+
 private:
     OpticalFlow_backend *backend;
 
@@ -85,7 +90,7 @@ private:
     AP_Int16 _flowScalerX;          // X axis flow scale factor correction - parts per thousand
     AP_Int16 _flowScalerY;          // Y axis flow scale factor correction - parts per thousand
     AP_Int16 _yawAngle_cd;          // yaw angle of sensor X axis with respect to vehicle X axis - centi degrees
-
+    AP_Vector3f _pos_offset;        // position offset of the flow sensor in the body frame
 
     // state filled in by backend
     struct OpticalFlow_state _state;

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -131,7 +131,26 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_ADDR", 23, RangeFinder, _address[0], 0),
 
-#if RANGEFINDER_MAX_INSTANCES > 1
+    // @Param: 1_POS_X
+    // @DisplayName:  X position offset
+    // @Description: X position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 1_POS_Y
+    // @DisplayName: Y position offset
+    // @Description: Y position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 1_POS_Z
+    // @DisplayName: Z position offset
+    // @Description: Z position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("1_POS", 49, RangeFinder, _pos_offset[0], 0.0f),
+
+    #if RANGEFINDER_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
     // @Description: What type of rangefinder device that is connected
@@ -224,6 +243,25 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("2_ADDR", 24, RangeFinder, _address[1], 0),
 
+    // @Param: 2_POS_X
+    // @DisplayName:  X position offset
+    // @Description: X position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 2_POS_Y
+    // @DisplayName: Y position offset
+    // @Description: Y position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 2_POS_Z
+    // @DisplayName: Z position offset
+    // @Description: Z position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("2_POS", 50, RangeFinder, _pos_offset[1], 0.0f),
+
 #endif
 
 #if RANGEFINDER_MAX_INSTANCES > 2
@@ -310,6 +348,25 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("3_ADDR", 36, RangeFinder, _address[2], 0),
 
+    // @Param: 3_POS_X
+    // @DisplayName:  X position offset
+    // @Description: X position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 3_POS_Y
+    // @DisplayName: Y position offset
+    // @Description: Y position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 3_POS_Z
+    // @DisplayName: Z position offset
+    // @Description: Z position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("3_POS", 51, RangeFinder, _pos_offset[2], 0.0f),
+
 #endif
 
 #if RANGEFINDER_MAX_INSTANCES > 3
@@ -395,6 +452,25 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_ADDR", 48, RangeFinder, _address[3], 0),
+
+    // @Param: 4_POS_X
+    // @DisplayName:  X position offset
+    // @Description: X position of the fourth rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 4_POS_Y
+    // @DisplayName: Y position offset
+    // @Description: Y position of the fourth rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+
+    // @Param: 4_POS_Z
+    // @DisplayName: Z position offset
+    // @Description: Z position of the fourth rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("4_POS", 52, RangeFinder, _pos_offset[3], 0.0f),
 #endif
     
     AP_GROUPEND

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -133,19 +133,19 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 
     // @Param: _POS_X
     // @DisplayName:  X position offset
-    // @Description: X position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: X position of the first rangefinder in body frame. Positive X is forward of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: _POS_Y
     // @DisplayName: Y position offset
-    // @Description: Y position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Y position of the first rangefinder in body frame. Positive Y is to the right of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: _POS_Z
     // @DisplayName: Z position offset
-    // @Description: Z position of the first rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Z position of the first rangefinder in body frame. Positive Z is down from the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("_POS", 49, RangeFinder, _pos_offset[0], 0.0f),
@@ -245,19 +245,19 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 
     // @Param: 2_POS_X
     // @DisplayName:  X position offset
-    // @Description: X position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: X position of the second rangefinder in body frame. Positive X is forward of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: 2_POS_Y
     // @DisplayName: Y position offset
-    // @Description: Y position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Y position of the second rangefinder in body frame. Positive Y is to the right of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: 2_POS_Z
     // @DisplayName: Z position offset
-    // @Description: Z position of the second rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Z position of the second rangefinder in body frame. Positive Z is down from the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("2_POS", 50, RangeFinder, _pos_offset[1], 0.0f),
@@ -350,19 +350,19 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 
     // @Param: 3_POS_X
     // @DisplayName:  X position offset
-    // @Description: X position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: X position of the third rangefinder in body frame. Positive X is forward of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: 3_POS_Y
     // @DisplayName: Y position offset
-    // @Description: Y position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Y position of the third rangefinder in body frame. Positive Y is to the right of the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
     // @Param: 3_POS_Z
     // @DisplayName: Z position offset
-    // @Description: Z position of the third rangefinder in body frame. Use the zero range datum point if supplied.
+    // @Description: Z position of the third rangefinder in body frame. Positive Z is down from the origin. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
     AP_GROUPINFO("3_POS", 51, RangeFinder, _pos_offset[2], 0.0f),

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -150,7 +150,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_POS", 49, RangeFinder, _pos_offset[0], 0.0f),
 
-    #if RANGEFINDER_MAX_INSTANCES > 1
+#if RANGEFINDER_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
     // @Description: What type of rangefinder device that is connected

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -131,24 +131,24 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_ADDR", 23, RangeFinder, _address[0], 0),
 
-    // @Param: 1_POS_X
+    // @Param: _POS_X
     // @DisplayName:  X position offset
     // @Description: X position of the first rangefinder in body frame. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
-    // @Param: 1_POS_Y
+    // @Param: _POS_Y
     // @DisplayName: Y position offset
     // @Description: Y position of the first rangefinder in body frame. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
 
-    // @Param: 1_POS_Z
+    // @Param: _POS_Z
     // @DisplayName: Z position offset
     // @Description: Z position of the first rangefinder in body frame. Use the zero range datum point if supplied.
     // @Units: m
     // @User: Advanced
-    AP_GROUPINFO("1_POS", 49, RangeFinder, _pos_offset[0], 0.0f),
+    AP_GROUPINFO("_POS", 49, RangeFinder, _pos_offset[0], 0.0f),
 
     #if RANGEFINDER_MAX_INSTANCES > 1
     // @Param: 2_TYPE

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -93,6 +93,7 @@ public:
     AP_Int8  _ground_clearance_cm[RANGEFINDER_MAX_INSTANCES];
     AP_Int8  _address[RANGEFINDER_MAX_INSTANCES];
     AP_Int16 _powersave_range;
+    AP_Vector3f _pos_offset[RANGEFINDER_MAX_INSTANCES]; // position offset in body frame
 
     static const struct AP_Param::GroupInfo var_info[];
     
@@ -181,6 +182,14 @@ public:
       the min and 2m can be captured
      */
     bool pre_arm_check() const;
+
+    // return a 3D vector defining the position offset of the sensor in metres relative to the body frame origin
+    const Vector3f get_pos_offset(uint8_t instance) const {
+        return _pos_offset[instance];
+    }
+    const Vector3f get_pos_offset(void) const {
+        return _pos_offset[primary_instance];
+    }
 
 private:
     RangeFinder_State state[RANGEFINDER_MAX_INSTANCES];

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -43,6 +43,8 @@ Aircraft::Aircraft(const char *home_str, const char *frame_str) :
     frame_height(0),
     dcm(),
     gyro(),
+    gyro_prev(),
+    ang_accel(),
     velocity_ef(),
     mass(0),
     accel_body(0, 0, -GRAVITY_MSS),
@@ -332,6 +334,9 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     fdm.rollRate  = degrees(gyro.x);
     fdm.pitchRate = degrees(gyro.y);
     fdm.yawRate   = degrees(gyro.z);
+    fdm.angAccel.x = degrees(ang_accel.x);
+    fdm.angAccel.y = degrees(ang_accel.y);
+    fdm.angAccel.z = degrees(ang_accel.z);
     float r, p, y;
     dcm.to_euler(&r, &p, &y);
     fdm.rollDeg  = degrees(r);
@@ -408,6 +413,11 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
     gyro.x = constrain_float(gyro.x, -radians(2000), radians(2000));
     gyro.y = constrain_float(gyro.y, -radians(2000), radians(2000));
     gyro.z = constrain_float(gyro.z, -radians(2000), radians(2000));
+
+    // estimate angular acceleration using a first order difference calculation
+    // TODO the simulator interface should provide the angular acceleration
+    ang_accel = (gyro - gyro_prev) / delta_time;
+    gyro_prev = gyro;
     
     // update attitude
     dcm.rotate(gyro * delta_time);

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -115,6 +115,8 @@ protected:
     float frame_height;
     Matrix3f dcm;  // rotation matrix, APM conventions, from body to earth
     Vector3f gyro; // rad/s
+    Vector3f gyro_prev; // rad/s
+    Vector3f ang_accel; // rad/s/s
     Vector3f velocity_ef; // m/s, earth frame
     Vector3f wind_ef; // m/s, earth frame
     Vector3f velocity_air_ef; // velocity relative to airmass, earth frame

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -84,6 +84,10 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("PIN_MASK",      50, SITL,  pin_mask, 0),
     AP_GROUPINFO("ADSB_TX",       51, SITL,  adsb_tx, 0),
     AP_GROUPINFO("SPEEDUP",       52, SITL,  speedup, -1),
+    AP_GROUPINFO("IMU_POS",       53, SITL,  imu_pos_offset, 0),
+    AP_GROUPINFO("GPS_POS",       54, SITL,  gps_pos_offset, 0),
+    AP_GROUPINFO("SONAR_POS",     55, SITL,  rngfnd_pos_offset, 0),
+    AP_GROUPINFO("FLOW_POS",      56, SITL,  optflow_pos_offset, 0),
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -129,6 +129,12 @@ public:
     AP_Vector3f mag_anomaly_ned; // NED anomaly vector at ground level (mGauss)
     AP_Float mag_anomaly_hgt; // height above ground where anomally strength has decayed to 1/8 of the ground level value (m)
 
+    // Body frame sensor position offsets
+    AP_Vector3f imu_pos_offset;     // XYZ position of the IMU accelerometer relative to the body frame origin (m)
+    AP_Vector3f gps_pos_offset;     // XYZ position of the GPS antenna phase centre relative to the body frame origin (m)
+    AP_Vector3f rngfnd_pos_offset;  // XYZ position of the range finder zero range datum relative to the body frame origin (m)
+    AP_Vector3f optflow_pos_offset; // XYZ position of the optical flow sensor focal point relative to the body frame origin (m)
+
     void simstate_send(mavlink_channel_t chan);
 
     void Log_Write_SIMSTATE(DataFlash_Class *dataflash);

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -26,6 +26,7 @@ struct sitl_fdm {
     uint8_t rcin_chan_count;
     float  rcin[8];         // RC input 0..1
     Vector3f bodyMagField;  // Truth XYZ magnetic field vector in body-frame. Includes motor interference. Units are milli-Gauss.
+    Vector3f angAccel; // Angular acceleration in degrees/s/s about the XYZ body axes
 };
 
 // number of rc output channels


### PR DESCRIPTION
This PR enables the relative positions of the IMU GPS, range finder and optical flow sensor to be compensated for, enabling the EKF to produce a velocity and position estimate at a nominated reference datum on the vehicle body, and reducing the effect of vehicle attitude changes on navigation accuracy when using more precise sensors like RTK GPS and optical flow.

Sensor position locations have been added as user adjustable parameters to the sensor libraries.

Users should still be encouraged to locate the IMU as close to the vehicle c.g. as practical.

The branch has been bench tested with the effect of changing sensor offsets checked against expected results and has been flight tested on a small airframe. 