### PR TITLE
MAVLink: Report the compass calibration capability

### DIFF
--- a/APMrover2/capabilities.cpp
+++ b/APMrover2/capabilities.cpp
@@ -7,5 +7,6 @@ void Rover::init_capabilities(void)
                                MAV_PROTOCOL_CAPABILITY_MISSION_INT |
                                MAV_PROTOCOL_CAPABILITY_COMMAND_INT |
                                MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED |
-                               MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT);
+                               MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT |
+                               MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION);
 }

--- a/AntennaTracker/capabilities.cpp
+++ b/AntennaTracker/capabilities.cpp
@@ -2,5 +2,6 @@
 
 void Tracker::init_capabilities(void)
 {
-    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT |
+                               MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION);
 }

--- a/ArduCopter/capabilities.cpp
+++ b/ArduCopter/capabilities.cpp
@@ -9,7 +9,8 @@ void Copter::init_capabilities(void)
                                MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED |
                                MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT |
                                MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION |
-                               MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET);
+                               MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET |
+                               MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION);
 #if AP_TERRAIN_AVAILABLE && AC_TERRAIN
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_TERRAIN);
 #endif

--- a/ArduPlane/capabilities.cpp
+++ b/ArduPlane/capabilities.cpp
@@ -7,6 +7,7 @@ void Plane::init_capabilities(void)
                                MAV_PROTOCOL_CAPABILITY_COMMAND_INT |
                                MAV_PROTOCOL_CAPABILITY_MISSION_INT |
                                MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT |
-                               MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET);
+                               MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET |
+                               MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION);
 
 }


### PR DESCRIPTION
We never set the capability bit to report we could handle compass calibrations, not sure why.