### PR TITLE
CAN, AP_UAVCAN: Several CAN buses support

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -470,6 +470,12 @@ const AP_Param::Info Rover::var_info[] = {
     // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig.cpp
     GOBJECT(BoardConfig,            "BRD_",       AP_BoardConfig),
 
+#if HAL_WITH_UAVCAN
+    // @Group: CAN_
+    // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+    GOBJECT(BoardConfig_CAN,        "CAN_",       AP_BoardConfig_CAN),
+#endif
+
     // GPS driver
     // @Group: GPS_
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -22,6 +22,7 @@ public:
         //
         k_param_format_version = 0,
         k_param_software_type,
+        k_param_BoardConfig_CAN,
 
         // Misc
         //

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -61,6 +61,7 @@
 #include <APM_Control/APM_Control.h>
 #include <AP_L1_Control/AP_L1_Control.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 
 #include "AP_Arming.h"
@@ -128,6 +129,11 @@ private:
 
     // board specific config
     AP_BoardConfig BoardConfig;
+
+#if HAL_WITH_UAVCAN
+    // board specific config for CAN bus
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
 
     // primary control channels
     RC_Channel *channel_steer;

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -107,6 +107,9 @@ void Rover::init_ardupilot()
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
 
     BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
 
     // initialise notify system
     notify.init(false);

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -293,6 +293,12 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig.cpp
     GOBJECT(BoardConfig,            "BRD_",       AP_BoardConfig),
 
+#if HAL_WITH_UAVCAN
+    // @Group: CAN_
+    // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+    GOBJECT(BoardConfig_CAN,        "CAN_",       AP_BoardConfig_CAN),
+#endif
+
     // GPS driver
     // @Group: GPS_
     // @Path: ../libraries/AP_GPS/AP_GPS.cpp

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -92,6 +92,7 @@ public:
         k_param_gcs3,               // stream rates for fourth MAVLink port
         k_param_log_bitmask,        // 140
         k_param_notify,
+        k_param_BoardConfig_CAN,
 
         //
         // 150: Telemetry control

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -58,6 +58,7 @@
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Beacon/AP_Beacon.h>
@@ -141,6 +142,11 @@ private:
     GCS &gcs() { return _gcs; }
 
     AP_BoardConfig BoardConfig;
+
+#if HAL_WITH_UAVCAN
+    // board specific config for CAN bus
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
 
     struct Location current_loc;
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -41,6 +41,9 @@ void Tracker::init_tracker()
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
     
     BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
 
     // initialise notify
     notify.init(false);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -83,6 +83,7 @@
 #include <AP_Notify/AP_Notify.h>          // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_ADSB/AP_ADSB.h>
@@ -316,6 +317,11 @@ private:
 
     // board specific config
     AP_BoardConfig BoardConfig;
+
+#if HAL_WITH_UAVCAN
+    // board specific config for CAN bus
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
 
     // receiver RSSI
     uint8_t receiver_rssi;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -738,6 +738,12 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig.cpp
     GOBJECT(BoardConfig,            "BRD_",       AP_BoardConfig),
 
+#if HAL_WITH_UAVCAN
+    // @Group: CAN_
+    // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+    GOBJECT(BoardConfig_CAN,        "CAN_",       AP_BoardConfig_CAN),
+#endif
+
 #if SPRAYER == ENABLED
     // @Group: SPRAY_
     // @Path: ../libraries/AC_Sprayer/AC_Sprayer.cpp

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -55,6 +55,7 @@ public:
         k_param_NavEKF2,
         k_param_g2, // 2nd block of parameters
         k_param_NavEKF3,
+        k_param_BoardConfig_CAN,
 
         // simulation
         k_param_sitl = 10,

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -127,6 +127,9 @@ void Copter::init_ardupilot()
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
     
     BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
 
     // init cargo gripper
 #if GRIPPER_ENABLED == ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1124,6 +1124,12 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig.cpp
     GOBJECT(BoardConfig,            "BRD_",       AP_BoardConfig),
 
+#if HAL_WITH_UAVCAN
+    // @Group: CAN_
+    // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+    GOBJECT(BoardConfig_CAN,        "CAN_",       AP_BoardConfig_CAN),
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     // @Group: SIM_
     // @Path: ../libraries/SITL/SITL.cpp

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -53,6 +53,7 @@ public:
         k_param_avoidance_adsb,
         k_param_landing,
         k_param_NavEKF3,
+        k_param_BoardConfig_CAN,
 
         // Misc
         //

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -82,6 +82,7 @@
 
 #include <AP_Arming/AP_Arming.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
@@ -171,6 +172,11 @@ private:
 
     // board specific config
     AP_BoardConfig BoardConfig;
+
+    // board specific config for CAN bus
+#if HAL_WITH_UAVCAN
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
 
     // primary input channels
     RC_Channel *channel_roll;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -140,6 +140,9 @@ void Plane::init_ardupilot()
 
     // setup any board specific drivers
     BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
 
     relay.init();
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -624,6 +624,12 @@ const AP_Param::Info Sub::var_info[] = {
     // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig.cpp
     GOBJECT(BoardConfig,            "BRD_",       AP_BoardConfig),
 
+#if HAL_WITH_UAVCAN
+    // @Group: CAN_
+    // @Path: ../libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+    GOBJECT(BoardConfig_CAN,        "CAN_",       AP_BoardConfig_CAN),
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     GOBJECT(sitl, "SIM_", SITL::SITL),
 #endif

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -69,7 +69,7 @@ public:
         k_param_serial_manager, // Serial ports, AP_SerialManager
         k_param_notify, // Notify Library, AP_Notify
         k_param_arming = 26, // Arming checks
-
+        k_param_BoardConfig_CAN,
 
         // Sensor objects
         k_param_ins = 30, // AP_InertialSensor

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -69,6 +69,7 @@
 #include <AP_Notify/AP_Notify.h>          // Notify library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment
 #include <AP_LeakDetector/AP_LeakDetector.h> // Leak detector
@@ -250,6 +251,11 @@ private:
 
     // board specific config
     AP_BoardConfig BoardConfig;
+
+#if HAL_WITH_UAVCAN
+    // board specific config for CAN bus
+    AP_BoardConfig_CAN BoardConfig_CAN;
+#endif
 
     // Failsafe
     struct {

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -31,6 +31,9 @@ void Sub::init_ardupilot()
     load_parameters();
 
     BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
 
     // identify ourselves correctly with the ground station
     mavlink_system.sysid = g.sysid_this_mav;

--- a/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
@@ -4,6 +4,7 @@
 
 #include "AP_Baro_UAVCAN.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -12,9 +13,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define debug_baro_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig::get_can_debug()) { hal.console->printf(fmt, ##args); }} while (0)
-
-// There is limitation to use only one UAVCAN barometer now.
+#define debug_baro_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { printf(fmt, ##args); }} while (0)
 
 /*
   constructor - registers instance at top Baro driver
@@ -22,31 +21,48 @@ extern const AP_HAL::HAL& hal;
 AP_Baro_UAVCAN::AP_Baro_UAVCAN(AP_Baro &baro) :
     AP_Baro_Backend(baro)
 {
-    _instance = _frontend.register_sensor();
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            // Give time to receive some packets from CAN if baro sensor is present
-            // This way it will get calibrated correctly
-            hal.scheduler->delay(1000);
-            ap_uavcan->register_baro_listener(this, 1);
-
-            debug_baro_uavcan(2, "AP_Baro_UAVCAN loaded\n\r");
-        }
-    }
-
     _sem_baro = hal.util->new_semaphore();
 }
 
 AP_Baro_UAVCAN::~AP_Baro_UAVCAN()
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            ap_uavcan->remove_baro_listener(this);
-            debug_baro_uavcan(2, "AP_Baro_UAVCAN destructed\n\r");
+    if (_initialized) {
+        if (hal.can_mgr[_manager] != nullptr) {
+            AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
+            if (ap_uavcan != nullptr) {
+                ap_uavcan->remove_baro_listener(this);
+                debug_baro_uavcan(2, "AP_Baro_UAVCAN destructed\n\r");
+            }
         }
     }
+}
+
+AP_Baro_Backend *AP_Baro_UAVCAN::probe(AP_Baro &baro)
+{
+    AP_Baro_UAVCAN *sensor = nullptr;
+
+    if (AP_BoardConfig_CAN::get_can_num_ifaces() != 0) {
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+            if (hal.can_mgr[i] != nullptr) {
+                AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+                if (uavcan != nullptr) {
+                    uint8_t freebaro = uavcan->find_smallest_free_baro_node();
+                    if (freebaro != UINT8_MAX) {
+                        sensor = new AP_Baro_UAVCAN(baro);
+                        if (sensor->register_uavcan_baro(i, freebaro)) {
+                            debug_baro_uavcan(2, "AP_Baro_UAVCAN probed, drv: %d, node: %d\n\r", i, freebaro);
+                            return sensor;
+                        } else {
+                            delete sensor;
+                            sensor = nullptr;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return sensor;
 }
 
 // Read the sensor
@@ -68,6 +84,29 @@ void AP_Baro_UAVCAN::handle_baro_msg(float pressure, float temperature)
         _last_timestamp = AP_HAL::micros64();
         _sem_baro->give();
     }
+}
+
+bool AP_Baro_UAVCAN::register_uavcan_baro(uint8_t mgr, uint8_t node)
+{
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+
+        if (ap_uavcan != nullptr) {
+            _manager = mgr;
+
+            if (ap_uavcan->register_baro_listener_to_node(this, node))
+            {
+                _instance = _frontend.register_sensor();
+                debug_baro_uavcan(2, "AP_Baro_UAVCAN loaded\n\r");
+
+                _initialized = true;
+
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 #endif // HAL_WITH_UAVCAN

--- a/libraries/AP_Baro/AP_Baro_UAVCAN.h
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.h
@@ -8,16 +8,23 @@ public:
     AP_Baro_UAVCAN(AP_Baro &);
     ~AP_Baro_UAVCAN() override;
 
+    static AP_Baro_Backend *probe(AP_Baro &baro);
+
     void update() override;
 
     // This method is called from UAVCAN thread
     virtual void handle_baro_msg(float pressure, float temperature) override;
+
+    bool register_uavcan_baro(uint8_t mgr, uint8_t node);
 
 private:
     uint8_t _instance;
     float _pressure;
     float _temperature;
     uint64_t _last_timestamp;
+    uint8_t _manager;
+
+    bool _initialized;
 
     AP_HAL::Semaphore *_sem_baro;
 };

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -16,7 +16,6 @@
  *   AP_BoardConfig - board specific configuration
  */
 
-
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS.h>
@@ -30,10 +29,6 @@
 #include <unistd.h>
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_sbus.h>
-#endif
-
-#if HAL_WITH_UAVCAN
-#include <AP_UAVCAN/AP_UAVCAN.h>
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
@@ -131,12 +126,6 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("SERIAL_NUM", 5, AP_BoardConfig, vehicleSerialNumber, 0),
 
-#if HAL_WITH_UAVCAN
-    // @Group: CAN_
-    // @Path: ../AP_BoardConfig/canbus.cpp
-    AP_SUBGROUPINFO(_var_info_can, "CAN_", 6, AP_BoardConfig, AP_BoardConfig::CAN_var_info),
-#endif
-
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     // @Param: SAFETY_MASK
     // @DisplayName: Channels to which ignore the safety switch state
@@ -183,20 +172,10 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     AP_GROUPEND
 };
 
-#if HAL_WITH_UAVCAN
-int8_t AP_BoardConfig::_st_can_enable;
-int8_t AP_BoardConfig::_st_can_debug;
-#endif
-
 void AP_BoardConfig::init()
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     px4_setup();
-#endif
-
-#if HAL_WITH_UAVCAN
-    _st_can_enable = (int8_t) _var_info_can._can_enable;
-    _st_can_debug = (int8_t) _var_info_can._can_debug;
 #endif
 
 #if HAL_HAVE_IMU_HEATER

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -20,30 +20,9 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-#if HAL_WITH_UAVCAN
-    class CAN_var_info {
-        friend class AP_BoardConfig;
-
-    public:
-        CAN_var_info() : _uavcan(nullptr)
-        {
-            AP_Param::setup_object_defaults(this, var_info);
-        }
-        static const struct AP_Param::GroupInfo var_info[];
-
-    private:
-        AP_Int8 _can_enable;
-        AP_Int8 _can_debug;
-        AP_Int32 _can_bitrate;
-
-        AP_Int8 _uavcan_enable;
-
-        AP_UAVCAN *_uavcan;
-    };
-#endif
-
     // notify user of a fatal startup error related to available sensors. 
     static void sensor_config_error(const char *reason);
+
     // permit other libraries (in particular, GCS_MAVLink) to detect
     // that we're never going to boot properly:
     static bool in_sensor_config_error(void) { return _in_sensor_config_error; }
@@ -87,28 +66,8 @@ public:
     }
 #endif
 
-    static int8_t get_can_enable()
-    {
-#if HAL_WITH_UAVCAN
-        return _st_can_enable;
-#else
-        return 0;
-#endif
-    }
-    static int8_t get_can_debug()
-    {
-#if HAL_WITH_UAVCAN
-        return _st_can_debug;
-#else
-        return 0;
-#endif
-    }
 private:
     AP_Int16 vehicleSerialNumber;
-
-#if HAL_WITH_UAVCAN
-    CAN_var_info _var_info_can;
-#endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     struct {
@@ -126,11 +85,6 @@ private:
 
     static enum px4_board_type px4_configured_board;
 
-#if HAL_WITH_UAVCAN
-    static int8_t _st_can_enable;
-    static int8_t _st_can_debug;
-#endif
-
     void px4_drivers_start(void);
     void px4_setup(void);
     void px4_setup_pwm(void);
@@ -138,7 +92,6 @@ private:
     void px4_setup_safety_mask(void);
     void px4_setup_uart(void);
     void px4_setup_sbus(void);
-    void px4_setup_canbus(void);
     void px4_setup_drivers(void);
     void px4_setup_peripherals(void);
     void px4_setup_px4io(void);

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -1,0 +1,162 @@
+ /*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ *   AP_BoardConfig_CAN - board specific configuration for CAN interface
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include "AP_BoardConfig_CAN.h"
+
+#if HAL_WITH_UAVCAN
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <AP_HAL_PX4/CAN.h>
+#endif
+
+#include <AP_UAVCAN/AP_UAVCAN.h>
+
+extern const AP_HAL::HAL& hal;
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_BoardConfig_CAN::var_info[] = {
+
+#if MAX_NUMBER_OF_CAN_INTERFACES > 0
+    // @Group: P1_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can[0], "P1_", 1, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_if_var_info),
+#endif
+
+#if MAX_NUMBER_OF_CAN_INTERFACES > 1
+    // @Group: P2_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can[1], "P2_", 2, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_if_var_info),
+#endif
+
+#if MAX_NUMBER_OF_CAN_INTERFACES > 2
+    // @Group: P3_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can[2], "P3_", 3, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_if_var_info),
+#endif
+
+#if MAX_NUMBER_OF_CAN_DRIVERS > 0
+    // @Group: D1_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can_protocol[0], "D1_", 4, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
+#endif
+
+#if MAX_NUMBER_OF_CAN_DRIVERS > 1
+    // @Group: D2_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can_protocol[1], "D2_", 5, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
+#endif
+
+#if MAX_NUMBER_OF_CAN_DRIVERS > 2
+    // @Group: D3_
+    // @Path: ../AP_BoardConfig/canbus.cpp
+    AP_SUBGROUPINFO(_var_info_can_protocol[2], "D3_", 6, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
+#endif
+
+    AP_GROUPEND
+};
+
+int8_t AP_BoardConfig_CAN::_st_driver_number[MAX_NUMBER_OF_CAN_INTERFACES];
+int8_t AP_BoardConfig_CAN::_st_can_debug[MAX_NUMBER_OF_CAN_INTERFACES];
+
+void AP_BoardConfig_CAN::init()
+{
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++)
+    {
+        _st_driver_number[i] = (int8_t) _var_info_can[i]._driver_number;
+        _st_can_debug[i] = (int8_t) _var_info_can[i]._can_debug;
+    }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+    px4_setup_canbus();
+#endif
+
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+/*
+  setup CANBUS drivers
+ */
+void AP_BoardConfig_CAN::px4_setup_canbus(void)
+{
+    // Create all drivers that we need
+    bool initret = true;
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++) {
+        uint8_t drv_num = _var_info_can[i]._driver_number;
+
+        if (drv_num != 0 && drv_num <= MAX_NUMBER_OF_CAN_DRIVERS) {
+            if (hal.can_mgr[drv_num - 1] == nullptr) {
+                const_cast <AP_HAL::HAL&> (hal).can_mgr[drv_num - 1] = new PX4::PX4CANManager;
+            }
+
+            if (hal.can_mgr[drv_num - 1] != nullptr) {
+                initret &= hal.can_mgr[drv_num - 1]->begin(_var_info_can[i]._can_bitrate, i);
+            } else {
+                printf("Failed to initialize can interface %d\n\r", i + 1);
+            }
+        }
+    }
+
+    bool any_uavcan_present = false;
+
+    if (initret) {
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+            if (hal.can_mgr[i] != nullptr) {
+                hal.can_mgr[i]->initialized(true);
+                printf("can_mgr %d initialized well\n\r", i + 1);
+
+                if (_var_info_can_protocol[i]._protocol == UAVCAN_PROTOCOL_ENABLE) {
+                    _var_info_can_protocol[i]._uavcan = new AP_UAVCAN;
+
+                    if (_var_info_can_protocol[i]._uavcan != nullptr)
+                    {
+                        AP_Param::load_object_from_eeprom(_var_info_can_protocol[i]._uavcan, AP_UAVCAN::var_info);
+
+                        hal.can_mgr[i]->set_UAVCAN(_var_info_can_protocol[i]._uavcan);
+                        _var_info_can_protocol[i]._uavcan->set_parent_can_mgr(hal.can_mgr[i]);
+
+                        if (_var_info_can_protocol[i]._uavcan->try_init() == true) {
+                            any_uavcan_present = true;
+                        } else {
+                            printf("Failed to initialize uavcan interface %d\n\r", i + 1);
+                        }
+                    } else {
+                        AP_HAL::panic("Failed to allocate uavcan %d\n\r", i + 1);
+                    }
+                }
+            }
+        }
+
+        if (any_uavcan_present) {
+            // start UAVCAN working thread
+            hal.scheduler->create_uavcan_thread();
+
+            // Delay for magnetometer and barometer discovery
+            hal.scheduler->delay(2000);
+        }
+    }
+}
+#endif
+#endif
+

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -153,7 +153,7 @@ void AP_BoardConfig_CAN::px4_setup_canbus(void)
             hal.scheduler->create_uavcan_thread();
 
             // Delay for magnetometer and barometer discovery
