### PR TITLE
Fix LSM9DS1 orientation and change primary compass for Navio 2

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -577,7 +577,7 @@ void Compass::_detect_backends(void)
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NAVIO2
     _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
                  AP_Compass_AK8963::name, false);
-    _add_backend(AP_Compass_LSM9DS1::probe(*this, hal.spi->get_device("lsm9ds1_m")),
+    _add_backend(AP_Compass_LSM9DS1::probe(*this, hal.spi->get_device("lsm9ds1_m"), ROTATION_ROLL_180),
                  AP_Compass_LSM9DS1::name, false);
     _add_backend(AP_Compass_HMC5843::probe(*this, hal.i2c_mgr->get_device(HAL_COMPASS_HMC5843_I2C_BUS, HAL_COMPASS_HMC5843_I2C_ADDR), true),
                  AP_Compass_HMC5843::name, true);

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -575,10 +575,10 @@ void Compass::_detect_backends(void)
                      true),
                  AP_Compass_HMC5843::name, true);
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NAVIO2
-    _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
-                 AP_Compass_AK8963::name, false);
     _add_backend(AP_Compass_LSM9DS1::probe(*this, hal.spi->get_device("lsm9ds1_m"), ROTATION_ROLL_180),
                  AP_Compass_LSM9DS1::name, false);
+    _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
+                 AP_Compass_AK8963::name, false);
     _add_backend(AP_Compass_HMC5843::probe(*this, hal.i2c_mgr->get_device(HAL_COMPASS_HMC5843_I2C_BUS, HAL_COMPASS_HMC5843_I2C_ADDR), true),
                  AP_Compass_HMC5843::name, true);
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NAVIO

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -57,13 +57,23 @@ struct PACKED sample_regs {
 
 extern const AP_HAL::HAL &hal;
 
+AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(Compass &compass,
+                                       AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                       enum Rotation rotation)
+    : AP_Compass_Backend(compass)
+    , _dev(std::move(dev))
+    , _rotation(rotation)
+{
+}
+
 AP_Compass_Backend *AP_Compass_LSM9DS1::probe(Compass &compass,
-                                              AP_HAL::OwnPtr<AP_HAL::Device> dev)
+                                              AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                              enum Rotation rotation)
 {
     if (!dev) {
         return nullptr;
     }
-    AP_Compass_LSM9DS1 *sensor = new AP_Compass_LSM9DS1(compass, std::move(dev));
+    AP_Compass_LSM9DS1 *sensor = new AP_Compass_LSM9DS1(compass, std::move(dev), rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -97,6 +107,8 @@ bool AP_Compass_LSM9DS1::init()
     }
 
     _compass_instance = register_compass();
+
+    set_rotation(_compass_instance, _rotation);
 
     _dev->set_device_type(DEVTYPE_LSM9DS1);
     set_dev_id(_compass_instance, _dev->get_bus_id());
@@ -233,12 +245,6 @@ bool AP_Compass_LSM9DS1::_set_scale(void)
     _scaling = 0.58f;
 
     return true;
-}
-
-AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev)
-    : AP_Compass_Backend(compass)
-    , _dev(std::move(dev))
-{
 }
 
 uint8_t AP_Compass_LSM9DS1::_register_read(uint8_t reg)

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -203,10 +203,6 @@ void AP_Compass_LSM9DS1::read()
     _accum_count = 0;
 
     _sem->give();
-        
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
-    field.rotate(ROTATION_ROLL_180);
-#endif
 
     publish_filtered_field(field, _compass_instance);
 }

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -12,7 +12,8 @@ class AP_Compass_LSM9DS1 : public AP_Compass_Backend
 {
 public:
     static AP_Compass_Backend *probe(Compass &compass,
-                                     AP_HAL::OwnPtr<AP_HAL::Device> dev);
+                                     AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                     enum Rotation rotation = ROTATION_NONE);
 
     static constexpr const char *name = "LSM9DS1";
 
@@ -21,7 +22,8 @@ public:
     virtual ~AP_Compass_LSM9DS1() {}
 
 private:
-    AP_Compass_LSM9DS1(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Compass_LSM9DS1(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                       enum Rotation rotation = ROTATION_NONE);
     bool init();
     bool _check_id(void);
     bool _configure(void);
@@ -41,4 +43,5 @@ private:
     float _mag_y_accum;
     float _mag_z_accum;
     uint32_t _accum_count;
+    enum Rotation _rotation;
 };


### PR DESCRIPTION
LSM9DS1's orientation hasn't been correctly set. Since we've had the long-awaited boilerplate code in master for compass rotations, it's gotten easier to spot a bug which hadn't popped up as often as to notice it. That's why it's been neglected for such a long time. LSM9DS1 worked correctly with offsets calculated on board but yielded Inconsistent compasses error if Live calibration was used.