### PR TITLE
Navigation: Loiter radius calculations

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -27,7 +27,7 @@ Rover::Rover(void) :
     DataFlash{FIRMWARE_STRING},
     in_log_download(false),
     modes(&g.mode1),
-    L1_controller(ahrs),
+    L1_controller(ahrs, nullptr),
     nav_controller(&L1_controller),
     steerController(ahrs),
     mission(ahrs,

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -216,8 +216,8 @@ private:
     AP_AHRS_DCM ahrs {ins, barometer, gps};
 #endif
 
-    AP_L1_Control L1_controller {ahrs};
     AP_TECS TECS_controller {ahrs, aparm, landing, g2.soaring_controller};
+    AP_L1_Control L1_controller {ahrs, &TECS_controller};
 
     // Attitude to servo controllers
     AP_RollController  rollController {ahrs, aparm, DataFlash};

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -17,11 +17,13 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Navigation/AP_Navigation.h>
+#include <AP_SpdHgtControl/AP_SpdHgtControl.h>
 
 class AP_L1_Control : public AP_Navigation {
 public:
-    AP_L1_Control(AP_AHRS &ahrs)
-        : _ahrs(ahrs)
+    AP_L1_Control(AP_AHRS &ahrs, const AP_SpdHgtControl * spdHgtControl)
+        : _ahrs(ahrs),
+          _spdHgtControl(spdHgtControl)
     {
         AP_Param::setup_object_defaults(this, var_info);
     }
@@ -43,6 +45,7 @@ public:
     int32_t target_bearing_cd(void) const;
     float turn_distance(float wp_radius) const;
     float turn_distance(float wp_radius, float turn_angle) const;
+    float loiter_radius (const float loiter_radius) const;
     void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP);
     void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction);
     void update_heading_hold(int32_t navigation_heading_cd);
@@ -71,6 +74,9 @@ public:
 private:
     // reference to the AHRS object
     AP_AHRS &_ahrs;
+
+    // pointer to the SpdHgtControl object
+    const AP_SpdHgtControl *_spdHgtControl;
 
     // lateral acceration in m/s required to fly to the
     // L1 reference point (+ve to right)
@@ -112,6 +118,8 @@ private:
     float _L1_xtrack_i_gain_prev = 0;
     uint32_t _last_update_waypoint_us;
     bool _data_is_stale = true;
+
+    AP_Float _loiter_bank_limit;
 
     bool _reverse = false;
     float get_yaw();

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -375,9 +375,11 @@ void AP_Landing_Deepstall::build_approach_path(void)
     memcpy(&arc, &arc_exit, sizeof(Location));
     memcpy(&arc_entry, &arc_exit, sizeof(Location));
 
+    float loiter_radius = landing.nav_controller->loiter_radius(landing.aparm.loiter_radius);
+
     // TODO: Support loitering on either side of the approach path
