### PR TITLE
WIP: add sample counters for accel/gyro data

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -205,7 +205,6 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
         _sem->give();
     }
 
-    // log raw data if flag is set
     DataFlash_Class *dataflash = get_dataflash();
     if (dataflash != nullptr) {
         uint64_t now = AP_HAL::micros64();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -172,8 +172,8 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              const Vector3f &accel,
-                                                             bool fsync_set,
                                                              uint64_t sample_us,
+                                                             bool fsync_set,
                                                              uint32_t samp_cnt)
 {
     float dt;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -172,8 +172,8 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              const Vector3f &accel,
-                                                             uint64_t sample_us,
                                                              bool fsync_set,
+                                                             uint64_t sample_us,
                                                              uint32_t samp_cnt)
 {
     float dt;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -67,7 +67,8 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
 
 void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
                                                             const Vector3f &gyro,
-                                                            uint64_t sample_us)
+                                                            uint64_t sample_us,
+                                                            uint32_t samp_cnt)
 {
     float dt;
 
@@ -122,8 +123,8 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
         uint64_t now = AP_HAL::micros64();
         struct log_GYRO pkt = {
             LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GYR1_MSG+instance)),
-            time_us   : now,
-            sample_us : sample_us?sample_us:now,
+            time_us   : sample_us?sample_us:now,
+            samp_cnt  : samp_cnt,
             GyrX      : gyro.x,
             GyrY      : gyro.y,
             GyrZ      : gyro.z
@@ -172,7 +173,8 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              const Vector3f &accel,
                                                              uint64_t sample_us,
-                                                             bool fsync_set)
+                                                             bool fsync_set,
+                                                             uint32_t samp_cnt)
 {
     float dt;
 
@@ -203,13 +205,14 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
         _sem->give();
     }
 
+    // log raw data if flag is set
     DataFlash_Class *dataflash = get_dataflash();
     if (dataflash != nullptr) {
         uint64_t now = AP_HAL::micros64();
         struct log_ACCEL pkt = {
             LOG_PACKET_HEADER_INIT((uint8_t)(LOG_ACC1_MSG+instance)),
-            time_us   : now,
-            sample_us : sample_us?sample_us:now,
+            time_us   : sample_us?sample_us:now,
+            samp_cnt  : samp_cnt,
             AccX      : accel.x,
             AccY      : accel.y,
             AccZ      : accel.z

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -116,7 +116,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_accel)
-    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false, uint32_t samp_cnt=0);
+    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, bool fsync_set=false, uint64_t sample_us=0, uint32_t samp_cnt=0);
 
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -116,7 +116,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_accel)
-    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, bool fsync_set=false, uint64_t sample_us=0, uint32_t samp_cnt=0);
+    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false, uint32_t samp_cnt=0);
 
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -107,7 +107,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_gyro)
-    void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0);
+    void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, uint32_t samp_cnt=0);
 
     // rotate accel vector, scale, offset and publish
     void _publish_accel(uint8_t instance, const Vector3f &accel);
@@ -116,7 +116,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_accel)
-    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false);
+    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false, uint32_t samp_cnt=0);
 
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -633,7 +633,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
             _rotate_and_correct_accel(_accel_instance, _accum.accel);
             _rotate_and_correct_gyro(_gyro_instance, _accum.gyro);
             
-            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, now, false, _seqcnt);
+            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, false, now, _seqcnt);
             _notify_new_gyro_raw_sample(_gyro_instance, _accum.gyro, now, _seqcnt);
             
             _accum.accel.zero();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -564,6 +564,8 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         _rotate_and_correct_accel(_accel_instance, accel);
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
+        _seqcnt++;
+
         _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), fsync_set, _seqcnt);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro, _seqcnt);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -567,7 +567,7 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         _seqcnt++;
 
         _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), fsync_set, _seqcnt);
