### PR TITLE
add support for a user locations.txt file to sim_vehicle

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -485,14 +485,40 @@ def do_build(vehicledir, opts, frame_options):
     os.chdir(old_dir)
 
 
+def get_user_locations_path():
+    '''The user locations.txt file is located by default in
+    $XDG_CONFIG_DIR/ardupilot/locations.txt. If $XDG_CONFIG_DIR is
+    not defined, we look in $HOME/.config/ardupilot/locations.txt.  If
+    $HOME is not defined, we look in ./.config/ardpupilot/locations.txt.'''
+
+    config_dir = os.environ.get(
+        'XDG_CONFIG_DIR',
+        os.path.join(os.environ.get('HOME', '.'), '.config'))
+
+    user_locations_path = os.path.join(
+        config_dir, 'ardupilot', 'locations.txt')
+
+    return user_locations_path
+
+
 def find_location_by_name(autotest, locname):
     """Search locations.txt for locname, return GPS coords"""
+    locations_userpath = os.environ.get('ARDUPILOT_LOCATIONS',
+                                        get_user_locations_path())
+
     locations_filepath = os.path.join(autotest, "locations.txt")
-    for line in open(locations_filepath, 'r'):
-        line = line.rstrip("\n")
-        (name, loc) = line.split("=")
-        if name == locname:
-            return loc
+
+    for path in [locations_userpath, locations_filepath]:
+        if not os.path.isfile(path):
+            continue
+
+        with open(path, 'r') as fd:
+            for line in fd:
+                line = line.rstrip("\n")
+                (name, loc) = line.split("=")
+                if name == locname:
+                    return loc
+
     print("Failed to find location (%s)" % cmd_opts.location)
     sys.exit(1)
 


### PR DESCRIPTION
it is inconvenient to modify locations.txt in the source, because this
will lead to the file being constantly marked as modified by git (and
potentially included in pull requests by accident).

this commit adds support for a user-maintained list of locations.
This file lives by default in
`$XDG_CONFIG_DIR/ardupilot/locations.txt` (aka
`$HOME/.config/ardupilot/locations.txt`), but may also be specified in
the `ARDUPILOT_LOCATIONS` environment variable.