### PR TITLE
Baro: Temperature Related Fixups

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -35,6 +35,14 @@
 #include "AP_Baro_qflight.h"
 #include "AP_Baro_QURT.h"
 
+#define C_TO_KELVIN 273.15f
+// Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
+#define ISA_GAS_CONSTANT 287.26f
+#define ISA_LAPSE_RATE 0.0065f
+
+#define INTERNAL_TEMPERATURE_CLAMP 35.0f
+
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -60,7 +68,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @ReadOnly: True
     // @Volatile: True
     // @User: Advanced
-    AP_GROUPINFO("TEMP", 3, AP_Baro, sensors[0].ground_temperature, 0),
+    AP_GROUPINFO("TEMP", 3, AP_Baro, _user_ground_temperature, 0),
 
     // index 4 reserved for old AP_Int8 version in legacy FRAM
     //AP_GROUPINFO("ALT_OFFSET", 4, AP_Baro, _alt_offset, 0),
@@ -104,15 +112,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ABS_PRESS2", 9, AP_Baro, sensors[1].ground_pressure, 0),
 
-    // @Param: TEMP2
-    // @DisplayName: ground temperature
-    // @Description: calibrated ground temperature in degrees Celsius
-    // @Units: degrees celsius
-    // @Increment: 1
-    // @ReadOnly: True
-    // @Volatile: True
-    // @User: Advanced
-    AP_GROUPINFO("TEMP2", 10, AP_Baro, sensors[1].ground_temperature, 0),
+    // Slot 10 used to be TEMP2
 #endif
 
 #if BARO_MAX_INSTANCES > 2
@@ -126,15 +126,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ABS_PRESS3", 11, AP_Baro, sensors[2].ground_pressure, 0),
 
-    // @Param: TEMP3
-    // @DisplayName: ground temperature
-    // @Description: calibrated ground temperature in degrees Celsius
-    // @Units: degrees celsius
-    // @Increment: 1
-    // @ReadOnly: True
-    // @Volatile: True
-    // @User: Advanced
-    AP_GROUPINFO("TEMP3", 12, AP_Baro, sensors[2].ground_temperature, 0),
+    // Slot 12 used to be TEMP3
 #endif
 
     AP_GROUPEND
@@ -209,10 +201,11 @@ void AP_Baro::calibrate(bool save)
         } else {
             if (save) {
                 sensors[i].ground_pressure.set_and_save(sum_pressure[i] / count[i]);
-                sensors[i].ground_temperature.set_and_save(sum_temperature[i] / count[i]);
             }
         }
     }
+
+    _guessed_ground_temperature = get_external_temperature();
 
     // panic if all sensors are not calibrated
     for (uint8_t i=0; i<_num_sensors; i++) {
@@ -234,22 +227,20 @@ void AP_Baro::update_calibration()
         if (healthy(i)) {
             sensors[i].ground_pressure.set(get_pressure(i));
         }
-        float last_temperature = sensors[i].ground_temperature;
-        sensors[i].ground_temperature.set(get_calibration_temperature(i));
 
         // don't notify the GCS too rapidly or we flood the link
         uint32_t now = AP_HAL::millis();
         if (now - _last_notify_ms > 10000) {
             sensors[i].ground_pressure.notify();
-            sensors[i].ground_temperature.notify();
             _last_notify_ms = now;
         }
-        if (fabsf(last_temperature - sensors[i].ground_temperature) > 3) {
-            // reset _EAS2TAS to force it to recalculate. This happens
-            // when a digital airspeed sensor comes online
-            _EAS2TAS = 0;
-        }
     }
+
+    // always update the guessed ground temp
+    _guessed_ground_temperature = get_external_temperature();
+
+    // force EAS2TAS to recalculate
+    _EAS2TAS = 0;
 }
 
 // return altitude difference in meters between current pressure and a
