### PR TITLE
Baro: Correct EAS2TAS calculations

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -102,5 +102,5 @@ void Rover::update_home()
             GCS_MAVLINK::send_home_all(gps.location());
         }
     }
-    barometer.update_calibration();
+    barometer.update_calibration(gps);
 }

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -6,7 +6,7 @@ void Rover::init_barometer(bool full_calibration)
     if (full_calibration) {
         barometer.calibrate();
     } else {
-        barometer.update_calibration();
+        barometer.update_calibration(gps);
     }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -6,7 +6,7 @@ void Tracker::init_barometer(bool full_calibration)
     if (full_calibration) {
         barometer.calibrate();
     } else {
-        barometer.update_calibration();
+        barometer.update_calibration(gps);
     }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -6,7 +6,7 @@ void Copter::init_barometer(bool full_calibration)
     if (full_calibration) {
         barometer.calibrate();
     }else{
-        barometer.update_calibration();
+        barometer.update_calibration(gps);
     }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -942,6 +942,7 @@ private:
     void trim_radio();
     bool rc_failsafe_active(void);
     void init_barometer(bool full_calibration);
+    void update_barometer_calibration(void);
     void init_rangefinder(void);
     void read_rangefinder(void);
     void read_airspeed(void);

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -141,5 +141,5 @@ void Plane::update_home()
             GCS_MAVLINK::send_home_all(loc);
         }
     }
-    barometer.update_calibration();
+    update_barometer_calibration();
 }

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -7,9 +7,13 @@ void Plane::init_barometer(bool full_calibration)
     if (full_calibration) {
         barometer.calibrate();
     } else {
-        barometer.update_calibration();
+        update_barometer_calibration();
     }
     gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+}
+
+void Plane::update_barometer_calibration (void) {
+    barometer.update_calibration(gps);
 }
 
 void Plane::init_rangefinder(void)
@@ -107,7 +111,7 @@ void Plane::zero_airspeed(bool in_startup)
     airspeed.calibrate(in_startup);
     read_airspeed();
     // update barometric calibration with new airspeed supplied temperature
-    barometer.update_calibration();
+    update_barometer_calibration();
     gcs_send_text(MAV_SEVERITY_INFO,"Airspeed calibration started");
 }
 

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -664,7 +664,7 @@ void Replay::read_sensors(const char *type)
         if (!done_baro_init) {
             done_baro_init = true;
             ::printf("Barometer initialised\n");
-            _vehicle.barometer.update_calibration();
+            _vehicle.barometer.update_calibration(_vehicle.gps);
         }
     } 
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -226,7 +226,7 @@ void AP_Baro::calibrate(bool save)
             return;
         }
     }
-    AP_HAL::panic("AP_Baro: all sensors uncalibrated");
+    AP_HAL::panic("AP_Baro: unable to calibrate all sensors");
 }
 
 /*

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -291,7 +291,7 @@ float AP_Baro::get_altitude_difference(float base_pressure, float pressure) cons
 float AP_Baro::get_EAS2TAS(void)
 {
     float altitude = get_altitude();
-    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 100.0f) && !is_zero(_EAS2TAS)) {
+    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 25.0f) && !is_zero(_EAS2TAS)) {
         // not enough change to require re-calculating
         return _EAS2TAS;
     }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -35,6 +35,12 @@
 #include "AP_Baro_qflight.h"
 #include "AP_Baro_QURT.h"
 
+#define C_TO_KELVIN 273.15f
+// Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
+#define ISA_GAS_CONSTANT 287.26f
+#define ISA_LAPSE_RATE 0.0065f
+#define ISA_TEMP_C 15.0f
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -227,16 +233,29 @@ void AP_Baro::calibrate(bool save)
    update the barometer calibration
    this updates the baro ground calibration to the current values. It
    can be used before arming to keep the baro well calibrated
+
+   The GPS is used to estimate and corect foour deviation from an ISA day.
+   If there is no GPS available we will attempt to fit the current data to
+   match an ISA day. (This is the worst case for accuracy of the model)
 */
