### PR TITLE
Add EKF support for multiple GPS receivers

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -250,7 +250,6 @@ void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_man
     memset(&_last_time_updated, 0, sizeof(_last_time_updated));
     memset(&_blend_weights, 0, sizeof(_blend_weights));
     memset(&timing[GPS_MAX_RECEIVERS], 0, sizeof(timing[GPS_MAX_RECEIVERS]));
-    memset(&_output_location_corrected, 0, sizeof(_output_location_corrected));
     _blended_antenna_offset.zero();
     _omega_lpf = 1.0f / constrain_float(_blend_tc, 5.0f, 30.0f);
     _output_is_blended = false;
@@ -610,7 +609,6 @@ AP_GPS::update(void)
 
             // copy the primary instance to the blended instance
             state[GPS_MAX_RECEIVERS] = state[primary_instance];
-            _output_location_corrected = state[primary_instance].location;
             _blended_antenna_offset = _antenna_offset[primary_instance];
 
             // we are using hard switching logic, so no blending
@@ -1333,11 +1331,6 @@ void AP_GPS::calc_blended_state(void)
             blended_alt_offset_cm += (float)(corrected_location[i].alt - state[GPS_MAX_RECEIVERS].location.alt) * _blend_weights[i];
         }
     }
-
-    // Add the sum of weighted offsets to the blended location to obtain the corrected location
-    _output_location_corrected = state[GPS_MAX_RECEIVERS].location;
-    location_offset(_output_location_corrected, blended_NE_offset_m.x, blended_NE_offset_m.y);
-    _output_location_corrected.alt += (int)blended_alt_offset_cm;
 
     // If the GPS week is the same then use a blended time_week_ms
     // If week is different, then use time stamp from GPs with largest weighting

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1081,7 +1081,7 @@ void AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_hpos_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_2D) {
+            if (state[i].status >= GPS_OK_FIX_2D && state[i].horizontal_accuracy > 0.001f) {
                 hpos_blend_weights[i] = horizontal_accuracy_sum_sq / (state[i].horizontal_accuracy * state[i].horizontal_accuracy);
                 sum_of_hpos_weights += hpos_blend_weights[i];
             } else {
@@ -1107,7 +1107,7 @@ void AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_vpos_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_3D) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].vertical_accuracy > 0.001f) {
                 vpos_blend_weights[i] = vertical_accuracy_sum_sq / (state[i].vertical_accuracy * state[i].vertical_accuracy);
                 sum_of_vpos_weights += vpos_blend_weights[i];
             } else {
@@ -1133,7 +1133,7 @@ void AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_spd_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_3D) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].speed_accuracy > 0.001f) {
                 spd_blend_weights[i] = speed_accuracy_sum_sq / (state[i].speed_accuracy * state[i].speed_accuracy);
                 sum_of_spd_weights += spd_blend_weights[i];
             } else {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -66,6 +66,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @DisplayName: Automatic Switchover Setting
     // @Description: Automatic switchover to GPS reporting best lock
     // @Values: 0:Disabled,1:Hard,2:Soft
+    // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, 1),
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: AUTO_SWITCH
     // @DisplayName: Automatic Switchover Setting
     // @Description: Automatic switchover to GPS reporting best lock
-    // @Values: 0:Disabled,1:Enabled
+    // @Values: 0:Disabled,1:Hard,2:Soft
     // @User: Advanced
     AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, 1),
 
@@ -213,6 +213,23 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
+
+    // @Param: BLEND_MASK
+    // @DisplayName: Multi GPS Blending Mask
+    // @Description: Determines which of the accuracy measures Horizontal position, Vertical Position and Speed are used to calculate the weighting on each GPS receiver when soft switching has been selected by setting GPS_AUTO_SWITCH to 3.
+    // @Values: 5:Default
+    // @Bitmask: 0:Horiz Pos,1:Vert Pos,2:Speed
+    // @User: Advanced
+    AP_GROUPINFO("BLEND_MASK", 20, AP_GPS, _blend_mask, 5),
+
+    // @Param: BLEND_TC
+    // @DisplayName: Blending time constant
+    // @Description: Controls the slowest time constant applied to the calculation of GPS position and height offsets used to adjust different GPS receivers for steady state position differences.
+    // @Units: seconds
+    // @Range: 5.0 30.0
+    // @User: Advanced
+    AP_GROUPINFO("BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),
+
     AP_GROUPEND
 };
 
@@ -226,6 +243,19 @@ void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_man
     _port[0] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 0);
     _port[1] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 1);
     _last_instance_swap_ms = 0;
+
+    // Initialise class variables used to do GPS blending
+    memset(&_NE_pos_offset_m, 0, sizeof(_NE_pos_offset_m));
+    memset(&_hgt_offset_cm, 0, sizeof(_hgt_offset_cm));
+    memset(&state[GPS_MAX_INSTANCES], 0, sizeof(state[GPS_MAX_INSTANCES]));
+    memset(&_last_time_updated, 0, sizeof(_last_time_updated));
+    memset(&_blend_weights, 0, sizeof(_blend_weights));
+    memset(&timing[GPS_MAX_INSTANCES], 0, sizeof(timing[GPS_MAX_INSTANCES]));
+    memset(&_output_location_corrected, 0, sizeof(_output_location_corrected));
+    _blended_antenna_offset.zero();
+    _omega_lpf = 1.0f / constrain_float(_blend_tc, 5.0f, 30.0f);
+    _output_is_blended = false;
+
 }
 
 // baudrates to try to detect GPSes with
@@ -527,47 +557,70 @@ AP_GPS::update(void)
         update_instance(i);
     }
 
