### PR TITLE
Warning removals

### DIFF
--- a/Tools/ardupilotwaf/cmake.py
+++ b/Tools/ardupilotwaf/cmake.py
@@ -135,7 +135,7 @@ import sys
 
 class cmake_configure_task(Task.Task):
     vars = ['CMAKE_BLD_DIR']
-    run_str = '${CMAKE} ${CMAKE_SRC_DIR} ${CMAKE_VARS} ${CMAKE_GENERATOR_OPTION}'
+    run_str = '${CMAKE} ${CMAKE_FLAGS} ${CMAKE_SRC_DIR} ${CMAKE_VARS} ${CMAKE_GENERATOR_OPTION}'
     color = 'BLUE'
 
     def exec_command(self, cmd, **kw):
@@ -151,6 +151,7 @@ class cmake_configure_task(Task.Task):
             u(self.env.get_flat('CMAKE_SRC_DIR'))
             u(self.env.get_flat('CMAKE_BLD_DIR'))
             u(self.env.get_flat('CMAKE_VARS'))
+            u(self.env.get_flat('CMAKE_FLAGS'))
             self.uid_ = m.digest()
 
         return self.uid_
@@ -219,12 +220,13 @@ class CMakeConfig(object):
     CMake configuration. This object shouldn't be instantiated directly. Use
     bld.cmake().
     '''
-    def __init__(self, bld, name, srcnode, bldnode, cmake_vars):
+    def __init__(self, bld, name, srcnode, bldnode, cmake_vars, cmake_flags):
         self.bld = bld
         self.name = name
         self.srcnode = srcnode
         self.bldnode = bldnode
         self.vars = cmake_vars
+        self.flags = cmake_flags
 
         self._config_task = None
         self.last_build_task = None
@@ -241,6 +243,8 @@ class CMakeConfig(object):
             m.update(s.encode('utf-8'))
         u(self.srcnode.abspath())
         u(self.bldnode.abspath())
+        for v in self.flags:
+            u(v)
         keys = self.vars_keys()
         for k in keys:
             u(k)
@@ -263,6 +267,7 @@ class CMakeConfig(object):
 
         keys = self.vars_keys()
         env.CMAKE_VARS = ["-D%s='%s'" % (k, self.vars[k]) for k in keys]
+        env.CMAKE_FLAGS = self.flags
 
         self._config_task.set_outputs(
             self.bldnode.find_or_declare('CMakeCache.txt'),
@@ -285,7 +290,7 @@ def get_cmake(name):
     return _cmake_instances[name]
 
 @conf
-def cmake(bld, name, cmake_src=None, cmake_bld=None, cmake_vars={}):
+def cmake(bld, name, cmake_src=None, cmake_bld=None, cmake_vars={}, cmake_flags=''):
     '''
     This function has two signatures:
      - bld.cmake(name, cmake_src, cmake_bld, cmake_vars):
@@ -307,7 +312,7 @@ def cmake(bld, name, cmake_src=None, cmake_bld=None, cmake_vars={}):
     elif not isinstance(cmake_bld, Node.Node):
         cmake_bld = bld.bldnode.make_node(cmake_bld)
 
-    c = CMakeConfig(bld, name, cmake_src, cmake_bld, cmake_vars)
+    c = CMakeConfig(bld, name, cmake_src, cmake_bld, cmake_vars, cmake_flags)
     _cmake_instances[name] = c
     return c
 

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -286,6 +286,7 @@ def build(bld):
         name='px4',
         cmake_src=bld.srcnode.find_dir('modules/PX4Firmware'),
         cmake_vars=bld.env.PX4_CMAKE_VARS,
