### PR TITLE
Tracker AVR: Merging tracker fixes from master to master-AVR

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -529,12 +529,23 @@ void Tracker::mavlink_check_target(const mavlink_message_t* msg)
     //  Note: this doesn't check success for all sends meaning it's not guaranteed the vehicle's positions will be sent at 1hz
     for (uint8_t i=0; i < num_gcs; i++) {
         if (gcs[i].initialised) {
+            // request position
             if (comm_get_txspace((mavlink_channel_t)i) - MAVLINK_NUM_NON_PAYLOAD_BYTES >= MAVLINK_MSG_ID_DATA_STREAM_LEN) {
                 mavlink_msg_request_data_stream_send(
                     (mavlink_channel_t)i,
                     msg->sysid,
                     msg->compid,
                     MAV_DATA_STREAM_POSITION,
+                    1,  // 1hz
+                    1); // start streaming
+            }
+            // request air pressure
+            if (comm_get_txspace((mavlink_channel_t)i) - MAVLINK_NUM_NON_PAYLOAD_BYTES >= MAVLINK_MSG_ID_DATA_STREAM_LEN) {
+                mavlink_msg_request_data_stream_send(
+                    (mavlink_channel_t)i,
+                    msg->sysid,
+                    msg->compid,
+                    MAV_DATA_STREAM_RAW_SENSORS,
                     1,  // 1hz
                     1); // start streaming
             }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -613,11 +613,19 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 } else if (is_equal(packet.param5,1.0f)) {
                     float trim_roll, trim_pitch;
                     AP_InertialSensor_UserInteract_MAVLink interact(this);
+                    // start with gyro calibration
+                    tracker.ins.init_gyro();
+                    // reset ahrs gyro bias
+                    if (tracker.ins.gyro_calibrated_ok_all()) {
+                        tracker.ahrs.reset_gyro_drift();
+                    }
                     if(tracker.ins.calibrate_accel(&interact, trim_roll, trim_pitch)) {
                         // reset ahrs's trim to suggested values from calibration routine
                         tracker.ahrs.set_trim(Vector3f(trim_roll, trim_pitch, 0));
                     }
                 } else if (is_equal(packet.param5,2.0f)) {
+                    // start with gyro calibration
+                    tracker.ins.init_gyro();
                     // accel trim
                     float trim_roll, trim_pitch;
                     if(tracker.ins.calibrate_trim(trim_roll, trim_pitch)) {

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -14,7 +14,17 @@
 #define GOBJECTN(v, pname, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## pname, (const void *)&tracker.v, {group_info : class::var_info} }
 
 const AP_Param::Info Tracker::var_info[] PROGMEM = {
+    // @Param: FORMAT_VERSION
+    // @DisplayName: Eeprom format version number
+    // @Description: This value is incremented when changes are made to the eeprom format
+    // @User: Advanced
     GSCALAR(format_version,         "FORMAT_VERSION", 0),
+
+    // @Param: SYSID_SW_TYPE
+    // @DisplayName: Software Type
+    // @Description: This is used by the ground station to recognise the software type (eg ArduPlane vs ArduCopter)
+    // @Values: 0:ArduPlane,4:AntennaTracker,10:Copter,20:Rover
+    // @User: Advanced
     GSCALAR(software_type,          "SYSID_SW_TYPE",  Parameters::k_software_type),
 
     // @Param: SYSID_THISMAV
@@ -267,7 +277,64 @@ const AP_Param::Info Tracker::var_info[] PROGMEM = {
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp
     GOBJECT(serial_manager,    "SERIAL",   AP_SerialManager),
 
+    // @Param: PITCH2SRV_P
+    // @DisplayName: Pitch axis controller P gain
+    // @Description: Pitch axis controller P gain.  Converts the difference between desired pitch angle and actual pitch angle into a pitch servo pwm change
+    // @Range: 0.0 3.0
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: PITCH2SRV_I
+    // @DisplayName: Pitch axis controller I gain
+    // @Description: Pitch axis controller I gain.  Corrects long-term difference in desired pitch angle vs actual pitch angle
+    // @Range: 0.0 3.0
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: PITCH2SRV_IMAX
+    // @DisplayName: Pitch axis controller I gain maximum
+    // @Description: Pitch axis controller I gain maximum.  Constrains the maximum pwm change that the I gain will output
+    // @Range: 0 4000
+    // @Increment: 10
+    // @Units: Percent*10
+    // @User: Standard
+
+    // @Param: PITCH2SRV_D
+    // @DisplayName: Pitch axis controller D gain
+    // @Description: Pitch axis controller D gain.  Compensates for short-term change in desired pitch angle vs actual pitch angle
+    // @Range: 0.001 0.1
+    // @Increment: 0.001
+    // @User: Standard
 	GGROUP(pidPitch2Srv,       "PITCH2SRV_", PID),
+
+    // @Param: YAW2SRV_P
+    // @DisplayName: Yaw axis controller P gain
+    // @Description: Yaw axis controller P gain.  Converts the difference between desired yaw angle (heading) and actual yaw angle into a yaw servo pwm change
+    // @Range: 0.0 3.0
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: YAW2SRV_I
+    // @DisplayName: Yaw axis controller I gain
+    // @Description: Yaw axis controller I gain.  Corrects long-term difference in desired yaw angle (heading) vs actual yaw angle
+    // @Range: 0.0 3.0
+    // @Increment: 0.01
+    // @User: Standard
+
+    // @Param: YAW2SRV_IMAX
+    // @DisplayName: Yaw axis controller I gain maximum
+    // @Description: Yaw axis controller I gain maximum.  Constrains the maximum pwm change that the I gain will output
+    // @Range: 0 4000
+    // @Increment: 10
+    // @Units: Percent*10
+    // @User: Standard
+
+    // @Param: YAW2SRV_D
+    // @DisplayName: Yaw axis controller D gain
+    // @Description: Yaw axis controller D gain.  Compensates for short-term change in desired yaw angle (heading) vs actual yaw angle
+    // @Range: 0.001 0.1
+    // @Increment: 0.001
+    // @User: Standard
 	GGROUP(pidYaw2Srv,         "YAW2SRV_", PID),
 
     // @Param: CMD_TOTAL

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -294,10 +294,10 @@ void Tracker::load_parameters(void)
         // save the current format version
         g.format_version.set_and_save(Parameters::k_format_version);
         hal.console->println_P(PSTR("done."));
-    } else {
-        uint32_t before = hal.scheduler->micros();
-        // Load all auto-loaded EEPROM variables
-        AP_Param::load_all();
-        hal.console->printf_P(PSTR("load_all took %luus\n"), (unsigned long)(hal.scheduler->micros() - before));
     }
+
+    uint32_t before = hal.scheduler->micros();
+    // Load all auto-loaded EEPROM variables
+    AP_Param::load_all();
+    hal.console->printf_P(PSTR("load_all took %luus\n"), (unsigned long)(hal.scheduler->micros() - before));
 }

--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 Antenna Tracker Release Notes:
 ------------------------------------------------------------------
+AntennaTracker 0.7.4 23-Dec-2015
+Changes from 0.7.2
+1) Request baro pressure from vehicle at 1hz
+------------------------------------------------------------------
 AntennaTracker 0.7.2 1-Aug-2015
 Changes from 0.7.1
 1) Fixed Pitch

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -1,7 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
-#define THISFIRMWARE "AntennaTracker V0.7.2"
-#define FIRMWARE_VERSION 0,7,2,FIRMWARE_VERSION_TYPE_DEV
+#define THISFIRMWARE "AntennaTracker V0.7.3"
+#define FIRMWARE_VERSION 0,7,3,FIRMWARE_VERSION_TYPE_DEV
 
 /*
    Lead developers: Matthew Ridley and Andrew Tridgell

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -1,7 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
-#define THISFIRMWARE "AntennaTracker V0.7.3"
-#define FIRMWARE_VERSION 0,7,3,FIRMWARE_VERSION_TYPE_DEV
+#define THISFIRMWARE "AntennaTracker V0.7.4"
+#define FIRMWARE_VERSION 0,7,4,FIRMWARE_VERSION_TYPE_DEV
 
 /*
    Lead developers: Matthew Ridley and Andrew Tridgell

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -94,8 +94,12 @@ void Tracker::init_tracker()
 
     // use given start positions - useful for indoor testing, and
     // while waiting for GPS lock
-    current_loc.lat = g.start_latitude * 1.0e7f;
-    current_loc.lng = g.start_longitude * 1.0e7f;
+    // sanity check location
+    if (fabsf(current_loc.lat) <= 90.0f && fabsf(current_loc.lng) <= 180.0f) {
+        current_loc.lat = g.start_latitude * 1.0e7f;
+        current_loc.lng = g.start_longitude * 1.0e7f;
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("ignoring invalid START_LATITUDE or START_LONGITUDE parameter"));
+    }
 
     // see if EEPROM has a default location as well
     if (current_loc.lat == 0 && current_loc.lng == 0) {

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -95,7 +95,7 @@ void Tracker::init_tracker()
     // use given start positions - useful for indoor testing, and
     // while waiting for GPS lock
     // sanity check location
-    if (fabsf(current_loc.lat) <= 90.0f && fabsf(current_loc.lng) <= 180.0f) {
+    if (fabsf(g.start_latitude) <= 90.0f && fabsf(g.start_longitude) <= 180.0f) {
         current_loc.lat = g.start_latitude * 1.0e7f;
         current_loc.lng = g.start_longitude * 1.0e7f;
         gcs_send_text_P(SEVERITY_MEDIUM, PSTR("ignoring invalid START_LATITUDE or START_LONGITUDE parameter"));

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -98,7 +98,7 @@ void Tracker::init_tracker()
     if (fabsf(current_loc.lat) <= 90.0f && fabsf(current_loc.lng) <= 180.0f) {
         current_loc.lat = g.start_latitude * 1.0e7f;
         current_loc.lng = g.start_longitude * 1.0e7f;
-        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("ignoring invalid START_LATITUDE or START_LONGITUDE parameter"));
+        gcs_send_text_P(SEVERITY_MEDIUM, PSTR("ignoring invalid START_LATITUDE or START_LONGITUDE parameter"));
     }
 
     // see if EEPROM has a default location as well


### PR DESCRIPTION
I had a crack at merging the changes in master for Tracker across to master-AVR for Tracker mostly because I have an APM based Tracker.  Things that are missing from this PR but harder to merge:

Onboard Compass Cal : 0c004c13a180f06a216eb7e8e6cf70d52ff0faf6
Send Home Position: 012b632d095a95c5536770f04c0be81dd2aab2c3
Add Dataflash Logging: ecf01732d980d2978c49f7a2d4cad86c1e60ab64
Accel Cal: 0e18b5eaad7ef7e035874d54a52777af96927ced

I note them here in case anyone else is keen and has time.