### PR TITLE
AP_Math: vector2::angle(vector2) distinguish between parallel and antiparallel vectors

### DIFF
--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -131,8 +131,11 @@ float Vector2<T>::angle(const Vector2<T> &v2) const
         return 0.0f;
     }
     float cosv = ((*this)*v2) / len;
-    if (fabsf(cosv) >= 1) {
+    if (cosv >= 1) {
         return 0.0f;
+    }
+    if (cosv <= -1) {
+        return M_PI;
     }
     return acosf(cosv);
 }

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -92,6 +92,7 @@ struct Vector2
     T operator %(const Vector2<T> &v) const;
 
     // computes the angle between this vector and another vector
+    // returns 0 if the vectors are parallel, and M_PI if they are antiparallel
     float angle(const Vector2<T> &v2) const;
 
     // computes the angle in radians between the origin and this vector


### PR DESCRIPTION
There are a number of uses cases where knowing if a pair of vectors are parallel or antiparallel is very important.

The only user I've found of vector2::angle(vector2) is actually deepstall landing, angle() was used to determine if the plane's ground track was facing a waypoint, however because anti parallel returned 0, we sometimes did a 180 turn when not expected.