### PR TITLE
NFC: Improve the parameter descriptions of PWM parameters

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -287,7 +287,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: FS_THR_VALUE
     // @DisplayName: Throttle Failsafe Value
-    // @Description: The PWM level on channel 3 below which throttle failsafe triggers
+    // @Description: The PWM level in microseconds on channel 3 below which throttle failsafe triggers
     // @Range: 925 1100
     // @Units: PWM
     // @Increment: 1
@@ -296,7 +296,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: THR_DZ
     // @DisplayName: Throttle deadzone
-    // @Description: The deadzone above and below mid throttle.  Used in AltHold, Loiter, PosHold flight modes
+    // @Description: The deadzone above and below mid throttle in PWM microseconds. Used in AltHold, Loiter, PosHold flight modes
     // @User: Standard
     // @Range: 0 300
     // @Units: PWM

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -221,7 +221,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Param: THR_DZ
     // @DisplayName: Throttle deadzone
-    // @Description: The deadzone above and below mid throttle.  Used in AltHold, Loiter, PosHold flight modes
+    // @Description: The PWM deadzone in microseconds above and below mid throttle. Used in AltHold, Loiter, PosHold flight modes
     // @User: Standard
     // @Range: 0 300
     // @Units: PWM
@@ -304,7 +304,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Param: JS_CAM_TILT_STEP
     // @DisplayName: Camera tilt step size
-    // @Description: Size of PWM increment on camera tilt servo
+    // @Description: Size of PWM increment in microseconds on camera tilt servo
     // @User: Standard
     // @Range: 30 400
     // @Units: PWM
@@ -312,7 +312,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Param: JS_LIGHTS_STEP
     // @DisplayName: Lights step size
-    // @Description: Size of PWM increment on lights servo
+    // @Description: Size of PWM increment in microseconds on lights servo
     // @User: Standard
     // @Range: 30 400
     // @Units: PWM
