### PR TITLE
Rover: Fixed LOITER_UNLIM to be an active loiter

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -526,7 +526,7 @@ private:
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_loiter_time(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
-    bool verify_loiter_unlim();
+    bool verify_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     bool verify_loiter_time(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);


### PR DESCRIPTION
This changes brings the LOITER commands in line so both LOITER_UNLIM
and LOITER_TIME are actively loitering.