### PR TITLE
AP_SteerController: Steer limit on speed

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -47,6 +47,8 @@ if [ "$CI_BUILD_TARGET" = "sitltest" ]; then
     Tools/autotest/autotest.py -j2 build.ArduCopter fly.ArduCopter
     echo "Running SITL QuadPlane test"
     Tools/autotest/autotest.py -j2 build.ArduPlane fly.QuadPlane
+    echo "Running SITL Rover test"
+    Tools/autotest/autotest.py -j2 build.APMrover2 drive.APMrover2
     exit 0
 fi
 

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -59,6 +59,10 @@ private:
 	uint32_t _last_t;
 	float _last_out;
 
+	AP_Float _deratespeed;
+	AP_Float _deratefactor;
+	AP_Float _mindegree;
+
     DataFlash_Class::PID_Info _pid_info {};
 
 	AP_AHRS &_ahrs;


### PR DESCRIPTION
AP_SteerController: added derating of steer angle depending on speed

When using steering controller on my plane (big - 30 kg, 3.6m wingspan) at high speed sometimes controller oversteers that leads to rolling on the wing.
Derating of steering was added.
Below certain speed - no derating, then as speed raises - maximum throw is lowered until defined minimum throw is reached.