### PR TITLE
Copter: sport mode relaxes attitude target while landed

### DIFF
--- a/ArduCopter/control_sport.cpp
+++ b/ArduCopter/control_sport.cpp
@@ -139,6 +139,9 @@ void Copter::sport_run()
             motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         }
 
+#if FRAME_CONFIG != HELI_FRAME
+        attitude_control->relax_attitude_controllers();
+#endif
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_yaw_target_to_current_heading();
         attitude_control->input_euler_rate_roll_pitch_yaw(target_roll_rate, target_pitch_rate, target_yaw_rate);


### PR DESCRIPTION
This resolves an issue raised during AC3.5 beta testing in which the vehicle was armed but landed in Sport mode and the user's pitch stick input was off center.  This resulted in the target attitude becoming inverted so when the user raised the throttle, the vehicle immediately flipped over.

Issue: http://discuss.ardupilot.org/t/89-degree-att-rolldes-flip-start-with-u11-27-props-hexacopter-3-5-0-rc4