### PR TITLE
Compass calibration reporting

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -573,12 +573,10 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         break;
 
     case MSG_MAG_CAL_PROGRESS:
-        CHECK_PAYLOAD_SIZE(MAG_CAL_PROGRESS);
         rover.compass.send_mag_cal_progress(chan);
         break;
 
     case MSG_MAG_CAL_REPORT:
-        CHECK_PAYLOAD_SIZE(MAG_CAL_REPORT);
         rover.compass.send_mag_cal_report(chan);
         break;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -857,12 +857,10 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         break;
 
     case MSG_MAG_CAL_PROGRESS:
-        CHECK_PAYLOAD_SIZE(MAG_CAL_PROGRESS);
         plane.compass.send_mag_cal_progress(chan);
         break;
 
     case MSG_MAG_CAL_REPORT:
-        CHECK_PAYLOAD_SIZE(MAG_CAL_REPORT);
         plane.compass.send_mag_cal_report(chan);
         break;
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -384,7 +384,6 @@ Compass::Compass(void) :
     for (uint8_t i=0; i<COMPASS_MAX_BACKEND; i++) {
         _backends[i] = NULL;
         _state[i].last_update_usec = 0;
-        _reports_sent[i] = 0;
     }
 
     // default device ids to zero.  init() method will overwrite with the actual device ids

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -51,8 +51,6 @@
 #define COMPASS_MAX_BACKEND   3
 
 //MAXIMUM COMPASS REPORTS
-#define MAX_CAL_REPORTS 10
-#define CONTINUOUS_REPORTS 0
 #define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(50.0f)
 #define AP_COMPASS_MAX_XY_ANG_DIFF radians(30.0f)
 #define AP_COMPASS_MAX_XY_LENGTH_DIFF 100.0f
@@ -316,9 +314,6 @@ private:
     // load backend drivers
     bool _add_backend(AP_Compass_Backend *backend, const char *name, bool external);
     void _detect_backends(void);
-
-    //keep track of number of calibration reports sent
-    uint8_t _reports_sent[COMPASS_MAX_INSTANCES];
 
     //autoreboot after compass calibration
     bool _compass_cal_autoreboot;

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -185,6 +185,11 @@ Compass::send_mag_cal_progress(mavlink_channel_t chan)
     uint8_t cal_mask = get_cal_mask();
 
     for (uint8_t compass_id=0; compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
+        // ensure we don't try to send with no space available
+        if (!HAVE_PAYLOAD_SPACE(chan, MAG_CAL_PROGRESS)) {
+            return;
+        }
+
         auto& calibrator = _calibrator[compass_id];
         uint8_t cal_status = calibrator.get_status();
 
@@ -195,11 +200,6 @@ Compass::send_mag_cal_progress(mavlink_channel_t chan)
             auto& completion_mask = calibrator.get_completion_mask();
             Vector3f direction(0.0f,0.0f,0.0f);
             uint8_t attempt = _calibrator[compass_id].get_attempt();
-
-            // ensure we don't try to send with no space available
-            if (!HAVE_PAYLOAD_SPACE(chan, MAG_CAL_PROGRESS)) {
-                return;
-            }
 
             mavlink_msg_mag_cal_progress_send(
                 chan,
@@ -216,6 +216,10 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
     uint8_t cal_mask = get_cal_mask();
 
     for (uint8_t compass_id=0; compass_id<COMPASS_MAX_INSTANCES; compass_id++) {
+        // ensure we don't try to send with no space available
+        if (!HAVE_PAYLOAD_SPACE(chan, MAG_CAL_REPORT)) {
+            return;
+        }
 
         uint8_t cal_status = _calibrator[compass_id].get_status();
 
@@ -226,11 +230,6 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
             _calibrator[compass_id].get_calibration(ofs, diag, offdiag);
             uint8_t autosaved = _calibrator[compass_id].get_autosave();
 
-            // ensure we don't try to send with no space available
-            if (!HAVE_PAYLOAD_SPACE(chan, MAG_CAL_REPORT)) {
-                return;
-            }
-            
             mavlink_msg_mag_cal_report_send(
                 chan,
                 compass_id, cal_mask,

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -85,6 +85,7 @@ _sample_buffer(NULL)
 
 void CompassCalibrator::clear() {
     set_status(COMPASS_CAL_NOT_STARTED);
+    _saved = false;
 }
 
 void CompassCalibrator::start(bool retry, bool autosave, float delay) {
@@ -97,6 +98,7 @@ void CompassCalibrator::start(bool retry, bool autosave, float delay) {
     _delay_start_sec = delay;
     _start_time_ms = AP_HAL::millis();
     set_status(COMPASS_CAL_WAITING_TO_START);
+    _saved = false;
 }
 
 void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals) {
@@ -259,7 +261,6 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
     if (status != COMPASS_CAL_NOT_STARTED && _status == status) {
         return true;
     }
-
     switch(status) {
         case COMPASS_CAL_NOT_STARTED:
             reset_state();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -42,6 +42,8 @@ public:
     float get_fitness() const { return sqrtf(_fitness); }
     bool get_autosave() const { return _autosave; }
     uint8_t get_attempt() const { return _attempt; }
+    bool is_saved() const { return _saved; }
+    void set_saved(bool saved) { _saved = saved; }
 
 private:
     class param_t {
@@ -84,6 +86,7 @@ private:
     bool _retry;
     float _tolerance;
     uint8_t _attempt;
+    bool _saved;
 
     completion_mask_t _completion_mask;
 


### PR DESCRIPTION
Sends compass calibration reports continuously until accepted/cancelled by a ground station.

The primary driver for the change is that is the current implementation has a bug that causes a telemetry channel to potentially never see the MAG_CAL_REPORT which then causes a GCS to never realize that the calibration has completed. This is the cause of this bug: https://github.com/ArduPilot/MissionPlanner/issues/1246

The change will send messages until acknowledged by a ground station. They are set at the STREAM_EXTRA3 rate so they shouldn't be overflowing the GCS, and since a reboot is required after calibration anyways the extra telemetry load isn't considered a large problem.

The other significant behavior change is that if a compass hasn't started calibration we won't consider this a failure when receiving a mask of channels to accept. What was happening is that sending MAV_CMD_DO_ACCEPT_MAG_CAL with a mask of 0, which meant accept all compasses, would fail if there was no compass2/3 present. This made the mask of 0 pointless as a GCS always had to provide the correct mask anyways for the number of compasses present.

Other slight changes were to change where we check for payload space to send the messages so that we don't build messages that will be discarded. (Plane and rover were checking for space when they were better off allowing the compass cal library to check anyways as there are potentially 3 messages to accept).