### PR TITLE
AP_BattMonitor: Added Maxcell Battery support

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -18,16 +18,18 @@
 class AP_BattMonitor_Backend;
 class AP_BattMonitor_Analog;
 class AP_BattMonitor_SMBus;
-class AP_BattMonitor_SMBus_I2C;
+class AP_BattMonitor_SMBus_Solo;
 class AP_BattMonitor_SMBus_PX4;
+class AP_BattMonitor_SMBus_Maxcell;
 
 class AP_BattMonitor
 {
     friend class AP_BattMonitor_Backend;
     friend class AP_BattMonitor_Analog;
     friend class AP_BattMonitor_SMBus;
-    friend class AP_BattMonitor_SMBus_I2C;
+    friend class AP_BattMonitor_SMBus_Solo;
     friend class AP_BattMonitor_SMBus_PX4;
+    friend class AP_BattMonitor_SMBus_Maxcell;
 
 public:
 
@@ -40,7 +42,8 @@ public:
         BattMonitor_TYPE_ANALOG_VOLTAGE_ONLY        = 3,
         BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT = 4,
         BattMonitor_TYPE_SMBUS                      = 5,
-        BattMonitor_TYPE_BEBOP                      = 6
+        BattMonitor_TYPE_BEBOP                      = 6,
+        BattMonitor_TYPE_MAXCELL                    = 7
     };
 
     // The BattMonitor_State structure is filled in by the backend driver

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -23,4 +23,5 @@ public:
 
 // include specific implementations
 #include "AP_BattMonitor_SMBus_PX4.h"
-#include "AP_BattMonitor_SMBus_I2C.h"
+#include "AP_BattMonitor_SMBus_Solo.h"
+#include "AP_BattMonitor_SMBus_Maxcell.h"

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxcell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxcell.cpp
@@ -1,0 +1,103 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_BattMonitor.h"
+#include "AP_BattMonitor_SMBus_Maxcell.h"
+#include <utility>
+
+extern const AP_HAL::HAL& hal;
+
+#include <AP_HAL/AP_HAL.h>
+
+#define BATTMONITOR_SMBUS_TEMP      0x08    // temperature register
+#define BATTMONITOR_SMBUS_VOLTAGE   0x09    // voltage register
+#define BATTMONITOR_SMBUS_CURRENT               0x0a    // current register
+#define BATTMONITOR_SMBUS_CHARGE_STATUS         0x0d    // relative state of charge
+#define BATTMONITOR_SMBUS_BATTERY_STATUS        0x16    // battery status register including alarms
+#define BATTMONITOR_SMBUS_BATTERY_CYCLE_COUNT   0x17    // cycle count
+#define BATTMONITOR_SMBUS_DESIGN_VOLTAGE        0x19    // design voltage register
+#define BATTMONITOR_SMBUS_SPECIFICATION_INFO    0x1a    // specification info
+#define BATTMONITOR_SMBUS_MANUFACTURE_NAME      0x1b    // manufacturer name
+#define BATTMONITOR_SMBUS_SERIALNUM             0x1c    // serial number register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE6         0x3a    // cell voltage register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE5         0x3b    // cell voltage register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE4         0x3c    // cell voltage register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE3         0x3d    // cell voltage register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE2         0x3e    // cell voltage register
+#define BATTMONITOR_SMBUS_CELL_VOLTAGE1         0x3f    // cell voltage register
+#define BATTMONITOR_SMBUS_HEALTH_STATUS         0x4f    // state of health
+#define BATTMONITOR_SMBUS_SAFETY_ALERT          0x50    // safety alert
+#define BATTMONITOR_SMBUS_SAFETY_STATUS         0x50    // safety status
+#define BATTMONITOR_SMBUS_PF_ALERT              0x52    // safety status
+#define BATTMONITOR_SMBUS_PF_STATUS             0x53    // safety status
+
+// Constructor
+AP_BattMonitor_SMBus_Maxcell::AP_BattMonitor_SMBus_Maxcell(AP_BattMonitor &mon, uint8_t instance,
+                                                   AP_BattMonitor::BattMonitor_State &mon_state,
+                                                   AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+    : AP_BattMonitor_SMBus(mon, instance, mon_state)
+    , _dev(std::move(dev))
+{
+    _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Maxcell::timer, void));
+}
+
+/// Read the battery voltage and current.  Should be called at 10hz
+void AP_BattMonitor_SMBus_Maxcell::read()
+{
+    // nothing to do - all done in timer()
+}
+
+void AP_BattMonitor_SMBus_Maxcell::timer()
+{
+    uint16_t data;
+    uint32_t tnow = AP_HAL::micros();
+
+//    // read temperature (K)
+//    if (read_word(BATTMONITOR_SMBUS_TEMP, data, 2)) {
+//    	float temperature = (float)data / 10.0f;
+//    }
+//
+//    // read relative state of charge (0-100%)
+//    if (read_word(BATTMONITOR_SMBUS_CHARGE_STATUS, data, 1)) {
+//    	uint8_t capacity_remaining = data;
+//    }
+
+    // read voltage (V)
+    if (read_word(BATTMONITOR_SMBUS_VOLTAGE, data, 2)) {
+        _state.voltage = (float)data / 1000.0f;
+        _state.last_time_micros = tnow;
+        _state.healthy = true;
+    }
+
+    // read current (A)
+    if (read_word(BATTMONITOR_SMBUS_CURRENT, data, 2)) {
+        _state.current_amps = (float)((int16_t)data) / 1000.0f;
+        _state.last_time_micros = tnow;
+    }
+
+    // timeout after 5 seconds
+    if ((tnow - _state.last_time_micros) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
+        _state.healthy = false;
+    }
+}
+
+// read word from register
+// returns true if read was successful, false if failed
+bool AP_BattMonitor_SMBus_Maxcell::read_word(uint8_t reg, uint16_t& data, uint8_t size) const
+{
+    uint8_t buff[size];    // buffer to hold results
+
+    // read three bytes and place in last three bytes of buffer
+    if (!_dev->read_registers(reg, buff, sizeof(buff))) {
+        return false;
+    }
+
+    // convert buffer to word
+    data = (uint16_t)buff[0];
+    for (int i = 1; i < size; i++) {
+        data |= (uint16_t)buff[i]<<(8*i);
+    }
+
+    // return success
+    return true;
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxcell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxcell.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_BattMonitor_SMBus.h"
+#include <AP_HAL/I2CDevice.h>
+
+#define BATTMONITOR_SBUS_I2C_BUS 1
+#define BATTMONITOR_SMBUS_I2C_ADDR 0x0B    // default I2C bus address
+
+class AP_BattMonitor_SMBus_Maxcell : public AP_BattMonitor_SMBus
+{
+public:
+
+    // Constructor
+    AP_BattMonitor_SMBus_Maxcell(AP_BattMonitor &mon, uint8_t instance,
+                             AP_BattMonitor::BattMonitor_State &mon_state,
+                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
+    // Read the battery voltage and current.  Should be called at 10hz
+    void read();
+
+private:
+
+    void timer(void);
+
+    // read word from register
+    // returns true if read was successful, false if failed
+    bool read_word(uint8_t reg, uint16_t& data, uint8_t size) const;
+
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+};

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -2,7 +2,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include "AP_BattMonitor.h"
-#include "AP_BattMonitor_SMBus_I2C.h"
+#include "AP_BattMonitor_SMBus_Solo.h"
 #include <utility>
 
 extern const AP_HAL::HAL& hal;
@@ -24,22 +24,22 @@ extern const AP_HAL::HAL& hal;
 #define BATTMONITOR_SMBUS_CURRENT               0x2a    // current register
 
 // Constructor
-AP_BattMonitor_SMBus_I2C::AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance,
+AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon, uint8_t instance,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
                                                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
     : AP_BattMonitor_SMBus(mon, instance, mon_state)
     , _dev(std::move(dev))
 {
-    _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_I2C::timer, void));
+    _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Solo::timer, void));
 }
 
 /// Read the battery voltage and current.  Should be called at 10hz
