### PR TITLE
EKF: Improve recovery from badly conditioned covariance matrix

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -708,6 +708,7 @@ void NavEKF2_core::FuseMagnetometer()
             faultStatus.bad_zmag = true;
         }
         CovarianceInit();
+        hal.util->perf_end(_perf_test[5]);
         return;
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -707,6 +707,8 @@ void NavEKF2_core::FuseMagnetometer()
         } else if (obsIndex == 2) {
             faultStatus.bad_zmag = true;
         }
+        CovarianceInit();
+        return;
     }
 
     hal.util->perf_end(_perf_test[5]);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -695,6 +695,8 @@ void NavEKF3_core::FuseMagnetometer()
             } else if (obsIndex == 2) {
                 faultStatus.bad_zmag = true;
             }
+            CovarianceInit();
+            return;
         }
     }
 }


### PR DESCRIPTION
If the magnetometer fusion will increase state variances then the covariance matrix is badly conditioned and must be reset.