### PR TITLE
Library: Change the parse unnecessary character string to print or println.

### DIFF
--- a/libraries/AP_ADC/AP_ADC_ADS1115.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.cpp
@@ -192,7 +192,7 @@ float AP_ADC_ADS1115::_convert_register_data_to_mv(int16_t word) const
         break;
     default:
         pga = 0.0f;
-        hal.console->printf("Wrong gain");
+        hal.console->print("Wrong gain");
         AP_HAL::panic("ADS1115: wrong gain selected");
         break;
     }

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -131,7 +131,7 @@ void AP_ADSB::init(void)
 
         if (in_state.vehicle_list == nullptr) {
             // dynamic RAM allocation of _vehicle_list[] failed, disable gracefully
-            hal.console->printf("Unable to initialize ADS-B vehicle list\n");
+            hal.console->println("Unable to initialize ADS-B vehicle list");
             _enabled.set_and_notify(0);
         }
     }

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -136,7 +136,7 @@ void AP_Avoidance::init(void)
 
         if (_obstacles == nullptr) {
             // dynamic RAM allocation of _obstacles[] failed, disable gracefully
-            hal.console->printf("Unable to initialize Avoidance obstacle list\n");
+            hal.console->println("Unable to initialize Avoidance obstacle list");
             // disable ourselves to avoid repeated allocation attempts
             _enabled.set(0);
             return;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_PX4.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_PX4.cpp
@@ -49,7 +49,7 @@ AP_BattMonitor_SMBus_PX4::AP_BattMonitor_SMBus_PX4(AP_BattMonitor &mon, uint8_t 
 void AP_BattMonitor_SMBus_PX4::init()
 {
     if (!AP_BoardConfig::px4_start_driver(batt_smbus_main, "batt_smbus", "-b 2 start")) {
-        hal.console->printf("Unable to start batt_smbus driver\n");
+        hal.console->println("Unable to start batt_smbus driver");
     } else {
         // give it time to initialise
         hal.scheduler->delay(500);

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -133,7 +133,7 @@ void AP_BoardConfig::px4_setup_safety_mask()
     int px4io_fd = open("/dev/px4io", 0);
     if (px4io_fd != -1) {
         if (ioctl(px4io_fd, PWM_SERVO_IGNORE_SAFETY, (uint16_t)px4.ignore_safety_channels) != 0) {
-            hal.console->printf("IGNORE_SAFETY failed\n");
+            hal.console->println("IGNORE_SAFETY failed");
         }
     }
     int px4fmu_fd = open("/dev/px4fmu", 0);
@@ -143,7 +143,7 @@ void AP_BoardConfig::px4_setup_safety_mask()
             mask >>= 8;
         }
         if (ioctl(px4fmu_fd, PWM_SERVO_IGNORE_SAFETY, (uint16_t)mask) != 0) {
-            hal.console->printf("IGNORE_SAFETY failed\n");
+            hal.console->println("IGNORE_SAFETY failed");
         }
         close(px4fmu_fd);
     }
@@ -198,7 +198,7 @@ void AP_BoardConfig::px4_setup_sbus(void)
             }
         }
         if (!hal.rcout->enable_sbus_out(rate)) {
-            hal.console->printf("Failed to enable SBUS out\n");
+            hal.console->println("Failed to enable SBUS out");
         }
     }
 #endif
@@ -217,11 +217,11 @@ void AP_BoardConfig::px4_setup_canbus(void)
         // before the hmc5883
         hal.scheduler->delay(500);
         if (px4_start_driver(uavcan_main, "uavcan", "start")) {
-            hal.console->printf("UAVCAN: started\n");            
+            hal.console->println("UAVCAN: started");
             // give some time for CAN bus initialisation
             hal.scheduler->delay(2000);
         } else {
-            hal.console->printf("UAVCAN: failed to start\n");
+            hal.console->println("UAVCAN: failed to start");
         }
         // give time for canbus drivers to register themselves
         hal.scheduler->delay(2000);
@@ -239,7 +239,7 @@ void AP_BoardConfig::px4_setup_canbus(void)
                    AP_HAL::millis() - start_wait_ms < 7000) {
                 hal.scheduler->delay(500);
             }
-            hal.console->printf("UAVCAN: node discovery complete\n");
+            hal.console->println("UAVCAN: node discovery complete");
             close(fd);
         }
     }
@@ -470,7 +470,7 @@ void AP_BoardConfig::px4_autodetect(void)
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
     // only one choice
     px4.board_type.set(PX4_BOARD_PX4V1);
