### PR TITLE
AP_Mount: extension of functionality for Alexmos mounts

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -120,6 +120,33 @@ template auto wrap_360_cd<short>(const short angle) -> decltype(wrap_360(angle, 
 template auto wrap_360_cd<double>(const double angle) -> decltype(wrap_360(angle, 100.f));
 
 template <class T>
+float wrap_2x720(const T angle, float unit_mod = 1)
+{
+    const float ang_1440 = 4.f * 360.f * unit_mod;
+    const float ang_720 = 2.f * 360.f * unit_mod;
+    float res = fmodf(static_cast<float>(angle), ang_1440);
+    if (res >= ang_720) { res -= ang_1440; }
+    if (res < -ang_720) { res += ang_1440; }
+    return res;   
+}
+
+template float wrap_2x720<int>(const int angle, float unit_mod);
+template float wrap_2x720<short>(const short angle, float unit_mod);
+template float wrap_2x720<float>(const float angle, float unit_mod);
+template float wrap_2x720<double>(const double angle, float unit_mod);
+
+template <class T>
+auto wrap_2x720_cd(const T angle) -> decltype(wrap_2x720(angle, 100.f))
+{
+    return wrap_2x720(angle, 100.f);
+}
+
+template auto wrap_2x720_cd<int>(const int angle) -> decltype(wrap_2x720(angle, 100.f));
+template auto wrap_2x720_cd<short>(const short angle) -> decltype(wrap_2x720(angle, 100.f));
+template auto wrap_2x720_cd<float>(const float angle) -> decltype(wrap_2x720(angle, 100.f));
+template auto wrap_2x720_cd<double>(const double angle) -> decltype(wrap_2x720(angle, 100.f));
+
+template <class T>
 float wrap_PI(const T radian)
 {
     auto res = wrap_2PI(radian);
@@ -148,6 +175,22 @@ template float wrap_2PI<int>(const int radian);
 template float wrap_2PI<short>(const short radian);
 template float wrap_2PI<float>(const float radian);
 template float wrap_2PI<double>(const double radian);
+
+template <class T>
+float wrap_2x4PI(const T radian)
+{
+    const float rad_8PI = 4.f * M_2PI;
+    const float rad_4PI = 2.f * M_2PI;
+    float res = fmodf(static_cast<float>(radian), rad_8PI);
+    if (res >= rad_4PI) { res -= rad_8PI; }
+    if (res < -rad_4PI) { res += rad_8PI; }
+    return res;
+}
+
+template float wrap_2x4PI<int>(const int radian);
+template float wrap_2x4PI<short>(const short radian);
+template float wrap_2x4PI<float>(const float radian);
+template float wrap_2x4PI<double>(const double radian);
 
 template <class T>
 T constrain_value(const T amt, const T low, const T high)

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -94,6 +94,21 @@ template <class T>
 auto wrap_360_cd(const T angle) -> decltype(wrap_360(angle, 100.f));
 
 /*
+ * Wrapping function specific for Alexmos Mount
+ * Constrain an euler angle to be within the range: -720 to 720 degrees. The
+ * second parameter changes the units. Default: 1 == degrees, 10 == dezi,
+ * 100 == centi.
+ */
+template <class T>
+float wrap_2x720(const T angle, float unit_mod = 1);
+
+/*
+ * Wrap an angle in centi-degrees. See wrap_2x720().
+ */
+template <class T>
+auto wrap_2x720_cd(const T angle) -> decltype(wrap_2x720(angle, 100.0f));
+
+/*
   wrap an angle in radians to -PI ~ PI (equivalent to +- 180 degrees)
  */
 template <class T>
@@ -104,6 +119,13 @@ float wrap_PI(const T radian);
  */
 template <class T>
 float wrap_2PI(const T radian);
+
+/*
+ * wrap an angle defined in radians to the interval [-4*PI,4*PI)
+ * Function specific for Alexmos Mount
+ */
+template <class T>
+float wrap_2x4PI(const T radian);
 
 /*
  * Constrain a value to be within the range: low and high

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -642,3 +642,10 @@ void AP_Mount::send_gimbal_report(mavlink_channel_t chan)
         }
     }    
 }
+
+void AP_Mount::trigger_imu_helper(uint8_t mntCal)
+{
+    if (_backends[0] != NULL) {
+        _backends[0]->trigger_imu_helper(mntCal);
+    }
+}

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -132,6 +132,9 @@ public:
     // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     void status_msg(mavlink_channel_t chan);
 
+    // mount IMU helper mode
+    void trigger_imu_helper(uint8_t mntCal);
+
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -245,7 +245,7 @@ void AP_Mount_Alexmos::get_boardinfo()
 /*
   control_axis : send new angles to the gimbal at a fixed speed of 30 deg/s2
 */
-void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degrees)
+void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degrees, float boost)
 {
     // convert to degrees if necessary
     Vector3f target_deg = angle;
@@ -254,11 +254,11 @@ void AP_Mount_Alexmos::control_axis(const Vector3f& angle, bool target_in_degree
     }
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode = AP_MOUNT_ALEXMOS_MODE_ANGLE;
-    outgoing_buffer.angle_speed.speed_roll = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
+    outgoing_buffer.angle_speed.speed_roll = boost * DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
     outgoing_buffer.angle_speed.angle_roll = DEGREE_TO_VALUE(target_deg.x);
-    outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
+    outgoing_buffer.angle_speed.speed_pitch = boost * DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(target_deg.y);
-    outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
+    outgoing_buffer.angle_speed.speed_yaw = boost * DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
     outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(target_deg.z);
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -83,6 +83,12 @@ void AP_Mount_Alexmos::status_msg(mavlink_channel_t chan)
     mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y*100, _current_angle.x*100, _current_angle.z*100);
 }
 
