### PR TITLE
AP_GPS: revert changes that broke gps time calculations

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -611,9 +611,9 @@ AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms,
     istate.hdop = hdop;
     istate.num_sats = _num_sats;
     istate.last_gps_time_ms = tnow;
-    uint64_t gps_time_ms = time_epoch_ms - UNIX_OFFSET_MSEC;
-    istate.time_week     = gps_time_ms / MSEC_PER_WEEK;
-    istate.time_week_ms  = gps_time_ms - istate.time_week * MSEC_PER_WEEK;
+    uint64_t gps_time_ms = time_epoch_ms - (17000ULL*86400ULL + 52*10*7000ULL*86400ULL - GPS_LEAPSECONDS_MILLIS);
+    istate.time_week     = gps_time_ms / (86400*7*(uint64_t)1000);
+    istate.time_week_ms  = gps_time_ms - istate.time_week*(86400*7*(uint64_t)1000);
     timing[instance].last_message_time_ms = tnow;
     timing[instance].last_fix_time_ms = tnow;
     _type[instance].set(GPS_TYPE_HIL);

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -34,8 +34,6 @@
 // the number of GPS leap seconds
 #define GPS_LEAPSECONDS_MILLIS 18000ULL
 
-#define UNIX_OFFSET_MSEC (17000ULL * 86400ULL + 52 * 10 * MSEC_PER_WEEK - GPS_LEAPSECONDS_MILLIS)
-
 class DataFlash_Class;
 class AP_GPS_Backend;
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -63,7 +63,9 @@ int16_t AP_GPS_Backend::swap_int16(int16_t v) const
  */
 uint64_t AP_GPS::time_epoch_convert(uint16_t gps_week, uint32_t gps_ms)
 {
-    uint64_t fix_time_ms = UNIX_OFFSET_MSEC + gps_week * MSEC_PER_WEEK + gps_ms;
+    const uint64_t ms_per_week = 7000ULL*86400ULL;
+    const uint64_t unix_offset = 17000ULL*86400ULL + 52*10*7000ULL*86400ULL - GPS_LEAPSECONDS_MILLIS;
+    uint64_t fix_time_ms = unix_offset + gps_week*ms_per_week + gps_ms;
     return fix_time_ms;
 }
 
@@ -118,8 +120,8 @@ void AP_GPS_Backend::make_gps_time(uint32_t bcd_date, uint32_t bcd_milliseconds)
     ret -= 272764785UL;
 
     // get GPS week and time
-    state.time_week = ret / SEC_PER_WEEK;
-    state.time_week_ms = (ret % SEC_PER_WEEK) * MSEC_PER_SEC;
+    state.time_week = ret / (7*86400UL);
+    state.time_week_ms = (ret % (7*86400UL)) * 1000;
     state.time_week_ms += msec;
 }
 

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -179,10 +179,10 @@ static void gps_time(uint16_t *time_week, uint32_t *time_week_ms)
     simulation_timeval(&tv);
     const uint32_t epoch = 86400*(10*365 + (1980-1969)/4 + 1 + 6 - 2) - (GPS_LEAPSECONDS_MILLIS / 1000ULL);
     uint32_t epoch_seconds = tv.tv_sec - epoch;
-    *time_week = epoch_seconds / SEC_PER_WEEK;
+    *time_week = epoch_seconds / (86400*7UL);
     uint32_t t_ms = tv.tv_usec / 1000;
     // round time to nearest 200ms
-    *time_week_ms = (epoch_seconds % SEC_PER_WEEK) * MSEC_PER_SEC + ((t_ms/200) * 200);
+    *time_week_ms = (epoch_seconds % (86400*7UL))*1000 + ((t_ms/200) * 200);
 }
 
 /*

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -68,6 +68,3 @@ static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 #define NSEC_PER_USEC   1000ULL
 #define USEC_PER_SEC    1000000ULL
 #define USEC_PER_MSEC   1000ULL
-#define MSEC_PER_SEC    1000UL
-#define SEC_PER_WEEK    (7UL * 86400UL)
-#define MSEC_PER_WEEK   (SEC_PER_WEEK * MSEC_PER_SEC)


### PR DESCRIPTION
A change went in back on Feb 4th that was intended to be a simple clean-up of the gps time calculations but sadly it broke them.  I think the issue has to do with the size of the definitions (UL vs ULL) but I don't feel qualified to resolve it in a smarter way so I'm just intending to revert the commits.

Reverted commits:
- https://github.com/ArduPilot/ardupilot/commit/30151c8253f469b20ae0c5505dde178472efa6cc
- https://github.com/ArduPilot/ardupilot/commit/9f09442548a980e9c1e9f0d966fbe4ec2b063e0d

This resolves this issue: https://github.com/ArduPilot/ardupilot/issues/5842

To test this, the gps time can also be seen using the Mission Planner's Status screen.  Look for "gpstime".  Before these changes it was always Feb 1970.  After these changes it becomes today's date.

This will likely conflict with the GPS blending PR but I will resolve that conflict.