### PR TITLE
AP_Math: Change mask value to hexadecimal number.

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -183,15 +183,26 @@ template float constrain_value<float>(const float amt, const float low, const fl
 template double constrain_value<double>(const double amt, const double low, const double high);
 
 
-/*
-  simple 16 bit random number generator
+/**
+ * simple 16 bit random number generator
+ *
+ * @return 16 bit random number
  */
 uint16_t get_random16(void)
+{
+    return static_cast<uint16_t>(get_random32() & 0xFFFF);
+}
+
+/**
+ * simple 32 bit random number generator
+ *
+ * @return 32 bit random number
+ */
+uint32_t get_random32(void)
 {
     static uint32_t m_z = 1234;
     static uint32_t m_w = 76542;
     m_z = 36969 * (m_z & 0xFFFFu) + (m_z >> 16);
     m_w = 18000 * (m_w & 0xFFFFu) + (m_w >> 16);
-    return ((m_z << 16) + m_w) & 0xFFFF;
+    return (m_z << 16) + m_w;
 }
-

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -190,8 +190,8 @@ uint16_t get_random16(void)
 {
     static uint32_t m_z = 1234;
     static uint32_t m_w = 76542;
-    m_z = 36969 * (m_z & 65535) + (m_z >> 16);
-    m_w = 18000 * (m_w & 65535) + (m_w >> 16);
+    m_z = 36969 * (m_z & 0xFFFFu) + (m_z >> 16);
+    m_w = 18000 * (m_w & 0xFFFFu) + (m_w >> 16);
     return ((m_z << 16) + m_w) & 0xFFFF;
 }
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -220,4 +220,5 @@ float linear_interpolate(float low_output, float high_output,
 
 /* simple 16 bit random number generator */
 uint16_t get_random16(void);
-
+/* simple 32 bit random number generator */
+uint32_t get_random32(void);


### PR DESCRIPTION
1. AP_Math: Change mask value to hexadecimal number.
Processing to leave only the lower 16 bits is difficult to understand with decimal number.
Therefore
Change to hexadecimal value.

2. AP_Math: Delete useless operation.
Shift the value of m_z to the left by 16 bits, add the value of m_w, and leave the lower 16 bits.
Therefore
Since the value of m_z is not used, delete it.