-        _notify_new_gyro_raw_sample(_gyro_instance, gyro, _seqcnt);
+        _notify_new_gyro_raw_sample(_gyro_instance, gyro, AP_HAL::micros64(), _seqcnt);
 
         _temp_filtered = _temp_filter.apply(temp);
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -564,7 +564,7 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         _rotate_and_correct_accel(_accel_instance, accel);
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
-        _notify_new_accel_raw_sample(_accel_instance, accel, fsync_set);
+        _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), fsync_set, _seqcnt);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro, _seqcnt);
 
         _temp_filtered = _temp_filter.apply(temp);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -367,6 +367,7 @@ void AP_InertialSensor_Invensense::_fifo_reset()
     hal.scheduler->delay_microseconds(1);
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
     _last_stat_user_ctrl = user_ctrl | BIT_USER_CTRL_FIFO_EN;
+    _seqcnt = 0;
 }
 
 bool AP_InertialSensor_Invensense::_has_auxiliary_bus()
@@ -563,8 +564,8 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         _rotate_and_correct_accel(_accel_instance, accel);
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
-        _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), fsync_set);
-        _notify_new_gyro_raw_sample(_gyro_instance, gyro);
+        _notify_new_accel_raw_sample(_accel_instance, accel, fsync_set);
+        _notify_new_gyro_raw_sample(_gyro_instance, gyro, _seqcnt);
 
         _temp_filtered = _temp_filter.apply(temp);
     }
@@ -586,10 +587,12 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
     bool clipped = false;
     bool ret = true;
     
+    uint64_t now = AP_HAL::micros64();
+
     for (uint8_t i = 0; i < n_samples; i++) {
         const uint8_t *data = samples + MPU_SAMPLE_SIZE * i;
 
-        // use temperatue to detect FIFO corruption
+        // use temperature to detect FIFO corruption
         int16_t t2 = int16_val(data, 3);
         if (!_check_raw_temp(t2)) {
             debug("temp reset %d %d", _raw_temp, t2);
@@ -618,6 +621,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
 
         _accum.gyro += _accum.gyro_filter.apply(g);
         _accum.count++;
+        _seqcnt++;
 
         if (_accum.count == MPU_FIFO_DOWNSAMPLE_COUNT) {
             float ascale = _accel_scale / (MPU_FIFO_DOWNSAMPLE_COUNT/2);
@@ -629,8 +633,8 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
             _rotate_and_correct_accel(_accel_instance, _accum.accel);
             _rotate_and_correct_gyro(_gyro_instance, _accum.gyro);
             
-            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, AP_HAL::micros64(), false);
-            _notify_new_gyro_raw_sample(_gyro_instance, _accum.gyro);
+            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, now, false, _seqcnt);
+            _notify_new_gyro_raw_sample(_gyro_instance, _accum.gyro, now, _seqcnt);
             
             _accum.accel.zero();
             _accum.gyro.zero();
@@ -658,6 +662,7 @@ void AP_InertialSensor_Invensense::_read_fifo()
     bool need_reset = false;
 
     if (!_block_read(MPUREG_FIFO_COUNTH, rx, 2)) {
+        _seqcnt = 0;
         goto check_registers;
     }
 
@@ -668,6 +673,19 @@ void AP_InertialSensor_Invensense::_read_fifo()
         /* Not enough data in FIFO */
         goto check_registers;
     }
