### PR TITLE
Copter: fix esc calibration for one-shot

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -104,6 +104,7 @@ void Copter::esc_calibration_passthrough()
     motors->armed(true);
     motors->enable();
     SRV_Channels::enable_by_mask(motors->get_motor_mask());
+    hal.util->set_soft_armed(true);
 
     while(1) {
         // flash LEDs
@@ -117,7 +118,9 @@ void Copter::esc_calibration_passthrough()
         delay(3);
 
         // pass through to motors
+        hal.rcout->cork();
         motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() / 1000.0f);
+        hal.rcout->push();
     }
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
@@ -149,6 +152,7 @@ void Copter::esc_calibration_auto()
     motors->armed(true);
     motors->enable();
     SRV_Channels::enable_by_mask(motors->get_motor_mask());
+    hal.util->set_soft_armed(true);
 
     // flash LEDs
     esc_calibration_notify();
@@ -162,7 +166,9 @@ void Copter::esc_calibration_auto()
             gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Push safety switch");
             printed_msg = true;
         }
+        hal.rcout->cork();
         motors->set_throttle_passthrough_for_esc_calibration(1.0f);
+        hal.rcout->push();
         esc_calibration_notify();
         delay(3);
     }


### PR DESCRIPTION
This PR resolves a problem with master and Copter-3.5.0-rc6 in which the ESC calibration is yet again not working for some setups.  The issue is the cork/push need to be done from the vehicle level.  I'm unsure why this only affects OneShot while regular PWM continued to work but I'm sure there's a good reason!