### PR TITLE
AP_GPS_GSOF-NOVA: fix last_gps_time_ms

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -298,7 +298,7 @@ AP_GPS_GSOF::process_message(void)
                 state.location.lng = (int32_t)(RAD_TO_DEG_DOUBLE * (SwapDouble(gsof_msg.data, a + 8)) * (double)1e7);
                 state.location.alt = (int32_t)(SwapDouble(gsof_msg.data, a + 16) * 100);
 
-                state.last_gps_time_ms = state.time_week_ms;
+                state.last_gps_time_ms = AP_HAL::millis();
 
                 valid++;
             }

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -194,7 +194,7 @@ AP_GPS_NOVA::process_message(void)
 
         state.time_week = nova_msg.header.nova_headeru.week;
         state.time_week_ms = (uint32_t) nova_msg.header.nova_headeru.tow;
-        state.last_gps_time_ms = state.time_week_ms;
+        state.last_gps_time_ms = AP_HAL::millis();
 
         state.location.lat = (int32_t) (bestposu.lat * (double)1e7);
         state.location.lng = (int32_t) (bestposu.lng * (double)1e7);
@@ -270,7 +270,7 @@ AP_GPS_NOVA::process_message(void)
     }
 
     // ensure out position and velocity stay insync
-    if (_new_position && _new_speed && _last_vel_time == state.last_gps_time_ms) {
+    if (_new_position && _new_speed && _last_vel_time == state.time_week_ms) {
         _new_speed = _new_position = false;
         
         return true;


### PR DESCRIPTION
this is to fix a possible time bug that is exposed by
uint64_t AP_GPS::time_epoch_usec(uint8_t instance)

found by Buzz