-    hal.console->printf("Detected PX4v1\n");
+    hal.console->println("Detected PX4v1");
 
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
     if ((spi_check_register(HAL_INS_MPU60x0_EXT_NAME, MPUREG_WHOAMI, MPU_WHOAMI_MPU60X0) ||
@@ -479,26 +479,26 @@ void AP_BoardConfig::px4_autodetect(void)
         spi_check_register(HAL_INS_LSM9DS0_EXT_A_NAME, LSMREG_WHOAMI, LSM_WHOAMI_LSM303D)) {
         // Pixhawk2 has LSM303D and MPUxxxx on external bus
         px4.board_type.set(PX4_BOARD_PIXHAWK2);
-        hal.console->printf("Detected PIXHAWK2\n");
+        hal.console->println("Detected PIXHAWK2");
     } else if (spi_check_register(HAL_INS_ICM20608_AM_NAME, MPUREG_WHOAMI, MPU_WHOAMI_ICM20608) &&
                spi_check_register(HAL_INS_MPU9250_NAME, MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) {
         // PHMINI has an ICM20608 and MPU9250 on sensor bus
         px4.board_type.set(PX4_BOARD_PHMINI);
-        hal.console->printf("Detected PixhawkMini\n");
+        hal.console->println("Detected PixhawkMini");
     } else if (spi_check_register(HAL_INS_LSM9DS0_A_NAME, LSMREG_WHOAMI, LSM_WHOAMI_LSM303D) &&
                (spi_check_register(HAL_INS_MPU60x0_NAME, MPUREG_WHOAMI, MPU_WHOAMI_MPU60X0) ||
                 spi_check_register(HAL_INS_ICM20608_NAME, MPUREG_WHOAMI, MPU_WHOAMI_ICM20608) ||
                 spi_check_register(HAL_INS_MPU9250_NAME, MPUREG_WHOAMI, MPU_WHOAMI_MPU9250))) {
         // classic or upgraded Pixhawk1
         px4.board_type.set(PX4_BOARD_PIXHAWK);
-        hal.console->printf("Detected Pixhawk\n");
+        hal.console->println("Detected Pixhawk");
     } else {
         px4_sensor_error("Unable to detect board type");
     }
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
     // only one choice
     px4.board_type.set_and_notify(PX4_BOARD_PIXRACER);    
-    hal.console->printf("Detected Pixracer\n");
+    hal.console->println("Detected Pixracer");
 #endif
     
 }

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -126,32 +126,32 @@ bool AP_Compass_AK8963::init()
     AP_HAL::Semaphore *bus_sem = _bus->get_semaphore();
 
     if (!bus_sem || !_bus->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        hal.console->printf("AK8963: Unable to get bus semaphore\n");
+        hal.console->println("AK8963: Unable to get bus semaphore");
         return false;
     }
 
     if (!_bus->configure()) {
-        hal.console->printf("AK8963: Could not configure the bus\n");
+        hal.console->println("AK8963: Could not configure the bus");
         goto fail;
     }
 
     if (!_check_id()) {
-        hal.console->printf("AK8963: Wrong id\n");
+        hal.console->println("AK8963: Wrong id");
         goto fail;
     }
 
     if (!_calibrate()) {
-        hal.console->printf("AK8963: Could not read calibration data\n");
+        hal.console->println("AK8963: Could not read calibration data");
         goto fail;
     }
 
     if (!_setup_mode()) {
-        hal.console->printf("AK8963: Could not setup mode\n");
+        hal.console->println("AK8963: Could not setup mode");
         goto fail;
     }
 
     if (!_bus->start_measurements()) {
-        hal.console->printf("AK8963: Could not start measurements\n");
+        hal.console->println("AK8963: Could not start measurements");
         goto fail;
     }
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -128,7 +128,7 @@ bool AP_Compass_BMM150::init()
     bool ret;
 
     if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        hal.console->printf("BMM150: Unable to get bus semaphore\n");
+        hal.console->println("BMM150: Unable to get bus semaphore");
         return false;
     }
 
@@ -151,7 +151,7 @@ bool AP_Compass_BMM150::init()
         goto bus_error;
     }
     if (val != CHIP_ID_VAL) {
-        hal.console->printf("BMM150: Wrong id\n");
+        hal.console->println("BMM150: Wrong id");
         goto fail;
     }
 
@@ -195,7 +195,7 @@ bool AP_Compass_BMM150::init()
     return true;
 
 bus_error:
-    hal.console->printf("BMM150: Bus communication error\n");
+    hal.console->println("BMM150: Bus communication error");
 fail:
     _dev->get_semaphore()->give();
     return false;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -155,7 +155,7 @@ bool AP_Compass_HMC5843::init()
     AP_HAL::Semaphore *bus_sem = _bus->get_semaphore();
 
     if (!bus_sem || !bus_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        hal.console->printf("HMC5843: Unable to get bus semaphore\n");
+        hal.console->println("HMC5843: Unable to get bus semaphore");
         return false;
     }
 
@@ -163,17 +163,17 @@ bool AP_Compass_HMC5843::init()
     _bus->set_retries(10);
     
     if (!_bus->configure()) {
-        hal.console->printf("HMC5843: Could not configure the bus\n");
+        hal.console->println("HMC5843: Could not configure the bus");
         goto errout;
     }
 
     if (!_check_whoami()) {
-        hal.console->printf("HMC5843: not a HMC device\n");
+        hal.console->println("HMC5843: not a HMC device");
         goto errout;
     }
 
     if (!_calibrate()) {
-        hal.console->printf("HMC5843: Could not calibrate sensor\n");
+        hal.console->println("HMC5843: Could not calibrate sensor");
         goto errout;
     }
 
@@ -182,7 +182,7 @@ bool AP_Compass_HMC5843::init()
     }
 
     if (!_bus->start_measurements()) {
-        hal.console->printf("HMC5843: Could not start measurements on bus\n");
+        hal.console->println("HMC5843: Could not start measurements on bus");
         goto errout;
     }
 

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -87,22 +87,22 @@ bool AP_Compass_LSM9DS1::init()
     AP_HAL::Semaphore *bus_sem = _dev->get_semaphore();
 
     if (!bus_sem || !bus_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        hal.console->printf("LSM9DS1: Unable to get bus semaphore\n");
+        hal.console->println("LSM9DS1: Unable to get bus semaphore");
         return false;
     }
 
     if (!_check_id()) {
-        hal.console->printf("LSM9DS1: Could not check id\n");
+        hal.console->println("LSM9DS1: Could not check id");
         goto errout;
     }
 
     if (!_configure()) {
-        hal.console->printf("LSM9DS1: Could not check id\n");
+        hal.console->println("LSM9DS1: Could not check id");
         goto errout;
     }
 
     if (!_set_scale()) {
-        hal.console->printf("LSM9DS1: Could not set scale\n");
+        hal.console->println("LSM9DS1: Could not set scale");
         goto errout;
     }
 