-            hal.scheduler->delay(2000);
+            hal.scheduler->delay(5000);
         }
     }
 }

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_BoardConfig.h"
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <sys/ioctl.h>
+
+#if HAL_WITH_UAVCAN
+#define UAVCAN_PROTOCOL_ENABLE  1
+
+class AP_BoardConfig_CAN {
+public:
+    // constructor
+    AP_BoardConfig_CAN(void)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
+
+    void init(void);
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    class CAN_if_var_info {
+        friend class AP_BoardConfig_CAN;
+
+    public:
+        CAN_if_var_info()
+        {
+            AP_Param::setup_object_defaults(this, var_info);
+        }
+
+        static const struct AP_Param::GroupInfo var_info[];
+
+    private:
+        AP_Int8 _driver_number;
+        AP_Int8 _can_debug;
+        AP_Int32 _can_bitrate;
+    };
+
+    class CAN_driver_var_info {
+        friend class AP_BoardConfig_CAN;
+
+    public:
+        CAN_driver_var_info() :
+                _uavcan(nullptr)
+        {
+            AP_Param::setup_object_defaults(this, var_info);
+        }
+        static const struct AP_Param::GroupInfo var_info[];
+
+    private:
+        AP_Int8 _protocol;
+
+        AP_UAVCAN* _uavcan;
+    };
+
+    // returns number of enabled CAN interfaces
+    static int8_t get_can_num_ifaces(void)
+    {
+        uint8_t ret = 0;
+
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++) {
+            if (_st_driver_number[i]) {
+                ret++;
+            }
+        }
+
+        return ret;
+    }
+
+    static int8_t get_can_debug(uint8_t i)
+    {
+        if (i < MAX_NUMBER_OF_CAN_INTERFACES) {
+            return _st_can_debug[i];
+        }
+        return 0;
+    }
+
+    // return maximum level of debug
+    static int8_t get_can_debug(void)
+    {
+        uint8_t ret = 0;
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++) {
+            uint8_t dbg = get_can_debug(i);
+            ret = (dbg > ret) ? dbg : ret;
+        }
+        return ret;
+    }
+
+    CAN_if_var_info _var_info_can[MAX_NUMBER_OF_CAN_INTERFACES];
+    CAN_driver_var_info _var_info_can_protocol[MAX_NUMBER_OF_CAN_DRIVERS];
+
+    static int8_t _st_driver_number[MAX_NUMBER_OF_CAN_INTERFACES];
+    static int8_t _st_can_debug[MAX_NUMBER_OF_CAN_INTERFACES];
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+    void px4_setup_canbus(void);
+#endif // HAL_BOARD_PX4 || HAL_BOARD_VRBRAIN
+};
+#endif

