### PR TITLE
AP_Param: fixed a bug in default file handling

### DIFF
--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -473,12 +473,7 @@ private:
                                     enum ap_var_type *ptype);
 
     // find a default value given a pointer to a default value in flash
-    static float get_default_value(const float *def_value_ptr);
-
-    /*
-      find the def_value for a variable by name
-    */
-    static const float *find_def_value_ptr(const char *name);
+    static float get_default_value(const AP_Param *object_ptr, const float *def_value_ptr);
 
 #if HAL_OS_POSIX_IO == 1
     /*
@@ -500,7 +495,7 @@ private:
       list of overridden values from load_defaults_file()
     */
     struct param_override {
-        const float *def_value_ptr;
+        const AP_Param *object_ptr;
         float value;
     };
     static struct param_override *param_overrides;


### PR DESCRIPTION
this fixes a bug in how default file values are handled that affects
any common sub-objects. When we had a default value for something like
SERVO12_FUNCTION then configured_in_defaults_file() would return true
for SERVO1_FUNCTION as it shares a common default value pointer

this changes the implementation to use the object pointer instead