### PR TITLE
Plane: support for vectored tailsitters (WIP)

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -722,7 +722,7 @@ void QuadPlane::run_z_controller(void)
     if (now - last_pidz_active_ms > 2000) {
         // set alt target to current height on transition. This
         // starts the Z controller off with the right values
-        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reset alt target to %.1f", inertial_nav.get_altitude());
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)inertial_nav.get_altitude());
         pos_control->set_alt_target(inertial_nav.get_altitude());
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -366,6 +366,20 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: This controls what input channel will activate the Q_TAILSIT_MASK mask. When this channel goes above 1700 then the pilot will have direct manual control of the output channels specified in Q_TAILSIT_MASK. Set to zero to disable.
     // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
     AP_GROUPINFO("TAILSIT_MASKCH", 52, QuadPlane, tailsitter.input_mask_chan, 0),
+
+    // @Param: TAILSIT_VFGAIN
+    // @DisplayName: Tailsitter vector thrust gain in forward flight
+    // @Description: This controls the amount of vectored thrust control used in forward flight for a vectored tailsitter
+    // @Range: 0 1
+    // @Increment: 0.01
+    AP_GROUPINFO("TAILSIT_VFGAIN", 53, QuadPlane, tailsitter.vectored_forward_gain, 0),
+
+    // @Param: TAILSIT_VHGAIN
+    // @DisplayName: Tailsitter vector thrust gain in hover
+    // @Description: This controls the amount of vectored thrust control used in hover for a vectored tailsitter
+    // @Range: 0 1
+    // @Increment: 0.01
+    AP_GROUPINFO("TAILSIT_VHGAIN", 54, QuadPlane, tailsitter.vectored_hover_gain, 0.5),
     
     AP_GROUPEND
 };

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -358,6 +358,8 @@ private:
         AP_Int8 input_type;
         AP_Int8 input_mask;
         AP_Int8 input_mask_chan;
+        AP_Float vectored_forward_gain;
+        AP_Float vectored_hover_gain;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -40,6 +40,18 @@ bool QuadPlane::tailsitter_active(void)
 void QuadPlane::tailsitter_output(void)
 {
     if (!tailsitter_active()) {
+        if (tailsitter.vectored_forward_gain > 0) {
+            // thrust vectoring in fixed wing flight
+            float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
+            float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
+            float tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain;
+            float tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
+        } else {
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, 0);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 0);
+        }
         return;
     }
 
@@ -47,6 +59,17 @@ void QuadPlane::tailsitter_output(void)
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
 
+    if (tailsitter.vectored_hover_gain > 0) {
+        // thrust vectoring VTOL modes
+        float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
+        float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
+        float tilt_left  = (elevator + aileron) * tailsitter.vectored_hover_gain;
+        float tilt_right = (elevator - aileron) * tailsitter.vectored_hover_gain;
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
+    }
+    
+    
     if (tailsitter.input_mask_chan > 0 &&
         tailsitter.input_mask > 0 &&
         hal.rcin->read(tailsitter.input_mask_chan-1) > 1700) {

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -35,6 +35,15 @@ void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type f
     _flags.initialised_ok = (frame_class == MOTOR_FRAME_TAILSITTER);
 }
 
+
+/// Constructor
+AP_MotorsTailsitter::AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz) :
+    AP_MotorsMulticopter(loop_rate, speed_hz)
+{
+    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleLeft, speed_hz);
+    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleRight, speed_hz);
+}
+
 void AP_MotorsTailsitter::output_to_motors()
 {
     if (!_flags.initialised_ok) {

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -42,16 +42,10 @@ void AP_MotorsTailsitter::output_to_motors()
     }
     switch (_spool_mode) {
         case SHUT_DOWN:
-            _aileron = 0;
-            _elevator = 0;
-            _rudder = 0;
             _throttle = 0;
             break;
         case SPIN_WHEN_ARMED:
             // sends output to motors when armed but not flying
-            _aileron = 0;
-            _elevator = 0;
-            _rudder = 0;
             _throttle = constrain_float(_spin_up_ratio, 0.0f, 1.0f) * _spin_min;
             break;
         case SPOOL_UP:

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -12,10 +12,7 @@ class AP_MotorsTailsitter : public AP_MotorsMulticopter {
 public:
 
     /// Constructor
-    AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_MotorsMulticopter(loop_rate, speed_hz)
-    {
-    };
+    AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 
     // init
     void init(motor_frame_class frame_class, motor_frame_type frame_type);

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -334,6 +334,9 @@ public:
 
     // call set_range() on matching channels
     static void set_range(SRV_Channel::Aux_servo_function_t function, uint16_t range);
+
+    // set output refresh frequency on a servo function
+    static void set_rc_frequency(SRV_Channel::Aux_servo_function_t function, uint16_t frequency);
     
     // control pass-thru of channels
     void disable_passthrough(bool disable) {

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -103,6 +103,8 @@ public:
         k_tracker_pitch         = 72,            ///< antennatracker pitch
         k_throttleLeft          = 73,
         k_throttleRight         = 74,
+        k_tiltMotorLeft         = 75,            ///< vectored thrust, left tilt
+        k_tiltMotorRight        = 76,            ///< vectored thrust, right tilt
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -789,3 +789,18 @@ void SRV_Channels::upgrade_motors_servo(uint8_t ap_motors_key, uint8_t ap_motors
     }
 }
 
+
+// set RC output frequency on a function output
+void SRV_Channels::set_rc_frequency(SRV_Channel::Aux_servo_function_t function, uint16_t frequency_hz)
+{
+    uint16_t mask = 0;
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        SRV_Channel &ch = channels[i];
+        if (ch.function == function) {
+            mask |= (1U<<ch.ch_num);
+        }
+    }
+    if (mask != 0) {
+        hal.rcout->set_freq(mask, frequency_hz);
+    }
+}

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -106,6 +106,8 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_steering:
     case k_flaperon1:
     case k_flaperon2:
+    case k_tiltMotorLeft:
+    case k_tiltMotorRight:
         set_angle(4500);
         break;
     case k_throttle:


### PR DESCRIPTION
This adds support for vectored tailsitters like this one:
https://www.youtube.com/watch?v=koOqenMpvck
It adds two new parameters:
Q_TAILSIT_VFGAIN and Q_TAILSIT_VHGAIN for forward flight and hover gain for thrust vectoring. You then set one SERVOn_FUNCTION to 75 for left motor tilt and another to 76 for right motor tilt.
See discussions of this type of aircraft here:
http://discuss.ardupilot.org/t/dual-motor-tailsitters/15302