### PR TITLE
AP_Beacon: The exclusive OR checksum check is exclusive ORed including the checksum.

### DIFF
--- a/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
@@ -111,11 +111,11 @@ void AP_Beacon_Pozyx::parse_buffer()
     uint8_t checksum = 0;
     checksum ^= parse_msg_id;
     checksum ^= parse_msg_len;
-    for (uint8_t i=0; i<linebuf_len-1; i++) {
+    for (uint8_t i=0; i<linebuf_len; i++) {
         checksum ^= linebuf[i];
     }
     // return if failed checksum check
-    if (checksum != linebuf[linebuf_len-1]) {
+    if (checksum != 0) {
         return;
     }
 


### PR DESCRIPTION
The exclusive OR is used as the checksum value.
Therefore
Checksum checks are "0" when exclusive OR is performed including checksum and same value.