### PR TITLE
Improved INS timing

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -300,25 +300,28 @@ void AP_AHRS_NavEKF::update_SITL(void)
         _accel_ef_ekf_blended = _accel_ef_ekf[0];
 
     }
-    // use SITL states to write body frame odometry data at 20Hz
-    uint32_t timeStamp_ms = AP_HAL::millis();
-    if (timeStamp_ms - _last_body_odm_update_ms > 50) {
-        const float quality = 100.0f;
-        const Vector3f posOffset = Vector3f(0.0f,0.0f,0.0f);
-        float delTime = 0.001f*(timeStamp_ms - _last_body_odm_update_ms);
-        _last_body_odm_update_ms = timeStamp_ms;
-        timeStamp_ms -= (timeStamp_ms - _last_body_odm_update_ms)/2; // correct for first order hold average delay
-        Vector3f delAng = Vector3f(radians(fdm.rollRate),
-                                   radians(fdm.pitchRate),
-                                   radians(fdm.yawRate));
-        delAng *= delTime;
-        // rotate earth velocity into body frame and calculate delta position
-        Matrix3f Tbn;
-        Tbn.from_euler(radians(fdm.rollDeg),radians(fdm.pitchDeg),radians(fdm.yawDeg));
-        Vector3f earth_vel = Vector3f(fdm.speedN,fdm.speedE,fdm.speedD);
-        Vector3f delPos = Tbn.transposed() * (earth_vel * delTime);
-        // write to EKF
-        EKF3.writeBodyFrameOdom(quality, delPos, delAng, delTime, timeStamp_ms, posOffset);
+
+    if (_sitl->odom_enable) {
+        // use SITL states to write body frame odometry data at 20Hz
+        uint32_t timeStamp_ms = AP_HAL::millis();
+        if (timeStamp_ms - _last_body_odm_update_ms > 50) {
+            const float quality = 100.0f;
+            const Vector3f posOffset = Vector3f(0.0f,0.0f,0.0f);
+            float delTime = 0.001f*(timeStamp_ms - _last_body_odm_update_ms);
+            _last_body_odm_update_ms = timeStamp_ms;
+            timeStamp_ms -= (timeStamp_ms - _last_body_odm_update_ms)/2; // correct for first order hold average delay
+            Vector3f delAng = Vector3f(radians(fdm.rollRate),
+                                       radians(fdm.pitchRate),
+                                       radians(fdm.yawRate));
+            delAng *= delTime;
+            // rotate earth velocity into body frame and calculate delta position
+            Matrix3f Tbn;
+            Tbn.from_euler(radians(fdm.rollDeg),radians(fdm.pitchDeg),radians(fdm.yawDeg));
+            Vector3f earth_vel = Vector3f(fdm.speedN,fdm.speedE,fdm.speedD);
+            Vector3f delPos = Tbn.transposed() * (earth_vel * delTime);
+            // write to EKF
+            EKF3.writeBodyFrameOdom(quality, delPos, delAng, delTime, timeStamp_ms, posOffset);
+        }
     }
 }
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -512,6 +512,7 @@ uint8_t AP_InertialSensor::register_gyro(uint16_t raw_sample_rate_hz,
     }
 
     _gyro_raw_sample_rates[_gyro_count] = raw_sample_rate_hz;
+    _gyro_over_sampling[_gyro_count] = 1;
 
     bool saved = _gyro_id[_gyro_count].load();
 
@@ -544,6 +545,8 @@ uint8_t AP_InertialSensor::register_accel(uint16_t raw_sample_rate_hz,
     }
 
     _accel_raw_sample_rates[_accel_count] = raw_sample_rate_hz;
+    _accel_over_sampling[_accel_count] = 1;
+
     bool saved = _accel_id[_accel_count].load();
 
     if (!saved) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -133,6 +133,10 @@ public:
     bool accel_calibrated_ok_all() const;
     bool use_accel(uint8_t instance) const;
 
