### PR TITLE
AP_BattMonitor: SMBus: Fetch serial numbers and pack capacity

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -180,25 +180,25 @@ AP_BattMonitor::init()
             case BattMonitor_TYPE_ANALOG_VOLTAGE_ONLY:
             case BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT:
                 state[instance].instance = instance;
-                drivers[instance] = new AP_BattMonitor_Analog(*this, instance, state[instance]);
+                drivers[instance] = new AP_BattMonitor_Analog(*this, state[instance]);
                 _num_instances++;
                 break;
             case BattMonitor_TYPE_SOLO:
                 state[instance].instance = instance;
-                drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, instance, state[instance],
+                drivers[instance] = new AP_BattMonitor_SMBus_Solo(*this, state[instance],
                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_INTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR));
                 _num_instances++;
                 break;
             case BattMonitor_TYPE_MAXELL:
                 state[instance].instance = instance;
-                drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, instance, state[instance],
+                drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance],
                                                                  hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR));
                 _num_instances++;
                 break;
             case BattMonitor_TYPE_BEBOP:
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
                 state[instance].instance = instance;
-                drivers[instance] = new AP_BattMonitor_Bebop(*this, instance, state[instance]);
+                drivers[instance] = new AP_BattMonitor_Bebop(*this, state[instance]);
                 _num_instances++;
 #endif
                 break;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -68,7 +68,11 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     AP_GROUPINFO("_WATT_MAX", 9, AP_BattMonitor, _watt_max[0], AP_BATT_MAX_WATT_DEFAULT),
 #endif
 
-    // 10 is left for future expansion
+    // @Param: _SERIAL_NUM
+    // @DisplayName: Battery serial number
+    // @Description: Battery serial number, automatically filled in for SMBus batteries, otherwise will be -1
+    // @User: Advanced
+    AP_GROUPINFO("_SERIAL_NUM", 10, AP_BattMonitor, _serial_numbers[0], AP_BATT_SERIAL_NUMBER_DEFAULT),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
     // @Param: 2_MONITOR
@@ -130,6 +134,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("2_WATT_MAX", 18, AP_BattMonitor, _watt_max[1], AP_BATT_MAX_WATT_DEFAULT),
 #endif
+
+    // @Param: 2_SERIAL_NUM
+    // @DisplayName: Battery serial number
+    // @Description: Battery serial number, automatically filled in for SMBus batteries, otherwise will be -1
+    // @User: Advanced
+    AP_GROUPINFO("2_SERIAL_NUM", 20, AP_BattMonitor, _serial_numbers[1], AP_BATT_SERIAL_NUMBER_DEFAULT),
 
 #endif // AP_BATT_MONITOR_MAX_INSTANCES > 1
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -14,6 +14,7 @@
 #define AP_BATT_CAPACITY_DEFAULT            3300
 #define AP_BATT_LOW_VOLT_TIMEOUT_MS         10000   // low voltage of 10 seconds will cause battery_exhausted to return true
 #define AP_BATT_MAX_WATT_DEFAULT            0
+#define AP_BATT_SERIAL_NUMBER_DEFAULT       -1
 
 #define AP_BATT_MONITOR_TIMEOUT             5000
 
@@ -147,6 +148,7 @@ protected:
     AP_Float    _curr_amp_offset[AP_BATT_MONITOR_MAX_INSTANCES];    /// offset voltage that is subtracted from current pin before conversion to amps
     AP_Int32    _pack_capacity[AP_BATT_MONITOR_MAX_INSTANCES];      /// battery pack capacity less reserve in mAh
     AP_Int16    _watt_max[AP_BATT_MONITOR_MAX_INSTANCES];           /// max battery power allowed. Reduce max throttle to reduce current to satisfy this limit
+    AP_Int32    _serial_numbers[AP_BATT_MONITOR_MAX_INSTANCES];     /// battery serial number, automatically filled in on SMBus batteries
 
 private:
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -7,11 +7,11 @@
 extern const AP_HAL::HAL& hal;
 
 /// Constructor
-AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state) :
-    AP_BattMonitor_Backend(mon, instance, mon_state)
+AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state) :
+    AP_BattMonitor_Backend(mon, mon_state)
 {
-    _volt_pin_analog_source = hal.analogin->channel(mon._volt_pin[instance]);
-    _curr_pin_analog_source = hal.analogin->channel(mon._curr_pin[instance]);
+    _volt_pin_analog_source = hal.analogin->channel(mon._volt_pin[_state.instance]);
+    _curr_pin_analog_source = hal.analogin->channel(mon._curr_pin[_state.instance]);
 
     // always healthy
     _state.healthy = true;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -82,7 +82,7 @@ class AP_BattMonitor_Analog : public AP_BattMonitor_Backend
 public:
 
     /// Constructor
-    AP_BattMonitor_Analog(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state);
+    AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state);
 
     /// Read the battery voltage and current.  Should be called at 10hz
     void read();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -22,10 +22,9 @@
   base class constructor.
   This incorporates initialisation as well.
 */
-AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state) :
+AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state) :
         _mon(mon),
-        _state(mon_state),
-        _instance(instance)
+        _state(mon_state)
 {
 }
 
@@ -43,11 +42,11 @@ uint8_t AP_BattMonitor_Backend::capacity_remaining_pct() const
 /// set capacity for this instance
 void AP_BattMonitor_Backend::set_capacity(uint32_t capacity)
 {
-    _mon._pack_capacity[_instance] = capacity;
+    _mon._pack_capacity[_state.instance] = capacity;
 }
 
 /// get capacity for this instance
 int32_t AP_BattMonitor_Backend::get_capacity() const
 {
-    return _mon.pack_capacity_mah(_instance);
+    return _mon.pack_capacity_mah(_state.instance);
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -39,12 +39,6 @@ uint8_t AP_BattMonitor_Backend::capacity_remaining_pct() const
     }
 }
 
-/// set capacity for this instance
-void AP_BattMonitor_Backend::set_capacity(uint32_t capacity)
-{
-    _mon._pack_capacity[_state.instance] = capacity;
-}
-
 /// get capacity for this instance
 int32_t AP_BattMonitor_Backend::get_capacity() const
 {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -37,9 +37,6 @@ public:
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const;
 
-    /// set capacity for this instance
-    void set_capacity(uint32_t capacity);
-    
     /// get capacity for this instance
     int32_t get_capacity() const;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -22,7 +22,7 @@ class AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_Backend(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state);
+    AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state);
 
     // we declare a virtual destructor so that BattMonitor driver can
     // override with a custom destructor if need be
@@ -46,5 +46,4 @@ public:
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)
-    uint8_t                              _instance; // this instance
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
@@ -22,8 +22,8 @@ class AP_BattMonitor_Bebop :public AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_Bebop(AP_BattMonitor &mon, uint8_t instance, AP_BattMonitor::BattMonitor_State &mon_state):
-        AP_BattMonitor_Backend(mon, instance, mon_state),
+    AP_BattMonitor_Bebop(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state):
+        AP_BattMonitor_Backend(mon, mon_state),
         _prev_vbat_raw(0.0f),
         _prev_vbat(0.0f),
         _battery_voltage_max(0.0f)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -10,7 +10,8 @@ AP_BattMonitor_SMBus::AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                                            AP_BattMonitor::BattMonitor_State &mon_state,
                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
         : AP_BattMonitor_Backend(mon, mon_state),
