### PR TITLE
continue driver re-work

### DIFF
--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
@@ -17,9 +17,6 @@ set(config_module_list
     drivers/led
     drivers/px4fmu
     drivers/rgbled
-    drivers/mpu6000
-    drivers/hmc5883
-    drivers/ms5611
     drivers/mb12xx
     drivers/ll40ls
     drivers/trone

--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v1_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v1_apm.cmake
@@ -1,6 +1,9 @@
 include(configs/nuttx_px4fmu-common_apm)
 
 list(APPEND config_module_list
+    drivers/mpu6000
+    drivers/hmc5883
+    drivers/ms5611
     drivers/boards/px4fmu-v1
     drivers/px4io
     drivers/px4flow

--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v2_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v2_apm.cmake
@@ -4,6 +4,9 @@ list(APPEND config_module_list
     drivers/lsm303d
     drivers/l3gd20
     drivers/mpu9250
+    drivers/mpu6000
+    drivers/hmc5883
+    drivers/ms5611
     drivers/boards/px4fmu-v2
     drivers/pwm_input
     modules/uavcan

--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v4_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-v4_apm.cmake
@@ -1,7 +1,6 @@
 include(configs/nuttx_px4fmu-common_apm)
 
 list(APPEND config_module_list
-    drivers/mpu9250
     drivers/boards/px4fmu-v4
     drivers/pwm_input
     modules/uavcan

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -299,7 +299,8 @@ void AP_Baro::init(void)
         _num_drivers = 1;
 #endif
     } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V2 ||
-               AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PHMINI) {
+               AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PHMINI ||
+               AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PH2SLIM) {
         drivers[0] = new AP_Baro_MS5611(*this,
                                         std::move(hal.spi->get_device(HAL_BARO_MS5611_NAME)));
         _num_drivers = 1;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -110,8 +110,6 @@ private:
     void px4_start_fmuv1_sensors(void);
     void px4_start_fmuv2_sensors(void);
     void px4_start_fmuv4_sensors(void);
-    void px4_start_pixhawk2slim_sensors(void);
-    void px4_start_phmini_sensors(void);
     void px4_start_optional_sensors(void);
 #endif
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -109,7 +109,6 @@ private:
     void px4_start_common_sensors(void);
     void px4_start_fmuv1_sensors(void);
     void px4_start_fmuv2_sensors(void);
-    void px4_start_fmuv4_sensors(void);
     void px4_start_optional_sensors(void);
 #endif
 

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -408,34 +408,11 @@ void AP_BoardConfig::px4_start_fmuv1_sensors(void)
 }
 
 /*
-  setup sensors for FMUv4
- */
-void AP_BoardConfig::px4_start_fmuv4_sensors(void)
-{
-#if defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
-    printf("Starting FMUv4 sensors\n");
-    if (px4_start_driver(hmc5883_main, "hmc5883", "-C -T -S -R 2 start")) {
-        printf("Have SPI hmc5883\n");
-    } else {
-        printf("No SPI hmc5883\n");
-    }
-
-    if (px4_start_driver(mpu6000_main, "mpu6000", "-R 2 -T 20608 start")) {
-        printf("Found ICM-20608 internal\n");
-    }
-
-    if (px4_start_driver(mpu9250_main, "mpu9250", "-R 2 start")) {
-        printf("Found mpu9250 internal\n");
-    }
-    px4.board_type.set_and_notify(PX4_BOARD_PIXRACER);
-#endif // CONFIG_ARCH_BOARD_PX4FMU_V4
-}
-
-/*
   setup common sensors
  */
 void AP_BoardConfig::px4_start_common_sensors(void)
 {
+#ifndef CONFIG_ARCH_BOARD_PX4FMU_V4
     if (px4_start_driver(ms5611_main, "ms5611", "start")) {
         printf("ms5611 started OK\n");
     } else {
@@ -446,6 +423,7 @@ void AP_BoardConfig::px4_start_common_sensors(void)
     } else {
         printf("No external hmc5883\n");
     }
+#endif
 }
 
 
@@ -644,7 +622,6 @@ void AP_BoardConfig::px4_setup_drivers(void)
     default:
         px4_start_fmuv1_sensors();
         px4_start_fmuv2_sensors();
-        px4_start_fmuv4_sensors();
         break;
     }
     px4_start_optional_sensors();

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -387,48 +387,6 @@ void AP_BoardConfig::px4_start_fmuv2_sensors(void)
 
 
 /*
-  setup sensors for Pixhawk2-slim
- */
-void AP_BoardConfig::px4_start_pixhawk2slim_sensors(void)
-{
-#if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
-    printf("Starting PH2SLIM sensors\n");
-    if (px4_start_driver(hmc5883_main, "hmc5883", "-C -T -I -R 4 start")) {
-        printf("Have internal hmc5883\n");
-    } else {
-        printf("No internal hmc5883\n");
-    }
-
-    if (px4_start_driver(mpu9250_main, "mpu9250", "-R 14 start")) {
-        printf("Found MPU9250 internal\n");
-    } else if (px4_start_driver(mpu6000_main, "mpu6000", "-R 14 -T 20608 start")) {
-        printf("Found ICM20608 internal\n");
-    } else if (px4_start_driver(mpu6000_main, "mpu6000", "-R 14 start")) {
-        printf("Found MPU6000 internal\n");
-    } else {
-        px4_sensor_error("No MPU9250 or ICM20608 or MPU6000");
-    }
-
-    // on Pixhawk2 default IMU temperature to 60
-    _imu_target_temperature.set_default(60);
-    
-    printf("PH2SLIM sensors started\n");
-#endif // CONFIG_ARCH_BOARD_PX4FMU_V2
-}
-
-
-/*
-  setup sensors for PHMINI
- */
-void AP_BoardConfig::px4_start_phmini_sensors(void)
-{
-#if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
-    // we will use the internal sensor drivers for the mini, so nothing to do here
-    printf("PHMINI: using in-tree IMU drivers\n");
-#endif // CONFIG_ARCH_BOARD_PX4FMU_V2
-}
-
-/*
   setup sensors for PX4v1
  */
 void AP_BoardConfig::px4_start_fmuv1_sensors(void)
@@ -662,11 +620,16 @@ void AP_BoardConfig::px4_setup_drivers(void)
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
     px4.board_type.set_and_notify(PX4_BOARD_PIXRACER);
 #endif
+
+    if (px4.board_type == PX4_BOARD_PH2SLIM) {
+        _imu_target_temperature.set_default(60);
+    }
     
     if (px4.board_type == PX4_BOARD_TEST_V1 ||
         px4.board_type == PX4_BOARD_TEST_V2 ||
         px4.board_type == PX4_BOARD_TEST_V3 ||
         px4.board_type == PX4_BOARD_PHMINI ||
+        px4.board_type == PX4_BOARD_PH2SLIM ||
         px4.board_type == PX4_BOARD_PIXRACER) {
         // use in-tree drivers
         printf("Using in-tree drivers\n");
@@ -677,14 +640,6 @@ void AP_BoardConfig::px4_setup_drivers(void)
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     px4_start_common_sensors();
     switch ((px4_board_type)px4.board_type.get()) {
-    case PX4_BOARD_PH2SLIM:
-        px4_start_pixhawk2slim_sensors();
-        break;
-
-    case PX4_BOARD_PHMINI:
-        px4_start_phmini_sensors();
-        break;
-
     case PX4_BOARD_AUTO:
     default:
         px4_start_fmuv1_sensors();

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -514,14 +514,11 @@ void Compass::_detect_backends(void)
                      AP_Compass_LSM303D::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3) {
-        _add_backend(AP_Compass_HMC5843::probe(*this, hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
-                                               false, ROTATION_PITCH_180),
-                     AP_Compass_HMC5843::name, false);
-        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
+        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_PITCH_180),
                      AP_Compass_AK8963::name, false);
-        _add_backend(AP_Compass_LSM303D::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME)),
+        _add_backend(AP_Compass_LSM303D::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME), ROTATION_YAW_270),
                      AP_Compass_LSM303D::name, false);
