### PR TITLE
AP_Arming: Do not set check results each time.

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -445,24 +445,21 @@ bool AP_Arming::board_voltage_checks(bool report)
 
 bool AP_Arming::pre_arm_checks(bool report)
 {
-    bool ret = true;
     if (armed || require == NONE) {
         // if we are already armed or don't need any arming checks
         // then skip the checks
         return true;
     }
 
-    ret &= hardware_safety_check(report);
-    ret &= barometer_checks(report);
-    ret &= ins_checks(report);
-    ret &= compass_checks(report);
-    ret &= gps_checks(report);
-    ret &= battery_checks(report);
-    ret &= logging_checks(report);
-    ret &= manual_transmitter_checks(report);
-    ret &= board_voltage_checks(report);
-
-    return ret;
+    return hardware_safety_check(report)
+        &  barometer_checks(report)
+        &  ins_checks(report)
+        &  compass_checks(report)
+        &  gps_checks(report)
+        &  battery_checks(report)
+        &  logging_checks(report)
+        &  manual_transmitter_checks(report)
+        &  board_voltage_checks(report);
 }
 
 bool AP_Arming::arm_checks(uint8_t method)


### PR DESCRIPTION
I put a check result each time.
It is possible with one statement.
Therefore,
1. Delete the check result variable
2. Immediately return the check result.