### PR TITLE
Plane: Add separate rudder mix param for takeoff

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -455,7 +455,13 @@ void Plane::calc_nav_yaw_coordinated(float speed_scaler)
         commanded_rudder = yawController.get_servo_out(speed_scaler, disable_integrator);
 
         // add in rudder mixing from roll
-        commanded_rudder += SRV_Channels::get_output_scaled(SRV_Channel::k_aileron) * g.kff_rudder_mix;
+        float rudder_mix;
+        if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF && g2.takeoff_rudder_mix_height > 0 && g2.takeoff_rudder_mix_height > (-1.0f*relative_altitude)) {
+            rudder_mix = g2.takeoff_rudder_mix;
+        } else {
+            rudder_mix = g.kff_rudder_mix;
+        }
+        commanded_rudder += SRV_Channels::get_output_scaled(SRV_Channel::k_aileron) * rudder_mix;
         commanded_rudder += rudder_input;
     }
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1226,6 +1226,23 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RUDD_DT_GAIN", 9, ParametersG2, rudd_dt_gain, 10),
 
+    // @Param: TKOFF_RDDR_FF
+    // @DisplayName: Takeoff aileron to Rudder feedforward
+    // @Description: This parameter sets aileron to rudder ff below the TKOFF_RDDR_FF_H hieght, helpful to resolve tendency of plane to roll during takeoff.
+    // @Range: 0 1
+    // @Increment: 0.01
+    // @User: User
+    AP_GROUPINFO("TKOFF_RDDR_MIX", 10, ParametersG2, takeoff_rudder_mix, 0),
+
+    // @Param: TKOFF_RDDR_FF_H
+    // @DisplayName: Takeoff rudder feedforward min altitude
+    // @Description: Height below which the TKOFF_RDDR_FF will be active setting it to 0 will disable the takeoff roll to rudder feedforward
+    // @Units: m
+    // @Range: 0 10
+    // @Increment: 1.0
+    // @User: User
+    AP_GROUPINFO("TKOFF_RDDR_MIX_H", 11, ParametersG2, takeoff_rudder_mix_height, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -543,6 +543,10 @@ public:
     // whether to enforce acceptance of packets only from sysid_my_gcs
     AP_Int8 sysid_enforce;
     
+    // Takeoff Rudder Mix
+    AP_Float takeoff_rudder_mix_height;
+    AP_Float takeoff_rudder_mix;
+
     // ArduSoar parameters
     SoaringController soaring_controller;
 


### PR DESCRIPTION
This PR adds an option to have separate Feedforward Gain from Aileron to Rudder during takeoff compared to inflight gain i.e. KFF_RUDDER_MIX. The reason for this is to give user an option to skip inflight rudder use or have a different inflight value. 

The reason for usage if this parameter could be due to number of reasons, to name a few: very high motor throttle during takeoff inducing torque in one roll direction, prop-wash slipstreaming and pushing on the rudder, roll during throw by user, slight CG imbalance etc. All of this could be controlled during normal flight stage where ailerons have good command but not during takeoff, where for a short while plane might have airspeed below stall speed. Additionally, in our current plane configuration we observed that addition of higher KFF_RUDDER_MIX was worsening overall navigation. The reason deduced was that command over roll by ailerons is increased heavily compared to instant after takeoff release and rudder was making the system overshoot heavily during normal nav.

The performance of takeoff improved for the frame we are using (i.e. Flying wing with tail rudder) after introduction of this parameter.