+// camera rig parameters
+void AP_Mount_Alexmos::trigger_imu_helper(uint8_t mntCal)
+{
+    compensate_mount_imu(mntCal);
+}
+
 /*
  * get_angles
  */

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -35,7 +35,7 @@ void AP_Mount_Alexmos::update()
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            control_axis(_angle_ef_target_rad, false);
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
@@ -48,7 +48,7 @@ void AP_Mount_Alexmos::update()
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
             if(_frontend._ahrs.get_gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
-                calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, true, false);
+                calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, true, true, false);
                 control_axis(_angle_ef_target_rad, false);
             }
             break;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -137,6 +137,9 @@ public:
     // status_msg - called to allow mounts to send their status to GCS via MAVLink
     virtual void status_msg(mavlink_channel_t chan) ;
 
+    // mount IMU helper mode
+    virtual void trigger_imu_helper(uint8_t mntCal);
+
 private:
 
     // get_angles -

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -161,7 +161,7 @@ private:
     void get_boardinfo();
 
     // control_axis - send new angles to the gimbal at a fixed speed of 30 deg/s
-    void control_axis(const Vector3f& angle , bool targets_in_degrees);
+    void control_axis(const Vector3f& angle, bool targets_in_degrees, float boost = 1.0f);
 
     // read_params - read current profile profile_id and global parameters from the gimbal settings
     void read_params(uint8_t profile_id);

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -409,6 +409,8 @@ private:
 
     Vector3f _angle_ef_target_2x720;
 
+    enum MAV_MOUNT_MODE _prev_mount_mode;
+
     uint16_t _rt_data_timestamp;
 
     // CMD_READ_PARAMS has been called once

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -81,7 +81,7 @@ void AP_Mount_Backend::control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_
 }
 
 // update_targets_from_rc - updates angle targets using input from receiver
