### PR TITLE
Copter: apply yaw expo to all modes

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -20,7 +20,7 @@ void Copter::get_pilot_desired_lean_angles(float roll_in, float pitch_in, float 
     angle_max = constrain_float(angle_max, 1000, aparm.angle_max);
 
     // scale roll_in, pitch_in to ANGLE_MAX parameter range
-    float scaler = aparm.angle_max/(float)ROLL_PITCH_INPUT_MAX;
+    float scaler = aparm.angle_max/(float)ROLL_PITCH_YAW_INPUT_MAX;
     roll_in *= scaler;
     pitch_in *= scaler;
 
@@ -60,10 +60,10 @@ float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
         }
 
         // yaw expo
-        y_in = float(stick_angle)/ROLL_PITCH_INPUT_MAX;
+        y_in = float(stick_angle)/ROLL_PITCH_YAW_INPUT_MAX;
         y_in3 = y_in*y_in*y_in;
         y_out = (g2.acro_y_expo * y_in3) + ((1.0f - g2.acro_y_expo) * y_in);
-        yaw_request = ROLL_PITCH_INPUT_MAX * y_out * g.acro_yaw_p;
+        yaw_request = ROLL_PITCH_YAW_INPUT_MAX * y_out * g.acro_yaw_p;
     }
     // convert pilot input to the desired yaw rate
     return yaw_request;

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -45,8 +45,28 @@ void Copter::get_pilot_desired_lean_angles(float roll_in, float pitch_in, float 
 // returns desired yaw rate in centi-degrees per second
 float Copter::get_pilot_desired_yaw_rate(int16_t stick_angle)
 {
+    float yaw_request;
+
+    // calculate yaw rate request
+    if (g2.acro_y_expo <= 0) {
+        yaw_request = stick_angle * g.acro_yaw_p;
+    } else {
+        // expo variables
+        float y_in, y_in3, y_out;
+
+        // range check expo
+        if (g2.acro_y_expo > 1.0f || g2.acro_y_expo < 0.5f) {
+            g2.acro_y_expo = 1.0f;
+        }
+
+        // yaw expo
+        y_in = float(stick_angle)/ROLL_PITCH_INPUT_MAX;
+        y_in3 = y_in*y_in*y_in;
+        y_out = (g2.acro_y_expo * y_in3) + ((1.0f - g2.acro_y_expo) * y_in);
+        yaw_request = ROLL_PITCH_INPUT_MAX * y_out * g.acro_yaw_p;
+    }
     // convert pilot input to the desired yaw rate
-    return stick_angle * g.acro_yaw_p;
+    return yaw_request;
 }
 
 /*************************************************************

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -509,8 +509,8 @@
 //////////////////////////////////////////////////////////////////////////////
 // Stabilize Rate Control
 //
-#ifndef ROLL_PITCH_INPUT_MAX
- # define ROLL_PITCH_INPUT_MAX      4500            // roll, pitch input range
+#ifndef ROLL_PITCH_YAW_INPUT_MAX
+ # define ROLL_PITCH_YAW_INPUT_MAX      4500            // roll, pitch input range
 #endif
 #ifndef DEFAULT_ANGLE_MAX
  # define DEFAULT_ANGLE_MAX         4500            // ANGLE_MAX parameters default value

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -96,23 +96,7 @@ void Copter::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, in
     }
 
     // calculate yaw rate request
-    if (g.acro_rp_expo <= 0) {
-        rate_bf_request.z = yaw_in * g.acro_yaw_p;
-    } else {
-        // expo variables
-        float y_in, y_in3, y_out;
-
-        // range check expo
-        if (g2.acro_y_expo > 1.0f || g2.acro_y_expo < 0.5f) {
-            g2.acro_y_expo = 1.0f;
-        }
-
-        // yaw expo
-        y_in = float(yaw_in)/ROLL_PITCH_INPUT_MAX;
-        y_in3 = y_in*y_in*y_in;
-        y_out = (g2.acro_y_expo * y_in3) + ((1.0f - g2.acro_y_expo) * y_in);
-        rate_bf_request.z = ROLL_PITCH_INPUT_MAX * y_out * g.acro_yaw_p;
-    }
+    rate_bf_request.z = get_pilot_desired_yaw_rate(yaw_in);
 
 
     // calculate earth frame rate corrections to pull the copter back to level while in ACRO mode

--- a/ArduCopter/control_acro.cpp
+++ b/ArduCopter/control_acro.cpp
@@ -63,8 +63,8 @@ void Copter::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, in
     // apply circular limit to pitch and roll inputs
     float total_in = norm(pitch_in, roll_in);
 
-    if (total_in > ROLL_PITCH_INPUT_MAX) {
-        float ratio = (float)ROLL_PITCH_INPUT_MAX / total_in;
+    if (total_in > ROLL_PITCH_YAW_INPUT_MAX) {
+        float ratio = (float)ROLL_PITCH_YAW_INPUT_MAX / total_in;
         roll_in *= ratio;
         pitch_in *= ratio;
     }
@@ -83,16 +83,16 @@ void Copter::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, in
         }
 
         // roll expo
-        rp_in = float(roll_in)/ROLL_PITCH_INPUT_MAX;
+        rp_in = float(roll_in)/ROLL_PITCH_YAW_INPUT_MAX;
         rp_in3 = rp_in*rp_in*rp_in;
         rp_out = (g.acro_rp_expo * rp_in3) + ((1.0f - g.acro_rp_expo) * rp_in);
-        rate_bf_request.x = ROLL_PITCH_INPUT_MAX * rp_out * g.acro_rp_p;
+        rate_bf_request.x = ROLL_PITCH_YAW_INPUT_MAX * rp_out * g.acro_rp_p;
 
         // pitch expo
-        rp_in = float(pitch_in)/ROLL_PITCH_INPUT_MAX;
+        rp_in = float(pitch_in)/ROLL_PITCH_YAW_INPUT_MAX;
         rp_in3 = rp_in*rp_in*rp_in;
         rp_out = (g.acro_rp_expo * rp_in3) + ((1.0f - g.acro_rp_expo) * rp_in);
-        rate_bf_request.y = ROLL_PITCH_INPUT_MAX * rp_out * g.acro_rp_p;
+        rate_bf_request.y = ROLL_PITCH_YAW_INPUT_MAX * rp_out * g.acro_rp_p;
     }
 
     // calculate yaw rate request

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -44,7 +44,7 @@
 #define AUTOTUNE_AXIS_BITMASK_YAW             4
 
 #define AUTOTUNE_PILOT_OVERRIDE_TIMEOUT_MS  500     // restart tuning if pilot has left sticks in middle for 2 seconds
-#define AUTOTUNE_TESTING_STEP_TIMEOUT_MS    750     // timeout for tuning mode's testing step
+#define AUTOTUNE_TESTING_STEP_TIMEOUT_MS   1000     // timeout for tuning mode's testing step
 #define AUTOTUNE_LEVEL_ANGLE_CD             300     // angle which qualifies as level
 #define AUTOTUNE_LEVEL_RATE_RP_CD          1000     // rate which qualifies as level for roll and pitch
 #define AUTOTUNE_LEVEL_RATE_Y_CD            750     // rate which qualifies as level for yaw

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -8,15 +8,15 @@
 
 void Copter::default_dead_zones()
 {
-    channel_roll->set_default_dead_zone(30);
-    channel_pitch->set_default_dead_zone(30);
+    channel_roll->set_default_dead_zone(10);
+    channel_pitch->set_default_dead_zone(10);
 #if FRAME_CONFIG == HELI_FRAME
     channel_throttle->set_default_dead_zone(10);
     channel_yaw->set_default_dead_zone(15);
     g.rc_8.set_default_dead_zone(10);
 #else
     channel_throttle->set_default_dead_zone(30);
-    channel_yaw->set_default_dead_zone(40);
+    channel_yaw->set_default_dead_zone(10);
 #endif
     g.rc_6.set_default_dead_zone(0);
 }

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -29,9 +29,9 @@ void Copter::init_rc_in()
     channel_yaw      = RC_Channel::rc_channel(rcmap.yaw()-1);
 
     // set rc channel ranges
-    channel_roll->set_angle(ROLL_PITCH_INPUT_MAX);
-    channel_pitch->set_angle(ROLL_PITCH_INPUT_MAX);
-    channel_yaw->set_angle(4500);
+    channel_roll->set_angle(ROLL_PITCH_YAW_INPUT_MAX);
+    channel_pitch->set_angle(ROLL_PITCH_YAW_INPUT_MAX);
+    channel_yaw->set_angle(ROLL_PITCH_YAW_INPUT_MAX);
     channel_throttle->set_range(0, 1000);
 
     channel_roll->set_type(RC_CHANNEL_TYPE_ANGLE_RAW);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -464,7 +464,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     }
 
     // set input to PID
-    _pid_accel_z.set_input_filter_d(_accel_error.z);
+    _pid_accel_z.set_input_filter_all(_accel_error.z);
     _pid_accel_z.set_desired_rate(accel_target_z);
 
     // separately calculate p, i, d values for logging


### PR DESCRIPTION
This PR contains a few changes:
1. add yaw expo to all flight modes.
2. reduce pilot input dead zone default
3. increase autotune timeout