--- a/libraries/AP_BoardConfig/canbus.cpp
+++ b/libraries/AP_BoardConfig/canbus.cpp
@@ -18,41 +18,48 @@
 #include "AP_BoardConfig.h"
 
 #if HAL_WITH_UAVCAN
+#include "AP_BoardConfig_CAN.h"
 #include <AP_UAVCAN/AP_UAVCAN.h>
 
 // table of user settable CAN bus parameters
-const AP_Param::GroupInfo AP_BoardConfig::CAN_var_info::var_info[] = {
-    // @Param: ENABLE
-    // @DisplayName:  Enable use of CAN buses
+const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_if_var_info::var_info[] = {
+    // @Param: DRIVER
+    // @DisplayName: Index of virtual driver to be used with physical CAN interface
     // @Description: Enabling this option enables use of CAN buses.
-    // @Values: 0:Disabled,1:Enabled first channel,2:Enabled both channels
-    // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_BoardConfig::CAN_var_info, _can_enable, 0, AP_PARAM_FLAG_ENABLE),
+    // @Values: 0:Disabled,1:First driver,2:Second driver
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO_FLAGS("DRIVER", 1, AP_BoardConfig_CAN::CAN_if_var_info, _driver_number, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: BITRATE
-    // @DisplayName:  Bitrate of CAN interface
+    // @DisplayName: Bitrate of CAN interface
     // @Description: Bit rate can be set up to from 10000 to 1000000
     // @Range: 10000 1000000
     // @User: Advanced
-    AP_GROUPINFO("BITRATE", 2, AP_BoardConfig::CAN_var_info, _can_bitrate, 1000000),
+    AP_GROUPINFO("BITRATE", 2, AP_BoardConfig_CAN::CAN_if_var_info, _can_bitrate, 1000000),
 
     // @Param: DEBUG
-    // @DisplayName:  Level of debug for CAN devices
+    // @DisplayName: Level of debug for CAN devices
     // @Description: Enabling this option will provide debug messages
     // @Values: 0:Disabled,1:Major messages,2:All messages
     // @User: Advanced
-    AP_GROUPINFO("DEBUG", 3, AP_BoardConfig::CAN_var_info, _can_debug, 2),
+    AP_GROUPINFO("DEBUG", 3, AP_BoardConfig_CAN::CAN_if_var_info, _can_debug, 2),
 
-    // @Param: UC_EN
-    // @DisplayName:  Enable use of UAVCAN devices
-    // @Description: Enabling this option starts UAVCAN protocol.
-    // @Values: 0:Disabled,1:Enabled
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_driver_var_info::var_info[] = {
+    // @Param: PROTOCOL
+    // @DisplayName: Enable use of specific protocol over virtual driver
+    // @Description: Enabling this option starts selected protocol that will use this virtual driver
+    // @Values: 0:Disabled,1:UAVCAN
     // @User: Advanced
-    AP_GROUPINFO("UC_EN", 4, AP_BoardConfig::CAN_var_info, _uavcan_enable, 1),
+    // @RebootRequired: True
+    AP_GROUPINFO("PROTOCOL", 1, AP_BoardConfig_CAN::CAN_driver_var_info, _protocol, UAVCAN_PROTOCOL_ENABLE),
 
     // @Group: UC_
     // @Path: ../AP_UAVCAN/AP_UAVCAN.cpp
-    AP_SUBGROUPPTR(_uavcan, "UC_", 5, AP_BoardConfig::CAN_var_info, AP_UAVCAN),
+    AP_SUBGROUPPTR(_uavcan, "UC_", 2, AP_BoardConfig_CAN::CAN_driver_var_info, AP_UAVCAN),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -25,12 +25,11 @@
 #include <unistd.h>
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 
 extern const AP_HAL::HAL& hal;
 
-#define debug_mag_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig::get_can_debug()) { hal.console->printf(fmt, ##args); }} while (0)
-
-// There is limitation to use only one UAVCAN magnetometer now.
+#define debug_mag_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { printf(fmt, ##args); }} while (0)
 
 /*
   constructor - registers instance at top Compass driver
@@ -38,57 +37,95 @@ extern const AP_HAL::HAL& hal;
 AP_Compass_UAVCAN::AP_Compass_UAVCAN(Compass &compass):
     AP_Compass_Backend(compass)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            // Give time to receive some packets from CAN if baro sensor is present
-            // This way it will get calibrated correctly
-            _instance = register_compass();
-            hal.scheduler->delay(1000);
-            uint8_t listener_channel = ap_uavcan->register_mag_listener(this, 1);
-
-            struct DeviceStructure {
-                uint8_t bus_type : 3;
-                uint8_t bus: 5;
-                uint8_t address;
-                uint8_t devtype;
-            };
-            union DeviceId {
-                struct DeviceStructure devid_s;
-                uint32_t devid;
-            };
-            union DeviceId d;
-
-            d.devid_s.bus_type = 3;
-            d.devid_s.bus = 0;
-            d.devid_s.address = listener_channel;
-            d.devid_s.devtype = 0;
-
-            set_dev_id(_instance, d.devid);
-            set_external(_instance, true);
-
-            _sum.zero();
-            _count = 0;
-
-            accumulate();
-
-            debug_mag_uavcan(2, "AP_Compass_UAVCAN loaded\n\r");
-        }
-    }
-
     _mag_baro = hal.util->new_semaphore();
 }
 
 AP_Compass_UAVCAN::~AP_Compass_UAVCAN()
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            ap_uavcan->remove_mag_listener(this);
+    if (_initialized)
+    {
+        if (hal.can_mgr[_manager] != nullptr) {
+            AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
+            if (ap_uavcan != nullptr) {
+                ap_uavcan->remove_mag_listener(this);
 
-            debug_mag_uavcan(2, "AP_Compass_UAVCAN destructed\n\r");
+                debug_mag_uavcan(2, "AP_Compass_UAVCAN destructed\n\r");
+            }
         }
     }
+}
+
+AP_Compass_Backend *AP_Compass_UAVCAN::probe(Compass &compass)
+{
+    AP_Compass_UAVCAN *sensor = nullptr;
+
+    if (AP_BoardConfig_CAN::get_can_num_ifaces() != 0) {
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+            if (hal.can_mgr[i] != nullptr) {
+                AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+                if (uavcan != nullptr) {
+                    uint8_t freemag = uavcan->find_smallest_free_mag_node();
+                    if (freemag != UINT8_MAX) {
+                        sensor = new AP_Compass_UAVCAN(compass);
+                        if (sensor->register_uavcan_compass(i, freemag)) {
+                            debug_mag_uavcan(2, "AP_Compass_UAVCAN probed, drv: %d, node: %d\n\r", i, freemag);
+                            return sensor;
+                        } else {
+                            delete sensor;
+                            sensor = nullptr;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return sensor;
+}
+
+bool AP_Compass_UAVCAN::register_uavcan_compass(uint8_t mgr, uint8_t node)
+{
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+        if (ap_uavcan != nullptr) {
+            _manager = mgr;
+
+            if (ap_uavcan->register_mag_listener_to_node(this, node)) {
+                _instance = register_compass();
+
+                struct DeviceStructure {
+                    uint8_t bus_type : 3;
+                    uint8_t bus: 5;
+                    uint8_t address;
+                    uint8_t devtype;
+                };
+                union DeviceId {
+                    struct DeviceStructure devid_s;
+                    uint32_t devid;
+                };
+                union DeviceId d;
+
+                d.devid_s.bus_type = 3;
+                d.devid_s.bus = mgr;
+                d.devid_s.address = node;
+                d.devid_s.devtype = 1;
+
+                set_dev_id(_instance, d.devid);
+                set_external(_instance, true);
+
+                _sum.zero();
+                _count = 0;
+
+                accumulate();
+
+                debug_mag_uavcan(2, "AP_Compass_UAVCAN loaded\n\r");
+
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 void AP_Compass_UAVCAN::read(void)

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.h
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.h
@@ -12,6 +12,10 @@ public:
     AP_Compass_UAVCAN(Compass &compass);
     ~AP_Compass_UAVCAN() override;
 
+    static AP_Compass_Backend *probe(Compass &compass);
+
+    bool register_uavcan_compass(uint8_t mgr, uint8_t node);
+
     // This method is called from UAVCAN thread
     void handle_mag_msg(Vector3f &mag);
 
@@ -21,6 +25,9 @@ private:
     Vector3f _sum;
     uint32_t _count;
     uint64_t _last_timestamp;
+
+    bool _initialized;
+    uint8_t _manager;
 
     AP_HAL::Semaphore *_mag_baro;
 };

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -22,10 +22,11 @@
 #if HAL_WITH_UAVCAN
 #include <AP_UAVCAN/AP_UAVCAN.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 
 extern const AP_HAL::HAL& hal;
 
-#define debug_gps_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig::get_can_debug()) { hal.console->printf(fmt, ##args); }} while (0)
+#define debug_gps_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { printf(fmt, ##args); }} while (0)
 
 AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
@@ -37,14 +38,19 @@ AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UA
 // For each instance we need to deregister from AP_UAVCAN class
 AP_GPS_UAVCAN::~AP_GPS_UAVCAN()
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[_manager] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             ap_uavcan->remove_gps_listener(this);
 
             debug_gps_uavcan(2, "AP_GPS_UAVCAN destructed\n\r");
         }
     }
+}
+
+void AP_GPS_UAVCAN::set_uavcan_manager(uint8_t mgr)
+{
+    _manager = mgr;
 }
 
 // Consume new data and mark it received

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.h
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.h
@@ -30,6 +30,7 @@ public:
     ~AP_GPS_UAVCAN() override;
 
     bool read() override;
+    void set_uavcan_manager(uint8_t mgr);
 
     // This method is called from UAVCAN thread
     void handle_gnss_msg(const AP_GPS::GPS_State &msg) override;
@@ -38,6 +39,7 @@ public:
 
 private:
     bool _new_data;
+    uint8_t _manager;
 
     AP_GPS::GPS_State _interm_state;
     AP_HAL::Semaphore *_sem_gnss;

--- a/libraries/AP_HAL/CAN.h
+++ b/libraries/AP_HAL/CAN.h
@@ -29,6 +29,9 @@
 #include <uavcan/driver/can.hpp>
 #include <uavcan/time.hpp>
 
+#define MAX_NUMBER_OF_CAN_INTERFACES    2
+#define MAX_NUMBER_OF_CAN_DRIVERS       2
+
 class AP_UAVCAN;
 
 /**
@@ -108,6 +111,7 @@ public:
      true - CAN manager is initialized
      */
     virtual bool is_initialized() = 0;
+    virtual void initialized(bool val);
 
     virtual AP_UAVCAN *get_UAVCAN(void);
     virtual void set_UAVCAN(AP_UAVCAN *uavcan);

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -34,7 +34,11 @@ public:
         AP_HAL::Scheduler*  _scheduler,
         AP_HAL::Util*       _util,
         AP_HAL::OpticalFlow *_opticalflow,
-        AP_HAL::CANManager* _can_mgr)
+#if HAL_WITH_UAVCAN
+        AP_HAL::CANManager* _can_mgr[MAX_NUMBER_OF_CAN_DRIVERS])
+#else
+        AP_HAL::CANManager** _can_mgr)
+#endif
         :
         uartA(_uartA),
         uartB(_uartB),
@@ -52,9 +56,18 @@ public:
         rcout(_rcout),
         scheduler(_scheduler),
         util(_util),
-        opticalflow(_opticalflow),
-        can_mgr(_can_mgr)
+        opticalflow(_opticalflow)
     {
+#if HAL_WITH_UAVCAN
+        if (_can_mgr == nullptr) {
+            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++)
+                can_mgr[i] = nullptr;
+        } else {
+            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++)
+                can_mgr[i] = _can_mgr[i];
+        }
+#endif
+
         AP_HAL::init();
     }
 
