### PR TITLE
Plane: Land/navigate into the wind

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1092,6 +1092,7 @@ private:
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);
+    void do_nav_into_wind(const AP_Mission::Mission_Command& cmd);
     void do_land(const AP_Mission::Mission_Command& cmd);
     void loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd);
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
@@ -1103,6 +1104,7 @@ private:
     void do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_vtol_land(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
+    bool verify_nav_into_wind(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -586,10 +586,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_NAV_INTO_WIND:                         // MAV ID: 26
-        cmd.p1 = packet.param1;
-        cmd.content.wind.angle_deg_start = packet.param2;
-        cmd.content.wind.angle_deg_stop = packet.param3;
-        cmd.content.wind.altitude = packet.param4;
+        cmd.p1 = packet.param1;                         //distance(radius) from next waypoint
+        cmd.content.wind.deg_start = packet.param2;     //allowed angle - start of interval (0=north, 90=east)
+        cmd.content.wind.deg_stop = packet.param3;      //allowed angle - stop of interval (0=north, 90=east)
+        cmd.content.wind.altitude = packet.param4;      //altitude over the next waypoint
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
@@ -1036,10 +1036,10 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         break;
 
     case MAV_CMD_NAV_INTO_WIND:                         // MAV ID: 26
-        packet.param1 = cmd.p1;
-        packet.param2 = cmd.content.wind.angle_deg_start;
-        packet.param3 = cmd.content.wind.angle_deg_stop;
-        packet.param4 = cmd.content.wind.altitude;
+        packet.param1 = cmd.p1;                         //distance(radius) from next waypoint
+        packet.param2 = cmd.content.wind.deg_start;     //allowed angle - start of interval (0=north, 90=east)
+        packet.param3 = cmd.content.wind.deg_stop;      //allowed angle - stop of interval (0=north, 90=east)
+        packet.param4 = cmd.content.wind.altitude;      //altitude over the next waypoint
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -585,6 +585,13 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.p1 = packet.param1;                         // minimum pitch (plane only)
         break;
 
+    case MAV_CMD_NAV_INTO_WIND:                         // MAV ID: 26
+        cmd.p1 = packet.param1;
+        cmd.content.wind.angle_deg_start = packet.param2;
+        cmd.content.wind.angle_deg_stop = packet.param3;
+        cmd.content.wind.altitude = packet.param4;
+        break;
+
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
         copy_location = true;                           // lat/lng used for heading lock
         cmd.p1 = packet.param1;                         // Climb/Descend
@@ -1026,6 +1033,13 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22
         copy_location = true;                           // only altitude is used
         packet.param1 = cmd.p1;                         // minimum pitch (plane only)
+        break;
+
+    case MAV_CMD_NAV_INTO_WIND:                         // MAV ID: 26
+        packet.param1 = cmd.p1;
+        packet.param2 = cmd.content.wind.angle_deg_start;
+        packet.param3 = cmd.content.wind.angle_deg_stop;
+        packet.param4 = cmd.content.wind.altitude;
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -50,6 +50,13 @@ public:
         int16_t num_times;      // num times to repeat.  -1 = repeat forever
     };
 
+    // land into wind
+    struct PACKED Land_Wind_Command {
+        uint16_t angle_deg_start;
+        uint16_t angle_deg_stop;
+        uint16_t altitude;
+    };
+
     // condition delay command structure
     struct PACKED Conditional_Delay_Command {
         float seconds;          // period of delay in seconds
@@ -179,6 +186,9 @@ public:
     union PACKED Content {
         // jump structure
         Jump_Command jump;
+
+        // nav into wind
+        Land_Wind_Command wind;
 
         // conditional delay
         Conditional_Delay_Command delay;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -52,9 +52,9 @@ public:
 
     // land into wind
     struct PACKED Land_Wind_Command {
-        uint16_t angle_deg_start;
-        uint16_t angle_deg_stop;
-        uint16_t altitude;
+        uint16_t deg_start;     //allowed angle - start of interval (0=north, 90=east)
+        uint16_t deg_stop;      //allowed angle - stop of interval (0=north, 90=east)
+        uint16_t altitude;      //altitude over the next waypoint
     };
 
     // condition delay command structure


### PR DESCRIPTION
Based on my own needs for automatic landing into the wind, as well as requests of others (https://groups.google.com/forum/#!topic/drones-discuss/awS2GPRWA9E), and this discussions #2303 I think this might be a good addition, and maybe part of a fully automatic landing in the future.

As of now this adds a new type of waypoint which will dynamically be placed in relation to the next NAV_WAYPOINY (i.e. LAND). The exact placement is dependent on the 4 parameters of the command, and the estimated wind direction at the moment of executing the command.
1: Radius (m) - distance from the next waypoint
2: Degrees start - (0-north, 90-east), if one wants to limit the possible approach
3: Degrees stop - (0-north, 90-east), if one wants to limit the possible approach
4: Altitude (m)  - altitude over the next waypoint

Drawing which might help explain this feature:
![nav_into_wind](https://cloud.githubusercontent.com/assets/5460908/19534340/ac1019cc-9643-11e6-9382-4b18acb29272.png)

Note that I'm yet to test it on one of the real planes.
I'm looking forward to hearing your thoughts.