### PR TITLE
Rover: FS parameters default values macros are not used, so delete them

### DIFF
--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -125,22 +125,6 @@
 
 
 //////////////////////////////////////////////////////////////////////////////
-// failsafe defaults
-#ifndef THROTTLE_FAILSAFE
-  #define THROTTLE_FAILSAFE      ENABLED
-#endif
-#ifndef THROTTLE_FS_VALUE
-  #define THROTTLE_FS_VALUE      950
-#endif
-#ifndef LONG_FAILSAFE_ACTION
-  #define LONG_FAILSAFE_ACTION   0
-#endif
-#ifndef GCS_HEARTBEAT_FAILSAFE
-  #define GCS_HEARTBEAT_FAILSAFE DISABLED
-#endif
-
-
-//////////////////////////////////////////////////////////////////////////////
 // THROTTLE_OUT
 //
 #ifndef THROTTE_OUT


### PR DESCRIPTION
*NFC*

@OXINARF told me that they existed.
@tridge told me I should delete them, now that we have run-time parameters, and this just adds indirection to the code.
