### PR TITLE
Fix bug not letting some Pixhawk type boards to read gpio pins on FMU

### DIFF
--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -165,9 +165,6 @@ uint8_t PX4GPIO::read(uint8_t pin) {
 
     case PX4_GPIO_FMU_SERVO_PIN(0) ... PX4_GPIO_FMU_SERVO_PIN(5): {
             uint32_t relays = 0;
-            if (_gpio_io_fd == -1) {
-                return LOW;
-            }
             ioctl(_gpio_fmu_fd, GPIO_GET, (unsigned long)&relays);
             return (relays & (1U<<(pin-PX4_GPIO_FMU_SERVO_PIN(0))))?HIGH:LOW;
         }


### PR DESCRIPTION
A minor bug fix not letting Pixhawk type boards without IO board to read GPIO pins connected to FMU/main controller. This patch removes the check looking for _gpio_io_fd's existence even while reading gpio pins connected to fmu board. 