### PR TITLE
AP_RangeFinder: fixed LeddarOne busy wait

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -20,13 +20,6 @@
 extern const AP_HAL::HAL& hal;
 
 /*
-   The based on Arduino LeddarOne sample
-   --------------------------------------------------------
-       http://playground.arduino.cc/Code/Leddar
-   --------------------------------------------------------
- */
-
-/*
    The constructor also initialises the rangefinder. Note that this
    constructor is not called until detect() returns true, so we
    already know that we should setup the rangefinder
@@ -169,14 +162,14 @@ bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCh
 LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
 {
     uint8_t send_buffer[10] = {0};
-    uint8_t i = 0;
+    uint8_t index = 0;
 
     uint32_t nbytes = uart->available();
 
     // clear buffer
     while (nbytes-- > 0) {
         uart->read();
-        if (++i > 250) {
+        if (++index > 250) {
             return LEDDARONE_ERR_SERIAL_PORT;
         }
     }
@@ -195,8 +188,8 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
     CRC16(send_buffer, 6, false);
 
     // write buffer data with CRC16 bits
-    for (i=0; i<8; i++) {
-        uart->write(send_buffer[i]);
+    for (index=0; index<8; index++) {
+        uart->write(send_buffer[index]);
     }
     uart->flush();
 
@@ -208,18 +201,18 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
   */
 LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detections)
 {
-    uint8_t i;
+    uint8_t index;
     uint8_t index_offset = LEDDARONE_DATA_INDEX_OFFSET;
 
     // read serial
     uint32_t nbytes = uart->available();
 
     if (nbytes != 0)  {
-        for (i=read_len; i<nbytes+read_len; i++) {
-            if (i >= 25) {
+        for (index=read_len; index<nbytes+read_len; index++) {
+            if (index >= 25) {
                 return LEDDARONE_ERR_BAD_RESPONSE;
             }
-            read_buffer[i] = uart->read();
+            read_buffer[index] = uart->read();
         }
 
         read_len += nbytes;
@@ -248,10 +241,10 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
 
     memset(detections, 0, sizeof(detections));
     sum_distance = 0;
-    for (i=0; i<number_detections; i++) {
+    for (index=0; index<number_detections; index++) {
         // construct data word from two bytes and convert mm to cm
-        detections[i] =  (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
-        sum_distance += detections[i];
+        detections[index] =  (static_cast<uint16_t>(read_buffer[index_offset])*256 + read_buffer[index_offset+1]) / 10;
+        sum_distance += detections[index];
         index_offset += 4;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -2,22 +2,30 @@
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
-#include <GCS_MAVLink/GCS.h>
 
 #define LEDDARONE_DETECTIONS_MAX 3
 
 // default slave address
 #define LEDDARONE_DEFAULT_ADDRESS 0x01
+#define LEDDARONE_DATA_INDEX_OFFSET 11
 
 // LeddarOne status
 enum LeddarOne_Status {
     LEDDARONE_OK = 0,
+	LEDDARONE_READING_BUFFER = 1,
     LEDDARONE_ERR_BAD_CRC = -1,
     LEDDARONE_ERR_NO_RESPONSES = -2,
     LEDDARONE_ERR_BAD_RESPONSE = -3,
     LEDDARONE_ERR_SHORT_RESPONSE = -4,
     LEDDARONE_ERR_SERIAL_PORT = -5,
     LEDDARONE_ERR_NUMBER_DETECTIONS = -6
+};
+
+// LeddarOne Modbus status
+enum LeddarOne_ModbusStatus {
+	LEDDARONE_MODBUS_PRE_SEND_REQUEST = 0,
+	LEDDARONE_MODBUS_SENT_REQUEST,
+	LEDDARONE_MODBUS_AVAILABLE
 };
 
 class AP_RangeFinder_LeddarOne : public AP_RangeFinder_Backend
@@ -49,7 +57,12 @@ private:
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms;
+    uint32_t last_sending_request_ms;
 
     uint16_t detections[LEDDARONE_DETECTIONS_MAX];
     uint32_t sum_distance;
+
+    LeddarOne_ModbusStatus modbus_status = LEDDARONE_MODBUS_PRE_SEND_REQUEST;
+    uint8_t read_buffer[25];
+    uint32_t read_len;
 };

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -634,15 +634,11 @@ void RangeFinder::detect_instance(uint8_t instance)
         }
     }
     if (type == RangeFinder_TYPE_LEDDARONE) {
-#if 0
         if (AP_RangeFinder_LeddarOne::detect(*this, instance, serial_manager)) {
             state[instance].instance = instance;
             drivers[instance] = new AP_RangeFinder_LeddarOne(*this, instance, state[instance], serial_manager);
             return;
         }
-#else
-        hal.console->printf("LEDDARONE driver disabled\n");
-#endif
     }
 #if (CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || \
      CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO) && defined(HAVE_LIBIIO)


### PR DESCRIPTION
fixed LeddarOne busy wait. removed wait code for uart->available().
I tested flying with LeddarOne. 
The flight log is uploaded to the below link.

[Flight log with LeddarOne](https://dl.dropboxusercontent.com/u/2586545/LeddarOne/2016-11-03%2013-56-22.bin)

[Graph image CTUN/SAlt](https://dl.dropboxusercontent.com/u/2586545/LeddarOne/CTUN-Alt-SAlt.emf)