### PR TITLE
RCOutput_Bebop: fix motor order

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -448,7 +448,7 @@ void RCOutput_Bebop::_run_rcout()
      * keep current order. The order changes from version 2 on bebop 1 and
      * remains the same as this for bebop 2
      */
-    if (info.version_maj == 1 || info.version_maj == 5) {
+    if (info.version_maj == 1) {
         bebop_bldc_right_front = BEBOP_BLDC_MOTOR_1;
         bebop_bldc_left_front  = BEBOP_BLDC_MOTOR_2;
         bebop_bldc_left_back   = BEBOP_BLDC_MOTOR_3;


### PR DESCRIPTION
Accidentally pushed in commit 298f7bffb9ca7eb9ae5b9329351c98acddab8fa2
The order of the motors shouldn't have been changed on version 5 because
it is specific to older versions of the ESC controller firmware