### PR TITLE
Move GPS configuration disabled in the sim out of the arming and into AP_GPS

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -357,7 +357,6 @@ bool AP_Arming::gps_checks(bool report)
         }
     }
 
-#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
         uint8_t first_unconfigured = gps.first_unconfigured_gps();
         if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
@@ -370,7 +369,6 @@ bool AP_Arming::gps_checks(bool report)
             return false;
         }
     }
-#endif
     return true;
 }
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -105,11 +105,15 @@ public:
     void inject_data(const uint8_t *data, uint16_t len) override;
     
     bool is_configured(void) {
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (!gps._auto_config) {
             return true;
         } else {
             return !_unconfigured_messages;
         }
+#else
+        return true;
+#endif // CONFIG_HAL_BOARD != HAL_BOARD_SITL
     }
 
     void broadcast_configuration_failure_reason(void) const override;


### PR DESCRIPTION
EKF3 relies upon a configured GPS which breaks SITL EKF3 testing.