### PR TITLE
APMRover2: add initial support for MAV_CMD_CONDITION_YAW

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -444,9 +444,13 @@ void Rover::update_current_mode(void)
         if (!in_auto_reverse) {
             set_reverse(false);
         }
-        calc_lateral_acceleration();
-        calc_nav_steer();
-        calc_throttle(g.speed_cruise);
+        if (!do_auto_rotation) {
+            calc_lateral_acceleration();
+            calc_nav_steer();
+            calc_throttle(g.speed_cruise);
+        } else {
+            do_yaw_rotation();
+        }
         break;
 
     case GUIDED: {
@@ -554,6 +558,9 @@ void Rover::update_navigation()
 
     case AUTO:
         mission.update();
+        if (do_auto_rotation) {
+            do_yaw_rotation();
+        }
         break;
 
     case RTL:

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -49,6 +49,7 @@ Rover::Rover(void) :
     frsky_telemetry(ahrs, battery, sonar),
 #endif
     home(ahrs.get_home()),
+    do_auto_rotation(false),
     G_Dt(0.02f)
 {
 }

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -323,6 +323,9 @@ private:
     // For example in a delay command the condition_start records that start time for the delay
     int32_t condition_start;
 
+    // Use for stoping navigation in auto mode and do rotation on spot.
+    bool do_auto_rotation;
+
     // 3D Location vectors
     // Location structure defined in AP_Common
     // The home location used for RTL.  The location is set when we first get stable GPS lock
@@ -477,6 +480,7 @@ private:
     bool verify_RTL();
     bool verify_wait_delay();
     bool verify_within_distance();
+    bool verify_yaw();
 #if CAMERA == ENABLED
     void do_take_picture();
     void log_picture();
@@ -548,6 +552,7 @@ private:
     bool verify_loiter_time(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
+    void do_yaw(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
 #if CAMERA == ENABLED
@@ -564,6 +569,7 @@ private:
     void update_home();
     void accel_cal_update(void);
     void nav_set_yaw_speed();
+    bool do_yaw_rotation();
     bool in_stationary_loiter(void);
     void set_loiter_active(const AP_Mission::Mission_Command& cmd);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);


### PR DESCRIPTION
Working on SITL.
Tests to come on real rover (skid steer)

Got a crash check raised on sitl... Cannot reproduce easily ...