-        _dev(std::move(dev))
+        _dev(std::move(dev)),
+        _serial_number(-1)
 {
     _mon._serial_numbers[_state.instance] = AP_BATT_SERIAL_NUMBER_DEFAULT;
     _mon._pack_capacity[_state.instance] = 0;
@@ -66,7 +67,7 @@ bool AP_BattMonitor_SMBus::read_serial_number(void) {
     uint16_t data;
 
     // don't recheck the serial number if we already have it
-    if (_serial_number != 0) {
+    if (_serial_number != -1) {
         return true;
     } else if (read_word(BATTMONITOR_SMBUS_SERIAL, data)) {
         _serial_number = data;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -28,6 +28,10 @@ protected:
 
     void read(void) override;
 
+    // reads the pack full charge capacity
+    // returns true if the read was successful, or if we already knew the pack capacity
+    bool read_full_charge_capacity(void);
+
     // reads the temperature word from the battery
     // returns true if the read was successful
     bool read_temp(void);
@@ -48,6 +52,7 @@ protected:
     bool _pec_supported; // true if PEC is supported
 
     uint16_t _serial_number;        // battery serial number
+    uint16_t _full_charge_capacity; // full charge capacity, used to stash the value before setting the parameter
 
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -51,7 +51,7 @@ protected:
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
     bool _pec_supported; // true if PEC is supported
 
-    uint16_t _serial_number;        // battery serial number
+    int32_t _serial_number;         // battery serial number
     uint16_t _full_charge_capacity; // full charge capacity, used to stash the value before setting the parameter
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -18,10 +18,7 @@ public:
     /// Constructor
     AP_BattMonitor_SMBus(AP_BattMonitor &mon, uint8_t instance,
                     AP_BattMonitor::BattMonitor_State &mon_state,
-                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-        : AP_BattMonitor_Backend(mon, instance, mon_state),
-          _dev(std::move(dev))
-    {}
+                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // virtual destructor to reduce compiler warnings
     virtual ~AP_BattMonitor_SMBus() {}
@@ -29,9 +26,15 @@ public:
 
 protected:
 
+    void read(void) override;
+
     // reads the temperature word from the battery
     // returns true if the read was successful
     bool read_temp(void);
+
+    // reads the serial number if it's not already known
+    // returns true if the read was successful, or the number was already known
+    bool read_serial_number(void);
 
      // read word from register
      // returns true if read was successful, false if failed
@@ -43,6 +46,8 @@ protected:
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
     bool _pec_supported; // true if PEC is supported
+
+    uint16_t _serial_number;        // battery serial number
 
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -16,7 +16,7 @@ class AP_BattMonitor_SMBus : public AP_BattMonitor_Backend
 public:
 
     /// Constructor
-    AP_BattMonitor_SMBus(AP_BattMonitor &mon, uint8_t instance,
+    AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                     AP_BattMonitor::BattMonitor_State &mon_state,
                     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -82,6 +82,8 @@ void AP_BattMonitor_SMBus_Maxell::timer()
         _state.last_time_micros = tnow;
     }
 
+    read_full_charge_capacity();
+
     read_temp();
 
     read_serial_number();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -44,12 +44,6 @@ AP_BattMonitor_SMBus_Maxell::AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon, ui
     _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Maxell::timer, void));
 }
 
-/// Read the battery voltage and current.  Should be called at 10hz
-void AP_BattMonitor_SMBus_Maxell::read()
-{
-    // nothing to do - all done in timer()
-}
-
 void AP_BattMonitor_SMBus_Maxell::timer()
 {
 	// check if PEC is supported
@@ -89,6 +83,8 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     }
 
     read_temp();
+
+    read_serial_number();
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -36,10 +36,10 @@ uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
 */
 
 // Constructor
-AP_BattMonitor_SMBus_Maxell::AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon, uint8_t instance,
+AP_BattMonitor_SMBus_Maxell::AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
                                                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, instance, mon_state, std::move(dev))
+    : AP_BattMonitor_SMBus(mon, mon_state, std::move(dev))
 {
     _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Maxell::timer, void));
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
@@ -11,7 +11,7 @@ class AP_BattMonitor_SMBus_Maxell : public AP_BattMonitor_SMBus
 public:
 
     // Constructor
-    AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon, uint8_t instance,
+    AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
@@ -15,9 +15,6 @@ public:
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
-    // read does nothing, all done in timer
-    void read() override;
-
 private:
 
     void timer(void);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -38,12 +38,6 @@ AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon, uint8_
     _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Solo::timer, void));
 }
 
-/// Read the battery voltage and current.  Should be called at 10hz
-void AP_BattMonitor_SMBus_Solo::read()
-{
-    // nothing to do - all done in timer()
-}
-
 void AP_BattMonitor_SMBus_Solo::timer()
 {
     uint16_t data;
@@ -118,6 +112,8 @@ void AP_BattMonitor_SMBus_Solo::timer()
     }
 
     read_temp();
+
+    read_serial_number();
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -29,10 +29,10 @@
  */
 
 // Constructor
-AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon, uint8_t instance,
+AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
                                                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, instance, mon_state, std::move(dev))
+    : AP_BattMonitor_SMBus(mon, mon_state, std::move(dev))
 {
     _pec_supported = true;
     _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_SMBus_Solo::timer, void));

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
@@ -15,9 +15,6 @@ public:
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
-    // read does nothing, all done in timer
-    void read() override;
-
 private:
 
     void timer(void);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
@@ -11,7 +11,7 @@ class AP_BattMonitor_SMBus_Solo : public AP_BattMonitor_SMBus
 public:
 
     // Constructor
-    AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon, uint8_t instance,
+    AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 


### PR DESCRIPTION
This is another round of SMBus enhancements. The first one is that we now read the battery serial number, and stash it in a parameter to notify the user. (I didn't see any other convenient way to transport and log the value, and it's the same behavior we already do for capacity). We can't set_and_notify on a parameter from an timer context so the value is first stashed in the backend before being sent out.

The second commit is simply a cleanup I noticed while making the first change set. We kept a direct reference to the instance of the driver in the backend, but also stored the reference within the battery state object. It didn't make sense to have both references, I flipped a coin and the _state.instance got to live (although I could be convinced that having the instance reference live outside the state block might make more sense) :)

Finally I moved the fetching of full charge capacity into a common helper and leverage it within the Maxell driver as well. This is also an attempt to correct an outstanding bug on ArduPilot master with Solo batteries where we don't actually fetch the full charge capacity correctly. (Related to the fact that the default parameter value meant we never attempted to update the parameter).

The initial serial number pass was tested by @Pedals2Paddles, but some of the fetching of it was reworked, as well as the patches to correct full charge capacity. Those both need to be tested on a Solo before this can be merged. Whoever I can coerce into testing I'd really like to see a DF log as well that is done with LOG_DISARMED 1.