### PR TITLE
Copter: esc calibration fixes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -589,6 +589,9 @@ private:
     // last valid RC input time
     uint32_t last_radio_update_ms;
 
+    // last esc calibration notification update
+    uint32_t esc_calibration_notify_update_ms;
+
 #if VISUAL_ODOMETRY_ENABLED == ENABLED
     // last visual odometry update time
     uint32_t visual_odom_last_update_ms;
@@ -939,6 +942,7 @@ private:
     void esc_calibration_startup_check();
     void esc_calibration_passthrough();
     void esc_calibration_auto();
+    void esc_calibration_notify();
     bool should_disarm_on_failsafe();
     void failsafe_radio_on_event();
     void failsafe_radio_off_event();

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -125,6 +125,9 @@ void Copter::esc_calibration_auto()
 #if FRAME_CONFIG != HELI_FRAME
     bool printed_msg = false;
 
+    // clear esc flag for next time
+    g.esc_calibrate.set_and_save(ESCCAL_NONE);
+
     if (motors->get_pwm_type() >= AP_Motors::PWM_TYPE_ONESHOT) {
         // run at full speed for oneshot ESCs (actually done on push)
         motors->set_update_rate(g.rc_speed);
@@ -168,9 +171,6 @@ void Copter::esc_calibration_auto()
 
     // reduce throttle to minimum
     motors->set_throttle_passthrough_for_esc_calibration(0.0f);
-
-    // clear esc parameter
-    g.esc_calibrate.set_and_save(ESCCAL_NONE);
 
     // block until we restart
     while(1) {

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -97,6 +97,9 @@ void Copter::esc_calibration_passthrough()
     // send message to GCS
     gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Passing pilot throttle to ESCs");
 
+    // disable safety if requested
+    BoardConfig.init_safety();
+
     // arm motors
     motors->armed(true);
     motors->enable();
@@ -109,7 +112,7 @@ void Copter::esc_calibration_passthrough()
         // read pilot input
         read_radio();
 
-        // we run at high rate do make oneshot ESCs happy. Normal ESCs
+        // we run at high rate to make oneshot ESCs happy. Normal ESCs
         // will only see pulses at the RC_SPEED
         delay(3);
 
@@ -138,6 +141,9 @@ void Copter::esc_calibration_auto()
 
     // send message to GCS
     gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Auto calibration");
+
+    // disable safety if requested
+    BoardConfig.init_safety();
 
     // arm and enable motors
     motors->armed(true);

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -59,9 +59,6 @@ void Copter::init_rc_out()
     hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #endif
 
-    // check if we should enter esc calibration mode
-    esc_calibration_startup_check();
-
     // refresh auxiliary channel to function map
     SRV_Channels::update_aux_servo_function();
 
@@ -72,6 +69,9 @@ void Copter::init_rc_out()
     uint16_t safety_ignore_mask = (~copter.motors->get_motor_mask()) & 0x3FFF;
     BoardConfig.set_default_safety_ignore_mask(safety_ignore_mask);
 #endif
+
+    // check if we should enter esc calibration mode
+    esc_calibration_startup_check();
 }
 
 


### PR DESCRIPTION
This PR resolves a few issues:

- ESC calibration was waiting for the safety switch to be pressed even if it had been disabled
- "auto" ESC calibration could get stuck waiting for a safety switch to be pressed and there was no way (as far as I can see) for the user to "un-stick" it even a reboot wouldn't have resolved the issue because it would immediately try to do the auto calibration on the next reboot.
- fix flashing of the LEDs during auto calibration

In addition it includes a minor change so the check for esc calibration starts after the servo functions are initialised.  I think this is a good idea although we haven't had any reports of problems.  I imagine a problem could have occurred if a motor output was setup on a non-standard channel and the user then tried to perform an ESC calibration - that non-standard channel output may not have received the correct outputs during the calibration.