### PR TITLE
copter: GCS failsafe now functions for all modes.

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -179,11 +179,19 @@ const AP_Param::Info Copter::var_info[] = {
     GSCALAR(fs_batt_mah,            "FS_BATT_MAH", FS_BATT_MAH_DEFAULT),
 
     // @Param: FS_GCS_ENABLE
-    // @DisplayName: Ground Station Failsafe Enable
-    // @Description: Controls whether failsafe will be invoked (and what action to take) when connection with Ground station is lost for at least 5 seconds. NB. The GCS Failsafe is only active when RC_OVERRIDE is being used to control the vehicle.
-    // @Values: 0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode
+    // @DisplayName: Ground Control Station (GCS) Failsafe Enable
+    // @Description: Controls whether failsafe will be invoked (and what action to take) when connection with Ground station is lost for at least FS_GCS_TIMEOUT seconds. NB. The GCS Failsafe is active when RC_OVERRIDE is being used to control the vehicle OR when the value is set to "Enabled always RTL" or "Enabled only in GUIDED" or "Enable only in GUIDED and AUTO".
+    // @Values: 0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode, 3: Enabled and RTL only from GUIDED mode, 4: Enabled and RTL only fom GUIDED or AUTO mode.
     // @User: Standard
     GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_ENABLED_ALWAYS_RTL),
+    
+    // @Param: FS_GCS_TIMEOUT
+    // @DisplayName: Ground Control Station (GCS) Failsafe Timeout
+    // @Description: Controls how long the autopilot waits after losing contact with the GCS before engaging the GCS_FAILSAFE.  Note that the failsafe will only engage if it is enabled (see FS_GCS_ENABLE parameter).
+    // @Units: Seconds
+    // @Increment: 1
+    // @User: Standard    
+    GSCALAR(failsafe_gcs_timeout, "FS_GCS_TIMEOUT", 5),
 
     // @Param: GPS_HDOP_GOOD
     // @DisplayName: GPS Hdop Good

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -292,6 +292,7 @@ public:
         k_param_radio_tuning,
         k_param_radio_tuning_high,
         k_param_radio_tuning_low,
+        k_param_failsafe_gcs_timeout = 190,
         k_param_rc_speed = 192,
         k_param_failsafe_battery_enabled,
         k_param_throttle_mid,           // remove
@@ -396,6 +397,7 @@ public:
     AP_Float        fs_batt_mah;                // battery capacity (in mah) below which failsafe will be triggered
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior
+    AP_Int8         failsafe_gcs_timeout;      // ground station failsafe timeout
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position
 
     AP_Int8         compass_enabled;

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -191,9 +191,6 @@
 #ifndef FS_GCS
  # define FS_GCS                        DISABLED
 #endif
-#ifndef FS_GCS_TIMEOUT_MS
- # define FS_GCS_TIMEOUT_MS             5000    // gcs failsafe triggers after 5 seconds with no GCS heartbeat
-#endif
 
 // Radio failsafe while using RC_override
 #ifndef FS_RADIO_RC_OVERRIDE_TIMEOUT_MS

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -469,6 +469,8 @@ enum DevOptions {
 #define FS_GCS_DISABLED                     0
 #define FS_GCS_ENABLED_ALWAYS_RTL           1
 #define FS_GCS_ENABLED_CONTINUE_MISSION     2
+#define FS_GCS_ENABLED_GUIDED               3
+#define FS_GCS_ENABLED_GUIDED_AUTO          4
 
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe


### PR DESCRIPTION
This patch causes the GCS failsafe to function when the aircraft is following waypoints in AUTO mode.  Previously the GCS failsafe only functioned for GUIDED mode.