+        cmake_flags=['-Wno-deprecated'],
     )
 
     px4.build(

--- a/Tools/scripts/install-apt-ci.sh
+++ b/Tools/scripts/install-apt-ci.sh
@@ -3,9 +3,22 @@
 
 set -ex
 
-PKGS="build-essential gawk ccache genromfs libc6-i386 \
-      libxml2-dev libxslt1-dev python-dev python-pip zlib1g-dev \
-      gcc-4.9 g++-4.9 cmake cmake-data" # clang-3.7 llvm-3.7"
+PKGS=" \
+    build-essential \
+    gawk \
+    ccache \
+    genromfs \
+    libc6-i386 \
+    libxml2-dev \
+    libxslt1-dev \
+    python-pip \
+    python-dev \
+    zlib1g-dev \
+    gcc-4.9 \
+    g++-4.9 \
+    cmake \
+    cmake-data \
+    "
 
 read -r UBUNTU_CODENAME <<<$(lsb_release -c -s)
 

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -154,9 +154,9 @@ AP_GPS_ERB::_parse_gps(void)
     case MSG_POS:
         Debug("Message POS");
         _last_pos_time        = _buffer.pos.time;
-        state.location.lng    = (int32_t)(_buffer.pos.longitude * 1e7);
-        state.location.lat    = (int32_t)(_buffer.pos.latitude * 1e7);
-        state.location.alt    = (int32_t)(_buffer.pos.altitude_msl * 1e2);
+        state.location.lng    = (int32_t)(_buffer.pos.longitude * (double)1e7);
+        state.location.lat    = (int32_t)(_buffer.pos.latitude * (double)1e7);
+        state.location.alt    = (int32_t)(_buffer.pos.altitude_msl * 100);
         state.status          = next_fix;
         _new_position = true;
         state.horizontal_accuracy = _buffer.pos.horizontal_accuracy * 1.0e-3f;

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -294,9 +294,9 @@ AP_GPS_GSOF::process_message(void)
             }
             else if (output_type == 2) // position
             {
-                state.location.lat = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a)) * 1e7);
-                state.location.lng = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a + 8)) * 1e7);
-                state.location.alt = (int32_t)(SwapDouble(gsof_msg.data, a + 16) * 1e2);
+                state.location.lat = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a)) * (double)1e7);
+                state.location.lng = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a + 8)) * (double)1e7);
+                state.location.alt = (int32_t)(SwapDouble(gsof_msg.data, a + 16) * 100);
 
                 state.last_gps_time_ms = state.time_week_ms;
 

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -196,9 +196,9 @@ AP_GPS_NOVA::process_message(void)
         state.time_week_ms = (uint32_t) nova_msg.header.nova_headeru.tow;
         state.last_gps_time_ms = state.time_week_ms;
 
-        state.location.lat = (int32_t) (bestposu.lat*1e7);
-        state.location.lng = (int32_t) (bestposu.lng*1e7);
-        state.location.alt = (int32_t) (bestposu.hgt*1e2);
+        state.location.lat = (int32_t) (bestposu.lat * (double)1e7);
+        state.location.lng = (int32_t) (bestposu.lng * (double)1e7);
+        state.location.alt = (int32_t) (bestposu.hgt * 100);
 
         state.num_sats = bestposu.svsused;
 

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -236,9 +236,9 @@ AP_GPS_SBF::process_message(void)
 
         // Update position state (don't use −2·10^10)
         if (temp.Latitude > -200000) {
-            state.location.lat = (int32_t)(temp.Latitude * RAD_TO_DEG_DOUBLE * 1e7);
-            state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * 1e7);
-            state.location.alt = (int32_t)(((float)temp.Height - temp.Undulation) * 1e2f );
+            state.location.lat = (int32_t)(temp.Latitude * RAD_TO_DEG_DOUBLE * (double)1e7);
+            state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * (double)1e7);
+            state.location.alt = (int32_t)(((float)temp.Height - temp.Undulation) * 1e2f);
         }
 
         if (temp.NrSV != 255) {

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -274,9 +274,9 @@ AP_GPS_SBP::_attempt_state_update()
 
         // Update position state
 
-        state.location.lat      = (int32_t) (pos_llh->lat*1e7);
-        state.location.lng      = (int32_t) (pos_llh->lon*1e7);
-        state.location.alt      = (int32_t) (pos_llh->height*1e2);
+        state.location.lat      = (int32_t) (pos_llh->lat * (double)1e7);
+        state.location.lng      = (int32_t) (pos_llh->lon * (double)1e7);
+        state.location.alt      = (int32_t) (pos_llh->height * 100);
         state.num_sats          = pos_llh->n_sats;
 
         if (pos_llh->flags == 0) {

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -384,7 +384,7 @@ void AP_Landing::type_slope_log(void) const
                                             type_slope_stage,
                                             flags,
                                             type_slope_flags,
-                                            slope,
-                                            initial_slope,
-                                            alt_offset);
+                                            (double)slope,
+                                            (double)initial_slope,
+                                            (double)alt_offset);
 }

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -33,8 +33,8 @@
 // GPS Specific double precision conversions
 // The precision here does matter when using the wsg* functions for converting
 // between LLH and ECEF coordinates.
