### PR TITLE
Plane: move all landing flight stages and logic into AP_Landing

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -867,48 +867,15 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
         return;
     }
 
-    // if we are changing away from a landing stage then reset all the internal state
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+    if (fs == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+        landing.in_progress = true;
+    } else {
         landing.in_progress = false;
-        // FIXME: Is this safe for abort reasons?
-        landing.reset();
-    }
-
-    switch (fs) {
-/*
-   // FIXME: move this into AP_Landing
-    case AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH:
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude());
-        landing.in_progress = true;
-#if GEOFENCE_ENABLED == ENABLED 
-        if (g.fence_autoenable == 1) {
-            if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
-            } else {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");
-            }
-        } else if (g.fence_autoenable == 2) {
-            if (! geofence_set_floor_enabled(false)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
-            } else {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
-            }
+        if (fs == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+            gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
+                              auto_state.takeoff_altitude_rel_cm/100);
         }
-#endif
-        break;
-*/
-    case AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND:
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm", auto_state.takeoff_altitude_rel_cm/100);
-        break;
-
-    case AP_Vehicle::FixedWing::FLIGHT_LAND:
-        landing.in_progress = true;
-        break;
-
-    default:
-        break;
     }
-    
 
     flight_stage = fs;
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -867,15 +867,12 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
         return;
     }
 
-    if (fs == AP_Vehicle::FixedWing::FLIGHT_LAND) {
-        landing.in_progress = true;
-    } else {
-        landing.in_progress = false;
+    landing.set_in_progress(fs == AP_Vehicle::FixedWing::FLIGHT_LAND);
+
         if (fs == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
             gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
                               auto_state.takeoff_altitude_rel_cm/100);
         }
-    }
 
     flight_stage = fs;
 
@@ -912,7 +909,7 @@ void Plane::update_alt()
     if (auto_throttle_mode && !throttle_suppressed) {        
 
         float distance_beyond_land_wp = 0;
-        if (landing.in_progress && location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND && location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
             distance_beyond_land_wp = get_distance(current_loc, next_WP_loc);
         }
 
@@ -1055,7 +1052,7 @@ float Plane::tecs_hgt_afe(void)
       coming.
     */
     float hgt_afe;
-    if (landing.in_progress) {
+    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
         hgt_afe = height_above_target();
         hgt_afe -= rangefinder_correction();
     } else {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -867,7 +867,7 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
         return;
     }
 
-    landing.set_in_progress(fs == AP_Vehicle::FixedWing::FLIGHT_LAND);
+    landing.handle_flight_stage_change(fs == AP_Vehicle::FixedWing::FLIGHT_LAND);
 
     if (fs == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
         gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -869,10 +869,10 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
 
     landing.set_in_progress(fs == AP_Vehicle::FixedWing::FLIGHT_LAND);
 
-        if (fs == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
-            gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
-                              auto_state.takeoff_altitude_rel_cm/100);
-        }
+    if (fs == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted, climbing to %dm",
+                          auto_state.takeoff_altitude_rel_cm/100);
+    }
 
     flight_stage = fs;
 
@@ -978,10 +978,6 @@ void Plane::update_flight_stage(void)
         set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_VTOL);
     } else {
         set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_NORMAL);
-    }
-
-    if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
-        landing.reset();
     }
 
     // tell AHRS the airspeed to true airspeed ratio

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -907,6 +907,7 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
     
 
     flight_stage = fs;
