### PR TITLE
AP_Params: fix seg fault in debug function

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -38,7 +38,7 @@ extern const AP_HAL::HAL &hal;
 #define ENABLE_DEBUG 1
 
 #if ENABLE_DEBUG
- # define Debug(fmt, args ...)  do {hal.console->printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
+ # define Debug(fmt, args ...)  do {::printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
 #else
  # define Debug(fmt, args ...)
 #endif


### PR DESCRIPTION
otherwise at start, when loading paramter is could fail at AP_Param.cpp:611, Debug("scan past end of eeprom")"
found in https://github.com/ArduPilot/ardupilot/pull/5455

Not sure this is the way the debug function is used but this is how it is write in https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_SITL/RCOutput.cpp#L10