### PR TITLE
Sprayer: split Enable from on/off and add simulator

### DIFF
--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -395,7 +395,7 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
 #endif
 #if SPRAYER == ENABLED
         case AUXSW_SPRAYER:
-            sprayer.enable(ch_flag == AUX_SWITCH_HIGH);
+            sprayer.run(ch_flag == AUX_SWITCH_HIGH);
             // if we are disarmed the pilot must want to test the pump
             sprayer.test_pump((ch_flag == AUX_SWITCH_HIGH) && !motors.armed());
             break;

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -63,10 +63,6 @@ AC_Sprayer::AC_Sprayer(const AP_InertialNav* inav) :
         _spinner_pwm.set_and_save(AC_SPRAYER_DEFAULT_SPINNER_PWM);
     }
 
-    // initialise flags
-    _flags.spraying = false;
-    _flags.testing = false;
-
     // To-Do: ensure that the pump and spinner servo channels are enabled
 }
 
@@ -96,9 +92,6 @@ void AC_Sprayer::enable(bool true_false)
 void
 AC_Sprayer::update()
 {
-    uint32_t now;
-    float ground_speed;
-
     // exit immediately if we are disabled (perhaps set pwm values back to defaults)
     if (!_enabled) {
         return;
@@ -111,10 +104,10 @@ AC_Sprayer::update()
 
     // get horizontal velocity
     const Vector3f &velocity = _inav->get_velocity();
-    ground_speed = norm(velocity.x,velocity.y);
+    float ground_speed = norm(velocity.x,velocity.y);
 
     // get the current time
-    now = AP_HAL::millis();
+    const uint32_t now = AP_HAL::millis();
 
     // check our speed vs the minimum
     if (ground_speed >= _speed_min) {
@@ -134,7 +127,7 @@ AC_Sprayer::update()
         // reset the speed under timer
         _speed_under_min_time = 0;
     }else{
-        // we are under the min speed.  If we are spraying
+        // we are under the min speed.
         if (_flags.spraying) {
             // set the timer if this is the first time we've dropped below the min speed
             if (_speed_under_min_time == 0) {

--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -37,11 +37,14 @@ public:
     /// Constructor
     AC_Sprayer(const AP_InertialNav* inav);
 
-    /// enable - allows sprayer to be enabled/disabled.  Note: this does not update the eeprom saved value
-    void enable(bool true_false);
+    /// run - allow or disallow spraying to occur
+    void run(bool true_false);
 
-    /// enabled - returns true if sprayer is enabled
-    bool enabled() const { return _enabled; }
+    /// running - returns true if spraying is currently permitted
+    bool running() const { return _flags.running; }
+
+    /// spraying - returns true if spraying is actually happening
+    bool spraying() const { return _flags.spraying; }
 
     /// test_pump - set to true to turn on pump as if travelling at 1m/s as a test
     void test_pump(bool true_false) { _flags.testing = true_false; }
@@ -70,9 +73,12 @@ private:
     struct sprayer_flags_type {
         uint8_t spraying    : 1;            ///< 1 if we are currently spraying
         uint8_t testing     : 1;            ///< 1 if we are testing the sprayer and should output a minimum value
+        uint8_t running     : 1;            ///< 1 if we are permitted to run sprayer
     } _flags;
 
     // internal variables
     uint32_t        _speed_over_min_time;   ///< time at which we reached speed minimum
     uint32_t        _speed_under_min_time;  ///< time at which we fell below speed minimum
+
+    void stop_spraying();
 };

--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -3,16 +3,14 @@
 
 /**
     The crop spraying functionality can be enabled in ArduCopter by doing the following:
-        1. add this line to APM_Config.h
-            #define SPRAYER ENABLED
-        2. set CH7_OPT or CH8_OPT parameter to 15 to allow turning the sprayer on/off from one of these channels
-        3. set RC10_FUNCTION to 22 to enable the servo output controlling the pump speed on RC10
-        4. set RC11_FUNCTION to 23 to enable the spervo output controlling the spinner on RC11
-        5. ensure the RC10_MIN, RC10_MAX, RC11_MIN, RC11_MAX accurately hold the min and maximum servo values you could possibly output to the pump and spinner
-        6. set the SPRAY_SPINNER to the pwm value the spinner should spin at when on
-        7. set the SPRAY_PUMP_RATE to the value the pump should servo should move to when the vehicle is travelling 1m/s expressed as a percentage (i.e. 0 ~ 100) of the full servo range.  I.e. 0 = the pump will not operate, 100 = maximum speed at 1m/s.  50 = 1/2 speed at 1m/s, full speed at 2m/s
-        8. set the SPRAY_PUMP_MIN to the minimum value that the pump servo should move to while engaged expressed as a percentage (i.e. 0 ~ 100) of the full servo range
-        9. set the SPRAY_SPEED_MIN to the minimum speed (in cm/s) the vehicle should be moving at before the pump and sprayer are turned on.  0 will mean the pump and spinner will always be on when the system is enabled with ch7/ch8 switch
+        - set CH7_OPT or CH8_OPT parameter to 15 to allow turning the sprayer on/off from one of these channels
+        - set RC10_FUNCTION to 22 to enable the servo output controlling the pump speed on servo-out 10
+        - set RC11_FUNCTION to 23 to enable the servo output controlling the spinner on servo-out 11
+        - ensure the RC10_MIN, RC10_MAX, RC11_MIN, RC11_MAX accurately hold the min and maximum servo values you could possibly output to the pump and spinner
+        - set the SPRAY_SPINNER to the pwm value the spinner should spin at when on
+        - set the SPRAY_PUMP_RATE to the value the pump servo should move to when the vehicle is travelling 1m/s expressed as a percentage (i.e. 0 ~ 100) of the full servo range.  I.e. 0 = the pump will not operate, 100 = maximum speed at 1m/s.  50 = 1/2 speed at 1m/s, full speed at 2m/s
+        - set the SPRAY_PUMP_MIN to the minimum value that the pump servo should move to while engaged expressed as a percentage (i.e. 0 ~ 100) of the full servo range
+        - set the SPRAY_SPEED_MIN to the minimum speed (in cm/s) the vehicle should be moving at before the pump and sprayer are turned on.  0 will mean the pump and spinner will always be on when the system is enabled with ch7/ch8 switch
 **/
 #pragma once
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -103,7 +103,9 @@ public:
     const Vector3f &get_mag_field_bf(void) const {
         return mag_bf;
     }
-    
+
+    virtual float gross_mass() const { return mass; }
+
 protected:
     SITL *sitl;
     Location home;

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -142,13 +142,11 @@ static Frame supported_frames[] =
 
 void Frame::init(float _mass, float hover_throttle, float _terminal_velocity, float _terminal_rotation_rate)
 {
-    mass = _mass;
-
     /*
        scaling from total motor power to Newtons. Allows the copter
        to hover against gravity when each motor is at hover_throttle
     */
-    thrust_scale = (mass * GRAVITY_MSS) / (num_motors * hover_throttle);
+    thrust_scale = (_mass * GRAVITY_MSS) / (num_motors * hover_throttle);
 
     terminal_velocity = _terminal_velocity;
     terminal_rotation_rate = _terminal_rotation_rate;
@@ -183,7 +181,7 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         thrust += mthrust;
     }
 
-    body_accel = thrust/mass;
+    body_accel = thrust/aircraft.gross_mass();
 
     if (terminal_rotation_rate > 0) {
         // rotational air resistance

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -54,7 +54,6 @@ public:
     float terminal_velocity;
     float terminal_rotation_rate;
     float thrust_scale;
-    float mass;
     uint8_t motor_offset;
 };
 }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -66,6 +66,9 @@ void MultiCopter::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    // update sprayer
+    sprayer.update(input);
 }
 
 

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -27,15 +27,19 @@ MultiCopter::MultiCopter(const char *home_str, const char *frame_str) :
     Aircraft(home_str, frame_str),
     frame(NULL)
 {
+    mass = 1.5f;
+
     frame = Frame::find_frame(frame_str);
     if (frame == NULL) {
         printf("Frame '%s' not found", frame_str);
         exit(1);
     }
+    // initial mass is passed through to Frame for it to calculate a
+    // hover thrust requirement.
     if (strstr(frame_str, "-fast")) {
-        frame->init(1.5, 0.5, 85, 4*radians(360));
+        frame->init(gross_mass(), 0.5, 85, 4*radians(360));
     } else {
-        frame->init(1.5, 0.51, 15, 4*radians(360));
+        frame->init(gross_mass(), 0.51, 15, 4*radians(360));
     }
     frame_height = 0.1;
     ground_behavior = GROUND_BEHAVIOR_NO_MOVEMENT;
@@ -71,4 +75,7 @@ void MultiCopter::update(const struct sitl_input &input)
     sprayer.update(input);
 }
 
-
+float MultiCopter::gross_mass() const
+{
+    return Aircraft::gross_mass() + sprayer.payload_mass();
+}

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -21,6 +21,7 @@
 #include "SIM_Aircraft.h"
 #include "SIM_Motor.h"
 #include "SIM_Frame.h"
+#include "SIM_Sprayer.h"
 
 namespace SITL {
 
@@ -43,6 +44,11 @@ protected:
     // calculate rotational and linear accelerations
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     Frame *frame;
+
+    // The numbers here are offsets into the input servos array
+    // (generally output-servo-number-1 e.g. 2 for throttle)
+    Sprayer sprayer{6, 7};
+
 };
 
 }

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -49,6 +49,7 @@ protected:
     // (generally output-servo-number-1 e.g. 2 for throttle)
     Sprayer sprayer{6, 7};
 
+    float gross_mass() const override;
 };
 
 }

