### PR TITLE
Global: Change from magic number 0 to definition name.

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -56,7 +56,7 @@ bool AP_Airspeed_MS4525::init()
         if (!_dev) {
             continue;
         }
-        if (!_dev->get_semaphore()->take(0)) {
+        if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             continue;
         }
 
@@ -138,7 +138,7 @@ void AP_Airspeed_MS4525::_collect()
     
     _voltage_correction(press, temp);
 
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _press_sum += press;
         _temp_sum += temp;
         _press_count++;
@@ -192,7 +192,7 @@ bool AP_Airspeed_MS4525::get_differential_pressure(float &pressure)
     if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (_press_count > 0) {
             _pressure = _press_sum / _press_count;
             _press_count = 0;
@@ -210,7 +210,7 @@ bool AP_Airspeed_MS4525::get_temperature(float &temperature)
     if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (_temp_count > 0) {
             _temperature = _temp_sum / _temp_count;
             _temp_count = 0;

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -66,7 +66,7 @@ bool AP_Airspeed_MS5525::init()
         if (!dev) {
             continue;
         }
-        if (!dev->get_semaphore()->take(0)) {
+        if (!dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             continue;
         }
 
@@ -213,7 +213,7 @@ void AP_Airspeed_MS5525::calculate(void)
     }
 #endif
     
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         pressure_sum += P_Pa;
         temperature_sum += Temp_C;
         press_count++;
@@ -258,7 +258,7 @@ bool AP_Airspeed_MS5525::get_differential_pressure(float &_pressure)
     if ((AP_HAL::millis() - last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (press_count > 0) {
             pressure = pressure_sum / press_count;
             press_count = 0;
@@ -276,7 +276,7 @@ bool AP_Airspeed_MS5525::get_temperature(float &_temperature)
     if ((AP_HAL::millis() - last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (temp_count > 0) {
             temperature = temperature_sum / temp_count;
             temp_count = 0;

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -211,7 +211,7 @@ void AP_Baro_BMP085::_calculate()
     x2 = (-7357 * p) >> 16;
     p += ((x1 + x2 + 3791) >> 4);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _pressure_filter.apply(p);
         _has_sample = true;
         _sem->give();

--- a/libraries/AP_Baro/AP_Baro_BMP280.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP280.cpp
@@ -66,7 +66,7 @@ AP_Baro_Backend *AP_Baro_BMP280::probe(AP_Baro &baro,
 
 bool AP_Baro_BMP280::_init()
 {
-    if (!_dev | !_dev->get_semaphore()->take(0)) {
+    if (!_dev | !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 
@@ -158,7 +158,7 @@ void AP_Baro_BMP280::_update_temperature(int32_t temp_raw)
     var2 = (((((temp_raw >> 4) - ((int32_t)_t1)) * ((temp_raw >> 4) - ((int32_t)_t1))) >> 12) * ((int32_t)_t3)) >> 14;
     _t_fine = var1 + var2;
     t = (_t_fine * 5 + 128) >> 8;
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _temperature = ((float)t) / 100;
         _sem->give();
     }
@@ -187,7 +187,7 @@ void AP_Baro_BMP280::_update_pressure(int32_t press_raw)
     var2 = (((int64_t)_p8) * p) >> 19;
     p = ((p + var1 + var2) >> 8) + (((int64_t)_p7) << 4);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _pressure = (float)p / 25600;
         _has_sample = true;
         _sem->give();

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -81,7 +81,7 @@ bool AP_Baro_MS56XX::_init()
         return false;
     }
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         AP_HAL::panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
     }
 
@@ -324,7 +324,7 @@ void AP_Baro_MS56XX::update()
     uint32_t sD1, sD2;
     uint8_t d1count, d2count;
 
-    if (!_sem->take(0)) {
+    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 

--- a/libraries/AP_Baro/AP_Baro_qflight.cpp
+++ b/libraries/AP_Baro/AP_Baro_qflight.cpp
@@ -40,7 +40,7 @@ void AP_Baro_QFLIGHT::timer_update(void)
         return;
     }
 
-    if (!_sem->take(0)) {
+    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -69,7 +69,7 @@ AP_Compass_AK09916::AP_Compass_AK09916(Compass &compass,
 
 bool AP_Compass_AK09916::init()
 {
-    if (!dev->get_semaphore()->take(0)) {
+    if (!dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 
@@ -147,7 +147,7 @@ void AP_Compass_AK09916::timer()
     /* correct raw_field for known errors */
     correct_field(field, compass_instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         accum += field;
         accum_count++;
         _sem->give();

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -250,7 +250,7 @@ void AP_Compass_AK8963::_update()
     // correct raw_field for known errors
     correct_field(raw_field, _compass_instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _mag_x_accum += raw_field.x;
         _mag_y_accum += raw_field.y;
         _mag_z_accum += raw_field.z;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -261,7 +261,7 @@ void AP_Compass_HMC5843::_timer()
     // correct raw_field for known errors
     correct_field(raw_field, _compass_instance);
     
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _mag_x_accum += raw_field.x;
         _mag_y_accum += raw_field.y;
         _mag_z_accum += raw_field.z;

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -167,7 +167,7 @@ void AP_Compass_IST8310::timer()
     /* correct raw_field for known errors */
     correct_field(field, _instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _accum += field;
         _accum_count++;
         _sem->give();

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -78,7 +78,7 @@ AP_Compass_LIS3MDL::AP_Compass_LIS3MDL(Compass &compass,
 
 bool AP_Compass_LIS3MDL::init()
 {
-    if (!dev->get_semaphore()->take(0)) {
+    if (!dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 
@@ -169,7 +169,7 @@ void AP_Compass_LIS3MDL::timer()
     /* correct raw_field for known errors */
     correct_field(field, compass_instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         accum += field;
         accum_count++;
         _sem->give();

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -360,7 +360,7 @@ void AP_Compass_LSM303D::_update()
     // correct raw_field for known errors
     correct_field(raw_field, _compass_instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _mag_x_accum += raw_field.x;
         _mag_y_accum += raw_field.y;
         _mag_z_accum += raw_field.z;

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -168,7 +168,7 @@ void AP_Compass_LSM9DS1::_update(void)
     // correct raw_field for known errors
     correct_field(raw_field, _compass_instance);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _mag_x_accum += raw_field.x;
         _mag_y_accum += raw_field.y;
         _mag_z_accum += raw_field.z;

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -109,7 +109,7 @@ void RCOutput_Bebop::_start_prop()
 {
     uint8_t data = BEBOP_BLDC_STARTPROP;
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -138,7 +138,7 @@ void RCOutput_Bebop::_set_ref_speed(uint16_t rpm[BEBOP_BLDC_MOTORS_NUM])
     data.enable_security = 0;
     data.checksum = _checksum((uint8_t *) &data, sizeof(data) - 1);
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -155,7 +155,7 @@ bool RCOutput_Bebop::_get_info(struct bldc_info *info)
 
     memset(info, 0, sizeof(struct bldc_info));
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
     _dev->read_registers(BEBOP_BLDC_GET_INFO, (uint8_t*)info, sizeof(*info));
@@ -186,7 +186,7 @@ int RCOutput_Bebop::read_obs_data(BebopBLDC_ObsData &obs)
     } data;
 
     memset(&data, 0, sizeof(data));
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return -EBUSY;
     }
 
@@ -241,7 +241,7 @@ int RCOutput_Bebop::read_obs_data(BebopBLDC_ObsData &obs)
 
 void RCOutput_Bebop::_toggle_gpio(uint8_t mask)
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -253,7 +253,7 @@ void RCOutput_Bebop::_stop_prop()
 {
     uint8_t data = BEBOP_BLDC_STOP_PROP;
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -265,7 +265,7 @@ void RCOutput_Bebop::_clear_error()
 {
     uint8_t data = BEBOP_BLDC_CLEAR_ERROR;
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -275,7 +275,7 @@ void RCOutput_Bebop::_clear_error()
 
 void RCOutput_Bebop::_play_sound(uint8_t sound)
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -309,7 +309,7 @@ void RCOutput_Bebop::play_note(uint8_t pwm,
     msg.period = htobe16(period_us);
     msg.duration = htobe16(duration_ms);
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 

--- a/libraries/AP_IRLock/AP_IRLock_I2C.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_I2C.cpp
@@ -128,7 +128,7 @@ void AP_IRLock_I2C::read_frames(void)
     pixel_to_1M_plane(corner1_pix_x, corner1_pix_y, corner1_pos_x, corner1_pos_y);
     pixel_to_1M_plane(corner2_pix_x, corner2_pix_y, corner2_pos_x, corner2_pos_y);
 
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         /* convert to angles */
         _target_info.timestamp = AP_HAL::millis();
         _target_info.pos_x = 0.5f*(corner1_pos_x+corner2_pos_x);
@@ -157,7 +157,7 @@ bool AP_IRLock_I2C::update()
     if (!dev || !sem) {
         return false;
     }
-    if (sem->take(0)) {
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (_last_update_ms != _target_info.timestamp) {
             new_data = true;
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -152,7 +152,7 @@ void AP_InertialSensor_BMI160::start()
 {
     bool r;
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -428,7 +428,7 @@ bool AP_InertialSensor_BMI160::_hardware_init()
 
     hal.scheduler->delay(BMI160_POWERUP_DELAY_MSEC);
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -97,7 +97,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
     delta_coning = delta_coning % delta_angle;
     delta_coning *= 0.5f;
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         // integrate delta angle accumulator
         // the angles and coning corrections are accumulated separately in the
         // referenced paper, but in simulation little difference was found between
@@ -187,7 +187,7 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     
     _imu.calc_vibration_and_clipping(instance, accel, dt);
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         // delta velocity
         _imu._delta_velocity_acc[instance] += accel * dt;
         _imu._delta_velocity_acc_dt[instance] += dt;
@@ -273,7 +273,7 @@ void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float tem
  */
 void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
 {    
-    if (!_sem->take(0)) {
+    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -296,7 +296,7 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
  */
 void AP_InertialSensor_Backend::update_accel(uint8_t instance)
 {    
-    if (!_sem->take(0)) {
+    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -372,7 +372,7 @@ bool AP_InertialSensor_Invensense::_has_auxiliary_bus()
 
 void AP_InertialSensor_Invensense::start()
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
@@ -825,7 +825,7 @@ bool AP_InertialSensor_Invensense::_check_whoami(void)
 
 bool AP_InertialSensor_Invensense::_hardware_init(void)
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 

--- a/libraries/AP_Notify/Display_SH1106_I2C.cpp
+++ b/libraries/AP_Notify/Display_SH1106_I2C.cpp
@@ -103,13 +103,13 @@ void Display_SH1106_I2C::_timer()
         command.page = 0xB0 | (i & 0x0F);
         _dev->transfer((uint8_t *)&command, sizeof(command), nullptr, 0);
 
-        if (_displaybuffer_sem->take(0)) {
+        if (_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             memcpy(&display_buffer.db[0], &_displaybuffer[i * SH1106_COLUMNS], SH1106_COLUMNS/2);
             _displaybuffer_sem->give();
             _dev->transfer((uint8_t *)&display_buffer, SH1106_COLUMNS/2 + 1, nullptr, 0);
         }
 
-        if (_displaybuffer_sem->take(0)) {
+        if (_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             memcpy(&display_buffer.db[0], &_displaybuffer[i * SH1106_COLUMNS + SH1106_COLUMNS/2 ], SH1106_COLUMNS/2);
             _displaybuffer_sem->give();
             _dev->transfer((uint8_t *)&display_buffer, SH1106_COLUMNS/2 + 1, nullptr, 0);
@@ -124,7 +124,7 @@ void Display_SH1106_I2C::set_pixel(uint16_t x, uint16_t y)
         return;
     }
     // set pixel in buffer
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
     _displaybuffer[x + (y / 8 * SH1106_COLUMNS)] |= 1 << (y % 8);
@@ -137,7 +137,7 @@ void Display_SH1106_I2C::clear_pixel(uint16_t x, uint16_t y)
     if ((x >= SH1106_COLUMNS) || (y >= SH1106_ROWS)) {
         return;
     }
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
     // clear pixel in buffer
@@ -147,7 +147,7 @@ void Display_SH1106_I2C::clear_pixel(uint16_t x, uint16_t y)
 
 void Display_SH1106_I2C::clear_screen()
 {
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
     memset(_displaybuffer, 0, SH1106_COLUMNS * SH1106_ROWS_PER_PAGE);

--- a/libraries/AP_Notify/Display_SSD1306_I2C.cpp
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.cpp
@@ -109,13 +109,13 @@ void Display_SSD1306_I2C::_timer()
         command.cmd[4] = i;
         _dev->transfer((uint8_t *)&command, sizeof(command), nullptr, 0);
 
-        if (_displaybuffer_sem->take(0)) {
+        if (_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             memcpy(&display_buffer.db[0], &_displaybuffer[i * SSD1306_COLUMNS], SSD1306_COLUMNS/2);
             _displaybuffer_sem->give();
             _dev->transfer((uint8_t *)&display_buffer, SSD1306_COLUMNS/2 + 1, nullptr, 0);
         }
 
-        if (_displaybuffer_sem->take(0)) {
+        if (_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             memcpy(&display_buffer.db[0], &_displaybuffer[i * SSD1306_COLUMNS + SSD1306_COLUMNS/2 ], SSD1306_COLUMNS/2);
             _displaybuffer_sem->give();
             _dev->transfer((uint8_t *)&display_buffer, SSD1306_COLUMNS/2 + 1, nullptr, 0);
@@ -129,7 +129,7 @@ void Display_SSD1306_I2C::set_pixel(uint16_t x, uint16_t y)
     if ((x >= SSD1306_COLUMNS) || (y >= SSD1306_ROWS)) {
         return;
     }
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
     // set pixel in buffer
@@ -143,7 +143,7 @@ void Display_SSD1306_I2C::clear_pixel(uint16_t x, uint16_t y)
     if ((x >= SSD1306_COLUMNS) || (y >= SSD1306_ROWS)) {
         return;
     }
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
     // clear pixel in buffer
@@ -153,7 +153,7 @@ void Display_SSD1306_I2C::clear_pixel(uint16_t x, uint16_t y)
 
 void Display_SSD1306_I2C::clear_screen()
 {
-    if (!_displaybuffer_sem->take(0)) {
+    if (!_displaybuffer_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
      memset(_displaybuffer, 0, SSD1306_COLUMNS * SSD1306_ROWS_PER_PAGE);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -66,7 +66,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
         if (!tdev) {
             continue;
         }
-        if (!tdev->get_semaphore()->take(0)) {
+        if (!tdev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             continue;
         }
         struct i2c_integral_frame frame;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -100,7 +100,7 @@ AP_OpticalFlow_Pixart *AP_OpticalFlow_Pixart::detect(OpticalFlow &_frontend)
 // setup the device
 bool AP_OpticalFlow_Pixart::setup_sensor(void)
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         AP_HAL::panic("Unable to get bus semaphore");
     }
 
@@ -278,7 +278,7 @@ void AP_OpticalFlow_Pixart::timer(void)
     float dt = dt_us * 1.0e-6;
     const Vector3f &gyro = get_ahrs().get_gyro();
 
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         integral.sum.x += burst.delta_x;
         integral.sum.y += burst.delta_y;
         integral.sum_us += dt_us;
@@ -316,7 +316,7 @@ void AP_OpticalFlow_Pixart::update(void)
     state.device_id = 1;
     state.surface_quality = burst.squal;
     
-    if (integral.sum_us > 0 && _sem->take(0)) {
+    if (integral.sum_us > 0 && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         const Vector2f flowScaler = _flowScaler();
         float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;
         float flowScaleFactorY = 1.0f + 0.001f * flowScaler.y;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -45,7 +45,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_LightWareI2C::detect(RangeFinder &_ranger
         return nullptr;
     }
 
-    if (sensor->_dev->get_semaphore()->take(0)) {
+    if (sensor->_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         uint16_t reading_cm;
         if (!sensor->get_reading(reading_cm)) {
             sensor->_dev->get_semaphore()->give();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -68,7 +68,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder &_range
  */
 bool AP_RangeFinder_MaxsonarI2CXL::_init(void)
 {
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
     
@@ -130,7 +130,7 @@ void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 {
     uint16_t d;
     if (get_reading(d)) {
-        if (_sem->take(0)) {
+        if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
             distance = d;
             new_distance = true;
             _sem->give();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -142,7 +142,7 @@ static const struct settings_table settings_v2[] = {
  */
 bool AP_RangeFinder_PulsedLightLRF::init(void)
 {
-    if (!_dev || !_dev->get_semaphore()->take(0)) {
+    if (!_dev || !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
     _dev->set_retries(3);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_trone.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_trone.cpp
@@ -67,7 +67,7 @@ AP_RangeFinder_Backend *AP_RangeFinder_trone::detect(uint8_t bus, RangeFinder &_
  */
 bool AP_RangeFinder_trone::init(void)
 {
-    if (!dev->get_semaphore()->take(0)) {
+    if (!dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 
@@ -138,7 +138,7 @@ void AP_RangeFinder_trone::timer(void)
 {
     // take a reading
     uint16_t distance_cm;
-    if (collect(distance_cm) && _sem->take(0)) {
+    if (collect(distance_cm) && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         accum.sum += distance_cm;
         accum.count++;
         _sem->give();
@@ -154,7 +154,7 @@ void AP_RangeFinder_trone::timer(void)
 */
 void AP_RangeFinder_trone::update(void)
 {
-    if (_sem->take(0)) {
+    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (accum.count > 0) {
             state.distance_cm = accum.sum / accum.count;
             accum.sum = 0;


### PR DESCRIPTION
The designation that waits until a semaphore can be taken is often magic number 0.
0 is defined.
Therefore,
Change from magic number 0 to definition name.