### PR TITLE
Tools: install wide range of arm compiler options

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -7,7 +7,7 @@ BASE_PKGS="build-essential ccache g++ gawk git make wget"
 PYTHON_PKGS="future lxml pymavlink MAVProxy"
 PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo libftdi-dev zlib1g-dev \
-          zip genromfs python-empy cmake cmake-data"
+          zip genromfs python-empy cmake cmake-data arm-none-*"
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing realpath"
 ASSUME_YES=false


### PR DESCRIPTION
The install-prereq-ubuntu.sh script does not apt-get install all the arm-none-*4_9* libs. We could install the specific 4_9 but it is EOL soon so we might as well just install a bunch and let make/waf use whatever it's configured for.