### PR TITLE
Use SI units in parameters when possible, validate units in Travis, generate documentation

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -77,7 +77,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: Telemetry startup delay
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Standard
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -125,7 +125,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: SPEED_TURN_GAIN
     // @DisplayName: Target speed reduction while turning
     // @Description: The percentage to reduce the throttle while turning. If this is 100% then the target speed is not reduced while turning. If this is 50% then the target speed is reduced in proportion to the turn rate, with a reduction of 50% when the steering is maximally deflected.
-    // @Units: percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -134,7 +134,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: SPEED_TURN_DIST
     // @DisplayName: Distance to turn to start reducing speed
     // @Description: The distance to the next turn at which the rover reduces its target speed by the SPEED_TURN_GAIN
-    // @Units: meters
+    // @Units: m
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
@@ -143,7 +143,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: BRAKING_PERCENT
     // @DisplayName: Percentage braking to apply
     // @Description: The maximum reverse throttle braking percentage to apply when cornering
-    // @Units: percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -161,7 +161,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: PIVOT_TURN_ANGLE
     // @DisplayName: Pivot turn angle
     // @Description: Navigation angle threshold in degrees to switch to pivot steering when SKID_STEER_OUT is 1. This allows you to setup a skid steering rover to turn on the spot in auto mode when the angle it needs to turn it greater than this angle. An angle of zero means to disable pivot turning. Note that you will probably also want to set a low value for WP_RADIUS to get neat turns.
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @Increment: 1
     // @User: Standard
@@ -177,7 +177,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
     // @Description: The minimum throttle setting to which the autopilot will apply. This is mostly useful for rovers with internal combustion motors, to prevent the motor from cutting out in auto mode.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -186,7 +186,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
     // @Description: The maximum throttle setting to which the autopilot will apply. This can be used to prevent overheating a ESC or motor on an electric rover.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -195,7 +195,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CRUISE_THROTTLE
     // @DisplayName: Base throttle percentage in auto
     // @Description: The base throttle percentage to use in auto mode. The CRUISE_SPEED parameter controls the target speed, but the rover starts with the CRUISE_THROTTLE setting as the initial estimate for how much throttle is needed to achieve that speed. It then adjusts the throttle based on how fast the rover is actually going.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -204,7 +204,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
     // @Description: maximum percentage change in throttle per second. A setting of 10 means to not change the throttle by more than 10% of the full throttle range in one second. A value of zero means no limit. A value of 100 means the throttle can change over its full range in one second. Note that for some NiMH powered rovers setting a lower value like 40 or 50 may be worthwhile as the sudden current demand on the battery of a big rise in throttle may cause a brownout.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -234,7 +234,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout
     // @Description: How long a failsafe event need to happen for before we trigger the failsafe action
-    // @Units: seconds
+    // @Units: s
     // @User: Standard
     GSCALAR(fs_timeout,    "FS_TIMEOUT",     5),
 
@@ -270,7 +270,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TRIGGR_CM
     // @DisplayName: Rangefinder trigger distance
     // @Description: The distance from an obstacle in centimeters at which the rangefinder triggers a turn to avoid the obstacle
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 1000
     // @Increment: 1
     // @User: Standard
@@ -279,7 +279,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TURN_ANGL
     // @DisplayName: Rangefinder trigger angle
     // @Description: The course deviation in degrees to apply while avoiding an obstacle detected with the rangefinder. A positive number means to turn right, and a negative angle means to turn left.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: -45 45
     // @Increment: 1
     // @User: Standard
@@ -288,7 +288,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: RNGFND_TURN_TIME
     // @DisplayName: Rangefinder turn time
     // @Description: The amount of time in seconds to apply the RNGFND_TURN_ANGL after detecting an obstacle.
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 100
     // @Increment: 0.1
     // @User: Standard
@@ -359,7 +359,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint radius
     // @Description: The distance in meters from a waypoint when we consider the waypoint has been reached. This determines when the rover will turn along the next waypoint path.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000
     // @Increment: 0.1
     // @User: Standard

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -57,7 +57,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW_SLEW_TIME
     // @DisplayName: Time for yaw to slew through its full range
     // @Description: This controls how rapidly the tracker will change the servo output for yaw. It is set as the number of seconds to do a full rotation. You can use this parameter to slow the trackers movements, which may help with some types of trackers. A value of zero will allow for unlimited servo movement per update.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 20
     // @User: Standard
@@ -66,7 +66,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH_SLEW_TIME
     // @DisplayName: Time for pitch to slew through its full range
     // @Description: This controls how rapidly the tracker will change the servo output for pitch. It is set as the number of seconds to do a full range of pitch movement. You can use this parameter to slow the trackers movements, which may help with some types of trackers. A value of zero will allow for unlimited servo movement per update.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 20
     // @User: Standard
@@ -75,7 +75,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: SCAN_SPEED
     // @DisplayName: Speed at which to rotate in scan mode
     // @Description: This controls how rapidly the tracker will move the servos in SCAN mode
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Increment: 1
     // @Range: 0 100
     // @User: Standard
@@ -84,7 +84,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: MIN_REVERSE_TIME
     // @DisplayName: Minimum time to apply a yaw reversal
     // @Description: When the tracker detects it has reached the limit of servo movement in yaw it will reverse and try moving to the other extreme of yaw. This parameter controls the minimum time it should reverse for. It is used to cope with trackers that have a significant lag in movement to ensure they do move all the way around.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 1
     // @Range: 0 20
     // @User: Standard
@@ -93,7 +93,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: START_LATITUDE
     // @DisplayName: Initial Latitude before GPS lock
     // @Description: Combined with START_LONGITUDE this parameter allows for an initial position of the tracker to be set. This position will be used until the GPS gets lock. It can also be used to run a stationary tracker with no GPS attached.
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.000001
     // @Range: -90 90
     // @User: Standard
@@ -102,7 +102,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: START_LONGITUDE
     // @DisplayName: Initial Longitude before GPS lock
     // @Description: Combined with START_LATITUDE this parameter allows for an initial position of the tracker to be set. This position will be used until the GPS gets lock. It can also be used to run a stationary tracker with no GPS attached.
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.000001
     // @Range: -180 180
     // @User: Standard
@@ -111,7 +111,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: STARTUP_DELAY
     // @DisplayName: Delay before first servo movement from trim
     // @Description: This parameter can be used to force the servos to their trim value for a time on startup. This can help with some servo types
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @Range: 0 10
     // @User: Standard
@@ -134,7 +134,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_YAW_RATE
     // @DisplayName: Yaw rate for on/off servos
     // @Description: Rate of change of yaw in degrees/second for on/off servos
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Increment: 0.1
     // @Range: 0 50
     // @User: Standard
@@ -143,7 +143,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_PITCH_RATE
     // @DisplayName: Pitch rate for on/off servos
     // @Description: Rate of change of pitch in degrees/second for on/off servos
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Increment: 0.1
     // @Range: 0 50
     // @User: Standard
@@ -152,7 +152,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_YAW_MINT
     // @DisplayName: Yaw minimum movement time
     // @Description: Minimum amount of time in seconds to move in yaw
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.01
     // @Range: 0 2
     // @User: Standard
@@ -161,7 +161,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: ONOFF_PITCH_MINT
     // @DisplayName: Pitch minimum movement time
     // @Description: Minimim amount of time in seconds to move in pitch
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.01
     // @Range: 0 2
     // @User: Standard
@@ -170,7 +170,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW_TRIM
     // @DisplayName: Yaw trim
     // @Description: Amount of extra yaw to add when tracking. This allows for small adjustments for an out of trim compass.
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.1
     // @Range: -10 10
     // @User: Standard
@@ -179,7 +179,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH_TRIM
     // @DisplayName: Pitch trim
     // @Description: Amount of extra pitch to add when tracking. This allows for small adjustments for a badly calibrated barometer.
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.1
     // @Range: -10 10
     // @User: Standard
@@ -188,7 +188,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW_RANGE
     // @DisplayName: Yaw Angle Range
     // @Description: Yaw axis total range of motion in degrees
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.1
     // @Range: 0 360
     // @User: Standard
@@ -197,7 +197,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: DISTANCE_MIN
     // @DisplayName: Distance minimum to target
     // @Description: Tracker will track targets at least this distance away
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @Range: 0 100
     // @User: Standard
@@ -222,7 +222,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH_MIN
     // @DisplayName: Minimum Pitch Angle
     // @Description: The lowest angle the pitch can reach
-    // @Units: Degrees
+    // @Units: deg
     // @Increment: 1
     // @Range: -90 0
     // @User: Standard
@@ -231,7 +231,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH_MAX
     // @DisplayName: Maximum Pitch Angle
     // @Description: The highest angle the pitch can reach
-    // @Units: Degrees
+    // @Units: deg
     // @Increment: 1
     // @Range: 0 90
     // @User: Standard
@@ -331,7 +331,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Description: Pitch axis controller I gain maximum.  Constrains the maximum pwm change that the I gain will output
     // @Range: 0 4000
     // @Increment: 10
-    // @Units: Percent*10
+    // @Units: d%
     // @User: Standard
 
     // @Param: PITCH2SRV_D
@@ -361,7 +361,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Description: Yaw axis controller I gain maximum.  Constrains the maximum pwm change that the I gain will output
     // @Range: 0 4000
     // @Increment: 10
-    // @Units: Percent*10
+    // @Units: d%
     // @User: Standard
 
     // @Param: YAW2SRV_D

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -80,7 +80,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Pilot takeoff altitude
     // @Description: Altitude that altitude control modes will climb to when a takeoff is triggered with the throttle stick.
     // @User: Standard
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0.0 1000.0
     // @Increment: 10
     GSCALAR(pilot_takeoff_alt,  "PILOT_TKOFF_ALT",  PILOT_TKOFF_ALT_DEFAULT),
@@ -109,7 +109,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Telemetry startup delay
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Advanced
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -125,7 +125,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_ALT
     // @DisplayName: RTL Altitude
     // @Description: The minimum relative altitude the model will move to before Returning to Launch.  Set to zero to return at current altitude.
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0 8000
     // @Increment: 1
     // @User: Standard
@@ -167,7 +167,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_BATT_VOLTAGE
     // @DisplayName: Failsafe battery voltage
     // @Description: Battery voltage to trigger failsafe. Set to 0 to disable battery voltage failsafe. If the battery voltage drops below this voltage then the copter will RTL
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", FS_BATT_VOLTAGE_DEFAULT),
@@ -175,7 +175,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_BATT_MAH
     // @DisplayName: Failsafe battery milliAmpHours
     // @Description: Battery capacity remaining to trigger failsafe. Set to 0 to disable battery remaining failsafe. If the battery remaining drops below this level then the copter will RTL
-    // @Units: mAh
+    // @Units: mA.h
     // @Increment: 50
     // @User: Standard
     GSCALAR(fs_batt_mah,            "FS_BATT_MAH", FS_BATT_MAH_DEFAULT),
@@ -211,7 +211,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_ALT_FINAL
     // @DisplayName: RTL Final Altitude
     // @Description: This is the altitude the vehicle will move to as the final stage of Returning to Launch or after completing a mission.  Set to zero to land.
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: -1 1000
     // @Increment: 1
     // @User: Standard
@@ -220,7 +220,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: RTL_CLIMB_MIN
     // @DisplayName: RTL minimum climb
     // @Description: The vehicle will climb this many cm during the initial climb portion of the RTL
-    // @Units: Centimeters
+    // @Units: cm
     // @Range: 0 3000
     // @Increment: 10
     // @User: Standard
@@ -263,7 +263,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: PILOT_VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
-    // @Units: Centimeters/Second
+    // @Units: cm/s
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard
@@ -289,7 +289,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Throttle Failsafe Value
     // @Description: The PWM level on channel 3 below which throttle failsafe triggers
     // @Range: 925 1100
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     GSCALAR(failsafe_throttle_value, "FS_THR_VALUE",      FS_THR_VALUE_DEFAULT),
@@ -299,7 +299,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: The deadzone above and below mid throttle.  Used in AltHold, Loiter, PosHold flight modes
     // @User: Standard
     // @Range: 0 300
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     GSCALAR(throttle_deadzone,  "THR_DZ",    THR_DZ_DEFAULT),
 
@@ -444,7 +444,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: DISARM_DELAY
     // @DisplayName: Disarm delay
     // @Description: Delay before automatic disarm in seconds. A value of zero disables auto disarm.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0 127
     // @User: Advanced
     GSCALAR(disarm_delay, "DISARM_DELAY",           AUTO_DISARMING_DELAY),
@@ -452,7 +452,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: ANGLE_MAX
     // @DisplayName: Angle Max
     // @Description: Maximum lean angle in all flight modes
-    // @Units: Centi-degrees
+    // @Units: cdeg
     // @Range: 1000 8000
     // @User: Advanced
     ASCALAR(angle_max, "ANGLE_MAX",                 DEFAULT_ANGLE_MAX),
@@ -470,7 +470,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: PHLD_BRAKE_RATE
     // @DisplayName: PosHold braking rate
     // @Description: PosHold flight mode's rotation rate during braking in deg/sec
-    // @Units: deg/sec
+    // @Units: deg/s
     // @Range: 4 12
     // @User: Advanced
     GSCALAR(poshold_brake_rate, "PHLD_BRAKE_RATE",  POSHOLD_BRAKE_RATE_DEFAULT),
@@ -478,7 +478,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: PHLD_BRAKE_ANGLE
     // @DisplayName: PosHold braking angle max
     // @Description: PosHold flight mode's max lean angle during braking in centi-degrees
-    // @Units: Centi-degrees
+    // @Units: cdeg
     // @Range: 2000 4500
     // @User: Advanced
     GSCALAR(poshold_brake_angle_max, "PHLD_BRAKE_ANGLE",  POSHOLD_BRAKE_ANGLE_DEFAULT),
@@ -613,7 +613,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Throttle acceleration controller I gain maximum
     // @Description: Throttle acceleration controller I gain maximum.  Constrains the maximum pwm that the I term will generate
     // @Range: 0 1000
-    // @Units: Percent*10
+    // @Units: d%
     // @User: Standard
 
     // @Param: ACCEL_Z_D

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -64,7 +64,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Telemetry startup delay 
     // @Description: The amount of time (in seconds) to delay radio telemetry to prevent an Xbee bricking on power up
     // @User: Standard
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 30
     // @Increment: 1
     GSCALAR(telem_delay,            "TELEM_DELAY",     0),
@@ -97,7 +97,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This controls the amount of down pitch to add in FBWA and AUTOTUNE modes when at low throttle. No down trim is added when throttle is above TRIM_THROTTLE. Below TRIM_THROTTLE downtrim is added in proportion to the amount the throttle is below TRIM_THROTTLE. At zero throttle the full downpitch specified in this parameter is added. This parameter is meant to help keep airspeed up when flying in FBWA mode with low throttle, such as when on a landing approach, without relying on an airspeed sensor. A value of 2 degrees is good for many planes, although a higher value may be needed for high drag aircraft.
     // @Range: 0 15
     // @Increment: 0.1
-    // @Units: Degrees
+    // @Units: deg
     // @User: Advanced
     GSCALAR(stab_pitch_down, "STAB_PITCH_DOWN",   2.0f),
 
@@ -106,7 +106,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This controls the minimum altitude change for a waypoint before a glide slope will be used instead of an immediate altitude change. The default value is 15 meters, which helps to smooth out waypoint missions where small altitude changes happen near waypoints. If you don't want glide slopes to be used in missions then you can set this to zero, which will disable glide slope calculations. Otherwise you can set it to a minimum number of meters of altitude error to the destination waypoint before a glide slope will be used to change altitude.
     // @Range: 0 1000
     // @Increment: 1
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     GSCALAR(glide_slope_min, "GLIDE_SLOPE_MIN", 15),
 
@@ -115,7 +115,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: This controls the height above the glide slope the plane may be before rebuilding a glide slope. This is useful for smoothing out an autotakeoff
     // @Range: 0 100
     // @Increment: 1
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     GSCALAR(glide_slope_threshold, "GLIDE_SLOPE_THR", 5.0),
 
