### PR TITLE
AP_BattMonitor: Cell voltages and Temperature

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -162,6 +162,9 @@ AP_BattMonitor::init()
 
     // create each instance
     for (uint8_t instance=0; instance<AP_BATT_MONITOR_MAX_INSTANCES; instance++) {
+        // clear out the cell voltages
+        memset(&state[instance].cell_voltages, 0xFF, sizeof(cells));
+
         uint8_t monitor_type = _monitoring[instance];
         switch (monitor_type) {
             case BattMonitor_TYPE_ANALOG_VOLTAGE_ONLY:
@@ -332,4 +335,14 @@ bool AP_BattMonitor::overpower_detected(uint8_t instance) const
 #else
     return false;
 #endif
+}
+
+// return the current cell voltages, returns the first monitor instances cells if the instance is out of range
+const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t instance) const
+{
+    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES) {
+        return state[AP_BATT_PRIMARY_INSTANCE].cell_voltages;
+    } else {
+        return state[instance].cell_voltages;
+    }
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -346,3 +346,14 @@ const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t in
         return state[instance].cell_voltages;
     }
 }
+
+// returns true if there is a temperature reading
+bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance) const
+{
+    if (instance >= AP_BATT_MONITOR_MAX_INSTANCES) {
+        return false;
+    } else {
+        temperature = state[instance].temperature;
+        return (AP_HAL::millis() - state[instance].temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
+    }
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -3,6 +3,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
 
 // maximum number of battery monitors
 #define AP_BATT_MONITOR_MAX_INSTANCES       2
@@ -44,6 +45,10 @@ public:
         BattMonitor_TYPE_MAXELL                     = 7
     };
 
+    struct cells {
+        uint16_t cells[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
+    };
+
     // The BattMonitor_State structure is filled in by the backend driver
     struct BattMonitor_State {
         uint8_t     instance;           // the instance number of this monitor
@@ -54,6 +59,7 @@ public:
         float       current_total_mah;  // total current draw since start-up
         uint32_t    last_time_micros;   // time when voltage and current was last read
         uint32_t    low_voltage_start_ms;  // time when voltage dropped below the minimum
+        cells       cell_voltages;      // battery cell voltages in millivolts, 10 cells matches the MAVLink spec
     };
 
     // Return the number of battery monitor instances
@@ -115,6 +121,10 @@ public:
     /// true when (voltage * current) > watt_max
     bool overpower_detected() const;
     bool overpower_detected(uint8_t instance) const;
+
+    // cell voltages
+    const cells & get_cell_voltages() { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); };
+    const cells & get_cell_voltages(const uint8_t instance) const;
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -15,6 +15,8 @@
 #define AP_BATT_LOW_VOLT_TIMEOUT_MS         10000   // low voltage of 10 seconds will cause battery_exhausted to return true
 #define AP_BATT_MAX_WATT_DEFAULT            0
 
+#define AP_BATT_MONITOR_TIMEOUT             5000
+
 // declare backend class
 class AP_BattMonitor_Backend;
 class AP_BattMonitor_Analog;
@@ -60,6 +62,8 @@ public:
         uint32_t    last_time_micros;   // time when voltage and current was last read
         uint32_t    low_voltage_start_ms;  // time when voltage dropped below the minimum
         cells       cell_voltages;      // battery cell voltages in millivolts, 10 cells matches the MAVLink spec
+        float       temperature;        // battery temperature in celsius
+        uint32_t    temperature_time;   // timestamp of the last recieved temperature message
     };
 
     // Return the number of battery monitor instances
@@ -125,6 +129,10 @@ public:
     // cell voltages
     const cells & get_cell_voltages() { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); };
     const cells & get_cell_voltages(const uint8_t instance) const;
+
+    // temperature
+    bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); };
+    bool get_temperature(float &temperature, const uint8_t instance) const;
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -15,6 +15,14 @@ extern const AP_HAL::HAL& hal;
 #define BATTMONITOR_SMBUS_MAXELL_SPECIFICATION_INFO    0x1a    // specification info
 #define BATTMONITOR_SMBUS_MAXELL_MANUFACTURE_NAME  0x20    // manufacturer name
 
+#define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGES 6
+uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
+                              0x3e,  // cell 2
+                              0x3d,  // cell 3
+                              0x3c,  // cell 4
+                              0x3b,  // cell 5
+                              0x3a}; // cell 6
+
 #define SMBUS_READ_BLOCK_MAXIMUM_TRANSFER    0x20   // A Block Read or Write is allowed to transfer a maximum of 32 data bytes.
 
 #define SMBUS_PEC_POLYNOME  0x07 // Polynome for CRC generation
@@ -28,12 +36,6 @@ extern const AP_HAL::HAL& hal;
  * #define BATTMONITOR_SMBUS_MAXELL_DESIGN_VOLTAGE        0x19    // design voltage register
  * #define BATTMONITOR_SMBUS_MAXELL_MANUFACTURE_DATE      0x1b    // manufacturer date
  * #define BATTMONITOR_SMBUS_MAXELL_SERIALNUM             0x1c    // serial number register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE6         0x3a    // cell voltage register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE5         0x3b    // cell voltage register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE4         0x3c    // cell voltage register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE3         0x3d    // cell voltage register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE2         0x3e    // cell voltage register
