### PR TITLE
AP_Common: Added termios header missing file.

### DIFF
--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -67,6 +67,19 @@ def ap_common_checks(cfg):
         mandatory=False,
     )
 
+    cfg.check(
+        compiler='cxx',
+        fragment='''
+        #include <termios.h>
+
+        int main() {
+          return cfsetspeed(nullptr, 0);
+        }''',
+        define_name="HAVE_TERMIOS_CFSETSPEED",
+        msg="Checking for HAVE_TERMIOS_CFSETSPEED",
+        mandatory=False,
+    )
+
     # NEED_CMATH_FUNCTION_STD_NAMESPACE checks are needed due to
     # new gcc versions being more restrictive.
     #

--- a/libraries/AP_Common/missing/termios.h
+++ b/libraries/AP_Common/missing/termios.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include_next <termios.h>
+
+#if defined(__ANDROID__) && !defined(HAVE_TERMIOS_CFSETSPEED)
+
+int cfsetspeed(struct termios *s, speed_t  speed)
+{
+    s->c_cflag = (s->c_cflag & ~CBAUD) | (speed & CBAUD);
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
Added missing function cfsetspeed in termios header for C++Builder with Android NDK.