### PR TITLE
AP_Notify: Rework to allow selecting different devices at runtime take 2

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -130,11 +130,6 @@ void AP_Notify::init(bool enable_external_leds)
             boardled = new DiscreteRGBLed(4, 27, 6, false);
             break;
 
-#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
-        case Board_Type_BH:
-            boardled = new RCOutputRGBLed(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
-            break;
-
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
         case Board_Type_Disco:
             boardled = new DiscoLED();
@@ -158,9 +153,15 @@ void AP_Notify::init(bool enable_external_leds)
         case Board_Type_MinLure:
         case Board_Type_ERLEBrain2:
         case Board_Type_PXFMini:
-        case Board_Type_BH:
         case Board_Type_Disco:
             toshibaled = nullptr;
+            
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
+        case Board_Type_BH:
+            toshibaled = new RCOutputRGBLed(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
+            break;
+#endif
+
         default:
            toshibaled = new ToshibaLED_I2C();
            break;
@@ -217,7 +218,9 @@ void AP_Notify::init(bool enable_external_leds)
     switch (_board_type) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
         case Board_Type_Solo:
+#if !HAL_MINIMIZE_FEATURES
             oreoled = new OreoLED_PX4();
+#endif
             break;
 #endif
             

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -33,6 +33,7 @@
 #include "DiscoLED.h"
 #include <stdio.h>
 
+#define CONFIG_NOTIFY_DEVICES_COUNT 5
 
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Notify::var_info[] = {
@@ -65,6 +66,13 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DISPLAY_TYPE", 3, AP_Notify, _display_type, 0),
 
+    // @Param: BRD_TYPE
+    // @DisplayName: Board type for notify devices
+    // @Description: This sets up the notification devices based on board, Defaults to PX4
+    // @Values: 0:None,1:PX4,2:PX4_V4,3:Solo,4:VRBrain,5:VRBrain_45,6:Linux_Default,7:Navio,8:Navio3,9:BBBMini,10:Blue,11:RASPilot,12:MinLure,13:ERLEBrain2,14:PXFMini,15:BH,16:Disco
+    // @User: Advanced
+    AP_GROUPINFO("BRD_TYPE", 4, AP_Notify, _board_type, 1),
+
     AP_GROUPEND
 };
 
@@ -78,92 +86,154 @@ AP_Notify::AP_Notify()
 struct AP_Notify::notify_flags_and_values_type AP_Notify::flags;
 struct AP_Notify::notify_events_type AP_Notify::events;
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
-    PixRacerLED boardled;
-#else
-    AP_BoardLED boardled;
-#endif
-    ToshibaLED_I2C toshibaled;
-    Display display;
-
-#if AP_NOTIFY_SOLO_TONES == 1
-    ToneAlarm_PX4_Solo tonealarm;
-#else
-    ToneAlarm_PX4 tonealarm;
-#endif
-
-#if AP_NOTIFY_OREOLED == 1
-    OreoLED_PX4 oreoled;
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled, &display};
-#else
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &display};
-#endif
-
-#elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    ToneAlarm_PX4 tonealarm;
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_VRBRAIN_V45
-    AP_BoardLED boardled;
-#else
-    VRBoard_LED boardled;
-#endif
-    ToshibaLED_I2C toshibaled;
-    ExternalLED externalled;
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &externalled, &tonealarm};
-
-#elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
-        NavioLED_I2C navioled;
-        ToshibaLED_I2C toshibaled;
-        NotifyDevice *AP_Notify::_devices[] = {&navioled, &toshibaled};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
-        DiscreteRGBLed navioled(4, 27, 6, false);
-        ToshibaLED_I2C toshibaled;
-        NotifyDevice *AP_Notify::_devices[] = {&navioled, &toshibaled};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
-        AP_BoardLED boardled;
-        Buzzer buzzer;
-        Display display;
-        NotifyDevice *AP_Notify::_devices[] = {&boardled, &display, &buzzer};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BLUE
-        AP_BoardLED boardled;
-        NotifyDevice *AP_Notify::_devices[] = {&boardled};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
-        ToshibaLED_I2C toshibaled;
-        ToneAlarm_Linux tonealarm;
-        NotifyDevice *AP_Notify::_devices[] = {&toshibaled, &tonealarm};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE
-        RCOutputRGBLedOff led(15, 13, 14, 255);
-        NotifyDevice *AP_Notify::_devices[] = { &led };
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2 || \
-      CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXFMINI
-        AP_BoardLED boardled;
-        NotifyDevice *AP_Notify::_devices[] = {&boardled};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
-        AP_BoardLED boardled;
-        RCOutputRGBLed bhled(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
-        NotifyDevice *AP_Notify::_devices[] = {&boardled, &bhled};
-    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
-        DiscoLED discoled;
-        ToneAlarm_Linux tonealarm;
-        NotifyDevice *AP_Notify::_devices[] = {&discoled, &tonealarm};
-    #else
-        AP_BoardLED boardled;
-        ToshibaLED_I2C toshibaled;
-        ToneAlarm_Linux tonealarm;
-        NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm};
-    #endif
-#else
-    AP_BoardLED boardled;
-    ToshibaLED_I2C toshibaled;
-    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled};
-#endif
-
-#define CONFIG_NOTIFY_DEVICES_COUNT (ARRAY_SIZE(AP_Notify::_devices))
+NotifyDevice *AP_Notify::_devices[] = {nullptr, nullptr, nullptr, nullptr, nullptr};
 
 // initialisation
 void AP_Notify::init(bool enable_external_leds)
 {
+    // Select Board LED Type based on board
+    switch (_board_type) {
+        case Board_Type_PX4:
+        case Board_Type_Solo:
+        case Board_Type_VRBrain_45:
+        case Board_Type_Blue:
+        case Board_Type_ERLEBrain2:
+        case Board_Type_PXFMini:
+        case Board_Type_BH:
+        case Board_Type_BBBMini:
+            boardled = new AP_BoardLED();
+            break;
+            
+        
+        case Board_Type_RASPilot:
+            boardled = nullptr;
+            break;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+        case Board_Type_VRBrain:
+            boardled = new VRBoard_LED();
+            break;
+#endif
+            
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
+        case Board_Type_PX4_V4:
+            boardled = new PixRacerLED();
+            break;
+
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
+        case Board_Type_Navio:
+            boardled = new NavioLED_I2C();
+            break;
+
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
+        case Board_Type_Navio2:
+            boardled = new DiscreteRGBLed(4, 27, 6, false);
+            break;
+
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
+        case Board_Type_BH:
+            boardled = new RCOutputRGBLed(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
+            break;
+
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
+        case Board_Type_Disco:
+            boardled = new DiscoLED();
+            break;
+
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE
+        case Board_Type_MinLure:
+            boardled = new RCOutputRGBLedOff(15, 13, 14, 255);
+            break;
+#endif
+            
+        default:
+            boardled = new AP_BoardLED();
+            break;
+    }
+    
+    // Select Toshiba Led based on board
+    switch (_board_type) {
+        case Board_Type_BBBMini:
+        case Board_Type_Blue:
+        case Board_Type_MinLure:
+        case Board_Type_ERLEBrain2:
+        case Board_Type_PXFMini:
+        case Board_Type_BH:
+        case Board_Type_Disco:
+            toshibaled = nullptr;
+        default:
+           toshibaled = new ToshibaLED_I2C();
+           break;
+    }
+    
+    // Select Display based on board
+    switch (_board_type) {
+        case Board_Type_PX4:
+        case Board_Type_PX4_V4:
+        case Board_Type_Solo:
+        case Board_Type_BBBMini:
+            display = new Display();
+            break;
+        default:
+            display = nullptr;
+            break;
+    }
+
+    // Select Tone Alarm Type based on board
+    switch (_board_type) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+        case Board_Type_PX4:
+        case Board_Type_PX4_V4:
+        case Board_Type_VRBrain:
+        case Board_Type_VRBrain_45:
+            tonealarm = new ToneAlarm_PX4();
+            break;
+        case Board_Type_Solo:
+            tonealarm = new ToneAlarm_PX4_Solo();
+            break;
+#endif
+            
+        case Board_Type_BBBMini:
+            tonealarm = new Buzzer();
+            break;
+ 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+        case Board_Type_RASPilot:
+        case Board_Type_Disco:
+            tonealarm = new ToneAlarm_Linux();
+            break;
+#endif
+            
+        default:
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+            tonealarm = new ToneAlarm_Linux();
+#else
+            tonealarm = nullptr;
+#endif
+            break;
+    }
+
+    // Select Oreo Leds based on board
+    switch (_board_type) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+        case Board_Type_Solo:
+            oreoled = new OreoLED_PX4();
+            break;
+#endif
+            
+        default:
+            oreoled = nullptr;
+            break;
+    }
+
+    
+    _devices[0] = boardled;
+    _devices[1] = toshibaled;
+    _devices[2] = tonealarm;
+    _devices[3] = oreoled;
+    _devices[4] = display;
+    
+    
     // clear all flags and events
     memset(&AP_Notify::flags, 0, sizeof(AP_Notify::flags));
     memset(&AP_Notify::events, 0, sizeof(AP_Notify::events));
