### PR TITLE
AC_Fence & ArduSub: add support beacon fence

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -77,7 +77,7 @@ Copter::Copter(void) :
     camera_mount(ahrs, current_loc),
 #endif
 #if AC_FENCE == ENABLED
-    fence(ahrs, inertial_nav),
+    fence(ahrs, inertial_nav, g2.beacon),
 #endif
 #if AC_AVOID_ENABLED == ENABLED
     avoid(ahrs, inertial_nav, fence, g2.proximity),

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -36,6 +36,7 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(three_hz_loop,          3,     75),
     SCHED_TASK(update_turn_counter,   10,     50),
     SCHED_TASK(compass_accumulate,   100,    100),
+    SCHED_TASK(update_beacon,         50,     50),
     SCHED_TASK(barometer_accumulate,  50,     90),
     SCHED_TASK(update_notify,         50,     90),
     SCHED_TASK(one_hz_loop,            1,    100),
@@ -308,6 +309,7 @@ void Sub::ten_hz_logging_loop()
     }
     if (should_log(MASK_LOG_CTUN)) {
         attitude_control.control_monitor_log();
+        Log_Write_Beacon();
     }
 }
 

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -427,6 +427,16 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
+// Write beacon position and distances
+void Sub::Log_Write_Beacon()
+{
+    // exit immediately if feature is disabled
+    if (!g2.beacon.enabled()) {
+        return;
+    }
+    DataFlash.Log_Write_Beacon(g2.beacon);
+}
+
 const struct LogStructure Sub::log_structure[] = {
     LOG_COMMON_STRUCTURES,
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow),       

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -752,6 +752,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/RC_Channel/RC_Channels.cpp
     AP_SUBGROUPINFO(rc_channels, "RC", 17, ParametersG2, RC_Channels),
 
+    // @Group: BCN
+    // @Path: ../libraries/AP_Beacon/AP_Beacon.cpp
+    AP_SUBGROUPINFO(beacon, "BCN", 18, ParametersG2, AP_Beacon),
+
     AP_GROUPEND
 };
 
@@ -759,6 +763,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
   constructor for g2 object
  */
 ParametersG2::ParametersG2(void)
+    : beacon(sub.serial_manager)
 #if PROXIMITY_ENABLED == ENABLED
     : proximity(sub.serial_manager)
 #endif

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -356,6 +356,9 @@ public:
     AP_Proximity proximity;
 #endif
 
+    // beacon (non-GPS positioning) library
+    AP_Beacon beacon;
+
     // RC input channels
     RC_Channels rc_channels;
 

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -68,7 +68,7 @@ Sub::Sub(void) :
           camera_mount(ahrs, current_loc),
 #endif
 #if AC_FENCE == ENABLED
-          fence(ahrs, inertial_nav),
+          fence(ahrs, inertial_nav, g2.beacon),
 #endif
 #if AC_RALLY == ENABLED
           rally(ahrs),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -457,6 +457,8 @@ private:
     void update_turn_counter();
     void read_AHRS(void);
     void update_altitude();
+    void init_beacon();
+    void update_beacon();
     void set_home_state(enum HomeState new_home_state);
     bool home_is_set();
     float get_smoothing_gain();
@@ -513,6 +515,7 @@ private:
     void Log_Write_Home_And_Origin();
     void Log_Sensor_Health();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_Beacon();
     void Log_Write_Vehicle_Startup_Messages();
     void start_logging() ;
     void load_parameters(void);

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -67,6 +67,18 @@ void Sub::read_rangefinder(void)
 #endif
 }
 
+// init beacons used for non-gps position estimates
+void Sub::init_beacon()
+{
+    g2.beacon.init();
+}
+
+// update beacons
+void Sub::update_beacon()
+{
+    g2.beacon.update();
+}
+
 // return true if rangefinder_alt can be used
 bool Sub::rangefinder_alt_ok()
 {

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -84,6 +84,9 @@ void Sub::init_ardupilot()
      */
     hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
+    // give AHRS the rnage beacon sensor
+    ahrs.set_beacon(&g2.beacon);
+
     // Do GPS init
     gps.init(&DataFlash, serial_manager);
 
@@ -156,6 +159,9 @@ void Sub::init_ardupilot()
 #if RANGEFINDER_ENABLED == ENABLED
     init_rangefinder();
 #endif
+
+    // init beacons used for non-gps position estimation
+    init_beacon();
 
     // initialise AP_RPM library
 #if RPM_ENABLED == ENABLED

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -59,6 +59,7 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
     if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
         adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_vel);
         adjust_velocity_polygon_fence(kP, accel_cmss_limited, desired_vel);
