### PR TITLE
AP_BoardConfig: Deconflict Aero FC and PX4 BRD_TYPE enums

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -66,7 +66,7 @@ public:
         PX4_BOARD_PIXRACER = 4,
         PX4_BOARD_PHMINI   = 5,
         PX4_BOARD_PH2SLIM  = 6,
-        PX4_BOARD_AEROFC   = 7,
+        PX4_BOARD_AEROFC   = 13,
         PX4_BOARD_AUAV21   = 20,
         PX4_BOARD_OLDDRIVERS = 100,
 #endif


### PR DESCRIPTION
Aero FC stole a VRBrain BRD_TYPE value.