### PR TITLE
Copter: delay up to 2sec for first radio pulse

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -93,10 +93,16 @@ void Copter::esc_calibration_passthrough()
     // arm motors
     motors->armed(true);
     motors->enable();
-    
+
+    uint32_t last_notify_update_ms = 0;
     while(1) {
         // flash LEDS
         AP_Notify::flags.esc_calibration = true;
+        uint32_t now = AP_HAL::millis();
+        if (now - last_notify_update_ms > 20) {
+            last_notify_update_ms = now;
+            update_notify();
+        }
 
         // read pilot input
         read_radio();

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -55,7 +55,9 @@ void Copter::init_rc_out()
     motors->set_throttle_range(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #endif
 
-    for(uint8_t i = 0; i < 5; i++) {
+    // delay up to 2 second for first radio input
+    uint8_t i = 0;
+    while ((i++ < 100) && (last_radio_update_ms == 0)) {
         delay(20);
         read_radio();
     }


### PR DESCRIPTION
Pixracer boards can take close to 1 second to start reading RC input.  This ensure we see the user's high throttle to indicate the user wants to perform the ESC calibration.

This come after testing with PhillipK in which we found he was unable to reliably do the ESC calibration.  Upon further investigation I found that my pixracer had the same problem.

This patch does slow the pixracer start-up time by up to 1 second but shouldn't have an effect for other boards.