### PR TITLE
Plane: Change some user facing statustexts

### DIFF
--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -111,8 +111,6 @@ void Plane::init_home()
     Log_Write_Home_And_Origin();
     GCS_MAVLINK::send_home_all(gps.location());
 
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "GPS alt: %lu", (unsigned long)home.alt);
-
     // Save Home to EEPROM
     mission.write_home_to_storage();
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -746,7 +746,7 @@ bool Plane::verify_RTL()
     update_loiter(abs(g.rtl_radius));
 	if (auto_state.wp_distance <= (uint32_t)MAX(g.waypoint_radius,0) || 
         reached_loiter_target()) {
-			gcs_send_text(MAV_SEVERITY_INFO,"Reached HOME");
+			gcs_send_text(MAV_SEVERITY_INFO,"Reached RTL location");
 			return true;
     } else {
         return false;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -275,11 +275,11 @@ void Plane::startup_ground(void)
 {
     set_mode(INITIALISING, MODE_REASON_UNKNOWN);
 
-    gcs_send_text(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
-
 #if (GROUND_START_DELAY > 0)
-    gcs_send_text(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
+    gcs_send_text(MAV_SEVERITY_NOTICE,"Ground start with delay");
     delay(GROUND_START_DELAY * 1000);
+#else
+    gcs_send_text(MAV_SEVERITY_INFO,"Ground start");
 #endif
 
     //INS ground start
@@ -312,7 +312,7 @@ void Plane::startup_ground(void)
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
     ins.set_dataflash(&DataFlash);
 
-    gcs_send_text(MAV_SEVERITY_INFO,"Ready to fly");
+    gcs_send_text(MAV_SEVERITY_INFO,"Ground start complete");
 }
 
 enum FlightMode Plane::get_previous_mode() {

--- a/Tools/scripts/runplanetest.py
+++ b/Tools/scripts/runplanetest.py
@@ -37,7 +37,7 @@ def wait_time(mav, simtime):
 
 cmd = 'sim_vehicle.py -j4 -D -f plane'
 mavproxy = pexpect.spawn(cmd, logfile=sys.stdout, timeout=30)
-mavproxy.expect("Ready to fly")
+mavproxy.expect("Ground start complete")
 
 mav = mavutil.mavlink_connection('127.0.0.1:14550')
 


### PR DESCRIPTION
Adjust some status texts that Plane currently broadcasts.

Rough justification in order:
1. GPS alt that home was locked at is already sent via the home waypoint which is broadcast, and it was poorly formatted so as to be confusing to the user (lack of decimal places)
2. Plane doesn't necessarily go home on RTL, which means that broadcasting a message that says reached home is really confusing if you went to a rally point
3. I don't see any good reason for prefacing ground start with arrows, just makes the statustexts look more confusing
4. Just because ground start is done doesn't mean you are ready to fly. In fact if you are using arming checks which we want you to be you probably aren't even close to being ready to fly. (Arming checks, EKF aren't even close to being ready to be flown at this stage). I've had this confuse users in the past.