### PR TITLE
Solo LED and tones

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -64,6 +64,20 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Values: 0:Disable,1:ssd1306,2:sh1106
     // @User: Advanced
     AP_GROUPINFO("DISPLAY_TYPE", 3, AP_Notify, _display_type, 0),
+	
+	// @Param: SOLO_LED_ENABLE
+    // @DisplayName: 3DR Solo OreoLEDs
+    // @Description: This enables the Solo's motor arm LEDs
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("SOLO_LED_ENABLE", 4, AP_Notify, _solo_led_enable, 0),
+
+// @Param: SOLO_TONES_ENABLE
+    // @DisplayName: 3DR Solo notification tones
+    // @Description: This enables the Solo's custom notification tones
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("SOLO_TONES_ENABLE", 5, AP_Notify, _solo_tones_enable, 0),
 
     AP_GROUPEND
 };
@@ -87,13 +101,15 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     ToshibaLED_I2C toshibaled;
     Display display;
 
-#if AP_NOTIFY_SOLO_TONES == 1
+//#if AP_NOTIFY_SOLO_TONES == 1  Replaced by testing _solo_tones_enable parameter. True is solo enable.
+#if (_solo_tones_enable)
     ToneAlarm_PX4_Solo tonealarm;
 #else
     ToneAlarm_PX4 tonealarm;
 #endif
 
-#if AP_NOTIFY_OREOLED == 1
+//#if AP_NOTIFY_OREOLED == 1    Replaced by testing _solo_led_enable parameter. True is solo enable
+#if (_solo_led_enable)
     OreoLED_PX4 oreoled;
     NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
 #else

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -21,11 +21,11 @@
 #include "NotifyDevice.h"
 
 
-#ifndef AP_NOTIFY_OREOLED
+#ifndef AP_NOTIFY_OREOLED		// Use replaced by checking new parameter _Solo_LED_Enable in AP_Notify.cpp.
 #define AP_NOTIFY_OREOLED 0
 #endif
 
-#ifndef AP_NOTIFY_SOLO_TONES
+#ifndef AP_NOTIFY_SOLO_TONES	// Use replaced by checking new parameter _Solo_Tones_Enable in AP_Notify.cpp.
 #define AP_NOTIFY_SOLO_TONES 0
 #endif
 
@@ -138,6 +138,8 @@ private:
     AP_Int8 _rgb_led_override;
     AP_Int8 _buzzer_enable;
     AP_Int8 _display_type;
+	  AP_Int8 _solo_led_enable;
+    AP_Int8_solo_tones_enable;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed


### PR DESCRIPTION
Added parameters to AP_Notify library to enable/disable Solo's OreoLEDs and custom tones.
_SOLO_LED_ENABLE and _SOLO_TONES_ENABLE respectively enable/disable the LEDs and tones. I made them separate because people are building custom vehicles that may not have the LEDs. These parameters replace the function of the hard codes parameters that were previously set for zero.