### PR TITLE
Correction for is_equal function

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -1,11 +1,18 @@
 #include "AP_Math.h"
 #include <float.h>
 
-template <class FloatOne, class FloatTwo>
-bool is_equal(const FloatOne v_1, const FloatTwo v_2)
+template <class Arithmetic1, class Arithmetic2>
+typename std::enable_if<std::is_integral<typename std::common_type<Arithmetic1, Arithmetic2>::type>::value ,bool>::type
+is_equal(const Arithmetic1 v_1, const Arithmetic2 v_2)
 {
-    static_assert(std::is_arithmetic<FloatOne>::value, "template parameter not of type float or int");
-    static_assert(std::is_arithmetic<FloatTwo>::value, "template parameter not of type float or int");
+    typedef typename std::common_type<Arithmetic1, Arithmetic2>::type common_type;
+    return static_cast<common_type>(v_1) == static_cast<common_type>(v_2);
+}
+
+template <class Arithmetic1, class Arithmetic2>
+typename std::enable_if<std::is_floating_point<typename std::common_type<Arithmetic1, Arithmetic2>::type>::value, bool>::type
+is_equal(const Arithmetic1 v_1, const Arithmetic2 v_2)
+{
     return fabsf(v_1 - v_2) < std::numeric_limits<decltype(v_1 - v_2)>::epsilon();
 }
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -24,8 +24,13 @@ AP_PARAMDEFV(Vector3f, Vector3f, AP_PARAM_VECTOR3F);
 /*
  * Check whether two floats are equal
  */
-template <class FloatOne, class FloatTwo>
-bool is_equal(const FloatOne, const FloatTwo);
+template <class Arithmetic1, class Arithmetic2>
+typename std::enable_if<std::is_integral<typename std::common_type<Arithmetic1, Arithmetic2>::type>::value ,bool>::type
+is_equal(const Arithmetic1 v_1, const Arithmetic2 v_2);
+
+template <class Arithmetic1, class Arithmetic2>
+typename std::enable_if<std::is_floating_point<typename std::common_type<Arithmetic1, Arithmetic2>::type>::value, bool>::type
+is_equal(const Arithmetic1 v_1, const Arithmetic2 v_2);
 
 /* 
  * @brief: Check whether a float is zero

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -74,6 +74,8 @@ TEST(MathTest, IsZero)
 
 TEST(MathTest, IsEqual)
 {
+    EXPECT_FALSE(is_equal(1, 0));
+    EXPECT_TRUE(is_equal(1, 1));
     EXPECT_FALSE(is_equal(0.1,  0.10001));
     EXPECT_FALSE(is_equal(0.1, -0.1001));
     EXPECT_TRUE(is_equal(0.f,   0.0f));

--- a/libraries/AP_Math/tests/test_vector2.cpp
+++ b/libraries/AP_Math/tests/test_vector2.cpp
@@ -1,0 +1,18 @@
+#include <AP_gtest.h>
+
+#include <AP_Math/AP_Math.h>
+
+TEST(Vector2Test, IsEqual)
+{
+    Vector2l v_int1(1, 1);
+    Vector2l v_int2(1, 0);
+    Vector2f v_float1(1.0f, 1.0f);
+    Vector2f v_float2(1.0f, 0.0f);
+
+    EXPECT_FALSE(v_int1 == v_int2);
+    EXPECT_TRUE(v_int1 == v_int1);
+    EXPECT_FALSE(v_float1 == v_float2);
+    EXPECT_TRUE(v_float1 == v_float1);
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
The current solution doesn't works for int as epsilon for int is 0 . But as fabsf always return a float and this function is only used with float and not double, we should use FLT_EPSILON in all case