### PR TITLE
AP_Notify & AP_AHRS: Creates GPS Fusion Notify Flag

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -192,6 +192,9 @@ void AP_AHRS_NavEKF::update_EKF2(void)
                 }
             }
             _accel_ef_ekf_blended = _accel_ef_ekf[primary_imu>=0?primary_imu:_ins.get_primary_accel()];
+            nav_filter_status filt_state;
+            EKF2.getFilterStatus(-1,filt_state);
+            AP_Notify::flags.gps_fusion = filt_state.flags.using_gps; // Drives AP_Notify flag for usable GPS.
         }
     }
 }
@@ -260,6 +263,9 @@ void AP_AHRS_NavEKF::update_EKF3(void)
                 }
             }
             _accel_ef_ekf_blended = _accel_ef_ekf[_ins.get_primary_accel()];
+            nav_filter_status filt_state;
+            EKF3.getFilterStatus(-1,filt_state);
+            AP_Notify::flags.gps_fusion = filt_state.flags.using_gps; // Drives AP_Notify flag for usable GPS.
         }
     }
 }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -72,6 +72,7 @@ public:
         uint32_t compass_cal_running: 1;    // 1 if a compass calibration is running
         uint32_t leak_detected      : 1;    // 1 if leak detected
         float    battery_voltage       ;    // battery voltage
+        uint32_t gps_fusion         : 1;    // 0 = GPS fix rejected by EKF, not usable for flight. 1 = GPS in use by EKF, usable for flight
 
         // additional flags
         uint32_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)


### PR DESCRIPTION
This creates a new AP_Notify flag called `gps_fusion`.  Currently, the
only flags related to GPS are what type of lock the GPS has. Whether the
EKF finds the fix to be useful or not is a totally different matter. You
can have a 3D lock, and the EKF still won't use the position due to
drift. So this flag indicates whether the GPS position is actually
usable and in use by the EKF.  `gps_fusion` will be true when the GPS is
usable, and false when it is not usable.  This will provide feedback to
the user through the GCS that they did not previously have.

In practice, I am now using this on my Solo and it's working nicely. I
have it turn the rear LEDs yellow when the GPS is not usable, and also
sound a loud tone.  This provides the operator with visual and audible
feedback of system status. The GCS can easily make use of this flag for
a warning too.