### PR TITLE
Copter: object avoidance for AltHold mode

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -395,42 +395,42 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: CH7_OPT
     // @DisplayName: Channel 7 option
     // @Description: Select which function is performed when CH7 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch7_option, "CH7_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH8_OPT
     // @DisplayName: Channel 8 option
     // @Description: Select which function is performed when CH8 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch8_option, "CH8_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH9_OPT
     // @DisplayName: Channel 9 option
     // @Description: Select which function is performed when CH9 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch9_option, "CH9_OPT",                  AUXSW_DO_NOTHING),
 
     // @Param: CH10_OPT
     // @DisplayName: Channel 10 option
     // @Description: Select which function is performed when CH10 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch10_option, "CH10_OPT",                AUXSW_DO_NOTHING),
 
     // @Param: CH11_OPT
     // @DisplayName: Channel 11 option
     // @Description: Select which function is performed when CH11 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch11_option, "CH11_OPT",                AUXSW_DO_NOTHING),
 
     // @Param: CH12_OPT
     // @DisplayName: Channel 12 option
     // @Description: Select which function is performed when CH12 is above 1800 pwm
-    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter
+    // @Values: 0:Do Nothing, 2:Flip, 3:Simple Mode, 4:RTL, 5:Save Trim, 7:Save WP, 9:Camera Trigger, 10:RangeFinder, 11:Fence, 13:Super Simple Mode, 14:Acro Trainer, 15:Sprayer, 16:Auto, 17:AutoTune, 18:Land, 19:Gripper, 21:Parachute Enable, 22:Parachute Release, 23:Parachute 3pos, 24:Auto Mission Reset, 25:AttCon Feed Forward, 26:AttCon Accel Limits, 27:Retract Mount, 28:Relay On/Off, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 29:Landing Gear, 30:Lost Copter Sound, 31:Motor Emergency Stop, 32:Motor Interlock, 33:Brake, 37:Throw, 38:Avoidance, 39:PrecLoiter, 40:Object Avoidance
     // @User: Standard
     GSCALAR(ch12_option, "CH12_OPT",                AUXSW_DO_NOTHING),
 

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -620,9 +620,9 @@ bool Copter::pre_arm_proximity_check(bool display_failure)
         return false;
     }
 
-    // get closest object
+    // get closest object if we might use it for avoidance
     float angle_deg, distance;
-    if (g2.proximity.get_closest_object(angle_deg, distance)) {
+    if (avoid.proximity_avoidance_enabled() && g2.proximity.get_closest_object(angle_deg, distance)) {
         // display error if something is within 60cm
         if (distance <= 0.6f) {
             if (display_failure) {

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -134,6 +134,10 @@ void Copter::althold_run()
 
     case AltHold_Flying:
         motors.set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+
+        // apply avoidance
+        avoid.adjust_roll_pitch(target_roll, target_pitch, aparm.angle_max);
+
         // call attitude controller
         attitude_control.input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -69,6 +69,7 @@ enum aux_sw_func {
     AUXSW_THROW =               37,  // change to THROW flight mode
     AUXSW_AVOID_ADSB =          38,  // enable AP_Avoidance library
     AUXSW_PRECISION_LOITER =    39,  // enable precision loiter
+    AUXSW_AVOID_PROXIMITY =     40,  // enable object avoidance using proximity sensors (ie. horizontal lidar)
     AUXSW_SWITCH_MAX,
 };
 
@@ -396,6 +397,8 @@ enum DevOptions {
 #define DATA_EKF_YAW_RESET                  62
 #define DATA_AVOIDANCE_ADSB_ENABLE          63
 #define DATA_AVOIDANCE_ADSB_DISABLE         64
+#define DATA_AVOIDANCE_PROXIMITY_ENABLE     65
+#define DATA_AVOIDANCE_PROXIMITY_DISABLE    66
 
 // Centi-degrees to radians
 #define DEGX100 5729.57795f

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -194,6 +194,7 @@ void Copter::init_aux_switch_function(int8_t ch_option, uint8_t ch_flag)
         case AUXSW_MOTOR_INTERLOCK:
         case AUXSW_AVOID_ADSB:
         case AUXSW_PRECISION_LOITER:
+        case AUXSW_AVOID_PROXIMITY:
             do_aux_switch_function(ch_option, ch_flag);
             break;
     }
@@ -570,6 +571,20 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
 #endif
             break;
 
+        case AUXSW_AVOID_PROXIMITY:
+#if PROXIMITY_ENABLED == ENABLED
+            switch (ch_flag) {
+                case AUX_SWITCH_HIGH:
+                    avoid.proximity_avoidance_enable(true);
+                    Log_Write_Event(DATA_AVOIDANCE_PROXIMITY_ENABLE);
+                    break;
+                case AUX_SWITCH_LOW:
+                    avoid.proximity_avoidance_enable(false);
+                    Log_Write_Event(DATA_AVOIDANCE_PROXIMITY_DISABLE);
+                    break;
+            }
+#endif
+            break;
     }
 }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -10,6 +10,21 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_ALL),
 
+    // @Param: ANGLE MAX
+    // @DisplayName: Avoidance max lean angle in non-GPS flight modes
+    // @Description: Max lean angle used to avoid obstacles while in non-GPS modes
+    // @Range: 0 4500
+    // @User: Standard
+    AP_GROUPINFO("ANGLE_MAX", 2,  AC_Avoid, _angle_max, 1000),
+
+    // @Param: DIST_MAX
+    // @DisplayName: Avoidance distance maximum in non-GPS flight modes
+    // @Description: Distance from object at which obstacle avoidance will begin in non-GPS modes
+    // @Units: meters
+    // @Range: 3 30
+    // @User: Standard
+    AP_GROUPINFO("DIST_MAX", 3,  AC_Avoid, _dist_max, AC_AVOID_NONGPS_DIST_MAX_DEFAULT),
+
     AP_GROUPEND
 };
 
