### PR TITLE
Create GCS_Rover,GCS_Copter and GCS_Tracker  subclasses

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -63,7 +63,7 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_GROUND_ROVER,
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(MAV_TYPE_GROUND_ROVER,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -1562,7 +1562,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 void Rover::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs_chan[0].initialised || in_mavlink_delay) {
+    if (!gcs().chan(0).initialised || in_mavlink_delay) {
         return;
     }
 
@@ -1597,11 +1597,7 @@ void Rover::mavlink_delay_cb()
  */
 void Rover::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].send_message(id);
-        }
-    }
+    gcs().send_message(id);
 }
 
 /*
@@ -1609,12 +1605,7 @@ void Rover::gcs_send_message(enum ap_message id)
  */
 void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].mission_item_reached_index = mission_index;
-            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
-        }
-    }
+    gcs().send_mission_item_reached_message(mission_index);
 }
 
 /*
@@ -1622,11 +1613,7 @@ void Rover::gcs_send_mission_item_reached_message(uint16_t mission_index)
  */
 void Rover::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].data_stream_send();
-        }
-    }
+    gcs().data_stream_send();
 }
 
 /*
@@ -1634,15 +1621,7 @@ void Rover::gcs_data_stream_send(void)
  */
 void Rover::gcs_update(void)
 {
-    for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-#if CLI_ENABLED == ENABLED
-            gcs_chan[i].update(g.cli_enabled == 1 ? FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *) : nullptr);
-#else
-            gcs_chan[i].update(nullptr);
-#endif
-        }
-    }
+    gcs().update();
 }
 
 void Rover::gcs_send_text(MAV_SEVERITY severity, const char *str)

--- a/APMrover2/GCS_Rover.cpp
+++ b/APMrover2/GCS_Rover.cpp
@@ -1,0 +1,15 @@
+#include "GCS_Rover.h"
+#include "Rover.h"
+
+bool GCS_Rover::cli_enabled() const
+{
+#if CLI_ENABLED == ENABLED
+    return rover.g.cli_enabled;
+#else
+    return false;
+#endif
+}
+
+AP_HAL::BetterStream* GCS_Rover::cliSerial() {
+    return rover.cliSerial;
+}

--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include "GCS_Mavlink.h"
+
+class GCS_Rover : public GCS
+{
+    friend class Rover; // for access to _chan in parameter declarations
+
+public:
+
+    // return the number of valid GCS objects
+    uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
+
+    // return GCS link at offset ofs
+    GCS_MAVLINK_Rover &chan(const uint8_t ofs) override { return _chan[ofs]; };
+
+private:
+
+    GCS_MAVLINK_Rover _chan[MAVLINK_COMM_NUM_BUFFERS];
+
+    bool cli_enabled() const override;
+    AP_HAL::BetterStream* cliSerial() override;
+
+};

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -473,9 +473,7 @@ void Rover::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
 
-    for (uint8_t i=0; i < num_gcs; i++) {
-        gcs_chan[i].reset_cli_timeout();
-    }
+    gcs().reset_cli_timeout();
 
     if (g.log_bitmask != 0) {
         start_logging();

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -402,19 +402,19 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -33,7 +33,6 @@ Rover::Rover(void) :
             FUNCTOR_BIND_MEMBER(&Rover::start_command, bool, const AP_Mission::Mission_Command&),
             FUNCTOR_BIND_MEMBER(&Rover::verify_command_callback, bool, const AP_Mission::Mission_Command&),
             FUNCTOR_BIND_MEMBER(&Rover::exit_mission, void)),
-    num_gcs(MAVLINK_COMM_NUM_BUFFERS),
     ServoRelayEvents(relay),
 #if CAMERA == ENABLED
     camera(&relay),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -86,6 +86,7 @@
 #endif
 #include "Parameters.h"
 #include "GCS_Mavlink.h"
+#include "GCS_Rover.h"
 
 #include <AP_Declination/AP_Declination.h>          // ArduPilot Mega Declination Helper Library
 
@@ -102,6 +103,7 @@ public:
 #if ADVANCED_FAILSAFE == ENABLED
     friend class AP_AdvancedFailsafe_Rover;
 #endif
+    friend class GCS_Rover;
 
     Rover(void);
 
@@ -189,10 +191,8 @@ private:
 
     // GCS handling
     AP_SerialManager serial_manager;
-    const uint8_t num_gcs;
-    GCS_MAVLINK_Rover gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
-    GCS _gcs;  // avoid using this; use gcs()
-    GCS &gcs() { return _gcs; }
+    GCS_Rover _gcs;  // avoid using this; use gcs()
+    GCS_Rover &gcs() { return _gcs; }
 
     // relay support
     AP_Relay relay;

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -100,11 +100,18 @@ void Rover::init_ardupilot()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
+
+    // specify callback function for CLI menu system
+#if CLI_ENABLED == ENABLED
+    if (gcs().cli_enabled()) {
+        gcs().set_run_cli_func(FUNCTOR_BIND_MEMBER(&Rover::run_cli, void, AP_HAL::UARTDriver *));
+    }
+#endif
 
     BoardConfig.init();
 #if HAL_WITH_UAVCAN
