### PR TITLE
AP_Frsky_Telem: remove arming check for transmitting params

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -97,7 +97,7 @@ void AP_Frsky_Telem::send_SPort_Passthrough(void)
         } else { // send other sensor data if it's time for them, and reset the corresponding timer if sent
             _passthrough.send_attiandrng = true; // next iteration, send attitude b/c it needs frequent updates to remain smooth
             uint32_t now = AP_HAL::millis();
-            if (((now - _passthrough.params_timer) >= 1000) && (!AP_Notify::flags.armed)) {
+            if ((now - _passthrough.params_timer) >= 1000) {
                 send_uint32(DIY_FIRST_ID+7, calc_param());
                 _passthrough.params_timer = AP_HAL::millis();
                 return;


### PR DESCRIPTION
Otherwise, on Plane, if ARMING REQUIRED is set to 0 (automatically
armed), no parameters are transmitted.