### PR TITLE
Reduce start delays when using EKF3 and fix time delay bug (Extension of #6290)

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -965,7 +965,9 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
     loc.flags.terrain_alt = 0;
     location_offset(loc, _position_offset_north, _position_offset_east);
     if (_flags.fly_forward && _have_position) {
-        location_update(loc, _gps.ground_course_cd() * 0.01f, _gps.ground_speed() * _gps.get_lag());
+        float gps_delay_sec = 0;
+        _gps.get_lag(gps_delay_sec);
+        location_update(loc, _gps.ground_course_cd() * 0.01f, _gps.ground_speed() * gps_delay_sec);
     }
     return _have_position;
 }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -490,12 +490,12 @@ void AP_GPS::detect_instance(uint8_t instance)
         _port[instance]->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
         dstate->last_baud_change_ms = now;
 
-        if (_auto_config == 1) {
+        if (_auto_config == GPS_AUTO_CONFIG_ENABLE) {
             send_blob_start(instance, _initialisation_blob, sizeof(_initialisation_blob));
         }
     }
 
-    if (_auto_config == 1) {
+    if (_auto_config == GPS_AUTO_CONFIG_ENABLE) {
         send_blob_update(instance);
     }
 
@@ -594,7 +594,7 @@ void AP_GPS::update_instance(uint8_t instance)
         return;
     }
 
-    if (_auto_config == 1) {
+    if (_auto_config == GPS_AUTO_CONFIG_ENABLE) {
         send_blob_update(instance);
     }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1059,8 +1059,8 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
     } else {
         // the user has not specified a delay so we determine it from the GPS type
         lag_sec = drivers[instance]->get_lag();
-        // check that for a valid GPS configuration
-        return (_type[instance] != GPS_TYPE_NONE && (drivers[instance] == nullptr || !drivers[instance]->is_configured()));
+        // check for a valid GPS configuration
+        return drivers[instance]->is_configured();
     }
 }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1040,7 +1040,7 @@ void AP_GPS::Write_DataFlash_Log_Startup_messages()
 bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
     // return lag of blended GPS
-    if (instance == GPS_MAX_RECEIVERS) {
+    if (instance == GPS_BLENDED_INSTANCE) {
         lag_sec = _blended_lag_sec;
         // auto switching uses all GPS receivers, so all must be configured
         return all_configured();

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1451,7 +1451,7 @@ void AP_GPS::calc_blended_state(void)
         if (_blend_weights[i] > 0.0f) {
             temp_time_1 += (double)timing[i].last_fix_time_ms * (double) _blend_weights[i];
             temp_time_2 += (double)timing[i].last_message_time_ms * (double)_blend_weights[i];
-            _blended_lag_sec += get_lag(i) * _blended_lag_sec;
+            _blended_lag_sec += get_lag(i) * _blend_weights[i];
         }
     }
     timing[GPS_BLENDED_INSTANCE].last_fix_time_ms = (uint32_t)temp_time_1;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -308,10 +308,8 @@ public:
     // the expected lag (in seconds) in the position and velocity readings from the gps
     // return true if the GPS hardware configuration is known or the lag parameter has been set manually
     bool get_lag(uint8_t instance, float &lag_sec) const;
-    bool get_lag(float &lag_sec) const
-    {
-        bool is_valid = get_lag(primary_instance, lag_sec);
-        return is_valid;
+    bool get_lag(float &lag_sec) const {
+        return get_lag(primary_instance, lag_sec);
     }
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -306,8 +306,13 @@ public:
     }
 
     // the expected lag (in seconds) in the position and velocity readings from the gps
-    float get_lag(uint8_t instance) const;
-    float get_lag(void) const { return get_lag(primary_instance); }
+    // return true if the GPS hardware configuration is known or the lag parameter has been set manually
+    bool get_lag(uint8_t instance, float &lag_sec) const;
+    bool get_lag(float &lag_sec) const
+    {
+        bool is_valid = get_lag(primary_instance, lag_sec);
+        return is_valid;
+    }
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -487,4 +487,11 @@ private:
 
     // calculate the blended state
     void calc_blended_state(void);
+
+    // Auto configure types
+    enum GPS_AUTO_CONFIG {
+        GPS_AUTO_CONFIG_DISABLE = 0,
+        GPS_AUTO_CONFIG_ENABLE  = 1
+    };
+
 };

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -33,6 +33,7 @@
 #define GPS_RTK_INJECT_TO_ALL 127
 #define GPS_MAX_RATE_MS 200 // maximum value of rate_ms (i.e. slowest update rate) is 5hz or 200ms
 #define GPS_UNKNOWN_DOP UINT16_MAX // set unknown DOP's to maximum value, which is also correct for MAVLink
