### PR TITLE
Correct Replay.elf to not segfault

### DIFF
--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <AP_Param/AP_Param.h>
+#include <GCS_MAVLink/GCS.h>
 #include "Parameters.h"
 #include "VehicleType.h"
 #include "MsgHandler.h"
@@ -926,5 +927,13 @@ bool Replay::check_user_param(const char *name)
     }
     return false;
 }
+
+class GCS_Replay : public GCS
+{
+    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) override {
+        ::fprintf(stderr, "GCS: %s\n", text);
+    }
+};
+GCS_Replay _gcs;
 
 AP_HAL_MAIN_CALLBACKS(&replay);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -416,7 +416,7 @@ public:
         return _singleton;
     }
 
-    void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
+    virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
     void service_statustext(void);
 
     /*


### PR DESCRIPTION
gcs() is expected to return an object - so we do that.

This also adds some handy debug.
