### PR TITLE
AP_Baro: If semaphore can not be acquired, false is returned.

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -83,6 +83,7 @@ bool AP_Baro_MS56XX::_init()
 
     if (!_dev->get_semaphore()->take(0)) {
         AP_HAL::panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
+        return false;
     }
 
     // high retries for init


### PR DESCRIPTION
Even though semaphores can not be acquired, processing continues.
Therefore,
If a semaphore can not be acquired, it returns with false after outputting an error message.