### PR TITLE
AP_Beacon: Changed if statements to switch statement.

### DIFF
--- a/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
@@ -58,49 +58,49 @@ void AP_Beacon_Pozyx::update(void)
 
         switch (parse_state) {
 
+        default:
+        case ParseState_WaitingForHeader:
+            if (c == AP_BEACON_POZYX_HEADER) {
+                parse_state = ParseState_WaitingForMsgId;
+                linebuf_len = 0;
+            }
+            break;
+
+        case ParseState_WaitingForMsgId:
+            parse_msg_id = c;
+            switch (parse_msg_id) {
+            case AP_BEACON_POZYX_MSGID_BEACON_CONFIG:
+            case AP_BEACON_POZYX_MSGID_BEACON_DIST:
+            case AP_BEACON_POZYX_MSGID_POSITION:
+                parse_state = ParseState_WaitingForLen;
+                break;
             default:
-            case ParseState_WaitingForHeader:
-                if (c == AP_BEACON_POZYX_HEADER) {
-                    parse_state = ParseState_WaitingForMsgId;
-                    linebuf_len = 0;
-                }
+                // invalid message id
+                parse_state = ParseState_WaitingForHeader;
                 break;
+            }
+            break;
 
-            case ParseState_WaitingForMsgId:
-                parse_msg_id = c;
-                switch (parse_msg_id) {
-                case AP_BEACON_POZYX_MSGID_BEACON_CONFIG:
-                case AP_BEACON_POZYX_MSGID_BEACON_DIST:
-                case AP_BEACON_POZYX_MSGID_POSITION:
-                    parse_state = ParseState_WaitingForLen;
-                    break;
-                default:
-                    // invalid message id
-                    parse_state = ParseState_WaitingForHeader;
-                    break;
-                }
-                break;
+        case ParseState_WaitingForLen:
+            parse_msg_len = c;
+            if (parse_msg_len > AP_BEACON_POZYX_MSG_LEN_MAX) {
+                // invalid message length
+                parse_state = ParseState_WaitingForHeader;
+            } else {
+                parse_state = ParseState_WaitingForContents;
+            }
+            break;
 
-            case ParseState_WaitingForLen:
-                parse_msg_len = c;
-                if (parse_msg_len > AP_BEACON_POZYX_MSG_LEN_MAX) {
-                    // invalid message length
-                    parse_state = ParseState_WaitingForHeader;
-                } else {
-                    parse_state = ParseState_WaitingForContents;
-                }
-                break;
-
-            case ParseState_WaitingForContents:
-                // add to buffer
-                linebuf[linebuf_len++] = c;
-                if ((linebuf_len == parse_msg_len) || (linebuf_len == sizeof(linebuf))) {
-                    // process buffer
-                    parse_buffer();
-                    // reset state for next message
-                    parse_state = ParseState_WaitingForHeader;
-                }
-                break;
+        case ParseState_WaitingForContents:
+            // add to buffer
+            linebuf[linebuf_len++] = c;
+            if ((linebuf_len == parse_msg_len) || (linebuf_len == sizeof(linebuf))) {
+                // process buffer
+                parse_buffer();
+                // reset state for next message
+                parse_state = ParseState_WaitingForHeader;
+            }
+            break;
         }
     }
 }
