### PR TITLE
Accel calibration: add better MAVLink reporting

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1082,6 +1082,15 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+        case MAV_CMD_ACCELCAL_VEHICLE_POS:
+            result = MAV_RESULT_FAILED;
+
+            if (rover.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+                result = MAV_RESULT_ACCEPTED;
+            }
+            break;
+
+
         default:
                 break;
             }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -680,6 +680,14 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
                 result = tracker.compass.handle_mag_cal_command(packet);
                 break;
 
+            case MAV_CMD_ACCELCAL_VEHICLE_POS:
+                result = MAV_RESULT_FAILED;
+
+                if (tracker.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+                    result = MAV_RESULT_ACCEPTED;
+                }
+                break;
+
             default:
                 break;
         }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1498,6 +1498,14 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+        case MAV_CMD_ACCELCAL_VEHICLE_POS:
+            result = MAV_RESULT_FAILED;
+
+            if (copter.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+                result = MAV_RESULT_ACCEPTED;
+            }
+            break;
+
         default:
             result = MAV_RESULT_UNSUPPORTED;
             break;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1510,6 +1510,14 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
+
+        case MAV_CMD_ACCELCAL_VEHICLE_POS:
+            result = MAV_RESULT_FAILED;
+
+            if (plane.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+                result = MAV_RESULT_ACCEPTED;
+            }
+            break;
             
         default:
             break;

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -17,6 +17,8 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_HAL/AP_HAL.h>
 
+#define AP_ACCELCAL_POSITION_REQUEST_INTERVAL_MS 1000
+
 const extern AP_HAL::HAL& hal;
 static bool _start_collect_sample;
 static void _snoop(const mavlink_message_t* msg);
@@ -69,33 +71,41 @@ void AP_AccelCal::update()
                 if (step != _step) {
                     _step = step;
 
-                    const char *msg;
-                    switch (step) {
-                        case ACCELCAL_VEHICLE_POS_LEVEL:
-                            msg = "level";
-                            break;
-                        case ACCELCAL_VEHICLE_POS_LEFT:
-                            msg = "on its LEFT side";
-                            break;
-                        case ACCELCAL_VEHICLE_POS_RIGHT:
-                            msg = "on its RIGHT side";
-                            break;
-                        case ACCELCAL_VEHICLE_POS_NOSEDOWN:
-                            msg = "nose DOWN";
-                            break;
-                        case ACCELCAL_VEHICLE_POS_NOSEUP:
-                            msg = "nose UP";
-                            break;
-                        case ACCELCAL_VEHICLE_POS_BACK:
-                            msg = "on its BACK";
-                            break;
-                        default:
-                            fail();
-                            return;
+                    if(_use_gcs_snoop) {
+                        const char *msg;
+                        switch (step) {
+                            case ACCELCAL_VEHICLE_POS_LEVEL:
+                                msg = "level";
+                                break;
+                            case ACCELCAL_VEHICLE_POS_LEFT:
+                                msg = "on its LEFT side";
+                                break;
+                            case ACCELCAL_VEHICLE_POS_RIGHT:
+                                msg = "on its RIGHT side";
+                                break;
+                            case ACCELCAL_VEHICLE_POS_NOSEDOWN:
+                                msg = "nose DOWN";
+                                break;
+                            case ACCELCAL_VEHICLE_POS_NOSEUP:
+                                msg = "nose UP";
+                                break;
+                            case ACCELCAL_VEHICLE_POS_BACK:
+                                msg = "on its BACK";
+                                break;
+                            default:
+                                fail();
+                                return;
+                        }
+                        _printf("Place vehicle %s and press any key.", msg);
+                        // setup snooping of packets so we can see the COMMAND_ACK
+                        _gcs->set_snoop(_snoop);
                     }
-                    _printf("Place vehicle %s and press any key.", msg);
-                    // setup snooping of packets so we can see the COMMAND_ACK
-                    _gcs->set_snoop(_snoop);
+                }
+
+                uint32_t now = AP_HAL::millis();
+                if (now - _last_position_request_ms > AP_ACCELCAL_POSITION_REQUEST_INTERVAL_MS) {
+                    _last_position_request_ms = now;
+                    _gcs->send_accelcal_vehicle_position(step);
                 }
                 break;
             }
@@ -167,6 +177,8 @@ void AP_AccelCal::start(GCS_MAVLINK *gcs)
     _started = true;
     _saving = false;
     _gcs = gcs;
+    _use_gcs_snoop = true;
+    _last_position_request_ms = 0;
     _step = 0;
 
     update_status();
@@ -327,6 +339,18 @@ static void _snoop(const mavlink_message_t* msg)
     if (msg->msgid == MAVLINK_MSG_ID_COMMAND_ACK) {
         _start_collect_sample = true;
     }
