### PR TITLE
AP_AHRS: Added AOA and SSA estimation

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -279,6 +279,9 @@ void Plane::update_logging1(void)
 
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_IMU))
         Log_Write_IMU();
+
+    if (should_log(MASK_LOG_ATTITUDE_MED))
+        Log_Write_AOA_SSA();
 }
 
 /*

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -121,6 +121,14 @@ void Plane::send_attitude(mavlink_channel_t chan)
         omega.z);
 }
 
+void Plane::send_aoa_ssa(mavlink_channel_t chan)
+{
+    mavlink_msg_aoa_ssa_send(
+        chan,
+        ahrs.getAOA(),
+        ahrs.getSSA());
+}
+
 #if GEOFENCE_ENABLED == ENABLED
 void Plane::send_fence_status(mavlink_channel_t chan)
 {
@@ -684,6 +692,11 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
         plane.adsb.send_adsb_vehicle(chan);
         break;
+
+    case MSG_AOA_SSA:
+        CHECK_PAYLOAD_SIZE(AOA_SSA);
+        plane.send_aoa_ssa(chan);
+        break;
     }
     return true;
 }
@@ -870,6 +883,8 @@ GCS_MAVLINK_Plane::data_stream_send(void)
         send_message(MSG_ATTITUDE);
         send_message(MSG_SIMSTATE);
         send_message(MSG_RPM);
+        send_message(MSG_AOA_SSA);
+
         if (plane.control_mode != MANUAL) {
             send_message(MSG_PID_TUNING);
         }

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -460,6 +460,12 @@ void Plane::Log_Write_Airspeed(void)
     DataFlash.Log_Write_Airspeed(airspeed);
 }
 
+// Write a AOA and SSA packet
+void Plane::Log_Write_AOA_SSA(void)
+{
+    DataFlash.Log_Write_AOA_SSA(ahrs);
+}
+
 // log ahrs home and EKF origin to dataflash
 void Plane::Log_Write_Home_And_Origin()
 {
@@ -497,6 +503,8 @@ const struct LogStructure Plane::log_structure[] = {
       "STAT", "QBfBBBBBB",  "TimeUS,isFlying,isFlyProb,Armed,Safety,Crash,Still,Stage,Hit" },
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
       "QTUN", "Qffffehhffff", "TimeUS,AngBst,ThrOut,DAlt,Alt,BarAlt,DCRt,CRt,DVx,DVy,DAx,DAy" },
+    { LOG_AOA_SSA_MSG, sizeof(log_AOA_SSA),
+      "AOA", "Qff", "TimeUS,AOA,SSA" },
 #if OPTFLOW == ENABLED
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow),
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY" },

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1217,6 +1217,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_Soaring/AP_Soaring.cpp
     AP_SUBGROUPINFO(soaring_controller, "SOAR_", 8, ParametersG2, SoaringController),
   
+    // @Param: AOA_CRIT
+    // @DisplayName: Critical Angel of Atack
+    // @Description: Angle of attack which produces maximum lift coefficient. This is also called the "stall angle of attack". Above this critical angle of attack, the aircraft is said to be in a stall. A fixed-wing aircraft by definition is stalled at or above the critical angle of attack rather than at or below a particular airspeed.
+    // @Units: Degrees
+    // @Values: 0-40
+    // @User: Advanced
+    AP_GROUPINFO("AOA_CRIT", 6, ParametersG2, aoa_crit, 25),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -545,6 +545,9 @@ public:
     
     // ArduSoar parameters
     SoaringController soaring_controller;
+
+    // critical angle of attack
+    AP_Float aoa_crit;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -810,6 +810,9 @@ private:
     void send_rpm(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
+
+    void send_aoa_ssa(mavlink_channel_t chan);
+
     bool telemetry_delayed(mavlink_channel_t chan);
     void gcs_send_message(enum ap_message id);
     void gcs_send_mission_item_reached_message(uint16_t mission_index);
@@ -838,6 +841,7 @@ private:
     void Log_Write_Airspeed(void);
     void Log_Write_Home_And_Origin();
     void Log_Write_Vehicle_Startup_Messages();
+    void Log_Write_AOA_SSA();
     void Log_Read(uint16_t log_num, int16_t start_page, int16_t end_page);
     void start_logging();
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -510,6 +510,16 @@ public:
     // create a view
     AP_AHRS_View *create_view(enum Rotation rotation);
     
+    // return calculated AOA
+    float getAOA(void)	const   {
+        return _AOA;
+    }
+
+    // return calculated SSA
+	float getSSA(void)	const   {
+        return _SSA;
+    }
+
 protected:
     AHRS_VehicleClass _vehicle_class;
 
@@ -602,6 +612,10 @@ protected:
 
     // optional view class
     AP_AHRS_View *_view;
+
+    // AOA and SSA
+    float _AOA, _SSA;
+    void update_AOA_SSA(void);
 };
 
 #include "AP_AHRS_DCM.h"

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -237,7 +237,7 @@ public:
 
     // get the index of the current primary gyro sensor
     uint8_t get_primary_gyro_index(void) const override;
-    
+
 private:
     enum EKF_TYPE {EKF_TYPE_NONE=0,
                    EKF_TYPE3=3,
@@ -271,6 +271,9 @@ private:
     void update_DCM(void);
     void update_EKF2(void);
     void update_EKF3(void);
+
+    // update of AOA and SSA estimations
+    void update_AOA_SSA(void);
 
     // get the index of the current primary IMU
     uint8_t get_primary_IMU_index(void) const;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -148,6 +148,7 @@ public:
                         const AC_AttitudeControl &attitude_control,
                         const AC_PosControl &pos_control);
     void Log_Write_Rally(const AP_Rally &rally);
+    void Log_Write_AOA_SSA(const AP_AHRS &ahrs);
 
     void Log_Write(const char *name, const char *labels, const char *fmt, ...);
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -2086,3 +2086,16 @@ void DataFlash_Class::Log_Write_Rally(const AP_Rally &rally)
         }
     }
 }
+
+// Write AOA and SSA
+void DataFlash_Class::Log_Write_AOA_SSA(const AP_AHRS &ahrs)
+{
+    struct log_AOA_SSA aoa_ssa = {
+        LOG_PACKET_HEADER_INIT(LOG_AOA_SSA_MSG),
+        time_us         : AP_HAL::micros64(),
+        AOA             : ahrs.getAOA(),
+        SSA             : ahrs.getSSA()
+    };
+
+    WriteBlock(&aoa_ssa, sizeof(aoa_ssa));
+}

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -751,6 +751,13 @@ struct PACKED log_Rally {
     int16_t altitude;
 };
 
+struct PACKED log_AOA_SSA {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float AOA;
+    float SSA;
+};
+
 // #endif // SBP_HW_LOGGING
 
 /*
@@ -1097,6 +1104,8 @@ enum LogMessages {
     LOG_GIMBAL3_MSG,
     LOG_RATE_MSG,
     LOG_RALLY_MSG,
+
+    LOG_AOA_SSA_MSG,
 };
 
 enum LogOriginType {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -70,6 +70,7 @@ enum ap_message {
     MSG_MISSION_ITEM_REACHED,
     MSG_POSITION_TARGET_GLOBAL_INT,
     MSG_ADSB_VEHICLE,
+    MSG_AOA_SSA,
     MSG_RETRY_DEFERRED // this must be last
 };
 


### PR DESCRIPTION
Added AOA and SSA estimation, logging, transmitting to GCS.

~~Also message definition was added to mavlink:
`        <message id="227" name="AOA_SSA">`
`          <description>Angle of Attack and Side Slip Angle</description>`
`          <field name="AOA" type="float">AOA (degrees)</field>`
`          <field name="SSA" type="float">SSA (degrees)</field>`
`        </message>`
But it did not get into the commit. Please advice how it should be done with resulting change in PX4firmware/mavlink.
Without it build will fail because mavlink_msg_aoa_ssa_send will not be declared.~~
Made pull request to mavlink.
https://github.com/ArduPilot/mavlink/pull/23

One more issue regarding tests:
EKF2 methods getQuaternion and getRotationBodyToNED both return unity rotation. It was discovered in SITL. What can be wrong?