### PR TITLE
Plane & Rover: Reset home to AHRS location rather then GPS

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -95,17 +95,12 @@ void Rover::restart_nav()
 void Rover::update_home()
 {
     if (home_is_set == HOME_SET_NOT_LOCKED) {
-        Location loc = gps.location();
-        Location origin;
-        // if an EKF origin is available then we leave home equal to
-        // the height of that origin. This ensures that our relative
-        // height calculations are using the same origin
-        if (ahrs.get_origin(origin)) {
-            loc.alt = origin.alt;
+        Location loc;
+        if (ahrs.get_position(loc)) {
+            ahrs.set_home(loc);
+            Log_Write_Home_And_Origin();
+            GCS_MAVLINK::send_home_all(gps.location());
         }
-        ahrs.set_home(loc);
-        Log_Write_Home_And_Origin();
-        GCS_MAVLINK::send_home_all(gps.location());
     }
     barometer.update_calibration();
 }

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -136,10 +136,12 @@ void Plane::update_home()
         return;
     }
     if (home_is_set == HOME_SET_NOT_LOCKED) {
-        Location loc = gps.location();
-        ahrs.set_home(loc);
-        Log_Write_Home_And_Origin();
-        GCS_MAVLINK::send_home_all(loc);
+        Location loc;
+        if(ahrs.get_position(loc)) {
+            ahrs.set_home(loc);
+            Log_Write_Home_And_Origin();
+            GCS_MAVLINK::send_home_all(loc);
+        }
     }
     barometer.update_calibration();
 }


### PR DESCRIPTION
The current behavior in Plane is to take a snapshot of GPS position as the home location. This has several unfortunate side effects:
- The aircraft reset it's home but is actually showing a significantly lower or higher altitude then it's new home which is expected to match
- The GPS isn't assessed for fix quality, by grabbing it from AHRS we have a filtered and more accurate position which reduces susceptibility to GPS spikes.

This approach was discussed with @priseborough without finding any downsides to approaching it in this manner.

@gmorph I converted rover to match plane as well, including to not lock the home alt to the EKF origin altitude. However, I didn't complete the audit for the rest of rover altitudes. As I don't think any rover model can actually chase a different altitude I believe this is okay. If I missed how rover is managing altitude let me know, the only line I noticed that seemed to be deriving a relative altitude was in GCS_Mavlink.cpp and that is fine with this change. If I missed anything else let me know and I can try and address it.