### PR TITLE
GPS Blending (attempt2)

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -464,26 +464,17 @@ bool AP_Arming_Copter::pre_arm_gps_checks(bool display_failure)
         return true;
     }
 
-#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
-    // check GPS configuration has completed
-    uint8_t first_unconfigured = copter.gps.first_unconfigured_gps();
-    if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
-        if (display_failure) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,
-                                             "PreArm: GPS %d failing configuration checks",
-                                              first_unconfigured + 1);
-            copter.gps.broadcast_first_configuration_failure_reason();
-        }
-        return false;
-    }
-#endif
-
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (copter.gps.get_hdop() > copter.g.gps_hdop_good) {
         if (display_failure) {
             gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: High GPS HDOP");
         }
         AP_Notify::flags.pre_arm_gps_check = false;
+        return false;
+    }
+
+    // call parent gps checks
+    if (!AP_Arming::gps_checks(display_failure)) {
         return false;
     }
 

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -31,9 +31,9 @@ protected:
     // NOTE! the following check functions *DO* call into AP_Arming:
     bool ins_checks(bool display_failure) override;
     bool compass_checks(bool display_failure) override;
+    bool gps_checks(bool display_failure) override;
 
     // NOTE! the following check functions *DO NOT* call into AP_Arming!
-    bool gps_checks(bool display_failure);
     bool fence_checks(bool display_failure);
     bool board_voltage_checks(bool display_failure);
     bool parameter_checks(bool display_failure);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -331,6 +331,7 @@ private:
     struct {
         uint8_t baro        : 1;    // true if baro is healthy
         uint8_t compass     : 1;    // true if compass is healthy
+        uint8_t primary_gps;        // primary gps index
     } sensor_health;
 
     // Motor Output

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -621,6 +621,12 @@ void Copter::Log_Sensor_Health()
         sensor_health.compass = compass.healthy();
         Log_Write_Error(ERROR_SUBSYSTEM_COMPASS, (sensor_health.compass ? ERROR_CODE_ERROR_RESOLVED : ERROR_CODE_UNHEALTHY));
     }
+
+    // check primary GPS
+    if (sensor_health.primary_gps != gps.primary_sensor()) {
+        sensor_health.primary_gps = gps.primary_sensor();
+        Log_Write_Event(DATA_GPS_PRIMARY_CHANGED);
+    }
 }
 
 struct PACKED log_Heli {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -393,6 +393,7 @@ enum DevOptions {
 #define DATA_AVOIDANCE_ADSB_DISABLE         64
 #define DATA_AVOIDANCE_PROXIMITY_ENABLE     65
 #define DATA_AVOIDANCE_PROXIMITY_DISABLE    66
+#define DATA_GPS_PRIMARY_CHANGED            67
 
 // Centi-degrees to radians
 #define DEGX100 5729.57795f

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -381,7 +381,7 @@ bool AP_Arming::gps_checks(bool report)
             }
             return false;
         }
-        if (!gps.blend_healthy()) {
+        if (!gps.blend_health_check()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: GPS blending unhealthy");
             }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -376,8 +376,8 @@ bool AP_Arming::gps_checks(bool report)
         if (!gps.all_consistent(distance_m)) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,
-                                                 "PreArm: GPSs inconsistent by %4.1fm",
-                                                  (double)distance_m);
+                                                 "PreArm: GPS positions differ by %4.1fm",
+                                                 (double)distance_m);
             }
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -369,6 +369,26 @@ bool AP_Arming::gps_checks(bool report)
             return false;
         }
     }
+
+    // check GPSs are within 50m of each other and that blending is healthy
+    if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
+        float distance_m;
+        if (!gps.all_consistent(distance_m)) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,
+                                                 "PreArm: GPSs inconsistent by %4.1fm",
+                                                  (double)distance_m);
+            }
+            return false;
+        }
+        if (!gps.blend_healthy()) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: GPS blending unhealthy");
+            }
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -92,7 +92,7 @@ protected:
 
     virtual bool compass_checks(bool report);
 
-    bool gps_checks(bool report);
+    virtual bool gps_checks(bool report);
 
     bool battery_checks(bool report);
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -638,6 +638,10 @@ AP_GPS::update(void)
         } else if (_blend_health_counter > 0) {
             _blend_health_counter--;
         }
+        // stop blending if unhealthy
+        if (_blend_health_counter >= 50) {
+            _output_is_blended = false;
+        }
     } else {
         _output_is_blended = false;
         _blend_health_counter = 0;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -998,7 +998,7 @@ void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
     // see if this fragment is consistent with existing fragments
     if (rtcm_buffer->fragments_received &&
         (rtcm_buffer->sequence != sequence ||
-         rtcm_buffer->fragments_received & (1U<<fragment))) {
+        (rtcm_buffer->fragments_received & (1U<<fragment)))) {
         // we have one or more partial fragments already received
         // which conflict with the new fragment, discard previous fragments
         memset(rtcm_buffer, 0, sizeof(*rtcm_buffer));

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -35,6 +35,13 @@
 #include "AP_GPS_MAV.h"
 #include "GPS_Backend.h"
 
+#define GPS_BAUD_TIME_MS 1200
+
+// defines used to specify the mask position for use of different accuracy metrics in the blending algorithm
+#define BLEND_MASK_USE_HPOS_ACC     1
+#define BLEND_MASK_USE_VPOS_ACC     2
+#define BLEND_MASK_USE_SPD_ACC      4
+
 extern const AP_HAL::HAL &hal;
 
 // table of user settable parameters
@@ -65,7 +72,8 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: AUTO_SWITCH
     // @DisplayName: Automatic Switchover Setting
     // @Description: Automatic switchover to GPS reporting best lock
-    // @Values: 0:Disabled,1:Enabled
+    // @Values: 0:Disabled,1:UseBest,2:Blend
+    // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("AUTO_SWITCH", 3, AP_GPS, _auto_switch, 1),
 
@@ -213,6 +221,22 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
+
+    // @Param: BLEND_MASK
+    // @DisplayName: Multi GPS Blending Mask
+    // @Description: Determines which of the accuracy measures Horizontal position, Vertical Position and Speed are used to calculate the weighting on each GPS receiver when soft switching has been selected by setting GPS_AUTO_SWITCH to 2
+    // @Bitmask: 0:Horiz Pos,1:Vert Pos,2:Speed
+    // @User: Advanced
+    AP_GROUPINFO("BLEND_MASK", 20, AP_GPS, _blend_mask, 5),
+
+    // @Param: BLEND_TC
+    // @DisplayName: Blending time constant
+    // @Description: Controls the slowest time constant applied to the calculation of GPS position and height offsets used to adjust different GPS receivers for steady state position differences.
+    // @Units: seconds
+    // @Range: 5.0 30.0
+    // @User: Advanced
+    AP_GROUPINFO("BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),
+
     AP_GROUPEND
 };
 
@@ -226,6 +250,10 @@ void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_man
     _port[0] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 0);
     _port[1] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 1);
     _last_instance_swap_ms = 0;
+
+    // Initialise class variables used to do GPS blending
+    _omega_lpf = 1.0f / constrain_float(_blend_tc, 5.0f, 30.0f);
+
 }
 
 // baudrates to try to detect GPSes with
@@ -536,51 +564,90 @@ AP_GPS::update_instance(uint8_t instance)
 void
 AP_GPS::update(void)
 {
-    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         update_instance(i);
     }
 
-    // work out which GPS is the primary, and how many sensors we have
-    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+    // calculate number of instances
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         if (state[i].status != NO_GPS) {
             num_instances = i+1;
         }
-        if (_auto_switch) {            
-            if (i == primary_instance) {
-                continue;
-            }
-            if (state[i].status > state[primary_instance].status) {
-                // we have a higher status lock, change GPS
-                primary_instance = i;
-                continue;
-            }
+    }
 
-            bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
+    // if blending is requested, attempt to calculate weighting for each GPS
+    if (_auto_switch == 2) {
+        _output_is_blended = calc_blend_weights();
+    } else {
+        _output_is_blended = false;
+    }
 
