### PR TITLE
Allow arbitrary brushed motor periods

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -695,6 +695,11 @@ void Copter::allocate_motors(void)
         break;
     }
 
+    // brushed 16kHz defaults to 16kHz pulses
+    if (motors->get_pwm_type() >= AP_Motors::PWM_TYPE_BRUSHED) {
+        g.rc_speed.set_default(16000);
+    }
+    
     if (upgrading_frame_params) {
         // do frame specific upgrade. This is only done the first time we run the new firmware
 #if FRAME_CONFIG == HELI_FRAME

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -130,7 +130,7 @@ public:
     enum output_mode {
         MODE_PWM_NORMAL,
         MODE_PWM_ONESHOT,
-        MODE_PWM_BRUSHED16KHZ
+        MODE_PWM_BRUSHED
     };
     virtual void    set_output_mode(enum output_mode mode) {}
 };

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -100,7 +100,7 @@ void PX4RCOutput::_init_alt_channels(void)
  */
 void PX4RCOutput::set_freq_fd(int fd, uint32_t chmask, uint16_t freq_hz, uint32_t &rate_mask) 
 {
-    if (_output_mode == MODE_PWM_BRUSHED16KHZ) {
+    if (_output_mode == MODE_PWM_BRUSHED) {
         freq_hz /= 8; // divide by 8 for 8MHz clock
         // remember max period
         _period_max = 1000000UL/freq_hz;
@@ -165,7 +165,7 @@ void PX4RCOutput::set_freq_fd(int fd, uint32_t chmask, uint16_t freq_hz, uint32_
         hal.console->printf("RCOutput: Unable to set alt rate mask to 0x%x\n", (unsigned)rate_mask);
     }
 
-    if (_output_mode == MODE_PWM_BRUSHED16KHZ) {
+    if (_output_mode == MODE_PWM_BRUSHED) {
         ioctl(fd, PWM_SERVO_SET_UPDATE_CLOCK, 8);
     }    
 }
@@ -188,7 +188,7 @@ void PX4RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
     
     // greater than 400 doesn't give enough room at higher periods for
     // the down pulse
-    if (freq_hz > 400 && _output_mode != MODE_PWM_BRUSHED16KHZ) {
+    if (freq_hz > 400 && _output_mode != MODE_PWM_BRUSHED) {
         freq_hz = 400;
     }
     uint32_t primary_mask = chmask & ((1UL<<_servo_count)-1);
@@ -329,7 +329,7 @@ void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
         _max_channel = ch + 1;
     }
 
-    if (_output_mode == MODE_PWM_BRUSHED16KHZ) {
+    if (_output_mode == MODE_PWM_BRUSHED) {
         // map from the PWM range to 0 t0 100% duty cycle. For 16kHz
         // this ends up being 0 to 500 pulse width in units of
         // 125usec.
@@ -623,7 +623,7 @@ void PX4RCOutput::set_output_mode(enum output_mode mode)
             ioctl(_alt_fd, PWM_SERVO_SET_ONESHOT, 0);
         }
         break;
-    case MODE_PWM_BRUSHED16KHZ:
+    case MODE_PWM_BRUSHED:
         // setup an 8MHz clock. This has the effect of scaling all outputs by 8x
         ioctl(_pwm_fd, PWM_SERVO_SET_UPDATE_CLOCK, 8);
         if (_alt_fd != -1) {

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -56,6 +56,7 @@ private:
     uint32_t _rate_mask_main;
     uint32_t _rate_mask_alt;
     uint16_t _enabled_channels;
+    uint32_t _period_max;
     struct {
         int pwm_sub;
         actuator_outputs_s outputs;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -83,7 +83,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: PWM_TYPE
     // @DisplayName: Output PWM type
     // @Description: This selects the output PWM type, allowing for normal PWM continuous output, OneShot or brushed motor output
-    // @Values: 0:Normal,1:OneShot,2:OneShot125,3:Brushed16kHz
+    // @Values: 0:Normal,1:OneShot,2:OneShot125,3:Brushed
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, PWM_TYPE_NORMAL),

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -120,8 +120,8 @@ void AP_Motors::rc_set_freq(uint32_t mask, uint16_t freq_hz)
         mask != 0) {
         // tell HAL to do immediate output
         hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_ONESHOT);
-    } else if (_pwm_type == PWM_TYPE_BRUSHED16kHz) {
-        hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_BRUSHED16KHZ);
+    } else if (_pwm_type == PWM_TYPE_BRUSHED) {
+        hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_BRUSHED);
     }
 }
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -164,7 +164,7 @@ public:
     // set loop rate. Used to support loop rate as a parameter
     void                set_loop_rate(uint16_t loop_rate) { _loop_rate = loop_rate; }
 
-    enum pwm_type { PWM_TYPE_NORMAL=0, PWM_TYPE_ONESHOT=1, PWM_TYPE_ONESHOT125=2, PWM_TYPE_BRUSHED16kHz=3 };
+    enum pwm_type { PWM_TYPE_NORMAL=0, PWM_TYPE_ONESHOT=1, PWM_TYPE_ONESHOT125=2, PWM_TYPE_BRUSHED=3 };
     pwm_type            get_pwm_type(void) const { return (pwm_type)_pwm_type.get(); }
     
 protected:


### PR DESCRIPTION
This is a varient of an earlier patch by @khancyr that allows brushed motors to be run with any period