-    location_update(arc, target_heading_deg + 90.0, landing.aparm.loiter_radius);
-    location_update(arc_entry, target_heading_deg + 90.0, landing.aparm.loiter_radius * 2);
+    location_update(arc, target_heading_deg + 90.0, loiter_radius);
+    location_update(arc_entry, target_heading_deg + 90.0, loiter_radius * 2);
 
 #ifdef DEBUG_PRINTS
     // TODO: Send this information via a MAVLink packet

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -13,96 +13,95 @@
 
 class AP_Navigation {
 public:
-	// return the desired roll angle in centi-degrees to move towards
-	// the target waypoint
-	virtual int32_t nav_roll_cd(void) const = 0;
+    // return the desired roll angle in centi-degrees to move towards
+    // the target waypoint
+    virtual int32_t nav_roll_cd(void) const = 0;
 
-	// return the desired lateral acceleration in m/s/s to move towards
-	// the target waypoint
-	virtual float lateral_acceleration(void) const = 0;
+    // return the desired lateral acceleration in m/s/s to move towards
+    // the target waypoint
+    virtual float lateral_acceleration(void) const = 0;
 
-	// note: all centi-degree values returned in AP_Navigation should
-	// be wrapped at -18000 to 18000 in centi-degrees.
+    // note: all centi-degree values returned in AP_Navigation should
+    // be wrapped at -18000 to 18000 in centi-degrees.
 
-	// return the tracking bearing that the navigation controller is
-	// using in centi-degrees. This is used to display an arrow on
-	// ground stations showing the effect of the cross-tracking in the
-	// controller
-	virtual int32_t nav_bearing_cd(void) const = 0;
+    // return the tracking bearing that the navigation controller is
+    // using in centi-degrees. This is used to display an arrow on
+    // ground stations showing the effect of the cross-tracking in the
+    // controller
+    virtual int32_t nav_bearing_cd(void) const = 0;
 
-	// return the difference between the vehicles current course and
-	// the nav_bearing_cd() in centi-degrees. A positive value means
-	// the vehicle is tracking too far to the left of the correct
-	// bearing.
-	virtual int32_t bearing_error_cd(void) const = 0;
+    // return the difference between the vehicles current course and
+    // the nav_bearing_cd() in centi-degrees. A positive value means
+    // the vehicle is tracking too far to the left of the correct
+    // bearing.
+    virtual int32_t bearing_error_cd(void) const = 0;
 
-	// return the target bearing in centi-degrees. This is the bearing
-	// from the vehicles current position to the target waypoint. This
-	// should be calculated in the update_*() functions below.
-	virtual int32_t target_bearing_cd(void) const = 0;
+    // return the target bearing in centi-degrees. This is the bearing
+    // from the vehicles current position to the target waypoint. This
+    // should be calculated in the update_*() functions below.
+    virtual int32_t target_bearing_cd(void) const = 0;
 
-	// return the crosstrack error in meters. This is the distance in
-	// the X-Y plane that we are off the desired track
+    // return the crosstrack error in meters. This is the distance in
+    // the X-Y plane that we are off the desired track
     virtual float crosstrack_error(void) const = 0;
     virtual float crosstrack_error_integrator(void) const { return 0; }
 
-	
-	// return the distance in meters at which a turn should commence
-	// to allow the vehicle to neatly move to the next track in the
-	// mission when approaching a waypoint. Assumes 90 degree turn
-	virtual float turn_distance(float wp_radius) const = 0;
+    // return the distance in meters at which a turn should commence
+    // to allow the vehicle to neatly move to the next track in the
+    // mission when approaching a waypoint. Assumes 90 degree turn
+    virtual float turn_distance(float wp_radius) const = 0;
 
-	// return the distance in meters at which a turn should commence
-	// to allow the vehicle to neatly move to the next track in the
-	// mission when approaching a waypoint
-	virtual float turn_distance(float wp_radius, float turn_angle) const = 0;
+    // return the distance in meters at which a turn should commence
+    // to allow the vehicle to neatly move to the next track in the
+    // mission when approaching a waypoint
+    virtual float turn_distance(float wp_radius, float turn_angle) const = 0;
 
-	// update the internal state of the navigation controller, given
-	// the previous and next waypoints. This is the step function for
-	// navigation control for path following between two points.  This
-	// function is called at regular intervals (typically 10Hz). The
-	// main flight code will call an output function (such as
-	// nav_roll_cd()) after this function to ask for the new required
-	// navigation attitude/steering.
-	virtual void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP) = 0;
+    // update the internal state of the navigation controller, given
+    // the previous and next waypoints. This is the step function for
+    // navigation control for path following between two points.  This
+    // function is called at regular intervals (typically 10Hz). The
+    // main flight code will call an output function (such as
+    // nav_roll_cd()) after this function to ask for the new required
+    // navigation attitude/steering.
+    virtual void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP) = 0;
 
-	// update the internal state of the navigation controller for when
-	// the vehicle has been commanded to circle about a point.  This
-	// is the step function for navigation control for circling.  This
-	// function is called at regular intervals (typically 10Hz). The
-	// main flight code will call an output function (such as
-	// nav_roll_cd()) after this function to ask for the new required
-	// navigation attitude/steering.
-	virtual void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction) = 0;
+    // update the internal state of the navigation controller for when
+    // the vehicle has been commanded to circle about a point.  This
+    // is the step function for navigation control for circling.  This
+    // function is called at regular intervals (typically 10Hz). The
+    // main flight code will call an output function (such as
+    // nav_roll_cd()) after this function to ask for the new required
+    // navigation attitude/steering.
+    virtual void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction) = 0;
 
-	// update the internal state of the navigation controller, given a
-	// fixed heading. This is the step function for navigation control
-	// for a fixed heading.  This function is called at regular
-	// intervals (typically 10Hz). The main flight code will call an
-	// output function (such as nav_roll_cd()) after this function to
-	// ask for the new required navigation attitude/steering.
-	virtual void update_heading_hold(int32_t navigation_heading_cd) = 0;
+    // update the internal state of the navigation controller, given a
+    // fixed heading. This is the step function for navigation control
+    // for a fixed heading.  This function is called at regular
+    // intervals (typically 10Hz). The main flight code will call an
+    // output function (such as nav_roll_cd()) after this function to
+    // ask for the new required navigation attitude/steering.
+    virtual void update_heading_hold(int32_t navigation_heading_cd) = 0;
 