-        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 1),
+        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 1, ROTATION_YAW_270),
                      AP_Compass_AK8963::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXRACER) {

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -514,10 +514,10 @@ void Compass::_detect_backends(void)
                      AP_Compass_LSM303D::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3) {
-        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_PITCH_180),
-                     AP_Compass_AK8963::name, false);
         _add_backend(AP_Compass_LSM303D::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME), ROTATION_YAW_270),
                      AP_Compass_LSM303D::name, false);
+        // we run the AK8963 only on the 2nd MPU9250, which leaves the
+        // first MPU9250 to run without disturbance at high rate
         _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 1, ROTATION_YAW_270),
                      AP_Compass_AK8963::name, false);
     }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -496,6 +496,7 @@ void Compass::_detect_backends(void)
         AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V2 ||
         AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3 ||
         AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PHMINI ||
+        AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PH2SLIM ||
         AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXRACER) {
         // external i2c bus
         _add_backend(AP_Compass_HMC5843::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_HMC5843_I2C_ADDR),
@@ -504,16 +505,18 @@ void Compass::_detect_backends(void)
         // internal i2c bus
         _add_backend(AP_Compass_HMC5843::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_HMC5843_I2C_ADDR), false),
                          AP_Compass_HMC5843::name, false);
-        // try for SPI device too
+    }
+    if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V2) {
         _add_backend(AP_Compass_HMC5843::probe(*this, hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
                                                false, ROTATION_PITCH_180),
                      AP_Compass_HMC5843::name, false);
-    }
-    if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V2) {
         _add_backend(AP_Compass_LSM303D::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME)),
                      AP_Compass_LSM303D::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3) {
+        _add_backend(AP_Compass_HMC5843::probe(*this, hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
+                                               false, ROTATION_PITCH_180),
+                     AP_Compass_HMC5843::name, false);
         _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
                      AP_Compass_AK8963::name, false);
         _add_backend(AP_Compass_LSM303D::probe(*this, hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME)),
