### PR TITLE
Landing: Send deepstall mavlink messages to the GCS

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -487,6 +487,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_GIMBAL_REPORT:
     case MSG_RPM:
     case MSG_POSITION_TARGET_GLOBAL_INT:
+    case MSG_LANDING:
         break;  // just here to prevent a warning
     }
     return true;

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -272,6 +272,7 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
     case MSG_MISSION_ITEM_REACHED:
     case MSG_POSITION_TARGET_GLOBAL_INT:
     case MSG_AOA_SSA:
+    case MSG_LANDING:
         break; // just here to prevent a warning
     }
     return true;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -563,6 +563,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     case MSG_POSITION_TARGET_GLOBAL_INT:
     case MSG_SERVO_OUT:
     case MSG_AOA_SSA:
+    case MSG_LANDING:
         // unused
         break;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -699,6 +699,8 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
     case MSG_AOA_SSA:
         CHECK_PAYLOAD_SIZE(AOA_SSA);
         plane.send_aoa_ssa(chan);
+    case MSG_LANDING:
+        plane.landing.send_landing_message(chan);
         break;
     }
     return true;
@@ -884,6 +886,7 @@ GCS_MAVLINK_Plane::data_stream_send(void)
         if (plane.control_mode != MANUAL) {
             send_message(MSG_PID_TUNING);
         }
+        send_message(MSG_LANDING);
     }
 
     if (plane.gcs_out_of_time) return;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -650,6 +650,7 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
     case MSG_WIND:
     case MSG_POSITION_TARGET_GLOBAL_INT:
     case MSG_AOA_SSA:
+    case MSG_LANDING:
         // unused
         break;
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -263,6 +263,21 @@ void AP_Landing::adjust_landing_slope_for_rangefinder_bump(AP_Vehicle::FixedWing
     }
 }
 
+// send out any required mavlink messages
+bool AP_Landing::send_landing_message(mavlink_channel_t chan) {
+    if (!flags.in_progress) {
+        return false;
+    }
+
+    switch (type) {
+    case TYPE_DEEPSTALL:
+        return deepstall.send_deepstall_message(chan);
+    case TYPE_STANDARD_GLIDE_SLOPE:
+    default:
+        return false;
+    }
+}
+
 bool AP_Landing::is_flaring(void) const
 {
     if (!flags.in_progress) {

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -20,6 +20,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
 #include <AP_Navigation/AP_Navigation.h>
+#include <GCS_MAVLink/GCS.h>
 #include "AP_Landing_Deepstall.h"
 
 /// @class  AP_Landing
@@ -72,6 +73,7 @@ public:
     void handle_flight_stage_change(const bool _in_landing_stage);
     int32_t constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool get_target_altitude_location(Location &location);
+    bool send_landing_message(mavlink_channel_t chan);
 
     // helper functions
     bool restart_landing_sequence(void);

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -241,7 +241,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         float relative_alt_D;
         landing.ahrs.get_relative_position_D_home(relative_alt_D);
 
-        const float travel_distance = predict_travel_distance(landing.ahrs.wind_estimate(), -relative_alt_D);
+        const float travel_distance = predict_travel_distance(landing.ahrs.wind_estimate(), -relative_alt_D, false);
 
         memcpy(&entry_point, &landing_point, sizeof(Location));
         location_update(entry_point, target_heading_deg + 180.0, travel_distance);
@@ -253,6 +253,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
             }
             return false;
         }
+        predict_travel_distance(landing.ahrs.wind_estimate(), -relative_alt_D, true);
         stage = DEEPSTALL_STAGE_LAND;
         stall_entry_time = AP_HAL::millis();
 
@@ -401,7 +402,7 @@ void AP_Landing_Deepstall::build_approach_path(void)
     //extend the approach point to 1km away so that there is always a navigational target
     location_update(extended_approach, target_heading_deg, 1000.0);
 
-    float expected_travel_distance = predict_travel_distance(wind, landing_point.alt / 100);
+    float expected_travel_distance = predict_travel_distance(wind, landing_point.alt * 0.01f, false);
     float approach_extension_m = expected_travel_distance + approach_extension;
     // an approach extensions must be at least half the loiter radius, or the aircraft has a
     // decent chance to be misaligned on final approach
@@ -432,7 +433,7 @@ void AP_Landing_Deepstall::build_approach_path(void)
 
 }
 
