### PR TITLE
PX4: support flash storage (WIP)

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -58,6 +58,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Button',
     'AP_ICEngine',
     'AP_Frsky_Telem',
+    'AP_FlashStorage',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_Common/Bitmask.h
+++ b/libraries/AP_Common/Bitmask.h
@@ -1,0 +1,70 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple bitmask class
+ */
+
+class Bitmask {
+public:
+    Bitmask(uint16_t numbits) :
+        numwords((numbits+31)/32) {
+        bits = new uint32_t[numwords];
+    }
+    ~Bitmask(void) {
+        delete[] bits;
+    }
+
+    // set given bitnumber
+    void set(uint16_t bit) {
+        uint16_t word = bit/32;
+        uint8_t ofs = bit & 0x1f;
+        bits[word] |= (1U << ofs);
+    }
+
+    // clear given bitnumber
+    void clear(uint16_t bit) {
+        uint16_t word = bit/32;
+        uint8_t ofs = bit & 0x1f;
+        bits[word] &= ~(1U << ofs);
+    }
+
+    // clear all bits
+    void clearall(void) {
+        for (uint16_t i=0; i<numwords; i++) {
+            bits[i] = 0;
+        }
+    }
+    
+    // return true if given bitnumber is set
+    bool get(uint16_t bit) {
+        uint16_t word = bit/32;
+        uint8_t ofs = bit & 0x1f;
+        return (bits[word] & (1U << ofs)) != 0;
+    }
+
+    // return true if all bits are clear
+    bool empty(void) {
+        for (uint16_t i=0; i<numwords; i++) {
+            if (bits[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+private:
+    uint16_t numwords;
+    uint32_t *bits;
+};

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -371,7 +371,7 @@ void CompassCalibrator::thin_samples() {
     // shuffle the samples http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
     // this is so that adjacent samples don't get sequentially eliminated
     for(uint16_t i=_samples_collected-1; i>=1; i--) {
-        uint16_t j = get_random() % (i+1);
+        uint16_t j = get_random16() % (i+1);
         CompassSample temp = _sample_buffer[i];
         _sample_buffer[i] = _sample_buffer[j];
         _sample_buffer[j] = temp;
@@ -685,15 +685,6 @@ void CompassCalibrator::run_ellipsoid_fit()
     }
 }
 
-
-uint16_t CompassCalibrator::get_random(void)
-{
-    static uint32_t m_z = 1234;
-    static uint32_t m_w = 76542;
-    m_z = 36969 * (m_z & 65535) + (m_z >> 16);
-    m_w = 18000 * (m_w & 65535) + (m_w >> 16);
-    return ((m_z << 16) + m_w) & 0xFFFF;
-}
 
 //////////////////////////////////////////////////////////
 //////////// CompassSample public interface //////////////

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -135,6 +135,4 @@ private:
      * Reset and update #_completion_mask with the current samples.
      */
     void update_completion_mask();
-
-    uint16_t get_random();
 };

--- a/libraries/AP_FlashStorage/AP_FlashStorage.cpp
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.cpp
@@ -1,0 +1,345 @@
+/*
+   Please contribute your ideas! See http://dev.ardupilot.org for details
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_FlashStorage/AP_FlashStorage.h>
+#include <stdio.h>
+
+#define FLASHSTORAGE_DEBUG 0
+
+#if FLASHSTORAGE_DEBUG
+#define debug(fmt, args...)  do { printf(fmt, ##args); } while(0)
+#else
+#define debug(fmt, args...)  do { } while(0)
+#endif
+
+// constructor.
+AP_FlashStorage::AP_FlashStorage(uint8_t *_mem_buffer,
+                                 uint32_t _flash_sector_size,
+                                 FlashWrite _flash_write,
+                                 FlashRead _flash_read,
+                                 FlashErase _flash_erase) :
+    mem_buffer(_mem_buffer),
+    flash_sector_size(_flash_sector_size),
+    flash_write(_flash_write),
+    flash_read(_flash_read),
+    flash_erase(_flash_erase) {}
+
+// initialise storage
+bool AP_FlashStorage::init(void)
+{
+    debug("running init()\n");
+    
+    // start with empty memory buffer
+    memset(mem_buffer, 0, storage_size);
+
+    // find state of sectors
+    struct sector_header header[2];
+
+    // read headers and possibly initialise if bad signature
+    for (uint8_t i=0; i<2; i++) {
+        if (!flash_read(i, 0, (uint8_t *)&header[i], sizeof(header[i]))) {
+            return false;
+        }
+        bool bad_header = (header[i].signature != signature);
+        enum SectorState state = (enum SectorState)header[i].state;
+        if (state != SECTOR_STATE_AVAILABLE &&
+            state != SECTOR_STATE_IN_USE &&
+            state != SECTOR_STATE_FULL &&
+            state != SECTOR_STATE_FREE) {
+            bad_header = true;
+        }
+
+        // initialise if bad header
+        if (bad_header) {
+            return erase_all();
+        }
+    }
+
+    // work out the first sector to read from using sector states
+    enum SectorState states[2] {(enum SectorState)header[0].state, (enum SectorState)header[1].state};
+    uint8_t first_sector;
+
+    if (states[0] == states[1]) {
+        if (states[0] != SECTOR_STATE_AVAILABLE) {
+            return erase_all();
+        }
+        first_sector = 0;
+    } else if (states[0] == SECTOR_STATE_FULL) {
+        first_sector = 0;
+    } else if (states[1] == SECTOR_STATE_FULL) {
+        first_sector = 1;
+    } else if (states[0] == SECTOR_STATE_IN_USE) {
+        first_sector = 0;
+    } else if (states[1] == SECTOR_STATE_IN_USE) {
+        first_sector = 1;
+    } else {
+        // doesn't matter which is first
+        first_sector = 0;
+    }
+
+    // load data from any current sectors
+    for (uint8_t i=0; i<2; i++) {
+        uint8_t sector = (first_sector + i) & 1;
+        if (states[sector] == SECTOR_STATE_IN_USE ||
+            states[sector] == SECTOR_STATE_FULL) {
+            if (!load_sector(sector)) {
+                return erase_all();
+            }
+        }
+    }
+
+    // clear any write error
+    write_error = false;
+    reserved_space = 0;
+    
+    // if the first sector is full then write out all data so we can erase it
+    if (states[first_sector] == SECTOR_STATE_FULL) {
+        current_sector = first_sector ^ 1;
+        if (!write_all()) {
+            return erase_all();
+        }
+    }
+
+    // erase any sectors marked full or free
+    for (uint8_t i=0; i<2; i++) {
+        if (states[i] == SECTOR_STATE_FULL ||
+            states[i] == SECTOR_STATE_FREE) {
+            if (!erase_sector(i)) {
+                return false;
+            }
+        }
+    }
+
+    reserved_space = 0;
+    
+    // ready to use
+    return true;
+}
+
+// write some data to virtual EEPROM
+bool AP_FlashStorage::write(uint16_t offset, uint16_t length)
+{
+    if (write_error) {
+        return false;
+    }
+    //debug("write at %u for %u write_offset=%u\n", offset, length, write_offset);
+    
+    while (length > 0) {
+        uint8_t n = max_write;
+        if (length < n) {
+            n = length;
+        }
+
+        if (write_offset > flash_sector_size - (sizeof(struct block_header) + max_write + reserved_space)) {
+            if (!switch_sectors()) {
+                return false;
+            }
+        }
+        
+        struct block_header header;
+        header.state = BLOCK_STATE_WRITING;
+        header.block_num = offset / block_size;
+        header.num_blocks_minus_one = ((n + (block_size - 1)) / block_size)-1;
+        uint16_t block_ofs = header.block_num*block_size;
+        uint16_t block_nbytes = (header.num_blocks_minus_one+1)*block_size;
+        
+        if (!flash_write(current_sector, write_offset, (uint8_t*)&header, sizeof(header))) {
+            return false;
+        }
+        if (!flash_write(current_sector, write_offset+sizeof(header), &mem_buffer[block_ofs], block_nbytes)) {
+            return false;
+        }
+        header.state = BLOCK_STATE_VALID;
+        if (!flash_write(current_sector, write_offset, (uint8_t*)&header, sizeof(header))) {
+            return false;
+        }
+        write_offset += sizeof(header) + block_nbytes;
+
+        uint8_t n2 = block_nbytes - (offset % block_size);
+        //debug("write_block at %u for %u n2=%u\n", block_ofs, block_nbytes, n2);
+        if (n2 > length) {
+            break;
+        }
+        offset += n2;
+        length -= n2;
+    }
+    
+    // handle wrap to next sector
+    // write data
+    // write header word
+    return true;
+}
+
+/*
+  load all data from a flash sector into mem_buffer
+ */
+bool AP_FlashStorage::load_sector(uint8_t sector)
+{
+    uint32_t ofs = sizeof(sector_header);
+    while (ofs < flash_sector_size - sizeof(struct block_header)) {
+        struct block_header header;
+        if (!flash_read(sector, ofs, (uint8_t *)&header, sizeof(header))) {
+            return false;
+        }
+        enum BlockState state = (enum BlockState)header.state;
+
+        switch (state) {
+        case BLOCK_STATE_AVAILABLE:
+            // we've reached the end
+            write_offset = ofs;
+            return true;
+
+        case BLOCK_STATE_VALID:
+        case BLOCK_STATE_WRITING: {
+            uint16_t block_ofs = header.block_num*block_size;
+            uint16_t block_nbytes = (header.num_blocks_minus_one+1)*block_size;
+            if (block_ofs + block_nbytes > storage_size) {
+                return false;
+            }
+            if (state == BLOCK_STATE_VALID &&
+                !flash_read(sector, ofs+sizeof(header), &mem_buffer[block_ofs], block_nbytes)) {
+                return false;
+            }
+            //debug("read at %u for %u\n", block_ofs, block_nbytes);
+            ofs += block_nbytes + sizeof(header);
+            break;
+        }
+        default:
+            // invalid state
+            return false;
+        }
+    }
+    write_offset = ofs;
+    return true;
+}
+
+/*
+  erase one sector
+ */
+bool AP_FlashStorage::erase_sector(uint8_t sector)
+{
+    if (!flash_erase(sector)) {
+        return false;
+    }
+
+    struct sector_header header;
+    header.signature = signature;
+    header.state = SECTOR_STATE_AVAILABLE;
+    return flash_write(sector, 0, (const uint8_t *)&header, sizeof(header));
+}
+
+/*
+  erase both sectors
+ */
+bool AP_FlashStorage::erase_all(void)
+{
+    write_error = false;
+    
+    // start with empty memory buffer
+    memset(mem_buffer, 0, storage_size);
+    current_sector = 0;
+    write_offset = sizeof(struct sector_header);
+    
+    if (!erase_sector(0) || !erase_sector(1)) {
+        return false;
+    }
+    
+    // mark current sector as in-use
+    struct sector_header header;
+    header.signature = signature;
+    header.state = SECTOR_STATE_IN_USE;
+    return flash_write(current_sector, 0, (const uint8_t *)&header, sizeof(header));    
+}
+
+/*
+  write all of mem_buffer to current sector
+ */
+bool AP_FlashStorage::write_all(void)
+{
+    debug("write_all to sector %u at %u with reserved_space=%u\n",
+           current_sector, write_offset, reserved_space);
+    for (uint16_t ofs=0; ofs<storage_size; ofs += max_write) {
+        if (!all_zero(ofs, max_write)) {
+            if (!write(ofs, max_write)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// return true if all bytes are zero
+bool AP_FlashStorage::all_zero(uint16_t ofs, uint16_t size)
+{
+    while (size--) {
+        if (mem_buffer[ofs++] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// switch to next sector for writing
+bool AP_FlashStorage::switch_sectors(void)
+{
+    if (reserved_space != 0) {
+        // other sector is already full
+        debug("both sectors are full\n");
+        return false;
+    }
+
+    // mark current sector as full
+    struct sector_header header;
+    header.signature = signature;
+    header.state = SECTOR_STATE_FULL;
+    if (!flash_write(current_sector, 0, (const uint8_t *)&header, sizeof(header))) {
+        return false;
+    }
+
+    // switch sectors
+    current_sector ^= 1;
+
+    debug("switching to sector %u\n", current_sector);
+    
+    // check sector is available
+    if (!flash_read(current_sector, 0, (uint8_t *)&header, sizeof(header))) {
+        return false;
+    }
+    if (header.signature != signature) {
+        write_error = true;
+        return false;
+    }
+    if (SECTOR_STATE_AVAILABLE != (enum SectorState)header.state) {
+        write_error = true;
+        debug("both sectors full\n");
+        return false;
+    }
+
+    // mark it in-use
+    header.state = SECTOR_STATE_IN_USE;
+    if (!flash_write(current_sector, 0, (const uint8_t *)&header, sizeof(header))) {
+        return false;
+    }
+
+    // we need to reserve some space in next sector to ensure we can successfully do a
+    // full write out on init()
+    reserved_space = reserve_size;
+    
+    write_offset = sizeof(header);
+    return true;    
+}

--- a/libraries/AP_FlashStorage/AP_FlashStorage.h
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.h
@@ -1,0 +1,140 @@
+/*
+   Please contribute your ideas! See http://dev.ardupilot.org for details
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  a class to allow for FLASH to be used as a memory backed storage
+  backend for any HAL. The basic methodology is to use a log based
+  storage system over two flash sectors. Key design elements:
+
+  - erase of sectors only called on init, as erase will lock the flash
+    and prevent code execution
+
+  - write using log based system
+
+  - read requires scan of all log elements. This is expected to be called rarely
+
+  - assumes flash that erases to 0xFF and where writing can only clear
+    bits, not set them
+
+  - assumes flash sectors are much bigger than storage size. If they
+    aren't then caller can aggregate multiple sectors. Designed for
+    128k flash sectors with 16k storage size.
+
+  - assumes two flash sectors are available
+ */
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+/*
+  The StorageManager holds the layout of non-volatile storeage
+ */
+class AP_FlashStorage {
+private:
+    static const uint8_t block_size = 8;
+    static const uint16_t num_blocks = 2048;
+    static const uint8_t max_write = 64;
+
+public:
+    // caller provided function to write to a flash sector
+    FUNCTOR_TYPEDEF(FlashWrite, bool, uint8_t , uint32_t , const uint8_t *, uint16_t );
+
+    // caller provided function to read from a flash sector. Only called on init()
+    FUNCTOR_TYPEDEF(FlashRead, bool, uint8_t , uint32_t , uint8_t *, uint16_t );
+    
+    // caller provided function to erase a flash sector. Only called from init()
+    FUNCTOR_TYPEDEF(FlashErase, bool, uint8_t );
+
+    // constructor. 
+    AP_FlashStorage(uint8_t *mem_buffer,        // buffer of storage_size bytes
+                    uint32_t flash_sector_size, // size of each flash sector in bytes
+                    FlashWrite flash_write,     // function to write to flash
+                    FlashRead flash_read,       // function to read from flash
+                    FlashErase flash_erase);    // function to erase flash
+
+    // initialise storage, filling mem_buffer with current contents
+    bool init(void);
+    
+    // write some data to storage from mem_buffer
+    bool write(uint16_t offset, uint16_t length);
+
+    // fixed storage size
+    static const uint16_t storage_size = block_size * num_blocks;
+    
+private:
+    uint8_t *mem_buffer;
+    const uint32_t flash_sector_size;
+    FlashWrite flash_write;
+    FlashRead flash_read;
+    FlashErase flash_erase;
+
+    uint8_t current_sector;
+    uint32_t write_offset;
+    uint32_t reserved_space;
+    bool write_error;
+
+    // 24 bit signature
+    static const uint32_t signature = 0x51685B;
+
+    // 8 bit sector states
+    enum SectorState {
+        SECTOR_STATE_AVAILABLE = 0xFF,
+        SECTOR_STATE_IN_USE    = 0xFE,
+        SECTOR_STATE_FULL      = 0xFC,
+        SECTOR_STATE_FREE      = 0xF8,
+    };
+
+    // header in first word of each sector
+    struct sector_header {
+        uint32_t state:8;
+        uint32_t signature:24;
+    };
+
+
+    enum BlockState {
+        BLOCK_STATE_AVAILABLE = 0x3,
+        BLOCK_STATE_WRITING   = 0x1,
+        BLOCK_STATE_VALID     = 0x0
+    };
+    
+    // header of each block of data
+    struct block_header {
+        uint16_t state:2;
+        uint16_t block_num:11;
+        uint16_t num_blocks_minus_one:3;
+    };
+
+    // amount of space needed to write full storage
+    static const uint32_t reserve_size = (storage_size / max_write) * (sizeof(block_header) + max_write) + max_write;
+        
+    // load data from a sector
+    bool load_sector(uint8_t sector);
+
+    // erase a sector and write header
+    bool erase_sector(uint8_t sector);
+
+    // erase all sectors and reset
+    bool erase_all(void);
+
+    // write all of mem_buffer to current sector
+    bool write_all(void);
+
+    // return true if all bytes are zero
+    bool all_zero(uint16_t ofs, uint16_t size);
+
+    // switch to next sector for writing
+    bool switch_sectors(void);
+};

--- a/libraries/AP_FlashStorage/AP_FlashStorage.h
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.h
@@ -58,15 +58,23 @@ public:
     // caller provided function to erase a flash sector. Only called from init()
     FUNCTOR_TYPEDEF(FlashErase, bool, uint8_t );
 
+    // caller provided function to indicate if erasing is allowed
+    FUNCTOR_TYPEDEF(FlashEraseOK, bool);
+    
     // constructor. 
     AP_FlashStorage(uint8_t *mem_buffer,        // buffer of storage_size bytes
                     uint32_t flash_sector_size, // size of each flash sector in bytes
                     FlashWrite flash_write,     // function to write to flash
                     FlashRead flash_read,       // function to read from flash
-                    FlashErase flash_erase);    // function to erase flash
+                    FlashErase flash_erase,     // function to erase flash
+                    FlashEraseOK flash_erase_ok); // function to check if erasing allowed
 
     // initialise storage, filling mem_buffer with current contents
     bool init(void);
+
+    // switch full sector - should only be called when safe to have CPU
+    // offline for considerable periods as an erase will be needed
+    bool switch_full_sector(void);
     
     // write some data to storage from mem_buffer
     bool write(uint16_t offset, uint16_t length);
@@ -80,6 +88,7 @@ private:
     FlashWrite flash_write;
     FlashRead flash_read;
     FlashErase flash_erase;
+    FlashEraseOK flash_erase_ok;
 
     uint8_t current_sector;
     uint32_t write_offset;
@@ -93,8 +102,7 @@ private:
     enum SectorState {
         SECTOR_STATE_AVAILABLE = 0xFF,
         SECTOR_STATE_IN_USE    = 0xFE,
-        SECTOR_STATE_FULL      = 0xFC,
-        SECTOR_STATE_FREE      = 0xF8,
+        SECTOR_STATE_FULL      = 0xFC
     };
 
     // header in first word of each sector

--- a/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
+++ b/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
@@ -1,0 +1,155 @@
+//
+// Unit tests for the AP_Math rotations code
+//
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_FlashStorage/AP_FlashStorage.h>
+#include <stdio.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class FlashTest : public AP_HAL::HAL::Callbacks {
+public:
+    // HAL::Callbacks implementation.
+    void setup() override;
+    void loop() override;
+
+private:
+    static const uint32_t flash_sector_size = 128U * 1024U;
+
+    uint8_t mem_buffer[AP_FlashStorage::storage_size];
+    uint8_t mem_mirror[AP_FlashStorage::storage_size];
+
+    // flash buffer
+    uint8_t flash[2][flash_sector_size];
+
+    bool flash_write(uint8_t sector, uint32_t offset, const uint8_t *data, uint16_t length);
+    bool flash_read(uint8_t sector, uint32_t offset, uint8_t *data, uint16_t length);
+    bool flash_erase(uint8_t sector);
+    
+    AP_FlashStorage storage{mem_buffer,
+            flash_sector_size,
+            FUNCTOR_BIND_MEMBER(&FlashTest::flash_write, bool, uint8_t, uint32_t, const uint8_t *, uint16_t),
+            FUNCTOR_BIND_MEMBER(&FlashTest::flash_read, bool, uint8_t, uint32_t, uint8_t *, uint16_t),
+            FUNCTOR_BIND_MEMBER(&FlashTest::flash_erase, bool, uint8_t)};
+
+    // write to storage and mem_mirror
+    void write(uint16_t offset, const uint8_t *data, uint16_t length);
+};
+
+bool FlashTest::flash_write(uint8_t sector, uint32_t offset, const uint8_t *data, uint16_t length)
+{
+    if (sector > 1) {
+        AP_HAL::panic("FATAL: write to sector %u\n", (unsigned)sector);
+    }
+    if (offset + length > flash_sector_size) {
+        AP_HAL::panic("FATAL: write to sector %u at offset %u length %u\n",
+                      (unsigned)sector,
+                      (unsigned)offset,
+                      (unsigned)length);
+    }
+    uint8_t *b = &flash[sector][offset];
+    for (uint16_t i=0; i<length; i++) {
+        b[i] &= data[i];
+    }
+    return true;
+}
+
+bool FlashTest::flash_read(uint8_t sector, uint32_t offset, uint8_t *data, uint16_t length)
+{
+    if (sector > 1) {
+        AP_HAL::panic("FATAL: read from sector %u\n", (unsigned)sector);
+    }
+    if (offset + length > flash_sector_size) {
+        AP_HAL::panic("FATAL: read from sector %u at offset %u length %u\n",
+                      (unsigned)sector,
+                      (unsigned)offset,
+                      (unsigned)length);
+    }
+    memcpy(data, &flash[sector][offset], length);
+    return true;
+}
+
+bool FlashTest::flash_erase(uint8_t sector)
+{
+    if (sector > 1) {
+        AP_HAL::panic("FATAL: erase sector %u\n", (unsigned)sector);
+    }
+    memset(&flash[sector][0], 0xFF, flash_sector_size);
+    return true;
+}
+
+void FlashTest::write(uint16_t offset, const uint8_t *data, uint16_t length)
+{
+    memcpy(&mem_mirror[offset], data, length);
+    memcpy(&mem_buffer[offset], data, length);
+    if (!storage.write(offset, length)) {
+        printf("Failed to write at %u for %u\n", offset, length);
+        if (!storage.init()) {
+            AP_HAL::panic("Failed to re-init");
+        }
+        memcpy(&mem_buffer[offset], data, length);
+        if (!storage.write(offset, length)) {
+            AP_HAL::panic("Failed 2nd write at %u for %u", offset, length);
+        }
+        printf("re-init OK\n");
+    }
+}
+
+/*
+ * test flash storage
+ */
+void FlashTest::setup(void)
+{
+    flash_erase(0);
+    flash_erase(1);
+    hal.console->printf("AP_FlashStorage test\n");
+
+    if (!storage.init()) {
+        AP_HAL::panic("Failed first init()");
+    }
+
+    // fill with 10k random writes
+    for (uint32_t i=0; i<50000000; i++) {
+        uint16_t ofs = get_random16() % sizeof(mem_buffer);
+        uint16_t length = get_random16() & 0x1F;
+        length = MIN(length, sizeof(mem_buffer) - ofs);
+        uint8_t data[length];
+        for (uint8_t j=0; j<length; j++) {
+            data[j] = get_random16() & 0xFF;
+        }
+        write(ofs, data, length);
+
+        if (i % 1000 == 0) {
+            if (memcmp(mem_buffer, mem_mirror, sizeof(mem_buffer)) != 0) {
+                AP_HAL::panic("FATAL: data mis-match at i=%u", i);
+            }
+        }
+    }
+
+    if (memcmp(mem_buffer, mem_mirror, sizeof(mem_buffer)) != 0) {
+        AP_HAL::panic("FATAL: data mis-match before re-init");
+    }
+    
+    // re-init
+    printf("re-init\n");
+    memset(mem_buffer, 0, sizeof(mem_buffer));
+    if (!storage.init()) {
+        AP_HAL::panic("Failed second init()");
+    }
+
+    if (memcmp(mem_buffer, mem_mirror, sizeof(mem_buffer)) != 0) {
+        AP_HAL::panic("FATAL: data mis-match");
+    }
+    AP_HAL::panic("TEST PASSED");
+}
+
+void FlashTest::loop(void)
+{
+    hal.console->printf("loop\n");
+}
+
+FlashTest flashtest;
+
+AP_HAL_MAIN_CALLBACKS(&flashtest);

--- a/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
+++ b/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
@@ -16,7 +16,7 @@ public:
     void loop() override;
 
 private:
-    static const uint32_t flash_sector_size = 128U * 1024U;
+    static const uint32_t flash_sector_size = 32U * 1024U;
 
     uint8_t mem_buffer[AP_FlashStorage::storage_size];
     uint8_t mem_mirror[AP_FlashStorage::storage_size];

--- a/libraries/AP_FlashStorage/examples/FlashTest/wscript
+++ b/libraries/AP_FlashStorage/examples/FlashTest/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_example(
+        use='ap',
+    )

--- a/libraries/AP_HAL_PX4/Storage.cpp
+++ b/libraries/AP_HAL_PX4/Storage.cpp
@@ -21,13 +21,8 @@ using namespace PX4;
 // name the storage file after the sketch so you can use the same sd
 // card for ArduCopter and ArduPlane
 #define STORAGE_DIR "/fs/microsd/APM"
-#define OLD_STORAGE_FILE STORAGE_DIR "/" SKETCHNAME ".stg"
-#define OLD_STORAGE_FILE_BAK STORAGE_DIR "/" SKETCHNAME ".bak"
 //#define SAVE_STORAGE_FILE STORAGE_DIR "/" SKETCHNAME ".sav"
 #define MTD_PARAMS_FILE "/fs/mtd"
-#define MTD_SIGNATURE 0x14012014
-#define MTD_SIGNATURE_OFFSET (8192-4)
-#define STORAGE_RENAME_OLD_FILE 0
 
 extern const AP_HAL::HAL& hal;
 
@@ -37,89 +32,6 @@ PX4Storage::PX4Storage(void) :
     _perf_errors(perf_alloc(PC_COUNT, "APM_storage_errors"))
 {
 }
-
-/*
-  get signature from bytes at offset MTD_SIGNATURE_OFFSET
-*/
-uint32_t PX4Storage::_mtd_signature(void)
-{
-    int mtd_fd = open(MTD_PARAMS_FILE, O_RDONLY);
-    if (mtd_fd == -1) {
-        AP_HAL::panic("Failed to open " MTD_PARAMS_FILE);
-    }
-    uint32_t v;
-    if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        AP_HAL::panic("Failed to seek in " MTD_PARAMS_FILE);
-    }
-    bus_lock(true);
-    if (read(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        AP_HAL::panic("Failed to read signature from " MTD_PARAMS_FILE);
-    }
-    bus_lock(false);
-    close(mtd_fd);
-    return v;
-}
-
-/*
-  put signature bytes at offset MTD_SIGNATURE_OFFSET
-*/
-void PX4Storage::_mtd_write_signature(void)
-{
-    int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
-    if (mtd_fd == -1) {
-        AP_HAL::panic("Failed to open " MTD_PARAMS_FILE);
-    }
-    uint32_t v = MTD_SIGNATURE;
-    if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        AP_HAL::panic("Failed to seek in " MTD_PARAMS_FILE);
-    }
-    bus_lock(true);
-    if (write(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        AP_HAL::panic("Failed to write signature in " MTD_PARAMS_FILE);
-    }
-    bus_lock(false);
-    close(mtd_fd);
-}
-
-/*
-  upgrade from microSD to MTD (FRAM)
-*/
-void PX4Storage::_upgrade_to_mtd(void)
-{
-    // the MTD is completely uninitialised - try to get a
-    // copy from OLD_STORAGE_FILE
-    int old_fd = open(OLD_STORAGE_FILE, O_RDONLY);
-    if (old_fd == -1) {
-        ::printf("Failed to open %s\n", OLD_STORAGE_FILE);
-        return;
-    }
-
-    int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
-    if (mtd_fd == -1) {
-        AP_HAL::panic("Unable to open MTD for upgrade");
-    }
-
-    if (::read(old_fd, _buffer, sizeof(_buffer)) != sizeof(_buffer)) {
-        close(old_fd);
-        close(mtd_fd);
-        ::printf("Failed to read %s\n", OLD_STORAGE_FILE);
-        return;
-    }
-    close(old_fd);
-    ssize_t ret;
-    bus_lock(true);
-    if ((ret=::write(mtd_fd, _buffer, sizeof(_buffer))) != sizeof(_buffer)) {
-        ::printf("mtd write of %u bytes returned %d errno=%d\n", sizeof(_buffer), ret, errno);
-        AP_HAL::panic("Unable to write MTD for upgrade");
-    }
-    bus_lock(false);
-    close(mtd_fd);
-#if STORAGE_RENAME_OLD_FILE
-    rename(OLD_STORAGE_FILE, OLD_STORAGE_FILE_BAK);
-#endif
-    ::printf("Upgraded MTD from %s\n", OLD_STORAGE_FILE);
-}
-
 
 void PX4Storage::_storage_open(void)
 {
@@ -134,26 +46,6 @@ void PX4Storage::_storage_open(void)
     if (!have_mtd) {
         AP_HAL::panic("Failed to find " MTD_PARAMS_FILE);
     }
-
-    /*
-      cope with upgrading from OLD_STORAGE_FILE to MTD
-    */
-    bool good_signature = (_mtd_signature() == MTD_SIGNATURE);
-    if (stat(OLD_STORAGE_FILE, &st) == 0) {
-        if (good_signature) {
-#if STORAGE_RENAME_OLD_FILE
-            rename(OLD_STORAGE_FILE, OLD_STORAGE_FILE_BAK);
-#endif
-        } else {
-            _upgrade_to_mtd();
-        }
-    }
-
-    // we write the signature every time, even if it already is
-    // good, as this gives us a way to detect if the MTD device is
-    // functional. It is better to panic now than to fail to save
-    // parameters in flight
-    _mtd_write_signature();
 
     _dirty_mask.clearall();
     

--- a/libraries/AP_HAL_PX4/Storage.cpp
+++ b/libraries/AP_HAL_PX4/Storage.cpp
@@ -234,7 +234,7 @@ void PX4Storage::_flash_write(uint16_t line)
 {
     if (_flash.write(line*PX4_STORAGE_LINE_SIZE, PX4_STORAGE_LINE_SIZE)) {
         // mark the line clean
-        _dirty_mask.clear(line);        
+        _dirty_mask.clear(line);
     } else {
         perf_count(_perf_errors);
     }
@@ -266,6 +266,15 @@ bool PX4Storage::_flash_read_data(uint8_t sector, uint32_t offset, uint8_t *data
 bool PX4Storage::_flash_erase_sector(uint8_t sector)
 {
     return up_progmem_erasepage(_flash_page+sector) > 0;
+}
+
+/*
+  callback to check if erase is allowed
+ */
+bool PX4Storage::_flash_erase_ok(void)
+{
+    // only allow erase while disarmed
+    return !hal.util->get_soft_armed();
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -52,13 +52,16 @@ private:
     bool _flash_write_data(uint8_t sector, uint32_t offset, const uint8_t *data, uint16_t length);
     bool _flash_read_data(uint8_t sector, uint32_t offset, uint8_t *data, uint16_t length);
     bool _flash_erase_sector(uint8_t sector);
+    bool _flash_erase_ok(void);
     uint8_t _flash_page;
+    bool _flash_failed;
     
     AP_FlashStorage _flash{_buffer,
             128*1024U, 
             FUNCTOR_BIND_MEMBER(&PX4Storage::_flash_write_data, bool, uint8_t, uint32_t, const uint8_t *, uint16_t),
             FUNCTOR_BIND_MEMBER(&PX4Storage::_flash_read_data, bool, uint8_t, uint32_t, uint8_t *, uint16_t),
-            FUNCTOR_BIND_MEMBER(&PX4Storage::_flash_erase_sector, bool, uint8_t)};
+            FUNCTOR_BIND_MEMBER(&PX4Storage::_flash_erase_sector, bool, uint8_t),
+            FUNCTOR_BIND_MEMBER(&PX4Storage::_flash_erase_ok, bool)};
     
     void _flash_load(void);
     void _flash_write(uint16_t line);

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -3,9 +3,9 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_PX4_Namespace.h"
 #include <systemlib/perf_counter.h>
+#include <AP_Common/Bitmask.h>
 
 #define PX4_STORAGE_SIZE HAL_STORAGE_SIZE
-#define PX4_STORAGE_MAX_WRITE 512
 #define PX4_STORAGE_LINE_SHIFT 9
 #define PX4_STORAGE_LINE_SIZE (1<<PX4_STORAGE_LINE_SHIFT)
 #define PX4_STORAGE_NUM_LINES (PX4_STORAGE_SIZE/PX4_STORAGE_LINE_SIZE)
@@ -27,10 +27,9 @@ private:
     void _storage_open(void);
     void _mark_dirty(uint16_t loc, uint16_t length);
     uint8_t _buffer[PX4_STORAGE_SIZE] __attribute__((aligned(4)));
-    volatile uint32_t _dirty_mask;
+    Bitmask _dirty_mask{PX4_STORAGE_NUM_LINES};
     perf_counter_t  _perf_storage;
     perf_counter_t  _perf_errors;
-    bool _have_mtd;
     void _upgrade_to_mtd(void);
     uint32_t _mtd_signature(void);
     void _mtd_write_signature(void);

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -21,7 +21,6 @@ public:
     void _timer_tick(void);
 
 private:
-    int _fd;
     volatile bool _initialised;
     void _storage_create(void);
     void _storage_open(void);
@@ -31,6 +30,10 @@ private:
     perf_counter_t  _perf_storage;
     perf_counter_t  _perf_errors;
 
+    int _fd = -1;
+    void _mtd_load(void);
+    void _mtd_write(uint16_t line);
+    
 #if defined (CONFIG_ARCH_BOARD_PX4FMU_V4)
     irqstate_t irq_state;
 #endif

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -30,9 +30,6 @@ private:
     Bitmask _dirty_mask{PX4_STORAGE_NUM_LINES};
     perf_counter_t  _perf_storage;
     perf_counter_t  _perf_errors;
-    void _upgrade_to_mtd(void);
-    uint32_t _mtd_signature(void);
-    void _mtd_write_signature(void);
 
 #if defined (CONFIG_ARCH_BOARD_PX4FMU_V4)
     irqstate_t irq_state;

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#define USE_FLASH_STORAGE 1
+#ifndef USE_FLASH_STORAGE
+#define USE_FLASH_STORAGE 0
+#endif
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_PX4_Namespace.h"
@@ -41,14 +43,18 @@ private:
     perf_counter_t  _perf_storage;
     perf_counter_t  _perf_errors;
 
+#if !USE_FLASH_STORAGE
     int _fd = -1;
+    void bus_lock(bool lock);
     void _mtd_load(void);
     void _mtd_write(uint16_t line);
 #if defined (CONFIG_ARCH_BOARD_PX4FMU_V4)
     irqstate_t irq_state;
 #endif
-    void bus_lock(bool lock);
+#endif
 
+
+#if USE_FLASH_STORAGE
     bool _flash_write_data(uint8_t sector, uint32_t offset, const uint8_t *data, uint16_t length);
     bool _flash_read_data(uint8_t sector, uint32_t offset, uint8_t *data, uint16_t length);
     bool _flash_erase_sector(uint8_t sector);
@@ -65,4 +71,5 @@ private:
     
     void _flash_load(void);
     void _flash_write(uint16_t line);
+#endif
 };

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -25,6 +25,7 @@ void panic(const char *errormsg, ...)
 {
     va_list ap;
 
+    fflush(stdout);
     va_start(ap, errormsg);
     vprintf(errormsg, ap);
     va_end(ap);

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -174,3 +174,17 @@ template int constrain_value<int>(const int amt, const int low, const int high);
 template short constrain_value<short>(const short amt, const short low, const short high);
 template float constrain_value<float>(const float amt, const float low, const float high);
 template double constrain_value<double>(const double amt, const double low, const double high);
+
+
+/*
+  simple 16 bit random number generator
+ */
+uint16_t get_random16(void)
+{
+    static uint32_t m_z = 1234;
+    static uint32_t m_w = 76542;
+    m_z = 36969 * (m_z & 65535) + (m_z >> 16);
+    m_w = 18000 * (m_w & 65535) + (m_w >> 16);
+    return ((m_z << 16) + m_w) & 0xFFFF;
+}
+

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -212,3 +212,7 @@ inline uint32_t usec_to_hz(uint32_t usec)
 float linear_interpolate(float low_output, float high_output,
                          float var_value,
                          float var_low, float var_high);
+
+/* simple 16 bit random number generator */
+uint16_t get_random16(void);
+

--- a/mk/make.inc
+++ b/mk/make.inc
@@ -2,4 +2,4 @@
 LIBRARIES += AP_Module
 LIBRARIES += AP_Button
 LIBRARIES += AP_ICEngine
-
+LIBRARIES += AP_FlashStorage


### PR DESCRIPTION
This adds support for using two flash sectors on stm32 to hold stored data. This means parameters, waypoints etc are stored in flash instead of ram using a log structured approach. It is enabled in this work-in-progress PR, but the intention is that this won't be enabled by default in master. It will be a build time option. 
The motivation is to allow building of considerably simpler and cheaper boards as the FRAM chip is one of the most expensive parts on a current stm32 based board.
Note that this also requires a bootloader update. See https://github.com/ArduPilot/Bootloader/tree/pr-flash-reserve
