### PR TITLE
EKF Miscellaneous Improvements and Bug Fixes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TRANSITION_MS
     // @DisplayName: Transition time
     // @Description: Transition time in milliseconds after minimum airspeed is reached
-    // @Units: milli-seconds
+    // @Units: milliseconds
     // @Range: 0 30000
     // @User: Advanced
     AP_GROUPINFO("TRANSITION_MS", 11, QuadPlane, transition_time_ms, 5000),

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -381,7 +381,7 @@ void LR_MsgHandler_NTUN_Copter::process_message(uint8_t *msg)
 
 bool LR_MsgHandler::set_parameter(const char *name, float value)
 {
-    const char *ignore_parms[] = { "GPS_TYPE", "AHRS_EKF_TYPE", "EK2_ENABLE", 
+    const char *ignore_parms[] = { "GPS_TYPE", "AHRS_EKF_TYPE", "EK2_ENABLE", "EK3_ENABLE"
                                    "COMPASS_ORIENT", "COMPASS_ORIENT2",
                                    "COMPASS_ORIENT3", "LOG_FILE_BUFSIZE"};
     for (uint8_t i=0; i < ARRAY_SIZE(ignore_parms); i++) {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -221,7 +221,7 @@ public:
     bool getGpsGlitchStatus();
 
     // used by Replay to force start at right timestamp
-    void force_ekf_start(void) { force_ekf = true; }
+    void force_ekf_start(void) { _force_ekf = true; }
 
     // is the EKF backend doing its own sensor logging?
     bool have_ekf_logging(void) const override;
@@ -248,10 +248,9 @@ private:
 
     NavEKF2 &EKF2;
     NavEKF3 &EKF3;
-    bool ekf1_started:1;
-    bool ekf2_started:1;
-    bool ekf3_started:1;
-    bool force_ekf:1;
+    bool _ekf2_started;
+    bool _ekf3_started;
+    bool _force_ekf;
     Matrix3f _dcm_matrix;
     Vector3f _dcm_attitude;
     Vector3f _gyro_bias;

--- a/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
@@ -130,7 +130,7 @@ void AP_Beacon_Pozyx::parse_buffer()
                 int32_t beacon_x = (uint32_t)linebuf[5] << 24 | (uint32_t)linebuf[4] << 16 | (uint32_t)linebuf[3] << 8 | (uint32_t)linebuf[2];
                 int32_t beacon_y = (uint32_t)linebuf[9] << 24 | (uint32_t)linebuf[8] << 16 | (uint32_t)linebuf[7] << 8 | (uint32_t)linebuf[6];
                 int32_t beacon_z = (uint32_t)linebuf[13] << 24 | (uint32_t)linebuf[12] << 16 | (uint32_t)linebuf[11] << 8 | (uint32_t)linebuf[10];
-                Vector3f beacon_pos(beacon_x / 1000.0f, beacon_y / 1000.0f, beacon_z / 1000.0f);
+                Vector3f beacon_pos(beacon_x / 1000.0f, -beacon_y / 1000.0f, -beacon_z / 1000.0f);
                 if (beacon_pos.length() <= AP_BEACON_DISTANCE_MAX) {
                     set_beacon_position(beacon_id, beacon_pos);
                     parsed = true;
@@ -156,7 +156,7 @@ void AP_Beacon_Pozyx::parse_buffer()
                 int32_t vehicle_y = (uint32_t)linebuf[7] << 24 | (uint32_t)linebuf[6] << 16 | (uint32_t)linebuf[5] << 8 | (uint32_t)linebuf[4];
                 int32_t vehicle_z = (uint32_t)linebuf[11] << 24 | (uint32_t)linebuf[10] << 16 | (uint32_t)linebuf[9] << 8 | (uint32_t)linebuf[8];
                 int16_t position_error = (uint32_t)linebuf[13] << 8 | (uint32_t)linebuf[12];
-                Vector3f veh_pos(Vector3f(vehicle_x / 1000.0f, vehicle_y / 1000.0f, vehicle_z / 1000.0f));
+                Vector3f veh_pos(Vector3f(vehicle_x / 1000.0f, -vehicle_y / 1000.0f, -vehicle_z / 1000.0f));
                 if (veh_pos.length() <= AP_BEACON_DISTANCE_MAX) {
                     set_vehicle_position(veh_pos, position_error);
                     parsed = true;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -884,10 +884,6 @@ float AP_GPS::get_lag(uint8_t instance) const
     if (_delay_ms[instance] > 0) {
         // if the user has specified a non zero time delay, always return that value
         return 0.001f * (float)_delay_ms[instance];
-    } else if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
-        // the user has not specified a value and we cannot determine it from the GPS type
-        // so return a default delay of 1 measurement interval
-        return 0.001f * (float)_rate_ms[instance];
     } else {
         // the user has not specified a delay so we determine it from the GPS type
         return drivers[instance]->get_lag();

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -860,3 +860,15 @@ void AP_GPS::inject_data_all(const uint8_t *data, uint16_t len)
     }
     
 }
+
+/*
+  return expected lag from a GPS
+ */
+float AP_GPS::get_lag(uint8_t instance) const
+{
+    if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
+        // return default;
+        return 0.2f;
+    }
+    return drivers[instance]->get_lag();
+}

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -201,7 +201,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: DELAY_MS
     // @DisplayName: GPS delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
-    // @Units: msec
+    // @Units: milliseconds
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS", 18, AP_GPS, _delay_ms[0], 0),
@@ -209,7 +209,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: DELAY_MS2
     // @DisplayName: GPS 2 delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
-    // @Units: msec
+    // @Units: milliseconds
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -884,6 +884,10 @@ float AP_GPS::get_lag(uint8_t instance) const
     if (_delay_ms[instance] > 0) {
         // if the user has specified a non zero time delay, always return that value
         return 0.001f * (float)_delay_ms[instance];
+    } else if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
+        // no GPS was detected in this instance
+        // so return a default delay of 1 measurement interval
+        return 0.001f * (float)_rate_ms[instance];
     } else {
         // the user has not specified a delay so we determine it from the GPS type
         return drivers[instance]->get_lag();

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -198,6 +198,21 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("POS2", 17, AP_GPS, _antenna_offset[1], 0.0f),
 
+    // @Param: DELAY_MS
+    // @DisplayName: GPS delay in milliseconds
+    // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
+    // @Units: msec
+    // @Range: 0 250
+    // @User: Advanced
+    AP_GROUPINFO("DELAY_MS", 18, AP_GPS, _delay_ms[0], 0),
+
+    // @Param: DELAY_MS2
+    // @DisplayName: GPS 2 delay in milliseconds
+    // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
+    // @Units: msec
+    // @Range: 0 250
+    // @User: Advanced
+    AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
     AP_GROUPEND
 };
 
@@ -866,9 +881,15 @@ void AP_GPS::inject_data_all(const uint8_t *data, uint16_t len)
  */
 float AP_GPS::get_lag(uint8_t instance) const
 {
-    if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
-        // return default;
-        return 0.2f;
+    if (_delay_ms[instance] > 0) {
+        // if the user has specified a non zero time delay, always return that value
+        return 0.001f * (float)_delay_ms[instance];
+    } else if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
+        // the user has not specified a value and we cannot determine it from the GPS type
+        // so return a default delay of 1 measurement interval
+        return 0.001f * (float)_rate_ms[instance];
+    } else {
+        // the user has not specified a delay so we determine it from the GPS type
+        return drivers[instance]->get_lag();
     }
-    return drivers[instance]->get_lag();
 }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -354,6 +354,7 @@ public:
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
     AP_Vector3f _antenna_offset[2];
+    AP_Int16 _delay_ms[2];
 
     // handle sending of initialisation strings to the GPS
     void send_blob_start(uint8_t instance, const char *_blob, uint16_t size);

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -377,6 +377,11 @@ public:
     uint8_t first_unconfigured_gps(void) const;
     void broadcast_first_configuration_failure_reason(void) const;
 
+    // return true if all GPS instances have finished configuration
+    bool all_configured(void) const {
+        return first_unconfigured_gps() == GPS_ALL_CONFIGURED;
+    }
+    
 private:
     struct GPS_timing {
         // the time we got our last fix in system milliseconds

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -314,7 +314,8 @@ public:
     }
 
     // the expected lag (in seconds) in the position and velocity readings from the gps
