### PR TITLE
RASPilot: fixed SPI bus usage

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -66,7 +66,7 @@ void AP_Baro_MS56XX::_init()
         return;
     }
 
-    if (!_dev->get_semaphore()->take(10)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
     }
 

--- a/libraries/AP_HAL_Linux/AnalogIn_Raspilot.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_Raspilot.cpp
@@ -81,21 +81,11 @@ void AnalogIn_Raspilot::init()
         return;
     }
 
-    hal.scheduler->suspend_timer_procs();
-    hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AnalogIn_Raspilot::_update, void));
-    hal.scheduler->resume_timer_procs();
+    _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AnalogIn_Raspilot::_update, bool));
 }
 
-void AnalogIn_Raspilot::_update()
+bool AnalogIn_Raspilot::_update()
 {
-    if (AP_HAL::micros() - _last_update_timestamp < 100000) {
-        return;
-    }
-
-    if (!_dev->get_semaphore()->take_nonblocking()) {
-        return;
-    }
-
     struct IOPacket tx = { }, rx = { };
     uint16_t count = RASPILOT_ADC_MAX_CHANNELS;
     tx.count_code = count | PKT_CODE_READ;
@@ -119,8 +109,6 @@ void AnalogIn_Raspilot::_update()
     /* get reg4 data from raspilotio */
     _dev->transfer((uint8_t *)&tx, sizeof(tx), (uint8_t *)&rx, sizeof(rx));
 
-    _dev->get_semaphore()->give();
-
     for (int16_t i = 0; i < RASPILOT_ADC_MAX_CHANNELS; i++) {
         for (int16_t j=0; j < RASPILOT_ADC_MAX_CHANNELS; j++) {
             AnalogSource_Raspilot *source = _channels[j];
@@ -130,6 +118,5 @@ void AnalogIn_Raspilot::_update()
             }
         }
     }
-
-    _last_update_timestamp = AP_HAL::micros();
+    return true;
 }

--- a/libraries/AP_HAL_Linux/AnalogIn_Raspilot.h
+++ b/libraries/AP_HAL_Linux/AnalogIn_Raspilot.h
@@ -35,13 +35,12 @@ public:
     float board_voltage(void);
 
 protected:
-    void _update();
+    bool _update();
 
     AP_HAL::AnalogSource *_vcc_pin_analog_source;
     AnalogSource_Raspilot *_channels[RASPILOT_ADC_MAX_CHANNELS];
 
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _dev;
 
-    uint32_t _last_update_timestamp;
     uint8_t _channels_number;
 };

--- a/libraries/AP_HAL_Linux/RCInput_Raspilot.h
+++ b/libraries/AP_HAL_Linux/RCInput_Raspilot.h
@@ -13,11 +13,9 @@ public:
     void init();
 
 private:
-    uint32_t _last_timer;
-
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _dev;
 
-    void _poll_data(void);
+    bool _poll_data(void);
 };
 
 }

--- a/libraries/AP_HAL_Linux/RCOutput_Raspilot.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Raspilot.h
@@ -20,12 +20,13 @@ public:
 
 private:
     void reset();
-    void _update(void);
+    bool _update(void);
 
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _dev;
 
     uint32_t _last_update_timestamp;
     uint16_t _frequency;
+    uint16_t _new_frequency;
     uint16_t _period_us[8];
     bool _corked;
 };

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
@@ -8,7 +8,7 @@
 
 #include "px4io_protocol.h"
 
-#define RPIOUART_POLL_TIME_INTERVAL 10000
+#define RPIOUART_POLL_TIME_INTERVAL 20000000
 
 extern const AP_HAL::HAL& hal;
 
@@ -29,21 +29,10 @@ using namespace Linux;
 RPIOUARTDriver::RPIOUARTDriver() :
     UARTDriver(false),
     _dev(nullptr),
-    _last_update_timestamp(0),
     _external(false),
     _need_set_baud(false),
     _baudrate(0)
 {
-}
-
-bool RPIOUARTDriver::sem_take_nonblocking()
-{
-    return _dev->get_semaphore()->take_nonblocking();
-}
-
-void RPIOUARTDriver::sem_give()
-{
-    _dev->get_semaphore()->give();
 }
 
 bool RPIOUARTDriver::isExternal()
@@ -76,18 +65,20 @@ void RPIOUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     _readbuf.set_size(rxS);
     _writebuf.set_size(txS);
 
-   _dev = hal.spi->get_device("raspio");
+    if (!_registered_callback) {
+        _dev = hal.spi->get_device("raspio");
+        _registered_callback = true;
+        _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&RPIOUARTDriver::_bus_timer, bool));
+    }
 
     /* set baudrate */
     _baudrate = b;
     _need_set_baud = true;
-    while (_need_set_baud) {
-        hal.scheduler->delay(1);
-    }
 
     if (_writebuf.get_size() && _readbuf.get_size()) {
         _initialised = true;
     }
+
 }
 
 int RPIOUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
@@ -114,14 +105,13 @@ void RPIOUARTDriver::_timer_tick(void)
         UARTDriver::_timer_tick();
         return;
     }
+}
 
