### PR TITLE
ci: add ~/.local/bin to PATH

### DIFF
--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -69,6 +69,7 @@ ln -s ~/opt/$CCACHE_ROOT/ccache ~/ccache/clang
 
 exportline="export PATH=$HOME/ccache"
 exportline="${exportline}:$HOME/bin"
+exportline="${exportline}:$HOME/.local/bin"
 exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin"
 exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
 exportline="${exportline}:$HOME/opt/$CCACHE_ROOT"


### PR DESCRIPTION
In semaphoreci it doesn't have ~/.local/bin by default on path making
us not able to find the mavproxy.py executable.