### PR TITLE
AP_Scheduler: To add a comment to _loop_rate_hz variable.

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -101,7 +101,7 @@ private:
     AP_Int8 _debug;
 
     // overall scheduling rate in Hz
-    AP_Int16 _loop_rate_hz;
+    AP_Int16 _loop_rate_hz;  // The value of this variable can be changed with the non-initialization. (Ex. Tuning by GDB)
     
     // progmem list of tasks to run
     const struct Task *_tasks;


### PR DESCRIPTION
After initializing the value of _loop_rate_hz variable and may be changed by tuning.
I do not know from the comment.
For this reason, it is misunderstood.