@@ -154,7 +154,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_THR_DELAY
     // @DisplayName: Takeoff throttle delay
     // @Description: This parameter sets the time delay (in 1/10ths of a second) that the ground speed check is delayed after the forward acceleration check controlled by TKOFF_THR_MINACC has passed. For hand launches with pusher propellers it is essential that this is set to a value of no less than 2 (0.2 seconds) to ensure that the aircraft is safely clear of the throwers arm before the motor can start. For bungee launches a larger value can be used (such as 30) to give time for the bungee to release from the aircraft before the motor is started.
-    // @Units: 0.1 seconds
+    // @Units: ds
     // @Range: 0 127
     // @Increment: 1
     // @User: User
@@ -163,7 +163,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_TDRAG_ELEV
     // @DisplayName: Takeoff tail dragger elevator
     // @Description: This parameter sets the amount of elevator to apply during the initial stage of a takeoff. It is used to hold the tail wheel of a taildragger on the ground during the initial takeoff stage to give maximum steering. This option should be combined with the TKOFF_TDRAG_SPD1 option and the GROUND_STEER_ALT option along with tuning of the ground steering controller. A value of zero means to bypass the initial "tail hold" stage of takeoff. Set to zero for hand and catapult launch. For tail-draggers you should normally set this to 100, meaning full up elevator during the initial stage of takeoff. For most tricycle undercarriage aircraft a value of zero will work well, but for some tricycle aircraft a small negative value (say around -20 to -30) will apply down elevator which will hold the nose wheel firmly on the ground during initial acceleration. Only use a negative value if you find that the nosewheel doesn't grip well during takeoff. Too much down elevator on a tricycle undercarriage may cause instability in steering as the plane pivots around the nosewheel. Add down elevator 10 percent at a time.
-    // @Units: Percent
+    // @Units: %
     // @Range: -100 100
     // @Increment: 1
     // @User: User
@@ -190,7 +190,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_THR_SLEW
     // @DisplayName: Takeoff throttle slew rate
     // @Description: This parameter sets the slew rate for the throttle during auto takeoff. When this is zero the THR_SLEWRATE parameter is used during takeoff. For rolling takeoffs it can be a good idea to set a lower slewrate for takeoff to give a slower acceleration which can improve ground steering control. The value is a percentage throttle change per second, so a value of 20 means to advance the throttle over 5 seconds on takeoff. Values below 20 are not recommended as they may cause the plane to try to climb out with too little throttle.
-    // @Units: percent
+    // @Units: %/s
     // @Range: 0 127
     // @Increment: 1
     // @User: User
@@ -199,7 +199,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_PLIM_SEC
     // @DisplayName: Takeoff pitch limit reduction
     // @Description: This parameter reduces the pitch minimum limit of an auto-takeoff just a few seconds before it reaches the target altitude. This reduces overshoot by allowing the flight controller to start leveling off a few seconds before reaching the target height. When set to zero, the mission pitch min is enforced all the way to and through the target altitude, otherwise the pitch min slowly reduces to zero in the final segment. This is the pitch_min, not the demand. The flight controller should still be commanding to gain altitude to finish the takeoff but with this param it is not forcing it higher than it wants to be.
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 10
     // @Increment: 0.5
     // @User: Advanced
@@ -209,7 +209,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Takeoff flap percentage
     // @Description: The amount of flaps (as a percentage) to apply in automatic takeoff
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @User: Advanced
     GSCALAR(takeoff_flap_percent,     "TKOFF_FLAP_PCNT", 0),
 
@@ -222,7 +222,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LEVEL_ROLL_LIMIT
     // @DisplayName: Level flight roll limit
     // @Description: This controls the maximum bank angle in degrees during flight modes where level flight is desired, such as in the final stages of landing, and during auto takeoff. This should be a small angle (such as 5 degrees) to prevent a wing hitting the runway during takeoff or landing. Setting this to zero will completely disable heading hold on auto takeoff and final landing approach.
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @Increment: 1
     // @User: User
@@ -252,7 +252,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: ALT_OFFSET
     // @DisplayName: Altitude offset
     // @Description: This is added to the target altitude in automatic flight. It can be used to add a global altitude offset to a mission
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Advanced
@@ -261,7 +261,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint Radius
     // @Description: Defines the maximum distance from a waypoint that when crossed indicates the waypoint may be complete. To avoid the aircraft looping around the waypoint in case it misses by more than the WP_RADIUS an additional check is made to see if the aircraft has crossed a "finish line" passing through the waypoint and perpendicular to the flight path from the previous waypoint. If that finish line is crossed then the waypoint is considered complete. Note that the navigation controller may decide to turn later than WP_RADIUS before a waypoint, based on how sharp the turn is and the speed of the aircraft. It is safe to set WP_RADIUS much larger than the usual turn radius of your aircraft and the navigation controller will work out when to turn. If you set WP_RADIUS too small then you will tend to overshoot the turns.
-    // @Units: Meters
+    // @Units: m
     // @Range: 1 32767
     // @Increment: 1
     // @User: Standard
@@ -270,7 +270,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_MAX_RADIUS
     // @DisplayName: Waypoint Maximum Radius
     // @Description: Sets the maximum distance to a waypoint for the waypoint to be considered complete. This overrides the "cross the finish line" logic that is normally used to consider a waypoint complete. For normal AUTO behaviour this parameter should be set to zero. Using a non-zero value is only recommended when it is critical that the aircraft does approach within the given radius, and should loop around until it has done so. This can cause the aircraft to loop forever if its turn radius is greater than the maximum radius set.
-    // @Units: Meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -279,7 +279,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: WP_LOITER_RAD
     // @DisplayName: Waypoint Loiter Radius
     // @Description: Defines the distance from the waypoint center, the plane will maintain during a loiter. If you set this value to a negative number then the default loiter direction will be counter-clockwise instead of clockwise.
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Standard
@@ -288,7 +288,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: RTL_RADIUS
     // @DisplayName: RTL loiter radius
     // @Description: Defines the radius of the loiter circle when in RTL mode. If this is zero then WP_LOITER_RAD is used. If the radius is negative then a counter-clockwise is used. If positive then a clockwise loiter is used.
-    // @Units: Meters
+    // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Standard
@@ -317,7 +317,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_MINALT
     // @DisplayName: Fence Minimum Altitude
     // @Description: Minimum altitude allowed before geofence triggers
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -326,7 +326,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_MAXALT
     // @DisplayName: Fence Maximum Altitude
     // @Description: Maximum altitude allowed before geofence triggers
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -335,7 +335,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FENCE_RETALT
     // @DisplayName: Fence Return Altitude
     // @Description: Altitude the aircraft will transit to when a fence breach occurs.  If FENCE_RETALT is <= 0 then the midpoint between FENCE_MAXALT and FENCE_MINALT is used, unless FENCE_MAXALT < FENCE_MINALT.  If FENCE_MAXALT < FENCE_MINALT AND FENCE_RETALT is <= 0 then ALT_HOLD_RTL is the altitude used on a fence breach.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @Increment: 1
     // @User: Standard
@@ -400,7 +400,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Terrain lookahead
     // @Description: This controls how far ahead the terrain following code looks to ensure it stays above upcoming terrain. A value of zero means no lookahead, so the controller will track only the terrain directly below the aircraft. The lookahead will never extend beyond the next waypoint when in AUTO mode.
     // @Range: 0 10000
-    // @Units: meters
+    // @Units: m
     // @User: Standard
     GSCALAR(terrain_lookahead, "TERRAIN_LOOKAHD",  2000),
 #endif
@@ -417,7 +417,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
     // @Description: The minimum throttle setting (as a percentage) which the autopilot will apply. For the final stage of an automatic landing this is always zero. If your ESC supports reverse, use a negative value to configure for reverse thrust.
-    // @Units: Percent
+    // @Units: %
     // @Range: -100 100
     // @Increment: 1
     // @User: Standard
@@ -426,7 +426,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
     // @Description: The maximum throttle setting (as a percentage) which the autopilot will apply.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -435,7 +435,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TKOFF_THR_MAX
     // @DisplayName: Maximum Throttle for takeoff
     // @Description: The maximum throttle setting during automatic takeoff. If this is zero then THR_MAX is used for takeoff as well.
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Advanced
@@ -444,7 +444,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
     // @Description: maximum percentage change in throttle per second. A setting of 10 means to not change the throttle by more than 10% of the full throttle range in one second.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 127
     // @Increment: 1
     // @User: Standard
@@ -453,7 +453,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FLAP_SLEWRATE
     // @DisplayName: Flap slew rate
     // @Description: maximum percentage change in flap output per second. A setting of 25 means to not change the flap by more than 25% of the full flap range in one second. A value of 0 means no rate limiting.
-    // @Units: Percent
+    // @Units: %/s
     // @Range: 0 100
     // @Increment: 1
     // @User: Advanced
@@ -492,7 +492,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TRIM_THROTTLE
     // @DisplayName: Throttle cruise percentage
     // @Description: The target percentage of throttle to apply for normal flight
-    // @Units: Percent
+    // @Units: %
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
@@ -515,7 +515,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_SHORT_TIMEOUT
     // @DisplayName: Short failsafe timeout
     // @Description: The time in seconds that a failsafe condition has to persist before a short failsafe event will occur. This defaults to 1.5 seconds
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 100
     // @Increment: 0.5
     // @User: Standard
@@ -531,7 +531,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_LONG_TIMEOUT
     // @DisplayName: Long failsafe timeout
     // @Description: The time in seconds that a failsafe condition has to persist before a long failsafe event will occur. This defaults to 5 seconds.
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 300
     // @Increment: 0.5
     // @User: Standard
@@ -540,7 +540,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_BATT_VOLTAGE
     // @DisplayName: Failsafe battery voltage
     // @Description: Battery voltage to trigger failsafe. Set to 0 to disable battery voltage failsafe. If the battery voltage drops below this voltage continuously for 10 seconds then the plane will switch to RTL mode.
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", 0),
@@ -548,7 +548,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FS_BATT_MAH
     // @DisplayName: Failsafe battery milliAmpHours
     // @Description: Battery capacity remaining to trigger failsafe. Set to 0 to disable battery remaining failsafe. If the battery remaining drops below this level then the plane will switch to RTL mode immediately.
-    // @Units: mAh
+    // @Units: mA.h
     // @Increment: 50
     // @User: Standard
     GSCALAR(fs_batt_mah,            "FS_BATT_MAH", 0),
@@ -618,7 +618,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LIM_ROLL_CD
     // @DisplayName: Maximum Bank Angle
     // @Description: The maximum commanded bank angle in either direction
-    // @Units: centi-Degrees
+    // @Units: cdeg
     // @Range: 0 9000
     // @Increment: 1
     // @User: Standard
@@ -627,7 +627,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LIM_PITCH_MAX
     // @DisplayName: Maximum Pitch Angle
     // @Description: The maximum commanded pitch up angle
-    // @Units: centi-Degrees
+    // @Units: cdeg
     // @Range: 0 9000
     // @Increment: 1
     // @User: Standard
@@ -636,7 +636,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LIM_PITCH_MIN
     // @DisplayName: Minimum Pitch Angle
     // @Description: The minimum commanded pitch down angle
-    // @Units: centi-Degrees
+    // @Units: cdeg
     // @Range: -9000 0
     // @Increment: 1
     // @User: Standard
@@ -645,7 +645,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: ACRO_ROLL_RATE
     // @DisplayName: ACRO mode roll rate
     // @Description: The maximum roll rate at full stick deflection in ACRO mode
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Range: 10 500
     // @Increment: 1
     // @User: Standard
@@ -654,7 +654,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: ACRO_PITCH_RATE
     // @DisplayName: ACRO mode pitch rate
     // @Description: The maximum pitch rate at full stick deflection in ACRO mode
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Range: 10 500
     // @Increment: 1
     // @User: Standard
@@ -670,7 +670,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: GROUND_STEER_ALT
     // @DisplayName: Ground steer altitude
     // @Description: Altitude at which to use the ground steering controller on the rudder. If non-zero then the STEER2SRV controller will be used to control the rudder for altitudes within this limit of the home altitude.
-    // @Units: Meters
+    // @Units: m
     // @Range: -100 100
     // @Increment: 0.1
     // @User: Standard
@@ -679,7 +679,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: GROUND_STEER_DPS
     // @DisplayName: Ground steer rate
     // @Description: Ground steering rate in degrees per second for full rudder stick deflection
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Range: 10 360
     // @Increment: 1
     // @User: Advanced
@@ -752,7 +752,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: MIXING_OFFSET
     // @DisplayName: Mixing Offset
     // @Description: The offset for the Vtail and elevon output mixers, as a percentage. This can be used in combination with MIXING_GAIN to configure how the control surfaces respond to input. The response to aileron or elevator input can be increased by setting this parameter to a positive or negative value. A common usage is to enter a positive value to increase the aileron response of the elevons of a flying wing. The default value of zero will leave the aileron-input response equal to the elevator-input response.
-    // @Units: percent
+    // @Units: d%
     // @Range: -1000 1000
     // @User: User
     GSCALAR(mixing_offset,          "MIXING_OFFSET",  0),
@@ -760,7 +760,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: DSPOILR_RUD_RATE
     // @DisplayName: Differential spoilers rudder rate
     // @Description: Sets the amount of deflection that the rudder output will apply to the differential spoilers, as a percentage. The default value of 100 results in full rudder applying full deflection. A value of 0 will result in the differential spoilers exactly following the elevons (no rudder effect).
-    // @Units: percent
+    // @Units: d%
     // @Range: -1000 1000
     // @User: User
     GSCALAR(dspoiler_rud_rate,      "DSPOILR_RUD_RATE",  DSPOILR_RUD_RATE_DEFAULT),
@@ -815,21 +815,21 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TRIM_PITCH_CD
     // @DisplayName: Pitch angle offset
     // @Description: offset to add to pitch - used for in-flight pitch trimming. It is recommended that instead of using this parameter you level your plane correctly on the ground for good flight attitude.
-    // @Units: centi-Degrees
+    // @Units: cdeg
     // @User: Advanced
     GSCALAR(pitch_trim_cd,        "TRIM_PITCH_CD",  0),
 
     // @Param: ALT_HOLD_RTL
     // @DisplayName: RTL altitude
     // @Description: Return to launch target altitude. This is the relative altitude the plane will aim for and loiter at when returning home. If this is negative (usually -1) then the plane will use the current altitude at the time of entering RTL. Note that when transiting to a Rally Point the altitude of the Rally Point is used instead of ALT_HOLD_RTL.
-    // @Units: centimeters
+    // @Units: cm
     // @User: User
     GSCALAR(RTL_altitude_cm,        "ALT_HOLD_RTL",   ALT_HOLD_HOME_CM),
 
     // @Param: ALT_HOLD_FBWCM
     // @DisplayName: Minimum altitude for FBWB mode
     // @Description: This is the minimum altitude in centimeters that FBWB and CRUISE modes will allow. If you attempt to descend below this altitude then the plane will level off. A value of zero means no limit.
-    // @Units: centimeters
+    // @Units: cm
     // @User: User
     GSCALAR(FBWB_min_altitude_cm,   "ALT_HOLD_FBWCM", ALT_HOLD_FBW_CM),
 
@@ -857,7 +857,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Flap 1 percentage
     // @Description: The percentage change in flap position when FLAP_1_SPEED is reached. Use zero to disable flaps
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @User: Advanced
     GSCALAR(flap_1_percent,         "FLAP_1_PERCNT",  FLAP_1_PERCENT),
 
@@ -874,7 +874,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Flap 2 percentage
     // @Description: The percentage change in flap position when FLAP_2_SPEED is reached. Use zero to disable flaps
     // @Range: 0 100
-	// @Units: Percent
+	// @Units: %
     // @User: Advanced
     GSCALAR(flap_2_percent,         "FLAP_2_PERCNT",  FLAP_2_PERCENT),
 
@@ -927,7 +927,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: HIL_ERR_LIMIT
     // @DisplayName: Limit of error in HIL attitude before reset
     // @Description: This controls the maximum error in degrees on any axis before HIL will reset the DCM attitude to match the HIL_STATE attitude. This limit will prevent poor timing on HIL from causing a major attitude error. If the value is zero then no limit applies.
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 90
     // @Increment: 0.1
     // @User: Advanced
@@ -951,7 +951,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Crash Deceleration Threshold
     // @Description: X-Axis deceleration threshold to notify the crash detector that there was a possible impact which helps disarm the motor quickly after a crash. This value should be much higher than normal negative x-axis forces during normal flight, check flight log files to determine the average IMU.x values for your aircraft and motor type. Higher value means less sensative (triggers on higher impact). For electric planes that don't vibrate much during fight a value of 25 is good (that's about 2.5G). For petrol/nitro planes you'll want a higher value. Set to 0 to disable the collision detector.
     // @Units: m/s/s