+bool RPIOUARTDriver::_bus_timer(void)
+{
     /* set the baudrate of raspilotio */
     if (_need_set_baud) {
         if (_baudrate != 0) {
-            if (!_dev->get_semaphore()->take_nonblocking()) {
-                return;
-            }
-
             struct IOPacket _packet_tx = {0}, _packet_rx = {0};
 
             _packet_tx.count_code = 2 | PKT_CODE_WRITE;
@@ -134,33 +124,23 @@ void RPIOUARTDriver::_timer_tick(void)
                            (uint8_t *)&_packet_rx, sizeof(_packet_rx));
 
             hal.scheduler->delay(1);
-
-            _dev->get_semaphore()->give();
-
         }
 
         _need_set_baud = false;
     }
     /* finish set */
 
-    if (!_initialised) return;
-
-    /* lower the update rate */
-    if (AP_HAL::micros() - _last_update_timestamp < RPIOUART_POLL_TIME_INTERVAL) {
-        return;
+    if (!_initialised) {
+        return true;
     }
 
     _in_timer = true;
-
-    if (!_dev->get_semaphore()->take_nonblocking()) {
-        return;
-    }
 
     struct IOPacket _packet_tx = {0}, _packet_rx = {0};
 
     /* get write_buf bytes */
     uint32_t max_size = MIN((uint32_t) PKT_MAX_REGS * 2,
-                            _baudrate / 10 / (1000000 / RPIOUART_POLL_TIME_INTERVAL));
+                            _baudrate / 10 / (1000000 / 100000));
     uint32_t n = MIN(_writebuf.available(), max_size);
 
     _writebuf.read(&((uint8_t *)_packet_tx.regs)[0], n);
@@ -185,9 +165,6 @@ void RPIOUARTDriver::_timer_tick(void)
 
     hal.scheduler->delay_microseconds(100);
 
-    /* release sem */
-    _dev->get_semaphore()->give();
-
     if (_packet_rx.page == PX4IO_PAGE_UART_BUFFER) {
         /* add bytes to read buf */
         max_size = MIN(_packet_rx.offset, PKT_MAX_REGS * 2);
@@ -198,5 +175,5 @@ void RPIOUARTDriver::_timer_tick(void)
 
     _in_timer = false;
 
-    _last_update_timestamp = AP_HAL::micros();
+    return true;
 }

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.h
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.h
@@ -26,14 +26,12 @@ protected:
 private:
     bool _in_timer;
 
-    bool sem_take_nonblocking();
-    void sem_give();
+    bool _bus_timer(void);
 
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> _dev;
 
-    uint32_t _last_update_timestamp;
-
     bool _external;
+    bool _registered_callback;
 
     bool _need_set_baud;
     uint32_t _baudrate;

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -106,7 +106,7 @@ SPIDesc SPIDeviceManager::_device[] = {
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
 SPIDesc SPIDeviceManager::_device[] = {
     /* MPU9250 is restricted to 1MHz for non-data and interrupt registers */
-    SPIDesc("mpu6000",    0, 0, SPI_MODE_3, 8, RPI_GPIO_25,  1*MHZ, 20*MHZ),
+    SPIDesc("mpu6000",    0, 0, SPI_MODE_3, 8, RPI_GPIO_25,  1*MHZ,  11*MHZ),
     SPIDesc("ms5611",     0, 0, SPI_MODE_3, 8, RPI_GPIO_23,  10*MHZ, 10*MHZ),
     SPIDesc("lsm9ds0_am", 0, 0, SPI_MODE_3, 8, RPI_GPIO_22,  10*MHZ, 10*MHZ),
     SPIDesc("lsm9ds0_g",  0, 0, SPI_MODE_3, 8, RPI_GPIO_12,  10*MHZ, 10*MHZ),

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -152,7 +152,7 @@ void AP_InertialSensor_BMI160::start()
 {
     bool r;
 
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("BMI160: Unable to get semaphore");
     }
 
@@ -429,7 +429,7 @@ bool AP_InertialSensor_BMI160::_hardware_init()
 
     hal.scheduler->delay(BMI160_POWERUP_DELAY_MSEC);
 
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("BMI160: Unable to get semaphore");
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -344,7 +344,7 @@ bool AP_InertialSensor_MPU6000::_has_auxiliary_bus()
 
 void AP_InertialSensor_MPU6000::start()
 {
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("MPU6000: Unable to get semaphore");
     }
 
@@ -717,7 +717,7 @@ bool AP_InertialSensor_MPU6000::_check_whoami(void)
 
 bool AP_InertialSensor_MPU6000::_hardware_init(void)
 {
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("MPU6000: Unable to get semaphore");
     }
 
@@ -798,7 +798,7 @@ bool AP_InertialSensor_MPU6000::_hardware_init(void)
 void AP_InertialSensor_MPU6000::_dump_registers(void)
 {
     hal.console->println("MPU6000 registers");
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -295,7 +295,7 @@ bool AP_InertialSensor_MPU9250::_has_auxiliary_bus()
 
 void AP_InertialSensor_MPU9250::start()
 {
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("MPU92500: Unable to get semaphore");
     }
 
@@ -595,7 +595,7 @@ void AP_InertialSensor_MPU9250::_register_write(uint8_t reg, uint8_t val, bool c
 
 bool AP_InertialSensor_MPU9250::_hardware_init(void)
 {
-    if (!_dev->get_semaphore()->take(100)) {
+    if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("MPU9250: Unable to get semaphore");
     }
 


### PR DESCRIPTION
use thread per bus, fixed mpu6000 bus speed and semaphore timeouts

note that there is still a problem with very slow SPI transfers that needs to be fixed