+}
+
+bool AP_AccelCal::gcs_vehicle_position(float position)
+{
+    _use_gcs_snoop = false;
+
+    if (_status == ACCEL_CAL_WAITING_FOR_ORIENTATION && is_equal((float) _step, position)) {
+        _start_collect_sample = true;
+        return true;
+    }
+
+    return false;
 }
 
 void AP_AccelCal::_printf(const char* fmt, ...)

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -71,22 +71,22 @@ void AP_AccelCal::update()
 
                     const char *msg;
                     switch (step) {
-                        case 1:
+                        case ACCELCAL_VEHICLE_POS_LEVEL:
                             msg = "level";
                             break;
-                        case 2:
+                        case ACCELCAL_VEHICLE_POS_LEFT:
                             msg = "on its LEFT side";
                             break;
-                        case 3:
+                        case ACCELCAL_VEHICLE_POS_RIGHT:
                             msg = "on its RIGHT side";
                             break;
-                        case 4:
+                        case ACCELCAL_VEHICLE_POS_NOSEDOWN:
                             msg = "nose DOWN";
                             break;
-                        case 5:
+                        case ACCELCAL_VEHICLE_POS_NOSEUP:
                             msg = "nose UP";
                             break;
-                        case 6:
+                        case ACCELCAL_VEHICLE_POS_BACK:
                             msg = "on its BACK";
                             break;
                         default:

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -45,8 +45,6 @@ void AP_AccelCal::update()
         }
         if(_start_collect_sample) {
             collect_sample();
-            _gcs->set_snoop(nullptr);
-            _start_collect_sample = false;
         }
         switch(_status) {
             case ACCEL_CAL_NOT_STARTED:
@@ -96,9 +94,9 @@ void AP_AccelCal::update()
                             return;
                     }
                     _printf("Place vehicle %s and press any key.", msg);
+                    // setup snooping of packets so we can see the COMMAND_ACK
+                    _gcs->set_snoop(_snoop);
                 }
-                // setup snooping of packets so we can see the COMMAND_ACK
-                _gcs->set_snoop(_snoop);
                 break;
             }
             case ACCEL_CAL_COLLECTING_SAMPLE:
@@ -246,6 +244,7 @@ void AP_AccelCal::collect_sample()
     }
     // setup snooping of packets so we can see the COMMAND_ACK
     _gcs->set_snoop(nullptr);
+    _start_collect_sample = false;
     update_status();
 }
 

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -10,6 +10,7 @@ class AP_AccelCal_Client;
 class AP_AccelCal {
 public:
     AP_AccelCal():
+    _use_gcs_snoop(true),
     _started(false),
     _saving(false)
     { update_status(); }
@@ -25,12 +26,17 @@ public:
 
     // get the status of the calibrator server as a whole
     accel_cal_status_t get_status() { return _status; }
+    
+    // Set vehicle position sent by the GCS
+    bool gcs_vehicle_position(float position);
 
     // interface to the clients for registration
     static void register_client(AP_AccelCal_Client* client);
 
 private:
     GCS_MAVLINK *_gcs;
+    bool _use_gcs_snoop;
+    uint32_t _last_position_request_ms;
     uint8_t _step;
     accel_cal_status_t _status;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1634,8 +1634,8 @@ void AP_InertialSensor::_acal_save_calibrations()
 void AP_InertialSensor::_acal_event_failure()
 {
     for (uint8_t i=0; i<_accel_count; i++) {
-        _accel_offset[i].set_and_save(Vector3f(0,0,0));
-        _accel_scale[i].set_and_save(Vector3f(0,0,0));
+        _accel_offset[i].set_and_notify(Vector3f(0,0,0));
+        _accel_scale[i].set_and_notify(Vector3f(1,1,1));
     }
 }
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -636,6 +636,13 @@ public:
         _value = v;
     }
 
+    /// Value setter - set value, tell GCS
+    ///
+    void set_and_notify(const T &v) {
+        set(v);
+        notify();
+    }
+
     /// Combined set and save
     ///
     bool set_and_save(const T &v) {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -171,6 +171,7 @@ public:
     void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
+    void send_accelcal_vehicle_position(uint8_t position);
 
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1747,6 +1747,20 @@ void GCS_MAVLINK::send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_C
     }
 }
 
+void GCS_MAVLINK::send_accelcal_vehicle_position(uint8_t position)
+{
+    if (HAVE_PAYLOAD_SPACE(chan, COMMAND_LONG)) {
+        mavlink_msg_command_long_send(
+            chan,
+            0,
+            0,
+            MAV_CMD_ACCELCAL_VEHICLE_POS,
+            0,
+            (float) position,
+            0, 0, 0, 0, 0, 0);
+    }
+}
+
 /*
   handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
 


### PR DESCRIPTION
Currently, accelerometer calibration sends status text once to request the user to put the vehicle in a specific position. The GCS answers back with a COMMAND_ACK when the vehicle is in position.
This has two issues: the status text could be lost in transit and never reach the GCS and the COMMAND_ACK could really be from anything.

This new approach keeps the old one but adds a new message (a command) that is sent once a second to the GCS. Once the vehicle is ready, the GCS should send an identical message back.
When the vehicle receives this new command, it stops using the old method as it is assumed that the GCS knows this new, more reliable, method.

Also changed what happens in case of an accel cal failure: previously it was overriding the saved values (which doesn't make much sense to me) and it was setting the scaling to 0 - that would make ArduPilot crash if a first accel cal failure happened and you tried to do a second.

I tested it with MAVProxy, using the *watch* and *long* commands.

Depends on https://github.com/ArduPilot/mavlink/pull/21