### PR TITLE
Copter: add support for dodeca-hexa copter (12 motors)

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -987,7 +987,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 11:Heli_Dual, 12:DodecaHexa
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, 0),

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -536,6 +536,8 @@ uint8_t Copter::get_frame_mav_type()
         case AP_Motors::MOTOR_FRAME_COAX:
         case AP_Motors::MOTOR_FRAME_TAILSITTER:
             return MAV_TYPE_COAXIAL;
+        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
+            return MAV_TYPE_HEXAROTOR;
     }
     // unknown frame so return generic
     return MAV_TYPE_GENERIC;
@@ -567,6 +569,8 @@ const char* Copter::get_frame_string()
             return "COAX";
         case AP_Motors::MOTOR_FRAME_TAILSITTER:
             return "TAILSITTER";
+        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
+            return "DODECA_HEXA";
         case AP_Motors::MOTOR_FRAME_UNDEFINED:
         default:
             return "UNKNOWN";
@@ -585,6 +589,7 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_Y6:
         case AP_Motors::MOTOR_FRAME_OCTA:
         case AP_Motors::MOTOR_FRAME_OCTAQUAD:
+        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
         default:
             motors = new AP_MotorsMatrix(MAIN_LOOP_RATE);
             motors_var_info = AP_MotorsMatrix::var_info;

