### PR TITLE
Reduce start delays when using EKF3 and fix time delay bug

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -965,7 +965,9 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
     loc.flags.terrain_alt = 0;
     location_offset(loc, _position_offset_north, _position_offset_east);
     if (_flags.fly_forward && _have_position) {
-        location_update(loc, _gps.ground_course_cd() * 0.01f, _gps.ground_speed() * _gps.get_lag());
+        float gps_delay_sec = 0;
+        _gps.get_lag(gps_delay_sec);
+        location_update(loc, _gps.ground_course_cd() * 0.01f, _gps.ground_speed() * gps_delay_sec);
     }
     return _have_position;
 }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1039,7 +1039,7 @@ void AP_GPS::Write_DataFlash_Log_Startup_messages()
 bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
     // return lag of blended GPS
-    if (instance == GPS_MAX_RECEIVERS) {
+    if (instance == GPS_BLENDED_INSTANCE) {
         lag_sec = _blended_lag_sec;
         // auto switching uses all GPS receivers, so all must be configured
         return all_configured();

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1034,24 +1034,32 @@ void AP_GPS::Write_DataFlash_Log_Startup_messages()
 
 /*
   return the expected lag (in seconds) in the position and velocity readings from the gps
+  return true if the GPS hardware configuration is known or the delay parameter has been set
  */
-float AP_GPS::get_lag(uint8_t instance) const
+bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
     // return lag of blended GPS
     if (instance == GPS_MAX_RECEIVERS) {
-        return _blended_lag_sec;
+        lag_sec = _blended_lag_sec;
+        // auto switching uses all GPS receivers, so all must be configured
+        return all_configured();
     }
 
     if (_delay_ms[instance] > 0) {
         // if the user has specified a non zero time delay, always return that value
-        return 0.001f * (float)_delay_ms[instance];
+        lag_sec = 0.001f * (float)_delay_ms[instance];
+        // the user is always right !!
+        return true;
     } else if (drivers[instance] == nullptr || state[instance].status == NO_GPS) {
-        // no GPS was detected in this instance
-        // so return a default delay of 1 measurement interval
-        return 0.001f * (float)get_rate_ms(instance);
+        // no GPS was detected in this instance so return a default delay of 1 measurement interval
+        lag_sec = 0.001f * (float)get_rate_ms(instance);
+        // check lack of GPS is consistent with user expectation
+        return state[instance].status == NO_GPS;
     } else {
         // the user has not specified a delay so we determine it from the GPS type
-        return drivers[instance]->get_lag();
+        lag_sec = drivers[instance]->get_lag();
+        // check that for a valid GPS configuration
+        return (_type[instance] != GPS_TYPE_NONE && (drivers[instance] == nullptr || !drivers[instance]->is_configured()));
     }
 }
 
@@ -1450,7 +1458,9 @@ void AP_GPS::calc_blended_state(void)
         if (_blend_weights[i] > 0.0f) {
             temp_time_1 += (double)timing[i].last_fix_time_ms * (double) _blend_weights[i];
             temp_time_2 += (double)timing[i].last_message_time_ms * (double)_blend_weights[i];
-            _blended_lag_sec += get_lag(i) * _blend_weights[i];
+            float gps_lag_sec = 0;
+            get_lag(i, gps_lag_sec);
+            _blended_lag_sec += gps_lag_sec * _blend_weights[i];
         }
     }
     timing[GPS_BLENDED_INSTANCE].last_fix_time_ms = (uint32_t)temp_time_1;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1058,8 +1058,8 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
     } else {
         // the user has not specified a delay so we determine it from the GPS type
         lag_sec = drivers[instance]->get_lag();
-        // check that for a valid GPS configuration
-        return (_type[instance] != GPS_TYPE_NONE && (drivers[instance] == nullptr || !drivers[instance]->is_configured()));
+        // check for a valid GPS configuration
+        return drivers[instance]->is_configured();
     }
 }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1450,7 +1450,7 @@ void AP_GPS::calc_blended_state(void)
         if (_blend_weights[i] > 0.0f) {
             temp_time_1 += (double)timing[i].last_fix_time_ms * (double) _blend_weights[i];
             temp_time_2 += (double)timing[i].last_message_time_ms * (double)_blend_weights[i];
-            _blended_lag_sec += get_lag(i) * _blended_lag_sec;
+            _blended_lag_sec += get_lag(i) * _blend_weights[i];
         }
     }
     timing[GPS_BLENDED_INSTANCE].last_fix_time_ms = (uint32_t)temp_time_1;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -305,8 +305,13 @@ public:
     }
 
     // the expected lag (in seconds) in the position and velocity readings from the gps
-    float get_lag(uint8_t instance) const;
-    float get_lag(void) const { return get_lag(primary_instance); }
+    // return true if the GPS hardware configuration is known or the lag parameter has been set manually
+    bool get_lag(uint8_t instance, float &lag_sec) const;
+    bool get_lag(float &lag_sec) const
+    {
+        bool is_valid = get_lag(primary_instance, lag_sec);
+        return is_valid;
+    }
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -307,10 +307,8 @@ public:
     // the expected lag (in seconds) in the position and velocity readings from the gps
     // return true if the GPS hardware configuration is known or the lag parameter has been set manually
     bool get_lag(uint8_t instance, float &lag_sec) const;
-    bool get_lag(float &lag_sec) const
-    {
-        bool is_valid = get_lag(primary_instance, lag_sec);
-        return is_valid;
+    bool get_lag(float &lag_sec) const {
+        return get_lag(primary_instance, lag_sec);
     }
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -441,7 +441,9 @@ void NavEKF3_core::readGpsData()
             // estimate when the GPS fix was valid, allowing for GPS processing and other delays
             // ideally we should be using a timing signal from the GPS receiver to set this time
             // Use the driver specified delay
-            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(_ahrs->get_gps().get_lag() * 1000.0f);
+            float gps_delay_sec = 0;
+            _ahrs->get_gps().get_lag(gps_delay_sec);
+            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(gps_delay_sec * 1000.0f);
 
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -71,7 +71,8 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     // GPS sensing can have large delays and should not be included if disabled
     if (_frontend->_fusionModeGPS != 3) {
         // Wait for the configuration of all GPS units to be confirmed. Until this has occurred the GPS driver cannot provide a correct time delay
-        if (!_ahrs->get_gps().all_configured()) {
+        float gps_delay_sec = 0;
+        if (!_ahrs->get_gps().get_lag(gps_delay_sec)) {
             if (AP_HAL::millis() - lastInitFailReport_ms > 10000) {
                 lastInitFailReport_ms = AP_HAL::millis();
                 // provide an escalating series of messages
@@ -86,7 +87,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
             return false;
         }
         // limit the time delay value from the GPS library to a max of 250 msec which is the max value the EKF has been tested for.
-        maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(_ahrs->get_gps().get_lag() * 1000.0f),250));
+        maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(gps_delay_sec * 1000.0f),250));
     }
 
     // airspeed sensing can have large delays and should not be included if disabled


### PR DESCRIPTION
1) Fixes a bug in AP_GPS that causes the blended time delay to be calculated incorrectly
2) Reworks the AP_GPS reporting of measurement lag so that a validity flag is included. The flag will be true if a time delay has been specified by the user or if the GPs configuration is known.
3) Modifies EKF3 to require a valid time delay rather than all_configured to be true when sizing the data buffers. This means that provided the GPS_DELAY_MS parameters are set, the EKF will not wait for the GPS configuration to be verified before it can start.