### PR TITLE
Terrain: Coverity updates

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -220,11 +220,11 @@ bool AP_Terrain::height_above_terrain(float &terrain_altitude, bool extrapolate)
         // we don't know where we are
         return false;
     }
-    float relative_home_altitude = loc.alt*0.01f;
-    if (!loc.flags.relative_alt) {
-        // loc.alt has home altitude added, remove it
-        relative_home_altitude -= ahrs.get_home().alt*0.01f;
-    }
+
+    float relative_home_altitude;
+    ahrs.get_relative_position_D_home(relative_home_altitude);
+    relative_home_altitude = -relative_home_altitude;
+
     terrain_altitude = relative_home_altitude - terrain_difference;
     return true;
 }

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -178,9 +178,13 @@ void AP_Terrain::open_file(void)
     // create directory if need be
     if (!directory_created) {
         *p = 0;
-        mkdir(file_path, 0755);
-        directory_created = true;
+        directory_created = !mkdir(file_path, 0755);
         *p = '/';
+        // if we didn't succeed at making the directory, then IO failed
+        if(!directory_created) {
+            io_failure = true;
+            return;
+        }
     }
 
     if (fd != -1) {


### PR DESCRIPTION
Fixes coverity issues 91367 and 91361

Also converts to using the get_relative_position_D_home() functions rather then attempting to derive home itself