@@ -176,8 +246,10 @@ void AP_Notify::init(bool enable_external_leds)
     AP_Notify::flags.external_leds = enable_external_leds;
 
     for (uint8_t i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
-        _devices[i]->pNotify = this;
-        _devices[i]->init();
+        if (_devices[i] != nullptr) {
+            _devices[i]->pNotify = this;
+            _devices[i]->init();
+        }
     }
 }
 
@@ -185,7 +257,9 @@ void AP_Notify::init(bool enable_external_leds)
 void AP_Notify::update(void)
 {
     for (uint8_t i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
-        _devices[i]->update();
+        if (_devices[i] != nullptr) {
+            _devices[i]->update();
+        }
     }
 
     //reset the events
@@ -196,7 +270,9 @@ void AP_Notify::update(void)
 void AP_Notify::handle_led_control(mavlink_message_t *msg)
 {
     for (uint8_t i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
-        _devices[i]->handle_led_control(msg);
+        if (_devices[i] != nullptr) {
+            _devices[i]->handle_led_control(msg);
+        }
     }
 }
 
@@ -204,7 +280,9 @@ void AP_Notify::handle_led_control(mavlink_message_t *msg)
 void AP_Notify::handle_play_tune(mavlink_message_t *msg)
 {
     for (uint8_t i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
-        _devices[i]->handle_play_tune(msg);
+        if (_devices[i] != nullptr) {
+            _devices[i]->handle_play_tune(msg);
+        }
     }
 }
 

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -101,48 +101,48 @@ void AP_Notify::init(bool enable_external_leds)
         case Board_Type_PXFMini:
         case Board_Type_BH:
         case Board_Type_BBBMini:
-            boardled = new AP_BoardLED();
+            _devices[0] = new AP_BoardLED();
             break;
             
         
         case Board_Type_RASPilot:
-            boardled = nullptr;
+            _devices[0] = nullptr;
             break;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
         case Board_Type_VRBrain:
-            boardled = new VRBoard_LED();
+            _devices[0] = new VRBoard_LED();
             break;
 #endif
             
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
         case Board_Type_PX4_V4:
-            boardled = new PixRacerLED();
+            _devices[0] = new PixRacerLED();
             break;
 
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
         case Board_Type_Navio:
-            boardled = new NavioLED_I2C();
+            _devices[0] = new NavioLED_I2C();
             break;
 
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
         case Board_Type_Navio2:
-            boardled = new DiscreteRGBLed(4, 27, 6, false);
+            _devices[0] = new DiscreteRGBLed(4, 27, 6, false);
             break;
 
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
         case Board_Type_Disco:
-            boardled = new DiscoLED();
+            _devices[0] = new DiscoLED();
             break;
 
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE
         case Board_Type_MinLure:
-            boardled = new RCOutputRGBLedOff(15, 13, 14, 255);
+            _devices[0] = new RCOutputRGBLedOff(15, 13, 14, 255);
             break;
 #endif
             
         default:
-            boardled = new AP_BoardLED();
+            _devices[0] = new AP_BoardLED();
             break;
     }
     
