### PR TITLE
PX4: startup more drivers on demand

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -46,6 +46,7 @@ public:
         PX4_BOARD_PIXRACER = 4,
         PX4_BOARD_PHMINI   = 5,
         PX4_BOARD_PH2SLIM  = 6,
+        PX4_BOARD_OLDDRIVERS = 100,
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
         VRX_BOARD_BRAIN51  = 7,
@@ -55,9 +56,6 @@ public:
         VRX_BOARD_CORE10   = 11,
         VRX_BOARD_BRAIN54  = 12,
 #endif
-        PX4_BOARD_TEST_V1 = 101,
-        PX4_BOARD_TEST_V2 = 102,
-        PX4_BOARD_TEST_V3 = 103
     };
 #endif
 
@@ -111,7 +109,6 @@ private:
     void px4_start_common_sensors(void);
     void px4_start_fmuv1_sensors(void);
     void px4_start_fmuv2_sensors(void);
-    void px4_start_optional_sensors(void);
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
@@ -122,7 +119,6 @@ private:
     void vrx_start_ubrain52_sensors(void);
     void vrx_start_core10_sensors(void);
     void vrx_start_brain54_sensors(void);
-    void vrx_start_optional_sensors(void);
 #endif
 
 #endif // HAL_BOARD_PX4 || HAL_BOARD_VRBRAIN

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -45,10 +45,6 @@ extern "C" {
     int l3gd20_main(int , char **);
     int lsm303d_main(int , char **);
     int hmc5883_main(int , char **);
-    int ll40ls_main(int, char **);
-    int trone_main(int, char **);
-    int mb12xx_main(int, char **);
-    int pwm_input_main(int, char **);
     int uavcan_main(int, char **);
     int fmu_main(int, char **);
     int px4io_main(int, char **);
@@ -376,9 +372,6 @@ void AP_BoardConfig::px4_start_fmuv2_sensors(void)
     if (have_FMUV3) {
         // on Pixhawk2 default IMU temperature to 60
         _imu_target_temperature.set_default(60);
-        px4.board_type.set_and_notify(PX4_BOARD_PIXHAWK2);
-    } else {
-        px4.board_type.set_and_notify(PX4_BOARD_PIXHAWK);
     }
     
     printf("FMUv2 sensors started\n");
@@ -403,7 +396,6 @@ void AP_BoardConfig::px4_start_fmuv1_sensors(void)
     } else {
         px4_sensor_error("mpu6000");
     }
-    px4.board_type.set_and_notify(PX4_BOARD_PX4V1);
 #endif // CONFIG_ARCH_BOARD_PX4FMU_V1
 }
 
@@ -426,32 +418,7 @@ void AP_BoardConfig::px4_start_common_sensors(void)
 #endif
 }
 
-
-/*
-  setup optional sensors
- */
-void AP_BoardConfig::px4_start_optional_sensors(void)
-{
-    if (px4_start_driver(ll40ls_main, "ll40ls", "-X start")) {
-        printf("Found external ll40ls sensor\n");
-    }
-    if (px4_start_driver(ll40ls_main, "ll40ls", "-I start")) {
-        printf("Found internal ll40ls sensor\n");
-    }
-    if (px4_start_driver(trone_main, "trone", "start")) {
-        printf("Found trone sensor\n");
-    }
-    if (px4_start_driver(mb12xx_main, "mb12xx", "start")) {
-        printf("Found mb12xx sensor\n");
-    }
-
-#if !defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
-    if (px4_start_driver(pwm_input_main, "pwm_input", "start")) {
-        printf("started pwm_input driver\n");
-    }
-#endif
-}
-#endif
+#endif // CONFIG_HAL_BOARD
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
 void AP_BoardConfig::vrx_start_brain51_sensors(void)
@@ -556,31 +523,7 @@ void AP_BoardConfig::vrx_start_common_sensors(void)
     }
 }
 