+
+#if defined(INVENSENSE_DEBUG)
+	_tot_samples += n_samples;
+    if (++_dcnt >= 1000) {
+    	_dcnt = 0;
+    	uint64_t now = AP_HAL::micros64();
+    	float delt = 1e-3 * (now - _dtim);
+    	float drate = _tot_samples / delt;
+		::printf("MPU[%u]:  %d samples, %5.3f msec, %5.3f KHz\n", _accel_instance, _tot_samples, (double) delt, (double) drate);
+    	_dtim = now;
+    	_tot_samples = 0;
+    }
+#endif
 
     /*
       testing has shown that if we have more than 32 samples in the
@@ -859,7 +877,7 @@ bool AP_InertialSensor_Invensense::_hardware_init(void)
         _last_stat_user_ctrl = _register_read(MPUREG_USER_CTRL);
 
         /* First disable the master I2C to avoid hanging the slaves on the
-         * aulixiliar I2C bus - it will be enabled again if the AuxiliaryBus
+         * auxiliary I2C bus - it will be enabled again if the AuxiliaryBus
          * is used */
         if (_last_stat_user_ctrl & BIT_USER_CTRL_I2C_MST_EN) {
             _last_stat_user_ctrl &= ~BIT_USER_CTRL_I2C_MST_EN;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -633,7 +633,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
             _rotate_and_correct_accel(_accel_instance, _accum.accel);
             _rotate_and_correct_gyro(_gyro_instance, _accum.gyro);
             
-            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, false, now, _seqcnt);
+            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, now, false, _seqcnt);
             _notify_new_gyro_raw_sample(_gyro_instance, _accum.gyro, now, _seqcnt);
             
             _accum.accel.zero();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -122,6 +122,24 @@ private:
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
 
+    // use a sample counter to "timestamp" samples from the sensor
+    // Since the system timebase is not synchronized to the sensor sample clock,
+    // this is the best way to identify missing samples in the log. With this
+    // counter supplied to the notify methods, the SampleUS field becomes an integer
+    // sequence which increments each time a sample is read from the FIFO. As long as
+    // the FIFO is read at a sufficient rate, there should be no dropped samples
+    // between the sensor and the call to notify, with the exception of FIFO corruption:
+    // if corruption is detected, _seqcnt is zeroed to indicate a break in continuity.
+    uint32_t _seqcnt;
+
+#define INVENSENSE_DEBUG 1
+//#undef INVENSENSE_DEBUG
+#if defined(INVENSENSE_DEBUG)
+    unsigned _dcnt = 0;
+    uint64_t _dtim = 0;
+    int _tot_samples = 0;
+#endif
+
     // Last status from register user control
     uint8_t _last_stat_user_ctrl;    
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -132,8 +132,6 @@ private:
     // if corruption is detected, _seqcnt is zeroed to indicate a break in continuity.
     uint32_t _seqcnt;
 
-//#define INVENSENSE_DEBUG 1
-#undef INVENSENSE_DEBUG
 #if defined(INVENSENSE_DEBUG)
     uint16_t _dcnt = 0;
     uint64_t _dtim = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -125,19 +125,19 @@ private:
     // use a sample counter to "timestamp" samples from the sensor
     // Since the system timebase is not synchronized to the sensor sample clock,
     // this is the best way to identify missing samples in the log. With this
-    // counter supplied to the notify methods, the SampleUS field becomes an integer
+    // counter supplied to the notify methods, the SampleC field becomes an integer
     // sequence which increments each time a sample is read from the FIFO. As long as
     // the FIFO is read at a sufficient rate, there should be no dropped samples
     // between the sensor and the call to notify, with the exception of FIFO corruption:
     // if corruption is detected, _seqcnt is zeroed to indicate a break in continuity.
     uint32_t _seqcnt;
 
-#define INVENSENSE_DEBUG 1
-//#undef INVENSENSE_DEBUG
+//#define INVENSENSE_DEBUG 1
+#undef INVENSENSE_DEBUG
 #if defined(INVENSENSE_DEBUG)
-    unsigned _dcnt = 0;
+    uint16_t _dcnt = 0;
     uint64_t _dtim = 0;
-    int _tot_samples = 0;
+    uint32_t _tot_samples = 0;
 #endif
 
     // Last status from register user control