+    landing.stage = fs;
 
     if (should_log(MASK_LOG_MODE)) {
         Log_Write_Status();

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -218,17 +218,15 @@ void Plane::stabilize_stick_mixing_fbw()
  */
 void Plane::stabilize_yaw(float speed_scaler)
 {
-    if (control_mode == AUTO && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
-        // in land final setup for ground steering
+    if (landing.is_flaring()) {
+        // in flaring then enable ground steering
         steering_control.ground_steering = true;
     } else {
         // otherwise use ground steering when no input control and we
         // are below the GROUND_STEER_ALT
         steering_control.ground_steering = (channel_roll->get_control_in() == 0 && 
                                             fabsf(relative_altitude()) < g.ground_steer_alt);
-        if (control_mode == AUTO &&
-                (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
-                flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE)) {
+        if (landing.is_on_approach()) {
             // don't use ground steering on landing approach
             steering_control.ground_steering = false;
         }
@@ -237,12 +235,11 @@ void Plane::stabilize_yaw(float speed_scaler)
 
     /*
       first calculate steering_control.steering for a nose or tail
-      wheel.
-      We use "course hold" mode for the rudder when either in the
-      final stage of landing (when the wings are help level) or when
-      in course hold in FBWA mode (when we are below GROUND_STEER_ALT)
+      wheel. We use "course hold" mode for the rudder when either performing
+      a flare (when the wings are held level) or when in course hold in
+      FBWA mode (when we are below GROUND_STEER_ALT)
      */
-    if ((control_mode == AUTO && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) ||
+    if (landing.is_flaring() ||
         (steer_state.hold_course_cd != -1 && steering_control.ground_steering)) {
         calc_nav_yaw_course();
     } else if (steering_control.ground_steering) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1344,8 +1344,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_DO_GO_AROUND:
             result = MAV_RESULT_FAILED;
 
-            //Not allowing go around at FLIGHT_LAND_FINAL stage on purpose --
-            //if plane is close to the ground a go around could be dangerous.
             if (plane.landing.in_progress) {
                 // Initiate an aborted landing. This will trigger a pitch-up and
                 // climb-out to a safe altitude holding heading then one of the

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1344,7 +1344,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_DO_GO_AROUND:
             result = MAV_RESULT_FAILED;
 
-            if (plane.landing.in_progress) {
+            if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
                 // Initiate an aborted landing. This will trigger a pitch-up and
                 // climb-out to a safe altitude holding heading then one of the
                 // following actions will occur, check for in this order:

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -379,7 +379,7 @@ void Plane::set_offset_altitude_location(const Location &loc)
     }
 #endif
 
-    if (!landing.in_progress) {
+    if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         // if we are within GLIDE_SLOPE_MIN meters of the target altitude
         // then reset the offset to not use a glide slope. This allows for
         // more accurate flight of missions where the aircraft may lose or
@@ -470,7 +470,7 @@ float Plane::mission_alt_offset(void)
 {
     float ret = g.alt_offset;
     if (control_mode == AUTO &&
-            (landing.in_progress || auto_state.wp_is_land_approach)) {
+            (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND || auto_state.wp_is_land_approach)) {
         // when landing after an aborted landing due to too high glide
         // slope we use an offset from the last landing attempt
         ret += landing.alt_offset;
@@ -572,9 +572,7 @@ float Plane::rangefinder_correction(void)
     }
 
     // for now we only support the rangefinder for landing 
-    bool using_rangefinder = (g.rangefinder_landing &&
-                              control_mode == AUTO && 
-                              landing.in_progress);
+    bool using_rangefinder = (g.rangefinder_landing && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND);
     if (!using_rangefinder) {
         return 0;
     }
@@ -615,7 +613,7 @@ void Plane::rangefinder_height_update(void)
         } else {
             rangefinder_state.in_range = true;
             if (!rangefinder_state.in_use &&
-                (landing.in_progress ||
+                (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND ||
                  control_mode == QLAND ||
                  control_mode == QRTL ||
                  (control_mode == AUTO && plane.mission.get_current_nav_cmd().id == MAV_CMD_NAV_VTOL_LAND)) &&

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -29,12 +29,11 @@ void Plane::adjust_altitude_target()
         control_mode == CRUISE) {
         return;
     }
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
-        // in land final TECS uses TECS_LAND_SINK as a target sink
+    if (landing.is_flaring()) {
+        // during a landing flare, use TECS_LAND_SINK as a target sink
         // rate, and ignores the target altitude
         set_target_altitude_location(next_WP_loc);
-    } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
-            flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) {
+    } else if (landing.is_on_approach()) {
         landing.setup_landing_glide_slope(prev_WP_loc, next_WP_loc, current_loc, target_altitude.offset_cm);
         landing.adjust_landing_slope_for_rangefinder_bump(rangefinder_state, prev_WP_loc, next_WP_loc, current_loc, auto_state.wp_distance, target_altitude.offset_cm);
     } else if (reached_loiter_target()) {

--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -25,7 +25,7 @@ MAV_COLLISION_ACTION AP_Avoidance_Plane::handle_avoidance(const AP_Avoidance::Ob
     // take no action in some flight modes
     if (plane.control_mode == MANUAL ||
         (plane.control_mode == AUTO && !plane.auto_state.takeoff_complete) ||
-        (plane.control_mode == AUTO && plane.landing.in_progress) || // TODO: consider allowing action during approach
+        (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) || // TODO: consider allowing action during approach
         plane.control_mode == AUTOTUNE ||
         plane.control_mode == QLAND) {
         actual_action = MAV_COLLISION_ACTION_NONE;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -13,8 +13,6 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         DataFlash.Log_Write_Mission_Cmd(mission, cmd);
     }
 
-    landing.reset();
-
     // special handling for nav vs non-nav commands
     if (AP_Mission::is_nav_cmd(cmd)) {
         // set land_complete to false to stop us zeroing the throttle
@@ -138,7 +136,6 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         break;
 
     case MAV_CMD_DO_LAND_START:
-        // handled in landing.reset()
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -247,12 +247,14 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
         return verify_nav_wp(cmd);
 
     case MAV_CMD_NAV_LAND:
-        {
-        // use rangefinder to correct if possible
-        float height = height_above_target() - rangefinder_correction();
+        if (flight_stage == AP_Vehicle::FixedWing::FlightStage::FLIGHT_ABORT_LAND) {
+            return landing.verify_abort_landing(prev_WP_loc, next_WP_loc, current_loc, auto_state.takeoff_altitude_rel_cm, throttle_suppressed);
 
-        return landing.verify_land(flight_stage, prev_WP_loc, next_WP_loc, current_loc,
-                auto_state.takeoff_altitude_rel_cm, height, auto_state.sink_rate, auto_state.wp_proportion, auto_state.last_flying_ms, arming.is_armed(), is_flying(), rangefinder_state.in_range, throttle_suppressed);
+        } else {
+            // use rangefinder to correct if possible
+            const float height = height_above_target() - rangefinder_correction();
+            return landing.verify_land(prev_WP_loc, next_WP_loc, current_loc,
+                height, auto_state.sink_rate, auto_state.wp_proportion, auto_state.last_flying_ms, arming.is_armed(), is_flying(), rangefinder_state.in_range);
         }
 
     case MAV_CMD_NAV_LOITER_UNLIM:

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -401,6 +401,24 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
 
     // zero rangefinder state, start to accumulate good samples now
     memset(&rangefinder_state, 0, sizeof(rangefinder_state));
+
+    landing.do_land(cmd, relative_altitude());
+
+#if GEOFENCE_ENABLED == ENABLED 
+    if (g.fence_autoenable == 1) {
+        if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
+            gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
+        } else {
+            gcs_send_text(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");
+        }
+    } else if (g.fence_autoenable == 2) {
+        if (! geofence_set_floor_enabled(false)) {
+            gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
+        } else {
+            gcs_send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
+        }
+    }
+#endif
 }
 
 void Plane::loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -141,7 +141,7 @@ void Plane::low_battery_event(void)
     }
     gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Low battery %.2fV used %.0f mAh",
                       (double)battery.voltage(), (double)battery.current_total_mah());
-    if (!landing.in_progress) {
+    if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
     	set_mode(RTL, MODE_REASON_BATTERY_FAILSAFE);
     	aparm.throttle_cruise.load();
     }

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -310,7 +310,7 @@ void Plane::geofence_check(bool altitude_check_only)
     struct Location loc;
 
     // Never trigger a fence breach in the final stage of landing
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL || flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) {
+    if (landing.is_expecting_impact()) {
         return;
     }
 

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -286,7 +286,6 @@ void Plane::crash_detection_update(void)
             if (aparm.crash_detection_enable & CRASH_DETECT_ACTION_BITMASK_DISARM) {
                 disarm_motors();
             }
-            landing.complete = true;
             if (crashed_near_land_waypoint) {
                 gcs_send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");
             } else {

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -95,7 +95,7 @@ void Plane::calc_airspeed_errors()
 
     } else if (control_mode == AUTO && landing.in_progress) {
         // Landing airspeed target
-        target_airspeed_cm = landing.get_target_airspeed_cm(flight_stage);
+        target_airspeed_cm = landing.get_target_airspeed_cm();
 
     } else {
         // Normal airspeed target

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -93,7 +93,7 @@ void Plane::calc_airspeed_errors()
                               channel_throttle->get_control_in()) +
                              ((int32_t)aparm.airspeed_min * 100);
 
-    } else if (control_mode == AUTO && landing.in_progress) {
+    } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
         // Landing airspeed target
         target_airspeed_cm = landing.get_target_airspeed_cm();
 

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -33,7 +33,7 @@ void Plane::read_rangefinder(void)
 #endif
     {
         // use the best available alt estimate via baro above home
-        if (landing.in_progress) {
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
             // ensure the rangefinder is powered-on when land alt is higher than home altitude.
             // This is done using the target alt which we know is below us and we are sinking to it
             height = height_above_target();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -28,7 +28,7 @@ void Plane::throttle_slew_limit(void)
     if (control_mode==AUTO) {
         if (auto_state.takeoff_complete == false && g.takeoff_throttle_slewrate != 0) {
             slewrate = g.takeoff_throttle_slewrate;
-        } else if (landing.get_throttle_slewrate() != 0 && landing.in_progress) {
+        } else if (landing.get_throttle_slewrate() != 0 && flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
             slewrate = landing.get_throttle_slewrate();
         }
     }
@@ -495,7 +495,7 @@ void Plane::set_servos_flaps(void)
             auto_flap_percent = g.flap_1_percent;
         } //else flaps stay at default zero deflection
 
-        if (landing.in_progress && landing.get_flap_percent() != 0) {
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND && landing.get_flap_percent() != 0) {
             auto_flap_percent = landing.get_flap_percent();
         }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -553,7 +553,7 @@ void Plane::check_long_failsafe()
     uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if(failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && !landing.in_progress) {
+    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         if (failsafe.state == FAILSAFE_SHORT &&
                    (tnow - failsafe.ch3_timer_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_LONG, MODE_REASON_RADIO_FAILSAFE);
@@ -586,7 +586,7 @@ void Plane::check_short_failsafe()
 {
     // only act on changes
     // -------------------
-    if(failsafe.state == FAILSAFE_NONE && !landing.in_progress) {
+    if(failsafe.state == FAILSAFE_NONE && flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
         // The condition is checked and the flag ch3_failsafe is set in radio.cpp
         if(failsafe.ch3_failsafe) {
             failsafe_short_on_event(FAILSAFE_SHORT, MODE_REASON_RADIO_FAILSAFE);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -338,9 +338,6 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 
     // reset landing check
     auto_state.checked_for_autoland = false;
-
-    // reset landing
-    landing.reset();
     
     // zero locked course
     steer_state.locked_course_err = 0;

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -147,9 +147,7 @@ void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float rel
         type_slope_do_land(cmd, relative_altitude);
         break;
     default:
-        // returning TRUE while executing verify_land() will increment the
-        // mission index which in many cases will trigger an RTL for end-of-mission
-        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Landing configuration error, invalid LAND_TYPE");
+        // a incorrect type is handled in the verify_land
         break;
     }
 }

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -141,7 +141,11 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     AP_GROUPEND
 };
 
-void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude) {
+void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
+{
+    complete = false;
+    commanded_go_around = false;
+
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_do_land(cmd, relative_altitude);
@@ -266,20 +270,6 @@ void AP_Landing::setup_landing_glide_slope(const Location &prev_WP_loc, const Lo
     default:
         break;
     }
-}
-
-/*
- * initialize state for new nav command
- */
-void AP_Landing::reset(void)
-{
-    complete = false;
-    commanded_go_around = false;
-    initial_slope = 0;
-    slope = 0;
-
-    // once landed, post some landing statistics to the GCS
-    post_stats = false;
 }
 
 /*

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -197,6 +197,18 @@ bool AP_Landing::is_on_approach(void) const
     }
 }
 
+// return true when at the last stages of a land when an impact with the ground is expected soon
+bool AP_Landing::is_expecting_impact(void) const
+{
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_is_expecting_impact();
+
+    default:
+        return false;
+    }
+}
+
 
 /*
   a special glide slope calculation for the landing approach

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -141,6 +141,18 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     AP_GROUPEND
 };
 
+void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude) {
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        type_slope_do_land(cmd, relative_altitude);
+        break;
+    default:
+        // returning TRUE while executing verify_land() will increment the
+        // mission index which in many cases will trigger an RTL for end-of-mission
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Landing configuration error, invalid LAND_TYPE");
+        break;
+    }
+}
 
 /*
   update navigation for landing. Called when on landing approach or

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -150,19 +150,25 @@ bool AP_Landing::verify_land(const AP_Vehicle::FixedWing::FlightStage flight_sta
         const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed)
 {
     switch (type) {
-    default:
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_verify_land(flight_stage,prev_WP_loc, next_WP_loc, current_loc,
                 auto_state_takeoff_altitude_rel_cm, height,sink_rate, wp_proportion, last_flying_ms, is_armed, is_flying, rangefinder_state_in_range, throttle_suppressed);
+    default:
+        // returning TRUE while executing verify_land() will increment the
+        // mission index which in many cases will trigger an RTL for end-of-mission
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Landing configuration error, invalid LAND_TYPE");
+        return true;
     }
 }
 
 void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm)
 {
     switch (type) {
-    default:
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_adjust_landing_slope_for_rangefinder_bump(rangefinder_state, prev_WP_loc, next_WP_loc, current_loc, wp_distance, target_altitude_offset_cm);
+        break;
+
+    default:
         break;
     }
 }
@@ -185,6 +191,7 @@ bool AP_Landing::is_on_approach(void) const
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_on_approach();
+
     default:
         return false;
     }
@@ -203,9 +210,11 @@ bool AP_Landing::is_on_approach(void) const
 void AP_Landing::setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm)
 {
     switch (type) {
-    default:
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_setup_landing_glide_slope(prev_WP_loc, next_WP_loc, current_loc, target_altitude_offset_cm);
+        break;
+
+    default:
         break;
     }
 }
@@ -356,9 +365,11 @@ int32_t AP_Landing::get_target_airspeed_cm(const AP_Vehicle::FixedWing::FlightSt
 bool AP_Landing::request_go_around(void)
 {
     switch (type) {
-    default:
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_request_go_around();
+
+    default:
+        return false;
     }
 }
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -336,6 +336,16 @@ bool AP_Landing::restart_landing_sequence()
     return success;
 }
 
+int32_t AP_Landing::constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd)
+{
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_constrain_roll(desired_roll_cd, level_roll_limit_cd);
+    default:
+        return desired_roll_cd;
+    }
+}
+
 /*
  * Determine how aligned heading_deg is with the wind. Return result
  * is 1.0 when perfectly aligned heading into wind, -1 when perfectly

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -217,6 +217,10 @@ void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing
 // return true while the aircraft should be in a flaring state
 bool AP_Landing::is_flaring(void) const
 {
+    if (!in_progress) {
+        return false;
+    }
+
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_flaring();
@@ -229,6 +233,10 @@ bool AP_Landing::is_flaring(void) const
 // return true while the aircraft is performing a landing approach
 bool AP_Landing::is_on_approach(void) const
 {
+    if (!in_progress) {
+        return false;
+    }
+
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_on_approach();
@@ -241,6 +249,10 @@ bool AP_Landing::is_on_approach(void) const
 // return true when at the last stages of a land when an impact with the ground is expected soon
 bool AP_Landing::is_expecting_impact(void) const
 {
+    if (!in_progress) {
+        return false;
+    }
+
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_expecting_impact();
@@ -356,6 +368,11 @@ float AP_Landing::head_wind(void)
  */
 int32_t AP_Landing::get_target_airspeed_cm(void)
 {
+    if (!in_progress) {
+        // not landing, use regular cruise airspeed
+        return aparm.airspeed_cruise_cm;
+    }
+
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_get_target_airspeed_cm();
@@ -378,6 +395,12 @@ bool AP_Landing::request_go_around(void)
     default:
         return false;
     }
+}
+
+void AP_Landing::handle_flight_stage_change(const bool _in_landing_stage)
+{
+    in_progress = _in_landing_stage;
+    commanded_go_around = false;
 }
 
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -167,6 +167,30 @@ void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing
     }
 }
 
+// return true while the aircraft should be in a flaring state
+bool AP_Landing::is_flaring(void) const
+{
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_is_flaring();
+
+    default:
+        return false;
+    }
+}
+
+// return true while the aircraft is performing a landing approach
+bool AP_Landing::is_on_approach(void) const
+{
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_is_on_approach();
+    default:
+        return false;
+    }
+}
+
+
 /*
   a special glide slope calculation for the landing approach
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -143,7 +143,6 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
 
 void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
 {
-    complete = false;
     commanded_go_around = false;
 
     switch (type) {
@@ -183,7 +182,6 @@ bool AP_Landing::verify_abort_landing(const Location &prev_WP_loc, Location &nex
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_verify_abort_landing(prev_WP_loc, next_WP_loc, throttle_suppressed);
         break;
-
     default:
         break;
     }
@@ -208,7 +206,6 @@ void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_adjust_landing_slope_for_rangefinder_bump(rangefinder_state, prev_WP_loc, next_WP_loc, current_loc, wp_distance, target_altitude_offset_cm);
         break;
-
     default:
         break;
     }
@@ -224,7 +221,6 @@ bool AP_Landing::is_flaring(void) const
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_flaring();
-
     default:
         return false;
     }
@@ -240,7 +236,6 @@ bool AP_Landing::is_on_approach(void) const
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_on_approach();
-
     default:
         return false;
     }
@@ -256,7 +251,6 @@ bool AP_Landing::is_expecting_impact(void) const
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_expecting_impact();
-
     default:
         return false;
     }
@@ -278,7 +272,6 @@ void AP_Landing::setup_landing_glide_slope(const Location &prev_WP_loc, const Lo
     case TYPE_STANDARD_GLIDE_SLOPE:
         type_slope_setup_landing_glide_slope(prev_WP_loc, next_WP_loc, current_loc, target_altitude_offset_cm);
         break;
-
     default:
         break;
     }
@@ -386,7 +379,6 @@ int32_t AP_Landing::get_target_airspeed_cm(void)
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_get_target_airspeed_cm();
-
     default:
         return SpdHgt_Controller->get_land_airspeed();
     }
@@ -401,7 +393,6 @@ bool AP_Landing::request_go_around(void)
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_request_go_around();
-
     default:
         return false;
     }
@@ -411,6 +402,19 @@ void AP_Landing::handle_flight_stage_change(const bool _in_landing_stage)
 {
     in_progress = _in_landing_stage;
     commanded_go_around = false;
+}
+
+/*
+ * returns true when a landing is complete, usually used to disable throttle
+ */
+bool AP_Landing::is_complete(void) const
+{
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_is_complete();
+    default:
+        return true;
+    }
 }
 
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -157,9 +157,9 @@ private:
 
     // Land Type STANDARD GLIDE SLOPE
     enum slope_stage {
-        SLOPE_APPROACH,
-        SLOPE_PREFLARE,
-        SLOPE_FINAL
+        SLOPE_STAGE_APPROACH,
+        SLOPE_STAGE_PREFLARE,
+        SLOPE_STAGE_FINAL
     };
     slope_stage type_slope_stage;
     void type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -97,7 +97,8 @@ public:
     int8_t get_throttle_slewrate(void) const { return throttle_slewrate; }
     bool is_commanded_go_around(void) const { return commanded_go_around; }
     bool is_complete(void) const { return complete; }
-    void set_initial_slope() { initial_slope = slope; }
+    void set_initial_slope(void) { initial_slope = slope; }
+    bool is_expecting_impact(void) const;
 
     AP_Vehicle::FixedWing::FlightStage stage;
 
@@ -170,6 +171,7 @@ private:
     bool type_slope_request_go_around(void);
     bool type_slope_is_flaring(void) const;
     bool type_slope_is_on_approach(void) const;
+    bool type_slope_is_expecting_impact(void) const;
 
 
 };

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -68,6 +68,7 @@ public:
 //      TODO: TYPE_HELICAL,
     };
 
+    void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
     bool verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const int32_t auto_state_takeoff_altitude_rel_cm, bool &throttle_suppressed);
     bool verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
@@ -161,6 +162,7 @@ private:
                        SLOPE_PREFLARE,
                        SLOPE_FINAL};
     slope_stage type_slope_stage;
+    void type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
     void type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed);
     bool type_slope_verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -79,6 +79,7 @@ public:
     bool is_flaring(void) const;
     bool is_on_approach(void) const;
     void handle_flight_stage_change(const bool _in_landing_stage);
+    int32_t constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
 
     // helper functions
     bool restart_landing_sequence(void);
@@ -173,6 +174,7 @@ private:
     void type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     int32_t type_slope_get_target_airspeed_cm(void);
     void type_slope_check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
+    int32_t type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool type_slope_request_go_around(void);
     bool type_slope_is_flaring(void) const;
     bool type_slope_is_on_approach(void) const;

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -85,13 +85,12 @@ public:
     bool restart_landing_sequence(void);
     float wind_alignment(const float heading_deg);
     float head_wind(void);
-    int32_t get_target_airspeed_cm(const AP_Vehicle::FixedWing::FlightStage flight_stage);
+    int32_t get_target_airspeed_cm(void);
 
     // accessor functions for the params and states
     static const struct AP_Param::GroupInfo var_info[];
     int16_t get_pitch_cd(void) const { return pitch_cd; }
     float get_flare_sec(void) const { return flare_sec; }
-    float get_pre_flare_airspeed(void) const { return pre_flare_airspeed; }
     int8_t get_disarm_delay(void) const { return disarm_delay; }
     int8_t get_then_servos_neutral(void) const { return then_servos_neutral; }
     int8_t get_abort_throttle_enable(void) const { return abort_throttle_enable; }
@@ -102,14 +101,9 @@ public:
     void set_initial_slope(void) { initial_slope = slope; }
     bool is_expecting_impact(void) const;
 
-    AP_Vehicle::FixedWing::FlightStage stage;
-
     // Flag to indicate if we have landed.
     // Set land_complete if we are within 2 seconds distance or within 3 meters altitude of touchdown
     bool complete;
-
-    // Flag to indicate if we have triggered pre-flare. This occurs when we have reached LAND_PF_ALT
-    bool pre_flare;
 
     // are we in auto and flight mode is approach || pre-flare || final (flare)
     bool in_progress;
@@ -163,6 +157,10 @@ private:
     AP_Int8 type;
 
     // Land Type STANDARD GLIDE SLOPE
+    enum slope_stage {SLOPE_APPROACH,
+                       SLOPE_PREFLARE,
+                       SLOPE_FINAL};
+    slope_stage type_slope_stage;
     void type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed);
     bool type_slope_verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
             const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);
