### PR TITLE
Copter: add upward facing object avoidance

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -504,9 +504,6 @@ void Copter::one_hz_loop()
 
     check_usb_mux();
 
-    // update position controller alt limits
-    update_poscon_alt_max();
-
     // enable/disable raw gyro/accel logging
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -302,17 +302,6 @@ void Copter::set_accel_throttle_I_from_pilot_throttle()
     g.pid_accel_z.set_integrator((pilot_throttle-motors->get_throttle_hover()) * 1000.0f);
 }
 
-// updates position controller's maximum altitude using fence and EKF limits
-void Copter::update_poscon_alt_max()
-{
-    // get alt limit from EKF (limited during optical flow flight)
-    float ekf_limit_cm;
-    if (inertial_nav.get_hgt_ctrl_limit(ekf_limit_cm)) {
-        // pass limit to pos controller
-        pos_control->set_alt_max(ekf_limit_cm);
-    }
-}
-
 // rotate vector from vehicle's perspective to North-East frame
 void Copter::rotate_body_frame_to_NE(float &x, float &y)
 {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -674,7 +674,6 @@ private:
     void auto_takeoff_set_start_alt(void);
     void auto_takeoff_attitude_run(float target_yaw_rate);
     void set_accel_throttle_I_from_pilot_throttle();
-    void update_poscon_alt_max();
     void rotate_body_frame_to_NE(float &x, float &y);
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -670,6 +670,7 @@ private:
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle();
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
+    float get_avoidance_adjusted_climbrate(float target_rate);
     void auto_takeoff_set_start_alt(void);
     void auto_takeoff_attitude_run(float target_yaw_rate);
     void set_accel_throttle_I_from_pilot_throttle();

--- a/ArduCopter/control_althold.cpp
+++ b/ArduCopter/control_althold.cpp
@@ -108,6 +108,9 @@ void Copter::althold_run()
         // get take-off adjusted pilot and takeoff climb rates
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
         // call attitude controller
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
 
@@ -148,6 +151,9 @@ void Copter::althold_run()
             // if rangefinder is ok, use surface tracking
             target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
         }
+
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
         // call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -855,9 +855,7 @@ void Copter::auto_payload_place_run_loiter()
     const float target_yaw_rate = 0;
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate, get_smoothing_gain());
 
-    // update altitude target and call position controller
-    // const float target_climb_rate = 0;
-    // pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
+    // call position controller
     pos_control->update_z_controller();
 }
 

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -285,6 +285,9 @@ void Copter::autotune_run()
     // get pilot desired climb rate
     target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
 
+    // get avoidance adjusted climb rate
+    target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
     // check for pilot requested take-off - this should not actually be possible because of autotune_init() checks
     if (ap.land_complete && target_climb_rate > 0) {
         // indicate we are taking off

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -580,6 +580,9 @@ void Copter::guided_angle_control_run()
     // constrain climb rate
     float climb_rate_cms = constrain_float(guided_angle_state.climb_rate_cms, -fabsf(wp_nav->get_speed_down()), wp_nav->get_speed_up());
 
+    // get avoidance adjusted climb rate
+    climb_rate_cms = get_avoidance_adjusted_climbrate(climb_rate_cms);
+
     // check for timeout - set lean angles and climb rate to zero if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - guided_angle_state.update_time_ms > GUIDED_ATTITUDE_TIMEOUT_MS) {

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -162,6 +162,9 @@ void Copter::loiter_run()
         // get takeoff adjusted pilot and takeoff climb rates
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
         // run loiter controller
         wp_nav->update_loiter(ekfGndSpdLimit, ekfNavVelGainScaler);
 
@@ -211,6 +214,9 @@ void Copter::loiter_run()
             // if rangefinder is ok, use surface tracking
             target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
         }
+
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
         // update altitude target and call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);

--- a/ArduCopter/control_poshold.cpp
+++ b/ArduCopter/control_poshold.cpp
@@ -538,6 +538,10 @@ void Copter::poshold_run()
             // if rangefinder is ok, use surface tracking
             target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
         }
+
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
         // update altitude target and call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
         pos_control->add_takeoff_climb_rate(takeoff_climb_rate, G_Dt);

