### PR TITLE
Copter: GPS filter default to Airborne 2G

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -183,7 +183,7 @@ private:
     // Dataflash
     DataFlash_Class DataFlash;
 
-    AP_GPS gps;
+    AP_GPS gps {AP_GPS::GPS_ENGINE_AIRBORNE_2G};
 
     // flight modes convenience array
     AP_Int8 *flight_modes;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -60,7 +60,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Description: Navigation filter engine setting
     // @Values: 0:Portable,2:Stationary,3:Pedestrian,4:Automotive,5:Sea,6:Airborne1G,7:Airborne2G,8:Airborne4G
     // @User: Advanced
-    AP_GROUPINFO("NAVFILTER", 2, AP_GPS, _navfilter, GPS_ENGINE_AIRBORNE_4G),
+    AP_GROUPINFO("NAVFILTER", 2, AP_GPS, _navfilter, GPS_NAVFILTER_DEFAULT),
 
     // @Param: AUTO_SWITCH
     // @DisplayName: Automatic Switchover Setting
@@ -215,6 +215,14 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
     AP_GROUPEND
 };
+
+// constructor
+AP_GPS::AP_GPS(GPS_Engine_Setting nav_filter_default)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+
+    _navfilter.set_default(nav_filter_default);
+}
 
 /// Startup initialisation.
 void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_manager)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -30,6 +30,7 @@
  */
 #define GPS_MAX_INSTANCES 2
 #define GPS_RTK_INJECT_TO_ALL 127
+#define GPS_NAVFILTER_DEFAULT GPS_ENGINE_AIRBORNE_4G
 
 // the number of GPS leap seconds
 #define GPS_LEAPSECONDS_MILLIS 18000ULL
@@ -44,18 +45,6 @@ class AP_GPS_Backend;
 class AP_GPS
 {
 public:
-    // constructor
-	AP_GPS() {
-		AP_Param::setup_object_defaults(this, var_info);
-    }
-
-    /// Startup initialisation.
-    void init(DataFlash_Class *dataflash, const AP_SerialManager& serial_manager);
-
-    /// Update GPS state based on possible bytes received from the module.
-    /// This routine must be called periodically (typically at 10Hz or
-    /// more) to process incoming data.
-    void update(void);
 
     // GPS driver types
     enum GPS_Type {
@@ -105,6 +94,17 @@ public:
    enum GPS_Config {
        GPS_ALL_CONFIGURED = 255
    };
+
+   // constructor
+   AP_GPS(GPS_Engine_Setting nav_filter_default = GPS_NAVFILTER_DEFAULT);
+
+   /// Startup initialisation.
+   void init(DataFlash_Class *dataflash, const AP_SerialManager& serial_manager);
+
+   /// Update GPS state based on possible bytes received from the module.
+   /// This routine must be called periodically (typically at 10Hz or
+   /// more) to process incoming data.
+   void update(void);
 
     /*
       The GPS_State structure is filled in by the backend driver as it


### PR DESCRIPTION
This PR allows setting vehicle specific GPS navigation filters instead of all being "Airborne4G" which is the current default for all vehicles.  The only vehicle changed is Copter which is set to "Airborne 2G"

Getting the appropriate filter affects glitch protection within the GPS itself which could improve safety.  As a data point the Solo was apparently set by default to "Airborne 1G".

Alternatively we could set the default to Airborne 4G for all vehicles except Copter which is the one that I'm personally most motivated to have changed.