### PR TITLE
Allow to stop ardupilot process

### DIFF
--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -142,6 +142,7 @@ private:
     uint16_t downsample = 0;
     bool logmatch = false;
     uint32_t output_counter = 0;
+    uint64_t last_timestamp = 0;
 
     struct {
         float max_roll_error;
@@ -176,6 +177,7 @@ private:
     bool parse_param_line(char *line, char **vname, float &value);
     void load_param_file(const char *filename);
     void set_signal_handlers(void);
+    void flush_and_exit();
 };
 
 enum {

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -14,7 +14,7 @@ public:
      * in the C++ type system.)
      */
     virtual void init() = 0;
-    virtual void deinit() {};
+    virtual void teardown() {};
 
     /**
      * Return true if there has been new input since the last read()

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -1,6 +1,7 @@
 #include "HAL_Linux_Class.h"
 
 #include <assert.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -348,6 +349,8 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         }
     }
 
+    setup_signal_handlers();
+
     scheduler->init();
     gpio->init();
     rcout->init();
@@ -372,12 +375,33 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
     callbacks->setup();
     AP_Module::call_hook_setup_complete();
 
-    for (;;) {
+    while (!_should_exit) {
         callbacks->loop();
     }
+
+    rcin->teardown();
+    I2CDeviceManager::from(i2c_mgr)->teardown();
+    SPIDeviceManager::from(spi)->teardown();
 }
 
-const AP_HAL::HAL& AP_HAL::get_HAL() {
-    static const HAL_Linux hal;
-    return hal;
+void HAL_Linux::setup_signal_handlers() const
+{
+    struct sigaction sa = { };
+
+    sa.sa_flags = SA_NOCLDSTOP;
+    sa.sa_handler = HAL_Linux::exit_signal_handler;
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGINT, &sa, NULL);
+}
+
+static HAL_Linux halInstance;
+
+void HAL_Linux::exit_signal_handler(int signum)
+{
+    halInstance._should_exit = true;
+}
+
+const AP_HAL::HAL &AP_HAL::get_HAL()
+{
+    return halInstance;
 }

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -382,6 +382,7 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
     rcin->teardown();
     I2CDeviceManager::from(i2c_mgr)->teardown();
     SPIDeviceManager::from(spi)->teardown();
+    Scheduler::from(scheduler)->teardown();
 }
 
 void HAL_Linux::setup_signal_handlers() const

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.h
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.h
@@ -6,4 +6,11 @@ class HAL_Linux : public AP_HAL::HAL {
 public:
     HAL_Linux();
     void run(int argc, char* const* argv, Callbacks* callbacks) const override;
+
+    void setup_signal_handlers() const;
+
+    static void exit_signal_handler(int);
+
+protected:
+    bool _should_exit = false;
 };

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -388,4 +388,17 @@ void I2CDeviceManager::_unregister(I2CBus &b)
     }
 }
 
+void I2CDeviceManager::teardown()
+{
+    for (auto it = _buses.begin(); it != _buses.end(); it++) {
+        /* Try to stop thread - it may not even be started yet */
+        (*it)->thread.stop();
+    }
+
+    for (auto it = _buses.begin(); it != _buses.end(); it++) {
+        /* Try to join thread - failing is normal if thread was not started */
+        (*it)->thread.join();
+    }
+}
+
 }

--- a/libraries/AP_HAL_Linux/I2CDevice.h
+++ b/libraries/AP_HAL_Linux/I2CDevice.h
@@ -105,6 +105,13 @@ public:
     /* AP_HAL::I2CDeviceManager implementation */
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address) override;
 
+    /*
+     * Stop all I2C threads and block until they are finalized. This doesn't
+     * free memory because they can still be used by devices, however device
+     * drivers won't receive any new event
+     */
+    void teardown();
+
 protected:
     void _unregister(I2CBus &b);
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _create_device(I2CBus &b, uint8_t address) const;