--- a/ArduCopter/control_sport.cpp
+++ b/ArduCopter/control_sport.cpp
@@ -119,6 +119,9 @@ void Copter::sport_run()
         // get take-off adjusted pilot and takeoff climb rates
         takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+
         // call attitude controller
         attitude_control->input_euler_rate_roll_pitch_yaw(target_roll_rate, target_pitch_rate, target_yaw_rate);
 
@@ -153,6 +156,9 @@ void Copter::sport_run()
             // if rangefinder is ok, use surface tracking
             target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
         }
+
+        // get avoidance adjusted climb rate
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
         // call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -52,7 +52,6 @@ AC_PosControl::AC_PosControl(const AP_AHRS& ahrs, const AP_InertialNav& inav,
     _leash_up_z(POSCONTROL_LEASH_LENGTH_MIN),
     _roll_target(0.0f),
     _pitch_target(0.0f),
-    _alt_max(0.0f),
     _distance_to_target(0.0f),
     _accel_target_jerk_limited(0.0f,0.0f),
     _accel_target_filter(POSCONTROL_ACCEL_FILTER_HZ)
@@ -166,12 +165,6 @@ void AC_PosControl::set_alt_target_from_climb_rate(float climb_rate_cms, float d
         _pos_target.z += climb_rate_cms * dt;
     }
 
-    // do not let target alt get above limit
-    if (_alt_max > 0 && _pos_target.z > _alt_max) {
-        _pos_target.z = _alt_max;
-        _limit.pos_up = true;
-    }
-
     // do not use z-axis desired velocity feed forward
     // vel_desired set to desired climb rate for reporting and land-detector
     _flags.use_desvel_ff_z = false;
@@ -211,14 +204,6 @@ void AC_PosControl::set_alt_target_from_climb_rate_ff(float climb_rate_cms, floa
     // To-Do: add check of _limit.pos_down?
     if ((_vel_desired.z<0 && (!_motors.limit.throttle_lower || force_descend)) || (_vel_desired.z>0 && !_motors.limit.throttle_upper && !_limit.pos_up)) {
         _pos_target.z += _vel_desired.z * dt;
-    }
-
-    // do not let target alt get above limit
-    if (_alt_max > 0 && _pos_target.z > _alt_max) {
-        _pos_target.z = _alt_max;
-        _limit.pos_up = true;
-        // decelerate feed forward to zero
-        _vel_desired.z = constrain_float(0.0f, _vel_desired.z-vel_change_limit, _vel_desired.z+vel_change_limit);
     }
 }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -172,6 +172,9 @@ public:
     float get_leash_down_z() const { return _leash_down_z; }
     float get_leash_up_z() const { return _leash_up_z; }
 
+    /// get_pos_z_kP - returns z position controller's kP gain
+    float get_pos_z_kP() const { return _p_pos_z.kP(); }
+
     ///
     /// xy position controller
     ///

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -76,11 +76,6 @@ public:
     /// z position controller
     ///
 
-    /// set_alt_max - sets maximum altitude above the ekf origin in cm
-    ///   only enforced when set_alt_target_from_climb_rate is used
-    ///   set to zero to disable limit
-    void set_alt_max(float alt) { _alt_max = alt; }
-
     /// set_speed_z - sets maximum climb and descent rates
     ///     speed_down can be positive or negative but will always be interpreted as a descent speed
     ///     leash length will be recalculated the next time update_z_controller() is called
@@ -417,7 +412,6 @@ private:
     Vector3f    _accel_error;           // desired acceleration in cm/s/s  // To-Do: are xy actually required?
     Vector3f    _accel_feedforward;     // feedforward acceleration in cm/s/s
     Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
-    float       _alt_max;               // max altitude - should be updated from the main code with altitude limit from fence
     float       _distance_to_target;    // distance to position target - for reporting only
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -289,7 +289,7 @@ void AC_Avoid::limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel,
 /*
  * Gets the current xy-position, relative to home (not relative to EKF origin)
  */
-Vector2f AC_Avoid::get_position()
+Vector2f AC_Avoid::get_position() const
 {
     const Vector3f position_xyz = _inav.get_position();
     const Vector2f position_xy(position_xyz.x,position_xyz.y);

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -104,6 +104,16 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         limit_alt = true;
     }
 
