### PR TITLE
Fix LSM9DS1 orientation in ArduCopter stable

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -490,10 +490,10 @@ void Compass::_detect_backends(void)
                      true),
                  AP_Compass_HMC5843::name, true);
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NAVIO2
-    _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
-                 AP_Compass_AK8963::name, false);
     _add_backend(AP_Compass_LSM9DS1::probe(*this, hal.spi->get_device("lsm9ds1_m")),
                  AP_Compass_LSM9DS1::name, false);
+    _add_backend(AP_Compass_AK8963::probe_mpu9250(*this, 0),
+                 AP_Compass_AK8963::name, false);
     _add_backend(AP_Compass_HMC5843::probe(*this, hal.i2c_mgr->get_device(HAL_COMPASS_HMC5843_I2C_BUS, HAL_COMPASS_HMC5843_I2C_ADDR), true),
                  AP_Compass_HMC5843::name, true);
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_NAVIO

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -158,6 +158,10 @@ void AP_Compass_LSM9DS1::_update(void)
 
     raw_field *= _scaling;
 
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
+    raw_field.rotate(ROTATION_ROLL_180);
+#endif
+
     // rotate raw_field from sensor frame to body frame
     rotate_field(raw_field, _compass_instance);
 
@@ -199,10 +203,6 @@ void AP_Compass_LSM9DS1::read()
     _reset_filter();
 
     hal.scheduler->resume_timer_procs();
-
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
-    field.rotate(ROTATION_ROLL_180);
-#endif
 
     publish_filtered_field(field, _compass_instance);
 


### PR DESCRIPTION
LSM9DS1's orientation hasn't been correctly set. Since we've had the long-awaited boilerplate code in master for compass rotations, it's gotten easier to spot a bug which hadn't popped up as often as to notice it. That's why it's been neglected for such a long time. LSM9DS1 worked correctly with offsets calculated on board but yielded Inconsistent compasses error if Live calibration was used.

ArduCopter 3.4 doesn't have new infrusture for compass orientation setting in ```::probe()```. That's why we fix the error by moving rotation to the place it should've always been.