### PR TITLE
AP_ServoRelayEvents: Remove constraint on 'channel' value

### DIFF
--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -106,10 +106,6 @@ void AP_ServoRelayEvents::update_events(void)
         return;
     }
 
-    if (channel > NUM_SERVO_CHANNELS || channel == 0) {
-        return;
-    }
-
     start_time_ms = AP_HAL::millis();
 
     switch (type) {


### PR DESCRIPTION
This was preventing proper function of Relay #0, and the intention of
this check was redundant

Introduced in https://github.com/ArduPilot/ardupilot/commit/f73f3be. The meaning of 'channel' here isn't the same in the case of a relay event.

The appropriate checks are performed elsewhere.