### PR TITLE
AP_AHRS: Set degree level board orientation for racing quads making use of tilted rotors

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -123,6 +123,27 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     AP_GROUPINFO("EKF_TYPE",  14, AP_AHRS, _ekf_type, 2),
 #endif
 
+    // @Param: PIT_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the pitch axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("PIT_TLT", 15, AP_AHRS, _pitch_tilt, 0),
+
+    // @Param: ROL_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the roll axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("ROL_TLT", 16, AP_AHRS, _roll_tilt, 0),
+   
+    // @Param: YAW_TLT
+    // @DisplayName: Board Orientation
+    // @Description: How many degrees is the board tilted along the yaw axis
+    // @Values: Angle in degrees: -90° to 90°
+    // @User: Advanced
+    AP_GROUPINFO("YAW_TLT", 17, AP_AHRS, _yaw_tilt, 0),
+   
     AP_GROUPEND
 };
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -141,8 +141,11 @@ public:
     // this makes initial config easier
     void set_orientation() {
         _ins.set_board_orientation((enum Rotation)_board_orientation.get());
+        _ins.set_board_orientation(Matrix3f::matrix_from_euler(ToRad(_roll_tilt), ToRad(_pitch_tilt), ToRad(_yaw_tilt)));
+        
         if (_compass != NULL) {
             _compass->set_board_orientation((enum Rotation)_board_orientation.get());
+            _compass->set_board_orientation(Matrix3f::matrix_from_euler(ToRad(_roll_tilt), ToRad(_pitch_tilt), ToRad(_yaw_tilt)));
         }
     }
 
@@ -484,6 +487,11 @@ protected:
     AP_Int8 _gps_delay;
     AP_Int8 _ekf_type;
 
+    // should replace "_board_orientation"
+    AP_Int8 _pitch_tilt;
+    AP_Int8 _roll_tilt;
+    AP_Int8 _yaw_tilt;
+    
     // flags structure
     struct ahrs_flags {
         uint8_t have_initial_yaw        : 1;    // whether the yaw value has been intialised with a reference

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -795,6 +795,9 @@ void Compass::setHIL(uint8_t instance, float roll, float pitch, float yaw)
     if (!_state[0].external) {
         // and add in AHRS_ORIENTATION setting if not an external compass
         _hil.field[instance].rotate(_board_orientation);
+        
+        // and add in AHRS_ORIENTATION setting if not an external compass (new parameters)
+        _hil.field[instance] = _board_rotation * _hil.field[instance];
     }
     _hil.healthy[instance] = true;
 }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -208,6 +208,11 @@ public:
     void set_board_orientation(enum Rotation orientation) {
         _board_orientation = orientation;
     }
+    
+    // set overall board orientation
+    void set_board_orientation(const Matrix3f &rotation) {
+        _board_rotation = rotation;
+    }
 
     /// Set the motor compensation type
     ///
@@ -337,6 +342,7 @@ private:
 
     // board orientation from AHRS
     enum Rotation _board_orientation;
+    Matrix3f      _board_rotation;
 
     // primary instance
     AP_Int8     _primary;

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -19,6 +19,9 @@ void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
     if (!state.external) {
         // and add in AHRS_ORIENTATION setting if not an external compass
         mag.rotate(_compass._board_orientation);
+        
+        // and add in AHRS_ORIENTATION setting if not an external compass (new parameters)
+        mag = _compass._board_rotation * mag;
     } else {
         // add user selectable orientation
         mag.rotate((enum Rotation)state.orientation.get());

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -776,8 +776,7 @@ bool AP_InertialSensor::use_accel(uint8_t instance) const
     return (get_accel_health(instance) && _use[instance]);
 }
 