-#define DEG_TO_RAD_DOUBLE 0.0174532925199432954743716805978692718781530857086181640625
-#define RAD_TO_DEG_DOUBLE 57.29577951308232286464772187173366546630859375
+static const double DEG_TO_RAD_DOUBLE = asin(1) / 90;
+static const double RAD_TO_DEG_DOUBLE = 1 / DEG_TO_RAD_DOUBLE;
 
 #define RadiansToCentiDegrees(x) (static_cast<float>(x) * RAD_TO_DEG * static_cast<float>(100))
 
@@ -50,15 +50,19 @@
 #define LATLON_TO_CM    1.113195f
 
 // Semi-major axis of the Earth, in meters.
-#define WGS84_A         6378137.0
+static const double WGS84_A = 6378137.0;
+
 //Inverse flattening of the Earth
-#define WGS84_IF        298.257223563
+static const double WGS84_IF = 298.257223563;
+
 // The flattening of the Earth
-#define WGS84_F         (1.0 / WGS84_IF)
+static const double WGS84_F = ((double)1.0 / WGS84_IF);
+
 // Semi-minor axis of the Earth in meters
-#define WGS84_B         (WGS84_A * (1 - WGS84_F))
+static const double WGS84_B = (WGS84_A * (1 - WGS84_F));
+
 // Eccentricity of the Earth
-#define WGS84_E         (sqrt(2 * WGS84_F - WGS84_F * WGS84_F))
+static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 
 #define NSEC_PER_SEC    1000000000ULL
 #define NSEC_PER_USEC   1000ULL

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -4,30 +4,17 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-// Double precision math must be activated
-#if defined(DBL_MATH) && CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-  #ifndef M_PI
-    #define M_PI      (3.14159265358979323846)
-  #endif
-
-  #ifndef M_PI_2
-    #define M_PI_2    (M_PI / 2)
-  #endif
-
-  #define M_GOLDEN    1.618033988749894
-#else    // Standard single precision math
-  #ifdef M_PI
-    #undef M_PI
-  #endif
-  #define M_PI      (3.141592653589793f)
-
-  #ifdef M_PI_2
-    #undef M_PI_2
-  #endif
-  #define M_PI_2    (M_PI / 2)
-
-  #define M_GOLDEN  1.6180339f
+#ifdef M_PI
+# undef M_PI
 #endif
