### PR TITLE
Device: read API

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -18,12 +18,14 @@
  */
 #include "AP_Airspeed_MS5525.h"
 
+#include <stdio.h>
+#include <utility>
+
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/I2CDevice.h>
+#include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
-#include <stdio.h>
-#include <utility>
 
 extern const AP_HAL::HAL &hal;
 
@@ -140,9 +142,12 @@ bool AP_Airspeed_MS5525::read_prom(void)
 
     bool all_zero = true;
     for (uint8_t i = 0; i < 8; i++) {
-        if (!dev->read_uint16_be(REG_PROM_BASE+i*2, prom[i])) {
+        be16_t val;
+        if (!dev->read_registers(REG_PROM_BASE+i*2, (uint8_t *) &val,
+                                 sizeof(uint16_t))) {
             return false;
         }
+        prom[i] = be16toh(val);
         if (prom[i] != 0) {
             all_zero = false;
         }

--- a/libraries/AP_HAL/Device.cpp
+++ b/libraries/AP_HAL/Device.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "Device.h"
+
 #include <stdio.h>
 
 /*
@@ -105,31 +106,5 @@ bool AP_HAL::Device::check_next_register(void)
         return false;
     }
     _checked.next = (_checked.next+1) % _checked.n_set;
-    return true;
-}
-
-/**
- * read 16 bit unsigned integer, little endian
- *
- * Return: true on a successful transfer, false on failure.
- */
-bool AP_HAL::Device::read_uint16_le(uint8_t first_reg, uint16_t &value)
-{
-    // assume we are on a LE platform
-    return read_registers(first_reg, (uint8_t *)&value, 2);
-}
-
-/**
- * read 16 bit unsigned integer, big endian
- *
- * Return: true on a successful transfer, false on failure.
- */
-bool AP_HAL::Device::read_uint16_be(uint8_t first_reg, uint16_t &value)
-{
-    if (!read_uint16_le(first_reg, value)) {
-        return false;
-    }
-    uint8_t *b = (uint8_t *)&value;
-    value = (((uint16_t)b[0])<<8) | b[1];
     return true;
 }

--- a/libraries/AP_HAL/Device.cpp
+++ b/libraries/AP_HAL/Device.cpp
@@ -90,7 +90,7 @@ bool AP_HAL::Device::check_next_register(void)
         return true;
     }
     _checked.counter = 0;
-    
+
     struct checkreg &reg = _checked.regs[_checked.next];
     uint8_t v;
     if (!read_registers(reg.regnum, &v, 1) || v != reg.value) {

--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -55,7 +55,7 @@ public:
     uint8_t bus_num(void) const {
         return _bus_id.devid_s.bus;
     }
-    
+
     // return 24 bit bus identifier
     uint32_t get_bus_id(void) const {
         return _bus_id.devid;
@@ -65,13 +65,13 @@ public:
     uint8_t get_bus_address(void) const {
         return _bus_id.devid_s.address;
     }
-    
+
     // set device type within a device class (eg. AP_COMPASS_TYPE_LSM303D)
     void set_device_type(uint8_t devtype) {
         _bus_id.devid_s.devtype = devtype;
     }
-    
-    
+
+
     virtual ~Device() {
         if (_checked.regs != nullptr) {
             delete[] _checked.regs;
@@ -123,7 +123,7 @@ public:
      * Return: true on a successful transfer, false on failure.
      */
     bool read_uint16_be(uint8_t first_reg, uint16_t &value);
-    
+
     /**
      * Wrapper function over #transfer() to write a byte to the register reg.
      * The transfer is done by sending reg and val in that order.
@@ -155,7 +155,7 @@ public:
      * or register checking has not been setup
      */
     bool check_next_register(void);
-    
+
     /**
      * Wrapper function over #transfer() to read a sequence of bytes from
      * device. No value is written, differently from the #read_registers()
@@ -211,7 +211,7 @@ public:
      * specific delays
      */
     virtual bool set_chip_select(bool set) { return false; }
-    
+
     /**
      * Some devices connected on the I2C or SPI bus require a bit to be set on
      * the register address in order to perform a read operation. This sets a
@@ -257,7 +257,7 @@ public:
 
     /* set number of retries on transfers */
     virtual void set_retries(uint8_t retries) {};
-    
+
 protected:
     uint8_t _read_flag = 0;
 
@@ -278,7 +278,7 @@ protected:
         struct DeviceStructure devid_s;
         uint32_t devid;
     };
-    
+
     union DeviceId _bus_id;
 
     // set device address (eg. i2c bus address or spi CS)

--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -111,20 +111,6 @@ public:
     }
 
     /**
-     * read 16 bit unsigned integer, little endian
-     *
-     * Return: true on a successful transfer, false on failure.
-     */
-    bool read_uint16_le(uint8_t first_reg, uint16_t &value);
-
-    /**
-     * read 16 bit unsigned integer, big endian
-     *
-     * Return: true on a successful transfer, false on failure.
-     */
-    bool read_uint16_be(uint8_t first_reg, uint16_t &value);
-
-    /**
      * Wrapper function over #transfer() to write a byte to the register reg.
      * The transfer is done by sending reg and val in that order.
      *


### PR DESCRIPTION
@tridge assigning to you since you added these APIs. In several other places we are already using be16toh(), be32toh() in the caller. Sometimes we transfer a block and call the conversion function in some of the fields. There's only one user right now of the new API and it assumes we are running on LE while the be16* macros do the right thing independently... so, I don't see a need for a special function in the Device class.