### PR TITLE
Copter, Sub, Heli: run rate controllers before AHRS updates

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -255,14 +255,13 @@ void Copter::loop()
 // Main loop - 400hz
 void Copter::fast_loop()
 {
+    // run low level rate controllers that only require IMU data
+    attitude_control->rate_controller_run();
 
     // IMU DCM Algorithm
     // --------------------
     read_AHRS();
 
-    // run low level rate controllers that only require IMU data
-    attitude_control->rate_controller_run();
-    
 #if FRAME_CONFIG == HELI_FRAME
     update_heli_control_dynamics();
 #endif //HELI_FRAME

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -590,10 +590,9 @@ Vector3f AC_AttitudeControl::update_ang_vel_target_from_att_error(Vector3f attit
 }
 
 // Run the roll angular velocity PID controller and return the output
-float AC_AttitudeControl::rate_target_to_motor_roll(float rate_target_rads)
+float AC_AttitudeControl::rate_target_to_motor_roll(float rate_actual_rads, float rate_target_rads)
 {
-    float current_rate_rads = _ahrs.get_gyro().x;
-    float rate_error_rads = rate_target_rads - current_rate_rads;
+    float rate_error_rads = rate_target_rads - rate_actual_rads;
 
     // pass error to PID controller
     get_rate_roll_pid().set_input_filter_d(rate_error_rads);
@@ -614,10 +613,9 @@ float AC_AttitudeControl::rate_target_to_motor_roll(float rate_target_rads)
 }
 
 // Run the pitch angular velocity PID controller and return the output
-float AC_AttitudeControl::rate_target_to_motor_pitch(float rate_target_rads)
+float AC_AttitudeControl::rate_target_to_motor_pitch(float rate_actual_rads, float rate_target_rads)
 {
-    float current_rate_rads = _ahrs.get_gyro().y;
-    float rate_error_rads = rate_target_rads - current_rate_rads;
+    float rate_error_rads = rate_target_rads - rate_actual_rads;
 
     // pass error to PID controller
     get_rate_pitch_pid().set_input_filter_d(rate_error_rads);
@@ -638,10 +636,9 @@ float AC_AttitudeControl::rate_target_to_motor_pitch(float rate_target_rads)
 }
 
 // Run the yaw angular velocity PID controller and return the output
-float AC_AttitudeControl::rate_target_to_motor_yaw(float rate_target_rads)
+float AC_AttitudeControl::rate_target_to_motor_yaw(float rate_actual_rads, float rate_target_rads)
 {
-    float current_rate_rads = _ahrs.get_gyro().z;
-    float rate_error_rads = rate_target_rads - current_rate_rads;
+    float rate_error_rads = rate_target_rads - rate_actual_rads;
 
     // pass error to PID controller
     get_rate_yaw_pid().set_input_filter_all(rate_error_rads);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -269,13 +269,13 @@ protected:
     Vector3f update_ang_vel_target_from_att_error(Vector3f attitude_error_rot_vec_rad);
 
     // Run the roll angular velocity PID controller and return the output
-    float rate_target_to_motor_roll(float rate_target_rads);
+    float rate_target_to_motor_roll(float rate_actual_rads, float rate_target_rads);
 
     // Run the pitch angular velocity PID controller and return the output
-    float rate_target_to_motor_pitch(float rate_target_rads);
+    float rate_target_to_motor_pitch(float rate_actual_rads, float rate_target_rads);
 
     // Run the yaw angular velocity PID controller and return the output
-    virtual float rate_target_to_motor_yaw(float rate_target_rads);
+    virtual float rate_target_to_motor_yaw(float rate_actual_rads, float rate_target_rads);
 
     // Return angle in radians to be added to roll angle. Used by heli to counteract
     // tail rotor thrust in hover. Overloaded by AC_Attitude_Heli to return angle.

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -116,8 +116,8 @@ private:
     //
 	// rate_bf_to_motor_roll_pitch - ask the rate controller to calculate the motor outputs to achieve the target body-frame rate (in radians/sec) for roll, pitch and yaw
     // outputs are sent directly to motor class
-    void rate_bf_to_motor_roll_pitch(float rate_roll_target_rads, float rate_pitch_target_rads);
-    float rate_target_to_motor_yaw(float rate_yaw_rads);
+    void rate_bf_to_motor_roll_pitch(const Vector3f &rate_rads, float rate_roll_target_rads, float rate_pitch_target_rads);
+    float rate_target_to_motor_yaw(float rate_yaw_actual_rads, float rate_yaw_rads) override;
 
     //
     // throttle methods

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -255,9 +255,10 @@ void AC_AttitudeControl_Multi::rate_controller_run()
     // move throttle vs attitude mixing towards desired (called from here because this is conveniently called on every iteration)
     update_throttle_rpy_mix();
 
-    _motors.set_roll(rate_target_to_motor_roll(_rate_target_ang_vel.x));
-    _motors.set_pitch(rate_target_to_motor_pitch(_rate_target_ang_vel.y));
-    _motors.set_yaw(rate_target_to_motor_yaw(_rate_target_ang_vel.z));
+    Vector3f gyro_latest = _ahrs.get_gyro_latest();
+    _motors.set_roll(rate_target_to_motor_roll(gyro_latest.x, _rate_target_ang_vel.x));
+    _motors.set_pitch(rate_target_to_motor_pitch(gyro_latest.y, _rate_target_ang_vel.y));
+    _motors.set_yaw(rate_target_to_motor_yaw(gyro_latest.z, _rate_target_ang_vel.z));
 
     control_monitor_update();
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -262,9 +262,10 @@ void AC_AttitudeControl_Sub::rate_controller_run()
     // move throttle vs attitude mixing towards desired (called from here because this is conveniently called on every iteration)
     update_throttle_rpy_mix();
 
-    _motors.set_roll(rate_target_to_motor_roll(_rate_target_ang_vel.x));
-    _motors.set_pitch(rate_target_to_motor_pitch(_rate_target_ang_vel.y));
-    _motors.set_yaw(rate_target_to_motor_yaw(_rate_target_ang_vel.z));
+    Vector3f gyro_latest = _ahrs.get_gyro_latest();
+    _motors.set_roll(rate_target_to_motor_roll(gyro_latest.x, _rate_target_ang_vel.x));
+    _motors.set_pitch(rate_target_to_motor_pitch(gyro_latest.y, _rate_target_ang_vel.y));
+    _motors.set_yaw(rate_target_to_motor_yaw(gyro_latest.z, _rate_target_ang_vel.z));
 
     control_monitor_update();
 }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -131,6 +131,13 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     AP_GROUPEND
 };
 