-    // work out which GPS is the primary, and how many sensors we have
-    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
-        if (state[i].status != NO_GPS) {
-            num_instances = i+1;
-        }
-        if (_auto_switch) {            
-            if (i == primary_instance) {
-                continue;
+    // Implement soft switch logic
+    if (_auto_switch == 2) {
+        // calculate weighting for each GPS
+        calc_blend_weights();
+
+        // Use the weighting to calculate blended GPS states
+        calc_blended_state();
+
+        // update notify with gps status. Used blended data
+        AP_Notify::flags.gps_status = state[GPS_MAX_INSTANCES].status;
+        AP_Notify::flags.gps_num_sats = state[GPS_MAX_INSTANCES].num_sats;
+
+    } else {
+        // use hard switch logic
+        // work out which GPS is the primary, and how many sensors we have
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status != NO_GPS) {
+                num_instances = i+1;
             }
-            if (state[i].status > state[primary_instance].status) {
-                // we have a higher status lock, change GPS
-                primary_instance = i;
-                continue;
-            }
-
-            bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
-
-            if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
-
-                uint32_t now = AP_HAL::millis();
-                bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
-
-                if ( (another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
-                     (another_gps_has_2_or_more_sats && (now - _last_instance_swap_ms) >= 5000 ) ) {
-                // this GPS has more satellites than the
-                // current primary, switch primary. Once we switch we will
-                // then tend to stick to the new GPS as primary. We don't
-                // want to switch too often as it will look like a
-                // position shift to the controllers.
-                primary_instance = i;
-                _last_instance_swap_ms = now;
+            if (_auto_switch) {
+                if (i == primary_instance) {
+                    continue;
                 }
+                if (state[i].status > state[primary_instance].status) {
+                    // we have a higher status lock, change GPS
+                    primary_instance = i;
+                    continue;
+                }
+
+                bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
+
+                if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
+
+                    uint32_t now = AP_HAL::millis();
+                    bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
+
+                    if ( (another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
+                         (another_gps_has_2_or_more_sats && (now - _last_instance_swap_ms) >= 5000 ) ) {
+                    // this GPS has more satellites than the
+                    // current primary, switch primary. Once we switch we will
+                    // then tend to stick to the new GPS as primary. We don't
+                    // want to switch too often as it will look like a
+                    // position shift to the controllers.
+                    primary_instance = i;
+                    _last_instance_swap_ms = now;
+                    }
+                }
+            } else {
+                primary_instance = 0;
             }
-        } else {
-            primary_instance = 0;
+
+            // copy the primary instance to the blended instance
+            state[GPS_MAX_INSTANCES] = state[primary_instance];
+            _output_location_corrected = state[primary_instance].location;
+            _blended_antenna_offset = _antenna_offset[primary_instance];
+
+            // we are using hard switching logic, so no blending
+            _output_is_blended = false;
         }
+        // update notify with gps status. We always base this on the primary_instance
+        AP_Notify::flags.gps_status = state[primary_instance].status;
+        AP_Notify::flags.gps_num_sats = state[primary_instance].num_sats;
     }
 
-    // update notify with gps status. We always base this on the primary_instance
-    AP_Notify::flags.gps_status = state[primary_instance].status;
-    AP_Notify::flags.gps_num_sats = state[primary_instance].num_sats;
 }
 
 /*
@@ -898,4 +951,412 @@ float AP_GPS::get_lag(uint8_t instance) const
         // the user has not specified a delay so we determine it from the GPS type
         return drivers[instance]->get_lag();
     }
+}
+
+/*
+ calculate the weightings used to blend GPs location and velocity data
+*/
+void AP_GPS::calc_blend_weights(void)
+{
+    // zero the blend weights
+    memset(&_blend_weights, 0, sizeof(_blend_weights));
+
+    // determine how many GPS receivers are returning a fix and the instance of the first receiver that is
+    uint8_t first_instance = 0;
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (state[i].status > NO_FIX) {
+            num_instances = i+1;
+            if (first_instance == 0) {
+                first_instance = i;
+            }
+        }
+    }
+
+    // If not enough receivers to do blending or blending has  been disabled, set the primary instance and weighting to the first receiver detected
+    if (num_instances < 2 || _auto_switch != 2) {
+        primary_instance = first_instance;
+        _output_is_blended = false;
+        _blend_weights[primary_instance] = 1.0f;
+        return;
+    }
+
+    // calculate the sum squared speed accuracy across all GPS sensors
+    float speed_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & USE_SPD_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                if (state[i].have_speed_accuracy && state[i].speed_accuracy > 0.0f) {
+                    speed_accuracy_sum_sq += state[i].speed_accuracy * state[i].speed_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    speed_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+
+    // calculate the sum squared horizontal position accuracy across all GPS sensors
+    float horizontal_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & USE_HPOS_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_2D) {
+                if (state[i].have_horizontal_accuracy && state[i].horizontal_accuracy > 0.0f) {
+                    horizontal_accuracy_sum_sq += state[i].horizontal_accuracy * state[i].horizontal_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    horizontal_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+
+    // calculate the sum squared vertical position accuracy across all GPS sensors
+    float vertical_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & USE_VPOS_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                if (state[i].have_vertical_accuracy && state[i].vertical_accuracy > 0.0f) {
+                    vertical_accuracy_sum_sq += state[i].vertical_accuracy * state[i].vertical_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    vertical_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+    // Check if we can do blending using reported accuracy
+    bool can_do_blending = (horizontal_accuracy_sum_sq > 0.0f || vertical_accuracy_sum_sq > 0.0f || speed_accuracy_sum_sq > 0.0f);
+
+    // if we cant do blending using reported accuracy, set the weight to the receiver with the highest solution status
+    if (!can_do_blending) {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+                if (state[i].status > state[primary_instance].status) {
+                    // we have a higher status lock, change GPS
+                    primary_instance = i;
+                }
+        }
+        _output_is_blended = false;
+        _blend_weights[primary_instance] = 1.0f;
+        return;
+    }
+
+    float sum_of_all_weights = 0.0f;
+
+    // calculate a weighting using the reported horizontal position
+    float hpos_blend_weights[GPS_MAX_INSTANCES];
+    if (horizontal_accuracy_sum_sq > 0.0f && (_blend_mask & USE_HPOS_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_hpos_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_2D) {
+                hpos_blend_weights[i] = horizontal_accuracy_sum_sq / (state[i].horizontal_accuracy * state[i].horizontal_accuracy);
+                sum_of_hpos_weights += hpos_blend_weights[i];
+            } else {
+                hpos_blend_weights[i] = 0.0f;
+            }
+        }
+        // normalise the weights
+        if (sum_of_hpos_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+                hpos_blend_weights[i] = hpos_blend_weights[i] / sum_of_hpos_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        }
+    } else {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            hpos_blend_weights[i] = 0.0f;
+        }
+    }
+
+    // calculate a weighting using the reported vertical position accuracy
+    float vpos_blend_weights[GPS_MAX_INSTANCES];
+    if (vertical_accuracy_sum_sq > 0.0f && (_blend_mask & USE_VPOS_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_vpos_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                vpos_blend_weights[i] = vertical_accuracy_sum_sq / (state[i].vertical_accuracy * state[i].vertical_accuracy);
+                sum_of_vpos_weights += vpos_blend_weights[i];
+            } else {
+                vpos_blend_weights[i] = 0.0f;
+            }
+        }
+        // normalise the weights
+        if (sum_of_vpos_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+                vpos_blend_weights[i] = vpos_blend_weights[i] / sum_of_vpos_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        };
+    } else {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            vpos_blend_weights[i] = 0.0f;
+        }
+    }
+
+    // calculate a weighting using the reported speed accuracy
+    float spd_blend_weights[GPS_MAX_INSTANCES];
+    if (speed_accuracy_sum_sq > 0.0f && (_blend_mask & USE_SPD_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_spd_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                spd_blend_weights[i] = speed_accuracy_sum_sq / (state[i].speed_accuracy * state[i].speed_accuracy);
+                sum_of_spd_weights += spd_blend_weights[i];
+            } else {
+                spd_blend_weights[i] = 0.0f;
+            }
+        }
+        // normalise the weights
+        if (sum_of_spd_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+                spd_blend_weights[i] = spd_blend_weights[i] / sum_of_spd_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        }
+    } else {
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            spd_blend_weights[i] = 0.0f;
+        }
+    }
+
+    // calculate an overall weight
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        _blend_weights[i] = (hpos_blend_weights[i] + vpos_blend_weights[i] + spd_blend_weights[i]) / sum_of_all_weights;
+    }
+
+    primary_instance = GPS_MAX_INSTANCES;
+    _output_is_blended = true;
+
+    return;
+
+}
+
+/*
+ calculate a blended GPS state
+*/
+void AP_GPS::calc_blended_state(void)
+{
+    // initialise the blended states so we can accumulate the results using the weightings for each GPS receiver
+    state[GPS_MAX_INSTANCES].instance = 255; // set to 255 to indicate this is a blended solution
+    state[GPS_MAX_INSTANCES].status = NO_GPS;
+    state[GPS_MAX_INSTANCES].time_week_ms = 0;
+    state[GPS_MAX_INSTANCES].time_week = 0;
+    state[GPS_MAX_INSTANCES].ground_speed = 0.0f;
+    state[GPS_MAX_INSTANCES].ground_course = 0.0f;
+    state[GPS_MAX_INSTANCES].hdop = -1;
+    state[GPS_MAX_INSTANCES].vdop = -1;
+    state[GPS_MAX_INSTANCES].num_sats = 0;
+    state[GPS_MAX_INSTANCES].velocity.zero();
+    state[GPS_MAX_INSTANCES].speed_accuracy = 1e6f;
+    state[GPS_MAX_INSTANCES].horizontal_accuracy = 1e6f;
+    state[GPS_MAX_INSTANCES].vertical_accuracy = 1e6f;
+    state[GPS_MAX_INSTANCES].have_vertical_velocity = false;
+    state[GPS_MAX_INSTANCES].have_speed_accuracy = false;
+    state[GPS_MAX_INSTANCES].have_horizontal_accuracy = false;
+    state[GPS_MAX_INSTANCES].have_vertical_accuracy = false;
+    state[GPS_MAX_INSTANCES].last_gps_time_ms = -1;
+
+    _blended_antenna_offset.zero();
+
+    timing[GPS_MAX_INSTANCES].last_fix_time_ms = 0;
+    timing[GPS_MAX_INSTANCES].last_message_time_ms = 0;
+
+    // combine the states into a blended solution
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        // use the highest status
+        if (state[i].status > state[GPS_MAX_INSTANCES].status) {
+            state[GPS_MAX_INSTANCES].status = state[i].status;
+        }
+
+        // calculate a blended average velocity
+        state[GPS_MAX_INSTANCES].velocity += state[i].velocity * _blend_weights[i];
+
+        // report the best valid accuracies and DOP metrics
+
+        if (state[i].have_horizontal_accuracy && state[i].horizontal_accuracy > 0.0f && state[i].horizontal_accuracy < state[GPS_MAX_INSTANCES].horizontal_accuracy) {
+            state[GPS_MAX_INSTANCES].have_horizontal_accuracy = true;
+            state[GPS_MAX_INSTANCES].horizontal_accuracy = state[i].horizontal_accuracy;
+        }
+
+        if (state[i].have_vertical_accuracy && state[i].vertical_accuracy > 0.0f && state[i].vertical_accuracy < state[GPS_MAX_INSTANCES].vertical_accuracy) {
+            state[GPS_MAX_INSTANCES].have_vertical_accuracy = true;
+            state[GPS_MAX_INSTANCES].vertical_accuracy = state[i].vertical_accuracy;
+        }
+
+        if (state[i].have_vertical_velocity ) {
+            state[GPS_MAX_INSTANCES].have_vertical_velocity = true;
+        }
+
+        if (state[i].have_speed_accuracy && state[i].speed_accuracy > 0.0f && state[i].speed_accuracy < state[GPS_MAX_INSTANCES].speed_accuracy) {
+            state[GPS_MAX_INSTANCES].have_speed_accuracy = true;
+            state[GPS_MAX_INSTANCES].speed_accuracy = state[i].speed_accuracy;
+        }
+
+        if (state[i].hdop > 0 && state[i].hdop < state[GPS_MAX_INSTANCES].hdop) {
+            state[GPS_MAX_INSTANCES].hdop = state[i].hdop;
+        }
+
+        if (state[i].vdop > 0 && state[i].vdop < state[GPS_MAX_INSTANCES].vdop) {
+            state[GPS_MAX_INSTANCES].vdop = state[i].vdop;
+        }
+
+        if (state[i].num_sats > 0 && state[i].num_sats > state[GPS_MAX_INSTANCES].num_sats) {
+            state[GPS_MAX_INSTANCES].num_sats = state[i].num_sats;
+        }
+
+        // Use oldest update data to prevent use of GPS data by consumers until all instances have had a chance to report
+        // TODO add timeout logic so that we don't wait too long for a faulty receiver to report
+        if (state[i].last_gps_time_ms < state[GPS_MAX_INSTANCES].last_gps_time_ms && state[i].last_gps_time_ms != 0) {
+            state[GPS_MAX_INSTANCES].last_gps_time_ms = state[i].last_gps_time_ms;
+        }
+
+        // report a blended average GPS antenna position
+        Vector3f temp_antenna_offset = _antenna_offset[i];
+        temp_antenna_offset *= _blend_weights[i];
+        _blended_antenna_offset += temp_antenna_offset;
+
+        // blend the timing data
+        if (timing[i].last_fix_time_ms > timing[GPS_MAX_INSTANCES].last_fix_time_ms) {
+            timing[GPS_MAX_INSTANCES].last_fix_time_ms = timing[i].last_fix_time_ms;
+        }
+        if (timing[i].last_message_time_ms > timing[GPS_MAX_INSTANCES].last_message_time_ms) {
+            timing[GPS_MAX_INSTANCES].last_message_time_ms = timing[i].last_message_time_ms;
+        }
+
+    }
+
+    /*
+     * Calculate an instantaneous weighted/blended average location from the available GPS instances and store in the _output_state.
+     * This will be statisticaly the most likely location, but will be not stable enough for direct use by the autopilot.
+    */
+
+    // Use the GPS with the highest weighting as the reference position
+    float best_weight = 0.0f;
+    uint8_t best_index = 0;
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (_blend_weights[i] > best_weight) {
+            best_weight = _blend_weights[i];
+            best_index = i;
+            state[GPS_MAX_INSTANCES].location = state[i].location;
+        }
+    }
+
+    // Calculate the weighted sum of horizontal and vertical position offsets relative to the reference position
+    Vector2f blended_NE_offset_m;
+    float blended_alt_offset_cm = 0.0f;
+    blended_NE_offset_m.zero();
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (_blend_weights[i] > 0.0f && i != best_index) {
+            //TODO correct for antenna position
+            blended_NE_offset_m += location_diff(state[GPS_MAX_INSTANCES].location, state[i].location) * _blend_weights[i];
+            blended_alt_offset_cm += (float)(state[i].location.alt - state[GPS_MAX_INSTANCES].location.alt) * _blend_weights[i];
+        }
+    }
+
+    // Add the sum of weighted offsets to the reference location to obtain the blended location
+    location_offset(state[GPS_MAX_INSTANCES].location, blended_NE_offset_m.x, blended_NE_offset_m.y);
+    state[GPS_MAX_INSTANCES].location.alt += (int)blended_alt_offset_cm;
+
+    // Calculate ground speed and course from blended velocity vector
+    state[GPS_MAX_INSTANCES].ground_speed = norm(state[GPS_MAX_INSTANCES].velocity.x, state[GPS_MAX_INSTANCES].velocity.y);
+    state[GPS_MAX_INSTANCES].ground_course = wrap_360(degrees(atan2f(state[GPS_MAX_INSTANCES].velocity.x, state[GPS_MAX_INSTANCES].velocity.x)));
+
+    /*
+     * The blended location in _output_state.location is not stable enough to be used by the autopilot
+     * as it will move around as the relative accuracy changes. To mitigate this effect a low-pass filtered
+     * offset from each GPS location to the blended location is calculated and the filtered offset is applied
+     * to each receiver.
+    */
+
+    // Calculate filter coefficients to be applied to the offsets for each GPS position and height offset
+    // A weighting of 1 will make the offset adjust the slowest, a weighting of 0 will make it adjust with zero filtering
+    float alpha[GPS_MAX_INSTANCES];
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (state[i].last_gps_time_ms > _last_time_updated[i]) {
+            float min_alpha = constrain_float(_omega_lpf * 0.001f * (float)(state[i].last_gps_time_ms - _last_time_updated[i]), 0.0f, 1.0f);
+            if (_blend_weights[i] > min_alpha) {
+                alpha[i] = min_alpha / _blend_weights[i];
+            } else {
+                alpha[i] = 1.0f;
+            }
+        }
+    }
+
+    // Calculate the offset from each GPS solution to the blended solution
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        _NE_pos_offset_m[i] = location_diff(state[i].location, state[GPS_MAX_INSTANCES].location) * alpha[i] + _NE_pos_offset_m[i] * (1.0f - alpha[i]);
+        _hgt_offset_cm[i] = (float)(state[GPS_MAX_INSTANCES].location.alt - state[i].location.alt) *  alpha[i] + _hgt_offset_cm[i] * (1.0f - alpha[i]);
+    }
+
+    // Calculate a corrected location for each GPS
+    Location corrected_location[GPS_MAX_INSTANCES];
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            corrected_location[i] = state[i].location;
+            location_offset(corrected_location[i], _NE_pos_offset_m[i].x, _NE_pos_offset_m[i].y);
+            corrected_location[i].alt += (int)(_hgt_offset_cm[i]);
+    }
+
+    // Calculate the weighted sum of horizontal and vertical position offsets relative to the blended location
+    blended_alt_offset_cm = 0.0f;
+    blended_NE_offset_m.zero();
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (_blend_weights[i] > 0.0f) {
+            blended_NE_offset_m += location_diff(state[GPS_MAX_INSTANCES].location, corrected_location[i]) * _blend_weights[i];
+            blended_alt_offset_cm += (float)(corrected_location[i].alt - state[GPS_MAX_INSTANCES].location.alt) * _blend_weights[i];
+        }
+    }
+
+    // Add the sum of weighted offsets to the blended location to obtain the corrected location
+    _output_location_corrected = state[GPS_MAX_INSTANCES].location;
+    location_offset(_output_location_corrected, blended_NE_offset_m.x, blended_NE_offset_m.y);
+    _output_location_corrected.alt += (int)blended_alt_offset_cm;
+
+    // If the GPS week is the same then use a blended time_week_ms
+    // If week is different, then use time stamp from GPs with largest weighting
+    // detect inconsistent week data
+    uint8_t last_week_instance = 0;
+    bool weeks_inconsistent = false;
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (last_week_instance == 0 && _blend_weights[i] > 0) {
+            // this is our first valid sensor week data
+            last_week_instance = state[i].time_week;
+        } else if (last_week_instance != 0 && _blend_weights[i] > 0 && last_week_instance != state[i].time_week) {
+            // there is valid sensor week data that is inconsistent
+            weeks_inconsistent = true;
+        }
+    }
+    // calculate output
+    if (!weeks_inconsistent) {
+        // use data from highest weighted sensor
+        state[GPS_MAX_INSTANCES].time_week = state[best_index].time_week;
+        state[GPS_MAX_INSTANCES].time_week_ms = state[best_index].time_week_ms;
+    } else {
+        // use week number from highest weighting GPS (they should all have the same week number)
+        state[GPS_MAX_INSTANCES].time_week = state[best_index].time_week;
+        // calculate a blended value for the number of ms lapsed in the week
+        double temp_time_0 = 0.0;
+        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+            if (_blend_weights[i] > 0.0f) {
+                temp_time_0 += (double)state[i].time_week_ms * _blend_weights[i];
+            }
+        }
+        state[GPS_MAX_INSTANCES].time_week_ms = (uint32_t)temp_time_0;
+    }
+
+    // calculate a blended value for the timing data
+    double temp_time_1 = 0.0;
+    double temp_time_2 = 0.0;
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (_blend_weights[i] > 0.0f) {
+            temp_time_1 += (double)timing[i].last_fix_time_ms * _blend_weights[i];
+            temp_time_2 += (double)timing[i].last_message_time_ms * _blend_weights[i];
+        }
+    }
+    timing[GPS_MAX_INSTANCES].last_fix_time_ms = (uint32_t)temp_time_1;
+    timing[GPS_MAX_INSTANCES].last_message_time_ms = (uint32_t)temp_time_2;
+
 }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -479,7 +479,6 @@ private:
     float _hgt_offset_cm[GPS_MAX_RECEIVERS]; // Filtered height offset from GPS instance relative to blended solution in _output_state.location (cm)
     Vector3f _blended_antenna_offset; // blended antenna offset
     float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