@@ -522,11 +525,18 @@ void Compass::_detect_backends(void)
                      AP_Compass_AK8963::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXRACER) {
+        _add_backend(AP_Compass_HMC5843::probe(*this, hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
+                                               false, ROTATION_PITCH_180),
+                     AP_Compass_HMC5843::name, false);
         _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_ROLL_180_YAW_90),
                      AP_Compass_AK8963::name, false);
     }
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PHMINI) {
         _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_ROLL_180),
+                     AP_Compass_AK8963::name, false);
+    }
+    if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PH2SLIM) {
+        _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_YAW_270),
                      AP_Compass_AK8963::name, false);
     }
     // also add any px4 level drivers (for canbus magnetometers)

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -35,13 +35,13 @@ public:
 
     virtual ~AP_Compass_AK8963();
 
-    bool init() override;
     void read() override;
 
 private:
     AP_Compass_AK8963(Compass &compass, AP_AK8963_BusDriver *bus,
                       enum Rotation rotation = ROTATION_NONE);
 
+    bool init();
     void _make_factory_sensitivity_adjustment(Vector3f &field) const;
     void _make_adc_sensitivity_adjustment(Vector3f &field) const;
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.h
+++ b/libraries/AP_Compass/AP_Compass_BMM150.h
@@ -30,7 +30,6 @@ public:
     static AP_Compass_Backend *probe(Compass &compass,
                                      AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
-    bool init() override;
     void read() override;
 
     static constexpr const char *name = "BMM150";
@@ -41,6 +40,7 @@ private:
     /**
      * Device periodic callback to read data from the sensor.
      */
+    bool init();
     bool _update();
     bool _load_trim_values();
     int16_t _compensate_xy(int16_t xy, uint32_t rhall, int32_t txy1, int32_t txy2);

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -31,9 +31,6 @@ public:
     // override with a custom destructor if need be.
     virtual ~AP_Compass_Backend(void) {}
 
-    // initialize the magnetometers
-    virtual bool init(void) = 0;
-
     // read sensor data
     virtual void read(void) = 0;
 

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -28,13 +28,13 @@ public:
 
     virtual ~AP_Compass_HMC5843();
 
-    bool init() override;
     void read() override;
 
 private:
     AP_Compass_HMC5843(Compass &compass, AP_HMC5843_BusDriver *bus,
                        bool force_external, enum Rotation rotation);
 
+    bool init();
     bool _check_whoami();
     bool _calibrate();
     bool _setup_sampling_mode();

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -160,13 +160,14 @@ AP_Compass_LSM303D::AP_Compass_LSM303D(Compass &compass, AP_HAL::OwnPtr<AP_HAL::
 }
 
 AP_Compass_Backend *AP_Compass_LSM303D::probe(Compass &compass,
-                                              AP_HAL::OwnPtr<AP_HAL::Device> dev)
+                                              AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                              enum Rotation rotation)
 {
     if (!dev) {
         return nullptr;
     }
     AP_Compass_LSM303D *sensor = new AP_Compass_LSM303D(compass, std::move(dev));
-    if (!sensor || !sensor->init()) {
+    if (!sensor || !sensor->init(rotation)) {
         delete sensor;
         return nullptr;
     }
@@ -254,7 +255,7 @@ bool AP_Compass_LSM303D::_read_sample()
     return true;
 }
 
-bool AP_Compass_LSM303D::init()
+bool AP_Compass_LSM303D::init(enum Rotation rotation)
 {
     if (LSM303D_DRDY_M_PIN >= 0) {
         _drdy_pin_m = hal.gpio->channel(LSM303D_DRDY_M_PIN);
@@ -271,6 +272,8 @@ bool AP_Compass_LSM303D::init()
 
     /* register the compass instance in the frontend */
     _compass_instance = register_compass();
+
+    set_rotation(_compass_instance, rotation);
 
     _dev->set_device_type(DEVTYPE_LSM303D);
     set_dev_id(_compass_instance, _dev->get_bus_id());

--- a/libraries/AP_Compass/AP_Compass_LSM303D.h
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.h
@@ -12,11 +12,11 @@ class AP_Compass_LSM303D : public AP_Compass_Backend
 {
 public:
     static AP_Compass_Backend *probe(Compass &compass,
-                                     AP_HAL::OwnPtr<AP_HAL::Device> dev);
+                                     AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                     enum Rotation = ROTATION_NONE);
 
     static constexpr const char *name = "LSM303D";
 
-    bool init() override;
     void read() override;
 
     virtual ~AP_Compass_LSM303D() { }
@@ -24,6 +24,7 @@ public:
 private:
     AP_Compass_LSM303D(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
+    bool init(enum Rotation rotation);
     uint8_t _register_read(uint8_t reg);
     void _register_write(uint8_t reg, uint8_t val);
     void _register_modify(uint8_t reg, uint8_t clearbits, uint8_t setbits);

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -16,13 +16,13 @@ public:
 
     static constexpr const char *name = "LSM9DS1";
 
-    bool init() override;
     void read() override;
 
     virtual ~AP_Compass_LSM9DS1() {}
 
 private:
     AP_Compass_LSM9DS1(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    bool init();
     bool _check_id(void);
     bool _configure(void);
     bool _set_scale(void);

--- a/libraries/AP_Compass/AP_Compass_QURT.h
+++ b/libraries/AP_Compass/AP_Compass_QURT.h
@@ -6,7 +6,6 @@
 class AP_Compass_QURT : public AP_Compass_Backend
 {
 public:
-    bool        init(void) override;
     void        read(void) override;
 
     AP_Compass_QURT(Compass &compass);
@@ -15,6 +14,7 @@ public:
     static AP_Compass_Backend *detect(Compass &compass);
 
 private:
+    bool        init(void);
     void timer_update(void);
 
     uint8_t  instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -686,23 +686,23 @@ AP_InertialSensor::detect_backends(void)
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME), ROTATION_ROLL_180));
     } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3) {
-        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_EXT_NAME), ROTATION_PITCH_180));
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_EXT_NAME), false, ROTATION_PITCH_180));
         _add_backend(AP_InertialSensor_LSM9DS0::probe(*this,
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME), ROTATION_ROLL_180_YAW_270));
-        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), ROTATION_YAW_270));
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), false, ROTATION_YAW_270));
     } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXRACER) {
         _add_backend(AP_InertialSensor_MPU6000::probe(*this, hal.spi->get_device(HAL_INS_ICM20608_NAME), ROTATION_ROLL_180_YAW_90));
-        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), ROTATION_ROLL_180_YAW_90));
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), false, ROTATION_ROLL_180_YAW_90));
     } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PHMINI) {
         // PHMINI uses ICM20608 on the ACCEL_MAG device and a MPU9250 on the old MPU6000 CS line
         _add_backend(AP_InertialSensor_MPU6000::probe(*this, hal.spi->get_device(HAL_INS_ICM20608_AM_NAME), ROTATION_ROLL_180));
-        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), ROTATION_ROLL_180));
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), false, ROTATION_ROLL_180));
     }
     // also add any PX4 backends (eg. canbus sensors)
     _add_backend(AP_InertialSensor_PX4::detect(*this));
 #elif HAL_INS_DEFAULT == HAL_INS_MPU9250_SPI && defined(HAL_INS_DEFAULT_ROTATION)
