### PR TITLE
AP_Motors: split H_COL_MIN/MID/MAX into two sets of parameters for tandem frames

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     AP_GROUPINFO("RSC_PWM_REV", 15, AP_MotorsHeli_Dual, _rotor._pwm_rev, 1),
 
 
-    // @Param: COL_MIN
+    // @Param: COL2_MIN
     // @DisplayName: Collective Pitch Minimum for rear swashplate
     // @Description: Lowest possible servo position for the rear swashplate
     // @Range: 1000 2000
@@ -155,7 +155,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("COL2_MIN", 16, AP_MotorsHeli_Dual, _collective2_min, AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN),
 
-    // @Param: COL_MAX
+    // @Param: COL2_MAX
     // @DisplayName: Collective Pitch Maximum for rear swashplate
     // @Description: Highest possible servo position for the rear swashplate
     // @Range: 1000 2000

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -35,6 +35,11 @@
 // maximum number of swashplate servos
 #define AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS    6
 
+// default collective min, max and midpoints for the rear swashplate
+#define AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN 1250
+#define AP_MOTORS_HELI_DUAL_COLLECTIVE2_MAX 1750
+#define AP_MOTORS_HELI_DUAL_COLLECTIVE2_MID 1500
+
 /// @class AP_MotorsHeli_Dual
 class AP_MotorsHeli_Dual : public AP_MotorsHeli {
 public:
@@ -46,6 +51,7 @@ public:
     {
         AP_Param::setup_object_defaults(this, var_info);
     };
+
 
     // set_update_rate - set update rate to motors
     void set_update_rate( uint16_t speed_hz ) override;
@@ -114,6 +120,9 @@ protected:
     float _pitch_test = 0.0f;                       // over-ride for pitch output, used by servo_test function
 
     // parameters
+    AP_Int16        _collective2_min;               // Lowest possible servo position for the rear swashplate
+    AP_Int16        _collective2_max;               // Highest possible servo position for the rear swashplate
+    AP_Int16        _collective2_mid;               // Swash servo position corresponding to zero collective pitch for the rear swashplate (or zero lift for Asymmetrical blades)
     AP_Int16        _servo1_pos;                    // angular location of swash servo #1
     AP_Int16        _servo2_pos;                    // angular location of swash servo #2
     AP_Int16        _servo3_pos;                    // angular location of swash servo #3
@@ -133,8 +142,9 @@ protected:
     SRV_Channel    *_swash_servo_4;
     SRV_Channel    *_swash_servo_5;
     SRV_Channel    *_swash_servo_6;
-    
+
     // internal variables
+    float           _collective2_mid_pct = 0.0f;      // collective mid parameter value for rear swashplate converted to 0 ~ 1 range
     float           _rollFactor[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];
     float           _pitchFactor[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];
     float           _collectiveFactor[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];


### PR DESCRIPTION
This PR aims to allow tandem-heli frames to adjust their collective limits individually for their front and rear swashplates. 

- add COL2_MIN/MID/MAX parameters that control limits of rear swashplate
- output collective_mid correctly for rear swashplate when servo is in manual mode