-    float get_lag() const { return 0.2f; }
+    float get_lag(uint8_t instance) const;
+    float get_lag(void) const { return get_lag(primary_instance); }
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1284,3 +1284,21 @@ AP_GPS_UBLOX::broadcast_configuration_failure_reason(void) const {
         }
     }
 }
+
+/*
+  return velocity lag in seconds
+ */
+float AP_GPS_UBLOX::get_lag(void) const
+{
+    switch (_hardware_generation) {
+    case UBLOX_5:
+    case UBLOX_6:
+    default:
+        return 0.22f;
+    case UBLOX_7:
+    case UBLOX_M8:
+        // based on flight logs the 7 and 8 series seem to produce about 120ms lag
+        return 0.12f;
+        break;
+    };
+}

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -111,6 +111,10 @@ public:
     }
 
     void broadcast_configuration_failure_reason(void) const override;
+
+    // return velocity lag
+    float get_lag(void) const override;
+
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -52,6 +52,9 @@ public:
 
     virtual void handle_msg(const mavlink_message_t *msg) { return ; }
 
+    // driver specific lag
+    virtual float get_lag(void) const { return 0.2f; }
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -192,7 +192,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("GPS_DELAY", 8, NavEKF2, _gpsDelay_ms, 220),
 
     // Height measurement parameters
@@ -227,7 +227,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF2, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -328,7 +328,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF2, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -515,7 +515,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF2, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -433,6 +433,7 @@ void NavEKF2_core::FuseMagnetometer()
 
         // if the magnetometer is unhealthy, do not proceed further
         if (!magHealth) {
+            hal.util->perf_end(_perf_test[2]);
             return;
         }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -360,7 +360,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Units: m/s/s/s
     AP_GROUPINFO("ABIAS_P_NSE", 28, NavEKF3, _accelBiasProcessNoise, ABIAS_P_NSE_DEFAULT),
 
-    // 29 previously used for EK2_MAG_P_NSE parameter that has been replaced with EK2_MAGE_P_NSE and EK2_MAGB_P_NSE
+    // 29 previously used for EK2_MAG_P_NSE parameter that has been replaced with EK3_MAGE_P_NSE and EK3_MAGB_P_NSE
 
     // @Param: WIND_P_NSE
     // @DisplayName: Wind velocity process noise (m/s^2)

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -219,7 +219,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF3, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -321,7 +321,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF3, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -503,7 +503,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: msec
+    // @Units: milliseconds
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF3, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -189,7 +189,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @User: Advanced
     // @Units: msec
-    AP_GROUPINFO("GPS_DELAY", 8, NavEKF3, _gpsDelay_ms, 220),
+    AP_GROUPINFO("GPS_DELAY", 8, NavEKF3, _gpsDelay_ms, 150),
 
     // Height measurement parameters
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -214,9 +214,10 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: HGT_DELAY
     // @DisplayName: Height measurement delay (msec)
-    // @Description: This is the number of msec that the Height measurements lag behind the inertial measurements. The autpilot should be restarted after adjusting this parameter.
+    // @Description: This is the number of msec that the Height measurements lag behind the inertial measurements.
     // @Range: 0 250
     // @Increment: 10
+    // @RebootRequired: True
     // @User: Advanced
     // @Units: msec
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF3, _hgtDelay_ms, 60),
@@ -315,9 +316,10 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: FLOW_DELAY
     // @DisplayName: Optical Flow measurement delay (msec)
-    // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.  The autpilot should be restarted after adjusting this parameter.
+    // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
     // @Range: 0 250
     // @Increment: 10
+    // @RebootRequired: True
     // @User: Advanced
     // @Units: msec
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF3, _flowDelay_ms, FLOW_MEAS_DELAY),
@@ -496,9 +498,10 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: BCN_DELAY
     // @DisplayName: Range beacon measurement delay (msec)
-    // @Description: This is the number of msec that the range beacon measurements lag behind the inertial measurements. The autpilot should be restarted after adjusting this parameter.
+    // @Description: This is the number of msec that the range beacon measurements lag behind the inertial measurements.
     // @Range: 0 250
     // @Increment: 10
+    // @RebootRequired: True
     // @User: Advanced
     // @Units: msec
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF3, _rngBcnDelay_ms, 50),

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -184,7 +184,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: GPS_DELAY
     // @DisplayName: GPS measurement delay (msec)
-    // @Description: This is the number of msec that the GPS measurements lag behind the inertial measurements.
+    // @Description: This is the number of msec that the GPS measurements lag behind the inertial measurements. The autpilot should be restarted after adjusting this parameter.
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
@@ -219,7 +219,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: HGT_DELAY
     // @DisplayName: Height measurement delay (msec)
-    // @Description: This is the number of msec that the Height measurements lag behind the inertial measurements.
+    // @Description: This is the number of msec that the Height measurements lag behind the inertial measurements. The autpilot should be restarted after adjusting this parameter.
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
@@ -320,7 +320,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: FLOW_DELAY
     // @DisplayName: Optical Flow measurement delay (msec)
-    // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
+    // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.  The autpilot should be restarted after adjusting this parameter.
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
@@ -501,7 +501,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // @Param: BCN_DELAY
     // @DisplayName: Range beacon measurement delay (msec)
-    // @Description: This is the number of msec that the range beacon measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
+    // @Description: This is the number of msec that the range beacon measurements lag behind the inertial measurements. The autpilot should be restarted after adjusting this parameter.
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
@@ -559,6 +559,7 @@ NavEKF3::NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng) :
     gndEffectBaroScaler(4.0f),      // scaler applied to the barometer observation variance when operating in ground effect
     gndGradientSigma(50),           // RMS terrain gradient percentage assumed by the terrain height estimation
     fusionTimeStep_ms(10),          // The minimum number of msec between covariance prediction and fusion operations
+    sensorIntervalMin_ms(50),       // The minimum allowed time between measurements from any non-IMU sensor (msec)
     runCoreSelection(false)         // true when the default primary core has stabilised after startup and core selection can run
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1085,11 +1085,12 @@ void NavEKF3::getFlowDebug(int8_t instance, float &varFlow, float &gndOffset, fl
 }
 
 // return data for debugging range beacon fusion
-bool NavEKF3::getRangeBeaconDebug(int8_t instance, uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED, float &offsetHigh, float &offsetLow)
+bool NavEKF3::getRangeBeaconDebug(int8_t instance, uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED,
+                                  float &offsetHigh, float &offsetLow, Vector3f &posNED)
 {
     if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        return core[instance].getRangeBeaconDebug(ID, rng, innov, innovVar, testRatio, beaconPosNED, offsetHigh, offsetLow);
+        return core[instance].getRangeBeaconDebug(ID, rng, innov, innovVar, testRatio, beaconPosNED, offsetHigh, offsetLow, posNED);
     } else {
         return false;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -537,7 +537,7 @@ NavEKF3::NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng) :
     gpsDVelVarAccScale(0.07f),      // Scale factor applied to vertical velocity measurement variance due to manoeuvre acceleration - used when GPS doesn't report speed error
     gpsPosVarAccScale(0.05f),       // Scale factor applied to horizontal position measurement variance due to manoeuvre acceleration
     magDelay_ms(60),                // Magnetometer measurement delay (msec)
-    tasDelay_ms(240),               // Airspeed measurement delay (msec)
+    tasDelay_ms(100),               // Airspeed measurement delay (msec)
     tiltDriftTimeMax_ms(15000),      // Maximum number of ms allowed without any form of tilt aiding (GPS, flow, TAS, etc)
     posRetryTimeUseVel_ms(10000),   // Position aiding retry time with velocity measurements (msec)
     posRetryTimeNoVel_ms(7000),     // Position aiding retry time without velocity measurements (msec)

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -874,11 +874,9 @@ bool NavEKF3::resetHeightDatum(void)
 }
 
 // Commands the EKF to not use GPS.
-// This command must be sent prior to arming as it will only be actioned when the filter is in static mode
-// This command is forgotten by the EKF each time it goes back into static mode (eg the vehicle disarms)
+// This command must be sent prior to vehicle arming and EKF commencement of GPS usage
 // Returns 0 if command rejected