--- a/libraries/SITL/SIM_Sprayer.cpp
+++ b/libraries/SITL/SIM_Sprayer.cpp
@@ -1,0 +1,90 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple sprayer simulator class
+*/
+
+#include "SIM_Sprayer.h"
+#include <stdio.h>
+
+using namespace SITL;
+
+/*
+  update sprayer state
+ */
+void Sprayer::update(const Aircraft::sitl_input &input)
+{
+    const uint64_t now = AP_HAL::micros64();
+    const float dt = (now - last_update_us) * 1.0e-6f;
+
+    // update remaining payload
+    if (capacity > 0) {
+        const double delta = last_pump_output * pump_max_rate * dt;
+        capacity -= delta;
+        if (capacity < 0) {
+            capacity = 0.0f;
+        }
+    }
+
+    // update pump
+    float pump_demand = (input.servos[pump_servo]-1000) * 0.001f;
+    // ::fprintf(stderr, "pump_demand=%f\n", pump_demand);
+    if (pump_demand < 0) { // never updated
+        pump_demand = 0;
+    }
+    const float pump_max_change = pump_slew_rate/100.0f * dt;
+    last_pump_output = constrain_float(pump_demand, last_pump_output-pump_max_change, last_pump_output+pump_max_change);
+    last_pump_output = constrain_float(last_pump_output, 0, 1);
+
+    // update spinner (if any)
+    if (spinner_servo >= 0) {
+        const float spinner_demand = (input.servos[spinner_servo]-1000) * 0.001f;
+        const float spinner_max_change = spinner_slew_rate * 0.01f * dt;
+        last_spinner_output = constrain_float(spinner_demand, last_spinner_output-spinner_max_change, last_spinner_output+spinner_max_change);
+        last_spinner_output = constrain_float(last_spinner_output, 0, 1);
+    }
+
+    if (should_report()) {
+        printf("Remaining: %f litres\n", capacity);
+        printf("Pump: %f l/s\n", last_pump_output * pump_max_rate);
+        if (spinner_servo >= 0) {
+            printf("Spinner: %f rev/s\n", (last_spinner_output * spinner_max_rate)/360.0f);
+        }
+        last_report_us = now;
+    }
+
+    last_update_us = now;
+    return;
+}
+
+bool Sprayer::should_report()
+{
+    if (AP_HAL::micros64() - last_report_us < report_interval) {
+        return false;
+    }
+
+    if (!is_zero(last_pump_output) || !is_zero(last_spinner_output)) {
+        zero_report_done = false;
+        return true;
+    }
+
+    if (!zero_report_done) {
+        zero_report_done = true;
+        return true;
+    }
+
+    return false;
+}
+

