### PR TITLE
Copter: improve object avoidance using mini-fence

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -708,6 +708,7 @@ private:
     void send_vfr_hud(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
+    void send_proximity(mavlink_channel_t chan, uint16_t count_max);
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();
     void button_update();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -995,6 +995,7 @@ private:
     bool pre_arm_gps_checks(bool display_failure);
     bool pre_arm_ekf_attitude_check();
     bool pre_arm_terrain_check(bool display_failure);
+    bool pre_arm_proximity_check(bool display_failure);
     bool arm_checks(bool display_failure, bool arming_from_gcs);
     void init_disarm_motors();
     void motors_output();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -761,6 +761,8 @@ struct PACKED log_Proximity {
     float dist225;
     float dist270;
     float dist315;
+    float closest_angle;
+    float closest_dist;
 };
 
 // Write proximity sensor distances
@@ -782,6 +784,9 @@ void Copter::Log_Write_Proximity()
     g2.proximity.get_horizontal_distance(270, sector_distance[6]);
     g2.proximity.get_horizontal_distance(315, sector_distance[7]);
 
+    float close_ang = 0.0f, close_dist = 0.0f;
+    g2.proximity.get_closest_object(close_ang, close_dist);
+
     struct log_Proximity pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
         time_us         : AP_HAL::micros64(),
@@ -793,7 +798,9 @@ void Copter::Log_Write_Proximity()
         dist180         : sector_distance[4],
         dist225         : sector_distance[5],
         dist270         : sector_distance[6],
-        dist315         : sector_distance[7]
+        dist315         : sector_distance[7],
+        closest_angle   : close_ang,
+        closest_dist    : close_dist
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 #endif
@@ -842,7 +849,7 @@ const struct LogStructure Copter::log_structure[] = {
     { LOG_THROW_MSG, sizeof(log_Throw),
       "THRO",  "QBffffbbbb",  "TimeUS,Stage,Vel,VelZ,Acc,AccEfZ,Throw,AttOk,HgtOk,PosOk" },
     { LOG_PROXIMITY_MSG, sizeof(log_Proximity),
-      "PRX",   "QBffffffff",  "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315" },
+      "PRX",   "QBffffffffff","TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,CAng,CDist" },
 };
 
 #if CLI_ENABLED == ENABLED

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -34,8 +34,8 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
-        adjust_velocity_circle(kP, accel_cmss_limited, desired_vel);
         adjust_velocity_poly(kP, accel_cmss_limited, desired_vel);
+        adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_vel);
     }
 
     if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0) {
@@ -55,7 +55,7 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel
 /*
  * Adjusts the desired velocity for the circular fence.
  */
-void AC_Avoid::adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel)
+void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f &desired_vel)
 {
     // exit if circular fence is not enabled
     if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) == 0) {

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -34,8 +34,8 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
-        adjust_velocity_poly(kP, accel_cmss_limited, desired_vel);
         adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_vel);
+        adjust_velocity_polygon_fence(kP, accel_cmss_limited, desired_vel);
     }
 
     if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0) {
@@ -96,8 +96,7 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
 /*
  * Adjusts the desired velocity for the polygon fence.
  */
-
-void AC_Avoid::adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel)
+void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2f &desired_vel)
 {
     // exit if the polygon fence is not enabled
     if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_POLYGON) == 0) {

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -23,7 +23,7 @@ AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fen
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel)
+void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel)
 {
     // exit immediately if disabled
     if (_enabled == AC_AVOID_DISABLED) {
@@ -44,7 +44,7 @@ void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector2f 
 }
 
 // convenience function to accept Vector3f.  Only x and y are adjusted
-void AC_Avoid::adjust_velocity(const float kP, const float accel_cmss, Vector3f &desired_vel)
+void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel)
 {
     Vector2f des_vel_xy(desired_vel.x, desired_vel.y);
     adjust_velocity(kP, accel_cmss, des_vel_xy);
@@ -193,7 +193,7 @@ void AC_Avoid::adjust_velocity_proximity(const float kP, const float accel_cmss,
  * Uses velocity adjustment idea from Randy's second email on this thread:
  * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
  */
-void AC_Avoid::limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float limit_distance) const
+void AC_Avoid::limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance) const
 {
     const float max_speed = get_max_speed(kP, accel_cmss, limit_distance);
     // project onto limit direction
@@ -219,7 +219,7 @@ Vector2f AC_Avoid::get_position()
  * Computes the speed such that the stopping distance
  * of the vehicle will be exactly the input distance.
  */
-float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const float distance) const
+float AC_Avoid::get_max_speed(float kP, float accel_cmss, float distance) const
 {
     return AC_AttitudeControl::sqrt_controller(distance, kP, accel_cmss);
 }
