### PR TITLE
AP_HAL: Disco: move default param file path

### DIFF
--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -68,7 +68,7 @@
 #define HAL_FLOW_PX4_MAX_FLOW_PIXEL 4
 #define HAL_FLOW_PX4_BOTTOM_FLOW_FEATURE_THRESHOLD 30
 #define HAL_FLOW_PX4_BOTTOM_FLOW_VALUE_THRESHOLD 5000
-#define HAL_PARAM_DEFAULTS_PATH "/etc/arducopter/bebop.parm"
+#define HAL_PARAM_DEFAULTS_PATH "/data/ftp/internal_000/ardupilot/bebop.parm"
 #define HAL_RCOUT_BEBOP_BLDC_I2C_BUS 1
 #define HAL_RCOUT_BEBOP_BLDC_I2C_ADDR 0x08
 /* focal length 3.6 um, 2x binning in each direction
@@ -111,7 +111,7 @@
 #define HAL_FLOW_PX4_BOTTOM_FLOW_VALUE_THRESHOLD 5000
 #define HAL_RCOUT_DISCO_BLDC_I2C_BUS 1
 #define HAL_RCOUT_DISCO_BLDC_I2C_ADDR 0x08
-#define HAL_PARAM_DEFAULTS_PATH "/etc/arduplane/disco.parm"
+#define HAL_PARAM_DEFAULTS_PATH "/data/ftp/internal_000/ardupilot/disco.parm"
 /* focal length 3.6 um, 2x binning in each direction
  * 240x240 crop rescaled to 64x64 */
 #define HAL_FLOW_PX4_FOCAL_LENGTH_MILLIPX (2.5 / (3.6 * 2.0 * 240 / 64))

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -34,8 +34,8 @@
 #define HAL_GPIO_LED_ON           LOW
 #define HAL_GPIO_LED_OFF          HIGH
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
-#define HAL_BOARD_LOG_DIRECTORY "/data/ftp/internal_000/APM/logs"
-#define HAL_BOARD_TERRAIN_DIRECTORY "/data/ftp/internal_000/APM/terrain"
+#define HAL_BOARD_LOG_DIRECTORY "/data/ftp/internal_000/ardupilot/logs"
+#define HAL_BOARD_TERRAIN_DIRECTORY "/data/ftp/internal_000/ardupilot/terrain"
 #define HAL_INS_DEFAULT HAL_INS_MPU60XX_I2C
 #define HAL_INS_DEFAULT_ROTATION ROTATION_YAW_270
 #define HAL_INS_MPU60x0_I2C_BUS 2
@@ -76,8 +76,8 @@
 #define HAL_RANGEFINDER_LIGHTWARE_I2C_BUS 0
 #define HAL_FLOW_PX4_FOCAL_LENGTH_MILLIPX (2.5 / (3.6 * 2.0 * 240 / 64))
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
-#define HAL_BOARD_LOG_DIRECTORY "/data/ftp/internal_000/APM/logs"
-#define HAL_BOARD_TERRAIN_DIRECTORY "/data/ftp/internal_000/APM/terrain"
+#define HAL_BOARD_LOG_DIRECTORY "/data/ftp/internal_000/ardupilot/logs"
+#define HAL_BOARD_TERRAIN_DIRECTORY "/data/ftp/internal_000/ardupilot/terrain"
 #define HAL_INS_DEFAULT HAL_INS_MPU60XX_I2C
 #define HAL_INS_DEFAULT_ROTATION ROTATION_PITCH_180_YAW_90
 #define HAL_INS_MPU60x0_I2C_BUS 2


### PR DESCRIPTION
In future Disco releases, no ardupilot binary nor default param file
will be provided.

So move HAL_PARAM_DEFAULTS_PATH to ardupilot folder in RW memory.