### PR TITLE
ArduCopter: radio fix passthrough range on heli/coax/single

### DIFF
--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -182,5 +182,5 @@ void Copter::set_throttle_zero_flag(int16_t throttle_control)
 // pass pilot's inputs to motors library (used to allow wiggling servos while disarmed on heli, single, coax copters)
 void Copter::radio_passthrough_to_motors()
 {
-    motors->set_radio_passthrough(channel_roll->get_control_in()/1000.0f, channel_pitch->get_control_in()/1000.0f, channel_throttle->get_control_in()/1000.0f, channel_yaw->get_control_in()/1000.0f);
+    motors->set_radio_passthrough(channel_roll->norm_input(), channel_pitch->norm_input(), channel_throttle->norm_input(), channel_yaw->norm_input());
 }


### PR DESCRIPTION
There was a bug as radio_passthrough_to_motors take  control_in set by pwm_to_angle() (https://github.com/ArduPilot/ardupilot/blob/master/libraries/RC_Channel/RC_Channel.cpp#L119) and pwm_to_angle() return an "angle in centidegrees" (normally -4500 to 4500) from the current radio_in value;
Then those paththrough value are in -4.5;4.5 range .
When used in Coax for example : https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Motors/AP_MotorsCoax.cpp#L92 
calc_pwm_output_1to1() expect value in -1;1 range so the calculated value are wong ! set rc 1 1750 gives servo1_ouput 2000  ...
See : https://www.youtube.com/watch?v=f7YlkjQycAo