@@ -170,11 +168,11 @@ private:
     void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
 
     void type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
+    int32_t type_slope_get_target_airspeed_cm(void);
     void type_slope_check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
     bool type_slope_request_go_around(void);
     bool type_slope_is_flaring(void) const;
     bool type_slope_is_on_approach(void) const;
     bool type_slope_is_expecting_impact(void) const;
-
 
 };

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -81,7 +81,6 @@ public:
     void set_in_progress(const bool _in_progress) { in_progress = _in_progress; }
 
     // helper functions
-    void reset(void);
     bool restart_landing_sequence(void);
     float wind_alignment(const float heading_deg);
     float head_wind(void);

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -158,9 +158,11 @@ private:
     AP_Int8 type;
 
     // Land Type STANDARD GLIDE SLOPE
-    enum slope_stage {SLOPE_APPROACH,
-                       SLOPE_PREFLARE,
-                       SLOPE_FINAL};
+    enum slope_stage {
+        SLOPE_APPROACH,
+        SLOPE_PREFLARE,
+        SLOPE_FINAL
+    };
     slope_stage type_slope_stage;
     void type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
     void type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed);

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -68,8 +68,10 @@ public:
 //      TODO: TYPE_HELICAL,
     };
 
-    bool verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
-            const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed);
+    bool verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+            const int32_t auto_state_takeoff_altitude_rel_cm, bool &throttle_suppressed);
+    bool verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+            const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);
     void adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
     void setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     void check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