+#define M_PI      (3.141592653589793f)
+
+#ifdef M_PI_2
+# undef M_PI_2
+#endif
+#define M_PI_2    (M_PI / 2)
+
+#define M_GOLDEN  1.6180339f
 
 #define M_2PI         (M_PI * 2)
 

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -202,7 +202,7 @@ void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon)
 
 void wgsllh2ecef(const Vector3d &llh, Vector3d &ecef) {
   double d = WGS84_E * sin(llh[0]);
-  double N = WGS84_A / sqrt(1. - d*d);
+  double N = WGS84_A / sqrt(1 - d*d);
 
   ecef[0] = (N + llh[2]) * cos(llh[0]) * cos(llh[1]);
   ecef[1] = (N + llh[2]) * cos(llh[0]) * sin(llh[1]);
@@ -222,7 +222,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
 
   /* If we are close to the pole then convergence is very slow, treat this is a
    * special case. */
-  if (p < WGS84_A*1e-16) {
+  if (p < WGS84_A * double(1e-16)) {
     llh[0] = copysign(M_PI_2, ecef[2]);
     llh[2] = fabs(ecef[2]) - WGS84_B;
     return;
@@ -230,7 +230,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
 
   /* Calculate some other constants as defined in the Fukushima paper. */
   const double P = p / WGS84_A;
-  const double e_c = sqrt(1. - WGS84_E*WGS84_E);
+  const double e_c = sqrt(1 - WGS84_E*WGS84_E);
   const double Z = fabs(ecef[2]) * e_c / WGS84_A;
 
   /* Initial values for S and C correspond to a zero height solution. */
@@ -253,7 +253,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
     A_n = sqrt(S*S + C*C);
     D_n = Z*A_n*A_n*A_n + WGS84_E*WGS84_E*S*S*S;
     F_n = P*A_n*A_n*A_n - WGS84_E*WGS84_E*C*C*C;
-    B_n = 1.5*WGS84_E*S*C*C*(A_n*(P*S - Z*C) - WGS84_E*S*C);
+    B_n = double(1.5) * WGS84_E*S*C*C*(A_n*(P*S - Z*C) - WGS84_E*S*C);
 
     /* Update step. */
     S = D_n*F_n - B_n*S;
@@ -289,7 +289,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
     }
 
     /* Check for convergence and exit early if we have converged. */
-    if (fabs(S - prev_S) < 1e-16 && fabs(C - prev_C) < 1e-16) {
+    if (fabs(S - prev_S) < double(1e-16) && fabs(C - prev_C) < double(1e-16)) {
       break;
     } else {
       prev_S = S;

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -84,7 +84,7 @@ TEST(MathTest, IsEqual)
     EXPECT_TRUE(is_equal(1.f, (float)(1.f - DBL_EPSILON)));
 
     // false because the common type is double
-    EXPECT_FALSE(is_equal(1., 1. + 2 * std::numeric_limits<double>::epsilon()));
+    EXPECT_FALSE(is_equal(double(1.), 1 + 2 * std::numeric_limits<double>::epsilon()));
 
     // true because the common type is float
     EXPECT_TRUE(is_equal(1.f, (float)(1. + std::numeric_limits<double>::epsilon())));

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -436,4 +436,3 @@ template bool Vector3<double>::operator ==(const Vector3<double> &v) const;
 template bool Vector3<double>::operator !=(const Vector3<double> &v) const;
 template bool Vector3<double>::is_nan(void) const;
 template bool Vector3<double>::is_inf(void) const;
-template float Vector3<double>::angle(const Vector3<double> &v) const;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -542,11 +542,16 @@ public:
             set(v);
         }
     }
-    
+
     /// Value setter - set value, tell GCS
     ///
     void set_and_notify(const T &v) {
+// We do want to compare each value, even floats, since it being the same here
+// is the result of previously setting it.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
         if (v != _value) {
+#pragma GCC diagnostic pop
             set(v);
             notify();
         }

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -28,7 +28,12 @@ This provides some support code and variables for MAVLink enabled sketches
 
 
 #ifdef MAVLINK_SEPARATE_HELPERS
+// Shut up warnings about missing declarations; TODO: should be fixed on
+// mavlink/pymavlink project for when MAVLINK_SEPARATE_HELPERS is defined
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #include "include/mavlink/v2.0/mavlink_helpers.h"
+#pragma GCC diagnostic pop
 #endif
 
 AP_HAL::UARTDriver	*mavlink_comm_port[MAVLINK_COMM_NUM_BUFFERS];


### PR DESCRIPTION
Alternative to my suggestion on #5620 

We go the other way around as requested by @tridge and make sure double literals are handled as floats, proper double casts are put in place where needed and double functions removed when possible.

I'm not sure about this commit: "AP_Param: compare direct memory values"... it can go wrong if the value is coming from somewhere else.  Alternative is another commit with pragmas for warning suppression that I have stashed here.