### PR TITLE
AP_InertialSensor: support the L3GD20H gyro

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -699,7 +699,9 @@ AP_InertialSensor::detect_backends(void)
         _add_backend(AP_InertialSensor_LSM9DS0::probe(*this,
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME),
-                                                      ROTATION_ROLL_180, ROTATION_ROLL_180_YAW_270));
+                                                      ROTATION_ROLL_180,
+                                                      ROTATION_ROLL_180_YAW_270,
+                                                      ROTATION_PITCH_180));
         break;
 
     case AP_BoardConfig::PX4_BOARD_PIXHAWK2:
@@ -709,7 +711,9 @@ AP_InertialSensor::detect_backends(void)
         _add_backend(AP_InertialSensor_LSM9DS0::probe(*this,
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_G_NAME),
                                                       hal.spi->get_device(HAL_INS_LSM9DS0_EXT_A_NAME),
-                                                      ROTATION_ROLL_180_YAW_270, ROTATION_ROLL_180_YAW_90));
+                                                      ROTATION_ROLL_180_YAW_270,
+                                                      ROTATION_ROLL_180_YAW_90,
+                                                      ROTATION_ROLL_180_YAW_90));
         _add_backend(AP_InertialSensor_Invensense::probe(*this, hal.spi->get_device(HAL_INS_MPU9250_NAME), ROTATION_YAW_270));
         break;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
@@ -19,7 +19,8 @@ public:
                                             AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev_gyro,
                                             AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev_accel,
                                             enum Rotation rotation_a = ROTATION_NONE,
-                                            enum Rotation rotation_g = ROTATION_NONE);
+                                            enum Rotation rotation_g = ROTATION_NONE,
+                                            enum Rotation rotation_gH = ROTATION_NONE);
 
 private:
     AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,
@@ -27,7 +28,8 @@ private:
                               AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev_accel,
                               int drdy_pin_num_a, int drdy_pin_num_b,
                               enum Rotation rotation_a,
-                              enum Rotation rotation_g);
+                              enum Rotation rotation_g,
+                              enum Rotation rotation_gH);
 
     struct PACKED sensor_raw_data {
         int16_t x;
@@ -97,10 +99,14 @@ private:
     uint8_t _gyro_instance;
     uint8_t _accel_instance;
 
+    // gyro whoami
+    uint8_t whoami_g;
+    
     /*
       for boards that have a separate LSM303D and L3GD20 there can be
       different rotations for each
      */
     enum Rotation _rotation_a;
-    enum Rotation _rotation_g;
+    enum Rotation _rotation_g;  // for L3GD20
+    enum Rotation _rotation_gH; // for L3GD20H
 };


### PR DESCRIPTION
this is used by the MRo Pixhawk1
the orientation handling matches the old PX4 driver
