### PR TITLE
build: rephrase the need to read waf book

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,9 @@
 # Building ArduPilot #
 
 Ardupilot is gradually moving from the make-based build system to
-[Waf](https://waf.io/). You can read the [Waf Book](https://waf.io/book/) if
-you want to learn more about Waf.
+[Waf](https://waf.io/). The instructions below should be enough for you to
+build Ardupilot, but you can also read more about the build system in the
+[Waf Book](https://waf.io/book/).
 
 Waf should always be called from the ardupilot's root directory. Differently
 from the make-based build, with Waf there's a configure step to choose the


### PR DESCRIPTION
It's not needed and sometimes waf.io is offline, leaving people with the
impression they need to read it for compiling.