-void AP_Baro::update_calibration()
+void AP_Baro::update_calibration(const AP_GPS &gps)
 {
     for (uint8_t i=0; i<_num_sensors; i++) {
+        sensors[i].ground_temperature.set(_get_external_temperature_C(i));
+
         if (healthy(i)) {
             sensors[i].ground_pressure.set(get_pressure(i));
-        }
-        float last_temperature = sensors[i].ground_temperature;
-        sensors[i].ground_temperature.set(get_calibration_temperature(i));
 
+            // update ground altitude estimate
+            if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+                sensors[i].ground_altitude = gps.location().alt * 0.01f;
+                sensors[i].delta_ISA_C = sensors[i].ground_temperature - _get_ISA_temperature_C(sensors[i].ground_altitude);
+            } else {
+                // we don't have a valid external altitude reference, assume an ISA atmosphere
+                sensors[i].ground_altitude = (sensors[i].ground_temperature - ISA_TEMP_C) / ISA_LAPSE_RATE;
+                sensors[i].delta_ISA_C = 0.0f;
+            }
+        }
         // don't notify the GCS too rapidly or we flood the link
         uint32_t now = AP_HAL::millis();
         if (now - _last_notify_ms > 10000) {
@@ -244,11 +263,9 @@ void AP_Baro::update_calibration()
             sensors[i].ground_temperature.notify();
             _last_notify_ms = now;
         }
-        if (fabsf(last_temperature - sensors[i].ground_temperature) > 3) {
-            // reset _EAS2TAS to force it to recalculate. This happens
-            // when a digital airspeed sensor comes online
-            _EAS2TAS = 0;
-        }
+        // reset _EAS2TAS to force it to recalculate. This happens
+        // when a digital airspeed sensor comes online
+        _EAS2TAS = 0;
     }
 }
 
@@ -257,7 +274,7 @@ void AP_Baro::update_calibration()
 float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
 {
     float ret;
-    float temp    = get_ground_temperature() + 273.15f;
+    float temp    = get_ground_temperature() + C_TO_KELVIN;
     float scaling = pressure / base_pressure;
 
     // This is an exact calculation that is within +-2.5m of the standard
@@ -279,8 +296,8 @@ float AP_Baro::get_EAS2TAS(void)
         return _EAS2TAS;
     }
 
-    float tempK = get_calibration_temperature() + 273.15f - 0.0065f * altitude;
-    _EAS2TAS = safe_sqrt(1.225f / ((float)get_pressure() / (287.26f * tempK)));
+    float tempK =  C_TO_KELVIN +  _get_ISA_temperature_C(altitude + _get_ground_altitude()) +  _get_delta_ISA_C();
+    _EAS2TAS = safe_sqrt(1.225f / ((float)get_pressure() / (ISA_GAS_CONSTANT * tempK)));
     _last_altitude_EAS2TAS = altitude;
     return _EAS2TAS;
 }
@@ -320,9 +337,10 @@ void AP_Baro::set_external_temperature(float temperature)
 }
 
 /*
-  get the temperature in degrees C to be used for calibration purposes
+  Get the current external temperature in degrees C.
+  If no external temperature is available, use the barometers temperature
  */