+    // get observed sensor rates, including any internal sampling multiplier
+    uint16_t get_gyro_rate_hz(uint8_t instance) const { return uint16_t(_gyro_raw_sample_rates[instance] * _gyro_over_sampling[instance]); }
+    uint16_t get_accel_rate_hz(uint8_t instance) const { return uint16_t(_accel_raw_sample_rates[instance] * _accel_over_sampling[instance]); }
+    
     // get accel offsets in m/s/s
     const Vector3f &get_accel_offsets(uint8_t i) const { return _accel_offset[i]; }
     const Vector3f &get_accel_offsets(void) const { return get_accel_offsets(_primary_accel); }
@@ -344,6 +348,10 @@ private:
     // accelerometer and gyro raw sample rate in units of Hz
     float  _accel_raw_sample_rates[INS_MAX_INSTANCES];
     float  _gyro_raw_sample_rates[INS_MAX_INSTANCES];
+
+    // how many sensors samples per notify to the backend
+    uint8_t _accel_over_sampling[INS_MAX_INSTANCES];
+    uint8_t _gyro_over_sampling[INS_MAX_INSTANCES];
 
     // last sample time in microseconds. Use for deltaT calculations
     // on non-FIFO sensors

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -342,9 +342,20 @@ private:
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
     // accelerometer and gyro raw sample rate in units of Hz
-    uint16_t _accel_raw_sample_rates[INS_MAX_INSTANCES];
-    uint16_t _gyro_raw_sample_rates[INS_MAX_INSTANCES];
+    float  _accel_raw_sample_rates[INS_MAX_INSTANCES];
+    float  _gyro_raw_sample_rates[INS_MAX_INSTANCES];
 
+    // last sample time in microseconds. Use for deltaT calculations
+    // on non-FIFO sensors
+    uint64_t _accel_last_sample_us[INS_MAX_INSTANCES];
+    uint64_t _gyro_last_sample_us[INS_MAX_INSTANCES];
+
+    // sample times for checking real sensor rate for FIFO sensors
+    uint16_t _sample_accel_count[INS_MAX_INSTANCES];
+    uint32_t _sample_accel_start_us[INS_MAX_INSTANCES];
+    uint16_t _sample_gyro_count[INS_MAX_INSTANCES];
+    uint32_t _sample_gyro_start_us[INS_MAX_INSTANCES];
+    
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -3,6 +3,9 @@
 #include "AP_InertialSensor_Backend.h"
 #include <DataFlash/DataFlash.h>
 #include <AP_Module/AP_Module.h>
+#include <stdio.h>
+
+#define SENSOR_RATE_DEBUG 0
 
 const extern AP_HAL::HAL& hal;
 
@@ -10,6 +13,52 @@ AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
     _imu(imu)
 {
     _sem = hal.util->new_semaphore();
+}
+
+/*
+  notify of a FIFO reset so we don't use bad data to update observed sensor rate
+ */
+void AP_InertialSensor_Backend::notify_accel_fifo_reset(uint8_t instance)
+{
+    _imu._sample_accel_count[instance] = 0;
+    _imu._sample_accel_start_us[instance] = 0;    
+}
+
+/*
+  notify of a FIFO reset so we don't use bad data to update observed sensor rate
+ */
+void AP_InertialSensor_Backend::notify_gyro_fifo_reset(uint8_t instance)
+{
+    _imu._sample_gyro_count[instance] = 0;
+    _imu._sample_gyro_start_us[instance] = 0;
+}
+
+/*
+  update the sensor rate for FIFO sensors
+
+  FIFO sensors produce samples at a fixed rate, but the clock in the
+  sensor may vary slightly from the system clock. This slowly adjusts
+  the rate to the observed rate
+*/
+void AP_InertialSensor_Backend::_update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz)
+{
+    uint32_t now = AP_HAL::micros();
+    if (start_us == 0) {
+        count = 0;
+        start_us = now;
+    } else {
+        count++;
+        if (now - start_us > 1000000UL) {
+            float observed_rate_hz = count * 1.0e6 / (now - start_us);
+#if SENSOR_RATE_DEBUG
+            printf("RATE: %.1f should be %.1f\n", observed_rate_hz, rate_hz);
+#endif
+            observed_rate_hz = constrain_float(observed_rate_hz, rate_hz*0.95, rate_hz*1.05);
+            rate_hz = 0.90 * rate_hz + 0.1 * observed_rate_hz;
+            count = 0;
+            start_us = now;
+        }
+    }
 }
 
 void AP_InertialSensor_Backend::_rotate_and_correct_accel(uint8_t instance, Vector3f &accel) 
