### PR TITLE
GPS: add support for HIL_GPS

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1331,6 +1331,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
+    case MAVLINK_MSG_ID_HIL_GPS:
         {
             rover.gps.handle_msg(msg);
             break;

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -865,6 +865,7 @@ mission_failed:
 
     case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
+    case MAVLINK_MSG_ID_HIL_GPS:
         tracker.gps.handle_msg(msg);
         break;
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1770,6 +1770,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
+    case MAVLINK_MSG_ID_HIL_GPS:
     {
       result = MAV_RESULT_ACCEPTED;
       copter.gps.handle_msg(msg);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1765,6 +1765,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_GPS_RTCM_DATA:
     case MAVLINK_MSG_ID_GPS_INPUT:
+    case MAVLINK_MSG_ID_HIL_GPS:
     {
         plane.gps.handle_msg(msg);
         break;

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -65,7 +65,7 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
             loc.lat = packet.lat;
             loc.lng = packet.lon;
             if (have_alt) {
-                loc.alt = packet.alt;
+                loc.alt = packet.alt * 100; // convert to centimeters
             }
             state.location = loc;
             state.location.options = 0;

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -130,13 +130,15 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
             }
             Vector3f vel(packet.vn/100.0f, packet.ve/100.0f, packet.vd/100.0f);
             state.velocity = vel;
-            if (packet.cog < 65535) {
+            if (packet.cog < 36000) {
                 state.ground_course = packet.cog / 100.0f;
             }
             state.have_speed_accuracy = 0;
             state.have_horizontal_accuracy = 0;
             state.have_vertical_accuracy = 0;
-            state.num_sats = packet.satellites_visible;
+            if (packet.satellites_visible < 255) {
+                state.num_sats = packet.satellites_visible;
+            }
             state.last_gps_time_ms = AP_HAL::millis();
             _new_data = true;
             break;

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -42,67 +42,107 @@ bool AP_GPS_MAV::read(void)
 // corresponding gps data appropriately;
 void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
 {
-    mavlink_gps_input_t packet;
-    mavlink_msg_gps_input_decode(msg, &packet);
+    switch (msg->msgid) {
 
-    bool have_alt    = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_ALT) == 0);
-    bool have_hdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_HDOP) == 0);
-    bool have_vdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VDOP) == 0);
-    bool have_vel_h  = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VEL_HORIZ) == 0);
-    bool have_vel_v  = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VEL_VERT) == 0);
-    bool have_sa     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY) == 0);
-    bool have_ha     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY) == 0);
-    bool have_va     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY) == 0);
+        case MAVLINK_MSG_ID_GPS_INPUT: {
+            mavlink_gps_input_t packet;
+            mavlink_msg_gps_input_decode(msg, &packet);
 
-    state.time_week     = packet.time_week;
-    state.time_week_ms  = packet.time_week_ms;
-    state.status = (AP_GPS::GPS_Status)packet.fix_type;
+            bool have_alt    = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_ALT) == 0);
+            bool have_hdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_HDOP) == 0);
+            bool have_vdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VDOP) == 0);
+            bool have_vel_h  = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VEL_HORIZ) == 0);
+            bool have_vel_v  = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VEL_VERT) == 0);
+            bool have_sa     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY) == 0);
+            bool have_ha     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY) == 0);
+            bool have_va     = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY) == 0);
 