+    // get distance from proximity sensor (in meters, convert to cm)
+    float proximity_alt_diff_m;
+    if (_proximity.get_upward_distance(proximity_alt_diff_m)) {
+        float proximity_alt_diff_cm = proximity_alt_diff_m * 100.0f;
+        if (!limit_alt || proximity_alt_diff_cm < alt_diff_cm) {
+            alt_diff_cm = proximity_alt_diff_cm;
+        }
+        limit_alt = true;
+    }
+
     // limit climb rate
     if (limit_alt) {
         // do not allow climbing if we've breached the safe altitude

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -39,6 +39,9 @@ public:
     void adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel);
     void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel);
 
+    // adjust vertical climb rate so vehicle does not break the vertical fence
+    void adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_cms);
+
     // adjust roll-pitch to push vehicle away from objects
     // roll and pitch value are in centi-degrees
     // angle_max is the user defined maximum lean angle for the vehicle in centi-degrees
@@ -83,9 +86,10 @@ private:
     void limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance) const;
 
     /*
-     * Gets the current position, relative to home (not relative to EKF origin)
+     * Gets the current position or altitude, relative to home (not relative to EKF origin) in cm
      */
     Vector2f get_position() const;
+    float get_alt_above_home() const;
 
     /*
      * Computes the speed such that the stopping distance

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -85,7 +85,7 @@ private:
     /*
      * Gets the current position, relative to home (not relative to EKF origin)
      */