-void AP_BattMonitor_SMBus_I2C::read()
+void AP_BattMonitor_SMBus_Solo::read()
 {
     // nothing to do - all done in timer()
 }
 
-void AP_BattMonitor_SMBus_I2C::timer()
+void AP_BattMonitor_SMBus_Solo::timer()
 {
     uint16_t data;
     uint8_t buff[4];
@@ -66,7 +66,7 @@ void AP_BattMonitor_SMBus_I2C::timer()
 
 // read word from register
 // returns true if read was successful, false if failed
-bool AP_BattMonitor_SMBus_I2C::read_word(uint8_t reg, uint16_t& data) const
+bool AP_BattMonitor_SMBus_Solo::read_word(uint8_t reg, uint16_t& data) const
 {
     uint8_t buff[3];    // buffer to hold results
 
@@ -89,7 +89,7 @@ bool AP_BattMonitor_SMBus_I2C::read_word(uint8_t reg, uint16_t& data) const
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful
-uint8_t AP_BattMonitor_SMBus_I2C::read_block(uint8_t reg, uint8_t* data, uint8_t max_len, bool append_zero) const
+uint8_t AP_BattMonitor_SMBus_Solo::read_block(uint8_t reg, uint8_t* data, uint8_t max_len, bool append_zero) const
 {
     uint8_t buff[max_len+2];    // buffer to hold results (2 extra byte returned holding length and PEC)
 
@@ -127,7 +127,7 @@ uint8_t AP_BattMonitor_SMBus_I2C::read_block(uint8_t reg, uint8_t* data, uint8_t
 #define SMBUS_PEC_POLYNOME  0x07 // Polynome for CRC generation
 
 /// get_PEC - calculate packet error correction code of buffer
-uint8_t AP_BattMonitor_SMBus_I2C::get_PEC(const uint8_t i2c_addr, uint8_t cmd, bool reading, const uint8_t buff[], uint8_t len) const
+uint8_t AP_BattMonitor_SMBus_Solo::get_PEC(const uint8_t i2c_addr, uint8_t cmd, bool reading, const uint8_t buff[], uint8_t len) const
 {
     // exit immediately if no data
     if (len <= 0) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
@@ -9,12 +9,12 @@
 #define BATTMONITOR_SBUS_I2C_BUS 1
 #define BATTMONITOR_SMBUS_I2C_ADDR 0x0B    // default I2C bus address
 
-class AP_BattMonitor_SMBus_I2C : public AP_BattMonitor_SMBus
+class AP_BattMonitor_SMBus_Solo : public AP_BattMonitor_SMBus
 {
 public:
 
     // Constructor
-    AP_BattMonitor_SMBus_I2C(AP_BattMonitor &mon, uint8_t instance,
+    AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon, uint8_t instance,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 


### PR DESCRIPTION
Added Maxcell Battery (62KSP545483-1) to AP_BattMonitor.

[add]
AP_BattMonitor_SMBus_Maxcell
[rename]
AP_BattMonitor_SMBus_I2C => AP_BattMonitor_SMBus_Solo