### PR TITLE
Copter: reduce porpoising in Auto and Guided when speed is set too high

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -485,7 +485,7 @@
 // Velocity (horizontal) gains
 //
 #ifndef VEL_XY_P
- # define VEL_XY_P              1.0f
+ # define VEL_XY_P              1.8f
 #endif
 #ifndef VEL_XY_I
  # define VEL_XY_I              0.5f

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -115,7 +115,7 @@ private:
     AC_P                    p_alt_hold{1};
     AC_P                    p_vel_z{5};
     AC_PID                  pid_accel_z{0.3, 1, 0, 800, 10, 0.02};
-    AC_PI_2D                pi_vel_xy{0.7, 0.35, 1000, 5, 0.02};
+    AC_PI_2D                pi_vel_xy{1.26, 0.35, 1000, 5, 0.02};
 
     AP_Int8 frame_class;
     AP_Int8 frame_type;

--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -265,7 +265,7 @@
 // Velocity (horizontal) gains
 //
 #ifndef VEL_XY_P
-# define VEL_XY_P              1.0f
+# define VEL_XY_P              1.8f
 #endif
 #ifndef VEL_XY_I
 # define VEL_XY_I              0.5f

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -888,13 +888,6 @@ void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
 {
     Vector2f vel_xy_p, vel_xy_i;
 
-    // reset last velocity target to current target
-    if (_flags.reset_rate_to_accel_xy) {
-        _vel_last.x = _vel_target.x;
-        _vel_last.y = _vel_target.y;
-        _flags.reset_rate_to_accel_xy = false;
-    }
-
     // check if vehicle velocity is being overridden
     if (_flags.vehicle_horiz_vel_override) {
         _flags.vehicle_horiz_vel_override = false;
@@ -903,11 +896,18 @@ void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
         _vehicle_horiz_vel.y = _inav.get_velocity().y;
     }
 
+    // reset last velocity target to current target
+    if (_flags.reset_rate_to_accel_xy) {
+        _vel_last.x = _vel_desired.x;
+        _vel_last.y = _vel_desired.y;
+        _flags.reset_rate_to_accel_xy = false;
+    }
+
     // feed forward desired acceleration calculation
     if (dt > 0.0f) {
     	if (!_flags.freeze_ff_xy) {
-    		_accel_feedforward.x = (_vel_target.x - _vel_last.x)/dt;
-    		_accel_feedforward.y = (_vel_target.y - _vel_last.y)/dt;
+    	    _accel_feedforward.x = (_vel_desired.x - _vel_last.x)/dt;
+    	    _accel_feedforward.y = (_vel_desired.y - _vel_last.y)/dt;
         } else {
     		// stop the feed forward being calculated during a known discontinuity
     		_flags.freeze_ff_xy = false;
@@ -918,8 +918,8 @@ void AC_PosControl::rate_to_accel_xy(float dt, float ekfNavVelGainScaler)
     }
 
     // store this iteration's velocities for the next iteration
-    _vel_last.x = _vel_target.x;
-    _vel_last.y = _vel_target.y;
+    _vel_last.x = _vel_desired.x;
+    _vel_last.y = _vel_desired.y;
 
     // calculate velocity error
     _vel_error.x = _vel_target.x - _vehicle_horiz_vel.x;

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -370,7 +370,7 @@ void AC_WPNav::update_brake(float ekfGndSpdLimit, float ekfNavVelGainScaler)
 
         // send adjusted feed forward velocity back to position controller
         _pos_control.set_desired_velocity_xy(0,0);
-        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_LIMITED_AND_VEL_FF, ekfNavVelGainScaler, false);
+        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_LIMITED_AND_VEL_FF, ekfNavVelGainScaler, true);
     }
 }
 
@@ -766,7 +766,7 @@ bool AC_WPNav::update_wpnav()
         }
         _pos_control.freeze_ff_z();
 
-        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, false);
+        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, true);
         check_wp_leash_length();
 
         _wp_last_update = AP_HAL::millis();
@@ -1059,7 +1059,7 @@ bool AC_WPNav::update_spline()
         _pos_control.freeze_ff_z();
 
         // run horizontal position controller
-        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, false);
+        _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, true);
 
         _wp_last_update = AP_HAL::millis();
     }


### PR DESCRIPTION
This PR does two things to reduce porpoising:

- turns on the lean angle limiting in brake, spline and straight waypoint modes
- horizontal acceleration feedforward uses the change in desired velocity instead of the change in the complete target velocity.  This softens the response to disturbances while maintaining the responsiveness to requested velocity changes.

The work is mostly by Leonard with me helping with integration and testing.

I need to perform a bit more testing especially in Loiter and with Guided's velocity controller