@@ -38,7 +53,7 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
         adjust_velocity_polygon_fence(kP, accel_cmss_limited, desired_vel);
     }
 
-    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0) {
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
         adjust_velocity_proximity(kP, accel_cmss_limited, desired_vel);
     }
 }
@@ -50,6 +65,54 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel
     adjust_velocity(kP, accel_cmss, des_vel_xy);
     desired_vel.x = des_vel_xy.x;
     desired_vel.y = des_vel_xy.y;
+}
+
+// adjust roll-pitch to push vehicle away from objects
+// roll and pitch value are in centi-degrees
+void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float angle_max)
+{
+    // exit immediately if proximity based avoidance is disabled
+    if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) == 0 || !_proximity_enabled) {
+        return;
+    }
+
+    // exit immediately if angle max is zero
+    if (_angle_max <= 0.0f || angle_max <= 0.0f) {
+        return;
+    }
+
+    float roll_positive = 0.0f;    // maximum positive roll value
+    float roll_negative = 0.0f;    // minimum negative roll value
+    float pitch_positive = 0.0f;   // maximum position pitch value
+    float pitch_negative = 0.0f;   // minimum negative pitch value
+
+    // get maximum positive and negative roll and pitch percentages from proximity sensor
+    get_proximity_roll_pitch_pct(roll_positive, roll_negative, pitch_positive, pitch_negative);
+
+    // add maximum positive and negative percentages together for roll and pitch, convert to centi-degrees
+    Vector2f rp_out((roll_positive + roll_negative) * 4500.0f, (pitch_positive + pitch_negative) * 4500.0f);
+
+    // apply avoidance angular limits
+    // the object avoidance lean angle is never more than 75% of the total angle-limit to allow the pilot to override
+    float angle_limit = constrain_float(_angle_max, 0.0f, angle_max * AC_AVOID_ANGLE_MAX_PERCENT);
+    float vec_len = rp_out.length();
+    if (vec_len > angle_limit) {
+        rp_out *= (angle_limit / vec_len);
+    }
+
+    // add passed in roll, pitch angles
+    rp_out.x += roll;
+    rp_out.y += pitch;
+
+    // apply total angular limits
+    vec_len = rp_out.length();
+    if (vec_len > angle_max) {
+        rp_out *= (angle_max / vec_len);
+    }
+
+    // return adjusted roll, pitch
+    roll = rp_out.x;
+    pitch = rp_out.y;
 }
 
 /*
@@ -262,5 +325,64 @@ float AC_Avoid::get_stopping_distance(float kP, float accel_cmss, float speed) c
     } else {
         // accel_cmss/(2.0f*kP*kP) is the distance at which we switch from linear to sqrt response
         return accel_cmss/(2.0f*kP*kP) + (speed*speed)/(2.0f*accel_cmss);
+    }
+}
+
+// convert distance (in meters) to a lean percentage (in 0~1 range) for use in manual flight modes
+float AC_Avoid::distance_to_lean_pct(float dist_m)
+{
+    // ignore objects beyond DIST_MAX
+    if (dist_m <= 0.0f || dist_m >= _dist_max || _dist_max <= 0.0f) {
+        return 0.0f;
+    }
+    // objects at 0m cause maximum lean
+    if (dist_m <= 0.0f) {
+        return 1.0f;
+    }
+    // inverted but linear response
+    return 1.0f - (dist_m / _dist_max);
+}
+
+// returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
+void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative)
+{
+    // exit immediately if proximity sensor is not present
+    if (_proximity.get_status() != AP_Proximity::Proximity_Good) {
+        return;
+    }
+
+    uint8_t obj_count = _proximity.get_object_count();
+
+    // if no objects return
+    if (obj_count == 0) {
+        return;
+    }
+
+    // calculate maximum roll, pitch values from objects
+    for (uint8_t i=0; i<obj_count; i++) {
+        float ang_deg, dist_m;
+        if (_proximity.get_object_angle_and_distance(i, ang_deg, dist_m)) {
+            if (dist_m < _dist_max) {
+                // convert distance to lean angle (in 0 to 1 range)
+                float lean_pct = distance_to_lean_pct(dist_m);
+                // convert angle to roll and pitch lean percentages
+                float angle_rad = radians(ang_deg);
+                float roll_pct = -sinf(angle_rad) * lean_pct;
+                float pitch_pct = cosf(angle_rad) * lean_pct;
+                // update roll, pitch maximums
+                if (roll_pct > 0.0f) {
+                    roll_positive = MAX(roll_positive, roll_pct);
+                }
+                if (roll_pct < 0.0f) {
+                    roll_negative = MIN(roll_negative, roll_pct);
+                }
+                if (pitch_pct > 0.0f) {
+                    pitch_positive = MAX(pitch_positive, pitch_pct);
+                }
+                if (pitch_pct < 0.0f) {
+                    pitch_negative = MIN(pitch_negative, pitch_pct);
+                }
+            }
+        }
     }
 }

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -46,6 +46,7 @@ public:
 
     // enable/disable proximity based avoidance
     void proximity_avoidance_enable(bool on_off) { _proximity_enabled = on_off; }
+    bool proximity_avoidance_enabled() { return _proximity_enabled; }
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -20,7 +20,6 @@
 // definitions for non-GPS avoidance
 #define AC_AVOID_NONGPS_DIST_MAX_DEFAULT    10.0f   // objects over 10m away are ignored (default value for DIST_MAX parameter)
 #define AC_AVOID_ANGLE_MAX_PERCENT          0.75f   // object avoidance max lean angle as a percentage (expressed in 0 ~ 1 range) of total vehicle max lean angle
-#define AC_AVOID_NONGPS_P                   1.0f    // p gain used in conversion from distance to lean angle
 
 /*
  * This class prevents the vehicle from leaving a polygon fence in

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -17,6 +17,11 @@
 #define AC_AVOID_USE_PROXIMITY_SENSOR   2       // stop based on proximity sensor output
 #define AC_AVOID_ALL                    3       // use fence and promiximity sensor
 
+// definitions for non-GPS avoidance
+#define AC_AVOID_NONGPS_DIST_MAX_DEFAULT    10.0f   // objects over 10m away are ignored (default value for DIST_MAX parameter)
+#define AC_AVOID_ANGLE_MAX_PERCENT          0.75f   // object avoidance max lean angle as a percentage (expressed in 0 ~ 1 range) of total vehicle max lean angle
+#define AC_AVOID_NONGPS_P                   1.0f    // p gain used in conversion from distance to lean angle
+
 /*
  * This class prevents the vehicle from leaving a polygon fence in
  * 2 dimensions by limiting velocity (adjust_velocity).
@@ -34,6 +39,14 @@ public:
      */
     void adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel);
     void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel);