--- a/libraries/AP_Compass/AP_Compass_PX4.cpp
+++ b/libraries/AP_Compass/AP_Compass_PX4.cpp
@@ -85,7 +85,7 @@ bool AP_Compass_PX4::init(void)
 
         // average over up to 20 samples
         if (ioctl(_mag_fd[i], SENSORIOCSQUEUEDEPTH, 20) != 0) {
-            hal.console->printf("Failed to setup compass queue\n");
+            hal.console->println("Failed to setup compass queue");
             return false;                
         }
 
@@ -100,7 +100,7 @@ bool AP_Compass_PX4::init(void)
     hal.scheduler->delay(40);
     accumulate();
     if (_count[0] == 0) {
-        hal.console->printf("Failed initial compass accumulate\n");        
+        hal.console->println("Failed initial compass accumulate");
     }
 
     return true;

--- a/libraries/AP_HAL_Linux/CameraSensor_Mt9v117.cpp
+++ b/libraries/AP_HAL_Linux/CameraSensor_Mt9v117.cpp
@@ -267,7 +267,7 @@ void CameraSensor_Mt9v117::_config_change()
     }
 
     if ((cmd_status & HOST_COMMAND_OK) == 0) {
-        hal.console->printf("mt9v117:config change failed\n");
+        hal.console->println("mt9v117:config change failed");
     }
 }
 
@@ -338,7 +338,7 @@ void CameraSensor_Mt9v117::_apply_patch()
              (timeout > 0));
 
     if ((cmd_status & HOST_COMMAND_OK) == 0) {
-        hal.console->printf("mt9v117:patch apply failed\n");
+        hal.console->println("mt9v117:patch apply failed");
     }
 }
 

--- a/libraries/AP_HAL_Linux/RCInput_UDP.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_UDP.cpp
@@ -18,7 +18,7 @@ void RCInput_UDP::init()
 {
     _port = RCINPUT_UDP_DEF_PORT;
     if(!_socket.bind("0.0.0.0", _port)) {
-        hal.console->printf("failed to bind UDP socket\n");
+        hal.console->println("failed to bind UDP socket");
     }
 
     _socket.set_blocking(false);
@@ -34,7 +34,7 @@ void RCInput_UDP::_timer_tick(void)
     /* Read from udp */
     while (_socket.recv(&_buf, sizeof(_buf), 10) == sizeof(_buf)) {
         if (_buf.version != RCINPUT_UDP_VERSION) {
-            hal.console->printf("bad protocol version for UDP RCInput\n");
+            hal.console->println("bad protocol version for UDP RCInput");
             return;
         }
         if (_last_buf_ts != 0 &&

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
@@ -40,7 +40,7 @@ bool RPIOUARTDriver::isExternal()
 
 void RPIOUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 {
-    //hal.console->printf("[RPIOUARTDriver]: begin \n");
+    //hal.console->println("[RPIOUARTDriver]: begin ");
 
     if (device_path != nullptr) {
         UARTDriver::begin(b,rxS,txS);

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
@@ -56,7 +56,7 @@ void SPIUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         /* Do not allocate new buffer, if we're just changing speed */
         _buffer = new uint8_t[rxS];
         if (_buffer == nullptr) {
-            hal.console->printf("Not enough memory\n");
+            hal.console->println("Not enough memory");
             AP_HAL::panic("Not enough memory\n");
         }
     }

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -188,7 +188,7 @@ void Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        hal.console->println("Out of timer processes");
     }
 }
 
@@ -213,7 +213,7 @@ bool Scheduler::_register_timesliced_proc(AP_HAL::MemberProc proc,
     uint8_t best_timeslot;
 
     if (_num_timesliced_procs > LINUX_SCHEDULER_MAX_TIMESLICED_PROCS) {
-        hal.console->printf("Out of timesliced processes\n");
+        hal.console->println("Out of timesliced processes");
         return false;
     }
 
@@ -267,7 +267,7 @@ void Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        hal.console->println("Out of IO processes");
     }
 }
 

--- a/libraries/AP_HAL_Linux/ToneAlarm.cpp
+++ b/libraries/AP_HAL_Linux/ToneAlarm.cpp
@@ -50,7 +50,7 @@ bool ToneAlarm::init()
 {
     tune_num = 0;                    //play startup tune
     if((period_fd == -1) || (duty_fd == -1) || (run_fd == -1)){
-        hal.console->printf("ToneAlarm: Error!! please check if PWM overlays are loaded correctly");
+        hal.console->print("ToneAlarm: Error!! please check if PWM overlays are loaded correctly");
         return false;
     }
     return true;

--- a/libraries/AP_HAL_Linux/VideoIn.cpp
+++ b/libraries/AP_HAL_Linux/VideoIn.cpp
@@ -80,7 +80,7 @@ bool VideoIn::open_device(const char *device_path, uint32_t memtype)
     memset(&cap, 0, sizeof cap);
     ret = ioctl(_fd, VIDIOC_QUERYCAP, &cap);
     if (ret < 0) {
-        hal.console->printf("Error querying caps\n");
+        hal.console->println("Error querying caps");
         return false;
     }
 
@@ -116,7 +116,7 @@ bool VideoIn::allocate_buffers(uint32_t nbufs)
 
     buffers = (struct buffer *)malloc(rb.count * sizeof buffers[0]);
     if (buffers == nullptr) {
-        hal.console->printf("Unable to allocate buffers\n");
+        hal.console->println("Unable to allocate buffers");
         return false;
     }
 

--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -35,10 +35,10 @@ void PX4GPIO::init()
         AP_HAL::panic("Unable to open " LED0_DEVICE_PATH);
     }
     if (ioctl(_led_fd, LED_OFF, LED_BLUE) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
+        hal.console->println("GPIO: Unable to setup GPIO LED BLUE");
     }
     if (ioctl(_led_fd, LED_OFF, LED_RED) != 0) {
-         hal.console->printf("GPIO: Unable to setup GPIO LED RED\n");
+         hal.console->println("GPIO: Unable to setup GPIO LED RED");
     }
 #endif
     _tone_alarm_fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
@@ -52,7 +52,7 @@ void PX4GPIO::init()
     }
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_EXT_1) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO_1\n");
+        hal.console->println("GPIO: Unable to setup GPIO_1");
     }
 #endif
 