@@ -135,9 +142,7 @@ void Rover::init_ardupilot()
     check_usb_mux();
 
     // setup telem slots with serial ports
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-    }
+    gcs().setup_uarts(serial_manager);
 
     // setup frsky telemetry
 #if FRSKY_TELEM_ENABLED == ENABLED
@@ -193,22 +198,7 @@ void Rover::init_ardupilot()
 
 
 #if CLI_ENABLED == ENABLED
-    // If the switch is in 'menu' mode, run the main menu.
-    //
-    // Since we can't be sure that the setup or test mode won't leave
-    // the system in an odd state, we don't let the user exit the top
-    // menu; they must reset in order to fly.
-    //
-    if (g.cli_enabled == 1) {
-        const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
-        cliSerial->printf("%s\n", msg);
-        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
-            gcs_chan[1].get_uart()->printf("%s\n", msg);
-        }
-        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
-            gcs_chan[2].get_uart()->printf("%s\n", msg);
-        }
-    }
+    gcs().handle_interactive_setup();
 #endif
 
     init_capabilities();

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -58,7 +58,7 @@ void Tracker::send_heartbeat(mavlink_channel_t chan)
         base_mode |= MAV_MODE_FLAG_SAFETY_ARMED;
     }
 
-    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(MAV_TYPE_ANTENNA_TRACKER,
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(MAV_TYPE_ANTENNA_TRACKER,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -111,7 +111,7 @@ void Tracker::send_hwstatus(mavlink_channel_t chan)
 
 void Tracker::send_waypoint_request(mavlink_channel_t chan)
 {
-    gcs_chan[chan-MAVLINK_COMM_0].queued_waypoint_send();
+    gcs().chan(chan-MAVLINK_COMM_0).queued_waypoint_send();
 }
 
 void Tracker::send_nav_controller_output(mavlink_channel_t chan)
@@ -485,30 +485,8 @@ void Tracker::mavlink_check_target(const mavlink_message_t* msg)
 
     // send data stream request to target on all channels
     //  Note: this doesn't check success for all sends meaning it's not guaranteed the vehicle's positions will be sent at 1hz
-    for (uint8_t i=0; i < num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            // request position
-            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, DATA_STREAM)) {
-                mavlink_msg_request_data_stream_send(
-                    (mavlink_channel_t)i,
-                    msg->sysid,
-                    msg->compid,
-                    MAV_DATA_STREAM_POSITION,
-                    g.mavlink_update_rate,
-                    1); // start streaming
-            }
-            // request air pressure
-            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, DATA_STREAM)) {
-                mavlink_msg_request_data_stream_send(
-                    (mavlink_channel_t)i,
-                    msg->sysid,
-                    msg->compid,
-                    MAV_DATA_STREAM_RAW_SENSORS,
-                    g.mavlink_update_rate,
-                    1); // start streaming
-            }
-        }
-    }
+    gcs().request_datastream_position(msg->sysid, msg->compid);
+    gcs().request_datastream_airpressure(msg->sysid, msg->compid);
 
     // flag target has been set
     target_set = true;
@@ -869,7 +847,9 @@ mission_failed:
 void Tracker::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs_chan[0].initialised) return;
+    if (!gcs().chan(0).initialised) {
+        return;
+    }
 
     tracker.in_mavlink_delay = true;
     DataFlash.EnableWrites(false);
@@ -899,11 +879,7 @@ void Tracker::mavlink_delay_cb()
  */
 void Tracker::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].send_message(id);
-        }
-    }
+    gcs().send_message(id);
 }
 
 /*
@@ -911,11 +887,7 @@ void Tracker::gcs_send_message(enum ap_message id)
  */
 void Tracker::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].data_stream_send();
-        }
-    }
+    gcs().data_stream_send();
 }
 
 /*
@@ -923,11 +895,7 @@ void Tracker::gcs_data_stream_send(void)
  */
 void Tracker::gcs_update(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].update(nullptr);
-        }
-    }
+    gcs().update();
 }
 
 void Tracker::gcs_send_text(MAV_SEVERITY severity, const char *str)

