### PR TITLE
Send ahrs groundspeed estimate instead of GPS groundspeed in VFR_HUD message

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -398,7 +398,7 @@ void NOINLINE Copter::send_vfr_hud(mavlink_channel_t chan)
     mavlink_msg_vfr_hud_send(
         chan,
         gps.ground_speed(),
-        gps.ground_speed(),
+        ahrs.groundspeed(),
         (ahrs.yaw_sensor / 100) % 360,
         (int16_t)(motors.get_throttle() * 100),
         current_loc.alt / 100.0f,

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -443,7 +443,7 @@ void Plane::send_vfr_hud(mavlink_channel_t chan)
     mavlink_msg_vfr_hud_send(
         chan,
         aspeed,
-        gps.ground_speed(),
+        ahrs.groundspeed(),
         (ahrs.yaw_sensor / 100) % 360,
         abs(throttle_percentage()),
         current_loc.alt / 100.0f,


### PR DESCRIPTION
Discussed with @tridge today who said this would be a good idea to use ahrs groundspeed estimate instead of GPS groundspeed in VFR_HUD messages.

@tridge also said there should be some followup cleanup whereas instead of calling groundspeed_vector() throughout the code, the value(s) should be calculated during the ahrs update... I'll address that soon in another PR.
