### PR TITLE
Use SI units in parameters when possible (part one, no UTF8 characters)

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -77,7 +77,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: Telemetry startup delay
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Standard
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -125,7 +125,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: SPEED_TURN_GAIN
     // @DisplayName: Target speed reduction while turning
     // @Description: The percentage to reduce the throttle while turning. If this is 100% then the target speed is not reduced while turning. If this is 50% then the target speed is reduced in proportion to the turn rate, with a reduction of 50% when the steering is maximally deflected.
-    // @Units: percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -134,7 +134,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: SPEED_TURN_DIST
     // @DisplayName: Distance to turn to start reducing speed
     // @Description: The distance to the next turn at which the rover reduces its target speed by the SPEED_TURN_GAIN
-    // @Units: meters
+    // @Units: m
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
@@ -143,7 +143,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: BRAKING_PERCENT
     // @DisplayName: Percentage braking to apply
     // @Description: The maximum reverse throttle braking percentage to apply when cornering
-    // @Units: percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -233,7 +233,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
     // @Description: The minimum throttle setting to which the autopilot will apply. This is mostly useful for rovers with internal combustion motors, to prevent the motor from cutting out in auto mode.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -242,7 +242,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
     // @Description: The maximum throttle setting to which the autopilot will apply. This can be used to prevent overheating a ESC or motor on an electric rover.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -251,7 +251,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CRUISE_THROTTLE
     // @DisplayName: Base throttle percentage in auto
     // @Description: The base throttle percentage to use in auto mode. The CRUISE_SPEED parameter controls the target speed, but the rover starts with the CRUISE_THROTTLE setting as the initial estimate for how much throttle is needed to achieve that speed. It then adjusts the throttle based on how fast the rover is actually going.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -260,7 +260,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
     // @Description: maximum percentage change in throttle per second. A setting of 10 means to not change the throttle by more than 10% of the full throttle range in one second. A value of zero means no limit. A value of 100 means the throttle can change over its full range in one second. Note that for some NiMH powered rovers setting a lower value like 40 or 50 may be worthwhile as the sudden current demand on the battery of a big rise in throttle may cause a brownout.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -290,7 +290,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout
     // @Description: How long a failsafe event need to happen for before we trigger the failsafe action
-    // @Units: seconds
+    // @Units: s
     // @User: Standard
     GSCALAR(fs_timeout,    "FS_TIMEOUT",     5),
 
@@ -326,7 +326,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TRIGGR_CM
     // @DisplayName: Rangefinder trigger distance
     // @Description: The distance from an obstacle in centimeters at which the rangefinder triggers a turn to avoid the obstacle
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 1000
     // @Increment: 1
     // @User: Standard
@@ -335,7 +335,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TURN_ANGL
     // @DisplayName: Rangefinder trigger angle
     // @Description: The course deviation in degrees to apply while avoiding an obstacle detected with the rangefinder. A positive number means to turn right, and a negative angle means to turn left.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: -45 45
     // @Increment: 1
     // @User: Standard
@@ -344,7 +344,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TURN_TIME
     // @DisplayName: Rangefinder turn time
     // @Description: The amount of time in seconds to apply the RNGFND_TURN_ANGL after detecting an obstacle.
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
@@ -415,7 +415,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint radius
     // @Description: The distance in meters from a waypoint when we consider the waypoint has been reached. This determines when the rover will turn along the next waypoint path.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000
     // @Increment: 0.1
     // @User: Standard

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -57,7 +57,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW_SLEW_TIME
     // @DisplayName: Time for yaw to slew through its full range
     // @Description: This controls how rapidly the tracker will change the servo output for yaw. It is set as the number of seconds to do a full rotation. You can use this parameter to slow the trackers movements, which may help with some types of trackers. A value of zero will allow for unlimited servo movement per update.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 20
     // @User: Standard
@@ -66,7 +66,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH_SLEW_TIME
     // @DisplayName: Time for pitch to slew through its full range
     // @Description: This controls how rapidly the tracker will change the servo output for pitch. It is set as the number of seconds to do a full range of pitch movement. You can use this parameter to slow the trackers movements, which may help with some types of trackers. A value of zero will allow for unlimited servo movement per update.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 20
     // @User: Standard
@@ -84,7 +84,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: MIN_REVERSE_TIME
     // @DisplayName: Minimum time to apply a yaw reversal
     // @Description: When the tracker detects it has reached the limit of servo movement in yaw it will reverse and try moving to the other extreme of yaw. This parameter controls the minimum time it should reverse for. It is used to cope with trackers that have a significant lag in movement to ensure they do move all the way around.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 1
     // @Range: 0 20
     // @User: Standard
@@ -111,7 +111,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: STARTUP_DELAY
     // @DisplayName: Delay before first servo movement from trim
     // @Description: This parameter can be used to force the servos to their trim value for a time on startup. This can help with some servo types
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 10
     // @User: Standard
@@ -152,7 +152,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_YAW_MINT
     // @DisplayName: Yaw minimum movement time
     // @Description: Minimum amount of time in seconds to move in yaw
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.01
     // @Range: 0 2
     // @User: Standard
@@ -161,7 +161,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_PITCH_MINT
     // @DisplayName: Pitch minimum movement time
     // @Description: Minimim amount of time in seconds to move in pitch
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.01
     // @Range: 0 2
     // @User: Standard
@@ -197,7 +197,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: DISTANCE_MIN
     // @DisplayName: Distance minimum to target
     // @Description: Tracker will track targets at least this distance away
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @Range: 0 100
     // @User: Standard

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -78,7 +78,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Pilot takeoff altitude
     // @Description: Altitude that altitude control modes will climb to when a takeoff is triggered with the throttle stick.
     // @User: Standard
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0.0 1000.0
     // @Increment: 10
     GSCALAR(pilot_takeoff_alt,  "PILOT_TKOFF_ALT",  PILOT_TKOFF_ALT_DEFAULT),
@@ -107,7 +107,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Telemetry startup delay
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Advanced
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -123,7 +123,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_ALT
     // @DisplayName: RTL Altitude
     // @Description: The minimum relative altitude the model will move to before Returning to Launch.  Set to zero to return at current altitude.
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0 8000
     // @Increment: 1
     // @User: Standard