-    Location _output_location_corrected; // output location after application of the  filtered offset corrections _NE_pos_offset_m and _hgt_offset_cm
     uint32_t _last_time_updated[GPS_MAX_RECEIVERS]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -28,7 +28,8 @@
    maximum number of GPS instances available on this platform. If more
    than 1 then redundant sensors may be available
  */
-#define GPS_MAX_INSTANCES 2
+#define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not additional 'virtual' GPS created by blending receiver data
+#define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximumum number of GPs instances including the 'virtual' GPS created by blending receiver data
 #define GPS_RTK_INJECT_TO_ALL 127
 
 // the number of GPS leap seconds
@@ -326,7 +327,7 @@ public:
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const {
-        if (instance == GPS_MAX_INSTANCES) {
+        if (instance == GPS_MAX_RECEIVERS) {
             // return an offset for the blended GPS solution
             return _blended_antenna_offset;
         } else {
@@ -351,7 +352,7 @@ public:
     DataFlash_Class *_DataFlash;
 
     // configuration parameters
-    AP_Int8 _type[GPS_MAX_INSTANCES];
+    AP_Int8 _type[GPS_MAX_RECEIVERS];
     AP_Int8 _navfilter;
     AP_Int8 _auto_switch;
     AP_Int8 _min_dgps;
@@ -361,12 +362,12 @@ public:
     AP_Int8 _sbas_mode;
     AP_Int8 _min_elevation;
     AP_Int8 _raw_data;
-    AP_Int8 _gnss_mode[GPS_MAX_INSTANCES];
-    AP_Int16 _rate_ms[GPS_MAX_INSTANCES];
+    AP_Int8 _gnss_mode[GPS_MAX_RECEIVERS];
+    AP_Int16 _rate_ms[GPS_MAX_RECEIVERS];
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
-    AP_Vector3f _antenna_offset[GPS_MAX_INSTANCES];
-    AP_Int16 _delay_ms[GPS_MAX_INSTANCES];
+    AP_Vector3f _antenna_offset[GPS_MAX_RECEIVERS];
+    AP_Int16 _delay_ms[GPS_MAX_RECEIVERS];
     AP_Int8 _blend_mask;
     AP_Float _blend_tc;
 
@@ -406,10 +407,10 @@ private:
         uint32_t last_message_time_ms;
     };
     // Note allowance for an additional instance to contain blended data
-    GPS_timing timing[GPS_MAX_INSTANCES+1];
-    GPS_State state[GPS_MAX_INSTANCES+1];
-    AP_GPS_Backend *drivers[GPS_MAX_INSTANCES];
-    AP_HAL::UARTDriver *_port[GPS_MAX_INSTANCES];
+    GPS_timing timing[GPS_MAX_RECEIVERS+1];
+    GPS_State state[GPS_MAX_RECEIVERS+1];
+    AP_GPS_Backend *drivers[GPS_MAX_RECEIVERS];
+    AP_HAL::UARTDriver *_port[GPS_MAX_RECEIVERS];
 
     /// primary GPS instance
     uint8_t primary_instance:2;
@@ -432,12 +433,12 @@ private:
         struct NMEA_detect_state nmea_detect_state;
         struct SBP_detect_state sbp_detect_state;
         struct ERB_detect_state erb_detect_state;
-    } detect_state[GPS_MAX_INSTANCES];
+    } detect_state[GPS_MAX_RECEIVERS];
 
     struct {
         const char *blob;
         uint16_t remaining;
-    } initblob_state[GPS_MAX_INSTANCES];
+    } initblob_state[GPS_MAX_RECEIVERS];
 
     static const uint32_t  _baudrates[];
     static const char _initialisation_blob[];