-    _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), HAL_INS_DEFAULT_ROTATION));
+    _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), false, HAL_INS_DEFAULT_ROTATION));
 #elif HAL_INS_DEFAULT == HAL_INS_MPU9250_SPI
     _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME)));
 #elif HAL_INS_DEFAULT == HAL_INS_LSM9DS0

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -698,6 +698,8 @@ AP_InertialSensor::detect_backends(void)
         // PHMINI uses ICM20608 on the ACCEL_MAG device and a MPU9250 on the old MPU6000 CS line
         _add_backend(AP_InertialSensor_MPU6000::probe(*this, hal.spi->get_device(HAL_INS_ICM20608_AM_NAME), ROTATION_ROLL_180));
         _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), false, ROTATION_ROLL_180));
+    } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PH2SLIM) {
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), true, ROTATION_YAW_270));        
     }
     // also add any PX4 backends (eg. canbus sensors)
     _add_backend(AP_InertialSensor_PX4::detect(*this));

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -686,7 +686,7 @@ AP_InertialSensor::detect_backends(void)
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME), ROTATION_ROLL_180));
     } else if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_TEST_V3) {
-        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_EXT_NAME), false, ROTATION_PITCH_180));
+        _add_backend(AP_InertialSensor_MPU9250::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_EXT_NAME), true, ROTATION_PITCH_180));
         _add_backend(AP_InertialSensor_LSM9DS0::probe(*this,
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME), ROTATION_ROLL_180_YAW_270));

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -174,6 +174,12 @@ protected:
     void set_accel_orientation(uint8_t instance, enum Rotation rotation) {
         _imu._accel_orientation[instance] = rotation;
     }
