### PR TITLE
Rover: NFC improve SPEED_TURN_GAIN parameter description

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -124,7 +124,7 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: SPEED_TURN_GAIN
     // @DisplayName: Target speed reduction while turning
-    // @Description: The percentage to reduce the throttle while turning. If this is 100% then the target speed is not reduced while turning. If this is 50% then the target speed is reduced in proportion to the turn rate, with a reduction of 50% when the steering is maximally deflected.
+    // @Description: The percentage to reduce the throttle to while turning. If this is 100% then the target speed is not reduced while turning. If this is 50% then the target speed is reduced in proportion to the turn rate, with a reduction of 50% when the steering is maximally deflected.
     // @Units: %
     // @Range: 0 100
     // @Increment: 1


### PR DESCRIPTION
Be more explicit that a SPEED_TURN_GAIN value of 80% reduces "to 80%" and not "by 80%"