### PR TITLE
Lidar Lite v3 fix for Linux

### DIFF
--- a/libraries/AP_HAL/I2CDevice.h
+++ b/libraries/AP_HAL/I2CDevice.h
@@ -62,6 +62,9 @@ public:
     /* See Device::adjust_periodic_callback() */
     virtual bool adjust_periodic_callback(
         Device::PeriodicHandle h, uint32_t period_usec) override = 0;
+
+    /* force I2C transfers to be split between send and receive */
+    virtual void set_split_transfers(bool set) {};    
 };
 
 class I2CDeviceManager {

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -154,6 +154,16 @@ I2CDevice::~I2CDevice()
 bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
                          uint8_t *recv, uint32_t recv_len)
 {
+    if (send_len > 0 && recv_len > 0 && _split_transfers) {
+        /*
+          optionally split all I2C transfers. This is needed for some
+          devices (such as LidarLite) that require that STOP only
+          happen with SCL high
+         */
+        return transfer(send, send_len, nullptr, 0) &&
+            transfer(nullptr, 0, recv, recv_len);
+    }
+    
     struct i2c_msg msgs[2] = { };
     unsigned nmsgs = 0;
 

--- a/libraries/AP_HAL_Linux/I2CDevice.h
+++ b/libraries/AP_HAL_Linux/I2CDevice.h
@@ -71,10 +71,16 @@ public:
     bool adjust_periodic_callback(
         AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 
+    /* set split transfers flag */
+    void set_split_transfers(bool set) override {
+        _split_transfers = set;
+    }
+    
 protected:
     I2CBus &_bus;
     uint8_t _address;
     uint8_t _retries = 0;
+    bool _split_transfers = false;
 };
 
 class I2CDeviceManager : public AP_HAL::I2CDeviceManager {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -148,6 +148,9 @@ bool AP_RangeFinder_PulsedLightLRF::init(void)
     }
     _dev->set_retries(3);
 
+    // LidarLite needs split transfers
+    _dev->set_split_transfers(true);
+
     if (!(_dev->read_registers(LL40LS_HW_VERSION, &hw_version, 1) &&
           hw_version > 0 &&
           _dev->read_registers(LL40LS_SW_VERSION, &sw_version, 1) &&


### PR DESCRIPTION
This is a fix @tridge did some time ago to fix the Lidar Lite v3 for Linux. If I'm not mistaken in PX4 we always do separate receive and send transfers but that's not the case for Linux.

@patrickpoirier51 on Gitter confirmed this works so it would be nice to get it into master.