### PR TITLE
Readd output value limit

### DIFF
--- a/AntennaTracker/control_manual.cpp
+++ b/AntennaTracker/control_manual.cpp
@@ -12,11 +12,9 @@ void Tracker::update_manual(void)
 {
     // copy yaw and pitch input to output
     SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_yaw, RC_Channels::rc_channel(CH_YAW)->get_radio_in());
-    SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_yaw);
-    
+
     SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_pitch, RC_Channels::rc_channel(CH_PITCH)->get_radio_in());
-    SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_pitch);
-    
+
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
 }

--- a/AntennaTracker/control_servo_test.cpp
+++ b/AntennaTracker/control_servo_test.cpp
@@ -26,13 +26,11 @@ bool Tracker::servo_test_set_servo(uint8_t servo_num, uint16_t pwm)
     // set yaw servo pwm and send output to servo
     if (servo_num == CH_YAW) {
         SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_yaw, pwm);
-        SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_yaw);
     }
 
     // set pitch servo pwm and send output to servo
     if (servo_num == CH_PITCH) {
         SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_pitch, pwm);
-        SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_pitch);
     }
 
     SRV_Channels::calc_pwm();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -223,8 +223,9 @@ void Plane::channel_output_mixer(uint8_t mixing_type, SRV_Channel::Aux_servo_fun
     chan2_out = chan2->get_output_pwm();
     
     channel_output_mixer_pwm(mixing_type, chan1_out, chan2_out);
-
+    // SRV_Channels::set_output_unlimited_once(func1);
     chan1->set_output_pwm(chan1_out);
+    // SRV_Channels::set_output_unlimited_once(func2);
     chan2->set_output_pwm(chan2_out);
 }
 
@@ -276,7 +277,9 @@ void Plane::flaperon_update(int8_t flap_percent)
     // The *5 is to take a percentage to a value from -500 to 500 for the mixer
     ch2 = 1500 - flap_percent * 5;
     channel_output_mixer_pwm(g.flaperon_output, ch1, ch2);
+    // SRV_Channels::set_output_unlimited_once(SRV_Channel::k_flaperon1);
     SRV_Channels::set_output_pwm_trimmed(SRV_Channel::k_flaperon1, ch1);
+    // SRV_Channels::set_output_unlimited_once(SRV_Channel::k_flaperon2);
     SRV_Channels::set_output_pwm_trimmed(SRV_Channel::k_flaperon2, ch2);
 }
 
@@ -365,7 +368,9 @@ void Plane::set_servos_old_elevons(void)
     }
     
     // directly set the radio_out values for elevon mode
+    SRV_Channels::set_output_unlimited_once(SRV_Channel::k_aileron);
     SRV_Channels::set_output_pwm_first(SRV_Channel::k_aileron, elevon.trim1 + (BOOL_TO_SIGN(g.reverse_ch1_elevon) * (ch1 * 500.0f/ SERVO_MAX)));
+    SRV_Channels::set_output_unlimited_once(SRV_Channel::k_elevator);
     SRV_Channels::set_output_pwm_first(SRV_Channel::k_elevator, elevon.trim2 + (BOOL_TO_SIGN(g.reverse_ch2_elevon) * (ch2 * 500.0f/ SERVO_MAX)));
 }
 
@@ -620,7 +625,9 @@ void Plane::servo_output_mixers(void)
                     ch4 -= ruddVal;
                 }
                 // change elevon 1 & 2 positions; constrain min/max:
+                SRV_Channels::set_output_unlimited_once(SRV_Channel::k_aileron);
                 SRV_Channels::set_output_pwm_first(SRV_Channel::k_aileron, constrain_int16(ch1, 900, 2100));
+                SRV_Channels::set_output_unlimited_once(SRV_Channel::k_elevator);
                 SRV_Channels::set_output_pwm_first(SRV_Channel::k_elevator, constrain_int16(ch2, 900, 2100));
                 // constrain min/max for intermediate dspoiler positions:
                 ch3 = constrain_int16(ch3, 900, 2100);
@@ -760,7 +767,7 @@ void Plane::set_servos(void)
             break;
 
         case AP_Arming::YES_ZERO_PWM:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, 0);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             break;
 
         case AP_Arming::YES_MIN_PWM:

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -301,6 +301,7 @@ bool AP_Landing_Deepstall::override_servos(void)
     }
 
     // mix the elevator to the correct value
