### PR TITLE
AccelCal: Continuously report success/failure to the GCS

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -39,6 +39,7 @@ private:
     uint32_t _last_position_request_ms;
     uint8_t _step;
     accel_cal_status_t _status;
+    accel_cal_status_t _last_result;
 
     static uint8_t _num_clients;
     static AP_AccelCal_Client* _clients[AP_ACCELCAL_MAX_NUM_CLIENTS];

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -162,7 +162,7 @@ public:
     void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
-    void send_accelcal_vehicle_position(uint8_t position);
+    void send_accelcal_vehicle_position(uint32_t position);
 
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1509,7 +1509,7 @@ void GCS_MAVLINK::send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_C
     }
 }
 
-void GCS_MAVLINK::send_accelcal_vehicle_position(uint8_t position)
+void GCS_MAVLINK::send_accelcal_vehicle_position(uint32_t position)
 {
     if (HAVE_PAYLOAD_SPACE(chan, COMMAND_LONG)) {
         mavlink_msg_command_long_send(


### PR DESCRIPTION
When we complete the calibration the only way for the GCS to reliably detect this is to watch for the parameters to change, which requires continuously polling them, and comparing to the previous values. This PR (and associated MAVLink commit) instead continously broadcasts the success/failure state to the GCS that requested the calibration. This isn't a waste of bandwidth as a you have to reboot after an Accel cal anyways. (This is the same approach compass calibration takes).

EDIT: Requires: https://github.com/ArduPilot/mavlink/pull/45 to be merged