@@ -165,7 +165,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_BATT_VOLTAGE
     // @DisplayName: Failsafe battery voltage
     // @Description: Battery voltage to trigger failsafe. Set to 0 to disable battery voltage failsafe. If the battery voltage drops below this voltage then the copter will RTL
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", FS_BATT_VOLTAGE_DEFAULT),
@@ -209,7 +209,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_ALT_FINAL
     // @DisplayName: RTL Final Altitude
     // @Description: This is the altitude the vehicle will move to as the final stage of Returning to Launch or after completing a mission.  Set to zero to land.
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: -1 1000
     // @Increment: 1
     // @User: Standard
@@ -218,7 +218,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_CLIMB_MIN
     // @DisplayName: RTL minimum climb
     // @Description: The vehicle will climb this many cm during the initial climb portion of the RTL
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0 3000
     // @Increment: 10
     // @User: Standard
@@ -261,7 +261,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: PILOT_VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
-    // @Units: Centimeters/Second
+    // @Units: cm/s
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard
@@ -445,7 +445,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: DISARM_DELAY
     // @DisplayName: Disarm delay
     // @Description: Delay before automatic disarm in seconds. A value of zero disables auto disarm.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0 127
     // @User: Advanced
     GSCALAR(disarm_delay, "DISARM_DELAY",           AUTO_DISARMING_DELAY),

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -64,7 +64,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Telemetry startup delay 
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Standard
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -106,7 +106,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This controls the minimum altitude change for a waypoint before a glide slope will be used instead of an immediate altitude change. The default value is 15 meters, which helps to smooth out waypoint missions where small altitude changes happen near waypoints. If you don't want glide slopes to be used in missions then you can set this to zero, which will disable glide slope calculations. Otherwise you can set it to a minimum number of meters of altitude error to the destination waypoint before a glide slope will be used to change altitude.
     // @Range: 0 1000
     // @Increment: 1
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     GSCALAR(glide_slope_min, "GLIDE_SLOPE_MIN", 15),
 
@@ -115,7 +115,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This controls the height above the glide slope the plane may be before rebuilding a glide slope. This is useful for smoothing out an autotakeoff
     // @Range: 0 100
     // @Increment: 1
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     GSCALAR(glide_slope_threshold, "GLIDE_SLOPE_THR", 5.0),
 
@@ -163,7 +163,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_TDRAG_ELEV
     // @DisplayName: Takeoff tail dragger elevator
     // @Description: This parameter sets the amount of elevator to apply during the initial stage of a takeoff. It is used to hold the tail wheel of a taildragger on the ground during the initial takeoff stage to give maximum steering. This option should be combined with the TKOFF_TDRAG_SPD1 option and the GROUND_STEER_ALT option along with tuning of the ground steering controller. A value of zero means to bypass the initial "tail hold" stage of takeoff. Set to zero for hand and catapult launch. For tail-draggers you should normally set this to 100, meaning full up elevator during the initial stage of takeoff. For most tricycle undercarriage aircraft a value of zero will work well, but for some tricycle aircraft a small negative value (say around -20 to -30) will apply down elevator which will hold the nose wheel firmly on the ground during initial acceleration. Only use a negative value if you find that the nosewheel doesn't grip well during takeoff. Too much down elevator on a tricycle undercarriage may cause instability in steering as the plane pivots around the nosewheel. Add down elevator 10 percent at a time.
-    // @Units: Percent
+    // @Units: %
     // @Range: -100 100
     // @Increment: 1
     // @User: User
@@ -199,7 +199,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_PLIM_SEC
     // @DisplayName: Takeoff pitch limit reduction
     // @Description: This parameter reduces the pitch minimum limit of an auto-takeoff just a few seconds before it reaches the target altitude. This reduces overshoot by allowing the flight controller to start leveling off a few seconds before reaching the target height. When set to zero, the mission pitch min is enforced all the way to and through the target altitude, otherwise the pitch min slowly reduces to zero in the final segment. This is the pitch_min, not the demand. The flight controller should still be commanding to gain altitude to finish the takeoff but with this param it is not forcing it higher than it wants to be.
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 10
     // @Increment: 0.5
     // @User: Advanced
@@ -209,7 +209,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Takeoff flap percentage
     // @Description: The amount of flaps (as a percentage) to apply in automatic takeoff
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @User: Advanced
     GSCALAR(takeoff_flap_percent,     "TKOFF_FLAP_PCNT", 0),
 
@@ -261,7 +261,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: ALT_OFFSET
     // @DisplayName: Altitude offset
     // @Description: This is added to the target altitude in automatic flight. It can be used to add a global altitude offset to a mission
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Advanced
@@ -270,7 +270,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint Radius
     // @Description: Defines the maximum distance from a waypoint that when crossed indicates the waypoint may be complete. To avoid the aircraft looping around the waypoint in case it misses by more than the WP_RADIUS an additional check is made to see if the aircraft has crossed a "finish line" passing through the waypoint and perpendicular to the flight path from the previous waypoint. If that finish line is crossed then the waypoint is considered complete. Note that the navigation controller may decide to turn later than WP_RADIUS before a waypoint, based on how sharp the turn is and the speed of the aircraft. It is safe to set WP_RADIUS much larger than the usual turn radius of your aircraft and the navigation controller will work out when to turn. If you set WP_RADIUS too small then you will tend to overshoot the turns.
-    // @Units: Meters
+    // @Units: m
     // @Range: 1 32767
     // @Increment: 1
     // @User: Standard
@@ -279,7 +279,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_MAX_RADIUS
     // @DisplayName: Waypoint Maximum Radius
     // @Description: Sets the maximum distance to a waypoint for the waypoint to be considered complete. This overrides the "cross the finish line" logic that is normally used to consider a waypoint complete. For normal AUTO behaviour this parameter should be set to zero. Using a non-zero value is only recommended when it is critical that the aircraft does approach within the given radius, and should loop around until it has done so. This can cause the aircraft to loop forever if its turn radius is greater than the maximum radius set.
