### PR TITLE
Copter: respond to param requests received before init completes

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1149,7 +1149,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
             send_text(MAV_SEVERITY_INFO, "PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION);
 #endif
-            handle_param_request_list(msg);
+            handle_param_request_list();
             break;
         }
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -524,7 +524,7 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
     {
-        handle_param_request_list(msg);
+        handle_param_request_list();
         break;
     }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -274,6 +274,7 @@ private:
             uint8_t land_repo_active        : 1; // 22      // true if the pilot is overriding the landing position
             uint8_t motor_interlock_switch  : 1; // 23      // true if pilot is requesting motor interlock enable
             uint8_t in_arming_delay         : 1; // 24      // true while we are armed but waiting to spin motors
+            uint8_t initialised_params      : 1; // 25      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
         };
         uint32_t value;
     } ap;
@@ -1086,6 +1087,7 @@ private:
     void print_hit_enter();
     void tuning();
     void gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...);
+    void gcs_send_deferred_param_request_list();
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -873,7 +873,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         send_text(MAV_SEVERITY_INFO, "PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION);
 #endif
         GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "Frame: %s", copter.get_frame_string());
-        handle_param_request_list(msg);
+        handle_param_request_list();
         break;
     }
 

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -11,13 +11,16 @@ class GCS_MAVLINK_Copter : public GCS_MAVLINK
 public:
 
     void data_stream_send(void) override;
+    void send_deferred_param_request_list();
 
 protected:
 
     uint32_t telem_delay() const override;
 
     bool accept_packet(const mavlink_status_t &status, mavlink_message_t &msg) override;
-    
+
+    void handle_param_request_list() override;
+
 private:
 
     void handleMessage(mavlink_message_t * msg) override;
@@ -27,4 +30,7 @@ private:
 
     void packetReceived(const mavlink_status_t &status,
                         mavlink_message_t &msg) override;
+
+    // cache parameter request during startup
+    bool param_request_during_startup = false;
 };

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -184,7 +184,14 @@ void Copter::init_ardupilot()
     // allocate the motors class
     allocate_motors();
 
-    init_rc_out();              // sets up motors and output to escs
+    // sets up motors and output to escs
+    init_rc_out();
+
+    // motors initialised so parameters can be sent
+    ap.initialised_params = true;
+
+    // send parameter list now if requested during startup
+    gcs_send_deferred_param_request_list();
 
     // initialise which outputs Servo and Relay events can use
     ServoRelayEvents.set_channel_mask(~motors->get_motor_mask());

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1604,7 +1604,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
         send_text(MAV_SEVERITY_INFO, "PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION);
 #endif
-        handle_param_request_list(msg);
+        handle_param_request_list();
         break;
     }
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -928,7 +928,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
         send_text(MAV_SEVERITY_INFO, "PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION);
 #endif
-        handle_param_request_list(msg);
+        handle_param_request_list();
         break;
     }
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -244,7 +244,7 @@ protected:
     bool handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
 
     void handle_param_set(mavlink_message_t *msg, DataFlash_Class *DataFlash);
-    void handle_param_request_list();
+    virtual void handle_param_request_list();
     void handle_param_request_read(mavlink_message_t *msg);
 
     void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -244,7 +244,7 @@ protected:
     bool handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
 
     void handle_param_set(mavlink_message_t *msg, DataFlash_Class *DataFlash);
-    void handle_param_request_list(mavlink_message_t *msg);
+    void handle_param_request_list();
     void handle_param_request_read(mavlink_message_t *msg);
 
     void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -186,11 +186,8 @@ void GCS_MAVLINK::handle_request_data_stream(mavlink_message_t *msg, bool save)
     }
 }
 
-void GCS_MAVLINK::handle_param_request_list(mavlink_message_t *msg)
+void GCS_MAVLINK::handle_param_request_list()
 {
-    mavlink_param_request_list_t packet;
-    mavlink_msg_param_request_list_decode(msg, &packet);
-
     // send system ID if we can
     char sysid[40];
     if (hal.util->get_system_id(sysid)) {


### PR DESCRIPTION
This PR resolves issue #6199.  The slow parameter load was because we were simply throwing away requests from the GCS to provide the full parameter list if they arrived before initialisation had completed. The GCS would not receive a reply and would then begin requesting parameters individually which is extremely slow.

It is important we not send the parameter list before the motor library is initialised because the number of parameters may change slightly.

This PR does the following:

- add a new initialised_motor flag which becomes true as soon as the motor library is initialised.  This occurs before the gyro calibration which can take a long time especially if the vehicle is on a moving platform.
- record if a parameter-request-list message was received during startup and then send the parameter list right after the initialised_motors flag becomes true.

Note: the handle_param_request_list method previously accepted a pointer to a mavlink message but it never used it so I removed it.  This made it easier to send the parameter list later without having to save a copy of the original request.