### PR TITLE
Plane: add parameter RUDD_DT_GAIN for dual motor tailsitter

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1217,6 +1217,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_Soaring/AP_Soaring.cpp
     AP_SUBGROUPINFO(soaring_controller, "SOAR_", 8, ParametersG2, SoaringController),
   
+    // @Param: RUDD_DT_GAIN
+    // @DisplayName: rudder differential thrust gain
+    // @Description: gain control from rudder to differential thrust
+    // @Range: 0 100
+    // @Units: Percent
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RUDD_DT_GAIN", 9, ParametersG2, rudd_dt_gain, 10),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -545,6 +545,9 @@ public:
     
     // ArduSoar parameters
     SoaringController soaring_controller;
+
+    // dual motor tailsitter rudder to differential thrust scaling: 0-100%
+    AP_Int8 rudd_dt_gain;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -399,6 +399,7 @@ static const struct defaults_struct defaults_table_tailsitter[] = {
     { "LIM_PITCH_MAX",    3000 },
     { "LIM_PITCH_MIN",    -3000 },
     { "MIXING_GAIN",      1.0 },
+    { "RUDD_DT_GAIN",      10 },
 };
 
 QuadPlane::QuadPlane(AP_AHRS_NavEKF &_ahrs) :

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -622,7 +622,8 @@ void Plane::servo_output_mixers(void)
 void Plane::servos_twin_engine_mix(void)
 {
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
-    float rudder = SRV_Channels::get_output_scaled(SRV_Channel::k_rudder) / float(SERVO_MAX);
+    float rud_gain = float(plane.g2.rudd_dt_gain) / 100;
+    float rudder = rud_gain * SRV_Channels::get_output_scaled(SRV_Channel::k_rudder) / float(SERVO_MAX);
     float throttle_left, throttle_right;
     
     if (throttle < 0 && aparm.throttle_min < 0) {


### PR DESCRIPTION
controls rudder to differential thrust mixing in FW mode
defaults to 10%
bench tested only