### PR TITLE
Rover: push servo outputs

### DIFF
--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -353,7 +353,9 @@ void Rover::set_servos(void) {
 #if HIL_MODE == HIL_MODE_DISABLED || HIL_SERVOS
     // send values to the PWM timers for output
     // ----------------------------------------
+    hal.rcout->cork();
     SRV_Channels::output_ch_all();
+    hal.rcout->push();
 #endif
 }
 

--- a/libraries/AP_Notify/RCOutputRGBLed.cpp
+++ b/libraries/AP_Notify/RCOutputRGBLed.cpp
@@ -69,13 +69,6 @@ bool RCOutputRGBLed::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
         hal.rcout->set_freq(mask, freq_motor);
     }
 
-    /*
-     * Not calling push() to have a better performance on RCOutput's that
-     * implements cork()/push(), so this changes will be committed together
-     * with the motors.
-     */
-    hal.rcout->cork();
-
     uint16_t usec_duty = usec_period * red / _led_bright;
     SRV_Channels::set_output_pwm_chan(_red_channel, usec_duty);
 


### PR DESCRIPTION
In case something uses cork()/push() somewhere, PWM won't be issued.

It might be a wrong place to put the fix in but nevertheless it's an issue that should be resolved.
I tested it on Navio 2 and it did the trick. In order to reproduce the bug I changed Notify device to RCOutputRGBLed which implements cork() routine.