### PR TITLE
Plane: On Critical Battery, Land

### DIFF
--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -317,7 +317,8 @@ bool Copter::board_voltage_checks(bool display_failure)
 
     // check battery voltage
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
-        if (failsafe.battery || (!ap.usb_connected && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah))) {
+        if (failsafe.battery || (!ap.usb_connected && 
+            (battery.status(g.fs_batt_voltage, 0.0, g.fs_batt_mah,  0.0) != AP_BattMonitor::BattMonitor_STATUS_NORMAL))) {
             if (display_failure) {
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check Battery");
             }
@@ -752,7 +753,8 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
 
     // check battery voltage
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
-        if (failsafe.battery || (!ap.usb_connected && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah))) {
+        if (failsafe.battery || (!ap.usb_connected && 
+            (battery.status(g.fs_batt_voltage, 0.0, g.fs_batt_mah,  0.0) != AP_BattMonitor::BattMonitor_STATUS_NORMAL))) {
             if (display_failure) {
                 gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Check Battery");
             }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -169,7 +169,8 @@ void Copter::read_battery(void)
 
     // check for low voltage or current if the low voltage check hasn't already been triggered
     // we only check when we're not powered by USB to avoid false alarms during bench tests
-    if (!ap.usb_connected && !failsafe.battery && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah)) {
+    if (!ap.usb_connected && !failsafe.battery && 
+        (battery.status(g.fs_batt_voltage, 0.0, g.fs_batt_mah, 0.0) != AP_BattMonitor::BattMonitor_STATUS_NORMAL)) {
         failsafe_battery_event();
     }
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1362,6 +1362,22 @@ const AP_Param::Info Plane::var_info[] = {
     // @Group: 
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),
+
+    // @Param: FS_BATT_CRT_VOLT
+    // @DisplayName: Failsafe battery critical voltage
+    // @Description: Battery voltage to trigger critcal failsafe. Set to 0 to disable critical battery failsafe. If the battery voltage drops below this level then the plane will switch to a preplanned landing if present, otherwise RTL.
+    // @Units: Volts
+    // @Increment: 0.1
+    // @User: Standard
+    GSCALAR(fs_batt_critical_voltage, "FS_BATT_CRT_VOLT", 0),
+
+    // @Param: FS_BATT_CRT_MAH
+    // @DisplayName: Failsafe battery critical mah
+    // @Description: Battery mAh to trigger critcal failsafe. Set to 0 to disable critical battery failsafe. If the remaining battery drops below this level then the plane will switch to a preplanned landing if present, otherwise RTL.
+    // @Units: mAh
+    // @Increment: 50
+    // @User: Standard
+    GSCALAR(fs_batt_critical_mah, "FS_BATT_CRT_MAH", 0),
     
     AP_VAREND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -346,6 +346,8 @@ public:
         k_param_mixing_offset,
         k_param_dspoiler_rud_rate,
 
+        k_param_fs_batt_critical_voltage = 251,
+        k_param_fs_batt_critical_mah = 252,
         k_param_DataFlash = 253, // Logging Group
 
         // 254,255: reserved
@@ -436,7 +438,9 @@ public:
     AP_Float long_fs_timeout;
     AP_Int8 gcs_heartbeat_fs_enabled;
     AP_Float fs_batt_voltage;
+    AP_Float fs_batt_critical_voltage;
     AP_Float fs_batt_mah;
+    AP_Float fs_batt_critical_mah;
 
     // Flight modes
     //

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -355,6 +355,9 @@ private:
         // flag to hold whether battery low voltage threshold has been breached
         uint8_t low_battery:1;
 
+        // flag to hold whether battery critical voltage threshold has been breached
+        uint8_t critical_battery:1;
+
         // true if an adsb related failsafe has occurred
         uint8_t adsb:1;
 
@@ -920,6 +923,7 @@ private:
     void failsafe_long_on_event(enum failsafe_state fstype, mode_reason_t reason);
     void failsafe_short_off_event(mode_reason_t reason);
     void low_battery_event(void);
+    void critical_battery_event(void);
     void update_events(void);
     uint8_t max_fencepoints(void);
     Vector2l get_fence_point_with_index(unsigned i);

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -126,10 +126,18 @@ void Plane::read_battery(void)
     battery.read();
     compass.set_current(battery.current_amps());
 
-    if (!usb_connected && 
-        hal.util->get_soft_armed() &&
-        battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah)) {
-        low_battery_event();
+    if (!usb_connected && hal.util->get_soft_armed()) {
+
+        switch(battery.status(g.fs_batt_voltage, g.fs_batt_critical_voltage, g.fs_batt_mah, g.fs_batt_critical_mah)){
+            case AP_BattMonitor::BattMonitor_STATUS_NORMAL:
+                break;
+            case AP_BattMonitor::BattMonitor_STATUS_LOW:
+                low_battery_event();
+                break;
+            case AP_BattMonitor::BattMonitor_STATUS_CRITICAL:
+                critical_battery_event();
+                break;
+        }
     }
     
     if (should_log(MASK_LOG_CURRENT)) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -279,12 +279,31 @@ uint8_t AP_BattMonitor::capacity_remaining_pct(uint8_t instance) const
     }
  }
  
- /// exhausted - returns true if the voltage remains below the low_voltage for 10 seconds or remaining capacity falls below min_capacity_mah
-bool AP_BattMonitor::exhausted(uint8_t instance, float low_voltage, float min_capacity_mah)
+ /// status - returns BattMonitor_STATUS_CRITICAL if the voltage remains below the critical_voltage
+ ///                  for 10 seconds or remaining capacity falls below critical_capacity_mah.
+ ///          returns BattMonitor_STATUS_LOW if the voltage remains below the low_voltage for 10 
+ ///                  seconds or remaining capacity falls below min_capacity_mah.
+ ///          returns BattMonitor_STATUS_NORMAL otherwise.
+AP_BattMonitor::BattMonitor_Status AP_BattMonitor::status(uint8_t instance, float low_voltage, 
+                    float critical_voltage, float min_capacity_mah, float critical_capacity_mah)
 {
     // exit immediately if no monitors setup
     if (_num_instances == 0 || instance >= _num_instances) {
-        return false;
+        return BattMonitor_STATUS_NORMAL;
+    }
+
+    if((state[instance].voltage > 0) && (critical_voltage > 0) && (state[instance].voltage < critical_voltage)) {
+        // this is the first time our voltage has dropped below minimum so start timer
+        if (state[instance].critical_voltage_start_ms == 0) {
+            state[instance].critical_voltage_start_ms = AP_HAL::millis();
+        } else if (AP_HAL::millis() - state[instance].critical_voltage_start_ms > AP_BATT_LOW_VOLT_TIMEOUT_MS) {
+            return BattMonitor_STATUS_CRITICAL;
+        }
+    }
+
+    // check capacity if current monitoring is enabled
+    if (has_current(instance) && (critical_capacity_mah > 0) && (_pack_capacity[instance] - state[instance].current_total_mah < critical_capacity_mah)) {
+        return BattMonitor_STATUS_CRITICAL;
     }
 
     // check voltage
@@ -293,20 +312,20 @@ bool AP_BattMonitor::exhausted(uint8_t instance, float low_voltage, float min_ca
         if (state[instance].low_voltage_start_ms == 0) {
             state[instance].low_voltage_start_ms = AP_HAL::millis();
         } else if (AP_HAL::millis() - state[instance].low_voltage_start_ms > AP_BATT_LOW_VOLT_TIMEOUT_MS) {
-            return true;
+            return BattMonitor_STATUS_LOW;
         }
     } else {
         // acceptable voltage so reset timer
         state[instance].low_voltage_start_ms = 0;
+        state[instance].critical_voltage_start_ms = 0;
     }
 
-    // check capacity if current monitoring is enabled
     if (has_current(instance) && (min_capacity_mah > 0) && (_pack_capacity[instance] - state[instance].current_total_mah < min_capacity_mah)) {
-        return true;
+        return BattMonitor_STATUS_LOW;
     }
 
     // if we've gotten this far then battery is ok
-    return false;
+    return BattMonitor_STATUS_NORMAL;
 }
 
 // return true if any battery is pushing too much power

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -44,6 +44,13 @@ public:
         BattMonitor_TYPE_BEBOP                      = 6
     };
 
