### PR TITLE
PWM_Sysfs: add an init method to do hal dependent stuff

### DIFF
--- a/libraries/AP_HAL_Linux/Heat_Pwm.cpp
+++ b/libraries/AP_HAL_Linux/Heat_Pwm.cpp
@@ -38,6 +38,7 @@ HeatPwm::HeatPwm(uint8_t pwm_num, float Kp, float Ki, uint32_t period_ns) :
     _period_ns(period_ns)
 {
     _pwm = new PWM_Sysfs_Bebop(pwm_num);
+    _pwm->init();
     _pwm->set_period(_period_ns);
     _pwm->set_duty_cycle(0);
     _pwm->enable(true);

--- a/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
+++ b/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
@@ -76,6 +76,7 @@ void OpticalFlow_Onboard::init(AP_HAL::OpticalFlow::Gyro_Cb get_gyro)
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
     _pwm = new PWM_Sysfs_Bebop(BEBOP_CAMV_PWM);
+    _pwm->init();
     _pwm->set_freq(BEBOP_CAMV_PWM_FREQ);
     _pwm->enable(true);
 

--- a/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
@@ -38,6 +38,20 @@ PWM_Sysfs_Base::PWM_Sysfs_Base(char* export_path, char* polarity_path,
     , _enable_path(enable_path)
     , _duty_path(duty_path)
     , _period_path(period_path)
+    , _channel(channel)
+{
+}
+
+PWM_Sysfs_Base::~PWM_Sysfs_Base()
+{
+    ::close(_duty_cycle_fd);
+
+    free(_polarity_path);
+    free(_enable_path);
+    free(_period_path);
+}
+
+void PWM_Sysfs_Base::init()
 {
     if (_export_path == NULL || _enable_path == NULL ||
         _period_path == NULL || _duty_path == NULL) {
@@ -48,7 +62,7 @@ PWM_Sysfs_Base::PWM_Sysfs_Base(char* export_path, char* polarity_path,
     /* Not checking the return of write_file since it will fail if
      * the pwm has already been exported
      */
-    Util::from(hal.util)->write_file(_export_path, "%u", channel);
+    Util::from(hal.util)->write_file(_export_path, "%u", _channel);
     free(_export_path);
 
     _duty_cycle_fd = ::open(_duty_path, O_RDWR | O_CLOEXEC);
@@ -57,15 +71,6 @@ PWM_Sysfs_Base::PWM_Sysfs_Base(char* export_path, char* polarity_path,
                       _duty_path, strerror(errno));
     }
     free(_duty_path);
-}
-
-PWM_Sysfs_Base::~PWM_Sysfs_Base()
-{
-    ::close(_duty_cycle_fd);
-
-    free(_polarity_path);
-    free(_enable_path);
-    free(_period_path);
 }
 
 void PWM_Sysfs_Base::enable(bool value)

--- a/libraries/AP_HAL_Linux/PWM_Sysfs.h
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.h
@@ -16,6 +16,7 @@ public:
         INVERSE = 1,
     };
 
+    void init();
     void enable(bool value);
     bool is_enabled();
     void set_period(uint32_t nsec_period);
@@ -46,6 +47,7 @@ protected:
 private:
     uint32_t _nsec_duty_cycle_value = 0;
     int _duty_cycle_fd = -1;
+    uint8_t _channel;
     char *_export_path = NULL;
     char *_polarity_path = NULL;
     char *_enable_path = NULL;

--- a/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
@@ -51,6 +51,7 @@ void RCOutput_Sysfs::init()
         if (!_pwm_channels[i]) {
             AP_HAL::panic("RCOutput_Sysfs_PWM: Unable to setup PWM pin.");
         }
+        _pwm_channels[i]->init();
         _pwm_channels[i]->enable(false);
 
         /* Set the initial frequency */

--- a/libraries/AP_Notify/DiscoLED.cpp
+++ b/libraries/AP_Notify/DiscoLED.cpp
@@ -30,32 +30,35 @@
 #define DISCO_LED_OFF    0x00
 
 DiscoLED::DiscoLED():
-    RGBLed(DISCO_LED_OFF, DISCO_LED_HIGH, DISCO_LED_MEDIUM, DISCO_LED_LOW)
+    RGBLed(DISCO_LED_OFF, DISCO_LED_HIGH, DISCO_LED_MEDIUM, DISCO_LED_LOW),
+    red_pwm(RED_PWM_INDEX),
+    green_pwm(GREEN_PWM_INDEX),
+    blue_pwm(BLUE_PWM_INDEX)
 {
 }
 
 bool DiscoLED::hw_init()
 {
-    red_pwm = new Linux::PWM_Sysfs_Bebop(RED_PWM_INDEX);
-    green_pwm = new Linux::PWM_Sysfs_Bebop(GREEN_PWM_INDEX);
-    blue_pwm = new Linux::PWM_Sysfs_Bebop(BLUE_PWM_INDEX);
+    red_pwm_period = red_pwm.get_period();
+    green_pwm_period = green_pwm.get_period();
+    blue_pwm_period = blue_pwm.get_period();
 
-    red_pwm_period = red_pwm->get_period();
-    green_pwm_period = green_pwm->get_period();
-    blue_pwm_period = blue_pwm->get_period();
+    red_pwm.init();
+    green_pwm.init();
+    blue_pwm.init();
 
-    red_pwm->enable(true);
-    green_pwm->enable(true);
-    blue_pwm->enable(true);
+    red_pwm.enable(true);
+    green_pwm.enable(true);
+    blue_pwm.enable(true);
 
     return true;
 }
 
 bool DiscoLED::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 {
-    red_pwm->set_duty_cycle(red / UINT8_MAX * red_pwm_period);
-    green_pwm->set_duty_cycle(green / UINT8_MAX * green_pwm_period);
-    blue_pwm->set_duty_cycle(blue / UINT8_MAX * blue_pwm_period);
+    red_pwm.set_duty_cycle(red / UINT8_MAX * red_pwm_period);
+    green_pwm.set_duty_cycle(green / UINT8_MAX * green_pwm_period);
+    blue_pwm.set_duty_cycle(blue / UINT8_MAX * blue_pwm_period);
 
     return true;
 }

--- a/libraries/AP_Notify/DiscoLED.h
+++ b/libraries/AP_Notify/DiscoLED.h
@@ -28,9 +28,9 @@ public:
     bool hw_init(void);
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b);
 private:
-    Linux::PWM_Sysfs_Bebop *red_pwm;
-    Linux::PWM_Sysfs_Bebop *green_pwm;
-    Linux::PWM_Sysfs_Bebop *blue_pwm;
+    Linux::PWM_Sysfs_Bebop red_pwm;
+    Linux::PWM_Sysfs_Bebop green_pwm;
+    Linux::PWM_Sysfs_Bebop blue_pwm;
 
     uint32_t red_pwm_period;
     uint32_t green_pwm_period;


### PR DESCRIPTION
When PWM_Sysfs_Base constructor is called, global variable hal may not
have been initialized resulting in NULL dereferencing error.