--- a/libraries/AP_HAL_Linux/Poller.cpp
+++ b/libraries/AP_HAL_Linux/Poller.cpp
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <stdio.h>
 #include <sys/epoll.h>
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -27,6 +28,14 @@
 extern const AP_HAL::HAL &hal;
 
 namespace Linux {
+
+Poller::Poller()
+{
+    _epfd = epoll_create1(EPOLL_CLOEXEC);
+    if (_epfd == -1) {
+        fprintf(stderr, "Failed to create epoll: %m\n");
+    }
+}
 
 bool Poller::register_pollable(Pollable *p, uint32_t events)
 {

--- a/libraries/AP_HAL_Linux/Poller.h
+++ b/libraries/AP_HAL_Linux/Poller.h
@@ -36,9 +36,25 @@ public:
 
     int get_fd() const { return _fd; }
 
+    /* Called whenever the underlying file descriptor has data to be read. */
     virtual void on_can_read() { }
+
+    /*
+     * Called whenever the underlying file descriptor is ready to receive new
+     * data, i.e. its buffer is not full.
+     */
     virtual void on_can_write() { }
+
+    /*
+     * Called when an error occurred and is signaled by the OS - its meaning
+     * depends on the file descriptor being used.
+     */
     virtual void on_error() { }
+
+    /*
+     * Called when the other side closes its end - the exact meaning
+     * depends on the file descriptor being used.
+     */
     virtual void on_hang_up() { }
 
 protected:
@@ -50,9 +66,24 @@ public:
     Poller() : _epfd(epoll_create1(EPOLL_CLOEXEC)) { }
     ~Poller() { close(_epfd); }
 
-    bool register_pollable(Pollable*, uint32_t events);
-    void unregister_pollable(const Pollable*);
 
+    /*
+     * Register @p in this poller so calls to poll() will wait for
+     * events specified in @events argument.
+     */
+    bool register_pollable(Pollable *p, uint32_t events);
+
+    /*
+     * Unregister @p from this Poller so it doesn't generate any more
+     * event. Note that this doesn't destroy @p.
+     */
+    void unregister_pollable(const Pollable *p);
+
+    /*
+     * Wait for events on all Pollable objects registered with
+     * register_pollable(). New Pollable objects can be registered at any
+     * time, including when a thread is sleeping on a poll() call.
+     */
     int poll() const;
 
 private:

--- a/libraries/AP_HAL_Linux/Poller.h
+++ b/libraries/AP_HAL_Linux/Poller.h
@@ -30,7 +30,7 @@ class Pollable {
     friend class Poller;
 public:
     Pollable(int fd) : _fd(fd) { }
-    Pollable() : _fd(-1) { }
+    Pollable() { }
 
     virtual ~Pollable();
 
@@ -42,7 +42,7 @@ public:
     virtual void on_hang_up() { }
 
 protected:
-    int _fd;
+    int _fd = -1;
 };
 
 class Poller {

--- a/libraries/AP_HAL_Linux/Poller.h
+++ b/libraries/AP_HAL_Linux/Poller.h
@@ -16,7 +16,6 @@
  */
 #pragma once
 
-#include <sys/epoll.h>
 #include <unistd.h>
 
 #include "AP_HAL/utility/RingBuffer.h"
@@ -63,9 +62,23 @@ protected:
 
 class Poller {
 public:
-    Poller() : _epfd(epoll_create1(EPOLL_CLOEXEC)) { }
-    ~Poller() { close(_epfd); }
+    Poller();
 
+    ~Poller() {
+        if (_epfd >= 0) {
+            close(_epfd);
+        }
+    }
+
+    /*
+     * Check if this Poller is not initialized
+     */
+    bool operator!() const { return _epfd == -1; }
+
+    /*
+     * Check if this Poller is succesfully initialized
+     */
+    explicit operator bool() const { return _epfd != -1; }
 
     /*
      * Register @p in this poller so calls to poll() will wait for
@@ -87,7 +100,8 @@ public:
     int poll() const;
 
 private:
-    int _epfd;
+
+    int _epfd = -1;
 };
 
 }

--- a/libraries/AP_HAL_Linux/PollerThread.cpp
+++ b/libraries/AP_HAL_Linux/PollerThread.cpp
@@ -140,10 +140,25 @@ void PollerThread::mainloop()
         return;
     }
 
-    while (true) {
+    while (!_should_exit) {
         _poller.poll();
         _cleanup_timers();
     }
+
+    _started = false;
+    _should_exit = false;
+}
+
+bool PollerThread::stop()
+{
+    if (!is_started()) {
+        return false;
+    }
+
+    _should_exit = true;
+    _poller.wakeup();
+
+    return true;
 }
 
 }

--- a/libraries/AP_HAL_Linux/PollerThread.cpp
+++ b/libraries/AP_HAL_Linux/PollerThread.cpp
@@ -92,6 +92,9 @@ TimerPollable *PollerThread::add_timer(TimerPollable::PeriodicCb cb,
                                        TimerPollable::WrapperCb *wrapper,
                                        uint32_t timeout_usec)
 {
+    if (!_poller) {
+        return nullptr;
+    }
     TimerPollable *p = new TimerPollable(cb, wrapper);
     if (!p || !p->setup_timer(timeout_usec) ||
         !_poller.register_pollable(p, POLLIN)) {
@@ -117,6 +120,10 @@ bool PollerThread::adjust_timer(TimerPollable *p, uint32_t timeout_usec)
 
 void PollerThread::_cleanup_timers()
 {
+    if (!_poller) {
+        return;
+    }
+
     for (auto it = _timers.begin(); it != _timers.end(); it++) {
         TimerPollable *p = *it;
         if (p->_removeme) {
@@ -129,6 +136,10 @@ void PollerThread::_cleanup_timers()
 
 void PollerThread::mainloop()
 {
+    if (!_poller) {
+        return;
+    }
+
     while (true) {
         _poller.poll();
         _cleanup_timers();

--- a/libraries/AP_HAL_Linux/PollerThread.h
+++ b/libraries/AP_HAL_Linux/PollerThread.h
@@ -56,7 +56,7 @@ protected:
 
     PeriodicCb _cb;
     WrapperCb *_wrapper;
-    bool _removeme;
+    bool _removeme = false;
 };
 
 
@@ -76,7 +76,7 @@ protected:
     void _cleanup_timers();
 
     Poller _poller{};
-    std::vector<TimerPollable*> _timers;
+    std::vector<TimerPollable*> _timers{};
 };
 
 }

--- a/libraries/AP_HAL_Linux/PollerThread.h
+++ b/libraries/AP_HAL_Linux/PollerThread.h
@@ -72,6 +72,8 @@ public:
 
     void mainloop();
 
+    bool stop() override;
+
 protected:
     void _cleanup_timers();
 

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -421,7 +421,7 @@ RCInput_RPI::~RCInput_RPI()
     delete con_blocks;
 }
 
-void RCInput_RPI::deinit()
+void RCInput_RPI::teardown()
 {
     stop_dma();
 }

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -379,7 +379,9 @@ void RCInput_RPI::init_DMA()
 void RCInput_RPI::set_sigaction()
 {
     for (int i = 0; i < NSIG; i++) {
-        //catch all signals (like ctrl+c, ctrl+z, ...) to ensure DMA is disabled
+        // catch all signals to ensure DMA is disabled - some of them may
+        // already be handled elsewhere in cases we consider normal
+        // termination. In those cases the teardown() method must be called.
         struct sigaction sa, sa_old;
         memset(&sa, 0, sizeof(sa));
         sigaction(i, nullptr, &sa_old);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.h
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.h
@@ -127,7 +127,7 @@ private:
     static void termination_handler(int signum);
     void set_sigaction();
     void set_physical_addresses(int version);
-    void deinit() override;
+    void teardown() override;
 };
 
 }

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -481,4 +481,17 @@ void SPIDeviceManager::_unregister(SPIBus &b)
     }
 }
 
+void SPIDeviceManager::teardown()
+{
+    for (auto it = _buses.begin(); it != _buses.end(); it++) {
+        /* Try to stop thread - it may not even be started yet */
+        (*it)->thread.stop();
+    }
+
+    for (auto it = _buses.begin(); it != _buses.end(); it++) {
+        /* Try to join thread - failing is normal if thread was not started */
+        (*it)->thread.join();
+    }
+}
+
 }

--- a/libraries/AP_HAL_Linux/SPIDevice.h
+++ b/libraries/AP_HAL_Linux/SPIDevice.h
@@ -89,7 +89,15 @@ public:
         _buses.reserve(3);
     }
 
