### PR TITLE
AP_Motors: Fix comment on expected variable range

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -431,10 +431,10 @@ void AP_MotorsHeli_Dual::update_motor_control(RotorControlState state)
 //
 // move_actuators - moves swash plate to attitude of parameters passed in
 //                - expected ranges:
-//                       roll : -4500 ~ 4500
-//                       pitch: -4500 ~ 4500
-//                       collective: 0 ~ 1000
-//                       yaw:   -4500 ~ 4500
+//                       roll : -1 ~ +1
+//                       pitch: -1 ~ +1
+//                       collective: 0 ~ 1
+//                       yaw:   -1 ~ +1
 //
 void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {


### PR DESCRIPTION
The move_actuators function in AP_MotorsHeli_Dual previously indicated incorrect ranges for its input variables. AP_MotorsHeli_Single indicated that the ranges were -1 ~ +1 for roll, pitch and yaw, and 0 ~ 1 for the collective, whereas AP_MotorsHeli_Dual indicated -4500 ~ 4500 and 0 - 1000 respectively. The documentation comment for AP_MotorsHeli_Dual has been updated accordingly. 