### PR TITLE
AP_Motors: Don't set esc scaling in constructor for SITL build.

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -189,8 +189,9 @@ AP_MotorsMulticopter::AP_MotorsMulticopter(uint16_t loop_rate, uint16_t speed_hz
     _batt_voltage_filt.set_cutoff_frequency(AP_MOTORS_BATT_VOLT_FILT_HZ);
     _batt_voltage_filt.reset(1.0f);
 
-    // default throttle ranges (i.e. _throttle_radio_min, _throttle_radio_max)
-    set_throttle_range(1100, 1900);
+    // default throttle range
+    _throttle_radio_min = 1100;
+    _throttle_radio_max = 1900;
 };
 
 // output - sends commands to the motors


### PR DESCRIPTION
This fixes a broken SITL for Sub introduced by https://github.com/ArduPilot/ardupilot/commit/ade18763188983f2fa6656d3d705ed5b8ff516d1.

This was causing SITL to hang at boot, with the following output:
```
RiTW: Starting ArduSub : /home/jack/git/ardupilot/build/sitl/bin/ardusub -S -I0 --home -35.363261,149.165230,584,353 --model vectored --speedup 1 --defaults /home/jack/git/ardupilot/Tools/autotest/default_params/sub.parm
Connect tcp:127.0.0.1:5760 source_system=255
[Errno 111] Connection refused sleeping
[Errno 111] Connection refused sleeping
Failed to connect to tcp:127.0.0.1:5760 : [Errno 111] Connection refused
SIM_VEHICLE: MAVProxy exited
SIM_VEHICLE: Killing tasks
```

I'm not sure why this is the case, it was still working fine on px4-v2, maybe someone can lend some insight. 