### PR TITLE
Copter: fixed a problem with initial parameter fetch

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -848,6 +848,20 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:         // MAV ID: 21
     {
+        // if we have not yet allocated the motors object we drop this
+        // request. That prevents the GCS from getting a confusing
+        // parameter count during bootup. Hoever if FRAME_CLASS isn't
+        // set we need to process this request to allow the user to
+        // set FRAME_CLASS from the GCS. If we are more than 15s past
+        // boot then start accepting again, to make sure we cope with
+        // other failures
+        if (copter.g2.frame_class != 0 &&
+            copter.motors == nullptr &&
+            AP_HAL::millis() < 15000) {
+            // drop the message until motors are allocated
+            break;
+        }
+        
         // mark the firmware version in the tlog
         send_text(MAV_SEVERITY_INFO, FIRMWARE_STRING);
 


### PR DESCRIPTION
if the GCS connects before the motors have been allocated then it will
get an incorrect parameter count from the MAVLink param protocol. We
need to prevent the PARAM_REQUEST_LIST message from being replied to
until motors are allocated.

If however FRAME_CLASS isn't set yet then we must reply immediately, so
user can use MAVLink to set FRAME_CLASS

This problem was reported by @DonLakeFlyer for QGC. Thanks Don!