+        // Battery monitor driver types
+    enum BattMonitor_Status {
+        BattMonitor_STATUS_NORMAL,
+        BattMonitor_STATUS_LOW,
+        BattMonitor_STATUS_CRITICAL,
+    };
+
     // The BattMonitor_State structure is filled in by the backend driver
     struct BattMonitor_State {
         uint8_t     instance;           // the instance number of this monitor
@@ -54,6 +61,7 @@ public:
         float       current_total_mah;  // total current draw since start-up
         uint32_t    last_time_micros;   // time when voltage and current was last read
         uint32_t    low_voltage_start_ms;  // time when voltage dropped below the minimum
+        uint32_t    critical_voltage_start_ms;  // time when voltage dropped below the minimum
     };
 
     // Return the number of battery monitor instances
@@ -98,9 +106,14 @@ public:
     int32_t pack_capacity_mah(uint8_t instance) const;
     int32_t pack_capacity_mah() const { return pack_capacity_mah(AP_BATT_PRIMARY_INSTANCE); }
  
-    /// exhausted - returns true if the battery's voltage remains below the low_voltage for 10 seconds or remaining capacity falls below min_capacity
-    bool exhausted(uint8_t instance, float low_voltage, float min_capacity_mah);
-    bool exhausted(float low_voltage, float min_capacity_mah) { return exhausted(AP_BATT_PRIMARY_INSTANCE, low_voltage, min_capacity_mah); }
+    /// status - returns BattMonitor_STATUS_CRITICAL if the voltage remains below the critical_voltage
+    ///                  for 10 seconds or remaining capacity falls below critical_capacity_mah.
+    ///          returns BattMonitor_STATUS_LOW if the voltage remains below the low_voltage for 10 
+    ///                  seconds or remaining capacity falls below min_capacity_mah.
+    ///          returns BattMonitor_STATUS_NORMAL otherwise.
+    enum BattMonitor_Status status(uint8_t instance, float low_voltage, float critical_voltage, float min_capacity_mah, float critical_capacity_mah);
+    enum BattMonitor_Status status(float low_voltage, float critical_voltage, float min_capacity_mah, float critical_capacity_mah) { 
+        return status(AP_BATT_PRIMARY_INSTANCE, low_voltage, critical_voltage, min_capacity_mah, critical_capacity_mah); }
 
     /// get_type - returns battery monitor type
     enum BattMonitor_Type get_type() { return get_type(AP_BATT_PRIMARY_INSTANCE); }


### PR DESCRIPTION
Created a critical voltage and critical mAh parameter. When these are crossed, the plane enters landing sequence if present, otherwise RTL. See #3950.
