### PR TITLE
Ability to choose camera feedback location source.

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -100,6 +100,7 @@ private:
     // pin number for accurate camera feedback messages
     AP_Int8         _feedback_pin;
     AP_Int8         _feedback_polarity;
+    AP_Int8         _feedback_location_source;
 
     // this is set to 1 when camera trigger pin has fired
     static volatile bool   _camera_triggered;


### PR DESCRIPTION
Some people have high accuracy GPS receivers
which they want to use as a source for the
camera feedback messages. This patch adds a
parameter called FEEDBACK_SRC which allows
a user to choose between normal data fusion,
GPS1 or GPS2.