### PR TITLE
Fixed GPS timestamping and EKF time horizon issues

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -401,6 +401,9 @@ private:
 
         // the time we got our last fix in system milliseconds
         uint32_t last_message_time_ms;
+
+        // estimate of the offset between GPS time and system clock
+        uint64_t gps_ms_offset;
     };
     // Note allowance for an additional instance to contain blended data
     GPS_timing timing[GPS_MAX_RECEIVERS+1];
@@ -483,4 +486,7 @@ private:
 
     // calculate the blended state
     void calc_blended_state(void);
+
+    // estimate last_fix_time_ms
+    void estimate_fix_time(uint8_t instance, uint32_t now);
 };

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -516,6 +516,7 @@ private:
 
     uint32_t        _last_vel_time;
     uint32_t        _last_pos_time;
+    uint32_t        _last_sol_time;
     uint32_t        _last_cfg_sent_time;
     uint8_t         _num_cfg_save_tries;
     uint32_t        _last_config_time;
@@ -532,6 +533,8 @@ private:
     bool            _new_position:1;
     // do we have new speed information?
     bool            _new_speed:1;
+    // do we have a new GPS timestamp?
+    bool            _new_timestamp:1;
 
     uint8_t         _disable_counter;
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -30,6 +30,7 @@ class HALSITL::SITL_State {
     friend class HALSITL::Scheduler;
     friend class HALSITL::Util;
     friend class HALSITL::GPIO;
+    friend class HALSITL::UARTDriver;
 public:
     void init(int argc, char * const argv[]);
 

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -75,6 +75,12 @@ private:
     const char *_uart_path;
     uint32_t _uart_baudrate;
 
+    struct {
+        bool enabled;
+        uint64_t delay_till_us;
+        uint16_t promised;
+    } _jitter;
+
     // IPv4 address of target for uartC
     const char *_tcp_client_addr;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -313,6 +313,12 @@ void NavEKF2_core::setAidingMode()
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF2 IMU%u initial beacon pos D offset = %3.1f (m)",(unsigned)imu_index,(double)bcnPosOffset);
             }
             // reset the last fusion accepted times to prevent unwanted activation of timeout logic
+            // we need to reset the GPS timers to prevent GPS timeout logic being invoked on entry into GPS aiding
+            // this is because the EKF can be interrupted for an arbitrary amount of time during vehicle arming checks
+            lastTimeGpsReceived_ms = imuSampleTime_ms;
+            lastTimeGpsFix_ms = imuSampleTime_ms;
+            secondLastGpsTime_ms = imuSampleTime_ms;
+            // reset the last valid position fix time to prevent unwanted activation of GPS glitch logic
             lastPosPassTime_ms = imuSampleTime_ms;
             lastVelPassTime_ms = imuSampleTime_ms;
             lastRngBcnPassTime_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -412,14 +412,15 @@ void NavEKF2_core::readGpsData()
             gpsCheckStatus.bad_fix = false;
 
             // store fix time from previous read
-            secondLastGpsTime_ms = lastTimeGpsReceived_ms;
+            secondLastGpsTime_ms = lastTimeGpsFix_ms;
 
             // get current fix time
             lastTimeGpsReceived_ms = _ahrs->get_gps().last_message_time_ms();
-
+            lastTimeGpsFix_ms = _ahrs->get_gps().last_fix_time_ms();
+            
             // estimate when the GPS fix was valid, allowing for GPS processing and other delays
             // ideally we should be using a timing signal from the GPS receiver to set this time
-            gpsDataNew.time_ms = lastTimeGpsReceived_ms - frontend->_gpsDelay_ms;
+            gpsDataNew.time_ms = lastTimeGpsFix_ms - frontend->_gpsDelay_ms;
 
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;
@@ -435,7 +436,7 @@ void NavEKF2_core::readGpsData()
 
             // Use the speed and position accuracy from the GPS if available, otherwise set it to zero.
             // Apply a decaying envelope filter with a 5 second time constant to the raw accuracy data
-            float alpha = constrain_float(0.0002f * (lastTimeGpsReceived_ms - secondLastGpsTime_ms),0.0f,1.0f);
+            float alpha = constrain_float(0.0002f * (lastTimeGpsFix_ms - secondLastGpsTime_ms),0.0f,1.0f);
             gpsSpdAccuracy *= (1.0f - alpha);
             float gpsSpdAccRaw;
             if (!_ahrs->get_gps().speed_accuracy(gpsSpdAccRaw)) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -435,9 +435,6 @@ void NavEKF2_core::readGpsData()
             // ideally we should be using a timing signal from the GPS receiver to set this time
             gpsDataNew.time_ms = lastTimeGpsFix_ms - frontend->_gpsDelay_ms;
 
