### PR TITLE
AP_HAL_Sitl cleanup and minor fixes

### DIFF
--- a/libraries/AP_HAL_SITL/AP_HAL_SITL.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL.h
@@ -6,4 +6,4 @@
 
 #include "HAL_SITL_Class.h"
 
-#endif // CONFIG_HAL_BOARD
+#endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
@@ -14,4 +14,4 @@ class Util;
 class Semaphore;
 class GPIO;
 class DigitalSource;
-}
+}  // namespace HALSITL

--- a/libraries/AP_HAL_SITL/AnalogIn.cpp
+++ b/libraries/AP_HAL_SITL/AnalogIn.cpp
@@ -9,7 +9,7 @@ using namespace HALSITL;
 
 extern const AP_HAL::HAL& hal;
 
-ADCSource::ADCSource(SITL_State *sitlState, uint8_t pin) :
+ADCSource::ADCSource(SITL_State *sitlState, int16_t pin) :
     _sitlState(sitlState),
     _pin(pin)
 {}

--- a/libraries/AP_HAL_SITL/AnalogIn.h
+++ b/libraries/AP_HAL_SITL/AnalogIn.h
@@ -9,7 +9,7 @@ class HALSITL::ADCSource : public AP_HAL::AnalogSource {
 public:
     friend class HALSITL::AnalogIn;
     /* pin designates the ADC input number */
-    ADCSource(SITL_State *sitlState, uint8_t pin);
+    ADCSource(SITL_State *sitlState, int16_t pin);
 
     /* implement AnalogSource virtual api: */
     float read_average();
@@ -25,16 +25,14 @@ public:
 
 private:
     SITL_State *_sitlState;
-    uint8_t _pin;
+    int16_t _pin;
 };
 
 /* AnalogIn : a concrete class providing the implementations of the
  * timer event and the AP_HAL::AnalogIn interface */
 class HALSITL::AnalogIn : public AP_HAL::AnalogIn {
 public:
-    AnalogIn(SITL_State *sitlState) {
-        _sitlState = sitlState;
-    }
+    explicit AnalogIn(SITL_State *sitlState): _sitlState(sitlState) {}
     void init();
     AP_HAL::AnalogSource* channel(int16_t n);
     float board_voltage(void) {

--- a/libraries/AP_HAL_SITL/GPIO.cpp
+++ b/libraries/AP_HAL_SITL/GPIO.cpp
@@ -13,33 +13,32 @@ void GPIO::pinMode(uint8_t pin, uint8_t output)
 
 int8_t GPIO::analogPinToDigitalPin(uint8_t pin)
 {
-	return pin;
+    return pin;
 }
-
 
 uint8_t GPIO::read(uint8_t pin)
 {
-    if (!sitlState->_sitl) {
+    if (!_sitlState->_sitl) {
         return 0;
     }
-    uint8_t mask = sitlState->_sitl->pin_mask.get();
-    return mask & (1U<<pin)? 1: 0;
+    uint8_t mask = static_cast<uint8_t>(_sitlState->_sitl->pin_mask.get());
+    return static_cast<uint8_t>((mask & (1U << pin)) ? 1 : 0);
 }
 
 void GPIO::write(uint8_t pin, uint8_t value)
 {
-    if (!sitlState->_sitl) {
+    if (!_sitlState->_sitl) {
         return;
     }
-    uint8_t mask = sitlState->_sitl->pin_mask.get();
+    uint8_t mask = static_cast<uint8_t>(_sitlState->_sitl->pin_mask.get());
     uint8_t new_mask = mask;
     if (value) {
-        new_mask |= (1U<<pin);
+        new_mask |= (1U << pin);
     } else {
-        new_mask &= ~(1U<<pin);
+        new_mask &= ~(1U << pin);
     }
     if (mask != new_mask) {
-        sitlState->_sitl->pin_mask.set_and_notify(new_mask);
+        _sitlState->_sitl->pin_mask.set_and_notify(new_mask);
     }
 }
 
@@ -50,7 +49,12 @@ void GPIO::toggle(uint8_t pin)
 
 /* Alternative interface: */
 AP_HAL::DigitalSource* GPIO::channel(uint16_t n) {
-    return new DigitalSource(0);
+    if (n < 8){  // (ie. sizeof(pin_mask)*8)
+        return new DigitalSource(static_cast<uint8_t>(n));
+    } else {
+        return nullptr;
+    }
+
 }
 
 /* Interrupt interface: */
@@ -64,8 +68,8 @@ bool GPIO::usb_connected(void)
     return false;
 }
 
-DigitalSource::DigitalSource(uint8_t v) :
-    pin(v)
+DigitalSource::DigitalSource(uint8_t pin) :
+    _pin(pin)
 {}
 
 void DigitalSource::mode(uint8_t output)
@@ -73,16 +77,16 @@ void DigitalSource::mode(uint8_t output)
 
 uint8_t DigitalSource::read()
 {
-    return hal.gpio->read(pin);
+    return hal.gpio->read(_pin);
 }
 
 void DigitalSource::write(uint8_t value)
 {
-    value = value?1:0;
-    return hal.gpio->write(pin, value);
+    value = static_cast<uint8_t>(value ? 1 : 0);
+    return hal.gpio->write(_pin, value);
 }
 
 void DigitalSource::toggle()
 {
-    return hal.gpio->write(pin, !hal.gpio->read(pin));
+    return hal.gpio->write(_pin, !hal.gpio->read(_pin));
 }

--- a/libraries/AP_HAL_SITL/GPIO.h
+++ b/libraries/AP_HAL_SITL/GPIO.h
@@ -4,38 +4,36 @@
 
 class HALSITL::GPIO : public AP_HAL::GPIO {
 public:
-    GPIO(SITL_State *_sitlState) {
-        sitlState = _sitlState;
-    }
-    void    init();
-    void    pinMode(uint8_t pin, uint8_t output);
-    int8_t  analogPinToDigitalPin(uint8_t pin);
+    explicit GPIO(SITL_State *sitlState): _sitlState(sitlState) {}
+    void init();
+    void pinMode(uint8_t pin, uint8_t output);
+    int8_t analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
-    void    write(uint8_t pin, uint8_t value);
-    void    toggle(uint8_t pin);
+    void write(uint8_t pin, uint8_t value);
+    void toggle(uint8_t pin);
 
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n);
 
     /* Interrupt interface: */
-    bool    attach_interrupt(uint8_t interrupt_num, AP_HAL::Proc p,
+    bool attach_interrupt(uint8_t interrupt_num, AP_HAL::Proc p,
             uint8_t mode);
 
     /* return true if USB cable is connected */
-    bool    usb_connected(void);
+    bool usb_connected(void);
 
 private:
-    SITL_State *sitlState;
+    SITL_State *_sitlState;
 };
 
 class HALSITL::DigitalSource : public AP_HAL::DigitalSource {
 public:
-    DigitalSource(uint8_t _pin);
-    void    mode(uint8_t output);
+    explicit DigitalSource(uint8_t pin);
+    void mode(uint8_t output);
     uint8_t read();
-    void    write(uint8_t value); 
-    void    toggle();
+    void write(uint8_t value);
+    void toggle();
 
 private:
-    uint8_t pin;
+    uint8_t _pin;
 };

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -46,22 +46,22 @@ static Util utilInstance(&sitlState);
 
 HAL_SITL::HAL_SITL() :
     AP_HAL::HAL(
-        &sitlUart0Driver,  /* uartA */
-        &sitlUart1Driver,  /* uartB */
-        &sitlUart2Driver,  /* uartC */
-        &sitlUart3Driver,  /* uartD */
-        &sitlUart4Driver,  /* uartE */
-        &sitlUart5Driver,  /* uartF */
+        &sitlUart0Driver,   /* uartA */
+        &sitlUart1Driver,   /* uartB */
+        &sitlUart2Driver,   /* uartC */
+        &sitlUart3Driver,   /* uartD */
+        &sitlUart4Driver,   /* uartE */
+        &sitlUart5Driver,   /* uartF */
         &i2c_mgr_instance,
-        &emptySPI, /* spi */
-        &sitlAnalogIn, /* analogin */
+        &emptySPI,          /* spi */
+        &sitlAnalogIn,      /* analogin */
         &sitlEEPROMStorage, /* storage */
-        &sitlUart0Driver, /* console */
-        &sitlGPIO, /* gpio */
-        &sitlRCInput,  /* rcinput */
-        &sitlRCOutput, /* rcoutput */
-        &sitlScheduler, /* scheduler */
-        &utilInstance, /* util */
+        &sitlUart0Driver,   /* console */
+        &sitlGPIO,          /* gpio */
+        &sitlRCInput,       /* rcinput */
+        &sitlRCOutput,      /* rcoutput */
+        &sitlScheduler,     /* scheduler */
+        &utilInstance,      /* util */
         &emptyOpticalFlow), /* onboard optical flow */
     _sitl_state(&sitlState)
 {}
@@ -77,7 +77,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     rcin->init();
     rcout->init();
 
-    //spi->init();
+    // spi->init();
     analogin->init();
 
     callbacks->setup();
@@ -93,4 +93,4 @@ const AP_HAL::HAL& AP_HAL::get_HAL() {
     return hal;
 }
 
-#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -17,4 +17,4 @@ private:
     HALSITL::SITL_State *_sitl_state;
 };
 
-#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_SITL/RCInput.cpp
@@ -37,10 +37,10 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     if (len > SITL_RC_INPUT_CHANNELS) {
         len = SITL_RC_INPUT_CHANNELS;
     }
-    for (uint8_t i=0; i<len; i++) {
+    for (uint8_t i=0; i < len; i++) {
         periods[i] = read(i);
     }
-    return 8;
+    return len;
 }
 
 bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
@@ -57,9 +57,11 @@ bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
 
 bool RCInput::set_override(uint8_t channel, int16_t override)
 {
-    if (override < 0) return false; /* -1: no change. */
+    if (override < 0){
+        return false;  /* -1: no change. */
+    }
     if (channel < SITL_RC_INPUT_CHANNELS) {
-        _override[channel] = override;
+        _override[channel] = static_cast<uint16_t>(override);
         if (override != 0) {
             return true;
         }

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -9,11 +9,9 @@
 
 class HALSITL::RCInput : public AP_HAL::RCInput {
 public:
-    RCInput(SITL_State *sitlState) {
-        _sitlState = sitlState;
-    }
+    explicit RCInput(SITL_State *sitlState): _sitlState(sitlState) {}
     void init() override;
-    bool  new_input() override;
+    bool new_input() override;
     uint8_t num_channels() override {
         return SITL_RC_INPUT_CHANNELS;
     }
@@ -26,7 +24,6 @@ public:
 
 private:
     SITL_State *_sitlState;
-    bool _valid;
 
     /* override state */
     uint16_t _override[SITL_RC_INPUT_CHANNELS];

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -2,12 +2,12 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include "RCOutput.h"
-#include <stdio.h>
 
 #define ENABLE_DEBUG 0
 
 #if ENABLE_DEBUG
-# define Debug(fmt, args ...)  do {::printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
+# include <stdio.h>
+# define Debug(fmt, args ...)  do {::printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while (0)
 #else
 # define Debug(fmt, args ...)
 #endif
@@ -18,7 +18,7 @@ void RCOutput::init() {}
 
 void RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
 {
-    Debug("set_freq(0x%04x, %u)\n", (unsigned)chmask, (unsigned)freq_hz);
+    Debug("set_freq(0x%04x, %u)\n", static_cast<uint32_t>(chmask), static_cast<uint32_t>(freq_hz));
     _freq_hz = freq_hz;
 }
 
@@ -29,18 +29,18 @@ uint16_t RCOutput::get_freq(uint8_t ch)
 
 void RCOutput::enable_ch(uint8_t ch)
 {
-    if (!(_enable_mask & (1U<<ch))) {
+    if (!(_enable_mask & (1U << ch))) {
         Debug("enable_ch(%u)\n", ch);
     }
-    _enable_mask |= 1U<<ch;
+    _enable_mask |= 1U << ch;
 }
 
 void RCOutput::disable_ch(uint8_t ch)
 {
-    if (_enable_mask & (1U<<ch)) {
+    if (_enable_mask & (1U << ch)) {
         Debug("disable_ch(%u)\n", ch);
     }
-    _enable_mask &= ~1U<<ch;
+    _enable_mask &= ~1U << ch;
 }
 
 void RCOutput::write(uint8_t ch, uint16_t period_us)
@@ -64,18 +64,18 @@ uint16_t RCOutput::read(uint8_t ch)
 
 void RCOutput::read(uint16_t* period_us, uint8_t len)
 {
-    memcpy(period_us, _sitlState->pwm_output, len*sizeof(uint16_t));
+    memcpy(period_us, _sitlState->pwm_output, len * sizeof(uint16_t));
 }
 
 void RCOutput::cork(void)
 {
-    memcpy(_pending, _sitlState->pwm_output, SITL_NUM_CHANNELS*sizeof(uint16_t));
+    memcpy(_pending, _sitlState->pwm_output, SITL_NUM_CHANNELS * sizeof(uint16_t));
     _corked = true;
 }
 
 void RCOutput::push(void)
 {
-    memcpy(_sitlState->pwm_output, _pending, SITL_NUM_CHANNELS*sizeof(uint16_t));
+    memcpy(_sitlState->pwm_output, _pending, SITL_NUM_CHANNELS * sizeof(uint16_t));
     _corked = false;
 }
 

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -6,20 +6,17 @@
 
 class HALSITL::RCOutput : public AP_HAL::RCOutput {
 public:
-    RCOutput(SITL_State *sitlState) {
-        _sitlState = sitlState;
-        _freq_hz = 50;
-    }
-    void     init() override;
-    void     set_freq(uint32_t chmask, uint16_t freq_hz) override;
+    explicit RCOutput(SITL_State *sitlState): _sitlState(sitlState), _freq_hz(50) {}
+    void init() override;
+    void set_freq(uint32_t chmask, uint16_t freq_hz) override;
     uint16_t get_freq(uint8_t ch) override;
-    void     enable_ch(uint8_t ch) override;
-    void     disable_ch(uint8_t ch) override;
-    void     write(uint8_t ch, uint16_t period_us) override;
+    void enable_ch(uint8_t ch) override;
+    void disable_ch(uint8_t ch) override;
+    void write(uint8_t ch, uint16_t period_us) override;
     uint16_t read(uint8_t ch) override;
-    void     read(uint16_t* period_us, uint8_t len) override;
-    void     cork(void);
-    void     push(void);
+    void read(uint16_t* period_us, uint8_t len) override;
+    void cork(void);
+    void push(void);
 
 private:
     SITL_State *_sitlState;

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -5,7 +5,6 @@
 #include "Scheduler.h"
 #include "UARTDriver.h"
 #include <sys/time.h>
-#include <unistd.h>
 #include <fenv.h>
 
 using namespace HALSITL;
@@ -43,11 +42,7 @@ void Scheduler::delay_microseconds(uint16_t usec)
         if (dtime >= usec) {
             break;
         }
-        if (_stopped_clock_usec) {
-            _sitlState->wait_clock(start + usec);
-        } else {
-            usleep(usec - dtime);
-        }
+        _sitlState->wait_clock(start + usec);
     } while (true);
 }
 
@@ -83,7 +78,6 @@ void Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     }
-
 }
 
 void Scheduler::register_io_process(AP_HAL::MemberProc proc)
@@ -98,7 +92,6 @@ void Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     }
-
 }
 
 void Scheduler::register_timer_failsafe(AP_HAL::Proc failsafe, uint32_t period_us)
@@ -141,10 +134,11 @@ void Scheduler::system_initialized() {
 }
 
 void Scheduler::sitl_end_atomic() {
-    if (_nested_atomic_ctr == 0)
+    if (_nested_atomic_ctr == 0) {
         hal.uartA->println("NESTED ATOMIC ERROR");
-    else
+    } else {
         _nested_atomic_ctr--;
+    }
 }
 
 void Scheduler::reboot(bool hold_in_bootloader)

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -10,39 +10,39 @@
 /* Scheduler implementation: */
 class HALSITL::Scheduler : public AP_HAL::Scheduler {
 public:
-    Scheduler(SITL_State *sitlState);
+    explicit Scheduler(SITL_State *sitlState);
     static Scheduler *from(AP_HAL::Scheduler *scheduler) {
         return static_cast<HALSITL::Scheduler*>(scheduler);
     }
 
     /* AP_HAL::Scheduler methods */
 
-    void     init();
-    void     delay(uint16_t ms);
-    void     delay_microseconds(uint16_t us);
-    void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
+    void init();
+    void delay(uint16_t ms);
+    void delay_microseconds(uint16_t us);
+    void register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
 
-    void     register_timer_process(AP_HAL::MemberProc);
-    void     register_io_process(AP_HAL::MemberProc);
-    void     suspend_timer_procs();
-    void     resume_timer_procs();
+    void register_timer_process(AP_HAL::MemberProc);
+    void register_io_process(AP_HAL::MemberProc);
+    void suspend_timer_procs();
+    void resume_timer_procs();
 
-    bool     in_timerprocess();
+    bool in_timerprocess();
 
-    void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
+    void register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    void     system_initialized();
+    void system_initialized();
 
-    void     reboot(bool hold_in_bootloader);
+    void reboot(bool hold_in_bootloader);
 
-    bool     interrupts_are_blocked(void) {
+    bool interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;
     }
 
-    void     sitl_begin_atomic() {
+    void sitl_begin_atomic() {
         _nested_atomic_ctr++;
     }
-    void     sitl_end_atomic();
+    void sitl_end_atomic();
 
     static void timer_event() {
         _run_timer_procs(true);
@@ -67,16 +67,12 @@ private:
     static AP_HAL::MemberProc _io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS];
     static uint8_t _num_timer_procs;
     static uint8_t _num_io_procs;
-    static bool    _in_timer_proc;
-    static bool    _in_io_proc;
+    static bool _in_timer_proc;
+    static bool _in_io_proc;
 
     void stop_clock(uint64_t time_usec);
 
     bool _initialized;
     uint64_t _stopped_clock_usec;
 };
-#endif // CONFIG_HAL_BOARD
-
-
-
-
+#endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/Semaphores.cpp
+++ b/libraries/AP_HAL_SITL/Semaphores.cpp
@@ -8,12 +8,12 @@ extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
 
-bool Semaphore::give() 
+bool Semaphore::give()
 {
     return pthread_mutex_unlock(&_lock) == 0;
 }
 
-bool Semaphore::take(uint32_t timeout_ms) 
+bool Semaphore::take(uint32_t timeout_ms)
 {
     if (timeout_ms == 0) {
         return pthread_mutex_lock(&_lock) == 0;
@@ -27,13 +27,13 @@ bool Semaphore::take(uint32_t timeout_ms)
         if (take_nonblocking()) {
             return true;
         }
-    } while ((AP_HAL::micros64() - start) < timeout_ms*1000);
+    } while ((AP_HAL::micros64() - start) < timeout_ms * 1000);
     return false;
 }
 
-bool Semaphore::take_nonblocking() 
+bool Semaphore::take_nonblocking()
 {
     return pthread_mutex_trylock(&_lock) == 0;
 }
 
-#endif // CONFIG_HAL_BOARD
+#endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/Semaphores.h
+++ b/libraries/AP_HAL_SITL/Semaphores.h
@@ -17,5 +17,5 @@ public:
 private:
     pthread_mutex_t _lock;
 };
-#endif // CONFIG_HAL_BOARD
+#endif  // CONFIG_HAL_BOARD
 


### PR DESCRIPTION
Hi,
There is a first serie of PR that clean the AP_HAL_SITL workspace. 
It is mostly indentation, whitespace fix and cast fix.

The only two importants modifications are in RCInput.cpp (return 16 input instead of 8) and Scheduler.cpp (remove use of usleep, that is deprecated, for c++11 portable chrono that use nanosleep on linux)

Those were catch by cpplint, cppcheck and Clion IDE