### PR TITLE
build: remove batt_smbus from waf as well

### DIFF
--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
@@ -17,7 +17,6 @@ set(config_module_list
     drivers/led
     drivers/px4fmu
     drivers/mkblctrl
-    drivers/batt_smbus
 
 #
 # System commands


### PR DESCRIPTION
It has been removed from make build system, but not from waf.