### PR TITLE
AP_RangeFinder: LeddarOne remove clear buffer in send_request

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -27,19 +27,7 @@ extern const AP_HAL::HAL& hal;
 AP_RangeFinder_LeddarOne::AP_RangeFinder_LeddarOne(RangeFinder &_ranger, uint8_t instance,
                                                                RangeFinder::RangeFinder_State &_state,
                                                                AP_SerialManager &serial_manager) :
-    AP_RangeFinder_Backend(_ranger, instance, _state),
-    // Modbus send request buffer
-    // read input register (function code 0x04)
-    send_request_buffer {
-        LEDDARONE_DEFAULT_ADDRESS,
-        LEDDARONE_MODOBUS_FUNCTION_CODE,
-        0,
-        LEDDARONE_MODOBUS_FUNCTION_REGISTER_ADDRESS,   // 20: Address of first register to read
-        0,
-        LEDDARONE_MODOBUS_FUNCTION_READ_NUMBER,        // 10: The number of consecutive registers to read
-        0x30,   // CRC Lo
-        0x09    // CRC Hi
-    }
+    AP_RangeFinder_Backend(_ranger, instance, _state)
 {
     uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar, 0);
     if (uart != nullptr) {
@@ -90,7 +78,7 @@ bool AP_RangeFinder_LeddarOne::get_reading(uint16_t &reading_cm)
 
     case LEDDARONE_MODBUS_STATE_PRE_SEND_REQUEST:
         // send a request message for Modbus function 4
-        uart->write(send_request_buffer, 8);
+        uart->write(send_request_buffer, sizeof(send_request_buffer));
         modbus_status = LEDDARONE_MODBUS_STATE_SENT_REQUEST;
         last_sending_request_ms = AP_HAL::millis();
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -162,17 +162,6 @@ bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCh
 LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
 {
     uint8_t send_buffer[8] = {0};
-    uint8_t index = 0;
-
-    uint32_t nbytes = uart->available();
-
-    // clear buffer
-    while (nbytes-- > 0) {
-        uart->read();
-        if (++index > LEDDARONE_SERIAL_PORT_MAX) {
-            return LEDDARONE_STATE_ERR_SERIAL_PORT;
-        }
-    }
 
     // Modbus read input register (function code 0x04)
     send_buffer[0] = LEDDARONE_DEFAULT_ADDRESS;
@@ -186,7 +175,7 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::send_request(void)
     CRC16(send_buffer, 6, false);
 
     // write buffer data with CRC16 bits
-    for (index=0; index<8; index++) {
+    for (uint8_t index=0; index<8; index++) {
         uart->write(send_buffer[index]);
     }
     uart->flush();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -59,7 +59,7 @@ private:
     bool CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCheck);
 
     // send a request message to execute ModBus function
-    LeddarOne_Status send_request(void);
+    void send_request(void);
 
     // parse a response message from ModBus
     LeddarOne_Status parse_response(uint8_t &number_detections);
@@ -74,4 +74,6 @@ private:
     LeddarOne_ModbusStatus modbus_status = LEDDARONE_MODBUS_STATE_INIT;
     uint8_t read_buffer[LEDDARONE_READ_BUFFER_SIZE];
     uint32_t read_len;
+
+    uint8_t send_request_buffer[8] = {0};
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -58,15 +58,13 @@ private:
     // CRC16
     bool CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCheck);
 
-    // send a request message to execute ModBus function
-    void send_request(void);
-
     // parse a response message from ModBus
     LeddarOne_Status parse_response(uint8_t &number_detections);
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms;
     uint32_t last_sending_request_ms;
+    uint32_t last_available_ms;
 
     uint16_t detections[LEDDARONE_DETECTIONS_MAX];
     uint32_t sum_distance;
@@ -75,5 +73,5 @@ private:
     uint8_t read_buffer[LEDDARONE_READ_BUFFER_SIZE];
     uint32_t read_len;
 
-    uint8_t send_request_buffer[8] = {0};
+    const uint8_t send_request_buffer[8];
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -73,5 +73,16 @@ private:
     uint8_t read_buffer[LEDDARONE_READ_BUFFER_SIZE];
     uint32_t read_len;
 
-    const uint8_t send_request_buffer[8];
+    // Modbus send request buffer
+    // read input register (function code 0x04)
+    const uint8_t send_request_buffer[8] = {
+        LEDDARONE_DEFAULT_ADDRESS,
+        LEDDARONE_MODOBUS_FUNCTION_CODE,
+        0,
+        LEDDARONE_MODOBUS_FUNCTION_REGISTER_ADDRESS,   // 20: Address of first register to read
+        0,
+        LEDDARONE_MODOBUS_FUNCTION_READ_NUMBER,        // 10: The number of consecutive registers to read
+        0x30,   // CRC Lo
+        0x09    // CRC Hi
+    };
 };


### PR DESCRIPTION
remove clear buffer in send_request function. 

checked by logging whether available bytes exist. There were no available bytes.