### PR TITLE
AP_HAL_SITL: reorder the use of P param after loading param file

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -81,6 +81,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     analogin->init();
 
     callbacks->setup();
+    _sitl_state->_set_param_default();
     scheduler->system_initialized();
 
     for (;;) {

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -23,9 +23,9 @@ extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
 
-void SITL_State::_set_param_default(const char *parm)
+void SITL_State::_set_param_default()
 {
-    char *pdup = strdup(parm);
+    char *pdup = strdup(_parm_to_default);
     char *p = strchr(pdup, '=');
     if (p == nullptr) {
         printf("Please specify parameter as NAME=VALUE");

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -73,10 +73,11 @@ public:
         "GPS2",
         "tcp:4",
     };
-    
+    void _set_param_default();
+
 private:
     void _parse_command_line(int argc, char * const argv[]);
-    void _set_param_default(const char *parm);
+
     void _usage(void);
     void _sitl_setup(const char *home_str);
     void _setup_fdm(void);
@@ -169,7 +170,7 @@ private:
     bool _synthetic_clock_mode;
 
     bool _use_rtscts;
-    
+    const char *_parm_to_default;
     const char *_fdm_address;
 
     // delay buffer variables

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -199,7 +199,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         }
         break;
         case 'P':
-            _set_param_default(gopt.optarg);
+            _parm_to_default = gopt.optarg;
             break;
         case 'S':
             _synthetic_clock_mode = true;


### PR DESCRIPTION
This is a request for coments PR.
The parameter -P in sitl doesn't works if -w or --default parameter are used. 
This PR is a proposal to solve this issues (related to https://github.com/ArduPilot/ardupilot/issues/5164)

It allow for example to change the mav id on launch without having to create a param file for it or using a GCS (very valuable in swarm config)