### PR TITLE
Copter: fixed upgrade of parameters

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1071,9 +1071,6 @@ void Copter::load_parameters(void)
     AP_Param::load_all(false);
     AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
     cliSerial->printf("load_all took %uus\n", (unsigned)(micros() - before));
-
-    // upgrade parameters
-    convert_pid_parameters();
 }
 
 // handle conversion of PID gains from Copter-3.3 to Copter-3.4

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -649,4 +649,7 @@ void Copter::allocate_motors(void)
         }
 #endif
     }
+
+    // upgrade parameters. This must be done after allocating the objects
+    convert_pid_parameters();
 }


### PR DESCRIPTION
now that we dynamically allocate many key objects in copter we need to
move the parameter upgrade code to after when the objects are allocated