### PR TITLE
AP_GPS: Use a static assert to check that the init blob is small enough

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -20,6 +20,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <climits>
 
 #include "AP_GPS_NOVA.h"
 #include "AP_GPS_ERB.h"
@@ -258,6 +259,9 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 // constructor
 AP_GPS::AP_GPS()
 {
+    static_assert((sizeof(_initialisation_blob) * (CHAR_BIT + 2)) < (4800 * GPS_BAUD_TIME_MS * 1e-3),
+                    "GPS initilisation blob is to large to be completely sent before the baud rate changes");
+
     AP_Param::setup_object_defaults(this, var_info);
 }
 


### PR DESCRIPTION
One day we will make an init blob that is to large to be sent to the slowest UART baud rate we support, this is just trying to add some sanity checking to it and save time on the day that someone does make one to large.

I debated if I should be making #define's for the number of bits/slowest supported baud rate. Happy to change to whatever the majority prefer.