### PR TITLE
Fix parameter metadata

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -88,7 +88,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Takeoff trigger deadzone
     // @Description: Offset from mid stick at which takeoff is triggered
     // @User: Standard
-    // @Range: 0.0 500.0
+    // @Range: 0 500
     // @Increment: 10
     GSCALAR(takeoff_trigger_dz, "PILOT_TKOFF_DZ", THR_DZ_DEFAULT),
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: SERIAL_NUM
     // @DisplayName: User-defined serial number
     // @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
-    // @Range: -32767 32768
+    // @Range: -32768 32767
     // @User: Standard
     AP_GROUPINFO("SERIAL_NUM", 5, AP_BoardConfig, vehicleSerialNumber, 0),
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -117,7 +117,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: SBP_LOGMASK
     // @DisplayName: Swift Binary Protocol Logging Mask
     // @Description: Masked with the SBP msg_type field to determine whether SBR1/SBR2 data is logged
-    // @Values: 0x0000:None, 0xFFFF:All, 0xFF00:External only
+    // @Values: 0:None (0x0000),-1:All (0xFFFF),-256:External only (0xFF00)
     // @User: Advanced
     AP_GROUPINFO("SBP_LOGMASK", 8, AP_GPS, _sbp_logmask, 0xFF00),
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -325,7 +325,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: FLOW_DELAY
     // @DisplayName: Optical Flow measurement delay (msec)
     // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
-    // @Range: 0 250
+    // @Range: 0 127
     // @Increment: 10
     // @User: Advanced
     // @Units: milliseconds
@@ -512,7 +512,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: BCN_DELAY
     // @DisplayName: Range beacon measurement delay (msec)
     // @Description: This is the number of msec that the range beacon measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
-    // @Range: 0 250
+    // @Range: 0 127
     // @Increment: 10
     // @User: Advanced
     // @Units: milliseconds

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @Param: _BUS_ID
     // @DisplayName: ID on the bus
     // @Description: This is used to select between multiple possible bus IDs for some sensor types. For PX4Flow you can choose 0 to 7 for the 8 possible addresses on the I2C bus.
-    // @Range: 0 255
+    // @Range: 0 127
     // @User: Advanced
     AP_GROUPINFO("_BUS_ID", 5,  OpticalFlow, _bus_id,   0),
     


### PR DESCRIPTION
There are a few parameters that popped up with bad ranges with debugging output enabled in QGC. This PR addresses the following QGC errors:

```
APMParameterMetaDataLog: Invalid max value, name: "BRD_SERIAL_NUM"  type: 3  max: "32768"  error: "Value must be within -32767 and 32767"
APMParameterMetaDataLog: Invalid max value, name: "EK2_BCN_DELAY"  type: 1  max: "250"  error: "Value must be within 0 and 127"
APMParameterMetaDataLog: Invalid max value, name: "EK2_FLOW_DELAY"  type: 1  max: "250"  error: "Value must be within 0 and 127"
APMParameterMetaDataLog: Invalid max value, name: "FLOW_BUS_ID"  type: 1  max: "255"  error: "Value must be within 0 and 127"
APMParameterMetaDataLog: Invalid enum value, name: "GPS_SBP_LOGMASK"  type: 3  value: "0x0000"  error: "Invalid number"
APMParameterMetaDataLog: Invalid min value, name: "PILOT_TKOFF_DZ"  type: 3  min: "0.0"  error: "Invalid number"
APMParameterMetaDataLog: Invalid max value, name: "PILOT_TKOFF_DZ"  type: 3  max: "500.0"  error: "Invalid number"
APMParameterMetaDataLog: Invalid enum value, name: "RTL_CONE_SLOPE"  type: 6  value: "0"  error: "Value must be within 0.5 and 10"
```