@@ -154,16 +154,16 @@ void AP_Notify::init(bool enable_external_leds)
         case Board_Type_ERLEBrain2:
         case Board_Type_PXFMini:
         case Board_Type_Disco:
-            toshibaled = nullptr;
+            _devices[1] = nullptr;
             
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
         case Board_Type_BH:
-            toshibaled = new RCOutputRGBLed(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
+            _devices[1] = new RCOutputRGBLed(HAL_RCOUT_RGBLED_RED, HAL_RCOUT_RGBLED_GREEN, HAL_RCOUT_RGBLED_BLUE);
             break;
 #endif
 
         default:
-           toshibaled = new ToshibaLED_I2C();
+           _devices[1] = new ToshibaLED_I2C();
            break;
     }
     
@@ -173,10 +173,10 @@ void AP_Notify::init(bool enable_external_leds)
         case Board_Type_PX4_V4:
         case Board_Type_Solo:
         case Board_Type_BBBMini:
-            display = new Display();
+            _devices[4] = new Display();
             break;
         default:
-            display = nullptr;
+            _devices[4] = nullptr;
             break;
     }
 
@@ -187,29 +187,29 @@ void AP_Notify::init(bool enable_external_leds)
         case Board_Type_PX4_V4:
         case Board_Type_VRBrain:
         case Board_Type_VRBrain_45:
