### PR TITLE
Compass: added MMC3416 driver

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -20,6 +20,7 @@
 #if HAL_WITH_UAVCAN
 #include "AP_Compass_UAVCAN.h"
 #endif
+#include "AP_Compass_MMC3416.h"
 #include "AP_Compass.h"
 
 extern AP_HAL::HAL& hal;

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -60,6 +60,7 @@ public:
         DEVTYPE_AK09916 = 0x09,
         DEVTYPE_IST8310 = 0x0A,
         DEVTYPE_ICM20948 = 0x0B,
+        DEVTYPE_MMC3416 = 0x0C,
     };
 
 

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -30,6 +30,12 @@ extern const AP_HAL::HAL &hal;
 #define REG_CONTROL0        0x07
 #define REG_CONTROL1        0x08
 
+// bits in REG_CONTROL0
+#define REG_CONTROL0_REFILL 0x80
+#define REG_CONTROL0_RESET  0x40
+#define REG_CONTROL0_SET    0x20
+#define REG_CONTROL0_TM     0x01
+
 AP_Compass_Backend *AP_Compass_MMC3416::probe(Compass &compass,
                                               AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
                                               bool force_external,
@@ -102,6 +108,9 @@ bool AP_Compass_MMC3416::init()
     dev->register_periodic_callback(10000,
                                     FUNCTOR_BIND_MEMBER(&AP_Compass_MMC3416::timer, bool));
 
+    // wait 250ms for the compass to make it's initial readings
+    hal.scheduler->delay(250);
+    
     return true;
 
 fail:
@@ -112,18 +121,29 @@ fail:
 bool AP_Compass_MMC3416::timer()
 {
     uint32_t now = AP_HAL::millis();
+    const uint8_t measure_count_limit = 50;
+    const uint16_t zero_offset = 32768; // 16 bit mode
+    const uint16_t sensitivity = 2048; // counts per Gauss, 16 bit mode
+    const float counts_to_milliGauss = 1.0e3f / sensitivity;
     
+    /*
+      we use the SET/RESET method to remove bridge offset every
+      measure_count_limit measurements. This involves a fairly complex
+      state machine, but means we are much less sensitive to
+      temperature changes
+     */
     switch (state) {
     case STATE_REFILL1:
-        if (dev->write_register(REG_CONTROL0, 0x80)) { // REFILL
+        if (dev->write_register(REG_CONTROL0, REG_CONTROL0_REFILL)) {
             state = STATE_REFILL1_WAIT;
+            last_state_ms = AP_HAL::millis();
         }
         break;
 
     case STATE_REFILL1_WAIT:
         if (now - last_state_ms >= 50) {
-            if (!dev->write_register(REG_CONTROL0, 0x20) || // SET
-                !dev->write_register(REG_CONTROL0, 0x01)) { // Take Measurement
+            if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_SET) ||
+                !dev->write_register(REG_CONTROL0, REG_CONTROL0_TM)) { // Take Measurement
                 state = STATE_REFILL1;
             } else {
                 state = STATE_MEASURE_WAIT1;
@@ -138,10 +158,11 @@ bool AP_Compass_MMC3416::timer()
                 state = STATE_REFILL1;
                 break;
             }
-            if (!dev->write_register(REG_CONTROL0, 0x80)) { // REFILL
+            if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_REFILL)) {
                 state = STATE_REFILL1;
             } else {
                 state = STATE_REFILL2_WAIT;
+                last_state_ms = AP_HAL::millis();
             }
         }
         break;
@@ -149,8 +170,8 @@ bool AP_Compass_MMC3416::timer()
 
     case STATE_REFILL2_WAIT:
         if (now - last_state_ms >= 50) {
-            if (!dev->write_register(REG_CONTROL0, 0x40) || // RESET
-                !dev->write_register(REG_CONTROL0, 0x01)) { // Take Measurement
+            if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_RESET) ||
+                !dev->write_register(REG_CONTROL0, REG_CONTROL0_TM)) { // Take Measurement
                 state = STATE_REFILL1;
             } else {
                 state = STATE_MEASURE_WAIT2;
@@ -168,45 +189,100 @@ bool AP_Compass_MMC3416::timer()
             state = STATE_REFILL1;
             break;
         }
-        const uint16_t zero_offset = 32768; // 16 bit mode
-        const uint16_t sensitivity = 2048; // counts per Gauss, 16 bit mode
-        const float counts_to_milliGauss = 1.0e3f / sensitivity;
         Vector3f field;
-    
+
+        /*
+          calculate field and offset
+         */
         Vector3f f1(float(data0[0]) - zero_offset,
                     float(data0[1]) - zero_offset,
                     float(data0[2]) - zero_offset);
         Vector3f f2(float(data1[0]) - zero_offset,
                     float(data1[1]) - zero_offset,
                     float(data1[2]) - zero_offset);
-        field = (f1 - f2) / 2;
-        field * counts_to_milliGauss;
-        
-        /* rotate raw_field from sensor frame to body frame */
-        rotate_field(field, compass_instance);
-        
-        /* publish raw_field (uncorrected point sample) for calibration use */
-        publish_raw_field(field, AP_HAL::micros(), compass_instance);
-        
-        /* correct raw_field for known errors */
-        correct_field(field, compass_instance);
-        
-        if (_sem->take(0)) {
-            accum += field;
-            accum_count++;
-            _sem->give();
+        field = (f1 - f2) * (counts_to_milliGauss / 2);
+        Vector3f new_offset = (f1 + f2) * (counts_to_milliGauss / 2);
+        if (!have_initial_offset) {
+            offset = new_offset;
+        } else {
+            // low pass changes to the offset
+            offset = offset * 0.95 + new_offset * 0.05;
         }
-        state = STATE_REFILL1;
+
+#if 0
+        printf("F(%.1f %.1f %.1f) O(%.1f %.1f %.1f)\n",
+               field.x, field.y, field.z,
+               offset.x, offset.y, offset.z);
+#endif
+
+        accumulate_field(field);
+
+        if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_TM)) { // Take Measurement
+            state = STATE_REFILL1;
+        } else {
+            state = STATE_MEASURE_WAIT3;
+        }
+        break;
+    }
+
+    case STATE_MEASURE_WAIT3: {
+        uint8_t status;
+        if (!dev->read_registers(REG_STATUS, &status, 1) || !(status & 1)) {
+            break;
+        }
+        uint16_t data1[3];
+        if (!dev->read_registers(REG_XOUT_L, (uint8_t *)&data1[0], 6)) {
+            state = STATE_REFILL1;
+            break;
+        }
+        Vector3f field(float(data1[0]) - zero_offset,
+                       float(data1[1]) - zero_offset,
+                       float(data1[2]) - zero_offset);
+        field *= -counts_to_milliGauss;
+        field += offset;
+
+        accumulate_field(field);
+
+        // we stay in STATE_MEASURE_WAIT3 for measure_count_limit cycles
+        if (measure_count++ >= measure_count_limit) {
+            measure_count = 0;
+            state = STATE_REFILL1;
+        } else {
+            if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_TM)) { // Take Measurement
+                state = STATE_REFILL1;
+            }
+        }
         break;
     }
     }