@@ -257,7 +248,7 @@ void AP_Baro::update_calibration()
 float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
 {
     float ret;
-    float temp    = get_ground_temperature() + 273.15f;
+    float temp    = get_ground_temperature() + C_TO_KELVIN;
     float scaling = pressure / base_pressure;
 
     // This is an exact calculation that is within +-2.5m of the standard
@@ -274,13 +265,16 @@ float AP_Baro::get_altitude_difference(float base_pressure, float pressure) cons
 float AP_Baro::get_EAS2TAS(void)
 {
     float altitude = get_altitude();
-    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 100.0f) && !is_zero(_EAS2TAS)) {
+    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 25.0f) && !is_zero(_EAS2TAS)) {
         // not enough change to require re-calculating
         return _EAS2TAS;
     }
 
-    float tempK = get_calibration_temperature() + 273.15f - 0.0065f * altitude;
-    _EAS2TAS = safe_sqrt(1.225f / ((float)get_pressure() / (287.26f * tempK)));
+    // only estimate lapse rate for the difference from the ground location
+    // provides a more consistent reading then trying to estimate a complete
+    // ISA model atmosphere
+    float tempK = get_ground_temperature() + C_TO_KELVIN - ISA_LAPSE_RATE * altitude;
+    _EAS2TAS = safe_sqrt(1.225f / ((float)get_pressure() / (ISA_GAS_CONSTANT * tempK)));
     _last_altitude_EAS2TAS = altitude;
     return _EAS2TAS;
 }
@@ -288,9 +282,9 @@ float AP_Baro::get_EAS2TAS(void)
 // return air density / sea level density - decreases as altitude climbs
 float AP_Baro::get_air_density_ratio(void)
 {
-    float eas2tas = get_EAS2TAS();
+    const float eas2tas = get_EAS2TAS();
     if (eas2tas > 0.0f) {
-        return 1.0f/(sq(get_EAS2TAS()));
+        return 1.0f/(sq(eas2tas));
     } else {
         return 1.0f;
     }
@@ -309,6 +303,17 @@ float AP_Baro::get_climb_rate(void)
     return _climb_rate_filter.slope() * 1.0e3f;
 }
 
+// returns the ground temperature in degrees C, selecting either a user
+// provided one, or the internal estimate
+float AP_Baro::get_ground_temperature(void) const
+{
+    if (is_zero(_user_ground_temperature)) {
+        return _guessed_ground_temperature;
+    } else {
+        return _user_ground_temperature;
+    }
+}
+
 
 /*
   set external temperature to be used for calibration (degrees C)
@@ -322,22 +327,21 @@ void AP_Baro::set_external_temperature(float temperature)
 /*
   get the temperature in degrees C to be used for calibration purposes
  */
-float AP_Baro::get_calibration_temperature(uint8_t instance) const
+float AP_Baro::get_external_temperature(const uint8_t instance) const
 {
     // if we have a recent external temperature then use it
     if (_last_external_temperature_ms != 0 && AP_HAL::millis() - _last_external_temperature_ms < 10000) {
         return _external_temperature;
     }
     // if we don't have an external temperature then use the minimum
-    // of the barometer temperature and 25 degrees C. The reason for
+    // of the barometer temperature and 35 degrees C. The reason for
     // not just using the baro temperature is it tends to read high,
     // often 30 degrees above the actual temperature. That means the
-    // EAS2TAS tends to be off by quite a large margin
-    float ret = get_temperature(instance);
-    if (ret > 25) {
-        ret = 25;
-    }
-    return ret;
+    // EAS2TAS tends to be off by quite a large margin, as well as
+    // the calculation of altitude difference betweeen two pressures
+    // reporting a high temperature will cause the aircraft to
+    // estimate itself as flying higher then it actually is.
+    return MIN(get_temperature(instance), INTERNAL_TEMPERATURE_CLAMP);
 }
 
 
