### PR TITLE
AP_Math: Increase the accuracy in the logarithmic value.

### DIFF
--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -19,7 +19,7 @@
   #ifdef M_PI
     #undef M_PI
   #endif
-  #define M_PI      (3.141592653589793f)
+  #define M_PI      (3.141592653589793116e0)
 
   #ifdef M_PI_2
     #undef M_PI_2


### PR DESCRIPTION
In the case of non-logarithm of the value, the value is different in point # 6.
In the case of the logarithm of the value is the same until the point # 15.
Therefore,
In order to reduce the error in the calculation result, to the value of the logarithm.
Set value is "3.141592653589793116e0".
PI value is "3.141592653589793238" 
Even including logarithmic conversion error is smaller than pi.
"3.141592653589793116" < "3.141592653589793238"

Verification
float is [3.141592653589793f] → 3.14159274101257324219
double is [(double)3.141592653589793f] → 3.14159274101257324219
logarithm is [3.141592653589793e0] → 3.14159265358979311600