--- a/libraries/SITL/SIM_Sprayer.h
+++ b/libraries/SITL/SIM_Sprayer.h
@@ -1,0 +1,62 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple sprayer simulation class
+*/
+
+#pragma once
+
+#include "SIM_Aircraft.h"
+
+namespace SITL {
+
+class Sprayer {
+public:
+    const uint8_t pump_servo;
+    const int8_t spinner_servo;
+
+    Sprayer(const uint8_t _pump_servo, int8_t _spinner_servo) :
+        pump_servo(_pump_servo),
+        spinner_servo(_spinner_servo)
+    {}
+
+    // update sprayer state
+    void update(const struct Aircraft::sitl_input &input);
+
+    float payload_mass() const { return capacity; }; // kg; water, so kg=l
+
+private:
+
+    const uint32_t report_interval = 1000000; // microseconds
+    uint64_t last_report_us;
+
+    const float pump_max_rate = 0.01; // litres/second
+    const float pump_slew_rate = 20; // percent/scond
+    float last_pump_output; // percentage
+
+    const float spinner_max_rate = 3600; // degrees/second
+    const float spinner_slew_rate = 20; // percent/second
+    float last_spinner_output; // percentage
+
+    double capacity = 0.25; // litres
+
+    uint64_t start_time_us;
+    uint64_t last_update_us;
+
+    bool should_report();
+    bool zero_report_done = false;
+};
+
+}


### PR DESCRIPTION
Before this series of commits, it is not possible to change the sprayer parameters without enabling the output of the sprayer.  This constitutes not just a bad interface, but a safety and possible moral hazard.

The cause of this is the sharing of the "ENABLE"  flag for both "parameter group enable" and "distribute tasty, tasty Brawndo to surrounding plants".

This series of commits splits "ENABLE" into two concepts; parameters should be shown (and sprayer subsystem enabled) and "run", which permits the sprayer to move.

In addition to that split, a simulated sprayer is introduced to help test the sprayer code.  The SITL-simulated multicopter now has a sprayer attachment; you can improve the simulated vehicle's performance by distributing electrolytes to surrounding (simulated) plants.

Please merge; it's what drones crave.