@@ -60,7 +60,7 @@ void PX4GPIO::init()
     // also try to setup for the relay pins on the IO board
     _gpio_io_fd = open(PX4IO_DEVICE_PATH, O_RDWR);
     if (_gpio_io_fd == -1) {
-        hal.console->printf("GPIO: Unable to open px4io\n");
+        hal.console->println("GPIO: Unable to open px4io");
     }
 #endif
 }

--- a/libraries/AP_HAL_PX4/NSHShellStream.cpp
+++ b/libraries/AP_HAL_PX4/NSHShellStream.cpp
@@ -44,14 +44,14 @@ void NSHShellStream::start_shell(void)
     if (hal.util->available_memory() < 8192) {
         if (!showed_memory_warning) {
             showed_memory_warning = true;
-            hal.console->printf("Not enough memory for shell\n");
+            hal.console->println("Not enough memory for shell");
         }
         return;
     }
     if (hal.util->get_soft_armed()) {
         if (!showed_armed_warning) {
             showed_armed_warning = true;
-            hal.console->printf("Disarm to start nsh shell\n");
+            hal.console->println("Disarm to start nsh shell");
         }
         // don't allow shell start when armed
         return;

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -124,7 +124,7 @@ bool PX4RCInput::rc_bind(int dsmMode)
         fd = open("/dev/px4fmu", 0);
     }
     if (fd == -1) {
-        hal.console->printf("RCInput: failed to open /dev/px4io or /dev/px4fmu\n");
+        hal.console->println("RCInput: failed to open /dev/px4io or /dev/px4fmu");
         return false;
     }
 
@@ -132,7 +132,7 @@ bool PX4RCInput::rc_bind(int dsmMode)
     int ret = ioctl(fd, DSM_BIND_START, mode);
     close(fd);
     if (ret != 0) {
-        hal.console->printf("RCInput: Unable to start DSM bind\n");
+        hal.console->println("RCInput: Unable to start DSM bind");
         return false;
     }
     return true;

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -32,10 +32,10 @@ void PX4RCOutput::init()
         AP_HAL::panic("Unable to open " PWM_OUTPUT0_DEVICE_PATH);
     }
     if (ioctl(_pwm_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming\n");
+        hal.console->println("RCOutput: Unable to setup IO arming");
     }
     if (ioctl(_pwm_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup IO arming OK");
     }
 
     _rate_mask = 0;
@@ -44,7 +44,7 @@ void PX4RCOutput::init()
     _alt_servo_count = 0;
 
     if (ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
 
@@ -59,7 +59,7 @@ void PX4RCOutput::init()
     if (stat("/dev/px4io", &st) == 0) {
         _alt_fd = open("/dev/px4fmu", O_RDWR);
         if (_alt_fd == -1) {
-            hal.console->printf("RCOutput: failed to open /dev/px4fmu");
+            hal.console->print("RCOutput: failed to open /dev/px4fmu");
         }
     }
 #endif
@@ -83,15 +83,15 @@ void PX4RCOutput::_init_alt_channels(void)
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming OK");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
     }
 }
 
@@ -181,11 +181,11 @@ void PX4RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
 
     // re-fetch servo count as it might have changed due to a change in BRD_PWM_COUNT
     if (_pwm_fd != -1 && ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
     if (_alt_fd != -1 && ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get alt servo count\n");        
+        hal.console->println("RCOutput: Unable to get alt servo count");
         return;
     }
     

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -179,7 +179,7 @@ void PX4Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        hal.console->println("Out of timer processes");
     }
 }
 
@@ -195,7 +195,7 @@ void PX4Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        hal.console->println("Out of IO processes");
     }
 }
 

--- a/libraries/AP_HAL_PX4/Util.cpp
+++ b/libraries/AP_HAL_PX4/Util.cpp
@@ -64,7 +64,7 @@ bool PX4Util::run_debug_shell(AP_HAL::BetterStream *stream)
     nsh_consolemain(0, nullptr);
     
     // this shouldn't happen
-    hal.console->printf("shell exited\n");
+    hal.console->println("shell exited");
     return true;
 }
 

--- a/libraries/AP_HAL_QURT/Scheduler.cpp
+++ b/libraries/AP_HAL_QURT/Scheduler.cpp
@@ -106,7 +106,7 @@ void Scheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        hal.console->println("Out of timer processes");
     }
 }
 
@@ -122,7 +122,7 @@ void Scheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        hal.console->println("Out of IO processes");
     }
 }
 