@@ -474,12 +475,12 @@ private:
     void inject_data_all(const uint8_t *data, uint16_t len);
 
     // GPS blending and switching
-    Vector2f _NE_pos_offset_m[GPS_MAX_INSTANCES]; // Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
-    float _hgt_offset_cm[GPS_MAX_INSTANCES]; // Filtered height offset from GPS instance relative to blended solution in _output_state.location (cm)
+    Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS]; // Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
+    float _hgt_offset_cm[GPS_MAX_RECEIVERS]; // Filtered height offset from GPS instance relative to blended solution in _output_state.location (cm)
     Vector3f _blended_antenna_offset; // blended antenna offset
-    float _blend_weights[GPS_MAX_INSTANCES]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
+    float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
     Location _output_location_corrected; // output location after application of the  filtered offset corrections _NE_pos_offset_m and _hgt_offset_cm
-    uint32_t _last_time_updated[GPS_MAX_INSTANCES]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
+    uint32_t _last_time_updated[GPS_MAX_RECEIVERS]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -578,7 +578,7 @@ void NavEKF2::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 255, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), _ahrs->get_gps().primary_sensor(), imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -578,7 +578,7 @@ void NavEKF2::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 0, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 255, imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -1,5 +1,8 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/priseborough/
+  InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/
+  GenerateNavFilterEquations.m
+
   Converted from Matlab to C++ by Paul Riseborough
 
   EKF Tuning parameters refactored by Tom Cauchois

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -236,44 +236,6 @@ void NavEKF2_core::SelectVelPosFusion()
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE) {
-        // check if the GPS has changed and reset the position if it has
-        if (gpsDataDelayed.sensor_idx != last_gps_idx) {
-            // record the ID of the GPS that we are using for the reset
-            last_gps_idx = gpsDataDelayed.sensor_idx;
-
-            // Store the position before the reset so that we can record the reset delta
-            posResetNE.x = stateStruct.position.x;
-            posResetNE.y = stateStruct.position.y;
-
-            // Set the position states to the position from the new GPS
-            stateStruct.position.x = gpsDataNew.pos.x;
-            stateStruct.position.y = gpsDataNew.pos.y;
-
-            // Calculate the position offset due to the reset
-            posResetNE.x = stateStruct.position.x - posResetNE.x;
-            posResetNE.y = stateStruct.position.y - posResetNE.y;
-
-            // Add the offset to the output observer states
-            for (uint8_t i=0; i<imu_buffer_length; i++) {
-                storedOutput[i].position.x += posResetNE.x;
-                storedOutput[i].position.y += posResetNE.y;
-            }
-            outputDataNew.position.x += posResetNE.x;
-            outputDataNew.position.y += posResetNE.y;
-            outputDataDelayed.position.x += posResetNE.x;
-            outputDataDelayed.position.y += posResetNE.y;
-
-            // store the time of the reset
-            lastPosReset_ms = imuSampleTime_ms;
-        }
-        // Don't fuse velocity data if GPS doesn't support it
-        if (frontend->_fusionModeGPS <= 1) {
-            fuseVelData = true;
-        } else {
-            fuseVelData = false;
-        }
-        fusePosData = true;
-
         // correct GPS data for position offset of antenna phase centre relative to the IMU
         Vector3f posOffsetBody = _ahrs->get_gps().get_antenna_offset(gpsDataDelayed.sensor_idx) - accelPosOffset;
         if (!posOffsetBody.is_zero()) {
@@ -289,6 +251,16 @@ void NavEKF2_core::SelectVelPosFusion()
             gpsDataDelayed.pos.y -= posOffsetEarth.y;
             gpsDataDelayed.hgt += posOffsetEarth.z;
         }
+
+
+        // Don't fuse velocity data if GPS doesn't support it
+        if (frontend->_fusionModeGPS <= 1) {
+            fuseVelData = true;
+        } else {
+            fuseVelData = false;
+        }
+        fusePosData = true;
+
     } else {
         fuseVelData = false;
         fusePosData = false;
@@ -301,6 +273,54 @@ void NavEKF2_core::SelectVelPosFusion()
 
     // Select height data to be fused from the available baro, range finder and GPS sources
     selectHeightForFusion();
+
+    // if we are using GPS, check for a change in receiver and reset position and height
+    if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE && gpsDataDelayed.sensor_idx != last_gps_idx) {
+        // record the ID of the GPS that we are using for the reset
+        last_gps_idx = gpsDataDelayed.sensor_idx;
+
+        // Store the position before the reset so that we can record the reset delta
+        posResetNE.x = stateStruct.position.x;
+        posResetNE.y = stateStruct.position.y;
+
+        // Set the position states to the position from the new GPS
+        stateStruct.position.x = gpsDataNew.pos.x;
+        stateStruct.position.y = gpsDataNew.pos.y;
+
+        // Calculate the position offset due to the reset
+        posResetNE.x = stateStruct.position.x - posResetNE.x;
+        posResetNE.y = stateStruct.position.y - posResetNE.y;
+
+        // Add the offset to the output observer states
+        for (uint8_t i=0; i<imu_buffer_length; i++) {
+            storedOutput[i].position.x += posResetNE.x;
+            storedOutput[i].position.y += posResetNE.y;
+        }
+        outputDataNew.position.x += posResetNE.x;
+        outputDataNew.position.y += posResetNE.y;
+        outputDataDelayed.position.x += posResetNE.x;
+        outputDataDelayed.position.y += posResetNE.y;
+
+        // store the time of the reset
+        lastPosReset_ms = imuSampleTime_ms;
+
+        // If we are alseo using GPS as the height reference, reset the height
+        if (activeHgtSource == HGT_SOURCE_GPS) {
+            // Store the position before the reset so that we can record the reset delta
+            posResetD = stateStruct.position.z;
+
+            // write to the state vector
+            stateStruct.position.z = -hgtMea;
+            outputDataNew.position.z = stateStruct.position.z;
+            outputDataDelayed.position.z = stateStruct.position.z;
+
+            // Calculate the position jump due to the reset
+            posResetD = stateStruct.position.z - posResetD;
+
+            // store the time of the reset
+            lastPosResetD_ms = imuSampleTime_ms;
+        }
+    }
 
     // If we are operating without any aiding, fuse in the last known position
     // to constrain tilt drift. This assumes a non-manoeuvring vehicle

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -311,11 +311,16 @@ void NavEKF2_core::SelectVelPosFusion()
 
             // write to the state vector
             stateStruct.position.z = -hgtMea;
