### PR TITLE
AC_PrecLand: Use distance_to_target as alternative to rangefinder, #5636

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -33,6 +33,9 @@ public:
     // return true if there is a valid los measurement available
     virtual bool have_los_meas() = 0;
     
+    // return distance to target
+    virtual float distance_to_target() = 0;
+
     // parses a mavlink message from the companion computer
     virtual void handle_msg(mavlink_message_t* msg) {};
 

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -48,6 +48,12 @@ bool AC_PrecLand_Companion::have_los_meas()
     return _have_los_meas;
 }
 
+// return distance to target
+float AC_PrecLand_Companion::distance_to_target()
+{
+    return _distance_to_target;
+}
+    
 void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 {
     // parse mavlink message

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -31,6 +31,9 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas();
     
+    // return distance to target
+    float distance_to_target();
+    
     // parses a mavlink message from the companion computer
     void handle_msg(mavlink_message_t* msg);
 

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
@@ -58,4 +58,10 @@ bool AC_PrecLand_IRLock::have_los_meas() {
     return _have_los_meas;
 }
 
+// return distance to target
+float AC_PrecLand_IRLock::distance_to_target()
+{
+    return _distance_to_target;
+}
+
 #endif // PX4

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -39,11 +39,15 @@ public:
     
     // return true if there is a valid los measurement available
     bool have_los_meas();
+    
+    // return distance to target
+    float distance_to_target();
 
 private:
     AP_IRLock_I2C irlock;
 
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
+    float               _distance_to_target;    // distance from the camera to target in meters
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -48,6 +48,11 @@ bool AC_PrecLand_SITL::have_los_meas() {
     return AP_HAL::millis() - _los_meas_time_ms < 1000;
 }
 
+// return distance to target
+float AC_PrecLand_SITL::distance_to_target()
+{
+    return _distance_to_target;
+}
 
 // provides a unit vector towards the target in body frame
 //  returns same as have_los_meas()

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -31,10 +31,14 @@ public:
 
     // return true if there is a valid los measurement available
     bool have_los_meas();
+    
+    // return distance to target
+    float distance_to_target();
 
 private:
 
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
+    float               _distance_to_target;    // distance from the camera to target in meters
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };
 

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
@@ -55,4 +55,10 @@ bool AC_PrecLand_SITL_Gazebo::have_los_meas() {
     return _have_los_meas;
 }
 
+// return distance to target
+float AC_PrecLand_SITL_Gazebo::distance_to_target()
+{
+    return _distance_to_target;
+}
+
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
@@ -34,10 +34,14 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas();
 
+    // return distance to target
+    float distance_to_target();
+    
 private:
     AP_IRLock_SITL irlock;
 
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
+    float               _distance_to_target;    // distance from the camera to target in meters
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
 };


### PR DESCRIPTION
PR to resolve  https://github.com/ArduPilot/ardupilot/issues/5636

Currently Precision Landing requires an active rangefinder providing distance to ground.  However, the Companion backend consumes the landing_target mavlink message which includes a distance parameter.  This distance parameter can act as an alternative to rangefinder.  This PR adds distance_to_target() to PrecLand, in the Companion backend returns the distance parameter from landing_target message, and then if distance_to_target is truthy uses it as an alternative to rangefinder in the mini EKF logic.