### PR TITLE
AP_GPS: SBF report VDOP

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -447,6 +447,7 @@ void AP_GPS::detect_instance(uint8_t instance)
     state[instance].instance = instance;
     state[instance].status = NO_GPS;
     state[instance].hdop = 9999;
+    state[instance].vdop = 9999;
 
     switch (_type[instance]) {
     // by default the sbf/trimble gps outputs no data on its port, until configured.
@@ -578,6 +579,7 @@ void AP_GPS::update_instance(uint8_t instance)
         // not enabled
         state[instance].status = NO_GPS;
         state[instance].hdop = 9999;
+        state[instance].vdop = 9999;
         return;
     }
     if (locked_ports & (1U<<instance)) {
@@ -613,6 +615,7 @@ void AP_GPS::update_instance(uint8_t instance)
             state[instance].instance = instance;
             state[instance].status = NO_GPS;
             state[instance].hdop = 9999;
+            state[instance].vdop = 9999;
             timing[instance].last_message_time_ms = tnow;
         }
     } else {

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -210,8 +210,6 @@ AP_GPS_SBF::process_message(void)
 
         state.last_gps_time_ms = AP_HAL::millis();
 
-        state.hdop = last_hdop;
-
         // Update velocity state (don't use −2·10^10)
         if (temp.Vn > -200000) {
             state.velocity.x = (float)(temp.Vn);
@@ -285,9 +283,8 @@ AP_GPS_SBF::process_message(void)
     else if (blockid == 4001) {
         const msg4001 &temp = sbf_msg.data.msg4001u;
 
-        last_hdop = temp.HDOP;
-
-        state.hdop = last_hdop;
+        state.hdop = temp.HDOP;
+        state.vdop = temp.VDOP;
     }
     // ReceiverStatus
     else if (blockid == 4014) {

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -60,7 +60,6 @@ private:
     "spm, Rover, StandAlone+SBAS+DGPS+RTK\n",
     "sso, Stream2, Dsk1, postprocess+event, msec100\n"};
    
-    uint32_t last_hdop = 9999;
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;
     bool validcommand = false;


### PR DESCRIPTION
We were actually already receiving the appropriate message from the GPS, so all we had to do was actually report the message. Also did a slight walk through the GPS front end to make sure vdop's were getting cleared out to a more reasonable value. (I was seeing 0 on the GCS when vdop wasn't reported, which is not correct). #6293 is relevant for fixing the dop reporting further but is out of scope of the change set.