### PR TITLE
AP_OpticalFlow: fix onboard init

### DIFF
--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -59,7 +59,8 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
 
 // default constructor
 OpticalFlow::OpticalFlow(AP_AHRS_NavEKF &ahrs)
-    : _last_update_ms(0)
+    : _last_update_ms(0),
+      _ahrs(ahrs)
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -76,12 +77,13 @@ void OpticalFlow::init(void)
         backend = new AP_OpticalFlow_PX4(*this);
 #elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
         backend = new AP_OpticalFlow_HIL(*this);
-#elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-        backend = new AP_OpticalFlow_Linux(*this, hal.i2c_mgr->get_device(HAL_OPTFLOW_PX4FLOW_I2C_BUS, HAL_OPTFLOW_PX4FLOW_I2C_ADDRESS));
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP ||\
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE ||\
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
-        backend = new AP_OpticalFlow_Onboard(*this, ahrs);
+        backend = new AP_OpticalFlow_Onboard(*this, _ahrs);
+#elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+        backend = new AP_OpticalFlow_Linux(*this, hal.i2c_mgr->get_device(HAL_OPTFLOW_PX4FLOW_I2C_BUS, HAL_OPTFLOW_PX4FLOW_I2C_ADDRESS));
+
 #endif
     }
 

--- a/libraries/AP_OpticalFlow/OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow.h
@@ -80,6 +80,7 @@ public:
 
 private:
     OpticalFlow_backend *backend;
+    AP_AHRS_NavEKF &_ahrs;
 
     struct AP_OpticalFlow_Flags {
         uint8_t healthy     : 1;    // true if sensor is healthy


### PR DESCRIPTION
mistake in patch to avoid segfault which enabled
AP_OpticalFlow_Linux instead of AP_OpticalFlow_Onboard.
Store a reference to ahrs in order to execute init later, when
ahrs is initialized.