### PR TITLE
Plane: fixed climb rate for quadplanes in CRUISE

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -712,6 +712,12 @@ private:
         // lookahead value for height error reporting
         float lookahead;
 #endif
+
+        // last input for FBWB/CRUISE height control
+        float last_elevator_input;
+
+        // last time we checked for pilot control of height
+        uint32_t last_elev_check_us;
     } target_altitude {};
 
     float relative_altitude = 0.0f;


### PR DESCRIPTION
the high loop rate of quadplanes led to less than 1cm/loop change in
height, which got truncated to zero. Adjusting height at 10Hz fixes
that.

Thanks to Marco for reporting this!