### PR TITLE
SRV_Channel: skip rcout write for disabled channels

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -30,8 +30,10 @@ void SRV_Channel::output_ch(void)
     int8_t passthrough_from = -1;
 
     // take care of special function cases
-    switch(function)
-    {
+    switch (function) {
+    case k_none:
+        // if channel is disabled, return immediately without writing to RCOUT
+        return;
     case k_manual:              // manual
         passthrough_from = ch_num;
         break;


### PR DESCRIPTION
In recent testing, the motors on one of my larger quads have been jerking quite a bit as though the PWM signals to the ESCs were corrupted. However, the motors were fine with a direct passthrough during ESC calibration or throttle failsafe.

It turns out, in the SRV_Channel::output_ch() function, because the switch statement doesn't explicitly deal with a servo channel whose function is set to k_none (i.e. disabled), it allows the "hal.rcout->write()" function to be called for channel numbers that are outside of the size of the 'periodhi[]' array in RCOutput_ZYNQ. Once the output_ch() function gets around to channels 9-12 - which I have set to k_none -  the rcout->write() ends up messing with the PWM signal to motors 1-4.

This pull request merely adds a case for k_none such that it truly disables a servo channel by immediately returning out of the out_ch() function (just like the case for k_motor1 ... k_motor8).