### PR TITLE
AP_BoardConfig: add extra uavcan options

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: CAN_ENABLE
     // @DisplayName:  Enable use of UAVCAN devices
     // @Description: Enabling this option on a Pixhawk enables UAVCAN devices. Note that this uses about 25k of memory
-    // @Values: 0:Disabled,1:Enabled,2:Dynamic ID/Update,3:Motors/Update
+    // @Values: 0:Disabled,1:Enabled,2:Dynamic ID/Update
     // @User: Advanced
     AP_GROUPINFO("CAN_ENABLE", 6, AP_BoardConfig, px4.can_enable, 0),
 #endif

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: CAN_ENABLE
     // @DisplayName:  Enable use of UAVCAN devices
     // @Description: Enabling this option on a Pixhawk enables UAVCAN devices. Note that this uses about 25k of memory
-    // @Values: 0:Disabled,1:Enabled
+    // @Values: 0:Disabled,1:Enabled,2:Dynamic ID/Update,3:Motors/Update
     // @User: Advanced
     AP_GROUPINFO("CAN_ENABLE", 6, AP_BoardConfig, px4.can_enable, 0),
 #endif


### PR DESCRIPTION
this enables the display of dynamic id assignment, which prevents the need for a serial connection to the esc, for first config.