@@ -161,8 +163,9 @@ private:
     AP_Int8 type;
 
     // Land Type STANDARD GLIDE SLOPE
-    bool type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage flight_stage, const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
-            const int32_t auto_state_takeoff_altitude_rel_cm, const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range, bool &throttle_suppressed);
+    void type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed);
+    bool type_slope_verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
+            const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range);
 
     void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -78,7 +78,7 @@ public:
     bool request_go_around(void);
     bool is_flaring(void) const;
     bool is_on_approach(void) const;
-    void set_in_progress(const bool _in_progress) { in_progress = _in_progress; }
+    void handle_flight_stage_change(const bool _in_landing_stage);
 
     // helper functions
     bool restart_landing_sequence(void);
@@ -157,6 +157,7 @@ private:
 
     // Land Type STANDARD GLIDE SLOPE
     enum slope_stage {
+        SLOPE_STAGE_NORMAL,
         SLOPE_STAGE_APPROACH,
         SLOPE_STAGE_PREFLARE,
         SLOPE_STAGE_FINAL

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -71,6 +71,8 @@ public:
     void setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     void check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
     bool request_go_around(void);
+    bool is_flaring(void) const;
+    bool is_on_approach(void) const;
 
 
     // helper functions
@@ -94,7 +96,7 @@ public:
     bool is_complete(void) const { return complete; }
     void set_initial_slope() { initial_slope = slope; }
 
-
+    AP_Vehicle::FixedWing::FlightStage stage;
 
     // Flag to indicate if we have landed.
     // Set land_complete if we are within 2 seconds distance or within 3 meters altitude of touchdown
@@ -163,5 +165,8 @@ private:
     void type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
     void type_slope_check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
     bool type_slope_request_go_around(void);
+    bool type_slope_is_flaring(void) const;
+    bool type_slope_is_on_approach(void) const;
+
 
 };

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -19,7 +19,6 @@
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_Navigation/AP_Navigation.h>
 
 /// @class  AP_Landing
