### PR TITLE
AP_GPS_SBF: Adjust the initial value of HDOP

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -53,7 +53,7 @@ private:
     "spm, Rover, StandAlone+SBAS+DGPS+RTK\n",
     "sso, Stream2, Dsk1, postprocess+event, msec100\n"};
    
-    uint32_t last_hdop = 999;
+    uint32_t last_hdop = 9999;
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;
     bool validcommand = false;


### PR DESCRIPTION
The initial value of the hdop of AP_GPS.cpp is 9999.
According to the this value, modify from 999 in 9999.