--- a/libraries/AP_HAL_VRBRAIN/GPIO.cpp
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.cpp
@@ -34,13 +34,13 @@ void VRBRAINGPIO::init()
         AP_HAL::panic("Unable to open " LED0_DEVICE_PATH);
     }
     if (ioctl(_led_fd, LED_OFF, LED_BLUE) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
+        hal.console->println("GPIO: Unable to setup GPIO LED BLUE");
     }
     if (ioctl(_led_fd, LED_OFF, LED_RED) != 0) {
-         hal.console->printf("GPIO: Unable to setup GPIO LED RED\n");
+         hal.console->println("GPIO: Unable to setup GPIO LED RED");
     }
     if (ioctl(_led_fd, LED_OFF, LED_GREEN) != 0) {
-         hal.console->printf("GPIO: Unable to setup GPIO LED GREEN\n");
+         hal.console->println("GPIO: Unable to setup GPIO LED GREEN");
     }
 
     _tone_alarm_fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
@@ -54,17 +54,17 @@ void VRBRAINGPIO::init()
     }
 #ifdef GPIO_SERVO_1
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_SERVO_1) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO_1\n");
+        hal.console->println("GPIO: Unable to setup GPIO_1");
     }
 #endif
 #ifdef GPIO_SERVO_2
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_SERVO_2) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO_2\n");
+        hal.console->println("GPIO: Unable to setup GPIO_2");
     }
 #endif
 #ifdef GPIO_SERVO_3
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_SERVO_3) != 0) {
-        hal.console->printf("GPIO: Unable to setup GPIO_3\n");
+        hal.console->println("GPIO: Unable to setup GPIO_3");
     }
 #endif
 }

--- a/libraries/AP_HAL_VRBRAIN/NSHShellStream.cpp
+++ b/libraries/AP_HAL_VRBRAIN/NSHShellStream.cpp
@@ -44,14 +44,14 @@ void NSHShellStream::start_shell(void)
     if (hal.util->available_memory() < 8192) {
         if (!showed_memory_warning) {
             showed_memory_warning = true;
-            hal.console->printf("Not enough memory for shell\n");
+            hal.console->println("Not enough memory for shell");
         }
         return;
     }
     if (hal.util->get_soft_armed()) {
         if (!showed_armed_warning) {
             showed_armed_warning = true;
-            hal.console->printf("Disarm to start nsh shell\n");
+            hal.console->println("Disarm to start nsh shell");
         }
         // don't allow shell start when armed
         return;

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -32,10 +32,10 @@ void VRBRAINRCOutput::init()
         AP_HAL::panic("Unable to open " PWM_OUTPUT0_DEVICE_PATH);
     }
     if (ioctl(_pwm_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming\n");
+        hal.console->println("RCOutput: Unable to setup IO arming");
     }
     if (ioctl(_pwm_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup IO arming OK");
     }
 
     _rate_mask = 0;
@@ -44,7 +44,7 @@ void VRBRAINRCOutput::init()
     _alt_servo_count = 0;
 
     if (ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
 
@@ -55,7 +55,7 @@ void VRBRAINRCOutput::init()
 
 //    _alt_fd = open("/dev/px4fmu", O_RDWR);
 //    if (_alt_fd == -1) {
-//        hal.console->printf("RCOutput: failed to open /dev/px4fmu");
+//        hal.console->print("RCOutput: failed to open /dev/px4fmu");
 //        return;
 //    }
 
@@ -80,15 +80,15 @@ void VRBRAINRCOutput::_init_alt_channels(void)
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_ARM, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_SET_ARM_OK, 0) != 0) {
-        hal.console->printf("RCOutput: Unable to setup alt IO arming OK\n");
+        hal.console->println("RCOutput: Unable to setup alt IO arming OK");
         return;
     }
     if (ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
     }
 }
 
@@ -177,11 +177,11 @@ void VRBRAINRCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
 
     // re-fetch servo count as it might have changed due to a change in BRD_PWM_COUNT
     if (_pwm_fd != -1 && ioctl(_pwm_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get servo count\n");        
+        hal.console->println("RCOutput: Unable to get servo count");
         return;
     }
     if (_alt_fd != -1 && ioctl(_alt_fd, PWM_SERVO_GET_COUNT, (unsigned long)&_alt_servo_count) != 0) {
-        hal.console->printf("RCOutput: Unable to get alt servo count\n");        
+        hal.console->println("RCOutput: Unable to get alt servo count");
         return;
     }
     

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -179,7 +179,7 @@ void VRBRAINScheduler::register_timer_process(AP_HAL::MemberProc proc)
         _timer_proc[_num_timer_procs] = proc;
         _num_timer_procs++;
     } else {
-        hal.console->printf("Out of timer processes\n");
+        hal.console->println("Out of timer processes");
     }
 }
 
@@ -195,7 +195,7 @@ void VRBRAINScheduler::register_io_process(AP_HAL::MemberProc proc)
         _io_proc[_num_io_procs] = proc;
         _num_io_procs++;
     } else {
-        hal.console->printf("Out of IO processes\n");
+        hal.console->println("Out of IO processes");
     }
 }
 

--- a/libraries/AP_HAL_VRBRAIN/Util.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Util.cpp
@@ -64,7 +64,7 @@ bool VRBRAINUtil::run_debug_shell(AP_HAL::BetterStream *stream)
     nsh_consolemain(0, nullptr);
     
     // this shouldn't happen
-    hal.console->printf("shell exited\n");
+    hal.console->println("shell exited");
     return true;
 }
 

--- a/libraries/AP_IRLock/AP_IRLock_SITL.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_SITL.cpp
@@ -46,7 +46,7 @@ void AP_IRLock_SITL::init()
     sock.reuseaddress();
     sock.set_blocking(false);
 
