### PR TITLE
Autotest: Added functions to arducopter autotest for motor failure testing

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1325,6 +1325,11 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
         else:
             print("Flew copter mission OK")
 
+        print("# Fly motor failure test")
+        if not fly_motor_fail(mavproxy, mav, fail_mul=0, fail_servo=0):
+            failed_test_msg = "fly motor failure test failed"
+            print(failed_test_msg)
+            failed = True
         # wait for disarm
         mav.motors_disarmed_wait()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1021,7 +1021,30 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
 
     # setup test parameters
     if params_file is None:
-        params_file = "{testdir}/default_params/copter.parm"
+        if frame == 'hexa':
+            params_file = "{testdir}/default_params/copter-hexa.parm"
+        elif frame == 'octa-quad':
+            params_file = "{testdir}/default_params/copter-octaquad.parm"
+        elif frame == 'octa':
+            params_file = "{testdir}/default_params/copter-octa.parm"
+        elif frame == 'tri':
+            params_file = "{testdir}/default_params/copter-tri.parm"
+        elif frame == 'y6':
+            params_file = "{testdir}/default_params/copter-y6.parm"
+        elif frame == 'firefly':
+            params_file = "{testdir}/default_params/firefly.parm"
+        elif frame == 'gazebo-iris':
+            params_file = "{testdir}/default_params/gazebo-iris.parm"
+        elif frame == 'heli':
+            params_file = "{testdir}/default_params/copter-heli.parm"
+        elif frame == 'heli-dual':
+            params_file = "{testdir}/default_params/copter-heli-dual.parm"
+        elif frame == 'singlecopter':
+            params_file = "{testdir}/default_params/copter-single.parm"
+        elif frame == 'coax':
+            params_file = "{testdir}/default_params/copter-coax.parm"
+        else:
+            params_file = "{testdir}/default_params/copter.parm"
     mavproxy.send("param load %s\n" % params_file.format(testdir=testdir))
     mavproxy.expect('Loaded [0-9]+ parameters')
     mavproxy.send("param set LOG_REPLAY 1\n")


### PR DESCRIPTION
This PR firstly extends the changes made to sim_vehicle.py made in #5914 to include different parameter files by default on the arducopter autotest function. It also includes a function, using the changes from this same PR, I am using to test motor failure on hexacopters and quadcopters.

Apologies @peterbarker for closing the other PR (#6021) as I made a mistake rebasing to master and inadvertly closed it, the changes you mencioned were all added to this PR