### PR TITLE
Added DO_TRIGGER_CONTROL

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1223,6 +1223,12 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             result = MAV_RESULT_ACCEPTED;
             break;
+
+        case MAV_CMD_DO_TRIGGER_CONTROL:
+            copter.camera.trigger_pic(true);
+            copter.log_picture();
+            result = MAV_RESULT_ACCEPTED;
+            break;
 #endif // CAMERA == ENABLED
         case MAV_CMD_DO_MOUNT_CONTROL:
 #if MOUNT == ENABLED


### PR DESCRIPTION
This is a mavlink command, which when received
by APM triggers a camera with all logging and
camera configurations.

This is useful because until now for a GCS to
issue a camera trigger to APM it needed to
do an RC override and have one channel assigned
to do the triggering. Overriding the RC is bad
in most cases. Another option was some form of servo command
which doesn't log the pictures.

Let me know what  needs correction.