### PR TITLE
AP_GPS: Ublox: Skip SBAS request if we don't want to alter it

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -114,7 +114,11 @@ AP_GPS_UBLOX::_request_next_config(void)
         }
         break;
     case STEP_POLL_SBAS:
-        _send_message(CLASS_CFG, MSG_CFG_SBAS, nullptr, 0);
+        if (gps._sbas_mode != 2) {
+            _send_message(CLASS_CFG, MSG_CFG_SBAS, nullptr, 0);
+        } else {
+            _unconfigured_messages &= ~CONFIG_SBAS;
+        }
 	break;
     case STEP_POLL_NAV:
         _send_message(CLASS_CFG, MSG_CFG_NAV_SETTINGS, nullptr, 0);


### PR DESCRIPTION
Fix a SBAS problem with M8P's. (Set GPS_SBAS_MODE to 2 with a M8P).