### PR TITLE
Tools: Rename BEBOP_PKGS and add pkg-config-arm-linux-gnueabihf package

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -7,7 +7,7 @@ PYTHON_PKGS="future lxml pymavlink MAVProxy"
 PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo libftdi-dev zlib1g-dev \
           zip genromfs python-empy libc6-i386 cmake cmake-data"
-ARM_LINUX_PKGS="g++-arm-linux-gnueabihf"
+ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing realpath"
 ASSUME_YES=false
 

--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -7,7 +7,7 @@ PYTHON_PKGS="future lxml pymavlink MAVProxy"
 PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo libftdi-dev zlib1g-dev \
           zip genromfs python-empy libc6-i386 cmake cmake-data"
-BEBOP_PKGS="g++-arm-linux-gnueabihf"
+ARM_LINUX_PKGS="g++-arm-linux-gnueabihf"
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing realpath"
 ASSUME_YES=false
 
@@ -78,7 +78,7 @@ sudo usermod -a -G dialout $USER
 
 $APT_GET remove modemmanager
 $APT_GET update
-$APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $BEBOP_PKGS
+$APT_GET install $BASE_PKGS $SITL_PKGS $PX4_PKGS $ARM_LINUX_PKGS
 sudo pip2 -q install -U $PYTHON_PKGS
 
 if [ ! -d $OPT/$ARM_ROOT ]; then


### PR DESCRIPTION
Tools/scripts/install-prereqs-ubuntu.sh
* rename `BEBOP_PKGS`to `ARM_LINUX_PKGS` because navio, erle, bbbmini need these packages to
* add `pkg-config-arm-linux-gnueabihf` it is necessary to build ArduPilot for Linux 