### PR TITLE
fixed description to warn against setting the wrong heater param

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -151,7 +151,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 #if HAL_HAVE_IMU_HEATER
     // @Param: IMU_TARGTEMP
     // @DisplayName: Target IMU temperature
-    // @Description: This sets the target IMU temperature for boards with controllable IMU heating units. A value of -1 disables heating.
+    // @Description: This sets the target IMU temperature for boards with controllable IMU heating units. DO NOT SET -1 on The Cube. A value of -1 sets PH1 behaviour 
     // @Range: -1 80
     // @Units: degreesC
     // @User: Advanced


### PR DESCRIPTION
fixed description to warn against setting the wrong heater value in The Cube