### PR TITLE
AP_Motors: allow one to many mapping of motors

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -101,7 +101,6 @@ void Copter::esc_calibration_passthrough()
 
     // arm motors
     motors->armed(true);
-    motors->enable();
     SRV_Channels::enable_by_mask(motors->get_motor_mask());
     hal.util->set_soft_armed(true);
 
@@ -149,7 +148,6 @@ void Copter::esc_calibration_auto()
 
     // arm and enable motors
     motors->armed(true);
-    motors->enable();
     SRV_Channels::enable_by_mask(motors->get_motor_mask());
     hal.util->set_soft_armed(true);
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -79,7 +79,6 @@ void Copter::init_rc_out()
 void Copter::enable_motor_output()
 {
     // enable motors
-    motors->enable();
     motors->output_min();
 }
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -48,9 +48,15 @@ void Copter::init_rc_in()
  // init_rc_out -- initialise motors and check if pilot wants to perform ESC calibration
 void Copter::init_rc_out()
 {
-    motors->set_update_rate(g.rc_speed);
     motors->set_loop_rate(scheduler.get_loop_rate_hz());
     motors->init((AP_Motors::motor_frame_class)g2.frame_class.get(), (AP_Motors::motor_frame_type)g.frame_type.get());
+
+    // enable aux servos to cope with multiple output channels per motor
+    SRV_Channels::enable_aux_servos();
+
+    // update rate must be set after motors->init() to allow for motor mapping
+    motors->set_update_rate(g.rc_speed);
+
 #if FRAME_CONFIG != HELI_FRAME
     motors->set_throttle_range(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #else

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1088,9 +1088,6 @@ void QuadPlane::set_armed(bool armed)
         return;
     }
     motors->armed(armed);
-    if (armed) {
-        motors->enable();
-    }
 }
 
 

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -3,8 +3,6 @@
 // enable_motor_output() - enable and output lowest possible value to motors
 void Sub::enable_motor_output()
 {
-    // enable motors
-    motors.enable();
     motors.output_min();
 }
 

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -72,18 +72,6 @@ void AP_MotorsCoax::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsCoax::enable()
-{
-    // enable output channels
-    rc_enable_ch(AP_MOTORS_MOT_1);
-    rc_enable_ch(AP_MOTORS_MOT_2);
-    rc_enable_ch(AP_MOTORS_MOT_3);
-    rc_enable_ch(AP_MOTORS_MOT_4);
-    rc_enable_ch(AP_MOTORS_MOT_5);
-    rc_enable_ch(AP_MOTORS_MOT_6);
-}
-
 void AP_MotorsCoax::output_to_motors()
 {
     switch (_spool_mode) {

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -37,9 +37,6 @@ public:
     // set update rate to motors - a value in hertz
     void                set_update_rate( uint16_t speed_hz );
 
-    // enable - starts allowing signals to be sent to motors
-    virtual void        enable();
-
     // output_test - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
     //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -68,9 +68,6 @@ public:
     // set update rate to motors - a value in hertz
     virtual void set_update_rate( uint16_t speed_hz ) = 0;
 
-    // enable - starts allowing signals to be sent to motors
-    virtual void enable() = 0;
-
     // output_min - sets servos to neutral point with motors stopped
     void output_min();
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -193,20 +193,6 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsHeli_Dual::enable()
-{
-    // enable output channels
-    rc_enable_ch(AP_MOTORS_MOT_1);
-    rc_enable_ch(AP_MOTORS_MOT_2);
-    rc_enable_ch(AP_MOTORS_MOT_3);
-    rc_enable_ch(AP_MOTORS_MOT_4);
-    rc_enable_ch(AP_MOTORS_MOT_5);
-    rc_enable_ch(AP_MOTORS_MOT_6);
-
-    rc_enable_ch(AP_MOTORS_HELI_DUAL_RSC);
-}
-
 // init_outputs
 bool AP_MotorsHeli_Dual::init_outputs()
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -54,9 +54,6 @@ public:
     // set_update_rate - set update rate to motors
     void set_update_rate( uint16_t speed_hz ) override;
 
-    // enable - starts allowing signals to be sent to motors
-    void enable() override;
-
     // output_test - spin a motor at the pwm value specified
     void output_test(uint8_t motor_seq, int16_t pwm) override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -62,17 +62,6 @@ void AP_MotorsHeli_Quad::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsHeli_Quad::enable()
-{
-    // enable output channels
-    for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        rc_enable_ch(AP_MOTORS_MOT_1+i);
-    }
-
-    rc_enable_ch(AP_MOTORS_HELI_QUAD_RSC);
-}
-
 // init_outputs
 bool AP_MotorsHeli_Quad::init_outputs()
 {
@@ -81,7 +70,6 @@ bool AP_MotorsHeli_Quad::init_outputs()
     }
 
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        rc_enable_ch(AP_MOTORS_MOT_1+i);
         _servo[i] = SRV_Channels::get_channel_for(SRV_Channel::Aux_servo_function_t(SRV_Channel::k_motor1+i), CH_1+i);
         if (!_servo[i]) {
             return false;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -33,9 +33,6 @@ public:
     // set_update_rate - set update rate to motors
     void set_update_rate( uint16_t speed_hz ) override;
 
-    // enable - starts allowing signals to be sent to motors
-    void enable() override;
-
     // output_test - spin a motor at the pwm value specified
     void output_test(uint8_t motor_seq, int16_t pwm) override;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -157,18 +157,6 @@ void AP_MotorsHeli_Single::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors and servos
-void AP_MotorsHeli_Single::enable()
-{
-    // enable output channels
-    rc_enable_ch(AP_MOTORS_MOT_1);    // swash servo 1
-    rc_enable_ch(AP_MOTORS_MOT_2);    // swash servo 2
-    rc_enable_ch(AP_MOTORS_MOT_3);    // swash servo 3
-    rc_enable_ch(AP_MOTORS_MOT_4);    // yaw
-    rc_enable_ch(AP_MOTORS_HELI_SINGLE_AUX);                                 // output for gyro gain or direct drive variable pitch tail motor
-    rc_enable_ch(AP_MOTORS_HELI_SINGLE_RSC);                                 // output for main rotor esc
-}
-
 // init_outputs - initialise Servo/PWM ranges and endpoints
 bool AP_MotorsHeli_Single::init_outputs()
 {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -57,9 +57,6 @@ public:
     // set update rate to motors - a value in hertz
     void set_update_rate(uint16_t speed_hz) override;
 
-    // enable - starts allowing signals to be sent to motors and servos
-    void enable() override;
-
     // output_test - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
     //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -40,19 +40,12 @@ void AP_MotorsMatrix::init(motor_frame_class frame_class, motor_frame_type frame
 // set update rate to motors - a value in hertz
 void AP_MotorsMatrix::set_update_rate( uint16_t speed_hz )
 {
-    uint8_t i;
-
     // record requested speed
     _speed_hz = speed_hz;
 
-    // check each enabled motor
-    uint32_t mask = 0;
-    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
-        if( motor_enabled[i] ) {
-		mask |= 1U << i;
-        }
-    }
-    rc_set_freq( mask, _speed_hz );
+    // we can use a mask of 0xFF here as rc_set_freq masks with actual
+    // motor mask
+    rc_set_freq(0xFF, _speed_hz );
 }
 
 // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -72,19 +72,6 @@ void AP_MotorsMatrix::set_frame_class_and_type(motor_frame_class frame_class, mo
     set_update_rate(_speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsMatrix::enable()
-{
-    int8_t i;
-
-    // enable output channels
-    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
-        if( motor_enabled[i] ) {
-            rc_enable_ch(i);
-        }
-    }
-}
-
 void AP_MotorsMatrix::output_to_motors()
 {
     int8_t i;

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -29,9 +29,6 @@ public:
     // you must have setup_motors before calling this
     void                set_update_rate(uint16_t speed_hz);
 
-    // enable - starts allowing signals to be sent to motors
-    void                enable();
-
     // output_test - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
     //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -78,18 +78,6 @@ void AP_MotorsSingle::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsSingle::enable()
-{
-    // enable output channels
-    rc_enable_ch(AP_MOTORS_MOT_1);
-    rc_enable_ch(AP_MOTORS_MOT_2);
-    rc_enable_ch(AP_MOTORS_MOT_3);
-    rc_enable_ch(AP_MOTORS_MOT_4);
-    rc_enable_ch(AP_MOTORS_MOT_5);
-    rc_enable_ch(AP_MOTORS_MOT_6);
-}
-
 void AP_MotorsSingle::output_to_motors()
 {
     if (!_flags.initialised_ok) {

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -37,9 +37,6 @@ public:
     // set update rate to motors - a value in hertz
     void                set_update_rate( uint16_t speed_hz );
 
-    // enable - starts allowing signals to be sent to motors
-    virtual void        enable();
-
     // output_test - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
     //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -20,7 +20,6 @@ public:
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) {}
     void set_update_rate( uint16_t speed_hz ) {}
-    void enable() {}
 
     void output_test(uint8_t motor_seq, int16_t pwm) {}
 

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -75,16 +75,6 @@ void AP_MotorsTri::set_update_rate( uint16_t speed_hz )
     rc_set_freq(mask, _speed_hz);
 }
 
-// enable - starts allowing signals to be sent to motors
-void AP_MotorsTri::enable()
-{
-    // enable output channels
-    rc_enable_ch(AP_MOTORS_MOT_1);
-    rc_enable_ch(AP_MOTORS_MOT_2);
-    rc_enable_ch(AP_MOTORS_MOT_4);
-    rc_enable_ch(AP_MOTORS_CH_TRI_YAW);
-}
-
 void AP_MotorsTri::output_to_motors()
 {
     switch (_spool_mode) {

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -32,9 +32,6 @@ public:
     // set update rate to motors - a value in hertz
     void                set_update_rate( uint16_t speed_hz );
 
-    // enable - starts allowing signals to be sent to motors
-    virtual void        enable();
-
     // output_test - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
     //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -125,15 +125,6 @@ void AP_Motors::rc_set_freq(uint32_t mask, uint16_t freq_hz)
     }
 }
 
-void AP_Motors::rc_enable_ch(uint8_t chan)
-{
-    if (_motor_map_mask & (1U<<chan)) {
-        // we have a mapped motor number for this channel
-        chan = _motor_map[chan];
-    }
-    hal.rcout->enable_ch(chan);
-}
-
 /*
   map an internal motor mask to real motor mask
  */

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -214,9 +214,7 @@ protected:
     float               _batt_resistance;       // latest battery resistance estimate in ohms
     float               _air_density_ratio;     // air density / sea level density - decreases in altitude
 
-    // mapping to output channels
-    uint8_t             _motor_map[AP_MOTORS_MAX_NUM_MOTORS];
-    uint16_t            _motor_map_mask;
+    // mask of what channels need fast output
     uint16_t            _motor_fast_mask;
 
     // pass through variables

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -141,9 +141,6 @@ public:
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     virtual void        set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
 
-    // enable - starts allowing signals to be sent to motors
-    virtual void        enable() = 0;
-
     // output - sends commands to the motors
     virtual void        output() = 0;
 
@@ -173,7 +170,6 @@ protected:
     virtual void        output_armed_stabilizing()=0;
     virtual void        rc_write(uint8_t chan, uint16_t pwm);
     virtual void        rc_set_freq(uint32_t mask, uint16_t freq_hz);
-    virtual void        rc_enable_ch(uint8_t chan);
     virtual uint32_t    rc_map_mask(uint32_t mask) const;
 
     // add a motor to the motor map

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -29,6 +29,7 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
@@ -64,7 +65,6 @@ void setup()
     motors.set_throttle_range(1000,2000);
     motors.set_throttle_avg_max(0.5f);
 #endif
-    motors.enable();
     motors.output_min();
 
     // setup radio
@@ -138,6 +138,7 @@ void stability_test()
     // arm motors
     motors.armed(true);
     motors.set_interlock(true);
+    SRV_Channels::enable_aux_servos();
 
 #if NUM_OUTPUTS <= 4
     hal.console->printf("Roll,Pitch,Yaw,Thr,Mot1,Mot2,Mot3,Mot4,AvgOut,LimRP,LimY,LimThD,LimThU\n");                       // quad

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -278,6 +278,9 @@ public:
     // return zero on error.
     static float get_output_norm(SRV_Channel::Aux_servo_function_t function);
 
+    // get output channel mask for a function
+    static uint16_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);
+    
     // limit slew rate to given limit in percent per second
     static void limit_slew_rate(SRV_Channel::Aux_servo_function_t function, float slew_rate, float dt);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -408,6 +408,7 @@ bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t fun
     channels[channel].function.set(function);
     channels[channel].aux_servo_function_setup();
     function_mask.set((uint8_t)function);
+    functions[function].channel_mask |= 1U<<channel;
     return true;
 }
 
@@ -465,6 +466,9 @@ int16_t SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t functi
  */
 uint16_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t function)
 {
+    if (!initialised) {
+        update_aux_servo_function();
+    }
     if (function < SRV_Channel::k_nr_aux_servo_functions) {
         return functions[function].channel_mask;
     }

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -38,10 +38,6 @@ void SRV_Channel::output_ch(void)
     case k_rcin1 ... k_rcin16: // rc pass-thru
         passthrough_from = int8_t(function - k_rcin1);
         break;
-    case k_motor1 ... k_motor8:
-    case k_motor9 ... k_motor12:
-        // handled by AP_Motors::rc_write()
-        return;
     }
     if (passthrough_from != -1) {
         // we are doing passthrough from input to output for this channel

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -460,6 +460,18 @@ int16_t SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t functi
     return 0;
 }
 
+/*
+  get mask of output channels for a function
+ */
+uint16_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t function)
+{
+    if (function < SRV_Channel::k_nr_aux_servo_functions) {
+        return functions[function].channel_mask;
+    }
+    return 0;
+}
+
+
 // set the trim for a function channel to given pwm
 void SRV_Channels::set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t function, int16_t pwm)
 {


### PR DESCRIPTION
This allows multiple RC output channels to be used for a single AP_Motors motor channel, and also fixes it to use the SRV_Channels API instead of hal.rcout->write(), which makes us consistent right across the code base
This has not been test flown outside of SITL