-    Location loc = {};
-    loc.lat = packet.lat;
-    loc.lng = packet.lon;
-    if (have_alt) {
-        loc.alt = packet.alt;
+            state.time_week     = packet.time_week;
+            state.time_week_ms  = packet.time_week_ms;
+            state.status = (AP_GPS::GPS_Status)packet.fix_type;
+
+            Location loc = {};
+            loc.lat = packet.lat;
+            loc.lng = packet.lon;
+            if (have_alt) {
+                loc.alt = packet.alt;
+            }
+            state.location = loc;
+            state.location.options = 0;
+
+            if (have_hdop) {
+                state.hdop = packet.hdop * 100; // convert to centimeters
+            }
+
+            if (have_vdop) {
+                state.vdop = packet.vdop * 100; // convert to centimeters
+            }
+
+            if (have_vel_h) {
+                Vector3f vel(packet.vn, packet.ve, 0);
+                if (have_vel_v)
+                    vel.z = packet.vd;
+
+                state.velocity = vel;
+                state.ground_course = wrap_360(degrees(atan2f(vel.y, vel.x)));
+                state.ground_speed = norm(vel.x, vel.y);
+            }
+
+            if (have_sa) {
+                state.speed_accuracy = packet.speed_accuracy;
+                state.have_speed_accuracy = 1;
+            }
+
+            if (have_ha) {
+                state.horizontal_accuracy = packet.horiz_accuracy;
+                state.have_horizontal_accuracy = 1;
+            }
+
+            if (have_va) {
+                state.vertical_accuracy = packet.vert_accuracy;
+                state.have_vertical_accuracy = 1;
+            }
+
+            state.num_sats = packet.satellites_visible;
+            state.last_gps_time_ms = AP_HAL::millis();
+            _new_data = true;
+            break;
+            }
+
+        case MAVLINK_MSG_ID_HIL_GPS: {
+            mavlink_hil_gps_t packet;
+            mavlink_msg_hil_gps_decode(msg, &packet);
+
+            state.time_week = 0;
+            state.time_week_ms  = packet.time_usec/1000;
+            state.status = (AP_GPS::GPS_Status)packet.fix_type;
+
+            Location loc = {};
+            loc.lat = packet.lat;
+            loc.lng = packet.lon;
+            loc.alt = packet.alt;
+            state.location = loc;
+            state.location.options = 0;
+            state.hdop = MAX(packet.eph, 9999);
+            state.vdop = MAX(packet.epv, 9999);
+            if (packet.vel < 65535) {
+                state.ground_speed = packet.vel / 100.0f;
+            }
+            Vector3f vel(packet.vn/100.0f, packet.ve/100.0f, packet.vd/100.0f);
+            state.velocity = vel;
+            if (packet.cog < 65535) {
+                state.ground_course = packet.cog / 100.0f;
+            }
+            state.have_speed_accuracy = 0;
+            state.have_horizontal_accuracy = 0;
+            state.have_vertical_accuracy = 0;
+            state.num_sats = packet.satellites_visible;
+            state.last_gps_time_ms = AP_HAL::millis();
+            _new_data = true;
+            break;
+            }
+        default:
+            // ignore all other messages
+            break;
     }
-    state.location = loc;
-    state.location.options = 0;
-
-    if (have_hdop) {
-        state.hdop = packet.hdop * 100; // convert to centimeters
-    }
-
-    if (have_vdop) {
-        state.vdop = packet.vdop * 100; // convert to centimeters
-    }
-
-    if (have_vel_h) {
-        Vector3f vel(packet.vn, packet.ve, 0);
-        if (have_vel_v)
-            vel.z = packet.vd;
-
-        state.velocity = vel;
-        state.ground_course = wrap_360(degrees(atan2f(vel.y, vel.x)));
-        state.ground_speed = norm(vel.x, vel.y);
-    }
-
-    if (have_sa) {
-        state.speed_accuracy = packet.speed_accuracy;
-        state.have_speed_accuracy = 1;
-    }
-
-    if (have_ha) {
-        state.horizontal_accuracy = packet.horiz_accuracy;
-        state.have_horizontal_accuracy = 1;
-    }
-
-    if (have_va) {
-        state.vertical_accuracy = packet.vert_accuracy;
-        state.have_vertical_accuracy = 1;
-    }
-
-    state.num_sats = packet.satellites_visible;
-
-    state.last_gps_time_ms = AP_HAL::millis();
-
-    _new_data = true;
 }


### PR DESCRIPTION
This PR adds support for the HIL_GPS message within the GPS MAV driver.  ROS's mavros apparently sends this message instead of GPS_INPUT so adding support improves integration with ROS.

This should resolve https://github.com/ArduPilot/ardupilot/issues/5344
