### PR TITLE
Allow PX4 boards with other names

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -418,15 +418,12 @@ class px4(Board):
     toolchain = 'arm-none-eabi'
 
     def __init__(self):
-        self.version = None
         self.bootloader_name = None
         self.board_name = None
         self.px4io_name = None
         self.ROMFS_EXCLUDE = []
 
     def configure(self, cfg):
-        if not self.version:
-            cfg.fatal('configure: px4: version required')
         if not self.bootloader_name:
             cfg.fatal('configure: px4: bootloader name is required')
         if not self.board_name:
@@ -463,7 +460,6 @@ class px4(Board):
         ]
         env.ROMFS_EXCLUDE = self.ROMFS_EXCLUDE
 
-        env.PX4_VERSION = self.version
         env.PX4_BOOTLOADER_NAME = self.bootloader_name
         env.PX4_BOARD_NAME = self.board_name
         env.PX4_PX4IO_NAME = self.px4io_name
@@ -483,7 +479,6 @@ class px4_v1(px4):
     name = 'px4-v1'
     def __init__(self):
         super(px4_v1, self).__init__()
-        self.version = '1'
         self.bootloader_name = 'px4fmu_bl.bin'
         self.board_name = 'px4fmu-v1'
         self.px4io_name = 'px4io-v1'
@@ -493,7 +488,6 @@ class px4_v2(px4):
     name = 'px4-v2'
     def __init__(self):
         super(px4_v2, self).__init__()
-        self.version = '2'
         self.bootloader_name = 'px4fmuv2_bl.bin'
         self.board_name = 'px4fmu-v2'
         self.px4io_name = 'px4io-v2'
@@ -503,7 +497,6 @@ class px4_v3(px4):
     name = 'px4-v3'
     def __init__(self):
         super(px4_v3, self).__init__()
-        self.version = '3'
         self.bootloader_name = 'px4fmuv2_bl.bin'
         self.board_name = 'px4fmu-v3'
         self.px4io_name = 'px4io-v2'
@@ -512,7 +505,6 @@ class px4_v4(px4):
     name = 'px4-v4'
     def __init__(self):
         super(px4_v4, self).__init__()
-        self.version = '4'
         self.bootloader_name = 'px4fmuv4_bl.bin'
         self.board_name = 'px4fmu-v4'
         self.romfs_exclude(['oreoled.bin'])

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -420,6 +420,7 @@ class px4(Board):
     def __init__(self):
         self.version = None
         self.bootloader_name = None
+        self.board_name = None
         self.use_px4io = True
         self.ROMFS_EXCLUDE = []
 
@@ -428,6 +429,8 @@ class px4(Board):
             cfg.fatal('configure: px4: version required')
         if not self.bootloader_name:
             cfg.fatal('configure: px4: bootloader name is required')
+        if not self.board_name:
+            cfg.fatal('configure: px4: board name is required')
 
         super(px4, self).configure(cfg)
         cfg.load('px4')
@@ -462,6 +465,7 @@ class px4(Board):
 
         env.PX4_VERSION = self.version
         env.PX4_BOOTLOADER_NAME = self.bootloader_name
+        env.PX4_BOARD_NAME = self.board_name
         env.PX4_USE_PX4IO = True if self.use_px4io else False
 
         env.AP_PROGRAM_AS_STLIB = True
@@ -481,6 +485,7 @@ class px4_v1(px4):
         super(px4_v1, self).__init__()
         self.version = '1'
         self.bootloader_name = 'px4fmu_bl.bin'
+        self.board_name = 'px4fmu-v1'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v2(px4):
@@ -489,6 +494,7 @@ class px4_v2(px4):
         super(px4_v2, self).__init__()
         self.version = '2'
         self.bootloader_name = 'px4fmuv2_bl.bin'
+        self.board_name = 'px4fmu-v2'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v3(px4):
@@ -497,6 +503,7 @@ class px4_v3(px4):
         super(px4_v3, self).__init__()
         self.version = '3'
         self.bootloader_name = 'px4fmuv2_bl.bin'
+        self.board_name = 'px4fmu-v3'
 
 class px4_v4(px4):
     name = 'px4-v4'
