### PR TITLE
Added MAV_CMD_DO_SET_CAM_TRIGG_DIST to Mavlink commands

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -858,7 +858,12 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             }
             result = MAV_RESULT_ACCEPTED;
             break;
-#endif  // CAMERA == ENABLED
+
+        case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+            rover.camera.set_trigger_distance(packet.param1);
+            result = MAV_RESULT_ACCEPTED;
+            break;
+#endif // CAMERA == ENABLED
 
             case MAV_CMD_DO_MOUNT_CONTROL:
 #if MOUNT == ENABLED

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1223,6 +1223,12 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             result = MAV_RESULT_ACCEPTED;
             break;
+
+        case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+            copter.camera.set_trigger_distance(packet.param1);
+            result = MAV_RESULT_ACCEPTED;
+            break;
+
 #endif // CAMERA == ENABLED
         case MAV_CMD_DO_MOUNT_CONTROL:
 #if MOUNT == ENABLED

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1165,6 +1165,11 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             }
             result = MAV_RESULT_ACCEPTED;
             break;
+
+      case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
+            plane.camera.set_trigger_distance(packet.param1);
+            result = MAV_RESULT_ACCEPTED;
+            break;
 #endif // CAMERA == ENABLED
 
         case MAV_CMD_DO_MOUNT_CONTROL:


### PR DESCRIPTION
@rmackay9 said in PR #6280:

> What I think might be better is to instead add support for receiving the MAV_CMD_DO_SET_CAM_TRIGG_DIST within a command-long (i.e. implement within the GCS_MAVLink file). Doing that would allow the ground station to start the distance based camera triggering in real-time not just from within a mission which is what we have now.

Based on his feedback I added this feature.