### PR TITLE
Tracker: Change from printf statement to print, println statement.

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -394,7 +394,7 @@ void Tracker::load_parameters(void)
         g.format_version != Parameters::k_format_version) {
 
         // erase all parameters
-        hal.console->printf("Firmware change: erasing EEPROM...\n");
+        hal.console->println("Firmware change: erasing EEPROM...");
         AP_Param::erase_all();
 
         // save the current format version


### PR DESCRIPTION
A character string that does not require a parser improves performance by replacing it with a print or println statement that does not have a parser.