+        adjust_velocity_beacon_fence(kP, accel_cmss_limited, desired_vel);
     }
 
     if ((_enabled & AC_AVOID_USE_PROXIMITY_SENSOR) > 0 && _proximity_enabled) {
@@ -251,6 +252,32 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
     Vector2f* boundary = _fence.get_polygon_points(num_points);
 
     // adjust velocity using polygon
+    adjust_velocity_polygon(kP, accel_cmss, desired_vel, boundary, num_points, true, _fence.get_margin());
+}
+
+/*
+ * Adjusts the desired velocity for the beacon fence.
+ */
+void AC_Avoid::adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f &desired_vel)
+{
+    // exit if the beacon fence is not enabled
+    if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_BEACON) == 0) {
+        return;
+    }
+
+    // exit immediately if no desired velocity
+    if (desired_vel.is_zero()) {
+        return;
+    }
+
+    // get boundary from beacons
+    uint16_t num_points;
+    Vector2f* boundary = _fence.get_beacon_points(num_points);
+    if (boundary == nullptr) {
+        return;
+    }
+
+    // adjust velocity using beacon
     adjust_velocity_polygon(kP, accel_cmss, desired_vel, boundary, num_points, true, _fence.get_margin());
 }
 

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -66,6 +66,11 @@ private:
     void adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2f &desired_vel);
 
     /*
+     * Adjusts the desired velocity for the beacon fence.
+     */
+    void adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f &desired_vel);
+
+    /*
      * Adjusts the desired velocity based on output from the proximity sensor
      */
     void adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel);

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -9,12 +9,14 @@
 #include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_Fence/AC_PolyFence_loader.h>
 #include <AP_Common/Location.h>
+#include <AP_Beacon/AP_Beacon.h>
 
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_NONE                          0       // fence disabled
 #define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
 #define AC_FENCE_TYPE_CIRCLE                        2       // circular horizontal fence (usually initiates an RTL)
 #define AC_FENCE_TYPE_POLYGON                       4       // polygon horizontal fence
+#define AC_FENCE_TYPE_BEACON                        8       // beacon horizontal fence
 
 // valid actions should a fence be breached
 #define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
@@ -37,7 +39,7 @@ class AC_Fence
 public:
 
     /// Constructor
-    AC_Fence(const AP_AHRS& ahrs, const AP_InertialNav& inav);
+    AC_Fence(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AP_Beacon& beacon);
 
     /// enable - allows fence to be enabled/disabled.  Note: this does not update the eeprom saved value
     void enable(bool true_false) { _enabled = true_false; }
@@ -111,6 +113,15 @@ public:
     /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object
     bool boundary_breached(const Vector2f& location, uint16_t num_points, const Vector2f* points) const;
 
+
+    ///
+    /// beacon related methods
+    ///
+
+    /// returns pointer to array of beacon points and num_points is filled in with the total number
+    Vector2f* get_beacon_points(uint16_t& num_points) const;
+
+
     /// handler for polygon fence messages with GCS
     void handle_msg(mavlink_channel_t chan, mavlink_message_t* msg);
 
@@ -130,6 +141,7 @@ private:
     // pointers to other objects we depend upon
     const AP_AHRS& _ahrs;
     const AP_InertialNav& _inav;
+    const AP_Beacon& _beacon;
 
     // parameters
     AP_Int8         _enabled;               // top level enable/disable control
@@ -166,4 +178,9 @@ private:
     bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
     bool            _boundary_loaded = false;       // true if boundary array has been loaded from eeprom
     bool            _boundary_valid = false;        // true if boundary forms a closed polygon
+
+    // beacon fence variables
+    Vector2f        *_beacon_boundary = nullptr;        // array of boundary points.  Note: point 0 is the return point
+    uint8_t         _beacon_boundary_num_points = 0;    // number of points in the boundary array
+    bool            _beacon_boundary_valid = false;     // true if boundary forms a closed beacon polygon
 };

--- a/libraries/AP_Beacon/AP_Beacon.h
+++ b/libraries/AP_Beacon/AP_Beacon.h
@@ -24,6 +24,7 @@ class AP_Beacon_Backend;
 
 #define AP_BEACON_MAX_BEACONS 4
 #define AP_BEACON_TIMEOUT_MS 300
+#define AP_BEACON_MINIMUM_FENCE_BEACONS 3
 
 class AP_Beacon
 {
@@ -90,6 +91,12 @@ public:
     // return last update time from beacon
     uint32_t beacon_last_update_ms(uint8_t beacon_instance) const;
 
+    // update fence boundary array
+    bool update_boundary_points();
+
+    // return fence boundary array
+    Vector2f* get_boundary_points(uint16_t& num_points) const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -116,4 +123,8 @@ private:
     // individual beacon data
     uint8_t num_beacons = 0;
     BeaconState beacon_state[AP_BEACON_MAX_BEACONS];
+
+    // fence boundary
+    Vector2f *_boundary = nullptr;
+    uint8_t boundary_num_beacons = 0;
 };

--- a/libraries/AP_Beacon/AP_Beacon_Backend.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Backend.cpp
@@ -68,6 +68,9 @@ void AP_Beacon_Backend::set_beacon_position(uint8_t beacon_instance, const Vecto
 
     // set position after correcting yaw
     _frontend.beacon_state[beacon_instance].position = correct_for_orient_yaw(pos);
+
+    // update boundary for fence
+    _frontend.update_boundary_points();
 }
 
 // rotate vector to correct for beacon system yaw orientation


### PR DESCRIPTION
add support beacon fence. I added beacon object to AC_Fence so I need to add beacon to ArduSub.
I didn't do rebase -i because I think It is easy for reviewers to review ArduSub modified codes.

I only tested using Copter SITL with libraries/AP_Beacon/sitl/sitl_beacons.param.

I also changed these defines.

#define BEACON_SPACING_NORTH 1000.0
#define BEACON_SPACING_EAST 1000.0
