### PR TITLE
AP_Notify: Solo LEDs and tones

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -64,6 +64,20 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Values: 0:Disable,1:ssd1306,2:sh1106
     // @User: Advanced
     AP_GROUPINFO("DISPLAY_TYPE", 3, AP_Notify, _display_type, 0),
+	
+	// @Param: SOLO_LED_ENABLE
+    // @DisplayName: 3DR Solo OreoLEDs
+    // @Description: This enables the Solo's motor arm LEDs
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("SOLO_LED_ENABLE", 4, AP_Notify, _solo_led_enable, 0),
+
+// @Param: SOLO_TONES_ENABLE
+    // @DisplayName: 3DR Solo notification tones
+    // @Description: This enables the Solo's custom notification tones
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("SOLO_TONES_ENABLE", 5, AP_Notify, _solo_tones_enable, 0),
 
     AP_GROUPEND
 };
@@ -87,13 +101,15 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     ToshibaLED_I2C toshibaled;
     Display display;
 
-#if AP_NOTIFY_SOLO_TONES == 1
+//#if AP_NOTIFY_SOLO_TONES == 1  Replaced by testing _solo_tones_enable parameter. True is solo enable.
+#if (_solo_tones_enable)
     ToneAlarm_PX4_Solo tonealarm;
 #else
     ToneAlarm_PX4 tonealarm;
 #endif
 
-#if AP_NOTIFY_OREOLED == 1
+//#if AP_NOTIFY_OREOLED == 1    Replaced by testing _solo_led_enable parameter. True is solo enable
+#if (_solo_led_enable)
     OreoLED_PX4 oreoled;
     NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
 #else

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -101,22 +101,6 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     ToshibaLED_I2C toshibaled;
     Display display;
 
-//#if AP_NOTIFY_SOLO_TONES == 1  Replaced by testing _solo_tones_enable parameter. True is solo enable.
-if (_solo_tones_enable)
-    ToneAlarm_PX4_Solo tonealarm;
-else
-    ToneAlarm_PX4 tonealarm;
-endif
-
-// #if AP_NOTIFY_OREOLED == 1    Replaced by testing _solo_led_enable parameter. True is solo enable
-// removed # so this works at runtime.
-if (_solo_led_enable)
-    OreoLED_PX4 oreoled;
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
-else
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &display};
-endif
-
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     ToneAlarm_PX4 tonealarm;
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_VRBRAIN_V45
@@ -180,6 +164,21 @@ endif
 // initialisation
 void AP_Notify::init(bool enable_external_leds)
 {
+    // Check the solo tones parameter and set tone alarm. Formerly a hard coded parameter on compile
+    if (_solo_tones_enable)
+        ToneAlarm_PX4_Solo tonealarm;
+    else
+        ToneAlarm_PX4 tonealarm;
+    endif
+
+    //Check the solo LED parameter and set notify devices. Formerly a hard coded parameter on compile.
+    if (_solo_led_enable)
+        OreoLED_PX4 oreoled;
+        NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
+    else
+        NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &display};
+    endif
+    
     // clear all flags and events
     memset(&AP_Notify::flags, 0, sizeof(AP_Notify::flags));
     memset(&AP_Notify::events, 0, sizeof(AP_Notify::events));

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -65,14 +65,14 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DISPLAY_TYPE", 3, AP_Notify, _display_type, 0),
 	
-	// @Param: SOLO_LED_ENABLE
+    // @Param: SOLO_LED_ENABLE
     // @DisplayName: 3DR Solo OreoLEDs
     // @Description: This enables the Solo's motor arm LEDs
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO("SOLO_LED_ENABLE", 4, AP_Notify, _solo_led_enable, 0),
 
-// @Param: SOLO_TONES_ENABLE
+    // @Param: SOLO_TONES_ENABLE
     // @DisplayName: 3DR Solo notification tones
     // @Description: This enables the Solo's custom notification tones
     // @Values: 0:Disable,1:Enable