-            // Correct for the average intersampling delay due to the filter updaterate
-            gpsDataNew.time_ms -= localFilterTimeStep_ms/2;
-
             // Get which GPS we are using for position information
             gpsDataNew.sensor_idx = _ahrs->get_gps().primary_sensor();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -234,6 +234,15 @@ void NavEKF2_core::SelectVelPosFusion()
     // read GPS data from the sensor and check for new data in the buffer
     readGpsData();
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
+
+    if (gpsDataToFuse && imuDataDelayed.time_ms != gpsDataDelayed.time_ms) {
+        // adjust for any remaining time difference between the time
+        // of the GPS data and the time we are fusing at. We expect
+        // this to be small, but with RTK GPS it starts to become
+        // significant
+        propogateGpsData(gpsDataDelayed, imuDataDelayed.time_ms);
+    }
+    
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE) {
         // correct GPS data for position offset of antenna phase centre relative to the IMU

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -127,6 +127,7 @@ void NavEKF2_core::InitialiseVariables()
     lastTasPassTime_ms = 0;
     lastSynthYawTime_ms = imuSampleTime_ms;
     lastTimeGpsReceived_ms = 0;
+    lastTimeGpsFix_ms = 0;
     secondLastGpsTime_ms = 0;
     lastDecayTime_ms = imuSampleTime_ms;
     timeAtLastAuxEKF_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -553,6 +553,9 @@ private:
     // check for new valid GPS data and update stored measurement if available
     void readGpsData();
 
+    // propogate GPS position data forward to the given time
+    void propogateGpsData(gps_elements &gpsData, uint32_t new_time_ms);
+    
     // check for new altitude measurement data and update stored measurement if available
     void readBaroData();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -782,6 +782,7 @@ private:
     uint32_t lastHgtPassTime_ms;    // time stamp when height measurement last passed innovation consistency check (msec)
     uint32_t lastTasPassTime_ms;    // time stamp when airspeed measurement last passed innovation consistency check (msec)
     uint32_t lastTimeGpsReceived_ms;// last time we received GPS data
+    uint32_t lastTimeGpsFix_ms;     // last fix time we received GPS data
     uint32_t timeAtLastAuxEKF_ms;   // last time the auxiliary filter was run to fuse range or optical flow measurements
     uint32_t secondLastGpsTime_ms;  // time of second last GPS fix used to determine how long since last update
     uint32_t lastHealthyMagTime_ms; // time the magnetometer was last declared healthy

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -94,6 +94,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("GPS2_TYPE",     61, SITL,  gps2_type,  SITL::GPS_TYPE_UBLOX),
     AP_GROUPINFO("ODOM_ENABLE",   62, SITL,  odom_enable, 0),
     AP_SUBGROUPEXTENSION("",      63, SITL,  var_info2),
+
     AP_GROUPEND
 };
 
@@ -103,6 +104,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("TEMP_FLIGHT",  2, SITL,  temp_flight, 35),
     AP_GROUPINFO("TEMP_TCONST",  3, SITL,  temp_tconst, 30),
     AP_GROUPINFO("TEMP_BFACTOR", 4, SITL,  temp_baro_factor, 0),
+    AP_GROUPINFO("GPS_JITTER",   5, SITL,  gps_timing_jitter, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -108,6 +108,7 @@ public:
     AP_Vector3f gps_glitch;  // glitch offsets in lat, lon and altitude
     AP_Vector3f gps2_glitch; // glitch offsets in lat, lon and altitude for 2nd GPS
     AP_Int8  gps_hertz;   // GPS update rate in Hz
+    AP_Int16 gps_timing_jitter; // GPS UART timing jitter
     AP_Float batt_voltage; // battery voltage base
     AP_Float accel_fail;  // accelerometer failure value
     AP_Int8  rc_fail;     // fail RC input


### PR DESCRIPTION
This fixes a problem with timing jitter on UARTs leading to higher EKF position innovations. It does 3 things:
- adds simulation of UART timing jitter in SITL with SIM_GPS_JITTER
- makes the fix time from AP_GPS automatically correct for UART timing jitter
- fixes the EKF to propogate GPS data to the correct time horizon to remove IMU/GPS timing jitter

This work was done after 70ms timing jitter was seen in flight logs for a Disco, but it applies (to a smaller degree) to all systems.
