### PR TITLE
Rover cleanup

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -71,12 +71,12 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(compass_accumulate,     50,    900),
     SCHED_TASK(update_notify,          50,    300),
     SCHED_TASK(one_second_loop,         1,   3000),
-    SCHED_TASK(compass_cal_update,     50,    100), 
+    SCHED_TASK(compass_cal_update,     50,    100),
     SCHED_TASK(accel_cal_update,       10,    100),
     SCHED_TASK(dataflash_periodic,     50,    300),
-    SCHED_TASK(button_update,          5,     100),
-    SCHED_TASK(stats_update,           1,     100),
-    SCHED_TASK(crash_check,           10,    1000),
+    SCHED_TASK(button_update,           5,    100),
+    SCHED_TASK(stats_update,            1,    100),
+    SCHED_TASK(crash_check,            10,   1000),
 };
 
 /*
@@ -91,7 +91,7 @@ void Rover::stats_update(void)
 /*
   setup is called when the sketch starts
  */
-void Rover::setup() 
+void Rover::setup()
 {
     cliSerial = hal.console;
 
@@ -101,7 +101,7 @@ void Rover::setup()
     notify.init(false);
 
     AP_Notify::flags.failsafe_battery = false;
-    
+
     rssi.init();
 
     init_ardupilot();
@@ -124,8 +124,9 @@ void Rover::loop()
     G_Dt                = delta_us_fast_loop * 1.0e-6f;
     fast_loopTimer_us   = timer;
 
-    if (delta_us_fast_loop > G_Dt_max)
+    if (delta_us_fast_loop > G_Dt_max) {
         G_Dt_max = delta_us_fast_loop;
+    }
 
     mainLoop_count++;
 
@@ -175,8 +176,9 @@ void Rover::ahrs_update()
         ground_speed = norm(velocity.x, velocity.y);
     }
 
-    if (should_log(MASK_LOG_ATTITUDE_FAST))
+    if (should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
+    }
 
     if (should_log(MASK_LOG_IMU)) {
         DataFlash.Log_Write_IMU(ins);
@@ -205,7 +207,7 @@ void Rover::update_trigger(void)
         if (should_log(MASK_LOG_CAMERA)) {
             DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
         }
-    } 
+    }
 #endif
 }
 
@@ -259,14 +261,17 @@ void Rover::update_compass(void)
  */
 void Rover::update_logging1(void)
 {
-    if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST))
+    if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST)) {
         Log_Write_Attitude();
+    }
 
-    if (should_log(MASK_LOG_CTUN))
+    if (should_log(MASK_LOG_CTUN)) {
         Log_Write_Control_Tuning();
+    }
 
-    if (should_log(MASK_LOG_NTUN))
+    if (should_log(MASK_LOG_NTUN)) {
         Log_Write_Nav_Tuning();
+    }
 }
 
 /*
@@ -280,8 +285,9 @@ void Rover::update_logging2(void)
         }
     }
 
-    if (should_log(MASK_LOG_RC))
+    if (should_log(MASK_LOG_RC)) {
         Log_Write_RC();
+    }
 
     if (should_log(MASK_LOG_IMU)) {
         DataFlash.Log_Write_Vibration(ins);
@@ -302,8 +308,9 @@ void Rover::update_aux(void)
  */
 void Rover::one_second_loop(void)
 {
-    if (should_log(MASK_LOG_CURRENT))
+    if (should_log(MASK_LOG_CURRENT)) {
         Log_Write_Current();
+    }
     // send a heartbeat
     gcs_send_message(MSG_HEARTBEAT);
 
@@ -332,8 +339,9 @@ void Rover::one_second_loop(void)
         if (scheduler.debug() != 0) {
             hal.console->printf("G_Dt_max=%lu\n", (unsigned long)G_Dt_max);
         }
-        if (should_log(MASK_LOG_PM))
+        if (should_log(MASK_LOG_PM)) {
             Log_Write_Performance();
+        }
         G_Dt_max = 0;
         resetPerfData();
     }
@@ -347,7 +355,7 @@ void Rover::one_second_loop(void)
     }
 
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
-    
+
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not
@@ -365,7 +373,7 @@ void Rover::update_GPS_50Hz(void)
     static uint32_t last_gps_reading[GPS_MAX_INSTANCES];
     gps.update();
 