@@ -504,5 +511,6 @@ class px4_v4(px4):
         super(px4_v4, self).__init__()
         self.version = '4'
         self.bootloader_name = 'px4fmuv4_bl.bin'
+        self.board_name = 'px4fmu-v4'
         self.use_px4io = False
         self.romfs_exclude(['oreoled.bin', 'px4io.bin'])

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -419,12 +419,15 @@ class px4(Board):
 
     def __init__(self):
         self.version = None
+        self.bootloader_name = None
         self.use_px4io = True
         self.ROMFS_EXCLUDE = []
 
     def configure(self, cfg):
         if not self.version:
             cfg.fatal('configure: px4: version required')
+        if not self.bootloader_name:
+            cfg.fatal('configure: px4: bootloader name is required')
 
         super(px4, self).configure(cfg)
         cfg.load('px4')
@@ -458,6 +461,7 @@ class px4(Board):
         env.ROMFS_EXCLUDE = self.ROMFS_EXCLUDE
 
         env.PX4_VERSION = self.version
+        env.PX4_BOOTLOADER_NAME = self.bootloader_name
         env.PX4_USE_PX4IO = True if self.use_px4io else False
 
         env.AP_PROGRAM_AS_STLIB = True
@@ -476,6 +480,7 @@ class px4_v1(px4):
     def __init__(self):
         super(px4_v1, self).__init__()
         self.version = '1'
+        self.bootloader_name = 'px4fmu_bl.bin'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v2(px4):
@@ -483,6 +488,7 @@ class px4_v2(px4):
     def __init__(self):
         super(px4_v2, self).__init__()
         self.version = '2'
+        self.bootloader_name = 'px4fmuv2_bl.bin'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v3(px4):
@@ -490,11 +496,13 @@ class px4_v3(px4):
     def __init__(self):
         super(px4_v3, self).__init__()
         self.version = '3'
+        self.bootloader_name = 'px4fmuv2_bl.bin'
 
 class px4_v4(px4):
     name = 'px4-v4'
     def __init__(self):
         super(px4_v4, self).__init__()
         self.version = '4'
+        self.bootloader_name = 'px4fmuv4_bl.bin'
         self.use_px4io = False
         self.romfs_exclude(['oreoled.bin', 'px4io.bin'])

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -421,7 +421,7 @@ class px4(Board):
         self.version = None
         self.bootloader_name = None
         self.board_name = None
-        self.use_px4io = True
+        self.px4io_name = None
         self.ROMFS_EXCLUDE = []
 
     def configure(self, cfg):
@@ -466,7 +466,7 @@ class px4(Board):
         env.PX4_VERSION = self.version
         env.PX4_BOOTLOADER_NAME = self.bootloader_name
         env.PX4_BOARD_NAME = self.board_name
-        env.PX4_USE_PX4IO = True if self.use_px4io else False
+        env.PX4_PX4IO_NAME = self.px4io_name
 
         env.AP_PROGRAM_AS_STLIB = True
 
@@ -486,6 +486,7 @@ class px4_v1(px4):
         self.version = '1'
         self.bootloader_name = 'px4fmu_bl.bin'
         self.board_name = 'px4fmu-v1'
+        self.px4io_name = 'px4io-v1'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v2(px4):
@@ -495,6 +496,7 @@ class px4_v2(px4):
         self.version = '2'
         self.bootloader_name = 'px4fmuv2_bl.bin'
         self.board_name = 'px4fmu-v2'
+        self.px4io_name = 'px4io-v2'
         self.romfs_exclude(['oreoled.bin'])
 
 class px4_v3(px4):
@@ -504,6 +506,7 @@ class px4_v3(px4):
         self.version = '3'
         self.bootloader_name = 'px4fmuv2_bl.bin'
         self.board_name = 'px4fmu-v3'
+        self.px4io_name = 'px4io-v2'
 
 class px4_v4(px4):
     name = 'px4-v4'
@@ -512,5 +515,4 @@ class px4_v4(px4):
         self.version = '4'
         self.bootloader_name = 'px4fmuv4_bl.bin'
         self.board_name = 'px4fmu-v4'
