### PR TITLE
HAL_PX4: Change the parse unnecessary character string to print or println.

### DIFF
--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -35,10 +35,10 @@ void PX4GPIO::init()
         AP_HAL::panic("Unable to open " LED0_DEVICE_PATH);
     }
     if (ioctl(_led_fd, LED_OFF, LED_BLUE) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
+        hal.console->println("GPIO: Unable to setup GPIO LED BLUE");
     }
     if (ioctl(_led_fd, LED_OFF, LED_RED) != 0) {
-         hal.console->printf("GPIO: Unable to setup GPIO LED RED\n");
+         hal.console->println("GPIO: Unable to setup GPIO LED RED");
     }
 #endif
     _tone_alarm_fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
@@ -52,7 +52,7 @@ void PX4GPIO::init()
     }
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_EXT_1) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO_1\n");
+        hal.console->println("GPIO: Unable to setup GPIO_1");
     }
 #endif
 
@@ -60,7 +60,7 @@ void PX4GPIO::init()
     // also try to setup for the relay pins on the IO board
     _gpio_io_fd = open(PX4IO_DEVICE_PATH, O_RDWR);
     if (_gpio_io_fd == -1) {
-        hal.console->printf("GPIO: Unable to open px4io\n");
+        hal.console->println("GPIO: Unable to open px4io");
     }
 #endif
 }

--- a/libraries/AP_HAL_PX4/NSHShellStream.cpp
+++ b/libraries/AP_HAL_PX4/NSHShellStream.cpp
@@ -44,14 +44,14 @@ void NSHShellStream::start_shell(void)
     if (hal.util->available_memory() < 8192) {
         if (!showed_memory_warning) {
             showed_memory_warning = true;
-            hal.console->printf("Not enough memory for shell\n");
+            hal.console->println("Not enough memory for shell");
         }
         return;
     }
     if (hal.util->get_soft_armed()) {
         if (!showed_armed_warning) {
             showed_armed_warning = true;
-            hal.console->printf("Disarm to start nsh shell\n");
+            hal.console->println("Disarm to start nsh shell");
         }
         // don't allow shell start when armed
         return;

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -124,7 +124,7 @@ bool PX4RCInput::rc_bind(int dsmMode)
         fd = open("/dev/px4fmu", 0);
     }
     if (fd == -1) {
-        hal.console->printf("RCInput: failed to open /dev/px4io or /dev/px4fmu\n");
+        hal.console->println("RCInput: failed to open /dev/px4io or /dev/px4fmu");
         return false;
     }
 
@@ -132,7 +132,7 @@ bool PX4RCInput::rc_bind(int dsmMode)
     int ret = ioctl(fd, DSM_BIND_START, mode);
     close(fd);
     if (ret != 0) {
-        hal.console->printf("RCInput: Unable to start DSM bind\n");
+        hal.console->println("RCInput: Unable to start DSM bind");
         return false;
     }
     return true;

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -32,10 +32,10 @@ void PX4RCOutput::init()
         AP_HAL::panic("Unable to open " PWM_OUTPUT0_DEVICE_PATH);
     }
     if (ioctl(_pwm_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming\n");
+        hal.console->println("RCOutput: Unable to setup IO arming");
     }
     if (ioctl(_pwm_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup IO arming OK");
     }
 
     _rate_mask = 0;
@@ -44,7 +44,7 @@ void PX4RCOutput::init()
     _alt_servo_count = 0;
 
     if (ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
 
@@ -59,7 +59,7 @@ void PX4RCOutput::init()
     if (stat("/dev/px4io", &st) == 0) {
         _alt_fd = open("/dev/px4fmu", O_RDWR);
         if (_alt_fd == -1) {
-            hal.console->printf("RCOutput: failed to open /dev/px4fmu");
+            hal.console->print("RCOutput: failed to open /dev/px4fmu");
         }
     }
 #endif
@@ -83,15 +83,15 @@ void PX4RCOutput::_init_alt_channels(void)
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming OK");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
     }
 }
 
@@ -181,11 +181,11 @@ void PX4RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
 
     // re-fetch servo count as it might have changed due to a change in BRD_PWM_COUNT
     if (_pwm_fd != -1 && ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
     if (_alt_fd != -1 && ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get alt servo count\n");        
+        hal.console->println("RCOutput: Unable to get alt servo count");
         return;
     }
     

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -179,7 +179,7 @@ void PX4Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        hal.console->println("Out of timer processes");
     }
 }
 
@@ -195,7 +195,7 @@ void PX4Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        hal.console->println("Out of IO processes");
     }
 }
 

--- a/libraries/AP_HAL_PX4/Util.cpp
+++ b/libraries/AP_HAL_PX4/Util.cpp
@@ -64,7 +64,7 @@ bool PX4Util::run_debug_shell(AP_HAL::BetterStream *stream)
     nsh_consolemain(0, nullptr);
     
     // this shouldn't happen
-    hal.console->printf("shell exited\n");
+    hal.console->println("shell exited");
     return true;
 }
 


### PR DESCRIPTION
The printf method is used for character string output which does not need parsing.
Therefore
Change to a print or println method without parsing.