### PR TITLE
WIP - Live mixer tuning through mavlink including px4io

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/PX4Firmware"]
 	path = modules/PX4Firmware
-	url = git://github.com/ArduPilot/PX4Firmware.git
+	url = git://github.com/crashmatt/Firmware.git
 [submodule "modules/PX4NuttX"]
 	path = modules/PX4NuttX
 	url = git://github.com/ArduPilot/PX4NuttX.git
@@ -15,7 +15,7 @@
 	url = git://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/ArduPilot/mavlink
+	url = git://github.com/crashmatt/mavlink
 [submodule "gtest"]
 	path = modules/gtest
 	url = git://github.com/ArduPilot/googletest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/PX4Firmware"]
 	path = modules/PX4Firmware
-	url = git://github.com/crashmatt/Firmware.git
+	url = https://github.com/crashmatt/Firmware.git
 [submodule "modules/PX4NuttX"]
 	path = modules/PX4NuttX
 	url = git://github.com/ArduPilot/PX4NuttX.git
@@ -15,7 +15,7 @@
 	url = git://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/crashmatt/mavlink
+	url = https://github.com/crashmatt/mavlink.git
 [submodule "gtest"]
 	path = modules/gtest
 	url = git://github.com/ArduPilot/googletest

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1716,6 +1716,20 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+#if defined(MIXER_CONFIGURATION)
+    case MAVLINK_MSG_ID_MIXER_DATA_REQUEST:
+    {
+    	handle_mixer_data_request(msg);
+    	break;
+    }
+
+    case MAVLINK_MSG_ID_MIXER_PARAMETER_SET:
+    {
+    	handle_mixer_parameter_set(msg);
+    	break;
+    }
+#endif 	//MIXER_CONFIGURATION
+
     case MAVLINK_MSG_ID_GIMBAL_REPORT:
     {
 #if MOUNT == ENABLED

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -659,12 +659,12 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
         plane.adsb.send_adsb_vehicle(chan);
         break;
-#if defined(MIXER_CONFIGURATION)
     case MSG_MIXER_DATA:
+#if defined(MIXER_CONFIGURATION)
         CHECK_PAYLOAD_SIZE(MIXER_DATA);
         plane.mixer.send_mixer_data(chan);
-        break;
 #endif 	//MIXER_CONFIGURATION
+        break;
     }
     return true;
 }
@@ -784,9 +784,11 @@ GCS_MAVLINK_Plane::data_stream_send(void)
         }
     }
 
+#if defined(MIXER_CONFIGURATION)
     if(plane.mixer.send_queued()){
     	send_message(MSG_MIXER_DATA);
     }
+#endif //MIXER_CONFIGURATION
 
     if (plane.gcs_out_of_time) return;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -659,6 +659,12 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);
         plane.adsb.send_adsb_vehicle(chan);
         break;
+#if defined(MIXER_CONFIGURATION)
+    case MSG_MIXER_DATA:
+        CHECK_PAYLOAD_SIZE(MIXER_DATA);
+        plane.mixer.send_mixer_data(chan);
+        break;
+#endif 	//MIXER_CONFIGURATION
     }
     return true;
 }
@@ -776,6 +782,10 @@ GCS_MAVLINK_Plane::data_stream_send(void)
         if (stream_trigger(STREAM_PARAMS)) {
             send_message(MSG_NEXT_PARAM);
         }
+    }
+
+    if(plane.mixer.send_queued()){
+    	send_message(MSG_MIXER_DATA);
     }
 
     if (plane.gcs_out_of_time) return;
@@ -1718,14 +1728,9 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 
 #if defined(MIXER_CONFIGURATION)
     case MAVLINK_MSG_ID_MIXER_DATA_REQUEST:
-    {
-    	handle_mixer_data_request(msg);
-    	break;
-    }
-
     case MAVLINK_MSG_ID_MIXER_PARAMETER_SET:
     {
-    	handle_mixer_parameter_set(msg);
+    	plane.mixer.handle_msg(msg);
     	break;
     }
 #endif 	//MIXER_CONFIGURATION

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -32,7 +32,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Menu/AP_Menu.h>
-#include <AP_Param/AP_Param.h>
 #include <AP_RCMixer/AP_RCMixer.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_GPS/AP_GPS.h>         // ArduPilot GPS library