-    // @Units: Meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -288,7 +288,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_LOITER_RAD
     // @DisplayName: Waypoint Loiter Radius
     // @Description: Defines the distance from the waypoint center, the plane will maintain during a loiter. If you set this value to a negative number then the default loiter direction will be counter-clockwise instead of clockwise.
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Standard
@@ -297,7 +297,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: RTL_RADIUS
     // @DisplayName: RTL loiter radius
     // @Description: Defines the radius of the loiter circle when in RTL mode. If this is zero then WP_LOITER_RAD is used. If the radius is negative then a counter-clockwise is used. If positive then a clockwise loiter is used.
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Standard
@@ -326,7 +326,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_MINALT
     // @DisplayName: Fence Minimum Altitude
     // @Description: Minimum altitude allowed before geofence triggers
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -335,7 +335,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_MAXALT
     // @DisplayName: Fence Maximum Altitude
     // @Description: Maximum altitude allowed before geofence triggers
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -344,7 +344,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_RETALT
     // @DisplayName: Fence Return Altitude
     // @Description: Altitude the aircraft will transit to when a fence breach occurs.  If FENCE_RETALT is <= 0 then the midpoint between FENCE_MAXALT and FENCE_MINALT is used, unless FENCE_MAXALT < FENCE_MINALT.  If FENCE_MAXALT < FENCE_MINALT AND FENCE_RETALT is <= 0 then ALT_HOLD_RTL is the altitude used on a fence breach.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -409,7 +409,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Terrain lookahead
     // @Description: This controls how far ahead the terrain following code looks to ensure it stays above upcoming terrain. A value of zero means no lookahead, so the controller will track only the terrain directly below the aircraft. The lookahead will never extend beyond the next waypoint when in AUTO mode.
     // @Range: 0 10000
-    // @Units: meters
+    // @Units: m
     // @User: Standard
     GSCALAR(terrain_lookahead, "TERRAIN_LOOKAHD",  2000),
 #endif
@@ -426,7 +426,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
     // @Description: The minimum throttle setting (as a percentage) which the autopilot will apply. For the final stage of an automatic landing this is always zero. If your ESC supports reverse, use a negative value to configure for reverse thrust.
-    // @Units: Percent
+    // @Units: %
     // @Range: -100 100
     // @Increment: 1
     // @User: Standard
@@ -435,7 +435,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
     // @Description: The maximum throttle setting (as a percentage) which the autopilot will apply.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -444,7 +444,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_THR_MAX
     // @DisplayName: Maximum Throttle for takeoff
     // @Description: The maximum throttle setting during automatic takeoff. If this is zero then THR_MAX is used for takeoff as well.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Advanced
@@ -453,7 +453,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
     // @Description: maximum percentage change in throttle per second. A setting of 10 means to not change the throttle by more than 10% of the full throttle range in one second.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 127
     // @Increment: 1
     // @User: Standard
@@ -462,7 +462,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FLAP_SLEWRATE
     // @DisplayName: Flap slew rate
     // @Description: maximum percentage change in flap output per second. A setting of 25 means to not change the flap by more than 25% of the full flap range in one second. A value of 0 means no rate limiting.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 100
     // @Increment: 1
     // @User: Advanced
@@ -501,7 +501,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TRIM_THROTTLE
     // @DisplayName: Throttle cruise percentage
     // @Description: The target percentage of throttle to apply for normal flight
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -524,7 +524,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_SHORT_TIMEOUT
     // @DisplayName: Short failsafe timeout
     // @Description: The time in seconds that a failsafe condition has to persist before a short failsafe event will occur. This defaults to 1.5 seconds
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 100
     // @Increment: 0.5
     // @User: Standard
@@ -540,7 +540,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_LONG_TIMEOUT
     // @DisplayName: Long failsafe timeout
     // @Description: The time in seconds that a failsafe condition has to persist before a long failsafe event will occur. This defaults to 5 seconds.
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 300
     // @Increment: 0.5
     // @User: Standard
@@ -549,7 +549,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_BATT_VOLTAGE
     // @DisplayName: Failsafe battery voltage
     // @Description: Battery voltage to trigger failsafe. Set to 0 to disable battery voltage failsafe. If the battery voltage drops below this voltage continuously for 10 seconds then the plane will switch to RTL mode.
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", 0),
@@ -679,7 +679,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: GROUND_STEER_ALT
     // @DisplayName: Ground steer altitude
     // @Description: Altitude at which to use the ground steering controller on the rudder. If non-zero then the STEER2SRV controller will be used to control the rudder for altitudes within this limit of the home altitude.
-    // @Units: Meters
+    // @Units: m
     // @Range: -100 100
     // @Increment: 0.1
     // @User: Standard
@@ -831,14 +831,14 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: ALT_HOLD_RTL
     // @DisplayName: RTL altitude
     // @Description: Return to launch target altitude. This is the relative altitude the plane will aim for and loiter at when returning home. If this is negative (usually -1) then the plane will use the current altitude at the time of entering RTL. Note that when transiting to a Rally Point the altitude of the Rally Point is used instead of ALT_HOLD_RTL.
-    // @Units: centimeters
+    // @Units: cm
     // @User: User
     GSCALAR(RTL_altitude_cm,        "ALT_HOLD_RTL",   ALT_HOLD_HOME_CM),
 
     // @Param: ALT_HOLD_FBWCM
     // @DisplayName: Minimum altitude for FBWB mode
     // @Description: This is the minimum altitude in centimeters that FBWB and CRUISE modes will allow. If you attempt to descend below this altitude then the plane will level off. A value of zero means no limit.
-    // @Units: centimeters
+    // @Units: cm
     // @User: User
     GSCALAR(FBWB_min_altitude_cm,   "ALT_HOLD_FBWCM", ALT_HOLD_FBW_CM),
 
@@ -866,7 +866,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Flap 1 percentage
     // @Description: The percentage change in flap position when FLAP_1_SPEED is reached. Use zero to disable flaps
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @User: Advanced
     GSCALAR(flap_1_percent,         "FLAP_1_PERCNT",  FLAP_1_PERCENT),
 
@@ -883,7 +883,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Flap 2 percentage
     // @Description: The percentage change in flap position when FLAP_2_SPEED is reached. Use zero to disable flaps
     // @Range: 0 100
