### PR TITLE
mk: remove support for bare px4 build type

### DIFF
--- a/Tools/scripts/build_all.sh
+++ b/Tools/scripts/build_all.sh
@@ -11,59 +11,22 @@ set -x
 export BUILDROOT="/tmp/all.build"
 rm -rf $BUILDROOT
 
-echo "Testing ArduPlane build"
-pushd ArduPlane
-for b in sitl linux; do
-    pwd
-    make clean
-    make $b -j4
-done
-popd
+BOARDS="sitl linux"
 
-echo "Testing ArduCopter build"
-pushd ArduCopter
-for b in sitl linux; do
-    pwd
-    make clean
-    make $b -j4
+for b in $BOARDS; do
+    echo "Testing $b build"
+    ./waf configure --board $b
+    ./waf clean
+    ./waf
 done
-popd
 
-echo "Testing APMRover build"
-pushd APMrover2
-for b in sitl linux; do
-    pwd
-    make clean
-    make $b -j4
-done
-popd
-
-echo "Testing AntennaTracker build"
-pushd AntennaTracker
-for b in sitl; do
-    pwd
-    make clean
-    make $b -j4
-done
-popd
-
-echo "Testing ArduSub build"
-pushd ArduSub
-for b in sitl linux; do
-    pwd
-    make clean
-    make $b -j4
-done
-popd
-
+echo "Building Replay"
 pushd Tools/Replay
 make clean
 make
 popd
 
-test -n "$PX4_ROOT" && test -d "$PX4_ROOT" && {
-    ./Tools/scripts/build_all_px4.sh
-}
+./Tools/scripts/build_all_px4.sh
 
 test -n "$VRBRAIN_ROOT" && test -d "$VRBRAIN_ROOT" && {
     ./Tools/scripts/build_all_vrbrain.sh

--- a/Tools/scripts/build_all_px4.sh
+++ b/Tools/scripts/build_all_px4.sh
@@ -9,32 +9,15 @@ set -e
 set -x
 
 git submodule init
-git submodule update
+git submodule update --recursive
 
-for d in ArduPlane ArduCopter APMrover2 ArduSub; do
-    pushd $d
-    make px4-clean
-    popd
+builds="px4-v1 px4-v2 px4-v3 px4-v4"
+
+for b in $builds; do
+    echo "Testing $b build"
+    ./waf clean
+    ./waf configure --board $b
+    ./waf
 done
-
-echo "Testing ArduPlane build"
-pushd ArduPlane
-make px4
-popd
-
-echo "Testing ArduCopter build"
-pushd ArduCopter
-make px4
-popd
-
-echo "Testing APMrover2 build"
-pushd APMrover2
-make px4
-popd
-
-echo "Testing ArduSub build"
-pushd ArduSub
-make px4
-popd
 
 exit 0

--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -110,7 +110,7 @@ qurt: all
 
 # cope with copter and hil targets
 FRAMES = heli
-BOARDS = apm1 apm2 apm2beta apm1-1280 px4 px4-v1 px4-v2 px4-v3 px4-v4 sitl flymaple linux erle pxf navio navio2 raspilot bbbmini minlure erlebrain2 bhat qflight pxfmini
+BOARDS = apm1 apm2 apm2beta apm1-1280 px4-v1 px4-v2 px4-v3 px4-v4 sitl flymaple linux erle pxf navio navio2 raspilot bbbmini minlure erlebrain2 bhat qflight pxfmini
 BOARDS += vrbrain
 BOARDS += vrbrain-v51 vrbrain-v52 vrbrain-v54
 BOARDS += vrcore-v10


### PR DESCRIPTION
"make px4-heli" was not correctly setting up a heli build. Rather than
wasting time fixing the old makefile build I'd rather just remove that
option. "make px4-v2-heli" still works