### PR TITLE
Copter: add support for MANUAL_CONTROL message

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -993,6 +993,36 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_MANUAL_CONTROL:
+    {
+        if(msg->sysid != copter.g.sysid_my_gcs) break;                         // Only accept control from our gcs
+
+        mavlink_manual_control_t packet;
+        mavlink_msg_manual_control_decode(msg, &packet);
+
+        if (packet.z < 0) { // Copter doesn't do negative thrust
+            break;
+        }
+
+        bool override_active = false;
+        int16_t roll = (packet.y == INT16_MAX) ? 0 : copter.channel_roll->get_radio_min() + (copter.channel_roll->get_radio_max() - copter.channel_roll->get_radio_min()) * (packet.y + 1000) / 2000.0f;
+        int16_t pitch = (packet.x == INT16_MAX) ? 0 : copter.channel_pitch->get_radio_min() + (copter.channel_pitch->get_radio_max() - copter.channel_pitch->get_radio_min()) * (-packet.x + 1000) / 2000.0f;
+        int16_t throttle = (packet.z == INT16_MAX) ? 0 : copter.channel_throttle->get_radio_min() + (copter.channel_throttle->get_radio_max() - copter.channel_throttle->get_radio_min()) * (packet.z) / 1000.0f;
+        int16_t yaw = (packet.r == INT16_MAX) ? 0 : copter.channel_yaw->get_radio_min() + (copter.channel_yaw->get_radio_max() - copter.channel_yaw->get_radio_min()) * (packet.r + 1000) / 2000.0f;
+
+        override_active |= hal.rcin->set_override(uint8_t(copter.rcmap.roll() - 1), roll);
+        override_active |= hal.rcin->set_override(uint8_t(copter.rcmap.pitch() - 1), pitch);
+        override_active |= hal.rcin->set_override(uint8_t(copter.rcmap.throttle() - 1), throttle);
+        override_active |= hal.rcin->set_override(uint8_t(copter.rcmap.yaw() - 1), yaw);
+
+        // record that rc are overwritten so we can trigger a failsafe if we lose contact with groundstation
+        copter.failsafe.rc_override_active = override_active;
+
+        // a manual control message is considered to be a 'heartbeat' from the ground station for failsafe purposes
+        copter.failsafe.last_heartbeat_ms = AP_HAL::millis();
+        break;
+    }
+
     case MAVLINK_MSG_ID_COMMAND_INT:
     {
         // decode packet


### PR DESCRIPTION
During my (well deserved and needed) weekend away from all ArduPilot activity, it was time for some fun - and that couldn't be complete without a little flying, could it? So I took my Bebop2 with me, but I didn't want to carry my laptop around running MP with a joystick attached to it. I have QGC master version installed on my Android phone, but when enabling the virtual joystick it warns that it will use the MANUAL_CONTROL message - so on Saturday I spent some time implementing (more on that below) and testing it.

My plan was to fly it for some time on Sunday, but, with the festivities of the Father's day being more prolonged than expected, I ended up with 10 minutes to try it out. The test went almost well - my phone was playing stupid and I was losing connection to the Bebop, but while the connection was good it was working OK. It should be further tested before merging - although I don't know when I'll be able to do that.

Regarding the implementation: this message is good for basic roll/pitch/yaw/throttle control (since you don't need to worry about RCMAP being set for other channels or the exact RC max/min values), but not much more than that. It has a 16 bit buttons mask, indicating if the button was pressed or not - there are several ways we can handle this:

- assume the 16 bit mask corresponds to our 16 RC input channels and set the channel override value to min/max according to button pressed or not (this is what I did)
- the same as the previous one but exclude the first 6 channels since there is no way to set an option for them
- the same as one of the two previous ones, but use the pressed button as a toggle indication (so RC input would go low->middle->high->low); this is probably hard for the user to know in what state the inputs are in
- use the AP_JSButton library that come in with Sub, but, as I argued at the time, it is very hard to use a common library for vehicles that need different options
- completely ignore the buttons portion of the message

QGC doesn't have buttons in the virtual joystick so it always sends 0 - with the way I've implemented it, this means all channels will be set to the minimum RC value (including the flight mode switch and the tuning knob) except the roll/pitch/yaw/throttle channels.

I'm more inclined now to just ignore the buttons part, but I'd like to know other's opinion.