### PR TITLE
Fixed slew rate limit handling

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1000,6 +1000,20 @@ AP_GPS_UBLOX::_parse_gps(void)
         
         // time
         state.time_week_ms    = _buffer.pvt.itow;
+#if UBLOX_FAKE_3DLOCK
+        state.location.lng = 1491652300L;
+        state.location.lat = -353632610L;
+        state.location.alt = 58400;
+        state.vertical_accuracy = 0;
+        state.horizontal_accuracy = 0;
+        state.status = AP_GPS::GPS_OK_FIX_3D;
+        state.num_sats = 10;
+        state.time_week = 1721;
+        state.time_week_ms = AP_HAL::millis() + 3*60*60*1000 + 37000;
+        state.last_gps_time_ms = AP_HAL::millis();
+        state.hdop = 130;
+        next_fix = state.status;
+#endif
         break;
     case MSG_VELNED:
         Debug("MSG_VELNED");

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -558,7 +558,7 @@ void SRV_Channels::limit_slew_rate(SRV_Channel::Aux_servo_function_t function, f
         SRV_Channel &ch = channels[i];
         if (ch.function == function) {
             ch.calc_pwm(functions[function].output_scaled);
-            uint16_t last_pwm = hal.rcout->read(ch.ch_num);
+            uint16_t last_pwm = hal.rcout->read_last_sent(ch.ch_num);
             if (last_pwm == ch.output_pwm) {
                 continue;
             }


### PR DESCRIPTION
This fixes slew limit handling on stm32 with px4io. 
The bug could cause the forward throttle to slew on quadplanes at 6x slower than it should, leading to large problems in transition.
The AP_GPS fix was to help with reproducing the bug in bench testing