-    hal.console->printf("AP_IRLock_SITL::init()\n");
+    hal.console->println("AP_IRLock_SITL::init()");
 
     _flags.healthy = true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -762,17 +762,17 @@ AP_InertialSensor::detect_backends(void)
     AP_InertialSensor_Backend *backend = AP_InertialSensor_Invensense::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME));
     if (backend) {
         _add_backend(backend);
-        hal.console->printf("MPU9250: Onboard IMU detected\n");
+        hal.console->println("MPU9250: Onboard IMU detected");
     } else {
-        hal.console->printf("MPU9250: Onboard IMU not detected\n");
+        hal.console->println("MPU9250: Onboard IMU not detected");
     }
 
     backend = AP_InertialSensor_Invensense::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME_EXT));
     if (backend) {
         _add_backend(backend);
-        hal.console->printf("MPU9250: External IMU detected\n");
+        hal.console->println("MPU9250: External IMU detected");
     } else {
-        hal.console->printf("MPU9250: External IMU not detected\n");
+        hal.console->println("MPU9250: External IMU not detected");
     }
 #elif HAL_INS_DEFAULT == HAL_INS_AERO
     auto *backend = AP_InertialSensor_BMI160::probe(*this,
@@ -780,7 +780,7 @@ AP_InertialSensor::detect_backends(void)
     if (backend) {
         _add_backend(backend);
     } else {
-        hal.console->printf("aero: onboard IMU not detected\n");
+        hal.console->println("aero: onboard IMU not detected");
     }
 #else
     #error Unrecognised HAL_INS_TYPE setting

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -270,14 +270,14 @@ bool AP_InertialSensor_BMI160::_configure_int1_pin()
 
     r = _dev->write_register(BMI160_REG_INT_EN_1, BMI160_INT_FWM_EN);
     if (!r) {
-        hal.console->printf("BMI160: Unable to enable FIFO watermark interrupt engine\n");
+        hal.console->println("BMI160: Unable to enable FIFO watermark interrupt engine");
         return false;
     }
     hal.scheduler->delay(1);
 
     r = _dev->write_register(BMI160_REG_INT_MAP_1, BMI160_INT_MAP_INT1_FWM);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure interrupt mapping\n");
+        hal.console->println("BMI160: Unable to configure interrupt mapping");
         return false;
     }
     hal.scheduler->delay(1);
@@ -285,14 +285,14 @@ bool AP_InertialSensor_BMI160::_configure_int1_pin()
     r = _dev->write_register(BMI160_REG_INT_OUT_CTRL,
                              BMI160_INT1_OUTPUT_EN | BMI160_INT1_LVL);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure interrupt output\n");
+        hal.console->println("BMI160: Unable to configure interrupt output");
         return false;
     }
     hal.scheduler->delay(1);
 
     _int1_pin = hal.gpio->channel(BMI160_INT1_GPIO);
     if (_int1_pin == nullptr) {
-        hal.console->printf("BMI160: Couldn't request data ready GPIO channel\n");
+        hal.console->println("BMI160: Couldn't request data ready GPIO channel");
         return false;
     }
     _int1_pin->mode(HAL_GPIO_INPUT);
@@ -308,7 +308,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
     r = _dev->write_register(BMI160_REG_FIFO_CONFIG_0,
                              sizeof(struct RawData) / 4);
     if (!r) {
-        hal.console->printf("BMI160: Unable to configure FIFO watermark level\n");
+        hal.console->println("BMI160: Unable to configure FIFO watermark level");
         return false;
     }
     hal.scheduler->delay(1);
@@ -316,7 +316,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
     r = _dev->write_register(BMI160_REG_FIFO_CONFIG_1,
                              BMI160_FIFO_ACC_EN | BMI160_FIFO_GYR_EN);
     if (!r) {
-        hal.console->printf("BMI160: Unable to enable FIFO\n");
+        hal.console->println("BMI160: Unable to enable FIFO");
         return false;
     }
     hal.scheduler->delay(1);
@@ -325,7 +325,7 @@ bool AP_InertialSensor_BMI160::_configure_fifo()
 
     r = _dev->write_register(BMI160_REG_CMD, BMI160_CMD_FIFO_FLUSH);
     if (!r) {
-        hal.console->printf("BMI160: Unable to flush FIFO\n");
+        hal.console->println("BMI160: Unable to flush FIFO");
         return false;
     }
 
@@ -413,7 +413,7 @@ read_fifo_read_data:
 
 read_fifo_end:
     if (!r) {
-        hal.console->printf("BMI160: error on reading FIFO\n");
+        hal.console->println("BMI160: error on reading FIFO");
     }
 }
 
@@ -491,7 +491,7 @@ bool AP_InertialSensor_BMI160::_init()
 
     ret = _hardware_init();
     if (!ret) {
-        hal.console->printf("BMI160: failed to init\n");
+        hal.console->println("BMI160: failed to init");
     }
 
     return ret;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -729,7 +729,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     const uint8_t reg = OUT_X_L_A | 0xC0;
 
     if (!_dev_accel->transfer(&reg, 1, (uint8_t *) &raw_data, sizeof(raw_data))) {
-        hal.console->printf("LSM9DS0: error reading accelerometer\n");
+        hal.console->println("LSM9DS0: error reading accelerometer");
         return;
     }
 
