### PR TITLE
Build: More changes as we move to WAF

### DIFF
--- a/Tools/scripts/build_all.sh
+++ b/Tools/scripts/build_all.sh
@@ -47,19 +47,9 @@ for b in sitl; do
 done
 popd
 
-echo "Testing build of examples"
-
-examples="Tools/CPUInfo"
-for d in $examples; do
-    pushd $d
-    make clean
-    make sitl -j4
-    popd
-done
-
 pushd Tools/Replay
 make clean
-make linux -j4
+make
 popd
 
 test -n "$PX4_ROOT" && test -d "$PX4_ROOT" && {


### PR DESCRIPTION
This might not fix all the issues but it fixes a couple. 

The only example being built in build_all.sh was CPUInfo and that is really an APM tool.  Its being built using the old make system at this point and failing.  It will get built further down in when autotest.py calls build.Examples so we don't need to build it here.

And changing the Replay build to just call make which really means it will invoke waf as that's what the makefile does.