### PR TITLE
GPS: Raise the number of leap seconds

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -590,7 +590,7 @@ AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms,
     istate.hdop = hdop;
     istate.num_sats = _num_sats;
     istate.last_gps_time_ms = tnow;
-    uint64_t gps_time_ms = time_epoch_ms - (17000ULL*86400ULL + 52*10*7000ULL*86400ULL - 15000ULL);
+    uint64_t gps_time_ms = time_epoch_ms - (17000ULL*86400ULL + 52*10*7000ULL*86400ULL - GPS_LEAPSECONDS_MILLIS);
     istate.time_week     = gps_time_ms / (86400*7*(uint64_t)1000);
     istate.time_week_ms  = gps_time_ms - istate.time_week*(86400*7*(uint64_t)1000);
     timing[instance].last_message_time_ms = tnow;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -31,6 +31,9 @@
 #define GPS_MAX_INSTANCES 2
 #define GPS_RTK_INJECT_TO_ALL 127
 
+// the number of GPS leap seconds
+#define GPS_LEAPSECONDS_MILLIS 18000ULL
+
 class DataFlash_Class;
 class AP_GPS_Backend;
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -64,7 +64,7 @@ int16_t AP_GPS_Backend::swap_int16(int16_t v) const
 uint64_t AP_GPS::time_epoch_convert(uint16_t gps_week, uint32_t gps_ms)
 {
     const uint64_t ms_per_week = 7000ULL*86400ULL;
-    const uint64_t unix_offset = 17000ULL*86400ULL + 52*10*7000ULL*86400ULL - 15000ULL;
+    const uint64_t unix_offset = 17000ULL*86400ULL + 52*10*7000ULL*86400ULL - GPS_LEAPSECONDS_MILLIS;
     uint64_t fix_time_ms = unix_offset + gps_week*ms_per_week + gps_ms;
     return fix_time_ms;
 }
@@ -110,7 +110,7 @@ void AP_GPS_Backend::make_gps_time(uint32_t bcd_date, uint32_t bcd_milliseconds)
     }
 
     // get time in seconds since unix epoch
-    uint32_t ret = (year/4) - 15 + 367*rmon/12 + day;
+    uint32_t ret = (year/4) - (GPS_LEAPSECONDS_MILLIS / 1000UL) + 367*rmon/12 + day;
     ret += year*365 + 10501;
     ret = ret*24 + hour;
     ret = ret*60 + min;

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -177,7 +177,7 @@ static void gps_time(uint16_t *time_week, uint32_t *time_week_ms)
 {
     struct timeval tv;
     simulation_timeval(&tv);
-    const uint32_t epoch = 86400*(10*365 + (1980-1969)/4 + 1 + 6 - 2) - 15;
+    const uint32_t epoch = 86400*(10*365 + (1980-1969)/4 + 1 + 6 - 2) - (GPS_LEAPSECONDS_MILLIS / 1000ULL);
     uint32_t epoch_seconds = tv.tv_sec - epoch;
     *time_week = epoch_seconds / (86400*7UL);
     uint32_t t_ms = tv.tv_usec / 1000;


### PR DESCRIPTION
Follows the discussion from #5510 and the dev call this raises the number of hard coded leapseconds to be current.