### PR TITLE
AP_Notify: check all i2c buses for Display devices

### DIFF
--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -284,6 +284,9 @@ static const uint8_t _font[] = {
     0x00, 0x00, 0x00, 0x00, 0x00
 };
 
+// probe first 3 busses:
+static const uint8_t I2C_BUS_PROBE_MASK = 0x7;
+
 bool Display::init(void)
 {
     // exit immediately if already initialised
@@ -295,31 +298,33 @@ bool Display::init(void)
     _movedelay = 4; // ticker delay before shifting after new message displayed
 
     // initialise driver
-    switch (pNotify->_display_type) {
-        case DISPLAY_SSD1306:
-            for(uint8_t i=0; i<3; i++) {
-                Display_Backend *tmp_driver = new Display_SSD1306_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
-                if (tmp_driver && tmp_driver->hw_init()) {
-                    _driver = tmp_driver;
-                    break;
-                }
-                delete tmp_driver;
+    for(uint8_t i=0; i<8 && _driver == nullptr; i++) {
+        if (! (I2C_BUS_PROBE_MASK & (1<<i))) {
+            continue;
+        }
+        switch (pNotify->_display_type) {
+        case DISPLAY_SSD1306: {
+            Display_Backend *tmp_driver = new Display_SSD1306_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
+            if (tmp_driver && tmp_driver->hw_init()) {
+                _driver = tmp_driver;
+                break;
             }
+            delete tmp_driver;
             break;
-        case DISPLAY_SH1106:
-            for(uint8_t i=0; i<3; i++) {
-                Display_Backend *tmp_driver = new Display_SH1106_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
-                if (tmp_driver && tmp_driver->hw_init()) {
-                    _driver = tmp_driver;
-                    break;
-                }
-                delete tmp_driver;
+        }
+        case DISPLAY_SH1106: {
+            Display_Backend *tmp_driver = new Display_SH1106_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
+            if (tmp_driver && tmp_driver->hw_init()) {
+                _driver = tmp_driver;
+                break;
             }
+            delete tmp_driver;
             break;
-
+        }
         case DISPLAY_OFF:
         default:
             break;
+        }
     }
 
     if (_driver == nullptr) {

--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -297,11 +297,24 @@ bool Display::init(void)
     // initialise driver
     switch (pNotify->_display_type) {
         case DISPLAY_SSD1306:
-            _driver = new Display_SSD1306_I2C(hal.i2c_mgr->get_device(NOTIFY_DISPLAY_I2C_BUS, NOTIFY_DISPLAY_I2C_ADDR));
+            for(uint8_t i=0; i<3; i++) {
+                Display_Backend *tmp_driver = new Display_SSD1306_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
+                if (tmp_driver && tmp_driver->hw_init()) {
+                    _driver = tmp_driver;
+                    break;
+                }
+                delete tmp_driver;
+            }
             break;
-
         case DISPLAY_SH1106:
-            _driver = new Display_SH1106_I2C(hal.i2c_mgr->get_device(NOTIFY_DISPLAY_I2C_BUS, NOTIFY_DISPLAY_I2C_ADDR));
+            for(uint8_t i=0; i<3; i++) {
+                Display_Backend *tmp_driver = new Display_SH1106_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
+                if (tmp_driver && tmp_driver->hw_init()) {
+                    _driver = tmp_driver;
+                    break;
+                }
+                delete tmp_driver;
+            }
             break;
 
         case DISPLAY_OFF:
@@ -309,7 +322,7 @@ bool Display::init(void)
             break;
     }
 
-    if (!_driver || !_driver->hw_init()) {
+    if (_driver == nullptr) {
         _healthy = false;
         return false;
     }

--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <AP_GPS/AP_GPS.h>
 
+#include <utility>
+
 extern const AP_HAL::HAL& hal;
 
 static const uint8_t _font[] = {
@@ -304,21 +306,11 @@ bool Display::init(void)
         }
         switch (pNotify->_display_type) {
         case DISPLAY_SSD1306: {
-            Display_Backend *tmp_driver = new Display_SSD1306_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
-            if (tmp_driver && tmp_driver->hw_init()) {
-                _driver = tmp_driver;
-                break;
-            }
-            delete tmp_driver;
+            _driver = Display_SSD1306_I2C::probe(std::move(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR)));
             break;
         }
         case DISPLAY_SH1106: {
-            Display_Backend *tmp_driver = new Display_SH1106_I2C(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR));
-            if (tmp_driver && tmp_driver->hw_init()) {
-                _driver = tmp_driver;
-                break;
-            }
-            delete tmp_driver;
+            _driver = Display_SH1106_I2C::probe(std::move(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR)));
             break;
         }
         case DISPLAY_OFF:

--- a/libraries/AP_Notify/Display_Backend.h
+++ b/libraries/AP_Notify/Display_Backend.h
@@ -2,16 +2,14 @@
 
 #include "Display.h"
 
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
-#define NOTIFY_DISPLAY_I2C_BUS 2
-#else
-#define NOTIFY_DISPLAY_I2C_BUS 1
-#endif
 #define NOTIFY_DISPLAY_I2C_ADDR 0x3C
 
 class Display_Backend {
 
 public:
+
+    virtual ~Display_Backend() {}
+
     virtual bool hw_init() = 0;
     virtual void hw_update() = 0;
     virtual void set_pixel(uint16_t x, uint16_t y) = 0;

--- a/libraries/AP_Notify/Display_Backend.h
+++ b/libraries/AP_Notify/Display_Backend.h
@@ -8,11 +8,15 @@ class Display_Backend {
 
 public:
 
-    virtual ~Display_Backend() {}
-
-    virtual bool hw_init() = 0;
     virtual void hw_update() = 0;
     virtual void set_pixel(uint16_t x, uint16_t y) = 0;
     virtual void clear_pixel(uint16_t x, uint16_t y) = 0;
     virtual void clear_screen() = 0;
+
+protected:
+
+    virtual ~Display_Backend() {}
+
+    virtual bool hw_init() = 0;
+
 };

--- a/libraries/AP_Notify/Display_SH1106_I2C.cpp
+++ b/libraries/AP_Notify/Display_SH1106_I2C.cpp
@@ -38,6 +38,17 @@ Display_SH1106_I2C::~Display_SH1106_I2C()
     delete _displaybuffer_sem;
 }
 
+Display_SH1106_I2C *Display_SH1106_I2C::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev)
+{
+    Display_SH1106_I2C *driver = new Display_SH1106_I2C(std::move(dev));
+    if (!driver || !driver->hw_init()) {
+        delete driver;
+        return nullptr;
+    }
+    return driver;
+}
+
+
 bool Display_SH1106_I2C::hw_init()
 {
     struct PACKED {

--- a/libraries/AP_Notify/Display_SH1106_I2C.cpp
+++ b/libraries/AP_Notify/Display_SH1106_I2C.cpp
@@ -28,6 +28,16 @@ Display_SH1106_I2C::Display_SH1106_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev) :
     _displaybuffer_sem = hal.util->new_semaphore();
 }
 
+Display_SH1106_I2C::~Display_SH1106_I2C()
+{
+    // note that a callback is registered below.  here we delete the
+    // semaphore, in that callback we use it.  That means - don't
+    // delete this Display backend if you've ever registered that
+    // callback!  This delete is only here to not leak memory during
+    // the detection phase.
+    delete _displaybuffer_sem;
+}
+
 bool Display_SH1106_I2C::hw_init()
 {
     struct PACKED {

--- a/libraries/AP_Notify/Display_SH1106_I2C.h
+++ b/libraries/AP_Notify/Display_SH1106_I2C.h
@@ -12,20 +12,27 @@ class Display_SH1106_I2C: public Display_Backend {
 
 public:
 
-    Display_SH1106_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
-    ~Display_SH1106_I2C() override;
+    static Display_SH1106_I2C *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
-    bool hw_init() override;
     void hw_update() override;
     void set_pixel(uint16_t x, uint16_t y) override;
     void clear_pixel(uint16_t x, uint16_t y) override;
     void clear_screen() override;
 
+protected:
+
+    Display_SH1106_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    ~Display_SH1106_I2C() override;
+
 private:
+
+    bool hw_init() override;
+
     void _timer();
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
     uint8_t _displaybuffer[SH1106_COLUMNS * SH1106_ROWS_PER_PAGE];
     AP_HAL::Semaphore *_displaybuffer_sem;
     bool _need_hw_update;
+
 };

--- a/libraries/AP_Notify/Display_SH1106_I2C.h
+++ b/libraries/AP_Notify/Display_SH1106_I2C.h
@@ -11,7 +11,9 @@
 class Display_SH1106_I2C: public Display_Backend {
 
 public:
+
     Display_SH1106_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    ~Display_SH1106_I2C() override;
 
     bool hw_init() override;
     void hw_update() override;

--- a/libraries/AP_Notify/Display_SSD1306_I2C.cpp
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.cpp
@@ -39,6 +39,16 @@ Display_SSD1306_I2C::~Display_SSD1306_I2C()
 }
 
 
+Display_SSD1306_I2C *Display_SSD1306_I2C::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev)
+{
+    Display_SSD1306_I2C *driver = new Display_SSD1306_I2C(std::move(dev));
+    if (!driver || !driver->hw_init()) {
+        delete driver;
+        return nullptr;
+    }
+    return driver;
+}
+
 bool Display_SSD1306_I2C::hw_init()
 {
     struct PACKED {

--- a/libraries/AP_Notify/Display_SSD1306_I2C.cpp
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.cpp
@@ -28,6 +28,17 @@ Display_SSD1306_I2C::Display_SSD1306_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev) :
     _displaybuffer_sem = hal.util->new_semaphore();
 }
 
+Display_SSD1306_I2C::~Display_SSD1306_I2C()
+{
+    // note that a callback is registered below.  here we delete the
+    // semaphore, in that callback we use it.  That means - don't
+    // delete this Display backend if you've ever registered that
+    // callback!  This delete is only here to not leak memory during
+    // the detection phase.
+    delete _displaybuffer_sem;
+}
+
+
 bool Display_SSD1306_I2C::hw_init()
 {
     struct PACKED {

--- a/libraries/AP_Notify/Display_SSD1306_I2C.h
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.h
@@ -12,16 +12,22 @@ class Display_SSD1306_I2C: public Display_Backend {
 
 public:
 
-    Display_SSD1306_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
-    ~Display_SSD1306_I2C() override;
+    static Display_SSD1306_I2C *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
-    bool hw_init() override;
     void hw_update() override;
     void set_pixel(uint16_t x, uint16_t y) override;
     void clear_pixel(uint16_t x, uint16_t y) override;
     void clear_screen() override;
 
+protected:
+
+    Display_SSD1306_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    ~Display_SSD1306_I2C() override;
+
 private:
+
+    bool hw_init() override;
+
     void _timer();
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;

--- a/libraries/AP_Notify/Display_SSD1306_I2C.h
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.h
@@ -11,7 +11,9 @@
 class Display_SSD1306_I2C: public Display_Backend {
 
 public:
+
     Display_SSD1306_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    ~Display_SSD1306_I2C() override;
 
     bool hw_init() override;
     void hw_update() override;


### PR DESCRIPTION
Instead of hard-coding a single i2c bus on a per-platform basis, check each of the buses of a display device.

AFAICS we have no way of unregistering a periodic callback.  Since we currently don't delete an object once we have registered the callback, I've just added a comment warning about deleting one of the backends after he callback has been registered.

This PR allows a Display device to work on either bus on The Cube

Q: if this is the right way to look for things - should we have an I2C_BUS_MAX or something?
