### PR TITLE
AP_RangeFinder: Change the parse unnecessary character string to print or println.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
@@ -241,12 +241,12 @@ void AP_RangeFinder_Bebop::_loop(void)
         _capture();
 
         if (_apply_averaging_filter() < 0) {
-            hal.console->printf(
+            hal.console->print(
                     "AR_RangeFinder_Bebop: could not apply averaging filter");
         }
 
         if (_search_local_maxima() < 0) {
-            hal.console->printf("Did not find any local maximum");
+            hal.console->print("Did not find any local maximum");
         }
 
         max_index = _search_maximum_with_max_amplitude();
@@ -305,9 +305,9 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
     /* configure the output buffer for a purge */
     /* perform a purge */
     if (_launch_purge() < 0)
-        hal.console->printf("purge could not send data overspi");
+        hal.console->print("purge could not send data overspi");
     if (_capture() < 0)
-        hal.console->printf("purge could not capture data");
+        hal.console->print("purge could not capture data");
 
     switch (_mode) {
     case 1: /* low voltage */
@@ -317,7 +317,7 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
         _configure_gpio(1);
         break;
     default:
-        hal.console->printf("WARNING, invalid value to configure gpio\n");
+        hal.console->println("WARNING, invalid value to configure gpio");
         break;
     }
 }
@@ -364,7 +364,7 @@ int AP_RangeFinder_Bebop::_configure_capture()
     /* Create input buffer */
     _adc.buffer_size = RNFD_BEBOP_P7_COUNT;
     if (iio_device_set_kernel_buffers_count(_adc.device, 1)) {
-        hal.console->printf("cannot set buffer count");
+        hal.console->print("cannot set buffer count");
         goto error_destroy_context;
     }
     _adc.buffer = iio_device_create_buffer(_adc.device,

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
@@ -57,7 +57,7 @@ AP_RangeFinder_PX4::AP_RangeFinder_PX4(RangeFinder &_ranger, uint8_t instance, R
 
     // average over up to 20 samples
     if (ioctl(_fd, SENSORIOCSQUEUEDEPTH, 20) != 0) {
-        hal.console->printf("Failed to setup range finder queue\n");
+        hal.console->println("Failed to setup range finder queue");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
@@ -92,16 +92,16 @@ int AP_RangeFinder_PX4::open_driver(void)
           we start the px4 rangefinder drivers on demand
         */
         if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-X start")) {
-            hal.console->printf("Found external ll40ls sensor\n");
+            hal.console->println("Found external ll40ls sensor");
         }
         if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-I start")) {
-            hal.console->printf("Found internal ll40ls sensor\n");
+            hal.console->println("Found internal ll40ls sensor");
         }
         if (AP_BoardConfig::px4_start_driver(trone_main, "trone", "start")) {
-            hal.console->printf("Found trone sensor\n");
+            hal.console->println("Found trone sensor");
         }
         if (AP_BoardConfig::px4_start_driver(mb12xx_main, "mb12xx", "start")) {
-            hal.console->printf("Found mb12xx sensor\n");
+            hal.console->println("Found mb12xx sensor");
         }
     }
     // work out the device path based on how many PX4 drivers we have loaded

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
@@ -53,14 +53,14 @@ AP_RangeFinder_PX4_PWM::AP_RangeFinder_PX4_PWM(RangeFinder &_ranger, uint8_t ins
 {
     _fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);
     if (_fd == -1) {
-        hal.console->printf("Unable to open PX4 PWM rangefinder\n");
+        hal.console->println("Unable to open PX4 PWM rangefinder");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
 
     // keep a queue of 20 samples
     if (ioctl(_fd, SENSORIOCSQUEUEDEPTH, 20) != 0) {
-        hal.console->printf("Failed to setup range finder queue\n");
+        hal.console->println("Failed to setup range finder queue");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
@@ -87,7 +87,7 @@ bool AP_RangeFinder_PX4_PWM::detect(RangeFinder &_ranger, uint8_t instance)
 {
 #ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (AP_BoardConfig::px4_start_driver(pwm_input_main, "pwm_input", "start")) {
-        hal.console->printf("started pwm_input driver\n");
+        hal.console->println("started pwm_input driver");
     }
 #endif
     int fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);


### PR DESCRIPTION
The printf method is used for character string output which does not need parsing.
Therefore
Change to a print or println method without parsing.