-
-/*
-  setup optional sensors
- */
-void AP_BoardConfig::vrx_start_optional_sensors(void)
-{
-    if (px4_start_driver(ll40ls_main, "ll40ls", "-X start")) {
-        printf("Found external ll40ls sensor\n");
-    }
-    if (px4_start_driver(ll40ls_main, "ll40ls", "-I start")) {
-        printf("Found internal ll40ls sensor\n");
-    }
-
-    if (px4_start_driver(trone_main, "trone", "start")) {
-        printf("Found trone sensor\n");
-    }
-    if (px4_start_driver(mb12xx_main, "mb12xx", "start")) {
-        printf("Found mb12xx sensor\n");
-    }
-
-    if (px4_start_driver(pwm_input_main, "pwm_input", "start")) {
-        printf("started pwm_input driver\n");
-    }
-}
-#endif
+#endif // CONFIG_HAL_BOARD
 
 void AP_BoardConfig::px4_setup_drivers(void)
 {
@@ -623,8 +566,6 @@ void AP_BoardConfig::px4_setup_drivers(void)
         px4_start_fmuv2_sensors();
         break;
     }
-    px4_start_optional_sensors();
-
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     vrx_start_common_sensors();
     switch ((px4_board_type)px4.board_type.get()) {
@@ -655,8 +596,6 @@ void AP_BoardConfig::px4_setup_drivers(void)
     default:
         break;
     }
-    vrx_start_optional_sensors();
-
 #endif // HAL_BOARD_PX4
 
     px4_configured_board = (enum px4_board_type)px4.board_type.get();
@@ -797,13 +736,6 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
  */
 void AP_BoardConfig::px4_autodetect(void)
 {
-    if (px4.board_type == PX4_BOARD_TEST_V1 ||
-        px4.board_type == PX4_BOARD_TEST_V2 ||
-        px4.board_type == PX4_BOARD_TEST_V3) {
-        // these were old test values
-        px4.board_type.set(0);
-    }
-    
     if (px4.board_type != PX4_BOARD_AUTO) {
         // user has chosen a board type
         return;

--- a/libraries/AP_RPM/RPM_PX4_PWM.cpp
+++ b/libraries/AP_RPM/RPM_PX4_PWM.cpp
@@ -16,6 +16,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include "RPM_PX4_PWM.h"
 
 #include <sys/types.h>
@@ -35,12 +36,21 @@
 
 extern const AP_HAL::HAL& hal;
 
+extern "C" {
+    int pwm_input_main(int, char **);
+};
+
 /* 
    open the sensor in constructor
 */
 AP_RPM_PX4_PWM::AP_RPM_PX4_PWM(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_State &_state) :
 	AP_RPM_Backend(_ap_rpm, instance, _state)
 {
+#ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
+    if (AP_BoardConfig::px4_start_driver(pwm_input_main, "pwm_input", "start")) {
+        hal.console->printf("started pwm_input driver\n");
+    }
+#endif
     _fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);
     if (_fd == -1) {
         hal.console->printf("Unable to open %s\n", PWMIN0_DEVICE_PATH);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
@@ -16,6 +16,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include "AP_RangeFinder_PX4.h"
 
 #include <sys/types.h>
@@ -75,11 +76,35 @@ AP_RangeFinder_PX4::~AP_RangeFinder_PX4()
     }
 }
 
+extern "C" {
+    int ll40ls_main(int, char **);
+    int trone_main(int, char **);
+    int mb12xx_main(int, char **);
+    int pwm_input_main(int, char **);
+};
+
 /* 
    open the PX4 driver, returning the file descriptor
 */
 int AP_RangeFinder_PX4::open_driver(void)
 {
+    if (num_px4_instances == 0) {
+        /*
+          we start the px4 rangefinder drivers on demand
+        */
+        if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-X start")) {
+            hal.console->printf("Found external ll40ls sensor\n");
+        }
+        if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-I start")) {
+            hal.console->printf("Found internal ll40ls sensor\n");
+        }
+        if (AP_BoardConfig::px4_start_driver(trone_main, "trone", "start")) {
+            hal.console->printf("Found trone sensor\n");
+        }
+        if (AP_BoardConfig::px4_start_driver(mb12xx_main, "mb12xx", "start")) {
+            hal.console->printf("Found mb12xx sensor\n");
+        }
+    }
     // work out the device path based on how many PX4 drivers we have loaded
     char path[] = RANGE_FINDER_BASE_DEVICE_PATH "n";
     path[strlen(path)-1] = '0' + num_px4_instances;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