-	// @Units: Percent
+	// @Units: %
     // @User: Advanced
     GSCALAR(flap_2_percent,         "FLAP_2_PERCNT",  FLAP_2_PERCENT),
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
-    // @Units: Centimeters/Second
+    // @Units: cm/s
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Roll axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_RLL_D
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Pitch axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_PIT_D
@@ -102,7 +102,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Yaw axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_YAW_D

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -20,7 +20,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Param: DIST_MAX
     // @DisplayName: Avoidance distance maximum in non-GPS flight modes
     // @Description: Distance from object at which obstacle avoidance will begin in non-GPS modes
-    // @Units: meters
+    // @Units: m
     // @Range: 3 30
     // @User: Standard
     AP_GROUPINFO("DIST_MAX", 3,  AC_Avoid, _dist_max, AC_AVOID_NONGPS_DIST_MAX_DEFAULT),

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: ALT_MAX
     // @DisplayName: Fence Maximum Altitude
     // @Description: Maximum altitude allowed before geofence triggers
-    // @Units: Meters
+    // @Units: m
     // @Range: 10 1000
     // @Increment: 1
     // @User: Standard
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: RADIUS
     // @DisplayName: Circular Fence Radius
     // @Description: Circle fence radius which when breached will cause an RTL
-    // @Units: Meters
+    // @Units: m
     // @Range: 30 10000
     // @User: Standard
     AP_GROUPINFO("RADIUS",      4,  AC_Fence,   _circle_radius, AC_FENCE_CIRCLE_RADIUS_DEFAULT),
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: MARGIN
     // @DisplayName: Fence Margin
     // @Description: Distance that autopilot's should maintain from the fence to avoid a breach
-    // @Units: Meters
+    // @Units: m
     // @Range: 1 10
     // @User: Standard
     AP_GROUPINFO("MARGIN",      5,  AC_Fence,   _margin, AC_FENCE_MARGIN_DEFAULT),

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Range: -20 20
     // @Increment: 1
     // @User: Advanced
-    // @Units: Centimeters
+    // @Units: cm
     AP_GROUPINFO("LAND_OFS_X",    3, AC_PrecLand, _land_ofs_cm_x, 0),
 
     // @Param: LAND_OFS_Y
@@ -47,7 +47,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Range: -20 20
     // @Increment: 1
     // @User: Advanced
-    // @Units: Centimeters
+    // @Units: cm
     AP_GROUPINFO("LAND_OFS_Y",    4, AC_PrecLand, _land_ofs_cm_y, 0),
 
     // 5 RESERVED for EKF_TYPE

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
     // @Param: PUMP_RATE
     // @DisplayName: Pump speed
     // @Description: Desired pump speed when travelling 1m/s expressed as a percentage
-    // @Units: percentage
+    // @Units: %
     // @Range: 0 100
     // @User: Standard
     AP_GROUPINFO("PUMP_RATE",   1, AC_Sprayer, _pump_pct_1ms, AC_SPRAYER_DEFAULT_PUMP_RATE),
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
     // @Param: PUMP_MIN
     // @DisplayName: Pump speed minimum
     // @Description: Minimum pump speed expressed as a percentage
-    // @Units: percentage
+    // @Units: %
     // @Range: 0 100
     // @User: Standard
     AP_GROUPINFO("PUMP_MIN",   4, AC_Sprayer, _pump_min_pct, AC_SPRAYER_DEFAULT_PUMP_MIN),

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 	// @DisplayName: Pitch Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved pitch angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_PitchController, gains.tau,       0.5f),

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 	// @DisplayName: Roll Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved bank angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_RollController, gains.tau,       0.5f),

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
 	// @DisplayName: Steering Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved steering angle. A value of 0.75 is a good default and will work with nearly all rovers. Ground steering in aircraft needs a bit smaller time constant, and a value of 0.5 is recommended for best ground handling in fixed wing aircraft. A value of 0.75 means that the controller will try to correct any deviation between the desired and actual steering angle in 0.75 seconds. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the vehicle can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_SteerController, _tau,       0.75f),

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_X
     // @DisplayName: AHRS Trim Roll
     // @Description: Compensates for the roll angle difference between the control board and the frame. Positive values make the vehicle roll right.
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Standard
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_Y
     // @DisplayName: AHRS Trim Pitch
     // @Description: Compensates for the pitch angle difference between the control board and the frame. Positive values make the vehicle pitch up/back.
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Standard
@@ -83,7 +83,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_Z
     // @DisplayName: AHRS Trim Yaw
     // @Description: Not Used
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Advanced

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -81,20 +81,20 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @DisplayName: AMSL limit
     // @Description: This sets the AMSL (above mean sea level) altitude limit. If the pressure altitude determined by QNH exceeds this limit then flight termination will be forced. Note that this limit is in meters, whereas pressure altitude limits are often quoted in feet. A value of zero disables the pressure altitude limit.
     // @User: Advanced
-    // @Units: meters
+    // @Units: m
     AP_GROUPINFO("AMSL_LIMIT",   8, AP_AdvancedFailsafe, _amsl_limit,    0),
 
     // @Param: AMSL_ERR_GPS
     // @DisplayName: Error margin for GPS based AMSL limit
     // @Description: This sets margin for error in GPS derived altitude limit. This error margin is only used if the barometer has failed. If the barometer fails then the GPS will be used to enforce the AMSL_LIMIT, but this margin will be subtracted from the AMSL_LIMIT first, to ensure that even with the given amount of GPS altitude error the pressure altitude is not breached. OBC users should set this to comply with their D2 safety case. A value of -1 will mean that barometer failure will lead to immediate termination.
     // @User: Advanced
-    // @Units: meters
+    // @Units: m
     AP_GROUPINFO("AMSL_ERR_GPS", 9, AP_AdvancedFailsafe, _amsl_margin_gps,  -1),
 
     // @Param: QNH_PRESSURE
     // @DisplayName: QNH pressure
     // @Description: This sets the QNH pressure in millibars to be used for pressure altitude in the altitude limit. A value of zero disables the altitude limit.