-        
+
     return true;
+}
+
+/*
+  accumulate a field
+ */
+void AP_Compass_MMC3416::accumulate_field(Vector3f &field)
+{
+    /* rotate raw_field from sensor frame to body frame */
+    rotate_field(field, compass_instance);
+        
+    /* publish raw_field (uncorrected point sample) for calibration use */
+    publish_raw_field(field, AP_HAL::micros(), compass_instance);
+        
+    /* correct raw_field for known errors */
+    correct_field(field, compass_instance);
+        
+    if (_sem->take(0)) {
+        accum += field;
+        accum_count++;
+        _sem->give();
+    }
 }
 
 void AP_Compass_MMC3416::read()
 {
-    if (!_sem->take_nonblocking()) {
+    if (!_sem->take(0)) {
         return;
     }
     if (accum_count == 0) {
@@ -217,7 +293,7 @@ void AP_Compass_MMC3416::read()
     accum /= accum_count;
 
     publish_filtered_field(accum, compass_instance);
-
+    
     accum.zero();
     accum_count = 0;
     

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -1,0 +1,172 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Driver by Andrew Tridgell, Nov 2016
+ */
+#include "AP_Compass_MMC3416.h"
+
+#include <AP_HAL/AP_HAL.h>
+#include <utility>
+#include <AP_Math/AP_Math.h>
+#include <stdio.h>
+
+extern const AP_HAL::HAL &hal;
+
+#define REG_PRODUCT_ID      0x20
+#define REG_XOUT_L          0x00
+#define REG_STATUS          0x06
+#define REG_CONTROL0        0x07
+#define REG_CONTROL1        0x08
+
+AP_Compass_Backend *AP_Compass_MMC3416::probe(Compass &compass,
+                                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                              bool force_external,
+                                              enum Rotation rotation)
+{
+    if (!dev) {
+        return nullptr;
+    }
+    AP_Compass_MMC3416 *sensor = new AP_Compass_MMC3416(compass, std::move(dev), force_external, rotation);
+    if (!sensor || !sensor->init()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
+AP_Compass_MMC3416::AP_Compass_MMC3416(Compass &compass,
+                                       AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+                                       bool _force_external,
+                                       enum Rotation _rotation)
+    : AP_Compass_Backend(compass)
+    , dev(std::move(_dev))
+    , force_external(_force_external)
+    , rotation(_rotation)
+{
+}
+
+bool AP_Compass_MMC3416::init()
+{
+    if (!dev->get_semaphore()->take(0)) {
+        return false;
+    }
+
+    dev->set_retries(10);
+    
+    uint8_t whoami;
+    if (!dev->read_registers(REG_PRODUCT_ID, &whoami, 1) ||
+        whoami != 0x06) {
+        // not a MMC3416
+        goto fail;
+    }
+
+    dev->setup_checked_registers(2);
+
+    // reset sensor
+    dev->write_register(REG_CONTROL1, 0x80);
+    hal.scheduler->delay(10);
+    
+    dev->write_register(REG_CONTROL0, 0x0E, true); // continuous 50Hz
+    dev->write_register(REG_CONTROL1, 0x00, true); // 16 bit, 7.92ms
+    
+    dev->get_semaphore()->give();
+
+    /* register the compass instance in the frontend */
+    compass_instance = register_compass();
+
+    printf("Found a MMC3416 on 0x%x as compass %u\n", dev->get_bus_id(), compass_instance);
+    
+    set_rotation(compass_instance, rotation);
+
+    if (force_external) {
+        set_external(compass_instance, true);
+    }
+    
+    dev->set_device_type(DEVTYPE_MMC3416);
+    set_dev_id(compass_instance, dev->get_bus_id());
+
+    dev->set_retries(1);
+    
+    // call timer() at 50Hz
+    dev->register_periodic_callback(20000,
+                                    FUNCTOR_BIND_MEMBER(&AP_Compass_MMC3416::timer, bool));
+
+    return true;
+
+fail:
+    dev->get_semaphore()->give();
+    return false;
+}
+
+bool AP_Compass_MMC3416::timer()
+{
+    struct PACKED {
+        uint16_t magx;
+        uint16_t magy;
+        uint16_t magz;
+    } data;
+    const uint16_t zero_offset = 32768; // 16 bit mode
+    const uint16_t sensitivity = 2048; // counts per Gauss, 16 bit mode
+    const float counts_to_milliGauss = 1.0e3f / sensitivity;
+    Vector3f field;
+
+    if (!dev->read_registers(REG_XOUT_L, (uint8_t *)&data, sizeof(data))) {
+        goto check_registers;
+    }
+
+    // this assumes 16 bit output, which gives zero of 32768
+    field(float(data.magx) - zero_offset, float(data.magy) - zero_offset, float(data.magz) - zero_offset);
+    field *= counts_to_milliGauss;
+
+    /* rotate raw_field from sensor frame to body frame */
+    rotate_field(field, compass_instance);
+
+    /* publish raw_field (uncorrected point sample) for calibration use */
+    publish_raw_field(field, AP_HAL::micros(), compass_instance);
+
+    /* correct raw_field for known errors */
+    correct_field(field, compass_instance);
+
+    if (_sem->take(0)) {
+        accum += field;
+        accum_count++;
+        _sem->give();
+    }
+
+check_registers:
+    dev->check_next_register();
+    return true;
+}
+
+void AP_Compass_MMC3416::read()
+{
+    if (!_sem->take_nonblocking()) {
+        return;
+    }
+    if (accum_count == 0) {
+        _sem->give();
+        return;
+    }
+
+    accum /= accum_count;
+
+    publish_filtered_field(accum, compass_instance);
+
+    accum.zero();
+    accum_count = 0;
+    
+    _sem->give();
+}

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -112,7 +112,7 @@ bool AP_Compass_MMC3416::init()
     
     // call timer() at 100Hz
     dev->register_periodic_callback(10000,
-                                    FUNCTOR_BIND_MEMBER(&AP_Compass_MMC3416::timer, bool));
+                                    FUNCTOR_BIND_MEMBER(&AP_Compass_MMC3416::timer, void));
 
     // wait 250ms for the compass to make it's initial readings
     hal.scheduler->delay(250);
@@ -120,7 +120,7 @@ bool AP_Compass_MMC3416::init()
     return true;
 }
 
-bool AP_Compass_MMC3416::timer()
+void AP_Compass_MMC3416::timer()
 {
     const uint16_t measure_count_limit = 50;
     const uint16_t zero_offset = 32768; // 16 bit mode
@@ -280,8 +280,6 @@ bool AP_Compass_MMC3416::timer()
         break;
     }
     }
-
-    return true;
 }
 
 /*

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -66,11 +66,12 @@ private:
     uint16_t accum_count;
     bool force_external;
     Vector3f offset;
-    uint8_t measure_count;
+    uint16_t measure_count;
     bool have_initial_offset;
-
+    uint32_t refill_start_ms;
+    uint32_t last_sample_ms;
+    
     uint16_t data0[3];
-    uint32_t last_state_ms;
     
     enum Rotation rotation;
 };

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -1,0 +1,59 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/I2CDevice.h>
+#include <AP_Math/AP_Math.h>
+
+#include "AP_Compass.h"
+#include "AP_Compass_Backend.h"
+
+#ifndef HAL_COMPASS_MMC3416_I2C_ADDR
+# define HAL_COMPASS_MMC3416_I2C_ADDR 0x30
+#endif
+
+class AP_Compass_MMC3416 : public AP_Compass_Backend
+{
+public:
+    static AP_Compass_Backend *probe(Compass &compass,
+                                     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                     bool force_external = false,
+                                     enum Rotation rotation = ROTATION_NONE);
+
+    void read() override;
+
+    static constexpr const char *name = "MMC3416";
+
+private:
+    AP_Compass_MMC3416(Compass &compass, AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                       bool force_external,
+                       enum Rotation rotation);
+
+    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    
+    /**
+     * Device periodic callback to read data from the sensor.
+     */
+    bool init();
+    bool timer();
+
+    uint8_t compass_instance;
+    Vector3f accum;
+    uint16_t accum_count;
+    bool force_external;
+    enum Rotation rotation;
+};

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -44,6 +44,14 @@ private:
                        enum Rotation rotation);
 
     AP_HAL::OwnPtr<AP_HAL::Device> dev;