@@ -44,6 +43,7 @@
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_AHRS/AP_AHRS.h>         // ArduPilot Mega DCM Library
 #include <RC_Channel/RC_Channel.h>     // RC Channel Library
+#include <AP_RCMixer/AP_RCMixer.h>     // APM Mixer manager library
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
 #include <Filter/Filter.h>                     // Filter library

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -33,6 +33,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Menu/AP_Menu.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_RCMixer/AP_RCMixer.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_GPS/AP_GPS.h>         // ArduPilot GPS library
 #include <AP_Baro/AP_Baro.h>        // ArduPilot barometer library
@@ -749,6 +750,10 @@ private:
     AP_Arming_Plane arming {ahrs, barometer, compass, battery};
 
     AP_Param param_loader {var_info};
+
+#if defined(MIXER_CONFIGURATION)
+    AP_RCMixer mixer;
+#endif 	//MIXER_CONFIGURATION
 
     static const AP_Scheduler::Task scheduler_tasks[];
     static const AP_Param::Info var_info[];

--- a/ArduPlane/make.inc
+++ b/ArduPlane/make.inc
@@ -62,3 +62,5 @@ LIBRARIES += AP_Tuning
 LIBRARIES += AP_Stats
 LIBRARIES += AP_Landing
 LIBRARIES += AP_Beacon
+LIBRARIES += AP_RCMixer
+

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -112,6 +112,31 @@ public:
       enable SBUS out at the given rate
      */
     virtual bool     enable_sbus_out(uint16_t rate_gz) { return false; }
+
+    /*
+      get the number of mixers
+     */
+    virtual int     get_mixer_count(void) { return -1; }
+
+    /*
+      get the number of submixers for the mixer at given index
+     */
+    virtual int     get_submixer_count(uint16_t mixer_index) { return -1; }
+
+    /*
+      get the mixer type for the mixer/submixer at given indices
+     */
+    virtual int     get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) { return -1; }
+
+    /*
+      get the mixer parameter for the mixer/submixer at given indices
+     */
+    virtual bool    get_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float *param_value) { return false; }
+
+    /*
+      set the mixer parameter for the mixer/submixer at given indices to param_value
+     */
+    virtual bool    set_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float param_value) { return false; }
     
     /*
       output modes. Allows for support of oneshot

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -13,6 +13,7 @@
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_sbus.h>
+#include <drivers/drv_mixer.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -643,6 +644,118 @@ void PX4RCOutput::set_output_mode(enum output_mode mode)
         }
         break;
     }
+}
+
+/*
+  get the number of mixers
+ */
+int PX4RCOutput::get_mixer_count(void) {
+	int mixers = -1;
+
+	//Presume px4io
+    int fd = open("/dev/px4io", 0);
+    if (fd == -1) {
+        return -1;
+    }
+
+	if( ioctl(fd, MIXERIOCGETMIXERCOUNT, (unsigned long) &mixers) != 0) {
+		mixers = -1;
+	}
+	close(fd);
+	return mixers;
+}
+
+/*
+  get the number of submixers for the mixer at given index
+ */
+int PX4RCOutput::get_submixer_count(uint16_t mixer_index) {
+	int val = mixer_index;
+
+	//Presume px4io
+    int fd = open("/dev/px4io", 0);
+    if (fd == -1) {
+        return -1;
+    }
+
+	if( ioctl(fd, MIXERIOCGETSUBMIXERCOUNT, (unsigned long) &val) != 0) {
+		val = -1;
+	}
+	close(fd);
+	return val;
+}
+
+/*
+  get the mixer type for the mixer/submixer at given indices
+ */
+int PX4RCOutput::get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) {
+	int mix_type = -1;
+	mixer_type_s type;
+
+	type.mix_index = mixer_index;
+	type.mix_sub_index = submixer_index;
+
+	//Presume px4io
+    int fd = open("/dev/px4io", 0);
+    if (fd == -1) {
+        return -1;
+    }
+
+	if( ioctl(fd, MIXERIOCGETSUBMIXERCOUNT, (unsigned long) &type) == 0) {
+		mix_type = type.mix_type;
+	}
+	close(fd);
+	return mix_type;
+}
+
+/*
+  get the mixer parameter for the mixer/submixer at given indices
+ */
+bool PX4RCOutput::get_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float *param_value) {
+	mixer_param_s param;
+	bool ret = false;
+
+	//Presume px4io
+    int fd = open("/dev/px4io", 0);
+    if (fd == -1) {
+        return false;
+    }
+
+	param.mix_index = mixer_index;
+	param.param_index = parameter_index;
+	param.mix_sub_index = submixer_index;
+
+	if(ioctl(fd, MIXERIOCGETPARAM, (unsigned long) &param) == 0) {
+		*param_value = param.value;
+		ret = true;
+	}
+	close(fd);
+	return ret;
+}
+
+/*
+  set the mixer parameter for the mixer/submixer at given indices to param_value
+  WARNING - THIS WILL BLOCK UNTIL REMOTE MIXER WRITE IS DONE.  THIS MAY TAKE A WHILE.
+ */
+bool PX4RCOutput::set_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float param_value) {
+	mixer_param_s param;
+	bool ret = false;
+
+	//Presume px4io
+    int fd = open("/dev/px4io", 0);
+    if (fd == -1) {
+        return false;
+    }
+
+	param.mix_index = mixer_index;
+	param.param_index = parameter_index;
+	param.mix_sub_index = submixer_index;
+	param.value = param_value;
+
+	if(ioctl(fd, MIXERIOCSETPARAM, (unsigned long) &param) == 0) {
+		ret = true;
+	}
+	close(fd);
+	return ret;
 }
 
 

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -646,6 +646,7 @@ void PX4RCOutput::set_output_mode(enum output_mode mode)
     }
 }
 