-    Vector2f get_position();
+    Vector2f get_position() const;
 
     /*
      * Computes the speed such that the stopping distance

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -105,6 +105,14 @@ public:
     virtual float       get_altitude() const = 0;
 
     /**
+     * get_hgt_ctrl_limit - get maximum height to be observed by the control loops in cm and a validity flag
+     * this is used to limit height during optical flow navigation
+     * it will return invalid when no limiting is required
+     * @return
+     */
+    virtual bool       get_hgt_ctrl_limit(float& limit) const = 0;
+
+    /**
      * get_velocity_z - returns the current climbrate.
      *
      * @see get_velocity().z

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -371,3 +371,18 @@ float AP_Proximity::distance_min() const
     // get minimum distance from backend
     return drivers[primary_instance]->distance_min();
 }
+
+// get distance in meters upwards, returns true on success
+bool AP_Proximity::get_upward_distance(uint8_t instance, float &distance) const
+{
+    if ((drivers[instance] == nullptr) || (_type[instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get upward distance from backend
+    return drivers[instance]->get_upward_distance(distance);
+}
+
+bool AP_Proximity::get_upward_distance(float &distance) const
+{
+    return get_upward_distance(primary_instance, distance);
+}

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -107,6 +107,14 @@ public:
         enum Proximity_Status   status;     // sensor status
     };
 
+    //
+    // support for upwardward facing sensors
+    //
+
+    // get distance upwards in meters. returns true on success
+    bool get_upward_distance(uint8_t instance, float &distance) const;
+    bool get_upward_distance(float &distance) const;
+
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -39,6 +39,9 @@ public:
     virtual float distance_max() const = 0;
     virtual float distance_min() const = 0;
 
+    // get distance upwards in meters. returns true on success
+    virtual bool get_upward_distance(float &distance) const { return false; }
+
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(mavlink_message_t *msg) {}
 

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -43,6 +43,16 @@ void AP_Proximity_MAV::update(void)
     }
 }
 
+// get distance upwards in meters. returns true on success
+bool AP_Proximity_MAV::get_upward_distance(float &distance) const
+{
+    if ((_last_upward_update_ms != 0) && (AP_HAL::millis() - _last_upward_update_ms <= PROXIMITY_MAV_TIMEOUT_MS)) {
+        distance = _distance_upward;
+        return true;
+    }
+    return false;
+}
+
 // handle mavlink DISTANCE_SENSOR messages
 void AP_Proximity_MAV::handle_msg(mavlink_message_t *msg)
 {
@@ -59,5 +69,11 @@ void AP_Proximity_MAV::handle_msg(mavlink_message_t *msg)
         _distance_max = packet.max_distance / 100.0f;
         _last_update_ms = AP_HAL::millis();
         update_boundary_for_sector(sector);
+    }
+
+    // store upward distance
+    if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
+        _distance_upward = packet.current_distance / 100.0f;
+        _last_upward_update_ms = AP_HAL::millis();
     }
 }

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -19,6 +19,9 @@ public:
     float distance_max() const { return _distance_max; }
     float distance_min() const { return _distance_min; };
 
+    // get distance upwards in meters. returns true on success
+    bool get_upward_distance(float &distance) const;
+
     // handle mavlink DISTANCE_SENSOR messages
     void handle_msg(mavlink_message_t *msg) override;
 
@@ -27,7 +30,12 @@ private:
     // initialise sensor (returns true if sensor is succesfully initialised)
     bool initialise();
 
+    // horizontal distance support
     uint32_t _last_update_ms;   // system time of last DISTANCE_SENSOR message received
     float _distance_max;        // max range of sensor in meters
     float _distance_min;        // min range of sensor in meters
+
+    // upward distance support
+    uint32_t _last_upward_update_ms;    // system time of last update distance
+    float _distance_upward;             // upward distance in meters
 };

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -38,6 +38,10 @@ AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
     if (fence_count == nullptr || ptype != AP_PARAM_INT8) {
         AP_HAL::panic("Proximity_SITL: Failed to find FENCE_TOTAL");
     }
+    fence_alt_max = (AP_Float *)AP_Param::find("FENCE_ALT_MAX", &ptype);
+    if (fence_alt_max == nullptr || ptype != AP_PARAM_FLOAT) {
+        AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MAX");
+    }
 }
 
 // update the state of the sensor
@@ -123,6 +127,14 @@ float AP_Proximity_SITL::distance_max() const
 float AP_Proximity_SITL::distance_min() const
 {
     return 0.0f;
+}
+
+// get distance upwards in meters. returns true on success
+bool AP_Proximity_SITL::get_upward_distance(float &distance) const
+{
+    // return distance to fence altitude
+    distance = MAX(0.0f, fence_alt_max->get() - sitl->height_agl);
+    return true;
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -20,10 +20,14 @@ public:
     float distance_max() const;
     float distance_min() const;
 
+    // get distance upwards in meters. returns true on success
+    bool get_upward_distance(float &distance) const;
+
 private:
     SITL::SITL *sitl;
     Vector2l *fence;
     AP_Int8 *fence_count;
+    AP_Float *fence_alt_max;
     uint32_t last_load_ms;
     AC_PolyFence_loader fence_loader;
     Location current_loc;


### PR DESCRIPTION
This PR adds basic upward facing object avoidance through the following changes:

- AP_Proximity_MAV driver accepts DISTANCE_SENSOR messages with upward facing orientation
- AC_Avoidance gets "adjust_velocity_z" method which slows down the climb rate so vehicle doesn't go above the fence altitude limit, the EKF's optical flow alt limit and/or proximity sensor distance
- AC_PosControl loses it's altitude limit because it's all in AC_Avoidance now
- Copter flight modes use the new AC_Avoidance.adjust_velocity_z in all alt-hold-ish flight modes (AltHold, Loiter, PosHold, etc).

These changes resolve one long standing issue in which the vehicle could exceed the fence's altitude limit if the user set the PILOT_VELZ_MAX very high (i.e. 5m/s).  The issue was that AC_PosControl only ensured the altitude target would not go above the limit but it did not ensure the vehicle slowed down as it approached the limit.

There are three known issues that will be resolved with a follow-up PR:

- we do not force the vehicle to descend away from objects above the vehicle.  This is consistent with our horizontal object avoidance feature which also doesn't have a "back-away" feature.
- there is no connection between terrain following and upward facing object avoidance meaning upward object avoidance tends to win (i.e. the vehicle hits the ground before it hits the ceiling).
- we do not descend to ensure the vehicle is below the inav.get_hgt_ctrl_limit.  This could means an EKF failsafe is triggered for a vehicle flying with optical flow that is descending down a slope with the range finder disabled.  This is a real edge case though and we can address it when we handle the first issue.