+
+    // increment clipping counted. Used by drivers that do decimation before supplying
+    // samples to the frontend
+    void increment_clip_count(uint8_t instance) {
+        _imu._accel_clip_count[instance]++;
+    }
     
     // note that each backend is also expected to have a static detect()
     // function which instantiates an instance of the backend sensor

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -514,12 +514,20 @@ void AP_InertialSensor_MPU6000::_accumulate_fast_sampling(uint8_t *samples, uint
 {
     Vector3l asum, gsum;
     float tsum = 0;
-        
+    const int32_t clip_limit = AP_INERTIAL_SENSOR_ACCEL_CLIP_THRESH_MSS / _accel_scale;
+    bool clipped = false;
+    
     for (uint8_t i = 0; i < n_samples; i++) {
         uint8_t *data = samples + MPU6000_SAMPLE_SIZE * i;
-        asum += Vector3l(int16_val(data, 1),
-                          int16_val(data, 0),
-                         -int16_val(data, 2));
+        Vector3l a(int16_val(data, 1),
+                   int16_val(data, 0),
+                   -int16_val(data, 2));
+        if (abs(a.x) > clip_limit ||
+            abs(a.y) > clip_limit ||
+            abs(a.z) > clip_limit) {
+            clipped = true;
+        }
+        asum += a;
         gsum += Vector3l(int16_val(data, 5),
                          int16_val(data, 4),
                          -int16_val(data, 6));
@@ -530,6 +538,10 @@ void AP_InertialSensor_MPU6000::_accumulate_fast_sampling(uint8_t *samples, uint
         _last_temp = temp;
     }
 
+    if (clipped) {
+        increment_clip_count(_accel_instance);
+    }
+    
     float ascale = _accel_scale / n_samples;
     Vector3f accel(asum.x*ascale, asum.y*ascale, asum.z*ascale);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -513,6 +513,7 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
 void AP_InertialSensor_MPU6000::_accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples)
 {
     Vector3l asum, gsum;
+    float tsum = 0;
         
     for (uint8_t i = 0; i < n_samples; i++) {
         uint8_t *data = samples + MPU6000_SAMPLE_SIZE * i;
@@ -525,6 +526,7 @@ void AP_InertialSensor_MPU6000::_accumulate_fast_sampling(uint8_t *samples, uint
 
         float temp = int16_val(data, 3);
         temp = temp/340 + 36.53;
+        tsum += temp;
         _last_temp = temp;
     }
 
@@ -539,6 +541,8 @@ void AP_InertialSensor_MPU6000::_accumulate_fast_sampling(uint8_t *samples, uint
     
     _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), false);
     _notify_new_gyro_raw_sample(_gyro_instance, gyro);
+
+    _temp_filtered = _temp_filter.apply(tsum / n_samples);
 }
 
 /*

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -322,9 +322,10 @@ bool AP_InertialSensor_MPU6000::_init()
 
 void AP_InertialSensor_MPU6000::_fifo_reset()
 {
-    _register_write(MPUREG_USER_CTRL, 0);
-    _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_RESET);
-    _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_EN);
+    uint8_t user_ctrl = _master_i2c_enable?BIT_USER_CTRL_I2C_MST_EN:0;
+    _register_write(MPUREG_USER_CTRL, user_ctrl);
+    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_RESET);
+    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_EN);
 }
 
 void AP_InertialSensor_MPU6000::_fifo_enable()
@@ -907,6 +908,8 @@ void AP_MPU6000_AuxiliaryBus::_configure_slaves()
     uint8_t user_ctrl = backend._register_read(MPUREG_USER_CTRL);
     backend._register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_I2C_MST_EN);
 
+    backend._master_i2c_enable = true;
+    
     /* stop condition between reads; clock at 400kHz */
     backend._register_write(MPUREG_I2C_MST_CTRL,
                             BIT_I2C_MST_P_NSR | BIT_I2C_MST_CLK_400KHZ);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -87,6 +87,7 @@ private:
 
     void _accumulate(uint8_t *samples, uint8_t n_samples);
     void _accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples);
+    void _check_temperature(void);
 
     // instance numbers of accel and gyro data
     uint8_t _gyro_instance;
@@ -112,6 +113,7 @@ private:
     
     // last temperature reading, used to detect FIFO errors
     float _last_temp;
+    uint8_t _temp_counter;
 
     // buffer for fifo read
     uint8_t *_fifo_buffer;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -115,6 +115,9 @@ private:
     float _last_temp;
     uint8_t _temp_counter;
 
+    // has master i2c been enabled?
+    bool _master_i2c_enable;    
+    
     // buffer for fifo read
     uint8_t *_fifo_buffer;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -292,7 +292,7 @@ void AP_InertialSensor_MPU9250::_fifo_enable()
 
 bool AP_InertialSensor_MPU9250::_has_auxiliary_bus()
 {
-    return _dev->bus_type() != AP_HAL::Device::BUS_TYPE_I2C && !_fast_sampling;
+    return _dev->bus_type() != AP_HAL::Device::BUS_TYPE_I2C;
 }
 
 void AP_InertialSensor_MPU9250::start()

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -276,9 +276,10 @@ bool AP_InertialSensor_MPU9250::_init()
 
 void AP_InertialSensor_MPU9250::_fifo_reset()
 {
-    _register_write(MPUREG_USER_CTRL, 0);
-    _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_RESET);
-    _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_EN);
+    uint8_t user_ctrl = _master_i2c_enable?BIT_USER_CTRL_I2C_MST_EN:0;
+    _register_write(MPUREG_USER_CTRL, user_ctrl);
+    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_RESET);
+    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_EN);
 }
 
 void AP_InertialSensor_MPU9250::_fifo_enable()
