### PR TITLE
Plane: add prop-hang training option for tailsitter

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -763,7 +763,7 @@ void Plane::update_flight_mode(void)
     case QRTL: {
         // set nav_roll and nav_pitch using sticks
         int16_t roll_limit = MIN(roll_limit_cd, quadplane.aparm.angle_max);
-        nav_roll_cd  = channel_roll->norm_input() * roll_limit;
+        nav_roll_cd  = (channel_roll->get_control_in() / 4500.0) * roll_limit;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
         float pitch_input = channel_pitch->norm_input();
         if (pitch_input > 0) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -334,7 +334,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Values: 0:Continuous,1:Binary
     AP_GROUPINFO("TILT_TYPE", 47, QuadPlane, tilt.tilt_type, TILT_TYPE_CONTINUOUS),
 
-    // @Param: Q_TAILSIT_ANGLE
+    // @Param: TAILSIT_ANGLE
     // @DisplayName: Tailsitter transition angle
     // @Description: This is the angle at which tailsitter aircraft will change from VTOL control to fixed wing control.
     // @Range: 5 80
@@ -349,6 +349,12 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("TILT_RATE_DN", 49, QuadPlane, tilt.max_rate_down_dps, 0),
         
+    // @Param: TAILSIT_INPUT
+    // @DisplayName: Tailsitter input type
+    // @Description: This controls whether stick input when hovering as a tailsitter follows the conventions for fixed wing hovering or multicopter hovering. When multicopter input is selected the roll stick will roll the aircraft in earth frame and yaw stick will yaw in earth frame. When using fixed wing input the roll and yaw sticks will control the aircraft in body frame.
+    // @Values: 0:MultiCopterInput,1:FixedWingInput
+    AP_GROUPINFO("TAILSIT_INPUT", 50, QuadPlane, tailsitter.input_type, TAILSITTER_INPUT_MULTICOPTER),
+
     AP_GROUPEND
 };
 
@@ -851,7 +857,7 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void)
     }
 
     // add in rudder input
-    return plane.channel_rudder->norm_input() * 100 * yaw_rate_max;
+    return plane.channel_rudder->get_control_in() * yaw_rate_max / 45;
 }
 
 /*
@@ -1191,6 +1197,7 @@ void QuadPlane::update(void)
             transition_state = TRANSITION_DONE;
         } else if (is_tailsitter()) {
             transition_state = TRANSITION_ANGLE_WAIT;
+            transition_start_ms = AP_HAL::millis();
         } else {
             transition_state = TRANSITION_AIRSPEED_WAIT;
         }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -355,6 +355,18 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Values: 0:MultiCopterInput,1:FixedWingInput
     AP_GROUPINFO("TAILSIT_INPUT", 50, QuadPlane, tailsitter.input_type, TAILSITTER_INPUT_MULTICOPTER),
 
+    // @Param: TAILSIT_MASK
+    // @DisplayName: Tailsitter input mask
+    // @Description: This controls what channels have full manual control when hovering as a tailsitter and the Q_TAILSIT_MASKCH channel in high. This can be used to teach yourself to prop-hang a 3D plane by learning one or more channels at a time.
+    // @Bitmask: 0:Aileron,1:Elevator,2:Throttle,3:Rudder
+    AP_GROUPINFO("TAILSIT_MASK", 51, QuadPlane, tailsitter.input_mask, 0),
+
+    // @Param: TAILSIT_MASKCH
+    // @DisplayName: Tailsitter input mask channel
+    // @Description: This controls what input channel will activate the Q_TAILSIT_MASK mask. When this channel goes above 1700 then the pilot will have direct manual control of the output channels specified in Q_TAILSIT_MASK. Set to zero to disable.
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    AP_GROUPINFO("TAILSIT_MASKCH", 52, QuadPlane, tailsitter.input_mask_chan, 0),
+    
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -84,6 +84,9 @@ public:
     // create outputs for tailsitters
     void tailsitter_output(void);
 
+    // handle different tailsitter input types
+    void tailsitter_check_input(void);
+    
     // check if we have completed transition
     bool tailsitter_transition_complete(void);
     
@@ -328,9 +331,15 @@ private:
         bool motors_active:1;
     } tilt;
 
+    enum tailsitter_input {
+        TAILSITTER_INPUT_MULTICOPTER = 0,
+        TAILSITTER_INPUT_PLANE       = 1,
+    };
+    
     // tailsitter control variables
     struct {
         AP_Int8 transition_angle;
+        AP_Int8 input_type;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -335,11 +335,20 @@ private:
         TAILSITTER_INPUT_MULTICOPTER = 0,
         TAILSITTER_INPUT_PLANE       = 1,
     };
+
+    enum tailsitter_mask {
+        TAILSITTER_MASK_AILERON  = 1,
+        TAILSITTER_MASK_ELEVATOR = 2,
+        TAILSITTER_MASK_THROTTLE = 4,
+        TAILSITTER_MASK_RUDDER   = 8,
+    };
     
     // tailsitter control variables
     struct {
         AP_Int8 transition_angle;
         AP_Int8 input_type;
+        AP_Int8 input_mask;
+        AP_Int8 input_mask_chan;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -240,6 +240,9 @@ void Plane::read_radio()
         rudder_input = 0;
     }
 
+    // potentially swap inputs for tailsitters
+    quadplane.tailsitter_check_input();
+    
     // check for transmitter tuning changes
     tuning.check_input(control_mode);
 }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -39,10 +39,30 @@ bool QuadPlane::tailsitter_active(void)
  */
 void QuadPlane::tailsitter_output(void)
 {
-    if (tailsitter_active()) {
-        motors_output();
-        plane.pitchController.reset_I();
-        plane.rollController.reset_I();
+    if (!tailsitter_active()) {
+        return;
+    }
+
+    motors_output();
+    plane.pitchController.reset_I();
+    plane.rollController.reset_I();
+
+    if (tailsitter.input_mask_chan > 0 &&
+        tailsitter.input_mask > 0 &&
+        hal.rcin->read(tailsitter.input_mask_chan-1) > 1700) {
+        // the user is learning to prop-hang
+        if (tailsitter.input_mask & TAILSITTER_MASK_AILERON) {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.channel_roll->get_control_in_zero_dz());
+        }
+        if (tailsitter.input_mask & TAILSITTER_MASK_ELEVATOR) {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, plane.channel_pitch->get_control_in_zero_dz());
+        }
+        if (tailsitter.input_mask & TAILSITTER_MASK_THROTTLE) {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.channel_throttle->get_control_in_zero_dz());
+        }
+        if (tailsitter.input_mask & TAILSITTER_MASK_RUDDER) {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, plane.channel_rudder->get_control_in_zero_dz());
+        }
     }
 }
 


### PR DESCRIPTION
This adds a Q_TAILSIT_INPUT parameter which allows the inputs for a tailsitter in hover to match normal fixed wing pilot input (ie. all inputs in body frame). The default is still "multicopter" style stick inputs, which are earth frame.
It also adds two more parameters Q_TAILSIT_MASK and Q_TAILSIT_MASKCH which together allow for ArduPilot to be used as a training platform for prop-hang. The Q_TAILSIT_MASKCH is an input channel number which when high enables pass-through of the set of channels in the Q_TAILSIT_MASK bitmask.
So you can setup Q_TAILSIT_MASKCH to be your trainer switch and set Q_TAILSIT_MASKCH to be (for example) 3. In that case when you pull the trainer switch in hover the aileron and elevator inputs will be passed through directly, allowing you to learn to control those inputs manually. If you get in trouble you release the trainer switch and all channels will be under autopilot control again.
