### PR TITLE
Copter: Support NAV_GUIDED_ENABLE commands outside of a Mission.

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1152,6 +1152,15 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             result = MAV_RESULT_ACCEPTED;
             break;
 
+#if NAV_GUIDED == ENABLED
+        case MAV_CMD_NAV_GUIDED_ENABLE: {
+            AP_Mission::Mission_Command cmd = {0};
+            cmd.p1 = packet.param1;
+            copter.do_nav_guided_enable(cmd); 
+            break;
+        }
+#endif
+
 #if CAMERA == ENABLED
         case MAV_CMD_DO_DIGICAM_CONFIGURE:
             copter.camera.configure(packet.param1,


### PR DESCRIPTION
Good for companion computers that want to enable NAV_GUIDED.