+#if defined(MIXER_CONFIGURATION)
 /*
   get the number of mixers
  */
@@ -757,6 +758,7 @@ bool PX4RCOutput::set_mixer_parameter(uint16_t mixer_index, uint16_t submixer_in
 	close(fd);
 	return ret;
 }
+#endif 	//MIXER_CONFIGURATION
 
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -701,7 +701,7 @@ int PX4RCOutput::get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) {
         return -200;
     }
 
-	if( ioctl(fd, MIXERIOCGETSUBMIXERCOUNT, (unsigned long) &type) == 0) {
+	if( ioctl(fd, MIXERIOCGETTYPE, (unsigned long) &type) == 0) {
 		mix_type = type.mix_type;
 	} else {
 		mix_type = -203;

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -656,11 +656,11 @@ int PX4RCOutput::get_mixer_count(void) {
 	//Presume px4io
     int fd = open("/dev/px4io", 0);
     if (fd == -1) {
-        return -1;
+        return -200;
     }
 
 	if( ioctl(fd, MIXERIOCGETMIXERCOUNT, (unsigned long) &mixers) != 0) {
-		mixers = -1;
+		mixers = -201;
 	}
 	close(fd);
 	return mixers;
@@ -675,11 +675,11 @@ int PX4RCOutput::get_submixer_count(uint16_t mixer_index) {
 	//Presume px4io
     int fd = open("/dev/px4io", 0);
     if (fd == -1) {
-        return -1;
+        return -200;
     }
 
 	if( ioctl(fd, MIXERIOCGETSUBMIXERCOUNT, (unsigned long) &val) != 0) {
-		val = -1;
+		val = -202;
 	}
 	close(fd);
 	return val;
@@ -698,11 +698,13 @@ int PX4RCOutput::get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) {
 	//Presume px4io
     int fd = open("/dev/px4io", 0);
     if (fd == -1) {
-        return -1;
+        return -200;
     }
 
 	if( ioctl(fd, MIXERIOCGETSUBMIXERCOUNT, (unsigned long) &type) == 0) {
 		mix_type = type.mix_type;
+	} else {
+		mix_type = -203;
 	}
 	close(fd);
 	return mix_type;

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -36,13 +36,13 @@ public:
     
     void _timer_tick(void);
     bool enable_sbus_out(uint16_t rate_hz) override;
-
+#if defined(MIXER_CONFIGURATION)
     int     get_mixer_count(void) override;
     int     get_submixer_count(uint16_t mixer_index) override;
     int     get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) override;
     bool    get_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float *param_value) override;
     bool    set_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float param_value) override;
-
+#endif 	//MIXER_CONFIGURATION
 
 private:
     int _pwm_fd;

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -37,6 +37,13 @@ public:
     void _timer_tick(void);
     bool enable_sbus_out(uint16_t rate_hz) override;
 
+    int     get_mixer_count(void) override;
+    int     get_submixer_count(uint16_t mixer_index) override;
+    int     get_mixer_type(uint16_t mixer_index, uint16_t submixer_index) override;
+    bool    get_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float *param_value) override;
+    bool    set_mixer_parameter(uint16_t mixer_index, uint16_t submixer_index, uint16_t parameter_index, float param_value) override;
+
+
 private:
     int _pwm_fd;
     int _alt_fd;

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -22,12 +22,10 @@ AP_RCMixer::AP_RCMixer(void)
 void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 #if defined(MIXER_CONFIGURATION)
     switch (msg->msgid) {
-		case MAVLINK_MSG_ID_MIXER_DATA_REQUEST:
+		case MAVLINK_MSG_ID_MIXER_DATA_REQUEST: {
 		    mavlink_mixer_data_request_t packet;
 		    mavlink_msg_mixer_data_request_decode(msg, &packet);
 
-		    _target_system = packet.target_system;
-			_target_component = packet.target_component;
 		    _mixer_data.group = packet.mixer_group;
 		    _mixer_data.mixer = packet.mixer_index;
 		    _mixer_data.submixer = packet.mixer_sub_index;
@@ -65,9 +63,26 @@ void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 			}
 			_status = AP_RCMIXER_STATUS_SEND_DATA;
 			break;
+		}
+		case MAVLINK_MSG_ID_MIXER_PARAMETER_SET: {
+		    mavlink_mixer_parameter_set_t packet;
+		    mavlink_msg_mixer_parameter_set_decode(msg, &packet);
 
-		case MAVLINK_MSG_ID_MIXER_PARAMETER_SET:
+		    if( packet.mixer_group != 1){
+		    	break;
+		    }
+
+		    _mixer_data.group = packet.mixer_group;
+		    _mixer_data.mixer = packet.mixer_index;
+		    _mixer_data.submixer = packet.mixer_sub_index;
+		    _mixer_data.parameter = packet.parameter_index;
+		    _mixer_data.type = MIXER_DATA_TYPE_PARAMETER;
+		    _mixer_data.param_value = packet.param_value;
+		    _mixer_data.param_type = MAVLINK_TYPE_FLOAT;
+
+			hal.rcout->set_mixer_parameter(packet.mixer_index, packet.mixer_sub_index, _mixer_data.parameter, _mixer_data.param_value);
 			break;
+		}
 		default:
 			break;
 	}

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -35,7 +35,7 @@ void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 
 		    // Make sure we are talking to px4io only
 		    if(packet.mixer_group != 1){
-		    	_mixer_data.int_value = -1;
+		    	_mixer_data.int_value = -100;
 				_mixer_data.param_value = 0.0;
 				_status = AP_RCMIXER_STATUS_SEND_DATA;
 				return;

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -1,0 +1,11 @@
+#include <AP_HAL/AP_HAL.h>
+#include "AP_RCMixer.h"
+
+// object constructor.
+RCMixer::RCMixer(void)
+{
+}
+
+void RCMixer::request_mixer_data(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t type){
+
+}

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -80,7 +80,12 @@ void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 		    _mixer_data.param_value = packet.param_value;
 		    _mixer_data.param_type = MAVLINK_TYPE_FLOAT;
 
-			hal.rcout->set_mixer_parameter(packet.mixer_index, packet.mixer_sub_index, _mixer_data.parameter, _mixer_data.param_value);
+			if (hal.rcout->set_mixer_parameter(packet.mixer_index, packet.mixer_sub_index, _mixer_data.parameter, _mixer_data.param_value)) {
+				_mixer_data.int_value = 0;
+			} else {
+				_mixer_data.int_value = -1;
+			}
+			_status = AP_RCMIXER_STATUS_SEND_DATA;
 			break;
 		}
 		default:

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -1,5 +1,4 @@
 #include <AP_HAL/AP_HAL.h>