@@ -780,6 +781,8 @@ void AP_MPU9250_AuxiliaryBus::_configure_slaves()
     /* Enable the I2C master to slaves on the auxiliary I2C bus*/
     uint8_t user_ctrl = backend._register_read(MPUREG_USER_CTRL);
     backend._register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_I2C_MST_EN);
+
+    backend._master_i2c_enable = true;
 
     /* stop condition between reads; clock at 400kHz */
     backend._register_write(MPUREG_I2C_MST_CTRL,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -442,7 +442,8 @@ void AP_InertialSensor_MPU9250::_accumulate(uint8_t *samples, uint8_t n_samples)
 void AP_InertialSensor_MPU9250::_accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples)
 {
     Vector3l asum, gsum;
-        
+    float tsum = 0;
+
     for (uint8_t i = 0; i < n_samples; i++) {
         uint8_t *data = samples + MPU9250_SAMPLE_SIZE * i;
         asum += Vector3l(int16_val(data, 1),
@@ -454,6 +455,7 @@ void AP_InertialSensor_MPU9250::_accumulate_fast_sampling(uint8_t *samples, uint
 
         float temp = int16_val(data, 3);
         temp = temp/340 + 36.53;
+        tsum += temp;
         _last_temp = temp;
     }
 
@@ -468,6 +470,8 @@ void AP_InertialSensor_MPU9250::_accumulate_fast_sampling(uint8_t *samples, uint
     
     _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), false);
     _notify_new_gyro_raw_sample(_gyro_instance, gyro);
+
+    _temp_filtered = _temp_filter.apply(tsum / n_samples);
 }
 
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -487,7 +487,7 @@ void AP_InertialSensor_MPU9250::_check_temperature(void)
         // a 2 degree change in one sample is a highly likely
         // sign of a FIFO alignment error
         printf("FIFO temperature reset: %.2f %.2f\n",
-               temp, _last_temp);
+               (double)temp, (double)_last_temp);
         _last_temp = temp;
         _fifo_reset();
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -100,6 +100,9 @@ private:
 
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
+
+    // has master i2c been enabled?
+    bool _master_i2c_enable;
     
     // last temperature reading, used to detect FIFO errors
     float _last_temp;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -37,6 +37,7 @@ public:
 
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev,
+                                            bool fast_sampling = false,
                                             enum Rotation rotation = ROTATION_NONE);
 
     /* update accel and gyro state */
