### PR TITLE
AP_ADSB: Change sprintf method to secure snprintf method.

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -639,7 +639,7 @@ void AP_ADSB::set_callsign(const char* str, const bool append_icao)
     } // for i
 
     if (append_icao) {
-        sprintf(&out_state.cfg.callsign[4], "%04X", out_state.cfg.ICAO_id % 0x10000);
+        snprintf(&out_state.cfg.callsign[4], 5, "%04X", out_state.cfg.ICAO_id % 0x10000);
     }
 }
 


### PR DESCRIPTION
The sprintf method does not judge the write destination size.
Since this process specifies the number of characters in the format, no problem occurs.
However,
I think that it would be better to change to snprintf method which is safer than sprintf method.