### PR TITLE
Plane: don't check usb connection on battery failsafe

### DIFF
--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -118,8 +118,7 @@ void Plane::read_battery(void)
     battery.read();
     compass.set_current(battery.current_amps());
 
-    if (!usb_connected && 
-        hal.util->get_soft_armed() &&
+    if (hal.util->get_soft_armed() &&
         battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah)) {
         low_battery_event();
     }


### PR DESCRIPTION
We are already checking if we are armed, which is sufficient for normal
bench test usage. The USB check is preventing some users who are
connecting USB for companion computers from using battery failsafe.