### PR TITLE
AP_BoardConfig: added BRD_IO_ENABLE parameter

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -164,6 +164,16 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("TYPE", 9, AP_BoardConfig, px4.board_type, BOARD_TYPE_DEFAULT),
 #endif
+
+#if HAL_PX4_HAVE_PX4IO
+    // @Param: BRD_IO_ENABLE
+    // @DisplayName: Enable IO co-processor
+    // @Description: This allows for the IO co-processor on FMUv1 and FMUv2 to be disabled
+    // @Values: 0:Disabled,1:Enabled
+    // @RebootRequired: True
+    // @User: Advanced
+    AP_GROUPINFO("IO_ENABLE", 10, AP_BoardConfig, px4.io_enable, 1),
+#endif
     
     AP_GROUPEND
 };

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -88,6 +88,7 @@ private:
         AP_Int8 sbus_out_rate;
 #endif
         AP_Int8 board_type;
+        AP_Int8 io_enable;
     } px4;
 
     static enum px4_board_type px4_configured_board;

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -412,7 +412,9 @@ void AP_BoardConfig::px4_setup_peripherals(void)
     }
 
 #if HAL_PX4_HAVE_PX4IO
-    px4_setup_px4io();
+    if (px4.io_enable.get() != 0) {
+        px4_setup_px4io();
+    }
 #endif
 
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)


### PR DESCRIPTION
allow for px4io to be disabled completely