-float AP_Landing_Deepstall::predict_travel_distance(const Vector3f wind, const float height)
+float AP_Landing_Deepstall::predict_travel_distance(const Vector3f wind, const float height, const bool print)
 {
     bool reverse = false;
 
@@ -464,11 +465,19 @@ float AP_Landing_Deepstall::predict_travel_distance(const Vector3f wind, const f
 
     float estimated_forward = cosf(estimated_crab_angle) * forward_speed_ms + cosf(theta) * wind_length;
 
-    predicted_travel_distance = estimated_forward * height / down_speed + stall_distance;
+    if (is_positive(down_speed)) {
+        predicted_travel_distance = (estimated_forward * height / down_speed) + stall_distance;
+    } else {
+        // if we don't have a sane downward speed in a deepstall (IE not zero, and not
+        // an ascent) then just provide the stall_distance as a reasonable approximation
+        predicted_travel_distance = stall_distance;
+    }
 
-#ifdef DEBUG_PRINTS
-    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Predict: %f %f", stall_distance,  predicted_travel_distance);
-#endif // DEBUG_PRINTS
+    if(print) {
+        // allow printing the travel distances on the final entry as its used for tuning
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Deepstall: Entry: %0.1f (m) Travel: %0.1f (m)",
+                                         (double)stall_distance, (double)predicted_travel_distance);
+    }
 
     return predicted_travel_distance;
 }

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -20,12 +20,13 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
 #include <AP_Navigation/AP_Navigation.h>
+#include <GCS_MAVLink/GCS.h>
 #include <PID/PID.h>
 
 class AP_Landing;
 
-/// @class  AP_Landing
-/// @brief  Class managing ArduPlane landing methods
+/// @class  AP_Landing_Deepstall
+/// @brief  Class managing Plane Deepstall landing methods
 class AP_Landing_Deepstall
 {
 private:
@@ -81,6 +82,8 @@ private:
     float L1_xtrack_i;             // L1 integrator for navigation
     PID ds_PID;
     int32_t last_target_bearing;   // used for tracking the progress on loitering
+    float crosstrack_error; // current crosstrack error
+    float predicted_travel_distance; // distance the aircraft is perdicted to travel during deepstall
 
     //public AP_Landing interface
     void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
@@ -97,11 +100,13 @@ private:
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
 
+    bool send_deepstall_message(mavlink_channel_t chan) const;
+
     const DataFlash_Class::PID_Info& get_pid_info(void) const;
 
     //private helpers
     void build_approach_path();
-    float predict_travel_distance(const Vector3f wind, const float height) const;
+    float predict_travel_distance(const Vector3f wind, const float height);
     bool verify_breakout(const Location &current_loc, const Location &target_loc, const float height_error) const;
     float update_steering(void);
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -106,7 +106,7 @@ private:
 
     //private helpers
     void build_approach_path();
-    float predict_travel_distance(const Vector3f wind, const float height);
+    float predict_travel_distance(const Vector3f wind, const float height, const bool print);
     bool verify_breakout(const Location &current_loc, const Location &target_loc, const float height_error) const;
     float update_steering(void);
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -42,6 +42,28 @@ inline bool is_zero(const T fVal1) {
     return (fabsf(static_cast<float>(fVal1)) < FLT_EPSILON);
 }
 
+/* 
+ * @brief: Check whether a float is greater than zero
+ */
+template <class T>
+inline bool is_positive(const T fVal1) {
+    static_assert(std::is_floating_point<T>::value || std::is_base_of<T,AP_Float>::value,
+                  "Template parameter not of type float");
+    return (static_cast<float>(fVal1) > FLT_EPSILON);
+}
+
+
+/* 
+ * @brief: Check whether a float is less than zero
+ */
+template <class T>
+inline bool is_negative(const T fVal1) {
+    static_assert(std::is_floating_point<T>::value || std::is_base_of<T,AP_Float>::value,
+                  "Template parameter not of type float");
+    return (static_cast<float>(fVal1) < (-1.0 * FLT_EPSILON));
+}
+
+
 /*
  * A variant of asin() that checks the input ranges and ensures a valid angle
  * as output. If nan is given as input then zero is returned.

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -72,6 +72,7 @@ enum ap_message {
     MSG_ADSB_VEHICLE,
     MSG_BATTERY_STATUS,
     MSG_AOA_SSA,
+    MSG_LANDING,
     MSG_RETRY_DEFERRED // this must be last
 };
 


### PR DESCRIPTION
This provides a MAVLink message used to visualize the path the aircraft selected for a deepstall landing. Given the level of autonomy allowed during deepstall this is required to ensure that the operator is aware of where the aircraft will be navigating to, and what path is will be flying. Depends upon https://github.com/ArduPilot/mavlink/pull/42

![untitled](https://cloud.githubusercontent.com/assets/567688/26218153/d097d37c-3bbe-11e7-9234-38a91dfd7c9f.png)


Also attaches a small change to deepstall logic that sends a statustext to the GCS when the aircraft does the stall that allows the user to more easily tune the aircrafts stall prediction numbers.