@@ -123,50 +123,50 @@ void AP_Beacon_Pozyx::parse_buffer()
     bool parsed = false;
     switch (parse_msg_id) {
 
-        case AP_BEACON_POZYX_MSGID_BEACON_CONFIG:
-            {
-                uint8_t beacon_id = linebuf[0];
-                //uint8_t beacon_count = linebuf[1];
-                int32_t beacon_x = (uint32_t)linebuf[5] << 24 | (uint32_t)linebuf[4] << 16 | (uint32_t)linebuf[3] << 8 | (uint32_t)linebuf[2];
-                int32_t beacon_y = (uint32_t)linebuf[9] << 24 | (uint32_t)linebuf[8] << 16 | (uint32_t)linebuf[7] << 8 | (uint32_t)linebuf[6];
-                int32_t beacon_z = (uint32_t)linebuf[13] << 24 | (uint32_t)linebuf[12] << 16 | (uint32_t)linebuf[11] << 8 | (uint32_t)linebuf[10];
-                Vector3f beacon_pos(beacon_x / 1000.0f, beacon_y / 1000.0f, beacon_z / 1000.0f);
-                if (beacon_pos.length() <= AP_BEACON_DISTANCE_MAX) {
-                    set_beacon_position(beacon_id, beacon_pos);
-                    parsed = true;
-                }
+    case AP_BEACON_POZYX_MSGID_BEACON_CONFIG:
+        {
+            uint8_t beacon_id = linebuf[0];
+            //uint8_t beacon_count = linebuf[1];
+            int32_t beacon_x = (uint32_t)linebuf[5] << 24 | (uint32_t)linebuf[4] << 16 | (uint32_t)linebuf[3] << 8 | (uint32_t)linebuf[2];
+            int32_t beacon_y = (uint32_t)linebuf[9] << 24 | (uint32_t)linebuf[8] << 16 | (uint32_t)linebuf[7] << 8 | (uint32_t)linebuf[6];
+            int32_t beacon_z = (uint32_t)linebuf[13] << 24 | (uint32_t)linebuf[12] << 16 | (uint32_t)linebuf[11] << 8 | (uint32_t)linebuf[10];
+            Vector3f beacon_pos(beacon_x / 1000.0f, beacon_y / 1000.0f, beacon_z / 1000.0f);
+            if (beacon_pos.length() <= AP_BEACON_DISTANCE_MAX) {
+                set_beacon_position(beacon_id, beacon_pos);
+                parsed = true;
             }
-            break;
+        }
+        break;
 
-        case AP_BEACON_POZYX_MSGID_BEACON_DIST:
-            {
-                uint8_t beacon_id = linebuf[0];
-                uint32_t beacon_distance = (uint32_t)linebuf[4] << 24 | (uint32_t)linebuf[3] << 16 | (uint32_t)linebuf[2] << 8 | (uint32_t)linebuf[1];
-                float beacon_dist = beacon_distance/1000.0f;
-                if (beacon_dist <= AP_BEACON_DISTANCE_MAX) {
-                    set_beacon_distance(beacon_id, beacon_dist);
-                    parsed = true;
-                }
+    case AP_BEACON_POZYX_MSGID_BEACON_DIST:
+        {
+            uint8_t beacon_id = linebuf[0];
+            uint32_t beacon_distance = (uint32_t)linebuf[4] << 24 | (uint32_t)linebuf[3] << 16 | (uint32_t)linebuf[2] << 8 | (uint32_t)linebuf[1];
+            float beacon_dist = beacon_distance/1000.0f;
+            if (beacon_dist <= AP_BEACON_DISTANCE_MAX) {
+                set_beacon_distance(beacon_id, beacon_dist);
+                parsed = true;
             }
-            break;
+        }
+        break;
 
-        case AP_BEACON_POZYX_MSGID_POSITION:
-            {
-                int32_t vehicle_x = (uint32_t)linebuf[3] << 24 | (uint32_t)linebuf[2] << 16 | (uint32_t)linebuf[1] << 8 | (uint32_t)linebuf[0];
-                int32_t vehicle_y = (uint32_t)linebuf[7] << 24 | (uint32_t)linebuf[6] << 16 | (uint32_t)linebuf[5] << 8 | (uint32_t)linebuf[4];
-                int32_t vehicle_z = (uint32_t)linebuf[11] << 24 | (uint32_t)linebuf[10] << 16 | (uint32_t)linebuf[9] << 8 | (uint32_t)linebuf[8];
-                int16_t position_error = (uint32_t)linebuf[13] << 8 | (uint32_t)linebuf[12];
-                Vector3f veh_pos(Vector3f(vehicle_x / 1000.0f, vehicle_y / 1000.0f, vehicle_z / 1000.0f));
-                if (veh_pos.length() <= AP_BEACON_DISTANCE_MAX) {
-                    set_vehicle_position(veh_pos, position_error);
-                    parsed = true;
-                }
+    case AP_BEACON_POZYX_MSGID_POSITION:
+        {
+            int32_t vehicle_x = (uint32_t)linebuf[3] << 24 | (uint32_t)linebuf[2] << 16 | (uint32_t)linebuf[1] << 8 | (uint32_t)linebuf[0];
+            int32_t vehicle_y = (uint32_t)linebuf[7] << 24 | (uint32_t)linebuf[6] << 16 | (uint32_t)linebuf[5] << 8 | (uint32_t)linebuf[4];
+            int32_t vehicle_z = (uint32_t)linebuf[11] << 24 | (uint32_t)linebuf[10] << 16 | (uint32_t)linebuf[9] << 8 | (uint32_t)linebuf[8];
+            int16_t position_error = (uint32_t)linebuf[13] << 8 | (uint32_t)linebuf[12];
+            Vector3f veh_pos(Vector3f(vehicle_x / 1000.0f, vehicle_y / 1000.0f, vehicle_z / 1000.0f));
+            if (veh_pos.length() <= AP_BEACON_DISTANCE_MAX) {
+                set_vehicle_position(veh_pos, position_error);
+                parsed = true;
             }
-            break;
+        }
+        break;
 
-        default:
-            // unrecognised message id
-            break;
+    default:
+        // unrecognised message id
+        break;
     }
 
     // record success

--- a/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Pozyx.cpp
@@ -68,13 +68,16 @@ void AP_Beacon_Pozyx::update(void)
 
             case ParseState_WaitingForMsgId:
                 parse_msg_id = c;
-                if (parse_msg_id == AP_BEACON_POZYX_MSGID_BEACON_CONFIG ||
-                    parse_msg_id == AP_BEACON_POZYX_MSGID_BEACON_DIST ||
-                    parse_msg_id == AP_BEACON_POZYX_MSGID_POSITION) {
+                switch (parse_msg_id) {
+                case AP_BEACON_POZYX_MSGID_BEACON_CONFIG:
+                case AP_BEACON_POZYX_MSGID_BEACON_DIST:
+                case AP_BEACON_POZYX_MSGID_POSITION:
                     parse_state = ParseState_WaitingForLen;
-                } else {
+                    break;
+                default:
                     // invalid message id
                     parse_state = ParseState_WaitingForHeader;
+                    break;
                 }
                 break;
 


### PR DESCRIPTION
1. AP_Beacon: Changed if statements to switch statement.
Multiple judgments are made with the same variable with the argument of the if statement.
Therefore
Change it so that it is judged by the switch statement.

2.AP_Beacon: Shift the indentation of the switch statement to the left.
Adjust to the coding manners.