### PR TITLE
SITL: fix for connection problems with gimbal 

### DIFF
--- a/libraries/SITL/SIM_Gimbal.cpp
+++ b/libraries/SITL/SIM_Gimbal.cpp
@@ -181,6 +181,11 @@ void Gimbal::update(void)
 */
 void Gimbal::send_report(void)
 {
+    if (AP_HAL::millis() < 10000) {
+        // simulated aircraft don't appear until 10s after startup. This avoids a windows
+        // threading issue with non-blocking sockets and the initial wait on uartA
+        return;
+    }
     if (!mavlink.connected && mav_socket.connect(target_address, target_port)) {
         ::printf("Gimbal connected to %s:%u\n", target_address, (unsigned)target_port);
         mavlink.connected = true;


### PR DESCRIPTION
fix for #5748, "Unable to connect to SITL with virtual gimbal on Windows".

I just implemented @kshahar's solution by pasting the 10s startup delay from ADSB::send_report() into Gimbal::send_report():


```
void Gimbal::send_report(void)
{
    if (AP_HAL::millis() < 10000) {
        // simulated aircraft don't appear until 10s after startup. This avoids a windows
        // threading issue with non-blocking sockets and the initial wait on uartA
        return;
    }
```