### PR TITLE
mk: stop ignoring exit status of mavlink header generation

### DIFF
--- a/mk/mavgen.mk
+++ b/mk/mavgen.mk
@@ -9,4 +9,4 @@ $(MAVLINK_HEADERS): $(MESSAGE_DEFINITIONS)/ardupilotmega.xml $(MESSAGE_DEFINITIO
 	echo "Generating MAVLink headers..."
 	#goto mavlink module directory and run the most recent generator script
 	echo "Generating C code using mavgen.py located at" $(SKETCHBOOK)/modules/mavlink/
-	-PYTHONPATH=$(MAVLINK_DIR) python $(MAVLINK_DIR)/pymavlink/tools/mavgen.py --lang=C --wire-protocol=$(MAVLINK_WIRE_PROTOCOL) --output=$(MAVLINK_OUTPUT_DIR) $(MESSAGE_DEFINITIONS)/ardupilotmega.xml
+	PYTHONPATH=$(MAVLINK_DIR) python $(MAVLINK_DIR)/pymavlink/tools/mavgen.py --lang=C --wire-protocol=$(MAVLINK_WIRE_PROTOCOL) --output=$(MAVLINK_OUTPUT_DIR) $(MESSAGE_DEFINITIONS)/ardupilotmega.xml; if [ $$? -le 0 -o $$? -gt 128 ]; then echo "mavgen: success"; exit 0; else echo "mavgen: failed"; exit 1; fi


### PR DESCRIPTION
Accept a 0 exit status, or a status >127 (indicating a signal
caused the process to exit) as success.

The original intent of ignoring the exit status was that
the python executable was segfaulting after successfully
building headers.

Recently builds have been failing because people have not been
doing recursive submodule updates, and the mavlink header generation
has failed.  Since we are ignoring the error the build rumbles on
and fails later with a failed #include.

This patch tightens our ignoring of a bad exit status to just
signals.