### PR TITLE
EKF: Prevent successful velocity fusion blocking position timeout reset

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -238,8 +238,7 @@ void NavEKF2_core::setAidingMode()
                 maxLossTime_ms = frontend->posRetryTimeUseVel_ms;
             }
             posAidLossCritical = (imuSampleTime_ms - lastRngBcnPassTime_ms > maxLossTime_ms) &&
-                   (imuSampleTime_ms - lastPosPassTime_ms > maxLossTime_ms) &&
-                   (imuSampleTime_ms - lastVelPassTime_ms > maxLossTime_ms);
+                   (imuSampleTime_ms - lastPosPassTime_ms > maxLossTime_ms);
         }
 
         if (attAidLossCritical) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -252,8 +252,7 @@ void NavEKF3_core::setAidingMode()
                  maxLossTime_ms = frontend->posRetryTimeUseVel_ms;
              }
              posAidLossCritical = (imuSampleTime_ms - lastRngBcnPassTime_ms > maxLossTime_ms) &&
-                    (imuSampleTime_ms - lastPosPassTime_ms > maxLossTime_ms) &&
-                    (imuSampleTime_ms - lastVelPassTime_ms > maxLossTime_ms);
+                    (imuSampleTime_ms - lastPosPassTime_ms > maxLossTime_ms);
          }
 
          if (attAidLossCritical) {


### PR DESCRIPTION
Fixes a bug introduced when reset logic was reworked to accomodate range finder fusion

See https://github.com/ArduPilot/ardupilot/issues/5813