### PR TITLE
AP_Common: Added ANDROID macro for missing byteswap header.

### DIFF
--- a/libraries/AP_Common/missing/byteswap.h
+++ b/libraries/AP_Common/missing/byteswap.h
@@ -1,4 +1,4 @@
-#if defined(HAVE_BYTESWAP_H) && HAVE_BYTESWAP_H
+#if defined(HAVE_BYTESWAP_H) && HAVE_BYTESWAP_H && !defined(__ANDROID__)
 #include_next <byteswap.h>
 #else
 


### PR DESCRIPTION
It's needed for Android NDK API Level 19.