### PR TITLE
Added SERVO_AUTO_TRIM option

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -774,6 +774,11 @@ private:
         uint32_t last_log_dropped;
     } perf;
 
+    struct {
+        uint32_t last_trim_check;
+        uint32_t last_trim_save;
+    } auto_trim;
+    
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
@@ -1044,6 +1049,7 @@ private:
     void set_servos_flaps(void);
     void servo_output_mixers(void);
     void servos_output(void);
+    void servos_auto_trim(void);
     void throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle);
     bool allow_reverse_thrust(void);
     void update_aux();

--- a/libraries/RC_Channel/SRV_Channel.h
+++ b/libraries/RC_Channel/SRV_Channel.h
@@ -39,12 +39,25 @@ public:
 
     // setup output ESC scaling for a channel
     void set_esc_scaling(uint8_t chnum);
+
+    // return true when enabled
+    bool enabled(void) const { return enable; }
+
+    // return true when auto_trim enabled
+    bool auto_trim_enabled(void) const { return auto_trim; }
+    
+    // adjust trim of a channel by a small increment
+    void adjust_trim(uint8_t ch, float v);
+
+    // save trims
+    void save_trim(void);
     
 private:
     AP_Int8 enable;
 
     int8_t esc_cal_chan;
     bool last_enable;
+    uint8_t trimmed_mask;
 
     // PWM values for min/max and trim
     AP_Int16 servo_min[NUM_SERVO_RANGE_CHANNELS];
@@ -53,6 +66,8 @@ private:
 
     // reversal, following convention that < 0 means reversed, >= 0 means normal
     AP_Int8 reverse[NUM_SERVO_RANGE_CHANNELS];
+
+    AP_Int8 auto_trim;
 
     // remap a PWM value from a channel in value
     uint16_t remap_pwm(uint8_t ch, uint16_t pwm) const;


### PR DESCRIPTION
This adds automatic in-flight servo trimming. This is possible when SERVO_RNG_ENABLE=1, as it means that trimming does not affect R/C calibration.
When enabled the roll and pitch servo trim will automatically converge on the right value, and will be saved between flights.