-//#include <AP_Common/AP_Common.h>
 #include "AP_RCMixer.h"
 #include <GCS_MAVLink/GCS.h>
 
@@ -8,12 +7,19 @@ extern AP_HAL::HAL& hal;
 // object constructor.
 AP_RCMixer::AP_RCMixer(void)
 {
+    _mixer_data.group = 0;;
+    _mixer_data.mixer = 0;
+    _mixer_data.submixer = 0;
+    _mixer_data.parameter = 0;
+    _mixer_data.type = 0;
+	_mixer_data.int_value = -1;
+	_mixer_data.param_value = 0.0;
+
 	_status = AP_RCMIXER_STATUS_WAITING;
 }
 
 void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 #if defined(MIXER_CONFIGURATION)
-
     switch (msg->msgid) {
 		case MAVLINK_MSG_ID_MIXER_DATA_REQUEST:
 		    mavlink_mixer_data_request_t packet;
@@ -52,28 +58,18 @@ void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 
 		case MAVLINK_MSG_ID_MIXER_PARAMETER_SET:
 			break;
+		default:
+			break;
 	}
 #endif 	//MIXER_CONFIGURATION
 }
 
 //MAVLink mixer data send
 void AP_RCMixer::send_mixer_data(mavlink_channel_t chan){
+//	GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "send_mixer_data");
 	switch(int(_status)){
 	case AP_RCMIXER_STATUS_SEND_DATA:
-/*		mavlink_channel_t chan,
- * uint8_t target_system,
- * uint8_t target_component,
- * uint8_t mixer_group,
- * uint8_t mixer_index,
- * uint8_t mixer_sub_index,
- * uint8_t parameter_index,
- * uint8_t data_type,
- * int32_t data_value,
- * float param_value,
- * uint8_t param_type */
 		mavlink_msg_mixer_data_send(chan,
-						_target_system,
-						_target_component,
 						(uint8_t) _mixer_data.group,
 						(uint8_t) _mixer_data.mixer,
 						(uint8_t) _mixer_data.submixer,
@@ -84,6 +80,7 @@ void AP_RCMixer::send_mixer_data(mavlink_channel_t chan){
 						MAVLINK_TYPE_FLOAT
 						);
 		_status = AP_RCMIXER_STATUS_WAITING;
+		break;
 	default:
 		break;
 	}

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -14,6 +14,7 @@ AP_RCMixer::AP_RCMixer(void)
     _mixer_data.type = 0;
 	_mixer_data.int_value = -1;
 	_mixer_data.param_value = 0.0;
+	_mixer_data.param_type = 0.0;
 
 	_status = AP_RCMIXER_STATUS_WAITING;
 }
@@ -50,6 +51,15 @@ void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
 				_mixer_data.int_value = hal.rcout->get_submixer_count(_mixer_data.mixer);
 				_mixer_data.param_value = 0.0;
 				break;
+			case MIXER_DATA_TYPE_MIXTYPE:
+				_mixer_data.int_value = hal.rcout->get_mixer_type(_mixer_data.mixer, _mixer_data.submixer);
+				_mixer_data.param_value = 0.0;
+				break;
+			case MIXER_DATA_TYPE_PARAMETER:
+				_mixer_data.int_value = 0;
+				hal.rcout->get_mixer_parameter(_mixer_data.mixer, _mixer_data.submixer, _mixer_data.parameter, &_mixer_data.param_value);
+				_mixer_data.param_type = MAVLINK_TYPE_FLOAT;
+				break;
 			default:
 				break;
 			}
