### PR TITLE
AP_HAL_Linux: rename APM to ardupilot.

### DIFF
--- a/libraries/AP_HAL_Linux/Storage.cpp
+++ b/libraries/AP_HAL_Linux/Storage.cpp
@@ -21,7 +21,7 @@ using namespace Linux;
 // name the storage file after the sketch so you can use the same board
 // card for ArduCopter and ArduPlane
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
-#define STORAGE_DIR "/data/ftp/internal_000/APM"
+#define STORAGE_DIR "/data/ftp/internal_000/ardupilot"
 #elif APM_BUILD_TYPE(APM_BUILD_Replay)
 #define STORAGE_DIR "."
 #else


### PR DESCRIPTION
This rename should have happened here:
fdb2a9c99bffa65313778d3d2039fb70e59496d2 but was forgotten.