### PR TITLE
SITL: Added setup scripts for Windows (Cygwin) users

### DIFF
--- a/Tools/autotest/win_sitl/InstallCygwinAPM.ps1
+++ b/Tools/autotest/win_sitl/InstallCygwinAPM.ps1
@@ -1,0 +1,27 @@
+#Powershell script to donwload and configure the APM SITL environment
+
+Import-Module BitsTransfer
+
+Write-Output "Starting Downloads"
+
+Write-Output "Downloading MAVProxy (1/6)"
+Start-BitsTransfer -Source "http://firmware.ardupilot.org/Tools/MAVProxy/MAVProxySetup-latest.exe" -Destination "$PSScriptRoot\MAVProxySetup-latest.exe"
+
+Write-Output "Downloading Cygwin x64 (2/6)"
+Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
+
+Write-Output "Installing Cygwin x64 (3/6)"
+& $PSScriptRoot\setup-x86_64.exe --root="C:\cygwin" --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site="http://cygwin.mirror.constant.com" --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode | Out-Null
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode"
+
+Write-Output "Configuring Cygwin (4/6)"
+Copy-Item apm_install.sh C:\cygwin\home
+
+Write-Output "Downloading APM Source Code Cygwin (5/6)"
+Start-Process -wait -FilePath "C:\cygwin\bin\bash" -ArgumentList "--login -i -c ../apm_install.sh"
+
+Write-Output "Installing MAVProxy (6/6)"
+& $PSScriptRoot\MAVProxySetup-latest.exe /SILENT | Out-Null
+
+Write-Host "Finished. Press any key to continue ..."
+$x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/Tools/autotest/win_sitl/RunCopter.bat
+++ b/Tools/autotest/win_sitl/RunCopter.bat
@@ -1,0 +1,4 @@
+rem File run APM:Copter SITL
+rem Assumes a Cgywin install at C:\cygwin
+chdir C:\cygwin\bin
+bash --login -i -c "cd ./ardupilot/ArduCopter && ../Tools/autotest/sim_vehicle.py -j4"

--- a/Tools/autotest/win_sitl/RunCopter.bat
+++ b/Tools/autotest/win_sitl/RunCopter.bat
@@ -1,4 +1,4 @@
 rem File run APM:Copter SITL
 rem Assumes a Cgywin install at C:\cygwin
 chdir C:\cygwin\bin
-bash --login -i -c "cd ./ardupilot/ArduCopter && ../Tools/autotest/sim_vehicle.py -j4"
+bash --login -i -c "cd ./ardupilot/ArduCopter && ../Tools/autotest/sim_vehicle.py"

--- a/Tools/autotest/win_sitl/RunPlane.bat
+++ b/Tools/autotest/win_sitl/RunPlane.bat
@@ -1,4 +1,4 @@
 rem File run APM:Plane SITL
 rem Assumes a Cgywin install at C:\cygwin
 chdir C:\cygwin\bin
-bash --login -i -c "cd ./ardupilot/ArduPlane && ../Tools/autotest/sim_vehicle.py -j4"
+bash --login -i -c "cd ./ardupilot/ArduPlane && ../Tools/autotest/sim_vehicle.py"

--- a/Tools/autotest/win_sitl/RunPlane.bat
+++ b/Tools/autotest/win_sitl/RunPlane.bat
@@ -1,0 +1,4 @@
+rem File run APM:Plane SITL
+rem Assumes a Cgywin install at C:\cygwin
+chdir C:\cygwin\bin
+bash --login -i -c "cd ./ardupilot/ArduPlane && ../Tools/autotest/sim_vehicle.py -j4"

--- a/Tools/autotest/win_sitl/RunRover.bat
+++ b/Tools/autotest/win_sitl/RunRover.bat
@@ -1,0 +1,4 @@
+rem File run APM:Rover SITL
+rem Assumes a Cgywin install at C:\cygwin
+chdir C:\cygwin\bin
+bash --login -i -c "cd ./ardupilot/APMrover2 && ../Tools/autotest/sim_vehicle.py -j4"

