### PR TITLE
AP_Compass: BMM150: fix sampling time

### DIFF
--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -58,7 +58,7 @@
 #define DIG_XY2_REG 0x70
 #define DIG_XY1_REG 0x71
 
-#define MEASURE_TIME_USEC 10000
+#define MEASURE_TIME_USEC 33334
 
 extern const AP_HAL::HAL &hal;
 


### PR DESCRIPTION
We configure the sensor with an ODR of 30 Hz. There's no need to keep
calling the update function at 100Hz.