-    // @Values: 10 127
+    // @Range: 10 127
     // @User: Advanced
     GSCALAR(crash_accel_threshold,          "CRASH_ACC_THRESH",   0),
 
@@ -1221,7 +1221,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @DisplayName: rudder differential thrust gain
     // @Description: gain control from rudder to differential thrust
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("RUDD_DT_GAIN", 9, ParametersG2, rudd_dt_gain, 10),

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -18,7 +18,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: ANGLE_MAX
     // @DisplayName: Angle Max
     // @Description: Maximum lean angle in all VTOL flight modes
-    // @Units: Centi-degrees
+    // @Units: cdeg
     // @Range: 1000 8000
     // @User: Advanced
     AP_GROUPINFO("ANGLE_MAX", 10, QuadPlane, aparm.angle_max, 3000),
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TRANSITION_MS
     // @DisplayName: Transition time
     // @Description: Transition time in milliseconds after minimum airspeed is reached
-    // @Units: milliseconds
+    // @Units: ms
     // @Range: 0 30000
     // @User: Advanced
     AP_GROUPINFO("TRANSITION_MS", 11, QuadPlane, transition_time_ms, 5000),
@@ -91,7 +91,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @DisplayName: Throttle acceleration controller I gain maximum
     // @Description: Throttle acceleration controller I gain maximum.  Constrains the maximum pwm that the I term will generate
     // @Range: 0 1000
-    // @Units: Percent*10
+    // @Units: d%
     // @User: Standard
 
     // @Param: AZ_D
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
-    // @Units: Centimeters/Second
+    // @Units: cm/s
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard
@@ -173,7 +173,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: YAW_RATE_MAX
     // @DisplayName: Maximum yaw rate
     // @Description: This is the maximum yaw rate in degrees/second
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Range: 50 500
     // @Increment: 1
     // @User: Standard
@@ -204,7 +204,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: Maximum pitch during transition to auto fixed wing flight
     // @User: Standard
     // @Range: 0 30
-    // @Units: Degrees
+    // @Units: deg
     // @Increment: 1
     AP_GROUPINFO("TRAN_PIT_MAX", 29, QuadPlane, transition_pitch_max, 3),
 
@@ -273,7 +273,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TILT_RATE_UP
     // @DisplayName: Tiltrotor upwards tilt rate
     // @Description: This is the maximum speed at which the motor angle will change for a tiltrotor when moving from forward flight to hover
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Increment: 1
     // @Range: 10 300
     // @User: Standard
@@ -282,7 +282,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TILT_MAX
     // @DisplayName: Tiltrotor maximum VTOL angle
     // @Description: This is the maximum angle of the tiltable motors at which multicopter control will be enabled. Beyond this angle the plane will fly solely as a fixed wing aircraft and the motors will tilt to their maximum angle at the TILT_RATE
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 1
     // @Range: 20 80
     // @User: Standard
@@ -322,7 +322,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: ASSIST_ANGLE
     // @DisplayName: Quadplane assistance angle
     // @Description: This is the angular error in attitude beyond which the quadplane VTOL motors will provide stability assistance. This will only be used if Q_ASSIST_SPEED is also non-zero. Assistance will be given if the attitude is outside the normal attitude limits by at least 5 degrees and the angular error in roll or pitch is greater than this angle for at least 1 second. Set to zero to disable angle assistance.
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 90
     // @Increment: 1
     // @User: Standard
@@ -343,7 +343,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TILT_RATE_DN
     // @DisplayName: Tiltrotor downwards tilt rate
     // @Description: This is the maximum speed at which the motor angle will change for a tiltrotor when moving from hover to forward flight. When this is zero the Q_TILT_RATE_UP value is used.
-    // @Units: degrees/second
+    // @Units: deg/s
     // @Increment: 1
     // @Range: 10 300
     // @User: Standard

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -103,7 +103,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: FS_BATT_VOLTAGE
     // @DisplayName: Failsafe battery voltage
     // @Description: Battery voltage to trigger failsafe. Set to 0 to disable battery voltage failsafe.
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", FS_BATT_VOLTAGE_DEFAULT),
@@ -111,7 +111,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: FS_BATT_MAH
     // @DisplayName: Failsafe battery milliAmpHours
     // @Description: Battery capacity remaining to trigger failsafe. Set to 0 to disable battery remaining failsafe.
-    // @Units: mAh
+    // @Units: mA.h
     // @Increment: 50
     // @User: Standard
     GSCALAR(fs_batt_mah,            "FS_BATT_MAH", FS_BATT_MAH_DEFAULT),
@@ -147,14 +147,14 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: FS_PRESS_MAX
     // @DisplayName: Internal Pressure Failsafe Threshold
     // @Description: The maximum internal pressure allowed before triggering failsafe. Failsafe action is determined by FS_PRESS_ENABLE parameter
-    // @Units: Pascal
+    // @Units: Pa
     // @User: Standard
     GSCALAR(failsafe_pressure_max, "FS_PRESS_MAX", FS_PRESS_MAX_DEFAULT),
 
     // @Param: FS_TEMP_MAX
     // @DisplayName: Internal Temperature Failsafe Threshold
     // @Description: The maximum internal temperature allowed before triggering failsafe. Failsafe action is determined by FS_TEMP_ENABLE parameter.
-    // @Units: Degrees Centigrade
+    // @Units: degC
     // @User: Standard
     GSCALAR(failsafe_temperature_max, "FS_TEMP_MAX", FS_TEMP_MAX_DEFAULT),
 
@@ -175,7 +175,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: FS_PILOT_TIMEOUT
     // @DisplayName: Timeout for activation of pilot input failsafe
     // @Description: Controls the maximum interval between received pilot inputs before the failsafe action is triggered
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.1 3.0
     // @User: Standard
     GSCALAR(failsafe_pilot_input_timeout, "FS_PILOT_TIMEOUT", 1.0f),
@@ -204,7 +204,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: PILOT_VELZ_MAX
     // @DisplayName: Pilot maximum vertical speed
     // @Description: The maximum vertical velocity the pilot may request in cm/s
-    // @Units: Centimeters/Second
+    // @Units: cm/s
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard
@@ -224,7 +224,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Description: The deadzone above and below mid throttle.  Used in AltHold, Loiter, PosHold flight modes
     // @User: Standard
     // @Range: 0 300
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     GSCALAR(throttle_deadzone,  "THR_DZ",    THR_DZ_DEFAULT),
 
@@ -239,7 +239,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: ANGLE_MAX
     // @DisplayName: Angle Max
     // @Description: Maximum lean angle in all flight modes
-    // @Units: Centi-degrees
+    // @Units: cdeg
     // @Range: 1000 8000
     // @User: Advanced
     ASCALAR(angle_max, "ANGLE_MAX",                 DEFAULT_ANGLE_MAX),
@@ -307,6 +307,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Description: Size of PWM increment on camera tilt servo
     // @User: Standard
     // @Range: 30 400
+    // @Units: PWM
     GSCALAR(cam_tilt_step, "JS_CAM_TILT_STEP", 50),
 
     // @Param: JS_LIGHTS_STEP
@@ -314,6 +315,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Description: Size of PWM increment on lights servo
     // @User: Standard
     // @Range: 30 400
+    // @Units: PWM
     GSCALAR(lights_step, "JS_LIGHTS_STEP", 100),
 
     // @Param: JS_THR_GAIN
@@ -328,6 +330,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Description: Servo PWM at camera center position
     // @User: Standard
     // @Range: 1000 2000
+    // @Units: PWM
     GSCALAR(cam_tilt_center, "CAM_CENTER", 1500),
 
     // @Param: FRAME_CONFIG
@@ -510,7 +513,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @DisplayName: Throttle acceleration controller I gain maximum
     // @Description: Throttle acceleration controller I gain maximum.  Constrains the maximum pwm that the I term will generate
     // @Range: 0 1000
-    // @Units: Percent*10
+    // @Units: d%
     // @User: Standard
 
     // @Param: ACCEL_Z_D