@@ -55,10 +104,6 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._gyro[instance] = gyro;
     _imu._gyro_healthy[instance] = true;
 
-    if (_imu._gyro_raw_sample_rates[instance] <= 0) {
-        return;
-    }
-
     // publish delta angle
     _imu._delta_angle[instance] = _imu._delta_angle_acc[instance];
     _imu._delta_angle_dt[instance] = _imu._delta_angle_acc_dt[instance];
@@ -71,11 +116,28 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
 {
     float dt;
 
-    if (_imu._gyro_raw_sample_rates[instance] <= 0) {
-        return;
-    }
+    /*
+      we have two classes of sensors. FIFO based sensors produce data
+      at a very predictable overall rate, but the data comes in
+      bunches, so we use the provided sample rate for deltaT. Non-FIFO
+      sensors don't bunch up samples, but also tend to vary in actual
+      rate, so we use the provided sample_us to get the deltaT. The
+      difference between the two is whether sample_us is provided.
+     */
+    if (sample_us != 0 && _imu._gyro_last_sample_us[instance] != 0) {
+        dt = (sample_us - _imu._gyro_last_sample_us[instance]) * 1.0e-6;
+    } else {
+        _update_sensor_rate(_imu._sample_gyro_count[instance], _imu._sample_gyro_start_us[instance],
+                            _imu._gyro_raw_sample_rates[instance]);
 
-    dt = 1.0f / _imu._gyro_raw_sample_rates[instance];
+        // don't accept below 100Hz
+        if (_imu._gyro_raw_sample_rates[instance] < 100) {
+            return;
+        }
+
+        dt = 1.0f / _imu._gyro_raw_sample_rates[instance];
+    }
+    _imu._gyro_last_sample_us[instance] = sample_us;
 
     // call gyro_sample hook if any
     AP_Module::call_hook_gyro_sample(instance, dt, gyro);
@@ -140,10 +202,6 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     _imu._accel[instance] = accel;
     _imu._accel_healthy[instance] = true;
 
-    if (_imu._accel_raw_sample_rates[instance] <= 0) {
-        return;
-    }
-
     // publish delta velocity
     _imu._delta_velocity[instance] = _imu._delta_velocity_acc[instance];
     _imu._delta_velocity_dt[instance] = _imu._delta_velocity_acc_dt[instance];
@@ -176,13 +234,30 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
 {
     float dt;
 
-    if (_imu._accel_raw_sample_rates[instance] <= 0) {
-        return;
+    /*
+      we have two classes of sensors. FIFO based sensors produce data
+      at a very predictable overall rate, but the data comes in
+      bunches, so we use the provided sample rate for deltaT. Non-FIFO
+      sensors don't bunch up samples, but also tend to vary in actual
+      rate, so we use the provided sample_us to get the deltaT. The
+      difference between the two is whether sample_us is provided.
+     */
+    if (sample_us != 0 && _imu._accel_last_sample_us[instance] != 0) {
+        dt = (sample_us - _imu._accel_last_sample_us[instance]) * 1.0e-6;
+    } else {
+        _update_sensor_rate(_imu._sample_accel_count[instance], _imu._sample_accel_start_us[instance],
+                            _imu._accel_raw_sample_rates[instance]);
+
+        // don't accept below 100Hz
+        if (_imu._accel_raw_sample_rates[instance] < 100) {
+            return;
+        }
+
+        dt = 1.0f / _imu._accel_raw_sample_rates[instance];
     }
+    _imu._accel_last_sample_us[instance] = sample_us;
 
-    dt = 1.0f / _imu._accel_raw_sample_rates[instance];
-
-    // call gyro_sample hook if any
+    // call accel_sample hook if any
     AP_Module::call_hook_accel_sample(instance, dt, accel, fsync_set);
     
     _imu.calc_vibration_and_clipping(instance, accel, dt);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -33,6 +33,18 @@ void AP_InertialSensor_Backend::notify_gyro_fifo_reset(uint8_t instance)
     _imu._sample_gyro_start_us[instance] = 0;
 }
 
+// set the amount of oversamping a accel is doing
+void AP_InertialSensor_Backend::_set_accel_oversampling(uint8_t instance, uint8_t n)
+{
+    _imu._accel_over_sampling[instance] = n;
+}
+
+// set the amount of oversamping a gyro is doing
+void AP_InertialSensor_Backend::_set_gyro_oversampling(uint8_t instance, uint8_t n)
+{
+    _imu._gyro_over_sampling[instance] = n;
+}
+
 /*
   update the sensor rate for FIFO sensors
 
@@ -116,6 +128,9 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
 {
     float dt;
 
+    _update_sensor_rate(_imu._sample_gyro_count[instance], _imu._sample_gyro_start_us[instance],
+                        _imu._gyro_raw_sample_rates[instance]);
+
     /*
       we have two classes of sensors. FIFO based sensors produce data
       at a very predictable overall rate, but the data comes in
@@ -127,9 +142,6 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
     if (sample_us != 0 && _imu._gyro_last_sample_us[instance] != 0) {
         dt = (sample_us - _imu._gyro_last_sample_us[instance]) * 1.0e-6;
     } else {
-        _update_sensor_rate(_imu._sample_gyro_count[instance], _imu._sample_gyro_start_us[instance],
-                            _imu._gyro_raw_sample_rates[instance]);
-
         // don't accept below 100Hz
         if (_imu._gyro_raw_sample_rates[instance] < 100) {
             return;
@@ -234,6 +246,9 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
 {
     float dt;
 
+    _update_sensor_rate(_imu._sample_accel_count[instance], _imu._sample_accel_start_us[instance],
+                        _imu._accel_raw_sample_rates[instance]);
+
     /*
       we have two classes of sensors. FIFO based sensors produce data
       at a very predictable overall rate, but the data comes in
@@ -245,9 +260,6 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     if (sample_us != 0 && _imu._accel_last_sample_us[instance] != 0) {
         dt = (sample_us - _imu._accel_last_sample_us[instance]) * 1.0e-6;
     } else {
-        _update_sensor_rate(_imu._sample_accel_count[instance], _imu._sample_accel_start_us[instance],
-                            _imu._accel_raw_sample_rates[instance]);
-
         // don't accept below 100Hz
         if (_imu._accel_raw_sample_rates[instance] < 100) {
             return;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -125,6 +125,12 @@ protected:
     // sensors, and should be set to zero for FIFO based sensors
     void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false);
 
+    // set the amount of oversamping a accel is doing
+    void _set_accel_oversampling(uint8_t instance, uint8_t n);
+
+    // set the amount of oversamping a gyro is doing
+    void _set_gyro_oversampling(uint8_t instance, uint8_t n);
+    
     // update the sensor rate for FIFO sensors
     void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz);
     

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -70,6 +70,9 @@ public:
      */
     int16_t get_id() const { return _id; }
 
+    // notify of a fifo reset
+    void notify_fifo_reset(void);
+    
     /*
       device driver IDs. These are used to fill in the devtype field
       of the device ID, which shows up as INS*ID* parameters to
@@ -103,10 +106,12 @@ protected:
     // rotate gyro vector, offset and publish
     void _publish_gyro(uint8_t instance, const Vector3f &gyro);
 
-    // this should be called every time a new gyro raw sample is available -
-    // be it published or not
-    // the sample is raw in the sense that it's not filtered yet, but it must
-    // be rotated and corrected (_rotate_and_correct_gyro)
+    // this should be called every time a new gyro raw sample is
+    // available - be it published or not the sample is raw in the
+    // sense that it's not filtered yet, but it must be rotated and
+    // corrected (_rotate_and_correct_gyro)
+    // The sample_us value must be provided for non-FIFO based
+    // sensors, and should be set to zero for FIFO based sensors
     void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0);
 
     // rotate accel vector, scale, offset and publish
@@ -116,8 +121,13 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_accel)
+    // The sample_us value must be provided for non-FIFO based
+    // sensors, and should be set to zero for FIFO based sensors
     void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0, bool fsync_set=false);
 
+    // update the sensor rate for FIFO sensors
+    void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz);
+    
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
@@ -191,6 +201,12 @@ protected:
     bool enable_fast_sampling(uint8_t instance) {
         return (_imu._fast_sampling_mask & (1U<<instance)) != 0;
     }
+
+    /*
+      notify of a FIFO reset so we don't use bad data to update observed sensor rate
+    */
+    void notify_accel_fifo_reset(uint8_t instance);
+    void notify_gyro_fifo_reset(uint8_t instance);
     
     // note that each backend is also expected to have a static detect()
     // function which instantiates an instance of the backend sensor

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -367,6 +367,9 @@ void AP_InertialSensor_Invensense::_fifo_reset()
     hal.scheduler->delay_microseconds(1);
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
     _last_stat_user_ctrl = user_ctrl | BIT_USER_CTRL_FIFO_EN;
+
+    notify_accel_fifo_reset(_accel_instance);
+    notify_gyro_fifo_reset(_gyro_instance);
 }
 
 bool AP_InertialSensor_Invensense::_has_auxiliary_bus()
@@ -587,7 +590,7 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
         _rotate_and_correct_accel(_accel_instance, accel);
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
-        _notify_new_accel_raw_sample(_accel_instance, accel, AP_HAL::micros64(), fsync_set);
+        _notify_new_accel_raw_sample(_accel_instance, accel, 0, fsync_set);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro);
 
         _temp_filtered = _temp_filter.apply(temp);
