### PR TITLE
AP_BoardConfig: remove redundant BRD_ prefix, it also made this param…

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -170,7 +170,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
 #if HAL_PX4_HAVE_PX4IO
-    // @Param: BRD_IO_ENABLE
+    // @Param: IO_ENABLE
     // @DisplayName: Enable IO co-processor
     // @Description: This allows for the IO co-processor on FMUv1 and FMUv2 to be disabled
     // @Values: 0:Disabled,1:Enabled


### PR DESCRIPTION
…eter 17 characters long. And that is not good ;)