@@ -79,7 +78,7 @@ public:
     bool request_go_around(void);
     bool is_flaring(void) const;
     bool is_on_approach(void) const;
-
+    void set_in_progress(const bool _in_progress) { in_progress = _in_progress; }
 
     // helper functions
     void reset(void);
@@ -106,9 +105,6 @@ public:
     // Set land_complete if we are within 2 seconds distance or within 3 meters altitude of touchdown
     bool complete;
 
-    // are we in auto and flight mode is approach || pre-flare || final (flare)
-    bool in_progress;
-
     // landing altitude offset (meters)
     float alt_offset;
 
@@ -127,6 +123,9 @@ private:
 
     // calculated approach slope during auto-landing: ((prev_WP_loc.alt - next_WP_loc.alt)*0.01f - flare_sec * sink_rate) / get_distance(prev_WP_loc, next_WP_loc)
     float slope;
+
+    // are we in auto and flight_stage is LAND
+    bool in_progress;
 
     AP_Mission &mission;
     AP_AHRS &ahrs;

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -58,6 +58,9 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     }
 
+
+
+    // NOTE: make sure to update is_type_valid()
     enum Landing_Type {
         TYPE_STANDARD_GLIDE_SLOPE = 0,
 //      TODO: TYPE_DEEPSTALL,

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -97,13 +97,9 @@ public:
     int8_t get_flap_percent(void) const { return flap_percent; }
     int8_t get_throttle_slewrate(void) const { return throttle_slewrate; }
     bool is_commanded_go_around(void) const { return commanded_go_around; }
-    bool is_complete(void) const { return complete; }
+    bool is_complete(void) const;
     void set_initial_slope(void) { initial_slope = slope; }
     bool is_expecting_impact(void) const;
-
-    // Flag to indicate if we have landed.
-    // Set land_complete if we are within 2 seconds distance or within 3 meters altitude of touchdown
-    bool complete;
 
     // landing altitude offset (meters)
     float alt_offset;
@@ -176,6 +172,7 @@ private:
     void type_slope_check_if_need_to_abort(const AP_Vehicle::FixedWing::Rangefinder_State &rangefinder_state);
     int32_t type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool type_slope_request_go_around(void);
+    bool type_slope_is_complete(void) const;
     bool type_slope_is_flaring(void) const;
     bool type_slope_is_on_approach(void) const;
     bool type_slope_is_expecting_impact(void) const;

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -29,7 +29,7 @@ void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, cons
     // once landed, post some landing statistics to the GCS
     post_stats = false;
 
-    type_slope_stage = SLOPE_APPROACH;
+    type_slope_stage = SLOPE_STAGE_NORMAL;
     GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude);
 }
 
