### PR TITLE
Delay disable of safety switch to end of startup

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -217,6 +217,9 @@ void Rover::init_ardupilot()
     // set the correct flight mode
     // ---------------------------
     reset_control_switch();
+
+    // disable safety if requested
+    BoardConfig.init_safety();
 }
 
 //*********************************************************************************

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -120,6 +120,8 @@ void Tracker::init_tracker()
         prepare_servos();
     }
 
+    // disable safety if requested
+    BoardConfig.init_safety();    
 }
 
 // updates the status of the notify objects

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -316,6 +316,9 @@ void Copter::init_ardupilot()
         enable_motor_output();
     }
 
+    // disable safety if requested
+    BoardConfig.init_safety();    
+
     cliSerial->printf("\nReady to FLY ");
 
     // flag that initialisation has completed

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -261,6 +261,8 @@ void Plane::init_ardupilot()
     }
 #endif
 
+    // disable safety if requested
+    BoardConfig.init_safety();
 }
 
 //********************************************************************************

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -185,6 +185,9 @@ void Sub::init_ardupilot()
         start_logging(); // create a new log if necessary
     }
 
+    // disable safety if requested
+    BoardConfig.init_safety();    
+    
     hal.console->print("\nInit complete");
 
     // flag that initialisation has completed

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -213,3 +213,10 @@ void AP_BoardConfig::set_default_safety_ignore_mask(uint16_t mask)
     px4_setup_safety_mask();
 #endif
 }
+
+void AP_BoardConfig::init_safety()
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+    px4_init_safety();
+#endif
+}

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -16,6 +16,7 @@ public:
     };
 
     void init(void);
+    void init_safety(void);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -128,7 +129,7 @@ private:
     void px4_drivers_start(void);
     void px4_setup(void);
     void px4_setup_pwm(void);
-    void px4_setup_safety(void);
+    void px4_init_safety(void);
     void px4_setup_safety_mask(void);
     void px4_setup_uart(void);
     void px4_setup_sbus(void);

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -145,12 +145,10 @@ void AP_BoardConfig::px4_setup_safety_mask()
 }
 
 /*
-  setup safety switch
+  init safety state
  */
-void AP_BoardConfig::px4_setup_safety()
+void AP_BoardConfig::px4_init_safety()
 {
-    px4_setup_safety_mask();
-
     if (px4.safety_enable.get() == 0) {
         hal.rcout->force_safety_off();
         hal.rcout->force_safety_no_wait();
@@ -533,7 +531,7 @@ void AP_BoardConfig::px4_setup()
 {
     px4_setup_peripherals();
     px4_setup_pwm();
-    px4_setup_safety();
+    px4_setup_safety_mask();
     px4_setup_uart();
     px4_setup_sbus();
     px4_setup_drivers();


### PR DESCRIPTION
This fixes a problem on quadplanes where a software reboot over MAVLink could cause the motors to spin if BRD_SAFETEENABLE is set to zero.
The fix is to move the disabling of the safety switch until we have completed initialising all outputs