- * #define BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGE1         0x3f    // cell voltage register
  * #define BATTMONITOR_SMBUS_MAXELL_HEALTH_STATUS         0x4f    // state of health
  * #define BATTMONITOR_SMBUS_MAXELL_SAFETY_ALERT          0x50    // safety alert
  * #define BATTMONITOR_SMBUS_MAXELL_SAFETY_STATUS         0x50    // safety status
@@ -72,6 +74,14 @@ void AP_BattMonitor_SMBus_Maxell::timer()
         _state.voltage = (float)data / 1000.0f;
         _state.last_time_micros = tnow;
         _state.healthy = true;
+    }
+
+    for (uint8_t i = 0; i < BATTMONITOR_SMBUS_MAXELL_CELL_VOLTAGES; i++) {
+        if (read_word(maxell_cell_ids[i], data)) {
+            _state.cell_voltages.cells[i] = data;
+        } else {
+            _state.cell_voltages.cells[i] = UINT16_MAX;
+        }
     }
 
     // timeout after 5 seconds

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -11,7 +11,6 @@ extern const AP_HAL::HAL& hal;
 #include <AP_HAL/AP_HAL.h>
 
 #define BATTMONITOR_SMBUS_SOLO_TEMP                 0x08    // temperature register
-#define BATTMONITOR_SMBUS_SOLO_VOLTAGE              0x09    // voltage register
 #define BATTMONITOR_SMBUS_SOLO_REMAINING_CAPACITY   0x0f    // predicted remaining battery capacity in milliamps
 #define BATTMONITOR_SMBUS_SOLO_FULL_CHARGE_CAPACITY 0x10    // full capacity register
 #define BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA     0x23    /// manufacturer data
