### PR TITLE
AP_Mount: Remove solo gimbal from the minimal build support

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -442,11 +442,13 @@ void AP_Mount::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_m
             _num_instances++;
 
 #if AP_AHRS_NAVEKF_AVAILABLE
+#if !HAL_MINIMIZE_FEATURES
         // check for MAVLink mounts
         } else if (mount_type == Mount_Type_SoloGimbal) {
             _backends[instance] = new AP_Mount_SoloGimbal(*this, state[instance], instance);
             _num_instances++;
-#endif
+#endif // HAL_MINIMIZE_FEATURES
+#endif // AP_AHRS_NAVEKF_AVAILABLE
 
         // check for Alexmos mounts
         } else if (mount_type == Mount_Type_Alexmos) {


### PR DESCRIPTION
Saves 17472 bytes on Plane builds.