### PR TITLE
AP_Landing: Deepstall related improvements

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -601,6 +601,8 @@ void Plane::update_flight_mode(void)
     if (quadplane.in_vtol_mode() ||
         quadplane.in_assisted_flight()) {
         ahrs.set_fly_forward(false);
+    } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+        ahrs.set_fly_forward(landing.is_flying_forward());
     } else {
         ahrs.set_fly_forward(true);
     }

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -589,3 +589,20 @@ bool AP_Landing::is_throttle_suppressed(void) const
     }
 }
 
+/*
+ * returns false when the vehicle might not be flying forward while landing
+ */
+bool AP_Landing::is_flying_forward(void) const
+{
+    if (!flags.in_progress) {
+        return true;
+    }
+
+    switch (type) {
+    case TYPE_DEEPSTALL:
+        return deepstall.is_flying_forward();
+    case TYPE_STANDARD_GLIDE_SLOPE:
+    default:
+        return true;
+    }
+}

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -68,6 +68,7 @@ public:
     bool is_on_approach(void) const;
     bool is_ground_steering_allowed(void) const;
     bool is_throttle_suppressed(void) const;
+    bool is_flying_forward(void) const;
     void handle_flight_stage_change(const bool _in_landing_stage);
     int32_t constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool get_target_altitude_location(Location &location);

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -343,6 +343,11 @@ bool AP_Landing_Deepstall::is_throttle_suppressed(void) const
     return stage == DEEPSTALL_STAGE_LAND;
 }
 
+bool AP_Landing_Deepstall::is_flying_forward(void) const
+{
+    return stage != DEEPSTALL_STAGE_LAND;
+}
+
 bool AP_Landing_Deepstall::get_target_altitude_location(Location &location)
 {
     memcpy(&location, &landing_point, sizeof(Location));

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -95,6 +95,7 @@ private:
     bool get_target_altitude_location(Location &location);
     int32_t get_target_airspeed_cm(void) const;
     bool is_throttle_suppressed(void) const;
+    bool is_flying_forward(void) const;
 
     const DataFlash_Class::PID_Info& get_pid_info(void) const;
 


### PR DESCRIPTION
This is a couple of small fixups to deepstall landing, and the AP_Landing interface.

- Adds a minimum approach length for high wind days/low extension aircraft to ensure that the plane will always fly a deepstall path into the wind
- Recompute the target deepstall approach path while waiting for deepstall breakout. There is a restriction to not do more then 360 degrees during this, but this improves performance on windy days.
- Allows AP_Landing to indicate if it thinks the vehicle is ever in a stage where the fly forward assumption for the EKF is no longer valid. At the moment it's used by deepstall as moving vertical or backwards is very possible, but future uses also include parachute based landings if we move those into AP_Landing at some point.