### PR TITLE
Copter: resolve turn-too-early issue with waypoint commands

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -39,6 +39,7 @@
 #define WPNAV_LOITER_ACTIVE_TIMEOUT_MS     200      // loiter controller is considered active if it has been called within the past 200ms (0.2 seconds)
 
 #define WPNAV_YAW_DIST_MIN                 200      // minimum track length which will lead to target yaw being updated to point at next waypoint.  Under this distance the yaw target will be frozen at the current heading
+#define WPNAV_YAW_LEASH_PCT_MIN         0.134f      // target point must be at least this distance from the vehicle (expressed as a percentage of the maximum distance it can be from the vehicle - i.e. the leash length)
 
 #define WPNAV_RANGEFINDER_FILT_Z         0.25f      // range finder distance filtered at 0.25hz
 
@@ -210,8 +211,8 @@ public:
     // straight-fast - next segment is straight, vehicle's destination velocity should be directly along track from this segment's destination to next segment's destination
     // spline-fast - next segment is spline, vehicle's destination velocity should be parallel to position difference vector from previous segment's origin to this segment's destination
 
-    // get_yaw - returns target yaw in centi-degrees (used for wp and spline navigation)
-    float get_yaw() const { return _yaw; }
+    // get target yaw in centi-degrees (used for wp and spline navigation)
+    float get_yaw() const;
 
     /// set_spline_destination waypoint using location class
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated
@@ -278,6 +279,7 @@ protected:
         uint8_t recalc_wp_leash         : 1;    // true if we need to recalculate the leash lengths because of changes in speed or acceleration
         uint8_t new_wp_destination      : 1;    // true if we have just received a new destination.  allows us to freeze the position controller's xy feed forward
         SegmentType segment_type        : 1;    // active segment is either straight or spline
+        uint8_t wp_yaw_set              : 1;    // true if yaw target has been set
     } _flags;
 
     /// calc_loiter_desired_velocity - updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance
@@ -309,6 +311,9 @@ protected:
     // convert location to vector from ekf origin.  terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
     //      returns false if conversion failed (likely because terrain data was not available)
     bool get_vector_NEU(const Location_Class &loc, Vector3f &vec, bool &terrain_alt);
+
+    // set heading used for spline and waypoint navigation
+    void set_yaw_cd(float heading_cd);
 
     // references and pointers to external libraries
     const AP_InertialNav&   _inav;
@@ -342,6 +347,7 @@ protected:
     Vector3f    _destination;           // target destination in cm from home (equivalent to next_WP)
     Vector3f    _pos_delta_unit;        // each axis's percentage of the total track from origin to destination
     float       _track_length;          // distance in cm between origin and destination
+    float       _track_length_xy;       // horizontal distance in cm between origin and destination
     float       _track_desired;         // our desired distance along the track in cm
     float       _limited_speed_xy_cms;  // horizontal speed in cm/s used to advance the intermediate target towards the destination.  used to limit extreme acceleration after passing a waypoint
     float       _track_accel;           // acceleration along track


### PR DESCRIPTION
This resolves the long standing issue (#932) in which the vehicle turns to the next waypoint before it reaches the current waypoint.  This is accomplished by pointing the vehicle at the target point that it chases while moving along the line segment.

Because the direction to the target point can change a lot when it's close to the vehicle we only point at the target point if:

- the length of the waypoint line segment (i.e. distance from origin to destination) is at least 2m
- the distance from the vehicle to the target point is at least 2m
- the distance from the vehicle to the target point is at least 13.4% of the maximum leash length (i.e. if the target point is allowed to be 10m ahead of the vehicle, we don't turn towards the target point until it is 1.34m from the vehicle)
- the leash's maximum length is at least 2m (if it's very short it means the vehicle will be moving very slowly)

If some of the above conditions are not met, we fall back to the previous method which was:

- for straight line waypoint commands, use the heading from origin to destination
- for spline commands use the velocity vector from the spline calculator

Resolves issue #932 

This was a combined effort from @lthall and I.