-            tonealarm = new ToneAlarm_PX4();
+            _devices[2] = new ToneAlarm_PX4();
             break;
         case Board_Type_Solo:
-            tonealarm = new ToneAlarm_PX4_Solo();
+            _devices[2] = new ToneAlarm_PX4_Solo();
             break;
 #endif
             
         case Board_Type_BBBMini:
-            tonealarm = new Buzzer();
+            _devices[2] = new Buzzer();
             break;
  
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
         case Board_Type_RASPilot:
         case Board_Type_Disco:
-            tonealarm = new ToneAlarm_Linux();
+            _devices[2] = new ToneAlarm_Linux();
             break;
 #endif
             
         default:
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-            tonealarm = new ToneAlarm_Linux();
+            _devices[2] = new ToneAlarm_Linux();
 #else
-            tonealarm = nullptr;
+            _devices[2] = nullptr;
 #endif
             break;
     }
@@ -219,24 +219,16 @@ void AP_Notify::init(bool enable_external_leds)
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
         case Board_Type_Solo:
 #if !HAL_MINIMIZE_FEATURES
-            oreoled = new OreoLED_PX4();
+            _devices[3] = new OreoLED_PX4();
 #endif
             break;
 #endif
             
         default:
-            oreoled = nullptr;
+            _devices[3] = nullptr;
             break;
     }
 
-    
-    _devices[0] = boardled;
-    _devices[1] = toshibaled;
-    _devices[2] = tonealarm;
-    _devices[3] = oreoled;
-    _devices[4] = display;
-    
-    
     // clear all flags and events
     memset(&AP_Notify::flags, 0, sizeof(AP_Notify::flags));
     memset(&AP_Notify::events, 0, sizeof(AP_Notify::events));

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -21,13 +21,13 @@
 #include "NotifyDevice.h"
 
 
-#ifndef AP_NOTIFY_OREOLED
-#define AP_NOTIFY_OREOLED 0
-#endif
+//#ifndef AP_NOTIFY_OREOLED
+//#define AP_NOTIFY_OREOLED 0
+//#endif
 
-#ifndef AP_NOTIFY_SOLO_TONES
-#define AP_NOTIFY_SOLO_TONES 0
-#endif
+//#ifndef AP_NOTIFY_SOLO_TONES
+//#define AP_NOTIFY_SOLO_TONES 0
+//#endif
 
 // Device parameters values
 #define RGB_LED_OFF     0
