### PR TITLE
AP_GPS_SBF: fix accuracy reported by driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -226,9 +226,10 @@ AP_GPS_SBF::process_message(void)
             state.ground_speed = (float)safe_sqrt(ground_vector_sq);
 
             state.ground_course = wrap_360(degrees(atan2f(state.velocity[1], state.velocity[0])));
-
-            state.horizontal_accuracy = (float)temp.HAccuracy * 0.01f;
-            state.vertical_accuracy = (float)temp.VAccuracy * 0.01f;
+            
+            // value is expressed as twice the rms error = int16 * 0.01/2
+            state.horizontal_accuracy = (float)temp.HAccuracy * 0.005f;
+            state.vertical_accuracy = (float)temp.VAccuracy * 0.005f;
             state.have_horizontal_accuracy = true;
             state.have_vertical_accuracy = true;
         }


### PR DESCRIPTION
this fix's an issue with miss reporting the accuracy's by double. This has the biggest effect when flying in a non rtk mode. Under rtk mode the accuracy drops to 0.01m.