@@ -653,7 +656,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
             _rotate_and_correct_accel(_accel_instance, _accum.accel);
             _rotate_and_correct_gyro(_gyro_instance, _accum.gyro);
             
-            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, AP_HAL::micros64(), false);
+            _notify_new_accel_raw_sample(_accel_instance, _accum.accel, 0, false);
             _notify_new_gyro_raw_sample(_gyro_instance, _accum.gyro);
             
             _accum.accel.zero();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -810,6 +810,10 @@ void AP_InertialSensor_Invensense::_set_filter_register(void)
         _fast_sampling = (_mpu_type != Invensense_MPU6000 && _dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI);
         if (_fast_sampling) {
             hal.console->printf("MPU[%u]: enabled fast sampling\n", _accel_instance);
+
+            // for logging purposes set the oversamping rate
+            _set_accel_oversampling(_accel_instance, MPU_FIFO_DOWNSAMPLE_COUNT/2);
+            _set_gyro_oversampling(_accel_instance, MPU_FIFO_DOWNSAMPLE_COUNT);
         }
     }
     

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -744,7 +744,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     accel_data *= _accel_scale;
 
     _rotate_and_correct_accel(_accel_instance, accel_data);
-    _notify_new_accel_raw_sample(_accel_instance, accel_data);
+    _notify_new_accel_raw_sample(_accel_instance, accel_data, AP_HAL::micros64());
 }
 
 /*
@@ -765,7 +765,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
     gyro_data *= _gyro_scale;
 
     _rotate_and_correct_gyro(_gyro_instance, gyro_data);
-    _notify_new_gyro_raw_sample(_gyro_instance, gyro_data);
+    _notify_new_gyro_raw_sample(_gyro_instance, gyro_data, AP_HAL::micros64());
 }
 
 bool AP_InertialSensor_LSM9DS0::update()

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -523,7 +523,7 @@ fail_whoami:
 void AP_InertialSensor_LSM9DS0::start(void)
 {
     _gyro_instance = _imu.register_gyro(760, _dev_gyro->get_bus_id_devtype(DEVTYPE_GYR_L3GD20));
-    _accel_instance = _imu.register_accel(800, _dev_accel->get_bus_id_devtype(DEVTYPE_ACC_LSM303D));
+    _accel_instance = _imu.register_accel(1000, _dev_accel->get_bus_id_devtype(DEVTYPE_ACC_LSM303D));
 
     if (whoami_g == LSM9DS0_G_WHOAMI_H) {
         set_gyro_orientation(_gyro_instance, _rotation_gH);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_InertialSensor_SITL.h"
 #include <SITL/SITL.h>
+#include <stdio.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
@@ -36,8 +37,8 @@ bool AP_InertialSensor_SITL::init_sensor(void)
 
     // grab the used instances
     for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
-        gyro_instance[i] = _imu.register_gyro(sitl->update_rate_hz, i);
-        accel_instance[i] = _imu.register_accel(sitl->update_rate_hz, i);
+        gyro_instance[i] = _imu.register_gyro(gyro_sample_hz[i], i);
+        accel_instance[i] = _imu.register_accel(accel_sample_hz[i], i);
     }
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
@@ -45,32 +46,25 @@ bool AP_InertialSensor_SITL::init_sensor(void)
     return true;
 }
 
-void AP_InertialSensor_SITL::timer_update(void)
+/*
+  generate an accelerometer sample
+ */
+void AP_InertialSensor_SITL::generate_accel(uint8_t instance)
 {
     // minimum noise levels are 2 bits, but averaged over many
     // samples, giving around 0.01 m/s/s
     float accel_noise = 0.01f;
-    float accel2_noise = 0.01f;
 
-    // minimum gyro noise is also less than 1 bit
-    float gyro_noise = ToRad(0.04f);
     if (sitl->motors_on) {
         // add extra noise when the motors are on
         accel_noise += sitl->accel_noise;
-        accel2_noise += sitl->accel2_noise;
-        gyro_noise += ToRad(sitl->gyro_noise);
     }
 
     // add accel bias and noise
-    Vector3f accel_bias = sitl->accel_bias.get();
-    float xAccel1 = sitl->state.xAccel + accel_noise * rand_float() + accel_bias.x;
-    float yAccel1 = sitl->state.yAccel + accel_noise * rand_float() + accel_bias.y;
-    float zAccel1 = sitl->state.zAccel + accel_noise * rand_float() + accel_bias.z;
-
-    accel_bias = sitl->accel2_bias.get();
-    float xAccel2 = sitl->state.xAccel + accel2_noise * rand_float() + accel_bias.x;
-    float yAccel2 = sitl->state.yAccel + accel2_noise * rand_float() + accel_bias.y;
-    float zAccel2 = sitl->state.zAccel + accel2_noise * rand_float() + accel_bias.z;
+    Vector3f accel_bias = instance==0?sitl->accel_bias.get():sitl->accel2_bias.get();
+    float xAccel = sitl->state.xAccel + accel_noise * rand_float() + accel_bias.x;
+    float yAccel = sitl->state.yAccel + accel_noise * rand_float() + accel_bias.y;
+    float zAccel = sitl->state.zAccel + accel_noise * rand_float() + accel_bias.z;
 
     // correct for the acceleration due to the IMU position offset and angular acceleration
     // correct for the centripetal acceleration
@@ -87,49 +81,71 @@ void AP_InertialSensor_SITL::timer_update(void)
         Vector3f centripetal_accel = angular_rate % (angular_rate % pos_offset);
 
         // apply corrections
-        xAccel1 += lever_arm_accel.x + centripetal_accel.x;
-        yAccel1 += lever_arm_accel.y + centripetal_accel.y;
-        zAccel1 += lever_arm_accel.z + centripetal_accel.z;
+        xAccel += lever_arm_accel.x + centripetal_accel.x;
+        yAccel += lever_arm_accel.y + centripetal_accel.y;
+        zAccel += lever_arm_accel.z + centripetal_accel.z;
     }
 
     if (fabsf(sitl->accel_fail) > 1.0e-6f) {
-        xAccel1 = sitl->accel_fail;
-        yAccel1 = sitl->accel_fail;
-        zAccel1 = sitl->accel_fail;
+        xAccel = sitl->accel_fail;
+        yAccel = sitl->accel_fail;
+        zAccel = sitl->accel_fail;
     }
 