-            if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
+    if (_output_is_blended) {
+        // Use the weighting to calculate blended GPS states
+        calc_blended_state();
+        // set primary to the virtual instance
+        primary_instance = GPS_MAX_RECEIVERS;
+    } else {
+        // use switch logic to find best GPS
+        uint32_t now = AP_HAL::millis();
+        if (_auto_switch >= 1) {
+            // handling switching away from blended GPS
+            if (primary_instance == GPS_MAX_RECEIVERS) {
+                primary_instance = 0;
+                for (uint8_t i=1; i<GPS_MAX_RECEIVERS; i++) {
+                    // choose GPS with highest state or higher number of satellites
+                    if ((state[i].status > state[primary_instance].status) ||
+                        ((state[i].status == state[primary_instance].status) && (state[i].num_sats > state[primary_instance].num_sats))) {
+                        primary_instance = i;
+                        _last_instance_swap_ms = now;
+                    }
+                }
+            } else {
+                // handle switch between real GPSs
+                for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+                    if (i == primary_instance) {
+                        continue;
+                    }
+                    if (state[i].status > state[primary_instance].status) {
+                        // we have a higher status lock, or primary is set to the blended GPS, change GPS
+                        primary_instance = i;
+                        _last_instance_swap_ms = now;
+                        continue;
+                    }
 
-                uint32_t now = AP_HAL::millis();
-                bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
+                    bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
 
-                if ( (another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
-                     (another_gps_has_2_or_more_sats && (now - _last_instance_swap_ms) >= 5000 ) ) {
-                // this GPS has more satellites than the
-                // current primary, switch primary. Once we switch we will
-                // then tend to stick to the new GPS as primary. We don't
-                // want to switch too often as it will look like a
-                // position shift to the controllers.
-                primary_instance = i;
-                _last_instance_swap_ms = now;
+                    if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
+
+                        bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
+
+                        if ( (another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
+                             (another_gps_has_2_or_more_sats && (now - _last_instance_swap_ms) >= 5000 ) ) {
+                            // this GPS has more satellites than the
+                            // current primary, switch primary. Once we switch we will
+                            // then tend to stick to the new GPS as primary. We don't
+                            // want to switch too often as it will look like a
+                            // position shift to the controllers.
+                            primary_instance = i;
+                            _last_instance_swap_ms = now;
+                        }
+                    }
                 }
             }
         } else {
+            // AUTO_SWITCH is 0 so no switching of GPSs
             primary_instance = 0;
         }
+
+        // copy the primary instance to the blended instance in case it is enabled later
+        state[GPS_MAX_RECEIVERS] = state[primary_instance];
+        _blended_antenna_offset = _antenna_offset[primary_instance];
     }
 
     // update notify with gps status. We always base this on the primary_instance
     AP_Notify::flags.gps_status = state[primary_instance].status;
     AP_Notify::flags.gps_num_sats = state[primary_instance].num_sats;
+
 }
 
 /*
@@ -610,7 +677,7 @@ AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms,
                const Location &_location, const Vector3f &_velocity, uint8_t _num_sats, 
                uint16_t hdop)
 {
-    if (instance >= GPS_MAX_INSTANCES) {
+    if (instance >= GPS_MAX_RECEIVERS) {
         return;
     }
     uint32_t tnow = AP_HAL::millis();
@@ -659,7 +726,7 @@ void
 AP_GPS::lock_port(uint8_t instance, bool lock)
 {
 
-    if (instance >= GPS_MAX_INSTANCES) {
+    if (instance >= GPS_MAX_RECEIVERS) {
         return;
     }
     if (lock) {
@@ -675,7 +742,7 @@ AP_GPS::inject_data(uint8_t *data, uint8_t len)
 {
     //Support broadcasting to all GPSes.
     if (_inject_to == GPS_RTK_INJECT_TO_ALL) {
-        for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
             inject_data(i, data, len);
         }
     } else {
@@ -686,7 +753,7 @@ AP_GPS::inject_data(uint8_t *data, uint8_t len)
 void 
 AP_GPS::inject_data(uint8_t instance, uint8_t *data, uint8_t len)
 {
-    if (instance < GPS_MAX_INSTANCES && drivers[instance] != nullptr) {
+    if (instance < GPS_MAX_RECEIVERS && drivers[instance] != nullptr) {
         drivers[instance]->inject_data(data, len);
     }
 }  
@@ -773,7 +840,7 @@ AP_GPS::send_mavlink_gps2_rtk(mavlink_channel_t chan)
 uint8_t
 AP_GPS::first_unconfigured_gps(void) const
 {
-    for(int i = 0; i < GPS_MAX_INSTANCES; i++) {
+    for(int i = 0; i < GPS_MAX_RECEIVERS; i++) {
         if(_type[i] != GPS_TYPE_NONE && (drivers[i] == nullptr || !drivers[i]->is_configured())) {
             return i;
         }
@@ -896,10 +963,15 @@ void AP_GPS::inject_data_all(const uint8_t *data, uint16_t len)
 }
 
 /*
-  return expected lag from a GPS
+  return the expected lag (in seconds) in the position and velocity readings from the gps
  */
 float AP_GPS::get_lag(uint8_t instance) const
 {
+    // return lag of blended GPS
+    if (instance == GPS_MAX_RECEIVERS) {
+        return _blended_lag_sec;
+    }
+
     if (_delay_ms[instance] > 0) {
         // if the user has specified a non zero time delay, always return that value
         return 0.001f * (float)_delay_ms[instance];
@@ -911,4 +983,397 @@ float AP_GPS::get_lag(uint8_t instance) const
         // the user has not specified a delay so we determine it from the GPS type
         return drivers[instance]->get_lag();
     }
+}
+
+/*
+ calculate the weightings used to blend GPs location and velocity data
+*/
+bool AP_GPS::calc_blend_weights(void)
+{
+    // zero the blend weights
+    memset(&_blend_weights, 0, sizeof(_blend_weights));
+
+    // exit immediately if not enough receivers to do blending
+    if (num_instances < 2) {
+        return false;
+    }
+
+    // Use the oldest non-zero time, but if time difference is excessive, use newest to prevent a disconnected receiver from blocking updates
+    uint32_t max_ms = 0; // newest non-zero system time of arrival of a GPS message
+    uint32_t min_ms = -1; // oldest non-zero system time of arrival of a GPS message
+    int16_t max_rate_ms = 0; // largest update interval of a GPS receiver
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        // Find largest and smallest times
+        if (state[i].last_gps_time_ms > max_ms) {
+            max_ms = state[i].last_gps_time_ms;
+        }
+        if ((state[i].last_gps_time_ms < min_ms) && (state[i].last_gps_time_ms > 0)) {
+            min_ms = state[i].last_gps_time_ms;
+        }
+        if (_rate_ms[i] > max_rate_ms) {
+            max_rate_ms = _rate_ms[i];
+        }
+    }
+    if ((int32_t)(max_ms - min_ms) < (int32_t)(2 * max_rate_ms)) {
+        // data is not too delayed so use the oldest time_stamp to give a chance for data from that receiver to be updated
+        state[GPS_MAX_RECEIVERS].last_gps_time_ms = min_ms;
+    } else {
+        // receiver data has timed out so fail out of blending
+        state[GPS_MAX_RECEIVERS].last_gps_time_ms = max_ms;
+        return false;
+    }
+
+    // calculate the sum squared speed accuracy across all GPS sensors
+    float speed_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & BLEND_MASK_USE_SPD_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                if (state[i].have_speed_accuracy && state[i].speed_accuracy > 0.0f) {
+                    speed_accuracy_sum_sq += state[i].speed_accuracy * state[i].speed_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    speed_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+
+    // calculate the sum squared horizontal position accuracy across all GPS sensors
+    float horizontal_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & BLEND_MASK_USE_HPOS_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_2D) {
+                if (state[i].have_horizontal_accuracy && state[i].horizontal_accuracy > 0.0f) {
+                    horizontal_accuracy_sum_sq += state[i].horizontal_accuracy * state[i].horizontal_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    horizontal_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+
+    // calculate the sum squared vertical position accuracy across all GPS sensors
+    float vertical_accuracy_sum_sq = 0.0f;
+    if (_blend_mask & BLEND_MASK_USE_VPOS_ACC) {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D) {
+                if (state[i].have_vertical_accuracy && state[i].vertical_accuracy > 0.0f) {
+                    vertical_accuracy_sum_sq += state[i].vertical_accuracy * state[i].vertical_accuracy;
+                } else {
+                    // not all receivers support this metric so set it to zero and don't use it
+                    vertical_accuracy_sum_sq = 0.0f;
+                    break;
+                }
+            }
+        }
+    }
+    // Check if we can do blending using reported accuracy
+    bool can_do_blending = (horizontal_accuracy_sum_sq > 0.0f || vertical_accuracy_sum_sq > 0.0f || speed_accuracy_sum_sq > 0.0f);
+
+    // if we cant do blending using reported accuracy, return false and hard switch logic will be used instead
+    if (!can_do_blending) {
+        return false;
+    }
+
+    float sum_of_all_weights = 0.0f;
+
+    // calculate a weighting using the reported horizontal position
+    float hpos_blend_weights[GPS_MAX_RECEIVERS] = {};
+    if (horizontal_accuracy_sum_sq > 0.0f && (_blend_mask & BLEND_MASK_USE_HPOS_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_hpos_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_2D && state[i].horizontal_accuracy > 0.001f) {
+                hpos_blend_weights[i] = horizontal_accuracy_sum_sq / (state[i].horizontal_accuracy * state[i].horizontal_accuracy);
+                sum_of_hpos_weights += hpos_blend_weights[i];
+            }
+        }
+        // normalise the weights
+        if (sum_of_hpos_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+                hpos_blend_weights[i] = hpos_blend_weights[i] / sum_of_hpos_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        }
+    }
+
+    // calculate a weighting using the reported vertical position accuracy
+    float vpos_blend_weights[GPS_MAX_RECEIVERS];
+    if (vertical_accuracy_sum_sq > 0.0f && (_blend_mask & BLEND_MASK_USE_VPOS_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_vpos_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].vertical_accuracy > 0.001f) {
+                vpos_blend_weights[i] = vertical_accuracy_sum_sq / (state[i].vertical_accuracy * state[i].vertical_accuracy);
+                sum_of_vpos_weights += vpos_blend_weights[i];
+            } else {
+                vpos_blend_weights[i] = 0.0f;
+            }
+        }
+        // normalise the weights
+        if (sum_of_vpos_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+                vpos_blend_weights[i] = vpos_blend_weights[i] / sum_of_vpos_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        };
+    } else {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            vpos_blend_weights[i] = 0.0f;
+        }
+    }
+
+    // calculate a weighting using the reported speed accuracy
+    float spd_blend_weights[GPS_MAX_RECEIVERS];
+    if (speed_accuracy_sum_sq > 0.0f && (_blend_mask & BLEND_MASK_USE_SPD_ACC)) {
+        // calculate the weights using the inverse of the variances
+        float sum_of_spd_weights = 0.0f;
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].speed_accuracy > 0.001f) {
+                spd_blend_weights[i] = speed_accuracy_sum_sq / (state[i].speed_accuracy * state[i].speed_accuracy);
+                sum_of_spd_weights += spd_blend_weights[i];
+            } else {
+                spd_blend_weights[i] = 0.0f;
+            }
+        }
+        // normalise the weights
+        if (sum_of_spd_weights > 0.0f) {
+            for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+                spd_blend_weights[i] = spd_blend_weights[i] / sum_of_spd_weights;
+            }
+            sum_of_all_weights += 1.0f;
+        }
+    } else {
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            spd_blend_weights[i] = 0.0f;
+        }
+    }
+
+    // calculate an overall weight
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        _blend_weights[i] = (hpos_blend_weights[i] + vpos_blend_weights[i] + spd_blend_weights[i]) / sum_of_all_weights;
+    }
+
+    return true;
+}
+
+/*
+ calculate a blended GPS state
+*/
+void AP_GPS::calc_blended_state(void)
+{
+    // initialise the blended states so we can accumulate the results using the weightings for each GPS receiver
+    state[GPS_MAX_RECEIVERS].instance = GPS_MAX_RECEIVERS;
+    state[GPS_MAX_RECEIVERS].status = NO_GPS;
+    state[GPS_MAX_RECEIVERS].time_week_ms = 0;
+    state[GPS_MAX_RECEIVERS].time_week = 0;
+    state[GPS_MAX_RECEIVERS].ground_speed = 0.0f;
+    state[GPS_MAX_RECEIVERS].ground_course = 0.0f;
+    state[GPS_MAX_RECEIVERS].hdop = 9999;
+    state[GPS_MAX_RECEIVERS].vdop = 9999;
+    state[GPS_MAX_RECEIVERS].num_sats = 0;
+    state[GPS_MAX_RECEIVERS].velocity.zero();
+    state[GPS_MAX_RECEIVERS].speed_accuracy = 1e6f;
+    state[GPS_MAX_RECEIVERS].horizontal_accuracy = 1e6f;
+    state[GPS_MAX_RECEIVERS].vertical_accuracy = 1e6f;
+    state[GPS_MAX_RECEIVERS].have_vertical_velocity = false;
+    state[GPS_MAX_RECEIVERS].have_speed_accuracy = false;
+    state[GPS_MAX_RECEIVERS].have_horizontal_accuracy = false;
+    state[GPS_MAX_RECEIVERS].have_vertical_accuracy = false;
+    state[GPS_MAX_RECEIVERS].last_gps_time_ms = 0;
+    memset(&state[GPS_MAX_RECEIVERS].location, 0, sizeof(state[GPS_MAX_RECEIVERS].location));
+
+    _blended_antenna_offset.zero();
+    _blended_lag_sec = 0;
+
+    timing[GPS_MAX_RECEIVERS].last_fix_time_ms = 0;
+    timing[GPS_MAX_RECEIVERS].last_message_time_ms = 0;
+
+    // combine the states into a blended solution
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        // use the highest status
+        if (state[i].status > state[GPS_MAX_RECEIVERS].status) {
+            state[GPS_MAX_RECEIVERS].status = state[i].status;
+        }
+
+        // calculate a blended average velocity
+        state[GPS_MAX_RECEIVERS].velocity += state[i].velocity * _blend_weights[i];
+
+        // report the best valid accuracies and DOP metrics
+
+        if (state[i].have_horizontal_accuracy && state[i].horizontal_accuracy > 0.0f && state[i].horizontal_accuracy < state[GPS_MAX_RECEIVERS].horizontal_accuracy) {
+            state[GPS_MAX_RECEIVERS].have_horizontal_accuracy = true;
+            state[GPS_MAX_RECEIVERS].horizontal_accuracy = state[i].horizontal_accuracy;
+        }
+
+        if (state[i].have_vertical_accuracy && state[i].vertical_accuracy > 0.0f && state[i].vertical_accuracy < state[GPS_MAX_RECEIVERS].vertical_accuracy) {
+            state[GPS_MAX_RECEIVERS].have_vertical_accuracy = true;
+            state[GPS_MAX_RECEIVERS].vertical_accuracy = state[i].vertical_accuracy;
+        }
+
+        if (state[i].have_vertical_velocity ) {
+            state[GPS_MAX_RECEIVERS].have_vertical_velocity = true;
+        }
+
+        if (state[i].have_speed_accuracy && state[i].speed_accuracy > 0.0f && state[i].speed_accuracy < state[GPS_MAX_RECEIVERS].speed_accuracy) {
+            state[GPS_MAX_RECEIVERS].have_speed_accuracy = true;
+            state[GPS_MAX_RECEIVERS].speed_accuracy = state[i].speed_accuracy;
+        }
+
+        if (state[i].hdop > 0 && state[i].hdop < state[GPS_MAX_RECEIVERS].hdop) {
+            state[GPS_MAX_RECEIVERS].hdop = state[i].hdop;
+        }
+
+        if (state[i].vdop > 0 && state[i].vdop < state[GPS_MAX_RECEIVERS].vdop) {
+            state[GPS_MAX_RECEIVERS].vdop = state[i].vdop;
+        }
+
+        if (state[i].num_sats > 0 && state[i].num_sats > state[GPS_MAX_RECEIVERS].num_sats) {
+            state[GPS_MAX_RECEIVERS].num_sats = state[i].num_sats;
+        }
+
+        // report a blended average GPS antenna position
+        Vector3f temp_antenna_offset = _antenna_offset[i];
+        temp_antenna_offset *= _blend_weights[i];
+        _blended_antenna_offset += temp_antenna_offset;
+
+        // blend the timing data
+        if (timing[i].last_fix_time_ms > timing[GPS_MAX_RECEIVERS].last_fix_time_ms) {
+            timing[GPS_MAX_RECEIVERS].last_fix_time_ms = timing[i].last_fix_time_ms;
+        }
+        if (timing[i].last_message_time_ms > timing[GPS_MAX_RECEIVERS].last_message_time_ms) {
+            timing[GPS_MAX_RECEIVERS].last_message_time_ms = timing[i].last_message_time_ms;
+        }
+
+    }
+
+    /*
+     * Calculate an instantaneous weighted/blended average location from the available GPS instances and store in the _output_state.
+     * This will be statisticaly the most likely location, but will be not stable enough for direct use by the autopilot.
+    */
+
+    // Use the GPS with the highest weighting as the reference position
+    float best_weight = 0.0f;
+    uint8_t best_index = 0;
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (_blend_weights[i] > best_weight) {
+            best_weight = _blend_weights[i];
+            best_index = i;
+            state[GPS_MAX_RECEIVERS].location = state[i].location;
+        }
+    }
+
+    // Calculate the weighted sum of horizontal and vertical position offsets relative to the reference position
+    Vector2f blended_NE_offset_m;
+    float blended_alt_offset_cm = 0.0f;
+    blended_NE_offset_m.zero();
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (_blend_weights[i] > 0.0f && i != best_index) {
+            blended_NE_offset_m += location_diff(state[GPS_MAX_RECEIVERS].location, state[i].location) * _blend_weights[i];
+            blended_alt_offset_cm += (float)(state[i].location.alt - state[GPS_MAX_RECEIVERS].location.alt) * _blend_weights[i];
+        }
+    }
+
+    // Add the sum of weighted offsets to the reference location to obtain the blended location
+    location_offset(state[GPS_MAX_RECEIVERS].location, blended_NE_offset_m.x, blended_NE_offset_m.y);
+    state[GPS_MAX_RECEIVERS].location.alt += (int)blended_alt_offset_cm;
+
+    // Calculate ground speed and course from blended velocity vector
+    state[GPS_MAX_RECEIVERS].ground_speed = norm(state[GPS_MAX_RECEIVERS].velocity.x, state[GPS_MAX_RECEIVERS].velocity.y);
+    state[GPS_MAX_RECEIVERS].ground_course = wrap_360(degrees(atan2f(state[GPS_MAX_RECEIVERS].velocity.x, state[GPS_MAX_RECEIVERS].velocity.x)));
+
+    /*
+     * The blended location in _output_state.location is not stable enough to be used by the autopilot
+     * as it will move around as the relative accuracy changes. To mitigate this effect a low-pass filtered
+     * offset from each GPS location to the blended location is calculated and the filtered offset is applied
+     * to each receiver.
+    */
+
+    // Calculate filter coefficients to be applied to the offsets for each GPS position and height offset
+    // A weighting of 1 will make the offset adjust the slowest, a weighting of 0 will make it adjust with zero filtering
+    float alpha[GPS_MAX_RECEIVERS] = {};
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (state[i].last_gps_time_ms - _last_time_updated[i] > 0) {
+            float min_alpha = constrain_float(_omega_lpf * 0.001f * (float)(state[i].last_gps_time_ms - _last_time_updated[i]), 0.0f, 1.0f);
+            if (_blend_weights[i] > min_alpha) {
+                alpha[i] = min_alpha / _blend_weights[i];
+            } else {
+                alpha[i] = 1.0f;
+            }
+            _last_time_updated[i] = state[i].last_gps_time_ms;
+        }
+    }
+
+    // Calculate the offset from each GPS solution to the blended solution
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        _NE_pos_offset_m[i] = location_diff(state[i].location, state[GPS_MAX_RECEIVERS].location) * alpha[i] + _NE_pos_offset_m[i] * (1.0f - alpha[i]);
+        _hgt_offset_cm[i] = (float)(state[GPS_MAX_RECEIVERS].location.alt - state[i].location.alt) *  alpha[i] + _hgt_offset_cm[i] * (1.0f - alpha[i]);
+    }
+
+    // Calculate a corrected location for each GPS
+    Location corrected_location[GPS_MAX_RECEIVERS];
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        corrected_location[i] = state[i].location;
+        location_offset(corrected_location[i], _NE_pos_offset_m[i].x, _NE_pos_offset_m[i].y);
+        corrected_location[i].alt += (int)(_hgt_offset_cm[i]);
+    }
+
+    // Calculate the weighted sum of horizontal and vertical position offsets relative to the blended location
+    blended_alt_offset_cm = 0.0f;
+    blended_NE_offset_m.zero();
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (_blend_weights[i] > 0.0f) {
+            blended_NE_offset_m += location_diff(state[GPS_MAX_RECEIVERS].location, corrected_location[i]) * _blend_weights[i];
+            blended_alt_offset_cm += (float)(corrected_location[i].alt - state[GPS_MAX_RECEIVERS].location.alt) * _blend_weights[i];
+        }
+    }
+
+    // If the GPS week is the same then use a blended time_week_ms
+    // If week is different, then use time stamp from GPS with largest weighting
+    // detect inconsistent week data
+    uint8_t last_week_instance = 0;
+    bool weeks_consistent = true;
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (last_week_instance == 0 && _blend_weights[i] > 0) {
+            // this is our first valid sensor week data
+            last_week_instance = state[i].time_week;
+        } else if (last_week_instance != 0 && _blend_weights[i] > 0 && last_week_instance != state[i].time_week) {
+            // there is valid sensor week data that is inconsistent
+            weeks_consistent = false;
+        }
+    }
+    // calculate output
+    if (!weeks_consistent) {
+        // use data from highest weighted sensor
+        state[GPS_MAX_RECEIVERS].time_week = state[best_index].time_week;
+        state[GPS_MAX_RECEIVERS].time_week_ms = state[best_index].time_week_ms;
+    } else {
+        // use week number from highest weighting GPS (they should all have the same week number)
+        state[GPS_MAX_RECEIVERS].time_week = state[best_index].time_week;
+        // calculate a blended value for the number of ms lapsed in the week
+        double temp_time_0 = 0.0;
+        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+            if (_blend_weights[i] > 0.0f) {
+                temp_time_0 += (double)state[i].time_week_ms * _blend_weights[i];
+            }
+        }
+        state[GPS_MAX_RECEIVERS].time_week_ms = (uint32_t)temp_time_0;
+    }
+
+    // calculate a blended value for the timing data and lag
+    double temp_time_1 = 0.0;
+    double temp_time_2 = 0.0;
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (_blend_weights[i] > 0.0f) {
+            temp_time_1 += (double)timing[i].last_fix_time_ms * _blend_weights[i];
+            temp_time_2 += (double)timing[i].last_message_time_ms * _blend_weights[i];
+            _blended_lag_sec += get_lag(i) * _blended_lag_sec;
+        }
+    }
+    timing[GPS_MAX_RECEIVERS].last_fix_time_ms = (uint32_t)temp_time_1;
+    timing[GPS_MAX_RECEIVERS].last_message_time_ms = (uint32_t)temp_time_2;
+
 }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -235,6 +235,29 @@ const uint32_t AP_GPS::_baudrates[] = {4800U, 19200U, 38400U, 115200U, 57600U, 9
 // right mode
 const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY MTK_SET_BINARY SIRF_SET_BINARY;
 
+/**
+   convert GPS week and milliseconds to unix epoch in milliseconds
+ */
+uint64_t AP_GPS::time_epoch_convert(uint16_t gps_week, uint32_t gps_ms)
+{
+    uint64_t fix_time_ms = UNIX_OFFSET_MSEC + gps_week * MSEC_PER_WEEK + gps_ms;
+    return fix_time_ms;
+}
+
+/**
+   calculate current time since the unix epoch in microseconds
+ */
+uint64_t AP_GPS::time_epoch_usec(uint8_t instance)
+{
+    const GPS_State &istate = state[instance];
+    if (istate.last_gps_time_ms == 0) {
+        return 0;
+    }
+    uint64_t fix_time_ms = time_epoch_convert(istate.time_week, istate.time_week_ms);
+    // add in the milliseconds since the last fix
+    return (fix_time_ms + (AP_HAL::millis() - istate.last_gps_time_ms)) * 1000ULL;
+}
+
 /*
   send some more initialisation string bytes if there is room in the
   UART transmit buffer

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -44,6 +44,13 @@
 
 extern const AP_HAL::HAL &hal;
 
+// baudrates to try to detect GPSes with
+const uint32_t AP_GPS::_baudrates[] = {4800U, 19200U, 38400U, 115200U, 57600U, 9600U, 230400U};
+
+// initialisation blobs to send to the GPS to try to get it into the
+// right mode
+const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY MTK_SET_BINARY SIRF_SET_BINARY;
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE
@@ -270,8 +277,6 @@ void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_man
     }
 }
 
-// baudrates to try to detect GPSes with
-const uint32_t AP_GPS::_baudrates[] = {4800U, 19200U, 38400U, 115200U, 57600U, 9600U, 230400U};
 // return number of active GPS sensors. Note that if the first GPS
 // is not present but the 2nd is then we return 2. Note that a blended
 // GPS solution is treated as an additional sensor.
@@ -284,9 +289,6 @@ uint8_t AP_GPS::num_sensors(void) const
     }
 }
 
-// initialisation blobs to send to the GPS to try to get it into the
-// right mode
-const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY MTK_SET_BINARY SIRF_SET_BINARY;
 bool AP_GPS::speed_accuracy(uint8_t instance, float &sacc) const
 {
     if (state[instance].have_speed_accuracy) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -157,6 +157,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
     // @Units: milliseconds
     // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @Range: 100 200
     // @User: Advanced
     AP_GROUPINFO("RATE_MS", 14, AP_GPS, _rate_ms[0], 200),
 
@@ -165,6 +166,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
     // @Units: milliseconds
     // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @Range: 100 200
     // @User: Advanced
     AP_GROUPINFO("RATE_MS2", 15, AP_GPS, _rate_ms[1], 200),
 
@@ -254,6 +256,12 @@ void AP_GPS::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_man
     // Initialise class variables used to do GPS blending
     _omega_lpf = 1.0f / constrain_float(_blend_tc, 5.0f, 30.0f);
 
+    // sanity check update rate
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (_rate_ms[i] <= 0 || _rate_ms[i] > GPS_MAX_RATE_MS) {
+            _rate_ms[i] = GPS_MAX_RATE_MS;
+        }
+    }
 }
 
 // baudrates to try to detect GPSes with
@@ -978,11 +986,23 @@ float AP_GPS::get_lag(uint8_t instance) const
     } else if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
         // no GPS was detected in this instance
         // so return a default delay of 1 measurement interval
-        return 0.001f * (float)_rate_ms[instance];
+        return 0.001f * (float)get_rate_ms(instance);
     } else {
         // the user has not specified a delay so we determine it from the GPS type
         return drivers[instance]->get_lag();
     }
+}
+
+/*
+  return gps update rate in milliseconds
+*/
+uint16_t AP_GPS::get_rate_ms(uint8_t instance) const
+{
+    // sanity check
+    if (instance >= num_instances || _rate_ms[instance] <= 0) {
+        return GPS_MAX_RATE_MS;
+    }
+    return MIN(_rate_ms[instance], GPS_MAX_RATE_MS);
 }
 
 /*
@@ -1010,8 +1030,8 @@ bool AP_GPS::calc_blend_weights(void)
         if ((state[i].last_gps_time_ms < min_ms) && (state[i].last_gps_time_ms > 0)) {
             min_ms = state[i].last_gps_time_ms;
         }
-        if (_rate_ms[i] > max_rate_ms) {
-            max_rate_ms = _rate_ms[i];
+        if (get_rate_ms(i) > max_rate_ms) {
+            max_rate_ms = get_rate_ms(i);
         }
     }
     if ((int32_t)(max_ms - min_ms) < (int32_t)(2 * max_rate_ms)) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -448,16 +448,6 @@ AP_GPS::highest_supported_status(uint8_t instance) const
     return AP_GPS::GPS_OK_FIX_3D;
 }
 
-AP_GPS::GPS_Status 
-AP_GPS::highest_supported_status(void) const
-{
-    if (drivers[primary_instance] != nullptr) {
-        return drivers[primary_instance]->highest_supported_status();
-    }
-    return AP_GPS::GPS_OK_FIX_3D;
-}
-
-
 /*
   update one GPS instance. This should be called at 10Hz or greater
  */

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -501,7 +501,7 @@ found_gps:
 AP_GPS::GPS_Status 
 AP_GPS::highest_supported_status(uint8_t instance) const
 {
-    if (drivers[instance] != nullptr) {
+    if (instance < GPS_MAX_RECEIVERS && drivers[instance] != nullptr) {
         return drivers[instance]->highest_supported_status();
     }
     return AP_GPS::GPS_OK_FIX_3D;
@@ -710,6 +710,9 @@ AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms,
 // set accuracy for HIL
 void AP_GPS::setHIL_Accuracy(uint8_t instance, float vdop, float hacc, float vacc, float sacc, bool _have_vertical_velocity, uint32_t sample_ms)
 {
+    if (instance >= GPS_MAX_RECEIVERS) {
+        return;
+    }
     GPS_State &istate = state[instance];
     istate.vdop = vdop * 100;
     istate.horizontal_accuracy = hacc;
@@ -803,7 +806,7 @@ void
 AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
 {
     static uint32_t last_send_time_ms[MAVLINK_COMM_NUM_BUFFERS];
-    if (num_sensors() < 2 || status(1) <= AP_GPS::NO_GPS) {
+    if (num_instances < 2 || status(1) <= AP_GPS::NO_GPS) {
         return;
     }
     // when we have a GPS then only send new data

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1209,7 +1209,7 @@ bool AP_GPS::calc_blend_weights(void)
     }
 
     // calculate a weighting using the reported vertical position accuracy
-    float vpos_blend_weights[GPS_MAX_RECEIVERS];
+    float vpos_blend_weights[GPS_MAX_RECEIVERS] = {};
     if (vertical_accuracy_sum_sq > 0.0f && (_blend_mask & BLEND_MASK_USE_VPOS_ACC)) {
         // calculate the weights using the inverse of the variances
         float sum_of_vpos_weights = 0.0f;
@@ -1217,8 +1217,6 @@ bool AP_GPS::calc_blend_weights(void)
             if (state[i].status >= GPS_OK_FIX_3D && state[i].vertical_accuracy > 0.001f) {
                 vpos_blend_weights[i] = vertical_accuracy_sum_sq / (state[i].vertical_accuracy * state[i].vertical_accuracy);
                 sum_of_vpos_weights += vpos_blend_weights[i];
-            } else {
-                vpos_blend_weights[i] = 0.0f;
             }
         }
         // normalise the weights
@@ -1228,14 +1226,10 @@ bool AP_GPS::calc_blend_weights(void)
             }
             sum_of_all_weights += 1.0f;
         };
-    } else {
-        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            vpos_blend_weights[i] = 0.0f;
-        }
     }
 
     // calculate a weighting using the reported speed accuracy
-    float spd_blend_weights[GPS_MAX_RECEIVERS];
+    float spd_blend_weights[GPS_MAX_RECEIVERS] = {};
     if (speed_accuracy_sum_sq > 0.0f && (_blend_mask & BLEND_MASK_USE_SPD_ACC)) {
         // calculate the weights using the inverse of the variances
         float sum_of_spd_weights = 0.0f;
@@ -1243,8 +1237,6 @@ bool AP_GPS::calc_blend_weights(void)
             if (state[i].status >= GPS_OK_FIX_3D && state[i].speed_accuracy > 0.001f) {
                 spd_blend_weights[i] = speed_accuracy_sum_sq / (state[i].speed_accuracy * state[i].speed_accuracy);
                 sum_of_spd_weights += spd_blend_weights[i];
-            } else {
-                spd_blend_weights[i] = 0.0f;
             }
         }
         // normalise the weights
@@ -1253,10 +1245,6 @@ bool AP_GPS::calc_blend_weights(void)
                 spd_blend_weights[i] = spd_blend_weights[i] / sum_of_spd_weights;
             }
             sum_of_all_weights += 1.0f;
