### PR TITLE
Add AP_HAL_Common and ap::Mutex

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -243,6 +243,7 @@ class linux(Board):
         env.LINKFLAGS += ['-pthread',]
         env.AP_LIBRARIES = [
             'AP_HAL_Linux',
+            'AP_HAL_Common',
         ]
 
 
@@ -439,6 +440,7 @@ class px4(Board):
         ]
         env.AP_LIBRARIES += [
             'AP_HAL_PX4',
+            'AP_HAL_Common',
         ]
         env.GIT_SUBMODULES += [
             'PX4Firmware',

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -26,14 +26,13 @@ extern const AP_HAL::HAL &hal;
 AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend) :
     frontend(_frontend)
 {
-    sem = hal.util->new_semaphore();
+    lock = AP_HAL::Mutex::create();
 }
 
 AP_Airspeed_Backend::~AP_Airspeed_Backend(void)
 {
-    delete sem;
+    delete lock;
 }
- 
 
 int8_t AP_Airspeed_Backend::get_pin(void) const
 {

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -20,6 +20,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Mutex.h>
 
 class AP_Airspeed;
 
@@ -27,7 +28,7 @@ class AP_Airspeed_Backend {
 public:
     AP_Airspeed_Backend(AP_Airspeed &frontend);
     virtual ~AP_Airspeed_Backend();
-    
+
     // probe and initialise the sensor
     virtual bool init(void) = 0;
 
@@ -43,8 +44,8 @@ protected:
     uint8_t get_bus(void) const;
 
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *sem;    
-    
+    AP_HAL::Mutex *lock;
+
 private:
     AP_Airspeed &frontend;
 };

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -56,7 +56,7 @@ bool AP_Airspeed_MS4525::init()
         if (!_dev) {
             continue;
         }
-        if (!_dev->get_semaphore()->take(0)) {
+        if (!_dev->get_semaphore()->lock()) {
             continue;
         }
 
@@ -138,12 +138,12 @@ void AP_Airspeed_MS4525::_collect()
     
     _voltage_correction(press, temp);
 
-    if (sem->take(0)) {
+    if (lock->lock()) {
         _press_sum += press;
         _temp_sum += temp;
         _press_count++;
         _temp_count++;
-        sem->give();
+        lock->give();
     }
     
     _last_sample_time_ms = AP_HAL::millis();
@@ -193,13 +193,13 @@ bool AP_Airspeed_MS4525::get_differential_pressure(float &pressure)
     if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (lock->lock()) {
         if (_press_count > 0) {
             _pressure = _press_sum / _press_count;
             _press_count = 0;
             _press_sum = 0;
         }
-        sem->give();
+        lock->give();
     }
     pressure = _pressure;
     return true;
@@ -211,13 +211,13 @@ bool AP_Airspeed_MS4525::get_temperature(float &temperature)
     if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (lock->lock()) {
         if (_temp_count > 0) {
             _temperature = _temp_sum / _temp_count;
             _temp_count = 0;
             _temp_sum = 0;
         }
-        sem->give();
+        lock->give();
     }
     temperature = _temperature;
     return true;

--- a/libraries/AP_HAL/Mutex.h
+++ b/libraries/AP_HAL/Mutex.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <inttypes.h>
+
+#include <AP_HAL/AP_HAL_Macros.h>
+
+namespace AP_HAL {
+
+template <typename T>
+class Mutex {
+public:
+    virtual void lock() = 0;
+    virtual bool try_lock() WARN_IF_UNUSED = 0;
+    virtual bool try_lock(uint32_t timeout_msec) WARN_IF_UNUSED = 0;
+    virtual void unlock();
+    virtual ~Mutex() { }
+
+    static Mutex *create();
+};
+
+}

--- a/libraries/AP_HAL_Common/Mutex.cpp
+++ b/libraries/AP_HAL_Common/Mutex.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Mutex.h"
+
+#include <AP_HAL/AP_HAL.h>
+
+using namespace AP;
+
+const extern AP_HAL::HAL& hal;
+
+void Mutex::lock()
+{
+    pthread_mutex_lock(&_lock);
+}
+
+bool Mutex::try_lock()
+{
+    return pthread_mutex_trylock(&_lock) == 0;
+}
+
+bool Mutex::try_lock(uint32_t timeout_msec)
+{
+    if (timeout_msec == 0) {
+        lock();
+        return true;
+    }
+
+    if (try_lock()) {
+        return true;
+    }
+
+    uint64_t start = AP_HAL::micros64();
+    do {
+        hal.scheduler->delay_microseconds(200);
+        if (try_lock()) {
+            return true;
+        }
+    } while ((AP_HAL::micros64() - start) < timeout_msec * 1000);
+
+    return false;
+}
+
+void Mutex::unlock()
+{
+    pthread_mutex_unlock(&_lock);
+}
+
+
+static AP_HAL::Mutex *AP_HAL::create()
+{
+    return new Mutex{};
+}

--- a/libraries/AP_HAL_Common/Mutex.cpp
+++ b/libraries/AP_HAL_Common/Mutex.cpp
@@ -17,6 +17,7 @@
 #include "Mutex.h"
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Mutex.h>
 
 using namespace AP;
 
@@ -60,7 +61,7 @@ void Mutex::unlock()
 }
 
 
-static AP_HAL::Mutex *AP_HAL::create()
+AP_HAL::Mutex *AP_HAL::Mutex::create()
 {
-    return new Mutex{};
+    return new AP::Mutex{};
 }

--- a/libraries/AP_HAL_Common/Mutex.h
+++ b/libraries/AP_HAL_Common/Mutex.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <pthread.h>
+
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Mutex.h>
+
+namespace AP {
+
+class Mutex : public AP_HAL::Mutex {
+public:
+    void lock() override;
+    bool try_lock() override WARN_IF_UNUSED;
+    bool try_lock(uint32_t timeout_msec) override WARN_IF_UNUSED;
+    void unlock() override;
+
+private:
+    pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
+};
+
+}

--- a/libraries/AP_HAL_Common/README.md
+++ b/libraries/AP_HAL_Common/README.md
@@ -1,0 +1,1 @@
+Shared HAL implementation among different platforms/OSes.

--- a/libraries/AP_HAL_Linux/Mutex.h
+++ b/libraries/AP_HAL_Linux/Mutex.h
@@ -16,21 +16,15 @@
  */
 #pragma once
 
-#include <inttypes.h>
+#include <AP_HAL_Common/Mutex.h>
 
-#include <AP_HAL/AP_HAL_Macros.h>
+/*
+ * This uses the common arch and OS independent implementation from
+ * AP_HAL_Common
+ */
 
-namespace AP_HAL {
+namespace Linux {
 
-class Mutex {
-public:
-    virtual void lock() = 0;
-    virtual bool try_lock() WARN_IF_UNUSED = 0;
-    virtual bool try_lock(uint32_t timeout_msec) WARN_IF_UNUSED = 0;
-    virtual void unlock();
-    virtual ~Mutex() { }
-
-    static Mutex *create();
-};
+using Mutex = ap::Mutex
 
 }

--- a/libraries/AP_HAL_PX4/Mutex.h
+++ b/libraries/AP_HAL_PX4/Mutex.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_HAL_Common/Mutex.h>
+
+/*
+ * This uses the common arch and OS independent implementation from
+ * AP_HAL_Common
+ */
+
+namespace PX4 {
+
+using Mutex = ap::Mutex
+
+}


### PR DESCRIPTION
Hey, this is a RFC before I go on through the entire codebase.  I'm putting 2 things together here to collect opinions.

**1) A new AP_HAL_Common intended to have common HAL implementation among HALs**

NuttX and Linux can share some of the code that today is separate. See (2) for an example in this PR, but there are other candidates from AP_HAL like: micros, millis, micros64(), millis64(), Util::get_system_clock_ms, Util::get_system_clock_utc.

I think there are even more functions that could be shared. Several of them today are using the hal indirection for no good reason and in fact in the past we even added functions like `Plane::millis()` to reduce binary size due to using the indirection. 

**2) A new Mutex class**

This is a pet peeve of mine. Conceptually what we have implemented in Semaphore class is not really a semaphore, it's rather a Mutex.  Instead of renaming the class and users throughout the codebase and dealing with lots of conflicts I'm introducing here the Mutex class, that uses the infrastructure from (1) to share the implementation between Linux and NuttX.  It also uses methods with names a little bit different from what we have today and the reason is to be more similar to std::mutex and other mutex implementations.

This also removes the need for a `AP_HAL_*::Util::new_semaphore()` as we can add the static method in the class and have each implementation allocate the mutex.  After conversion throughout the codebase is done we can remove all Semaphore classes as well as theses methods.