### PR TITLE
AP_Baro: Change to secure code, from magic number to sizeof value.

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -53,7 +53,7 @@ AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> 
     }
 
     // We read the calibration data registers
-    if (!_dev->read_registers(0xAA, buff, 22)) {
+    if (!_dev->read_registers(0xAA, buff, sizeof(buff))) {
         AP_HAL::panic("BMP085: bad calibration registers");
     }
 
@@ -140,7 +140,7 @@ bool AP_Baro_BMP085::_read_pressure()
 {
     uint8_t buf[3];
 
-    if (!_dev->read_registers(0xF6, buf, 3)) {
+    if (!_dev->read_registers(0xF6, buf, sizeof(buf))) {
         _retry_time = AP_HAL::millis() + 1000;
         _dev->set_speed(AP_HAL::Device::SPEED_LOW);
         return false;
@@ -165,7 +165,7 @@ void AP_Baro_BMP085::_read_temp()
     uint8_t buf[2];
     int32_t _temp_sensor;
 
-    if (!_dev->read_registers(0xF6, buf, 2)) {
+    if (!_dev->read_registers(0xF6, buf, sizeof(buf))) {
         _dev->set_speed(AP_HAL::Device::SPEED_LOW);
         return;
     }

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -173,7 +173,7 @@ uint16_t AP_Baro_MS56XX::_read_prom_word(uint8_t word)
 {
     const uint8_t reg = CMD_MS56XX_PROM + (word << 1);
     uint8_t val[2];
-    if (!_dev->transfer(&reg, 1, val, 2)) {
+    if (!_dev->transfer(&reg, 1, val, sizeof(val))) {
         return 0;
     }
     return (val[0] << 8) | val[1];
@@ -182,7 +182,7 @@ uint16_t AP_Baro_MS56XX::_read_prom_word(uint8_t word)
 uint32_t AP_Baro_MS56XX::_read_adc()
 {
     uint8_t val[3];
-    if (!_dev->transfer(&CMD_MS56XX_READ_ADC, 1, val, 3)) {
+    if (!_dev->transfer(&CMD_MS56XX_READ_ADC, 1, val, sizeof(val))) {
         return 0;
     }
     return (val[0] << 16) | (val[1] << 8) | val[2];


### PR DESCRIPTION
The buffer size is set directly.
This inadvertently triggers memory destruction and access outside the area.
Therefore,
It is specified by the sizeof macro.
The memory used does not change with sizeof macros.