@@ -52,6 +53,7 @@ public:
 private:
     AP_InertialSensor_MPU9250(AP_InertialSensor &imu,
                               AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                              bool fast_sampling,
                               enum Rotation rotation);
 
 #if MPU9250_DEBUG
@@ -67,6 +69,9 @@ private:
     /* Read a single sample */
     bool _read_sample();
 
+    void _fifo_reset();
+    void _fifo_enable();
+    
     /* Check if there's data available by reading register */
     bool _data_ready();
     bool _data_ready(uint8_t int_status);
@@ -77,16 +82,31 @@ private:
     uint8_t _register_read(uint8_t reg);
     void _register_write(uint8_t reg, uint8_t val);
 
-    void _accumulate(uint8_t *sample);
+    void _accumulate(uint8_t *samples, uint8_t n_samples);
+    void _accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples);
+    void _check_temperature(void);
 
     // instance numbers of accel and gyro data
     uint8_t _gyro_instance;
     uint8_t _accel_instance;
 
+    float _temp_filtered;
+    LowPassFilter2pFloat _temp_filter;
+    
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
     AP_MPU9250_AuxiliaryBus *_auxiliary_bus;
 
     enum Rotation _rotation;
+
+    // are we doing more than 1kHz sampling?
+    bool _fast_sampling;
+    
+    // last temperature reading, used to detect FIFO errors
+    float _last_temp;
+    uint8_t _temp_counter;
+
+    // buffer for fifo read
+    uint8_t *_fifo_buffer;
 };
 
 class AP_MPU9250_AuxiliaryBusSlave : public AuxiliaryBusSlave

--- a/libraries/Filter/LowPassFilter.cpp
+++ b/libraries/Filter/LowPassFilter.cpp
@@ -24,11 +24,27 @@ T DigitalLPF<T>::apply(const T &sample, float cutoff_freq, float dt) {
         _output = sample;
         return _output;
     }
-
     float rc = 1.0f/(M_2PI*cutoff_freq);
-    float alpha = constrain_float(dt/(dt+rc), 0.0f, 1.0f);
+    alpha = constrain_float(dt/(dt+rc), 0.0f, 1.0f);
     _output += (sample - _output) * alpha;
     return _output;