+
+    enum {
+        STATE_REFILL1,
+        STATE_REFILL1_WAIT,
+        STATE_MEASURE_WAIT1,
+        STATE_REFILL2_WAIT,
+        STATE_MEASURE_WAIT2,
+    } state;
     
     /**
      * Device periodic callback to read data from the sensor.
@@ -55,5 +63,9 @@ private:
     Vector3f accum;
     uint16_t accum_count;
     bool force_external;
+
+    uint16_t data0[3];
+    uint32_t last_state_ms;
+    
     enum Rotation rotation;
 };

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -51,6 +51,7 @@ private:
         STATE_MEASURE_WAIT1,
         STATE_REFILL2_WAIT,
         STATE_MEASURE_WAIT2,
+        STATE_MEASURE_WAIT3,
     } state;
     
     /**
@@ -58,11 +59,15 @@ private:
      */
     bool init();
     bool timer();
+    void accumulate_field(Vector3f &field);
 
     uint8_t compass_instance;
     Vector3f accum;
     uint16_t accum_count;
     bool force_external;
+    Vector3f offset;
+    uint8_t measure_count;
+    bool have_initial_offset;
 
     uint16_t data0[3];
     uint32_t last_state_ms;

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -58,7 +58,7 @@ private:
      * Device periodic callback to read data from the sensor.
      */
     bool init();
-    bool timer();
+    void timer();
     void accumulate_field(Vector3f &field);
 
     uint8_t compass_instance;


### PR DESCRIPTION
This driver isn't in use by any of our supported boards yet, but I suspect it will be soon. I'd like it in the tree to prevent bitrot, and to save someone else having to re-implement it. It is a surprisingly tricky driver to get right.
I have an open question with the memsic engineers about the temperature compensation code, so there may be an update once that is clarified