### PR TITLE
AP_GPS_SBF: change reported altitude from geoid to MSL

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -237,7 +237,7 @@ AP_GPS_SBF::process_message(void)
         if (temp.Latitude > -200000) {
             state.location.lat = (int32_t)(temp.Latitude * RAD_TO_DEG_DOUBLE * 1e7);
             state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * 1e7);
-            state.location.alt = (int32_t)((float)temp.Height * 1e2f);
+            state.location.alt = (int32_t)(((float)temp.Height - temp.Undulation) * 1e2f );
         }
 
         if (temp.NrSV != 255) {


### PR DESCRIPTION
this change means that the Septentrio gps will report the same altitude value as the ublox.
