### PR TITLE
AP_Notify: Add a NULL pointer check.

### DIFF
--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -356,6 +356,9 @@ void Display::update_all()
 
 void Display::draw_text(uint16_t x, uint16_t y, const char* c)
 {
+    if (nullptr == c) {
+        return;
+    }
     while (*c != 0) {
         draw_char(x, y, *c);
         x += 7;


### PR DESCRIPTION
It is specified that the NULL pointer is not set.
I want to avoid inadvertent obstacles.
Therefore,
I think that it is better to check the NULL pointer.