### PR TITLE
PX4: support brushed motor PWM outputs

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -118,7 +118,8 @@ public:
      */
     enum output_mode {
         MODE_PWM_NORMAL,
-        MODE_PWM_ONESHOT
+        MODE_PWM_ONESHOT,
+        MODE_PWM_BRUSHED16KHZ
     };
     virtual void    set_output_mode(enum output_mode mode) {}
 };

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -327,13 +327,17 @@ void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
     }
 
     if (_output_mode == MODE_PWM_BRUSHED16KHZ) {
-        // map form 1000 to 2000 onto zero to 100% duty cycle
-        if (period_us <= 1000) {
+        // map from the PWM range to 0 t0 100% duty cycle. For 16kHz
+        // this ends up being 0 to 500 pulse width in units of
+        // 125usec.
+        const uint32_t period_max = 1000000UL/(16000/8);
+        if (period_us <= _esc_pwm_min) {
             period_us = 0;
-        } else if (period_us >= 2000) {
-            period_us = 500;
+        } else if (period_us >= _esc_pwm_max) {
+            period_us = period_max;
         } else {
-            period_us = (period_us - 1000)/2;
+            uint32_t pdiff = period_us - _esc_pwm_min;
+            period_us = pdiff*period_max/(_esc_pwm_max - _esc_pwm_min);
         }
     }
     

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -82,8 +82,8 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: PWM_TYPE
     // @DisplayName: Output PWM type
-    // @Description: This selects the output PWM type, allowing for normal PWM continuous output or OneShot125
-    // @Values: 0:Normal,1:OneShot,2:OneShot125
+    // @Description: This selects the output PWM type, allowing for normal PWM continuous output, OneShot or brushed motor output
+    // @Values: 0:Normal,1:OneShot,2:OneShot125,3:Brushed16kHz
     // @User: Advanced
     AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, PWM_TYPE_NORMAL),
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -118,6 +118,8 @@ void AP_Motors::rc_set_freq(uint32_t mask, uint16_t freq_hz)
         mask != 0) {
         // tell HAL to do immediate output
         hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_ONESHOT);
+    } else if (_pwm_type == PWM_TYPE_BRUSHED16kHz) {
+        hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_BRUSHED16KHZ);
     }
 }
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -134,7 +134,7 @@ public:
     // set loop rate. Used to support loop rate as a parameter
     void                set_loop_rate(uint16_t loop_rate) { _loop_rate = loop_rate; }
 
-    enum pwm_type { PWM_TYPE_NORMAL=0, PWM_TYPE_ONESHOT=1, PWM_TYPE_ONESHOT125=2 };
+    enum pwm_type { PWM_TYPE_NORMAL=0, PWM_TYPE_ONESHOT=1, PWM_TYPE_ONESHOT125=2, PWM_TYPE_BRUSHED16kHz=3 };
     pwm_type            get_pwm_type(void) const { return (pwm_type)_pwm_type.get(); }
     
 protected:


### PR DESCRIPTION
This adds MOT_PWM_TYPE=3 to support brushed motor PWM output at 16kHz. This is useful for very small quads where the lighter weight of the brushed motors matters
This has not been test flown yet