--- a/AntennaTracker/GCS_Tracker.cpp
+++ b/AntennaTracker/GCS_Tracker.cpp
@@ -1,0 +1,61 @@
+#include "GCS_Tracker.h"
+#include "Tracker.h"
+
+bool GCS_Tracker::cli_enabled() const
+{
+    return false;
+}
+
+AP_HAL::BetterStream* GCS_Tracker::cliSerial() {
+    return nullptr;
+}
+
+static void mavlink_snoop_static(const mavlink_message_t* msg)
+{
+    tracker.mavlink_snoop(msg);
+}
+
+void GCS_Tracker::setup_uarts(AP_SerialManager &serial_manager)
+{
+    GCS::setup_uarts(serial_manager);
+
+    for (uint8_t i = 1; i < num_gcs(); i++) {
+        gcs().chan(i).set_snoop(mavlink_snoop_static);
+    }
+}
+
+void GCS_Tracker::request_datastream_position(const uint8_t sysid, const uint8_t compid)
+{
+    for (uint8_t i=0; i < num_gcs(); i++) {
+        if (gcs().chan(i).initialised) {
+            // request position
+            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, DATA_STREAM)) {
+                mavlink_msg_request_data_stream_send(
+                    (mavlink_channel_t)i,
+                    sysid,
+                    compid,
+                    MAV_DATA_STREAM_POSITION,
+                    tracker.g.mavlink_update_rate,
+                    1); // start streaming
+            }
+        }
+    }
+}
+
+void GCS_Tracker::request_datastream_airpressure(const uint8_t sysid, const uint8_t compid)
+{
+    for (uint8_t i=0; i < num_gcs(); i++) {
+        if (gcs().chan(i).initialised) {
+            // request air pressure
+            if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, DATA_STREAM)) {
+                mavlink_msg_request_data_stream_send(
+                    (mavlink_channel_t)i,
+                    sysid,
+                    compid,
+                    MAV_DATA_STREAM_RAW_SENSORS,
+                    tracker.g.mavlink_update_rate,
+                    1); // start streaming
+            }
+        }
+    }
+}

--- a/AntennaTracker/GCS_Tracker.h
+++ b/AntennaTracker/GCS_Tracker.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include "GCS_Mavlink.h"
+
+class GCS_Tracker : public GCS
+{
+    friend class Tracker; // for access to _chan in parameter declarations
+
+public:
+
+    // return the number of valid GCS objects
+    uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
+
+    // return GCS link at offset ofs
+    GCS_MAVLINK_Tracker &chan(const uint8_t ofs) override { return _chan[ofs]; };
+
+    void setup_uarts(AP_SerialManager &serial_manager) override;
+
+private:
+
+    void request_datastream_position(uint8_t sysid, uint8_t compid);
+    void request_datastream_airpressure(uint8_t sysid, uint8_t compid);
+
+    GCS_MAVLINK_Tracker _chan[MAVLINK_COMM_NUM_BUFFERS];
+
+    bool cli_enabled() const override;
+    AP_HAL::BetterStream* cliSerial() override;
+
+};

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -96,9 +96,7 @@ void Tracker::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
 
-    for (uint8_t i=0; i<num_gcs; i++) {
-        gcs_chan[i].reset_cli_timeout();
-    }
+    gcs().reset_cli_timeout();
 
     if (g.log_bitmask != 0) {
         start_logging();

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -253,19 +253,19 @@ const AP_Param::Info Tracker::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[0], gcs0,        "SR0_",     GCS_MAVLINK),
+    GOBJECTN(gcs().chan(0), gcs0,        "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(gcs().chan(1),  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(gcs().chan(2),  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(gcs().chan(3),  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -69,6 +69,7 @@
 
 #include "Parameters.h"
 #include "GCS_Mavlink.h"
+#include "GCS_Tracker.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
@@ -77,6 +78,7 @@
 class Tracker : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Tracker;
+    friend class GCS_Tracker;
     friend class Parameters;
 
     Tracker(void);
@@ -136,10 +138,8 @@ private:
     bool pitch_servo_out_filt_init = false;
 
     AP_SerialManager serial_manager;
-    const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-    GCS_MAVLINK_Tracker gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
-    GCS _gcs; // avoid using this; use GCS::instance()
-    GCS &gcs() { return _gcs; }
+    GCS_Tracker _gcs; // avoid using this; use gcs()
+    GCS_Tracker &gcs() { return _gcs; }
 
     AP_BoardConfig BoardConfig;
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -4,11 +4,6 @@
 // mission storage
 static const StorageAccess wp_storage(StorageManager::StorageMission);
 
-static void mavlink_snoop_static(const mavlink_message_t* msg)
-{
-    tracker.mavlink_snoop(msg);
-}
-
 static void mavlink_delay_cb_static()
 {
     tracker.mavlink_delay_cb();
@@ -34,7 +29,7 @@ void Tracker::init_tracker()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -60,10 +55,7 @@ void Tracker::init_tracker()
     check_usb_mux();
 
     // setup telem slots with serial ports
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-        gcs_chan[i].set_snoop(mavlink_snoop_static);
-    }
+    gcs().setup_uarts(serial_manager);
 
 #if LOGGING_ENABLED == ENABLED
     log_init();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -99,6 +99,7 @@
 #include "config.h"
 
 #include "GCS_Mavlink.h"
+#include "GCS_Copter.h"
 #include "AP_Rally.h"           // Rally point library
 #include "AP_Arming.h"
 
@@ -136,6 +137,7 @@
 class Copter : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Copter;
+    friend class GCS_Copter;
     friend class AP_Rally_Copter;
     friend class Parameters;
     friend class ParametersG2;
@@ -245,11 +247,8 @@ private:
 
     // GCS selection
     AP_SerialManager serial_manager;
-    static const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
-
-    GCS_MAVLINK_Copter gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
-    GCS _gcs; // avoid using this; use gcs()
-    GCS &gcs() { return _gcs; }
+    GCS_Copter _gcs; // avoid using this; use gcs()
+    GCS_Copter &gcs() { return _gcs; }
 
     // User variables
 #ifdef USERHOOK_VARIABLES

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -1,0 +1,15 @@
+#include "GCS_Copter.h"
+#include "Copter.h"
+
+bool GCS_Copter::cli_enabled() const
+{
+#if CLI_ENABLED == ENABLED
+    return copter.g.cli_enabled;
+#else
+    return false;
+#endif
+}
+
+AP_HAL::BetterStream* GCS_Copter::cliSerial() {
+    return copter.cliSerial;
+}

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include "GCS_Mavlink.h"
+
+class GCS_Copter : public GCS
+{
+    friend class Copter; // for access to _chan in parameter declarations
+
+public:
+
+    // return the number of valid GCS objects
+    uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
+
+    // return GCS link at offset ofs
+    GCS_MAVLINK_Copter &chan(const uint8_t ofs) override {
+        return _chan[ofs];
+    };
+
+private:
+
+    GCS_MAVLINK_Copter _chan[MAVLINK_COMM_NUM_BUFFERS];
+
+    bool cli_enabled() const override;
+    AP_HAL::BetterStream* cliSerial() override;
+
+};

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -78,7 +78,7 @@ NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(get_frame_mav_type(),
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(get_frame_mav_type(),
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -2018,7 +2018,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 void Copter::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs_chan[0].initialised || in_mavlink_delay) return;
+    if (!gcs().chan(0).initialised || in_mavlink_delay) return;
 
     in_mavlink_delay = true;
     DataFlash.EnableWrites(false);
@@ -2051,11 +2051,7 @@ void Copter::mavlink_delay_cb()
  */
 void Copter::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].send_message(id);
-        }
-    }
+    gcs().send_message(id);
 }
 
 /*
@@ -2063,12 +2059,7 @@ void Copter::gcs_send_message(enum ap_message id)
  */
 void Copter::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].mission_item_reached_index = mission_index;
