### PR TITLE
AP_HAL_Linux: Remove misleading constant

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_SBUS.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_SBUS.cpp
@@ -35,11 +35,6 @@ extern const AP_HAL::HAL& hal;
 
 using namespace Linux;
 
-#ifndef B100000
-// disco uses 100000 for baud rate to give 100000 baud
-#define B100000 100000
-#endif
-
 #define SBUS_FRAME_SIZE 25
 
 void RCInput_SBUS::init()
@@ -60,10 +55,11 @@ void RCInput_SBUS::init()
         tio.c_iflag |= (INPCK | IGNPAR);
         tio.c_oflag &= ~OPOST;
         tio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-        tio.c_ispeed = B100000;
-        tio.c_ospeed = B100000;
         tio.c_cflag &= ~(CSIZE | CRTSCTS | PARODD | CBAUD);
+        // use BOTHER to specify speed directly in c_[io]speed member
         tio.c_cflag |= (CS8 | CSTOPB | CLOCAL | PARENB | BOTHER | CREAD);
+        tio.c_ispeed = 100000;
+        tio.c_ospeed = 100000;
         // see select() comment below
         tio.c_cc[VMIN] = SBUS_FRAME_SIZE;
         tio.c_cc[VTIME] = 0;


### PR DESCRIPTION
The constant passed to cflag is BOTHER, meaning the actual baud is set
in the other specific members.  Don't define B* constants as they are
misleading here and this is why it doesn't work with e.g.
cfset[io]speed()... that function expect a B* constant which in Linux
is not the speed, but an index to an array with speeds.