-	// update the internal state of the navigation controller for
-	// level flight on the current heading. This is the step function
-	// for navigation control for level flight.  This function is
-	// called at regular intervals (typically 10Hz). The main flight
-	// code will call an output function (such as nav_roll_cd()) after
-	// this function to ask for the new required navigation
-	// attitude/steering.
-	virtual void update_level_flight(void) = 0;
+    // update the internal state of the navigation controller for
+    // level flight on the current heading. This is the step function
+    // for navigation control for level flight.  This function is
+    // called at regular intervals (typically 10Hz). The main flight
+    // code will call an output function (such as nav_roll_cd()) after
+    // this function to ask for the new required navigation
+    // attitude/steering.
+    virtual void update_level_flight(void) = 0;
 
-	// return true if we have reached the target loiter location. This
-	// may be a fuzzy decision, depending on internal navigation
-	// parameters. For example the controller may return true only
-	// when on the circular path around the waypoint, and not when
-	// tracking towards the center. This function is only valid when
-	// the update_loiter() method is used
-	virtual bool reached_loiter_target(void) = 0;
+    // return true if we have reached the target loiter location. This
+    // may be a fuzzy decision, depending on internal navigation
+    // parameters. For example the controller may return true only
+    // when on the circular path around the waypoint, and not when
+    // tracking towards the center. This function is only valid when
+    // the update_loiter() method is used
+    virtual bool reached_loiter_target(void) = 0;
 
-	// notify Navigation controller that a new waypoint has just been
-	// processed. This means that until we handle an update_XXX() function
-	// the data is stale with old navigation information.
+    // notify Navigation controller that a new waypoint has just been
+    // processed. This means that until we handle an update_XXX() function
+    // the data is stale with old navigation information.
     virtual void set_data_is_stale(void) = 0;
 
     // return true if a new waypoint has been processed by mission
@@ -113,11 +112,11 @@ public:
 
     virtual void set_reverse(bool reverse) = 0;
 
-	// add new navigation controllers to this enum. Users can then
-	// select which navigation controller to use by setting the
-	// NAV_CONTROLLER parameter
-	enum ControllerType {
-	    CONTROLLER_DEFAULT      = 0,
-		CONTROLLER_L1           = 1
-	};
+    // add new navigation controllers to this enum. Users can then
+    // select which navigation controller to use by setting the
+    // NAV_CONTROLLER parameter
+    enum ControllerType {
+        CONTROLLER_DEFAULT      = 0,
+        CONTROLLER_L1           = 1
+    };
 };

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -56,6 +56,10 @@ public:
     // mission when approaching a waypoint
     virtual float turn_distance(float wp_radius, float turn_angle) const = 0;
 
+    // return the target loiter radius for the current location that
+    // will not cause excessive airframe loading
+    virtual float loiter_radius(const float radius) const = 0;
+
     // update the internal state of the navigation controller, given
     // the previous and next waypoints. This is the step function for
     // navigation control for path following between two points.  This


### PR DESCRIPTION
This addresses #5809 which is a plane issue relating to loiter radius's scaling with altitude and how that can cause problems.

This takes the approach of allowing the user to specify the bank angle their airframe can safely maintain at sea level. If this is provided we then always fly the currently requested loiter angle, or the lateral acceleration limit from sea level multiplied by the EAS2TAS scaler which ever is larger. This allows us to safely fly a consistent radius until the airframe would start to be excessively stressed by the bank angle at higher altitudes.

The default behavior of setting the parameter uses the current scaling logic, which will keep the aircraft at a reasonable (if excessive) radius at all altitudes.

There are a couple of issues with this at the moment:
1. ~Rover doesn't compile, as a AP_L1_Control now needs a reference to a SpdHgtControl object. I was wondering if anyone had any clever workarounds for this, otherwise I was going to address it by instead providing it with a constant pointer, and checking that the pointer isn't null. (This is straightforward, I was just curious if there was a better way to approach this).~ EDIT: Just did it in this manner.
2. The parameter name is pretty awful. I wanted to call it some variation on LIM_LOITER_BANK but I couldn't fit that in. I fully expect a rename to happen, hoping to source that from the DevCall. (And I need to hide this param from the rover build)

Other changes: (done in their own commits so we can easily drop them if someone doesn't like them)
- Fixed inconsistent whitespace in AP_Navigation, it was really bothering me.
- Updated deepstall to use the loiter radius that will actually be flown, which creates smoother approaches.