-            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
-        }
-    }
+    gcs().send_mission_item_reached_message(mission_index);
 }
 
 /*
@@ -2076,11 +2067,7 @@ void Copter::gcs_send_mission_item_reached_message(uint16_t mission_index)
  */
 void Copter::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].data_stream_send();
-        }
-    }
+    gcs().data_stream_send();
 }
 
 /*
@@ -2088,15 +2075,7 @@ void Copter::gcs_data_stream_send(void)
  */
 void Copter::gcs_check_input(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-#if CLI_ENABLED == ENABLED
-            gcs_chan[i].update(g.cli_enabled==1?FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *):nullptr);
-#else
-            gcs_chan[i].update(nullptr);
-#endif
-        }
-    }
+    gcs().update();
 }
 
 void Copter::gcs_send_text(MAV_SEVERITY severity, const char *str)

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -937,9 +937,7 @@ void Copter::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
 
-    for (uint8_t i=0; i<num_gcs; i++) {
-        gcs_chan[i].reset_cli_timeout();
-    }
+    gcs().reset_cli_timeout();
 }
 
 #else // LOGGING_ENABLED

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -702,19 +702,19 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[0],  gcs0,       "SR0_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[0],  gcs0,       "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: AHRS_
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -38,9 +38,11 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
         interference_pct[i] = 0.0f;
     }
 
+    GCS_MAVLINK_Copter &gcs_chan = gcs().chan(chan-MAVLINK_COMM_0);
+
     // check compass is enabled
     if (!g.compass_enabled) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -49,7 +51,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     compass.read();
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (!compass.healthy(i)) {
-            gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Check compass");
+            gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Check compass");
             ap.compass_mot = false;
             return MAV_RESULT_TEMPORARILY_REJECTED;
         }
@@ -58,7 +60,7 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check if radio is calibrated
     arming.pre_arm_rc_checks(true);
     if (!ap.pre_arm_rc_check) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "RC not calibrated");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "RC not calibrated");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -66,14 +68,14 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check throttle is at zero
     read_radio();
     if (channel_throttle->get_control_in() != 0) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
 
     // check we are landed
     if (!ap.land_complete) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Not landed");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Not landed");
         ap.compass_mot = false;
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
@@ -98,13 +100,13 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     AP_Notify::flags.esc_calibration = true;
 
     // warn user we are starting calibration
-    gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Starting calibration");
+    gcs_chan.send_text(MAV_SEVERITY_INFO, "Starting calibration");
 
     // inform what type of compensation we are attempting
     if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Current");
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Current");
     } else{
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Throttle");
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Throttle");
     }
 
     // disable throttle and battery failsafe