+
+    // adjust roll-pitch to push vehicle away from objects
+    // roll and pitch value are in centi-degrees
+    // angle_max is the user defined maximum lean angle for the vehicle in centi-degrees
+    void adjust_roll_pitch(float &roll, float &pitch, float angle_max);
+
+    // enable/disable proximity based avoidance
+    void proximity_avoidance_enable(bool on_off) { _proximity_enabled = on_off; }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -90,6 +103,16 @@ private:
      */
     float get_margin() const { return _fence.get_margin() * 100.0f; }
 
+    /*
+     * methods for avoidance in non-GPS flight modes
+     */
+
+    // convert distance (in meters) to a lean percentage (in 0~1 range) for use in manual flight modes
+    float distance_to_lean_pct(float dist_m);
+
+    // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
+    void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+
     // external references
     const AP_AHRS& _ahrs;
     const AP_InertialNav& _inav;
@@ -98,4 +121,8 @@ private:
 
     // parameters
     AP_Int8 _enabled;
+    AP_Int16 _angle_max;        // maximum lean angle to avoid obstacles (only used in non-GPS flight modes)
+    AP_Float _dist_max;         // distance (in meters) from object at which obstacle avoidance will begin in non-GPS modes
+
+    bool _proximity_enabled = true; // true if proximity sensor based avoidance is enabled (used to allow pilot to enable/disable)
 };