+#define GPS_WORST_LAG_SEC 0.22f // worst lag value any GPS driver is expected to return, expressed in seconds
 
 // the number of GPS leap seconds
 #define GPS_LEAPSECONDS_MILLIS 18000ULL

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -43,8 +43,8 @@ public:
 
     void broadcast_configuration_failure_reason(void) const override;
 
-     // return velocity lag
-     float get_lag(void) const override { return 0.08f; } ;
+    // get the velocity lag, returns true if the driver is confident in the returned value
+    bool get_lag(float &lag_sec) const override { lag_sec = 0.08f; return true; } ;
 
 private:
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -59,7 +59,7 @@ AP_GPS_UBLOX::AP_GPS_UBLOX(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UART
     _ublox_port(255),
     _have_version(false),
     _unconfigured_messages(CONFIG_ALL),
-    _hardware_generation(0),
+    _hardware_generation(UBLOX_UNKNOWN_HARDWARE_GENERATION),
     _new_position(0),
     _new_speed(0),
     _disable_counter(0),
@@ -104,7 +104,7 @@ AP_GPS_UBLOX::_request_next_config(void)
         break;
     case STEP_POLL_SVINFO:
         // not required once we know what generation we are on
-        if(_hardware_generation == 0) {
+        if(_hardware_generation == UBLOX_UNKNOWN_HARDWARE_GENERATION) {
             if (!_send_message(CLASS_NAV, MSG_NAV_SVINFO, 0, 0)) {
                 _next_message--;
             }
@@ -1307,19 +1307,27 @@ AP_GPS_UBLOX::broadcast_configuration_failure_reason(void) const {
 /*
   return velocity lag in seconds
  */
-float AP_GPS_UBLOX::get_lag(void) const
+bool AP_GPS_UBLOX::get_lag(float &lag_sec) const
 {
     switch (_hardware_generation) {
+    case UBLOX_UNKNOWN_HARDWARE_GENERATION:
+        lag_sec = 0.22f;
+        // always bail out in this case, it's used to indicate we have yet to receive a valid
+        // hardware generation, however the user may have inhibited us detecting the generation
+        // so if we aren't allowed to do configuration, we will accept this as the default delay
+        return gps._auto_config != 0;
     case UBLOX_5:
     case UBLOX_6:
     default:
-        return 0.22f;
+        lag_sec = 0.22f;
+        break;
     case UBLOX_7:
     case UBLOX_M8:
         // based on flight logs the 7 and 8 series seem to produce about 120ms lag
-        return 0.12f;
+        lag_sec = 0.12f;
         break;
     };
+    return true;
 }
 
 void AP_GPS_UBLOX::Write_DataFlash_Log_Startup_messages() const

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -79,7 +79,7 @@ void
 AP_GPS_UBLOX::_request_next_config(void)
 {
     // don't request config if we shouldn't configure the GPS
-    if (gps._auto_config == 0) {
+    if (gps._auto_config == AP_GPS::GPS_AUTO_CONFIG_DISABLE) {
         return;
     }
 
@@ -1315,7 +1315,7 @@ bool AP_GPS_UBLOX::get_lag(float &lag_sec) const
         // always bail out in this case, it's used to indicate we have yet to receive a valid
         // hardware generation, however the user may have inhibited us detecting the generation
         // so if we aren't allowed to do configuration, we will accept this as the default delay
-        return gps._auto_config != 0;
+        return gps._auto_config != AP_GPS::GPS_AUTO_CONFIG_ENABLE;
     case UBLOX_5:
     case UBLOX_6:
     default:

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -116,8 +116,8 @@ public:
     void broadcast_configuration_failure_reason(void) const override;
     void Write_DataFlash_Log_Startup_messages() const override;
 
-    // return velocity lag
-    float get_lag(void) const override;
+    // get the velocity lag, returns true if the driver is confident in the returned value
+    bool get_lag(float &lag_sec) const override;
 
     const char *name() const override { return "u-blox"; }
 
@@ -477,7 +477,9 @@ private:
         UBLOX_5,
         UBLOX_6,
         UBLOX_7,
-        UBLOX_M8
+        UBLOX_M8,
+        UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
+                                                 // flagging state in the driver
     };
 
     enum config_step {

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -53,8 +53,8 @@ public:
     virtual void handle_msg(const mavlink_message_t *msg) { return ; }
     virtual void handle_gnss_msg(const AP_GPS::GPS_State &msg) { return ; }
 
-    // driver specific lag
-    virtual float get_lag(void) const { return 0.2f; }
+    // driver specific lag, returns true if the driver is confident in the provided lag
+    virtual bool get_lag(float &lag) const { lag = 0.2f; return true; }
 
     virtual const char *name() const = 0;
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -441,7 +441,9 @@ void NavEKF3_core::readGpsData()
             // estimate when the GPS fix was valid, allowing for GPS processing and other delays
             // ideally we should be using a timing signal from the GPS receiver to set this time
             // Use the driver specified delay
-            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(_ahrs->get_gps().get_lag() * 1000.0f);
+            float gps_delay_sec = 0;
+            _ahrs->get_gps().get_lag(gps_delay_sec);
+            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(gps_delay_sec * 1000.0f);
 
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -71,7 +71,8 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     // GPS sensing can have large delays and should not be included if disabled
     if (_frontend->_fusionModeGPS != 3) {
         // Wait for the configuration of all GPS units to be confirmed. Until this has occurred the GPS driver cannot provide a correct time delay
-        if (!_ahrs->get_gps().all_configured()) {
+        float gps_delay_sec = 0;
+        if (!_ahrs->get_gps().get_lag(gps_delay_sec)) {
             if (AP_HAL::millis() - lastInitFailReport_ms > 10000) {
                 lastInitFailReport_ms = AP_HAL::millis();
                 // provide an escalating series of messages
@@ -86,7 +87,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
             return false;
         }
         // limit the time delay value from the GPS library to a max of 250 msec which is the max value the EKF has been tested for.
-        maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(_ahrs->get_gps().get_lag() * 1000.0f),250));
+        maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(gps_delay_sec * 1000.0f),250));
     }
 
     // airspeed sensing can have large delays and should not be included if disabled


### PR DESCRIPTION
This is only intended to present the last 2 commits for @priseborough (and others) to comment upon which can then be squashed/incorporated into his PR. The changes are to:
A) Allow a backend to report if it is confident in it's estimate of the lag value, which allows us to use it's reported lag immediately, rather then waiting for it to be reported as fully configured. (Significant time savings on a u-blox GPS rather then waiting for the full configuration checks to pass).
B) Rather then assume a rate of 1 measurement interval (which wasn't being correctly bounds checked anyways) we store the worst possible case for any driver that could be loaded, and return that instead. I looked at making it a per GPS driver static method, but it looked way more annoying then a single #define that just had to be maintained. (Since every backend *except* ublox currently uses the same default delay). The effect of this is that the EKF may create a slightly larger then needed buffer for storing the GPS data, but it will at least, A) init, B) doesn't risk having too small a buffer if a u-blox 5 or 6 is later connected.