@@ -250,10 +252,10 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
         }
         compass.save_motor_compensation();
         // display success message
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Calibration successful");
+        gcs_chan.send_text(MAV_SEVERITY_INFO, "Calibration successful");
     } else {
         // compensation vector never updated, report failure
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_NOTICE, "Failed");
+        gcs_chan.send_text(MAV_SEVERITY_NOTICE, "Failed");
         compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
     }
 

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -72,28 +72,30 @@ void Copter::motor_test_output()
 //  return true if tests can continue, false if not
 bool Copter::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
 {
+    GCS_MAVLINK_Copter &gcs_chan = gcs().chan(chan-MAVLINK_COMM_0);
+
     // check board has initialised
     if (!ap.initialised) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Board initialising");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Board initialising");
         return false;
     }
 
     // check rc has been calibrated
     arming.pre_arm_rc_checks(true);
     if(check_rc && !ap.pre_arm_rc_check) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: RC not calibrated");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL,"Motor Test: RC not calibrated");
         return false;
     }
 
     // ensure we are landed
     if (!ap.land_complete) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: vehicle not landed");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL,"Motor Test: vehicle not landed");
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Safety switch");
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Safety switch");
         return false;
     }
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -120,7 +120,15 @@ void Copter::init_ardupilot()
     serial_manager.init();
 
     // setup first port early to allow BoardConfig to report errors
-    gcs_chan[0].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+
+
+#if CLI_ENABLED == ENABLED
+    // specify callback function for CLI menu system
+    if (g.cli_enabled) {
+        gcs().set_run_cli_func(FUNCTOR_BIND_MEMBER(&Copter::run_cli, void, AP_HAL::UARTDriver *));
+    }
+#endif
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
@@ -154,9 +162,7 @@ void Copter::init_ardupilot()
     check_usb_mux();
 
     // setup telem slots with serial ports
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-    }
+    gcs().setup_uarts(serial_manager);
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // setup frsky, and pass a number of parameters to the library
@@ -249,16 +255,7 @@ void Copter::init_ardupilot()
 #endif
 
 #if CLI_ENABLED == ENABLED
-    if (g.cli_enabled) {
-        const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
-        cliSerial->printf("%s\n", msg);
-        if (gcs_chan[1].initialised && (gcs_chan[1].get_uart() != nullptr)) {
-            gcs_chan[1].get_uart()->printf("%s\n", msg);
-        }
-        if (num_gcs > 2 && gcs_chan[2].initialised && (gcs_chan[2].get_uart() != nullptr)) {
-            gcs_chan[2].get_uart()->printf("%s\n", msg);
-        }
-    }
+    gcs().handle_interactive_setup();
 #endif // CLI_ENABLED
 
 #if HIL_MODE != HIL_MODE_DISABLED

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -1,53 +1,22 @@
 #include "GCS_Plane.h"
 #include "Plane.h"
 
-void GCS_Plane::reset_cli_timeout()
+bool GCS_Plane::cli_enabled() const
 {
-    for (uint8_t i=0; i<_num_gcs; i++) {
-        _chan[i].reset_cli_timeout();
-    }
+#if CLI_ENABLED == ENABLED
+    return plane.g.cli_enabled;
+#else
+    return false;
+#endif
 }
 