@@ -370,6 +374,12 @@ bool AP_Baro::_add_backend(AP_Baro_Backend *backend)
  */
 void AP_Baro::init(void)
 {
+    // ensure that there isn't a previous ground temperature saved
+    if (!is_zero(_user_ground_temperature)) {
+        _user_ground_temperature.set_and_save(0.0f);
+        _user_ground_temperature.notify();
+    }
+
     if (_hil_mode) {
         drivers[0] = new AP_Baro_HIL(*this);
         _num_drivers = 1;

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -83,8 +83,7 @@ public:
 
     // ground temperature in degrees C
     // the ground values are only valid after calibration
-    float get_ground_temperature(void) const { return get_ground_temperature(_primary); }
-    float get_ground_temperature(uint8_t i)  const { return sensors[i].ground_temperature.get(); }
+    float get_ground_temperature(void) const;
 
     // ground pressure in Pascal
     // the ground values are only valid after calibration
@@ -103,8 +102,8 @@ public:
     // settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
-    float get_calibration_temperature(void) const { return get_calibration_temperature(_primary); }
-    float get_calibration_temperature(uint8_t instance) const;
+    float get_external_temperature(void) const { return get_external_temperature(_primary); };
+    float get_external_temperature(const uint8_t instance) const;
 
     // HIL (and SITL) interface, setting altitude
     void setHIL(float altitude_msl);
@@ -170,7 +169,6 @@ private:
         float pressure;                 // pressure in Pascal
         float temperature;              // temperature in degrees C
         float altitude;                 // calculated altitude
-        AP_Float ground_temperature;
         AP_Float ground_pressure;
     } sensors[BARO_MAX_INSTANCES];
 
@@ -184,7 +182,9 @@ private:
     uint32_t                            _last_external_temperature_ms;
     DerivativeFilterFloat_Size7         _climb_rate_filter;
     AP_Float                            _specific_gravity; // the specific gravity of fluid for an ROV 1.00 for freshwater, 1.024 for salt water
+    AP_Float                            _user_ground_temperature; // user override of the ground temperature used for EAS2TAS
     bool                                _hil_mode:1;
+    float                               _guessed_ground_temperature; // currently ground temperature estimate using our best abailable source
 
     // when did we last notify the GCS of new pressure reference?
     uint32_t                            _last_notify_ms;

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -829,6 +829,7 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
     }
     float climbrate = baro.get_climb_rate();
     float drift_offset = baro.get_baro_drift_offset();
+    float ground_temp = baro.get_ground_temperature();
     struct log_BARO pkt = {
         LOG_PACKET_HEADER_INIT(LOG_BARO_MSG),
         time_us       : time_us,
@@ -838,6 +839,7 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
         climbrate     : climbrate,
         sample_time_ms: baro.get_last_update(0),
         drift_offset  : drift_offset,
+        ground_temp   : ground_temp,
     };
     WriteBlock(&pkt, sizeof(pkt));
 
@@ -851,6 +853,7 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
             climbrate     : climbrate,
             sample_time_ms: baro.get_last_update(1),
             drift_offset  : drift_offset,
+            ground_temp   : ground_temp,
         };
         WriteBlock(&pkt2, sizeof(pkt2));
     }
@@ -865,6 +868,7 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
             climbrate     : climbrate,
             sample_time_ms: baro.get_last_update(2),
             drift_offset  : drift_offset,
