### PR TITLE
Build: removal of build-all from default autotest

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -173,7 +173,7 @@ opts, args = parser.parse_args()
 
 steps = [
     'prerequisites',
-    'build.All',
+    #'build.All',
     'build.Binaries',
     # 'build.DevRelease',
     'build.Examples',


### PR DESCRIPTION
I think we should remove build-all.sh from being invoked in the
standard autotest build.  Everything it builds will be built at some
stage in the later build jobs so its really just causing a delay.  I
think it was originally supposed to be a litmus test to check that
building was going to work but as it doesn't prevent any of the later
build steps running its not really doing that.

Note this doesn't remove build-all.sh and you can still run that
locally.