### PR TITLE
Remove legacy UAVCAN leftovers and mkblctrl

### DIFF
--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_px4fmu-common_apm.cmake
@@ -16,7 +16,6 @@ set(config_module_list
     drivers/stm32/tone_alarm
     drivers/led
     drivers/px4fmu
-    drivers/mkblctrl
 
 #
 # System commands

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -9,7 +9,6 @@
 #include <unistd.h>
 
 #include <drivers/drv_pwm_output.h>
-#include <uORB/topics/actuator_direct.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_sbus.h>
@@ -75,9 +74,6 @@ void PX4RCOutput::init()
     for (uint8_t i=0; i < PX4_NUM_OUTPUT_CHANNELS; i++) {
         _period[i] = PWM_IGNORE_THIS_CHANNEL;
     }
-
-    // publish actuator vaules on demand
-    _actuator_direct_pub = nullptr;
 }
 
 
@@ -471,7 +467,7 @@ void PX4RCOutput::_send_outputs(void)
         }
         if (to_send > 0) {
             _arm_actuators(true);
-            
+
             ::write(_pwm_fd, _period, to_send*sizeof(_period[0]));
         }
         if (_max_channel > _servo_count) {

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -418,6 +418,12 @@ void PX4RCOutput::_arm_actuators(bool arm)
     }
     _armed.lockdown = false;
     _armed.force_failsafe = false;
+
+    if (_actuator_armed_pub == nullptr) {
+        _actuator_armed_pub = orb_advertise(ORB_ID(actuator_armed), &_armed);
+    } else {
+        orb_publish(ORB_ID(actuator_armed), _actuator_armed_pub, &_armed);
+    }
 }
 
 void PX4RCOutput::_send_outputs(void)
@@ -464,6 +470,8 @@ void PX4RCOutput::_send_outputs(void)
             }
         }
         if (to_send > 0) {
+            _arm_actuators(true);
+            
             ::write(_pwm_fd, _period, to_send*sizeof(_period[0]));
         }
         if (_max_channel > _servo_count) {

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -62,13 +62,11 @@ private:
     } _outputs[ORB_MULTI_MAX_INSTANCES] {};
     actuator_armed_s _armed;
 
-    orb_advert_t _actuator_direct_pub;
     orb_advert_t _actuator_armed_pub;
     uint16_t _esc_pwm_min;
     uint16_t _esc_pwm_max;
 
     void _init_alt_channels(void);
-    void _publish_actuators(void);
     void _arm_actuators(bool arm);
     void set_freq_fd(int fd, uint32_t chmask, uint16_t freq_hz, uint32_t &rate_mask);
     bool _corking;

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -3,6 +3,7 @@
 #include "AP_HAL_PX4.h"
 #include <systemlib/perf_counter.h>
 #include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/actuator_armed.h>
 
 #define PX4_NUM_OUTPUT_CHANNELS 16
 
@@ -61,9 +62,10 @@ private:
     } _outputs[ORB_MULTI_MAX_INSTANCES] {};
     actuator_armed_s _armed;
 
-    orb_advert_t _actuator_direct_pub = nullptr;
-    uint16_t _esc_pwm_min = 0;
-    uint16_t _esc_pwm_max = 0;
+    orb_advert_t _actuator_direct_pub;
+    orb_advert_t _actuator_armed_pub;
+    uint16_t _esc_pwm_min;
+    uint16_t _esc_pwm_max;
 
     void _init_alt_channels(void);
     void _publish_actuators(void);

--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -3,9 +3,6 @@
 # APM startup script for NuttX on PX4
 
 # To disable APM startup add a /fs/microsd/APM/nostart file
-# To enable mkblctrl startup add a /fs/microsd/APM/mkblctrl file
-# To enable mkblctrl_+ startup add a /fs/microsd/APM/mkblctrl_+ file
-# To enable mkblctrl_x startup add a /fs/microsd/APM/mkblctrl_x file
 
 # check for an old file called APM, caused by 
 # a bug in an earlier firmware release
@@ -58,28 +55,6 @@ then
     echo "uorb started OK"
 else
     sh /etc/init.d/rc.error
-fi
-
-# start mkblctrl driver if configured
-if [ -f /fs/microsd/APM/mkblctrl ]
-then
-    echo "Setting up mkblctrl driver"
-    echo "Setting up mkblctrl driver" >> $logfile
-    mkblctrl -d /dev/pwm_output
-fi
-
-if [ -f /fs/microsd/APM/mkblctrl_+ ]
-then
-    echo "Setting up mkblctrl driver +"
-    echo "Setting up mkblctrl driver +" >> $logfile
-    mkblctrl -mkmode + -d /dev/pwm_output
-fi
-
-if [ -f /fs/microsd/APM/mkblctrl_x ]
-then
-    echo "Setting up mkblctrl driver x"
-    echo "Setting up mkblctrl driver x" >> $logfile
-    mkblctrl -mkmode x -d /dev/pwm_output
 fi
 
 echo Starting ArduPilot

--- a/mk/PX4/px4_common.mk
+++ b/mk/PX4/px4_common.mk
@@ -22,7 +22,6 @@ MODULES		+= drivers/px4fmu
 #MODULES	+= drivers/hott_telemetry
 #MODULES	+= drivers/blinkm
 #MODULES	+= modules/sensors
-MODULES		+= drivers/mkblctrl
 
 #
 # System commands


### PR DESCRIPTION
This removes some code that was left-over after #6032.

Also removes mkblctrl that would not work after the previous PR removed armed status publishing. Actually, it looks like it wouldn't be working for more than 2 years, when the PWM device path was changed from `/dev/pwm_output` to `/dev/pwm_output0`, but mkblctrl driver initialization wasn't changed.