### PR TITLE
Copter: improve fence pre-arm failure messages

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -91,13 +91,7 @@ bool AP_Arming_Copter::rc_calibration_checks(bool display_failure)
 {
     // pre-arm rc checks a prerequisite
     pre_arm_rc_checks(display_failure);
-    if (!copter.ap.pre_arm_rc_check) {
-        if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: RC not calibrated");
-        }
-        return false;
-    }
-    return true;
+    return copter.ap.pre_arm_rc_check;
 }
 
 bool AP_Arming_Copter::barometer_checks(bool display_failure)
@@ -357,7 +351,7 @@ void AP_Arming_Copter::pre_arm_rc_checks(const bool display_failure)
         // check if radio has been calibrated
         if (!channel->min_max_configured()) {
             if (display_failure) {
-                copter.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL,"PreArm: %s not configured", channel_name);
+                copter.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL,"PreArm: RC %s not configured", channel_name);
             }
             return;
         }
@@ -579,14 +573,14 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         //check if accelerometers have calibrated and require reboot
         if (_ins.accel_cal_requires_reboot()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
+                gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accels calibrated requires reboot");
             }
             return false;
         }
 
         if (!_ins.get_accel_health_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Accelerometers not healthy");
+                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Accels not healthy");
             }
             return false;
         }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -159,9 +159,10 @@ bool AP_Arming_Copter::fence_checks(bool display_failure)
 {
     #if AC_FENCE == ENABLED
     // check fence is initialised
-    if (!copter.fence.pre_arm_check()) {
-        if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: check fence");
+    const char *fail_msg = nullptr;
+    if (!copter.fence.pre_arm_check(fail_msg)) {
+        if (display_failure && fail_msg != nullptr) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: %s", fail_msg);
         }
         return false;
     }
@@ -406,17 +407,17 @@ bool AP_Arming_Copter::pre_arm_gps_checks(bool display_failure)
     }
 
     // check if flight mode requires GPS
-    bool gps_required = copter.mode_requires_GPS(copter.control_mode);
+    bool mode_requires_gps = copter.mode_requires_GPS(copter.control_mode);
 
+    // check if fence requires GPS
+    bool fence_requires_gps = false;
     #if AC_FENCE == ENABLED
-    // if circular fence is enabled we need GPS
-    if ((copter.fence.get_enabled_fences() & AC_FENCE_TYPE_CIRCLE) != 0) {
-        gps_required = true;
-    }
+    // if circular or polygon fence is enabled we need GPS
+    fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
     #endif
 
     // return true if GPS is not required
-    if (!gps_required) {
+    if (!mode_requires_gps && !fence_requires_gps) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }
@@ -428,7 +429,12 @@ bool AP_Arming_Copter::pre_arm_gps_checks(bool display_failure)
             if (reason) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: %s", reason);
             } else {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Need 3D Fix");
+                if (!mode_requires_gps && fence_requires_gps) {
+                    // clarify to user why they need GPS in non-GPS flight mode
+                    gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Fence enabled, need 3D Fix");
+                } else {
+                    gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Need 3D Fix");
+                }
             }
         }
         AP_Notify::flags.pre_arm_gps_check = false;
@@ -696,9 +702,10 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
 
     #if AC_FENCE == ENABLED
     // check vehicle is within fence
-    if (!copter.fence.pre_arm_check()) {
-        if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: check fence");
+    const char *fail_msg = nullptr;
+    if (!copter.fence.pre_arm_check(fail_msg)) {
+        if (display_failure && fail_msg != nullptr) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Arm: %s", fail_msg);
         }
         return false;
     }

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -121,7 +121,7 @@ bool AC_Fence::pre_arm_check() const
     }
 
     // if we have horizontal limits enabled, check inertial nav position is ok
-    if ((_enabled_fences & AC_FENCE_TYPE_CIRCLE)!=0 && !_inav.get_filter_status().flags.horiz_pos_abs && !_inav.get_filter_status().flags.pred_horiz_pos_abs) {
+    if ((_enabled_fences & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON))>0 && !_inav.get_filter_status().flags.horiz_pos_abs && !_inav.get_filter_status().flags.pred_horiz_pos_abs) {
         return false;
     }
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -108,8 +108,10 @@ uint8_t AC_Fence::get_enabled_fences() const
 }
 
 /// pre_arm_check - returns true if all pre-takeoff checks have completed successfully
-bool AC_Fence::pre_arm_check() const
+bool AC_Fence::pre_arm_check(const char* &fail_msg) const
 {
+    fail_msg = nullptr;
+
     // if not enabled or not fence set-up always return true
     if (!_enabled || _enabled_fences == AC_FENCE_TYPE_NONE) {
         return true;
@@ -117,11 +119,13 @@ bool AC_Fence::pre_arm_check() const
 
     // check no limits are currently breached
     if (_breached_fences != AC_FENCE_TYPE_NONE) {
+        fail_msg =  "vehicle outside fence";
         return false;
     }
 
     // if we have horizontal limits enabled, check inertial nav position is ok
     if ((_enabled_fences & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON))>0 && !_inav.get_filter_status().flags.horiz_pos_abs && !_inav.get_filter_status().flags.pred_horiz_pos_abs) {
+        fail_msg = "fence requires position";
         return false;
     }
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -49,7 +49,7 @@ public:
     uint8_t get_enabled_fences() const;
 
     /// pre_arm_check - returns true if all pre-takeoff checks have completed successfully
-    bool pre_arm_check() const;
+    bool pre_arm_check(const char* &fail_msg) const;
 
     ///
     /// methods to check we are within the boundaries and recover

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -189,13 +189,13 @@ bool AP_Arming::ins_checks(bool report)
         }
         if (!ins.get_accel_health_all()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accels not healthy");
             }
             return false;
         }
         if (!ins.accel_calibrated_ok_all()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: 3D accelerometers calibration needed");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: 3D Accel calibration needed");
             }
             return false;
         }
@@ -203,7 +203,7 @@ bool AP_Arming::ins_checks(bool report)
         //check if accelerometers have calibrated and require reboot
         if (ins.accel_cal_requires_reboot()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accels calibrated requires reboot");
             }
             return false;
         }
@@ -237,7 +237,7 @@ bool AP_Arming::ins_checks(bool report)
                 }
                 if (AP_HAL::millis() - last_accel_pass_ms[i] > 10000) {
                     if (report) {
-                        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers inconsistent");
+                        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accels inconsistent");
                     }
                     return false;
                 }


### PR DESCRIPTION
This PR makes the following changes:

- provides a failure message to the user if the fence pre-arm check fails, "vehicle outside fence" or "fence requires position"
- displays "Fence enabled, need 3D Fix" if the GPS pre-arm check fails and it's required only because the fence is enabled
- shorten "Accelerometers" to "Accels" in pre-arm checks to allow message to fix on the HUD and to be consistent with the "Gyros" failure messages.