-void
-AP_InertialSensor::_init_gyro()
+void AP_InertialSensor::_init_gyro()
 {
     uint8_t num_gyros = MIN(get_gyro_count(), INS_MAX_INSTANCES);
     Vector3f last_average[INS_MAX_INSTANCES], best_avg[INS_MAX_INSTANCES];
@@ -804,7 +803,9 @@ AP_InertialSensor::_init_gyro()
       having to rotate readings during the calibration
     */
     enum Rotation saved_orientation = _board_orientation;
+    Matrix3f saved_rotation = _board_rotation;
     _board_orientation = ROTATION_NONE;
+    _board_rotation = Matrix3f();
 
     // remove existing gyro offsets
     for (uint8_t k=0; k<num_gyros; k++) {
@@ -907,6 +908,7 @@ AP_InertialSensor::_init_gyro()
 
     // restore orientation
     _board_orientation = saved_orientation;
+    _board_rotation = saved_rotation;
 
     // record calibration complete
     _calibrating = false;
@@ -1455,6 +1457,7 @@ bool AP_InertialSensor::get_fixed_mount_accel_cal_sample(uint8_t sample_num, Vec
     }
     _accel_calibrator[_acc_body_aligned-1].get_sample_corrected(sample_num, ret);
     ret.rotate(_board_orientation);
+    ret = _board_rotation * ret;
     return true;
 }
 
@@ -1480,5 +1483,6 @@ bool AP_InertialSensor::get_primary_accel_cal_sample_avg(uint8_t sample_num, Vec
     avg /= count;
     ret = avg;
     ret.rotate(_board_orientation);
+    ret = _board_rotation * ret;
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -169,6 +169,11 @@ public:
         _board_orientation = orientation;
     }
 
+    // set overall board orientation
+    void set_board_orientation(const Matrix3f &rotation) {
+        _board_rotation = rotation;
+    }
+    
     // return the selected sample rate
     uint16_t get_sample_rate(void) const { return _sample_rate; }
 
@@ -339,6 +344,7 @@ private:
 
     // board orientation from AHRS
     enum Rotation _board_orientation;
+    Matrix3f      _board_rotation;
 
     // calibrated_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -32,6 +32,9 @@ void AP_InertialSensor_Backend::_rotate_and_correct_accel(uint8_t instance, Vect
 
     // rotate to body frame
     accel.rotate(_imu._board_orientation);
+    
+    // rotate to body frame (new parameters)
+    accel = _imu._board_rotation * accel;
 }
 
 void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro) 
@@ -39,6 +42,9 @@ void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vecto
     // gyro calibration is always assumed to have been done in sensor frame
     gyro -= _imu._gyro_offset[instance];
     gyro.rotate(_imu._board_orientation);
+    
+    // rotate to body frame (new parameters)
+    gyro = _imu._board_rotation * gyro;
 }
 
 /*
@@ -141,6 +147,9 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     if (_imu._accel_calibrator != NULL && _imu._accel_calibrator[instance].get_status() == ACCEL_CAL_COLLECTING_SAMPLE) {
         Vector3f cal_sample = _imu._delta_velocity[instance];
 
+        //remove rotation
+        cal_sample = Matrix3f::get_inverse(_imu._board_rotation) * cal_sample;
+        
         //remove rotation
         cal_sample.rotate_inverse(_imu._board_orientation);
 

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -47,7 +47,7 @@ public:
 
     // Vectors comprising the rows of the matrix
     Vector3<T>        a, b, c;
-
+    
     // trivial ctor
     // note that the Vector3 ctor will zero the vector elements
     constexpr Matrix3<T>() {}
@@ -66,6 +66,12 @@ public:
         , b(bx,by,bz)
         , c(cx,cy,cz) {}
 
+    static Matrix3<T> matrix_from_euler(const T roll, const T pitch, const T yaw) {
+        Matrix3<T> mat;
+        mat.from_euler(roll, pitch, yaw);
+        return mat;
+    }
+        
     // function call operator
     void operator        () (const Vector3<T> &a0, const Vector3<T> &b0, const Vector3<T> &c0)
     {
@@ -205,6 +211,20 @@ public:
      */
     bool inverse(Matrix3<T>& inv) const;
 
+    /**
+     * Calculate the inverse of this matrix.
+     *
+     * @param inv[in] Where to store the result.
+     *
+     * @return If this matrix is invertible, then true is returned. Otherwise,
+     * \p inv is unmodified and false is returned.
+     */
+    static Matrix3<T> get_inverse(Matrix3<T>& mat) {
+        Matrix3<T> inv = mat;
+        mat.inverse(inv);
+        return inv;
+    }
+    
     /**
      * Invert this matrix if it is invertible.
      *


### PR DESCRIPTION
This patchset allows free definitions of the board orientation.
Defining a board orientation with degree resolution is especially important for racing quads.
Such quads make often use of tilted rotors applied on the frame.
Currently, the tilit correction is applied directly after board orientation (enum) was applied. 

**Note:** I did not remove the old board orientation code, because of compatibility reasons, 
but I hope it will be fine to remove it later. Also want to mention that the condition of matrix3f is not good.

**Example:**  In case you use e.g. 10° tilted motor mounts, 
it is necessary to correct this tilt for stable hover, otherwise the copter goes straight on.
Here I added some parameters allow to define the board orientation at degre level. 
If the copter thinks it is tilted by e.g. 10° it should hover in a stable way with such mounts. 

@magicrub 
Thanks for review first version, but I added some changes. I think, this one will be able to fly. 