@@ -93,5 +106,9 @@ public:
     AP_HAL::Scheduler*  scheduler;
     AP_HAL::Util        *util;
     AP_HAL::OpticalFlow *opticalflow;
-    AP_HAL::CANManager* can_mgr;
+#if HAL_WITH_UAVCAN
+    AP_HAL::CANManager* can_mgr[MAX_NUMBER_OF_CAN_DRIVERS];
+#else
+    AP_HAL::CANManager** can_mgr;
+#endif
 };

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -16,6 +16,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 #if HAL_WITH_UAVCAN
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_UAVCAN/AP_UAVCAN.h>
 #endif
 
@@ -489,34 +490,35 @@ void PX4RCOutput::_send_outputs(void)
             }
         }
 
-        if(AP_BoardConfig::get_can_enable() >= 1)
-        {
 #if HAL_WITH_UAVCAN
-
-            if(hal.can_mgr != nullptr)
-            {
-                AP_UAVCAN *ap_uc = hal.can_mgr->get_UAVCAN();
-                if(ap_uc != nullptr)
+        if (AP_BoardConfig_CAN::get_can_num_ifaces() >= 1)
+        {
+            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+                if (hal.can_mgr[i] != nullptr)
                 {
-                    if(ap_uc->rc_out_sem_take())
+                    AP_UAVCAN *ap_uc = hal.can_mgr[i]->get_UAVCAN();
+                    if (ap_uc != nullptr)
                     {
-                        for(uint8_t i = 0; i < _max_channel; i++)
+                        if (ap_uc->rc_out_sem_take())
                         {
-                            ap_uc->rco_write(_period[i], i);
-                        }
+                            for (uint8_t j = 0; j < _max_channel; j++)
+                            {
+                                ap_uc->rco_write(_period[j], j);
+                            }
 
-                        if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
-                            ap_uc->rco_arm_actuators(true);
-                        } else {
-                            ap_uc->rco_arm_actuators(false);
-                        }
+                            if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
+                                ap_uc->rco_arm_actuators(true);
+                            } else {
+                                ap_uc->rco_arm_actuators(false);
+                            }
 
-                        ap_uc->rc_out_sem_give();
+                            ap_uc->rc_out_sem_give();
+                        }
                     }
                 }
             }