-        }
-    } else {
-        for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            spd_blend_weights[i] = 0.0f;
         }
     }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -943,7 +943,7 @@ bool AP_GPS::all_consistent(float &distance) const
 }
 
 // pre-arm check of GPS blending.  True means healthy or that blending is not being used
-bool AP_GPS::blend_healthy() const
+bool AP_GPS::blend_health_check() const
 {
     return (_blend_health_counter < 50);
 }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1198,7 +1198,7 @@ bool AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_hpos_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_2D && state[i].horizontal_accuracy > 0.001f) {
+            if (state[i].status >= GPS_OK_FIX_2D && state[i].horizontal_accuracy >= 0.001f) {
                 hpos_blend_weights[i] = horizontal_accuracy_sum_sq / (state[i].horizontal_accuracy * state[i].horizontal_accuracy);
                 sum_of_hpos_weights += hpos_blend_weights[i];
             }
@@ -1218,7 +1218,7 @@ bool AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_vpos_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_3D && state[i].vertical_accuracy > 0.001f) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].vertical_accuracy >= 0.001f) {
                 vpos_blend_weights[i] = vertical_accuracy_sum_sq / (state[i].vertical_accuracy * state[i].vertical_accuracy);
                 sum_of_vpos_weights += vpos_blend_weights[i];
             }
