### PR TITLE
AP_Notify: Represent the base of ASCII numeric code with letters.

### DIFF
--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -459,8 +459,8 @@ void Display::update_gps(uint8_t r)
 void Display::update_gps_sats(uint8_t r)
 {
     draw_text(COLUMN(0), ROW(r), "Sats:");
-    draw_char(COLUMN(8), ROW(r), (AP_Notify::flags.gps_num_sats / 10) + 48);
-    draw_char(COLUMN(9), ROW(r), (AP_Notify::flags.gps_num_sats % 10) + 48);
+    draw_char(COLUMN(8), ROW(r), (AP_Notify::flags.gps_num_sats / 10) + '0');
+    draw_char(COLUMN(9), ROW(r), (AP_Notify::flags.gps_num_sats % 10) + '0');
 }
 
 void Display::update_ekf(uint8_t r)


### PR DESCRIPTION
The decimal number 48 is the ASCII character code "0".
However, the character code is not familiar with the expression in decimal number.
Binary value is converted to character code.
Therefore, I thought that it would be better to specify that it is character code conversion.