### PR TITLE
AP_InertialSensor: FIFO MPU6000 and MPU9250 drivers improvements for fast sample.

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -115,9 +115,9 @@ private:
     float _last_temp;
     uint8_t _temp_counter;
 
-    // has master i2c been enabled?
-    bool _master_i2c_enable;    
-    
+    // Last status from register user control
+    uint8_t _last_stat_user_ctrl;    
+
     // buffer for fifo read
     uint8_t *_fifo_buffer;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -273,10 +273,9 @@ bool AP_InertialSensor_MPU9250::_init()
 
 void AP_InertialSensor_MPU9250::_fifo_reset()
 {
-    uint8_t user_ctrl = _master_i2c_enable?BIT_USER_CTRL_I2C_MST_EN:0;
-    _register_write(MPUREG_USER_CTRL, user_ctrl);
-    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_RESET);
-    _register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_FIFO_EN);
+    _register_write(MPUREG_USER_CTRL, _last_stat_user_ctrl & ~BIT_USER_CTRL_FIFO_EN);
+    _register_write(MPUREG_USER_CTRL, _last_stat_user_ctrl | BIT_USER_CTRL_FIFO_RESET);
+    _register_write(MPUREG_USER_CTRL, _last_stat_user_ctrl | BIT_USER_CTRL_FIFO_EN);
 }
 
 void AP_InertialSensor_MPU9250::_fifo_enable()
@@ -619,13 +618,14 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
     // Chip reset
     uint8_t tries;
     for (tries = 0; tries < 5; tries++) {
-        uint8_t user_ctrl = _register_read(MPUREG_USER_CTRL);
+        _last_stat_user_ctrl = _register_read(MPUREG_USER_CTRL);
 
         /* First disable the master I2C to avoid hanging the slaves on the
          * aulixiliar I2C bus - it will be enabled again if the AuxiliaryBus
          * is used */
-        if (user_ctrl & BIT_USER_CTRL_I2C_MST_EN) {
-            _register_write(MPUREG_USER_CTRL, user_ctrl & ~BIT_USER_CTRL_I2C_MST_EN);
+        if (_last_stat_user_ctrl & BIT_USER_CTRL_I2C_MST_EN) {
+            _last_stat_user_ctrl &= ~BIT_USER_CTRL_I2C_MST_EN;
+            _register_write(MPUREG_USER_CTRL, _last_stat_user_ctrl);
             hal.scheduler->delay(10);
         }
 
@@ -637,7 +637,8 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
         if (_dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
             /* Disable I2C bus if SPI selected (Recommended in Datasheet to be
              * done just after the device is reset) */
-            _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_I2C_IF_DIS);
+            _last_stat_user_ctrl |= BIT_USER_CTRL_I2C_IF_DIS;
+            _register_write(MPUREG_USER_CTRL, _last_stat_user_ctrl);
         }
 
         // Wake up device and select GyroZ clock. Note that the
@@ -817,10 +818,10 @@ void AP_MPU9250_AuxiliaryBus::_configure_slaves()
     auto &backend = AP_InertialSensor_MPU9250::from(_ins_backend);
 
     /* Enable the I2C master to slaves on the auxiliary I2C bus*/
-    uint8_t user_ctrl = backend._register_read(MPUREG_USER_CTRL);
-    backend._register_write(MPUREG_USER_CTRL, user_ctrl | BIT_USER_CTRL_I2C_MST_EN);
-
-    backend._master_i2c_enable = true;
+    if (!(backend._last_stat_user_ctrl & BIT_USER_CTRL_I2C_MST_EN)) {
+        backend._last_stat_user_ctrl |= BIT_USER_CTRL_I2C_MST_EN;
+        backend._register_write(MPUREG_USER_CTRL, backend._last_stat_user_ctrl);
+    }
 
     /* stop condition between reads; clock at 400kHz */
     backend._register_write(MPUREG_I2C_MST_CTRL,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -99,9 +99,9 @@ private:
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
 
-    // has master i2c been enabled?
-    bool _master_i2c_enable;
-    
+    // Last status from register user control
+    uint8_t _last_stat_user_ctrl;
+
     // last temperature reading, used to detect FIFO errors
     float _last_temp;
     uint8_t _temp_counter;


### PR DESCRIPTION
We need to store the byte entirely user control register and reset only the FIFO buffer later without touching other bits. With this one we use a one less read.

Try it first.