### PR TITLE
AP_GPS:UBLOX: publish times only when iTOW of components match

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -908,7 +908,8 @@ AP_GPS_UBLOX::_parse_gps(void)
               _buffer.solution.fix_status,
               _buffer.solution.fix_type);
         if (havePvtMsg) {
-            state.time_week = _buffer.solution.week;
+            pending_time_week_iTOW = _buffer.solution.time;
+            pending_time_week = _buffer.solution.week;
             break;
         }
         if (_buffer.solution.fix_status & NAV_STATUS_FIX_VALID) {
@@ -1009,11 +1010,13 @@ AP_GPS_UBLOX::_parse_gps(void)
             state.hdop        = _buffer.pvt.p_dop;
             state.vdop        = _buffer.pvt.p_dop;
         }
-                    
-        state.last_gps_time_ms = AP_HAL::millis();
-        
-        // time
-        state.time_week_ms    = _buffer.pvt.itow;
+
+        if (pending_time_week_iTOW == _buffer.pvt.itow) {
+            state.last_gps_time_ms = AP_HAL::millis();
+            state.time_week = pending_time_week;
+            state.time_week_ms = _buffer.pvt.itow;
+        }
+
 #if UBLOX_FAKE_3DLOCK
         state.location.lng = 1491652300L;
         state.location.lat = -353632610L;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -516,6 +516,11 @@ private:
 
     uint32_t        _last_vel_time;
     uint32_t        _last_pos_time;
+
+    // information to ensure time_week and time_week_ms are always correlated:
+    uint32_t        pending_time_week_iTOW;
+    uint16_t        pending_time_week;
+
     uint32_t        _last_cfg_sent_time;
     uint8_t         _num_cfg_save_tries;
     uint32_t        _last_config_time;


### PR DESCRIPTION
On GPS week roll-over we may currently set the time to be in the past, depending on message ordering.

With this patch we may drop an update.