-            outputDataNew.position.z = stateStruct.position.z;
-            outputDataDelayed.position.z = stateStruct.position.z;
 
             // Calculate the position jump due to the reset
             posResetD = stateStruct.position.z - posResetD;
+
+            // Add the offset to the output observer states
+            outputDataNew.position.z += posResetD;
+            outputDataDelayed.position.z += posResetD;
+            for (uint8_t i=0; i<imu_buffer_length; i++) {
+                storedOutput[i].position.z += posResetD;
+            }
 
             // store the time of the reset
             lastPosResetD_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -90,6 +90,8 @@ void NavEKF2_core::ResetPosition(void)
     } else  {
         // Use GPS data as first preference if fresh data is available
         if (imuSampleTime_ms - lastTimeGpsReceived_ms < 250) {
+            // record the ID of the GPS for the data we are using for the reset
+            last_gps_idx = gpsDataNew.sensor_idx;
             // write to state vector and compensate for offset  between last GPS measurement and the EKF time horizon
             stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
             stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
@@ -234,6 +236,36 @@ void NavEKF2_core::SelectVelPosFusion()
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE) {
+        // check if the GPS has changed and reset the position if it has
+        if (gpsDataDelayed.sensor_idx != last_gps_idx) {
+            // record the ID of the GPS that we are using for the reset
+            last_gps_idx = gpsDataDelayed.sensor_idx;
+
+            // Store the position before the reset so that we can record the reset delta
+            posResetNE.x = stateStruct.position.x;
+            posResetNE.y = stateStruct.position.y;
+
+            // Set the position states to the position from the new GPS
+            stateStruct.position.x = gpsDataNew.pos.x;
+            stateStruct.position.y = gpsDataNew.pos.y;
+
+            // Calculate the position offset due to the reset
+            posResetNE.x = stateStruct.position.x - posResetNE.x;
+            posResetNE.y = stateStruct.position.y - posResetNE.y;
+
+            // Add the offset to the output observer states
+            for (uint8_t i=0; i<imu_buffer_length; i++) {
+                storedOutput[i].position.x += posResetNE.x;
+                storedOutput[i].position.y += posResetNE.y;
+            }
+            outputDataNew.position.x += posResetNE.x;
+            outputDataNew.position.y += posResetNE.y;
+            outputDataDelayed.position.x += posResetNE.x;
+            outputDataDelayed.position.y += posResetNE.y;
+
+            // store the time of the reset
+            lastPosReset_ms = imuSampleTime_ms;
+        }
         // Don't fuse velocity data if GPS doesn't support it
         if (frontend->_fusionModeGPS <= 1) {
             fuseVelData = true;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -314,6 +314,7 @@ void NavEKF2_core::InitialiseVariables()
     OffsetMinInnovFilt = 0.0f;
     rngBcnFuseDataReportIndex = 0;
     memset(&rngBcnFusionReport, 0, sizeof(rngBcnFusionReport));
+    last_gps_idx = 0;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -795,6 +795,7 @@ private:
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
+    uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     struct Location EKF_origin;     // LLH origin of the NED axis system - do not change unless filter is reset
     bool validOrigin;               // true when the EKF origin is valid
     float gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1,5 +1,7 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/priseborough/
+  InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/
+  GenerateNavFilterEquations.m
 
   Converted from Matlab to C++ by Paul Riseborough
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -576,7 +576,7 @@ void NavEKF3::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 255, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), _ahrs->get_gps().primary_sensor(), imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -576,7 +576,7 @@ void NavEKF3::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 0, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 255, imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -1,8 +1,8 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
-  Converted from Matlab to C++ by Paul Riseborough
+  24 state EKF based on the derivation in https://github.com/PX4/ecl/
+  blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 
-  EKF Tuning parameters refactored by Tom Cauchois
+  Converted from Matlab to C++ by Paul Riseborough
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -316,11 +316,16 @@ void NavEKF3_core::SelectVelPosFusion()
 
             // write to the state vector
             stateStruct.position.z = -hgtMea;
-            outputDataNew.position.z = stateStruct.position.z;
-            outputDataDelayed.position.z = stateStruct.position.z;
 
             // Calculate the position jump due to the reset
             posResetD = stateStruct.position.z - posResetD;
+
+            // Add the offset to the output observer states
+            outputDataNew.position.z += posResetD;
+            outputDataDelayed.position.z += posResetD;
+            for (uint8_t i=0; i<imu_buffer_length; i++) {
+                storedOutput[i].position.z += posResetD;
+            }
 
             // store the time of the reset
             lastPosResetD_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -241,46 +241,6 @@ void NavEKF3_core::SelectVelPosFusion()
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE) {
-        // check if the GPS has changed and reset the position if it has
-        if (gpsDataDelayed.sensor_idx != last_gps_idx) {
-            // record the ID of the GPS that we are using for the reset
-            last_gps_idx = gpsDataDelayed.sensor_idx;
-
-            // Store the position before the reset so that we can record the reset delta
-            posResetNE.x = stateStruct.position.x;
-            posResetNE.y = stateStruct.position.y;
-
-            // Set the position states to the position from the new GPS
-            stateStruct.position.x = gpsDataNew.pos.x;
-            stateStruct.position.y = gpsDataNew.pos.y;
-
-            // Calculate the position offset due to the reset
-            posResetNE.x = stateStruct.position.x - posResetNE.x;
-            posResetNE.y = stateStruct.position.y - posResetNE.y;
-
-            // Add the offset to the output observer states
-            for (uint8_t i=0; i<imu_buffer_length; i++) {
-                storedOutput[i].position.x += posResetNE.x;
-                storedOutput[i].position.y += posResetNE.y;
-            }
-            outputDataNew.position.x += posResetNE.x;
-            outputDataNew.position.y += posResetNE.y;
-            outputDataDelayed.position.x += posResetNE.x;
-            outputDataDelayed.position.y += posResetNE.y;
-
-            // store the time of the reset
-            lastPosReset_ms = imuSampleTime_ms;
-
-        }
-
-        // Don't fuse velocity data if GPS doesn't support it
-        if (frontend->_fusionModeGPS <= 1) {
-            fuseVelData = true;
-        } else {
-            fuseVelData = false;
-        }
-        fusePosData = true;
-
         // correct GPS data for position offset of antenna phase centre relative to the IMU
         Vector3f posOffsetBody = _ahrs->get_gps().get_antenna_offset(gpsDataDelayed.sensor_idx) - accelPosOffset;
         if (!posOffsetBody.is_zero()) {
@@ -296,6 +256,16 @@ void NavEKF3_core::SelectVelPosFusion()
             gpsDataDelayed.pos.y -= posOffsetEarth.y;
             gpsDataDelayed.hgt += posOffsetEarth.z;
         }
+
+
+        // Don't fuse velocity data if GPS doesn't support it
+        if (frontend->_fusionModeGPS <= 1) {
+            fuseVelData = true;
+        } else {
+            fuseVelData = false;
+        }
+        fusePosData = true;
+
     } else {
         fuseVelData = false;
         fusePosData = false;
@@ -308,6 +278,54 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // Select height data to be fused from the available baro, range finder and GPS sources
     selectHeightForFusion();
+
+    // if we are using GPS, check for a change in receiver and reset position and height
+    if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE && gpsDataDelayed.sensor_idx != last_gps_idx) {
+        // record the ID of the GPS that we are using for the reset
+        last_gps_idx = gpsDataDelayed.sensor_idx;
+
+        // Store the position before the reset so that we can record the reset delta
+        posResetNE.x = stateStruct.position.x;
+        posResetNE.y = stateStruct.position.y;
+
+        // Set the position states to the position from the new GPS
+        stateStruct.position.x = gpsDataNew.pos.x;
+        stateStruct.position.y = gpsDataNew.pos.y;
+
+        // Calculate the position offset due to the reset
+        posResetNE.x = stateStruct.position.x - posResetNE.x;
+        posResetNE.y = stateStruct.position.y - posResetNE.y;
+
+        // Add the offset to the output observer states
+        for (uint8_t i=0; i<imu_buffer_length; i++) {
+            storedOutput[i].position.x += posResetNE.x;
+            storedOutput[i].position.y += posResetNE.y;
+        }
+        outputDataNew.position.x += posResetNE.x;
+        outputDataNew.position.y += posResetNE.y;
+        outputDataDelayed.position.x += posResetNE.x;
+        outputDataDelayed.position.y += posResetNE.y;
+
+        // store the time of the reset
+        lastPosReset_ms = imuSampleTime_ms;
+
+        // If we are alseo using GPS as the height reference, reset the height
+        if (activeHgtSource == HGT_SOURCE_GPS) {
+            // Store the position before the reset so that we can record the reset delta
+            posResetD = stateStruct.position.z;
+
+            // write to the state vector
+            stateStruct.position.z = -hgtMea;
+            outputDataNew.position.z = stateStruct.position.z;
+            outputDataDelayed.position.z = stateStruct.position.z;
+
+            // Calculate the position jump due to the reset
+            posResetD = stateStruct.position.z - posResetD;
+
+            // store the time of the reset
+            lastPosResetD_ms = imuSampleTime_ms;
+        }
+    }
 
     // If we are operating without any aiding, fuse in the last known position
     // to constrain tilt drift. This assumes a non-manoeuvring vehicle

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -249,7 +249,7 @@ void NavEKF3_core::InitialiseVariables()
     baroStoreIndex = 0;
     rangeStoreIndex = 0;
     magStoreIndex = 0;
-    gpsStoreIndex = 0;
+    last_gps_idx = 0;
     tasStoreIndex = 0;
     ofStoreIndex = 0;
     delAngCorrection.zero();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -848,7 +848,7 @@ private:
     uint8_t magStoreIndex;          // Magnetometer data storage index
     gps_elements gpsDataNew;        // GPS data at the current time horizon
     gps_elements gpsDataDelayed;    // GPS data at the fusion time horizon
-    uint8_t gpsStoreIndex;          // GPS data storage index
+    uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     output_elements outputDataNew;  // output state data at the current time step
     output_elements outputDataDelayed; // output state data at the current time step
     Vector3f delAngCorrection;      // correction applied to delta angles used by output observer to track the EKF

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1,6 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/PX4/ecl/
+  blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 
   Converted from Matlab to C++ by Paul Riseborough
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -710,7 +710,12 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, uint64_t time_
     if (time_us == 0) {
         time_us = AP_HAL::micros64();
     }
-    const struct Location &loc = gps.location(i);
+    struct Location loc;
+    if (i >= gps.num_sensors()) {
+        loc = gps.location();
+    } else {
+        loc = gps.location(i);
+    }
     struct log_GPS pkt = {
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GPS_MSG+i)),
         time_us       : time_us,

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -710,12 +710,7 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, uint64_t time_
     if (time_us == 0) {
         time_us = AP_HAL::micros64();
     }