@@ -51,6 +51,28 @@ class AP_Notify
 public:
     // Constructor
     AP_Notify();
+    
+    // ToneAlarm types
+    enum ToneAlarm_Type {
+        Board_Type_NONE         = 0,
+        Board_Type_PX4          = 1,
+        Board_Type_PX4_V4       = 2,
+        Board_Type_Solo         = 3,
+        Board_Type_VRBrain      = 4,
+        Board_Type_VRBrain_45   = 5,
+        Board_Type_Linux_Default= 6,
+        Board_Type_Navio        = 7,
+        Board_Type_Navio2       = 8,
+        Board_Type_BBBMini      = 9,
+        Board_Type_Blue         = 10,
+        Board_Type_RASPilot     = 11,
+        Board_Type_MinLure      = 12,
+        Board_Type_ERLEBrain2   = 13,
+        Board_Type_PXFMini      = 14,
+        Board_Type_BH           = 15,
+        Board_Type_Disco        = 16,
+        Board_Type_EnumEnd      = 100
+    };
 
     /// notify_flags_type - bitmask of notification flags
     struct notify_flags_and_values_type {
@@ -138,10 +160,17 @@ private:
     AP_Int8 _rgb_led_override;
     AP_Int8 _buzzer_enable;
     AP_Int8 _display_type;
+    AP_Int8 _board_type;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed
     char _flight_mode_str[5];
+    
+    NotifyDevice* boardled;
+    NotifyDevice* toshibaled;
+    NotifyDevice* tonealarm;
+    NotifyDevice* oreoled;
+    NotifyDevice* display;
 
     static NotifyDevice* _devices[];
 };

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -20,15 +20,6 @@
 
 #include "NotifyDevice.h"
 
-
-//#ifndef AP_NOTIFY_OREOLED
-//#define AP_NOTIFY_OREOLED 0
-//#endif
-
-//#ifndef AP_NOTIFY_SOLO_TONES
-//#define AP_NOTIFY_SOLO_TONES 0
-//#endif
-
 // Device parameters values
 #define RGB_LED_OFF     0
 #define RGB_LED_LOW     1

--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -59,6 +59,7 @@ extern "C" int oreoled_main(int, char **);
 // init - initialised the device
 bool OreoLED_PX4::init()
 {
+/* This code is breaking master when the OreoLeds are enabled in PX4-V2 so I guesss no one uses it and its not needed?
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
     if (!AP_BoardConfig::px4_start_driver(oreoled_main, "oreoled", "start autoupdate")) {
         hal.console->printf("Unable to start oreoled driver\n");
@@ -67,7 +68,7 @@ bool OreoLED_PX4::init()
         hal.scheduler->delay(500);
     }
 #endif
-    
+*/
     // open the device
     _oreoled_fd = open(OREOLED0_DEVICE_PATH, O_RDWR);
     if (_oreoled_fd == -1) {

--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -59,7 +59,6 @@ extern "C" int oreoled_main(int, char **);
 // init - initialised the device
 bool OreoLED_PX4::init()
 {
-/* This code is breaking master when the OreoLeds are enabled in PX4-V2 so I guesss no one uses it and its not needed?
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
     if (!AP_BoardConfig::px4_start_driver(oreoled_main, "oreoled", "start autoupdate")) {
         hal.console->printf("Unable to start oreoled driver\n");
@@ -68,7 +67,7 @@ bool OreoLED_PX4::init()
         hal.scheduler->delay(500);
     }
 #endif
-*/
+    
     // open the device
     _oreoled_fd = open(OREOLED0_DEVICE_PATH, O_RDWR);
     if (_oreoled_fd == -1) {


### PR DESCRIPTION
This removes the #defines used at compile time and instead populates the _devices array at runtime based on parameter NTF_BRD_TYPE. 
Parameter BRD_TYPE from AP_BoardConfig cannot be used as it is not available on all boards and does not have all boards available.(excluded on Linux Builds)

This is related to issue #5989, and #5986