### PR TITLE
AP_BattMonitor: SMBus fetch remaining capacity

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -2,7 +2,8 @@
 
 #define AP_BATTMONITOR_SMBUS_PEC_POLYNOME 0x07 // Polynome for CRC generation
 
-#define BATTMONITOR_SMBUS_TEMP                 0x08   // temperature register
+#define BATTMONITOR_SMBUS_TEMP                 0x08 // temperature register
+#define BATTMONITOR_SMBUS_REMAINING_CAPACITY   0x0F // remaining capacity
 #define BATTMONITOR_SMBUS_FULL_CHARGE_CAPACITY 0x10 // full charge capacity
 #define BATTMONITOR_SMBUS_SERIAL               0x1C // serial number
 
@@ -43,6 +44,24 @@ bool AP_BattMonitor_SMBus::read_full_charge_capacity(void)
         _full_charge_capacity = data;
         return true;
     }
+    return false;
+}
+
+// reads the remaining capacity
+// returns true if the read was succesful, which is only considered to be the
+// we know the full charge capacity
+bool AP_BattMonitor_SMBus::read_remaining_capacity(void)
+{
+    int32_t capacity = get_capacity();
+
+    if (capacity > 0) {
+        uint16_t data;
+        if (read_word(BATTMONITOR_SMBUS_REMAINING_CAPACITY, data)) {
+            _state.current_total_mah = MAX(0, capacity - data);
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -32,6 +32,11 @@ protected:
     // returns true if the read was successful, or if we already knew the pack capacity
     bool read_full_charge_capacity(void);
 
+    // reads the remaining capacity
+    // returns true if the read was succesful, which is only considered to be the
+    // we know the full charge capacity
+    bool read_remaining_capacity(void);
+
     // reads the temperature word from the battery
     // returns true if the read was successful
     bool read_temp(void);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -84,6 +84,9 @@ void AP_BattMonitor_SMBus_Maxell::timer()
 
     read_full_charge_capacity();
 
+    // FIXME: Preform current integration if the remaining capacity can't be requested
+    read_remaining_capacity();
+
     read_temp();
 
     read_serial_number();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -6,7 +6,6 @@
 #include "AP_BattMonitor_SMBus_Solo.h"
 #include <utility>
 
-#define BATTMONITOR_SMBUS_SOLO_REMAINING_CAPACITY   0x0f    // predicted remaining battery capacity in milliamps
 #define BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA     0x23    /// manufacturer data
 #define BATTMONITOR_SMBUS_SOLO_CELL_VOLTAGE         0x28    // cell voltage register
 #define BATTMONITOR_SMBUS_SOLO_CURRENT              0x2a    // current register
@@ -39,7 +38,6 @@ AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
 
 void AP_BattMonitor_SMBus_Solo::timer()
 {
-    uint16_t data;
     uint8_t buff[8];
     uint32_t tnow = AP_HAL::micros();
 
@@ -74,14 +72,8 @@ void AP_BattMonitor_SMBus_Solo::timer()
         _state.last_time_micros = tnow;
     }
 
-    if (read_full_charge_capacity()) {
-        // only read remaining capacity once we have the full capacity
-        if (get_capacity() > 0) {
-            if (read_word(BATTMONITOR_SMBUS_SOLO_REMAINING_CAPACITY, data)) {
-                _state.current_total_mah = MAX(0, get_capacity() - data);
-            }
-        }
-    }
+    read_full_charge_capacity();
+    read_remaining_capacity();
 
     // read the button press indicator
     if (read_block(BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA, buff, 6, false) == 6) {


### PR DESCRIPTION
Implements a generic SMBus fetcher for remaining capacity from the battery. It's a generic message from the SMBus spec, so it should be valid for all the battery backends. I don't have a Maxell battery so I couldn't test against it, and I need to get someone to test the solo one for me. (I have a Solo battery on my desk, I just need to get the appropriate connectors to test with it).

Tagged @rmackay9 and @Pedals2Paddles if you guys could be kind enough to test against Maxell and Solo batteries respectively :) (I'm most interested in just making sure that the Solo one didn't accidentally break).