--- a/libraries/AP_InertialSensor/examples/VibTest/VibTest.cpp
+++ b/libraries/AP_InertialSensor/examples/VibTest/VibTest.cpp
@@ -126,8 +126,8 @@ void loop(void)
 
                 struct log_ACCEL pkt = {
                     LOG_PACKET_HEADER_INIT((uint8_t)(LOG_ACC1_MSG+i)),
-                    time_us   : AP_HAL::micros64(),
-                    sample_us : accel_report.timestamp,
+                    time_us   : accel_report.timestamp,
+                    samp_cnt  : total_samples[i],
                     AccX      : accel_report.x,
                     AccY      : accel_report.y,
                     AccZ      : accel_report.z
@@ -150,8 +150,8 @@ void loop(void)
 
                 struct log_GYRO pkt = {
                     LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GYR1_MSG+i)),
-                    time_us   : AP_HAL::micros64(),
-                    sample_us : gyro_report.timestamp,
+                    time_us   : gyro_report.timestamp,
+                    samp_cnt  : total_samples[i],
                     GyrX      : gyro_report.x,
                     GyrY      : gyro_report.y,
                     GyrZ      : gyro_report.z

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -639,14 +639,14 @@ struct PACKED log_AIRSPEED {
 struct PACKED log_ACCEL {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    uint64_t sample_us;
+    uint32_t samp_cnt;
     float AccX, AccY, AccZ;
 };
 
 struct PACKED log_GYRO {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    uint64_t sample_us;
+    uint32_t samp_cnt;
     float GyrX, GyrY, GyrZ;
 };
 
@@ -925,17 +925,17 @@ Format characters in the format string for binary log messages
     { LOG_COMPASS3_MSG, sizeof(log_Compass), \
       "MAG3","QhhhhhhhhhBI",    "TimeUS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health,S" }, \
     { LOG_ACC1_MSG, sizeof(log_ACCEL), \
-      "ACC1", "QQfff",        "TimeUS,SampleUS,AccX,AccY,AccZ" }, \
+      "ACC1", "QIfff",        "TimeUS,SampleC,AccX,AccY,AccZ" }, \
     { LOG_ACC2_MSG, sizeof(log_ACCEL), \
-      "ACC2", "QQfff",        "TimeUS,SampleUS,AccX,AccY,AccZ" }, \
+      "ACC2", "QIfff",        "TimeUS,SampleC,AccX,AccY,AccZ" }, \
     { LOG_ACC3_MSG, sizeof(log_ACCEL), \
-      "ACC3", "QQfff",        "TimeUS,SampleUS,AccX,AccY,AccZ" }, \
+      "ACC3", "QIfff",        "TimeUS,SampleC,AccX,AccY,AccZ" }, \
     { LOG_GYR1_MSG, sizeof(log_GYRO), \
-      "GYR1", "QQfff",        "TimeUS,SampleUS,GyrX,GyrY,GyrZ" }, \
+      "GYR1", "QIfff",        "TimeUS,SampleC,GyrX,GyrY,GyrZ" }, \
     { LOG_GYR2_MSG, sizeof(log_GYRO), \
-      "GYR2", "QQfff",        "TimeUS,SampleUS,GyrX,GyrY,GyrZ" }, \
+      "GYR2", "QIfff",        "TimeUS,SampleC,GyrX,GyrY,GyrZ" }, \
     { LOG_GYR3_MSG, sizeof(log_GYRO), \
-      "GYR3", "QQfff",        "TimeUS,SampleUS,GyrX,GyrY,GyrZ" }, \
+      "GYR3", "QIfff",        "TimeUS,SampleC,GyrX,GyrY,GyrZ" }, \
     { LOG_PIDR_MSG, sizeof(log_PID), \
       "PIDR", "Qffffff",  "TimeUS,Des,P,I,D,FF,AFF" }, \
     { LOG_PIDP_MSG, sizeof(log_PID), \


### PR DESCRIPTION
this PR modifies the ACCn and GYRn log messages (only generated when IMU_RAW bit is set in log_bitmask) to timestamp with actual sample time and adds a sample sequence count field..
The sequence counter is used by pymavlink/tools/mavfft_int.py (see https://github.com/ArduPilot/pymavlink/pull/61) to calculate the actual sample rates and check for dropouts. 

Additional changes planned: add average sensor sample rate field to IMU messages