### PR TITLE
AP_HAL_PX4: fix UAVCAN armed state to depend on safety switch

### DIFF
--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -495,8 +495,7 @@ void PX4RCOutput::_send_outputs(void)
                             ap_uc->rco_write(_period[i], i);
                         }
 
-                        bool armed = hal.util->get_soft_armed();
-                        if (armed) {
+                        if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
                             ap_uc->rco_arm_actuators(true);
                         } else {
                             ap_uc->rco_arm_actuators(false);


### PR DESCRIPTION
This commit was originally in #6070, but I removed it so that PR can go in and discussion can continue here.