-    struct Location loc;
-    if (i >= gps.num_sensors()) {
-        loc = gps.location();
-    } else {
-        loc = gps.location(i);
-    }
+    const struct Location &loc = gps.location(i);
     struct log_GPS pkt = {
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GPS_MSG+i)),
         time_us       : time_us,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -783,6 +783,8 @@ Format characters in the format string for binary log messages
       "GPS",  "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPS2_MSG, sizeof(log_GPS), \
       "GPS2", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
+    { LOG_GPS3_MSG, sizeof(log_GPS), \
+       "GPS3", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPA_MSG,  sizeof(log_GPA), \
       "GPA",  "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_GPA2_MSG, sizeof(log_GPA), \
@@ -985,6 +987,7 @@ enum LogMessages {
     LOG_PARAMETER_MSG,
     LOG_GPS_MSG,
     LOG_GPS2_MSG,
+    LOG_GPS3_MSG,
     LOG_IMU_MSG,
     LOG_MESSAGE_MSG,
     LOG_RCIN_MSG,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -789,6 +789,8 @@ Format characters in the format string for binary log messages
       "GPA",  "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_GPA2_MSG, sizeof(log_GPA), \
       "GPA2", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
+    { LOG_GPA3_MSG, sizeof(log_GPA), \
+      "GPA3", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QffffffIIfBB",     "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt" }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \
@@ -1049,6 +1051,7 @@ enum LogMessages {
     LOG_RPM_MSG,
     LOG_GPA_MSG,
     LOG_GPA2_MSG,
+    LOG_GPA3_MSG,
     LOG_RFND_MSG,
     LOG_BAR3_MSG,
     LOG_NKF1_MSG,


### PR DESCRIPTION
**Problem**

The existing logic used to switch between GPS receivers can cause large unpredictable jumps in EKF position if dual GPs receivers are fitted and GPS_AUTO_SWITCH is set to 1.

**Solution**

Extend the GPS_AUTO_SWITCH to type 2 which is a soft switching/blending method using a weighted average of physical receivers to create a third 'virtual' GPS where:

1) The method is scaleable to more than 2 GPS receivers
2) A 'blended' location and velocity is calculated using a weighted average of the two receivers
3) Weights are calculated using the ratio of reported error variances.
4) A filtered location  offset correction is calculated for each receiver relative to the 'blended' location and used to correct the output from each receiver.
5) If less than 2 GPS units are available the first GPS instance detected will be used.
6) If there is not enough error reporting to support calculation of the blending weights, the first receiver with the equal highest solution status value will be used . This can happen if one of the two receivers does not provide a position or speed accuracy.

The existing hard switch logic has been left untouched and is selected with GPS_AUTO_SWITCH = 1 the same as before.

Logging has been updated to to log the blended GPS instance if it is being calculated.

**Status**

This is a draft for comment. it has had limited flight and bench testing.

**TODO**

Improve the legacy hard switch logic to use solution status and reported accuracy (if available) rather than number of satellites. Using the number of satellites doesn't work as a metric where there are mixed receiver models (eg GPS+GLONASS and GPS only).
Bench testing of various GPS failure modes - signal fade, loss of physical connection.