### PR TITLE
AP_Compass: solve typecast misbehaviour observed on one compiler version

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -683,7 +683,7 @@ void CompassCalibrator::run_ellipsoid_fit()
 //////////// CompassSample public interface //////////////
 //////////////////////////////////////////////////////////
 
-#define COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(__X) ((int16_t)constrain_float(roundf(__X*8.0f), INT16_MIN, INT16_MAX))
+#define COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(__X) ((int16_t)constrain_float(roundf(__X*8.0f), float(int16_t(INT16_MIN)), float(int16_t(INT16_MAX))))
 #define COMPASS_CAL_SAMPLE_SCALE_TO_FLOAT(__X) (__X/8.0f)
 
 Vector3f CompassCalibrator::CompassSample::get() const {


### PR DESCRIPTION
On following compiler version running on macos, I found that INT16_MIN translated to uint16 type instead of int16, this commit is to circumvent that issue:
```
arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 4.9.3 20150529 (release) [ARM/embedded-4_9-branch revision 227977]
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