-    Vector3f accel0 = Vector3f(xAccel1, yAccel1, zAccel1) + _imu.get_accel_offsets(0);
-    Vector3f accel1 = Vector3f(xAccel2, yAccel2, zAccel2) + _imu.get_accel_offsets(1);
-    _notify_new_accel_raw_sample(accel_instance[0], accel0);
-    _notify_new_accel_raw_sample(accel_instance[1], accel1);
+    Vector3f accel = Vector3f(xAccel, yAccel, zAccel) + _imu.get_accel_offsets(instance);
+
+    _notify_new_accel_raw_sample(accel_instance[instance], accel, AP_HAL::micros64());
+}
+
+/*
+  generate a gyro sample
+ */
+void AP_InertialSensor_SITL::generate_gyro(uint8_t instance)
+{
+    // minimum gyro noise is less than 1 bit
+    float gyro_noise = ToRad(0.04f);
+    
+    if (sitl->motors_on) {
+        // add extra noise when the motors are on
+        gyro_noise += ToRad(sitl->gyro_noise);
+    }
 
     float p = radians(sitl->state.rollRate) + gyro_drift();
     float q = radians(sitl->state.pitchRate) + gyro_drift();
     float r = radians(sitl->state.yawRate) + gyro_drift();
 
-    float p1 = p + gyro_noise * rand_float();
-    float q1 = q + gyro_noise * rand_float();
-    float r1 = r + gyro_noise * rand_float();
+    p += gyro_noise * rand_float();
+    q += gyro_noise * rand_float();
+    r += gyro_noise * rand_float();
 
-    float p2 = p + gyro_noise * rand_float();
-    float q2 = q + gyro_noise * rand_float();
-    float r2 = r + gyro_noise * rand_float();
-
-    Vector3f gyro0 = Vector3f(p1, q1, r1) + _imu.get_gyro_offsets(0);
-    Vector3f gyro1 = Vector3f(p2, q2, r2) + _imu.get_gyro_offsets(1);
+    Vector3f gyro = Vector3f(p, q, r) + _imu.get_gyro_offsets(instance);
 
     // add in gyro scaling
     Vector3f scale = sitl->gyro_scale;
-    gyro0.x *= (1 + scale.x*0.01);
-    gyro0.y *= (1 + scale.y*0.01);
-    gyro0.z *= (1 + scale.z*0.01);
+    gyro.x *= (1 + scale.x*0.01);
+    gyro.y *= (1 + scale.y*0.01);
+    gyro.z *= (1 + scale.z*0.01);
 
-    gyro1.x *= (1 + scale.x*0.01);
-    gyro1.y *= (1 + scale.y*0.01);
-    gyro1.z *= (1 + scale.z*0.01);
-    
-    _notify_new_gyro_raw_sample(gyro_instance[0], gyro0);
-    _notify_new_gyro_raw_sample(gyro_instance[1], gyro1);
+    _notify_new_gyro_raw_sample(gyro_instance[instance], gyro, AP_HAL::micros64());
+}
+
+void AP_InertialSensor_SITL::timer_update(void)
+{
+    uint64_t now = AP_HAL::micros64();
+    for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
+        if (now >= next_accel_sample[i]) {
+            generate_accel(i);
+            while (now >= next_accel_sample[i]) {
+                next_accel_sample[i] += 1000000UL / accel_sample_hz[i];
+            }
+        }
+        if (now >= next_gyro_sample[i]) {
+            generate_gyro(i);
+            while (now >= next_gyro_sample[i]) {
+                next_gyro_sample[i] += 1000000UL / gyro_sample_hz[i];
+            }
+        }
+    }
 }
 
 // generate a random float between -1 and 1

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -23,9 +23,17 @@ private:
     void timer_update();
     float rand_float(void);
     float gyro_drift(void);
