### PR TITLE
Copter: don't enable motors in oneshot till fast loop starts

### DIFF
--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -91,9 +91,14 @@ void Copter::init_rc_out()
 // enable_motor_output() - enable and output lowest possible value to motors
 void Copter::enable_motor_output()
 {
-    // enable motors
-    motors->enable();
-    motors->output_min();
+    // enable motors. We don't enable if in oneshot mode till we've
+    // completed setup(). This prevents us sending pulses at a slow
+    // rate
+    if (motors->get_pwm_type() < AP_Motors::PWM_TYPE_ONESHOT ||
+        ap.initialised) {
+        motors->enable();
+        motors->output_min();
+    }
 }
 
 void Copter::read_radio()


### PR DESCRIPTION
this prevents us sending slow pulses at startup, which can confuse
BLHeli and lead to ESCs not arming properly