@@ -23,6 +22,7 @@ extern const AP_HAL::HAL& hal;
 
 /*
  * Other potentially useful registers, listed here for future use
+ * #define BATTMONITOR_SMBUS_SOLO_VOLTAGE           0x09    // voltage register
  * #define BATTMONITOR_SMBUS_SOLO_BATTERY_STATUS    0x16    // battery status register including alarms
  * #define BATTMONITOR_SMBUS_SOLO_DESIGN_CAPACITY   0x18    // design capacity register
  * #define BATTMONITOR_SMBUS_SOLO_DESIGN_VOLTAGE    0x19    // design voltage register
@@ -55,9 +55,20 @@ void AP_BattMonitor_SMBus_Solo::timer()
     uint8_t buff[8];
     uint32_t tnow = AP_HAL::micros();
 
-    // read voltage
-    if (read_word(BATTMONITOR_SMBUS_SOLO_VOLTAGE, data)) {
-        _state.voltage = (float)data / 1000.0f;
+
+    // read cell voltages
+    if (read_block(BATTMONITOR_SMBUS_SOLO_CELL_VOLTAGE, buff, 8, false)) {
+        float pack_voltage_mv = 0.0f;
+        for (uint8_t i = 0; i < BATTMONITOR_SMBUS_SOLO_NUM_CELLS; i++) {
+            uint16_t cell = buff[(i * 2) + 1] << 8 | buff[i * 2];
+            _state.cell_voltages.cells[i] = cell;
+            pack_voltage_mv += (float)cell;
+        }
+        // accumulate the pack voltage out of the total of the cells
+        // because the Solo's I2C bus is so noisy, it's worth not spending the
+        // time and bus bandwidth to request the pack voltage as a seperate
+        // transaction
+        _state.voltage = pack_voltage_mv * 1e-3;
         _state.last_time_micros = tnow;
         _state.healthy = true;
     }
@@ -115,13 +126,6 @@ void AP_BattMonitor_SMBus_Solo::timer()
     if (read_word(BATTMONITOR_SMBUS_SOLO_TEMP, data)) {
          _state.temperature_time = AP_HAL::millis();
          _state.temperature = ((float)(data - 2731)) * 0.1f;
-    }
-
-    // read cell voltages
-    if (read_block(BATTMONITOR_SMBUS_SOLO_CELL_VOLTAGE, buff, 8, false)) {
-        for (uint8_t i = 0; i < BATTMONITOR_SMBUS_SOLO_NUM_CELLS; i++) {
-            _state.cell_voltages.cells[i] = buff[(i * 2) + 1] << 8 | buff[i * 2];
-        }
     }
 }
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1854,24 +1854,43 @@ void DataFlash_Class::Log_Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f 
 void DataFlash_Class::Log_Write_Current(const AP_BattMonitor &battery)
 {
     if (battery.num_instances() >= 1) {
+        float temp;
+        bool has_temp = battery.get_temperature(temp, 0);
         struct log_Current pkt = {
             LOG_PACKET_HEADER_INIT(LOG_CURRENT_MSG),
             time_us             : AP_HAL::micros64(),
             battery_voltage     : battery.voltage(0),
             current_amps        : battery.current_amps(0),
             current_total       : battery.current_total_mah(0),
+            temperature         : (int16_t)(has_temp ? (temp * 100) : 0),
         };
+        AP_BattMonitor::cells cells = battery.get_cell_voltages(0);
+
+        // check battery structure can hold all cells
+        static_assert(ARRAY_SIZE(cells.cells) == (sizeof(pkt.cell_voltages) / sizeof(pkt.cell_voltages[0])),
+                      "Battery cell number doesn't match in library and log structure");
+
+        for (uint8_t i = 0; i < ARRAY_SIZE(cells.cells); i++) {
+            pkt.cell_voltages[i] = cells.cells[i] + 1;
+        }
         WriteBlock(&pkt, sizeof(pkt));
     }
 
     if (battery.num_instances() >= 2) {
+        float temp;
+        bool has_temp = battery.get_temperature(temp, 1);
         struct log_Current pkt = {
             LOG_PACKET_HEADER_INIT(LOG_CURRENT2_MSG),
             time_us             : AP_HAL::micros64(),
             battery_voltage     : battery.voltage(1),
             current_amps        : battery.current_amps(1),
             current_total       : battery.current_total_mah(1),
+            temperature         : (int16_t)(has_temp ? (temp * 100) : 0),
         };
+        AP_BattMonitor::cells cells = battery.get_cell_voltages(1);
+        for (uint8_t i = 0; i < ARRAY_SIZE(cells.cells); i++) {
+            pkt.cell_voltages[i] = cells.cells[i] + 1;
+        }
         WriteBlock(&pkt, sizeof(pkt));
     }
 }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -490,6 +490,8 @@ struct PACKED log_Current {
     float    battery_voltage;
     float    current_amps;
     float    current_total;
+    int16_t  temperature; // degrees C * 100
+    uint16_t cell_voltages[10];
 };
 
 struct PACKED log_Compass {
@@ -799,6 +801,8 @@ struct PACKED log_Rally {
 #define QUAT_LABELS "TimeUS,Q1,Q2,Q3,Q4"
 #define QUAT_FMT    "Qffff"
 
+#define CURR_LABELS "TimeUS,Volt,Curr,CurrTot,Temp,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
+#define CURR_FMT    "QfffcHHHHHHHHHH"
 
 /*
 Format characters in the format string for binary log messages
@@ -866,9 +870,9 @@ Format characters in the format string for binary log messages
     { LOG_ARSP_MSG, sizeof(log_AIRSPEED), \
       "ARSP",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U" }, \
     { LOG_CURRENT_MSG, sizeof(log_Current), \
-      "CURR", "Qfff","TimeUS,Volt,Curr,CurrTot" },\
+      "CURR", CURR_FMT,CURR_LABELS }, \
     { LOG_CURRENT2_MSG, sizeof(log_Current), \
-      "CUR2", "Qfff","TimeUS,Volt,Curr,CurrTot" }, \
+      "CUR2", CURR_FMT,CURR_LABELS }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -240,11 +240,13 @@ void GCS_MAVLINK::send_battery_status(const AP_BattMonitor &battery, const uint8
     static_assert(sizeof(AP_BattMonitor::cells) >= (sizeof(uint16_t) * MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN),
                   "Not enough battery cells for the MAVLink message");
 
+    float temp;
+    bool got_temperature = battery.get_temperature(temp, instance);
     mavlink_msg_battery_status_send(chan,
                                     instance, // id
                                     MAV_BATTERY_FUNCTION_UNKNOWN, // function
                                     MAV_BATTERY_TYPE_UNKNOWN, // type
-                                    INT16_MAX, // temperature. INT16_MAX if unknown
+                                    got_temperature ? ((int16_t) (temp * 100)) : INT16_MAX, // temperature. INT16_MAX if unknown
                                     battery.get_cell_voltages(instance).cells, // cell voltages
                                     battery.has_current(instance) ? battery.current_amps(instance) * 100 : -1, // current
                                     battery.has_current(instance) ? battery.current_total_mah(instance) : -1, // total current


### PR DESCRIPTION
This builds upon the work presented in #6015 and fetches the per cell voltages and temperatures from both the Maxell and Solo SMBus drivers. I added 10 cells of support to AP_BattMonitor, as that is what the MAVLink spec calls for and gives us a transport mechanism for, while I think supporting 12 cells makes sense in the future, until we have someway to actually get more then 6 cells I didn't allocate that many.

There are a couple of debug status text messages that improve the testing ability that will have to be removed before this can be merged. (As well as getting #6015 merged).

This also corrects a buffer overflow that happens within the SMBus_Solo driver, it hasn't had a noticable impact to date because it tends to overflow into memory we are already done using. (The ManufacturerData was 6 bytes long, but read into a 4 byte destination).

Within Dataflash I pulled the current definitions out into a pair of common defines.

@tatsuy tested the Maxell driver last night, and found a small error with the temperature which I've since fixed, but otherwise functioned correctly. The solo implementation hasn't been tested by anyone yet, and was written against the data sheet as I don't have the hardware. The logging wasn't present when Tatsuy tested, so hopefully whoever tests the solo battery can also confirm that their DF log looks correct? (The cell voltages are in millivolts, 65535 for any cell that is unknown).