### PR TITLE
Copter: set EKF origin from first do-set-home command

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1176,10 +1176,8 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                if (!copter.far_from_EKF_origin(new_home_loc)) {
-                    if (copter.set_home_and_lock(new_home_loc)) {
-                        result = MAV_RESULT_ACCEPTED;
-                    }
+                if (copter.set_home_and_lock(new_home_loc)) {
+                    result = MAV_RESULT_ACCEPTED;
                 }
             }
             break;
@@ -2019,9 +2017,6 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             new_home_loc.lat = packet.latitude;
             new_home_loc.lng = packet.longitude;
             new_home_loc.alt = packet.altitude / 10;
-            if (copter.far_from_EKF_origin(new_home_loc)) {
-                break;
-            }
             copter.set_home_and_lock(new_home_loc);
         }
         break;

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -76,6 +76,18 @@ bool Copter::set_home(const Location& loc)
         return false;
     }
 
+    // set EKF origin to home if it hasn't been set yet and vehicle is disarmed
+    // this is required to allowing flying in AUTO and GUIDED with only an optical flow
+    Location ekf_origin;
+    if (!motors->armed() && !ahrs.get_origin(ekf_origin)) {
+        ahrs.set_origin(loc);
+    }
+
+    // check home is close to EKF origin
+    if (far_from_EKF_origin(loc)) {
+        return false;
+    }
+
     // set ahrs home (used for RTL)
     ahrs.set_home(loc);
 

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -1104,9 +1104,7 @@ void Copter::do_set_home(const AP_Mission::Mission_Command& cmd)
     if(cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
         set_home_to_current_location();
     } else {
-        if (!far_from_EKF_origin(cmd.content.location)) {
-            set_home(cmd.content.location);
-        }
+        set_home(cmd.content.location);
     }
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -441,6 +441,11 @@ public:
     // current barometer and GPS altitudes correspond to this altitude
     virtual void set_home(const Location &loc) = 0;
 
+    // set the EKF's origin location in 10e7 degrees.  This should only
+    // be called when the EKF has no absolute position reference (i.e. GPS)
+    // from which to decide the origin on its own
+    virtual bool set_origin(const Location &loc) { return false; }
+
     // return true if the AHRS object supports inertial navigation,
     // with very accurate position and velocity
     virtual bool have_inertial_nav(void) const {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -559,6 +559,27 @@ void AP_AHRS_NavEKF::set_home(const Location &loc)
     AP_AHRS_DCM::set_home(loc);
 }
 
+// set the EKF's origin location in 10e7 degrees.  This should only
+// be called when the EKF has no absolute position reference (i.e. GPS)
+// from which to decide the origin on its own
+bool AP_AHRS_NavEKF::set_origin(const Location &loc)
+{
+    bool ret2 = EKF2.setOriginLLH(loc);
+    bool ret3 = EKF3.setOriginLLH(loc);
+
+    // return success if active EKF's origin was set
+    switch (active_EKF_type()) {
+    case EKF_TYPE2:
+        return ret2;
+
+    case EKF_TYPE3:
+        return ret3;
+
+    default:
+        return false;
+    }
+}
+
 // return true if inertial navigation is active
 bool AP_AHRS_NavEKF::have_inertial_nav(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -124,6 +124,11 @@ public:
     // set home location
     void set_home(const Location &loc) override;
 
+    // set the EKF's origin location in 10e7 degrees.  This should only
+    // be called when the EKF has no absolute position reference (i.e. GPS)
+    // from which to decide the origin on its own
+    bool set_origin(const Location &loc) override;
+
     // returns the inertial navigation origin in lat/lon/alt
     bool get_origin(Location &ret) const;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -997,7 +997,7 @@ bool NavEKF2::getOriginLLH(struct Location &loc) const
 // All NED positions calculated by the filter will be relative to this location
 // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
 // Returns false if the filter has rejected the attempt to set the origin
-bool NavEKF2::setOriginLLH(struct Location &loc)
+bool NavEKF2::setOriginLLH(const Location &loc)
 {
     if (!core) {
         return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -165,7 +165,7 @@ public:
     // All NED positions calcualted by the filter will be relative to this location
     // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
     // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
+    bool setOriginLLH(const Location &loc);
 
     // return estimated height above ground level
     // return false if ground height is not being estimated.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -403,7 +403,7 @@ bool NavEKF2_core::assume_zero_sideslip(void) const
 }
 
 // set the LLH location of the filters NED origin
-bool NavEKF2_core::setOriginLLH(struct Location &loc)
+bool NavEKF2_core::setOriginLLH(const Location &loc)
 {
     if (PV_AidingMode == AID_ABSOLUTE) {
         return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -159,7 +159,7 @@ public:
     // All NED positions calcualted by the filter will be relative to this location
     // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
     // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
+    bool setOriginLLH(const Location &loc);
 
     // return estimated height above ground level
     // return false if ground height is not being estimated.

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1001,7 +1001,7 @@ bool NavEKF3::getOriginLLH(struct Location &loc) const
 // All NED positions calculated by the filter will be relative to this location
 // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
 // Returns false if the filter has rejected the attempt to set the origin
-bool NavEKF3::setOriginLLH(struct Location &loc)
+bool NavEKF3::setOriginLLH(const Location &loc)
 {
     if (!core) {
         return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -156,7 +156,7 @@ public:
     // All NED positions calcualted by the filter will be relative to this location
     // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
     // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
+    bool setOriginLLH(const Location &loc);
 
     // return estimated height above ground level
     // return false if ground height is not being estimated.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -431,7 +431,7 @@ bool NavEKF3_core::assume_zero_sideslip(void) const
 }
 
 // set the LLH location of the filters NED origin
-bool NavEKF3_core::setOriginLLH(struct Location &loc)
+bool NavEKF3_core::setOriginLLH(const Location &loc)
 {
     if (PV_AidingMode == AID_ABSOLUTE) {
         return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -165,7 +165,7 @@ public:
     // All NED positions calcualted by the filter will be relative to this location
     // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
     // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
+    bool setOriginLLH(const Location &loc);
 
     // return estimated height above ground level
     // return false if ground height is not being estimated.


### PR DESCRIPTION
This PR allows the EKF origin to be set from the first do-set-home command (received from the GCS) if it arrives before the EKF has set it's origin.

This is important for cases where the vehicle only has a relative velocity or position source like visual odometry or optical flow.  Without an origin, navigation commands that require an absolute position target (i.e. takeoff, waypoint, spline, etc) will fail.  This means that currently AUTO and GUIDED flight modes do not work with only visual odometry or optical flow. 

There's a little bit of unnecessary code in the AP_AHRS's set_origin call related to whether the method returns true or false.  In fact, we currently never use this return value anyway so we could remove this although I think what it returns is reasonable.