+}
+
+template <class T>
+T DigitalLPF<T>::apply(const T &sample) {
+    _output += (sample - _output) * alpha;
+    return _output;
+}
+
+template <class T>
+void DigitalLPF<T>::compute_alpha(float sample_freq, float cutoff_freq) {
+    if (cutoff_freq <= 0.0f || sample_freq <= 0.0f) {
+        alpha = 1.0;
+    } else {
+        float dt = 1.0/sample_freq;
+        float rc = 1.0f/(M_2PI*cutoff_freq);
+        alpha = constrain_float(dt/(dt+rc), 0.0f, 1.0f);
+    }
 }
 
 // get latest filtered value from filter (equal to the value returned by latest call to apply method)
@@ -61,6 +77,12 @@ void LowPassFilter<T>::set_cutoff_frequency(float cutoff_freq) {
     _cutoff_freq = cutoff_freq;
 }
 
+template <class T>
+void LowPassFilter<T>::set_cutoff_frequency(float sample_freq, float cutoff_freq) {
+    _cutoff_freq = cutoff_freq;
+    _filter.compute_alpha(sample_freq, cutoff_freq);
+}
+
 // return the cutoff frequency
 template <class T>
 float LowPassFilter<T>::get_cutoff_freq(void) const {
@@ -70,6 +92,11 @@ float LowPassFilter<T>::get_cutoff_freq(void) const {
 template <class T>
 T LowPassFilter<T>::apply(T sample, float dt) {
     return _filter.apply(sample, _cutoff_freq, dt);
+}
+
+template <class T>
+T LowPassFilter<T>::apply(T sample) {
+    return _filter.apply(sample);
 }
 
 template <class T>

--- a/libraries/Filter/LowPassFilter.h
+++ b/libraries/Filter/LowPassFilter.h
@@ -18,6 +18,30 @@
 /// @brief	A class to implement a low pass filter without losing precision even for int types
 ///         the downside being that it's a little slower as it internally uses a float
 ///         and it consumes an extra 4 bytes of memory to hold the constant gain
+
+/*
+  Note that this filter can be used in 2 ways:
+
+   1) providing dt on every sample, and calling apply like this:
+
+      // call once
+      filter.set_cutoff_frequency(frequency_hz);
+
+      // then on each sample
+      output = filter.apply(sample, dt);
+
+   2) providing a sample freq and cutoff_freq once at start
+
+      // call once
+      filter.set_cutoff_frequency(sample_freq, frequency_hz);
+
+      // then on each sample
+      output = filter.apply(sample);
+
+  The second approach is more CPU efficient as it doesn't have to
+  recalculate alpha each time, but it assumes that dt is constant
+ */
+
 #pragma once
 
 #include <AP_Math/AP_Math.h>
@@ -27,21 +51,20 @@
 template <class T>
 class DigitalLPF {
 public:
-    struct lpf_params {
-        float cutoff_freq;
-        float sample_freq;
-        float alpha;
-    };  
-
     DigitalLPF();
     // add a new raw value to the filter, retrieve the filtered result
     T apply(const T &sample, float cutoff_freq, float dt);
+    T apply(const T &sample);
+
+    void compute_alpha(float sample_freq, float cutoff_freq);
+    
     // get latest filtered value from filter (equal to the value returned by latest call to apply method)
     const T &get() const;
     void reset(T value);
 
 private:
     T _output;
+    float alpha = 1.0f;
 };
 
 // LPF base class
@@ -53,11 +76,15 @@ public:
 
     // change parameters
     void set_cutoff_frequency(float cutoff_freq);
+    void set_cutoff_frequency(float sample_freq, float cutoff_freq);
+
     // return the cutoff frequency
     float get_cutoff_freq(void) const;
     T apply(T sample, float dt);
+    T apply(T sample);
     const T &get() const;
     void reset(T value);
+    void reset(void) { reset(T()); }
     
 protected:
     float _cutoff_freq;


### PR DESCRIPTION
This moves the MPU9250 to always use the FIFO, and allows it to sample accels at 4kHz and gyros at 8kHz.
It also moved the PH2SLIM to always use the in-tree drivers and fixes an issue with temperature logging.