@@ -749,7 +749,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
     const uint8_t reg = OUT_X_L_G | 0xC0;
 
     if (!_dev_gyro->transfer(&reg, 1, (uint8_t *) &raw_data, sizeof(raw_data))) {
-        hal.console->printf("LSM9DS0: error reading gyroscope\n");
+        hal.console->println("LSM9DS0: error reading gyroscope");
         return;
     }
 

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -195,7 +195,7 @@ void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon)
 
     // print output including the minus sign
     if( lat_or_lon < 0 ) {
-        s->printf("-");
+        s->print("-");
     }
     s->printf("%ld.%07ld",(long)dec_portion,(long)frac_portion);
 }

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -287,7 +287,7 @@ bool inverse4x4(float m[],float invOut[])
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     int old = fedisableexcept(FE_OVERFLOW);
     if (old < 0) {
-        hal.console->printf("inverse4x4(): warning: error on disabling FE_OVERFLOW floating point exception\n");
+        hal.console->println("inverse4x4(): warning: error on disabling FE_OVERFLOW floating point exception");
     }
 #endif
 
@@ -407,7 +407,7 @@ bool inverse4x4(float m[],float invOut[])
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (old >= 0 && feenableexcept(old) < 0) {
-        hal.console->printf("inverse4x4(): warning: error on restoring floating exception mask\n");
+        hal.console->println("inverse4x4(): warning: error on restoring floating exception mask");
     }
 #endif
 