+    void generate_accel(uint8_t instance);
+    void generate_gyro(uint8_t instance);
 
     SITL::SITL *sitl;
 
+    // simulated sensor rates in Hz. This matches a pixhawk1
+    const uint16_t gyro_sample_hz[INS_SITL_INSTANCES]  { 1000, 760 };
+    const uint16_t accel_sample_hz[INS_SITL_INSTANCES] { 1000, 800 };
+
     uint8_t gyro_instance[INS_SITL_INSTANCES];
     uint8_t accel_instance[INS_SITL_INSTANCES];
+    uint64_t next_gyro_sample[INS_SITL_INSTANCES];
+    uint64_t next_accel_sample[INS_SITL_INSTANCES];
 };

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -838,7 +838,9 @@ void DataFlash_Class::Log_Write_IMU(const AP_InertialSensor &ins)
         accel_error : ins.get_accel_error_count(0),
         temperature : ins.get_temperature(0),
         gyro_health : (uint8_t)ins.get_gyro_health(0),
-        accel_health : (uint8_t)ins.get_accel_health(0)
+        accel_health : (uint8_t)ins.get_accel_health(0),
+        gyro_rate : ins.get_gyro_rate_hz(0),
+        accel_rate : ins.get_accel_rate_hz(0),
     };
     WriteBlock(&pkt, sizeof(pkt));
     if (ins.get_gyro_count() < 2 && ins.get_accel_count() < 2) {
@@ -860,7 +862,9 @@ void DataFlash_Class::Log_Write_IMU(const AP_InertialSensor &ins)
         accel_error : ins.get_accel_error_count(1),
         temperature : ins.get_temperature(1),
         gyro_health : (uint8_t)ins.get_gyro_health(1),
-        accel_health : (uint8_t)ins.get_accel_health(1)
+        accel_health : (uint8_t)ins.get_accel_health(1),
+        gyro_rate : ins.get_gyro_rate_hz(1),
+        accel_rate : ins.get_accel_rate_hz(1),
     };
     WriteBlock(&pkt2, sizeof(pkt2));
     if (ins.get_gyro_count() < 3 && ins.get_accel_count() < 3) {
@@ -881,7 +885,9 @@ void DataFlash_Class::Log_Write_IMU(const AP_InertialSensor &ins)
         accel_error : ins.get_accel_error_count(2),
         temperature : ins.get_temperature(2),
         gyro_health : (uint8_t)ins.get_gyro_health(2),
-        accel_health : (uint8_t)ins.get_accel_health(2)
+        accel_health : (uint8_t)ins.get_accel_health(2),
+        gyro_rate : ins.get_gyro_rate_hz(2),
+        accel_rate : ins.get_accel_rate_hz(2),
     };
     WriteBlock(&pkt3, sizeof(pkt3));
 }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -83,6 +83,7 @@ struct PACKED log_IMU {
     uint32_t gyro_error, accel_error;
     float temperature;
     uint8_t gyro_health, accel_health;
+    uint16_t gyro_rate, accel_rate;
 };
 
 struct PACKED log_IMUDT {
@@ -835,8 +836,8 @@ struct PACKED log_Beacon {
 #define IMT_LABELS "TimeUS,DelT,DelvT,DelaT,DelAX,DelAY,DelAZ,DelVX,DelVY,DelVZ"
 #define IMT_FMT    "Qfffffffff"
 
-#define IMU_LABELS "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt"
-#define IMU_FMT   "QffffffIIfBB"
+#define IMU_LABELS "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,EG,EA,T,GH,AH,GHz,AHz"
+#define IMU_FMT   "QffffffIIfBBHH"
 
 #define MAG_LABELS "TimeUS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health,S"
 #define MAG_FMT   "QhhhhhhhhhBI"

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -92,6 +92,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("GP2_GLITCH",    59, SITL,  gps2_glitch,  0),
     AP_GROUPINFO("ENGINE_FAIL",   60, SITL,  engine_fail,  0),
     AP_GROUPINFO("GPS2_TYPE",     61, SITL,  gps2_type,  SITL::GPS_TYPE_UBLOX),
+    AP_GROUPINFO("ODOM_ENABLE",   62, SITL,  odom_enable, 0),
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -115,7 +115,8 @@ public:
     AP_Int8  terrain_enable; // enable using terrain for height
     AP_Int8  pin_mask; // for GPIO emulation
     AP_Float speedup; // simulation speedup
-
+    AP_Int8  odom_enable; // enable visual odomotry data
+    
     // wind control
     float wind_speed_active;
     float wind_direction_active;


### PR DESCRIPTION
This fixes a major bug in the LSM303D driver, which was using an incorrect sample rate for its accelerometer data for calculating delta-velocity.
It also fixes all drivers sample rates. It splits sensor drivers into two types. FIFO based drivers use a learned sample rate to account for clock differences between sensor and system board. non-FIFO based drivers use the system clock to calculate deltaT.
This significantly improves data quality, and as a side effect it allows non-lock-step SITL backends (such as XPlane10 and FlightAxis to fly properly with EKF as primary estimator)