-    // @Units: millibar
+    // @Units: mbar
     // @User: Advanced
     AP_GROUPINFO("QNH_PRESSURE", 10, AP_AdvancedFailsafe, _qnh_pressure,    0),
 
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @DisplayName: RC failure time
     // @Description: This is the time in seconds in manual mode that failsafe termination will activate if RC input is lost. For the OBC rules this should be (1.5). Use 0 to disable.
     // @User: Advanced
-    // @Units: seconds
+    // @Units: s
     AP_GROUPINFO("RC_FAIL_TIME",   19, AP_AdvancedFailsafe, _rc_fail_time_seconds,    0),
 
     AP_GROUPEND

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -56,7 +56,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: MIN_VOLT
     // @DisplayName: Minimum arming voltage on the first battery
     // @Description: The minimum voltage on the first battery to arm, 0 disabes the check
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1 
     // @User: Standard
     AP_GROUPINFO("MIN_VOLT",      4,     AP_Arming,  _min_voltage[0],  0),
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: MIN_VOLT2
     // @DisplayName: Minimum arming voltage on the second battery
     // @Description: The minimum voltage on the first battery to arm, 0 disabes the check
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1 
     // @User: Standard
     AP_GROUPINFO("MIN_VOLT2",     5,     AP_Arming,  _min_voltage[1],  0),

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -76,36 +76,42 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     // @Param: W_TIME
     // @DisplayName: Time Horizon Warn
     // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than W_DIST_XY or W_DIST_Z then W_ACTION is undertaken (assuming F_ACTION is not undertaken)
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("W_TIME",      6, AP_Avoidance, _warn_time_horizon, AP_AVOIDANCE_WARN_TIME_DEFAULT),
 
     // @Param: F_TIME
     // @DisplayName: Time Horizon Fail
     // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than F_DIST_XY or F_DIST_Z then F_ACTION is undertaken
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("F_TIME",      7, AP_Avoidance, _fail_time_horizon, AP_AVOIDANCE_FAIL_TIME_DEFAULT),
 
     // @Param: W_DIST_XY
     // @DisplayName: Distance Warn XY
     // @Description: Closest allowed projected distance before W_ACTION is undertaken
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("W_DIST_XY",   8, AP_Avoidance, _warn_distance_xy, AP_AVOIDANCE_WARN_DISTANCE_XY_DEFAULT),
 
     // @Param: F_DIST_XY
     // @DisplayName: Distance Fail XY
     // @Description: Closest allowed projected distance before F_ACTION is undertaken
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("F_DIST_XY",   9, AP_Avoidance, _fail_distance_xy, AP_AVOIDANCE_FAIL_DISTANCE_XY_DEFAULT),
 
     // @Param: W_DIST_Z
     // @DisplayName: Distance Warn Z
     // @Description: Closest allowed projected distance before BEHAVIOUR_W is undertaken
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("W_DIST_Z",    10, AP_Avoidance, _warn_distance_z, AP_AVOIDANCE_WARN_DISTANCE_Z_DEFAULT),
 
     // @Param: F_DIST_Z
     // @DisplayName: Distance Fail Z
     // @Description: Closest allowed projected distance before BEHAVIOUR_F is undertaken
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("F_DIST_Z",    11, AP_Avoidance, _fail_distance_z, AP_AVOIDANCE_FAIL_DISTANCE_Z_DEFAULT),
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ABS_PRESS
     // @DisplayName: Absolute Pressure
     // @Description: calibrated ground pressure in Pascals
-    // @Units: pascals
+    // @Units: Pa
     // @Increment: 1
     // @ReadOnly: True
     // @Volatile: True
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ALT_OFFSET
     // @DisplayName: altitude offset
     // @Description: altitude offset in meters added to barometric altitude. This is used to allow for automatic adjustment of the base barometric altitude by a ground station equipped with a barometer. The value is added to the barometric altitude read by the aircraft. It is automatically reset to 0 when the barometer is calibrated on each reboot or when a preflight calibration is performed.
-    // @Units: meters
+    // @Units: m
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("ALT_OFFSET", 5, AP_Baro, _alt_offset, 0),

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -37,14 +37,14 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: _AMP_PERVOLT
     // @DisplayName: Amps per volt
     // @Description: Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