--- a/Tools/autotest/win_sitl/RunRover.bat
+++ b/Tools/autotest/win_sitl/RunRover.bat
@@ -1,4 +1,4 @@
 rem File run APM:Rover SITL
 rem Assumes a Cgywin install at C:\cygwin
 chdir C:\cygwin\bin
-bash --login -i -c "cd ./ardupilot/APMrover2 && ../Tools/autotest/sim_vehicle.py -j4"
+bash --login -i -c "cd ./ardupilot/APMrover2 && ../Tools/autotest/sim_vehicle.py"

--- a/Tools/autotest/win_sitl/UpdateAPMSource.bat
+++ b/Tools/autotest/win_sitl/UpdateAPMSource.bat
@@ -1,0 +1,5 @@
+rem File to update the APM source
+rem Assumes a Cgywin install at C:\cygwin
+chdir C:\cygwin\bin
+bash --login -i -c "cd ./ardupilot && git pull && git submodule update --init --recursive"
+pause

--- a/Tools/autotest/win_sitl/apm_install.sh
+++ b/Tools/autotest/win_sitl/apm_install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#A simple script to install the APM SITL environment into cygwin
+
+python -m ensurepip --user
+python -m pip install --user future
+git clone git://github.com/ArduPilot/ardupilot.git
+git clone git://github.com/tridge/jsbsim.git
+cd jsbsim
+./autogen.sh
+make
+cp src/JSBSim.exe /usr/local/bin
+cd ../ardupilot
+git submodule update --init --recursive
+./modules/waf/waf-light configure --board=sitl

--- a/Tools/autotest/win_sitl/readme.txt
+++ b/Tools/autotest/win_sitl/readme.txt
@@ -1,0 +1,43 @@
+SITL for Windows Automatic Installation Scripts
+
+This is a collection of batch files to automatically install and run APM SITL (http://ardupilot.org/dev/docs/sitl-simulator-software-in-the-loop.html) on a Windows-based PC/laptop.
+
+The scripts are based on the SITL setup instructions here: http://ardupilot.org/dev/docs/sitl-native-on-windows.html
+Prerequisites:
+
+    None! The scripts will take care of everything.
+    You will need an Internet connection and an hour of time (will be less with a fast Internet connection) for the scripts to download and install everything.
+
+Assumptions:
+
+    The scripts will install Cygwin, MAVProxy and the APM source to C:\cygwin. So access to the C:\ drive is required.
+
+Installing:
+
+    Download these scripts and unzip
+    Run the script "InstallCygwinAPM.ps1" (right click -> Run in Powershell). This will install Cygwin to C:\cygwin and MAVProxy to C:\Program Files (x86)\MAVProxy
+
+Running SITL:
+
+There are several options for running SITL. In all cases, SITL will output a mavlink stream on 127.0.0.1:14550 (UDP) for connection to any GCS software (Such as Mission Planner).
+
+An EEPROM (containing the state of the APM's flash memory - paramters, waypoints, etc) is saved for each vehicle type and (by default) will be re-loaded each time SITL is run. This can be overidden to start with a new EEPROM containing all default values.
+
+To continue with the current EEPROM, run:
+
+    RunCopter.bat for a quadcopter running APM:Copter
+    RunPlane.bat for running APM:Plane
+    RunRover.bat for running APM:Rover
+
+To delete the old EEPROM and start with all default settings, run:
+
+    ResetRunCopter.bat for a quadcopter running APM:Copter
+    ResetRunPlane.bat for running APM:Plane
+    ResetRunRover.bat for running APM:Rover
+
+Updating the APM source code
+
+To update the APM code with the latest of Github, run UpdateAPMSource.bat. Note this is bleeding-edge source code and some bugs may be present.
+Deleting the SITL environment
+
+To uninstall/delete the SITL environment, simply delete the "cygwin" folder in the C:\ drive.


### PR DESCRIPTION
Added scripts for Windows (Cygwin) users that automatically downloads and installs the SITL environment. There are also scripts for running APM SITL and updating the APM source.

Full documentation at https://github.com/stephendade/SimpleSITL