### PR TITLE
Rover: Station Keeping is implemented via NAV_LOITER_COMMAND

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -363,9 +363,11 @@ private:
     static const LogStructure log_structure[];
 
     // Loiter control
-    uint16_t loiter_time_max; // How long we should loiter at the nav_waypoint (time in seconds)
-    uint32_t loiter_time;     // How long have we been loitering - The start time in millis
+    uint16_t loiter_duration; // How long we should loiter at the nav_waypoint (time in seconds)
+    uint32_t loiter_start_time;     // How long have we been loitering - The start time in millis
+    bool active_loiter; // TRUE if we actively return to the loitering waypoint if we drift off
     float distance_past_wp; // record the distance we have gone past the wp
+    bool previously_reached_wp;  // set to true if we have EVER reached the waypoint
 
     // time that rudder/steering arming has been running
     uint32_t rudder_arm_timer;
@@ -522,8 +524,10 @@ private:
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
+    void do_loiter_time(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
     bool verify_loiter_unlim();
+    bool verify_loiter_time(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
@@ -540,6 +544,9 @@ private:
     void update_home();
     void accel_cal_update(void);
     void nav_set_yaw_speed();
+    bool in_stationary_loiter(void);
+    void set_loiter_active(const AP_Mission::Mission_Command& cmd);
+
 public:
     bool print_log_menu(void);
     int8_t dump_log(uint8_t argc, const Menu::arg *argv);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -75,6 +75,22 @@ bool Rover::use_pivot_steering(void) {
     return false;
 }
 
+/*
+  test if we are loitering AND should be stopped at a waypoint
+*/
+bool Rover::in_stationary_loiter()
+{
+    // Confirm we are in AUTO mode and need to loiter for a time period
+    if ((loiter_start_time > 0) && (control_mode == AUTO)) {
+        // Check if active loiter is enabled AND we are outside the waypoint loiter radius
+        // then NOT the result for the if logic
+        if (!(active_loiter && (wp_distance > g.waypoint_radius))) {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 /*
     calculate the throtte for auto-throttle modes
@@ -82,7 +98,7 @@ bool Rover::use_pivot_steering(void) {
 void Rover::calc_throttle(float target_speed) {
     // If not autostarting OR we are loitering at a waypoint
     // then set the throttle to minimum
-    if (!auto_check_trigger() || ((loiter_time > 0) && (control_mode == AUTO))) {
+    if (!auto_check_trigger() || in_stationary_loiter()) {
         channel_throttle->set_servo_out(g.throttle_min.get());
         // Stop rotation in case of loitering and skid steering
         if (g.skid_steer_out) {
@@ -163,7 +179,13 @@ void Rover::calc_throttle(float target_speed) {
 void Rover::calc_lateral_acceleration() {
     switch (control_mode) {
     case AUTO:
-        nav_controller->update_waypoint(prev_WP, next_WP);
+        // If we have reached the waypoint previously navigate
+        // back to it from our current position
+        if (previously_reached_wp && (loiter_duration > 0)) {
+            nav_controller->update_waypoint(current_loc, next_WP);
+        } else {
+            nav_controller->update_waypoint(prev_WP, next_WP);
+        }
         break;
 
     case RTL:
@@ -195,7 +217,7 @@ void Rover::calc_lateral_acceleration() {
 */
 void Rover::calc_nav_steer() {
     // check to see if the rover is loitering
-    if ((loiter_time > 0) && (control_mode == AUTO)) {
+    if (in_stationary_loiter()) {
         channel_steer->set_servo_out(0);
         return;
     }

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -271,7 +271,7 @@ void Rover::set_mode(enum mode mode)
 
     // If we are changing out of AUTO mode reset the loiter timer
     if (control_mode == AUTO) {
-        loiter_time = 0;
+        loiter_start_time = 0;
     }
 
     control_mode = mode;


### PR DESCRIPTION
It is a very simply form of station keeping.  If for example a boat is loitering on a waypoint and it gets blown off a distance outside the WAYPOINT_RADIUS it will automatically drive back to the waypoint.