### PR TITLE
AC_WPNav: unset yaw when setting new origin and destination

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -512,6 +512,7 @@ bool AC_WPNav::set_wp_origin_and_destination(const Vector3f& origin, const Vecto
     _flags.slowing_down = false;    // target is not slowing down yet
     _flags.segment_type = SEGMENT_STRAIGHT;
     _flags.new_wp_destination = true;   // flag new waypoint so we can freeze the pos controller's feed forward and smooth the transition
+    _flags.wp_yaw_set = false;
 
     // initialise the limited speed to current speed along the track
     const Vector3f &curr_vel = _inav.get_velocity();
@@ -1017,6 +1018,7 @@ bool AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const V
     _flags.reached_destination = false;
     _flags.segment_type = SEGMENT_SPLINE;
     _flags.new_wp_destination = true;   // flag new waypoint so we can freeze the pos controller's feed forward and smooth the transition
+    _flags.wp_yaw_set = false;
 
     // initialise yaw related variables
     _track_length_xy = safe_sqrt(sq(_destination.x - _origin.x)+sq(_destination.y - _origin.y));  // horizontal track length (used to decide if we should update yaw)


### PR DESCRIPTION
This is a small correction to an earlier PR: https://github.com/ArduPilot/ardupilot/pull/6143

This ensures that old yaw targets are not used in the short interval before they are initialised in advance_wp_target_along_track or advance_spline_along_track.

![acwpnav-yaw-unset-graph](https://cloud.githubusercontent.com/assets/1498098/25604601/9971f0a2-2f3f-11e7-9164-c23b79e645dc.png)

The above graph shows the small twitch that results in yaw for a small mission which included:

- fly north-west from home to a waypoint
- loiter at the waypoint location for 10 seconds
- execute CONDITION_YAW to change heading to point directly south
- loiter for an additional 10 seconds
- fly south-east back to the home location
![acwpnav-yaw-unset](https://cloud.githubusercontent.com/assets/1498098/25604557/33e8c49a-2f3f-11e7-9726-bab4e43af445.png)

Thanks to @OXINARF for finding this issue.