+            ground_temp   : ground_temp,
         };
         WriteBlock(&pkt3, sizeof(pkt3));
     }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -191,6 +191,7 @@ struct PACKED log_BARO {
     float   climbrate;
     uint32_t sample_time_ms;
     float   drift_offset;
+    float   ground_temp;
 };
 
 struct PACKED log_AHRS {
@@ -805,7 +806,7 @@ Format characters in the format string for binary log messages
     { LOG_RSSI_MSG, sizeof(log_RSSI), \
       "RSSI",  "Qf",     "TimeUS,RXRSSI" }, \
     { LOG_BARO_MSG, sizeof(log_BARO), \
-      "BARO",  "QffcfIf", "TimeUS,Alt,Press,Temp,CRt,SMS,Offset" }, \
+      "BARO",  "QffcfIff", "TimeUS,Alt,Press,Temp,CRt,SMS,Offset,GndTemp" }, \
     { LOG_POWR_MSG, sizeof(log_POWR), \
       "POWR","QffH","TimeUS,Vcc,VServo,Flags" },  \
     { LOG_CMD_MSG, sizeof(log_Cmd), \


### PR DESCRIPTION
**TL;DR** #5889 is to complicated, this is better, and fixes an over estimation of altitude.

---

This replaces #5889. It was to complicated, and resulted in different behaviors on copter depending upon if you took off with/without GPS (and when you took off).

The core problem with the EAS2TAS calculation that #5889 was attempting to fix was that the source of temperature for EAS2TAS is quite important for ensuring that we aren't providing a reasonable estimate of EAS2TAS. The problem with master is that we double count the affect of any change in altitude, causing the aircraft to change the ratio faster then it actually was.

This PR corrects the use of double counting the temperature for altitude. However while doing that a rethink of how we selected calibration temperatures was needed to further improve accuracies. @priseborough and I discussed a couple of options and the best option was to select an external temperature source if we had one available (airspeed on plane, in future work we can incorporate the concept of external baro sources) if there isn't an available external temperature source we can take the internal one, but given it's tendency to be high we can clip it at a reasonable value (35C covers most tropics/hot environment users safely while still improving the reported altitude for users in cooler regions). The concept of clipping the external temperature source isn't new (we were clipping it at 25C, but we were using it in EAS2TAS which we adjusted to quickly as well)

While implementing the rest of this I came across the fact that the actual relative altitude calculation uses the unclipped barometer temperature as well. This is actually quite poor if your barometer is reading 30 degrees warmer then it actually is (which is very common). This results in a linear error of the aircraft estimating it's higher then it actually is. Using the data collected by the [LOHAN](http://diydrones.com/profiles/blogs/pratchett-soars-to-31-000m-for-pixhawk-test-flight) project provided a great source of data to demonstrate this effect. The red line is the altitude ArduPilot would report using the current temperature selection method, the green line is the reported altitude if we were to clip the temperature sensor at 35C, and the blue line is the true altitude.

![figure_1-5](https://cloud.githubusercontent.com/assets/567688/24284194/4875f310-1027-11e7-8d79-e453d08ec8c6.png)
![figure_1-6](https://cloud.githubusercontent.com/assets/567688/24284195/487b2934-1027-11e7-9d60-5a090640e939.png)

As you can see there is nearly a 200m altitude error at 2km of altitude. That means we are overestimating our altitude by around 10% and flying lower then intended. On a long terrain following mission this would be especially problematic (Sidenote: GPS altitude is almost always a better altitude source for long missions or terrain following). If we had instead used the 35C clip approach (what this PR presents) we would instead have around 80 meters of altitude error (around 4%).

This PR clips the temperature source used for all altitude estimation at 35C as well. The final step that this PR takes is the GND_TEMP parameter can now be set to provide a true estimate of the ground temperature. During a preflight you can provide the temperature to this parameter (in degrees Celsius) and use your true OAT for the best result. (NOTE: Adjusting the value by a significant amount from the estimate will cause a step input, and upset the EKF. It will recover without any problem, but I don't recommend trying it in flight. For almost all users this is overkill, but for certain use cases the ability.

Because GND_TEMP is no longer the authoritative source on what ground temperature datum is being used this also now logs the current value of the ground temperature data in the BARO message.

Finally I recreated @khancyr's [patch](https://github.com/WickedShell/ardupilot/commit/f7dfac7adebec12b99d44ec8a4de79e20a7c427f) because I couldn't figure out how to easily pull just that patch in from the branch.