### PR TITLE
Reduce the risk of the buzzer affecting IMU's during the battery alarm

### DIFF
--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -52,7 +52,7 @@ const ToneAlarm_PX4::Tone ToneAlarm_PX4::_tones[] {
     #define AP_NOTIFY_PX4_TONE_QUIET_READY_OR_FINISHED 7
     { "MFT200L4<G#6A#6B#4", false },
     #define AP_NOTIFY_PX4_TONE_LOUD_ATTENTION_NEEDED 8
-    { "MFT100L4>B#B#B#B#", false },
+    { "MFT100L4>A#A#A#A#", false },
     #define AP_NOTIFY_PX4_TONE_QUIET_ARMING_WARNING 9
     { "MNT75L1O2G", false },
     #define AP_NOTIFY_PX4_TONE_LOUD_WP_COMPLETE 10
@@ -60,9 +60,9 @@ const ToneAlarm_PX4::Tone ToneAlarm_PX4::_tones[] {
     #define AP_NOTIFY_PX4_TONE_LOUD_LAND_WARNING_CTS 11
     { "MBT200L2A-G-A-G-A-G-", true },
     #define AP_NOTIFY_PX4_TONE_LOUD_VEHICLE_LOST_CTS 12
-    { "MBT200>B#1", true },
+    { "MBT200>A#1", true },
     #define AP_NOTIFY_PX4_TONE_LOUD_BATTERY_ALERT_CTS 13
-    { "MBNT255>B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8", true },
+    { "MBNT255>A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8A#8", true },
     #define AP_NOTIFY_PX4_TONE_QUIET_COMPASS_CALIBRATING_CTS 14
     { "MBNT255<C16P2", true },
     #define AP_NOTIFY_PX4_TONE_WAITING_FOR_THROW 15


### PR DESCRIPTION
Replicating work By Kevin Mehall to reduce the risk of IMU aliasing due to battery failsafe alarm