@@ -50,10 +50,23 @@ void AP_Landing::type_slope_verify_abort_landing(const Location &prev_WP_loc, Lo
 bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
         const float height, const float sink_rate, const float wp_proportion, const uint32_t last_flying_ms, const bool is_armed, const bool is_flying, const bool rangefinder_state_in_range)
 {
-        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Stage: %d Complete: %d", type_slope_stage, complete);
     // we don't 'verify' landing in the sense that it never completes,
     // so we don't verify command completion. Instead we use this to
     // adjust final landing parameters
+
+    // determine stage
+    if (type_slope_stage == SLOPE_STAGE_NORMAL) {
+        const bool heading_lined_up = abs(nav_controller->bearing_error_cd()) < 1000 && !nav_controller->data_is_stale();
+        const bool on_flight_line = fabsf(nav_controller->crosstrack_error()) < 5.0f && !nav_controller->data_is_stale();
+        const bool below_prev_WP = current_loc.alt < prev_WP_loc.alt;
+        if ((mission.get_prev_nav_cmd_id() == MAV_CMD_NAV_LOITER_TO_ALT) ||
+            (wp_proportion >= 0 && heading_lined_up && on_flight_line) ||
+            (wp_proportion > 0.15f && heading_lined_up && below_prev_WP) ||
+            (wp_proportion > 0.5f)) {
+            type_slope_stage = SLOPE_STAGE_APPROACH;
+        }
+    }
+
 
     /* Set land_complete (which starts the flare) under 3 conditions:
        1) we are within LAND_FLARE_ALT meters of the landing altitude
@@ -296,17 +309,12 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
 }
 
 int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
-    int32_t target_airspeed_cm = aparm.airspeed_cruise_cm;
-
-    if (!in_progress) {
-        // not landing, use regular cruise airspeed
-        return target_airspeed_cm;
-    }
 
     // we're landing, check for custom approach and
     // pre-flare airspeeds. Also increase for head-winds
 
     const float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+    int32_t target_airspeed_cm = aparm.airspeed_cruise_cm;
 
     switch (type_slope_stage) {
     case SLOPE_STAGE_APPROACH:
@@ -338,20 +346,18 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
 
 bool AP_Landing::type_slope_is_flaring(void) const
 {
-    return in_progress && type_slope_stage == SLOPE_STAGE_FINAL;
+    return (type_slope_stage == SLOPE_STAGE_FINAL);
 }
 
 
 bool AP_Landing::type_slope_is_on_approach(void) const
 {
-    return in_progress &&
-           (type_slope_stage == SLOPE_STAGE_APPROACH ||
+    return (type_slope_stage == SLOPE_STAGE_APPROACH ||
             type_slope_stage == SLOPE_STAGE_PREFLARE);
 }
 
 bool AP_Landing::type_slope_is_expecting_impact(void) const
 {
-    return in_progress &&
-            (type_slope_stage == SLOPE_STAGE_PREFLARE ||
-             type_slope_stage == SLOPE_STAGE_FINAL);
+    return (type_slope_stage == SLOPE_STAGE_PREFLARE ||
+            type_slope_stage == SLOPE_STAGE_FINAL);
 }

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -145,7 +145,9 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     }
 
     // check if we should auto-disarm after a confirmed landing
-    disarm_if_autoland_complete_fn();
+    if (complete) {
+        disarm_if_autoland_complete_fn();
+    }
 
     /*
       we return false as a landing mission item never completes
@@ -342,6 +344,14 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
 
     // Do not lower it or exceed cruise speed
     return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_cruise_cm);
+}
+
+int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd) {
+    if (type_slope_stage == SLOPE_STAGE_FINAL) {
+        return constrain_int32(desired_roll_cd, level_roll_limit_cd * -1, level_roll_limit_cd);
+    } else {
+        return desired_roll_cd;
+    }
 }
 
 bool AP_Landing::type_slope_is_flaring(void) const

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -298,4 +298,15 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     constrain_target_altitude_location_fn(loc, prev_WP_loc);
 }
 
+bool AP_Landing::type_slope_is_flaring(void) const
+{
+    return (stage == AP_Vehicle::FixedWing::FlightStage::FLIGHT_LAND_FINAL);
+}
+
+
+bool AP_Landing::type_slope_is_on_approach(void) const
+{
+    return (stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH ||
+            stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE);
+}
 

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -23,8 +23,14 @@
 
 void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
 {
-        type_slope_stage = SLOPE_APPROACH;
-        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude);
+    initial_slope = 0;
+    slope = 0;
+
+    // once landed, post some landing statistics to the GCS
+    post_stats = false;
+
+    type_slope_stage = SLOPE_APPROACH;
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude);
 }
 
 void AP_Landing::type_slope_verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, bool &throttle_suppressed)

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -37,10 +37,10 @@ bool AP_Landing::type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage
     // the altitude has been reached, restart the landing sequence
     if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
 
-        throttle_suppressed = false;
-        complete = false;
-        pre_flare = false;
-        nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
+    throttle_suppressed = false;
+    complete = false;
+    pre_flare = false;
+    nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
 
         // see if we have reached abort altitude
         if (adjusted_relative_altitude_cm_fn() > auto_state_takeoff_altitude_rel_cm) {
@@ -53,7 +53,7 @@ bool AP_Landing::type_slope_verify_land(const AP_Vehicle::FixedWing::FlightStage
         }
         // make sure to return false so it leaves the mission index alone
         return false;
-    }
+}
 
 
     /* Set land_complete (which starts the flare) under 3 conditions:
@@ -310,3 +310,8 @@ bool AP_Landing::type_slope_is_on_approach(void) const
             stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE);
 }
 
+bool AP_Landing::type_slope_is_expecting_impact(void) const
+{
+    return (stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE ||
+            stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL);
+}

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -92,7 +92,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
                                   (double)get_distance(current_loc, next_WP_loc));
             }
             complete = true;
-            type_slope_stage = SLOPE_FINAL;
+            type_slope_stage = SLOPE_STAGE_FINAL;
         }
 
 
@@ -105,11 +105,11 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
             aparm.min_gndspeed_cm.load();
             aparm.throttle_cruise.load();
         }
-    } else if (!complete && type_slope_stage != SLOPE_PREFLARE && pre_flare_airspeed > 0) {
+    } else if (!complete && type_slope_stage == SLOPE_STAGE_APPROACH && pre_flare_airspeed > 0) {
         bool reached_pre_flare_alt = pre_flare_alt > 0 && (height <= pre_flare_alt);
         bool reached_pre_flare_sec = pre_flare_sec > 0 && (height <= sink_rate * pre_flare_sec);
         if (reached_pre_flare_alt || reached_pre_flare_sec) {
-            type_slope_stage = SLOPE_PREFLARE;
+            type_slope_stage = SLOPE_STAGE_PREFLARE;
         }
     }
 
@@ -309,14 +309,14 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
     const float land_airspeed = SpdHgt_Controller->get_land_airspeed();
 
     switch (type_slope_stage) {
-    case SLOPE_APPROACH:
+    case SLOPE_STAGE_APPROACH:
         if (land_airspeed >= 0) {
             target_airspeed_cm = land_airspeed * 100;
         }
         break;
 
-    case SLOPE_PREFLARE:
-    case SLOPE_FINAL:
+    case SLOPE_STAGE_PREFLARE:
+    case SLOPE_STAGE_FINAL:
         if (pre_flare_airspeed > 0) {
             // if we just preflared then continue using the pre-flare airspeed during final flare
             target_airspeed_cm = pre_flare_airspeed * 100;
@@ -338,20 +338,20 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
 
 bool AP_Landing::type_slope_is_flaring(void) const
 {
-    return in_progress && type_slope_stage == SLOPE_FINAL;
+    return in_progress && type_slope_stage == SLOPE_STAGE_FINAL;
 }
 
 
 bool AP_Landing::type_slope_is_on_approach(void) const
 {
     return in_progress &&
-           (type_slope_stage == SLOPE_APPROACH ||
-            type_slope_stage == SLOPE_PREFLARE);
+           (type_slope_stage == SLOPE_STAGE_APPROACH ||
+            type_slope_stage == SLOPE_STAGE_PREFLARE);
 }
 
 bool AP_Landing::type_slope_is_expecting_impact(void) const
 {
     return in_progress &&
-            (type_slope_stage == SLOPE_PREFLARE ||
-            type_slope_stage == SLOPE_FINAL);
+            (type_slope_stage == SLOPE_STAGE_PREFLARE ||
+             type_slope_stage == SLOPE_STAGE_FINAL);
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -467,10 +467,10 @@ void AP_TECS::_update_height_demand(void)
     // Apply first order lag to height demand
     _hgt_dem_adj = 0.05f * _hgt_dem + 0.95f * _hgt_dem_adj_last;
 
-    // in final landing stage force height rate demand to the
+    // when flaring force height rate demand to the
     // configured sink rate and adjust the demanded height to
     // be kinematically consistent with the height rate.
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.is_flaring()) {
         _integSEB_state = 0;
         if (_flare_counter == 0) {
             _hgt_rate_dem = _climb_rate;
@@ -529,7 +529,7 @@ void AP_TECS::_detect_underspeed(void)
         _flags.underspeed = false;
     } else if (((_TAS_state < _TASmin * 0.9f) &&
             (_throttle_dem >= _THRmaxf * 0.95f) &&
-            _flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) ||
+            !_landing.is_flaring()) ||
             ((_height < _hgt_dem_adj) && _flags.underspeed))
     {
         _flags.underspeed = true;
@@ -806,7 +806,7 @@ void AP_TECS::_update_pitch(void)
     float integSEB_delta = integSEB_input * _DT;
 
 #if 0
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL && fabsf(_climb_rate) > 0.2f) {
+    if (_landing.is_flaring() && fabsf(_climb_rate) > 0.2f) {
         ::printf("_hgt_rate_dem=%.1f _hgt_dem_adj=%.1f climb=%.1f _flare_counter=%u _pitch_dem=%.1f SEB_dem=%.2f SEBdot_dem=%.2f SEB_error=%.2f SEBdot_error=%.2f\n",
                  _hgt_rate_dem, _hgt_dem_adj, _climb_rate, _flare_counter, degrees(_pitch_dem),
                  SEB_dem, SEBdot_dem, SEB_error, SEBdot_error);
@@ -825,7 +825,7 @@ void AP_TECS::_update_pitch(void)
     float temp = SEB_error + SEBdot_dem * timeConstant();
 
     float pitch_damp = _ptchDamp;
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.is_flaring()) {
         pitch_damp = _landDamp;
     } else if (!is_zero(_land_pitch_damp) && _flags.is_doing_auto_land) {
         pitch_damp = _land_pitch_damp;
@@ -978,7 +978,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
         _pitch_max_limit = 90;
     }
         
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_FINAL) {
+    if (_landing.is_flaring()) {
         // in flare use min pitch from LAND_PITCH_CD
         _PITCHminf = MAX(_PITCHminf, _landing.get_pitch_cd() * 0.01f);
 
@@ -989,7 +989,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
         // and allow zero throttle
         _THRminf = 0;
-    } else if ((flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_APPROACH || flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND_PREFLARE) && (-_climb_rate) > _land_sink) {
+    } else if (_landing.is_on_approach() && (-_climb_rate) > _land_sink) {
         // constrain the pitch in landing as we get close to the flare
         // point. Use a simple linear limit from 15 meters after the
         // landing point

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -936,7 +936,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     _DT = (now - _update_pitch_throttle_last_usec) * 1.0e-6f;
     _update_pitch_throttle_last_usec = now;
 
-    _flags.is_doing_auto_land = _landing.in_progress;
+    _flags.is_doing_auto_land = (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND);
     _distance_beyond_land_wp = distance_beyond_land_wp;
     _flight_stage = flight_stage;
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -682,7 +682,7 @@ void AP_TECS::_update_throttle_with_airspeed(void)
 float AP_TECS::_get_i_gain(void)
 {
     float i_gain = _integGain;
-    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF) {
+    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
         if (!is_zero(_integGain_takeoff)) {
             i_gain = _integGain_takeoff;
         }

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -64,9 +64,7 @@ public:
             FLIGHT_TAKEOFF       = 1,
             FLIGHT_VTOL          = 2,
             FLIGHT_NORMAL        = 3,
-            FLIGHT_LAND_APPROACH = 4,
-            FLIGHT_LAND_PREFLARE = 5,
-            FLIGHT_LAND_FINAL    = 6,
+            FLIGHT_LAND          = 4,
             FLIGHT_ABORT_LAND    = 7
         };
     };


### PR DESCRIPTION
Here's the next chapter in the ongoing AP_Landing abstraction saga. This was done /w @WickedShell and before we go much further we thought we'd get some input from you folks.

Idea is to remove the concept of plane specific landing types (ie standard glide slope) from Plane and TECS and have AP_Landing handle that abstraction. This lays the groundwork for other landing types to offer other arbitrary landing stages without having to sprinkle the stages throughout the entire codebase.

