### PR TITLE
Copter: rework rangefinder state to estimate terrain height

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -196,12 +196,11 @@ private:
     RangeFinder rangefinder {serial_manager, ROTATION_PITCH_270};
     struct {
         bool enabled:1;
-        bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
-        int16_t alt_cm;     // tilt compensated altitude (in cm) from rangefinder
+        bool terrain_height_healthy:1; // true if we can trust the altitude from the rangefinder
         uint32_t last_healthy_ms;
-        LowPassFilterFloat alt_cm_filt; // altitude filter
+        float terrain_height_filt_cm; // terrain height relative to origin, filtered
         int8_t glitch_count;
-    } rangefinder_state = { false, false, 0, 0 };
+    } rangefinder_state = { false, false, 0};
 
     AP_RPM rpm_sensor;
 
@@ -1022,6 +1021,7 @@ private:
     void read_barometer(void);
     void init_rangefinder(void);
     void read_rangefinder(void);
+    bool get_rangefinder_height_above_terrain(int32_t& ret);
     bool rangefinder_alt_ok();
     void init_compass();
     void init_optflow();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -320,6 +320,9 @@ void Copter::Log_Write_Control_Tuning()
     }
 #endif
 
+    int32_t rangefinder_height_above_terrain_cm = -1;
+    get_rangefinder_height_above_terrain(rangefinder_height_above_terrain_cm);
+
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CONTROL_TUNING_MSG),
         time_us             : AP_HAL::micros64(),
@@ -331,7 +334,7 @@ void Copter::Log_Write_Control_Tuning()
         inav_alt            : inertial_nav.get_altitude() / 100.0f,
         baro_alt            : baro_alt,
         desired_rangefinder_alt : (int16_t)target_rangefinder_alt,
-        rangefinder_alt     : rangefinder_state.alt_cm,
+        rangefinder_alt     : (int16_t)rangefinder_height_above_terrain_cm,
         terr_alt            : terr_alt,
         target_climb_rate   : (int16_t)pos_control->get_vel_target_z(),
         climb_rate          : climb_rate

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -104,10 +104,6 @@
  # define RANGEFINDER_TIMEOUT_MS  1000      // desired rangefinder alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
 #endif
 
-#ifndef RANGEFINDER_WPNAV_FILT_HZ
- # define RANGEFINDER_WPNAV_FILT_HZ   0.25f // filter frequency for rangefinder altitude provided to waypoint navigation class
-#endif
-
 #ifndef RANGEFINDER_TILT_CORRECTION         // by disable tilt correction for use of range finder data by EKF
  # define RANGEFINDER_TILT_CORRECTION ENABLED
 #endif

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -70,7 +70,9 @@ void Copter::update_land_detector()
         bool descent_rate_low = fabsf(inertial_nav.get_velocity_z()) < 100;
 
         // if we have a healthy rangefinder only allow landing detection below 2 meters
-        bool rangefinder_check = (!rangefinder_alt_ok() || rangefinder_state.alt_cm_filt.get() < LAND_RANGEFINDER_MIN_ALT_CM);
+        int32_t rangefinder_height_above_terrain_cm;
+        bool rangefinder_height_above_terrain_cm_valid = get_rangefinder_height_above_terrain(rangefinder_height_above_terrain_cm);
+        bool rangefinder_check = (!rangefinder_height_above_terrain_cm_valid || rangefinder_height_above_terrain_cm < LAND_RANGEFINDER_MIN_ALT_CM);
 
         if (motor_at_lower_limit && accel_stationary && descent_rate_low && rangefinder_check) {
             // landed criteria met - increment the counter and check if we've triggered

--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -13,17 +13,16 @@ void Copter::init_precland()
 
 void Copter::update_precland()
 {
-    int32_t height_above_ground_cm = current_loc.alt;
+    int32_t height_above_terrain_cm;
+    bool rangefinder_height_above_terrain_cm_valid = get_rangefinder_height_above_terrain(height_above_terrain_cm);
 
-    // use range finder altitude if it is valid, else try to get terrain alt
-    if (rangefinder_alt_ok()) {
-        height_above_ground_cm = rangefinder_state.alt_cm;
-    } else if (terrain_use()) {
-        if (!current_loc.get_alt_cm(Location_Class::ALT_FRAME_ABOVE_TERRAIN, height_above_ground_cm)) {
-            height_above_ground_cm = current_loc.alt;
+    // use range finder altitude if it is valid, else try to get terrain alt, else use height above home
+    if (!rangefinder_height_above_terrain_cm_valid) {
+        if (!terrain_use() || !current_loc.get_alt_cm(Location_Class::ALT_FRAME_ABOVE_TERRAIN, height_above_terrain_cm)) {
+            height_above_terrain_cm = current_loc.alt;
         }
     }
 
-    copter.precland.update(height_above_ground_cm, rangefinder_alt_ok());
+    copter.precland.update(height_above_terrain_cm, rangefinder_height_above_terrain_cm_valid);
 }
 #endif

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -43,8 +43,16 @@ void Copter::read_rangefinder(void)
         DataFlash.Log_Write_RFND(rangefinder);
     }
 
-    bool rangefinder_alt_meas_valid = ((rangefinder.status_orient(ROTATION_PITCH_270) == RangeFinder::RangeFinder_Good) && (rangefinder.range_valid_count_orient(ROTATION_PITCH_270) >= RANGEFINDER_HEALTH_MAX));
-    float rangefinder_alt_meas = rangefinder.distance_cm_orient(ROTATION_PITCH_270);
+    int8_t rangefinder_in_use = -1;
+    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+        if (rangefinder.get_orientation(i) == ROTATION_PITCH_270 && rangefinder.status(i) == RangeFinder::RangeFinder_Good && rangefinder.range_valid_count(i) >= RANGEFINDER_HEALTH_MAX) {
+            rangefinder_in_use = i;
+            break;
+        }
+    }
+
+    bool rangefinder_alt_meas_valid = (rangefinder_in_use != -1);
+    float rangefinder_alt_meas = rangefinder.distance_cm(rangefinder_in_use);
 
  #if RANGEFINDER_TILT_CORRECTION == ENABLED
     // correct alt for angle of the rangefinder


### PR DESCRIPTION
This has the advantage of interpolating the resulting height between rangefinder measurements and eliminates lag introduced by the terrain height filter.

This has so far only been tested in SITL.