### PR TITLE
AP_ADSB: do not transmit by default

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -107,7 +107,7 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Description: Transceiver RF selection for Rx enable and/or Tx enable.
     // @Values: 0:Disabled,1:Rx-Only,2:Tx-Only,3:Rx and Tx Enabled
     // @User: Advanced
-    AP_GROUPINFO("RF_SELECT",   9, AP_ADSB, out_state.cfg.rfSelect, UAVIONIX_ADSB_OUT_RF_SELECT_RX_ENABLED | UAVIONIX_ADSB_OUT_RF_SELECT_TX_ENABLED),
+    AP_GROUPINFO("RF_SELECT",   9, AP_ADSB, out_state.cfg.rfSelect, UAVIONIX_ADSB_OUT_RF_SELECT_RX_ENABLED),
 
 
 


### PR DESCRIPTION
In various countries transmitting on the ADSB frequencies is a
federal offence.

Let's not have our users do that be default.