@@ -77,7 +87,7 @@ void AP_RCMixer::send_mixer_data(mavlink_channel_t chan){
 						(uint8_t) _mixer_data.type,
 						_mixer_data.int_value,
 						_mixer_data.param_value,
-						MAVLINK_TYPE_FLOAT
+						_mixer_data.param_type
 						);
 		_status = AP_RCMIXER_STATUS_WAITING;
 		break;

--- a/libraries/AP_RCMixer/AP_RCMixer.cpp
+++ b/libraries/AP_RCMixer/AP_RCMixer.cpp
@@ -1,11 +1,92 @@
 #include <AP_HAL/AP_HAL.h>
+//#include <AP_Common/AP_Common.h>
 #include "AP_RCMixer.h"
+#include <GCS_MAVLink/GCS.h>
+
+extern AP_HAL::HAL& hal;
 
 // object constructor.
-RCMixer::RCMixer(void)
+AP_RCMixer::AP_RCMixer(void)
 {
+	_status = AP_RCMIXER_STATUS_WAITING;
 }
 
-void RCMixer::request_mixer_data(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t type){
+void AP_RCMixer::handle_msg(const mavlink_message_t *msg){
+#if defined(MIXER_CONFIGURATION)
 
+    switch (msg->msgid) {
+		case MAVLINK_MSG_ID_MIXER_DATA_REQUEST:
+		    mavlink_mixer_data_request_t packet;
+		    mavlink_msg_mixer_data_request_decode(msg, &packet);
+
+		    _target_system = packet.target_system;
+			_target_component = packet.target_component;
+		    _mixer_data.group = packet.mixer_group;
+		    _mixer_data.mixer = packet.mixer_index;
+		    _mixer_data.submixer = packet.mixer_sub_index;
+		    _mixer_data.parameter = packet.parameter_index;
+		    _mixer_data.type = packet.data_type;
+
+		    // Make sure we are talking to px4io only
+		    if(packet.mixer_group != 1){
+		    	_mixer_data.int_value = -1;
+				_mixer_data.param_value = 0.0;
+				_status = AP_RCMIXER_STATUS_SEND_DATA;
+				return;
+	    	}
+
+			switch(packet.data_type){
+			case MIXER_DATA_TYPE_MIXER_COUNT:
+				_mixer_data.int_value = hal.rcout->get_mixer_count();
+				_mixer_data.param_value = 0.0;
+				break;
+			case MIXER_DATA_TYPE_SUBMIXER_COUNT:
+				_mixer_data.int_value = hal.rcout->get_submixer_count(_mixer_data.mixer);
+				_mixer_data.param_value = 0.0;
+				break;
+			default:
+				break;
+			}
+			_status = AP_RCMIXER_STATUS_SEND_DATA;
+			break;
+
+		case MAVLINK_MSG_ID_MIXER_PARAMETER_SET:
+			break;
+	}
+#endif 	//MIXER_CONFIGURATION
 }
+
+//MAVLink mixer data send
+void AP_RCMixer::send_mixer_data(mavlink_channel_t chan){
+	switch(int(_status)){
+	case AP_RCMIXER_STATUS_SEND_DATA:
+/*		mavlink_channel_t chan,
+ * uint8_t target_system,
+ * uint8_t target_component,
+ * uint8_t mixer_group,
+ * uint8_t mixer_index,
+ * uint8_t mixer_sub_index,
+ * uint8_t parameter_index,
+ * uint8_t data_type,
+ * int32_t data_value,
+ * float param_value,
+ * uint8_t param_type */
+		mavlink_msg_mixer_data_send(chan,
+						_target_system,
+						_target_component,
+						(uint8_t) _mixer_data.group,
+						(uint8_t) _mixer_data.mixer,
+						(uint8_t) _mixer_data.submixer,
+						(uint8_t) _mixer_data.parameter,
+						(uint8_t) _mixer_data.type,
+						_mixer_data.int_value,
+						_mixer_data.param_value,
+						MAVLINK_TYPE_FLOAT
+						);
+		_status = AP_RCMIXER_STATUS_WAITING;
+	default:
+		break;
+	}
+}
+
+

--- a/libraries/AP_RCMixer/AP_RCMixer.h
+++ b/libraries/AP_RCMixer/AP_RCMixer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <inttypes.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+
+class RCMixer
+{
+public:
+    /// Constructor
+    ///
+    RCMixer();
+    void request_mixer_data(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t type);
+
+private:
+};

--- a/libraries/AP_RCMixer/AP_RCMixer.h
+++ b/libraries/AP_RCMixer/AP_RCMixer.h
@@ -49,6 +49,4 @@ public:
 private:
     mixer_data_s _mixer_data;
     AP_RCMIXER_STATUS _status;
-    uint8_t _target_system;
-	uint8_t _target_component;
 };

