### PR TITLE
Plane: use normalized rudder deflection for arming and disarming.

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -131,7 +131,7 @@ void Plane::rudder_arm_disarm_check()
 
 	if (!arming.is_armed()) {
 		// when not armed, full right rudder starts arming counter
-		if (channel_rudder->get_control_in() > 4000) {
+		if (channel_rudder->norm_input() > 0.9f) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||
@@ -151,7 +151,7 @@ void Plane::rudder_arm_disarm_check()
 		}
 	} else if (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM && !is_flying()) {
 		// when armed and not flying, full left rudder starts disarming counter
-		if (channel_rudder->get_control_in() < -4000) {
+		if (channel_rudder->norm_input() < -0.9f) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||


### PR DESCRIPTION
This should allow more users to easily access to rudder arming - some airframes make it impossible to safely setup a maximum rudder deflection above 40deg.