### PR TITLE
HAL_PX4: never wait on a semaphore in interrupt context

### DIFF
--- a/libraries/AP_HAL_PX4/Semaphores.cpp
+++ b/libraries/AP_HAL_PX4/Semaphores.cpp
@@ -3,6 +3,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
 
 #include "Semaphores.h"
+#include <nuttx/arch.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -15,6 +16,10 @@ bool Semaphore::give()
 
 bool Semaphore::take(uint32_t timeout_ms) 
 {
+    if (up_interrupt_context()) {
+        // don't ever wait on a semaphore in interrupt context
+        return take_nonblocking();
+    }
     if (timeout_ms == 0) {
         return pthread_mutex_lock(&_lock) == 0;
     }


### PR DESCRIPTION
this shouldn't ever happen, but better to check