### PR TITLE
AP_Notify: enable Pixracer LED (attempt 2)

### DIFF
--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -29,7 +29,7 @@ PX4GPIO::PX4GPIO()
 
 void PX4GPIO::init()
 {
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
+#if defined(CONFIG_ARCH_BOARD_PX4FMU_V1) || defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
     _led_fd = open(LED0_DEVICE_PATH, O_RDWR);
     if (_led_fd == -1) {
         AP_HAL::panic("Unable to open " LED0_DEVICE_PATH);
@@ -38,8 +38,13 @@ void PX4GPIO::init()
         hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
     }
     if (ioctl(_led_fd, LED_OFF, LED_RED) != 0) {
-         hal.console->printf("GPIO: Unable to setup GPIO LED RED\n");
+        hal.console->printf("GPIO: Unable to setup GPIO LED RED\n");
     }
+#ifdef CONFIG_ARCH_BOARD_PX4FMU_V4
+    if (ioctl(_led_fd, LED_OFF, LED_GREEN) != 0) {
+        hal.console->printf("GPIO: Unable to setup GPIO LED GREEN\n");
+    }
+#endif
 #endif
     _tone_alarm_fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
     if (_tone_alarm_fd == -1) {
@@ -174,7 +179,7 @@ void PX4GPIO::write(uint8_t pin, uint8_t value)
 {
     switch (pin) {
 
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
+#if defined(CONFIG_ARCH_BOARD_PX4FMU_V1) || defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
         case HAL_GPIO_A_LED_PIN:    // Arming LED
             if (value == LOW) {
                 ioctl(_led_fd, LED_OFF, LED_RED);
@@ -183,7 +188,12 @@ void PX4GPIO::write(uint8_t pin, uint8_t value)
             }
             break;
 
-        case HAL_GPIO_B_LED_PIN:    // not used yet 
+        case HAL_GPIO_B_LED_PIN:    // Green LED
+            if (value == LOW) {
+                ioctl(_led_fd, LED_OFF, LED_GREEN);
+            } else {
+                ioctl(_led_fd, LED_ON, LED_GREEN);
+            }
             break;
 
         case HAL_GPIO_C_LED_PIN:    // GPS LED 

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -16,6 +16,7 @@
 #include "AP_Notify.h"
 
 #include "AP_BoardLED.h"
+#include "PixRacerLED.h"
 #include "Buzzer.h"
 #include "Display.h"
 #include "ExternalLED.h"
@@ -79,7 +80,11 @@ struct AP_Notify::notify_flags_and_values_type AP_Notify::flags;
 struct AP_Notify::notify_events_type AP_Notify::events;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
+    PixRacerLED boardled;
+#else
     AP_BoardLED boardled;
+#endif
     ToshibaLED_PX4 toshibaled;
     Display display;
 

--- a/libraries/AP_Notify/PixRacerLED.cpp
+++ b/libraries/AP_Notify/PixRacerLED.cpp
@@ -1,0 +1,39 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PixRacerLED.h"
+
+extern const AP_HAL::HAL& hal;
+
+PixRacerLED::PixRacerLED() :
+    RGBLed(0, 1, 1, 1)
+{
+}
+
+bool PixRacerLED::hw_init(void)
+{
+    hal.gpio->write(HAL_GPIO_A_LED_PIN, 0);
+    hal.gpio->write(HAL_GPIO_B_LED_PIN, 0);
+    hal.gpio->write(HAL_GPIO_C_LED_PIN, 0);
+    return true;
+}
+
+bool PixRacerLED::hw_set_rgb(uint8_t r, uint8_t g, uint8_t b)
+{
+    hal.gpio->write(HAL_GPIO_A_LED_PIN, (r > 0));
+    hal.gpio->write(HAL_GPIO_B_LED_PIN, (g > 0));
+    hal.gpio->write(HAL_GPIO_C_LED_PIN, (b > 0));
+    return true;
+}

--- a/libraries/AP_Notify/PixRacerLED.cpp
+++ b/libraries/AP_Notify/PixRacerLED.cpp
@@ -15,6 +15,8 @@
 
 #include "PixRacerLED.h"
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 && CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
+
 extern const AP_HAL::HAL& hal;
 
 PixRacerLED::PixRacerLED() :
@@ -37,3 +39,8 @@ bool PixRacerLED::hw_set_rgb(uint8_t r, uint8_t g, uint8_t b)
     hal.gpio->write(HAL_GPIO_C_LED_PIN, (b > 0));
     return true;
 }
+
+#else
+bool PixRacerLED::hw_init(void) { return true; }
+bool PixRacerLED::hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) { return true; }
+#endif

--- a/libraries/AP_Notify/PixRacerLED.h
+++ b/libraries/AP_Notify/PixRacerLED.h
@@ -1,0 +1,30 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+
+#include "RGBLed.h"
+
+class PixRacerLED: public RGBLed
+{
+public:
+    PixRacerLED();
+
+protected:
+    bool hw_init(void) override;
+    bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
+};


### PR DESCRIPTION
This is a replacement PR for https://github.com/ArduPilot/ardupilot/pull/5354.

This PR includes:

- adds initialisation for HAL_GPIO_B_LED_PIN on Pixracer boards
- new PixRacerLED makes use of the 3 GPIO pins as an RGBLED

I'm unsure if it's OK to call the gpio->write from the main thread.  See PixRacerLED::hw_set_rgb.