### PR TITLE
Plane: Land with higher airspeed when into-wind

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -84,8 +84,6 @@ void Plane::calc_airspeed_errors()
 {
     float airspeed_measured_cm = airspeed.get_airspeed_cm();
 
-    // Normal airspeed target
-    target_airspeed_cm = aparm.airspeed_cruise_cm;
 
     // FBW_B airspeed target
     if (control_mode == FLY_BY_WIRE_B || 
@@ -94,31 +92,14 @@ void Plane::calc_airspeed_errors()
                                         aparm.airspeed_min) *
                               channel_throttle->get_control_in()) +
                              ((int32_t)aparm.airspeed_min * 100);
-    }
 
-    // Landing airspeed target
-    if (control_mode == AUTO) {
-        float land_airspeed = SpdHgt_Controller->get_land_airspeed();
-        switch (flight_stage) {
-        case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
-            if (land_airspeed >= 0) {
-                target_airspeed_cm = land_airspeed * 100;
-            }
-            break;
+    } else if (control_mode == AUTO && landing.in_progress) {
+        // Landing airspeed target
+        target_airspeed_cm = landing.get_target_airspeed_cm(flight_stage);
 
-        case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
-        case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
-            if (landing.pre_flare && landing.get_pre_flare_airspeed() > 0) {
-                // if we just preflared then continue using the pre-flare airspeed during final flare
-                target_airspeed_cm = landing.get_pre_flare_airspeed() * 100;
-            } else if (land_airspeed >= 0) {
-                target_airspeed_cm = land_airspeed * 100;
-            }
-            break;
-
-        default:
-            break;
-        }
+    } else {
+        // Normal airspeed target
+        target_airspeed_cm = aparm.airspeed_cruise_cm;
     }
 
     // Set target to current airspeed + ground speed undershoot,

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -236,3 +236,74 @@ bool AP_Landing::restart_landing_sequence()
     return success;
 }
 
+/*
+ * Determine how aligned heading_deg is with the wind. Return result
+ * is 1.0 when perfectly aligned heading into wind, -1 when perfectly
+ * aligned with-wind, and zero when perfect cross-wind. There is no
+ * distinction between a left or right cross-wind. Wind speed is ignored
+ */
+float AP_Landing::wind_alignment(const float heading_deg)
+{
+    const Vector3f wind = ahrs.wind_estimate();
+    const float wind_heading_rad = atan2f(-wind.y, -wind.x);
+    return cosf(wind_heading_rad - radians(heading_deg));
+}
+
+/*
+ * returns head-wind in m/s, 0 for tail-wind.
+ */
+float AP_Landing::head_wind(void)
+{
+    const float alignment = wind_alignment(ahrs.yaw_sensor*0.01f);
+
+    if (alignment <= 0) {
+        return 0;
+    }
+
+    return alignment * ahrs.wind_estimate().length();
+}
+
+/*
+ * returns target airspeed in cm/s depending on flight stage
+ */
+int32_t AP_Landing::get_target_airspeed_cm(const AP_SpdHgtControl::FlightStage flight_stage)
+{
+    int32_t target_airspeed_cm = aparm.airspeed_cruise_cm;
+
+    if (!in_progress) {
+        // not landing, use regular cruise airspeed
+        return target_airspeed_cm;
+    }
+
+    // we're landing, check for custom approach and
+    // pre-flare airspeeds. Also increase for head-winds
+
+    const float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+
+    switch (flight_stage) {
+    case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
+        if (land_airspeed >= 0) {
+            target_airspeed_cm = land_airspeed * 100;
+        }
+        break;
+
+    case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
+    case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
+        if (pre_flare && get_pre_flare_airspeed() > 0) {
+            // if we just preflared then continue using the pre-flare airspeed during final flare
+            target_airspeed_cm = get_pre_flare_airspeed() * 100;
+        } else if (land_airspeed >= 0) {
+            target_airspeed_cm = land_airspeed * 100;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    // when landing, add half of head-wind.
+    const int32_t head_wind_compensation_cm = head_wind() * 0.5f * 100;
+
+    // Do not lower it or exceed cruise speed
+    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_cruise_cm);
+}

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -86,6 +86,10 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    float wind_alignment(const float heading_deg);
+    float head_wind(void);
+    int32_t get_target_airspeed_cm(const AP_SpdHgtControl::FlightStage flight_stage);
+
     // accessor functions for the params
     int16_t get_pitch_cd(void) const { return pitch_cd; }
     float get_flare_sec(void) const { return flare_sec; }


### PR DESCRIPTION
When landing typically you want the lowest airspeed possible. However, gusty winds will cause a dangerous situation to cause a stall when flying slower than normal. This PR increases desired airspeed by half of the current head-wind. This is done in all landing flight stages.

A side effect of this is is more accurate landings when windy where you would normally land short. The landing spot is now more repeatable in variable wind conditions.