### PR TITLE
AP_GPS: SBF Report velocity and get lag

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -190,16 +190,16 @@ AP_GPS_SBF::log_ExtEventPVTGeodetic(const msg4007 &temp)
 bool
 AP_GPS_SBF::process_message(void)
 {
-    uint16_t blockid = (sbf_msg.blockid & 4095u);
+    uint16_t blockid = (sbf_msg.blockid & 8191u);
 
     Debug("BlockID %d", blockid);
 
-    // ExtEventPVTGeodetic
-    if (blockid == 4038) {
+    switch (blockid) {
+    case ExtEventPVTGeodetic:
         log_ExtEventPVTGeodetic(sbf_msg.data.msg4007u);
-    }
-    // PVTGeodetic
-    else if (blockid == 4007) {
+        break;
+    case PVTGeodetic:
+    {
         const msg4007 &temp = sbf_msg.data.msg4007u;
 
         // Update time state
@@ -272,24 +272,43 @@ AP_GPS_SBF::process_message(void)
                 break;
         }
         
-        if ((temp.Mode & 64) > 0) // gps is in base mode
+        if ((temp.Mode & 64) > 0) { // gps is in base mode
             state.status = AP_GPS::NO_FIX;
-        if ((temp.Mode & 128) > 0) // gps only has 2d fix
+        } else if ((temp.Mode & 128) > 0) { // gps only has 2d fix
             state.status = AP_GPS::GPS_OK_FIX_2D;
+        }
                     
         return true;
     }
-    // DOP
-    else if (blockid == 4001) {
+    case DOP:
+    {
         const msg4001 &temp = sbf_msg.data.msg4001u;
 
         state.hdop = temp.HDOP;
         state.vdop = temp.VDOP;
+        break;
     }
-    // ReceiverStatus
-    else if (blockid == 4014) {
+    case ReceiverStatus:
+    {
         const msg4014 &temp = sbf_msg.data.msg4014u;
         RxState = temp.RxState;
+        break;
+    }
+    case VelCovGeodetic:
+    {
+        const msg5908 &temp = sbf_msg.data.msg5908u;
+
+        // select the maximum variance, as the EKF will apply it to all the columnds in it's estimate
+        // FIXME: Support returning the covariance matric to the EKF
+        float max_variance_squared = MAX(temp.Cov_VnVn, MAX(temp.Cov_VeVe, temp.Cov_VuVu));
+        if (is_positive(max_variance_squared)) {
+            state.have_speed_accuracy = true;
+            state.speed_accuracy = sqrt(max_variance_squared);
+        } else {
+            state.have_speed_accuracy = false;
+        }
+        break;
+    }
     }
 
     return false;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -43,6 +43,9 @@ public:
 
     void broadcast_configuration_failure_reason(void) const override;
 
+     // return velocity lag
+     float get_lag(void) const override { return 0.08f; } ;
+
 private:
 
     bool parse(uint8_t temp);

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -54,7 +54,7 @@ private:
     uint8_t _init_blob_index = 0;
     uint32_t _init_blob_time = 0;
     const char* _initialisation_blob[5] = {
-    "sso, Stream1, COM1, PVTGeodetic+DOP+ExtEventPVTGeodetic+ReceiverStatus, msec100\n",
+    "sso, Stream1, COM1, PVTGeodetic+DOP+ExtEventPVTGeodetic+ReceiverStatus+VelCovGeodetic, msec100\n",
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, StandAlone+SBAS+DGPS+RTK\n",
@@ -65,7 +65,15 @@ private:
     bool validcommand = false;
     uint32_t RxState;
 
-    struct PACKED msg4007
+    enum sbf_ids {
+        DOP = 4001,
+        PVTGeodetic = 4007,
+        ReceiverStatus = 4014,
+        ExtEventPVTGeodetic = 4038,
+        VelCovGeodetic = 5908
+    };
+
+    struct PACKED msg4007 // PVTGeodetic
     {
          uint32_t TOW;
          uint16_t WNc;
@@ -99,7 +107,7 @@ private:
          uint8_t Misc;
     };
   
-    struct PACKED msg4001
+    struct PACKED msg4001 // DOP
     {
          uint32_t TOW;
          uint16_t WNc;
@@ -125,10 +133,29 @@ private:
          // remaining data is AGCData, which we don't have a use for, don't extract the data
     };
 
+    struct PACKED msg5908 // VelCovGeodetic
+    {
+        uint32_t TOW;
+        uint16_t WNc;
+        uint8_t Mode;
+        uint8_t Error;
+        float Cov_VnVn;
+        float Cov_VeVe;
+        float Cov_VuVu;
+        float Cov_DtDt;
+        float Cov_VnVe;
+        float Cov_VnVu;
+        float Cov_VnDt;
+        float Cov_VeVu;
+        float Cov_VeDt;
+        float Cov_VuDt;
+    };
+
     union PACKED msgbuffer {
         msg4007 msg4007u;
         msg4001 msg4001u;
         msg4014 msg4014u;
+        msg5908 msg5908u;
         uint8_t bytes[128];
     };
 


### PR DESCRIPTION
This exposes the speed accuracy from the GPS to the EKF. It's worth noting that Septentrio is actually providing us with a covarince matrix which would be a better input to the EKF, but the EKF doesn't yet have an interface that lets us take advantage of it. (This now gets us to 2 GPS types that support this, so I might start quietly nudging @priseborough  to support it). Anyways the speed accuracy number is currently used for each value in the covariance matrix in the EKF, so we simply select the worst reported accuracy and apply it to all axises rather then using the higher quality data from the GPS.

This also implements the get_lag() method on Septentrio, which allows us to provide a more sane lag value for users out of the box. This was selected as the best fit from my flight logs on plane which was done with a DGPS fix. I checked this against @meee1's logs which were on a copter with RTK Fixed positioning which was 20 ms less laggy. I selected the laggier value here in the PR as a slightly safer one for the buffer sizes, @priseborough made the offline comment that 20 ms either way isn't going to be noticeable, but the changes of 100 ms or more will have an impact (which is what this is doing to improbe it). Both mine and @meee1's graphs of lag error are pretty happy at that point though.
![figure_1-4](https://cloud.githubusercontent.com/assets/567688/26433524/21113b74-40b8-11e7-974b-02d9f0978451.png)

Also rewrote the core processing loop to use a switch() rather then if/else if chain as it was getting to be annoyingly long, and I wanted nicer labels that told me what each block was processing/describing.