### PR TITLE
Travis: added testing of FMUv1 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ matrix:
   fast_finish: true
   include:
     - compiler: "gcc"
+      env: CI_BUILD_TARGET="px4-v1"
+    - compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v2"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v3"


### PR DESCRIPTION
the motivation for this is that a recent PR (the i2c filter) broke the FMUv1 build. That made me realise we weren't testing it in travis.