-void AP_Mount_Backend::update_targets_from_rc()
+void AP_Mount_Backend::update_targets_from_rc(bool do_wrap_yaw)
 {
 #define rc_ch(i) RC_Channel::rc_channel(i-1)
 
@@ -102,7 +102,14 @@ void AP_Mount_Backend::update_targets_from_rc()
         }
         if (pan_rc_in && (rc_ch(pan_rc_in))) {
             _angle_ef_target_rad.z += rc_ch(pan_rc_in)->norm_input_dz() * 0.0001f * _frontend._joystick_speed;
-            _angle_ef_target_rad.z = constrain_float(_angle_ef_target_rad.z, radians(_state._pan_angle_min*0.01f), radians(_state._pan_angle_max*0.01f));
+
+            if (do_wrap_yaw) {
+                _angle_ef_target_rad.z = wrap_PI(_angle_ef_target_rad.z);
+            } else {
+                _angle_ef_target_rad.z = constrain_float(_angle_ef_target_rad.z,
+                                                         radians(_state._pan_angle_min*0.01f),
+                                                         radians(_state._pan_angle_max*0.01f));                
+            }
         }
     } else {
         // allow pilot position input to come directly from an RC_Channel

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -132,7 +132,7 @@ float AP_Mount_Backend::angle_input_rad(RC_Channel* rc, int16_t angle_min, int16
 }
 
 // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (and radians) to point at the given target
-void AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan)
+void AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan)
 {
     float GPS_vector_x = (target.lng-_frontend._current_loc.lng)*cosf(ToRad((_frontend._current_loc.lat+target.lat)*0.00000005f))*0.01113195f;
     float GPS_vector_y = (target.lat-_frontend._current_loc.lat)*0.01113195f;
@@ -150,6 +150,10 @@ void AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vec
     // pan calcs
     if (calc_pan) {
         // calc absolute heading and then onvert to vehicle relative yaw
-        angles_to_target_rad.z = wrap_PI(atan2f(GPS_vector_x, GPS_vector_y) - _frontend._ahrs.yaw);
+        angles_to_target_rad.z = atan2f(GPS_vector_x, GPS_vector_y);
+        if (relative_pan)
+        {
+            angles_to_target_rad.z = wrap_PI(angles_to_target_rad.z - _frontend._ahrs.yaw);
+        }
     }
 }

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -80,7 +80,7 @@ public:
 protected:
 
     // update_targets_from_rc - updates angle targets (i.e. _angle_ef_target_rad) using input from receiver
-    void update_targets_from_rc();
+    void update_targets_from_rc(bool do_wrap_yaw = false);
 
     // angle_input, angle_input_rad - convert RC input into an earth-frame target angle
     int32_t angle_input(RC_Channel* rc, int16_t angle_min, int16_t angle_max);

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -87,7 +87,7 @@ protected:
     float angle_input_rad(RC_Channel* rc, int16_t angle_min, int16_t angle_max);
 
     // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (and radians) to point at the given target
-    void calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan);
+    void calc_angle_to_location(const struct Location &target, Vector3f& angles_to_target_rad, bool calc_tilt, bool calc_pan, bool relative_pan = true);
 
     // get the mount mode from frontend
     MAV_MOUNT_MODE get_mode(void) const { return _frontend.get_mode(_instance); }

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -77,6 +77,9 @@ public:
     // send a GIMBAL_REPORT message to the GCS
     virtual void send_gimbal_report(mavlink_channel_t chan) {}
 
+    // mount IMU helper mode (FlyTech observation setup)
+    virtual void trigger_imu_helper(uint8_t mntCal) {}
+
 protected:
 
     // update_targets_from_rc - updates angle targets (i.e. _angle_ef_target_rad) using input from receiver

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -70,7 +70,7 @@ void AP_Mount_Servo::update()
         case MAV_MOUNT_MODE_GPS_POINT:
         {
             if(_frontend._ahrs.get_gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
-                calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, _flags.tilt_control, _flags.pan_control);
+                calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, _flags.tilt_control, _flags.pan_control, false);
                 stabilize();
             }
             break;


### PR DESCRIPTION
Hello all,

I have passed a few last weeks extending the support for Alexmos mount resulting in this PR. I hope you will bare with me during this quite verbose description.

