### PR TITLE
AC_Fence: Activate the create flag.

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -401,12 +401,13 @@ bool AC_Fence::load_polygon_from_eeprom(bool force_reload)
     // check if we need to create array
     if (!_boundary_create_attempted) {
         _boundary = (Vector2f *)_poly_loader.create_point_array(sizeof(Vector2f));
-        _boundary_create_attempted = true;
-    }
 
-    // exit if we could not allocate RAM for the boundary
-    if (_boundary == nullptr) {
-        return false;
+        // exit if we could not allocate RAM for the boundary
+        if (_boundary == nullptr) {
+            return false;
+        }
+
+        _boundary_create_attempted = true;
     }
 
     // get current location from EKF


### PR DESCRIPTION
Even if an array can not be generated, the generation flag is set to true.
Since the generation flag is true, the array pointer is checked.
Therefore,
Set the flag to true only when an array can be generated.