### PR TITLE
AP_Baro: fix example output

### DIFF
--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -32,6 +32,10 @@ void setup()
 
 void loop()
 {
+    if (!hal.console->is_initialized()) {
+        return;
+    }
+
     // run accumulate() at 50Hz and update() at 10Hz
     if ((AP_HAL::micros() - timer) > 20 * 1000UL) {
         timer = AP_HAL::micros();


### PR DESCRIPTION
PX4 boards can only start console after USB is connected so we need to check if it is available.

Fixes #5801.