### PR TITLE
Plane: setup better defaults for tailsitters

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -370,10 +370,15 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     AP_GROUPEND
 };
 
-static const struct {
+struct defaults_struct {
     const char *name;
     float value;
-} defaults_table[] = {
+};
+
+/*
+  defaults for all quadplanes
+ */
+static const struct defaults_struct defaults_table[] = {
     { "Q_A_RAT_RLL_P",    0.25 },
     { "Q_A_RAT_RLL_I",    0.25 },
     { "Q_A_RAT_RLL_FILT", 10.0 },
@@ -381,6 +386,19 @@ static const struct {
     { "Q_A_RAT_PIT_I",    0.25 },
     { "Q_A_RAT_PIT_FILT", 10.0 },
     { "Q_M_SPOOL_TIME",   0.25 },
+};
+
+/*
+  extra defaults for tailsitters
+ */
+static const struct defaults_struct defaults_table_tailsitter[] = {
+    { "KFF_RDDRMIX",       0.02 },
+    { "Q_A_RAT_PIT_FF",    0.2 },
+    { "Q_A_RAT_YAW_FF",    0.2 },
+    { "Q_A_RAT_YAW_I",    0.18 },
+    { "LIM_PITCH_MAX",    3000 },
+    { "LIM_PITCH_MIN",    -3000 },
+    { "MIXING_GAIN",      1.0 },
 };
 
 QuadPlane::QuadPlane(AP_AHRS_NavEKF &_ahrs) :
@@ -568,18 +586,32 @@ failed:
 }
 
 /*
+  setup default parameters from a defaults_struct table
+ */
+void QuadPlane::setup_defaults_table(const struct defaults_struct *table, uint8_t count)
+{
+    for (uint8_t i=0; i<count; i++) {
+        if (!AP_Param::set_default_by_name(table[i].name, table[i].value)) {
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "QuadPlane setup failure for %s",
+                                             table[i].name);
+            AP_HAL::panic("quadplane bad default %s", table[i].name);
+        }
+    }
+}
+
+/*
   setup default parameters from defaults_table
  */
 void QuadPlane::setup_defaults(void)
 {
-    for (uint8_t i=0; i<ARRAY_SIZE(defaults_table); i++) {
-        if (!AP_Param::set_default_by_name(defaults_table[i].name, defaults_table[i].value)) {
-            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "QuadPlane setup failure for %s",
-                                             defaults_table[i].name);
-            AP_HAL::panic("quadplane bad default %s", defaults_table[i].name);
-        }
-    }
+    setup_defaults_table(defaults_table, ARRAY_SIZE(defaults_table));
 
+    enum AP_Motors::motor_frame_class motor_class;
+    motor_class = (enum AP_Motors::motor_frame_class)frame_class.get();
+    if (motor_class == AP_Motors::MOTOR_FRAME_TAILSITTER) {
+        setup_defaults_table(defaults_table_tailsitter, ARRAY_SIZE(defaults_table_tailsitter));
+    }
+    
     // reset ESC calibration
     if (esc_calibration != 0) {
         esc_calibration.set_and_save(0);

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -28,7 +28,6 @@ public:
     void control_auto(const Location &loc);
     bool init_mode(void);
     bool setup(void);
-    void setup_defaults(void);
 
     void vtol_position_controller(void);
     void setup_target_position(void);
@@ -196,6 +195,9 @@ private:
     void check_throttle_suppression(void);
 
     void run_z_controller(void);
+
+    void setup_defaults(void);
+    void setup_defaults_table(const struct defaults_struct *defaults, uint8_t count);
     
     AP_Int16 transition_time_ms;
 


### PR DESCRIPTION
this is especially important for KFF_RDDRMIX with dual-motor tailsitters