### PR TITLE
Add a new AP_HAL_Linux Led_Sysfs class and use it for Disco

### DIFF
--- a/libraries/AP_HAL_Linux/Led_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/Led_Sysfs.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright (C) 2017 Mathieu Othacehe. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Led_Sysfs.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <unistd.h>
+
+#include <AP_HAL/AP_HAL.h>
+
+static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+namespace Linux {
+
+Led_Sysfs::Led_Sysfs(const char *led_name)
+    : _led_name(led_name)
+{
+}
+
+Led_Sysfs::~Led_Sysfs()
+{
+    if (_brightness_fd) {
+        close(_brightness_fd);
+    }
+}
+
+bool Led_Sysfs::init()
+{
+    char *br_path;
+    char *max_br_path;
+
+    if (asprintf(&br_path, "/sys/class/leds/%s/brightness", _led_name) == -1) {
+        AP_HAL::panic("LinuxLed_Sysfs : Couldn't allocate brightness path\n");
+    }
+
+    _brightness_fd = open(br_path, O_WRONLY | O_CLOEXEC);
+    if (_brightness_fd < 0) {
+        printf("LinuxLed_Sysfs: Unable to open file %s\n", br_path);
+        free(br_path);
+        return false;
+    }
+
+    if (asprintf(&max_br_path, "/sys/class/leds/%s/max_brightness", _led_name) == -1) {
+        AP_HAL::panic("LinuxLed_Sysfs : Couldn't allocate max_brightness path\n");
+    }
+
+    if (Util::from(hal.util)->read_file(max_br_path, "%u", &_max_brightness) < 0) {
+        AP_HAL::panic("LinuxLed_Sysfs : Unable to read max_brightness in %s\n",
+                      max_br_path);
+    }
+
+    free(max_br_path);
+    free(br_path);
+
+    return true;
+}
+
+bool Led_Sysfs::set_brightness(uint8_t brightness)
+{
+    if (_brightness_fd < 0) {
+        return false;
+    }
+
+    int br = brightness * _max_brightness / UINT8_MAX;
+
+    /* Don't log fails since this could spam the console */
+    if (dprintf(_brightness_fd, "%u", br) < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/libraries/AP_HAL_Linux/Led_Sysfs.h
+++ b/libraries/AP_HAL_Linux/Led_Sysfs.h
@@ -1,0 +1,41 @@
+/*
+  Copyright (C) 2017 Mathieu Othacehe. All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <AP_HAL/AP_HAL.h>
+
+#include "AP_HAL_Linux.h"
+#include "Util.h"
+
+#pragma once
+
+namespace Linux {
+
+class Led_Sysfs {
+public:
+    bool init();
+    bool set_brightness(uint8_t brightness);
+
+    Led_Sysfs(const char* led_name);
+    ~Led_Sysfs();
+
+private:
+    int _brightness_fd = -1;
+    int _max_brightness = 0;
+    const char *_led_name = nullptr;
+};
+
+}

--- a/libraries/AP_Notify/DiscoLED.cpp
+++ b/libraries/AP_Notify/DiscoLED.cpp
@@ -18,6 +18,7 @@
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/PWM_Sysfs.h>
+#include <AP_HAL_Linux/Led_Sysfs.h>
 #include "DiscoLED.h"
 
 #define RED_PWM_INDEX   9
@@ -29,16 +30,33 @@
 #define DISCO_LED_HIGH   0xFF
 #define DISCO_LED_OFF    0x00
 
+#define DISCO_LED_RED_NAME   "evinrude:red"
+#define DISCO_LED_GREEN_NAME "evinrude:green"
+#define DISCO_LED_BLUE_NAME  "evinrude:blue"
+
 DiscoLED::DiscoLED():
     RGBLed(DISCO_LED_OFF, DISCO_LED_HIGH, DISCO_LED_MEDIUM, DISCO_LED_LOW),
     red_pwm(RED_PWM_INDEX),
     green_pwm(GREEN_PWM_INDEX),
-    blue_pwm(BLUE_PWM_INDEX)
+    blue_pwm(BLUE_PWM_INDEX),
+
+    red_led(DISCO_LED_RED_NAME),
+    green_led(DISCO_LED_GREEN_NAME),
+    blue_led(DISCO_LED_BLUE_NAME)
 {
 }
 
 bool DiscoLED::hw_init()
 {
+    /* If led sysfs api is present, use it, else use pwm sysfs api to
+       drive Disco leds */
+    if (red_led.init() && green_led.init() && blue_led.init()) {
+        backend = LED_SYSFS;
+        return true;
+    }
+
+    backend = PWM_SYSFS;
+
     red_pwm_period = red_pwm.get_period();
     green_pwm_period = green_pwm.get_period();
     blue_pwm_period = blue_pwm.get_period();
@@ -56,9 +74,21 @@ bool DiscoLED::hw_init()
 
 bool DiscoLED::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 {
-    red_pwm.set_duty_cycle(red / UINT8_MAX * red_pwm_period);
-    green_pwm.set_duty_cycle(green / UINT8_MAX * green_pwm_period);
-    blue_pwm.set_duty_cycle(blue / UINT8_MAX * blue_pwm_period);
+
+    switch (backend) {
+    case PWM_SYSFS:
+        red_pwm.set_duty_cycle(red / UINT8_MAX * red_pwm_period);
+        green_pwm.set_duty_cycle(green / UINT8_MAX * green_pwm_period);
+        blue_pwm.set_duty_cycle(blue / UINT8_MAX * blue_pwm_period);
+        break;
+    case LED_SYSFS:
+        red_led.set_brightness(red);
+        green_led.set_brightness(green);
+        blue_led.set_brightness(blue);
+        break;
+    default:
+        return false;
+    }
 
     return true;
 }

--- a/libraries/AP_Notify/DiscoLED.h
+++ b/libraries/AP_Notify/DiscoLED.h
@@ -19,6 +19,7 @@
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/PWM_Sysfs.h>
+#include <AP_HAL_Linux/Led_Sysfs.h>
 #include "RGBLed.h"
 
 class DiscoLED: public RGBLed
@@ -32,8 +33,19 @@ private:
     Linux::PWM_Sysfs_Bebop green_pwm;
     Linux::PWM_Sysfs_Bebop blue_pwm;
 
+    Linux::Led_Sysfs red_led;
+    Linux::Led_Sysfs green_led;
+    Linux::Led_Sysfs blue_led;
+
     uint32_t red_pwm_period;
     uint32_t green_pwm_period;
     uint32_t blue_pwm_period;
+
+    enum led_backend {
+        LED_SYSFS,
+        PWM_SYSFS
+    };
+
+    enum led_backend backend;
 };
 #endif


### PR DESCRIPTION
In new Disco releases, the linux kernel led sysfs api will replace the pwm sysfs
api to drive the tricolor led.

Keep pwm sysfs api for compatibility reasons.