### PR TITLE
Copter: Change sprintf method to secure snprintf method.

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -920,7 +920,7 @@ void Copter::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by DataFlash
     char frame_buf[20];
-    sprintf(frame_buf, "Frame: %s", get_frame_string());
+    snprintf(frame_buf, sizeof(frame_buf), "Frame: %s", get_frame_string());
     DataFlash.Log_Write_Message(frame_buf);
     DataFlash.Log_Write_Mode(control_mode, control_mode_reason);
 #if AC_RALLY

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -158,7 +158,7 @@ void Copter::init_ardupilot()
 #if FRSKY_TELEM_ENABLED == ENABLED
     // setup frsky, and pass a number of parameters to the library
     char firmware_buf[50];
-    sprintf(firmware_buf, FIRMWARE_STRING " %s", get_frame_string());
+    snprintf(firmware_buf, sizeof(firmware_buf), FIRMWARE_STRING " %s", get_frame_string());
     frsky_telemetry.init(serial_manager, firmware_buf,
                          get_frame_mav_type(),
                          &g.fs_batt_voltage, &g.fs_batt_mah, &ap.value);
@@ -407,7 +407,7 @@ void Copter::update_auto_armed()
         if(mode_has_manual_throttle(control_mode) && ap.throttle_zero && !failsafe.radio) {
             set_auto_armed(false);
         }
-#if FRAME_CONFIG == HELI_FRAME 
+#if FRAME_CONFIG == HELI_FRAME
         // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
         // so that rotor runup is checked again before attempting to take-off
         if(ap.land_complete && !motors.rotor_runup_complete()) {


### PR DESCRIPTION
There is no limit to the number of characters returned by **get_frame_string** method.
If there are more than 30 characters in non-NULL characters, the stack is destroyed.
Therefore
Define the maximum number of characters 29 in the format.