--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -88,7 +88,7 @@ bool Polygon_outside(const Vector2<T> &P, const Vector2<T> *V, unsigned n)
 template <typename T>
 bool Polygon_complete(const Vector2<T> *V, unsigned n)
 {
-    return (n >= 4 && V[n-1] == V[0]);
+    return (n >= 4 && V[n-1].x == V[0].x && V[n-1].y == V[0].y);
 }
 
 // Necessary to avoid linker errors

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -307,6 +307,27 @@ bool AP_Proximity::get_closest_object(float& angle_deg, float &distance) const
     return drivers[primary_instance]->get_closest_object(angle_deg, distance);
 }
 
+// get number of objects, used for non-GPS avoidance
+uint8_t AP_Proximity::get_object_count() const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return 0;
+    }
+    // get count from backend
+    return drivers[primary_instance]->get_object_count();
+}
+
+// get an object's angle and distance, used for non-GPS avoidance
+// returns false if no angle or distance could be returned for some reason
+bool AP_Proximity::get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const
+{
+    if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get angle and distance from backend
+    return drivers[primary_instance]->get_object_angle_and_distance(object_number, angle_deg, distance);
+}
+
 // get distances in 8 directions. used for sending distances to ground station
 bool AP_Proximity::get_distances(Proximity_Distance_Array &prx_dist_array) const
 {

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -80,6 +80,10 @@ public:
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;
 
+    // get number of objects, angle and distance - used for non-GPS avoidance
+    uint8_t get_object_count() const;
+    bool get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const;
+
     // stucture holding distances in 8 directions
     struct Proximity_Distance_Array {
         uint8_t orientation[8]; // orientation (i.e. rough direction) of the distance (see MAV_SENSOR_ORIENTATION)

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -65,6 +65,24 @@ bool AP_Proximity_Backend::get_closest_object(float& angle_deg, float &distance)
     return sector_found;
 }
 
+// get number of objects, used for non-GPS avoidance
+uint8_t AP_Proximity_Backend::get_object_count() const
+{
+    return _num_sectors;
+}
+
+// get an object's angle and distance, used for non-GPS avoidance
+// returns false if no angle or distance could be returned for some reason
+bool AP_Proximity_Backend::get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const
+{
+    if (object_number < _num_sectors && _distance_valid[object_number]) {
+        angle_deg = _angle[object_number];
+        distance = _distance[object_number];
+        return true;
+    }
+    return false;
+}
+
 // get distances in 8 directions. used for sending distances to ground station
 bool AP_Proximity_Backend::get_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const
 {

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -50,6 +50,10 @@ public:
     //   returns true on success, false if no valid readings
     bool get_closest_object(float& angle_deg, float &distance) const;
 
+    // get number of objects, angle and distance - used for non-GPS avoidance
+    uint8_t get_object_count() const;
+    bool get_object_angle_and_distance(uint8_t object_number, float& angle_deg, float &distance) const;
+
     // get distances in 8 directions. used for sending distances to ground station
     bool get_distances(AP_Proximity::Proximity_Distance_Array &prx_dist_array) const;
 


### PR DESCRIPTION
This PR adds these changes:

- support for lean-angle based object avoidance in Altitude Hold mode
- ability to turn on/off proximity sensor (aka 360deg lidar) based object avoidance with an auxiliary switch

![manualavoidance](https://cloud.githubusercontent.com/assets/1498098/21311793/6d6322e6-c62c-11e6-88e5-9981ee481769.png)

Features of the Object Avoidance:

- distance to each object is converted to a lean-angle using a linear curve which starts at 0 degrees when the vehicle is AVOID_DIST_MAX to the object and ends with the vehicle at AVOID_ANGLE_MAX as it touches the object.
- in case of multiple objects, the vectors are combined together so that only the maximum roll and pitch responses are considered.  This ensures that multiple objects one side of the vehicle do not cause a larger response than a single object.  This is especially important if there's one object on one side of the vehicle, and multiple objects on the other.
- we do not add a dependency on the GPS/EKF's position/velocity estimate because, even if it's available, we can't trust that it's quality is good and relying on it some times and not others would introduce two possible responses to objects which could be confusing for the pilot.
- the pilot is always able to override the object avoidance because the response is never more than 75% of the vehicle's ANGLE_MAX parameter.

Some Issues:

- a fast moving vehicle may still crash into the object
- a slow moving vehicle may appear too maintain too large a distance from obstacles from the pilot's point of view but he/she can always force the vehicle through manually.
- when flying along a wall (with the pilot maintaining a lean angle into the wall) if the vehicle then reaches a corner (i.e. a perpendicular wall jutting out into the path of the vehicle) it may actually fly closer to the original wall as it leans back to avoid the new wall.  This happens if the overall object avoidance lean angle response exceeds the AVOID_ANGLE_MAX and thus the response becomes divided between roll and pitch.