### PR TITLE
Copter & Plane: Report battery failsafe via the sys_status message

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -307,12 +307,17 @@ void Copter::update_sensor_status_flags(void)
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
 #endif
+    if (copter.battery.healthy()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_BATTERY;
+    }
+
 
     // all present sensors enabled by default except altitude and position control and motors which we will set individually
     control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
-                                                         ~MAV_SYS_STATUS_LOGGING);
+                                                         ~MAV_SYS_STATUS_LOGGING &
+                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY);
 
     switch (control_mode) {
     case AUTO:
@@ -347,6 +352,11 @@ void Copter::update_sensor_status_flags(void)
     if (copter.DataFlash.logging_enabled()) {
         control_sensors_enabled |= MAV_SYS_STATUS_LOGGING;
     }
+
+    if (g.fs_batt_voltage > 0 || g.fs_batt_mah > 0) {
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_BATTERY;
+    }
+
 
 
     // default to all healthy
@@ -428,6 +438,9 @@ void Copter::update_sensor_status_flags(void)
         control_sensors_enabled &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
         control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
     }
+
+    if (copter.failsafe.battery) {
+         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_BATTERY;                                                                    }
     
 #if FRSKY_TELEM_ENABLED == ENABLED
     // give mask of error flags to Frsky_Telemetry


### PR DESCRIPTION
Adds a MAVLink enum for the SYS_STATUS_SENSOR_BATTERY field, reports as present if the AP_BattMonitor primary instance is healthy, reports enabled if either of the battery failsafes are enabled, reports healthy as long as battery failsafe hasn't been triggered.

This is meant to address the fact that there is 0 persistent indication to the GCS that the aircraft is in a low battery/failsafe state. If everyone is fine with it I can extend it to Copter/Rover. Long term we still need a proper failsafe reporting system, however this is an easy fix for the larger problem, and actually is very consistent with the current reporting mechanisms.