The main focus here is placed on:
 a) supporting additional messages from the SimpleBGC (FW version 2.60)
 b) adding full support for the GPS_POINT mode
 c) implementing NEUTRAL and RETRACTED modes in a way that ensures correct alignment of the mount in the copters reference frame
 d) supporting continuous infinite rotation in MAVLINK (position), RC (speed) and GPS_POINT modes
 e) providing smooth transitions between MAVLINK (position), RC (speed) and GPS_POINT modes (e.g. when switching between RC and GPS mount keeps pointing in the same direction as long as no joystick deflection is present)
 f) ensuring alignment of the mount's IMU reference frame North with the Magnetic North as measured by Copter's magnetometers
 g) add mechanism for compensating the mount's IMU zenith reference (to ensure level attitude reference during and after prolonged coordinated turns)
 h) translating (0,360) and/or (-180,180) pan/yaw range to Alexmos specific (-720, 720) yaw range (strange indeed but without this the gimbal controller would not make a correct transition via yaw range wrap). The use of (-720, 720) degree pan range does wrap correctly (gimbal continues rotating as demanded).
Some more details on points f and h are provided below.

HW config used for testing:
 - continuous rotation, 3-axis gimbal with single IMU mounted on the inner frame (axis order outside-in: YAW, ROLL, TILT)
 - gimbal controller is not fitted with any dedicated magnetometer
 - gimbal uses all 3 encoders (required to use the patch, encoders must be calibrated)
 - Alexmos mount Follow mode should be disabled for this PR to work
 - MNT_JSTKSPEED param set to 100

As for the f) above, since the SimpleBGS/Alexmos gimbal controller (HW as specified above) boots up it fixes its internal "North" reference forward (i.e. in the direction in which it is pointing during boot). Now, all CMD_CONTROL messages (except msg mode RELATIVE, which is totally different) will set Pan with respect to this arbitrary direction which has nothing to do with the True North. Hence, for correct operation of GPS point Alexmos IMU north must be compensated so I used the CMD_AHRS_HELPER msg here. Unfortunately, the rotation of the North and Zenith vectors from the copter frame to the mount IMU frame (installed on the inner gimbal) must be done by the APM using encoder reading since Alexmos built-in routines for translating the compensation vectors have side-effects (i.a. Gyro Offset gets messed with). All in all, having this North compensation is crucial for GPS_Point functionality.

As for h), the most surprising characteristic of the SimpleBGC is the fact that the reported pan/yaw angle is in the range of (-720, 720) deg (not the same as encoder reading!) and the commanded pan/yaw angle must use the same representation or otherwise the mount will rotate the wrong way after reaching the wrap-around angle.

Also, if you would want to do some additional testing I've pushed a (quite patchy) debug branch of this PR here:
https://github.com/lekston/ardupilot/tree/C3_4_2X_shared

Problems with this patch that I know of and I am open to suggestion on how to proceed:
 - mount's IMU north reference compensation is called only on entry to RETRACTED mode (so this mode must be re-entered from time-to-time during flight)
 - mount's IMU north reference compensation should be called on regular basis (how often? I tested once per 1, 3, 5 secs... and this should be customizable, I think as it has some impact on the gimbals stabilization quality)
 - mount's IMU zenith reference compensation is not called at all (when to do this? in most conditions the IMU on the stabilized inner frame works in more sterile conditions than the Copters EKF so I decided to refrain from calling this compensation routine as long as no coordinated turns are done)
 - currently only continuous 360deg gimbals works well in the above specified setup
 - the driver does not provide any customization to allow for other gimbal configurations
 - should we want customization, additional mount configuration parameters would fall within AP_Mount class which is the parent of AP_Mount_Alexmos - would that be acceptable at all?

I verified the operation of the code provided in this PR on a test bench (used during all development: Pixhawk hooked to 3D gimbal and to GPS NMEA emulator) and in-flight (1 x 15min flight).

Note: I had to use the patch presented in PR #5091 in order to make the gps_point mode work correctly.

Looking forward to any valuable feedback.

Best regards,
Przemek (alias Pshemeck)