### PR TITLE
AP_Mission: Prohibit resuming mission waypoints that are no longer in the mission

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -92,9 +92,13 @@ void AP_Mission::resume()
     }
 
     // ensure cache coherence
-    // don't bother checking if the read is successful. If it fails _nav_cmd
-    // won't change and we'll continue flying the old cached command.
-    read_cmd_from_storage(_nav_cmd.index, _nav_cmd);
+    if (!read_cmd_from_storage(_nav_cmd.index, _nav_cmd)) {
+        // if we failed to read the command from storage, then the command may have
+        // been from a previously loaded mission it is illogical to ever resume
+        // flying to a command that has been excluded from the current mission
+        start();
+        return;
+    }
 
     // restart active navigation command. We run these on resume()
     // regardless of whether the mission was stopped, as we may be


### PR DESCRIPTION
Addresses #6307

What was happening is that when we resumed a mission we would try and grab what that waypoint now was. However we ignored read failures, which is what happens if you attempt to resume flying to a waypoint that is no longer in the mission, which resulted in still flying to the old waypoint from the previous mission. This is incredibly surprising to the user, and is also inconsistent with the existing behavior where if you were flying to waypoint 4, go RTL, move waypoint 4 and resume we now fly to the new waypoint 4 location.