@@ -80,7 +80,6 @@ extern "C" {
     int ll40ls_main(int, char **);
     int trone_main(int, char **);
     int mb12xx_main(int, char **);
-    int pwm_input_main(int, char **);
 };
 
 /* 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
@@ -16,6 +16,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include "AP_RangeFinder_PX4_PWM.h"
 
 #include <sys/types.h>
@@ -32,6 +33,10 @@
 #include <cmath>
 
 extern const AP_HAL::HAL& hal;
+
+extern "C" {
+    int pwm_input_main(int, char **);
+};
 
 /* 
    The constructor also initialises the rangefinder. Note that this
@@ -80,6 +85,11 @@ AP_RangeFinder_PX4_PWM::~AP_RangeFinder_PX4_PWM()
 */
 bool AP_RangeFinder_PX4_PWM::detect(RangeFinder &_ranger, uint8_t instance)
 {
+#ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
+    if (AP_BoardConfig::px4_start_driver(pwm_input_main, "pwm_input", "start")) {
+        hal.console->printf("started pwm_input driver\n");
+    }
+#endif
     int fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);
     if (fd == -1) {
         return false;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -29,8 +29,13 @@ extern const AP_HAL::HAL& hal;
 AP_RangeFinder_PulsedLightLRF::AP_RangeFinder_PulsedLightLRF(RangeFinder &_ranger, uint8_t instance,
                                                              RangeFinder::RangeFinder_State &_state)
     : AP_RangeFinder_Backend(_ranger, instance, _state)
-    , _dev(hal.i2c_mgr->get_device(1, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR))
 {
+    // try external bus first
+    _dev = hal.i2c_mgr->get_device(1, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR);
+    if (!_dev) {
+        // then internal
+        _dev = hal.i2c_mgr->get_device(0, AP_RANGEFINDER_PULSEDLIGHTLRF_ADDR);        
+    }
 }
 
 /*

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -25,6 +25,7 @@
 #include "AP_RangeFinder_Bebop.h"
 #include "AP_RangeFinder_MAVLink.h"
 #include "AP_RangeFinder_LeddarOne.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -33,7 +34,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,12:LeddarOne
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,12:LeddarOne
     // @User: Standard
     AP_GROUPINFO("_TYPE",    0, RangeFinder, _type[0], 0),
 
@@ -153,7 +154,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,12:LeddarOne
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,12:LeddarOne
     // @User: Advanced
     AP_GROUPINFO("2_TYPE",    12, RangeFinder, _type[1], 0),
 
@@ -575,20 +576,13 @@ void RangeFinder::_add_backend(AP_RangeFinder_Backend *backend)
 
     drivers[num_instances++] = backend;
 }
-    
+
 /*
   detect if an instance of a rangefinder is connected. 
  */
 void RangeFinder::detect_instance(uint8_t instance)
 {
     uint8_t type = _type[instance];
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    if (type == RangeFinder_TYPE_PLI2C || 
-        type == RangeFinder_TYPE_MBI2C) {
-        // I2C sensor types are handled by the PX4Firmware code
-        type = RangeFinder_TYPE_PX4;
-    }
-#endif
     if (type == RangeFinder_TYPE_PLI2C) {
         _add_backend(AP_RangeFinder_PulsedLightLRF::detect(*this, instance, state[instance]));
     }


### PR DESCRIPTION
startup rangefinder and PWM drivers on demand when use selects the option rather than always starting