@@ -102,19 +102,20 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     Display display;
 
 //#if AP_NOTIFY_SOLO_TONES == 1  Replaced by testing _solo_tones_enable parameter. True is solo enable.
-#if (_solo_tones_enable)
+if (_solo_tones_enable)
     ToneAlarm_PX4_Solo tonealarm;
-#else
+else
     ToneAlarm_PX4 tonealarm;
-#endif
+endif
 
-//#if AP_NOTIFY_OREOLED == 1    Replaced by testing _solo_led_enable parameter. True is solo enable
-#if (_solo_led_enable)
+// #if AP_NOTIFY_OREOLED == 1    Replaced by testing _solo_led_enable parameter. True is solo enable
+// removed # so this works at runtime.
+if (_solo_led_enable)
     OreoLED_PX4 oreoled;
     NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
-#else
+else
     NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &display};
-#endif
+endif
 
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     ToneAlarm_PX4 tonealarm;

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -21,11 +21,11 @@
 #include "NotifyDevice.h"
 
 
-#ifndef AP_NOTIFY_OREOLED
+#ifndef AP_NOTIFY_OREOLED		// Use replaced by checking new parameter _Solo_LED_Enable in AP_Notify.cpp.
 #define AP_NOTIFY_OREOLED 0
 #endif
 
-#ifndef AP_NOTIFY_SOLO_TONES
+#ifndef AP_NOTIFY_SOLO_TONES	// Use replaced by checking new parameter _Solo_Tones_Enable in AP_Notify.cpp.
 #define AP_NOTIFY_SOLO_TONES 0
 #endif
 
@@ -138,6 +138,8 @@ private:
     AP_Int8 _rgb_led_override;
     AP_Int8 _buzzer_enable;
     AP_Int8 _display_type;
+	AP_Int8 _solo_led_enable;
+    AP_Int8 _solo_tones_enable;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -21,12 +21,12 @@
 #include "NotifyDevice.h"
 
 
-#ifndef AP_NOTIFY_OREOLED		// Use replaced by checking new parameter _Solo_LED_Enable in AP_Notify.cpp.
-#define AP_NOTIFY_OREOLED 0
+#ifndef AP_NOTIFY_OREOLED     // Use replaced by checking new parameter _Solo_LED_Enable in AP_Notify.cpp.
+#define AP_NOTIFY_OREOLED 0   // Use replaced by checking new parameter _Solo_LED_Enable in AP_Notify.cpp.
 #endif
 
-#ifndef AP_NOTIFY_SOLO_TONES	// Use replaced by checking new parameter _Solo_Tones_Enable in AP_Notify.cpp.
-#define AP_NOTIFY_SOLO_TONES 0
+#ifndef AP_NOTIFY_SOLO_TONES   // Use replaced by checking new parameter _Solo_Tones_Enable in AP_Notify.cpp.
+#define AP_NOTIFY_SOLO_TONES 0 // Use replaced by checking new parameter _Solo_Tones_Enable in AP_Notify.cpp.
 #endif
 
 // Device parameters values
@@ -138,7 +138,7 @@ private:
     AP_Int8 _rgb_led_override;
     AP_Int8 _buzzer_enable;
     AP_Int8 _display_type;
-	AP_Int8 _solo_led_enable;
+    AP_Int8 _solo_led_enable;
     AP_Int8 _solo_tones_enable;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];


### PR DESCRIPTION
Added two new parameters to AP_Notify library to enable/disable the Solo's Oreo LEDs and custom tones.
`_solo_led_enable` (default 0) replaces the hard coded parameter that was set for 0.
`_solo_tones_enable` (default 0) replaced the hard coded parameter that was set for 0.

I separated the LEDs and tones since many people are building custom vehicles using the Solo guts but not using the motor pods with integrated LEDs. So there would be no need to enable LEDs on those vehicles, but you would still need the tones. The default for both is zero, so it will not take effect until specifically enabled. These two will need to be in the Solo's parameter file for users to pull in after flashing master.

Hopefully I did this right this time :)