@@ -229,7 +229,7 @@ float AC_Avoid::get_max_speed(const float kP, const float accel_cmss, const floa
  *
  * Implementation copied from AC_PosControl.
  */
-float AC_Avoid::get_stopping_distance(const float kP, const float accel_cmss, const float speed) const
+float AC_Avoid::get_stopping_distance(float kP, float accel_cmss, float speed) const
 {
     // avoid divide by zero by using current position if the velocity is below 10cm/s, kP is very low or acceleration is zero
     if (kP <= 0.0f || accel_cmss <= 0.0f || is_zero(speed)) {

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -42,7 +42,7 @@ private:
     /*
      * Adjusts the desired velocity for the circular fence.
      */
-    void adjust_velocity_circle(const float kP, const float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f &desired_vel);
 
     /*
      * Adjusts the desired velocity for the polygon fence.

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -47,7 +47,7 @@ private:
     /*
      * Adjusts the desired velocity for the polygon fence.
      */
-    void adjust_velocity_poly(const float kP, const float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2f &desired_vel);
 
     /*
      * Adjusts the desired velocity based on output from the proximity sensor

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -56,8 +56,9 @@ private:
 
     /*
      * Adjusts the desired velocity given an array of boundary points
+     *   earth_frame should be true if boundary is in earth-frame, false for body-frame
      */
-    void adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f* boundary, uint16_t num_points);
+    void adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f* boundary, uint16_t num_points, bool earth_frame);
 
     /*
      * Limits the component of desired_vel in the direction of the unit vector

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -32,8 +32,8 @@ public:
      * before the fence/object.
      * Note: Vector3f version is for convenience and only adjusts x and y axis
      */
-    void adjust_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel);
-    void adjust_velocity(const float kP, const float accel_cmss, Vector3f &desired_vel);
+    void adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -52,7 +52,7 @@ private:
     /*
      * Adjusts the desired velocity based on output from the proximity sensor
      */
-    void adjust_velocity_proximity(const float kP, const float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel);
 
     /*
      * Limits the component of desired_vel in the direction of the unit vector
@@ -61,7 +61,7 @@ private:
      * Uses velocity adjustment idea from Randy's second email on this thread:
      * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
      */
-    void limit_velocity(const float kP, const float accel_cmss, Vector2f &desired_vel, const Vector2f limit_direction, const float limit_distance) const;
+    void limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance) const;
 
     /*
      * Gets the current position, relative to home (not relative to EKF origin)
@@ -72,12 +72,12 @@ private:
      * Computes the speed such that the stopping distance
      * of the vehicle will be exactly the input distance.
      */
-    float get_max_speed(const float kP, const float accel_cmss, const float distance) const;
+    float get_max_speed(float kP, float accel_cmss, float distance) const;
 
     /*
      * Computes distance required to stop, given current speed.
      */
