### PR TITLE
Plane: Trigger airspeed calibration via RC input

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1226,6 +1226,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RUDD_DT_GAIN", 9, ParametersG2, rudd_dt_gain, 10),
 
+    // @Param: ARSPD_CAL_RC
+    // @DisplayName: Enable airspeed calibration using RC input
+    // @Description: Enable airspeed calibration using RC input. When aircraft is disarmmed, holding max throttle and left rudder will trigger an airspeed sensor calibration.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("ARSPD_CAL_RC", 10, ParametersG2, allow_airspeed_cal_via_RC,  0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -548,6 +548,9 @@ public:
 
     // dual motor tailsitter rudder to differential thrust scaling: 0-100%
     AP_Int8 rudd_dt_gain;
+
+    // enable airspeed sensor calibration via RC input command
+    AP_Int8 allow_airspeed_cal_via_RC;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -784,6 +784,9 @@ private:
     // time that rudder arming has been running
     uint32_t rudder_arm_timer;
 
+    // time that airspeed cal triggered by RC has been running
+    uint32_t airspeed_cal_via_RC_timer;
+
     // support for quadcopter-plane
     QuadPlane quadplane{ahrs};
 
@@ -947,6 +950,7 @@ private:
     void init_rc_out_main();
     void init_rc_out_aux();
     void rudder_arm_disarm_check();
+    void rudder_airspeed_cal_check();
     void read_radio();
     void control_failsafe(uint16_t pwm);
     void trim_control_surfaces();

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -23,7 +23,7 @@ void Plane::update_is_flying_5Hz(void)
                                     (gps.ground_speed_cm() >= ground_speed_thresh_cm);
 
     // airspeed at least 75% of stall speed?
-    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (aparm.airspeed_min*0.75f));
+    bool airspeed_movement = ahrs.airspeed_estimate(&aspeed) && (aspeed >= (aparm.airspeed_min*0.75f)) && !airspeed.is_calibration_active();
 
 
     if (quadplane.is_flying()) {

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -247,7 +247,7 @@ void AP_Airspeed::read(void)
         return;
     }
     float raw_pressure = get_pressure();
-    if (_cal.start_ms != 0) {
+    if (is_calibration_active()) {
         update_calibration(raw_pressure);
     }
     

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -134,6 +134,8 @@ public:
 
     void setHIL(float airspeed, float diff_pressure, float temperature);
 
+    bool is_calibration_active() { return (_cal.start_ms != 0); }
+
     static const struct AP_Param::GroupInfo var_info[];
 
     enum pitot_tube_order { PITOT_TUBE_ORDER_POSITIVE = 0,


### PR DESCRIPTION
Trigger airspeed calibration via RC input.

    // to trigger an airspeed calibration via RC input:
    // - feature must be enabled
    // - airspeed sensor must be enabled
    // - are not flying
    // - must be disarmed
    // - must have high throttle
    // - must have full left rudder
    // - must hold for 3 seconds

This is helpful for pilots who are flying but don't have a computer to trigger it for them. Great for FPV where you can see the "done" message too to confirm it happened.

Closes issue https://github.com/ArduPilot/ardupilot/issues/6244