+// return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
+Vector3f AP_AHRS::get_gyro_latest(void) const
+{
+    uint8_t primary_gyro = get_primary_gyro_index();
+    return get_ins().get_gyro(primary_gyro) + get_gyro_drift();
+}
+
 // return airspeed estimate if available
 bool AP_AHRS::airspeed_estimate(float *airspeed_ret) const
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -235,6 +235,9 @@ public:
     // return a smoothed and corrected gyro vector
     virtual const Vector3f &get_gyro(void) const = 0;
 
+    // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
+    Vector3f get_gyro_latest(void) const;
+
     // return the current estimate of the gyro drift
     virtual const Vector3f &get_gyro_drift(void) const = 0;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1471,7 +1471,7 @@ bool AP_AHRS_NavEKF::have_ekf_logging(void) const
     return false;
 }
 
-// get earth-frame accel vector for primary IMU
+// get the index of the current primary IMU
 uint8_t AP_AHRS_NavEKF::get_primary_IMU_index() const
 {
     int8_t imu = -1;

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -67,3 +67,10 @@ void AP_AHRS_View::update(void)
                    trig.cos_roll, trig.cos_pitch, trig.cos_yaw,
                    trig.sin_roll, trig.sin_pitch, trig.sin_yaw);
 }
+
+// return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
+Vector3f AP_AHRS_View::get_gyro_latest(void) const {
+    Vector3f gyro_latest = ahrs.get_gyro_latest();
+    gyro_latest.rotate(rotation);
+    return gyro_latest;
+}

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -39,6 +39,9 @@ public:
         return gyro;
     }
 
+    // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
+    Vector3f get_gyro_latest(void) const;
+
     // return a DCM rotation matrix representing our current
     // attitude in this view
     const Matrix3f &get_rotation_body_to_ned(void) const {


### PR DESCRIPTION
This change reduces the lag between IMU updates and motor outputs by an average of 0.68 milliseconds by moving the rate controllers to run before the AHRS/EKF updates.

This is possible because we use gyro rates directly from the IMU combined with the AHRS/EKF's latest gyro bias estimates.  I.e. new gyro values with bias values from the previous iteration.  Because gyro bias values update slowly this mismatch is not a problem.

Below is a screen shot of the improvement in timing with the average improvement being about 0.6 ms but perhaps more importantly the variability in the timing is greatly reduced with the maximum delay falling from about 2.2ms to 0.2ms.
![ratecontrol_timing_before_and_after](https://cloud.githubusercontent.com/assets/1498098/23506557/47061592-ff8c-11e6-8082-29bbdb17b65e.png)

I have not actually test flown this yet but will do so tomorrow.