@@ -1238,7 +1238,7 @@ bool AP_GPS::calc_blend_weights(void)
         // calculate the weights using the inverse of the variances
         float sum_of_spd_weights = 0.0f;
         for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-            if (state[i].status >= GPS_OK_FIX_3D && state[i].speed_accuracy > 0.001f) {
+            if (state[i].status >= GPS_OK_FIX_3D && state[i].speed_accuracy >= 0.001f) {
                 spd_blend_weights[i] = speed_accuracy_sum_sq / (state[i].speed_accuracy * state[i].speed_accuracy);
                 sum_of_spd_weights += spd_blend_weights[i];
             }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -225,13 +225,14 @@ public:
         return ground_speed() * 100;
     }
 
-    // ground course in centidegrees
+    // ground course in degrees
     float ground_course(uint8_t instance) const {
         return state[instance].ground_course;
     }
     float ground_course() const {
         return ground_course(primary_instance);
     }
+    // ground course in centi-degrees
     int32_t ground_course_cd(uint8_t instance) const {
         return ground_course(instance) * 100;
     }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -30,6 +30,7 @@
  */
 #define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not include virtual GPS created by blending receiver data
 #define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximumum number of GPs instances including the 'virtual' GPS created by blending receiver data
+#define GPS_BLENDED_INSTANCE GPS_MAX_RECEIVERS  // the virtual blended GPS is always the highest instance (2)
 #define GPS_RTK_INJECT_TO_ALL 127
 #define GPS_MAX_RATE_MS 200 // maximum value of rate_ms (i.e. slowest update rate) is 5hz or 200ms
 