-#endif // HAL_WITH_UAVCAN
         }
+#endif // HAL_WITH_UAVCAN
 
         perf_end(_perf_rcout);
         _last_output = now;

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -104,9 +104,17 @@ void PX4Scheduler::create_uavcan_thread()
     (void) pthread_attr_setschedparam(&thread_attr, &param);
     pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
 
-    pthread_create(&_uavcan_thread_ctx, &thread_attr, &PX4Scheduler::_uavcan_thread, this);
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] != nullptr) {
+            if (hal.can_mgr[i]->get_UAVCAN() != nullptr) {
+                _uavcan_thread_arg *arg = new _uavcan_thread_arg;
+                arg->sched = this;
+                arg->uavcan_number = i;
 
-    printf("UAVCAN thread started\n\r");
+                pthread_create(&_uavcan_thread_ctx, &thread_attr, &PX4Scheduler::_uavcan_thread, arg);
+            }
+        }
+    }
 #endif
 }
 
@@ -408,18 +416,21 @@ void *PX4Scheduler::_storage_thread(void *arg)
 #if HAL_WITH_UAVCAN
 void *PX4Scheduler::_uavcan_thread(void *arg)
 {
-    PX4Scheduler *sched = (PX4Scheduler *) arg;
+    PX4Scheduler *sched = ((_uavcan_thread_arg *) arg)->sched;
+    uint8_t uavcan_number = ((_uavcan_thread_arg *) arg)->uavcan_number;
 
-    pthread_setname_np(pthread_self(), "apm_uavcan");
+    char name[15];
+    snprintf(name, sizeof(name), "apm_uavcan:%u", uavcan_number);
+    pthread_setname_np(pthread_self(), name);
 
     while (!sched->_hal_initialized) {
         poll(nullptr, 0, 1);
     }
 
     while (!_px4_thread_should_exit) {
-        if (((PX4CANManager *)hal.can_mgr)->is_initialized()) {
-            if (((PX4CANManager *)hal.can_mgr)->get_UAVCAN() != nullptr) {
-                (((PX4CANManager *)hal.can_mgr)->get_UAVCAN())->do_cyclic();
+        if (((PX4CANManager *)hal.can_mgr[uavcan_number])->is_initialized()) {
+            if (((PX4CANManager *)hal.can_mgr[uavcan_number])->get_UAVCAN() != nullptr) {
+                (((PX4CANManager *)hal.can_mgr[uavcan_number])->get_UAVCAN())->do_cyclic();
             } else {
                 sched->delay_microseconds_semaphore(10000);
             }
@@ -427,6 +438,7 @@ void *PX4Scheduler::_uavcan_thread(void *arg)
             sched->delay_microseconds_semaphore(10000);
         }
     }
+
     return nullptr;
 }
 #endif

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -90,6 +90,11 @@ private:
     pthread_t _uart_thread_ctx;
     pthread_t _uavcan_thread_ctx;
 
+    struct _uavcan_thread_arg {
+        PX4Scheduler *sched;
+        uint8_t uavcan_number;
+    };
+
     static void *_timer_thread(void *arg);
     static void *_io_thread(void *arg);
     static void *_storage_thread(void *arg);

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -12,6 +12,9 @@
 #include "AP_UAVCAN.h"
 #include <GCS_MAVLink/GCS.h>
 
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
+
 // Zubax GPS and other GPS, baro, magnetic sensors
 #include <uavcan/equipment/gnss/Fix.hpp>
 #include <uavcan/equipment/gnss/Auxiliary.hpp>
@@ -23,11 +26,9 @@
 #include <uavcan/equipment/actuator/Status.hpp>
 #include <uavcan/equipment/esc/RawCommand.hpp>
 
-#include <AP_BoardConfig/AP_BoardConfig.h>
-
 extern const AP_HAL::HAL& hal;
 
-#define debug_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig::get_can_debug()) { hal.console->printf(fmt, ##args); }} while (0)
+#define debug_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { hal.console->printf(fmt, ##args); }} while (0)
 
 // Translation of all messages from UAVCAN structures into AP structures is done
 // in AP_UAVCAN and not in corresponding drivers.
@@ -41,20 +42,33 @@ extern const AP_HAL::HAL& hal;
 // table of user settable CAN bus parameters
 const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
     // @Param: NODE
-    // @DisplayName: UAVCAN node that is used for Ardupilot
+    // @DisplayName: UAVCAN node that is used for this network
     // @Description: UAVCAN node should be set implicitly
     // @Range: 1 250
     // @User: Advanced
     AP_GROUPINFO("NODE", 1, AP_UAVCAN, _uavcan_node, 10),
 
+    // @Param: SRV_BM
+    // @DisplayName: RC Out channels to be transmitted as servo over UAVCAN
+    // @Description: Bitmask with one set for channel to be transmitted as a servo command over UAVCAN
+    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15
+    // @User: Advanced
+    AP_GROUPINFO("SRV_BM", 2, AP_UAVCAN, _servo_bm, 255),
+
+    // @Param: ESC_BM
+    // @DisplayName: RC Out channels to be transmitted as ESC over UAVCAN
+    // @Description: Bitmask with one set for channel to be transmitted as a ESC command over UAVCAN
+    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16
+    // @User: Advanced
+    AP_GROUPINFO("ESC_BM", 3, AP_UAVCAN, _esc_bm, 255),
+
     AP_GROUPEND
 };
 
-static uavcan::Subscriber<uavcan::equipment::gnss::Fix> *gnss_fix;
-static void gnss_fix_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg)
+static void gnss_fix_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
 
@@ -153,11 +167,17 @@ static void gnss_fix_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::g
     }
 }
 
-static uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary> *gnss_aux;
-static void gnss_aux_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg)
+static void gnss_fix_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg)
+{   gnss_fix_cb(msg, 0); }
+static void gnss_fix_cb1(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg)
+{   gnss_fix_cb(msg, 1); }
+static void (*gnss_fix_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg)
+        = { gnss_fix_cb0, gnss_fix_cb1 };
+
+static void gnss_aux_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
 
@@ -174,11 +194,17 @@ static void gnss_aux_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::g
     }
 }
 
-static uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength> *magnetic;
-static void magnetic_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg)
+static void gnss_aux_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg)
+{   gnss_aux_cb(msg, 0); }
+static void gnss_aux_cb1(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg)
+{   gnss_aux_cb(msg, 1); }
+static void (*gnss_aux_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg)
+        = { gnss_aux_cb0, gnss_aux_cb1 };
+
+static void magnetic_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get());
             if (state != nullptr) {
@@ -193,13 +219,20 @@ static void magnetic_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::a
     }
 }
 
-static uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure> *air_data_sp;
-static void air_data_sp_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg)
+static void magnetic_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg)
+{   magnetic_cb(msg, 0); }
+static void magnetic_cb1(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg)
+{   magnetic_cb(msg, 1); }
+static void (*magnetic_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg)
+        = { magnetic_cb0, magnetic_cb1 };
+
+static void air_data_sp_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
+
             if (state != nullptr) {
                 state->pressure = msg.static_pressure;
                 state->pressure_variance = msg.static_pressure_variance;
@@ -211,14 +244,21 @@ static void air_data_sp_cb(const uavcan::ReceivedDataStructure<uavcan::equipment
     }
 }
 
+static void air_data_sp_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg)
+{   air_data_sp_cb(msg, 0); }
+static void air_data_sp_cb1(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg)
+{   air_data_sp_cb(msg, 1); }
+static void (*air_data_sp_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg)
+        = { air_data_sp_cb0, air_data_sp_cb1 };
+
 // Temperature is not main parameter so do not update listeners when it is received
