### PR TITLE
AP_Motors: simplify current limiting feature

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -259,9 +259,7 @@ float AP_MotorsMulticopter::get_current_limit_max_throttle()
     }
 
     // calculate the maximum current to prevent voltage sag below _batt_voltage_min
-    float batt_current_max = MIN(_batt_current_max, _batt_current + (_batt_voltage-_batt_voltage_min)/_batt_resistance);
-
-    float batt_current_ratio = _batt_current/batt_current_max;
+    float batt_current_ratio = _batt_current/_batt_current_max;
 
     float loop_interval = 1.0f/_loop_rate;
     _throttle_limit += (loop_interval/(loop_interval+_batt_current_time_constant))*(1.0f - batt_current_ratio);


### PR DESCRIPTION
This fixes a bug where current limiting could fail if the current voltage is less than MOT_BAT_VOLT_MIN