@@ -379,7 +380,7 @@ protected:
     AP_Int8 _min_elevation;
     AP_Int8 _raw_data;
     AP_Int8 _gnss_mode[GPS_MAX_RECEIVERS];
-    AP_Int16 _rate_ms[GPS_MAX_RECEIVERS];
+    AP_Int16 _rate_ms[GPS_MAX_RECEIVERS];   // this parameter should always be accessed using get_rate_ms()
     AP_Int8 _save_config;
     AP_Int8 _auto_config;
     AP_Vector3f _antenna_offset[GPS_MAX_RECEIVERS];

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -46,10 +46,6 @@ class AP_GPS_Backend;
 class AP_GPS
 {
 public:
-    // constructor
-	AP_GPS() {
-		AP_Param::setup_object_defaults(this, var_info);
-    }
 
     /// Startup initialisation.
     void init(DataFlash_Class *dataflash, const AP_SerialManager& serial_manager);
@@ -58,6 +54,8 @@ public:
     /// This routine must be called periodically (typically at 10Hz or
     /// more) to process incoming data.
     void update(void);
+    // constructor
+	AP_GPS();
 
     // GPS driver types
     enum GPS_Type {
@@ -144,13 +142,7 @@ public:
     // return number of active GPS sensors. Note that if the first GPS
     // is not present but the 2nd is then we return 2. Note that a blended
     // GPS solution is treated as an additional sensor.
-    uint8_t num_sensors(void) const {
-        if (!_output_is_blended) {
-            return num_instances;
-        } else {
-            return num_instances+1;
-        }
-    }
+    uint8_t num_sensors(void) const;
 
     // Return the index of the primary sensor which is the index of the sensor contributing to
     // the output. A blended solution is available as an additional instance
@@ -177,38 +169,18 @@ public:
         return location(primary_instance);
     }
 
-    bool speed_accuracy(uint8_t instance, float &sacc) const {
-        if(state[instance].have_speed_accuracy) {
-            sacc = state[instance].speed_accuracy;
-            return true;
-        }
-        return false;
-    }
-
+    // report speed accuracy
+    bool speed_accuracy(uint8_t instance, float &sacc) const;
     bool speed_accuracy(float &sacc) const {
         return speed_accuracy(primary_instance, sacc);
     }
 
-    bool horizontal_accuracy(uint8_t instance, float &hacc) const {
-        if(state[instance].have_horizontal_accuracy) {
-            hacc = state[instance].horizontal_accuracy;
-            return true;
-        }
-        return false;
-    }
-
+    bool horizontal_accuracy(uint8_t instance, float &hacc) const;
     bool horizontal_accuracy(float &hacc) const {
         return horizontal_accuracy(primary_instance, hacc);
     }
 
-    bool vertical_accuracy(uint8_t instance, float &vacc) const {
-        if(state[instance].have_vertical_accuracy) {
-            vacc = state[instance].vertical_accuracy;
-            return true;
-        }
-        return false;
-    }
-
+    bool vertical_accuracy(uint8_t instance, float &vacc) const;
     bool vertical_accuracy(float &vacc) const {
         return vertical_accuracy(primary_instance, vacc);
     }
@@ -332,14 +304,7 @@ public:
     uint16_t get_rate_ms(uint8_t instance) const;
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
-    const Vector3f &get_antenna_offset(uint8_t instance) const {
-        if (instance == GPS_MAX_RECEIVERS) {
-            // return an offset for the blended GPS solution
-            return _blended_antenna_offset;
-        } else {
-            return _antenna_offset[instance];
-        }
-    }
+    const Vector3f &get_antenna_offset(uint8_t instance) const;
 
     // set position for HIL
     void setHIL(uint8_t instance, GPS_Status status, uint64_t time_epoch_ms, 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -322,9 +322,6 @@ public:
     const Vector3f &get_antenna_offset(uint8_t instance) const {
         return _antenna_offset[instance];
     }
-    const Vector3f &get_antenna_offset(void) const {
-        return _antenna_offset[primary_instance];
-    }
 
     // set position for HIL
     void setHIL(uint8_t instance, GPS_Status status, uint64_t time_epoch_ms, 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -166,7 +166,7 @@ public:
         return status(primary_instance);
     }
 
-    // Query the highest status this GPS supports
+    // Query the highest status this GPS supports (always reports GPS_OK_FIX_3D for the blended GPS)
     GPS_Status highest_supported_status(uint8_t instance) const;
 
     // location of last fix

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -345,8 +345,8 @@ public:
     // pre-arm check that all GPSs are close to each other.  farthest distance between GPSs (in meters) is returned
     bool all_consistent(float &distance) const;
 
-    // pre-arm check of GPS blending.  True means healthy or that blending is not being used
-    bool blend_healthy() const;
+    // pre-arm check of GPS blending.  False if blending is unhealthy, True if healthy or blending is not being used
+    bool blend_health_check() const;
 
     // handle sending of initialisation strings to the GPS - only used by backends
     void send_blob_start(uint8_t instance, const char *_blob, uint16_t size);

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -159,7 +159,6 @@ public:
 
     // Query the highest status this GPS supports
     GPS_Status highest_supported_status(uint8_t instance) const;
-    GPS_Status highest_supported_status(void) const;
 
     // location of last fix
     const Location &location(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -31,6 +31,7 @@
 #define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not include virtual GPS created by blending receiver data
 #define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximumum number of GPs instances including the 'virtual' GPS created by blending receiver data
 #define GPS_RTK_INJECT_TO_ALL 127
+#define GPS_MAX_RATE_MS 200 // maximum value of rate_ms (i.e. slowest update rate) is 5hz or 200ms
 
 // the number of GPS leap seconds
 #define GPS_LEAPSECONDS_MILLIS 18000ULL
@@ -142,7 +143,7 @@ public:
 
     // return number of active GPS sensors. Note that if the first GPS
     // is not present but the 2nd is then we return 2. Note that a blended
-    // GPS solution is treated as an addditional sensor.
+    // GPS solution is treated as an additional sensor.
     uint8_t num_sensors(void) const {
         if (!_output_is_blended) {
             return num_instances;
@@ -152,7 +153,7 @@ public:
     }
 
     // Return the index of the primary sensor which is the index of the sensor contributing to
-    // the output. A blended solution is avalable as an additional instance
+    // the output. A blended solution is available as an additional instance
     uint8_t primary_sensor(void) const {
         return primary_instance;
     }
@@ -326,6 +327,9 @@ public:
     // the expected lag (in seconds) in the position and velocity readings from the gps
     float get_lag(uint8_t instance) const;
     float get_lag(void) const { return get_lag(primary_instance); }
+
+    // return gps update rate in milliseconds
+    uint16_t get_rate_ms(uint8_t instance) const;
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -341,6 +341,12 @@ public:
         return first_unconfigured_gps() == GPS_ALL_CONFIGURED;
     }
 
+    // pre-arm check that all GPSs are close to each other.  farthest distance between GPSs (in meters) is returned
+    bool all_consistent(float &distance) const;
+
+    // pre-arm check of GPS blending.  True means healthy or that blending is not being used
+    bool blend_healthy() const;
+
     // handle sending of initialisation strings to the GPS - only used by backends
     void send_blob_start(uint8_t instance, const char *_blob, uint16_t size);
     void send_blob_update(uint8_t instance);
@@ -469,6 +475,7 @@ private:
     uint32_t _last_time_updated[GPS_MAX_RECEIVERS]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output
+    uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy
 
     // calculate the blend weight.  Returns true if blend could be calculated, false if not
     bool calc_blend_weights(void);

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -90,17 +90,17 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
 
             if (have_sa) {
                 state.speed_accuracy = packet.speed_accuracy;
-                state.have_speed_accuracy = 1;
+                state.have_speed_accuracy = true;
             }
 
             if (have_ha) {
                 state.horizontal_accuracy = packet.horiz_accuracy;
-                state.have_horizontal_accuracy = 1;
+                state.have_horizontal_accuracy = true;
             }
 
             if (have_va) {
                 state.vertical_accuracy = packet.vert_accuracy;
-                state.have_vertical_accuracy = 1;
+                state.have_vertical_accuracy = true;
             }
 
             state.num_sats = packet.satellites_visible;
@@ -133,7 +133,7 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
             if (packet.cog < 36000) {
                 state.ground_course = packet.cog / 100.0f;
             }
-            state.have_speed_accuracy = 0;
+            state.have_speed_accuracy = false;
             state.have_horizontal_accuracy = 0;
             state.have_vertical_accuracy = 0;
             if (packet.satellites_visible < 255) {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1269,7 +1269,7 @@ AP_GPS_UBLOX::_configure_rate(void)
 {
     struct ubx_cfg_nav_rate msg;
     // require a minimum measurement rate of 5Hz
-    msg.measure_rate_ms = MIN(gps._rate_ms[state.instance], MINIMUM_MEASURE_RATE_MS);
+    msg.measure_rate_ms = MIN(gps._rate_ms[state.instance], GPS_MAX_RATE_MS);
     msg.nav_rate        = 1;
     msg.timeref         = 0;     // UTC time
     _send_message(CLASS_CFG, MSG_CFG_RATE, &msg, sizeof(msg));

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1269,7 +1269,7 @@ AP_GPS_UBLOX::_configure_rate(void)
 {
     struct ubx_cfg_nav_rate msg;
     // require a minimum measurement rate of 5Hz
-    msg.measure_rate_ms = MIN(gps._rate_ms[state.instance], GPS_MAX_RATE_MS);
+    msg.measure_rate_ms = gps.get_rate_ms(state.instance);
     msg.nav_rate        = 1;
     msg.timeref         = 0;     // UTC time
     _send_message(CLASS_CFG, MSG_CFG_RATE, &msg, sizeof(msg));

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -48,7 +48,6 @@
 #define UBX_MSG_TYPES 2
 
 #define UBLOX_MAX_PORTS 6
-#define MINIMUM_MEASURE_RATE_MS 200
 
 #define RATE_POSLLH 1
 #define RATE_STATUS 1

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -58,29 +58,6 @@ int16_t AP_GPS_Backend::swap_int16(int16_t v) const
     return u.v;
 }
 
-/**
-   convert GPS week and milliseconds to unix epoch in milliseconds
- */
-uint64_t AP_GPS::time_epoch_convert(uint16_t gps_week, uint32_t gps_ms)
-{
-    uint64_t fix_time_ms = UNIX_OFFSET_MSEC + gps_week * MSEC_PER_WEEK + gps_ms;
-    return fix_time_ms;
-}
-
-/**
-   calculate current time since the unix epoch in microseconds
- */
-uint64_t AP_GPS::time_epoch_usec(uint8_t instance)
-{
-    const GPS_State &istate = state[instance];
-    if (istate.last_gps_time_ms == 0) {
-        return 0;
-    }
-    uint64_t fix_time_ms = time_epoch_convert(istate.time_week, istate.time_week_ms);
-    // add in the milliseconds since the last fix
-    return (fix_time_ms + (AP_HAL::millis() - istate.last_gps_time_ms)) * 1000ULL;
-}
-
 
 /**
    fill in time_week_ms and time_week from BCD date and time components

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -103,9 +103,9 @@ private:
 
     bool _gps_has_basestation_position;
     gps_data _gps_basestation_data;
-    void _gps_write(const uint8_t *p, uint16_t size);
-    void _gps_send_ubx(uint8_t msgid, uint8_t *buf, uint16_t size);
-    void _update_gps_ubx(const struct gps_data *d);
+    void _gps_write(const uint8_t *p, uint16_t size, uint8_t instance = 0);
+    void _gps_send_ubx(uint8_t msgid, uint8_t *buf, uint16_t size, uint8_t instance);
+    void _update_gps_ubx(const struct gps_data *d, uint8_t instance);
     void _update_gps_mtk(const struct gps_data *d);
     void _update_gps_mtk16(const struct gps_data *d);
     void _update_gps_mtk19(const struct gps_data *d);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -585,7 +585,7 @@ void NavEKF2::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 0, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), _ahrs->get_gps().primary_sensor(), imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -1,5 +1,8 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/priseborough/
+  InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/
+  GenerateNavFilterEquations.m
+
   Converted from Matlab to C++ by Paul Riseborough
 
   EKF Tuning parameters refactored by Tom Cauchois

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -314,6 +314,7 @@ void NavEKF2_core::InitialiseVariables()
     OffsetMinInnovFilt = 0.0f;
     rngBcnFuseDataReportIndex = 0;
     memset(&rngBcnFusionReport, 0, sizeof(rngBcnFusionReport));
+    last_gps_idx = 0;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -795,6 +795,7 @@ private:
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
+    uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     struct Location EKF_origin;     // LLH origin of the NED axis system - do not change unless filter is reset
     bool validOrigin;               // true when the EKF origin is valid
     float gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1,5 +1,7 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/priseborough/
+  InertialNav/blob/master/derivations/RotationVectorAttitudeParameterisation/
+  GenerateNavFilterEquations.m
 
   Converted from Matlab to C++ by Paul Riseborough
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -583,7 +583,7 @@ void NavEKF3::check_log_write(void)
         logging.log_compass = false;
     }
     if (logging.log_gps) {
-        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), 0, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_GPS(_ahrs->get_gps(), _ahrs->get_gps().primary_sensor(), imuSampleTime_us);
         logging.log_gps = false;
     }
     if (logging.log_baro) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -1,8 +1,8 @@
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
-  Converted from Matlab to C++ by Paul Riseborough
+  24 state EKF based on the derivation in https://github.com/PX4/ecl/
+  blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 
-  EKF Tuning parameters refactored by Tom Cauchois
+  Converted from Matlab to C++ by Paul Riseborough
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -92,6 +92,8 @@ void NavEKF3_core::ResetPosition(void)
     } else  {
         // Use GPS data as first preference if fresh data is available
         if ((imuSampleTime_ms - lastTimeGpsReceived_ms < 250 && posResetSource == DEFAULT) || posResetSource == GPS) {
+            // record the ID of the GPS for the data we are using for the reset
+            last_gps_idx = gpsDataNew.sensor_idx;
             // write to state vector and compensate for offset  between last GPS measurement and the EKF time horizon
             stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
             stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
@@ -239,14 +241,6 @@ void NavEKF3_core::SelectVelPosFusion()
     gpsDataToFuse = storedGPS.recall(gpsDataDelayed,imuDataDelayed.time_ms);
     // Determine if we need to fuse position and velocity data on this time step
     if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE) {
-        // Don't fuse velocity data if GPS doesn't support it
-        if (frontend->_fusionModeGPS <= 1) {
-            fuseVelData = true;
-        } else {
-            fuseVelData = false;
-        }
-        fusePosData = true;
-
         // correct GPS data for position offset of antenna phase centre relative to the IMU
         Vector3f posOffsetBody = _ahrs->get_gps().get_antenna_offset(gpsDataDelayed.sensor_idx) - accelPosOffset;
         if (!posOffsetBody.is_zero()) {
@@ -262,6 +256,16 @@ void NavEKF3_core::SelectVelPosFusion()
             gpsDataDelayed.pos.y -= posOffsetEarth.y;
             gpsDataDelayed.hgt += posOffsetEarth.z;
         }
+
+
+        // Don't fuse velocity data if GPS doesn't support it
+        if (frontend->_fusionModeGPS <= 1) {
+            fuseVelData = true;
+        } else {
+            fuseVelData = false;
+        }
+        fusePosData = true;
+
     } else {
         fuseVelData = false;
         fusePosData = false;
@@ -274,6 +278,59 @@ void NavEKF3_core::SelectVelPosFusion()
 
     // Select height data to be fused from the available baro, range finder and GPS sources
     selectHeightForFusion();
+
+    // if we are using GPS, check for a change in receiver and reset position and height
+    if (gpsDataToFuse && PV_AidingMode == AID_ABSOLUTE && gpsDataDelayed.sensor_idx != last_gps_idx) {
+        // record the ID of the GPS that we are using for the reset
+        last_gps_idx = gpsDataDelayed.sensor_idx;
+
+        // Store the position before the reset so that we can record the reset delta
+        posResetNE.x = stateStruct.position.x;
+        posResetNE.y = stateStruct.position.y;
+
+        // Set the position states to the position from the new GPS
+        stateStruct.position.x = gpsDataNew.pos.x;
+        stateStruct.position.y = gpsDataNew.pos.y;
+
+        // Calculate the position offset due to the reset
+        posResetNE.x = stateStruct.position.x - posResetNE.x;
+        posResetNE.y = stateStruct.position.y - posResetNE.y;
+
+        // Add the offset to the output observer states
+        for (uint8_t i=0; i<imu_buffer_length; i++) {
+            storedOutput[i].position.x += posResetNE.x;
+            storedOutput[i].position.y += posResetNE.y;
+        }
+        outputDataNew.position.x += posResetNE.x;
+        outputDataNew.position.y += posResetNE.y;
+        outputDataDelayed.position.x += posResetNE.x;
+        outputDataDelayed.position.y += posResetNE.y;
+
+        // store the time of the reset
+        lastPosReset_ms = imuSampleTime_ms;
+
+        // If we are alseo using GPS as the height reference, reset the height
+        if (activeHgtSource == HGT_SOURCE_GPS) {
+            // Store the position before the reset so that we can record the reset delta
+            posResetD = stateStruct.position.z;
+
+            // write to the state vector
+            stateStruct.position.z = -hgtMea;
+
+            // Calculate the position jump due to the reset
+            posResetD = stateStruct.position.z - posResetD;
+
+            // Add the offset to the output observer states
+            outputDataNew.position.z += posResetD;
+            outputDataDelayed.position.z += posResetD;
+            for (uint8_t i=0; i<imu_buffer_length; i++) {
+                storedOutput[i].position.z += posResetD;
+            }
+
+            // store the time of the reset
+            lastPosResetD_ms = imuSampleTime_ms;
+        }
+    }
 
     // If we are operating without any aiding, fuse in the last known position
     // to constrain tilt drift. This assumes a non-manoeuvring vehicle

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -249,7 +249,7 @@ void NavEKF3_core::InitialiseVariables()
     baroStoreIndex = 0;
     rangeStoreIndex = 0;
     magStoreIndex = 0;
-    gpsStoreIndex = 0;
+    last_gps_idx = 0;
     tasStoreIndex = 0;
     ofStoreIndex = 0;
     delAngCorrection.zero();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -848,7 +848,7 @@ private:
     uint8_t magStoreIndex;          // Magnetometer data storage index
     gps_elements gpsDataNew;        // GPS data at the current time horizon
     gps_elements gpsDataDelayed;    // GPS data at the fusion time horizon
-    uint8_t gpsStoreIndex;          // GPS data storage index
+    uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     output_elements outputDataNew;  // output state data at the current time step
     output_elements outputDataDelayed; // output state data at the current time step
     Vector3f delAngCorrection;      // correction applied to delta angles used by output observer to track the EKF

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1,6 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 /*
-  24 state EKF based on https://github.com/priseborough/InertialNav
+  24 state EKF based on the derivation in https://github.com/PX4/ecl/
+  blob/master/matlab/scripts/Inertial%20Nav%20EKF/GenerateNavFilterEquations.m
 
   Converted from Matlab to C++ by Paul Riseborough
 

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -786,10 +786,14 @@ Format characters in the format string for binary log messages
       "GPS",  "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPS2_MSG, sizeof(log_GPS), \
       "GPS2", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
+    { LOG_GPS3_MSG, sizeof(log_GPS), \
+       "GPS3", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPA_MSG,  sizeof(log_GPA), \
       "GPA",  "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_GPA2_MSG, sizeof(log_GPA), \
       "GPA2", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
+    { LOG_GPA3_MSG, sizeof(log_GPA), \
+      "GPA3", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QffffffIIfBB",     "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt" }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \
@@ -990,6 +994,7 @@ enum LogMessages {
     LOG_PARAMETER_MSG,
     LOG_GPS_MSG,
     LOG_GPS2_MSG,
+    LOG_GPS3_MSG,
     LOG_IMU_MSG,
     LOG_MESSAGE_MSG,
     LOG_RCIN_MSG,
@@ -1052,6 +1057,7 @@ enum LogMessages {
     LOG_RPM_MSG,
     LOG_GPA_MSG,
     LOG_GPA2_MSG,
+    LOG_GPA3_MSG,
     LOG_RFND_MSG,
     LOG_BAR3_MSG,
     LOG_NKF1_MSG,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -786,14 +786,14 @@ Format characters in the format string for binary log messages
       "GPS",  "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPS2_MSG, sizeof(log_GPS), \
       "GPS2", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
-    { LOG_GPS3_MSG, sizeof(log_GPS), \
-       "GPS3", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
+    { LOG_GPSB_MSG, sizeof(log_GPS), \
+      "GPSB", "QBIHBcLLefffB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_GPA_MSG,  sizeof(log_GPA), \
       "GPA",  "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_GPA2_MSG, sizeof(log_GPA), \
       "GPA2", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
-    { LOG_GPA3_MSG, sizeof(log_GPA), \
-      "GPA3", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
+    { LOG_GPAB_MSG, sizeof(log_GPA), \
+      "GPAB", "QCCCCBI", "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS" }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QffffffIIfBB",     "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt" }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \
@@ -994,7 +994,7 @@ enum LogMessages {
     LOG_PARAMETER_MSG,
     LOG_GPS_MSG,
     LOG_GPS2_MSG,
-    LOG_GPS3_MSG,
+    LOG_GPSB_MSG,
     LOG_IMU_MSG,
     LOG_MESSAGE_MSG,
     LOG_RCIN_MSG,
@@ -1057,7 +1057,7 @@ enum LogMessages {
     LOG_RPM_MSG,
     LOG_GPA_MSG,
     LOG_GPA2_MSG,
-    LOG_GPA3_MSG,
+    LOG_GPAB_MSG,
     LOG_RFND_MSG,
     LOG_BAR3_MSG,
     LOG_NKF1_MSG,

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -89,6 +89,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("FLOW_POS",      56, SITL,  optflow_pos_offset, 0),
     AP_GROUPINFO("ACC2_BIAS",     57, SITL,  accel2_bias, 0),
     AP_GROUPINFO("GPS_NOISE",     58, SITL,  gps_noise, 0),
+    AP_GROUPINFO("GP2_GLITCH",    59, SITL,  gps2_glitch,  0),
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -97,7 +97,8 @@ public:
     AP_Int8  gps_type;    // see enum GPSType
     AP_Float gps_byteloss;// byte loss as a percent
     AP_Int8  gps_numsats; // number of visible satellites
-    AP_Vector3f  gps_glitch;  // glitch offsets in lat, lon and altitude
+    AP_Vector3f gps_glitch;  // glitch offsets in lat, lon and altitude
+    AP_Vector3f gps2_glitch; // glitch offsets in lat, lon and altitude for 2nd GPS
     AP_Int8  gps_hertz;   // GPS update rate in Hz
     AP_Float batt_voltage; // battery voltage base
     AP_Float accel_fail;  // accelerometer failure value


### PR DESCRIPTION
This is an updated version of @priseborough's earlier PR: https://github.com/ArduPilot/ardupilot/pull/5642

This PR adds the following:

- GPS_AUTO_SWITCH parameter has new Blend ("2") option which blends the input from 2 GPSs into a 3rd "virtual" GPS.  The blending is performed within the AP_GPS library.  If successful the "primary_gps" is changed to the 3rd GPS (aka the virtual GPS).  The existing options "0" and "1" are not functionally changed by this PR.
- EKF2/EKF3 resets the horizontal and vertical height estimates if the primary GPS is changed.
- DataFlash logging of 3rd GPS (GPS3, GPA3 messages)
- Pre-arm check that GPSs (if present) are within 50m of each other (3 dimensional distance is used)
- Pre-arm check that blending is healthy (if GPS_AUTO_SWITCH is set to 2)
- SITL receives a new SIM_GP2_GLITCH vector for easier testing.  One downside is that the glitch only applies to the virtual Ublox GPS.  These commits can be removed from the PR if they're unacceptable.
- a few unrelated commits to the AP_GPS and AP_NavEKF2/3 libraries to remove unused methods, fix comments.  These can be moved to a separate PR if that would help with the review.


Previous explanation of the blending method from Paul:
GPS_AUTO_SWITCH type 2 is a soft switching/blending method using a weighted average of physical receivers to create a third 'virtual' GPS where:

- The method is scaleable to more than 2 GPS receivers
- A 'blended' location and velocity is calculated using a weighted average of the two receivers
- Weights are calculated using the ratio of reported error variances.
- A filtered location offset correction is calculated for each receiver relative to the 'blended' location and used to correct the output from each receiver.
- If less than 2 GPS units are available the first GPS instance detected will be used.
- If there is not enough error reporting to support calculation of the blending weights, the first receiver with the equal highest solution status value will be used . This can happen if one of the two receivers does not provide a position or speed accuracy.
- The existing hard switch logic has been left untouched and is selected with GPS_AUTO_SWITCH = 1 the same as before.

This has been tested in SITL and flight tested.