--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -3,7 +3,7 @@
 Emit docs in a form acceptable to the old Ardupilot wordpress docs site
 """
 
-from param import known_param_fields
+from param import known_param_fields, known_units
 from emit import Emit
 import cgi
 
@@ -71,6 +71,11 @@ DO NOT EDIT
                             v = value.split(':')
                             t += "<tr><td>%s</td><td>%s</td></tr>\n" % (v[0], v[1])
                         t += "</table>\n"
+                    elif field == 'Units':
+                        abreviated_units = param.__dict__[field]
+                        if abreviated_units != '':
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            t += "<li>%s: %s</li>\n" % (field, cgi.escape(units))
                     else:
                         t += "<li>%s: %s</li>\n" % (field, cgi.escape(param.__dict__[field]))
             t += "</ul>\n"

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -30,6 +30,71 @@ known_param_fields = [
              'ReadOnly',
                       ]
 
+# Follow SI units conventions from:
+# http://physics.nist.gov/cuu/Units/units.html
+# http://physics.nist.gov/cuu/Units/outside.html
+# and
+# http://physics.nist.gov/cuu/Units/checklist.html
+# http://www.bipm.org/en/publications/si-brochure/
+# http://www1.bipm.org/en/CGPM/db/3/2/   g_n unit for G-force
+# one further constrain is that only printable (7bit) ASCII characters are allowed
+known_units = {
+#          abreviation : full-text (used in .html .rst and .wiki files)
+# time
+             's'       : 'seconds'               ,
+             'ds'      : 'deciseconds'           ,
+             'cs'      : 'centiseconds'          ,
+             'ms'      : 'milliseconds'          ,
+             'PWM'     : 'PWM in microseconds'   , # should be microseconds, this is NOT a SI unit, but follows https://github.com/ArduPilot/ardupilot/pull/5538#issuecomment-271943061 and µs is not 7bit-ASCII
+             'Hz'      : 'hertz'                 ,
+# distance
+             'km'      : 'kilometers'                , # metre is the SI unit name, _NOT_ meter
+             'm'       : 'meters'                    , # metre is the SI unit name, _NOT_ meter
+             'm/s'     : 'meters per second'         , # metre is the SI unit name, _NOT_ meter
+             'm/s/s'   : 'meters per square second'  , # metre is the SI unit name, _NOT_ meter
+             'm/s/s/s' : 'meters per cubic second'   , # metre is the SI unit name, _NOT_ meter
+             'cm'      : 'centimeters'               , # metre is the SI unit name, _NOT_ meter
+             'cm/s'    : 'centimeters per second'    , # metre is the SI unit name, _NOT_ meter
+             'cm/s/s'  : 'centimeters per square second', # metre is the SI unit name, _NOT_ meter
+             'cm/s/s/s': 'centimeters per cubic second' , # metre is the SI unit name, _NOT_ meter
+             'mm'      : 'millimeters'               , # metre is the SI unit name, _NOT_ meter
+# temperature
+             'degC'    : 'degrees Celsius'       , # °C   would be the correct abreviation, but it is not 7bit-ASCII
+# angle
+             'deg'     : 'degrees'               , # °    would be the correct abreviation, but it is not 7bit-ASCII
+             'deg/s'   : 'degrees per second'    , # °/s  would be the correct abreviation, but it is not 7bit-ASCII
+             'cdeg'    : 'centidegrees'          , # c°   would be the correct abreviation, but it is not 7bit-ASCII
+             'cdeg/s'  : 'centidegrees per second', # c°/s would be the correct abreviation, but it is not 7bit-ASCII
+             'cdeg/s/s': 'centidegrees per square second' ,
+             'rad'     : 'radians'               ,
+             'rad/s'   : 'radians per second'    ,
+             'rad/s/s' : 'radians per square second' ,
+# electricity
+             'A'       : 'ampere'                ,
+             'V'       : 'volt'                  ,
+             'W'       : 'watt'                  ,
+# magnetism
+             'Gauss'   : 'gauss'                 , # Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
+             'Gauss/s' : 'gauss per second'      , # Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
+             'mGauss'  : 'milligauss'            , # Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
+# pressure
+             'Pa'      : 'pascal'                ,
+             'mbar'    : 'millibar'              ,
+# ratio
+             '%'       : 'percent'               ,
+             '%/s'     : 'percent per second'    ,
+             'd%'      : 'decipercent'           , # ‰ would be the correct abreviation, but it is not 7bit-ASCII. decipercent is strange, but "per-mille" is even more exotic
+# compound
+             'm.m/s/s' : 'square meter per square second', # m·m/s/s would be the correct abreviation, but it is not 7bit-ASCII
+             'deg/m/s' : 'degrees per meter per second'  , # °/m/s would be the correct abreviation, but it is not 7bit-ASCII
+             'm/s/m'   : 'meters per second per meter'   , # Why not use Hz here ????
+             'mGauss/A': 'milligauss per ampere' ,
+             'mA.h'    : 'milliampere hour'      , # mA·h would be the correct abreviation, but it is not 7bit-ASCII
+             'A/V'     : 'ampere per volt'       ,
+             'm/V'     : 'meters per volt'       ,
+             'gravities': 'standard acceleration due to gravity' , # g_n would be a more correct unit, but IMHO no one understands what g_n means
+             }
+
 required_param_fields = [
              'Description',
              'DisplayName',

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -59,13 +59,13 @@ known_units = {
              'cm/s/s/s': 'centimeters per cubic second' , # metre is the SI unit name, meter is the american spelling of it
              'mm'      : 'millimeters'               , # metre is the SI unit name, meter is the american spelling of it
 # temperature
-             'degC'    : 'degrees Celsius'       ,
+             'degC'    : 'degrees Celsius'       ,     # Not SI, but Kelvin is too cumbersome for most users
 # angle
-             'deg'     : 'degrees'               ,
-             'deg/s'   : 'degrees per second'    ,
-             'cdeg'    : 'centidegrees'          ,
-             'cdeg/s'  : 'centidegrees per second',
-             'cdeg/s/s': 'centidegrees per square second' ,
+             'deg'     : 'degrees'               ,     # Not SI, but is some situations more user-friendly than radians
+             'deg/s'   : 'degrees per second'    ,     # Not SI, but is some situations more user-friendly than radians
+             'cdeg'    : 'centidegrees'          ,     # Not SI, but is some situations more user-friendly than radians
+             'cdeg/s'  : 'centidegrees per second',    # Not SI, but is some situations more user-friendly than radians
+             'cdeg/s/s': 'centidegrees per square second' , # Not SI, but is some situations more user-friendly than radians
              'rad'     : 'radians'               ,
              'rad/s'   : 'radians per second'    ,
              'rad/s/s' : 'radians per square second' ,

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -45,26 +45,26 @@ known_units = {
              'ds'      : 'deciseconds'           ,
              'cs'      : 'centiseconds'          ,
              'ms'      : 'milliseconds'          ,
-             'PWM'     : 'PWM in microseconds'   , # should be microseconds, this is NOT a SI unit, but follows https://github.com/ArduPilot/ardupilot/pull/5538#issuecomment-271943061 and µs is not 7bit-ASCII
+             'PWM'     : 'PWM in microseconds'   , # should be microseconds, this is NOT a SI unit, but follows https://github.com/ArduPilot/ardupilot/pull/5538#issuecomment-271943061
              'Hz'      : 'hertz'                 ,
 # distance
-             'km'      : 'kilometers'                , # metre is the SI unit name, _NOT_ meter
-             'm'       : 'meters'                    , # metre is the SI unit name, _NOT_ meter
-             'm/s'     : 'meters per second'         , # metre is the SI unit name, _NOT_ meter
-             'm/s/s'   : 'meters per square second'  , # metre is the SI unit name, _NOT_ meter
-             'm/s/s/s' : 'meters per cubic second'   , # metre is the SI unit name, _NOT_ meter
-             'cm'      : 'centimeters'               , # metre is the SI unit name, _NOT_ meter
-             'cm/s'    : 'centimeters per second'    , # metre is the SI unit name, _NOT_ meter
-             'cm/s/s'  : 'centimeters per square second', # metre is the SI unit name, _NOT_ meter
-             'cm/s/s/s': 'centimeters per cubic second' , # metre is the SI unit name, _NOT_ meter
-             'mm'      : 'millimeters'               , # metre is the SI unit name, _NOT_ meter
+             'km'      : 'kilometers'                , # metre is the SI unit name, meter is the american spelling of it
+             'm'       : 'meters'                    , # metre is the SI unit name, meter is the american spelling of it
+             'm/s'     : 'meters per second'         , # metre is the SI unit name, meter is the american spelling of it
+             'm/s/s'   : 'meters per square second'  , # metre is the SI unit name, meter is the american spelling of it
+             'm/s/s/s' : 'meters per cubic second'   , # metre is the SI unit name, meter is the american spelling of it
+             'cm'      : 'centimeters'               , # metre is the SI unit name, meter is the american spelling of it
+             'cm/s'    : 'centimeters per second'    , # metre is the SI unit name, meter is the american spelling of it
+             'cm/s/s'  : 'centimeters per square second', # metre is the SI unit name, meter is the american spelling of it
+             'cm/s/s/s': 'centimeters per cubic second' , # metre is the SI unit name, meter is the american spelling of it
+             'mm'      : 'millimeters'               , # metre is the SI unit name, meter is the american spelling of it
 # temperature
-             'degC'    : 'degrees Celsius'       , # °C   would be the correct abreviation, but it is not 7bit-ASCII
+             'degC'    : 'degrees Celsius'       ,
 # angle
-             'deg'     : 'degrees'               , # °    would be the correct abreviation, but it is not 7bit-ASCII
-             'deg/s'   : 'degrees per second'    , # °/s  would be the correct abreviation, but it is not 7bit-ASCII
-             'cdeg'    : 'centidegrees'          , # c°   would be the correct abreviation, but it is not 7bit-ASCII
-             'cdeg/s'  : 'centidegrees per second', # c°/s would be the correct abreviation, but it is not 7bit-ASCII
+             'deg'     : 'degrees'               ,
+             'deg/s'   : 'degrees per second'    ,
+             'cdeg'    : 'centidegrees'          ,
+             'cdeg/s'  : 'centidegrees per second',
              'cdeg/s/s': 'centidegrees per square second' ,
              'rad'     : 'radians'               ,
              'rad/s'   : 'radians per second'    ,
@@ -83,13 +83,13 @@ known_units = {
 # ratio
              '%'       : 'percent'               ,
              '%/s'     : 'percent per second'    ,
-             'd%'      : 'decipercent'           , # ‰ would be the correct abreviation, but it is not 7bit-ASCII. decipercent is strange, but "per-mille" is even more exotic
+             'd%'      : 'decipercent'           , # decipercent is strange, but "per-mille" is even more exotic
 # compound
-             'm.m/s/s' : 'square meter per square second', # m·m/s/s would be the correct abreviation, but it is not 7bit-ASCII
-             'deg/m/s' : 'degrees per meter per second'  , # °/m/s would be the correct abreviation, but it is not 7bit-ASCII
+             'm.m/s/s' : 'square meter per square second',
+             'deg/m/s' : 'degrees per meter per second'  ,
              'm/s/m'   : 'meters per second per meter'   , # Why not use Hz here ????
              'mGauss/A': 'milligauss per ampere' ,
-             'mA.h'    : 'milliampere hour'      , # mA·h would be the correct abreviation, but it is not 7bit-ASCII
+             'mA.h'    : 'milliampere hour'      ,
              'A/V'     : 'ampere per volt'       ,
              'm/V'     : 'meters per volt'       ,
              'gravities': 'standard acceleration due to gravity' , # g_n would be a more correct unit, but IMHO no one understands what g_n means

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -7,7 +7,7 @@ import sys
 from optparse import OptionParser
 
 from param import (Library, Parameter, Vehicle, known_group_fields,
-                   known_param_fields, required_param_fields)
+                   known_param_fields, required_param_fields, known_units)
 from htmlemit import HtmlEmit
 from rstemit import RSTEmit
 from wikiemit import WikiEmit
@@ -203,6 +203,10 @@ def validate(param):
         if not is_number(max_value):
             error("Max value not number: %s %s" % (param.name, max_value))
             return
+    # Validate units
+    if (hasattr(param, "Units")):
+        if (param.__dict__["Units"] != "") and (param.__dict__["Units"] not in known_units):
+            error("unknown units field '%s'" % param.__dict__["Units"])
 
 for vehicle in vehicles:
     for param in vehicle.params:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import re
-from param import known_param_fields
+from param import known_param_fields, known_units
 from emit import Emit
 import cgi
 
@@ -241,6 +241,11 @@ Complete Parameter List
                     elif field == "Range":
                         (param_min, param_max) = (param.__dict__[field]).split(' ')
                         row.append("%s - %s" % (param_min, param_max,))
+                    elif field == 'Units':
+                        abreviated_units = param.__dict__[field]
+                        if abreviated_units != '':
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            row.append(cgi.escape(units))
                     else:
                         row.append(cgi.escape(param.__dict__[field]))
             if len(row):

--- a/Tools/autotest/param_metadata/wikiemit.py
+++ b/Tools/autotest/param_metadata/wikiemit.py
@@ -3,7 +3,7 @@
 import re
 
 from emit import Emit
-from param import known_param_fields
+from param import known_param_fields, known_units
 
 
 # Emit docs in a form acceptable to the APM wiki site
@@ -63,6 +63,11 @@ class WikiEmit(Emit):
                         for value in values:
                             v = value.split(':')
                             t += "|| " + v[0] + " || " + self.camelcase_escape(v[1]) + " ||\n"
+                    elif field == 'Units':
+                        abreviated_units = param.__dict__[field]
+                        if abreviated_units != '':
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            t += " * %s: %s\n" % (self.camelcase_escape(field), self.wikichars_escape(units))
                     else:
                         t += " * %s: %s\n" % (self.camelcase_escape(field), self.wikichars_escape(param.__dict__[field]))
 

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -3,7 +3,7 @@
 from xml.sax.saxutils import escape, quoteattr
 
 from emit import Emit
-from param import known_param_fields
+from param import known_param_fields, known_units
 
 
 # Emit APM documentation in an machine readable XML format
@@ -60,6 +60,12 @@ class XmlEmit(Emit):
                             t += '''<value code=%s>%s</value>\n''' % (quoteattr(v[0]), escape(v[1]))  # i.e. numeric value, string label
 
                         t += "</values>\n"
+                    elif field == 'Units':
+                        abreviated_units = param.__dict__[field]
+                        if abreviated_units != '':
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            t += '''<field name=%s>%s</field>\n''' % (quoteattr(field), escape(abreviated_units))  # i.e. A/s
+                            t += '''<field name=%s>%s</field>\n''' % (quoteattr('UnitText'), escape(units))        # i.e. ampere per second
                     else:
                         t += '''<field name=%s>%s</field>\n''' % (quoteattr(field), escape(param.__dict__[field]))  # i.e. Range: 0 10
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -10,7 +10,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Param: SLEW_YAW
     // @DisplayName: Yaw target slew rate
     // @Description: Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes
-    // @Units: Centi-Degrees/Sec
+    // @Units: cdeg/s
     // @Range: 500 18000
     // @Increment: 100
     // @User: Advanced
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Param: ACCEL_Y_MAX
     // @DisplayName: Acceleration Max for Yaw
     // @Description: Maximum acceleration in yaw axis
-    // @Units: Centi-Degrees/Sec/Sec
+    // @Units: cdeg/s/s
     // @Range: 0 72000
     // @Values: 0:Disabled, 18000:Slow, 36000:Medium, 54000:Fast
     // @Increment: 1000
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Param: ACCEL_R_MAX
     // @DisplayName: Acceleration Max for Roll
     // @Description: Maximum acceleration in roll axis
-    // @Units: Centi-Degrees/Sec/Sec
+    // @Units: cdeg/s/s
     // @Range: 0 180000
     // @Increment: 1000
     // @Values: 0:Disabled, 72000:Slow, 108000:Medium, 162000:Fast
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Param: ACCEL_P_MAX
     // @DisplayName: Acceleration Max for Pitch
     // @Description: Maximum acceleration in pitch axis
-    // @Units: Centi-Degrees/Sec/Sec
+    // @Units: cdeg/s/s
     // @Range: 0 180000
     // @Increment: 1000
     // @Values: 0:Disabled, 72000:Slow, 108000:Medium, 162000:Fast

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: HOVR_ROL_TRM
     // @DisplayName: Hover Roll Trim
     // @Description: Trim the hover roll angle to counter tail rotor thrust in a hover
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: 0 1000
     // @User: Advanced
     AP_GROUPINFO("HOVR_ROL_TRM",    1, AC_AttitudeControl_Heli, _hover_roll_trim, AC_ATTITUDE_HELI_HOVER_ROLL_TRIM_DEFAULT),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Roll axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_RLL_D
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Pitch axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_PIT_D
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Description: Yaw axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_YAW_D

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Roll axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_RLL_D
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Pitch axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_PIT_D
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Description: Yaw axis rate controller I gain maximum.  Constrains the maximum motor output that the I gain will output
     // @Range: 0 1
     // @Increment: 0.01
-    // @Units: Percent
+    // @Units: %
     // @User: Standard
 
     // @Param: RAT_YAW_D

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -13,6 +13,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Param: ANGLE_MAX
     // @DisplayName: Avoidance max lean angle in non-GPS flight modes
     // @Description: Max lean angle used to avoid obstacles while in non-GPS modes
+    // @Units: cdeg
     // @Range: 0 4500
     // @User: Standard
     AP_GROUPINFO("ANGLE_MAX", 2,  AC_Avoid, _angle_max, 1000),
@@ -20,7 +21,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Param: DIST_MAX
     // @DisplayName: Avoidance distance maximum in non-GPS flight modes
     // @Description: Distance from object at which obstacle avoidance will begin in non-GPS modes
-    // @Units: meters
+    // @Units: m
     // @Range: 3 30
     // @User: Standard
     AP_GROUPINFO("DIST_MAX", 3,  AC_Avoid, _dist_max, AC_AVOID_NONGPS_DIST_MAX_DEFAULT),
@@ -28,7 +29,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @Param: MARGIN
     // @DisplayName: Avoidance distance margin in GPS modes
     // @Description: Vehicle will attempt to stay at least this distance (in meters) from objects while in GPS modes
-    // @Units: meters
+    // @Units: m
     // @Range: 1 10
     // @User: Standard
     AP_GROUPINFO("MARGIN", 4, AC_Avoid, _margin, 2.0f),

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: ALT_MAX
     // @DisplayName: Fence Maximum Altitude
     // @Description: Maximum altitude allowed before geofence triggers
-    // @Units: Meters
+    // @Units: m
     // @Range: 10 1000
     // @Increment: 1
     // @User: Standard
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: RADIUS
     // @DisplayName: Circular Fence Radius
     // @Description: Circle fence radius which when breached will cause an RTL
-    // @Units: Meters
+    // @Units: m
     // @Range: 30 10000
     // @User: Standard
     AP_GROUPINFO("RADIUS",      4,  AC_Fence,   _circle_radius, AC_FENCE_CIRCLE_RADIUS_DEFAULT),
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: MARGIN
     // @DisplayName: Fence Margin
     // @Description: Distance that autopilot's should maintain from the fence to avoid a breach
-    // @Units: Meters
+    // @Units: m
     // @Range: 1 10
     // @User: Standard
     AP_GROUPINFO("MARGIN",      5,  AC_Fence,   _margin, AC_FENCE_MARGIN_DEFAULT),
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: ALT_MIN
     // @DisplayName: Fence Minimum Altitude
     // @Description: Minimum altitude allowed before geofence triggers
-    // @Units: Meters
+    // @Units: m
     // @Range: -100 100
     // @Increment: 1
     // @User: Standard

--- a/libraries/AC_InputManager/AC_InputManager_Heli.cpp
+++ b/libraries/AC_InputManager/AC_InputManager_Heli.cpp
@@ -13,7 +13,7 @@ const AP_Param::GroupInfo AC_InputManager_Heli::var_info[] = {
     // @DisplayName: Stabilize Mode Collective Point 1
     // @Description: Helicopter's minimum collective pitch setting at zero throttle input in Stabilize mode
     // @Range: 0 500
-    // @Units: Percent*10
+    // @Units: d%
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("STAB_COL_1",    1, AC_InputManager_Heli, _heli_stab_col_min, AC_ATTITUDE_HELI_STAB_COLLECTIVE_MIN_DEFAULT),
@@ -22,7 +22,7 @@ const AP_Param::GroupInfo AC_InputManager_Heli::var_info[] = {
     // @DisplayName: Stabilize Mode Collective Point 2
     // @Description: Helicopter's collective pitch setting at mid-low throttle input in Stabilize mode
     // @Range: 0 500
-    // @Units: Percent*10
+    // @Units: d%
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("STAB_COL_2",    2, AC_InputManager_Heli, _heli_stab_col_low, AC_ATTITUDE_HELI_STAB_COLLECTIVE_LOW_DEFAULT),
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo AC_InputManager_Heli::var_info[] = {
     // @DisplayName: Stabilize Mode Collective Point 3
     // @Description: Helicopter's collective pitch setting at mid-high throttle input in Stabilize mode
     // @Range: 500 1000
-    // @Units: Percent*10
+    // @Units: d%
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("STAB_COL_3",    3, AC_InputManager_Heli, _heli_stab_col_high, AC_ATTITUDE_HELI_STAB_COLLECTIVE_HIGH_DEFAULT),
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AC_InputManager_Heli::var_info[] = {
     // @DisplayName: Stabilize Mode Collective Point 4
     // @Description: Helicopter's maximum collective pitch setting at full throttle input in Stabilize mode
     // @Range: 500 1000
-    // @Units: Percent*10
+    // @Units: d%
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("STAB_COL_4",    4, AC_InputManager_Heli, _heli_stab_col_max, AC_ATTITUDE_HELI_STAB_COLLECTIVE_MAX_DEFAULT),

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -29,7 +29,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Range: 0 360
     // @Increment: 1
     // @User: Advanced
-    // @Units: Centi-degrees
+    // @Units: cdeg
     AP_GROUPINFO("YAW_ALIGN",    2, AC_PrecLand, _yaw_align, 0),
 
     // @Param: LAND_OFS_X
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Range: -20 20
     // @Increment: 1
     // @User: Advanced
-    // @Units: Centimeters
+    // @Units: cm
     AP_GROUPINFO("LAND_OFS_X",    3, AC_PrecLand, _land_ofs_cm_x, 0),
 
     // @Param: LAND_OFS_Y
@@ -47,7 +47,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Range: -20 20
     // @Increment: 1
     // @User: Advanced
-    // @Units: Centimeters
+    // @Units: cm
     AP_GROUPINFO("LAND_OFS_Y",    4, AC_PrecLand, _land_ofs_cm_y, 0),
 
     // @Param: EST_TYPE

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
     // @Param: PUMP_RATE
     // @DisplayName: Pump speed
     // @Description: Desired pump speed when traveling 1m/s expressed as a percentage
-    // @Units: percentage
+    // @Units: %
     // @Range: 0 100
     // @User: Standard
     AP_GROUPINFO("PUMP_RATE",   1, AC_Sprayer, _pump_pct_1ms, AC_SPRAYER_DEFAULT_PUMP_RATE),
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
     // @Param: PUMP_MIN
     // @DisplayName: Pump speed minimum
     // @Description: Minimum pump speed expressed as a percentage
-    // @Units: percentage
+    // @Units: %
     // @Range: 0 100
     // @User: Standard
     AP_GROUPINFO("PUMP_MIN",   4, AC_Sprayer, _pump_min_pct, AC_SPRAYER_DEFAULT_PUMP_MIN),

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 	// @DisplayName: Pitch Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved pitch angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_PitchController, gains.tau,       0.5f),
@@ -60,7 +60,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 	// @DisplayName: Pitch up max rate
 	// @Description: This sets the maximum nose up pitch rate that the controller will demand (degrees/sec). Setting it to zero disables the limit.
 	// @Range: 0 100
-	// @Units: degrees/second
+	// @Units: deg/s
 	// @Increment: 1
 	// @User: Advanced
 	AP_GROUPINFO("RMAX_UP",     4, AP_PitchController, gains.rmax,   0.0f),
@@ -69,7 +69,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 	// @DisplayName: Pitch down max rate
 	// @Description: This sets the maximum nose down pitch rate that the controller will demand (degrees/sec). Setting it to zero disables the limit.
 	// @Range: 0 100
-	// @Units: degrees/second
+	// @Units: deg/s
 	// @Increment: 1
 	// @User: Advanced
 	AP_GROUPINFO("RMAX_DN",     5, AP_PitchController, _max_rate_neg,   0.0f),

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 	// @DisplayName: Roll Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved bank angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_RollController, gains.tau,       0.5f),
@@ -60,7 +60,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 	// @DisplayName: Maximum Roll Rate
 	// @Description: This sets the maximum roll rate that the controller will demand (degrees/sec). Setting it to zero disables the limit. If this value is set too low, then the roll can't keep up with the navigation demands and the plane will start weaving. If it is set too high (or disabled by setting to zero) then ailerons will get large inputs at the start of turns. A limit of 60 degrees/sec is a good default.
 	// @Range: 0 180
-	// @Units: degrees/second
+	// @Units: deg/s
 	// @Increment: 1
 	// @User: Advanced
 	AP_GROUPINFO("RMAX",   4, AP_RollController, gains.rmax,       0),

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
 	// @DisplayName: Steering Time Constant
 	// @Description: This controls the time constant in seconds from demanded to achieved steering angle. A value of 0.75 is a good default and will work with nearly all rovers. Ground steering in aircraft needs a bit smaller time constant, and a value of 0.5 is recommended for best ground handling in fixed wing aircraft. A value of 0.75 means that the controller will try to correct any deviation between the desired and actual steering angle in 0.75 seconds. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the vehicle can achieve.
 	// @Range: 0.4 1.0
-	// @Units: seconds
+	// @Units: s
 	// @Increment: 0.1
 	// @User: Advanced
 	AP_GROUPINFO("TCONST",      0, AP_SteerController, _tau,       0.75f),
@@ -62,6 +62,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
 	// @Description: This limits the number of degrees of steering in centi-degrees over which the integrator will operate. At the default setting of 1500 centi-degrees, the integrator will be limited to +- 15 degrees of servo travel. The maximum servo deflection is +- 45 centi-degrees, so the default value represents a 1/3rd of the total control throw which is adequate unless the vehicle is severely out of trim.
 	// @Range: 0 4500
 	// @Increment: 1
+	// @Units: cdeg
 	// @User: Advanced
 	AP_GROUPINFO("IMAX",     5, AP_SteerController, _imax,        1500),
 
@@ -70,7 +71,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
 	// @Description: This is the minimum assumed ground speed in meters/second for steering. Having a minimum speed prevents oscillations when the vehicle first starts moving. The vehicle can still drive slower than this limit, but the steering calculations will be done based on this minimum speed.
 	// @Range: 0 5
 	// @Increment: 0.1
-    // @Units: m/s
+	// @Units: m/s
 	// @User: User
 	AP_GROUPINFO("MINSPD",   6, AP_SteerController, _minspeed,    1.0f),
 
@@ -89,7 +90,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
     // @Description: Speed after that the maximum degree of steering will start to derate. Set this speed to a maximum speed that a plane can do controlled turn at maximum angle of steering wheel without rolling to wing. If 0 then no derating is used.
     // @Range: 0.0 30.0
     // @Increment: 0.1
-	// @Units: m/s
+    // @Units: m/s
     // @User: Advanced
     AP_GROUPINFO("DRTSPD",  8, AP_SteerController, _deratespeed,        0),
 
@@ -98,7 +99,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
     // @Description: Degrees of steering wheel to derate at each additional m/s of speed above "Derating speed". Should be set so that at higher speeds the plane does not roll to the wing in turns.
     // @Range: 0.0 50.0
     // @Increment: 0.1
-    // @Units: degree/(m/s)
+    // @Units: deg/m/s
     // @User: Advanced
     AP_GROUPINFO("DRTFCT", 9, AP_SteerController, _deratefactor,        10),
 
@@ -107,7 +108,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
     // @Description: The angle that limits smallest angle of steering wheel at maximum speed. Even if it should derate below, it will stop derating at this angle.
     // @Range: 0.0 4500.0
     // @Increment: 0.1
-    // @Units: Centidegrees
+    // @Units: cdeg
     // @User: Advanced
     AP_GROUPINFO("DRTMIN", 10, AP_SteerController, _mindegree,        4500),
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -69,7 +69,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_X
     // @DisplayName: AHRS Trim Roll
     // @Description: Compensates for the roll angle difference between the control board and the frame. Positive values make the vehicle roll right.
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Standard
@@ -77,7 +77,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_Y
     // @DisplayName: AHRS Trim Pitch
     // @Description: Compensates for the pitch angle difference between the control board and the frame. Positive values make the vehicle pitch up/back.
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Standard
@@ -85,7 +85,7 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @Param: TRIM_Z
     // @DisplayName: AHRS Trim Yaw
     // @Description: Not Used
-    // @Units: Radians
+    // @Units: rad
     // @Range: -0.1745 +0.1745
     // @Increment: 0.01
     // @User: Advanced

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -81,20 +81,20 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @DisplayName: AMSL limit
     // @Description: This sets the AMSL (above mean sea level) altitude limit. If the pressure altitude determined by QNH exceeds this limit then flight termination will be forced. Note that this limit is in meters, whereas pressure altitude limits are often quoted in feet. A value of zero disables the pressure altitude limit.
     // @User: Advanced
-    // @Units: meters
+    // @Units: m
     AP_GROUPINFO("AMSL_LIMIT",   8, AP_AdvancedFailsafe, _amsl_limit,    0),
 
     // @Param: AMSL_ERR_GPS
     // @DisplayName: Error margin for GPS based AMSL limit
     // @Description: This sets margin for error in GPS derived altitude limit. This error margin is only used if the barometer has failed. If the barometer fails then the GPS will be used to enforce the AMSL_LIMIT, but this margin will be subtracted from the AMSL_LIMIT first, to ensure that even with the given amount of GPS altitude error the pressure altitude is not breached. OBC users should set this to comply with their D2 safety case. A value of -1 will mean that barometer failure will lead to immediate termination.
     // @User: Advanced
-    // @Units: meters
+    // @Units: m
     AP_GROUPINFO("AMSL_ERR_GPS", 9, AP_AdvancedFailsafe, _amsl_margin_gps,  -1),
 
     // @Param: QNH_PRESSURE
     // @DisplayName: QNH pressure
     // @Description: This sets the QNH pressure in millibars to be used for pressure altitude in the altitude limit. A value of zero disables the altitude limit.
-    // @Units: millibar
+    // @Units: mbar
     // @User: Advanced
     AP_GROUPINFO("QNH_PRESSURE", 10, AP_AdvancedFailsafe, _qnh_pressure,    0),
 
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @DisplayName: RC failure time
     // @Description: This is the time in seconds in manual mode that failsafe termination will activate if RC input is lost. For the OBC rules this should be (1.5). Use 0 to disable.
     // @User: Advanced
-    // @Units: seconds
+    // @Units: s
     AP_GROUPINFO("RC_FAIL_TIME",   19, AP_AdvancedFailsafe, _rc_fail_time_seconds,    0),
 
     AP_GROUPEND

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: MIN_VOLT
     // @DisplayName: Minimum arming voltage on the first battery
     // @Description: The minimum voltage on the first battery to arm, 0 disables the check.  This parameter is relevant for ArduPlane only.
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1 
     // @User: Standard
     AP_GROUPINFO("MIN_VOLT",      4,     AP_Arming,  _min_voltage[0],  0),
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: MIN_VOLT2
     // @DisplayName: Minimum arming voltage on the second battery
     // @Description: The minimum voltage on the first battery to arm, 0 disables the check. This parameter is relevant for ArduPlane only.
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.1 
     // @User: Standard
     AP_GROUPINFO("MIN_VOLT2",     5,     AP_Arming,  _min_voltage[1],  0),

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -76,42 +76,42 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     // @Param: W_TIME
     // @DisplayName: Time Horizon Warn
     // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than W_DIST_XY or W_DIST_Z then W_ACTION is undertaken (assuming F_ACTION is not undertaken)
-    // @Units: seconds
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("W_TIME",      6, AP_Avoidance, _warn_time_horizon, AP_AVOIDANCE_WARN_TIME_DEFAULT),
 
     // @Param: F_TIME
     // @DisplayName: Time Horizon Fail
     // @Description: Aircraft velocity vectors are multiplied by this time to determine closest approach.  If this results in an approach closer than F_DIST_XY or F_DIST_Z then F_ACTION is undertaken
-    // @Units: seconds
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("F_TIME",      7, AP_Avoidance, _fail_time_horizon, AP_AVOIDANCE_FAIL_TIME_DEFAULT),
 
     // @Param: W_DIST_XY
     // @DisplayName: Distance Warn XY
     // @Description: Closest allowed projected distance before W_ACTION is undertaken
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("W_DIST_XY",   8, AP_Avoidance, _warn_distance_xy, AP_AVOIDANCE_WARN_DISTANCE_XY_DEFAULT),
 
     // @Param: F_DIST_XY
     // @DisplayName: Distance Fail XY
     // @Description: Closest allowed projected distance before F_ACTION is undertaken
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("F_DIST_XY",   9, AP_Avoidance, _fail_distance_xy, AP_AVOIDANCE_FAIL_DISTANCE_XY_DEFAULT),
 
     // @Param: W_DIST_Z
     // @DisplayName: Distance Warn Z
     // @Description: Closest allowed projected distance before BEHAVIOUR_W is undertaken
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("W_DIST_Z",    10, AP_Avoidance, _warn_distance_z, AP_AVOIDANCE_WARN_DISTANCE_Z_DEFAULT),
 
     // @Param: F_DIST_Z
     // @DisplayName: Distance Fail Z
     // @Description: Closest allowed projected distance before BEHAVIOUR_F is undertaken
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("F_DIST_Z",    11, AP_Avoidance, _fail_distance_z, AP_AVOIDANCE_FAIL_DISTANCE_Z_DEFAULT),
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -56,7 +56,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ABS_PRESS
     // @DisplayName: Absolute Pressure
     // @Description: calibrated ground pressure in Pascals
-    // @Units: pascals
+    // @Units: Pa
     // @Increment: 1
     // @ReadOnly: True
     // @Volatile: True
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: TEMP
     // @DisplayName: ground temperature
     // @Description: calibrated ground temperature in degrees Celsius
-    // @Units: degrees celsius
+    // @Units: degC
     // @Increment: 1
     // @ReadOnly: True
     // @Volatile: True
@@ -79,7 +79,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ALT_OFFSET
     // @DisplayName: altitude offset
     // @Description: altitude offset in meters added to barometric altitude. This is used to allow for automatic adjustment of the base barometric altitude by a ground station equipped with a barometer. The value is added to the barometric altitude read by the aircraft. It is automatically reset to 0 when the barometer is calibrated on each reboot or when a preflight calibration is performed.
-    // @Units: meters
+    // @Units: m
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("ALT_OFFSET", 5, AP_Baro, _alt_offset, 0),
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ABS_PRESS2
     // @DisplayName: Absolute Pressure
     // @Description: calibrated ground pressure in Pascals
-    // @Units: pascals
+    // @Units: Pa
     // @Increment: 1
     // @ReadOnly: True
     // @Volatile: True
@@ -122,7 +122,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Param: ABS_PRESS3
     // @DisplayName: Absolute Pressure
     // @Description: calibrated ground pressure in Pascals
-    // @Units: pascals
+    // @Units: Pa
     // @Increment: 1
     // @ReadOnly: True
     // @Volatile: True

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -37,21 +37,21 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: _AMP_PERVOLT
     // @DisplayName: Amps per volt
     // @Description: Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
-    // @Units: Amps/Volt
+    // @Units: A/V
     // @User: Standard
     AP_GROUPINFO("_AMP_PERVOLT", 4, AP_BattMonitor, _curr_amp_per_volt[0], AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
 
     // @Param: _AMP_OFFSET
     // @DisplayName: AMP offset
     // @Description: Voltage offset at zero current on current sensor
-    // @Units: Volts
+    // @Units: V
     // @User: Standard
     AP_GROUPINFO("_AMP_OFFSET", 5, AP_BattMonitor, _curr_amp_offset[0], 0),
 
     // @Param: _CAPACITY
     // @DisplayName: Battery capacity
     // @Description: Capacity of the battery in mAh when full
-    // @Units: mAh
+    // @Units: mA.h
     // @Increment: 50
     // @User: Standard
     AP_GROUPINFO("_CAPACITY", 6, AP_BattMonitor, _pack_capacity[0], AP_BATT_CAPACITY_DEFAULT),
@@ -62,7 +62,7 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: _WATT_MAX
     // @DisplayName: Maximum allowed power (Watts)
     // @Description: If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable.
-    // @Units: Watts
+    // @Units: W
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_WATT_MAX", 9, AP_BattMonitor, _watt_max[0], AP_BATT_MAX_WATT_DEFAULT),
@@ -105,21 +105,21 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: 2_AMP_PERVOL
     // @DisplayName: Amps per volt
     // @Description: Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17.
-    // @Units: Amps/Volt
+    // @Units: A/V
     // @User: Standard
     AP_GROUPINFO("2_AMP_PERVOL", 15, AP_BattMonitor, _curr_amp_per_volt[1], AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
 
     // @Param: 2_AMP_OFFSET
     // @DisplayName: AMP offset
     // @Description: Voltage offset at zero current on current sensor
-    // @Units: Volts
+    // @Units: V
     // @User: Standard
     AP_GROUPINFO("2_AMP_OFFSET", 16, AP_BattMonitor, _curr_amp_offset[1], 0),
 
     // @Param: 2_CAPACITY
     // @DisplayName: Battery capacity
     // @Description: Capacity of the battery in mAh when full
-    // @Units: mAh
+    // @Units: mA.h
     // @Increment: 50
     // @User: Standard
     AP_GROUPINFO("2_CAPACITY", 17, AP_BattMonitor, _pack_capacity[1], AP_BATT_CAPACITY_DEFAULT),
@@ -129,7 +129,7 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: 2_WATT_MAX
     // @DisplayName: Maximum allowed current
     // @Description: If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable.
-    // @Units: Amps
+    // @Units: A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_WATT_MAX", 18, AP_BattMonitor, _watt_max[1], AP_BATT_MAX_WATT_DEFAULT),
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Param: _VOLT_TIMER
     // @DisplayName: Low voltage timeout
     // @Description: This is the timeout in seconds before a low voltage event will be triggered. For aircraft with low C batteries it may be necessary to raise this in order to cope with low voltage on long takeoffs. A value of zero disables low voltage errors.
-    // @Units: Seconds
+    // @Units: s
     // @Increment: 1
     // @Range: 0 120
     // @User: Advanced

--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Param: _LATITUDE
     // @DisplayName: Beacon origin's latitude
     // @Description: Beacon origin's latitude
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.000001
     // @Range: -90 90
     // @User: Advanced
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Param: _LONGITUDE
     // @DisplayName: Beacon origin's longitude
     // @Description: Beacon origin's longitude
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.000001
     // @Range: -180 180
     // @User: Advanced
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Param: _ALT
     // @DisplayName: Beacon origin's altitude above sealevel in meters
     // @Description: Beacon origin's altitude above sealevel in meters
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @Range: 0 10000
     // @User: Advanced
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo AP_Beacon::var_info[] = {
     // @Param: _ORIENT_YAW
     // @DisplayName: Beacon systems rotation from north in degrees
     // @Description: Beacon systems rotation from north in degrees
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 1
     // @Range: -180 +180
     // @User: Advanced

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -153,7 +153,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @DisplayName: Target IMU temperature
     // @Description: This sets the target IMU temperature for boards with controllable IMU heating units. A value of -1 disables heating.
     // @Range: -1 80
-    // @Units: degreesC
+    // @Units: degC
     // @User: Advanced
     AP_GROUPINFO("IMU_TARGTEMP", 8, AP_BoardConfig, _imu_target_temperature, HAL_IMU_TEMP_DEFAULT),
 #endif

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Param: DURATION
     // @DisplayName: Duration that shutter is held open
     // @Description: How long the shutter will be held open in 10ths of a second (i.e. enter 10 for 1second, 50 for 5seconds)
-    // @Units: deciseconds
+    // @Units: ds
     // @Range: 0 50
     // @User: Standard
     AP_GROUPINFO("DURATION",    1, AP_Camera, _trigger_duration, AP_CAMERA_TRIGGER_DEFAULT_DURATION),
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Param: SERVO_ON
     // @DisplayName: Servo ON PWM value
     // @Description: PWM value to move servo to when shutter is activated
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 1000 2000
     // @User: Standard
     AP_GROUPINFO("SERVO_ON",    2, AP_Camera, _servo_on_pwm, AP_CAMERA_SERVO_ON_PWM),
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @Param: SERVO_OFF
     // @DisplayName: Servo OFF PWM value
     // @Description: PWM value to move servo to when shutter is deactivated
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 1000 2000
     // @User: Standard
     AP_GROUPINFO("SERVO_OFF",   3, AP_Camera, _servo_off_pwm, AP_CAMERA_SERVO_OFF_PWM),
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @DisplayName: Camera trigger distance
     // @Description: Distance in meters between camera triggers. If this value is non-zero then the camera will trigger whenever the GPS position changes by this number of meters regardless of what mode the APM is in. Note that this parameter can also be set in an auto mission using the DO_SET_CAM_TRIGG_DIST command, allowing you to enable/disable the triggering of the camera during the flight.
     // @User: Standard
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000
     AP_GROUPINFO("TRIGG_DIST",  4, AP_Camera, _trigg_dist, 0),
 
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @DisplayName: Minimum time between photos
     // @Description: Postpone shooting if previous picture was taken less than preset time(ms) ago.
     // @User: Standard
-    // @Units: milliseconds
+    // @Units: ms
     // @Range: 0 10000
     AP_GROUPINFO("MIN_INTERVAL",  6, AP_Camera, _min_interval, 0),
 
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @DisplayName: Maximum photo roll angle.
     // @Description: Postpone shooting if roll is greater than limit. (0=Disable, will shoot regardless of roll).
     // @User: Standard
-    // @Units: Degrees
+    // @Units: deg
     // @Range: 0 180
     AP_GROUPINFO("MAX_ROLL",  7, AP_Camera, _max_roll, 0),
  

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the X axis
     // @Description: Offset to be added to the compass x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the Y axis
     // @Description: Offset to be added to the compass y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass offsets in milligauss on the Z axis
     // @Description: Offset to be added to the compass z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS",    1, Compass, _state[0].offset, 0),
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass declination
     // @Description: An angle to compensate between the true north and magnetic north
     // @Range: -3.142 3.142
-    // @Units: Radians
+    // @Units: rad
     // @Increment: 0.01
     // @User: Standard
     AP_GROUPINFO("DEC",    2, Compass, _declination, 0),
@@ -101,25 +101,25 @@ const AP_Param::GroupInfo Compass::var_info[] = {
 
     // @Param: MOT_X
     // @DisplayName: Motor interference compensation for body frame X axis
-    // @Description: Multiplied by the current throttle and added to the compass's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT_Y
     // @DisplayName: Motor interference compensation for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to the compass's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT_Z
     // @DisplayName: Motor interference compensation for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to the compass's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to the compass's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT",    7, Compass, _state[0].motor_compensation, 0),
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass2's x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -150,7 +150,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass2's y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -158,32 +158,32 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass2 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass2's z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS2",    10, Compass, _state[1].offset, 0),
 
     // @Param: MOT2_X
     // @DisplayName: Motor interference compensation to compass2 for body frame X axis
-    // @Description: Multiplied by the current throttle and added to compass2's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT2_Y
     // @DisplayName: Motor interference compensation to compass2 for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to compass2's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT2_Z
     // @DisplayName: Motor interference compensation to compass2 for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to compass2's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass2's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT2",    11, Compass, _state[1].motor_compensation, 0),
@@ -199,7 +199,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass3's x-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -207,7 +207,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass3's y-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
 
@@ -215,32 +215,32 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @DisplayName: Compass3 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass3's z-axis values to compensate for metal in the frame
     // @Range: -400 400
-    // @Units: milligauss
+    // @Units: mGauss
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFS3",    13, Compass, _state[2].offset, 0),
 
     // @Param: MOT3_X
     // @DisplayName: Motor interference compensation to compass3 for body frame X axis
-    // @Description: Multiplied by the current throttle and added to compass3's x-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's x-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT3_Y
     // @DisplayName: Motor interference compensation to compass3 for body frame Y axis
-    // @Description: Multiplied by the current throttle and added to compass3's y-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's y-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
 
     // @Param: MOT3_Z
     // @DisplayName: Motor interference compensation to compass3 for body frame Z axis
-    // @Description: Multiplied by the current throttle and added to compass3's z-axis values to compensate for motor interference
+    // @Description: Multiplied by the current throttle and added to compass3's z-axis values to compensate for motor interference (Offset per Amp or at Full Throttle)
     // @Range: -1000 1000
-    // @Units: Offset per Amp or at Full Throttle
+    // @Units: mGauss/A
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("MOT3",    14, Compass, _state[2].motor_compensation, 0),

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -109,7 +109,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @DisplayName: Minimum elevation
     // @Description: This sets the minimum elevation of satellites above the horizon for them to be used for navigation. Setting this to -100 leaves the minimum elevation set to the GPS modules default.
     // @Range: -100 90
-    // @Units: Degrees
+    // @Units: deg
     // @User: Advanced
     AP_GROUPINFO("MIN_ELEV", 6, AP_GPS, _min_elevation, -100),
 
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: RATE_MS
     // @DisplayName: GPS update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
-    // @Units: milliseconds
+    // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @Range: 50 200
     // @User: Advanced
@@ -177,7 +177,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: RATE_MS2
     // @DisplayName: GPS 2 update rate in milliseconds
     // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz is not allowed
-    // @Units: milliseconds
+    // @Units: ms
     // @Values: 100:10Hz,125:8Hz,200:5Hz
     // @Range: 50 200
     // @User: Advanced
@@ -224,7 +224,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: DELAY_MS
     // @DisplayName: GPS delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
-    // @Units: milliseconds
+    // @Units: ms
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS", 18, AP_GPS, _delay_ms[0], 0),
@@ -232,7 +232,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: DELAY_MS2
     // @DisplayName: GPS 2 delay in milliseconds
     // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
-    // @Units: milliseconds
+    // @Units: ms
     // @Range: 0 250
     // @User: Advanced
     AP_GROUPINFO("DELAY_MS2", 19, AP_GPS, _delay_ms[1], 0),
@@ -247,7 +247,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: BLEND_TC
     // @DisplayName: Blending time constant
     // @Description: Controls the slowest time constant applied to the calculation of GPS position and height offsets used to adjust different GPS receivers for steady state position differences.
-    // @Units: seconds
+    // @Units: s
     // @Range: 5.0 30.0
     // @User: Advanced
     AP_GROUPINFO("BLEND_TC", 21, AP_GPS, _blend_tc, 10.0f),

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
     // @Description: Time in seconds that gripper will regrab the cargo to ensure grip has not weakened; 0 to disable
     // @User: Advanced
     // @Range: 0 255
-    // @Units: seconds
+    // @Units: s
     AP_GROUPINFO("REGRAB",  5, AP_Gripper, config.regrab_interval, GRIPPER_REGRAB_DEFAULT),
 
     // @Param: UAVCAN_ID

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @DisplayName: Time to run starter
     // @Description: This is the number of seconds to run the starter when trying to start the engine
     // @User: Standard
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.1 5
     AP_GROUPINFO("STARTER_TIME", 2, AP_ICEngine, starter_time, 3),
 
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @DisplayName: Time to wait between starts
     // @Description: Delay between start attempts
     // @User: Standard
-    // @Units: Seconds
+    // @Units: s
     // @Range: 1 10
     AP_GROUPINFO("START_DELAY", 3, AP_ICEngine, starter_delay, 2),
     

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
     // @Param: PERIOD
     // @DisplayName: L1 control period
     // @Description: Period in seconds of L1 tracking loop. This parameter is the primary control for agressiveness of turns in auto mode. This needs to be larger for less responsive airframes. The default of 20 is quite conservative, but for most RC aircraft will lead to reasonable flight. For smaller more agile aircraft a value closer to 15 is appropriate, or even as low as 10 for some very agile aircraft. When tuning, change this value in small increments, as a value that is much too small (say 5 or 10 below the right value) can lead to very radical turns, and a risk of stalling.
-    // @Units: seconds
+    // @Units: s
     // @Range: 1 60
     // @Increment: 1
     // @User: Standard
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
     // @Param: LIM_BANK
     // @DisplayName: Loiter Radius Bank Angle Limit
     // @Description: The sealevel bank angle limit for a continous loiter. (Used to calculate airframe loading limits at higher altitudes). Setting to 0, will instead just scale the loiter radius directly
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 89
     // @User: Advanced
     AP_GROUPINFO_FRAME("LIM_BANK",   3, AP_L1_Control, _loiter_bank_limit, 0.0f, AP_PARAM_FRAME_PLANE),

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @DisplayName: Landing slope re-calc threshold
     // @Description: This parameter is used when using a rangefinder during landing for altitude correction from baro drift (RNGFND_LANDING=1) and the altitude correction indicates your altitude is lower than the intended slope path. This value is the threshold of the correction to re-calculate the landing approach slope. Set to zero to keep the original slope all the way down and any detected baro drift will be corrected by pitching/throttling up to snap back to resume the original slope path. Otherwise, when a rangefinder altitude correction exceeds this threshold it will trigger a slope re-calculate to give a shallower slope. This also smoothes out the approach when flying over objects such as trees. Recommend a value of 2m.
     // @Range: 0 5
-    // @Units: meters
+    // @Units: m
     // @Increment: 0.5
     // @User: Advanced
     AP_GROUPINFO("SLOPE_RCALC", 1, AP_Landing, slope_recalc_shallow_threshold, 2.0f),
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @DisplayName: Landing auto-abort slope threshold
     // @Description: This parameter is used when using a rangefinder during landing for altitude correction from baro drift (RNGFND_LANDING=1) and the altitude correction indicates your actual altitude is higher than the intended slope path. Normally it would pitch down steeply but that can result in a crash with high airspeed so this allows remembering the baro offset and self-abort the landing and come around for another landing with the correct baro offset applied for a perfect slope. An auto-abort go-around will only happen once, next attempt will not auto-abort again. This operation happens entirely automatically in AUTO mode. This value is the delta degrees threshold to trigger the go-around compared to the original slope. Example: if set to 5 deg and the mission planned slope is 15 deg then if the new slope is 21 then it will go-around. Set to 0 to disable. Requires LAND_SLOPE_RCALC > 0.
     // @Range: 0 90
-    // @Units: degrees
+    // @Units: deg
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("ABORT_DEG", 2, AP_Landing, slope_recalc_steep_threshold_to_abort, 0),
@@ -44,14 +44,14 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: PITCH_CD
     // @DisplayName: Landing Pitch
     // @Description: Used in autoland to give the minimum pitch in the final stage of landing (after the flare). This parameter can be used to ensure that the final landing attitude is appropriate for the type of undercarriage on the aircraft. Note that it is a minimum pitch only - the landing code will control pitch above this value to try to achieve the configured landing sink rate.
-    // @Units: centi-Degrees
+    // @Units: cdeg
     // @User: Advanced
     AP_GROUPINFO("PITCH_CD", 3, AP_Landing, pitch_cd, 0),
 
     // @Param: FLARE_ALT
     // @DisplayName: Landing flare altitude
     // @Description: Altitude in autoland at which to lock heading and flare to the LAND_PITCH_CD pitch. Note that this option is secondary to LAND_FLARE_SEC. For a good landing it preferable that the flare is triggered by LAND_FLARE_SEC.
-    // @Units: meters
+    // @Units: m
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("FLARE_ALT", 4, AP_Landing, flare_alt, 3.0f),
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: FLARE_SEC
     // @DisplayName: Landing flare time
     // @Description: Vertical time before landing point at which to lock heading and flare with the motor stopped. This is vertical time, and is calculated based solely on the current height above the ground and the current descent rate.  Set to 0 if you only wish to flare based on altitude (see LAND_FLARE_ALT).
-    // @Units: seconds
+    // @Units: s
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("FLARE_SEC", 5, AP_Landing, flare_sec, 2.0f),
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: PF_ALT
     // @DisplayName: Landing pre-flare altitude
     // @Description: Altitude to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. The pre-flare flight stage trigger works just like LAND_FLARE_ALT but higher. Disabled when LAND_PF_ARSPD is 0.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 30
     // @Increment: 0.1
     // @User: Advanced
@@ -76,7 +76,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: PF_SEC
     // @DisplayName: Landing pre-flare time
     // @Description: Vertical time to ground to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. This pre-flare flight stage trigger works just like LAND_FLARE_SEC but earlier. Disabled when LAND_PF_ARSPD is 0.
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 10
     // @Increment: 0.1
     // @User: Advanced
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: THR_SLEW
     // @DisplayName: Landing throttle slew rate
     // @Description: This parameter sets the slew rate for the throttle during auto landing. When this is zero the THR_SLEWRATE parameter is used during landing. The value is a percentage throttle change per second, so a value of 20 means to advance the throttle over 5 seconds on landing. Values below 50 are not recommended as it may cause a stall when airspeed is low and you can not throttle up fast enough.
-    // @Units: percent
+    // @Units: %
     // @Range: 0 127
     // @Increment: 1
     // @User: User
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: DISARMDELAY
     // @DisplayName: Landing disarm delay
     // @Description: After a landing has completed using a LAND waypoint, automatically disarm after this many seconds have passed. Use 0 to not disarm.
-    // @Units: seconds
+    // @Units: s
     // @Increment: 1
     // @Range: 0 127
     // @User: Advanced
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @DisplayName: Landing flap percentage
     // @Description: The amount of flaps (as a percentage) to apply in the landing approach and flare of an automatic landing
     // @Range: 0 100
-    // @Units: Percent
+    // @Units: %
     // @User: Advanced
     AP_GROUPINFO("FLAP_PERCNT", 13, AP_Landing, flap_percent, 0),
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @DisplayName: Deepstall approach extension
     // @Description: The forward velocity of the aircraft while stalled
     // @Range: 10 200
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("APP_EXT", 4, AP_Landing_Deepstall, approach_extension, 50),
 
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @DisplayName: Deepstall slew speed
     // @Description: The speed at which the elevator slews to deepstall
     // @Range: 0 2
-    // @Units: seconds
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("SLEW_SPD", 6, AP_Landing_Deepstall, slew_speed, 0.5),
 
@@ -97,7 +97,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @DisplayName: Deepstall L1 period
     // @Description: Deepstall L1 navigational controller period
     // @Range: 5 50
-    // @Units: meters
+    // @Units: m
     // @User: Advanced
     AP_GROUPINFO("L1", 10, AP_Landing_Deepstall, L1_period, 30.0),
 

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -12,7 +12,7 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     // @DisplayName: Landing Gear Servo Retracted PWM Value
     // @Description: Servo PWM value when landing gear is retracted
     // @Range: 1000 2000
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("SERVO_RTRACT", 0, AP_LandingGear, _servo_retract_pwm, AP_LANDINGGEAR_SERVO_RETRACT_PWM_DEFAULT),
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     // @DisplayName: Landing Gear Servo Deployed PWM Value
     // @Description: Servo PWM value when landing gear is deployed
     // @Range: 1000 2000
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("SERVO_DEPLOY", 1, AP_LandingGear, _servo_deploy_pwm, AP_LANDINGGEAR_SERVO_DEPLOY_PWM_DEFAULT),

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -85,7 +85,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: Landing Collective Minimum
     // @Description: Minimum collective position while landed or landing
     // @Range: 0 500
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("LAND_COL_MIN", 9, AP_MotorsHeli, _land_collective_min, AP_MOTORS_HELI_LAND_COLLECTIVE_MIN),
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: RSC Ramp Time
     // @Description: Time in seconds for the output to the main rotor's ESC to reach full speed
     // @Range: 0 60
-    // @Units: Seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("RSC_RAMP_TIME", 10, AP_MotorsHeli, _rsc_ramp_time, AP_MOTORS_HELI_RSC_RAMP_TIME),
 
@@ -102,7 +102,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: RSC Runup Time
     // @Description: Time in seconds for the main rotor to reach full speed.  Must be longer than RSC_RAMP_TIME
     // @Range: 0 60
-    // @Units: Seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("RSC_RUNUP_TIME", 11, AP_MotorsHeli, _rsc_runup_time, AP_MOTORS_HELI_RSC_RUNUP_TIME),
 
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @DisplayName: Cyclic Pitch Angle Max
     // @Description: Maximum pitch angle of the swash plate
     // @Range: 0 18000
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Increment: 100
     // @User: Advanced
     AP_GROUPINFO("CYC_MAX", 16, AP_MotorsHeli, _cyclic_max, AP_MOTORS_HELI_SWASH_CYCLIC_MAX),

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 1 Position
     // @Description: Angular location of swash servo #1
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV1_POS", 1, AP_MotorsHeli_Dual, _servo1_pos, AP_MOTORS_HELI_DUAL_SERVO1_POS),
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 2 Position
     // @Description: Angular location of swash servo #2
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV2_POS", 2, AP_MotorsHeli_Dual, _servo2_pos,  AP_MOTORS_HELI_DUAL_SERVO2_POS),
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 3 Position
     // @Description: Angular location of swash servo #3
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV3_POS", 3, AP_MotorsHeli_Dual, _servo3_pos,  AP_MOTORS_HELI_DUAL_SERVO3_POS),
@@ -54,7 +54,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 4 Position
     // @Description: Angular location of swash servo #4
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV4_POS", 4, AP_MotorsHeli_Dual, _servo4_pos, AP_MOTORS_HELI_DUAL_SERVO4_POS),
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 5 Position
     // @Description: Angular location of swash servo #5
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV5_POS", 5, AP_MotorsHeli_Dual, _servo5_pos, AP_MOTORS_HELI_DUAL_SERVO5_POS),
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Servo 6 Position
     // @Description: Angular location of swash servo #6
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV6_POS", 6, AP_MotorsHeli_Dual, _servo6_pos, AP_MOTORS_HELI_DUAL_SERVO6_POS),
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Swashplate 1 Phase Angle Compensation
     // @Description: Phase angle correction for rotor head.  If pitching the swash forward induces a roll, this can be correct the problem
     // @Range: -90 90
-    // @Units: Degrees
+    // @Units: deg
     // @User: Advanced
     // @Increment: 1
     AP_GROUPINFO("PHANG1", 7, AP_MotorsHeli_Dual, _swash1_phase_angle, 0),
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @DisplayName: Swashplate 2 Phase Angle Compensation
     // @Description: Phase angle correction for rotor head.  If pitching the swash forward induces a roll, this can be correct the problem
     // @Range: -90 90
-    // @Units: Degrees
+    // @Units: deg
     // @User: Advanced
     // @Increment: 1
     AP_GROUPINFO("PHANG2", 8, AP_MotorsHeli_Dual, _swash2_phase_angle, 0),

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @DisplayName: Servo 1 Position
     // @Description: Angular location of swash servo #1
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV1_POS", 1, AP_MotorsHeli_Single, _servo1_pos, AP_MOTORS_HELI_SINGLE_SERVO1_POS),
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @DisplayName: Servo 2 Position
     // @Description: Angular location of swash servo #2
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV2_POS", 2, AP_MotorsHeli_Single, _servo2_pos, AP_MOTORS_HELI_SINGLE_SERVO2_POS),
@@ -46,7 +46,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @DisplayName: Servo 3 Position
     // @Description: Angular location of swash servo #3
     // @Range: -180 180
-    // @Units: Degrees
+    // @Units: deg
     // @User: Standard
     // @Increment: 1
     AP_GROUPINFO("SV3_POS", 3, AP_MotorsHeli_Single, _servo3_pos, AP_MOTORS_HELI_SINGLE_SERVO3_POS),
@@ -78,7 +78,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @DisplayName: Swashplate Phase Angle Compensation
     // @Description: Phase angle correction for rotor head.  If pitching the swash forward induces a roll, this can be correct the problem
     // @Range: -90 90
-    // @Units: Degrees
+    // @Units: deg
     // @User: Advanced
     // @Increment: 1
     AP_GROUPINFO("PHANG", 7, AP_MotorsHeli_Single, _phase_angle, 0),

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Matrix Yaw Min
     // @Description: Yaw control is given at least this pwm range
     // @Range: 0 500
-    // @Units: pwm
+    // @Units: PWM
     // @User: Advanced
     AP_GROUPINFO("YAW_HEADROOM", 6, AP_MotorsMulticopter, _yaw_headroom, AP_MOTORS_YAW_HEADROOM_DEFAULT),
 
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.4 * cell count, 0 = Disabled
     // @Range: 6 35
-    // @Units: Volts
+    // @Units: V
     // @User: Advanced
     AP_GROUPINFO("BAT_VOLT_MAX", 10, AP_MotorsMulticopter, _batt_voltage_max, AP_MOTORS_BAT_VOLT_MAX_DEFAULT),
 
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled
     // @Range: 6 35
-    // @Units: Volts
+    // @Units: V
     // @User: Advanced
     AP_GROUPINFO("BAT_VOLT_MIN", 11, AP_MotorsMulticopter, _batt_voltage_min, AP_MOTORS_BAT_VOLT_MIN_DEFAULT),
 
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Motor Current Max
     // @Description: Maximum current over which maximum throttle is limited (0 = Disabled)
     // @Range: 0 200
-    // @Units: Amps
+    // @Units: A
     // @User: Advanced
     AP_GROUPINFO("BAT_CURR_MAX", 12, AP_MotorsMulticopter, _batt_current_max, AP_MOTORS_BAT_CURR_MAX_DEFAULT),
 
@@ -91,6 +91,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: PWM_MIN
     // @DisplayName: PWM output miniumum
     // @Description: This sets the min PWM output value that will ever be output to the motors, 0 = use input RC3_MIN
+    // @Units: PWM
     // @Range: 0 2000
     // @User: Advanced
     AP_GROUPINFO("PWM_MIN", 16, AP_MotorsMulticopter, _pwm_min, 0),
@@ -98,6 +99,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: PWM_MAX
     // @DisplayName: PWM output maximum
     // @Description: This sets the max PWM value that will ever be output to the motors, 0 = use input RC3_MAX
+    // @Units: PWM
     // @Range: 0 2000
     // @User: Advanced
     AP_GROUPINFO("PWM_MAX", 17, AP_MotorsMulticopter, _pwm_max, 0),
@@ -120,7 +122,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Motor Current Max Time Constant
     // @Description: Time constant used to limit the maximum current
     // @Range: 0 10
-    // @Units: Seconds
+    // @Units: s
     // @User: Advanced
     AP_GROUPINFO("BAT_CURR_TC", 20, AP_MotorsMulticopter, _batt_current_time_constant, AP_MOTORS_BAT_CURR_TC_DEFAULT),
 
@@ -149,7 +151,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Yaw Servo Max Lean Angle
     // @Description: Yaw servo's maximum lean angle
     // @Range: 5 80
-    // @Units: Degrees
+    // @Units: deg
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO_FRAME("YAW_SV_ANGLE", 35, AP_MotorsMulticopter,  _yaw_servo_angle_max_deg, 30, AP_PARAM_FRAME_TRICOPTER),
@@ -158,7 +160,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @DisplayName: Spool up time
     // @Description: Time in seconds to spool up the motors from zero to min throttle. 
     // @Range: 0 2
-    // @Units: Seconds
+    // @Units: s
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("SPOOL_TIME",   36, AP_MotorsMulticopter,  _spool_up_time, AP_MOTORS_SPOOL_UP_TIME_DEFAULT),

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _RETRACT_X
     // @DisplayName: Mount roll angle when in retracted position
     // @Description: Mount roll angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _RETRACT_Y
     // @DisplayName: Mount tilt/pitch angle when in retracted position
     // @Description: Mount tilt/pitch angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _RETRACT_Z
     // @DisplayName: Mount yaw/pan angle when in retracted position
     // @Description: Mount yaw/pan angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -44,7 +44,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _NEUTRAL_X
     // @DisplayName: Mount roll angle when in neutral position
     // @Description: Mount roll angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _NEUTRAL_Y
     // @DisplayName: Mount tilt/pitch angle when in neutral position
     // @Description: Mount tilt/pitch angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -60,7 +60,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _NEUTRAL_Z
     // @DisplayName: Mount pan/yaw angle when in neutral position
     // @Description: Mount pan/yaw angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMIN_ROL
     // @DisplayName: Minimum roll angle
     // @Description: Minimum physical roll angular position of mount.
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMAX_ROL
     // @DisplayName: Maximum roll angle
     // @Description: Maximum physical roll angular position of the mount
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMIN_TIL
     // @DisplayName: Minimum tilt angle
     // @Description: Minimum physical tilt (pitch) angular position of mount.
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -133,7 +133,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMAX_TIL
     // @DisplayName: Maximum tilt angle
     // @Description: Maximum physical tilt (pitch) angular position of the mount
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMIN_PAN
     // @DisplayName: Minimum pan angle
     // @Description: Minimum physical pan (yaw) angular position of mount.
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -158,7 +158,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _ANGMAX_PAN
     // @DisplayName: Maximum pan angle
     // @Description: Maximum physical pan (yaw) angular position of the mount
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -175,7 +175,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _LEAD_RLL
     // @DisplayName: Roll stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate, compensating for servo delay. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -184,7 +184,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _LEAD_PTCH
     // @DisplayName: Pitch stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -219,7 +219,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_RETRACT_X
     // @DisplayName: Mount2 roll angle when in retracted position
     // @Description: Mount2 roll angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -227,7 +227,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_RETRACT_Y
     // @DisplayName: Mount2 tilt/pitch angle when in retracted position
     // @Description: Mount2 tilt/pitch angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -235,7 +235,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_RETRACT_Z
     // @DisplayName: Mount2 yaw/pan angle when in retracted position
     // @Description: Mount2 yaw/pan angle when in retracted position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -244,7 +244,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_NEUTRAL_X
     // @DisplayName: Mount2 roll angle when in neutral position
     // @Description: Mount2 roll angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -252,7 +252,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_NEUTRAL_Y
     // @DisplayName: Mount2 tilt/pitch angle when in neutral position
     // @Description: Mount2 tilt/pitch angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -260,7 +260,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_NEUTRAL_Z
     // @DisplayName: Mount2 pan/yaw angle when in neutral position
     // @Description: Mount2 pan/yaw angle when in neutral position
-    // @Units: Degrees
+    // @Units: deg
     // @Range: -180.00 179.99
     // @Increment: 1
     // @User: Standard
@@ -299,7 +299,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMIN_ROL
     // @DisplayName: Mount2's minimum roll angle
     // @Description: Mount2's minimum physical roll angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -308,7 +308,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMAX_ROL
     // @DisplayName: Mount2's maximum roll angle
     // @Description: Mount2's maximum physical roll angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -324,7 +324,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMIN_TIL
     // @DisplayName: Mount2's minimum tilt angle
     // @Description: Mount2's minimum physical tilt (pitch) angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -333,7 +333,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMAX_TIL
     // @DisplayName: Mount2's maximum tilt angle
     // @Description: Mount2's maximum physical tilt (pitch) angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -349,7 +349,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMIN_PAN
     // @DisplayName: Mount2's minimum pan angle
     // @Description: Mount2's minimum physical pan (yaw) angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -358,7 +358,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_ANGMAX_PAN
     // @DisplayName: Mount2's maximum pan angle
     // @Description: MOunt2's maximum physical pan (yaw) angular position
-    // @Units: Centi-Degrees
+    // @Units: cdeg
     // @Range: -18000 17999
     // @Increment: 1
     // @User: Standard
@@ -367,7 +367,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_LEAD_RLL
     // @DisplayName: Mount2's Roll stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate, compensating for servo delay. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard
@@ -376,7 +376,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: 2_LEAD_PTCH
     // @DisplayName: Mount2's Pitch stabilization lead time
     // @Description: Causes the servo angle output to lead the current angle of the vehicle by some amount of time based on current angular rate. Increase until the servo is responsive but doesn't overshoot. Does nothing with pan stabilization enabled.
-    // @Units: Seconds
+    // @Units: s
     // @Range: 0.0 0.2
     // @Increment: .005
     // @User: Standard

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -192,7 +192,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("GPS_DELAY", 8, NavEKF2, _gpsDelay_ms, 220),
 
     // Height measurement parameters
@@ -227,7 +227,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF2, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -238,7 +238,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0.01 0.5
     // @Increment: 0.01
     // @User: Advanced
-    // @Units: gauss
+    // @Units: Gauss
     AP_GROUPINFO("MAG_M_NSE", 13, NavEKF2, _magNoise, MAG_M_NSE_DEFAULT),
 
     // @Param: MAG_CAL
@@ -328,7 +328,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 127
     // @Increment: 10
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF2, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -364,7 +364,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This noise controls the rate of gyro scale factor learning. Increasing it makes rate gyro scale factor estimation faster and noisier.
     // @Range: 0.000001 0.001
     // @User: Advanced
-    // @Units: 1/s
+    // @Units: Hz
     AP_GROUPINFO("GSCL_P_NSE", 27, NavEKF2, _gyroScaleProcessNoise, GSCALE_P_NSE_DEFAULT),
 
     // @Param: ABIAS_P_NSE
@@ -464,7 +464,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This state process noise controls the growth of earth magnetic field state error estimates. Increasing it makes earth magnetic field estimation faster and noisier.
     // @Range: 0.00001 0.01
     // @User: Advanced
-    // @Units: gauss/s
+    // @Units: Gauss/s
     AP_GROUPINFO("MAGE_P_NSE", 40, NavEKF2, _magEarthProcessNoise, MAGE_P_NSE_DEFAULT),
 
     // @Param: MAGB_P_NSE
@@ -472,7 +472,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This state process noise controls the growth of body magnetic field state error estimates. Increasing it makes magnetometer bias error estimation faster and noisier.
     // @Range: 0.00001 0.01
     // @User: Advanced
-    // @Units: gauss/s
+    // @Units: Gauss/s
     AP_GROUPINFO("MAGB_P_NSE", 41, NavEKF2, _magBodyProcessNoise, MAGB_P_NSE_DEFAULT),
 
     // @Param: RNG_USE_HGT
@@ -515,7 +515,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Range: 0 127
     // @Increment: 10
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF2, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -219,7 +219,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("HGT_DELAY", 12, NavEKF3, _hgtDelay_ms, 60),
 
     // Magnetometer measurement parameters
@@ -230,7 +230,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0.01 0.5
     // @Increment: 0.01
     // @User: Advanced
-    // @Units: gauss
+    // @Units: Gauss
     AP_GROUPINFO("MAG_M_NSE", 13, NavEKF3, _magNoise, MAG_M_NSE_DEFAULT),
 
     // @Param: MAG_CAL
@@ -321,7 +321,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("FLOW_DELAY", 23, NavEKF3, _flowDelay_ms, FLOW_MEAS_DELAY),
 
     // State and Covariance Predition Parameters
@@ -451,7 +451,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Description: This state process noise controls the growth of earth magnetic field state error estimates. Increasing it makes earth magnetic field estimation faster and noisier.
     // @Range: 0.00001 0.01
     // @User: Advanced
-    // @Units: gauss/s
+    // @Units: Gauss/s
     AP_GROUPINFO("MAGE_P_NSE", 40, NavEKF3, _magEarthProcessNoise, MAGE_P_NSE_DEFAULT),
 
     // @Param: MAGB_P_NSE
@@ -459,7 +459,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Description: This state process noise controls the growth of body magnetic field state error estimates. Increasing it makes magnetometer bias error estimation faster and noisier.
     // @Range: 0.00001 0.01
     // @User: Advanced
-    // @Units: gauss/s
+    // @Units: Gauss/s
     AP_GROUPINFO("MAGB_P_NSE", 41, NavEKF3, _magBodyProcessNoise, MAGB_P_NSE_DEFAULT),
 
     // @Param: RNG_USE_HGT
@@ -503,7 +503,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 10
     // @RebootRequired: True
     // @User: Advanced
-    // @Units: milliseconds
+    // @Units: ms
     AP_GROUPINFO("BCN_DELAY", 46, NavEKF3, _rngBcnDelay_ms, 50),
 
     // @Param: RNG_USE_SPD

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Parachute Servo ON PWM value
     // @Description: Parachute Servo PWM value when parachute is released
     // @Range: 1000 2000
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("SERVO_ON", 2, AP_Parachute, _servo_on_pwm, AP_PARACHUTE_SERVO_ON_PWM_DEFAULT),
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Servo OFF PWM value
     // @Description: Parachute Servo PWM value when parachute is not released
     // @Range: 1000 2000
-    // @Units: pwm
+    // @Units: PWM
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("SERVO_OFF", 3, AP_Parachute, _servo_off_pwm, AP_PARACHUTE_SERVO_OFF_PWM_DEFAULT),
@@ -46,7 +46,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Parachute min altitude in meters above home
     // @Description: Parachute min altitude above home.  Parachute will not be released below this altitude.  0 to disable alt check.
     // @Range: 0 32000
-    // @Units: Meters
+    // @Units: m
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("ALT_MIN", 4, AP_Parachute, _alt_min, AP_PARACHUTE_ALT_MIN_DEFAULT),
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @DisplayName: Parachute release delay
     // @Description: Delay in millseconds between motor stop and chute release
     // @Range: 0 5000
-    // @Units: Milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("DELAY_MS", 5, AP_Parachute, _delay_ms, AP_PARACHUTE_RELEASE_DELAY_MS),

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -44,7 +44,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _YAW_CORR
     // @DisplayName: Proximity sensor yaw correction
     // @Description: Proximity sensor yaw correction
-    // @Units: degrees
+    // @Units: deg
     // @Range: -180 180
     // @User: Standard
     AP_GROUPINFO("_YAW_CORR", 3, AP_Proximity, _yaw_correction[0], PROXIMITY_YAW_CORRECTION_DEFAULT),
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG1
     // @DisplayName: Proximity sensor ignore angle 1
     // @Description: Proximity sensor ignore angle 1
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG1", 4, AP_Proximity, _ignore_angle_deg[0], 0),
@@ -60,7 +60,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID1
     // @DisplayName: Proximity sensor ignore width 1
     // @Description: Proximity sensor ignore width 1
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID1", 5, AP_Proximity, _ignore_width_deg[0], 0),
@@ -68,7 +68,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG2
     // @DisplayName: Proximity sensor ignore angle 2
     // @Description: Proximity sensor ignore angle 2
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG2", 6, AP_Proximity, _ignore_angle_deg[1], 0),
@@ -76,7 +76,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID2
     // @DisplayName: Proximity sensor ignore width 2
     // @Description: Proximity sensor ignore width 2
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID2", 7, AP_Proximity, _ignore_width_deg[1], 0),
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG3
     // @DisplayName: Proximity sensor ignore angle 3
     // @Description: Proximity sensor ignore angle 3
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG3", 8, AP_Proximity, _ignore_angle_deg[2], 0),
@@ -92,7 +92,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID3
     // @DisplayName: Proximity sensor ignore width 3
     // @Description: Proximity sensor ignore width 3
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID3", 9, AP_Proximity, _ignore_width_deg[2], 0),
@@ -100,7 +100,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG4
     // @DisplayName: Proximity sensor ignore angle 4
     // @Description: Proximity sensor ignore angle 4
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG4", 10, AP_Proximity, _ignore_angle_deg[3], 0),
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID4
     // @DisplayName: Proximity sensor ignore width 4
     // @Description: Proximity sensor ignore width 4
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID4", 11, AP_Proximity, _ignore_width_deg[3], 0),
@@ -116,7 +116,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG5
     // @DisplayName: Proximity sensor ignore angle 5
     // @Description: Proximity sensor ignore angle 5
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG5", 12, AP_Proximity, _ignore_angle_deg[4], 0),
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID5
     // @DisplayName: Proximity sensor ignore width 5
     // @Description: Proximity sensor ignore width 5
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID5", 13, AP_Proximity, _ignore_width_deg[4], 0),
@@ -132,7 +132,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_ANG6
     // @DisplayName: Proximity sensor ignore angle 6
     // @Description: Proximity sensor ignore angle 6
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 360
     // @User: Standard
     AP_GROUPINFO("_IGN_ANG6", 14, AP_Proximity, _ignore_angle_deg[5], 0),
@@ -140,7 +140,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _IGN_WID6
     // @DisplayName: Proximity sensor ignore width 6
     // @Description: Proximity sensor ignore width 6
-    // @Units: degrees
+    // @Units: deg
     // @Range: 0 45
     // @User: Standard
     AP_GROUPINFO("_IGN_WID6", 15, AP_Proximity, _ignore_width_deg[5], 0),
@@ -164,7 +164,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: 2_YAW_CORR
     // @DisplayName: Second Proximity sensor yaw correction
     // @Description: Second Proximity sensor yaw correction
-    // @Units: degrees
+    // @Units: deg
     // @Range: -180 180
     // @User: Standard
     AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: PIN_LOW
     // @DisplayName: Receiver RSSI voltage low
     // @Description: This is the voltage value that the radio receiver will put on the RSSI_ANA_PIN when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_PIN_HIGH. 
-    // @Units: Volt
+    // @Units: V
     // @Increment: 0.01
     // @Range: 0 5.0
     // @User: Standard
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: PIN_HIGH
     // @DisplayName: Receiver RSSI voltage high
     // @Description: This is the voltage value that the radio receiver will put on the RSSI_ANA_PIN when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_PIN_LOW. 
-    // @Units: Volt
+    // @Units: V
     // @Increment: 0.01
     // @Range: 0 5.0
     // @User: Standard
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: CHAN_LOW
     // @DisplayName: Receiver RSSI PWM low value
     // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
-    // @Units: Microseconds
+    // @Units: PWM
     // @Range: 0 2000
     // @User: Standard
     AP_GROUPINFO("CHAN_LOW", 5, AP_RSSI, rssi_channel_low_pwm_value,  1000),
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: CHAN_HIGH
     // @DisplayName: Receiver RSSI PWM high value
     // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
-    // @Units: Microseconds
+    // @Units: PWM
     // @Range: 0 2000
     // @User: Standard
     AP_GROUPINFO("CHAN_HIGH", 6, AP_RSSI, rssi_channel_high_pwm_value,  2000),

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo AP_Rally::var_info[] = {
     // @DisplayName: Rally Limit
     // @Description: Maximum distance to rally point. If the closest rally point is more than this number of kilometers from the current position and the home location is closer than any of the rally points from the current position then do RTL to home rather than to the closest rally point. This prevents a leftover rally point from a different airfield being used accidentally. If this is set to 0 then the closest rally point is always used.
     // @User: Advanced
-    // @Units: kilometers
+    // @Units: km
     // @Increment: 0.1
     AP_GROUPINFO("LIMIT_KM", 1, AP_Rally, _rally_limit_km, RALLY_LIMIT_KM_DEFAULT),
 

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("_SCALING", 2, RangeFinder, _scaling[0], 3.0f),
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance for analog rangefinders. Offset added to distance in centimeters for PWM and I2C Lidars
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("_OFFSET",  3, RangeFinder, _offset[0], 0.0f),
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_MIN_CM",  5, RangeFinder, _min_distance_cm[0], 20),
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_MAX_CM",  6, RangeFinder, _max_distance_cm[0], 700),
@@ -96,7 +96,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _SETTLE
     // @DisplayName: Rangefinder settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("_SETTLE", 8, RangeFinder, _settle_time_ms[0], 0),
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _PWRRNG
     // @DisplayName: Powersave range
     // @Description: This parameter sets the estimated terrain distance in meters above which the sensor will be put into a power saving mode (if available). A value of zero means power saving is not enabled
-    // @Units: meters
+    // @Units: m
     // @Range: 0 32767
     // @User: Standard
     AP_GROUPINFO("_PWRRNG", 10, RangeFinder, _powersave_range, 0),
@@ -119,7 +119,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _GNDCLEAR
     // @DisplayName: Distance (in cm) from the range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 5 127
     // @Increment: 1
     // @User: Standard
@@ -177,7 +177,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("2_SCALING", 14, RangeFinder, _scaling[1], 3.0f),
@@ -185,7 +185,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("2_OFFSET",  15, RangeFinder, _offset[1], 0.0f),
@@ -200,7 +200,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_MIN_CM",  17, RangeFinder, _min_distance_cm[1], 20),
@@ -208,7 +208,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_MAX_CM",  18, RangeFinder, _max_distance_cm[1], 700),
@@ -223,7 +223,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("2_SETTLE", 20, RangeFinder, _settle_time_ms[1], 0),
@@ -238,7 +238,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_GNDCLEAR
     // @DisplayName: Distance (in cm) from the second range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the second range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced
@@ -298,7 +298,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("3_SCALING", 27, RangeFinder, _scaling[2], 3.0f),
@@ -306,7 +306,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("3_OFFSET",  28, RangeFinder, _offset[2], 0.0f),
@@ -321,7 +321,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_MIN_CM",  30, RangeFinder, _min_distance_cm[2], 20),
@@ -329,7 +329,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_MAX_CM",  31, RangeFinder, _max_distance_cm[2], 700),
@@ -344,7 +344,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("3_SETTLE", 33, RangeFinder, _settle_time_ms[2], 0),
@@ -359,7 +359,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_GNDCLEAR
     // @DisplayName: Distance (in cm) from the third range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the third range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced
@@ -419,7 +419,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_SCALING
     // @DisplayName: Rangefinder scaling
     // @Description: Scaling factor between rangefinder reading and distance. For the linear and inverted functions this is in meters per volt. For the hyperbolic function the units are meterVolts.
-    // @Units: meters/Volt
+    // @Units: m/V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("4_SCALING", 39, RangeFinder, _scaling[3], 3.0f),
@@ -427,7 +427,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_OFFSET
     // @DisplayName: rangefinder offset
     // @Description: Offset in volts for zero distance
-    // @Units: Volts
+    // @Units: V
     // @Increment: 0.001
     // @User: Advanced
     AP_GROUPINFO("4_OFFSET",  40, RangeFinder, _offset[3], 0.0f),
@@ -442,7 +442,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_MIN_CM
     // @DisplayName: Rangefinder minimum distance
     // @Description: Minimum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_MIN_CM",  42, RangeFinder, _min_distance_cm[3], 20),
@@ -450,7 +450,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_MAX_CM
     // @DisplayName: Rangefinder maximum distance
     // @Description: Maximum distance in centimeters that rangefinder can reliably read
-	// @Units: centimeters
+	// @Units: cm
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_MAX_CM",  43, RangeFinder, _max_distance_cm[3], 700),
@@ -465,7 +465,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_SETTLE
     // @DisplayName: Sonar settle time
     // @Description: The time in milliseconds that the rangefinder reading takes to settle. This is only used when a STOP_PIN is specified. It determines how long we have to wait for the rangefinder to give a reading after we set the STOP_PIN high. For a sonar rangefinder with a range of around 7m this would need to be around 50 milliseconds to allow for the sonar pulse to travel to the target and back again.
-    // @Units: milliseconds
+    // @Units: ms
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("4_SETTLE", 45, RangeFinder, _settle_time_ms[3], 0),
@@ -480,7 +480,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_GNDCLEAR
     // @DisplayName: Distance (in cm) from the fourth range finder to the ground
     // @Description: This parameter sets the expected range measurement(in cm) that the fourth range finder should return when the vehicle is on the ground.
-    // @Units: centimeters
+    // @Units: cm
     // @Range: 0 127
     // @Increment: 1
     // @User: Advanced

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: DIST_AHEAD
     // @DisplayName: Distance to thermal center
     // @Description: Initial guess of the distance to the thermal center
-    // @Units: metres
+    // @Units: m
     // @Range: 0 100
     // @User: Advanced
     AP_GROUPINFO("DIST_AHEAD", 6, SoaringController, thermal_distance_ahead, 5.0f),
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: MIN_THML_S
     // @DisplayName: Minimum thermalling time
     // @Description: Minimum number of seconds to spend thermalling
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 32768
     // @User: Advanced
     AP_GROUPINFO("MIN_THML_S", 7, SoaringController, min_thermal_s, 20),
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: MIN_CRSE_S
     // @DisplayName: Minimum cruising time
     // @Description: Minimum number of seconds to spend cruising
-    // @Units: seconds
+    // @Units: s
     // @Range: 0 32768
     // @User: Advanced
     AP_GROUPINFO("MIN_CRSE_S", 8, SoaringController, min_cruise_s, 30),
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: POLAR_K
     // @DisplayName: Cl factor
     // @Description: Cl factor 2*m*g/(rho*S)
-    // @Units: m*m/s/s
+    // @Units: m.m/s/s
     // @Range: 0 0.5
     // @User: Advanced
     AP_GROUPINFO("POLAR_K", 11, SoaringController, polar_K, 25.6),
@@ -97,7 +97,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: ALT_MAX
     // @DisplayName: Maximum soaring altitude, relative to the home location
     // @Description: Don't thermal any higher than this.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000.0
     // @User: Advanced
     AP_GROUPINFO("ALT_MAX", 12, SoaringController, alt_max, 350.0),
@@ -105,7 +105,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: ALT_MIN
     // @DisplayName: Minimum soaring altitude, relative to the home location
     // @Description: Don't get any lower than this.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000.0
     // @User: Advanced
     AP_GROUPINFO("ALT_MIN", 13, SoaringController, alt_min, 50.0),
@@ -113,7 +113,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: ALT_CUTOFF
     // @DisplayName: Maximum power altitude, relative to the home location
     // @Description: Cut off throttle at this alt.
-    // @Units: meters
+    // @Units: m
     // @Range: 0 1000.0
     // @User: Advanced
     AP_GROUPINFO("ALT_CUTOFF", 14, SoaringController, alt_cutoff, 250.0),

--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -16,21 +16,21 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Param: _FLTTIME
     // @DisplayName: Total FlightTime
     // @Description: Total FlightTime (seconds)
-    // @Units: seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_FLTTIME",    1, AP_Stats, params.flttime, 0),
 
     // @Param: _RUNTIME
     // @DisplayName: Total RunTime
     // @Description: Total time autopilot has run
-    // @Units: seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_RUNTIME",    2, AP_Stats, params.runtime, 0),
 
     // @Param: _RESET
     // @DisplayName: Reset time
     // @Description: Seconds since January 1st 2016 (Unix epoch+1451606400) since reset (set to 0 to reset statistics)
-    // @Units: seconds
+    // @Units: s
     // @User: Standard
     AP_GROUPINFO("_RESET",    3, AP_Stats, params.reset, 1),
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Param: SPACING
     // @DisplayName: Terrain grid spacing
     // @Description: Distance between terrain grid points in meters. This controls the horizontal resolution of the terrain data that is stored on te SD card and requested from the ground station. If your GCS is using the worldwide SRTM database then a resolution of 100 meters is appropriate. Some parts of the world may have higher resolution data available, such as 30 meter data available in the SRTM database in the USA. The grid spacing also controls how much data is kept in memory during flight. A larger grid spacing will allow for a larger amount of data in memory. A grid spacing of 100 meters results in the vehicle keeping 12 grid squares in memory with each grid square having a size of 2.7 kilometers by 3.2 kilometers. Any additional grid squares are stored on the SD once they are fetched from the GCS and will be demand loaded as needed.
-    // @Units: meters
+    // @Units: m
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("SPACING",   1, AP_Terrain, grid_spacing, 100),

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN
     // @DisplayName: RC min PWM
     // @Description: RC minimum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Advanced
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: TRIM
     // @DisplayName: RC trim PWM
     // @Description: RC trim (neutral) PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Advanced
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MAX
     // @DisplayName: RC max PWM
     // @Description: RC maximum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Advanced
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: DZ
     // @DisplayName: RC dead-zone
     // @Description: dead zone around trim or bottom
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 0 200
     // @User: Advanced
     AP_GROUPINFO("DZ",   5, RC_Channel, dead_zone, 0),

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: MIN
     // @DisplayName: Minimum PWM
     // @Description: minimum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Standard
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: MAX
     // @DisplayName: Maximum PWM
     // @Description: maximum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Standard
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: TRIM
     // @DisplayName: Trim PWM
     // @Description: Trim PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
-    // @Units: pwm
+    // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
     // @User: Standard


### PR DESCRIPTION
For some reason I could not reopen the https://github.com/ArduPilot/ardupilot/pull/5517 so I had to open a new PR for this.

Long story short:
* https://github.com/ArduPilot/ardupilot/pull/5517 uses short SI units
* https://github.com/ArduPilot/ardupilot/pull/6146 uses long textual SI units

Short units have been approved in the Dev Meeting. The documentation gets generated with full long text units, and travis tests that the units exist.

It is also very easy to add new units, just edit the param.py file.