-    for (uint8_t i=0; i<gps.num_sensors(); i++) {
+    for (uint8_t i=0; i < gps.num_sensors(); i++) {
         if (gps.last_message_time_ms(i) != last_gps_reading[i]) {
             last_gps_reading[i] = gps.last_message_time_ms(i);
             if (should_log(MASK_LOG_GPS)) {
@@ -383,7 +391,7 @@ void Rover::update_GPS_10Hz(void)
     if (gps.last_message_time_ms() != last_gps_msg_ms && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
         last_gps_msg_ms = gps.last_message_time_ms();
 
-        if (ground_start_count > 1){
+        if (ground_start_count > 1) {
             ground_start_count--;
 
         } else if (ground_start_count == 1) {
@@ -397,9 +405,9 @@ void Rover::update_GPS_10Hz(void)
 
                 // set system clock for log timestamps
                 uint64_t gps_timestamp = gps.time_epoch_usec();
-                
+
                 hal.util->set_system_clock(gps_timestamp);
-                
+
                 // update signing timestamp
                 GCS_MAVLINK::update_signing_timestamp(gps_timestamp);
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -483,7 +483,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_RPM:
     case MSG_POSITION_TARGET_GLOBAL_INT:
         break;  // just here to prevent a warning
-
     }
     return true;
 }
@@ -726,7 +725,6 @@ void GCS_MAVLINK_Rover::handle_change_alt_request(AP_Mission::Mission_Command &c
 void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
-
     case MAVLINK_MSG_ID_REQUEST_DATA_STREAM:
         {
             handle_request_data_stream(msg, true);
@@ -806,7 +804,6 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             // do command
 
             switch (packet.command) {
-
             case MAV_CMD_START_RX_PAIR:
                 result = handle_rc_bind(packet);
                 break;
@@ -1476,7 +1473,6 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
     default:
         handle_common_message(msg);
         break;
-
     }  // end switch
 }  // end handle mavlink
 
@@ -1521,7 +1517,7 @@ void Rover::mavlink_delay_cb()
  */
 void Rover::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
+    for (uint8_t i=0; i < num_gcs; i++) {
         if (gcs[i].initialised) {
             gcs[i].send_message(id);
         }
@@ -1533,7 +1529,7 @@ void Rover::gcs_send_message(enum ap_message id)
  */
 void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
+    for (uint8_t i=0; i < num_gcs; i++) {
         if (gcs[i].initialised) {
             gcs[i].mission_item_reached_index = mission_index;
             gcs[i].send_message(MSG_MISSION_ITEM_REACHED);
@@ -1546,7 +1542,7 @@ void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
  */
 void Rover::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
+    for (uint8_t i=0; i < num_gcs; i++) {
         if (gcs[i].initialised) {
             gcs[i].data_stream_send();
         }
@@ -1558,7 +1554,7 @@ void Rover::gcs_data_stream_send(void)
  */
 void Rover::gcs_update(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
+    for (uint8_t i=0; i < num_gcs; i++) {
         if (gcs[i].initialised) {
 #if CLI_ENABLED == ENABLED
             gcs[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -12,10 +12,10 @@
 // User enters the string in the console to call the functions on the right.
 // See class Menu in AP_Coommon for implementation details
 static const struct Menu::command log_menu_commands[] = {
-	{"dump",	MENU_FUNC(dump_log)},
-	{"erase",	MENU_FUNC(erase_logs)},
-	{"enable",	MENU_FUNC(select_logs)},
-	{"disable",	MENU_FUNC(select_logs)}
+    {"dump",    MENU_FUNC(dump_log)},
+    {"erase",   MENU_FUNC(erase_logs)},
+    {"enable",  MENU_FUNC(select_logs)},
+    {"disable", MENU_FUNC(select_logs)}
 };
 
 // A Macro to create the Menu
@@ -23,37 +23,37 @@ MENU2(log_menu, "Log", log_menu_commands, FUNCTOR_BIND(&rover, &Rover::print_log
 
 bool Rover::print_log_menu(void)
 {
-	cliSerial->print("logs enabled: ");
+    cliSerial->print("logs enabled: ");
 
-	if (0 == g.log_bitmask) {
-		cliSerial->print("none");
-	}else{
-		// Macro to make the following code a bit easier on the eye.
-		// Pass it the capitalised name of the log option, as defined
-		// in defines.h but without the LOG_ prefix.  It will check for
-		// the bit being set and print the name of the log option to suit.
-		#define PLOG(_s)	if (g.log_bitmask & MASK_LOG_ ## _s) cliSerial->printf(" %s", #_s)
-		PLOG(ATTITUDE_FAST);
-		PLOG(ATTITUDE_MED);
-		PLOG(GPS);
-		PLOG(PM);
-		PLOG(CTUN);
-		PLOG(NTUN);
-		PLOG(MODE);
-		PLOG(IMU);
-		PLOG(CMD);
-		PLOG(CURRENT);
-		PLOG(SONAR);
-		PLOG(COMPASS);
-		PLOG(CAMERA);
-		PLOG(STEERING);
-		#undef PLOG
-	}
+    if (0 == g.log_bitmask) {
+        cliSerial->print("none");
+    } else {
+        // Macro to make the following code a bit easier on the eye.
+        // Pass it the capitalised name of the log option, as defined
+        // in defines.h but without the LOG_ prefix.  It will check for
+        // the bit being set and print the name of the log option to suit.
+        #define PLOG(_s)    if (g.log_bitmask & MASK_LOG_ ## _s) cliSerial->printf(" %s", #_s)
+        PLOG(ATTITUDE_FAST);
+        PLOG(ATTITUDE_MED);
+        PLOG(GPS);
+        PLOG(PM);
+        PLOG(CTUN);
+        PLOG(NTUN);
+        PLOG(MODE);
+        PLOG(IMU);
+        PLOG(CMD);
+        PLOG(CURRENT);
+        PLOG(SONAR);
+        PLOG(COMPASS);
+        PLOG(CAMERA);
+        PLOG(STEERING);
+        #undef PLOG
+    }
 
-	cliSerial->println();
+    cliSerial->println();
 
     DataFlash.ListAvailableLogs(cliSerial);
-	return(true);
+    return(true);
 }
 
 int8_t Rover::dump_log(uint8_t argc, const Menu::arg *argv)
@@ -93,63 +93,63 @@ int8_t Rover::erase_logs(uint8_t argc, const Menu::arg *argv)
 
 int8_t Rover::select_logs(uint8_t argc, const Menu::arg *argv)
 {
-	uint16_t	bits;
+    uint16_t bits;
 
-	if (argc != 2) {
-		cliSerial->println("missing log type");
-		return(-1);
-	}
+    if (argc != 2) {
+        cliSerial->println("missing log type");
+        return(-1);
+    }
 
-	bits = 0;
+    bits = 0;
 
-	// Macro to make the following code a bit easier on the eye.
-	// Pass it the capitalised name of the log option, as defined
-	// in defines.h but without the LOG_ prefix.  It will check for
-	// that name as the argument to the command, and set the bit in
-	// bits accordingly.
-	//
-	if (!strcasecmp(argv[1].str, "all")) {
-		bits = ~0;
-	} else {
-		#define TARG(_s)	if (!strcasecmp(argv[1].str, #_s)) bits |= MASK_LOG_ ## _s
-		TARG(ATTITUDE_FAST);
-		TARG(ATTITUDE_MED);
-		TARG(GPS);
-		TARG(PM);
-		TARG(CTUN);
-		TARG(NTUN);
-		TARG(MODE);
-		TARG(IMU);
-		TARG(CMD);
-		TARG(CURRENT);
-		TARG(SONAR);
-		TARG(COMPASS);
-		TARG(CAMERA);
-		TARG(STEERING);
-		#undef TARG
-	}
+    // Macro to make the following code a bit easier on the eye.
+    // Pass it the capitalised name of the log option, as defined
+    // in defines.h but without the LOG_ prefix.  It will check for
+    // that name as the argument to the command, and set the bit in
+    // bits accordingly.
+    //
+    if (!strcasecmp(argv[1].str, "all")) {
+        bits = ~0;
+    } else {
+        #define TARG(_s)    if (!strcasecmp(argv[1].str, #_s)) bits |= MASK_LOG_ ## _s
+        TARG(ATTITUDE_FAST);
+        TARG(ATTITUDE_MED);
+        TARG(GPS);
+        TARG(PM);
+        TARG(CTUN);
+        TARG(NTUN);
+        TARG(MODE);
+        TARG(IMU);
+        TARG(CMD);
+        TARG(CURRENT);
+        TARG(SONAR);
+        TARG(COMPASS);
+        TARG(CAMERA);
+        TARG(STEERING);
+        #undef TARG
+    }
 
-	if (!strcasecmp(argv[0].str, "enable")) {
-		g.log_bitmask.set_and_save(g.log_bitmask | bits);
-	}else{
-		g.log_bitmask.set_and_save(g.log_bitmask & ~bits);
-	}
-	return(0);
+    if (!strcasecmp(argv[0].str, "enable")) {
+        g.log_bitmask.set_and_save(g.log_bitmask | bits);
+    } else {
+        g.log_bitmask.set_and_save(g.log_bitmask & ~bits);
+    }
+    return(0);
 }
 
 int8_t Rover::process_logs(uint8_t argc, const Menu::arg *argv)
 {
-	log_menu.run();
-	return 0;
+    log_menu.run();
+    return 0;
 }
 
-#endif // CLI_ENABLED == ENABLED
+#endif  // CLI_ENABLED == ENABLED
 
 void Rover::do_erase_logs(void)
 {
-	cliSerial->printf("\nErasing log...\n");
+    cliSerial->printf("\nErasing log...\n");
     DataFlash.EraseAll();
-	cliSerial->printf("\nLog erased.\n");
+    cliSerial->printf("\nLog erased.\n");
 }
 
 
@@ -179,7 +179,7 @@ void Rover::Log_Write_Performance()
         gyro_drift_y    : (int16_t)(ahrs.get_gyro_drift().y * 1000),
         gyro_drift_z    : (int16_t)(ahrs.get_gyro_drift().z * 1000),
         i2c_lockup_count: 0,
-        ins_error_count  : ins.error_count()
+        ins_error_count : ins.error_count()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -277,16 +277,16 @@ void Rover::Log_Write_Nav_Tuning()
 // Write an attitude packet
 void Rover::Log_Write_Attitude()
 {
-    Vector3f targets(0,0,0);       // Rover does not have attitude targets, use place-holder for commonality with Dataflash Log_Write_Attitude message
+    Vector3f targets(0, 0, 0);       // Rover does not have attitude targets, use place-holder for commonality with Dataflash Log_Write_Attitude message
 
     DataFlash.Log_Write_Attitude(ahrs, targets);
 
 #if AP_AHRS_NAVEKF_AVAILABLE
- #if defined(OPTFLOW) and (OPTFLOW == ENABLED)
-    DataFlash.Log_Write_EKF(ahrs,optflow.enabled());
- #else
-    DataFlash.Log_Write_EKF(ahrs,false);
- #endif
+  #if defined(OPTFLOW) and (OPTFLOW == ENABLED)
+    DataFlash.Log_Write_EKF(ahrs, optflow.enabled());
+  #else
+    DataFlash.Log_Write_EKF(ahrs, false);
+  #endif
     DataFlash.Log_Write_AHRS2(ahrs);
 #endif
     DataFlash.Log_Write_POS(ahrs);
@@ -439,19 +439,19 @@ void Rover::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_targ
 
 const LogStructure Rover::log_structure[] = {
     LOG_COMMON_STRUCTURES,
-    { LOG_PERFORMANCE_MSG, sizeof(log_Performance), 
+    { LOG_PERFORMANCE_MSG, sizeof(log_Performance),
       "PM",  "QIHIhhhBH", "TimeUS,LTime,MLC,gDt,GDx,GDy,GDz,I2CErr,INSErr" },
-    { LOG_STARTUP_MSG, sizeof(log_Startup),         
+    { LOG_STARTUP_MSG, sizeof(log_Startup),
       "STRT", "QBH",        "TimeUS,SType,CTot" },
-    { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
+    { LOG_CTUN_MSG, sizeof(log_Control_Tuning),
       "CTUN", "Qhcchf",     "TimeUS,Steer,Roll,Pitch,ThrOut,AccY" },
-    { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
+    { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),
       "NTUN", "QHfHHbf",    "TimeUS,Yaw,WpDist,TargBrg,NavBrg,Thr,XT" },
-    { LOG_SONAR_MSG, sizeof(log_Sonar),             
+    { LOG_SONAR_MSG, sizeof(log_Sonar),
       "SONR", "QfHHHbHCb",  "TimeUS,LatAcc,S1Dist,S2Dist,DCnt,TAng,TTim,Spd,Thr" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),
       "ARM", "QBH", "TimeUS,ArmState,ArmChecks" },
-    { LOG_STEERING_MSG, sizeof(log_Steering),             
+    { LOG_STEERING_MSG, sizeof(log_Steering),
       "STER", "Qff",   "TimeUS,Demanded,Achieved" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
@@ -461,21 +461,21 @@ const LogStructure Rover::log_structure[] = {
 
 void Rover::log_init(void)
 {
-	DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
+    DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
     if (!DataFlash.CardInserted()) {
         gcs_send_text(MAV_SEVERITY_WARNING, "No dataflash card inserted");
     } else if (DataFlash.NeedPrep()) {
         gcs_send_text(MAV_SEVERITY_INFO, "Preparing log system");
         DataFlash.Prep();
         gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
-        for (uint8_t i=0; i<num_gcs; i++) {
+        for (uint8_t i=0; i < num_gcs; i++) {
             gcs[i].reset_cli_timeout();
         }
     }
 
-	if (g.log_bitmask != 0) {
-		start_logging();
-	}
+    if (g.log_bitmask != 0) {
+        start_logging();
+    }
 }
 
 #if CLI_ENABLED == ENABLED
@@ -488,11 +488,11 @@ void Rover::Log_Read(uint16_t list_entry, uint16_t start_page, uint16_t end_page
 
     cliSerial->println(HAL_BOARD_NAME);
 
-	DataFlash.LogReadProcess(list_entry, start_page, end_page,
+    DataFlash.LogReadProcess(list_entry, start_page, end_page,
                              FUNCTOR_BIND_MEMBER(&Rover::print_mode, void, AP_HAL::BetterStream *, uint8_t),
                              cliSerial);
 }
-#endif // CLI_ENABLED
+#endif  // CLI_ENABLED
 
 void Rover::Log_Write_Vehicle_Startup_Messages()
 {
@@ -502,7 +502,7 @@ void Rover::Log_Write_Vehicle_Startup_Messages()
 }
 
 // start a new log
-void Rover::start_logging() 
+void Rover::start_logging()
 {
     in_mavlink_delay = true;
     DataFlash.set_mission(&mission);
@@ -513,7 +513,7 @@ void Rover::start_logging()
     in_mavlink_delay = false;
 }
 
-#else // LOGGING_ENABLED
+#else  // LOGGING_ENABLED
 
 // dummy functions
 void Rover::Log_Write_Startup(uint8_t type) {}
@@ -527,4 +527,4 @@ void Rover::Log_Write_Attitude() {}
 void Rover::start_logging() {}
 void Rover::Log_Write_RC(void) {}
 
-#endif // LOGGING_ENABLED
+#endif  // LOGGING_ENABLED

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -14,14 +14,14 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: Eeprom format version number
     // @Description: This value is incremented when changes are made to the eeprom format
     // @User: Advanced
-	GSCALAR(format_version,         "FORMAT_VERSION",   1),
-    
+    GSCALAR(format_version,         "FORMAT_VERSION",   1),
+
     // @Param: SYSID_SW_TYPE
     // @DisplayName: Software Type
     // @Description: This is used by the ground station to recognise the software type (eg ArduPlane vs ArduCopter)
     // @User: Advanced
     // @ReadOnly: True
-	GSCALAR(software_type,          "SYSID_SW_TYPE",    Parameters::k_software_type),
+    GSCALAR(software_type,          "SYSID_SW_TYPE",    Parameters::k_software_type),
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
@@ -29,40 +29,40 @@ const AP_Param::Info Rover::var_info[] = {
     // @Values: 0:Disabled,5190:APM2-Default,65535:PX4/Pixhawk-Default
     // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:SONAR,15:ARM/DISARM,19:IMU_RAW
     // @User: Advanced
-	GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
+    GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 
     // @Param: SYS_NUM_RESETS
     // @DisplayName: Num Resets
     // @Description: Number of APM board resets
     // @User: Advanced
-	GSCALAR(num_resets,             "SYS_NUM_RESETS",   0),
+    GSCALAR(num_resets,             "SYS_NUM_RESETS",   0),
 
     // @Param: RST_SWITCH_CH
     // @DisplayName: Reset Switch Channel
-    // @Description: RC channel to use to reset to last flight mode	after geofence takeover.
+    // @Description: RC channel to use to reset to last flight mode after geofence takeover.
     // @User: Advanced
-	GSCALAR(reset_switch_chan,      "RST_SWITCH_CH",    0),
+    GSCALAR(reset_switch_chan,      "RST_SWITCH_CH",    0),
 
     // @Param: INITIAL_MODE
     // @DisplayName: Initial driving mode
     // @Description: This selects the mode to start in on boot. This is useful for when you want to start in AUTO mode on boot without a receiver. Usually used in combination with when AUTO_TRIGGER_PIN or AUTO_KICKSTART.
     // @Values: 0:MANUAL,2:LEARNING,3:STEERING,4:HOLD,10:AUTO,11:RTL,15:GUIDED
     // @User: Advanced
-	GSCALAR(initial_mode,        "INITIAL_MODE",     MANUAL),
+    GSCALAR(initial_mode,        "INITIAL_MODE",     MANUAL),
 
     // @Param: SYSID_THIS_MAV
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network
     // @Range: 1 255
     // @User: Advanced
-	GSCALAR(sysid_this_mav,         "SYSID_THISMAV",    MAV_SYSTEM_ID),
+    GSCALAR(sysid_this_mav,         "SYSID_THISMAV",    MAV_SYSTEM_ID),
 
     // @Param: SYSID_MYGCS
     // @DisplayName: MAVLink ground station ID
     // @Description: The identifier of the ground station in the MAVLink protocol. Don't change this unless you also modify the ground station to match.
     // @Range: 1 255
     // @User: Advanced
-	GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",      255),
+    GSCALAR(sysid_my_gcs,           "SYSID_MYGCS",      255),
 
 #if CLI_ENABLED == ENABLED
     // @Param: CLI_ENABLED
@@ -74,7 +74,7 @@ const AP_Param::Info Rover::var_info[] = {
 #endif
 
     // @Param: TELEM_DELAY
-    // @DisplayName: Telemetry startup delay 
+    // @DisplayName: Telemetry startup delay
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Standard
     // @Units: seconds
@@ -95,23 +95,23 @@ const AP_Param::Info Rover::var_info[] = {
     // @Description: Setting this to Enabled(1) will enable the compass. Setting this to Disabled(0) will disable the compass. Note that this is separate from COMPASS_USE. This will enable the low level senor, and will enable logging of magnetometer data. To use the compass for navigation you must also set COMPASS_USE to 1.
     // @User: Standard
     // @Values: 0:Disabled,1:Enabled
-	GSCALAR(compass_enabled,        "MAG_ENABLE",       MAGNETOMETER),
+    GSCALAR(compass_enabled,        "MAG_ENABLE",       MAGNETOMETER),
 
-	// @Param: AUTO_TRIGGER_PIN
-	// @DisplayName: Auto mode trigger pin
-	// @Description: pin number to use to enable the throttle in auto mode. If set to -1 then don't use a trigger, otherwise this is a pin number which if held low in auto mode will enable the motor to run. If the switch is released while in AUTO then the motor will stop again. This can be used in combination with INITIAL_MODE to give a 'press button to start' rover with no receiver.
-	// @Values: -1:Disabled, 0-8:APM TriggerPin, 50-55: Pixhawk TriggerPin
-	// @User: standard
-	GSCALAR(auto_trigger_pin,        "AUTO_TRIGGER_PIN", -1),
+    // @Param: AUTO_TRIGGER_PIN
+    // @DisplayName: Auto mode trigger pin
+    // @Description: pin number to use to enable the throttle in auto mode. If set to -1 then don't use a trigger, otherwise this is a pin number which if held low in auto mode will enable the motor to run. If the switch is released while in AUTO then the motor will stop again. This can be used in combination with INITIAL_MODE to give a 'press button to start' rover with no receiver.
+    // @Values: -1:Disabled, 0-8:APM TriggerPin, 50-55: Pixhawk TriggerPin
+    // @User: standard
+    GSCALAR(auto_trigger_pin,        "AUTO_TRIGGER_PIN", -1),
 
-	// @Param: AUTO_KICKSTART
-	// @DisplayName: Auto mode trigger kickstart acceleration
-	// @Description: X acceleration in meters/second/second to use to trigger the motor start in auto mode. If set to zero then auto throttle starts immediately when the mode switch happens, otherwise the rover waits for the X acceleration to go above this value before it will start the motor
-	// @Units: m/s/s
-	// @Range: 0 20
-	// @Increment: 0.1
-	// @User: standard
-	GSCALAR(auto_kickstart,          "AUTO_KICKSTART", 0.0f),
+    // @Param: AUTO_KICKSTART
+    // @DisplayName: Auto mode trigger kickstart acceleration
+    // @Description: X acceleration in meters/second/second to use to trigger the motor start in auto mode. If set to zero then auto throttle starts immediately when the mode switch happens, otherwise the rover waits for the X acceleration to go above this value before it will start the motor
+    // @Units: m/s/s
+    // @Range: 0 20
+    // @Increment: 0.1
+    // @User: standard
+    GSCALAR(auto_kickstart,          "AUTO_KICKSTART", 0.0f),
 
     // @Param: CRUISE_SPEED
     // @DisplayName: Target cruise speed in auto modes
@@ -120,7 +120,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
-	GSCALAR(speed_cruise,        "CRUISE_SPEED",    SPEED_CRUISE),
+    GSCALAR(speed_cruise,        "CRUISE_SPEED",    SPEED_CRUISE),
 
     // @Param: SPEED_TURN_GAIN
     // @DisplayName: Target speed reduction while turning
@@ -129,7 +129,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(speed_turn_gain,    "SPEED_TURN_GAIN",  50),
+    GSCALAR(speed_turn_gain,    "SPEED_TURN_GAIN",  50),
 
     // @Param: SPEED_TURN_DIST
     // @DisplayName: Distance to turn to start reducing speed
@@ -138,7 +138,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
-	GSCALAR(speed_turn_dist,    "SPEED_TURN_DIST",  2.0f),
+    GSCALAR(speed_turn_dist,    "SPEED_TURN_DIST",  2.0f),
 
     // @Param: BRAKING_PERCENT
     // @DisplayName: Percentage braking to apply
@@ -147,7 +147,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(braking_percent,    "BRAKING_PERCENT",  0),
+    GSCALAR(braking_percent,    "BRAKING_PERCENT",  0),
 
     // @Param: BRAKING_SPEEDERR
     // @DisplayName: Speed error at which to apply braking
@@ -156,7 +156,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(braking_speederr,   "BRAKING_SPEEDERR",  3),
+    GSCALAR(braking_speederr,   "BRAKING_SPEEDERR",  3),
 
     // @Param: PIVOT_TURN_ANGLE
     // @DisplayName: Pivot turn angle
@@ -165,46 +165,46 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 360
     // @Increment: 1
     // @User: Standard
-	GSCALAR(pivot_turn_angle,   "PIVOT_TURN_ANGLE",  30),
+    GSCALAR(pivot_turn_angle,   "PIVOT_TURN_ANGLE",  30),
 
     // @Param: CH7_OPTION
     // @DisplayName: Channel 7 option
     // @Description: What to do use channel 7 for
     // @Values: 0:Nothing,1:LearnWaypoint
     // @User: Standard
-	GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
+    GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
 
     // @Group: RC1_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp
-	GGROUP(rc_1,                    "RC1_", RC_Channel),
+    GGROUP(rc_1,                    "RC1_", RC_Channel),
 
     // @Group: RC2_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp
-	GGROUP(rc_2,                    "RC2_", RC_Channel_aux),
+    GGROUP(rc_2,                    "RC2_", RC_Channel_aux),
 
     // @Group: RC3_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp
-	GGROUP(rc_3,                    "RC3_", RC_Channel),
+    GGROUP(rc_3,                    "RC3_", RC_Channel),
 
     // @Group: RC4_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
-	GGROUP(rc_4,                    "RC4_", RC_Channel_aux),
+    GGROUP(rc_4,                    "RC4_", RC_Channel_aux),
 
     // @Group: RC5_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
-	GGROUP(rc_5,                    "RC5_", RC_Channel_aux),
+    GGROUP(rc_5,                    "RC5_", RC_Channel_aux),
 
     // @Group: RC6_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
-	GGROUP(rc_6,                    "RC6_", RC_Channel_aux),
+    GGROUP(rc_6,                    "RC6_", RC_Channel_aux),
 
     // @Group: RC7_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
-	GGROUP(rc_7,                    "RC7_", RC_Channel_aux),
+    GGROUP(rc_7,                    "RC7_", RC_Channel_aux),
 
     // @Group: RC8_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
-	GGROUP(rc_8,                    "RC8_", RC_Channel_aux),
+    GGROUP(rc_8,                    "RC8_", RC_Channel_aux),
 
     // @Group: RC9_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp,../libraries/RC_Channel/RC_Channel_aux.cpp
@@ -237,7 +237,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(throttle_min,           "THR_MIN",          THROTTLE_MIN),
+    GSCALAR(throttle_min,           "THR_MIN",          THROTTLE_MIN),
 
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
@@ -246,7 +246,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(throttle_max,           "THR_MAX",          THROTTLE_MAX),
+    GSCALAR(throttle_max,           "THR_MAX",          THROTTLE_MAX),
 
     // @Param: CRUISE_THROTTLE
     // @DisplayName: Base throttle percentage in auto
@@ -255,7 +255,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(throttle_cruise,        "CRUISE_THROTTLE",    50),
+    GSCALAR(throttle_cruise,        "CRUISE_THROTTLE",    50),
 
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
@@ -264,42 +264,42 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(throttle_slewrate,      "THR_SLEWRATE",     100),
+    GSCALAR(throttle_slewrate,      "THR_SLEWRATE",     100),
 
     // @Param: SKID_STEER_OUT
     // @DisplayName: Skid steering output
     // @Description: Set this to 1 for skid steering controlled rovers (tank track style). When enabled, servo1 is used for the left track control, servo3 is used for right track control
     // @Values: 0:Disabled, 1:SkidSteeringOutput
     // @User: Standard
-	GSCALAR(skid_steer_out,          "SKID_STEER_OUT",     0),
+    GSCALAR(skid_steer_out,          "SKID_STEER_OUT",     0),
 
     // @Param: SKID_STEER_IN
     // @DisplayName: Skid steering input
     // @Description: Set this to 1 for skid steering input rovers (tank track style in RC controller). When enabled, servo1 is used for the left track control, servo3 is used for right track control
     // @Values: 0:Disabled, 1:SkidSteeringInput
     // @User: Standard
-	GSCALAR(skid_steer_in,           "SKID_STEER_IN",     0),
+    GSCALAR(skid_steer_in,           "SKID_STEER_IN",     0),
 
     // @Param: FS_ACTION
     // @DisplayName: Failsafe Action
     // @Description: What to do on a failsafe event
     // @Values: 0:Nothing,1:RTL,2:HOLD
     // @User: Standard
-	GSCALAR(fs_action,    "FS_ACTION",     2),
+    GSCALAR(fs_action,    "FS_ACTION",     2),
 
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout
     // @Description: How long a failsafe event need to happen for before we trigger the failsafe action
-	// @Units: seconds
+    // @Units: seconds
     // @User: Standard
-	GSCALAR(fs_timeout,    "FS_TIMEOUT",     5),
+    GSCALAR(fs_timeout,    "FS_TIMEOUT",     5),
 
     // @Param: FS_THR_ENABLE
     // @DisplayName: Throttle Failsafe Enable
     // @Description: The throttle failsafe allows you to configure a software failsafe activated by a setting on the throttle input channel to a low value. This can be used to detect the RC transmitter going out of range. Failsafe will be triggered when the throttle channel goes below the FS_THR_VALUE for FS_TIMEOUT seconds.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-	GSCALAR(fs_throttle_enabled,    "FS_THR_ENABLE",     1),
+    GSCALAR(fs_throttle_enabled,    "FS_THR_ENABLE",     1),
 
     // @Param: FS_THR_VALUE
     // @DisplayName: Throttle Failsafe Value
@@ -307,14 +307,14 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 925 1100
     // @Increment: 1
     // @User: Standard
-	GSCALAR(fs_throttle_value,      "FS_THR_VALUE",     910),
+    GSCALAR(fs_throttle_value,      "FS_THR_VALUE",     910),
 
     // @Param: FS_GCS_ENABLE
     // @DisplayName: GCS failsafe enable
     // @Description: Enable ground control station telemetry failsafe. When enabled the Rover will execute the FS_ACTION when it fails to receive MAVLink heartbeat packets for FS_TIMEOUT seconds.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-	GSCALAR(fs_gcs_enabled, "FS_GCS_ENABLE",   0),
+    GSCALAR(fs_gcs_enabled, "FS_GCS_ENABLE",   0),
 
     // @Param: FS_CRASH_CHECK
     // @DisplayName: Crash check action
@@ -323,94 +323,94 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Standard
     GSCALAR(fs_crash_check, "FS_CRASH_CHECK",    FS_CRASH_HOLD),
 
-	// @Param: RNGFND_TRIGGR_CM
-	// @DisplayName: Rangefinder trigger distance
-	// @Description: The distance from an obstacle in centimeters at which the rangefinder triggers a turn to avoid the obstacle
-	// @Units: centimeters
+    // @Param: RNGFND_TRIGGR_CM
+    // @DisplayName: Rangefinder trigger distance
+    // @Description: The distance from an obstacle in centimeters at which the rangefinder triggers a turn to avoid the obstacle
+    // @Units: centimeters
     // @Range: 0 1000
     // @Increment: 1
-	// @User: Standard
-	GSCALAR(sonar_trigger_cm,   "RNGFND_TRIGGR_CM",    100),
+    // @User: Standard
+    GSCALAR(sonar_trigger_cm,   "RNGFND_TRIGGR_CM",    100),
 
-	// @Param: RNGFND_TURN_ANGL
-	// @DisplayName: Rangefinder trigger angle
-	// @Description: The course deviation in degrees to apply while avoiding an obstacle detected with the rangefinder. A positive number means to turn right, and a negative angle means to turn left.
-	// @Units: centimeters
+    // @Param: RNGFND_TURN_ANGL
+    // @DisplayName: Rangefinder trigger angle
+    // @Description: The course deviation in degrees to apply while avoiding an obstacle detected with the rangefinder. A positive number means to turn right, and a negative angle means to turn left.
+    // @Units: centimeters
     // @Range: -45 45
     // @Increment: 1
-	// @User: Standard
-	GSCALAR(sonar_turn_angle,   "RNGFND_TURN_ANGL",    45),
+    // @User: Standard
+    GSCALAR(sonar_turn_angle,   "RNGFND_TURN_ANGL",    45),
 
-	// @Param: RNGFND_TURN_TIME
-	// @DisplayName: Rangefinder turn time
-	// @Description: The amount of time in seconds to apply the RNGFND_TURN_ANGL after detecting an obstacle.
-	// @Units: seconds
+    // @Param: RNGFND_TURN_TIME
+    // @DisplayName: Rangefinder turn time
+    // @Description: The amount of time in seconds to apply the RNGFND_TURN_ANGL after detecting an obstacle.
+    // @Units: seconds
     // @Range: 0 100
     // @Increment: 0.1
-	// @User: Standard
-	GSCALAR(sonar_turn_time,    "RNGFND_TURN_TIME",     1.0f),
+    // @User: Standard
+    GSCALAR(sonar_turn_time,    "RNGFND_TURN_TIME",     1.0f),
 
-	// @Param: RNGFND_DEBOUNCE
-	// @DisplayName: Rangefinder debounce count
-	// @Description: The number of 50Hz rangefinder hits needed to trigger an obstacle avoidance event. If you get a lot of false sonar events then raise this number, but if you make it too large then it will cause lag in detecting obstacles, which could cause you go hit the obstacle.
+    // @Param: RNGFND_DEBOUNCE
+    // @DisplayName: Rangefinder debounce count
+    // @Description: The number of 50Hz rangefinder hits needed to trigger an obstacle avoidance event. If you get a lot of false sonar events then raise this number, but if you make it too large then it will cause lag in detecting obstacles, which could cause you go hit the obstacle.
     // @Range: 1 100
     // @Increment: 1
-	// @User: Standard
-	GSCALAR(sonar_debounce,   "RNGFND_DEBOUNCE",    2),
+    // @User: Standard
+    GSCALAR(sonar_debounce,   "RNGFND_DEBOUNCE",    2),
 
     // @Param: LEARN_CH
     // @DisplayName: Learning channel
     // @Description: RC Channel to use for learning waypoints
     // @User: Advanced
-	GSCALAR(learn_channel,    "LEARN_CH",       7),
+    GSCALAR(learn_channel,    "LEARN_CH",       7),
 
     // @Param: MODE_CH
     // @DisplayName: Mode channel
     // @Description: RC Channel to use for driving mode control
     // @User: Advanced
-	GSCALAR(mode_channel,    "MODE_CH",       MODE_CHANNEL),
+    GSCALAR(mode_channel,    "MODE_CH",       MODE_CHANNEL),
 
     // @Param: MODE1
     // @DisplayName: Mode1
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
     // @Description: Driving mode for switch position 1 (910 to 1230 and above 2049)
-	GSCALAR(mode1,           "MODE1",         MODE_1),
+    GSCALAR(mode1,           "MODE1",         MODE_1),
 
     // @Param: MODE2
     // @DisplayName: Mode2
     // @Description: Driving mode for switch position 2 (1231 to 1360)
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
-	GSCALAR(mode2,           "MODE2",         MODE_2),
+    GSCALAR(mode2,           "MODE2",         MODE_2),
 
     // @Param: MODE3
     // @DisplayName: Mode3
     // @Description: Driving mode for switch position 3 (1361 to 1490)
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
-	GSCALAR(mode3,           "MODE3",         MODE_3),
+    GSCALAR(mode3,           "MODE3",         MODE_3),
 
     // @Param: MODE4
     // @DisplayName: Mode4
     // @Description: Driving mode for switch position 4 (1491 to 1620)
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
-	GSCALAR(mode4,           "MODE4",         MODE_4),
+    GSCALAR(mode4,           "MODE4",         MODE_4),
 
     // @Param: MODE5
     // @DisplayName: Mode5
     // @Description: Driving mode for switch position 5 (1621 to 1749)
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
-	GSCALAR(mode5,           "MODE5",         MODE_5),
+    GSCALAR(mode5,           "MODE5",         MODE_5),
 
     // @Param: MODE6
     // @DisplayName: Mode6
     // @Description: Driving mode for switch position 6 (1750 to 2049)
     // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
     // @User: Standard
-	GSCALAR(mode6,           "MODE6",         MODE_6),
+    GSCALAR(mode6,           "MODE6",         MODE_6),
 
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint radius
@@ -419,7 +419,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0 1000
     // @Increment: 0.1
     // @User: Standard
-	GSCALAR(waypoint_radius,        "WP_RADIUS",        2.0f),
+    GSCALAR(waypoint_radius,        "WP_RADIUS",        2.0f),
 
     // @Param: TURN_MAX_G
     // @DisplayName: Turning maximum G force
@@ -428,19 +428,19 @@ const AP_Param::Info Rover::var_info[] = {
     // @Range: 0.2 10
     // @Increment: 0.1
     // @User: Standard
-	GSCALAR(turn_max_g,             "TURN_MAX_G",      2.0f),
+    GSCALAR(turn_max_g,             "TURN_MAX_G",      2.0f),
 
     // @Group: STEER2SRV_
     // @Path: ../libraries/APM_Control/AP_SteerController.cpp
-	GOBJECT(steerController,        "STEER2SRV_",   AP_SteerController),
+    GOBJECT(steerController,        "STEER2SRV_",   AP_SteerController),
 
-	GGROUP(pidSpeedThrottle,        "SPEED2THR_", PID),
+    GGROUP(pidSpeedThrottle,        "SPEED2THR_", PID),
 
-	// variables not in the g class which contain EEPROM saved variables
+    // variables not in the g class which contain EEPROM saved variables
 
     // @Group: COMPASS_
     // @Path: ../libraries/AP_Compass/AP_Compass.cpp
-	GOBJECT(compass,                "COMPASS_",	Compass),
+    GOBJECT(compass,                "COMPASS_", Compass),
 
     // @Group: SCHED_
     // @Path: ../libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -548,10 +548,10 @@ const AP_Param::Info Rover::var_info[] = {
     // @Group: MIS_
     // @Path: ../libraries/AP_Mission/AP_Mission.cpp
     GOBJECT(mission, "MIS_",       AP_Mission),
-    
+
     // @Group: RSSI_
     // @Path: ../libraries/AP_RSSI/AP_RSSI.cpp
-    GOBJECT(rssi, "RSSI_",  AP_RSSI),        
+    GOBJECT(rssi, "RSSI_",  AP_RSSI),
 
     // @Group: NTF_
     // @Path: ../libraries/AP_Notify/AP_Notify.cpp
@@ -565,14 +565,13 @@ const AP_Param::Info Rover::var_info[] = {
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),
 
-	AP_VAREND
+    AP_VAREND
 };
 
 /*
   2nd group of parameters
  */
 const AP_Param::GroupInfo ParametersG2::var_info[] = {
-
     // @Group: STAT
     // @Path: ../libraries/AP_Stats/AP_Stats.cpp
     AP_SUBGROUPINFO(stats, "STAT", 1, ParametersG2, AP_Stats),
@@ -621,22 +620,21 @@ void Rover::load_parameters(void)
         AP_HAL::panic("Bad var table");
     }
 
-	if (!g.format_version.load() ||
-	     g.format_version != Parameters::k_format_version) {
+    if (!g.format_version.load() ||
+         g.format_version != Parameters::k_format_version) {
+        // erase all parameters
+        cliSerial->println("Firmware change: erasing EEPROM...");
+        AP_Param::erase_all();
 
-		// erase all parameters
-		cliSerial->println("Firmware change: erasing EEPROM...");
-		AP_Param::erase_all();
-
-		// save the current format version
-		g.format_version.set_and_save(Parameters::k_format_version);
-		cliSerial->println("done.");
+        // save the current format version
+        g.format_version.set_and_save(Parameters::k_format_version);
+        cliSerial->println("done.");
     }
 
     unsigned long before = micros();
     // Load all auto-loaded EEPROM variables
     AP_Param::load_all();
-    
+
     cliSerial->printf("load_all took %luus\n", micros() - before);
 
     // set a more reasonable default NAVL1_PERIOD for rovers

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -21,11 +21,11 @@ public:
         // Layout version number, always key zero.
         //
         k_param_format_version = 0,
-		k_param_software_type,
+        k_param_software_type,
 
         // Misc
         //
-        k_param_log_bitmask_old = 10, // unused
+        k_param_log_bitmask_old = 10,  // unused
         k_param_num_resets,
         k_param_reset_switch_chan,
         k_param_initial_mode,
@@ -37,7 +37,7 @@ public:
         k_param_rc_14,
 
         // IO pins
-        k_param_rssi_pin = 20,      // unused, replaced by rssi_ library parameters
+        k_param_rssi_pin = 20,  // unused, replaced by rssi_ library parameters
         k_param_battery_volt_pin,
         k_param_battery_curr_pin,
 
@@ -57,18 +57,18 @@ public:
 
         // 100: Arming parameters
         k_param_arming = 100,
-                
+
         // 110: Telemetry control
         //
-        k_param_gcs0 = 110, // stream rates for uartA
-        k_param_gcs1,       // stream rates for uartC
+        k_param_gcs0 = 110,         // stream rates for uartA
+        k_param_gcs1,               // stream rates for uartC
         k_param_sysid_this_mav,
         k_param_sysid_my_gcs,
         k_param_serial0_baud_old,
         k_param_serial1_baud_old,
         k_param_telem_delay,
-        k_param_skip_gyro_cal, // unused
-        k_param_gcs2,       // stream rates for uartD
+        k_param_skip_gyro_cal,      // unused
+        k_param_gcs2,               // stream rates for uartD
         k_param_serial2_baud_old,
         k_param_serial2_protocol,   // deprecated, can be deleted
         k_param_serial_manager,     // serial manager library
@@ -80,20 +80,20 @@ public:
         // 130: Sensor parameters
         //
         k_param_compass_enabled = 130,
-        k_param_steering_learn, // unused
-        k_param_NavEKF, // deprecated - remove
-        k_param_mission, // mission library
-        k_param_NavEKF2_old, // deprecated - remove
+        k_param_steering_learn,     // unused
+        k_param_NavEKF,             // deprecated - remove
+        k_param_mission,            // mission library
+        k_param_NavEKF2_old,        // deprecated - remove
         k_param_NavEKF2,
-        k_param_g2, // 2nd block of parameters
+        k_param_g2,                 // 2nd block of parameters
         k_param_NavEKF3,
 
         // 140: battery controls
         k_param_battery_monitoring = 140,   // deprecated, can be deleted
-        k_param_volt_div_ratio,     // deprecated, can be deleted
-        k_param_curr_amp_per_volt,  // deprecated, can be deleted
-        k_param_input_voltage, // deprecated, can be deleted
-        k_param_pack_capacity,      // deprecated, can be deleted
+        k_param_volt_div_ratio,             // deprecated, can be deleted
+        k_param_curr_amp_per_volt,          // deprecated, can be deleted
+        k_param_input_voltage,              // deprecated, can be deleted
+        k_param_pack_capacity,              // deprecated, can be deleted
         k_param_battery,
 
         //
@@ -107,7 +107,7 @@ public:
         k_param_ch7_option,
         k_param_auto_trigger_pin,
         k_param_auto_kickstart,
-        k_param_turn_circle, // unused
+        k_param_turn_circle,  // unused
         k_param_turn_max_g,
 
         //
@@ -140,15 +140,15 @@ public:
         k_param_fs_crash_check,
 
         // obstacle control
-        k_param_sonar_enabled = 190, // deprecated, can be removed
-        k_param_sonar_old, // unused
+        k_param_sonar_enabled = 190,  // deprecated, can be removed
+        k_param_sonar_old,            // unused
         k_param_sonar_trigger_cm,
         k_param_sonar_turn_angle,
         k_param_sonar_turn_time,
-        k_param_sonar2_old, // unused
+        k_param_sonar2_old,           // unused
         k_param_sonar_debounce,
-        k_param_sonar, // sonar object
-        
+        k_param_sonar,                // sonar object
+
         //
         // 210: driving modes
         //
@@ -178,7 +178,7 @@ public:
         //
         // 240: PID Controllers
         k_param_pidNavSteer = 230,
-        k_param_pidServoSteer, // unused
+        k_param_pidServoSteer,  // unused
         k_param_pidSpeedThrottle,
 
         // high RC channels
@@ -199,43 +199,43 @@ public:
         k_param_notify,
         k_param_button,
 
-        k_param_DataFlash = 253, // Logging Group
+        k_param_DataFlash = 253,  // Logging Group
 
         // 254,255: reserved
         };
 
     AP_Int16    format_version;
-	AP_Int8	    software_type;
+    AP_Int8     software_type;
 
     // Misc
     //
     AP_Int32    log_bitmask;
     AP_Int16    num_resets;
-    AP_Int8	    reset_switch_chan;
+    AP_Int8     reset_switch_chan;
     AP_Int8     initial_mode;
 
     // braking
     AP_Int8     braking_percent;
     AP_Float    braking_speederr;
 
-	// Telemetry control
-	//
-	AP_Int16    sysid_this_mav;
-	AP_Int16    sysid_my_gcs;
+    // Telemetry control
+    //
+    AP_Int16    sysid_this_mav;
+    AP_Int16    sysid_my_gcs;
     AP_Int8     telem_delay;
 #if CLI_ENABLED == ENABLED
     AP_Int8     cli_enabled;
 #endif
 
     // sensor parameters
-    AP_Int8	    compass_enabled; 
+    AP_Int8     compass_enabled;
 
     // navigation parameters
     //
     AP_Float    speed_cruise;
     AP_Int8     speed_turn_gain;
-    AP_Float    speed_turn_dist;    
-    AP_Int8	    ch7_option;
+    AP_Float    speed_turn_dist;
+    AP_Int8     ch7_option;
     AP_Int8     auto_trigger_pin;
     AP_Float    auto_kickstart;
     AP_Float    turn_max_g;
@@ -244,13 +244,13 @@ public:
 
     // RC channels
     RC_Channel      rc_1;
-    RC_Channel_aux	rc_2;
+    RC_Channel_aux  rc_2;
     RC_Channel      rc_3;
     RC_Channel_aux  rc_4;
-    RC_Channel_aux	rc_5;
-    RC_Channel_aux	rc_6;
-    RC_Channel_aux	rc_7;
-    RC_Channel_aux	rc_8;
+    RC_Channel_aux  rc_5;
+    RC_Channel_aux  rc_6;
+    RC_Channel_aux  rc_7;
+    RC_Channel_aux  rc_8;
     RC_Channel_aux  rc_9;
     RC_Channel_aux  rc_10;
     RC_Channel_aux  rc_11;
@@ -272,7 +272,7 @@ public:
     AP_Float    fs_timeout;
     AP_Int8     fs_throttle_enabled;
     AP_Int16    fs_throttle_value;
-	AP_Int8	    fs_gcs_enabled;
+    AP_Int8     fs_gcs_enabled;
     AP_Int8     fs_crash_check;
 
     // obstacle control
@@ -280,7 +280,7 @@ public:
     AP_Float    sonar_turn_angle;
     AP_Float    sonar_turn_time;
     AP_Int8     sonar_debounce;
-    
+
 
     // driving modes
     //
@@ -292,7 +292,7 @@ public:
     AP_Int8     mode5;
     AP_Int8     mode6;
     AP_Int8     learn_channel;
-    
+
     // Waypoints
     //
     AP_Float    waypoint_radius;
@@ -339,8 +339,6 @@ public:
 
     // whether to enforce acceptance of packets only from sysid_my_gcs
     AP_Int8 sysid_enforce;
-
 };
-
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -26,37 +26,37 @@
 #include <AP_Menu/AP_Menu.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
-#include <AP_GPS/AP_GPS.h>         // ArduPilot GPS library
-#include <AP_ADC/AP_ADC.h>         // ArduPilot Mega Analog to Digital Converter Library
+#include <AP_GPS/AP_GPS.h>                          // ArduPilot GPS library
+#include <AP_ADC/AP_ADC.h>                          // ArduPilot Mega Analog to Digital Converter Library
 #include <AP_Baro/AP_Baro.h>
-#include <AP_Compass/AP_Compass.h>     // ArduPilot Mega Magnetometer Library
-#include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
-#include <AP_InertialSensor/AP_InertialSensor.h> // Inertial Sensor (uncalibated IMU) Library
+#include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library
+#include <AP_Math/AP_Math.h>                        // ArduPilot Mega Vector/Matrix math Library
+#include <AP_InertialSensor/AP_InertialSensor.h>    // Inertial Sensor (uncalibated IMU) Library
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
-#include <AP_AHRS/AP_AHRS.h>         // ArduPilot Mega DCM Library
+#include <AP_AHRS/AP_AHRS.h>                        // ArduPilot Mega DCM Library
 #include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_NavEKF3/AP_NavEKF3.h>
-#include <AP_Mission/AP_Mission.h>     // Mission command library
+#include <AP_Mission/AP_Mission.h>                  // Mission command library
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Terrain/AP_Terrain.h>
-#include <PID/PID.h>            // PID library
-#include <RC_Channel/RC_Channel.h>     // RC Channel Library
-#include <AP_RangeFinder/AP_RangeFinder.h>	// Range finder library
-#include <Filter/Filter.h>			// Filter library
-#include <Filter/Butter.h>			// Filter library - butterworth filter
-#include <AP_Buffer/AP_Buffer.h>      // FIFO buffer library
-#include <Filter/ModeFilter.h>		// Mode Filter from Filter library
-#include <Filter/AverageFilter.h>	// Mode Filter from Filter library
-#include <AP_Relay/AP_Relay.h>       // APM relay
+#include <PID/PID.h>                                // PID library
+#include <RC_Channel/RC_Channel.h>                  // RC Channel Library
+#include <AP_RangeFinder/AP_RangeFinder.h>          // Range finder library
+#include <Filter/Filter.h>                          // Filter library
+#include <Filter/Butter.h>                          // Filter library - butterworth filter
+#include <AP_Buffer/AP_Buffer.h>                    // FIFO buffer library
+#include <Filter/ModeFilter.h>                      // Mode Filter from Filter library
+#include <Filter/AverageFilter.h>                   // Mode Filter from Filter library
+#include <AP_Relay/AP_Relay.h>                      // APM relay
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
-#include <AP_Mount/AP_Mount.h>		// Camera/Antenna mount
-#include <AP_Camera/AP_Camera.h>		// Camera triggering
-#include <AP_SerialManager/AP_SerialManager.h>   // Serial manager library
-#include <AP_Airspeed/AP_Airspeed.h>    // needed for AHRS build
-#include <AP_Vehicle/AP_Vehicle.h>     // needed for AHRS build
+#include <AP_Mount/AP_Mount.h>                      // Camera/Antenna mount
+#include <AP_Camera/AP_Camera.h>                    // Camera triggering
+#include <AP_SerialManager/AP_SerialManager.h>      // Serial manager library
+#include <AP_Airspeed/AP_Airspeed.h>                // needed for AHRS build
+#include <AP_Vehicle/AP_Vehicle.h>                  // needed for AHRS build
 #include <DataFlash/DataFlash.h>
-#include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library
-#include <AP_Scheduler/AP_Scheduler.h>       // main loop scheduler
+#include <AP_RCMapper/AP_RCMapper.h>                // RC input mapping library
+#include <AP_Scheduler/AP_Scheduler.h>              // main loop scheduler
 #include <AP_Navigation/AP_Navigation.h>
 #include <APM_Control/APM_Control.h>
 #include <AP_L1_Control/AP_L1_Control.h>
@@ -66,12 +66,12 @@
 #include <AP_Arming/AP_Arming.h>
 #include "compat.h"
 
-#include <AP_Notify/AP_Notify.h>      // Notify library
-#include <AP_BattMonitor/AP_BattMonitor.h> // Battery monitor library
-#include <AP_OpticalFlow/AP_OpticalFlow.h>     // Optical Flow library
-#include <AP_RSSI/AP_RSSI.h>                   // RSSI Library
+#include <AP_Notify/AP_Notify.h>                    // Notify library
+#include <AP_BattMonitor/AP_BattMonitor.h>          // Battery monitor library
+#include <AP_OpticalFlow/AP_OpticalFlow.h>          // Optical Flow library
+#include <AP_RSSI/AP_RSSI.h>                        // RSSI Library
 #include <AP_Button/AP_Button.h>
-#include <AP_Stats/AP_Stats.h>     // statistics library
+#include <AP_Stats/AP_Stats.h>                      // statistics library
 #include <AP_Beacon/AP_Beacon.h>
 
 // Configuration
@@ -82,7 +82,7 @@
 #include "Parameters.h"
 #include "GCS_Mavlink.h"
 
-#include <AP_Declination/AP_Declination.h> // ArduPilot Mega Declination Helper Library
+#include <AP_Declination/AP_Declination.h>          // ArduPilot Mega Declination Helper Library
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
@@ -139,9 +139,9 @@ private:
     AP_Button button;
 
     // flight modes convenience array
-    AP_Int8	*modes;
+    AP_Int8 *modes;
 
-// Inertial Navigation EKF
+    // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
     NavEKF2 EKF2{&ahrs, barometer, sonar};
     NavEKF3 EKF3{&ahrs, barometer, sonar};
@@ -150,7 +150,7 @@ private:
     AP_AHRS_DCM ahrs {ins, barometer, gps};
 #endif
 
-    // Arming/Disarming mangement class
+    // Arming/Disarming management class
     AP_Arming arming {ahrs, barometer, compass, battery, home_is_set};
 
     AP_L1_Control L1_controller;
@@ -167,9 +167,9 @@ private:
 #if AP_AHRS_NAVEKF_AVAILABLE
     OpticalFlow optflow{ahrs};
 #endif
-    
-    // RSSI 
-    AP_RSSI rssi;          
+
+    // RSSI
+    AP_RSSI rssi;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
@@ -195,7 +195,7 @@ private:
 
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
-    // current_loc uses the baro/gps soloution for altitude rather than gps only.
+    // current_loc uses the baro/gps solution for altitude rather than gps only.
     AP_Mount camera_mount;
 #endif
 
@@ -220,7 +220,7 @@ private:
 
     // Failsafe
     // A tracking variable for type of failsafe active
-    // Used for failsafe based on loss of RC signal or GCS signal. See 
+    // Used for failsafe based on loss of RC signal or GCS signal. See
     // FAILSAFE_EVENT_*
     struct {
         uint8_t bits;
@@ -246,7 +246,7 @@ private:
     int32_t next_navigation_leg_cd;
 
     // ground speed error in m/s
-    float groundspeed_error;	
+    float groundspeed_error;
 
     // 0-(throttle_max - throttle_cruise) : throttle nudge in Auto mode using top 1/2 of throttle stick travel
     int16_t     throttle_nudge;
@@ -264,7 +264,7 @@ private:
         float turn_angle;
         uint16_t sonar1_distance_cm;
         uint16_t sonar2_distance_cm;
-        
+
         // time when we last detected an obstacle, in milliseconds
         uint32_t detected_time_ms;
     } obstacle;
@@ -274,7 +274,7 @@ private:
 
     // Ground speed
     // The amount current ground speed is below min ground speed.  meters per second
-    float 	ground_speed;
+    float ground_speed;
     int16_t throttle_last;
     int16_t throttle;
 
@@ -312,7 +312,7 @@ private:
     int32_t condition_value;
     // A starting value used to check the status of a conditional command.
     // For example in a delay command the condition_start records that start time for the delay
-    int32_t	condition_start;
+    int32_t condition_start;
 
     // 3D Location vectors
     // Location structure defined in AP_Common
@@ -332,16 +332,16 @@ private:
     // IMU variables
     // The main loop execution time.  Seconds
     // This is the time between calls to the DCM algorithm and is the Integration time for the gyros.
-    float G_Dt;		
+    float G_Dt;
 
     // Performance monitoring
     // Timer used to accrue data and trigger recording of the performanc monitoring log message
-    int32_t	perf_mon_timer;
+    int32_t perf_mon_timer;
     // The maximum main loop execution time recorded in the current performance monitoring interval
     uint32_t G_Dt_max;
 
     // System Timers
-    // Time in microseconds of start of main control loop. 
+    // Time in microseconds of start of main control loop.
     uint32_t fast_loopTimer_us;
     // Number of milliseconds used in last main loop cycle
     uint32_t delta_us_fast_loop;
@@ -363,11 +363,11 @@ private:
     static const LogStructure log_structure[];
 
     // Loiter control
-    uint16_t loiter_duration; // How long we should loiter at the nav_waypoint (time in seconds)
+    uint16_t loiter_duration;       // How long we should loiter at the nav_waypoint (time in seconds)
     uint32_t loiter_start_time;     // How long have we been loitering - The start time in millis
-    bool active_loiter; // TRUE if we actively return to the loitering waypoint if we drift off
-    float distance_past_wp; // record the distance we have gone past the wp
-    bool previously_reached_wp;  // set to true if we have EVER reached the waypoint
+    bool active_loiter;             // TRUE if we actively return to the loitering waypoint if we drift off
+    float distance_past_wp;         // record the distance we have gone past the wp
+    bool previously_reached_wp;     // set to true if we have EVER reached the waypoint
 
     // time that rudder/steering arming has been running
     uint32_t rudder_arm_timer;
@@ -393,7 +393,7 @@ private:
     // private member functions
     void ahrs_update();
     void mount_update(void);
-    void update_trigger(void);    
+    void update_trigger(void);
     void update_alt();
     void gcs_failsafe_check(void);
     void compass_accumulate(void);
@@ -444,7 +444,7 @@ private:
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void log_init(void);
-    void start_logging() ;
+    void start_logging();
     void Log_Arm_Disarm();
 
     void load_parameters(void);
@@ -516,7 +516,7 @@ private:
     void check_usb_mux(void);
     uint8_t check_digital_pin(uint8_t pin);
     bool should_log(uint32_t mask);
-    void print_hit_enter();    
+    void print_hit_enter();
     void gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...);
     void print_mode(AP_HAL::BetterStream *port, uint8_t mode);
     bool start_command(const AP_Mission::Mission_Command& cmd);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -12,7 +12,7 @@ void Rover::throttle_slew_limit(int16_t last_throttle) {
         if (temp < 1) {
             temp = 1;
         }
-        channel_throttle->set_radio_out (constrain_int16(channel_throttle->get_radio_out(), last_throttle - temp, last_throttle + temp));
+        channel_throttle->set_radio_out(constrain_int16(channel_throttle->get_radio_out(), last_throttle - temp, last_throttle + temp));
     }
 }
 
@@ -314,12 +314,12 @@ void Rover::set_servos(void) {
     }
 
     if (!arming.is_armed()) {
-        //Some ESCs get noisy (beep error msgs) if PWM == 0.
-        //This little segment aims to avoid this.
+        // Some ESCs get noisy (beep error msgs) if PWM == 0.
+        // This little segment aims to avoid this.
         switch (arming.arming_required()) {
         case AP_Arming::NO:
-            //keep existing behavior: do nothing to radio_out
-            //(don't disarm throttle channel even if AP_Arming class is)
+            // keep existing behavior: do nothing to radio_out
+            // (don't disarm throttle channel even if AP_Arming class is)
             break;
 
         case AP_Arming::YES_ZERO_PWM:

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -1,10 +1,10 @@
 #include "Rover.h"
 
 /* Functions in this file:
-	void set_next_WP(const AP_Mission::Mission_Command& cmd)
-	void set_guided_WP(void)
-	void init_home()
-	void restart_nav()
+    void set_next_WP(const AP_Mission::Mission_Command& cmd)
+    void set_guided_WP(void)
+    void init_home()
+    void restart_nav()
 ************************************************************ 
 */
 
@@ -14,13 +14,13 @@
  */
 void Rover::set_next_WP(const struct Location& loc)
 {
-	// copy the current WP into the OldWP slot
-	// ---------------------------------------
-	prev_WP = next_WP;
+    // copy the current WP into the OldWP slot
+    // ---------------------------------------
+    prev_WP = next_WP;
 
-	// Load the next_WP slot
-	// ---------------------
-	next_WP = loc;
+    // Load the next_WP slot
+    // ---------------------
+    next_WP = loc;
 
     // are we already past the waypoint? This happens when we jump
     // waypoints, and it can cause us to skip a waypoint. If we are
@@ -32,24 +32,24 @@ void Rover::set_next_WP(const struct Location& loc)
         prev_WP = current_loc;
     }
 
-	// this is handy for the groundstation
-	wp_totalDistance 	= get_distance(current_loc, next_WP);
-	wp_distance 		= wp_totalDistance;
+    // this is handy for the groundstation
+    wp_totalDistance = get_distance(current_loc, next_WP);
+    wp_distance      = wp_totalDistance;
 }
 
 void Rover::set_guided_WP(void)
 {
-	// copy the current location into the OldWP slot
-	// ---------------------------------------
-	prev_WP = current_loc;
+    // copy the current location into the OldWP slot
+    // ---------------------------------------
+    prev_WP = current_loc;
 
-	// Load the next_WP slot
-	// ---------------------
-	next_WP = guided_WP;
+    // Load the next_WP slot
+    // ---------------------
+    next_WP = guided_WP;
 
-	// this is handy for the groundstation
-	wp_totalDistance 	= get_distance(current_loc, next_WP);
-	wp_distance 		= wp_totalDistance;
+    // this is handy for the groundstation
+    wp_totalDistance = get_distance(current_loc, next_WP);
+    wp_distance      = wp_totalDistance;
 }
 
 // run this at setup on the ground
@@ -61,27 +61,27 @@ void Rover::init_home()
         return;
     }
 
-	gcs_send_text(MAV_SEVERITY_INFO, "Init HOME");
+    gcs_send_text(MAV_SEVERITY_INFO, "Init HOME");
 
     ahrs.set_home(gps.location());
-	home_is_set = HOME_SET_NOT_LOCKED;
-	Log_Write_Home_And_Origin();
+    home_is_set = HOME_SET_NOT_LOCKED;
+    Log_Write_Home_And_Origin();
     GCS_MAVLINK::send_home_all(gps.location());
 
-	// Save Home to EEPROM
-	mission.write_home_to_storage();
+    // Save Home to EEPROM
+    mission.write_home_to_storage();
 
-	// Save prev loc
-	// -------------
-	next_WP = prev_WP = home;
+    // Save prev loc
+    // -------------
+    next_WP = prev_WP = home;
 
-	// Load home for a default guided_WP
-	// -------------
-	guided_WP = home;
+    // Load home for a default guided_WP
+    // -------------
+    guided_WP = home;
 }
 
 void Rover::restart_nav()
-{  
+{
     g.pidSpeedThrottle.reset_I();
     prev_WP = current_loc;
     mission.start_or_resume();

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -15,13 +15,13 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Executing command ID #%i",cmd.id);
+    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Executing command ID #%i", cmd.id);
 
     // remember the course of our next navigation leg
     next_navigation_leg_cd = mission.get_next_ground_course_cd(0);
 
     switch (cmd.id) {
-    case MAV_CMD_NAV_WAYPOINT:	// Navigate to Waypoint
+    case MAV_CMD_NAV_WAYPOINT:  // Navigate to Waypoint
         do_nav_wp(cmd);
         break;
 
@@ -161,7 +161,6 @@ Return true if we do not recognize the command so that we move on to the next co
 bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
 {
     switch (cmd.id) {
-
     case MAV_CMD_NAV_WAYPOINT:
         return verify_nav_wp(cmd);
 
@@ -197,11 +196,10 @@ bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
 
     default:
         // error message
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING,"Skipping invalid cmd #%i",cmd.id);
+        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Skipping invalid cmd #%i", cmd.id);
         // return true if we do not recognize the command so that we move on to the next command
         return true;
     }
-
 }
 
 /********************************************************************************/
@@ -211,7 +209,7 @@ bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
 void Rover::do_RTL(void)
 {
     prev_WP = current_loc;
-    control_mode 	= RTL;
+    control_mode = RTL;
     next_WP = home;
 }
 
@@ -238,7 +236,7 @@ void Rover::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
 {
     active_loiter = true;
     do_nav_wp(cmd);
-    loiter_duration = 100; // an arbitrary large loiter time
+    loiter_duration = 100;  // an arbitrary large loiter time
 }
 
 // do_loiter_time - initiate loitering at a point for a given time period
@@ -331,7 +329,7 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 bool Rover::verify_RTL()
 {
     if (wp_distance <= g.waypoint_radius) {
-        gcs_send_text(MAV_SEVERITY_INFO,"Reached destination");
+        gcs_send_text(MAV_SEVERITY_INFO, "Reached destination");
         rtl_complete = true;
         return true;
     }
@@ -413,7 +411,7 @@ void Rover::do_within_distance(const AP_Mission::Mission_Command& cmd)
 bool Rover::verify_wait_delay()
 {
     if ((uint32_t)(millis() - condition_start) > (uint32_t)condition_value) {
-        condition_value 	= 0;
+        condition_value = 0;
         return true;
     }
     return false;

--- a/APMrover2/commands_process.cpp
+++ b/APMrover2/commands_process.cpp
@@ -4,7 +4,7 @@
 // --------------------
 void Rover::update_commands(void)
 {
-    if(control_mode == AUTO) {
+    if (control_mode == AUTO) {
         if (home_is_set != HOME_UNSET && mission.num_commands() > 1) {
             mission.update();
         }

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -39,32 +39,32 @@
 // HIL_MODE                                 OPTIONAL
 
 #ifndef HIL_MODE
- #define HIL_MODE        HIL_MODE_DISABLED
+  #define HIL_MODE HIL_MODE_DISABLED
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-# define BATTERY_PIN_1	  1
-# define CURRENT_PIN_1	  2
+  #define BATTERY_PIN_1     1
+  #define CURRENT_PIN_1     2
 #elif CONFIG_HAL_BOARD == HAL_BOARD_PX4
-# define BATTERY_PIN_1	  -1
-# define CURRENT_PIN_1	  -1
+  #define BATTERY_PIN_1    -1
+  #define CURRENT_PIN_1    -1
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-# define BATTERY_PIN_1     -1
-# define CURRENT_PIN_1	   -1
+  #define BATTERY_PIN_1    -1
+  #define CURRENT_PIN_1    -1
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-# define BATTERY_PIN_1	  -1
-# define CURRENT_PIN_1	  -1
+  #define BATTERY_PIN_1    -1
+  #define CURRENT_PIN_1    -1
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // HIL_MODE                                 OPTIONAL
 
 #ifndef HIL_MODE
-#define HIL_MODE	HIL_MODE_DISABLED
+  #define HIL_MODE HIL_MODE_DISABLED
 #endif
 
 #ifndef MAV_SYSTEM_ID
-# define MAV_SYSTEM_ID		1
+  #define MAV_SYSTEM_ID    1
 #endif
 
 
@@ -73,29 +73,29 @@
 //
 
 #ifndef FRSKY_TELEM_ENABLED
-#define FRSKY_TELEM_ENABLED ENABLED
+  #define FRSKY_TELEM_ENABLED ENABLED
 #endif
 
 
 #ifndef CH7_OPTION
-# define CH7_OPTION		          CH7_SAVE_WP
+  #define CH7_OPTION CH7_SAVE_WP
 #endif
 
 #ifndef TUNING_OPTION
-# define TUNING_OPTION		          TUN_NONE
+  #define TUNING_OPTION TUN_NONE
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // INPUT_VOLTAGE
 //
 #ifndef INPUT_VOLTAGE
-# define INPUT_VOLTAGE			4.68	//  4.68 is the average value for a sample set.  This is the value at the processor with 5.02 applied at the servo rail
+  #define INPUT_VOLTAGE    4.68  //  4.68 is the average value for a sample set.  This is the value at the processor with 5.02 applied at the servo rail
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 //  MAGNETOMETER
 #ifndef MAGNETOMETER
-# define MAGNETOMETER			ENABLED
+  #define MAGNETOMETER ENABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -103,47 +103,47 @@
 // MODE_CHANNEL
 //
 #ifndef MODE_CHANNEL
-# define MODE_CHANNEL	8
+  #define MODE_CHANNEL    8
 #endif
 #if (MODE_CHANNEL != 5) && (MODE_CHANNEL != 6) && (MODE_CHANNEL != 7) && (MODE_CHANNEL != 8)
-# error XXX
-# error XXX You must set MODE_CHANNEL to 5, 6, 7 or 8
-# error XXX
+  #error XXX
+  #error XXX You must set MODE_CHANNEL to 5, 6, 7 or 8
+  #error XXX
 #endif
 
 #if !defined(MODE_1)
-# define MODE_1			LEARNING
+  #define MODE_1    LEARNING
 #endif
 #if !defined(MODE_2)
-# define MODE_2			LEARNING
+  #define MODE_2    LEARNING
 #endif
 #if !defined(MODE_3)
-# define MODE_3			LEARNING
+  #define MODE_3    LEARNING
 #endif
 #if !defined(MODE_4)
-# define MODE_4			LEARNING
+  #define MODE_4    LEARNING
 #endif
 #if !defined(MODE_5)
-# define MODE_5			LEARNING
+  #define MODE_5    LEARNING
 #endif
 #if !defined(MODE_6)
-# define MODE_6			MANUAL
+  #define MODE_6    MANUAL
 #endif
 
 
 //////////////////////////////////////////////////////////////////////////////
 // failsafe defaults
 #ifndef THROTTLE_FAILSAFE
-# define THROTTLE_FAILSAFE		ENABLED
+  #define THROTTLE_FAILSAFE      ENABLED
 #endif
 #ifndef THROTTLE_FS_VALUE
-# define THROTTLE_FS_VALUE		950
+  #define THROTTLE_FS_VALUE      950
 #endif
 #ifndef LONG_FAILSAFE_ACTION
-# define LONG_FAILSAFE_ACTION		0
+  #define LONG_FAILSAFE_ACTION   0
 #endif
 #ifndef GCS_HEARTBEAT_FAILSAFE
-# define GCS_HEARTBEAT_FAILSAFE		DISABLED
+  #define GCS_HEARTBEAT_FAILSAFE DISABLED
 #endif
 
 
@@ -151,7 +151,7 @@
 // THROTTLE_OUT
 //
 #ifndef THROTTE_OUT
-# define THROTTLE_OUT			ENABLED
+  #define THROTTLE_OUT ENABLED
 #endif
 
 
@@ -165,73 +165,73 @@
 // GROUND_START_DELAY
 //
 #ifndef GROUND_START_DELAY
-# define GROUND_START_DELAY		0
+  #define GROUND_START_DELAY    0
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // MOUNT (ANTENNA OR CAMERA)
 //
 #ifndef MOUNT
-# define MOUNT		ENABLED
+  #define MOUNT ENABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // CAMERA control
 //
 #ifndef CAMERA
-# define CAMERA ENABLED
+  #define CAMERA ENABLED
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // AIRSPEED_CRUISE
 //
 #ifndef SPEED_CRUISE
-# define SPEED_CRUISE		5 // in m/s
+  #define SPEED_CRUISE    5  // in m/s
 #endif
 
 #ifndef TURN_GAIN
-# define TURN_GAIN		5
+  #define TURN_GAIN       5
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Servo Mapping
 //
 #ifndef THROTTLE_MIN
-# define THROTTLE_MIN			0 // percent
+  #define THROTTLE_MIN      0  // percent
 #endif
 #ifndef THROTTLE_CRUISE
-# define THROTTLE_CRUISE		45
+  #define THROTTLE_CRUISE  45
 #endif
 #ifndef THROTTLE_MAX
-# define THROTTLE_MAX			100
+  #define THROTTLE_MAX    100
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Attitude control gains
 //
 #ifndef SERVO_STEER_P
-# define SERVO_STEER_P         0.4
+  #define SERVO_STEER_P          0.4
 #endif
 #ifndef SERVO_STEER_I
-# define SERVO_STEER_I         0.0
+  #define SERVO_STEER_I          0.0
 #endif
 #ifndef SERVO_STEER_D
-# define SERVO_STEER_D         0.0
+  #define SERVO_STEER_D          0.0
 #endif
 #ifndef SERVO_STEER_INT_MAX
-# define SERVO_STEER_INT_MAX   5
+  #define SERVO_STEER_INT_MAX    5
 #endif
-#define SERVO_STEER_INT_MAX_CENTIDEGREE SERVO_STEER_INT_MAX*100
+#define SERVO_STEER_INT_MAX_CENTIDEGREE (SERVO_STEER_INT_MAX * 100)
 
 
 //////////////////////////////////////////////////////////////////////////////
 // Dataflash logging control
 //
 #ifndef LOGGING_ENABLED
-# define LOGGING_ENABLED		ENABLED
+  #define LOGGING_ENABLED ENABLED
 #endif
 
-#define DEFAULT_LOG_BITMASK   0xffff
+#define DEFAULT_LOG_BITMASK    0xffff
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -240,12 +240,12 @@
 
 // use this to enable servos in HIL mode
 #ifndef HIL_SERVOS
-# define HIL_SERVOS DISABLED
+  #define HIL_SERVOS DISABLED
 #endif
 
 // use this to completely disable the CLI
 #ifndef CLI_ENABLED
-#define CLI_ENABLED ENABLED
+  #define CLI_ENABLED ENABLED
 #endif
 
 // if RESET_SWITCH_CH is not zero, then this is the PWM value on
@@ -253,5 +253,5 @@
 // position (to for example return to switched mode after failsafe or
 // fence breach)
 #ifndef RESET_SWITCH_CHAN_PWM
-# define RESET_SWITCH_CHAN_PWM 1750
+  #define RESET_SWITCH_CHAN_PWM    1750
 #endif

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -3,11 +3,13 @@
 void Rover::read_control_switch()
 {
     static bool switch_debouncer;
-	uint8_t switchPosition = readSwitch();
-	
-	// If switchPosition = 255 this indicates that the mode control channel input was out of range
-	// If we get this value we do not want to change modes.
-	if(switchPosition == 255) return;
+    uint8_t switchPosition = readSwitch();
+
+    // If switchPosition = 255 this indicates that the mode control channel input was out of range
+    // If we get this value we do not want to change modes.
+    if (switchPosition == 255) {
+        return;
+    }
 
     if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 100) {
         // only use signals that are less than 0.1s old.
@@ -20,10 +22,9 @@ void Rover::read_control_switch()
     // when returning to the previous mode after a failsafe or fence
     // breach. This channel is best used on a momentary switch (such
     // as a spring loaded trainer switch).
-	if (oldSwitchPosition != switchPosition ||
-        (g.reset_switch_chan != 0 && 
+    if (oldSwitchPosition != switchPosition ||
+        (g.reset_switch_chan != 0 &&
          hal.rcin->read(g.reset_switch_chan-1) > RESET_SWITCH_CHAN_PWM)) {
-
         if (switch_debouncer == false) {
             // this ensures that mode switches only happen if the
             // switch changes for 2 reads. This prevents momentary
@@ -33,34 +34,45 @@ void Rover::read_control_switch()
             return;
         }
 
-		set_mode((enum mode)modes[switchPosition].get());
+        set_mode((enum mode)modes[switchPosition].get());
 
-		oldSwitchPosition = switchPosition;
-		prev_WP = current_loc;
+        oldSwitchPosition = switchPosition;
+        prev_WP = current_loc;
 
-		// reset speed integrator
+        // reset speed integrator
         g.pidSpeedThrottle.reset_I();
-	}
+    }
 
     switch_debouncer = false;
-
 }
 
-uint8_t Rover::readSwitch(void){
+uint8_t Rover::readSwitch(void) {
     uint16_t pulsewidth = hal.rcin->read(g.mode_channel - 1);
-	if (pulsewidth <= 900 || pulsewidth >= 2200) 	return 255;	// This is an error condition
-	if (pulsewidth <= 1230)     return 0;
-	if (pulsewidth <= 1360) 	return 1;
-	if (pulsewidth <= 1490) 	return 2;
-	if (pulsewidth <= 1620) 	return 3;
-	if (pulsewidth <= 1749) 	return 4;	// Software Manual
-	return 5;	// Hardware Manual
+    if (pulsewidth <= 900 || pulsewidth >= 2200) {
+        return 255;  // This is an error condition
+    }
+    if (pulsewidth <= 1230) {
+        return 0;
+    }
+    if (pulsewidth <= 1360) {
+        return 1;
+    }
+    if (pulsewidth <= 1490) {
+        return 2;
+    }
+    if (pulsewidth <= 1620) {
+        return 3;
+    }
+    if (pulsewidth <= 1749) {
+        return 4;  // Software Manual
+    }
+    return 5;  // Hardware Manual
 }
 
 void Rover::reset_control_switch()
 {
-	oldSwitchPosition = 254;
-	read_control_switch();
+    oldSwitchPosition = 254;
+    read_control_switch();
 }
 
 #define CH_7_PWM_TRIGGER 1800
@@ -73,51 +85,50 @@ void Rover::read_trim_switch()
     case CH7_DO_NOTHING:
         break;
     case CH7_SAVE_WP:
-		if (channel_learn->get_radio_in() > CH_7_PWM_TRIGGER) {
+        if (channel_learn->get_radio_in() > CH_7_PWM_TRIGGER) {
             // switch is engaged
-			ch7_flag = true;
-		} else { // switch is disengaged
-			if (ch7_flag) {
-				ch7_flag = false;
+            ch7_flag = true;
+        } else {  // switch is disengaged
+            if (ch7_flag) {
+                ch7_flag = false;
 
-				switch (control_mode) {
-				case MANUAL:
+                switch (control_mode) {
+                case MANUAL:
                     hal.console->println("Erasing waypoints");
                     // if SW7 is ON in MANUAL = Erase the Flight Plan
-					mission.clear();
+                    mission.clear();
                     if (channel_steer->get_control_in() > 3000) {
-						// if roll is full right store the current location as home
+                        // if roll is full right store the current location as home
                         init_home();
                     }
-					return;
+                    break;
 
-				case LEARNING:
-				case STEERING: {
+                case LEARNING:
+                case STEERING: {
                     // if SW7 is ON in LEARNING = record the Wp
 
-				    // create new mission command
-				    AP_Mission::Mission_Command cmd = {};
+                    // create new mission command
+                    AP_Mission::Mission_Command cmd = {};
 
-				    // set new waypoint to current location
-				    cmd.content.location = current_loc;
+                    // set new waypoint to current location
+                    cmd.content.location = current_loc;
 
-				    // make the new command to a waypoint
-				    cmd.id = MAV_CMD_NAV_WAYPOINT;
+                    // make the new command to a waypoint
+                    cmd.id = MAV_CMD_NAV_WAYPOINT;
 
-				    // save command
-				    if(mission.add_cmd(cmd)) {
-                        hal.console->printf("Learning waypoint %u", (unsigned)mission.num_commands());
-				    }
-				    }
-				    break;
-
-				case AUTO:
-                    // if SW7 is ON in AUTO = set to RTL  
+                    // save command
+                    if (mission.add_cmd(cmd)) {
+                        hal.console->printf("Learning waypoint %u", (unsigned) mission.num_commands());
+                    }
+                    break;
+                }
+                case AUTO:
+                    // if SW7 is ON in AUTO = set to RTL
                     set_mode(RTL);
                     break;
 
-				default:
-				    break;
+                default:
+                    break;
                 }
             }
         }

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -3,41 +3,41 @@
 // Internal defines, don't edit and expect things to work
 // -------------------------------------------------------
 
-#define TRUE 1
+#define TRUE  1
 #define FALSE 0
 
 // Just so that it's completely clear...
-#define ENABLED                 1
-#define DISABLED                0
+#define ENABLED  1
+#define DISABLED 0
 
 // this avoids a very common config error
 #define ENABLE ENABLED
 #define DISABLE DISABLED
 
 #define DEBUG 0
-#define SERVO_MAX 4500	// This value represents 45 degrees and is just an arbitrary representation of servo max travel.
+#define SERVO_MAX 4500  // This value represents 45 degrees and is just an arbitrary representation of servo max travel.
 
 // CH 7 control
 enum ch7_option {
-    CH7_DO_NOTHING=0,
-    CH7_SAVE_WP=1
+    CH7_DO_NOTHING = 0,
+    CH7_SAVE_WP    = 1
 };
 
 // HIL enumerations
-#define HIL_MODE_DISABLED			0
-#define HIL_MODE_SENSORS			1
+#define HIL_MODE_DISABLED 0
+#define HIL_MODE_SENSORS  1
 
 // Auto Pilot modes
 // ----------------
 enum mode {
-    MANUAL=0,
-	LEARNING=2,
-    STEERING=3,
-    HOLD=4,
-    AUTO=10,
-    RTL=11,
-    GUIDED=15,
-    INITIALISING=16
+    MANUAL       = 0,
+    LEARNING     = 2,
+    STEERING     = 3,
+    HOLD         = 4,
+    AUTO         = 10,
+    RTL          = 11,
+    GUIDED       = 15,
+    INITIALISING = 16
 };
 
 enum GuidedMode {
@@ -52,35 +52,35 @@ enum GuidedMode {
 #define FAILSAFE_EVENT_RC       (1<<2)
 
 //  Logging parameters
-#define LOG_CTUN_MSG	        0x01
-#define LOG_NTUN_MSG    		0x02
-#define LOG_PERFORMANCE_MSG		0x03
-#define LOG_STARTUP_MSG 		0x06
-#define LOG_SONAR_MSG 		    0x07
+#define LOG_CTUN_MSG            0x01
+#define LOG_NTUN_MSG            0x02
+#define LOG_PERFORMANCE_MSG     0x03
+#define LOG_STARTUP_MSG         0x06
+#define LOG_SONAR_MSG           0x07
 #define LOG_ARM_DISARM_MSG      0x08
 #define LOG_STEERING_MSG        0x0D
 #define LOG_GUIDEDTARGET_MSG    0x0E
 #define LOG_ERROR_MSG           0x13
 
-#define TYPE_AIRSTART_MSG		0x00
-#define TYPE_GROUNDSTART_MSG	0x01
-#define MAX_NUM_LOGS			100
+#define TYPE_AIRSTART_MSG       0x00
+#define TYPE_GROUNDSTART_MSG    0x01
+#define MAX_NUM_LOGS            100
 
-#define MASK_LOG_ATTITUDE_FAST 	(1<<0)
-#define MASK_LOG_ATTITUDE_MED 	(1<<1)
-#define MASK_LOG_GPS 			(1<<2)
-#define MASK_LOG_PM 			(1<<3)
-#define MASK_LOG_CTUN 			(1<<4)
-#define MASK_LOG_NTUN			(1<<5)
-#define MASK_LOG_MODE			(1<<6)
-#define MASK_LOG_IMU			(1<<7)
-#define MASK_LOG_CMD			(1<<8)
-#define MASK_LOG_CURRENT		(1<<9)
-#define MASK_LOG_SONAR   		(1<<10)
-#define MASK_LOG_COMPASS   		(1<<11)
-#define MASK_LOG_CAMERA   		(1<<12)
-#define MASK_LOG_STEERING  		(1<<13)
-#define MASK_LOG_RC     		(1<<14)
+#define MASK_LOG_ATTITUDE_FAST  (1<<0)
+#define MASK_LOG_ATTITUDE_MED   (1<<1)
+#define MASK_LOG_GPS            (1<<2)
+#define MASK_LOG_PM             (1<<3)
+#define MASK_LOG_CTUN           (1<<4)
+#define MASK_LOG_NTUN           (1<<5)
+#define MASK_LOG_MODE           (1<<6)
+#define MASK_LOG_IMU            (1<<7)
+#define MASK_LOG_CMD            (1<<8)
+#define MASK_LOG_CURRENT        (1<<9)
+#define MASK_LOG_SONAR          (1<<10)
+#define MASK_LOG_COMPASS        (1<<11)
+#define MASK_LOG_CAMERA         (1<<12)
+#define MASK_LOG_STEERING       (1<<13)
+#define MASK_LOG_RC             (1<<14)
 #define MASK_LOG_ARM_DISARM     (1<<15)
 #define MASK_LOG_IMU_RAW        (1UL<<19)
 
@@ -93,9 +93,9 @@ enum GuidedMode {
 #define MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE (1<<11)
 
 // Error message sub systems and error codes
-#define ERROR_SUBSYSTEM_CRASH_CHECK         12
+#define ERROR_SUBSYSTEM_CRASH_CHECK  12
 // subsystem specific error codes -- crash checker
-#define ERROR_CODE_CRASH_CHECK_CRASH        1
+#define ERROR_CODE_CRASH_CHECK_CRASH 1
 
 enum fs_crash_action {
   FS_CRASH_DISABLE = 0,

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -31,19 +31,19 @@ void Rover::failsafe_check()
 
     if (tnow - last_timestamp > 200000) {
         // we have gone at least 0.2 seconds since the main loop
-        // ran. That means we're in trouble, or perhaps are in 
+        // ran. That means we're in trouble, or perhaps are in
         // an initialisation routine or log erase. Start passing RC
         // inputs through to outputs
         in_failsafe = true;
     }
 
-    if (in_failsafe && tnow - last_timestamp > 20000 && 
+    if (in_failsafe && tnow - last_timestamp > 20000 &&
         channel_throttle->read() >= (uint16_t)g.fs_throttle_value) {
-        // pass RC inputs to outputs every 20ms        
+        // pass RC inputs to outputs every 20ms
         last_timestamp = tnow;
         hal.rcin->clear_overrides();
         uint8_t start_ch = 0;
-        for (uint8_t ch=start_ch; ch<4; ch++) {
+        for (uint8_t ch=start_ch; ch < 4; ch++) {
             hal.rcout->write(ch, hal.rcin->read(ch));
         }
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_manual, true);

--- a/APMrover2/navigation.cpp
+++ b/APMrover2/navigation.cpp
@@ -5,23 +5,23 @@
 //****************************************************************
 void Rover::navigate()
 {
-	// do not navigate with corrupt data
-	// ---------------------------------
-	if (!have_position) {
-		return;
-	}
+    // do not navigate with corrupt data
+    // ---------------------------------
+    if (!have_position) {
+        return;
+    }
 
-	if ((next_WP.lat == 0 && next_WP.lng == 0) || (home_is_set==HOME_UNSET)){
-		return;
-	}
+    if ((next_WP.lat == 0 && next_WP.lng == 0) || (home_is_set == HOME_UNSET)){
+        return;
+    }
 
-	// waypoint distance from rover
-	// ----------------------------
-	wp_distance = get_distance(current_loc, next_WP);
+    // waypoint distance from rover
+    // ----------------------------
+    wp_distance = get_distance(current_loc, next_WP);
 
-	// control mode specific updates to nav_bearing
-	// --------------------------------------------
-	update_navigation();
+    // control mode specific updates to nav_bearing
+    // --------------------------------------------
+    update_navigation();
 }
 
 

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -9,8 +9,8 @@ void Rover::set_control_channels(void)
     channel_throttle = RC_Channel::rc_channel(rcmap.throttle()-1);
     channel_learn    = RC_Channel::rc_channel(g.learn_channel-1);
 
-	// set rc channel ranges
-	channel_steer->set_angle(SERVO_MAX);
+    // set rc channel ranges
+    channel_steer->set_angle(SERVO_MAX);
     channel_throttle->set_angle(100);
 
     // For a rover safety is TRIM throttle
@@ -20,19 +20,18 @@ void Rover::set_control_channels(void)
             hal.rcout->set_safety_pwm(1UL<<(rcmap.roll()-1),  channel_steer->get_radio_trim());
         }
     }
-
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
-    // take a proportion of speed. 
+    // take a proportion of speed.
     hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 }
 
 void Rover::init_rc_in()
 {
-	// set rc dead zones
-	channel_steer->set_default_dead_zone(30);
-	channel_throttle->set_default_dead_zone(30);
+    // set rc dead zones
+    channel_steer->set_default_dead_zone(30);
+    channel_throttle->set_default_dead_zone(30);
 
-	//set auxiliary ranges
+    // set auxiliary ranges
     update_aux();
 }
 
@@ -48,10 +47,10 @@ void Rover::init_rc_out()
         }
     }
 
-    RC_Channel::output_trim_all();    
+    RC_Channel::output_trim_all();
 
     // setup PWM values to send if the FMU firmware dies
-    RC_Channel::setup_failsafe_trim_all();  
+    RC_Channel::setup_failsafe_trim_all();
 
     // output throttle trim when safety off if arming
     // is setup for min on disarm.  MIN is from plane where MIN is effectively no throttle.
@@ -83,48 +82,47 @@ void Rover::rudder_arm_disarm_check()
         return;
     }
 
-	if (!arming.is_armed()) {
-		// when not armed, full right rudder starts arming counter
-		if (channel_steer->get_control_in() > 4000) {
-			uint32_t now = millis();
+    if (!arming.is_armed()) {
+        // when not armed, full right rudder starts arming counter
+        if (channel_steer->get_control_in() > 4000) {
+            uint32_t now = millis();
 
-			if (rudder_arm_timer == 0 ||
-				now - rudder_arm_timer < 3000) {
-
-				if (rudder_arm_timer == 0) {
+            if (rudder_arm_timer == 0 ||
+                now - rudder_arm_timer < 3000) {
+                if (rudder_arm_timer == 0) {
                     rudder_arm_timer = now;
                 }
-			} else {
-				//time to arm!
-				arm_motors(AP_Arming::RUDDER);
-				rudder_arm_timer = 0;
-			}
-		} else {
-			// not at full right rudder
-			rudder_arm_timer = 0;
-		}
-	} else if (!motor_active() & !g.skid_steer_out) {
-		// when armed and motor not active (not moving), full left rudder starts disarming counter
+            } else {
+                // time to arm!
+                arm_motors(AP_Arming::RUDDER);
+                rudder_arm_timer = 0;
+            }
+        } else {
+            // not at full right rudder
+            rudder_arm_timer = 0;
+        }
+    } else if (!motor_active() & !g.skid_steer_out) {
+        // when armed and motor not active (not moving), full left rudder starts disarming counter
         // This is disabled for skid steering otherwise when tring to turn a skid steering rover around
         // the rover would disarm
-		if (channel_steer->get_control_in() < -4000) {
-			uint32_t now = millis();
+        if (channel_steer->get_control_in() < -4000) {
+            uint32_t now = millis();
 
-			if (rudder_arm_timer == 0 ||
-				now - rudder_arm_timer < 3000) {
-				if (rudder_arm_timer == 0) {
+            if (rudder_arm_timer == 0 ||
+                now - rudder_arm_timer < 3000) {
+                if (rudder_arm_timer == 0) {
                     rudder_arm_timer = now;
                 }
-			} else {
-				//time to disarm!
-				disarm_motors();
-				rudder_arm_timer = 0;
-			}
-		} else {
-			// not at full left rudder
-			rudder_arm_timer = 0;
-		}
-	}
+            } else {
+                // time to disarm!
+                disarm_motors();
+                rudder_arm_timer = 0;
+            }
+        } else {
+            // not at full left rudder
+            rudder_arm_timer = 0;
+        }
+    }
 }
 
 void Rover::read_radio()
@@ -138,20 +136,20 @@ void Rover::read_radio()
 
     RC_Channel::set_pwm_all();
 
-	control_failsafe(channel_throttle->get_radio_in());
+    control_failsafe(channel_throttle->get_radio_in());
 
-	channel_throttle->set_servo_out(channel_throttle->get_control_in());
+    channel_throttle->set_servo_out(channel_throttle->get_control_in());
 
     // Check if the throttle value is above 50% and we need to nudge
     // Make sure its above 50% in the direction we are travelling
-	if ((abs(channel_throttle->get_servo_out()) > 50) &&
+    if ((abs(channel_throttle->get_servo_out()) > 50) &&
         (((channel_throttle->get_servo_out() < 0) && in_reverse) ||
          ((channel_throttle->get_servo_out() > 0) && !in_reverse))) {
             throttle_nudge = (g.throttle_max - g.throttle_cruise) *
                 ((fabsf(channel_throttle->norm_input())-0.5f) / 0.5f);
-	} else {
-		throttle_nudge = 0;
-	}
+    } else {
+        throttle_nudge = 0;
+    }
 
     if (g.skid_steer_in) {
         // convert the two radio_in values from skid steering values
@@ -184,26 +182,25 @@ void Rover::read_radio()
     }
 
     rudder_arm_disarm_check();
-
 }
 
 void Rover::control_failsafe(uint16_t pwm)
 {
-	if (!g.fs_throttle_enabled) {
+    if (!g.fs_throttle_enabled) {
         // no throttle failsafe
-		return;
+        return;
     }
 
-	// Check for failsafe condition based on loss of GCS control
-	if (rc_override_active) {
+    // Check for failsafe condition based on loss of GCS control
+    if (rc_override_active) {
         failsafe_trigger(FAILSAFE_EVENT_RC, (millis() - failsafe.rc_override_timer) > 1500);
-	} else if (g.fs_throttle_enabled) {
+    } else if (g.fs_throttle_enabled) {
         bool failed = pwm < (uint16_t)g.fs_throttle_value;
         if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 2000) {
             failed = true;
         }
         failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);
-	}
+    }
 }
 
 /*
@@ -227,11 +224,11 @@ bool Rover::throttle_failsafe_active(void)
 
 void Rover::trim_control_surfaces()
 {
-	read_radio();
-	// Store control surface trim values
-	// ---------------------------------
+    read_radio();
+    // Store control surface trim values
+    // ---------------------------------
     if (channel_steer->get_radio_in() > 1400) {
-		channel_steer->set_radio_trim(channel_steer->get_radio_in());
+        channel_steer->set_radio_trim(channel_steer->get_radio_in());
         // save to eeprom
         channel_steer->save_eeprom();
     }
@@ -239,8 +236,8 @@ void Rover::trim_control_surfaces()
 
 void Rover::trim_radio()
 {
-	for (int y = 0; y < 30; y++) {
-		read_radio();
-	}
+    for (int y = 0; y < 30; y++) {
+        read_radio();
+    }
     trim_control_surfaces();
 }

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -30,7 +30,7 @@ void Rover::read_receiver_rssi(void)
     receiver_rssi = rssi.read_receiver_rssi_uint8();
 }
 
-//Calibrate compass
+// Calibrate compass
 void Rover::compass_cal_update() {
     if (!hal.util->get_soft_armed()) {
         compass.compass_cal_update();
@@ -45,8 +45,8 @@ void Rover::accel_cal_update() {
     }
     ins.acal_update();
     // check if new trim values, and set them    float trim_roll, trim_pitch;
-    float trim_roll,trim_pitch;
-    if(ins.get_new_trim(trim_roll, trim_pitch)) {
+    float trim_roll, trim_pitch;
+    if (ins.get_new_trim(trim_roll, trim_pitch)) {
         ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
     }
 }
@@ -94,7 +94,7 @@ void Rover::read_sonars(void)
         obstacle.sonar1_distance_cm = sonar.distance_cm(0);
         obstacle.sonar2_distance_cm = 0;
         if (obstacle.sonar1_distance_cm < (uint16_t)g.sonar_trigger_cm)  {
-            // obstacle detected in front 
+            // obstacle detected in front
             if (obstacle.detected_count < 127) {
                 obstacle.detected_count++;
             }
@@ -111,7 +111,7 @@ void Rover::read_sonars(void)
 
     // no object detected - reset after the turn time
     if (obstacle.detected_count >= g.sonar_debounce &&
-        AP_HAL::millis() > obstacle.detected_time_ms + g.sonar_turn_time*1000) { 
+        AP_HAL::millis() > obstacle.detected_time_ms + g.sonar_turn_time*1000) {
         gcs_send_text_fmt(MAV_SEVERITY_INFO, "Obstacle passed");
         obstacle.detected_count = 0;
         obstacle.turn_angle = 0;
@@ -137,19 +137,24 @@ void Rover::update_sensor_status_flags(void)
 
     // first what sensors/controllers we have
     if (g.compass_enabled) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG; // compass present
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;  // compass present
     }
     if (gps.status() > AP_GPS::NO_GPS) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_GPS;
     }
 
-    if (rover.DataFlash.logging_present()) { // primary logging only (usually File)
+    if (rover.DataFlash.logging_present()) {  // primary logging only (usually File)
         control_sensors_present |= MAV_SYS_STATUS_LOGGING;
     }
 
 
     // all present sensors enabled by default except rate control, attitude stabilization, yaw, altitude, position control and motor output which we will set individually
-    control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL & ~MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION & ~MAV_SYS_STATUS_SENSOR_YAW_POSITION & ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL & ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS & ~MAV_SYS_STATUS_LOGGING);
+    control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL &
+                                                         ~MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION &
+                                                         ~MAV_SYS_STATUS_SENSOR_YAW_POSITION &
+                                                         ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL &
+                                                         ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
+                                                         ~MAV_SYS_STATUS_LOGGING);
 
     switch (control_mode) {
     case MANUAL:
@@ -158,17 +163,17 @@ void Rover::update_sensor_status_flags(void)
 
     case LEARNING:
     case STEERING:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL; // 3D angular rate control
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION; // attitude stabilisation
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL;    // 3D angular rate control
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;  // attitude stabilisation
         break;
 
     case AUTO:
     case RTL:
     case GUIDED:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL; // 3D angular rate control
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION; // attitude stabilisation
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_YAW_POSITION; // yaw position
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL; // X/Y position control
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL;    // 3D angular rate control
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;  // attitude stabilisation
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_YAW_POSITION;            // yaw position
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;     // X/Y position control
         break;
 
     case INITIALISING:
@@ -223,7 +228,6 @@ void Rover::update_sensor_status_flags(void)
         control_sensors_enabled &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
         control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
     }
-    
 #if FRSKY_TELEM_ENABLED == ENABLED
     // give mask of error flags to Frsky_Telemetry
     frsky_telemetry.update_sensor_status_flags(~control_sensors_health & control_sensors_enabled & control_sensors_present);

--- a/APMrover2/setup.cpp
+++ b/APMrover2/setup.cpp
@@ -4,9 +4,9 @@
 
 // Command/function table for the setup menu
 static const struct Menu::command setup_menu_commands[] = {
-	// command			function called
-	// =======        	===============
-	{"erase",			MENU_FUNC(setup_erase)}
+    // command          function called
+    // =======          ===============
+    {"erase",           MENU_FUNC(setup_erase)}
 };
 
 // Create the setup menu object.
@@ -15,40 +15,41 @@ MENU(setup_menu, "setup", setup_menu_commands);
 // Called from the top-level menu to run the setup menu.
 int8_t Rover::setup_mode(uint8_t argc, const Menu::arg *argv)
 {
-	// Give the user some guidance
-	cliSerial->printf("Setup Mode\n"
-						 "\n"
-						 "IMPORTANT: if you have not previously set this system up, use the\n"
-						 "'reset' command to initialize the EEPROM to sensible default values\n"
-						 "and then the 'radio' command to configure for your radio.\n"
-						 "\n");
+    // Give the user some guidance
+    cliSerial->printf("Setup Mode\n"
+                         "\n"
+                         "IMPORTANT: if you have not previously set this system up, use the\n"
+                         "'reset' command to initialize the EEPROM to sensible default values\n"
+                         "and then the 'radio' command to configure for your radio.\n"
+                         "\n");
 
-	// Run the setup menu.  When the menu exits, we will return to the main menu.
-	setup_menu.run();
+    // Run the setup menu.  When the menu exits, we will return to the main menu.
+    setup_menu.run();
     return 0;
 }
 
 int8_t Rover::setup_erase(uint8_t argc, const Menu::arg *argv)
 {
-	int			c;
+    int c;
 
-	cliSerial->printf("\nType 'Y' and hit Enter to erase all waypoint and parameter data, any other key to abort: ");
+    cliSerial->printf("\nType 'Y' and hit Enter to erase all waypoint and parameter data, any other key to abort: ");
 
-	do {
-		c = cliSerial->read();
-	} while (-1 == c);
+    do {
+        c = cliSerial->read();
+    } while (-1 == c);
 
-	if (('y' != c) && ('Y' != c))
-		return(-1);
-	zero_eeprom();
-	return 0;
+    if (('y' != c) && ('Y' != c)) {
+        return (-1);
+    }
+    zero_eeprom();
+    return 0;
 }
 
 void Rover::zero_eeprom(void)
 {
-	cliSerial->printf("\nErasing EEPROM\n");
+    cliSerial->printf("\nErasing EEPROM\n");
     StorageManager::erase();
-	cliSerial->println("done");
+    cliSerial->println("done");
 }
 
-#endif // CLI_ENABLED
+#endif  // CLI_ENABLED

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -48,7 +48,7 @@ int8_t Rover::reboot_board(uint8_t argc, const Menu::arg *argv)
 void Rover::run_cli(AP_HAL::UARTDriver *port)
 {
     // disable the failsafe code in the CLI
-    hal.scheduler->register_timer_failsafe(nullptr,1);
+    hal.scheduler->register_timer_failsafe(nullptr, 1);
 
     // disable the mavlink delay callback
     hal.scheduler->register_delay_callback(nullptr, 5);
@@ -62,7 +62,7 @@ void Rover::run_cli(AP_HAL::UARTDriver *port)
     }
 }
 
-#endif // CLI_ENABLED
+#endif  // CLI_ENABLED
 
 static void mavlink_delay_cb_static()
 {
@@ -105,7 +105,7 @@ void Rover::init_ardupilot()
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
-    
+
     BoardConfig.init();
 
     ServoRelayEvents.set_channel_mask(0xFFF0);
@@ -140,13 +140,13 @@ void Rover::init_ardupilot()
     log_init();
 #endif
 
-    if (g.compass_enabled==true) {
+    if (g.compass_enabled == true) {
         if (!compass.init()|| !compass.read()) {
             cliSerial->println("Compass initialisation failed!");
             g.compass_enabled = false;
         } else {
             ahrs.set_compass(&compass);
-            //compass.get_offsets();                        // load offsets to account for airframe magnetic interference
+            // compass.get_offsets();  // load offsets to account for airframe magnetic interference
         }
     }
 
@@ -208,21 +208,21 @@ void Rover::init_ardupilot()
     reset_control_switch();
 }
 
-//********************************************************************************
-//This function does all the calibrations, etc. that we need during a ground start
-//********************************************************************************
+//*********************************************************************************
+// This function does all the calibrations, etc. that we need during a ground start
+//*********************************************************************************
 void Rover::startup_ground(void)
 {
     set_mode(INITIALISING);
 
-    gcs_send_text(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
+    gcs_send_text(MAV_SEVERITY_INFO, "<startup_ground> Ground start");
 
     #if(GROUND_START_DELAY > 0)
-        gcs_send_text(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
+        gcs_send_text(MAV_SEVERITY_NOTICE, "<startup_ground> With delay");
         delay(GROUND_START_DELAY * 1000);
     #endif
 
-    //IMU ground start
+    // IMU ground start
     //------------------------
     //
 
@@ -242,7 +242,7 @@ void Rover::startup_ground(void)
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
     ins.set_dataflash(&DataFlash);
 
-    gcs_send_text(MAV_SEVERITY_INFO,"Ready to drive");
+    gcs_send_text(MAV_SEVERITY_INFO, "Ready to drive");
 }
 
 /*
@@ -263,7 +263,6 @@ void Rover::set_reverse(bool reverse)
 
 void Rover::set_mode(enum mode mode)
 {
-
     if (control_mode == mode){
         // don't switch modes if we are already in the correct mode.
         return;
@@ -282,12 +281,12 @@ void Rover::set_mode(enum mode mode)
 #if FRSKY_TELEM_ENABLED == ENABLED
     frsky_telemetry.update_control_mode(control_mode);
 #endif
-    
+
     if (control_mode != AUTO) {
         auto_triggered = false;
     }
 
-    switch(control_mode) {
+    switch (control_mode) {
     case MANUAL:
     case HOLD:
     case LEARNING:
@@ -537,7 +536,7 @@ bool Rover::disarm_motors(void)
         mission.reset();
     }
 
-    //only log if disarming was successful
+    // only log if disarming was successful
     change_arm_state();
 
     return true;

--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -7,23 +7,23 @@
 // User enters the string in the console to call the functions on the right.
 // See class Menu in AP_Common for implementation details
 static const struct Menu::command test_menu_commands[] = {
-	{"pwm",				MENU_FUNC(test_radio_pwm)},
-	{"radio",			MENU_FUNC(test_radio)},
-	{"passthru",		MENU_FUNC(test_passthru)},
-	{"failsafe",		MENU_FUNC(test_failsafe)},
-	{"relay",			MENU_FUNC(test_relay)},
-	{"waypoints",		MENU_FUNC(test_wp)},
-	{"modeswitch",		MENU_FUNC(test_modeswitch)},
+    {"pwm",             MENU_FUNC(test_radio_pwm)},
+    {"radio",           MENU_FUNC(test_radio)},
+    {"passthru",        MENU_FUNC(test_passthru)},
+    {"failsafe",        MENU_FUNC(test_failsafe)},
+    {"relay",           MENU_FUNC(test_relay)},
+    {"waypoints",       MENU_FUNC(test_wp)},
+    {"modeswitch",      MENU_FUNC(test_modeswitch)},
 
-	// Tests below here are for hardware sensors only present
-	// when real sensors are attached or they are emulated
-	{"gps",			MENU_FUNC(test_gps)},
-	{"ins",			MENU_FUNC(test_ins)},
-	{"sonartest",	MENU_FUNC(test_sonar)},
-	{"compass",		MENU_FUNC(test_mag)},
-	{"logging",		MENU_FUNC(test_logging)},
+    // Tests below here are for hardware sensors only present
+    // when real sensors are attached or they are emulated
+    {"gps",             MENU_FUNC(test_gps)},
+    {"ins",             MENU_FUNC(test_ins)},
+    {"sonartest",       MENU_FUNC(test_sonar)},
+    {"compass",         MENU_FUNC(test_mag)},
+    {"logging",         MENU_FUNC(test_logging)},
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    {"shell", 				MENU_FUNC(test_shell)},
+    {"shell",           MENU_FUNC(test_shell)},
 #endif
 };
 
@@ -32,60 +32,60 @@ MENU(test_menu, "test", test_menu_commands);
 
 int8_t Rover::test_mode(uint8_t argc, const Menu::arg *argv)
 {
-	cliSerial->printf("Test Mode\n\n");
-	test_menu.run();
+    cliSerial->printf("Test Mode\n\n");
+    test_menu.run();
     return 0;
 }
 
 void Rover::print_hit_enter()
 {
-	cliSerial->printf("Hit Enter to exit.\n\n");
+    cliSerial->printf("Hit Enter to exit.\n\n");
 }
 
 int8_t Rover::test_radio_pwm(uint8_t argc, const Menu::arg *argv)
 {
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
-	while(1){
-		delay(20);
+    while (1) {
+        delay(20);
 
-		// Filters radio input - adjust filters in the radio.cpp file
-		// ----------------------------------------------------------
-		read_radio();
+        // Filters radio input - adjust filters in the radio.cpp file
+        // ----------------------------------------------------------
+        read_radio();
 
-		cliSerial->printf("IN:\t1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-							channel_steer->get_radio_in(),
-							g.rc_2.get_radio_in(),
-							channel_throttle->get_radio_in(),
-							g.rc_4.get_radio_in(),
-							g.rc_5.get_radio_in(),
-							g.rc_6.get_radio_in(),
-							g.rc_7.get_radio_in(),
-							g.rc_8.get_radio_in());
+        cliSerial->printf("IN:\t1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
+                            channel_steer->get_radio_in(),
+                            g.rc_2.get_radio_in(),
+                            channel_throttle->get_radio_in(),
+                            g.rc_4.get_radio_in(),
+                            g.rc_5.get_radio_in(),
+                            g.rc_6.get_radio_in(),
+                            g.rc_7.get_radio_in(),
+                            g.rc_8.get_radio_in());
 
-		if(cliSerial->available() > 0){
-			return (0);
-		}
-	}
+        if (cliSerial->available() > 0) {
+            return (0);
+        }
+    }
 }
 
 
 int8_t Rover::test_passthru(uint8_t argc, const Menu::arg *argv)
 {
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
-	while(1){
-		delay(20);
+    while (1) {
+        delay(20);
 
         // New radio frame? (we could use also if((millis()- timer) > 20)
         if (hal.rcin->new_input()) {
             cliSerial->print("CH:");
-            for(int i = 0; i < 8; i++){
-                cliSerial->print(hal.rcin->read(i));	// Print channel values
+            for (int i = 0; i < 8; i++) {
+                cliSerial->print(hal.rcin->read(i));    // Print channel values
                 cliSerial->print(",");
-                hal.rcout->write(i, hal.rcin->read(i)); // Copy input to Servos
+                hal.rcout->write(i, hal.rcin->read(i));  // Copy input to Servos
             }
             cliSerial->println();
         }
@@ -98,131 +98,131 @@ int8_t Rover::test_passthru(uint8_t argc, const Menu::arg *argv)
 
 int8_t Rover::test_radio(uint8_t argc, const Menu::arg *argv)
 {
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
-	// read the radio to set trims
-	// ---------------------------
-	trim_radio();
+    // read the radio to set trims
+    // ---------------------------
+    trim_radio();
 
-	while(1){
-		delay(20);
-		read_radio();
+    while (1) {
+        delay(20);
+        read_radio();
 
-		channel_steer->calc_pwm();
-		channel_throttle->calc_pwm();
+        channel_steer->calc_pwm();
+        channel_throttle->calc_pwm();
 
-		// write out the servo PWM values
-		// ------------------------------
-		set_servos();
+        // write out the servo PWM values
+        // ------------------------------
+        set_servos();
 
-		cliSerial->printf("IN 1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
-							channel_steer->get_control_in(),
-							g.rc_2.get_control_in(),
-							channel_throttle->get_control_in(),
-							g.rc_4.get_control_in(),
-							g.rc_5.get_control_in(),
-							g.rc_6.get_control_in(),
-							g.rc_7.get_control_in(),
-							g.rc_8.get_control_in());
+        cliSerial->printf("IN 1: %d\t2: %d\t3: %d\t4: %d\t5: %d\t6: %d\t7: %d\t8: %d\n",
+                            channel_steer->get_control_in(),
+                            g.rc_2.get_control_in(),
+                            channel_throttle->get_control_in(),
+                            g.rc_4.get_control_in(),
+                            g.rc_5.get_control_in(),
+                            g.rc_6.get_control_in(),
+                            g.rc_7.get_control_in(),
+                            g.rc_8.get_control_in());
 
-		if(cliSerial->available() > 0){
-			return (0);
-		}
-	}
+        if (cliSerial->available() > 0) {
+            return (0);
+        }
+    }
 }
 
 int8_t Rover::test_failsafe(uint8_t argc, const Menu::arg *argv)
 {
-	uint8_t fail_test = 0;
-	print_hit_enter();
-	for(int i = 0; i < 50; i++){
-		delay(20);
-		read_radio();
-	}
+    uint8_t fail_test = 0;
+    print_hit_enter();
+    for (int i = 0; i < 50; i++) {
+        delay(20);
+        read_radio();
+    }
 
-	// read the radio to set trims
-	// ---------------------------
-	trim_radio();
+    // read the radio to set trims
+    // ---------------------------
+    trim_radio();
 
-	oldSwitchPosition = readSwitch();
+    oldSwitchPosition = readSwitch();
 
-	cliSerial->println("Unplug battery, throttle in neutral, turn off radio.");
-	while(channel_throttle->get_control_in() > 0){
-		delay(20);
-		read_radio();
-	}
+    cliSerial->println("Unplug battery, throttle in neutral, turn off radio.");
+    while (channel_throttle->get_control_in() > 0) {
+        delay(20);
+        read_radio();
+    }
 
-	while(1){
-		delay(20);
-		read_radio();
+    while (1) {
+        delay(20);
+        read_radio();
 
-		if(channel_throttle->get_control_in() > 0){
-			cliSerial->printf("THROTTLE CHANGED %d \n", channel_throttle->get_control_in());
-			fail_test++;
-		}
+        if (channel_throttle->get_control_in() > 0) {
+            cliSerial->printf("THROTTLE CHANGED %d \n", channel_throttle->get_control_in());
+            fail_test++;
+        }
 
-		if (oldSwitchPosition != readSwitch()){
-			cliSerial->print("CONTROL MODE CHANGED: ");
+        if (oldSwitchPosition != readSwitch()){
+            cliSerial->print("CONTROL MODE CHANGED: ");
             print_mode(cliSerial, readSwitch());
             cliSerial->println();
-			fail_test++;
-		}
+            fail_test++;
+        }
 
-        if(throttle_failsafe_active()) {
-			cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", channel_throttle->get_radio_in());
+        if (throttle_failsafe_active()) {
+            cliSerial->printf("THROTTLE FAILSAFE ACTIVATED: %d, ", channel_throttle->get_radio_in());
             print_mode(cliSerial, readSwitch());
             cliSerial->println();
-			fail_test++;
-		}
+            fail_test++;
+        }
 
-		if(fail_test > 0){
-			return (0);
-		}
-		if(cliSerial->available() > 0){
-			cliSerial->println("LOS caused no change in APM.");
-			return (0);
-		}
-	}
+        if (fail_test > 0) {
+            return (0);
+        }
+        if (cliSerial->available() > 0) {
+            cliSerial->println("LOS caused no change in APM.");
+            return (0);
+        }
+    }
 }
 
 int8_t Rover::test_relay(uint8_t argc, const Menu::arg *argv)
 {
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
-	while(1){
-		cliSerial->println("Relay on");
-		relay.on(0);
-		delay(3000);
-		if(cliSerial->available() > 0){
-			return (0);
-		}
+    while (1) {
+        cliSerial->println("Relay on");
+        relay.on(0);
+        delay(3000);
+        if (cliSerial->available() > 0) {
+            return (0);
+        }
 
-		cliSerial->println("Relay off");
-		relay.off(0);
-		delay(3000);
-		if(cliSerial->available() > 0){
-			return (0);
-		}
-	}
+        cliSerial->println("Relay off");
+        relay.off(0);
+        delay(3000);
+        if (cliSerial->available() > 0) {
+            return (0);
+        }
+    }
 }
 
 int8_t Rover::test_wp(uint8_t argc, const Menu::arg *argv)
 {
-	delay(1000);
+    delay(1000);
 
-	cliSerial->printf("%u waypoints\n", (unsigned)mission.num_commands());
-	cliSerial->printf("Hit radius: %f\n", (double)g.waypoint_radius.get());
+    cliSerial->printf("%u waypoints\n", (unsigned)mission.num_commands());
+    cliSerial->printf("Hit radius: %f\n", (double)g.waypoint_radius.get());
 
-	for(uint8_t i = 0; i < mission.num_commands(); i++){
+    for (uint8_t i = 0; i < mission.num_commands(); i++) {
         AP_Mission::Mission_Command temp_cmd;
-        if (mission.read_cmd_from_storage(i,temp_cmd)) {
+        if (mission.read_cmd_from_storage(i, temp_cmd)) {
             test_wp_print(temp_cmd);
         }
-	}
+    }
 
-	return (0);
+    return (0);
 }
 
 void Rover::test_wp_print(const AP_Mission::Mission_Command& cmd)
@@ -239,24 +239,24 @@ void Rover::test_wp_print(const AP_Mission::Mission_Command& cmd)
 
 int8_t Rover::test_modeswitch(uint8_t argc, const Menu::arg *argv)
 {
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
-	cliSerial->print("Control CH ");
+    cliSerial->print("Control CH ");
 
-	cliSerial->println(MODE_CHANNEL, BASE_DEC);
+    cliSerial->println(MODE_CHANNEL, BASE_DEC);
 
-	while(1){
-		delay(20);
-		uint8_t switchPosition = readSwitch();
-		if (oldSwitchPosition != switchPosition){
-			cliSerial->printf("Position %d\n",  switchPosition);
-			oldSwitchPosition = switchPosition;
-		}
-		if(cliSerial->available() > 0){
-			return (0);
-		}
-	}
+    while (1) {
+        delay(20);
+        uint8_t switchPosition = readSwitch();
+        if (oldSwitchPosition != switchPosition){
+            cliSerial->printf("Position %d\n",  switchPosition);
+            oldSwitchPosition = switchPosition;
+        }
+        if (cliSerial->available() > 0) {
+            return (0);
+        }
+    }
 }
 
 /*
@@ -264,7 +264,7 @@ int8_t Rover::test_modeswitch(uint8_t argc, const Menu::arg *argv)
  */
 int8_t Rover::test_logging(uint8_t argc, const Menu::arg *argv)
 {
-	cliSerial->println("Testing dataflash logging");
+    cliSerial->println("Testing dataflash logging");
     DataFlash.ShowDeviceInfo(cliSerial);
     return 0;
 }
@@ -279,7 +279,7 @@ int8_t Rover::test_gps(uint8_t argc, const Menu::arg *argv)
     delay(1000);
 
     uint32_t last_message_time_ms = 0;
-    while(1) {
+    while (1) {
         delay(100);
 
         gps.update();
@@ -295,7 +295,7 @@ int8_t Rover::test_gps(uint8_t argc, const Menu::arg *argv)
         } else {
             cliSerial->print(".");
         }
-        if(cliSerial->available() > 0) {
+        if (cliSerial->available() > 0) {
             return (0);
         }
     }
@@ -303,34 +303,34 @@ int8_t Rover::test_gps(uint8_t argc, const Menu::arg *argv)
 
 int8_t Rover::test_ins(uint8_t argc, const Menu::arg *argv)
 {
-	//cliSerial->print("Calibrating.");
-	ahrs.init();
+    // cliSerial->print("Calibrating.");
+    ahrs.init();
     ahrs.set_fly_forward(true);
 
     ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
-	print_hit_enter();
-	delay(1000);
+    print_hit_enter();
+    delay(1000);
 
     uint8_t medium_loopCounter = 0;
 
-	while(1){
+    while (1) {
         ins.wait_for_sample();
 
         ahrs.update();
 
-        if(g.compass_enabled) {
+        if (g.compass_enabled) {
             medium_loopCounter++;
-            if(medium_loopCounter >= 5){
+            if (medium_loopCounter >= 5) {
                 compass.read();
                 medium_loopCounter = 0;
             }
         }
-        
+
         // We are using the IMU
         // ---------------------
-        Vector3f gyros 	= ins.get_gyro();
+        Vector3f gyros = ins.get_gyro();
         Vector3f accels = ins.get_accel();
         cliSerial->printf("r:%4d  p:%4d  y:%3d  g=(%5.1f %5.1f %5.1f)  a=(%5.1f %5.1f %5.1f)\n",
                             (int)ahrs.roll_sensor / 100,
@@ -338,7 +338,7 @@ int8_t Rover::test_ins(uint8_t argc, const Menu::arg *argv)
                             (uint16_t)ahrs.yaw_sensor / 100,
                             (double)gyros.x, (double)gyros.y, (double)gyros.z,
                             (double)accels.x, (double)accels.y, (double)accels.z);
-        if(cliSerial->available() > 0){
+        if (cliSerial->available() > 0) {
             return (0);
         }
     }
@@ -346,19 +346,20 @@ int8_t Rover::test_ins(uint8_t argc, const Menu::arg *argv)
 
 void Rover::print_enabled(bool b)
 {
-       if(b)
-               cliSerial->print("en");
-       else
-               cliSerial->print("dis");
+       if (b) {
+           cliSerial->print("en");
+       } else {
+           cliSerial->print("dis");
+       }
        cliSerial->println("abled");
 }
 
 int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
 {
-	if (!g.compass_enabled) {
+    if (!g.compass_enabled) {
         cliSerial->print("Compass: ");
-		print_enabled(false);
-		return (0);
+        print_enabled(false);
+        return (0);
     }
 
     if (!compass.init()) {
@@ -373,19 +374,19 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
     ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
-	int counter = 0;
+    int counter = 0;
     float heading = 0;
 
     print_hit_enter();
 
     uint8_t medium_loopCounter = 0;
 
-    while(1) {
+    while (1) {
         ins.wait_for_sample();
         ahrs.update();
 
         medium_loopCounter++;
-        if(medium_loopCounter >= 5){
+        if (medium_loopCounter >= 5) {
             if (compass.read()) {
                 // Calculate heading
                 Matrix3f m = ahrs.get_rotation_body_to_ned();
@@ -394,9 +395,9 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
             }
             medium_loopCounter = 0;
         }
-        
+
         counter++;
-        if (counter>20) {
+        if (counter > 20) {
             if (compass.healthy()) {
                 const Vector3f mag_ofs = compass.get_offsets();
                 const Vector3f mag = compass.get_field();
@@ -407,7 +408,7 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
             } else {
                 cliSerial->println("compass not healthy");
             }
-            counter=0;
+            counter = 0;
         }
         if (cliSerial->available() > 0) {
             break;
@@ -415,7 +416,7 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
     }
 
     // save offsets. This allows you to get sane offset values using
-    // the CLI before you go flying.    
+    // the CLI before you go flying.
     cliSerial->println("saving offsets");
     compass.save_offsets();
     return (0);
@@ -435,20 +436,20 @@ int8_t Rover::test_sonar(uint8_t argc, const Menu::arg *argv)
     }
 
     print_hit_enter();
-    
+
     float sonar_dist_cm_min = 0.0f;
     float sonar_dist_cm_max = 0.0f;
-    float voltage_min=0.0f, voltage_max = 0.0f;
+    float voltage_min = 0.0f, voltage_max = 0.0f;
     float sonar2_dist_cm_min = 0.0f;
     float sonar2_dist_cm_max = 0.0f;
-    float voltage2_min=0.0f, voltage2_max = 0.0f;
+    float voltage2_min = 0.0f, voltage2_max = 0.0f;
     uint32_t last_print = 0;
 
-	while (true) {
+    while (true) {
         delay(20);
         sonar.update();
         uint32_t now = millis();
-    
+
         float dist_cm = sonar.distance_cm(0);
         float voltage = sonar.voltage_mv(0);
         if (is_zero(sonar_dist_cm_min)) {
@@ -489,7 +490,7 @@ int8_t Rover::test_sonar(uint8_t argc, const Menu::arg *argv)
         }
         if (cliSerial->available() > 0) {
             break;
-	    }
+        }
     }
     return (0);
 }
@@ -505,4 +506,4 @@ int8_t Rover::test_shell(uint8_t argc, const Menu::arg *argv)
 }
 #endif
 
-#endif // CLI_ENABLED
+#endif  // CLI_ENABLED


### PR DESCRIPTION
This PR cleanup rover workspace : 
It remove trailling whitespace, tabs, wrong indentation, add missign parenthesis without disturbing the code layout.
Rules for defines : 
- two space for #define after #ifdefine 
- try to alignate groups that make sense
- one space for text define
- 4 spaces for number

Tools used : cppling, cppcheck, Clion IDE
A following PR will correct , constness, cast and other c++11 stuff