-static uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature> *air_data_st;
-static void air_data_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg)
+static void air_data_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr->get_UAVCAN();
+    if (hal.can_mgr[mgr] != nullptr) {
+        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
         if (ap_uavcan != nullptr) {
             AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
+
             if (state != nullptr) {
                 state->temperature = msg.static_temperature;
                 state->temperature_variance = msg.static_temperature_variance;
@@ -227,12 +267,19 @@ static void air_data_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment
     }
 }
 
+static void air_data_st_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg)
+{   air_data_st_cb(msg, 0); }
+static void air_data_st_cb1(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg)
+{   air_data_st_cb(msg, 1); }
+static void (*air_data_st_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg)
+        = { air_data_st_cb0, air_data_st_cb1 };
+
 // publisher interfaces
-static uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand> *act_out_array;
-static uavcan::Publisher<uavcan::equipment::esc::RawCommand> *esc_raw;
+static uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>* act_out_array[MAX_NUMBER_OF_CAN_DRIVERS];
+static uavcan::Publisher<uavcan::equipment::esc::RawCommand>* esc_raw[MAX_NUMBER_OF_CAN_DRIVERS];
 
 AP_UAVCAN::AP_UAVCAN() :
-    _initialized(false), _rco_armed(false), _rco_safety(false), _rc_out_sem(nullptr), _node_allocator(
+    _node_allocator(
         UAVCAN_NODE_POOL_SIZE, UAVCAN_NODE_POOL_SIZE)
 {
     AP_Param::setup_object_defaults(this, var_info);
@@ -242,28 +289,28 @@ AP_UAVCAN::AP_UAVCAN() :
     }
 
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
-        _gps_nodes[i] = 255;
+        _gps_nodes[i] = UINT8_MAX;
         _gps_node_taken[i] = 0;
     }
 
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
-        _baro_nodes[i] = 255;
+        _baro_nodes[i] = UINT8_MAX;
         _baro_node_taken[i] = 0;
     }
 
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-        _mag_nodes[i] = 255;
+        _mag_nodes[i] = UINT8_MAX;
         _mag_node_taken[i] = 0;
     }
 
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
-        _gps_listener_to_node[i] = 255;
+        _gps_listener_to_node[i] = UINT8_MAX;
         _gps_listeners[i] = nullptr;
 
-        _baro_listener_to_node[i] = 255;
+        _baro_listener_to_node[i] = UINT8_MAX;
         _baro_listeners[i] = nullptr;
 
-        _mag_listener_to_node[i] = 255;
+        _mag_listener_to_node[i] = UINT8_MAX;
         _mag_listeners[i] = nullptr;
     }
 