--- a/libraries/AP_RCMixer/AP_RCMixer.h
+++ b/libraries/AP_RCMixer/AP_RCMixer.h
@@ -3,14 +3,51 @@
 #include <inttypes.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
-class RCMixer
+struct mixer_data_s{
+	uint16_t group;
+	uint16_t mixer;
+	uint16_t submixer;
+	uint16_t parameter;
+	uint16_t type;
+	float 	 param_value;
+	int32_t  int_value;
+};
+
+typedef enum
+{
+	AP_RCMIXER_STATUS_WAITING 	= 0,
+	AP_RCMIXER_STATUS_SEND_DATA = 1,
+} AP_RCMIXER_STATUS;
+
+class AP_RCMixer
 {
 public:
     /// Constructor
     ///
-    RCMixer();
-    void request_mixer_data(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t type);
+	AP_RCMixer();
+    // Pass mavlink data to message handlers (for MAV type)
+    void handle_msg(const mavlink_message_t *msg);
+
+    //MAVLink mixer data send
+    void send_mixer_data(mavlink_channel_t chan);
+
+    // Return true if waiting to send data
+    bool send_queued(void) {return(_status == AP_RCMIXER_STATUS_SEND_DATA);}
+
+//    static int mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd);
+//    static int mavlink_int_to_mission_cmd(const mavlink_mission_item_int_t& packet, AP_Mission::Mission_Command& cmd);
+//
+//    // mission_cmd_to_mavlink - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
+//    //  return true on success, false on failure
+//    static bool mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_t& packet);
+//    static bool mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& cmd, mavlink_mission_item_int_t& packet);
+//    AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
 
 private:
+    mixer_data_s _mixer_data;
+    AP_RCMIXER_STATUS _status;
+    uint8_t _target_system;
+	uint8_t _target_component;
 };