+    SRV_Channels::set_output_unlimited_once(SRV_Channel::k_elevator);
     elevator->set_output_pwm(linear_interpolate(initial_elevator_pwm, elevator_pwm,
                              slew_progress, 0.0f, 1.0f));
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -194,6 +194,7 @@ void AP_MotorsHeli_RSC::write_rsc(float servo_out)
         } else {
             pwm = _pwm_max - pwm;
         }
+        SRV_Channels::set_output_unlimited_once(_aux_fn);
         SRV_Channels::set_output_pwm(_aux_fn, pwm);
     }
 }

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -26,6 +26,8 @@
 extern const AP_HAL::HAL& hal;
 
 SRV_Channel::servo_mask_t SRV_Channel::have_pwm_mask;
+SRV_Channel::servo_mask_t SRV_Channel::limited_pwm_mask;
+
 
 const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: MIN
@@ -77,7 +79,9 @@ SRV_Channel::SRV_Channel(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
     // start with all pwm at zero
-    have_pwm_mask = ~uint16_t(0);
+    have_pwm_mask = UINT16_MAX;
+    // start with all ouput limited
+    limited_pwm_mask = UINT16_MAX;
 }
 
 
@@ -110,7 +114,7 @@ uint16_t SRV_Channel::pwm_from_angle(int16_t scaled_value) const
 
 void SRV_Channel::calc_pwm(int16_t output_scaled)
 {
-    if (have_pwm_mask & (1U<<ch_num)) {
+    if (have_pwm_mask & (1U << ch_num)) {
         return;
     }
     uint16_t pwm;
@@ -124,8 +128,14 @@ void SRV_Channel::calc_pwm(int16_t output_scaled)
 
 void SRV_Channel::set_output_pwm(uint16_t pwm)
 {
+    // contrain the ouput by default
+    if (limited_pwm_mask & (1U << ch_num)) {
+        pwm = static_cast<uint16_t>(constrain_int16(static_cast<int16_t>(pwm), servo_min, servo_max));
+    }
     output_pwm = pwm;
-    have_pwm_mask |= (1U<<ch_num);
+    have_pwm_mask |= (1U << ch_num);
+    // Relimit the ouput
+    limited_pwm_mask |= (1U << ch_num);
 }
 
 // set angular range of scaled output

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -198,3 +198,7 @@ bool SRV_Channel::is_motor(SRV_Channel::Aux_servo_function_t function)
     return ((function >= SRV_Channel::k_motor1 && function <= SRV_Channel::k_motor8) ||
             (function >= SRV_Channel::k_motor9 && function <= SRV_Channel::k_motor12));
 }
+
+void SRV_Channel::set_output_unlimited_once() {
+    limited_pwm_mask &= ~(1U << ch_num);
+}

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -214,6 +214,9 @@ private:
     // mask of channels where we have a output_pwm value. Cleared when a
     // scaled value is written. 
     static servo_mask_t have_pwm_mask;
+
+    // mask of channels where we store which channel will have limited output.
+    static servo_mask_t limited_pwm_mask;
 };
 
 /*
@@ -374,7 +377,7 @@ public:
     // upgrade RC* parameters into SERVO* parameters
     static bool upgrade_parameters(const uint8_t old_keys[14], uint16_t aux_channel_mask, RCMapper *rcmap);
     static void upgrade_motors_servo(uint8_t ap_motors_key, uint8_t ap_motors_idx, uint8_t new_channel);
-    
+
     static uint32_t get_can_servo_bm(void) {
         if(p_can_servo_bm != nullptr)
             return *p_can_servo_bm;
@@ -387,6 +390,8 @@ public:
         else
             return 0;
     }
+
+    static void set_output_unlimited_once(SRV_Channel::Aux_servo_function_t function);
 
 private:
     struct {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -207,7 +207,10 @@ private:
 
     // get normalised output from -1 to 1
     float get_output_norm(void);
-    
+
+    // set unlimited pwm mask for a channel function
+    void set_output_unlimited_once();
+
     // a bitmask type wide enough for NUM_SERVO_CHANNELS
     typedef uint16_t servo_mask_t;
 


### PR DESCRIPTION
Hi, after https://github.com/ArduPilot/ardupilot/pull/5519 , it seems that the limitation on output have disappeared leading in erroneous pwm output  like in https://github.com/ArduPilot/ardupilot/issues/5817
This PR thus relimit pwm calculated form angles, and limit all pwm between servo_min and servo_max