@@ -278,8 +325,21 @@ AP_UAVCAN::~AP_UAVCAN()
 
 bool AP_UAVCAN::try_init(void)
 {
-    if (hal.can_mgr != nullptr) {
-        if (hal.can_mgr->is_initialized() && !_initialized) {
+    if (_parent_can_mgr != nullptr) {
+        if (_parent_can_mgr->is_initialized() && !_initialized) {
+
+            _uavcan_i = UINT8_MAX;
+            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+                if (_parent_can_mgr == hal.can_mgr[i]) {
+                    _uavcan_i = i;
+                    break;
+                }
+            }
+
+            if(_uavcan_i == UINT8_MAX) {
+                return false;
+            }
+
             auto *node = get_node();
 
             if (node != nullptr) {
@@ -287,7 +347,10 @@ bool AP_UAVCAN::try_init(void)
                     uavcan::NodeID self_node_id(_uavcan_node);
                     node->setNodeID(self_node_id);
 
-                    uavcan::NodeStatusProvider::NodeName name("org.ardupilot");
+                    char ndname[20];
+                    snprintf(ndname, sizeof(ndname), "org.ardupilot:%u", _uavcan_i);
+
+                    uavcan::NodeStatusProvider::NodeName name(ndname);
                     node->setName(name);
 
                     uavcan::protocol::SoftwareVersion sw_version; // Standard type uavcan.protocol.SoftwareVersion
@@ -306,48 +369,54 @@ bool AP_UAVCAN::try_init(void)
                         debug_uavcan(1, "UAVCAN: node start problem\n\r");
                     }
 
+                    uavcan::Subscriber<uavcan::equipment::gnss::Fix> *gnss_fix;
                     gnss_fix = new uavcan::Subscriber<uavcan::equipment::gnss::Fix>(*node);
-                    const int gnss_fix_start_res = gnss_fix->start(gnss_fix_cb);
+
+                    const int gnss_fix_start_res = gnss_fix->start(gnss_fix_cb_arr[_uavcan_i]);
                     if (gnss_fix_start_res < 0) {
                         debug_uavcan(1, "UAVCAN GNSS subscriber start problem\n\r");
                         return false;
                     }
 
+                    uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary> *gnss_aux;
                     gnss_aux = new uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary>(*node);
-                    const int gnss_aux_start_res = gnss_aux->start(gnss_aux_cb);
+                    const int gnss_aux_start_res = gnss_aux->start(gnss_aux_cb_arr[_uavcan_i]);
                     if (gnss_aux_start_res < 0) {
                         debug_uavcan(1, "UAVCAN GNSS Aux subscriber start problem\n\r");
                         return false;
                     }
 
+                    uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength> *magnetic;
                     magnetic = new uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength>(*node);
-                    const int magnetic_start_res = magnetic->start(magnetic_cb);
+                    const int magnetic_start_res = magnetic->start(magnetic_cb_arr[_uavcan_i]);
                     if (magnetic_start_res < 0) {
                         debug_uavcan(1, "UAVCAN Compass subscriber start problem\n\r");
                         return false;
                     }
 
+                    uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure> *air_data_sp;
                     air_data_sp = new uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure>(*node);
-                    const int air_data_sp_start_res = air_data_sp->start(air_data_sp_cb);
+                    const int air_data_sp_start_res = air_data_sp->start(air_data_sp_cb_arr[_uavcan_i]);
                     if (air_data_sp_start_res < 0) {
                         debug_uavcan(1, "UAVCAN Baro subscriber start problem\n\r");
                         return false;
                     }
 
+                    uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature> *air_data_st;
                     air_data_st = new uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature>(*node);
-                    const int air_data_st_start_res = air_data_st->start(air_data_st_cb);
+                    const int air_data_st_start_res = air_data_st->start(air_data_st_cb_arr[_uavcan_i]);
                     if (air_data_st_start_res < 0) {
                         debug_uavcan(1, "UAVCAN Temperature subscriber start problem\n\r");
                         return false;
                     }
 
-                    act_out_array = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*node);
-                    act_out_array->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
-                    act_out_array->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+                    act_out_array[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*node);
+                    act_out_array[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+                    act_out_array[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
 
-                    esc_raw = new uavcan::Publisher<uavcan::equipment::esc::RawCommand>(*node);
-                    esc_raw->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
-                    esc_raw->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+                    esc_raw[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::esc::RawCommand>(*node);
+                    esc_raw[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+                    esc_raw[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
 
                     /*
                      * Informing other nodes that we're ready to work.
@@ -388,13 +457,11 @@ void AP_UAVCAN::rc_out_sem_give()
 
 void AP_UAVCAN::do_cyclic(void)
 {
-
-    uint32_t _servo_bm = SRV_Channels::get_can_servo_bm();
-    uint32_t _esc_bm = SRV_Channels::get_can_esc_bm();
-
     if (_initialized) {
         auto *node = get_node();
+
         const int error = node->spin(uavcan::MonotonicDuration::fromMSec(1));
+
         if (error < 0) {
             hal.scheduler->delay_microseconds(1000);
         } else {
@@ -440,7 +507,7 @@ void AP_UAVCAN::do_cyclic(void)
                             }
 
                             if (i > 0) {
-                                act_out_array->broadcast(msg);
+                                act_out_array[_uavcan_i]->broadcast(msg);
 
                                 if (i == 15) {
                                     repeat_send = true;
@@ -488,7 +555,7 @@ void AP_UAVCAN::do_cyclic(void)
                                 k++;
                             }
 
-                            esc_raw->broadcast(esc_msg);
+                            esc_raw[_uavcan_i]->broadcast(esc_msg);
                         }
                     }
                 }
@@ -501,6 +568,8 @@ void AP_UAVCAN::do_cyclic(void)
                 rc_out_sem_give();
             }
         }
+    } else {
+        hal.scheduler->delay_microseconds(1000);
     }
 }
 
@@ -511,11 +580,11 @@ uavcan::ISystemClock & AP_UAVCAN::get_system_clock()
 
 uavcan::ICanDriver * AP_UAVCAN::get_can_driver()
 {
-    if (hal.can_mgr != nullptr) {
-        if (hal.can_mgr->is_initialized() == false) {
+    if (_parent_can_mgr != nullptr) {
+        if (_parent_can_mgr->is_initialized() == false) {
             return nullptr;
         } else {
-            return hal.can_mgr;
+            return _parent_can_mgr;
         }
     }
     return nullptr;
@@ -569,9 +638,20 @@ void AP_UAVCAN::rco_write(uint16_t pulse_len, uint8_t ch)
     _rco_conf[ch].active = true;
 }
 
+uint8_t AP_UAVCAN::find_gps_without_listener(void)
+{
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
+        if (_gps_listeners[i] == nullptr && _gps_nodes[i] != UINT8_MAX) {
+            return _gps_nodes[i];
+        }
+    }
+
+    return UINT8_MAX;
+}
+
 uint8_t AP_UAVCAN::register_gps_listener(AP_GPS_Backend* new_listener, uint8_t preferred_channel)
 {
-    uint8_t sel_place = 255, ret = 0;
+    uint8_t sel_place = UINT8_MAX, ret = 0;
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
         if (_gps_listeners[i] == nullptr) {
             sel_place = i;
@@ -579,7 +659,7 @@ uint8_t AP_UAVCAN::register_gps_listener(AP_GPS_Backend* new_listener, uint8_t p
         }
     }
 
-    if (sel_place != 255) {
+    if (sel_place != UINT8_MAX) {
         if (preferred_channel != 0) {
             if (preferred_channel <= AP_UAVCAN_MAX_GPS_NODES) {
                 _gps_listeners[sel_place] = new_listener;
@@ -607,6 +687,34 @@ uint8_t AP_UAVCAN::register_gps_listener(AP_GPS_Backend* new_listener, uint8_t p
     return ret;
 }
 
+uint8_t AP_UAVCAN::register_gps_listener_to_node(AP_GPS_Backend* new_listener, uint8_t node)
+{
+    uint8_t sel_place = UINT8_MAX, ret = 0;
+
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
+        if (_gps_listeners[i] == nullptr) {
+            sel_place = i;
+            break;
+        }
+    }
+
+    if (sel_place != UINT8_MAX) {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
+            if (_gps_nodes[i] == node) {
+                _gps_listeners[sel_place] = new_listener;
+                _gps_listener_to_node[sel_place] = i;
+                _gps_node_taken[i]++;
+                ret = i + 1;
+
+                debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, i);
+                break;
+            }
+        }
+    }
+
+    return ret;
+}
+
 void AP_UAVCAN::remove_gps_listener(AP_GPS_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
@@ -618,7 +726,7 @@ void AP_UAVCAN::remove_gps_listener(AP_GPS_Backend* rem_listener)
             if (_gps_node_taken[_gps_listener_to_node[i]] > 0) {
                 _gps_node_taken[_gps_listener_to_node[i]]--;
             }
-            _gps_listener_to_node[i] = 255;
+            _gps_listener_to_node[i] = UINT8_MAX;
         }
     }
 }
@@ -634,7 +742,7 @@ AP_GPS::GPS_State *AP_UAVCAN::find_gps_node(uint8_t node)
 
     // If not - try to find free space for it
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
-        if (_gps_nodes[i] == 255) {
+        if (_gps_nodes[i] == UINT8_MAX) {
             _gps_nodes[i] = node;
             return &_gps_node_state[i];
         }
@@ -660,7 +768,7 @@ void AP_UAVCAN::update_gps_state(uint8_t node)
 
 uint8_t AP_UAVCAN::register_baro_listener(AP_Baro_Backend* new_listener, uint8_t preferred_channel)
 {
-    uint8_t sel_place = 255, ret = 0;
+    uint8_t sel_place = UINT8_MAX, ret = 0;
 
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
         if (_baro_listeners[i] == nullptr) {
@@ -669,7 +777,7 @@ uint8_t AP_UAVCAN::register_baro_listener(AP_Baro_Backend* new_listener, uint8_t
         }
     }
 
-    if (sel_place != 255) {
+    if (sel_place != UINT8_MAX) {
         if (preferred_channel != 0) {
             if (preferred_channel < AP_UAVCAN_MAX_BARO_NODES) {
                 _baro_listeners[sel_place] = new_listener;
@@ -697,6 +805,35 @@ uint8_t AP_UAVCAN::register_baro_listener(AP_Baro_Backend* new_listener, uint8_t
     return ret;
 }
 
+uint8_t AP_UAVCAN::register_baro_listener_to_node(AP_Baro_Backend* new_listener, uint8_t node)
+{
+    uint8_t sel_place = UINT8_MAX, ret = 0;
+
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
+        if (_baro_listeners[i] == nullptr) {
+            sel_place = i;
+            break;
+        }
+    }
+
+    if (sel_place != UINT8_MAX) {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
+            if (_baro_nodes[i] == node) {
+                _baro_listeners[sel_place] = new_listener;
+                _baro_listener_to_node[sel_place] = i;
+                _baro_node_taken[i]++;
+                ret = i + 1;
+
+                debug_uavcan(2, "reg_BARO place:%d, chan: %d\n\r", sel_place, i);
+                break;
+            }
+        }
+    }
+
+    return ret;
+}
+
+
 void AP_UAVCAN::remove_baro_listener(AP_Baro_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
@@ -708,7 +845,7 @@ void AP_UAVCAN::remove_baro_listener(AP_Baro_Backend* rem_listener)
             if (_baro_node_taken[_baro_listener_to_node[i]] > 0) {
                 _baro_node_taken[_baro_listener_to_node[i]]--;
             }
-            _baro_listener_to_node[i] = 255;
+            _baro_listener_to_node[i] = UINT8_MAX;
         }
     }
 }
@@ -724,7 +861,8 @@ AP_UAVCAN::Baro_Info *AP_UAVCAN::find_baro_node(uint8_t node)
 
     // If not - try to find free space for it
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
-        if (_baro_nodes[i] == 255) {
+        if (_baro_nodes[i] == UINT8_MAX) {
+
             _baro_nodes[i] = node;
             return &_baro_node_state[i];
         }
@@ -748,9 +886,25 @@ void AP_UAVCAN::update_baro_state(uint8_t node)
     }
 }
 
+/*
+ * Find discovered not taken baro node with smallest node ID
+ */
+uint8_t AP_UAVCAN::find_smallest_free_baro_node()
+{
+    uint8_t ret = UINT8_MAX;
+
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
+        if (_baro_node_taken[i] == 0) {
+            ret = MIN(ret, _baro_nodes[i]);
+        }
+    }
+
+    return ret;
+}
+
 uint8_t AP_UAVCAN::register_mag_listener(AP_Compass_Backend* new_listener, uint8_t preferred_channel)
 {
-    uint8_t sel_place = 255, ret = 0;
+    uint8_t sel_place = UINT8_MAX, ret = 0;
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
         if (_mag_listeners[i] == nullptr) {
             sel_place = i;
@@ -758,7 +912,7 @@ uint8_t AP_UAVCAN::register_mag_listener(AP_Compass_Backend* new_listener, uint8
         }
     }
 
-    if (sel_place != 255) {
+    if (sel_place != UINT8_MAX) {
         if (preferred_channel != 0) {
             if (preferred_channel < AP_UAVCAN_MAX_MAG_NODES) {
                 _mag_listeners[sel_place] = new_listener;
@@ -786,6 +940,34 @@ uint8_t AP_UAVCAN::register_mag_listener(AP_Compass_Backend* new_listener, uint8
     return ret;
 }
 
+uint8_t AP_UAVCAN::register_mag_listener_to_node(AP_Compass_Backend* new_listener, uint8_t node)
+{
+    uint8_t sel_place = UINT8_MAX, ret = 0;
+
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
+        if (_mag_listeners[i] == nullptr) {
+            sel_place = i;
+            break;
+        }
+    }
+
+    if (sel_place != UINT8_MAX) {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
+            if (_mag_nodes[i] == node) {
+                _mag_listeners[sel_place] = new_listener;
+                _mag_listener_to_node[sel_place] = i;
+                _mag_node_taken[i]++;
+                ret = i + 1;
+
+                debug_uavcan(2, "reg_MAG place:%d, chan: %d\n\r", sel_place, i);
+                break;
+            }
+        }
+    }
+
+    return ret;
+}
+
 void AP_UAVCAN::remove_mag_listener(AP_Compass_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
@@ -797,7 +979,7 @@ void AP_UAVCAN::remove_mag_listener(AP_Compass_Backend* rem_listener)
             if (_mag_node_taken[_mag_listener_to_node[i]] > 0) {
                 _mag_node_taken[_mag_listener_to_node[i]]--;
             }
-            _mag_listener_to_node[i] = 255;
+            _mag_listener_to_node[i] = UINT8_MAX;
         }
     }
 }
@@ -813,7 +995,7 @@ AP_UAVCAN::Mag_Info *AP_UAVCAN::find_mag_node(uint8_t node)
 
     // If not - try to find free space for it
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-        if (_mag_nodes[i] == 255) {
+        if (_mag_nodes[i] == UINT8_MAX) {
             _mag_nodes[i] = node;
             return &_mag_node_state[i];
         }
@@ -821,6 +1003,22 @@ AP_UAVCAN::Mag_Info *AP_UAVCAN::find_mag_node(uint8_t node)
 
     // If no space is left - return nullptr
     return nullptr;
+}
+
+/*
+ * Find discovered not taken mag node with smallest node ID
+ */
+uint8_t AP_UAVCAN::find_smallest_free_mag_node()
+{
+    uint8_t ret = UINT8_MAX;
+
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
+        if (_mag_node_taken[i] == 0) {
+            ret = MIN(ret, _mag_nodes[i]);
+        }
+    }
+
+    return ret;
 }
 
 void AP_UAVCAN::update_mag_state(uint8_t node)

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -1,5 +1,4 @@
 /*
- * AP_UAVCAN.h
  *
  *      Author: Eugene Shamaev
  */
@@ -54,8 +53,12 @@ public:
     // if preferred_channel > 0 then listener will be added to specific channel
     // return value is the number of assigned channel or 0 if fault
     // channel numbering starts from 1
-    uint8_t register_gps_listener(AP_GPS_Backend* new_listener,
-                                  uint8_t preferred_channel);
+    uint8_t register_gps_listener(AP_GPS_Backend* new_listener, uint8_t preferred_channel);
+
+    uint8_t register_gps_listener_to_node(AP_GPS_Backend* new_listener, uint8_t node);
+
+    uint8_t find_gps_without_listener(void);
+
     // Removes specified listener from all nodes
     void remove_gps_listener(AP_GPS_Backend* rem_listener);
 
@@ -73,20 +76,22 @@ public:
         float temperature_variance;
     };
 
-    uint8_t register_baro_listener(AP_Baro_Backend* new_listener,
-                                   uint8_t preferred_channel);
+    uint8_t register_baro_listener(AP_Baro_Backend* new_listener, uint8_t preferred_channel);
+    uint8_t register_baro_listener_to_node(AP_Baro_Backend* new_listener, uint8_t node);
     void remove_baro_listener(AP_Baro_Backend* rem_listener);
     Baro_Info *find_baro_node(uint8_t node);
+    uint8_t find_smallest_free_baro_node();
     void update_baro_state(uint8_t node);
 
     struct Mag_Info {
         Vector3f mag_vector;
     };
 
-    uint8_t register_mag_listener(AP_Compass_Backend* new_listener,
-                                  uint8_t preferred_channel);
+    uint8_t register_mag_listener(AP_Compass_Backend* new_listener, uint8_t preferred_channel);
     void remove_mag_listener(AP_Compass_Backend* rem_listener);
     Mag_Info *find_mag_node(uint8_t node);
+    uint8_t find_smallest_free_mag_node();
+    uint8_t register_mag_listener_to_node(AP_Compass_Backend* new_listener, uint8_t node);
     void update_mag_state(uint8_t node);
 
     // synchronization for RC output
@@ -191,6 +196,12 @@ private:
     uavcan::HeapBasedPoolAllocator<UAVCAN_NODE_POOL_BLOCK_SIZE, AP_UAVCAN::RaiiSynchronizer> _node_allocator;
 
     AP_Int8 _uavcan_node;
+    AP_Int32 _servo_bm;
+    AP_Int32 _esc_bm;
+
+    uint8_t _uavcan_i;
+
+    AP_HAL::CANManager* _parent_can_mgr;
 
 public:
     void do_cyclic(void);
@@ -202,6 +213,11 @@ public:
     void rco_force_safety_off(void);
     void rco_arm_actuators(bool arm);
     void rco_write(uint16_t pulse_len, uint8_t ch);
+
+    void set_parent_can_mgr(AP_HAL::CANManager* parent_can_mgr)
+    {
+        _parent_can_mgr = parent_can_mgr;
+    }
 };
 
 #endif /* AP_UAVCAN_H_ */

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -375,19 +375,6 @@ public:
     static bool upgrade_parameters(const uint8_t old_keys[14], uint16_t aux_channel_mask, RCMapper *rcmap);
     static void upgrade_motors_servo(uint8_t ap_motors_key, uint8_t ap_motors_idx, uint8_t new_channel);
     
-    static uint32_t get_can_servo_bm(void) {
-        if(p_can_servo_bm != nullptr)
-            return *p_can_servo_bm;
-        else
-            return 0;
-    }
-    static uint32_t get_can_esc_bm(void) {
-        if(p_can_esc_bm != nullptr)
-            return *p_can_esc_bm;
-        else
-            return 0;
-    }
-
 private:
     struct {
         bool k_throttle_reversible:1;
@@ -418,9 +405,4 @@ private:
     static bool passthrough_disabled(void) {
         return disabled_passthrough;
     }
-
-    AP_Int32 can_servo_bm;
-    AP_Int32 can_esc_bm;
-    static AP_Int32 *p_can_servo_bm;
-    static AP_Int32 *p_can_esc_bm;
 };

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -30,9 +30,6 @@ bool SRV_Channels::initialised;
 Bitmask SRV_Channels::function_mask{SRV_Channel::k_nr_aux_servo_functions};
 SRV_Channels::srv_function SRV_Channels::functions[SRV_Channel::k_nr_aux_servo_functions];
 
-AP_Int32* SRV_Channels::p_can_servo_bm = nullptr;
-AP_Int32* SRV_Channels::p_can_esc_bm = nullptr;
-
 const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Group: 1_
     // @Path: SRV_Channel.cpp
@@ -104,20 +101,6 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO_FRAME("_AUTO_TRIM",  17, SRV_Channels, auto_trim, 0, AP_PARAM_FRAME_PLANE),
-    
-    // @Param: _CANSRV_BM
-    // @DisplayName: RC Out channels to be transmitted as servo over CAN bus
-    // @Description: Bitmask with one set for channel to be transmitted as a servo command over CAN bus
-    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15
-    // @User: Standard
-    AP_GROUPINFO("_CANSRV_BM", 18, SRV_Channels, can_servo_bm, 0),
-
-    // @Param: _CANESC_BM
-    // @DisplayName: RC Out channels to be transmitted as ESC over CAN bus
-    // @Description: Bitmask with one set for channel to be transmitted as a ESC command over CAN bus
-    // @Bitmask: 0: ESC 1, 1: ESC 2, 2: ESC 3, 3: ESC 4, 4: ESC 5, 5: ESC 6, 6: ESC 7, 7: ESC 8, 8: ESC 9, 9: ESC 10, 10: ESC 11, 11: ESC 12, 12: ESC 13, 13: ESC 14, 14: ESC 15, 15: ESC 16
-    // @User: Standard
-    AP_GROUPINFO("_CANESC_BM", 19, SRV_Channels, can_esc_bm, 0),
 
     AP_GROUPEND
 };
@@ -128,8 +111,6 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
 SRV_Channels::SRV_Channels(void)
 {
     channels = obj_channels;
-    p_can_servo_bm = &can_servo_bm;
-    p_can_esc_bm = &can_esc_bm;
     
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);


### PR DESCRIPTION
Adds support for several separate nodes for CAN bus.

This extents the present functionality to a level that will be adequate for any future addition of other CAN protocols including redundant ones.
Main idea is to have possibility to group physical interfaces to several virtual drivers.
Each driver can then be assigned to any logical protocol be it UAVCAN or any other.
As I expect the number of available physical CAN interfaces to grow rapidly in nearest future, this is a solid ground for such expansion.

Default is one virtual driver with both physical interfaces bound to it.
This is a cable redundant configuration for UAVCAN.
Any other grouping is possible as well.
For example: 
- each physical CAN interface works with separate UAVCAN network;
- one CAN is working with UAVCAN and second one is working with CanOpen for example;
- first two are redundant UAVCAN and third one is for other protocol;
and so on.

Changes in configurations are:
- CAN group settings are separate for each physical interface;
- 'Enable' now sets the index of virtual driver to be used with this physical interface;
- CANDx_ group is added to configure virtual drivers and selection of protocol that will use it;

The code changes are that apart from several AP_HAL::CAN instances, now there are several instances AP_HAL::CANManager which in turn aggregate physical CAN interfaces.
All new protocols should follow the methodology of UAVCAN of using specific AP_HAL::CANManager as a single instance of accessing all available interfaces for this protocol.
In protocols where the redundancy is not needed, AP_HAL::CANManager will contain one AP_HAL::CAN instance and for redundant protocols, there will be several AP_HAL::CAN instances in AP_HAL::CANManager.
Simply saying, when protocol is granted AP_HAL::CANManager instance, all the physical interfaces contained in it are for this specific instance of the protocol.

The Scheduler now creates separate thread for each UAVCAN instance. For other protocols, this is preferred to separate instances from each other and simplify coding.

Additionally issues with baro and other sensors that had to present are solved. More to that, any number of the sensors can be on any network.