### PR TITLE
Copter: minimise latency of motor output from gyros

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -255,19 +255,22 @@ void Copter::loop()
 // Main loop - 400hz
 void Copter::fast_loop()
 {
+    // update INS immediately to get current gyro data populated
+    ins.update();
+    
     // run low level rate controllers that only require IMU data
     attitude_control->rate_controller_run();
 
-    // IMU DCM Algorithm
+    // send outputs to the motors library immediately
+    motors_output();
+
+    // run EKF state estimator (expensive)
     // --------------------
     read_AHRS();
 
 #if FRAME_CONFIG == HELI_FRAME
     update_heli_control_dynamics();
 #endif //HELI_FRAME
-
-    // send outputs to the motors library
-    motors_output();
 
     // Inertial Nav
     // --------------------
@@ -626,7 +629,8 @@ void Copter::read_AHRS(void)
     gcs_check_input();
 #endif
 
-    ahrs.update();
+    // we tell AHRS to skip INS update as we have already done it in fast_loop()
+    ahrs.update(true);
 }
 
 // read baro and rangefinder altitude at 10hz

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -210,7 +210,7 @@ public:
     }
 
     // Methods
-    virtual void update(void) = 0;
+    virtual void update(bool skip_ins_update=false) = 0;
 
     // report any reason for why the backend is refusing to initialise
     virtual const char *prearm_failure_reason(void) const {

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -47,7 +47,7 @@ AP_AHRS_DCM::reset_gyro_drift(void)
 
 // run a full DCM update round
 void
-AP_AHRS_DCM::update(void)
+AP_AHRS_DCM::update(bool skip_ins_update)
 {
     float delta_t;
 
@@ -55,8 +55,10 @@ AP_AHRS_DCM::update(void)
         _last_startup_ms = AP_HAL::millis();
     }
 
-    // tell the IMU to grab some data
-    _ins.update();
+    if (!skip_ins_update) {
+        // tell the IMU to grab some data
+        _ins.update();
+    }
 
     // ask the IMU how much time this sensor reading represents
     delta_t = _ins.get_delta_time();

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -78,7 +78,7 @@ public:
     void reset_gyro_drift() override;
 
     // Methods
-    void            update() override;
+    void            update(bool skip_ins_update=false) override;
     void            reset(bool recover_eulers = false) override;
 
     // reset the current attitude, used on new IMU calibration

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -79,13 +79,13 @@ void AP_AHRS_NavEKF::reset_gyro_drift(void)
     EKF3.resetGyroBias();
 }
 
-void AP_AHRS_NavEKF::update(void)
+void AP_AHRS_NavEKF::update(bool skip_ins_update)
 {
     // EKF1 is no longer supported - handle case where it is selected
     if (_ekf_type == 1) {
         _ekf_type.set(2);
     }
-    update_DCM();
+    update_DCM(skip_ins_update);
     update_EKF2();
     update_EKF3();
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -103,11 +103,11 @@ void AP_AHRS_NavEKF::update(void)
 
     if (_view != nullptr) {
         // update optional alternative attitude view
-        _view->update();
+        _view->update(skip_ins_update);
     }
 }
 
-void AP_AHRS_NavEKF::update_DCM(void)
+void AP_AHRS_NavEKF::update_DCM(bool skip_ins_update)
 {
     // we need to restore the old DCM attitude values as these are
     // used internally in DCM to calculate error values for gyro drift
@@ -117,7 +117,7 @@ void AP_AHRS_NavEKF::update_DCM(void)
     yaw = _dcm_attitude.z;
     update_cd_values();
 
-    AP_AHRS_DCM::update();
+    AP_AHRS_DCM::update(skip_ins_update);
 
     // keep DCM attitude available for get_secondary_attitude()
     _dcm_attitude(roll, pitch, yaw);

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -59,7 +59,7 @@ public:
     //  should be called if gyro offsets are recalculated
     void reset_gyro_drift() override;
 
-    void            update() override;
+    void            update(bool skip_ins_update=false) override;
     void            reset(bool recover_eulers = false) override;
 
     // reset the current attitude, used on new IMU calibration
@@ -268,7 +268,7 @@ private:
     Flags _ekf_flags;
 
     uint8_t ekf_type(void) const;
-    void update_DCM(void);
+    void update_DCM(bool skip_ins_update);
     void update_EKF2(void);
     void update_EKF3(void);
 

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -44,7 +44,7 @@ AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation) :
 }
 
 // update state
-void AP_AHRS_View::update(void)
+void AP_AHRS_View::update(bool skip_ins_update)
 {
     rot_body_to_ned = ahrs.get_rotation_body_to_ned();
     gyro = ahrs.get_gyro();

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -29,7 +29,7 @@ public:
     AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation);
 
     // update state
-    void update(void);
+    void update(bool skip_ins_update=false);
 
     // empty virtual destructor
     virtual ~AP_AHRS_View() {}


### PR DESCRIPTION
this fixes a problem with the 3.5 copter change that tries to minimise latency to the motors from the gyros. It missed a couple of places that had to be changed, and resulted in a slight latency increase instead of a decrease.
