### PR TITLE
EKF2: Fix bugs in reporting of state resets following a core selection change

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1172,27 +1172,34 @@ bool NavEKF2::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
-// return the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
-// returns the time of the last yaw angle reset or 0 if no reset has ever occurred
+// Returns the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
+// Returns the time of the last yaw angle reset or 0 if no reset or core switch has ever occurred
+// Where there are multiple consumers, they must access this function on the same frame as each other
 uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
 {
     if (!core) {
         return 0;
     }
 
-    // Record last time controller got the yaw reset
-    yaw_reset_data.last_function_call = imuSampleTime_us / 1000;
-    yawAngDelta = 0;
-    uint32_t lastYawReset_ms = 0;
+    yawAngDelta = 0.0f;
+
+    // Do the conversion to msec in one place
+    uint32_t now_time_ms = imuSampleTime_us / 1000;
+
+    // The last time we switched to the current primary core is the first reset event
+    uint32_t lastYawReset_ms = yaw_reset_data.last_primary_change;
 
     // There has been a change notification in the primary core that the controller has not consumed
-    if (yaw_reset_data.core_changed) {
+    // or this is a repeated acce
+    if (yaw_reset_data.core_changed || yaw_reset_data.last_function_call == now_time_ms) {
         yawAngDelta = yaw_reset_data.core_delta;
-        lastYawReset_ms = yaw_reset_data.last_primary_change;
         yaw_reset_data.core_changed = false;
     }
 
-    // There has been a reset inside the core since we switched
+    // Record last time controller got the yaw reset
+    yaw_reset_data.last_function_call = now_time_ms;
+
+    // There has been a reset inside the core since we switched so update the time and delta
     float temp_yawAng;
     uint32_t lastCoreYawReset_ms = core[primary].getLastYawResetAngle(temp_yawAng);
     if (lastCoreYawReset_ms > lastYawReset_ms) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1210,27 +1210,34 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
     return lastYawReset_ms;
 }
 
-// return the amount of NE position change due to the last position reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
+// Returns the amount of NE position change due to the last position reset or core switch in metres
+// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
+// Where there are multiple consumers, they must access this function on the same frame as each other
 uint32_t NavEKF2::getLastPosNorthEastReset(Vector2f &posDelta)
 {
     if (!core) {
         return 0;
     }
 
-    // Record last time controller got the position reset
-    pos_reset_data.last_function_call = imuSampleTime_us / 1000;
     posDelta.zero();
-    uint32_t lastPosReset_ms = 0;
+
+    // Do the conversion to msec in one place
+    uint32_t now_time_ms = imuSampleTime_us / 1000;
+
+    // The last time we switched to the current primary core is the first reset event
+    uint32_t lastPosReset_ms = pos_reset_data.last_primary_change;
 
     // There has been a change in the primary core that the controller has not consumed
-    if (pos_reset_data.core_changed) {
+    // allow for multiple consumers on the same frame
+    if (pos_reset_data.core_changed || pos_reset_data.last_function_call == now_time_ms) {
         posDelta = pos_reset_data.core_delta;
-        lastPosReset_ms = pos_reset_data.last_primary_change;
         pos_reset_data.core_changed = false;
     }
 
-    // There has been a reset inside the core since we switched
+    // Record last time controller got the position reset
+    pos_reset_data.last_function_call = now_time_ms;
+
+    // There has been a reset inside the core since we switched so update the time and delta
     Vector2f tempPosDelta;
     uint32_t lastCorePosReset_ms = core[primary].getLastPosNorthEastReset(tempPosDelta);
     if (lastCorePosReset_ms > lastPosReset_ms) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1267,27 +1267,34 @@ const char *NavEKF2::prearm_failure_reason(void) const
     return core[primary].prearm_failure_reason();
 }
 
-// return the amount of vertical position change due to the last reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
+// Returns the amount of vertical position change due to the last reset or core switch in metres
+// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
+// Where there are multiple consumers, they must access this function on the same frame as each other
 uint32_t NavEKF2::getLastPosDownReset(float &posDelta)
 {
     if (!core) {
         return 0;
     }
 
-    // Record last time controller got the position reset
-    pos_down_reset_data.last_function_call = imuSampleTime_us / 1000;
     posDelta = 0.0f;
-    uint32_t lastPosReset_ms = 0;
+
+    // Do the conversion to msec in one place
+    uint32_t now_time_ms = imuSampleTime_us / 1000;
+
+    // The last time we switched to the current primary core is the first reset event
+    uint32_t lastPosReset_ms = pos_down_reset_data.last_primary_change;
 
     // There has been a change in the primary core that the controller has not consumed
-    if (pos_down_reset_data.core_changed) {
+    // allow for multiple consumers on the same frame
+    if (pos_down_reset_data.core_changed || pos_down_reset_data.last_function_call == now_time_ms) {
         posDelta = pos_down_reset_data.core_delta;
-        lastPosReset_ms = pos_down_reset_data.last_primary_change;
         pos_down_reset_data.core_changed = false;
     }
 
-    // There has been a reset inside the core since we switched
+    // Record last time controller got the position reset
+    pos_down_reset_data.last_function_call = now_time_ms;
+
+    // There has been a reset inside the core since we switched so update the time and delta
     float tempPosDelta;
     uint32_t lastCorePosReset_ms = core[primary].getLastPosDownReset(tempPosDelta);
     if (lastCorePosReset_ms > lastPosReset_ms) {


### PR DESCRIPTION
This fixes a bug where the first reset delta reported to the control loops following a core select switch will be erroneous if the EKF that has been selected has previously experienced a reset.

Addresses an issue discussed here: https://github.com/ArduPilot/ardupilot/pull/5252#issuecomment-263035749

**Testing**

Here is the testing of the updated logic for the vertical position reset performed in SITL. The EK2_HGT_I_GATE param was set to 100 and the IMU2 Z accel offset set to 2.0 temporarily to force a reset of the IMU2 EKF core. The IMU1 Z accel offset was then set temporarily to 2.0 to force a core switch. Temporarily logging of the reset event time DBG.ResetMS and reset delta DBG.POSZ was added to assist with verification:

![screen shot 2016-11-30 at 10 56 40 am](https://cloud.githubusercontent.com/assets/3596952/20734384/2662b76a-b6ed-11e6-8d40-49f49718d06f.png)

Position reset testing is harder to perform using SITL and required a combination of reducing the position innovation gate size and setting large roll gyro offsets to induce large position innovations. Here are the east positions from the two EKF cores, controller and controller set-point. The second cores is made to diverge and reset first, then the first core to induce a core switch.
![screen shot 2016-11-30 at 11 31 37 am](https://cloud.githubusercontent.com/assets/3596952/20734897/92bc248e-b6f0-11e6-9eeb-263a8d9b4d92.png)

Zooming into the switch event we can see the single East position reset delta consumed by the controller logged in DBG.POSY
![screen shot 2016-11-30 at 11 36 06 am](https://cloud.githubusercontent.com/assets/3596952/20735010/33d34456-b6f1-11e6-82bd-d7b02a3bd589.png)

The yaw reset was simulated by setting both SIM_MAG_ALY_X and SIM_MAG_ALY_Y to -300 to simulate a large initial yaw angle error. The IMU2 yaw gyro offset was also set to 0.05 after alignment to casue the second EKF core to have a different heading error to the first. the copter was climbed to below 5m to avoid the final yaw reset and a core switch initiated by setting the first IMU X gyro bias to 0.2. The reset delta consumed by the yaw controller was logged in DB3.YAW and the timestamp in DB3.ResetMS.

![screen shot 2016-11-30 at 12 04 13 pm](https://cloud.githubusercontent.com/assets/3596952/20735716/10cc950c-b6f6-11e6-8bf0-8bdec3ce14c9.png)

Zooming into the core switch event we can see the controller set-point follows the reset and the reset delta is consistent with the core switch, ignoring the previous internal reset on the IMU2 EKF.

![screen shot 2016-11-30 at 12 06 39 pm](https://cloud.githubusercontent.com/assets/3596952/20735740/389cab6c-b6f6-11e6-9ec5-2654b8c59242.png)