--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -354,8 +354,7 @@ bool Plane::setup_failsafe_mixing(void)
     }
 
     for (uint8_t i = 0; i < pwm_values.channel_count; i++) {
-        if (SRV_Channels::channel_function(i) >= SRV_Channel::k_motor1 &&
-            SRV_Channels::channel_function(i) <= SRV_Channel::k_motor8) {
+        if (SRV_Channel::is_motor(SRV_Channels::channel_function(i))) {
             pwm_values.values[i] = quadplane.thr_min_pwm;
         } else {
             pwm_values.values[i] = 900;
@@ -367,8 +366,7 @@ bool Plane::setup_failsafe_mixing(void)
     }
 
     for (uint8_t i = 0; i < pwm_values.channel_count; i++) {
-        if (SRV_Channels::channel_function(i) >= SRV_Channel::k_motor1 &&
-            SRV_Channels::channel_function(i) <= SRV_Channel::k_motor8) {
+        if (SRV_Channel::is_motor(SRV_Channels::channel_function(i))) {
             hal.rcout->write(i, quadplane.thr_min_pwm);
             pwm_values.values[i] = quadplane.thr_min_pwm;
         } else {
@@ -415,6 +413,5 @@ failed:
     }
     return ret;
 }
-
 
 #endif // CONFIG_HAL_BOARD

--- a/Tools/autotest/default_params/copter-dodecahexa.parm
+++ b/Tools/autotest/default_params/copter-dodecahexa.parm
@@ -1,0 +1,1 @@
+FRAME_CLASS     12

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -62,6 +62,12 @@ class VehicleInfo(object):
                 "waf_target": "bin/arduplane",
                 "default_params_filename": "default_params/firefly.parm",
             },
+            "dodeca-hexa": {
+                "make_target": "sitl",
+                "waf_target": "bin/arducopter",
+                "default_params_filename": ["default_params/copter.parm",
+                                            "default_params/copter-dodecahexa.parm" ],
+            },
             # SIM
             "IrisRos": {
                 "waf_target": "bin/arducopter",

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -90,6 +90,7 @@ static const struct {
     { "x",                  MultiCopter::create },
     { "hexa",               MultiCopter::create },
     { "octa",               MultiCopter::create },
+    { "dodeca-hexa",        MultiCopter::create },
     { "tri",                MultiCopter::create },
     { "y6",                 MultiCopter::create },
     { "heli",               Helicopter::create },

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -583,6 +583,44 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             }
             break;
 
+        case MOTOR_FRAME_DODECAHEXA: {
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_PLUS:
+                    add_motor(AP_MOTORS_MOT_1,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);  // forward-top
+                    add_motor(AP_MOTORS_MOT_2,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);  // forward-bottom
+                    add_motor(AP_MOTORS_MOT_3,    60, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);  // forward-right-top
+                    add_motor(AP_MOTORS_MOT_4,    60, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 4);  // forward-right-bottom
+                    add_motor(AP_MOTORS_MOT_5,   120, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);  // back-right-top
+                    add_motor(AP_MOTORS_MOT_6,   120, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);  // back-right-bottom
+                    add_motor(AP_MOTORS_MOT_7,   180, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  7);  // back-top
+                    add_motor(AP_MOTORS_MOT_8,   180, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 8);  // back-bottom
+                    add_motor(AP_MOTORS_MOT_9,  -120, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 9);  // back-left-top
+                    add_motor(AP_MOTORS_MOT_10, -120, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  10); // back-left-bottom
+                    add_motor(AP_MOTORS_MOT_11,  -60, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  11); // forward-left-top
+                    add_motor(AP_MOTORS_MOT_12,  -60, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 12); // forward-left-bottom
+                    success = true;
+                    break;
+                case MOTOR_FRAME_TYPE_X:
+                    add_motor(AP_MOTORS_MOT_1,    30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1); // forward-right-top
+                    add_motor(AP_MOTORS_MOT_2,    30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   2); // forward-right-bottom
+                    add_motor(AP_MOTORS_MOT_3,    90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3); // right-top
+                    add_motor(AP_MOTORS_MOT_4,    90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  4); // right-bottom
+                    add_motor(AP_MOTORS_MOT_5,   150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  5); // back-right-top
+                    add_motor(AP_MOTORS_MOT_6,   150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   6); // back-right-bottom
+                    add_motor(AP_MOTORS_MOT_7,  -150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   7); // back-left-top
+                    add_motor(AP_MOTORS_MOT_8,  -150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  8); // back-left-bottom
+                    add_motor(AP_MOTORS_MOT_9,   -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  9); // left-top
+                    add_motor(AP_MOTORS_MOT_10,  -90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  10); // left-bottom
+                    add_motor(AP_MOTORS_MOT_11,  -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  11); // forward-left-top
+                    add_motor(AP_MOTORS_MOT_12,  -30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 12); // forward-left-bottom
+                    success = true;
+                    break;
+                default:
+                    // dodeca-hexa frame class does not support this frame type
+                    break;
+            }}
+            break;
+
         case MOTOR_FRAME_Y6:
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_Y6B:

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -198,10 +198,14 @@ void AP_Motors::add_motor_num(int8_t motor_num)
     // ensure valid motor number is provided
     if( motor_num >= 0 && motor_num < AP_MOTORS_MAX_NUM_MOTORS ) {
         uint8_t chan;
-        SRV_Channel::Aux_servo_function_t function = (SRV_Channel::Aux_servo_function_t)(SRV_Channel::k_motor1+motor_num);
+        SRV_Channel::Aux_servo_function_t function;
+        if (motor_num < 8) {
+            function = (SRV_Channel::Aux_servo_function_t)(SRV_Channel::k_motor1+motor_num);
+        } else {
+            function = (SRV_Channel::Aux_servo_function_t)(SRV_Channel::k_motor9+(motor_num-8));
+        }
         SRV_Channels::set_aux_channel_default(function, motor_num);
-        if (SRV_Channels::find_channel((SRV_Channel::Aux_servo_function_t)(SRV_Channel::k_motor1+motor_num),
-                                       chan) && chan != motor_num) {
+        if (SRV_Channels::find_channel(function, chan) && chan != motor_num) {
             _motor_map[motor_num] = chan;
             _motor_map_mask |= 1U<<motor_num;
         }

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -15,8 +15,12 @@
 #define AP_MOTORS_MOT_6 5U
 #define AP_MOTORS_MOT_7 6U
 #define AP_MOTORS_MOT_8 7U
+#define AP_MOTORS_MOT_9 8U
+#define AP_MOTORS_MOT_10 9U
+#define AP_MOTORS_MOT_11 10U
+#define AP_MOTORS_MOT_12 11U
 
-#define AP_MOTORS_MAX_NUM_MOTORS 8
+#define AP_MOTORS_MAX_NUM_MOTORS 12
 
 // motor update rate
 #define AP_MOTORS_SPEED_DEFAULT     490 // default output rate to the motors
@@ -38,6 +42,7 @@ public:
         MOTOR_FRAME_COAX = 9,
         MOTOR_FRAME_TAILSITTER = 10,
         MOTOR_FRAME_HELI_DUAL = 11,
+        MOTOR_FRAME_DODECAHEXA = 12,
     };
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -83,6 +83,22 @@ static Motor octa_quad_motors[] =
     Motor(AP_MOTORS_MOT_8, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6)
 };
 
+static Motor dodeca_hexa_motors[] =
+{
+    Motor(AP_MOTORS_MOT_1,   30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1),
+    Motor(AP_MOTORS_MOT_2,   30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   2),
+    Motor(AP_MOTORS_MOT_3,   90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3),
+    Motor(AP_MOTORS_MOT_4,   90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  4),
+    Motor(AP_MOTORS_MOT_5,  150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  5),
+    Motor(AP_MOTORS_MOT_6,  150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   6),
+    Motor(AP_MOTORS_MOT_7, -150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   7),
+    Motor(AP_MOTORS_MOT_8, -150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  8),
+    Motor(AP_MOTORS_MOT_9,  -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  9),
+    Motor(AP_MOTORS_MOT_10, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   10),
+    Motor(AP_MOTORS_MOT_11, -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   11),
+    Motor(AP_MOTORS_MOT_12, -30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  12)
+};
+
 static Motor tri_motors[] =
 {
     Motor(AP_MOTORS_MOT_1,   60, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1),
@@ -141,6 +157,7 @@ static Frame supported_frames[] =
     Frame("hexa",      6, hexa_motors),
     Frame("octa-quad", 8, octa_quad_motors),
     Frame("octa",      8, octa_motors),
+    Frame("dodeca-hexa", 12, dodeca_hexa_motors),
     Frame("tri",       3, tri_motors),
     Frame("tilttrivec",3, tilttri_vectored_motors),
     Frame("tilttri",   3, tilttri_motors),

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -182,3 +182,9 @@ uint16_t SRV_Channel::get_limit_pwm(LimitValue limit) const
     }
 }
 
+// return true if function is for a multicopter motor
+bool SRV_Channel::is_motor(SRV_Channel::Aux_servo_function_t function)
+{
+    return ((function >= SRV_Channel::k_motor1 && function <= SRV_Channel::k_motor8) ||
+            (function >= SRV_Channel::k_motor9 && function <= SRV_Channel::k_motor12));
+}

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -110,6 +110,10 @@ public:
         k_vtail_left            = 79,
         k_vtail_right           = 80,
         k_boost_throttle        = 81,            ///< vertical booster throttle
+        k_motor9                = 82,
+        k_motor10               = 83,
+        k_motor11               = 84,
+        k_motor12               = 85,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 
@@ -156,6 +160,9 @@ public:
     uint16_t get_trim(void) const {
         return servo_trim;
     }
+
+    // return true if function is for a multicopter motor
+    static bool is_motor(SRV_Channel::Aux_servo_function_t function);
 
 private:
     AP_Int16 servo_min;

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -39,6 +39,7 @@ void SRV_Channel::output_ch(void)
         passthrough_from = int8_t(function - k_rcin1);
         break;
     case k_motor1 ... k_motor8:
+    case k_motor9 ... k_motor12:
         // handled by AP_Motors::rc_write()
         return;
     }


### PR DESCRIPTION
This is a replacement for this PR: https://github.com/ArduPilot/ardupilot/pull/6267

This PR adds support for a dodeca-hexa copter.  This is a hexacopter (6 arms) with motors/propellers on the top and bottom of each arm.  The equivalent of an X8 except that it's a hexacopter.

![altigator_hydra_12](https://cloud.githubusercontent.com/assets/1498098/26384565/386ef1a0-4075-11e7-997c-12bbe4235c96.jpg)

The image above shows a commercially available drone that this PR could add support for.  The motor ordering is somewhat different (more sensible really) compared to existing setups.  The motors are ordered from the front-top motor, then front-bottom motor, then right-top, etc in a clockwise direction. 

motor1 : front right top (counter-clockwise)
motor2: front right bottom (clockwise)
motor3: right-top (clockwise)
motor4: right-bottom (counter-clockwise)
etc.

This has been tested in the simulator but does not yet in a real vehicle.
In order to see the output of motors 9~12 in the ground station, MAVlink2 must be used which requires setting the SERIALx_PROTOCOL to "2" for the relevant serial connection.