### PR TITLE
Fix for NAV_LOITER_TO_ALT -- now verifies heading when param 1 is set nonzero

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -681,6 +681,11 @@ bool Plane::verify_loiter_to_alt()
         if (labs(condition_value - current_loc.alt) < 500 && loiter.sum_cd > 1) {
             // primary goal completed, initialize secondary heading goal
             condition_value = 0;
+            if (mission.get_current_nav_cmd().content.location.flags.loiter_hdg_chk != 0) {
+                loiter.sum_cd = 3; //don't immediately stop loitering;
+                //wait for heading toward next wp or 3 complete loiters,
+                // whichever comes first.
+            }
             result = verify_loiter_heading(true);
         }
     } else {

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -109,7 +109,7 @@ char (&_ARRAY_SIZE_HELPER(T (&_arr)[0]))[0];
 
 struct PACKED Location_Option_Flags {
     uint8_t relative_alt : 1;           // 1 if altitude is relateive to home
-    uint8_t unused1      : 1;           // unused flag (defined so that loiter_ccw uses the correct bit)
+    uint8_t loiter_hdg_chk : 1;   // 1 if verify heading towards next waypoint before breaking out of loiter.
     uint8_t loiter_ccw   : 1;           // 0 if clockwise, 1 if counter clockwise
     uint8_t terrain_alt  : 1;           // this altitude is above terrain
     uint8_t origin_alt   : 1;           // this altitude is above ekf origin

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -598,6 +598,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
         copy_location = true;
         cmd.p1 = fabsf(packet.param2);                  // param2 is radius in meters
+        //param1 is whether or not to verify heading towards next waypoint
+        //before breaking out of loiter
+        cmd.content.location.flags.loiter_hdg_chk = (packet.param1 != 0);
         cmd.content.location.flags.loiter_ccw = (packet.param2 < 0);
         cmd.content.location.flags.loiter_xtrack = (packet.param4 > 0); // 0 to xtrack from center of waypoint, 1 to xtrack from tangent exit location
         break;
@@ -1043,6 +1046,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
         copy_location = true;
+        packet.param1 = cmd.content.location.flags.loiter_hdg_chk;
         packet.param2 = cmd.p1;                        // loiter radius(m)
         if (cmd.content.location.flags.loiter_ccw) {
             packet.param2 = -packet.param2;


### PR DESCRIPTION
NAV_LOITER_TO_ALT should verify that the aircraft is heading towards the next waypoint when param 1 of the mavlink message is not zero.  This patch fixes a bug where that was not happening.