### PR TITLE
Copter: fix Proximity MAV driver and support avoidance in a single direction

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1765,6 +1765,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
     {
         result = MAV_RESULT_ACCEPTED;
         copter.rangefinder.handle_msg(msg);
+#if PROXIMITY_ENABLED == ENABLED
+        copter.g2.proximity.handle_msg(msg);
+#endif
         break;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -242,6 +242,16 @@ AP_Proximity::Proximity_Status AP_Proximity::get_status() const
     return get_status(primary_instance);
 }
 
+// handle mavlink DISTANCE_SENSOR messages
+void AP_Proximity::handle_msg(mavlink_message_t *msg)
+{
+    for (uint8_t i=0; i<num_instances; i++) {
+        if ((drivers[i] != nullptr) && (_type[i] != Proximity_Type_None)) {
+            drivers[i]->handle_msg(msg);
+        }
+    }
+}
+
 //  detect if an instance of a proximity sensor is connected.
 void AP_Proximity::detect_instance(uint8_t instance)
 {
@@ -340,7 +350,7 @@ bool AP_Proximity::get_distances(Proximity_Distance_Array &prx_dist_array) const
     if ((drivers[primary_instance] == nullptr) || (_type[primary_instance] == Proximity_Type_None)) {
         return 0.0f;
     }
-    // get maximum distance from backend
+    // get distances from backend
     return drivers[primary_instance]->get_distances(prx_dist_array);
 }
 

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -98,6 +98,9 @@ public:
     float distance_max() const;
     float distance_min() const;
 
+    // handle mavlink DISTANCE_SENSOR messages
+    void handle_msg(mavlink_message_t *msg);
+
     // The Proximity_State structure is filled in by the backend driver
     struct Proximity_State {
         uint8_t                 instance;   // the instance number of this proximity sensor

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -38,6 +38,9 @@ public:
     virtual float distance_max() const = 0;
     virtual float distance_min() const = 0;
 
+    // handle mavlink DISTANCE_SENSOR messages
+    virtual void handle_msg(mavlink_message_t *msg) {}
+
     // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
     // returns true on successful read and places distance in distance
     bool get_horizontal_distance(float angle_deg, float &distance) const;

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -20,6 +20,7 @@
 
 #define PROXIMITY_SECTORS_MAX   12  // maximum number of sectors
 #define PROXIMITY_BOUNDARY_DIST_MIN 0.6f    // minimum distance for a boundary point.  This ensures the object avoidance code doesn't think we are outside the boundary.
+#define PROXIMITY_BOUNDARY_DIST_DEFAULT 100 // if we have no data for a sector, boundary is placed 100m out
 
 class AP_Proximity_Backend
 {
@@ -67,6 +68,10 @@ protected:
 
     // find which sector a given angle falls into
     bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
+
+    // initialise the boundary and sector_edge_vector array used for object avoidance
+    //   should be called if the sector_middle_deg or _setor_width_deg arrays are changed
+    void init_boundary();
 
     // update boundary points used for object avoidance based on a single sector's distance changing
     //   the boundary points lie on the line between sectors meaning two boundary points may be updated based on a single sector's distance changing

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.cpp
@@ -162,6 +162,9 @@ void AP_Proximity_LightWareSF40C::init_sectors()
     // set num sectors
     _num_sectors = sector;
 
+    // re-initialise boundary because sector locations have changed
+    init_boundary();
+
     // record success
     _sector_initialised = true;
 }

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -33,7 +33,7 @@ private:
         RequestType_DistanceMeasurement
     };
 
-    // initialise sensor (returns true if sensor is succesfully initialised)
+    // initialise sensor (returns true if sensor is successfully initialised)
     bool initialise();
     void init_sectors();
     void set_motor_speed(bool on_off);

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -58,5 +58,6 @@ void AP_Proximity_MAV::handle_msg(mavlink_message_t *msg)
         _distance_min = packet.min_distance / 100.0f;
         _distance_max = packet.max_distance / 100.0f;
         _last_update_ms = AP_HAL::millis();
+        update_boundary_for_sector(sector);
     }
 }

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -20,7 +20,7 @@ public:
     float distance_min() const { return _distance_min; };
 
     // handle mavlink DISTANCE_SENSOR messages
-    void handle_msg(mavlink_message_t *msg);
+    void handle_msg(mavlink_message_t *msg) override;
 
 private:
 


### PR DESCRIPTION
This PR accomplishes two things:

- fixes the consumption of the MAVLink DISTANCE_SENSOR messages (they were simply not being fed into the Proximity MAV driver)
- allows object avoidance when we only have a single distance measurement.  This is accomplished by creating a concave (i.e. cup shaped) boundary by copying the single distance measurement into the adjacent sectors as shown below.  This may seem odd but it's required because our boundary based object avoidance tends to slide along the boundary instead of just stopping at it.

![oa_singledistance](https://cloud.githubusercontent.com/assets/1498098/21797449/7372d23a-d752-11e6-9a78-fbde78823ea1.png)
