### PR TITLE
AP_AHRS: Set board orientation at degree level (useful e.g. for racing quads with tilted motors)

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -123,6 +123,27 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     AP_GROUPINFO("EKF_TYPE",  14, AP_AHRS, _ekf_type, 2),
 #endif
 
+    // @Param: PIT_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the pitch axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("PIT_TLT", 15, AP_AHRS, _pitch_tilt, 0),
+
+    // @Param: ROL_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the roll axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("ROL_TLT", 16, AP_AHRS, _roll_tilt, 0),
+   
+    // @Param: YAW_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the yaw axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("YAW_TLT", 17, AP_AHRS, _yaw_tilt, 0),
+   
     AP_GROUPEND
 };
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -141,8 +141,11 @@ public:
     // this makes initial config easier
     void set_orientation() {
         _ins.set_board_orientation((enum Rotation)_board_orientation.get());
+        _ins.set_board_orientation(Vector3f(_roll_tilt, _pitch_tilt, _yaw_tilt));
+        
         if (_compass != NULL) {
             _compass->set_board_orientation((enum Rotation)_board_orientation.get());
+            _compass->set_board_orientation(Vector3f(_roll_tilt, _pitch_tilt, _yaw_tilt));
         }
     }
 
@@ -484,6 +487,11 @@ protected:
     AP_Int8 _gps_delay;
     AP_Int8 _ekf_type;
 
+    // should replace "_board_orientation"
+    AP_Int8 _pitch_tilt;
+    AP_Int8 _roll_tilt;
+    AP_Int8 _yaw_tilt;
+    
     // flags structure
     struct ahrs_flags {
         uint8_t have_initial_yaw        : 1;    // whether the yaw value has been intialised with a reference

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -795,6 +795,12 @@ void Compass::setHIL(uint8_t instance, float roll, float pitch, float yaw)
     if (!_state[0].external) {
         // and add in AHRS_ORIENTATION setting if not an external compass
         _hil.field[instance].rotate(_board_orientation);
+        /*
+        // and add in AHRS_ORIENTATION setting if not an external compass (new parameters)
+        Matrix3f field = Matrix3f::matrix_from_euler(_hil.field[instance].x, _hil.field[instance].y, _hil.field[instance].z);
+        field.rotate(_board_rotation);
+        field.to_euler(&_hil.field[instance].x, &_hil.field[instance].y, &_hil.field[instance].z);
+        */
     }
     _hil.healthy[instance] = true;
 }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -208,6 +208,11 @@ public:
     void set_board_orientation(enum Rotation orientation) {
         _board_orientation = orientation;
     }
+    
+    // set overall board orientation
+    void set_board_orientation(const Vector3f &rotation) {
+        _board_rotation = rotation;
+    }
 
     /// Set the motor compensation type
     ///
@@ -337,6 +342,7 @@ private:
 
     // board orientation from AHRS
     enum Rotation _board_orientation;
+    Vector3f      _board_rotation = Vector3f(0,0,0);
 
     // primary instance
     AP_Int8     _primary;

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -19,6 +19,11 @@ void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
     if (!state.external) {
         // and add in AHRS_ORIENTATION setting if not an external compass
         mag.rotate(_compass._board_orientation);
+        
+        // and add in AHRS_ORIENTATION setting if not an external compass (new parameters)
+        Matrix3f field = Matrix3f::matrix_from_euler(mag.x, mag.y, mag.z);
+        field.rotate(_compass._board_rotation);
+        field.to_euler(&mag.x, &mag.y, &mag.z);
     } else {
         // add user selectable orientation
         mag.rotate((enum Rotation)state.orientation.get());

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -169,6 +169,11 @@ public:
         _board_orientation = orientation;
     }
 
+    // set overall board orientation
+    void set_board_orientation(const Vector3f &rotation) {
+        _board_rotation = rotation;
+    }
+    
     // return the selected sample rate
     uint16_t get_sample_rate(void) const { return _sample_rate; }
 
@@ -339,6 +344,7 @@ private:
 
     // board orientation from AHRS
     enum Rotation _board_orientation;
+    Vector3f      _board_rotation = Vector3f(0,0,0);;
 
     // calibrated_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -32,6 +32,11 @@ void AP_InertialSensor_Backend::_rotate_and_correct_accel(uint8_t instance, Vect
 
     // rotate to body frame
     accel.rotate(_imu._board_orientation);
+    
+    // rotate to body frame (new parameters)
+    Matrix3f attitude = Matrix3f::matrix_from_euler(accel.x, accel.y, accel.z);
+    attitude.rotate(_imu._board_rotation);
+    attitude.to_euler(&accel.x, &accel.y, &accel.z);
 }
 
 void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro) 
@@ -39,6 +44,11 @@ void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vecto
     // gyro calibration is always assumed to have been done in sensor frame
     gyro -= _imu._gyro_offset[instance];
     gyro.rotate(_imu._board_orientation);
+    
+    // rotate to body frame (new parameters)
+    Matrix3f attitude = Matrix3f::matrix_from_euler(gyro.x, gyro.y, gyro.z);
+    attitude.rotate(_imu._board_rotation);
+    attitude.to_euler(&gyro.x, &gyro.y, &gyro.z);
 }
 
 /*

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -47,7 +47,7 @@ public:
 
     // Vectors comprising the rows of the matrix
     Vector3<T>        a, b, c;
-
+    
     // trivial ctor
     // note that the Vector3 ctor will zero the vector elements
     constexpr Matrix3<T>() {}
@@ -66,6 +66,12 @@ public:
         , b(bx,by,bz)
         , c(cx,cy,cz) {}
 
+    static Matrix3<T> matrix_from_euler(const T roll, const T pitch, const T yaw) {
+        Matrix3<T> mat;
+        mat.from_euler(roll, pitch, yaw);
+        return mat;
+    }
+        
     // function call operator
     void operator        () (const Vector3<T> &a0, const Vector3<T> &b0, const Vector3<T> &c0)
     {


### PR DESCRIPTION
This patch set allows free definitions of the board orientation.
Defining a board orientation with degree resolution is especially important for racing quads.
Such quads make often use of tilted rotors applied on the frame.

Note: I haven't tested this yet and want to discuss at this point, 
whether it is the right approach to solve the issue like this.
I also was wondering whether we can delete the old *_orientation parameter?! 