-    float get_stopping_distance(const float kP, const float accel_cmss, const float speed) const;
+    float get_stopping_distance(float kP, float accel_cmss, float speed) const;
 
     /*
      * Gets the fence margin in cm

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -55,6 +55,11 @@ private:
     void adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel);
 
     /*
+     * Adjusts the desired velocity given an array of boundary points
+     */
+    void adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f* boundary, uint16_t num_points);
+
+    /*
      * Limits the component of desired_vel in the direction of the unit vector
      * limit_direction to be at most the maximum speed permitted by the limit_distance.
      *

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -194,3 +194,14 @@ bool AP_Proximity::get_horizontal_distance(float angle_deg, float &distance) con
 {
     return get_horizontal_distance(primary_instance, angle_deg, distance);
 }
+
+// get distance and angle to closest object (used for pre-arm check)
+//   returns true on success, false if no valid readings
+bool AP_Proximity::get_closest_object(float& angle_deg, float &distance) const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get closest object from backend
+    return drivers[primary_instance]->get_closest_object(angle_deg, distance);
+}

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -279,6 +279,23 @@ bool AP_Proximity::get_horizontal_distance(float angle_deg, float &distance) con
     return get_horizontal_distance(primary_instance, angle_deg, distance);
 }
 
+// get boundary points around vehicle for use by avoidance
+//   returns nullptr and sets num_points to zero if no boundary can be returned
+const Vector2f* AP_Proximity::get_boundary_points(uint8_t instance, uint16_t& num_points) const
+{
+    if ((drivers[instance] == nullptr) || (_type[instance] == Proximity_Type_None)) {
+        num_points = 0;
+        return nullptr;
+    }
+    // get boundary from backend
+    return drivers[primary_instance]->get_boundary_points(num_points);
+}
+
+const Vector2f* AP_Proximity::get_boundary_points(uint16_t& num_points) const
+{
+    return get_boundary_points(primary_instance, num_points);
+}
+
 // get distance and angle to closest object (used for pre-arm check)
 //   returns true on success, false if no valid readings
 bool AP_Proximity::get_closest_object(float& angle_deg, float &distance) const

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -306,3 +306,31 @@ bool AP_Proximity::get_closest_object(float& angle_deg, float &distance) const
     // get closest object from backend
     return drivers[primary_instance]->get_closest_object(angle_deg, distance);
 }
+
+// get distances in 8 directions. used for sending distances to ground station
+bool AP_Proximity::get_distances(Proximity_Distance_Array &prx_dist_array) const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return 0.0f;
+    }
+    // get maximum distance from backend
+    return drivers[primary_instance]->get_distances(prx_dist_array);
+}
+
+// get maximum and minimum distances (in meters) of primary sensor
+float AP_Proximity::distance_max() const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return 0.0f;
+    }
+    // get maximum distance from backend
+    return drivers[primary_instance]->distance_max();
+}
+float AP_Proximity::distance_min() const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return 0.0f;
+    }
+    // get minimum distance from backend
+    return drivers[primary_instance]->distance_min();
+}

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -44,27 +44,111 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_YAW_CORR", 3, AP_Proximity, _yaw_correction[0], PROXIMITY_YAW_CORRECTION_DEFAULT),
 
+    // @Param: _IGN_ANG1
+    // @DisplayName: Proximity sensor ignore angle 1
+    // @Description: Proximity sensor ignore angle 1
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG1", 4, AP_Proximity, _ignore_angle_deg[0], 0),
+
+    // @Param: _IGN_WID1
+    // @DisplayName: Proximity sensor ignore width 1
+    // @Description: Proximity sensor ignore width 1
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID1", 5, AP_Proximity, _ignore_width_deg[0], 0),
+
+    // @Param: _IGN_ANG2
+    // @DisplayName: Proximity sensor ignore angle 2
+    // @Description: Proximity sensor ignore angle 2
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG2", 6, AP_Proximity, _ignore_angle_deg[1], 0),
+
+    // @Param: _IGN_WID1
+    // @DisplayName: Proximity sensor ignore width 2
+    // @Description: Proximity sensor ignore width 2
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID2", 7, AP_Proximity, _ignore_width_deg[1], 0),
+
+    // @Param: _IGN_ANG3
+    // @DisplayName: Proximity sensor ignore angle 3
+    // @Description: Proximity sensor ignore angle 3
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG3", 8, AP_Proximity, _ignore_angle_deg[2], 0),
+
+    // @Param: _IGN_WID3
+    // @DisplayName: Proximity sensor ignore width 3
+    // @Description: Proximity sensor ignore width 3
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID3", 9, AP_Proximity, _ignore_width_deg[2], 0),
+
+    // @Param: _IGN_ANG4
+    // @DisplayName: Proximity sensor ignore angle 4
+    // @Description: Proximity sensor ignore angle 4
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG4", 10, AP_Proximity, _ignore_angle_deg[3], 0),
+
+    // @Param: _IGN_WID4
+    // @DisplayName: Proximity sensor ignore width 4
+    // @Description: Proximity sensor ignore width 4
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID4", 11, AP_Proximity, _ignore_width_deg[3], 0),
+
+    // @Param: _IGN_ANG5
+    // @DisplayName: Proximity sensor ignore angle 5
+    // @Description: Proximity sensor ignore angle 5
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG5", 12, AP_Proximity, _ignore_angle_deg[4], 0),
+
+    // @Param: _IGN_WID5
+    // @DisplayName: Proximity sensor ignore width 5
+    // @Description: Proximity sensor ignore width 5
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID5", 13, AP_Proximity, _ignore_width_deg[4], 0),
+
+    // @Param: _IGN_ANG6
+    // @DisplayName: Proximity sensor ignore angle 6
+    // @Description: Proximity sensor ignore angle 6
+    // @Range: 0 360
+    // @User: Standard
+    AP_GROUPINFO("_IGN_ANG6", 14, AP_Proximity, _ignore_angle_deg[5], 0),
+
+    // @Param: _IGN_WID6
+    // @DisplayName: Proximity sensor ignore width 6
+    // @Description: Proximity sensor ignore width 6
+    // @Range: 0 45
+    // @User: Standard
+    AP_GROUPINFO("_IGN_WID6", 15, AP_Proximity, _ignore_width_deg[5], 0),
+
 #if PROXIMITY_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Proximity type
     // @Description: What type of proximity sensor is connected
     // @Values: 0:None,1:LightWareSF40C
     // @User: Advanced
-    AP_GROUPINFO("2_TYPE", 4, AP_Proximity, _type[1], 0),
+    AP_GROUPINFO("2_TYPE", 16, AP_Proximity, _type[1], 0),
 
     // @Param: _ORIENT
     // @DisplayName: Second Proximity sensor orientation
     // @Description: Second Proximity sensor orientation
     // @Values: 0:Default,1:Upside Down
     // @User: Standard
-    AP_GROUPINFO("2_ORIENT", 5, AP_Proximity, _orientation[1], 0),
+    AP_GROUPINFO("2_ORIENT", 17, AP_Proximity, _orientation[1], 0),
 
     // @Param: _YAW_CORR
     // @DisplayName: Second Proximity sensor yaw correction
     // @Description: Second Proximity sensor yaw correction
     // @Range: -180 180
     // @User: Standard
-    AP_GROUPINFO("2_YAW_CORR", 6, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
+    AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
 #endif
 
     AP_GROUPEND

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -71,6 +71,11 @@ public:
     bool get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const;
     bool get_horizontal_distance(float angle_deg, float &distance) const;
 
+    // get boundary points around vehicle for use by avoidance
+    //   returns nullptr and sets num_points to zero if no boundary can be returned
+    const Vector2f* get_boundary_points(uint8_t instance, uint16_t& num_points) const;
+    const Vector2f* get_boundary_points(uint16_t& num_points) const;
+
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -70,6 +70,10 @@ public:
     bool get_horizontal_distance(uint8_t instance, float angle_deg, float &distance) const;
     bool get_horizontal_distance(float angle_deg, float &distance) const;
 
+    // get distance and angle to closest object (used for pre-arm check)
+    //   returns true on success, false if no valid readings
+    bool get_closest_object(float& angle_deg, float &distance) const;
+
     // The Proximity_State structure is filled in by the backend driver
     struct Proximity_State {
         uint8_t                 instance;   // the instance number of this proximity sensor

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -23,6 +23,7 @@
 
 #define PROXIMITY_MAX_INSTANCES             1   // Maximum number of proximity sensor instances available on this platform
 #define PROXIMITY_YAW_CORRECTION_DEFAULT    22  // default correction for sensor error in yaw
+#define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 
 class AP_Proximity_Backend;
 
@@ -94,6 +95,8 @@ private:
     AP_Int8  _type[PROXIMITY_MAX_INSTANCES];
     AP_Int8  _orientation[PROXIMITY_MAX_INSTANCES];
     AP_Int16 _yaw_correction[PROXIMITY_MAX_INSTANCES];
+    AP_Int16 _ignore_angle_deg[PROXIMITY_MAX_IGNORE];   // angle (in degrees) of area that should be ignored by sensor (i.e. leg shows up)
+    AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
 
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);  

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -80,6 +80,19 @@ public:
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;
 
+    // stucture holding distances in 8 directions
+    struct Proximity_Distance_Array {
+        uint8_t orientation[8]; // orientation (i.e. rough direction) of the distance (see MAV_SENSOR_ORIENTATION)
+        float distance[8];      // distance in meters
+    };
+
+    // get distances in 8 directions. used for sending distances to ground station
+    bool get_distances(Proximity_Distance_Array &prx_dist_array) const;
+
+    // get maximum and minimum distances (in meters) of primary sensor
+    float distance_max() const;
+    float distance_min() const;
+
     // The Proximity_State structure is filled in by the backend driver
     struct Proximity_State {
         uint8_t                 instance;   // the instance number of this proximity sensor

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -65,6 +65,55 @@ bool AP_Proximity_Backend::get_closest_object(float& angle_deg, float &distance)
     return sector_found;
 }
 
+// get distances in 8 directions. used for sending distances to ground station
+bool AP_Proximity_Backend::get_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const
+{
+    // exit immediately if we have no good ranges
+    bool valid_distances = false;
+    for (uint8_t i=0; i<_num_sectors; i++) {
+        if (_distance_valid[i]) {
+            valid_distances = true;
+        }
+    }
+    if (!valid_distances) {
+        return false;
+    }
+
+    // initialise orientations and directions
+    //  see MAV_SENSOR_ORIENTATION for orientations (0 = forward, 1 = 45 degree clockwise from north, etc)
+    //  distances initialised to maximum distances
+    bool dist_set[8];
+    for (uint8_t i=0; i<8; i++) {
+        prx_dist_array.orientation[i] = i;
+        prx_dist_array.distance[i] = distance_max();
+        dist_set[i] = false;
+    }
+
+    // cycle through all sectors filling in distances
+    for (uint8_t i=0; i<_num_sectors; i++) {
+        if (_distance_valid[i]) {
+            // convert angle to orientation
+            int16_t orientation = _angle[i] / 45;
+            if ((orientation >= 0) && (orientation < 8) && (_distance[i] < prx_dist_array.distance[orientation])) {
+                prx_dist_array.distance[orientation] = _distance[i];
+                dist_set[orientation] = true;
+            }
+        }
+    }
+
+    // fill in missing orientations with average of adjacent orientations if necessary and possible
+    for (uint8_t i=0; i<8; i++) {
+        if (!dist_set[i]) {
+            uint8_t orient_before = (i==0) ? 7 : (i-1);
+            uint8_t orient_after = (i==7) ? 0 : (i+1);
+            if (dist_set[orient_before] && dist_set[orient_after]) {
+                prx_dist_array.distance[i] = (prx_dist_array.distance[orient_before] + prx_dist_array.distance[orient_after]) / 2.0f;
+            }
+        }
+    }
+    return true;
+}
+
 // get boundary points around vehicle for use by avoidance
 //   returns nullptr and sets num_points to zero if no boundary can be returned
 const Vector2f* AP_Proximity_Backend::get_boundary_points(uint16_t& num_points) const

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -163,6 +163,9 @@ void AP_Proximity_Backend::update_boundary_for_sector(uint8_t sector)
     // boundary point lies on the line between the two sectors at the shorter distance found in the two sectors
     if (_distance_valid[sector] && _distance_valid[next_sector]) {
         float shortest_distance = MIN(_distance[sector], _distance[next_sector]);
+        if (shortest_distance < PROXIMITY_BOUNDARY_DIST_MIN) {
+            shortest_distance = PROXIMITY_BOUNDARY_DIST_MIN;
+        }
         _boundary_point[sector] = _sector_edge_vector[sector] * shortest_distance;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -112,3 +112,54 @@ bool AP_Proximity_Backend::convert_angle_to_sector(float angle_degrees, uint8_t 
 
     return false;
 }
+
+// get ignore area info
+uint8_t AP_Proximity_Backend::get_ignore_area_count() const
+{
+    // count number of ignore sectors
+    uint8_t count = 0;
+    for (uint8_t i=0; i < PROXIMITY_MAX_IGNORE; i++) {
+        if (frontend._ignore_width_deg[i] != 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+// get next ignore angle
+bool AP_Proximity_Backend::get_ignore_area(uint8_t index, uint16_t &angle_deg, uint8_t &width_deg) const
+{
+    if (index >= PROXIMITY_MAX_IGNORE) {
+        return false;
+    }
+    angle_deg = frontend._ignore_angle_deg[index];
+    width_deg = frontend._ignore_width_deg[index];
+    return true;
+}
+
+// retrieve start or end angle of next ignore area (i.e. closest ignore area higher than the start_angle)
+// start_or_end = 0 to get start, 1 to retrieve end
+bool AP_Proximity_Backend::get_next_ignore_start_or_end(uint8_t start_or_end, int16_t start_angle, int16_t &ignore_start) const
+{
+    bool found = false;
+    int16_t smallest_angle_diff = 0;
+    int16_t smallest_angle_start = 0;
+
+    for (uint8_t i=0; i < PROXIMITY_MAX_IGNORE; i++) {
+        if (frontend._ignore_width_deg[i] != 0) {
+            int16_t offset = start_or_end == 0 ? -frontend._ignore_width_deg[i] : +frontend._ignore_width_deg[i];
+            int16_t ignore_start_angle = wrap_360(frontend._ignore_angle_deg[i] + offset/2.0f);
+            int16_t ang_diff = wrap_360(ignore_start_angle - start_angle);
+            if (!found || ang_diff < smallest_angle_diff) {
+                smallest_angle_diff = ang_diff;
+                smallest_angle_start = ignore_start_angle;
+                found = true;
+            }
+        }
+    }
+
+    if (found) {
+        ignore_start = smallest_angle_start;
+    }
+    return found;
+}

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -41,6 +41,30 @@ bool AP_Proximity_Backend::get_horizontal_distance(float angle_deg, float &dista
     return false;
 }
 
+// get distance and angle to closest object (used for pre-arm check)
+//   returns true on success, false if no valid readings
+bool AP_Proximity_Backend::get_closest_object(float& angle_deg, float &distance) const
+{
+    bool sector_found = false;
+    uint8_t sector = 0;
+
+    // check all sectors for shorter distance
+    for (uint8_t i=0; i<_num_sectors; i++) {
+        if (_distance_valid[i]) {
+            if (!sector_found || (_distance[i] < _distance[sector])) {
+                sector = i;
+                sector_found = true;
+            }
+        }
+    }
+
+    if (sector_found) {
+        angle_deg = _angle[sector];
+        distance = _distance[sector];
+    }
+    return sector_found;
+}
+
 // set status and update valid count
 void AP_Proximity_Backend::set_status(AP_Proximity::Proximity_Status status)
 {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -49,6 +49,11 @@ protected:
     // find which sector a given angle falls into
     bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
 
+    // get ignore area info
+    uint8_t get_ignore_area_count() const;
+    bool get_ignore_area(uint8_t index, uint16_t &angle_deg, uint8_t &width_deg) const;
+    bool get_next_ignore_start_or_end(uint8_t start_or_end, int16_t start_angle, int16_t &ignore_start) const;
+
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -19,6 +19,7 @@
 #include "AP_Proximity.h"
 
 #define PROXIMITY_SECTORS_MAX   12  // maximum number of sectors
+#define PROXIMITY_BOUNDARY_DIST_MIN 0.6f    // minimum distance for a boundary point.  This ensures the object avoidance code doesn't think we are outside the boundary.
 
 class AP_Proximity_Backend
 {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -37,6 +37,10 @@ public:
     // returns true on successful read and places distance in distance
     bool get_horizontal_distance(float angle_deg, float &distance) const;
 
+    // get distance and angle to closest object (used for pre-arm check)
+    //   returns true on success, false if no valid readings
+    bool get_closest_object(float& angle_deg, float &distance) const;
+
 protected:
 
     // set status and update valid_count

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -37,6 +37,10 @@ public:
     // returns true on successful read and places distance in distance
     bool get_horizontal_distance(float angle_deg, float &distance) const;
 
+    // get boundary points around vehicle for use by avoidance
+    //   returns nullptr and sets num_points to zero if no boundary can be returned
+    const Vector2f* get_boundary_points(uint16_t& num_points) const;
+
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;
@@ -48,6 +52,11 @@ protected:
 
     // find which sector a given angle falls into
     bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
+
+    // update boundary points used for object avoidance based on a single sector's distance changing
+    //   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing
+    //   the boundary point is set to the shortest distance found in the two adjacent sectors, this is a conservative boundary around the vehicle
+    void update_boundary_for_sector(uint8_t sector);
 
     // get ignore area info
     uint8_t get_ignore_area_count() const;
@@ -66,4 +75,8 @@ protected:
     float _angle[PROXIMITY_SECTORS_MAX];            // angle to closest object within each sector
     float _distance[PROXIMITY_SECTORS_MAX];         // distance to closest object within each sector
     bool _distance_valid[PROXIMITY_SECTORS_MAX];    // true if a valid distance received for each sector
+
+    // fence boundary
+    Vector2f _sector_edge_vector[PROXIMITY_SECTORS_MAX];    // vector for right-edge of each sector, used to speed up calculation of boundary
+    Vector2f _boundary_point[PROXIMITY_SECTORS_MAX];        // bounding polygon around the vehicle calculated conservatively for object avoidance
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -18,6 +18,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Proximity.h"
 
+#define PROXIMITY_SECTORS_MAX   12  // maximum number of sectors
+
 class AP_Proximity_Backend
 {
 public:
@@ -33,13 +35,26 @@ public:
 
     // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
     // returns true on successful read and places distance in distance
-    virtual bool get_horizontal_distance(float angle_deg, float &distance) const = 0;
+    bool get_horizontal_distance(float angle_deg, float &distance) const;
 
 protected:
 
     // set status and update valid_count
     void set_status(AP_Proximity::Proximity_Status status);
 
+    // find which sector a given angle falls into
+    bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
+
     AP_Proximity &frontend;
     AP_Proximity::Proximity_State &state;   // reference to this instances state
+
+    // sectors
+    uint8_t _num_sectors = 8;
+    uint16_t _sector_middle_deg[PROXIMITY_SECTORS_MAX] = {0, 45, 90, 135, 180, 225, 270, 315, 0, 0, 0, 0};  // middle angle of each sector
+    uint8_t _sector_width_deg[PROXIMITY_SECTORS_MAX] = {45, 45, 45, 45, 45, 45, 45, 45, 0, 0, 0, 0};        // width (in degrees) of each sector
+
+    // sensor data
+    float _angle[PROXIMITY_SECTORS_MAX];            // angle to closest object within each sector
+    float _distance[PROXIMITY_SECTORS_MAX];         // distance to closest object within each sector
+    bool _distance_valid[PROXIMITY_SECTORS_MAX];    // true if a valid distance received for each sector
 };

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -33,6 +33,10 @@ public:
     // update the state structure
     virtual void update() = 0;
 
+    // get maximum and minimum distances (in meters) of sensor
+    virtual float distance_max() const = 0;
+    virtual float distance_min() const = 0;
+
     // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
     // returns true on successful read and places distance in distance
     bool get_horizontal_distance(float angle_deg, float &distance) const;
@@ -44,6 +48,9 @@ public:
     // get distance and angle to closest object (used for pre-arm check)
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;
+
+    // get distances in 8 directions. used for sending distances to ground station
+    bool get_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
 
 protected:
 

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -69,6 +69,16 @@ void AP_Proximity_LightWareSF40C::update(void)
     }
 }
 
+// get maximum and minimum distances (in meters) of primary sensor
+float AP_Proximity_LightWareSF40C::distance_max() const
+{
+    return 100.0f;
+}
+float AP_Proximity_LightWareSF40C::distance_min() const
+{
+    return 0.20f;
+}
+
 // initialise sensor (returns true if sensor is succesfully initialised)
 bool AP_Proximity_LightWareSF40C::initialise()
 {

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -43,19 +43,6 @@ bool AP_Proximity_LightWareSF40C::detect(AP_SerialManager &serial_manager)
     return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar360, 0) != nullptr;
 }
 
-// get distance in meters in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
-bool AP_Proximity_LightWareSF40C::get_horizontal_distance(float angle_deg, float &distance) const
-{
-    uint8_t sector;
-    if (convert_angle_to_sector(angle_deg, sector)) {
-        if (_distance_valid[sector]) {
-            distance = _distance[sector];
-            return true;
-        }
-    }
-    return false;
-}
-
 // update the state of the sensor
 void AP_Proximity_LightWareSF40C::update(void)
 {
@@ -375,46 +362,4 @@ void AP_Proximity_LightWareSF40C::clear_buffers()
     element_len[1] = 0;
     element_num = 0;
     memset(element_buf, 0, sizeof(element_buf));
-}
-
-bool AP_Proximity_LightWareSF40C::convert_angle_to_sector(float angle_degrees, uint8_t &sector) const
-{
-    // sanity check angle
-    if (angle_degrees > 360.0f || angle_degrees < -180.0f) {
-        return false;
-    }
-
-    // convert to 0 ~ 360
-    if (angle_degrees < 0.0f) {
-        angle_degrees += 360.0f;
-    }
-
-    bool closest_found = false;
-    uint8_t closest_sector;
-    float closest_angle;
-
-    // search for which sector angle_degrees falls into
-    for (uint8_t i = 0; i < _num_sectors; i++) {
-        float angle_diff = fabsf(wrap_180(_sector_middle_deg[i] - angle_degrees));
-
-        // record if closest
-        if (!closest_found || angle_diff < closest_angle) {
-            closest_found = true;
-            closest_sector = i;
-            closest_angle = angle_diff;
-        }
-
-        if (fabsf(angle_diff) <= _sector_width_deg[i] / 2.0f) {
-            sector = i;
-            return true;
-        }
-    }
-
-    // angle_degrees might have been within a gap between sectors
-    if (closest_found) {
-        sector = closest_sector;
-        return true;
-    }
-
-    return false;
 }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -401,6 +401,8 @@ bool AP_Proximity_LightWareSF40C::process_reply()
                 _distance_valid[sector] = true;
                 _last_distance_received_ms = AP_HAL::millis();
                 success = true;
+                // update boundary used for avoidance
+                update_boundary_for_sector(sector);
             }
             break;
         }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -91,7 +91,69 @@ bool AP_Proximity_LightWareSF40C::initialise()
         }
         return false;
     }
+    // initialise sectors
+    if (!_sector_initialised) {
+        init_sectors();
+        return false;
+    }
     return true;
+}
+
+// initialise sector angles using user defined ignore areas
+void AP_Proximity_LightWareSF40C::init_sectors()
+{
+    // use defaults if no ignore areas defined
+    uint8_t ignore_area_count = get_ignore_area_count();
+    if (ignore_area_count == 0) {
+        _sector_initialised = true;
+        return;
+    }
+
+    uint8_t sector = 0;
+
+    for (uint8_t i=0; i<ignore_area_count; i++) {
+
+        // get ignore area info
+        uint16_t ign_area_angle;
+        uint8_t ign_area_width;
+        if (get_ignore_area(i, ign_area_angle, ign_area_width)) {
+
+            // calculate how many degrees of space we have between this end of this ignore area and the start of the end
+            int16_t start_angle, end_angle;
+            get_next_ignore_start_or_end(1, ign_area_angle, start_angle);
+            get_next_ignore_start_or_end(0, start_angle, end_angle);
+            int16_t degrees_to_fill = wrap_360(end_angle - start_angle);
+
+            // divide up the area into sectors
+            while ((degrees_to_fill > 0) && (sector < PROXIMITY_SECTORS_MAX)) {
+                uint16_t sector_size;
+                if (degrees_to_fill >= 90) {
+                    // set sector to maximum of 45 degrees
+                    sector_size = 45;
+                } else if (degrees_to_fill > 45) {
+                    // use half the remaining area to optimise size of this sector and the next
+                    sector_size = degrees_to_fill / 2.0f;
+                } else  {
+                    // 45 degrees or less are left so put it all into the next sector
+                    sector_size = degrees_to_fill;
+                }
+                // record the sector middle and width
+                _sector_middle_deg[sector] = wrap_360(start_angle + sector_size / 2.0f);
+                _sector_width_deg[sector] = sector_size;
+
+                // move onto next sector
+                start_angle += sector_size;
+                sector++;
+                degrees_to_fill -= sector_size;
+            }
+        }
+    }
+
+    // set num sectors
+    _num_sectors = sector;
+
+    // record success
+    _sector_initialised = true;
 }
 
 // set speed of rotating motor

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -3,8 +3,6 @@
 #include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
 
-#define PROXIMITY_SF40C_SECTORS_MAX           8                                 // maximum number of sectors
-#define PROXIMITY_SF40C_SECTOR_WIDTH_DEG      (360/PROXIMITY_SF40C_SECTORS_MAX) // angular width of each sector
 #define PROXIMITY_SF40C_TIMEOUT_MS            200                               // requests timeout after 0.2 seconds
 
 class AP_Proximity_LightWareSF40C : public AP_Proximity_Backend
@@ -16,10 +14,6 @@ public:
 
     // static detection function
     static bool detect(AP_SerialManager &serial_manager);
-
-    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-    // returns true on successful read and places distance in distance
-    bool get_horizontal_distance(float angle_deg, float &distance) const;
 
     // update state
     void update(void);
@@ -50,7 +44,6 @@ private:
     bool check_for_reply();
     bool process_reply();
     void clear_buffers();
-    bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
 
     // reply related variables
     AP_HAL::UARTDriver *uart = nullptr;
@@ -90,14 +83,8 @@ private:
         uint16_t value;
     } _sensor_status;
 
-    // sensor data
+    // sensor config
     uint8_t _motor_speed;               // motor speed as reported by lidar
     uint8_t _motor_direction = 99;      // motor direction as reported by lidar
     int16_t _forward_direction = 999;   // forward direction as reported by lidar
-    uint8_t _num_sectors = PROXIMITY_SF40C_SECTORS_MAX;     // number of sectors we will search
-    uint16_t _sector_middle_deg[PROXIMITY_SF40C_SECTORS_MAX] = {0, 45, 90, 135, 180, 225, 270, 315};    // middle angle of each sector
-    uint8_t _sector_width_deg[PROXIMITY_SF40C_SECTORS_MAX] = {45, 45, 45, 45, 45, 45, 45, 45};          // width (in degrees) of each sector
-    float _angle[PROXIMITY_SF40C_SECTORS_MAX];              // angle to closest object within each sector
-    float _distance[PROXIMITY_SF40C_SECTORS_MAX];           // distance to closest object within each sector
-    bool _distance_valid[PROXIMITY_SF40C_SECTORS_MAX];      // true if a valid distance received for each sector
 };

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -31,6 +31,7 @@ private:
 
     // initialise sensor (returns true if sensor is succesfully initialised)
     bool initialise();
+    void init_sectors();
     void set_motor_speed(bool on_off);
     void set_motor_direction();
     void set_forward_direction();
@@ -87,4 +88,5 @@ private:
     uint8_t _motor_speed;               // motor speed as reported by lidar
     uint8_t _motor_direction = 99;      // motor direction as reported by lidar
     int16_t _forward_direction = 999;   // forward direction as reported by lidar
+    bool _sector_initialised = false;
 };

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -18,6 +18,10 @@ public:
     // update state
     void update(void);
 
+    // get maximum and minimum distances (in meters) of sensor
+    float distance_max() const;
+    float distance_min() const;
+
 private:
 
     enum RequestType {

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -22,8 +22,8 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define PROXIMITY_MAX_RANGE 200
-#define PROXIMITY_ACCURACY 0.1
+#define PROXIMITY_MAX_RANGE 200.0f
+#define PROXIMITY_ACCURACY 0.1f
 
 /* 
    The constructor also initialises the proximity sensor. 
@@ -113,6 +113,16 @@ bool AP_Proximity_SITL::get_distance_to_fence(float angle_deg, float &distance) 
     }
     distance = min_dist;
     return true;
+}
+
+// get maximum and minimum distances (in meters) of primary sensor
+float AP_Proximity_SITL::distance_max() const
+{
+    return PROXIMITY_MAX_RANGE;
+}
+float AP_Proximity_SITL::distance_min() const
+{
+    return 0.0f;
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -13,10 +13,6 @@ public:
     // constructor
     AP_Proximity_SITL(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
-    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
-    // returns true on successful read and places distance in distance
-    bool get_horizontal_distance(float angle_deg, float &distance) const override;
-
     // update state
     void update(void) override;
 
@@ -27,7 +23,14 @@ private:
     uint32_t last_load_ms;
     AC_PolyFence_loader fence_loader;
     Location current_loc;
-    
+
+    // latest sector updated
+    uint8_t last_sector;
+
     void load_fence(void);
+
+    // get distance in meters to fence in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
+    bool get_distance_to_fence(float angle_deg, float &distance) const;
+
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -16,6 +16,10 @@ public:
     // update state
     void update(void) override;
 
+    // get maximum and minimum distances (in meters) of sensor
+    float distance_max() const;
+    float distance_min() const;
+
 private:
     SITL::SITL *sitl;
     Vector2l *fence;


### PR DESCRIPTION
This PR implements these changes:

- AP_Proximity gets "boundary points" which can be used by AC_Avoidance just as if it were a polygon fence
- AP_Proximity gets "ignore areas" so the sf40c can ignore up to 6 areas allowing the sf40c to ignore the vehicle legs if it's mounted on the bottom of the vehicle.
- AC_Avoidance modified to use the proximity sensor's boundary points
- Vehicle pre-arm check modified to show the angle to the closest object within 60cm of the vehicle (useful for setting up the ignore areas)

Note: these changes have been tested in SITL and in particular it improves object avoidance in situations where the vehicle is flying parallel to a wall.  The previous method allowed the vehicle to get infinitely close to a wall if the pilot pushes the pitch forward to make a vehicle fly towards a wall and then applies gentle consistent yaw.  This PR improves this so that the vehicle maintains the desired 2m distance from the wall.

Here's a picture of how the mini fence is built.  In short, the fence points are on the line segments between the sectors at a distance equal to the closest object in either adjacent segment.
![avoidancemethods3](https://cloud.githubusercontent.com/assets/1498098/20303027/e693f99a-ab6c-11e6-8389-bc03873e0f51.png)
