### PR TITLE
AP_GPS: Unify inject_data interface for all classes

### DIFF
--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -223,17 +223,6 @@ AP_GPS_ERB::_parse_gps(void)
     return false;
 }
 
-void
-AP_GPS_ERB::inject_data(const uint8_t *data, uint16_t len)
-{
-
-    if (port->txspace() > len) {
-        port->write(data, len);
-    } else {
-        Debug("ERB: Not enough TXSPACE");
-    }
-}
-
 /*
   detect a ERB GPS. Adds one byte, and returns true if the stream
   matches a ERB

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -133,8 +133,6 @@ private:
     // Buffer parse & GPS state update
     bool _parse_gps();
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
     // used to update fix between status and position packets
     AP_GPS::GPS_Status next_fix;
 };

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -342,13 +342,3 @@ AP_GPS_GSOF::process_message(void)
     return false;
 }
 
-void
-AP_GPS_GSOF::inject_data(const uint8_t *data, uint16_t len)
-{
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("GSOF: Not enough TXSPACE");
-    }
-}

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -34,8 +34,6 @@ public:
     // Methods
     bool read();
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
 private:
 
     bool parse(uint8_t temp);
@@ -81,6 +79,4 @@ private:
     uint32_t gsofmsg_time = 0;
     uint8_t gsofmsgreq_index = 0;
     uint8_t gsofmsgreq[5] = {1,2,8,9,12};
-
-    uint32_t last_injected_data_ms = 0;
 };

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -292,14 +292,3 @@ AP_GPS_SBF::process_message(void)
     return false;
 }
 
-void
-AP_GPS_SBF::inject_data(const uint8_t *data, uint16_t len)
-{
-
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("SBF: Not enough TXSPACE");
-    }
-}

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -34,8 +34,6 @@ public:
     // Methods
     bool read();
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
 private:
 
     bool parse(uint8_t temp);

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1275,17 +1275,6 @@ AP_GPS_UBLOX::_configure_rate(void)
     _send_message(CLASS_CFG, MSG_CFG_RATE, &msg, sizeof(msg));
 }
 
-void
-AP_GPS_UBLOX::inject_data(const uint8_t *data, uint16_t len)
-{
-    if (port->txspace() > len) {
-        port->write(data, len);
-    } else {
-        Debug("UBX: Not enough TXSPACE");
-    }
-}
-
-
 static const char *reasons[] = {"navigation rate",
                                 "posllh rate",
                                 "status rate",

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -101,8 +101,6 @@ public:
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-    
     bool is_configured(void) {
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (!gps._auto_config) {

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -24,7 +24,7 @@
 class AP_GPS_Backend
 {
 public:
-	AP_GPS_Backend(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
+    AP_GPS_Backend(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
     // we declare a virtual destructor so that GPS drivers can
     // override with a custom destructor if need be.
@@ -41,7 +41,7 @@ public:
 
     virtual bool is_configured(void) { return true; }
 
-    virtual void inject_data(const uint8_t *data, uint16_t len) { return; }
+    virtual void inject_data(const uint8_t *data, uint16_t len);
 
     //MAVLink methods
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan) { return ; }


### PR DESCRIPTION
All backends (except of SBP/SBP2) use the exact same paths for data injection, it doesn't make sense to require a driver author to implement the interface. The debug message is also improved with this approach. All drivers should be able to accept data, if for some reason we didn't want to inject to that GPS we should just alter the injection mask.

GSOF didn't use last_injected_data_ms anyways, I suspect it was incorrectly copied from SBP in the first place.

Also saves a grand total of 128 bytes :p