-void GCS_Plane::send_message(enum ap_message id)
-{
-    for (uint8_t i=0; i<_num_gcs; i++) {
-        if (_chan[i].initialised) {
-            _chan[i].send_message(id);
-        }
-    }
-}
-
-void GCS_Plane::data_stream_send()
-{
-    for (uint8_t i=0; i<_num_gcs; i++) {
-        if (_chan[i].initialised) {
-            _chan[i].data_stream_send();
-        }
-    }
-}
-
-void GCS_Plane::update(void)
-{
-    for (uint8_t i=0; i<_num_gcs; i++) {
-        if (_chan[i].initialised) {
-            _chan[i].update(_run_cli);
-        }
-    }
-}
-
-void GCS_Plane::send_mission_item_reached_message(uint16_t mission_index)
-{
-    for (uint8_t i=0; i<_num_gcs; i++) {
-        if (_chan[i].initialised) {
-            _chan[i].mission_item_reached_index = mission_index;
-            _chan[i].send_message(MSG_MISSION_ITEM_REACHED);
-        }
-    }
+AP_HAL::BetterStream* GCS_Plane::cliSerial() {
+    return plane.cliSerial;
 }
 
 void GCS_Plane::send_airspeed_calibration(const Vector3f &vg)
 {
-    for (uint8_t i=0; i<_num_gcs; i++) {
+    for (uint8_t i=0; i<num_gcs(); i++) {
         if (_chan[i].initialised) {
             if (HAVE_PAYLOAD_SPACE((mavlink_channel_t)i, AIRSPEED_AUTOCAL)) {
                 plane.airspeed.log_mavlink_send((mavlink_channel_t)i, vg);
@@ -55,26 +24,3 @@ void GCS_Plane::send_airspeed_calibration(const Vector3f &vg)
         }
     }
 }
-
-void GCS_Plane::setup_uarts(AP_SerialManager &serial_manager)
-{
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        _chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-    }
-}
-
-#if CLI_ENABLED == ENABLED
-void GCS_Plane::handle_interactive_setup()
-{
-    if (plane.g.cli_enabled == 1) {
-        const char *msg = "\nPress ENTER 3 times to start interactive setup\n";
-        plane.cliSerial->printf("%s\n", msg);
-        if (_chan[1].initialised && (_chan[1].get_uart() != NULL)) {
-            _chan[1].get_uart()->printf("%s\n", msg);
-        }
-        if (num_gcs() > 2 && _chan[2].initialised && (_chan[2].get_uart() != NULL)) {
-            _chan[2].get_uart()->printf("%s\n", msg);
-        }
-    }
-}
-#endif

--- a/ArduPlane/GCS_Plane.h
+++ b/ArduPlane/GCS_Plane.h
@@ -6,35 +6,25 @@
 
 class GCS_Plane : public GCS
 {
-    friend class Plane; // for temporary access to num_gcs and links
+    friend class Plane;  // for access to _chan in parameter declarations
 
 public:
 
-    FUNCTOR_TYPEDEF(run_cli_fn, void, AP_HAL::UARTDriver*);
-
     // return the number of valid GCS objects
-    uint8_t num_gcs() const { return _num_gcs; };
+    uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
 
     // return GCS link at offset ofs
-    GCS_MAVLINK_Plane &chan(const uint8_t ofs) { return _chan[ofs]; };
+    GCS_MAVLINK_Plane &chan(const uint8_t ofs) override {
+        return _chan[ofs];
+    };
 
-    void reset_cli_timeout();
-    void send_message(enum ap_message id);
-    void send_mission_item_reached_message(uint16_t mission_index);
-    void data_stream_send();
-    void update();
     void send_airspeed_calibration(const Vector3f &vg);
-
-    void set_run_cli_func(run_cli_fn run_cli) { _run_cli = run_cli; }
-    void setup_uarts(AP_SerialManager &serial_manager);
-#if CLI_ENABLED == ENABLED
-    void handle_interactive_setup();
-#endif
 
 private:
 
-    uint8_t _num_gcs = MAVLINK_COMM_NUM_BUFFERS;
     GCS_MAVLINK_Plane _chan[MAVLINK_COMM_NUM_BUFFERS];
-    run_cli_fn _run_cli;
+
+    bool cli_enabled() const override;
+    AP_HAL::BetterStream* cliSerial() override;
 
 };

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -76,7 +76,7 @@ NOINLINE void Sub::send_heartbeat(mavlink_channel_t chan)
     uint8_t mav_type;
     mav_type = MAV_TYPE_SUBMARINE;
 
-    gcs_chan[chan-MAVLINK_COMM_0].send_heartbeat(mav_type,
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(mav_type,
                                             base_mode,
                                             custom_mode,
                                             system_status);
@@ -1804,7 +1804,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
 void Sub::mavlink_delay_cb()
 {
     static uint32_t last_1hz, last_50hz, last_5s;
-    if (!gcs_chan[0].initialised || in_mavlink_delay) {
+    if (!gcs().chan(0).initialised || in_mavlink_delay) {
         return;
     }
 
@@ -1838,11 +1838,7 @@ void Sub::mavlink_delay_cb()
  */
 void Sub::gcs_send_message(enum ap_message id)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].send_message(id);
-        }
-    }
+    gcs().send_message(id);
 }
 
 /*
@@ -1850,12 +1846,7 @@ void Sub::gcs_send_message(enum ap_message id)
  */
 void Sub::gcs_send_mission_item_reached_message(uint16_t mission_index)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].mission_item_reached_index = mission_index;
-            gcs_chan[i].send_message(MSG_MISSION_ITEM_REACHED);
-        }
-    }
+    gcs().send_mission_item_reached_message(mission_index);
 }
 
 /*
@@ -1863,11 +1854,7 @@ void Sub::gcs_send_mission_item_reached_message(uint16_t mission_index)
  */
 void Sub::gcs_data_stream_send(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].data_stream_send();
-        }
-    }
+    gcs().data_stream_send();
 }
 
 /*
@@ -1875,11 +1862,7 @@ void Sub::gcs_data_stream_send(void)
  */
 void Sub::gcs_check_input(void)
 {
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs_chan[i].initialised) {
-            gcs_chan[i].update(NULL);
-        }
-    }
+    gcs().update();
 }
 
 void Sub::gcs_send_text(MAV_SEVERITY severity, const char *str)

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -1,0 +1,11 @@
+#include "GCS_Sub.h"
+#include "Sub.h"
+
+bool GCS_Sub::cli_enabled() const
+{
+    return false;
+}
+
+AP_HAL::BetterStream* GCS_Sub::cliSerial() {
+    return NULL;
+}

