### PR TITLE
Linux: fixed RCInput bug

### DIFF
--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -17,12 +17,9 @@ public:
     virtual void teardown() {};
 
     /**
-     * Return true if there has been new input since the last read()
-     * call. This call also clears the new_input flag, so once it
-     * returns true it won't return true again until another frame is
-     * received.
+     * Return true if there has been new input since the last call to new_input()
      */
-    virtual bool new_input() = 0;
+    virtual bool new_input(void) = 0;
 
     /**
      * Return the number of valid channels in the last read

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -47,7 +47,8 @@ protected:
     void _process_rc_pulse(uint16_t width_s0, uint16_t width_s1);
     void _update_periods(uint16_t *periods, uint8_t len);
 
-    volatile bool new_rc_input;
+    volatile uint32_t rc_input_count;
+    uint32_t last_rc_input_count;
 
     uint16_t _pwm_values[LINUX_RC_INPUT_NUM_CHANNELS];
     uint8_t  _num_channels;

--- a/libraries/AP_HAL_Linux/RCInput_Multi.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Multi.cpp
@@ -58,7 +58,7 @@ void RCInput_Multi::_timer_tick(void)
         if (inputs[i]->new_input()) {
             inputs[i]->read(_pwm_values, inputs[i]->num_channels());
             _num_channels = inputs[i]->num_channels();
-            new_rc_input = true;
+            rc_input_count++;
         }        
     }
 }


### PR DESCRIPTION
this fixes a bug in the Linux RCInput that was fixed quite a long time ago for HAL_PX4. It bit me today on the Disco when it was entering failsafe while it had good R/C input. The problem was another library calling read() on an input was clearing the new input flag, so the main loop didn't see new input
