### PR TITLE
GCS_MAVLink: Change the parse unnecessary character string to print or println.

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1783,10 +1783,10 @@ uint8_t GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packe
                 // disable OVERRIDES so we don't run the mixer while
                 // rebooting
                 if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_OK, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_OK failed\n");
+                    hal.console->println("SET_OVERRIDE_OK failed");
                 }
                 if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_IMMEDIATE, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_IMMEDIATE failed\n");
+                    hal.console->println("SET_OVERRIDE_IMMEDIATE failed");
                 }
                 close(px4io_fd);
             }

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -75,7 +75,7 @@ void GCS_MAVLINK::handle_setup_signing(const mavlink_message_t *msg)
     memcpy(key.secret_key, packet.secret_key, 32);
 
     if (!signing_key_save(key)) {
-        hal.console->printf("Failed to save signing key");
+        hal.console->print("Failed to save signing key");
         return;
     }
 
@@ -121,7 +121,7 @@ void GCS_MAVLINK::load_signing_key(void)
     }
     mavlink_status_t *status = mavlink_get_channel_status(chan);
     if (status == nullptr) {
-        hal.console->printf("Failed to load signing key - no status");
+        hal.console->print("Failed to load signing key - no status");
         return;        
     }
     memcpy(signing.secret_key, key.secret_key, 32);


### PR DESCRIPTION
The printf method is used for character string output which does not need parsing.
Therefore
Change to a print or println method without parsing.