### PR TITLE
use HAL_SEMAPHORE_BLOCK_FOREVER

### DIFF
--- a/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
@@ -52,7 +52,7 @@ AP_Baro_UAVCAN::~AP_Baro_UAVCAN()
 // Read the sensor
 void AP_Baro_UAVCAN::update(void)
 {
-    if (_sem_baro->take(0)) {
+    if (_sem_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _copy_to_frontend(_instance, _pressure, _temperature);
 
         _frontend.set_external_temperature(_temperature);
@@ -62,7 +62,7 @@ void AP_Baro_UAVCAN::update(void)
 
 void AP_Baro_UAVCAN::handle_baro_msg(float pressure, float temperature)
 {
-    if (_sem_baro->take(0)) {
+    if (_sem_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _pressure = pressure;
         _temperature = temperature - 273.15f;
         _last_timestamp = AP_HAL::micros64();

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -98,7 +98,7 @@ void AP_Compass_UAVCAN::read(void)
         return;
     }
 
-    if (_mag_baro->take(0)) {
+    if (_mag_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _sum /= _count;
 
         publish_filtered_field(_sum, _instance);
@@ -123,7 +123,7 @@ void AP_Compass_UAVCAN::handle_mag_msg(Vector3f &mag)
     // correct raw_field for known errors
     correct_field(raw_field, _instance);
 
-    if (_mag_baro->take(0)) {
+    if (_mag_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         // accumulate into averaging filter
         _sum += raw_field;
         _count++;

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -50,7 +50,7 @@ AP_GPS_UAVCAN::~AP_GPS_UAVCAN()
 // Consume new data and mark it received
 bool AP_GPS_UAVCAN::read(void)
 {
-    if (_sem_gnss->take(0)) {
+    if (_sem_gnss->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         if (_new_data) {
             _new_data = false;
 
@@ -67,7 +67,7 @@ bool AP_GPS_UAVCAN::read(void)
 
 void AP_GPS_UAVCAN::handle_gnss_msg(const AP_GPS::GPS_State &msg)
 {
-    if (_sem_gnss->take(0)) {
+    if (_sem_gnss->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _interm_state = msg;
         _new_data = true;
         _sem_gnss->give();

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -278,7 +278,7 @@ void Scheduler::register_timer_failsafe(AP_HAL::Proc failsafe, uint32_t period_u
 
 void Scheduler::suspend_timer_procs()
 {
-    if (!_timer_semaphore.take(0)) {
+    if (!_timer_semaphore.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         printf("Failed to take timer semaphore\n");
     }
 }
@@ -297,7 +297,7 @@ void Scheduler::_timer_task()
     }
     _in_timer_proc = true;
 
-    if (!_timer_semaphore.take(0)) {
+    if (!_timer_semaphore.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         printf("Failed to take timer semaphore in %s\n", __PRETTY_FUNCTION__);
     }
     // now call the timer based drivers
@@ -350,7 +350,7 @@ void Scheduler::_timer_task()
 
 void Scheduler::_run_io(void)
 {
-    if (!_io_semaphore.take(0)) {
+    if (!_io_semaphore.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 

--- a/libraries/AP_HAL_PX4/Device.cpp
+++ b/libraries/AP_HAL_PX4/Device.cpp
@@ -63,7 +63,7 @@ void *DeviceBus::bus_thread(void *arg)
                     callback->next_usec += callback->period_usec;
                 }
                 // call it with semaphore held
-                if (binfo->semaphore.take(0)) {
+                if (binfo->semaphore.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
                     callback->cb();
                     binfo->semaphore.give();
                 }

--- a/libraries/AP_HAL_QURT/Storage.cpp
+++ b/libraries/AP_HAL_QURT/Storage.cpp
@@ -39,7 +39,7 @@ void Storage::write_block(uint16_t loc, const void *src, size_t n)
         return;
     }
     if (memcmp(src, &buffer[loc], n) != 0) {
-        lock.take(0);
+        lock.take(HAL_SEMAPHORE_BLOCK_FOREVER);
         memcpy(&buffer[loc], src, n);
         dirty = true;
         lock.give();

--- a/libraries/AP_HAL_QURT/UARTDriver.cpp
+++ b/libraries/AP_HAL_QURT/UARTDriver.cpp
@@ -206,7 +206,7 @@ int16_t UARTDriver::read()
     if (!initialised) {
         return -1;
     }
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
     if (readbuf->empty()) {
@@ -224,7 +224,7 @@ size_t UARTDriver::write(uint8_t c)
     if (!initialised) {
         return 0;
     }
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
 
@@ -257,7 +257,7 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
     size_t ret = writebuf->write(buffer, size);

--- a/libraries/AP_HAL_QURT/UDPDriver.cpp
+++ b/libraries/AP_HAL_QURT/UDPDriver.cpp
@@ -120,7 +120,7 @@ int16_t UDPDriver::read()
     if (!initialised) {
         return -1;
     }
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
     if (readbuf->empty()) {
@@ -138,7 +138,7 @@ size_t UDPDriver::write(uint8_t c)
     if (!initialised) {
         return 0;
     }
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
 
@@ -171,7 +171,7 @@ size_t UDPDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    if (!lock.take(0)) {
+    if (!lock.take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return 0;
     }
     size_t ret = writebuf->write(buffer, size);

--- a/libraries/AP_HAL_QURT/dsp_main.cpp
+++ b/libraries/AP_HAL_QURT/dsp_main.cpp
@@ -74,7 +74,7 @@ uint32_t ardupilot_set_storage(const uint8_t *buf, int len)
         HAP_PRINTF("Incorrect storage size %u", len);
         return 1;
     }
-    QURT::Storage::lock.take(0);
+    QURT::Storage::lock.take(HAL_SEMAPHORE_BLOCK_FOREVER);
     memcpy(QURT::Storage::buffer, buf, len);
     QURT::Storage::lock.give();
     return 0;
@@ -89,7 +89,7 @@ uint32_t ardupilot_get_storage(uint8_t *buf, int len)
     if (!QURT::Storage::dirty) {
         return 1;
     }
-    QURT::Storage::lock.take(0);
+    QURT::Storage::lock.take(HAL_SEMAPHORE_BLOCK_FOREVER);
     memcpy(buf, QURT::Storage::buffer, len);
     QURT::Storage::lock.give();
     return 0;

--- a/libraries/AP_TemperatureSensor/TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/TSYS01.cpp
@@ -29,7 +29,7 @@ bool TSYS01::init()
         return false;
     }
 
-    if (!_dev->get_semaphore()->take(0)) {
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         AP_HAL::panic("PANIC: TSYS01: failed to take serial semaphore for init");
     }
 


### PR DESCRIPTION
... whereever we were passing `0`

I believe these patches should be reviewed to ensure that block-forever is what the author thought was going to happen.