+    /* AP_HAL::SPIDeviceManager implementation */
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name);
+
+    /*
+     * Stop all SPI threads and block until they are finalized. This doesn't
+     * free memory because they can still be used by devices, however device
+     * drivers won't receive any new event
+     */
+    void teardown();
 
 protected:
     void _unregister(SPIBus &b);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -456,3 +456,18 @@ bool Scheduler::SchedulerThread::_run()
 
     return PeriodicThread::_run();
 }
+
+void Scheduler::teardown()
+{
+    _timer_thread.stop();
+    _io_thread.stop();
+    _rcin_thread.stop();
+    _uart_thread.stop();
+    _tonealarm_thread.stop();
+
+    _timer_thread.join();
+    _io_thread.join();
+    _rcin_thread.join();
+    _uart_thread.join();
+    _tonealarm_thread.join();
+}

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -50,6 +50,8 @@ public:
 
     void microsleep(uint32_t usec);
 
+    void teardown();
+
 private:
     class SchedulerThread : public PeriodicThread {
     public:

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -229,6 +229,10 @@ bool Thread::set_stack_size(size_t stack_size)
 
 bool PeriodicThread::_run()
 {
+    if (_period_usec == 0) {
+        return false;
+    }
+
     uint64_t next_run_usec = AP_HAL::micros64() + _period_usec;
 
     while (true) {

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -235,7 +235,7 @@ bool PeriodicThread::_run()
 
     uint64_t next_run_usec = AP_HAL::micros64() + _period_usec;
 
-    while (true) {
+    while (!_should_exit) {
         uint64_t dt = next_run_usec - AP_HAL::micros64();
         if (dt > _period_usec) {
             // we've lost sync - restart
@@ -247,6 +247,20 @@ bool PeriodicThread::_run()
 
         _task();
     }
+
+    _started = false;
+    _should_exit = false;
+
+    return true;
+}
+
+bool PeriodicThread::stop()
+{
+    if (!is_started()) {
+        return false;
+    }
+
+    _should_exit = true;
 
     return true;
 }

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -205,6 +205,23 @@ bool Thread::is_current_thread()
     return pthread_equal(pthread_self(), _ctx);
 }
 
+bool Thread::join()
+{
+    void *ret;
+
+    if (_ctx == 0) {
+        return false;
+    }
+
+    if (pthread_join(_ctx, &ret) != 0 ||
+        (intptr_t)ret != 0) {
+        return false;
+    }
+
+    return true;
+}
+
+
 bool PeriodicThread::set_rate(uint32_t rate_hz)
 {
     if (_started || rate_hz == 0) {

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -80,6 +80,8 @@ public:
 
     bool set_rate(uint32_t rate_hz);
 
+    bool stop() override;
+
 protected:
     bool _run() override;
 

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -47,6 +47,8 @@ public:
 
     virtual bool stop() { return false; }
 
+    bool join();
+
 protected:
     static void *_run_trampoline(void *arg);
 

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -58,15 +58,15 @@ protected:
     void _poison_stack();
 
     task_t _task;
-    bool _started;
-    pthread_t _ctx;
+    bool _started = false;
+    pthread_t _ctx = 0;
 
     struct stack_debug {
         uint32_t *start;
         uint32_t *end;
     } _stack_debug;
 
-    size_t _stack_size;
+    size_t _stack_size = 0;
 };
 
 class PeriodicThread : public Thread {
@@ -80,7 +80,7 @@ public:
 protected:
     bool _run() override;
 
-    uint64_t _period_usec;
+    uint64_t _period_usec = 0;
 };
 
 }

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -45,6 +45,8 @@ public:
 
     bool set_stack_size(size_t stack_size);
 
+    virtual bool stop() { return false; }
+
 protected:
     static void *_run_trampoline(void *arg);
 
@@ -59,6 +61,7 @@ protected:
 
     task_t _task;
     bool _started = false;
+    bool _should_exit = false;
     pthread_t _ctx = 0;
 
     struct stack_debug {

--- a/libraries/AP_HAL_Linux/system.cpp
+++ b/libraries/AP_HAL_Linux/system.cpp
@@ -30,7 +30,7 @@ void panic(const char *errormsg, ...)
     va_end(ap);
     UNUSED_RESULT(write(1, "\n", 1));
 
-    hal.rcin->deinit();
+    hal.rcin->teardown();
     hal.scheduler->delay_microseconds(10000);
     exit(1);
 }

--- a/libraries/AP_HAL_Linux/tests/test_thread.cpp
+++ b/libraries/AP_HAL_Linux/tests/test_thread.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <pthread.h>
+#include <unistd.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL_Linux/Thread.h>
+#include <AP_HAL_Linux/PollerThread.h>
+
+using namespace Linux;
+
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+class TestThread1 : public Thread {
+public:
+    TestThread1() : Thread(nullptr) { }
+
+    int n_loop = 0;
+
+protected:
+    bool _run() override {
+        n_loop = 1;
+        return true;
+    }
+};
+
+TEST(LinuxThread, override_run)
+{
+    TestThread1 thr;
+    EXPECT_TRUE(thr.start(nullptr, 0, 0));
+
+    while (thr.n_loop == 0) {
+        usleep(10000);
+    }
+
+    EXPECT_EQ(thr.n_loop, 1);
+}
+
+class TestThread2 : public Thread {
+public:
+    TestThread2() : Thread{FUNCTOR_BIND_MEMBER(&TestThread2::_task, void)} { }
+
+    int n_loop = 0;
+
+protected:
+    void _task() {
+        n_loop = 1;
+    }
+};
+
+TEST(LinuxThread, run_task)
+{
+    TestThread2 thr;
+    EXPECT_TRUE(thr.start(nullptr, 0, 0));
+
+    while (thr.n_loop == 0) {
+        usleep(10000);
+    }
+
+    EXPECT_EQ(thr.n_loop, 1);
+}
+
+TEST(LinuxThread, poller_thread)
+{
+    PollerThread thr;
+    EXPECT_TRUE(thr.start(nullptr, 0, 0));
+
+    while (!thr.is_started()) {
+        usleep(1000);
+    }
+
+    usleep(10000);
+
+    EXPECT_TRUE(thr.stop());
+    EXPECT_TRUE(thr.join());
+}
+
+class TestPeriodicThread1 : public PeriodicThread {
+public:
+    TestPeriodicThread1() : PeriodicThread{FUNCTOR_BIND_MEMBER(&TestPeriodicThread1::_task, void)} { }
+protected:
+    void _task() { }
+};
+
+TEST(LinuxThread, periodic_thread)
+{
+    TestPeriodicThread1 thr;
+    EXPECT_TRUE(thr.set_rate(1000));
+    EXPECT_TRUE(thr.start(nullptr, 0, 0));
+
+    while (!thr.is_started()) {
+        usleep(1000);
+    }
+
+    // this must fail as the thread already started
+    EXPECT_FALSE(thr.set_rate(10));
+
+    usleep(10000);
+
+    EXPECT_TRUE(thr.stop());
+    EXPECT_TRUE(thr.join());
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL_Linux/tests/wscript
+++ b/libraries/AP_HAL_Linux/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -1195,21 +1195,19 @@ void MissionTest::setup(void)
     // display basic info about command sizes
     hal.console->printf("Max Num Commands: %d\n",(int)mission.num_commands_max());
     hal.console->printf("Command size: %d bytes\n",(int)AP_MISSION_EEPROM_COMMAND_SIZE);
-}
 
-// loop
-void MissionTest::loop(void)
-{
     // uncomment line below to run one of the mission tests
     run_mission_test();
 
     // uncomment line below to run the mission pause/resume test
     //run_resume_test();
+}
 
-    // wait forever
-    while(true) {
-        hal.scheduler->delay(1000);
-    }
+// loop
+void MissionTest::loop(void)
+{
+    // loop forever
+    hal.scheduler->delay(1000);
 }
 
 void setup(void);

--- a/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
+++ b/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
@@ -202,10 +202,8 @@ void DataFlashTest_AllTypes::setup(void)
 
 void DataFlashTest_AllTypes::loop(void)
 {
-    while (true) {
-        hal.console->printf("all done\n");
-        hal.scheduler->delay(1000);
-    }
+    hal.console->printf("all done\n");
+    hal.scheduler->delay(1000);
 }
 
 static DataFlashTest_AllTypes dataflashtest;

--- a/wscript
+++ b/wscript
@@ -295,6 +295,7 @@ def _build_recursion(bld):
     ]
 
     hal_dirs_patterns = [
+        'libraries/%s/tests',
         'libraries/%s/*/tests',
         'libraries/%s/*/benchmarks',
         'libraries/%s/examples/*',


### PR DESCRIPTION
This adds the proper mechanism to stop bus and scheduler thread and add handlers to SIGINT and SIGTERM signals. This way we can check the return code when exiting to know if ardupilot exited successfully or due to an error.

Tested on minlure only.
