### PR TITLE
AP_HAL_Linux: init SPIDevice speed by default

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -209,6 +209,7 @@ SPIDevice::SPIDevice(SPIBus &bus, SPIDesc &device_desc)
 {
     set_device_bus(_bus.bus);
     set_device_address(_desc.subdev);
+    _speed = _desc.highspeed;
     
     if (_desc.cs_pin != SPI_CS_KERNEL) {
         _cs = hal.gpio->channel(_desc.cs_pin);


### PR DESCRIPTION
Else a speed of 0 will be sent at each transfer.
Behaviour has changed when introducing SPIDevice.

It broke the bebop's rangefinder (when not starting the regular autopilot first).