-        self.use_px4io = False
-        self.romfs_exclude(['oreoled.bin', 'px4io.bin'])
+        self.romfs_exclude(['oreoled.bin'])

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -99,6 +99,7 @@ _upload_task = []
 def px4_firmware(self):
     global _cp_px4io, _firmware_semaphorish_tasks, _upload_task
     version = self.env.get_flat('PX4_VERSION')
+    board_name = self.env.get_flat('PX4_BOARD_NAME')
 
     px4 = self.bld.cmake('px4')
     px4.vars['APM_PROGRAM_LIB'] = self.link_task.outputs[0].abspath()
@@ -128,7 +129,7 @@ def px4_firmware(self):
 
     fw_task = self.create_cmake_build_task(
         'px4',
-        'build_firmware_px4fmu-v%s' % version,
+        'build_firmware_%s' % board_name,
     )
     fw_task.set_run_after(self.link_task)
 
@@ -142,7 +143,7 @@ def px4_firmware(self):
         fw_task.set_run_after(_cp_px4io)
 
     firmware = px4.bldnode.make_node(
-        'src/firmware/nuttx/nuttx-px4fmu-v%s-apm.px4' % version,
+        'src/firmware/nuttx/nuttx-%s-apm.px4' % board_name,
     )
     fw_elf = px4.bldnode.make_node(
         'src/firmware/nuttx/firmware_nuttx',
@@ -237,7 +238,7 @@ def configure(cfg):
     def bldpath(path):
         return bldnode.make_node(path).abspath()
 
-    version = env.get_flat('PX4_VERSION')
+    board_name = env.get_flat('PX4_BOARD_NAME')
 
     # TODO: we should move stuff from mk/PX4 to Tools/ardupilotwaf/px4 after
     # stop using the make-based build system
@@ -254,7 +255,7 @@ def configure(cfg):
     if env.PX4_USE_PX4IO:
         env.PX4IO_ELF_DEST = 'px4-extra-files/px4io'
 
-    nuttx_config='nuttx_px4fmu-v%s_apm' % version
+    nuttx_config='nuttx_%s_apm' % board_name
         
     env.PX4_CMAKE_VARS = dict(
         CONFIG=nuttx_config,
@@ -286,7 +287,7 @@ def configure(cfg):
     )
 
 def build(bld):
-    version = bld.env.get_flat('PX4_VERSION')
+    board_name = bld.env.get_flat('PX4_BOARD_NAME')
     px4 = bld.cmake(
         name='px4',
         cmake_src=bld.srcnode.find_dir('modules/PX4Firmware'),
@@ -301,7 +302,7 @@ def build(bld):
     px4.build(
         'prebuild_targets',
         group='dynamic_sources',
-        cmake_output_patterns='px4fmu-v%s/NuttX/nuttx-export/**/*.h' % version,
+        cmake_output_patterns='%s/NuttX/nuttx-export/**/*.h' % board_name,
     )
 
     bld(

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -238,19 +238,12 @@ def configure(cfg):
         return bldnode.make_node(path).abspath()
 
     version = env.get_flat('PX4_VERSION')
-    
-    if env.PX4_VERSION == '1':
-        bootloader_name = 'px4fmu_bl.bin'
-    elif env.PX4_VERSION in ['2','3']:
-        bootloader_name = 'px4fmuv2_bl.bin'
-    else:
-        bootloader_name = 'px4fmuv%s_bl.bin' % version
 
     # TODO: we should move stuff from mk/PX4 to Tools/ardupilotwaf/px4 after
     # stop using the make-based build system
     env.PX4_ROMFS_SRC = 'mk/PX4/ROMFS'
     env.PX4_ROMFS_BLD = 'px4-extra-files/ROMFS'
-    env.PX4_BOOTLOADER = 'mk/PX4/bootloader/%s' % bootloader_name
+    env.PX4_BOOTLOADER = 'mk/PX4/bootloader/%s' % env.PX4_BOOTLOADER_NAME
 
     env.PX4_ADD_GIT_HASHES = srcpath('Tools/scripts/add_git_hashes.py')
     env.PX4_APM_ROOT = srcpath('')


### PR DESCRIPTION
Small changes to how we set the board names in waf to allow building for a board that's not px4fmu*