### PR TITLE
SITL: Scheduler correct misplaced parenthese

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -38,14 +38,17 @@ void Scheduler::init()
 void Scheduler::delay_microseconds(uint16_t usec)
 {
     uint64_t start = AP_HAL::micros64();
-    uint64_t dtime;
-    while ((dtime=(AP_HAL::micros64() - start) < usec)) {
+    do {
+        uint64_t dtime = AP_HAL::micros64() - start;
+        if (dtime >= usec) {
+            break;
+        }
         if (_stopped_clock_usec) {
-            _sitlState->wait_clock(start+usec);
+            _sitlState->wait_clock(start + usec);
         } else {
             usleep(usec - dtime);
         }
-    }
+    } while (true);
 }
 
 void Scheduler::delay(uint16_t ms)


### PR DESCRIPTION
the behaviour wanted is to compare dtime with usec not to assign the result of ((AP_HAL::micros64() - start) < usec) to dtime , right?