### PR TITLE
AP_GPS: To change from the decision process to bit processing.

### DIFF
--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -18,7 +18,7 @@
 //  MAVLINK GPS driver
 //
 #include "AP_GPS_MAV.h"
-#include "AP_Math/AP_Math.h"
+#include <AP_Math/AP_Math.h>
 #include <stdint.h>
 #include <bitset>
 

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -18,8 +18,8 @@
 //  MAVLINK GPS driver
 //
 #include "AP_GPS_MAV.h"
+#include "AP_Math/AP_Math.h"
 #include <stdint.h>
-#include <math.h>
 #include <bitset>
 
 AP_GPS_MAV::AP_GPS_MAV(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :


### PR DESCRIPTION
To change from the decision process to bit processing.
It expresses the non-use of the GPS information in the bit flag.
However, defining the position of the flag by the numerical value.
This definition is not easy to get a bit of information for numerical.
Therefore, the conversion from the numerical value of the bit value.
Can be obtained easily bit information by converting.