### PR TITLE
Plane: Landing stage split - WIP

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -896,14 +896,19 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
                 }
             }
     #endif
-        break;
+            break;
 
-        case AP_Landing::STAGE_UNKNOWN:
         case AP_Landing::STAGE_PREFLARE:
         case AP_Landing::STAGE_FINAL:
             landing.in_progress = true;
-        break;
+            break;
+
+        case AP_Landing::STAGE_UNKNOWN:
+        default:
+            landing.in_progress = false;
+            break;
         }
+        break;
 
     case AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND:
         gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm", auto_state.takeoff_altitude_rel_cm/100);

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -224,7 +224,7 @@ void Plane::stabilize_stick_mixing_fbw()
  */
 void Plane::stabilize_yaw(float speed_scaler)
 {
-    if (control_mode == AUTO && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (control_mode == AUTO && landing.get_stage() == AP_Landing::STAGE_FINAL) {
         // in land final setup for ground steering
         steering_control.ground_steering = true;
     } else {
@@ -233,8 +233,8 @@ void Plane::stabilize_yaw(float speed_scaler)
         steering_control.ground_steering = (channel_roll->get_control_in() == 0 && 
                                             fabsf(relative_altitude()) < g.ground_steer_alt);
         if (control_mode == AUTO &&
-                (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
-                flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE)) {
+                (landing.get_stage() == AP_Landing::STAGE_APPROACH ||
+                landing.get_stage() == AP_Landing::STAGE_PREFLARE)) {
             // don't use ground steering on landing approach
             steering_control.ground_steering = false;
         }
@@ -248,7 +248,7 @@ void Plane::stabilize_yaw(float speed_scaler)
       final stage of landing (when the wings are help level) or when
       in course hold in FBWA mode (when we are below GROUND_STEER_ALT)
      */
-    if ((control_mode == AUTO && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) ||
+    if ((control_mode == AUTO && landing.get_stage() == AP_Landing::STAGE_FINAL) ||
         (steer_state.hold_course_cd != -1 && steering_control.ground_steering)) {
         calc_nav_yaw_course();
     } else if (steering_control.ground_steering) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1344,8 +1344,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_DO_GO_AROUND:
             result = MAV_RESULT_FAILED;
 
-            //Not allowing go around at FLIGHT_LAND_FINAL stage on purpose --
-            //if plane is close to the ground a go around could be dangerous.
             if (plane.landing.in_progress) {
                 // Initiate an aborted landing. This will trigger a pitch-up and
                 // climb-out to a safe altitude holding heading then one of the

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -323,7 +323,7 @@ void Plane::Log_Write_Status()
         ,safety      : static_cast<uint8_t>(hal.util->safety_switch_state())
         ,is_crashed  : crash_state.is_crashed
         ,is_still    : plane.ins.is_still()
-        ,stage       : static_cast<uint8_t>(flight_stage)
+        ,stage       : landing.in_progress ? static_cast<uint8_t>(landing.get_stage()) : static_cast<uint8_t>(flight_stage)
         ,impact      : crash_state.impact_detected
         };
 

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -29,14 +29,21 @@ void Plane::adjust_altitude_target()
         control_mode == CRUISE) {
         return;
     }
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
-        // in land final TECS uses TECS_LAND_SINK as a target sink
-        // rate, and ignores the target altitude
-        set_target_altitude_location(next_WP_loc);
-    } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
-            flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) {
-        landing.setup_landing_glide_slope(prev_WP_loc, next_WP_loc, current_loc, target_altitude.offset_cm);
-        landing.adjust_landing_slope_for_rangefinder_bump(rangefinder_state, prev_WP_loc, next_WP_loc, current_loc, auto_state.wp_distance, target_altitude.offset_cm);
+    if (landing.in_progress) {
+        switch (landing.get_stage()) {
+        case AP_Landing::STAGE_FINAL:
+            // in land final TECS uses TECS_LAND_SINK as a target sink
+            // rate, and ignores the target altitude
+            set_target_altitude_location(next_WP_loc);
+        break;
+
+        case AP_Landing::STAGE_UNKNOWN:
+        case AP_Landing::STAGE_APPROACH:
+        case AP_Landing::STAGE_PREFLARE:
+            landing.setup_landing_glide_slope(prev_WP_loc, next_WP_loc, current_loc, target_altitude.offset_cm);
+            landing.adjust_landing_slope_for_rangefinder_bump(rangefinder_state, prev_WP_loc, next_WP_loc, current_loc, auto_state.wp_distance, target_altitude.offset_cm);
+            break;
+        }
     } else if (reached_loiter_target()) {
         // once we reach a loiter target then lock to the final
         // altitude target

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -251,7 +251,8 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
         // use rangefinder to correct if possible
         float height = height_above_target() - rangefinder_correction();
 
-        return landing.verify_land(flight_stage, prev_WP_loc, next_WP_loc, current_loc,
+        const bool is_aborting = (flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND);
+        return landing.verify_land(is_aborting, prev_WP_loc, next_WP_loc, current_loc,
                 auto_state.takeoff_altitude_rel_cm, height, auto_state.sink_rate, auto_state.wp_proportion, auto_state.last_flying_ms, arming.is_armed(), is_flying(), rangefinder_state.in_range, throttle_suppressed);
         }
 

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -310,7 +310,7 @@ void Plane::geofence_check(bool altitude_check_only)
     struct Location loc;
 
     // Never trigger a fence breach in the final stage of landing
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL || flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) {
+    if (landing.get_stage() == AP_Landing::STAGE_FINAL || landing.get_stage() == AP_Landing::STAGE_PREFLARE) {
         return;
     }
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -95,7 +95,7 @@ void Plane::calc_airspeed_errors()
 
     } else if (control_mode == AUTO && landing.in_progress) {
         // Landing airspeed target
-        target_airspeed_cm = landing.get_target_airspeed_cm(flight_stage);
+        target_airspeed_cm = landing.get_target_airspeed_cm();
 
     } else {
         // Normal airspeed target

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -465,7 +465,7 @@ void Plane::set_servos_controlled(void)
     }
     
     if (control_mode == AUTO) {
-        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+        if (landing.get_stage() == AP_Landing::STAGE_FINAL) {
             min_throttle = 0;
         }
         
@@ -571,9 +571,7 @@ void Plane::set_servos_flaps(void)
                     auto_flap_percent = g.takeoff_flap_percent;
                 }
                 break;
-            case AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH:
-            case AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE:
-            case AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL:
+            case AP_Vehicle::FixedWing::FLIGHT_LAND:
                 if (landing.get_flap_percent() != 0) {
                     auto_flap_percent = landing.get_flap_percent();
                 }

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -146,13 +146,13 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
   update navigation for landing. Called when on landing approach or
   final flare
  */
-bool AP_Landing::verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+bool AP_Landing::verify_land(const bool is_aborting, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
         const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed)
 {
     switch (type) {
     default:
     case TYPE_STANDARD_GLIDE_SLOPE:
-        return type_slope_verify_land(flight_stage,prev_WP_loc, next_WP_loc, current_loc,
+        return type_slope_verify_land(is_aborting,prev_WP_loc, next_WP_loc, current_loc,
                 auto_state_takeoff_altitude_rel_cm, height,sink_rate, wp_proportion, last_flying_ms, is_armed, is_flying, rangefinder_state_in_range, throttle_suppressed);
     }
 }
@@ -283,7 +283,7 @@ float AP_Landing::head_wind(void)
 /*
  * returns target airspeed in cm/s depending on flight stage
  */
-int32_t AP_Landing::get_target_airspeed_cm(const AP_Vehicle::FixedWing::FlightStage flight_stage)
+int32_t AP_Landing::get_target_airspeed_cm(void)
 {
     int32_t target_airspeed_cm = aparm.airspeed_cruise_cm;
 
@@ -297,15 +297,15 @@ int32_t AP_Landing::get_target_airspeed_cm(const AP_Vehicle::FixedWing::FlightSt
 
     const float land_airspeed = SpdHgt_Controller->get_land_airspeed();
 
-    switch (flight_stage) {
-    case AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH:
+    switch (stage) {
+    case STAGE_APPROACH:
         if (land_airspeed >= 0) {
             target_airspeed_cm = land_airspeed * 100;
         }
         break;
 
-    case AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE:
-    case AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL:
+    case STAGE_PREFLARE:
+    case STAGE_FINAL:
         if (pre_flare && get_pre_flare_airspeed() > 0) {
             // if we just preflared then continue using the pre-flare airspeed during final flare
             target_airspeed_cm = get_pre_flare_airspeed() * 100;

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -19,7 +19,6 @@
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_Navigation/AP_Navigation.h>
 
 /// @class  AP_Landing
@@ -58,6 +57,14 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     }
 
+    // stages of flight
+    enum LandingStage {
+        STAGE_UNKNOWN       = 0,
+        STAGE_APPROACH      = 4,
+        STAGE_PREFLARE      = 5,
+        STAGE_FINAL         = 6,
+    };
+
     enum Landing_Type {
         TYPE_STANDARD_GLIDE_SLOPE = 0,
 //      TODO: TYPE_DEEPSTALL,
@@ -65,7 +72,7 @@ public:
 //      TODO: TYPE_HELICAL,
     };
 
-    bool verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+    bool verify_land(const bool is_aborting, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed);
     void adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
     void setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
@@ -78,7 +85,7 @@ public:
     bool restart_landing_sequence(void);
     float wind_alignment(const float heading_deg);
     float head_wind(void);
-    int32_t get_target_airspeed_cm(const AP_Vehicle::FixedWing::FlightStage flight_stage);
+    int32_t get_target_airspeed_cm(void);
 
     // accessor functions for the params and states
     static const struct AP_Param::GroupInfo var_info[];
@@ -93,6 +100,8 @@ public:
     bool is_commanded_go_around(void) const { return commanded_go_around; }
     bool is_complete(void) const { return complete; }
     void set_initial_slope() { initial_slope = slope; }
+    void set_stage(LandingStage _stage) { stage = _stage; }
+    LandingStage get_stage() const { return stage; }
 
 
 
@@ -125,6 +134,9 @@ private:
     // calculated approach slope during auto-landing: ((prev_WP_loc.alt - next_WP_loc.alt)*0.01f - flare_sec * sink_rate) / get_distance(prev_WP_loc, next_WP_loc)
     float slope;
 
+    // flight stages for landing
+    LandingStage stage;
+
     AP_Mission &mission;
     AP_AHRS &ahrs;
     AP_SpdHgtControl *SpdHgt_Controller;
@@ -155,7 +167,7 @@ private:
     AP_Int8 type;
 
     // Land Type STANDARD GLIDE SLOPE
-    bool type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+    bool type_slope_verify_land(const bool is_aborting, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed);
 
     void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -26,7 +26,7 @@
   update navigation for landing. Called when on landing approach or
   final flare
  */
-bool AP_Landing::type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+bool AP_Landing::type_slope_verify_land(const bool is_aborting, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
         const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed)
 {
     // we don't 'verify' landing in the sense that it never completes,
@@ -35,7 +35,7 @@ bool AP_Landing::type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage
 
     // when aborting a landing, mimic the verify_takeoff with steering hold. Once
     // the altitude has been reached, restart the landing sequence
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+    if (is_aborting) {
 
         throttle_suppressed = false;
         complete = false;
@@ -72,8 +72,7 @@ bool AP_Landing::type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage
     // 2) passed land point and don't have an accurate AGL
     // 3) probably crashed (ensures motor gets turned off)
 
-    bool on_approach_stage = (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
-                              flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE);
+    bool on_approach_stage = (stage == STAGE_APPROACH || stage == STAGE_PREFLARE);
     bool below_flare_alt = (height <= flare_alt);
     bool below_flare_sec = (flare_sec > 0 && height <= sink_rate * flare_sec);
     bool probably_crashed = (aparm.crash_detection_enable && fabsf(sink_rate) < 0.2f && !is_flying);

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -470,7 +470,7 @@ void AP_TECS::_update_height_demand(void)
     // in final landing stage force height rate demand to the
     // configured sink rate and adjust the demanded height to
     // be kinematically consistent with the height rate.
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.get_stage() == AP_Landing::STAGE_FINAL) {
         _integSEB_state = 0;
         if (_flare_counter == 0) {
             _hgt_rate_dem = _climb_rate;
@@ -529,7 +529,7 @@ void AP_TECS::_detect_underspeed(void)
         _flags.underspeed = false;
     } else if (((_TAS_state < _TASmin * 0.9f) &&
             (_throttle_dem >= _THRmaxf * 0.95f) &&
-            _flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) ||
+            (_landing.get_stage() != AP_Landing::STAGE_FINAL)) ||
             ((_height < _hgt_dem_adj) && _flags.underspeed))
     {
         _flags.underspeed = true;
@@ -806,7 +806,7 @@ void AP_TECS::_update_pitch(void)
     float integSEB_delta = integSEB_input * _DT;
 
 #if 0
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL && fabsf(_climb_rate) > 0.2f) {
+    if (_landing.get_stage() == AP_Landing::STAGE__FINAL && fabsf(_climb_rate) > 0.2f) {
         ::printf("_hgt_rate_dem=%.1f _hgt_dem_adj=%.1f climb=%.1f _flare_counter=%u _pitch_dem=%.1f SEB_dem=%.2f SEBdot_dem=%.2f SEB_error=%.2f SEBdot_error=%.2f\n",
                  _hgt_rate_dem, _hgt_dem_adj, _climb_rate, _flare_counter, degrees(_pitch_dem),
                  SEB_dem, SEBdot_dem, SEB_error, SEBdot_error);
@@ -825,7 +825,7 @@ void AP_TECS::_update_pitch(void)
     float temp = SEB_error + SEBdot_dem * timeConstant();
 
     float pitch_damp = _ptchDamp;
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.get_stage() == AP_Landing::STAGE_FINAL) {
         pitch_damp = _landDamp;
     } else if (!is_zero(_land_pitch_damp) && _flags.is_doing_auto_land) {
         pitch_damp = _land_pitch_damp;
@@ -978,7 +978,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
         _pitch_max_limit = 90;
     }
         
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.get_stage() == AP_Landing::STAGE_FINAL) {
         // in flare use min pitch from LAND_PITCH_CD
         _PITCHminf = MAX(_PITCHminf, _landing.get_pitch_cd() * 0.01f);
 
@@ -989,7 +989,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
         // and allow zero throttle
         _THRminf = 0;
-    } else if ((flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH || flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) && (-_climb_rate) > _land_sink) {
+    } else if ((_landing.get_stage() == AP_Landing::STAGE_APPROACH || _landing.get_stage() == AP_Landing::STAGE_PREFLARE) && (-_climb_rate) > _land_sink) {
         // constrain the pitch in landing as we get close to the flare
         // point. Use a simple linear limit from 15 meters after the
         // landing point

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -64,10 +64,8 @@ public:
             FLIGHT_TAKEOFF       = 1,
             FLIGHT_VTOL          = 2,
             FLIGHT_NORMAL        = 3,
-            FLIGHT_LAND_APPROACH = 4,
-            FLIGHT_LAND_PREFLARE = 5,
-            FLIGHT_LAND_FINAL    = 6,
-            FLIGHT_ABORT_LAND    = 7
+            FLIGHT_LAND          = 4,
+            FLIGHT_ABORT_LAND    = 7,
         };
     };
 


### PR DESCRIPTION
This long list of commits is a an attempt of "obviously correct" baby steps to split up the Plane flight stages so that Landing handles all _LAND_ stages. I'm very confident in all the changes up until the last couple where the split actually happens - it gets a little messy there. There is still a little more work to do but I think this is ready to merge in after some more eyes look at it. Technically I don't think there are any functional changes, this is simply a huge migration of work moving the landing task to AP_Landing so it's less of a hack when we introduce additional landing features.

Biggest changes are:
- FlightStage enum is now in AP_Vehicle
- FlightStage enum only has a single FLIGHT_LAND, instead of three types
- FlightStage enum FLIGHT_LAND_ABORT renamed to FLIGHT_ABORT_LAND so it doesn't sound like a derivative of FLIGHT_LAND
- When Plane.flight_stage == FLIGHT_LAND then a switch is used checking landing.get_stage() which executes the usual three which are defined in AP_Landing::LandingStage. The enum values line up correctly still so logs will show the same values as it steps through a landing

This closes issue https://github.com/ArduPilot/ardupilot/issues/5323