### PR TITLE
Copter: respond to param list request after motor init

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -274,6 +274,7 @@ private:
             uint8_t land_repo_active        : 1; // 22      // true if the pilot is overriding the landing position
             uint8_t motor_interlock_switch  : 1; // 23      // true if pilot is requesting motor interlock enable
             uint8_t in_arming_delay         : 1; // 24      // true while we are armed but waiting to spin motors
+            uint8_t initialised_params      : 1; // 25      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
         };
         uint32_t value;
     } ap;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -862,7 +862,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         // if we have not yet initialised (including allocating the motors
         // object) we drop this request. That prevents the GCS from getting
         // a confusing parameter count during bootup
-        if (!copter.ap.initialised) {
+        if (!copter.ap.initialised_params) {
             break;
         }
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -184,7 +184,11 @@ void Copter::init_ardupilot()
     // allocate the motors class
     allocate_motors();
 
-    init_rc_out();              // sets up motors and output to escs
+    // sets up motors and output to escs
+    init_rc_out();
+
+    // motors initialised so parameters can be sent
+    ap.initialised_params = true;
 
     // initialise which outputs Servo and Relay events can use
     ServoRelayEvents.set_channel_mask(~motors->get_motor_mask());


### PR DESCRIPTION
This is a replacement PR for: https://github.com/ArduPilot/ardupilot/pull/6235

This PR adds a new "initialised_params" flag which becomes true earlier than the currently used "initialised" flag.  This allows Copter to respond to request-param-list requests before the gyro calibration completes (which can take a long time to complete especially when the vehicle is started on moving platforms).