--- a/libraries/AP_RCMixer/AP_RCMixer.h
+++ b/libraries/AP_RCMixer/AP_RCMixer.h
@@ -12,6 +12,7 @@ struct mixer_data_s{
 	uint16_t parameter;
 	uint16_t type;
 	float 	 param_value;
+	uint16_t param_type;
 	int32_t  int_value;
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -77,6 +77,7 @@ enum ap_message {
     MSG_MISSION_ITEM_REACHED,
     MSG_POSITION_TARGET_GLOBAL_INT,
     MSG_ADSB_VEHICLE,
+	MSG_MIXER_DATA,
     MSG_RETRY_DEFERRED // this must be last
 };
 
@@ -173,9 +174,6 @@ public:
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint8_t position);
-#if defined(MIXER_CONFIGURATION)
-    void send_mixer_data_value(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t parameter, uint16_t type, float real_val, signed int_val);
-#endif 	//MIXER_CONFIGURATION
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }
@@ -270,11 +268,6 @@ protected:
     void handle_param_set(mavlink_message_t *msg, DataFlash_Class *DataFlash);
     void handle_param_request_list(mavlink_message_t *msg);
     void handle_param_request_read(mavlink_message_t *msg);
-
-#if defined(MIXER_CONFIGURATION)
-    void handle_mixer_data_request(mavlink_message_t *msg);
-    void handle_mixer_parameter_set(mavlink_message_t *msg);
-#endif 	//MIXER_CONFIGURATION
 
     void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;
     void handle_radio_status(mavlink_message_t *msg, DataFlash_Class &dataflash, bool log_radio);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -16,6 +16,7 @@
 #include <AP_Avoidance/AP_Avoidance.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