-float AP_Baro::get_calibration_temperature(uint8_t instance) const
+float AP_Baro::_get_external_temperature_C(uint8_t instance) const
 {
     // if we have a recent external temperature then use it
     if (_last_external_temperature_ms != 0 && AP_HAL::millis() - _last_external_temperature_ms < 10000) {
@@ -338,6 +356,12 @@ float AP_Baro::get_calibration_temperature(uint8_t instance) const
         ret = 25;
     }
     return ret;
+}
+
+// returns the predicted ISA tempertature in C for a given altitude in meters
+float AP_Baro::_get_ISA_temperature_C(const float altitude) const
+{
+    return ISA_TEMP_C - (ISA_LAPSE_RATE * altitude);
 }
 
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -305,9 +305,9 @@ float AP_Baro::get_EAS2TAS(void)
 // return air density / sea level density - decreases as altitude climbs
 float AP_Baro::get_air_density_ratio(void)
 {
-    float eas2tas = get_EAS2TAS();
+    const float eas2tas = get_EAS2TAS();
     if (eas2tas > 0.0f) {
-        return 1.0f/(sq(get_EAS2TAS()));
+        return 1.0f/(sq(eas2tas));
     } else {
         return 1.0f;
     }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -2,6 +2,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_GPS/AP_GPS.h>
 #include <Filter/Filter.h>
 #include <Filter/DerivativeFilter.h>
 
@@ -60,7 +61,8 @@ public:
 
     // update the barometer calibration to the current pressure. Can
     // be used for incremental preflight update of baro
-    void update_calibration(void);
+    // gps is used to estimate the absolute altitude,
+    void update_calibration(const AP_GPS &gps);
 
     // get current altitude in meters relative to altitude at the time
     // of the last calibrate() call
@@ -102,9 +104,6 @@ public:
 
     // settable parameters
     static const struct AP_Param::GroupInfo var_info[];
-
-    float get_calibration_temperature(void) const { return get_calibration_temperature(_primary); }
-    float get_calibration_temperature(uint8_t instance) const;
 
     // HIL (and SITL) interface, setting altitude
     void setHIL(float altitude_msl);
@@ -172,6 +171,8 @@ private:
         float altitude;                 // calculated altitude
         AP_Float ground_temperature;
         AP_Float ground_pressure;
+        float ground_altitude;          // best guess of ground altitude
+        float delta_ISA_C;              // best guess of delta ISA temperature in C
     } sensors[BARO_MAX_INSTANCES];
 
     AP_Float                            _alt_offset;
@@ -191,4 +192,16 @@ private:
 
     void SimpleAtmosphere(const float alt, float &sigma, float &delta, float &theta);
     bool _add_backend(AP_Baro_Backend *backend);
+
+    float _get_delta_ISA_C(void) const { return _get_delta_ISA_C(_primary); }
+    float _get_delta_ISA_C(uint8_t instance) const { return sensors[instance].delta_ISA_C; }
+
+    float _get_external_temperature_C(void) const { return _get_external_temperature_C(_primary); }
+    float _get_external_temperature_C(uint8_t instance) const;
+
+    float _get_ground_altitude(void) const { return _get_ground_altitude(_primary); }
+    float _get_ground_altitude(uint8_t instance) const { return sensors[instance].ground_altitude; }
+
+    // returns the predicted ISA tempertature in C for a given altitude in meters
+    float _get_ISA_temperature_C(const float altitude) const;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -201,7 +201,7 @@ bool NavEKF2_core::resetHeightDatum(void)
     // record the old height estimate
     float oldHgt = -stateStruct.position.z;
     // reset the barometer so that it reads zero at the current height
-    frontend->_baro.update_calibration();
+    frontend->_baro.update_calibration(_ahrs->get_gps());
     // reset the height state
     stateStruct.position.z = 0.0f;
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -206,7 +206,7 @@ bool NavEKF3_core::resetHeightDatum(void)
     // record the old height estimate
     float oldHgt = -stateStruct.position.z;
     // reset the barometer so that it reads zero at the current height
-    frontend->_baro.update_calibration();
+    frontend->_baro.update_calibration(_ahrs->get_gps());
     // reset the height state
     stateStruct.position.z = 0.0f;
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same


### PR DESCRIPTION
There were a number of small bugs that had crept into the EAS2TAS calculations over time. They generally had the affect of causing you to overestimate your true airspeed.

The main problems were:
 -Applying the current external (if available) or internal temperature as the ground temperature
 -Then attempting to calculate the effect of altitude on top of the temperature using the ISA model.
 -Altitude into the ISA model was only calculated relative to your starting altitude.

The combination of the two had the effect of causing us to be effectively doubling the rate at which a change in altitude adjusted the EAS2TAS ratio.

The corrections used here are to estimate the temperature using the ISA model/lapse rate, and then apply a delta shift by comparing the altitude at a known location to the predicted temperature. Unfortunately the only source of this at the moment is a GPS unit, so the Baro needed to ingest a GPS instance in order to calculate a ground altitude/delta temperature.

We make the assumption that the delta ISA temperature stays the same for the air mass you are flying in. In the future it would be nice to allow a GCS to synchronize what the current delta/base pressures are, but that is a separate issue we've talked about for a long time.

Other small changes: Recalculate the EAS2TAS ratio every 25 meters so that it is smoother, fix a misleading HAL::panic() message I came across.

Has been validated so far by using some external aviation calculators and spot checking numbers produced in SITL at different altitudes.