### PR TITLE
Handle TIMESYNC mavlink messages

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1424,6 +1424,12 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+    case MAVLINK_MSG_ID_TIMESYNC:           // MAV ID: 111
+    {
+        handle_timesync(msg);
+        break;
+    }
+
     case MAVLINK_MSG_ID_LOG_REQUEST_DATA:
         rover.in_log_download = true;
         /* no break */

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1803,6 +1803,12 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_TIMESYNC:           // MAV ID: 111
+    {
+        handle_timesync(msg);
+        break;
+    }
+
     case MAVLINK_MSG_ID_LOG_REQUEST_DATA:
         copter.in_log_download = true;
         /* no break */

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1898,6 +1898,12 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_TIMESYNC:           // MAV ID: 111
+    {
+        handle_timesync(msg);
+        break;
+    }
+
     case MAVLINK_MSG_ID_LOG_REQUEST_DATA:
         plane.in_log_download = true;
         /* no break */

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1777,6 +1777,12 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_TIMESYNC:           // MAV ID: 111
+    {
+        handle_timesync(msg);
+        break;
+    }
+
     case MAVLINK_MSG_ID_LOG_REQUEST_DATA:
     case MAVLINK_MSG_ID_LOG_ERASE:
         sub.in_log_download = true;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -246,6 +246,8 @@ protected:
 
     void handle_gps_inject(const mavlink_message_t *msg, AP_GPS &gps);
 
+    void handle_timesync(mavlink_message_t *msg);
+
     void handle_common_message(mavlink_message_t *msg);
     void handle_log_message(mavlink_message_t *msg, DataFlash_Class &dataflash);
     void handle_setup_signing(const mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -767,6 +767,9 @@ void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &d
  */
 void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
 {
+    // Timestamp to return is usec since boot
+    uint64_t now = AP_HAL::micros64();
+    
     // Decode incoming timesync message
     mavlink_timesync_t tsync;
     mavlink_msg_timesync_decode(msg, &tsync);
@@ -774,12 +777,7 @@ void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
     // Create new timestruct to return
     mavlink_timesync_t rsync;
     rsync.ts1 = tsync.ts1;
-    rsync.tc1 = AP_HAL::micros64();
-
-    // If message is sent with tc > 1, calculate the offset and return that instead
-    if (tsync.tc1 > 0) {
-        rsync.tc1 = tsync.tc1 - AP_HAL::micros64();
-    }
+    rsync.tc1 = now;
 
     // Return a timesync message with updated tc1 field
     mavlink_msg_timesync_send(


### PR DESCRIPTION
PR to support #5884 
TIMESYNC mavlink message is used to synchronise the flight controller with systems connected over mavlink.  It can be used in one of two ways:

1.
 - Connected system sends a TIMESYNC message with a local timestamp
 - Flight Controller sends a TIMESYNC message back with the timestamp echoed and the local timestamp of the flight controller.
Once the connected system receives the returned TIMESYNC message, it can calculate the roundtrip time as well as receiving the local time since boot in usec of the flight controller.

2.
 - Connected system sends a TIMESYNC message with the estimated time of the flight controller, and a local timestamp.
 - Flight controller sends a TIMESYNC message back with the difference or offset between the estimated FC time and the actual FC time, and the original timestamp echoed.
Once the connected system receives the returned TIMESYNC message, it can accurately calculate the timestamp of the flight controller, and can continue to estimate it against the local clock of the connected system.  If TIMESYNC messages are exchanged at 10hz, time sync is typically as accurate as <1ms (fcoffset below is the difference between the two systems in microseconds):
```
fcoffset: 756 , fclocalfctime: 1090965029 , fctimecorrected: 1090964273
fcoffset: 846 , fclocalfctime: 1091065079 , fctimecorrected: 1091064233
fcoffset: 679 , fclocalfctime: 1091164872 , fctimecorrected: 1091164193
fcoffset: 647 , fclocalfctime: 1091264800 , fctimecorrected: 1091264153
fcoffset: 689 , fclocalfctime: 1091364802 , fctimecorrected: 1091364113
fcoffset: 676 , fclocalfctime: 1091464749 , fctimecorrected: 1091464073
fcoffset: 743 , fclocalfctime: 1091564776 , fctimecorrected: 1091564033
fcoffset: 683 , fclocalfctime: 1091664676 , fctimecorrected: 1091663993
```

Sample python/dronekit code:
```
class TrackTimer:
    def __init__(self, vehicle):
        self.fctimecorrected = None
        self.fcoffset = None
        self.fclocalstamp = None
        self.fclocalfctime = None
        self.debug = False
        self.vehicle = vehicle
        @self.vehicle.on_message("SYSTEM_TIME")
        def listener_systemtime(subself, name, message):
            # If the fctime is not set, set it from system_time.time_boot_ms for an initial sync.
            if not self.fclocalfctime:
                self.fclocalfctime = int(message.time_boot_ms*1000)
                self.fclocalstamp = int(time() * 1000000)
        @self.vehicle.on_message("TIMESYNC")
        def listener_timesync(subself, name, message):
            if message.ts1 == self.fclocalstamp:
                self.fcoffset = message.tc1
                self.fctimecorrected = self.fclocalfctime - self.fcoffset
                if self.debug:
                    print "fcoffset:",self.fcoffset,", fclocalfctime:",self.fclocalfctime,", fctimecorrected:",self.fctimecorrected
    def send_timesync(self, tc, ts):
        msg = self.vehicle.message_factory.timesync_encode(
            tc,          # tc1
            ts          # ts1
        )
        self.vehicle.send_mavlink(msg)
        self.vehicle.flush()
    def update(self):
        if self.fcoffset and self.fctimecorrected:
            oldlocalstamp = self.fclocalstamp
            self.fclocalstamp = int(time() * 1000000)
            newdiff = self.fclocalstamp - oldlocalstamp
            self.fclocalfctime = self.fctimecorrected+newdiff
            self.send_timesync(self.fclocalfctime, self.fclocalstamp)
        elif self.fclocalfctime:
            self.send_timesync(self.fclocalfctime, self.fclocalstamp)
    def actual(self):
        return self.fctimecorrected
    def estimate(self):
        if self.fctimecorrected:
            newdiff = int(time() * 1000000) - self.fclocalstamp
            return self.fctimecorrected + newdiff
        else:
            return None
```
To use the above class:
```
vehicle = connect(connectstr, wait_ready=True)
track_time = TrackTimer(vehicle)
track_time.debug = True
while True:
    track_time.update()
    sleep(0.1)
```

Note: This works quite differently to how PX4 processes the TIMESYNC request.  PX4 returns nanoseconds instead of microseconds, and sending a non-zero timesync.tc1 field does not return an offset (instead it does something different internally in PX4 firmware).