### PR TITLE
GCS_MAVLink: handle TIMESYNC messages (attempt 2)

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -246,8 +246,6 @@ protected:
 
     void handle_gps_inject(const mavlink_message_t *msg, AP_GPS &gps);
 
-    void handle_timesync(mavlink_message_t *msg);
-
     void handle_common_message(mavlink_message_t *msg);
     void handle_log_message(mavlink_message_t *msg, DataFlash_Class &dataflash);
     void handle_setup_signing(const mavlink_message_t *msg);
@@ -256,6 +254,8 @@ protected:
 
     void handle_device_op_read(mavlink_message_t *msg);
     void handle_device_op_write(mavlink_message_t *msg);
+
+    void handle_timesync(mavlink_message_t *msg);
     
 private:
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -246,6 +246,8 @@ protected:
 
     void handle_gps_inject(const mavlink_message_t *msg, AP_GPS &gps);
 
+    void handle_timesync(mavlink_message_t *msg);
+
     void handle_common_message(mavlink_message_t *msg);
     void handle_log_message(mavlink_message_t *msg, DataFlash_Class &dataflash);
     void handle_setup_signing(const mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -762,32 +762,6 @@ void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &d
 }
 
 /*
-  return a timesync request
-  Sends back ts1 as received, and tc1 is the local timestamp in usec
- */
-void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
-{
-    // Timestamp to return is usec since boot
-    uint64_t now = AP_HAL::micros64();
-    
-    // Decode incoming timesync message
-    mavlink_timesync_t tsync;
-    mavlink_msg_timesync_decode(msg, &tsync);
-
-    // Create new timestruct to return
-    mavlink_timesync_t rsync;
-    rsync.ts1 = tsync.ts1;
-    rsync.tc1 = now;
-
-    // Return a timesync message with updated tc1 field
-    mavlink_msg_timesync_send(
-        chan,
-        rsync.tc1,
-        rsync.ts1
-        );
-}
-
-/*
   handle an incoming mission item
   return true if this is the last mission item, otherwise false
  */
@@ -1855,6 +1829,35 @@ uint8_t GCS_MAVLINK::handle_rc_bind(const mavlink_command_long_t &packet)
 }
 
 /*
+  return a timesync request
+  Sends back ts1 as received, and tc1 is the local timestamp in usec
+ */
+void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
+{
+    // decode incoming timesync message
+    mavlink_timesync_t tsync;
+    mavlink_msg_timesync_decode(msg, &tsync);
+
+    // ignore messages in which tc1 field (timestamp 1) has already been filled in
+    if (tsync.tc1 != 0) {
+        return;
+    }
+
+    // create new timesync struct with tc1 field filled in
+    mavlink_timesync_t rsync;
+    rsync.tc1 = AP_HAL::micros64();
+    rsync.ts1 = tsync.ts1;
+
+    // respond with a timesync message
+    mavlink_msg_timesync_send(
+        chan,
+        rsync.tc1,
+        rsync.ts1
+        );
+}
+
+
+/*
   handle messages which don't require vehicle specific data
  */
 void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
@@ -1871,6 +1874,9 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
         break;
     case MAVLINK_MSG_ID_DEVICE_OP_WRITE:
         handle_device_op_write(msg);
+        break;
+    case MAVLINK_MSG_ID_TIMESYNC:
+        handle_timesync(msg);
         break;
     }
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1843,9 +1843,9 @@ void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
         return;
     }
 
-    // create new timesync struct with tc1 field filled in
+    // create new timesync struct with tc1 field as system time in nanoseconds
     mavlink_timesync_t rsync;
-    rsync.tc1 = AP_HAL::micros64();
+    rsync.tc1 = AP_HAL::micros64() * 1000;
     rsync.ts1 = tsync.ts1;
 
     // respond with a timesync message

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -761,6 +761,31 @@ void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &d
     }
 }
 
+/*
+  return a timesync request
+  Sends back ts1 as received, and tc1 is the local timestamp in usec
+ */
+void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
+{
+    // Timestamp to return is usec since boot
+    uint64_t now = AP_HAL::micros64();
+    
+    // Decode incoming timesync message
+    mavlink_timesync_t tsync;
+    mavlink_msg_timesync_decode(msg, &tsync);
+
+    // Create new timestruct to return
+    mavlink_timesync_t rsync;
+    rsync.ts1 = tsync.ts1;
+    rsync.tc1 = now;
+
+    // Return a timesync message with updated tc1 field
+    mavlink_msg_timesync_send(
+        chan,
+        rsync.tc1,
+        rsync.ts1
+        );
+}
 
 /*
   handle an incoming mission item


### PR DESCRIPTION
This is a replacement PR for https://github.com/ArduPilot/ardupilot/pull/5888.

This PR allows ArduPilot to respond to TIMESYNC mavlink messages which allows a companion computer to syncronise it's system clock with the flight controller's.

The TIMESYNC message (http://mavlink.org/messages/common#TIMESYNC) has two timestamps, "tc1" and "ts1".  The way it works seems to be:

- the companion computer (or whomever) sends a TIMESYNC message with it's own system time in the "ts1" field and "0" in the "tc1" field.
- the flight controller (i.e. ardupilot) accepts the message and if the "tc1" field is "0" (i.e. empty), fills in the "tc1" field and returns the message.
- the original sender then receives a filled in TIMESYNC message with both "tc1" (the flight controller's system time) and "ts1" (the system time when it sent the original message).
- the original sender can calculate the the time-difference between the two computers by comparing:
     a) the average of "ts1" and the current system time
     b) the difference between the above average and the "tc1" field.

Note:

- this PR only covers responding to the TIMESYNC message, we do not attempt to calculate the offset.
- the overall logic seems to assume that there is only one component on the network sending out TIMESYNC messages.  There is no system-id/component-id field in the TIMESYNC message to allow the responder to specify where the original message came from.

Some extra info:

- the TIMESYNC mavlink definition: http://mavlink.org/messages/common#TIMESYNC
- the mavros handler of this message: https://github.com/mavlink/mavros/blob/master/mavros/src/plugins/sys_time.cpp#L244