### PR TITLE
Copter: fixed var table loading for heli single parms

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -572,7 +572,7 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_HELI:
         default:
             motors = new AP_MotorsHeli_Single(MAIN_LOOP_RATE);
-            var_info = AP_MotorsHeli::var_info;
+            var_info = AP_MotorsHeli_Single::var_info;
             AP_Param::set_frame_type_flags(AP_PARAM_FRAME_HELI);
             break;            
 #endif


### PR DESCRIPTION
we were not loading parameters such as the swash angle