### PR TITLE
Plane: improve takeoff in vectored tailsitters

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -386,6 +386,13 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: This is the angle of the tilt servos when in VTOL mode and at minimum output. This needs to be set for Q_TILT_TYPE=3 to enable vectored control for yaw of tricopter tilt quadplanes.
     // @Range: 0 30
     AP_GROUPINFO("TILT_YAW_ANGLE", 55, QuadPlane, tilt.tilt_yaw_angle, 0),
+
+    // @Param: TAILSIT_VHPOW
+    // @DisplayName: Tailsitter vector thrust gain power
+    // @Description: This controls the amount of extra pitch given to the vectored control when at high pitch errors
+    // @Range: 0 4
+    // @Increment: 0.1
+    AP_GROUPINFO("TAILSIT_VHPOW", 56, QuadPlane, tailsitter.vectored_hover_power, 2.5),
     
     AP_GROUPEND
 };

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -369,6 +369,7 @@ private:
         AP_Int8 input_mask_chan;
         AP_Float vectored_forward_gain;
         AP_Float vectored_hover_gain;
+        AP_Float vectored_hover_power;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -293,9 +293,10 @@ void AP_AHRS_NavEKF::update_SITL(void)
                                   radians(fdm.yawRate));
 
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            _accel_ef_ekf[i] = Vector3f(fdm.xAccel,
-                                        fdm.yAccel,
-                                        fdm.zAccel);
+            Vector3f accel(fdm.xAccel,
+                           fdm.yAccel,
+                           fdm.zAccel);
+            _accel_ef_ekf[i] = _dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * accel;
         }
         _accel_ef_ekf_blended = _accel_ef_ekf[0];
 

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -55,16 +55,31 @@ void AP_MotorsTailsitter::output_to_motors()
     switch (_spool_mode) {
         case SHUT_DOWN:
             _throttle = 0;
+            // set limits flags
+            limit.roll_pitch = true;
+            limit.yaw = true;
+            limit.throttle_lower = true;
+            limit.throttle_upper = true;
             break;
         case SPIN_WHEN_ARMED:
             // sends output to motors when armed but not flying
             _throttle = constrain_float(_spin_up_ratio, 0.0f, 1.0f) * _spin_min;
+            // set limits flags
+            limit.roll_pitch = true;
+            limit.yaw = true;
+            limit.throttle_lower = true;
+            limit.throttle_upper = true;
             break;
         case SPOOL_UP:
         case THROTTLE_UNLIMITED:
         case SPOOL_DOWN:
             throttle_left  = constrain_float(_throttle + _rudder*0.5, 0, 1);
             throttle_right = constrain_float(_throttle - _rudder*0.5, 0, 1);
+            // initialize limits flags
+            limit.roll_pitch = false;
+            limit.yaw = false;
+            limit.throttle_lower = false;
+            limit.throttle_upper = false;
             break;
     }
     // outputs are setup here, and written to the HAL by the plane servos loop


### PR DESCRIPTION
This allows vectored motors to point straight up for vectored tailsitters when sitting on the ground. It should make takeoff much easier
Thanks to Leonard for the suggestion