-    // @Units: Amps/Volt
+    // @Units: A/V
     // @User: Standard
     AP_GROUPINFO("_AMP_PERVOLT", 4, AP_BattMonitor, _curr_amp_per_volt[0], AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
 
     // @Param: _AMP_OFFSET
     // @DisplayName: AMP offset
     // @Description: Voltage offset at zero current on current sensor
-    // @Units: Volts
+    // @Units: V
     // @User: Standard
     AP_GROUPINFO("_AMP_OFFSET", 5, AP_BattMonitor, _curr_amp_offset[0], 0),
 
@@ -62,7 +62,7 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: _WATT_MAX
     // @DisplayName: Maximum allowed power (Watts)
     // @Description: If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable.
-    // @Units: Watts
+    // @Units: W
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_WATT_MAX", 9, AP_BattMonitor, _watt_max[0], AP_BATT_MAX_WATT_DEFAULT),
@@ -101,14 +101,14 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: 2_AMP_PERVOL
     // @DisplayName: Amps per volt
     // @Description: Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
-    // @Units: Amps/Volt
+    // @Units: A/V
     // @User: Standard
     AP_GROUPINFO("2_AMP_PERVOL", 15, AP_BattMonitor, _curr_amp_per_volt[1], AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
 
     // @Param: 2_AMP_OFFSET
     // @DisplayName: AMP offset
     // @Description: Voltage offset at zero current on current sensor
-    // @Units: Volts
+    // @Units: V
     // @User: Standard
     AP_GROUPINFO("2_AMP_OFFSET", 16, AP_BattMonitor, _curr_amp_offset[1], 0),
 
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: 2_WATT_MAX
     // @DisplayName: Maximum allowed current
     // @Description: If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable.
-    // @Units: Amps
+    // @Units: A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_WATT_MAX", 18, AP_BattMonitor, _watt_max[1], AP_BATT_MAX_WATT_DEFAULT),

--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Param: _ALT
     // @DisplayName: Beacon origin's altitude above sealevel in meters
     // @Description: Beacon origin's altitude above sealevel in meters
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @Range: 0 10000
     // @User: Advanced

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Param: DURATION
     // @DisplayName: Duration that shutter is held open
     // @Description: How long the shutter will be held open in 10ths of a second (i.e. enter 10 for 1second, 50 for 5seconds)
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 50
     // @User: Standard
     AP_GROUPINFO("DURATION",    1, AP_Camera, _trigger_duration, AP_CAMERA_TRIGGER_DEFAULT_DURATION),
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @DisplayName: Camera trigger distance
     // @Description: Distance in meters between camera triggers. If this value is non-zero then the camera will trigger whenever the GPS position changes by this number of meters regardless of what mode the APM is in. Note that this parameter can also be set in an auto mission using the DO_SET_CAM_TRIGG_DIST command, allowing you to enable/disable the triggering of the camera during the flight.
     // @User: Standard
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000
     AP_GROUPINFO("TRIGG_DIST",  4, AP_Camera, _trigg_dist, 0),
 
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @DisplayName: Minimum time between photos
     // @Description: Postpone shooting if previous picture was taken less than preset time(ms) ago.
     // @User: Standard
-    // @Units: milliseconds
+    // @Units: ms
     // @Range: 0 10000
     AP_GROUPINFO("MIN_INTERVAL",  6, AP_Camera, _min_interval, 0),
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the X axis
     // @Description: Offset to be added to the compass x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the Y axis
     // @Description: Offset to be added to the compass y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the Z axis
     // @Description: Offset to be added to the compass z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS",    1, Compass, _state[0].offset, 0),
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass declination
     // @Description: An angle to compensate between the true north and magnetic north
     // @Range: -3.142 3.142
-    // @Units: Radians
+    // @Units: rad
     // @Increment: 0.01
     // @User: Standard
     AP_GROUPINFO("DEC",    2, Compass, _declination, 0),
@@ -94,25 +94,25 @@ const AP_Param::GroupInfo Compass::var_info[] = {
 
     // @Param: MOT_X
     // @DisplayName: Motor interference compensation for body frame X axis
-    // @Description: Multiplied by the current throttle and added to the compass's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT_Y
     // @DisplayName: Motor interference compensation for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to the compass's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT_Z
     // @DisplayName: Motor interference compensation for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to the compass's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT",    7, Compass, _state[0].motor_compensation, 0),
@@ -135,7 +135,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass2's x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass2's y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -151,32 +151,32 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass2's z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS2",    10, Compass, _state[1].offset, 0),
 
     // @Param: MOT2_X
     // @DisplayName: Motor interference compensation to compass2 for body frame X axis
-    // @Description: Multiplied by the current throttle and added to compass2's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT2_Y
     // @DisplayName: Motor interference compensation to compass2 for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to compass2's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT2_Z
     // @DisplayName: Motor interference compensation to compass2 for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to compass2's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT2",    11, Compass, _state[1].motor_compensation, 0),
@@ -192,7 +192,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass3's x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -200,7 +200,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass3's y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
 
@@ -208,32 +208,32 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass3's z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mgauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS3",    13, Compass, _state[2].offset, 0),
 
     // @Param: MOT3_X
     // @DisplayName: Motor interference compensation to compass3 for body frame X axis
-    // @Description: Multiplied by the current throttle and added to compass3's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT3_Y
     // @DisplayName: Motor interference compensation to compass3 for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to compass3's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT3_Z
     // @DisplayName: Motor interference compensation to compass3 for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to compass3's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: 1/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT3",    14, Compass, _state[2].motor_compensation, 0),

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -147,6 +147,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: RATE_MS
     // @DisplayName: GPS update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
+    // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @User: Advanced
     AP_GROUPINFO("RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
@@ -154,6 +155,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: RATE_MS2
     // @DisplayName: GPS 2 update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
+    // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @User: Advanced
     AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
     // @Description: Time in seconds that gripper will regrab the cargo to ensure grip has not weakened; 0 to disable
     // @User: Advanced
     // @Values: 0 255
-    // @Units: seconds
+    // @Units: s
     AP_GROUPINFO("REGRAB",  5, AP_Gripper, config.regrab_interval, GRIPPER_REGRAB_DEFAULT),
 
     // @Param: UAVCAN_ID

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @DisplayName: Time to run starter
     // @Description: This is the number of seconds to run the starter when trying to start the engine
     // @User: Standard
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.1 5
     AP_GROUPINFO("STARTER_TIME", 2, AP_ICEngine, starter_time, 3),
 
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @DisplayName: Time to wait between starts
     // @Description: Delay between start attempts
     // @User: Standard
-    // @Units: Seconds
+    // @Units: s
     // @Range: 1 10
     AP_GROUPINFO("START_DELAY", 3, AP_ICEngine, starter_delay, 2),
     

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
     // @Param: PERIOD
     // @DisplayName: L1 control period
     // @Description: Period in seconds of L1 tracking loop. This parameter is the primary control for agressiveness of turns in auto mode. This needs to be larger for less responsive airframes. The default of 20 is quite conservative, but for most RC aircraft will lead to reasonable flight. For smaller more agile aircraft a value closer to 15 is appropriate, or even as low as 10 for some very agile aircraft. When tuning, change this value in small increments, as a value that is much too small (say 5 or 10 below the right value) can lead to very radical turns, and a risk of stalling.
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 60
     // @Increment: 1
     // @User: Standard

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: RSC Ramp Time
     // @Description: Time in seconds for the output to the main rotor's ESC to reach full speed
     // @Range: 0 60
-    // @Units: Seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("RSC_RAMP_TIME", 10, AP_MotorsHeli, _rsc_ramp_time, AP_MOTORS_HELI_RSC_RAMP_TIME),
 
@@ -102,7 +102,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: RSC Runup Time
     // @Description: Time in seconds for the main rotor to reach full speed.  Must be longer than RSC_RAMP_TIME
     // @Range: 0 60
-    // @Units: Seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("RSC_RUNUP_TIME", 11, AP_MotorsHeli, _rsc_runup_time, AP_MOTORS_HELI_RSC_RUNUP_TIME),
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.4 * cell count, 0 = Disabled
     // @Range: 6 35
-    // @Units: Volts
+    // @Units: V
     // @User: Advanced
     AP_GROUPINFO("BAT_VOLT_MAX", 10, AP_MotorsMulticopter, _batt_voltage_max, AP_MOTORS_BAT_VOLT_MAX_DEFAULT),
 
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled
     // @Range: 6 35
-    // @Units: Volts
+    // @Units: V
     // @User: Advanced
     AP_GROUPINFO("BAT_VOLT_MIN", 11, AP_MotorsMulticopter, _batt_voltage_min, AP_MOTORS_BAT_VOLT_MIN_DEFAULT),
 
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Motor Current Max
     // @Description: Maximum current over which maximum throttle is limited (0 = Disabled)
     // @Range: 0 200
-    // @Units: Amps
+    // @Units: A
     // @User: Advanced
     AP_GROUPINFO("BAT_CURR_MAX", 12, AP_MotorsMulticopter, _batt_current_max, AP_MOTORS_BAT_CURR_MAX_DEFAULT),
 
@@ -120,7 +120,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Motor Current Max Time Constant
     // @Description: Time constant used to limit the maximum current
     // @Range: 0 10
-    // @Units: Seconds
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("BAT_CURR_TC", 20, AP_MotorsMulticopter, _batt_current_time_constant, AP_MOTORS_BAT_CURR_TC_DEFAULT),
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -175,7 +175,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _LEAD_RLL
     // @DisplayName: Roll stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate, compensating for servo delay. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -184,7 +184,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _LEAD_PTCH
     // @DisplayName: Pitch stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -367,7 +367,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_LEAD_RLL
     // @DisplayName: Mount2's Roll stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate, compensating for servo delay. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -376,7 +376,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_LEAD_PTCH
     // @DisplayName: Mount2's Pitch stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -192,7 +192,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("GPS_DELAY", 8, NavEKF2, _gpsDelay_ms, 220),
 
     // Height measurement parameters
@@ -227,7 +227,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF2, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -328,7 +328,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF2, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -364,7 +364,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This noise controls the rate of gyro scale factor learning. Increasing it makes rate gyro scale factor estimation faster and noisier.
     // @Range: 0.000001 0.001
     // @User: Advanced
-    // @Units: 1/s
+    // @Units: Hz
     AP_GROUPINFO("GSCL_P_NSE", 27, NavEKF2, _gyroScaleProcessNoise, GSCALE_P_NSE_DEFAULT),
 
     // @Param: ABIAS_P_NSE
@@ -439,7 +439,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0.05 1.0
     // @Increment: 0.05
     // @User: Advanced
-    // @Units: gauss
+    // @Units: rad
     AP_GROUPINFO("YAW_M_NSE", 37, NavEKF2, _yawNoise, 0.5f),
 
     // @Param: YAW_I_GATE
@@ -456,6 +456,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 10 50
     // @Increment: 5
     // @User: Advanced
+    // @Units: cs
     AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 25),
 
     // @Param: MAGE_P_NSE
@@ -514,7 +515,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF2, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD
@@ -523,7 +524,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 2.0 6.0
     // @Increment: 0.5
     // @User: Advanced
-    // @Units: m
+    // @Units: m/s
     AP_GROUPINFO("RNG_USE_SPD", 47, NavEKF2, _useRngSwSpd, 2.0f),
 
     AP_GROUPEND

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -188,15 +188,15 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("GPS_DELAY", 8, NavEKF3, _gpsDelay_ms, 220),
 
     // Height measurement parameters
 
     // @Param: ALT_SOURCE
+    // @DisplayName: Primary height source
     // @Description: This parameter controls the primary height sensor used by the EKF. If the selected option cannot be used, it will default to Baro as the primary height source. Setting 0 will use the baro altitude at all times. Setting 1 uses the range finder and is only available in combination with optical flow navigation (EK2_GPS_TYPE = 3). Setting 2 uses GPS. Setting 3 uses the range beacon data. NOTE - the EK2_RNG_USE_HGT parameter can be used to switch to range-finder when close to the ground.
     // @Values: 0:Use Baro, 1:Use Range Finder, 2:Use GPS, 3:Use Range Beacon
-    // @Values: 0:Use Baro, 1:Use Range Finder, 2:Use GPS
     // @User: Advanced
     AP_GROUPINFO("ALT_SOURCE", 9, NavEKF3, _altSource, 0),
 
@@ -223,7 +223,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF3, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -324,7 +324,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF3, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -411,7 +411,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Description: This sets the amount of position variation that the EKF allows for when operating without external measurements (eg GPS or optical flow). Increasing this parameter makes the EKF attitude estimate less sensitive to vehicle manoeuvres but more sensitive to IMU errors.
     // @Range: 0.5 50.0
     // @User: Advanced
-    // @Units: m/s
+    // @Units: m
     AP_GROUPINFO("NOAID_M_NSE", 35, NavEKF3, _noaidHorizNoise, 10.0f),
 
     // @Param: LOG_MASK
@@ -429,7 +429,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0.05 1.0
     // @Increment: 0.05
     // @User: Advanced
-    // @Units: gauss
+    // @Units: rad
     AP_GROUPINFO("YAW_M_NSE", 37, NavEKF3, _yawNoise, 0.5f),
 
     // @Param: YAW_I_GATE
@@ -446,6 +446,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 10 50
     // @Increment: 5
     // @User: Advanced
+    // @Units: cs
     AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF3, _tauVelPosOutput, 25),
 
     // @Param: MAGE_P_NSE
@@ -504,7 +505,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: msec
+    // @Units: ms
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF3, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD
@@ -513,7 +514,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 2.0 6.0
     // @Increment: 0.5
     // @User: Advanced
-    // @Units: m
+    // @Units: m/s
     AP_GROUPINFO("RNG_USE_SPD", 47, NavEKF3, _useRngSwSpd, 2.0f),
 
     // @Param: ACC_BIAS_LIM

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Parachute min altitude in meters above home
     // @Description: Parachute min altitude above home.  Parachute will not be released below this altitude.  0 to disable alt check.
     // @Range: 0 32000
-    // @Units: Meters
+    // @Units: m
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("ALT_MIN", 4, AP_Parachute, _alt_min, AP_PARACHUTE_ALT_MIN_DEFAULT),
@@ -54,7 +54,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Parachute release delay
     // @Description: Delay in millseconds between motor stop and chute release
     // @Range: 0 5000
-    // @Units: Milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("DELAY_MS", 5, AP_Parachute, _delay_ms, AP_PARACHUTE_RELEASE_DELAY_MS),

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: PIN_LOW
     // @DisplayName: Receiver RSSI voltage low
     // @Description: This is the voltage value that the radio receiver will put on the RSSI_ANA_PIN when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_PIN_HIGH. 
-    // @Units: Volt
+    // @Units: V
     // @Increment: 0.01
     // @Range: 0 5.0
     // @User: Standard
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: PIN_HIGH
     // @DisplayName: Receiver RSSI voltage high
     // @Description: This is the voltage value that the radio receiver will put on the RSSI_ANA_PIN when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_PIN_LOW. 
-    // @Units: Volt
+    // @Units: V
     // @Increment: 0.01
     // @Range: 0 5.0
     // @User: Standard

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo AP_Rally::var_info[] = {
     // @DisplayName: Rally Limit
     // @Description: Maximum distance to rally point. If the closest rally point is more than this number of kilometers from the current position and the home location is closer than any of the rally points from the current position then do RTL to home rather than to the closest rally point. This prevents a leftover rally point from a different airfield being used accidentally. If this is set to 0 then the closest rally point is always used.
     // @User: Advanced
-    // @Units: kilometers
+    // @Units: km
     // @Increment: 0.1
     AP_GROUPINFO("LIMIT_KM", 1, AP_Rally, _rally_limit_km, RALLY_LIMIT_KM_DEFAULT),
 

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("_SCALING", 2, RangeFinder, _scaling[0], 3.0f),
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance for analog rangefinders. Offset added to distance in centimeters for PWM and I2C Lidars
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("_OFFSET",  3, RangeFinder, _offset[0], 0.0f),
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_MIN_CM",  5, RangeFinder, _min_distance_cm[0], 20),
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_MAX_CM",  6, RangeFinder, _max_distance_cm[0], 700),
@@ -96,7 +96,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _SETTLE
     // @DisplayName: Rangefinder settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_SETTLE", 8, RangeFinder, _settle_time_ms[0], 0),
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _PWRRNG
     // @DisplayName: Powersave range
     // @Description: This parameter sets the estimated terrain distance in meters above which the sensor will be put into a power saving mode (if available). A value of zero means power saving is not enabled
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @User: Standard
     AP_GROUPINFO("_PWRRNG", 10, RangeFinder, _powersave_range, 0),
@@ -119,7 +119,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _GNDCLEAR
     // @DisplayName: Distance (in cm) from the range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Standard
@@ -170,7 +170,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("2_SCALING", 14, RangeFinder, _scaling[1], 3.0f),
@@ -178,7 +178,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("2_OFFSET",  15, RangeFinder, _offset[1], 0.0f),
@@ -193,7 +193,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_MIN_CM",  17, RangeFinder, _min_distance_cm[1], 20),
@@ -201,7 +201,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_MAX_CM",  18, RangeFinder, _max_distance_cm[1], 700),
@@ -216,7 +216,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_SETTLE", 20, RangeFinder, _settle_time_ms[1], 0),
@@ -231,7 +231,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_GNDCLEAR
     // @DisplayName: Distance (in cm) from the second range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the second range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced
@@ -285,7 +285,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("3_SCALING", 27, RangeFinder, _scaling[2], 3.0f),
@@ -293,7 +293,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("3_OFFSET",  28, RangeFinder, _offset[2], 0.0f),
@@ -308,7 +308,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_MIN_CM",  30, RangeFinder, _min_distance_cm[2], 20),
@@ -316,7 +316,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_MAX_CM",  31, RangeFinder, _max_distance_cm[2], 700),
@@ -331,7 +331,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_SETTLE", 33, RangeFinder, _settle_time_ms[2], 0),
@@ -346,7 +346,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_GNDCLEAR
     // @DisplayName: Distance (in cm) from the third range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the third range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced
@@ -400,7 +400,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("4_SCALING", 39, RangeFinder, _scaling[3], 3.0f),
@@ -408,7 +408,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("4_OFFSET",  40, RangeFinder, _offset[3], 0.0f),
@@ -423,7 +423,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_MIN_CM",  42, RangeFinder, _min_distance_cm[3], 20),
@@ -431,7 +431,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_MAX_CM",  43, RangeFinder, _max_distance_cm[3], 700),
@@ -446,7 +446,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_SETTLE", 45, RangeFinder, _settle_time_ms[3], 0),
@@ -461,7 +461,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_GNDCLEAR
     // @DisplayName: Distance (in cm) from the fourth range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the fourth range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced

--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -16,18 +16,21 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Param: _FLTTIME
     // @DisplayName: Total FlightTime
     // @Description: Total FlightTime (seconds)
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_FLTTIME",    1, AP_Stats, params.flttime, 0),
 
     // @Param: _RUNTIME
     // @DisplayName: Total RunTime
     // @Description: Total time autopilot has run
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_RUNTIME",    2, AP_Stats, params.runtime, 0),
 
     // @Param: _RESET
     // @DisplayName: Reset time
     // @Description: Seconds since January 1st 2016 (Unix epoch+1451606400) since reset (set to 0 to reset statistics)
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_RESET",    3, AP_Stats, params.reset, 1),
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Param: SPACING
     // @DisplayName: Terrain grid spacing
     // @Description: Distance between terrain grid points in meters. This controls the horizontal resolution of the terrain data that is stored on te SD card and requested from the ground station. If your GCS is using the worldwide SRTM database then a resolution of 100 meters is appropriate. Some parts of the world may have higher resolution data available, such as 30 meter data available in the SRTM database in the USA. The grid spacing also controls how much data is kept in memory during flight. A larger grid spacing will allow for a larger amount of data in memory. A grid spacing of 100 meters results in the vehicle keeping 12 grid squares in memory with each grid square having a size of 2.7 kilometers by 3.2 kilometers. Any additional grid squares are stored on the SD once they are fetched from the GCS and will be demand loaded as needed.
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("SPACING",   1, AP_Terrain, grid_spacing, 100),


### PR DESCRIPTION
This first part of the patch only contains ansi characters and should therefore be easier to digest :)