-// Returns 1 if attitude, vertical velocity and vertical position will be provided
-// Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
+// Returns 1 if command accepted
 uint8_t NavEKF3::setInhibitGPS(void)
 {
     if (!core) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -201,17 +201,21 @@ public:
     void getFlowDebug(int8_t instance, float &varFlow, float &gndOffset, float &flowInnovX, float &flowInnovY, float &auxInnov, float &HAGL, float &rngInnov, float &range, float &gndOffsetErr);
 
     /*
-        Returns the following data for debugging range beacon fusion from the specified instance
-        An out of range instance (eg -1) returns data for the the primary instance
+        Returns the following data for debugging range beacon fusion
         ID : beacon identifier
         rng : measured range to beacon (m)
         innov : range innovation (m)
         innovVar : innovation variance (m^2)
         testRatio : innovation consistency test ratio
         beaconPosNED : beacon NED position (m)
+        offsetHigh : high hypothesis for range beacons system vertical offset (m)
+        offsetLow : low hypothesis for range beacons system vertical offset (m)
+        posNED : North,East,Down position estimate of receiver from 3-state filter
+
         returns true if data could be found, false if it could not
     */
-    bool getRangeBeaconDebug(int8_t instance, uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED, float &offsetHigh, float &offsetLow);
+    bool getRangeBeaconDebug(int8_t instance, uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED,
+                             float &offsetHigh, float &offsetLow, Vector3f &posNED);
 
     // called by vehicle code to specify that a takeoff is happening
     // causes the EKF to compensate for expected barometer errors due to ground effect

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -386,7 +386,8 @@ private:
     const uint16_t gndEffectTimeout_ms; // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler;    // scaler applied to the barometer observation variance when ground effect mode is active
     const uint8_t gndGradientSigma;     // RMS terrain gradient percentage assumed by the terrain height estimation
-    const uint8_t fusionTimeStep_ms;    // The minimum time interval between covariance predictions and measurement fusions in msec
+    const uint16_t fusionTimeStep_ms;   // The minimum time interval between covariance predictions and measurement fusions in msec
+    const uint8_t sensorIntervalMin_ms; // The minimum allowed time between measurements from any non-IMU sensor (msec)
 
     struct {
         bool enabled:1;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -327,7 +327,6 @@ private:
     AP_Float _accNoise;             // accelerometer process noise : m/s^2
     AP_Float _gyroBiasProcessNoise; // gyro bias state process noise : rad/s
     AP_Float _accelBiasProcessNoise;// accel bias state process noise : m/s^2
-    AP_Int16 _gpsDelay_ms;          // effective average delay of GPS measurements relative to inertial measurement (msec)
     AP_Int16 _hgtDelay_ms;          // effective average delay of Height measurements relative to inertial measurements (msec)
     AP_Int8  _fusionModeGPS;        // 0 = use 3D velocity, 1 = use 2D velocity, 2 = use no velocity
     AP_Int16  _gpsVelInnovGate;     // Percentage number of standard deviations applied to GPS velocity innovation consistency check
@@ -422,6 +421,9 @@ private:
     } pos_down_reset_data;
 
     bool runCoreSelection; // true when the primary core has stabilised and the core selection logic can be started
+
+    bool coreSetupRequired[7]; // true when this core index needs to be setup
+    uint8_t coreImuIndex[7];   // IMU index used by this core
 
     // update the yaw reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -112,11 +112,9 @@ public:
     bool resetHeightDatum(void);
 
     // Commands the EKF to not use GPS.
-    // This command must be sent prior to arming as it will only be actioned when the filter is in static mode
-    // This command is forgotten by the EKF each time it goes back into static mode (eg the vehicle disarms)
+    // This command must be sent prior to vehicle arming and EKF commencement of GPS usage
     // Returns 0 if command rejected
-    // Returns 1 if attitude, vertical velocity and vertical position will be provided
-    // Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
+    // Returns 1 if command accepted
     uint8_t setInhibitGPS(void);
 
     // return the horizontal speed limit in m/s set by optical flow sensor limits

--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -9,8 +9,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -10,8 +10,6 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -318,7 +318,7 @@ void NavEKF3_core::setAidingMode()
             if (canUseRangeBeacon) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u is using range beacons",(unsigned)imu_index);
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u initial pos NE = %3.1f,%3.1f (m)",(unsigned)imu_index,(double)receiverPos.x,(double)receiverPos.y);
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u initial beacon pos D offset = %3.1f (m)",(unsigned)imu_index,(double)bcnPosOffset);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u initial beacon pos D offset = %3.1f (m)",(unsigned)imu_index,(double)bcnPosDownOffset);
             }
             // reset the last fusion accepted times to prevent unwanted activation of timeout logic
             lastPosPassTime_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -449,20 +449,17 @@ bool NavEKF3_core::checkGyroCalStatus(void)
 }
 
 // Commands the EKF to not use GPS.
-// This command must be sent prior to arming
-// This command is forgotten by the EKF each time the vehicle disarms
+// This command must be sent prior to vehicle arming and EKF commencement of GPS usage
 // Returns 0 if command rejected