--- a/ArduSub/GCS_Sub.h
+++ b/ArduSub/GCS_Sub.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <GCS_MAVLink/GCS.h>
+#include "GCS_Mavlink.h"
+
+class GCS_Sub : public GCS
+{
+    friend class Sub; // for access to _chan in parameter declarations
+
+public:
+
+    // return the number of valid GCS objects
+    uint8_t num_gcs() const override { return ARRAY_SIZE(_chan); };
+
+    // return GCS link at offset ofs
+    GCS_MAVLINK_Sub &chan(const uint8_t ofs) override {
+        return _chan[ofs];
+    };
+
+private:
+
+    GCS_MAVLINK_Sub _chan[MAVLINK_COMM_NUM_BUFFERS];
+
+    bool cli_enabled() const override;
+    AP_HAL::BetterStream* cliSerial() override;
+
+};

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -486,9 +486,7 @@ void Sub::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
 
-    for (uint8_t i=0; i<num_gcs; i++) {
-        gcs_chan[i].reset_cli_timeout();
-    }
+    gcs().reset_cli_timeout();
 }
 
 #else // LOGGING_ENABLED

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -584,19 +584,19 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Group: SR0_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[0],  gcs0,       "SR0_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[0],  gcs0,       "SR0_",     GCS_MAVLINK),
 
     // @Group: SR1_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[1],  gcs1,       "SR1_",     GCS_MAVLINK),
 
     // @Group: SR2_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[2],  gcs2,       "SR2_",     GCS_MAVLINK),
 
     // @Group: SR3_
     // @Path: GCS_Mavlink.cpp
-    GOBJECTN(gcs_chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
+    GOBJECTN(_gcs._chan[3],  gcs3,       "SR3_",     GCS_MAVLINK),
 
     // @Group: AHRS_
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -81,6 +81,7 @@
 #include "GCS_Mavlink.h"
 #include "Parameters.h"
 #include "AP_Arming_Sub.h"
+#include "GCS_Sub.h"
 
 // libraries which are dependent on #defines in defines.h and/or config.h
 #if OPTFLOW == ENABLED
@@ -122,6 +123,7 @@
 class Sub : public AP_HAL::HAL::Callbacks {
 public:
     friend class GCS_MAVLINK_Sub;
+    friend class GCS_Sub;
     friend class Parameters;
     friend class ParametersG2;
     friend class AP_Arming_Sub;
@@ -207,11 +209,9 @@ private:
 
     // GCS selection
     AP_SerialManager serial_manager;
-    static const uint8_t num_gcs = MAVLINK_COMM_NUM_BUFFERS;
 
-    GCS_MAVLINK_Sub gcs_chan[MAVLINK_COMM_NUM_BUFFERS];
-    GCS _gcs; // avoid using this; use gcs()
-    GCS &gcs() { return _gcs; }
+    GCS_Sub _gcs; // avoid using this; use gcs()
+    GCS_Sub &gcs() { return _gcs; }
 
     // User variables
 #ifdef USERHOOK_VARIABLES

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -41,6 +41,9 @@ void Sub::init_ardupilot()
     // initialise serial port
     serial_manager.init();
 
+    // setup first port early to allow BoardConfig to report errors
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
+
     // init cargo gripper
 #if GRIPPER_ENABLED == ENABLED
     g2.gripper.init();
@@ -62,9 +65,7 @@ void Sub::init_ardupilot()
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
 
     // setup telem slots with serial ports
-    for (uint8_t i = 0; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        gcs_chan[i].setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
-    }
+    gcs().setup_uarts(serial_manager);
 
 #if LOGGING_ENABLED == ENABLED
     log_init();

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <AP_Param/AP_Param.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
 #include "Parameters.h"
 #include "VehicleType.h"
 #include "MsgHandler.h"
@@ -928,12 +928,9 @@ bool Replay::check_user_param(const char *name)
     return false;
 }
 
-class GCS_Replay : public GCS
-{
-    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) override {
-        ::fprintf(stderr, "GCS: %s\n", text);
-    }
+const struct AP_Param::GroupInfo        GCS_MAVLINK::var_info[] = {
+    AP_GROUPEND
 };
-GCS_Replay _gcs;
+GCS_Dummy _gcs;
 
 AP_HAL_MAIN_CALLBACKS(&replay);

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -446,10 +446,12 @@ def start_antenna_tracker(autotest, opts):
     tracker_frame_options = vinfo.options["AntennaTracker"]["frames"][tracker_default_frame]
     do_build(vehicledir, opts, tracker_frame_options)
     tracker_instance = 1
+    oldpwd = os.getcwd()
     os.chdir(vehicledir)
     tracker_uarta = "tcp:127.0.0.1:" + str(5760 + 10 * tracker_instance)
     exe = os.path.join(vehicledir, "AntennaTracker.elf")
     run_in_terminal_window(autotest, "AntennaTracker", ["nice", exe, "-I" + str(tracker_instance), "--model=tracker", "--home=" + tracker_home])
+    os.chdir(oldpwd)
 
 
 def start_vehicle(binary, autotest, opts, stuff, loc):

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -6,7 +6,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
 
 void setup();
 void loop();
@@ -95,6 +95,9 @@ void loop(void)
     }
 }
 