+#include <AP_RCMixer/AP_RCMixer.h>
 
 // check if a message will fit in the payload space available
 #define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
@@ -172,7 +173,9 @@ public:
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint8_t position);
-
+#if defined(MIXER_CONFIGURATION)
+    void send_mixer_data_value(uint16_t group, uint16_t mixer, uint16_t submixer, uint16_t parameter, uint16_t type, float real_val, signed int_val);
+#endif 	//MIXER_CONFIGURATION
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }
@@ -188,6 +191,7 @@ public:
 
     // send a PARAM_VALUE message to all active MAVLink connections.
     static void send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value);
+
     
     /*
       send a MAVLink message to all components with this vehicle's system id
@@ -266,6 +270,11 @@ protected:
     void handle_param_set(mavlink_message_t *msg, DataFlash_Class *DataFlash);
     void handle_param_request_list(mavlink_message_t *msg);
     void handle_param_request_read(mavlink_message_t *msg);
+
+#if defined(MIXER_CONFIGURATION)
+    void handle_mixer_data_request(mavlink_message_t *msg);
+    void handle_mixer_parameter_set(mavlink_message_t *msg);
+#endif 	//MIXER_CONFIGURATION
 
     void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;
     void handle_radio_status(mavlink_message_t *msg, DataFlash_Class &dataflash, bool log_radio);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -676,6 +676,17 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
     }
 }
 
+#if defined(MIXER_CONFIGURATION)
+void GCS_MAVLINK::handle_mixer_data_request(mavlink_message_t *msg){
+
+}
+
+void GCS_MAVLINK::handle_mixer_parameter_set(mavlink_message_t *msg){
+
+}
+#endif 	//MIXER_CONFIGURATION
+
+
 // see if we should send a stream now. Called at 50Hz
 bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
 {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -676,17 +676,6 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
     }
 }
 
-#if defined(MIXER_CONFIGURATION)
-void GCS_MAVLINK::handle_mixer_data_request(mavlink_message_t *msg){
-
-}
-
-void GCS_MAVLINK::handle_mixer_parameter_set(mavlink_message_t *msg){
-
-}
-#endif 	//MIXER_CONFIGURATION
-
-
 // see if we should send a stream now. Called at 50Hz
 bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
 {


### PR DESCRIPTION
WORK IN PROGRESS - FOR REVIEW ONLY

This is the ardupilot version of this px4 pull request to enable fast tuning of mixer parameters.
https://github.com/PX4/Firmware/pull/6357

**REVIEW ACTIONS**

**Mixer solution**
Fix a consistent mixer solution for all platforms

**px4io**
PX4io resource and I2C loading.
Restriction on parameter writes according to operating/safety mode.  The mixer has to be live for this to work.

**Build configuration**
The mixer tuning feature is completely optional.  MIXER_CONFIGURATION must be defined for the build.  This is currently hard coded into px4_targets.  The original intent of this option is to reduce risk and reduce code build size on px4.

**CHANGES**
Changed from mavlink messages to mavlink commands.


**TODO**

- Fix submodules.. again
- Mixer save and recall.
- Fix the standard builds to pass the build tests
- Possibly change MIXER_CONFIGURATION to MIXER_TUNING.  This will enable space for a true mixer configuration feature.
- Tidy commits into one single item. 
- Tidy and comment code


**NOTE:** Mixer parameters are not the same as mavlink parameters.  There is good reason for this.  A description document is being maintained here:

https://docs.google.com/document/d/1LeQC2qtxqdesNuJ3RAWH_MJ_30xjf-PMN3bd5wtUAUo/edit?usp=sharing