--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -61,7 +61,7 @@ bool OreoLED_PX4::init()
 {
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
     if (!AP_BoardConfig::px4_start_driver(oreoled_main, "oreoled", "start autoupdate")) {
-        hal.console->printf("Unable to start oreoled driver\n");
+        hal.console->println("Unable to start oreoled driver");
     } else {
         // give it time to initialise
         hal.scheduler->delay(500);

--- a/libraries/AP_Notify/ToneAlarm_Linux.cpp
+++ b/libraries/AP_Notify/ToneAlarm_Linux.cpp
@@ -39,7 +39,7 @@ bool ToneAlarm_Linux::init()
     // open the tone alarm device
     _initialized = hal.util->toneAlarm_init();
     if (!_initialized) {
-        hal.console->printf("AP_Notify: Failed to initialise ToneAlarm");
+        hal.console->print("AP_Notify: Failed to initialise ToneAlarm");
         return false;
     }
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1273,7 +1273,7 @@ void AP_Param::load_object_from_eeprom(const void *object_pointer, const struct 
     uint16_t key;
 
     if (!find_key_by_pointer(object_pointer, key)) {
-        hal.console->printf("ERROR: Unable to find param pointer\n");
+        hal.console->println("ERROR: Unable to find param pointer");
         return;
     }
     

--- a/libraries/AP_RPM/RPM_PX4_PWM.cpp
+++ b/libraries/AP_RPM/RPM_PX4_PWM.cpp
@@ -48,7 +48,7 @@ AP_RPM_PX4_PWM::AP_RPM_PX4_PWM(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_St
 {
 #ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (AP_BoardConfig::px4_start_driver(pwm_input_main, "pwm_input", "start")) {
-        hal.console->printf("started pwm_input driver\n");
+        hal.console->println("started pwm_input driver");
     }
 #endif
     _fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);
@@ -59,7 +59,7 @@ AP_RPM_PX4_PWM::AP_RPM_PX4_PWM(AP_RPM &_ap_rpm, uint8_t instance, AP_RPM::RPM_St
 
     // keep a queue of 5 samples to reduce noise by averaging
     if (ioctl(_fd, SENSORIOCSQUEUEDEPTH, 5) != 0) {
-        hal.console->printf("Failed to setup RPM queue\n");
+        hal.console->println("Failed to setup RPM queue");
         close(_fd);
         _fd = -1;
         return;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Bebop.cpp
@@ -241,12 +241,12 @@ void AP_RangeFinder_Bebop::_loop(void)
         _capture();
 
         if (_apply_averaging_filter() < 0) {
-            hal.console->printf(
+            hal.console->print(
                     "AR_RangeFinder_Bebop: could not apply averaging filter");
         }
 
         if (_search_local_maxima() < 0) {
-            hal.console->printf("Did not find any local maximum");
+            hal.console->print("Did not find any local maximum");
         }
 
         max_index = _search_maximum_with_max_amplitude();
@@ -305,9 +305,9 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
     /* configure the output buffer for a purge */
     /* perform a purge */
     if (_launch_purge() < 0)
-        hal.console->printf("purge could not send data overspi");
+        hal.console->print("purge could not send data overspi");
     if (_capture() < 0)
-        hal.console->printf("purge could not capture data");
+        hal.console->print("purge could not capture data");
 
     switch (_mode) {
     case 1: /* low voltage */
@@ -317,7 +317,7 @@ void AP_RangeFinder_Bebop::_reconfigure_wave()
         _configure_gpio(1);
         break;
     default:
-        hal.console->printf("WARNING, invalid value to configure gpio\n");
+        hal.console->println("WARNING, invalid value to configure gpio");
         break;
     }
 }
@@ -364,7 +364,7 @@ int AP_RangeFinder_Bebop::_configure_capture()
     /* Create input buffer */
     _adc.buffer_size = RNFD_BEBOP_P7_COUNT;
     if (iio_device_set_kernel_buffers_count(_adc.device, 1)) {
-        hal.console->printf("cannot set buffer count");
+        hal.console->print("cannot set buffer count");
         goto error_destroy_context;
     }
     _adc.buffer = iio_device_create_buffer(_adc.device,

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
@@ -57,7 +57,7 @@ AP_RangeFinder_PX4::AP_RangeFinder_PX4(RangeFinder &_ranger, uint8_t instance, R
 
     // average over up to 20 samples
     if (ioctl(_fd, SENSORIOCSQUEUEDEPTH, 20) != 0) {
-        hal.console->printf("Failed to setup range finder queue\n");
+        hal.console->println("Failed to setup range finder queue");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
@@ -92,16 +92,16 @@ int AP_RangeFinder_PX4::open_driver(void)
           we start the px4 rangefinder drivers on demand
         */
         if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-X start")) {
-            hal.console->printf("Found external ll40ls sensor\n");
+            hal.console->println("Found external ll40ls sensor");
         }
         if (AP_BoardConfig::px4_start_driver(ll40ls_main, "ll40ls", "-I start")) {
-            hal.console->printf("Found internal ll40ls sensor\n");
+            hal.console->println("Found internal ll40ls sensor");
         }
         if (AP_BoardConfig::px4_start_driver(trone_main, "trone", "start")) {
-            hal.console->printf("Found trone sensor\n");
+            hal.console->println("Found trone sensor");
         }
         if (AP_BoardConfig::px4_start_driver(mb12xx_main, "mb12xx", "start")) {
-            hal.console->printf("Found mb12xx sensor\n");
+            hal.console->println("Found mb12xx sensor");
         }
     }
     // work out the device path based on how many PX4 drivers we have loaded

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
@@ -53,14 +53,14 @@ AP_RangeFinder_PX4_PWM::AP_RangeFinder_PX4_PWM(RangeFinder &_ranger, uint8_t ins
 {
     _fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);
     if (_fd == -1) {
-        hal.console->printf("Unable to open PX4 PWM rangefinder\n");
+        hal.console->println("Unable to open PX4 PWM rangefinder");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
 
     // keep a queue of 20 samples
     if (ioctl(_fd, SENSORIOCSQUEUEDEPTH, 20) != 0) {
-        hal.console->printf("Failed to setup range finder queue\n");
+        hal.console->println("Failed to setup range finder queue");
         set_status(RangeFinder::RangeFinder_NotConnected);
         return;
     }
@@ -87,7 +87,7 @@ bool AP_RangeFinder_PX4_PWM::detect(RangeFinder &_ranger, uint8_t instance)
 {
 #ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (AP_BoardConfig::px4_start_driver(pwm_input_main, "pwm_input", "start")) {
-        hal.console->printf("started pwm_input driver\n");
+        hal.console->println("started pwm_input driver");
     }
 #endif
     int fd = open(PWMIN0_DEVICE_PATH, O_RDONLY);

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -142,7 +142,7 @@ void DataFlash_File::Init()
     }
 
     if (!_writebuf.get_size()) {
-        hal.console->printf("Out of memory for logging\n");
+        hal.console->println("Out of memory for logging");
         return;
     }
 
@@ -800,7 +800,7 @@ uint16_t DataFlash_File::start_new_log(void)
     }
 
     if (disk_space_avail() < _free_space_min_avail) {
-        hal.console->printf("Out of space for logging\n");
+        hal.console->println("Out of space for logging");
         _open_error = true;
         return 0xffff;
     }
@@ -1049,7 +1049,7 @@ void DataFlash_File::_io_timer(void)
     if (tnow - _free_space_last_check_time > _free_space_check_interval) {
         _free_space_last_check_time = tnow;
         if (disk_space_avail() < _free_space_min_avail) {
-            hal.console->printf("Out of space for logging\n");
+            hal.console->println("Out of space for logging");
             stop_logging();
             _open_error = true; // prevent logging starting again
             return;

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -43,7 +43,7 @@ void DataFlash_Class::Init(const struct LogStructure *structures, uint8_t num_ty
 #endif
         }
         if (backends[_next_backend] == nullptr) {
-            hal.console->printf("Unable to open DataFlash_File");
+            hal.console->print("Unable to open DataFlash_File");
         } else {
             _next_backend++;
         }
@@ -64,7 +64,7 @@ void DataFlash_Class::Init(const struct LogStructure *structures, uint8_t num_ty
                                                             message_writer);
         }
         if (backends[_next_backend] == nullptr) {
-            hal.console->printf("Unable to open DataFlash_MAVLink");
+            hal.console->print("Unable to open DataFlash_MAVLink");
         } else {
             _next_backend++;
         }
@@ -494,7 +494,7 @@ void DataFlash_Backend::_print_log_entry(uint8_t msg_type,
             break;
         }
         if (ofs < msg_len) {
-            port->printf(", ");
+            port->print(", ");
         }
     }
     port->println();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1783,10 +1783,10 @@ uint8_t GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packe
                 // disable OVERRIDES so we don't run the mixer while
                 // rebooting
                 if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_OK, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_OK failed\n");
+                    hal.console->println("SET_OVERRIDE_OK failed");
                 }
                 if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_IMMEDIATE, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_IMMEDIATE failed\n");
+                    hal.console->println("SET_OVERRIDE_IMMEDIATE failed");
                 }
                 close(px4io_fd);
             }

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -75,7 +75,7 @@ void GCS_MAVLINK::handle_setup_signing(const mavlink_message_t *msg)
     memcpy(key.secret_key, packet.secret_key, 32);
 
     if (!signing_key_save(key)) {
-        hal.console->printf("Failed to save signing key");
+        hal.console->print("Failed to save signing key");
         return;
     }
 
@@ -121,7 +121,7 @@ void GCS_MAVLINK::load_signing_key(void)
     }
     mavlink_status_t *status = mavlink_get_channel_status(chan);
     if (status == nullptr) {
-        hal.console->printf("Failed to load signing key - no status");
+        hal.console->print("Failed to load signing key - no status");
         return;        
     }
     memcpy(signing.secret_key, key.secret_key, 32);


### PR DESCRIPTION
The printf method is used for character string output which does not need parsing.
Therefore
Change to a print or println method without parsing.