-GCS _gcs;
+const struct AP_Param::GroupInfo        GCS_MAVLINK::var_info[] = {
+    AP_GROUPEND
+};
+GCS_Dummy _gcs;
 
 AP_HAL_MAIN();

--- a/libraries/AP_HAL/examples/Storage/Storage.cpp
+++ b/libraries/AP_HAL/examples/Storage/Storage.cpp
@@ -9,13 +9,13 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-AP_HAL::Storage *st;
-
 void setup(void) 
 {
     /*
       init Storage API
      */
+    AP_HAL::Storage *st = hal.storage;
+
     hal.console->printf("Starting AP_HAL::Storage test\r\n");
     st->init();
 

--- a/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
+++ b/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
@@ -4,7 +4,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <DataFlash/DataFlash.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
@@ -205,14 +205,11 @@ void DataFlashTest_AllTypes::loop(void)
     hal.scheduler->delay(1000);
 }
 
-class GCS_Dataflash_AllTypes : public GCS
-{
-    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) override {
-        ::fprintf(stderr, "GCS: %s\n", text);
-    }
+const struct AP_Param::GroupInfo        GCS_MAVLINK::var_info[] = {
+    AP_GROUPEND
 };
+GCS_Dummy _gcs;
 
-GCS_Dataflash_AllTypes _gcs;
 
 static DataFlashTest_AllTypes dataflashtest;
 

--- a/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
+++ b/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
@@ -5,7 +5,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <DataFlash/DataFlash.h>
-#include <GCS_MAVLink/GCS.h>
+#include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
@@ -129,12 +129,9 @@ void loop()
     dataflashtest.loop();
 }
 
-class GCS_Dataflash_test : public GCS
-{
-    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) override {
-        ::fprintf(stderr, "GCS: %s\n", text);
-    }
+const struct AP_Param::GroupInfo        GCS_MAVLINK::var_info[] = {
+    AP_GROUPEND
 };
-GCS_Dataflash_test _gcs;
+GCS_Dummy _gcs;
 
 AP_HAL_MAIN();

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -431,6 +431,19 @@ public:
 
     virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
     void service_statustext(void);
+    virtual GCS_MAVLINK &chan(const uint8_t ofs) = 0;
+    virtual uint8_t num_gcs() const = 0;
+    void reset_cli_timeout();
+    void send_message(enum ap_message id);
+    void send_mission_item_reached_message(uint16_t mission_index);
+    void data_stream_send();
+    void update();
+    virtual void setup_uarts(AP_SerialManager &serial_manager);
+    void handle_interactive_setup();
+
+    FUNCTOR_TYPEDEF(run_cli_fn, void, AP_HAL::UARTDriver*);
+    run_cli_fn _run_cli;
+    void set_run_cli_func(run_cli_fn run_cli) { _run_cli = run_cli; }
 
     /*
       set a dataflash pointer for logging
@@ -456,6 +469,9 @@ public:
 private:
 
     static GCS *_singleton;
+
+    virtual bool cli_enabled() const = 0;
+    virtual AP_HAL::BetterStream*  cliSerial() = 0;
 
     struct statustext_t {
         uint8_t                 bitmask;

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -1,0 +1,31 @@
+#include "GCS.h"
+
+/*
+ *  GCS backend used for many examples and tools
+ */
+class GCS_MAVLINK_Dummy : public GCS_MAVLINK
+{
+    void data_stream_send(void) override {}
+    uint32_t telem_delay() const override { return 0; }
+    void handleMessage(mavlink_message_t * msg) override {}
+    bool try_send_message(enum ap_message id) { return true; }
+    bool handle_guided_request(AP_Mission::Mission_Command &cmd) override { return true; }
+    void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override {}
+};
+
+/*
+ * a GCS singleton used for many example sketches and tools
+ */
+
+extern const AP_HAL::HAL& hal;
+
+class GCS_Dummy : public GCS
+{
+    GCS_MAVLINK_Dummy dummy_backend;
+    uint8_t num_gcs() const override { return 1; }
+    GCS_MAVLINK &chan(const uint8_t ofs) override { return dummy_backend; }
+    bool cli_enabled() const override { return false; }
+    AP_HAL::BetterStream*  cliSerial() { return nullptr; }
+
+    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) { hal.console->printf("TOGCS: %s\n", text); }
+};


### PR DESCRIPTION
Subclasses `GCS::` just like Plane does; uses inherited methods for old functionality.

Some methods have moved up from GCS_Plane where they were applicable.