@@ -327,7 +327,7 @@ const AP_Param::Info Sub::var_info[] = {
 
     // @Param: CAM_CENTER
     // @DisplayName: Camera tilt mount center
-    // @Description: Servo PWM at camera center position
+    // @Description: Servo PWM in microseconds at camera center position
     // @User: Standard
     // @Range: 1000 2000
     // @Units: PWM

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
 
     // @Param: SERVO_ON
     // @DisplayName: Servo ON PWM value
-    // @Description: PWM value to move servo to when shutter is activated
+    // @Description: PWM value in microseconds to move servo to when shutter is activated
     // @Units: PWM
     // @Range: 1000 2000
     // @User: Standard
@@ -41,7 +41,7 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
 
     // @Param: SERVO_OFF
     // @DisplayName: Servo OFF PWM value
-    // @Description: PWM value to move servo to when shutter is deactivated
+    // @Description: PWM value in microseconds to move servo to when shutter is deactivated
     // @Units: PWM
     // @Range: 1000 2000
     // @User: Standard

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
 
     // @Param: GRAB
     // @DisplayName: Gripper Grab PWM
-    // @Description: PWM value sent to Gripper to initiate grabbing the cargo
+    // @Description: PWM value in microseconds sent to Gripper to initiate grabbing the cargo
     // @User: Advanced
     // @Range: 1000 2000
     // @Units: PWM
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
 
     // @Param: RELEASE
     // @DisplayName: Gripper Release PWM
-    // @Description: PWM value sent to Gripper to release the cargo
+    // @Description: PWM value in microseconds sent to Gripper to release the cargo
     // @User: Advanced
     // @Range: 1000 2000
     // @Units: PWM
@@ -44,7 +44,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
 
     // @Param: NEUTRAL
     // @DisplayName: Neutral PWM
-    // @Description: PWM value sent to grabber when not grabbing or releasing
+    // @Description: PWM value in microseconds sent to grabber when not grabbing or releasing
     // @User: Advanced
     // @Range: 1000 2000
     // @Units: PWM

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
 
     // @Param: ELEV_PWM
     // @DisplayName: Deepstall elevator PWM
-    // @Description: The PWM value for the elevator at full deflection in deepstall
+    // @Description: The PWM value in microseconds for the elevator at full deflection in deepstall
     // @Range: 900 2100
     // @Units: PWM
     // @User: Advanced

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -10,7 +10,7 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
 
     // @Param: SERVO_RTRACT
     // @DisplayName: Landing Gear Servo Retracted PWM Value
-    // @Description: Servo PWM value when landing gear is retracted
+    // @Description: Servo PWM value in microseconds when landing gear is retracted
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
 
     // @Param: SERVO_DEPLOY
     // @DisplayName: Landing Gear Servo Deployed PWM Value
-    // @Description: Servo PWM value when landing gear is deployed
+    // @Description: Servo PWM value in microseconds when landing gear is deployed
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: COL_MIN
     // @DisplayName: Collective Pitch Minimum
-    // @Description: Lowest possible servo position for the swashplate
+    // @Description: Lowest possible servo position in PWM microseconds for the swashplate
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: COL_MAX
     // @DisplayName: Collective Pitch Maximum
-    // @Description: Highest possible servo position for the swashplate
+    // @Description: Highest possible servo position in PWM microseconds for the swashplate
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: COL_MID
     // @DisplayName: Collective Pitch Mid-Point
-    // @Description: Swash servo position corresponding to zero collective pitch (or zero lift for Asymmetrical blades)
+    // @Description: Swash servo position in PWM microseconds corresponding to zero collective pitch (or zero lift for Asymmetrical blades)
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: RSC_SETPOINT
     // @DisplayName: External Motor Governor Setpoint
-    // @Description: PWM passed to the external motor governor when external governor is enabled
+    // @Description: PWM in microseconds passed to the external motor governor when external governor is enabled
     // @Range: 0 1000
     // @Units: PWM
     // @Increment: 10
@@ -83,7 +83,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Param: LAND_COL_MIN
     // @DisplayName: Landing Collective Minimum
-    // @Description: Minimum collective position while landed or landing
+    // @Description: Minimum collective position in PWM microseconds while landed or landing
     // @Range: 0 500
     // @Units: PWM
     // @Increment: 1

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -147,7 +147,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // @Param: COL2_MIN
     // @DisplayName: Collective Pitch Minimum for rear swashplate
-    // @Description: Lowest possible servo position for the rear swashplate
+    // @Description: Lowest possible servo position in PWM microseconds for the rear swashplate
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -156,7 +156,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // @Param: COL2_MAX
     // @DisplayName: Collective Pitch Maximum for rear swashplate
-    // @Description: Highest possible servo position for the rear swashplate
+    // @Description: Highest possible servo position in PWM microseconds for the rear swashplate
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -165,7 +165,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // @Param: COL2_MID
     // @DisplayName: Collective Pitch Mid-Point for rear swashplate
-    // @Description: Swash servo position corresponding to zero collective pitch for the rear swashplate (or zero lift for Asymmetrical blades)
+    // @Description: Swash servo position in PWM microseconds corresponding to zero collective pitch for the rear swashplate (or zero lift for Asymmetrical blades)
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
 
     // @Param: GYR_GAIN
     // @DisplayName: External Gyro Gain
-    // @Description: PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro
+    // @Description: PWM in microseconds sent to external gyro on ch7 when tail type is Servo w/ ExtGyro
     // @Range: 0 1000
     // @Units: PWM
     // @Increment: 1
@@ -100,7 +100,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
   
     // @Param: TAIL_SPEED
     // @DisplayName: Direct Drive VarPitch Tail ESC speed
-    // @Description: Direct Drive VarPitch Tail ESC speed.  Only used when TailType is DirectDrive VarPitch
+    // @Description: Direct Drive VarPitch Tail ESC speed in PWM microseconds.  Only used when TailType is DirectDrive VarPitch
     // @Range: 0 1000
     // @Units: PWM
     // @Increment: 1
@@ -109,7 +109,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
 
     // @Param: GYR_GAIN_ACRO
     // @DisplayName: External Gyro Gain for ACRO
-    // @Description: PWM sent to external gyro on ch7 when tail type is Servo w/ ExtGyro. A value of zero means to use H_GYR_GAIN
+    // @Description: PWM in microseconds sent to external gyro on ch7 when tail type is Servo w/ ExtGyro. A value of zero means to use H_GYR_GAIN
     // @Range: 0 1000
     // @Units: PWM
     // @Increment: 1

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: YAW_HEADROOM
     // @DisplayName: Matrix Yaw Min
-    // @Description: Yaw control is given at least this pwm range
+    // @Description: Yaw control is given at least this pwm in microseconds range
     // @Range: 0 500
     // @Units: PWM
     // @User: Advanced
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: PWM_MIN
     // @DisplayName: PWM output miniumum
-    // @Description: This sets the min PWM output value that will ever be output to the motors, 0 = use input RC3_MIN
+    // @Description: This sets the min PWM output value in microseconds that will ever be output to the motors, 0 = use input RC3_MIN
     // @Units: PWM
     // @Range: 0 2000
     // @User: Advanced
@@ -98,7 +98,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: PWM_MAX
     // @DisplayName: PWM output maximum
-    // @Description: This sets the max PWM value that will ever be output to the motors, 0 = use input RC3_MAX
+    // @Description: This sets the max PWM value in microseconds that will ever be output to the motors, 0 = use input RC3_MAX
     // @Units: PWM
     // @Range: 0 2000
     // @User: Advanced

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
 
     // @Param: SERVO_ON
     // @DisplayName: Parachute Servo ON PWM value
-    // @Description: Parachute Servo PWM value when parachute is released
+    // @Description: Parachute Servo PWM value in microseconds when parachute is released
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
 
     // @Param: SERVO_OFF
     // @DisplayName: Servo OFF PWM value
-    // @Description: Parachute Servo PWM value when parachute is not released
+    // @Description: Parachute Servo PWM value in microseconds when parachute is not released
     // @Range: 1000 2000
     // @Units: PWM
     // @Increment: 1

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
 
     // @Param: CHAN_LOW
     // @DisplayName: Receiver RSSI PWM low value
-    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Description: This is the PWM value in microseconds that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH.
     // @Units: PWM
     // @Range: 0 2000
     // @User: Standard
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
 
     // @Param: CHAN_HIGH
     // @DisplayName: Receiver RSSI PWM high value
-    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Description: This is the PWM value in microseconds that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW.
     // @Units: PWM
     // @Range: 0 2000
     // @User: Standard

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -30,7 +30,7 @@ extern const AP_HAL::HAL& hal;
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN
     // @DisplayName: RC min PWM
-    // @Description: RC minimum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: RC minimum PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
 
     // @Param: TRIM
     // @DisplayName: RC trim PWM
-    // @Description: RC trim (neutral) PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: RC trim (neutral) PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
 
     // @Param: MAX
     // @DisplayName: RC max PWM
-    // @Description: RC maximum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: RC maximum PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
 
     // @Param: DZ
     // @DisplayName: RC dead-zone
-    // @Description: dead zone around trim or bottom
+    // @Description: PWM dead zone in microseconds around trim or bottom
     // @Units: PWM
     // @Range: 0 200
     // @User: Advanced

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -30,7 +30,7 @@ SRV_Channel::servo_mask_t SRV_Channel::have_pwm_mask;
 const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: MIN
     // @DisplayName: Minimum PWM
-    // @Description: minimum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: minimum PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
 
     // @Param: MAX
     // @DisplayName: Maximum PWM
-    // @Description: maximum PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: maximum PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
 
     // @Param: TRIM
     // @DisplayName: Trim PWM
-    // @Description: Trim PWM pulse width. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
+    // @Description: Trim PWM pulse width in microseconds. Typically 1000 is lower limit, 1500 is neutral and 2000 is upper limit.
     // @Units: PWM
     // @Range: 800 2200
     // @Increment: 1


### PR DESCRIPTION
These are Non-Functional-Changes!!!!!

This PR builds on top of #6182, but it is added as a separated PR for easier review, and if this one is not accepted, then the other one ( #6182 ) can still be merged.

PWM is not a unit and mavlink uses "us" for microseconds. So this patch replaces "@Units: PWM" with "@Units: us" for consistency. The parameter descriptions have been updated to include the words "PWM in microseconds" for the case some user does not understand what "us" means. In some cases "PWM" and "microseconds" where not even mentioned in the description !!!

For reviwers: no, "µs" is not valid because it is not ASCII. So "us" it must be. 