-// Returns 1 if attitude, vertical velocity and vertical position will be provided
-// Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
+// Returns 1 if command accepted
 uint8_t NavEKF3_core::setInhibitGPS(void)
 {
-    if((PV_AidingMode == AID_ABSOLUTE) && motorsArmed) {
+    if((PV_AidingMode == AID_ABSOLUTE) || motorsArmed) {
         return 0;
     } else {
         gpsInhibit = true;
         return 1;
     }
-    // option 2 is not yet implemented as it requires a deeper integration of optical flow and GPS operation
 }
 
 // Update the filter status

--- a/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
@@ -7,8 +7,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 // reset the body axis gyro bias states to zero and re-initialise the corresponding covariances

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -278,7 +278,7 @@ void NavEKF3_core::SelectMagFusion()
     // from becoming badly conditioned. For planes we only do this on-ground because they can align the yaw from GPS when
     // airborne. For other platform types we do this all the time.
     if (!use_compass()) {
-        if ((onGround || assume_zero_sideslip()) && (imuSampleTime_ms - lastSynthYawTime_ms > 140)) {
+        if ((onGround || !assume_zero_sideslip()) && (imuSampleTime_ms - lastSynthYawTime_ms > 140)) {
             fuseEulerYaw();
             magTestRatio.zero();
             yawTestRatio = 0.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -260,15 +260,16 @@ void NavEKF3_core::SelectMagFusion()
                 FuseDeclination(0.34f);
             }
             // fuse the three magnetometer componenents sequentially
+            hal.util->perf_begin(_perf_test[0]);
             for (mag_state.obsIndex = 0; mag_state.obsIndex <= 2; mag_state.obsIndex++) {
-                hal.util->perf_begin(_perf_test[0]);
                 FuseMagnetometer();
-                hal.util->perf_end(_perf_test[0]);
                 // don't continue fusion if unhealthy
                 if (!magHealth) {
+                    hal.util->perf_end(_perf_test[0]);
                     break;
                 }
             }
+            hal.util->perf_end(_perf_test[0]);
             // zero the test ratio output from the inactive simple magnetometer yaw fusion
             yawTestRatio = 0.0f;
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -110,7 +110,7 @@ void NavEKF3_core::controlMagYawReset()
             stateStruct.quat = newQuat;
 
             // update the yaw angle variance using the variance of the measurement
-            angleErrVarVec.z = sq(fmaxf(frontend->_yawNoise, 1.0e-2f));
+            angleErrVarVec.z = sq(MAX(frontend->_yawNoise, 1.0e-2f));
 
             // reset the quaternion covariances using the rotation vector variances
             initialiseQuatCovariances(angleErrVarVec);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -8,8 +8,6 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -178,8 +178,10 @@ void NavEKF3_core::realignYawGPS()
             // calculate new filter quaternion states from Euler angles
             stateStruct.quat.from_euler(eulerAngles.x, eulerAngles.y, gpsYaw);
 
-            // reset the velocity and posiiton states as they will be inaccurate due to bad yaw
+            // reset the velocity and position states as they will be inaccurate due to bad yaw
+            velResetSource = GPS;
             ResetVelocity();
+            posResetSource = GPS;
             ResetPosition();
 
             // set the yaw angle variance to a larger value to reflect the uncertainty in yaw

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -283,7 +283,7 @@ void NavEKF3_core::readIMUData()
     dtIMUavg = ins.get_loop_delta_t();
 
     // the imu sample time is used as a common time reference throughout the filter
-    imuSampleTime_ms = AP_HAL::millis();
+    imuSampleTime_ms = frontend->imuSampleTime_us / 1000;
 
     // use the nominated imu or primary if not available
     if (ins.use_accel(imu_index)) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -417,8 +417,8 @@ void NavEKF3_core::readGpsData()
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;
 
-            // Prevent time delay exceeding age of oldest IMU data in the buffer
-            gpsDataNew.time_ms = MAX(gpsDataNew.time_ms,imuDataDelayed.time_ms);
+            // Prevent the time stamp falling outside the oldest and newest IMU data in the buffer
+            gpsDataNew.time_ms = MIN(MAX(gpsDataNew.time_ms,imuDataDelayed.time_ms),imuDataDownSampledNew.time_ms);
 
             // Get which GPS we are using for position information
             gpsDataNew.sensor_idx = _ahrs->get_gps().primary_sensor();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -26,9 +26,8 @@ void NavEKF3_core::readRangeFinder(void)
     // get theoretical correct range when the vehicle is on the ground
     rngOnGnd = frontend->_rng.ground_clearance_cm() * 0.01f;
 
-    // read range finder at 20Hz
-    // TODO better way of knowing if it has new data
-    if ((imuSampleTime_ms - lastRngMeasTime_ms) > 50) {
+    // limit update rate to maximum allowed by data buffers
+    if ((imuSampleTime_ms - lastRngMeasTime_ms) > frontend->sensorIntervalMin_ms) {
 
         // reset the timer used to control the measurement rate
         lastRngMeasTime_ms =  imuSampleTime_ms;
@@ -112,6 +111,11 @@ void NavEKF3_core::readRangeFinder(void)
 // this needs to be called externally.
 void NavEKF3_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, const Vector3f &posOffset)
 {
+    // limit update rate to maximum allowed by sensor buffers
+    if ((imuSampleTime_ms - flowMeaTime_ms) < frontend->sensorIntervalMin_ms) {
+        return;
+    }
+
     // The raw measurements need to be optical flow rates in radians/second averaged across the time since the last update
     // The PX4Flow sensor outputs flow rates with the following axis and sign conventions:
     // A positive X rate is produced by a positive sensor rotation about the X axis
@@ -168,8 +172,6 @@ void NavEKF3_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
         ofDataNew.time_ms = MAX(ofDataNew.time_ms,imuDataDelayed.time_ms);
         // Save data to buffer
         storedOF.push(ofDataNew);
-        // Check for data at the fusion time horizon
-        flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
     }
 }
 
@@ -193,9 +195,8 @@ void NavEKF3_core::readMagData()
         return;
     }
 
-    // do not accept new compass data faster than 14Hz (nominal rate is 10Hz) to prevent high processor loading
-    // because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
-    if (use_compass() && _ahrs->get_compass()->last_update_usec() - lastMagUpdate_us > 70000) {
+    // limit compass update rate to prevent high processor loading because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
+    if (use_compass() && ((_ahrs->get_compass()->last_update_usec() - lastMagUpdate_us) > 1000 * frontend->sensorIntervalMin_ms)) {
         frontend->logging.log_compass = true;
 
         // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
@@ -396,8 +397,8 @@ bool NavEKF3_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &d
 void NavEKF3_core::readGpsData()
 {
     // check for new GPS data
-    // do not accept data at a faster rate than 14Hz to avoid overflowing the FIFO buffer
-    if (_ahrs->get_gps().last_message_time_ms() - lastTimeGpsReceived_ms > 70) {
+    // limit update rate to avoid overflowing the FIFO buffer
+    if (_ahrs->get_gps().last_message_time_ms() - lastTimeGpsReceived_ms > frontend->sensorIntervalMin_ms) {
         if (_ahrs->get_gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
             // report GPS fix status
             gpsCheckStatus.bad_fix = false;
@@ -538,8 +539,8 @@ bool NavEKF3_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng) {
 void NavEKF3_core::readBaroData()
 {
     // check to see if baro measurement has changed so we know if a new measurement has arrived
-    // do not accept data at a faster rate than 14Hz to avoid overflowing the FIFO buffer
-    if (frontend->_baro.get_last_update() - lastBaroReceived_ms > 70) {
+    // limit update rate to avoid overflowing the FIFO buffer
+    if (frontend->_baro.get_last_update() - lastBaroReceived_ms > frontend->sensorIntervalMin_ms) {
         frontend->logging.log_baro = true;
 
         baroDataNew.hgt = frontend->_baro.get_altitude();
@@ -633,7 +634,7 @@ void NavEKF3_core::readAirSpdData()
     const AP_Airspeed *aspeed = _ahrs->get_airspeed();
     if (aspeed &&
             aspeed->use() &&
-            aspeed->last_update_ms() != timeTasReceived_ms) {
+            (aspeed->last_update_ms() - timeTasReceived_ms) > frontend->sensorIntervalMin_ms) {
         tasDataNew.tas = aspeed->get_airspeed() * aspeed->get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -618,7 +618,7 @@ void NavEKF3_core::calcFiltGpsHgtOffset()
     // correct the EKF origin and variance estimate if the innovation variance ratio is < 5-sigma
     if (ratio < 5.0f) {
         EKF_origin.alt -= (int)(100.0f * gain * innovation);
-        ekfOriginHgtVar -= fmaxf(gain * ekfOriginHgtVar , 0.0f);
+        ekfOriginHgtVar -= MAX(gain * ekfOriginHgtVar , 0.0f);
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -7,8 +7,6 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -755,6 +755,11 @@ void NavEKF3_core::readRngBcnData()
     // Check the buffer for measurements that have been overtaken by the fusion time horizon and need to be fused
     rngBcnDataToFuse = storedRangeBeacon.recall(rngBcnDataDelayed,imuDataDelayed.time_ms);
 
+    // Correct the range beacon earth frame origin for estimated offset relative to the EKF earth frame origin
+    if (rngBcnDataToFuse) {
+        rngBcnDataDelayed.beacon_posNED += bcnPosOffsetNED;
+    }
+
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -411,7 +411,8 @@ void NavEKF3_core::readGpsData()
 
             // estimate when the GPS fix was valid, allowing for GPS processing and other delays
             // ideally we should be using a timing signal from the GPS receiver to set this time
-            gpsDataNew.time_ms = lastTimeGpsReceived_ms - frontend->_gpsDelay_ms;
+            // Use the driver specified delay
+            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(_ahrs->get_gps().get_lag() * 1000.0f);
 
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -635,7 +635,7 @@ void NavEKF3_core::readAirSpdData()
     if (aspeed &&
             aspeed->use() &&
             (aspeed->last_update_ms() - timeTasReceived_ms) > frontend->sensorIntervalMin_ms) {
-        tasDataNew.tas = aspeed->get_airspeed() * aspeed->get_EAS2TAS();
+        tasDataNew.tas = aspeed->get_raw_airspeed() * aspeed->get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -7,8 +7,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -22,6 +22,12 @@ extern const AP_HAL::HAL& hal;
 // select fusion of optical flow measurements
 void NavEKF3_core::SelectFlowFusion()
 {
+    // start performance timer
+    hal.util->perf_begin(_perf_FuseOptFlow);
+
+    // Check for data at the fusion time horizon
+    flowDataToFuse = storedOF.recall(ofDataDelayed, imuDataDelayed.time_ms);
+
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
     // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
@@ -32,8 +38,6 @@ void NavEKF3_core::SelectFlowFusion()
         optFlowFusionDelayed = false;
     }
 
-    // start performance timer
-    hal.util->perf_begin(_perf_FuseOptFlow);
     // Perform Data Checks
     // Check if the optical flow data is still valid
     flowDataValid = ((imuSampleTime_ms - flowValidMeaTime_ms) < 1000);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -70,7 +70,8 @@ void NavEKF3_core::getFlowDebug(float &varFlow, float &gndOffset, float &flowInn
 }
 
 // return data for debugging range beacon fusion one beacon at a time, incrementing the beacon index after each call
-bool NavEKF3_core::getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED, float &offsetHigh, float &offsetLow)
+bool NavEKF3_core::getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED,
+                                       float &offsetHigh, float &offsetLow, Vector3f &posNED)
 {
     // if the states have not been initialised or we have not received any beacon updates then return zeros
     if (!statesInitialised || N_beacons == 0) {
@@ -88,10 +89,12 @@ bool NavEKF3_core::getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, fl
     innov = rngBcnFusionReport[rngBcnFuseDataReportIndex].innov;                // range innovation (m)
     innovVar = rngBcnFusionReport[rngBcnFuseDataReportIndex].innovVar;          // innovation variance (m^2)
     testRatio = rngBcnFusionReport[rngBcnFuseDataReportIndex].testRatio;        // innovation consistency test ratio
-    beaconPosNED = rngBcnFusionReport[rngBcnFuseDataReportIndex].beaconPosNED;  // beacon NED position
-    offsetHigh = bcnPosDownOffsetMax;                                           // beacon system vertical pos offset upper estimate
-    offsetLow = bcnPosDownOffsetMin;                                            // beacon system vertical pos offset lower estimate
+    beaconPosNED = rngBcnFusionReport[rngBcnFuseDataReportIndex].beaconPosNED;  // beacon receiver NED position (m)
+    offsetHigh = bcnPosDownOffsetMax;                                           // beacon system vertical pos offset upper estimate (m)
+    offsetLow = bcnPosDownOffsetMin;                                            // beacon system vertical pos offset lower estimate (m)
+    posNED = receiverPos;                                                      // beacon system NED offset (m)
     rngBcnFuseDataReportIndex++;
+    printf("%6.2f\n",(double)receiverPos.x);
     return true;
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -9,8 +9,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -92,9 +92,8 @@ bool NavEKF3_core::getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, fl
     beaconPosNED = rngBcnFusionReport[rngBcnFuseDataReportIndex].beaconPosNED;  // beacon receiver NED position (m)
     offsetHigh = bcnPosDownOffsetMax;                                           // beacon system vertical pos offset upper estimate (m)
     offsetLow = bcnPosDownOffsetMin;                                            // beacon system vertical pos offset lower estimate (m)
-    posNED = receiverPos;                                                      // beacon system NED offset (m)
+    posNED = receiverPos;                                                       // beacon system NED offset (m)
     rngBcnFuseDataReportIndex++;
-    printf("%6.2f\n",(double)receiverPos.x);
     return true;
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -9,8 +9,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -35,7 +35,7 @@ void NavEKF3_core::ResetVelocity(void)
         P[5][5] = P[4][4] = sq(frontend->_gpsHorizVelNoise);
     } else {
         // reset horizontal velocity states to the GPS velocity if available
-        if (imuSampleTime_ms - lastTimeGpsReceived_ms < 250) {
+        if ((imuSampleTime_ms - lastTimeGpsReceived_ms < 250 && velResetSource == DEFAULT) || velResetSource == GPS) {
             stateStruct.velocity.x  = gpsDataNew.vel.x;
             stateStruct.velocity.y  = gpsDataNew.vel.y;
             // set the variances using the reported GPS speed accuracy
@@ -69,6 +69,8 @@ void NavEKF3_core::ResetVelocity(void)
     // store the time of the reset
     lastVelReset_ms = imuSampleTime_ms;
 
+    // clear reset data source preference
+    velResetSource = DEFAULT;
 
 }
 
@@ -91,7 +93,7 @@ void NavEKF3_core::ResetPosition(void)
         P[7][7] = P[8][8] = sq(frontend->_gpsHorizPosNoise);
     } else  {
         // Use GPS data as first preference if fresh data is available
-        if (imuSampleTime_ms - lastTimeGpsReceived_ms < 250) {
+        if ((imuSampleTime_ms - lastTimeGpsReceived_ms < 250 && posResetSource == DEFAULT) || posResetSource == GPS) {
             // write to state vector and compensate for offset  between last GPS measurement and the EKF time horizon
             stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
             stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
@@ -100,7 +102,7 @@ void NavEKF3_core::ResetPosition(void)
             // clear the timeout flags and counters
             posTimeout = false;
             lastPosPassTime_ms = imuSampleTime_ms;
-        } else if (imuSampleTime_ms - rngBcnLast3DmeasTime_ms < 250) {
+        } else if ((imuSampleTime_ms - rngBcnLast3DmeasTime_ms < 250 && posResetSource == DEFAULT) || posResetSource == RNGBCN) {
             // use the range beacon data as a second preference
             stateStruct.position.x = receiverPos.x;
             stateStruct.position.y = receiverPos.y;
@@ -127,6 +129,9 @@ void NavEKF3_core::ResetPosition(void)
 
     // store the time of the reset
     lastPosReset_ms = imuSampleTime_ms;
+
+    // clear reset source preference
+    posResetSource = DEFAULT;
 
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -705,10 +705,18 @@ void NavEKF3_core::selectHeightForFusion()
             // If the terrain height is consistent and we are moving slowly, then it can be
             // used as a height reference in combination with a range finder
             // apply a hysteresis to the speed check to prevent rapid switching
-            float horizSpeed = norm(stateStruct.velocity.x, stateStruct.velocity.y);
-            bool dontTrustTerrain = ((horizSpeed > frontend->_useRngSwSpd) && filterStatus.flags.horiz_vel) || !terrainHgtStable;
-            float trust_spd_trigger = MAX((frontend->_useRngSwSpd - 1.0f),(frontend->_useRngSwSpd * 0.5f));
-            bool trustTerrain = (horizSpeed < trust_spd_trigger) && terrainHgtStable;
+            bool dontTrustTerrain, trustTerrain;
+            if (filterStatus.flags.horiz_vel) {
+                // We can use the velocity estimate
+                float horizSpeed = norm(stateStruct.velocity.x, stateStruct.velocity.y);
+                dontTrustTerrain = (horizSpeed > frontend->_useRngSwSpd) || !terrainHgtStable;
+                float trust_spd_trigger = MAX((frontend->_useRngSwSpd - 1.0f),(frontend->_useRngSwSpd * 0.5f));
+                trustTerrain = (horizSpeed < trust_spd_trigger) && terrainHgtStable;
+            } else {
+                // We can't use the velocity estimate
+                dontTrustTerrain = !terrainHgtStable;
+                trustTerrain = terrainHgtStable;
+            }
 
             /*
              * Switch between range finder and primary height source using height above ground and speed thresholds with

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -8,8 +8,6 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 /********************************************************

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -53,7 +53,7 @@ void NavEKF3_core::FuseRngBcn()
         // calculate the vertical offset from EKF datum to beacon datum
         CalcRangeBeaconPosDownOffset(R_BCN, stateStruct.position, false);
     } else {
-        bcnPosOffset = 0.0f;
+        bcnPosDownOffset = 0.0f;
     }
 
     // copy required states to local variable names
@@ -62,7 +62,7 @@ void NavEKF3_core::FuseRngBcn()
     pd = stateStruct.position.z;
     bcn_pn = rngBcnDataDelayed.beacon_posNED.x;
     bcn_pe = rngBcnDataDelayed.beacon_posNED.y;
-    bcn_pd = rngBcnDataDelayed.beacon_posNED.z + bcnPosOffset;
+    bcn_pd = rngBcnDataDelayed.beacon_posNED.z + bcnPosDownOffset;
 
     // predicted range
     Vector3f deltaPosNED = stateStruct.position - rngBcnDataDelayed.beacon_posNED;
@@ -313,7 +313,7 @@ void NavEKF3_core::FuseRngBcnStatic()
 
             } else {
                 // we are using the beacons as the primary height source, so don't modify their vertical position
-                bcnPosOffset = 0.0f;
+                bcnPosDownOffset = 0.0f;
 
             }
         } else {
@@ -344,7 +344,7 @@ void NavEKF3_core::FuseRngBcnStatic()
                 bcnPosDownOffsetMin = stateStruct.position.z - receverPosDownMax;
             } else {
                 // We are using the beacons as the primary height reference, so don't modify their vertical position
-                bcnPosOffset = 0.0f;
+                bcnPosDownOffset = 0.0f;
             }
         }
 
@@ -354,7 +354,7 @@ void NavEKF3_core::FuseRngBcnStatic()
         }
 
         // calculate the observation jacobian
-        float t2 = rngBcnDataDelayed.beacon_posNED.z - receiverPos.z + bcnPosOffset;
+        float t2 = rngBcnDataDelayed.beacon_posNED.z - receiverPos.z + bcnPosDownOffset;
         float t3 = rngBcnDataDelayed.beacon_posNED.y - receiverPos.y;
         float t4 = rngBcnDataDelayed.beacon_posNED.x - receiverPos.x;
         float t5 = t2*t2;
@@ -405,7 +405,7 @@ void NavEKF3_core::FuseRngBcnStatic()
 
         // calculate range measurement innovation
         Vector3f deltaPosNED = receiverPos - rngBcnDataDelayed.beacon_posNED;
-        deltaPosNED.z -= bcnPosOffset;
+        deltaPosNED.z -= bcnPosDownOffset;
         innovRngBcn = deltaPosNED.length() - rngBcnDataDelayed.rng;
 
         // update the state
@@ -571,10 +571,10 @@ void NavEKF3_core::CalcRangeBeaconPosDownOffset(float obsVar, Vector3f &vehicleP
     // calculate the innovation for the main filter using the offset with the smallest innovation history
     // apply hysteresis to prevent rapid switching
     if (!usingMinHypothesis && OffsetMinInnovFilt < 0.8f * OffsetMaxInnovFilt) {
-        bcnPosOffset = bcnPosDownOffsetMin;
+        bcnPosDownOffset = bcnPosDownOffsetMin;
         usingMinHypothesis = true;
     } else if (usingMinHypothesis && OffsetMaxInnovFilt < 0.8f * OffsetMinInnovFilt) {
-        bcnPosOffset = bcnPosDownOffsetMax;
+        bcnPosDownOffset = bcnPosDownOffsetMax;
         usingMinHypothesis = false;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -35,7 +35,7 @@ void NavEKF3_core::SelectRngBcnFusion()
                 FuseRngBcn();
             } else {
                 // If we are using GPS, then GPS is the primary reference, but we continue to use the beacon data
-                // to calculate an indpendant position that is used to update the beacon position offset if we need to
+                // to calculate an independant position that is used to update the beacon position offset if we need to
                 // start using beacon data as the primary reference.
                 FuseRngBcnStatic();
                 // record that the beacon origin needs to be initialised

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -10,8 +10,6 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <GCS_MAVLink/GCS.h>
 
-#include <stdio.h>
-
 extern const AP_HAL::HAL& hal;
 
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -84,11 +84,11 @@ bool NavEKF3_core::calcGpsGoodToAlign(void)
         // If the EKF settings require vertical GPS velocity and the receiver is not outputting it, then fail
         gpsVertVelFail = true;
         // if we have a 3D fix with no vertical velocity and
-        // EK2_GPS_TYPE=0 then change it to 1. It means the GPS is not
+        // EK3_GPS_TYPE=0 then change it to 1. It means the GPS is not
         // capable of giving a vertical velocity
         if (_ahrs->get_gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
             frontend->_fusionModeGPS.set(1);
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "EK2: Changed EK2_GPS_TYPE to 1");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "EK3: Changed EK3_GPS_TYPE to 1");
         }
     } else {
         gpsVertVelFail = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -115,7 +115,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
-    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 buffers, IMU=%u , OBS=%u , dt=%6.4f",(unsigned)imu_buffer_length,(unsigned)obs_buffer_length,dtEkfAvg);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u , OBS=%u , dt=%6.4f",(unsigned)imu_index,(unsigned)imu_buffer_length,(unsigned)obs_buffer_length,dtEkfAvg);
     return true;
 }
     

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -265,6 +265,8 @@ void NavEKF3_core::InitialiseVariables()
     ekfOriginHgtVar = 0.0f;
     velOffsetNED.zero();
     posOffsetNED.zero();
+    posResetSource = DEFAULT;
+    velResetSource = DEFAULT;
 
     // range beacon fusion variables
     memset(&rngBcnDataNew, 0, sizeof(rngBcnDataNew));
@@ -294,7 +296,6 @@ void NavEKF3_core::InitialiseVariables()
     N_beacons = 0;
     maxBcnPosD = 0.0f;
     minBcnPosD = 0.0f;
-    bcnPosDownOffset = 0.0f;
     bcnPosDownOffsetMax = 0.0f;
     bcnPosOffsetMaxVar = 0.0f;
     OffsetMaxInnovFilt = 0.0f;
@@ -303,6 +304,8 @@ void NavEKF3_core::InitialiseVariables()
     OffsetMinInnovFilt = 0.0f;
     rngBcnFuseDataReportIndex = 0;
     memset(&rngBcnFusionReport, 0, sizeof(rngBcnFusionReport));
+    bcnPosOffsetNED.zero();
+    bcnOriginEstInit = false;
 
     // zero data buffers
     storedIMU.reset();
@@ -588,6 +591,11 @@ void NavEKF3_core::UpdateStrapdownEquationsNED()
 
     // limit states to protect against divergence
     ConstrainStates();
+
+    // If main filter velocity states are valid, update the range beacon receiver position states
+    if (filterStatus.flags.horiz_vel) {
+        receiverPos += (stateStruct.velocity + lastVelocity) * (imuDataDelayed.delVelDT*0.5f);
+    }
 }
 
 /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -136,7 +136,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
-    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u , OBS=%u , dt=%6.4f",(unsigned)imu_index,(unsigned)imu_buffer_length,(unsigned)obs_buffer_length,dtEkfAvg);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u , OBS=%u , dt=%6.4f",(unsigned)imu_index,(unsigned)imu_buffer_length,(unsigned)obs_buffer_length,(double)dtEkfAvg);
     return true;
 }
     

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -498,9 +498,6 @@ void NavEKF3_core::UpdateFilter(bool predict)
 
     // TODO - in-flight restart method
 
-    //get starting time for update step
-    imuSampleTime_ms = frontend->imuSampleTime_us / 1000;
-
     // Check arm status and perform required checks and mode changes
     controlFilterModes();
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -56,7 +56,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     // Calculate the expected EKF time step
     if (_ahrs->get_ins().get_sample_rate() > 0) {
         dtEkfAvg = 1.0f / _ahrs->get_ins().get_sample_rate();
-        dtEkfAvg = fmaxf(dtEkfAvg,EKF_TARGET_DT);
+        dtEkfAvg = MAX(dtEkfAvg,EKF_TARGET_DT);
     } else {
         return false;
     }
@@ -738,7 +738,7 @@ void NavEKF3_core::calcOutputStates()
         // calculate a gain that provides tight tracking of the estimator states and
         // adjust for changes in time delay to maintain consistent damping ratio of ~0.7
         float timeDelay = 1e-3f * (float)(imuDataNew.time_ms - imuDataDelayed.time_ms);
-        timeDelay = fmaxf(timeDelay, dtIMUavg);
+        timeDelay = MAX(timeDelay, dtIMUavg);
         float errorGain = 0.5f / timeDelay;
 
         // calculate a corrrection to the delta angle

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -86,7 +86,8 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
             }
             return false;
         }
-        maxTimeDelay_ms = MAX(maxTimeDelay_ms , (uint16_t)(_ahrs->get_gps().get_lag() * 1000.0f));
+        // limit the time delay value from the GPS library to a max of 250 msec which is the max value the EKF has been tested for.
+        maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(_ahrs->get_gps().get_lag() * 1000.0f),250));
     }
 
     // airspeed sensing can have large delays and should not be included if disabled

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -294,7 +294,7 @@ void NavEKF3_core::InitialiseVariables()
     N_beacons = 0;
     maxBcnPosD = 0.0f;
     minBcnPosD = 0.0f;
-    bcnPosOffset = 0.0f;
+    bcnPosDownOffset = 0.0f;
     bcnPosDownOffsetMax = 0.0f;
     bcnPosOffsetMaxVar = 0.0f;
     OffsetMaxInnovFilt = 0.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -16,25 +16,25 @@ extern const AP_HAL::HAL& hal;
 NavEKF3_core::NavEKF3_core(void) :
     stateStruct(*reinterpret_cast<struct state_elements *>(&statesArray)),
 
-    _perf_UpdateFilter(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_UpdateFilter")),
-    _perf_CovariancePrediction(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_CovariancePrediction")),
-    _perf_FuseVelPosNED(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseVelPosNED")),
-    _perf_FuseMagnetometer(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseMagnetometer")),
-    _perf_FuseAirspeed(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseAirspeed")),
-    _perf_FuseSideslip(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseSideslip")),
-    _perf_TerrainOffset(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_TerrainOffset")),
-    _perf_FuseOptFlow(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_FuseOptFlow"))
+    _perf_UpdateFilter(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_UpdateFilter")),
+    _perf_CovariancePrediction(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_CovariancePrediction")),
+    _perf_FuseVelPosNED(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseVelPosNED")),
+    _perf_FuseMagnetometer(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseMagnetometer")),
+    _perf_FuseAirspeed(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseAirspeed")),
+    _perf_FuseSideslip(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseSideslip")),
+    _perf_TerrainOffset(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_TerrainOffset")),
+    _perf_FuseOptFlow(hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_FuseOptFlow"))
 {
-    _perf_test[0] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test0");
-    _perf_test[1] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test1");
-    _perf_test[2] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test2");
-    _perf_test[3] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test3");
-    _perf_test[4] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test4");
-    _perf_test[5] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test5");
-    _perf_test[6] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test6");
-    _perf_test[7] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test7");
-    _perf_test[8] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test8");
-    _perf_test[9] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK2_Test9");
+    _perf_test[0] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test0");
+    _perf_test[1] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test1");
+    _perf_test[2] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test2");
+    _perf_test[3] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test3");
+    _perf_test[4] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test4");
+    _perf_test[5] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test5");
+    _perf_test[6] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test6");
+    _perf_test[7] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test7");
+    _perf_test[8] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test8");
+    _perf_test[9] = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, "EK3_Test9");
     firstInitTime_ms = 0;
     lastInitFailReport_ms = 0;
 }
@@ -508,7 +508,7 @@ void NavEKF3_core::UpdateFilter(bool predict)
     }
 
     // start the timer used for load measurement
-#if EK2_DISABLE_INTERRUPTS
+#if EK3_DISABLE_INTERRUPTS
     irqstate_t istate = irqsave();
 #endif
     hal.util->perf_begin(_perf_UpdateFilter);
@@ -556,7 +556,7 @@ void NavEKF3_core::UpdateFilter(bool predict)
 
     // stop the timer used for load measurement
     hal.util->perf_end(_perf_UpdateFilter);
-#if EK2_DISABLE_INTERRUPTS
+#if EK3_DISABLE_INTERRUPTS
     irqrestore(istate);
 #endif
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -315,6 +315,7 @@ private:
     uint8_t imu_index;
     uint8_t core_index;
     uint8_t imu_buffer_length;
+    uint8_t obs_buffer_length;
 
     typedef float ftype;
 #if MATH_CHECK_INDEXES
@@ -720,10 +721,6 @@ private:
     
     // initialise the quaternion covariances using rotation vector variances
     void initialiseQuatCovariances(Vector3f &rotVarVec);
-
-    // Length of FIFO buffers used for non-IMU sensor data.
-    // Must be larger than the time period defined by IMU_BUFFER_LENGTH
-    static const uint32_t OBS_BUFFER_LENGTH = 5;
 
     // Variables
     bool statesInitialised;         // boolean true when filter states have been initialised

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -210,8 +210,14 @@ public:
         innovVar : innovation variance (m^2)
         testRatio : innovation consistency test ratio
         beaconPosNED : beacon NED position (m)
+        offsetHigh : high hypothesis for range beacons system vertical offset (m)
+        offsetLow : low hypothesis for range beacons system vertical offset (m)
+        posNED : North,East,Down position estimate of receiver from 3-state filter
+
+        returns true if data could be found, false if it could not
     */
-    bool getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED, float &offsetHigh, float &offsetLow);
+    bool getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, float &innovVar, float &testRatio, Vector3f &beaconPosNED,
+                             float &offsetHigh, float &offsetLow, Vector3f &posNED);
 
     // called by vehicle code to specify that a takeoff is happening
     // causes the EKF to compensate for expected barometer errors due to ground effect

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -125,11 +125,9 @@ public:
     bool resetHeightDatum(void);
 
     // Commands the EKF to not use GPS.
-    // This command must be sent prior to arming as it will only be actioned when the filter is in static mode
-    // This command is forgotten by the EKF each time it goes back into static mode (eg the vehicle disarms)
+    // This command must be sent prior to vehicle arming and EKF commencement of GPS usage
     // Returns 0 if command rejected
-    // Returns 1 if attitude, vertical velocity and vertical position will be provided
-    // Returns 2 if attitude, 3D-velocity, vertical position and relative horizontal position will be provided
+    // Returns 1 if command accepted
     uint8_t setInhibitGPS(void);
 
     // return the horizontal speed limit in m/s set by optical flow sensor limits

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -896,6 +896,7 @@ private:
     Vector3f outputTrackError;      // attitude (rad), velocity (m/s) and position (m) tracking error magnitudes from the output observer
     Vector3f velOffsetNED;          // This adds to the earth frame velocity estimate at the IMU to give the velocity at the body origin (m/s)
     Vector3f posOffsetNED;          // This adds to the earth frame position estimate at the IMU to give the position at the body origin (m)
+    uint32_t firstInitTime_ms;      // First time the initialise function was called (msec)
 
     // Specify preferred source of data to be used for a state reset
     enum resetDataSource {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1011,7 +1011,7 @@ private:
     uint8_t N_beacons;                  // Number of range beacons in use
     float maxBcnPosD;                   // maximum position of all beacons in the down direction (m)
     float minBcnPosD;                   // minimum position of all beacons in the down direction (m)
-    float bcnPosOffset;                 // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)
+    float bcnPosDownOffset;             // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)
     bool usingMinHypothesis;            // true when the min beacob constellatio offset hyopthesis is being used
 
     float bcnPosDownOffsetMax;          // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -620,8 +620,8 @@ private:
     // Calculate weighting that is applied to IMU1 accel data to blend data from IMU's 1 and 2
     void calcIMU_Weighting(float K1, float K2);
 
-    // return true if optical flow data is available
-    bool optFlowDataPresent(void) const;
+    // return true if the filter is ready to start using optical flow measurements
+    bool readyToUseOptFlow(void) const;
 
     // return true if we should use the range finder sensor
     bool useRngFinder(void) const;
@@ -667,8 +667,8 @@ private:
     // Assess GPS data quality and return true if good enough to align the EKF
     bool calcGpsGoodToAlign(void);
 
-    // return true and set the class variable true if the delta angle bias has been learned
-    bool checkGyroCalStatus(void);
+    // set the class variable true if the delta angle bias variances are sufficiently small
+    void checkGyroCalStatus(void);
 
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -21,7 +21,7 @@
 
 #pragma GCC optimize("O3")
 
-#define EK2_DISABLE_INTERRUPTS 0
+#define EK3_DISABLE_INTERRUPTS 0
 
 
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -899,15 +899,16 @@ private:
     uint32_t firstInitTime_ms;      // First time the initialise function was called (msec)
     uint32_t lastInitFailReport_ms; // Last time the buffer initialisation failure report wass sent (msec)
 
-    // Specify preferred source of data to be used for a state reset
+    // Specify source of data to be used for a partial state reset
+    // Checking the availability and quality of the data source specified is the responsibility of the caller
     enum resetDataSource {
-                    DEFAULT=0,      // Use best available data
-                    GPS=1,          // Use GPS if available
-                    RNGBCN=2,       // Use beacon range data if available
-                    FLOW=3,         // Use optical flow rates if available
-                    BARO=4,         // Use Baro height if available
-                    MAG=5,          // Use magnetometer data if available
-                    RNGFND=6        // Use rangefinder data if available
+                    DEFAULT=0,      // Use data source selected by reset function internal rules
+                    GPS=1,          // Use GPS
+                    RNGBCN=2,       // Use beacon range data
+                    FLOW=3,         // Use optical flow rates
+                    BARO=4,         // Use Baro height
+                    MAG=5,          // Use magnetometer data
+                    RNGFND=6        // Use rangefinder data
                         };
     resetDataSource posResetSource; // preferred soure of data for position reset
     resetDataSource velResetSource; // preferred source of data for a velocity reset

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -897,6 +897,7 @@ private:
     Vector3f velOffsetNED;          // This adds to the earth frame velocity estimate at the IMU to give the velocity at the body origin (m/s)
     Vector3f posOffsetNED;          // This adds to the earth frame position estimate at the IMU to give the position at the body origin (m)
     uint32_t firstInitTime_ms;      // First time the initialise function was called (msec)
+    uint32_t lastInitFailReport_ms; // Last time the buffer initialisation failure report wass sent (msec)
 
     // Specify preferred source of data to be used for a state reset
     enum resetDataSource {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -468,7 +468,7 @@ private:
     // use range beaon measurements to calculate a static position
     void FuseRngBcnStatic();
 
-    // calculate the offset from EKF vetical position datum to the range beacon system datum
+    // calculate the offset from EKF vertical position datum to the range beacon system datum
     void CalcRangeBeaconPosDownOffset(float obsVar, Vector3f &vehiclePosNED, bool aligning);
 
     // fuse magnetometer measurements
@@ -894,6 +894,19 @@ private:
     Vector3f velOffsetNED;          // This adds to the earth frame velocity estimate at the IMU to give the velocity at the body origin (m/s)
     Vector3f posOffsetNED;          // This adds to the earth frame position estimate at the IMU to give the position at the body origin (m)
 
+    // Specify preferred source of data to be used for a state reset
+    enum resetDataSource {
+                    DEFAULT=0,      // Use best available data
+                    GPS=1,          // Use GPS if available
+                    RNGBCN=2,       // Use beacon range data if available
+                    FLOW=3,         // Use optical flow rates if available
+                    BARO=4,         // Use Baro height if available
+                    MAG=5,          // Use magnetometer data if available
+                    RNGFND=6        // Use rangefinder data if available
+                        };
+    resetDataSource posResetSource; // preferred soure of data for position reset
+    resetDataSource velResetSource; // preferred source of data for a velocity reset
+
     // variables used to calculate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.
     float posDown;                  // Down position state used in calculation of posDownRate
@@ -1009,7 +1022,6 @@ private:
     uint8_t N_beacons;                  // Number of range beacons in use
     float maxBcnPosD;                   // maximum position of all beacons in the down direction (m)
     float minBcnPosD;                   // minimum position of all beacons in the down direction (m)
-    float bcnPosDownOffset;             // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)
     bool usingMinHypothesis;            // true when the min beacob constellatio offset hyopthesis is being used
 
     float bcnPosDownOffsetMax;          // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)
@@ -1019,6 +1031,9 @@ private:
     float bcnPosDownOffsetMin;          // Vertical position offset of the beacon constellation origin relative to the EKF origin (m)
     float bcnPosOffsetMinVar;           // Variance of the bcnPosDownOffsetMin state (m)
     float OffsetMinInnovFilt;           // Filtered magnitude of the range innovations using bcnPosOffsetLow
+
+    Vector3f bcnPosOffsetNED;           // NED position of the beacon origin in earth frame (m)
+    bool bcnOriginEstInit;              // True when the beacon origin has been initialised
 
     // Range Beacon Fusion Debug Reporting
     uint8_t rngBcnFuseDataReportIndex;// index of range beacon fusion data last reported

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -26,7 +26,6 @@
 
 #include <AP_Math/AP_Math.h>
 #include "AP_NavEKF3.h"
-#include <stdio.h>
 #include <AP_Math/vectorN.h>
 #include <AP_NavEKF3/AP_NavEKF3_Buffer.h>
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1420,7 +1420,10 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
                     beaconPosE : (int16_t)(100*beaconPosNED.y),
                     beaconPosD : (int16_t)(100*beaconPosNED.z),
                     offsetHigh : (int16_t)(100*bcnPosOffsetHigh),
-                    offsetLow : (int16_t)(100*bcnPosOffsetLow)
+                    offsetLow : (int16_t)(100*bcnPosOffsetLow),
+                    posN : 0,
+                    posE : 0,
+                    posD : 0
                 };
                 WriteBlock(&pkt10, sizeof(pkt10));
             }
@@ -1695,7 +1698,8 @@ void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     Vector3f beaconPosNED;
     float bcnPosOffsetHigh;
     float bcnPosOffsetLow;
-     if (ahrs.get_NavEKF3().getRangeBeaconDebug(-1, ID, rng, innov, innovVar, testRatio, beaconPosNED, bcnPosOffsetHigh, bcnPosOffsetLow)) {
+    Vector3f posNED;
+     if (ahrs.get_NavEKF3().getRangeBeaconDebug(-1, ID, rng, innov, innovVar, testRatio, beaconPosNED, bcnPosOffsetHigh, bcnPosOffsetLow, posNED)) {
         if (rng > 0.0f) {
             struct log_RngBcnDebug pkt10 = {
                 LOG_PACKET_HEADER_INIT(LOG_XKF10_MSG),
@@ -1709,7 +1713,11 @@ void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
                 beaconPosE : (int16_t)(100*beaconPosNED.y),
                 beaconPosD : (int16_t)(100*beaconPosNED.z),
                 offsetHigh : (int16_t)(100*bcnPosOffsetHigh),
-                offsetLow : (int16_t)(100*bcnPosOffsetLow)
+                offsetLow : (int16_t)(100*bcnPosOffsetLow),
+                posN : (int16_t)(100*posNED.x),
+                posE : (int16_t)(100*posNED.y),
+                posD : (int16_t)(100*posNED.z)
+
              };
             WriteBlock(&pkt10, sizeof(pkt10));
         }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -401,6 +401,9 @@ struct PACKED log_RngBcnDebug {
     int16_t beaconPosD;     // beacon down position (cm)
     int16_t offsetHigh;     // high estimate of vertical position offset of beacons rel to EKF origin (cm)
     int16_t offsetLow;      // low estimate of vertical position offset of beacons rel to EKF origin (cm)
+    int16_t posN;           // North position of receiver rel to EKF origin (cm)
+    int16_t posE;           // East position of receiver rel to EKF origin (cm)
+    int16_t posD;           // Down position of receiver rel to EKF origin (cm)
 };
 
 struct PACKED log_Cmd {
@@ -854,7 +857,7 @@ Format characters in the format string for binary log messages
     { LOG_NKF9_MSG, sizeof(log_NKF4), \
       "NKF9","QcccccfbbHBHHb","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI" }, \
     { LOG_NKF10_MSG, sizeof(log_RngBcnDebug), \
-      "NKF0","QBccCCccccc","TimeUS,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL" }, \
+      "NKF0","QBccCCcccccccc","TimeUS,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD" }, \
     { LOG_XKF1_MSG, sizeof(log_EKF1), \
       "XKF1","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_XKF2_MSG, sizeof(log_NKF2a), \
@@ -874,7 +877,7 @@ Format characters in the format string for binary log messages
     { LOG_XKF9_MSG, sizeof(log_NKF4), \
       "XKF9","QcccccfbbHBHHb","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI" }, \
     { LOG_XKF10_MSG, sizeof(log_RngBcnDebug), \
-      "XKF0","QBccCCccccc","TimeUS,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL" }, \
+      "XKF0","QBccCCcccccccc","TimeUS,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD" }, \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \
       "TERR","QBLLHffHH","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded" }, \
     { LOG_GPS_UBX1_MSG, sizeof(log_Ubx1), \


### PR DESCRIPTION
Allows use of range beacons simultaneously with GPS and optical flow
Fixes an error in the way that the Pozyx beacon system output is rotated into the local NED earth frame.
Makes the sensor buffer lengths adapt to the time delays to reduce output predictor errors
Uses the averaged, but unfiltered airspeed to reduce the effective time delay.
Fixes a potential bug that could allow the filter to start before the required sensor buffers are filled
Uses the time delay published by the GPS driver, instead of a value specified by a EKF parameter.
Updates EKF3 to allow copters to fly in non position aiding modes without a magnetometer.

TODO:

Add GPS_DELAY and GPS_DELAY2  parameters to the GPS library as discussed in https://github.com/ArduPilot/ardupilot/pull/5405
