### PR TITLE
GPS: Don't auto detect nmea instances

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -467,8 +467,8 @@ void AP_GPS::detect_instance(uint8_t instance)
         break;
     }
 
-    // record the time when we started detection. This is used to try
-    // to avoid initialising a uBlox as a NMEA GPS
+    // record the time when we started detection. This is used as a flag to
+    // indicate that the detected GPS baud rate should be broadcast
     if (dstate->detect_started_ms == 0) {
         dstate->detect_started_ms = now;
     }
@@ -539,13 +539,9 @@ void AP_GPS::detect_instance(uint8_t instance)
         else if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_ERB) &&
                  AP_GPS_ERB::_detect(dstate->erb_detect_state, data)) {
             new_gps = new AP_GPS_ERB(*this, state[instance], _port[instance]);
-        } else if (now - dstate->detect_started_ms > (ARRAY_SIZE(_baudrates) * GPS_BAUD_TIME_MS)) {
-            // prevent false detection of NMEA mode in
-            // a MTK or UBLOX which has booted in NMEA mode
-            if ((_type[instance] == GPS_TYPE_AUTO || _type[instance] == GPS_TYPE_NMEA) &&
-                AP_GPS_NMEA::_detect(dstate->nmea_detect_state, data)) {
-                new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);
-            }
+        } else if (_type[instance] == GPS_TYPE_NMEA &&
+                   AP_GPS_NMEA::_detect(dstate->nmea_detect_state, data)) {
+            new_gps = new AP_GPS_NMEA(*this, state[instance], _port[instance]);
         }
     }
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -419,9 +419,9 @@ private:
 
     // state of auto-detection process, per instance
     struct detect_state {
-        uint32_t detect_started_ms;
         uint32_t last_baud_change_ms;
         uint8_t current_baud;
+        bool auto_detected_baud;
         struct UBLOX_detect_state ublox_detect_state;
         struct MTK_detect_state mtk_detect_state;
         struct MTK19_detect_state mtk19_detect_state;

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -141,7 +141,7 @@ void AP_GPS_Backend::_detection_message(char *buffer, const uint8_t buflen) cons
     const uint8_t instance = state.instance;
     const struct AP_GPS::detect_state dstate = gps.detect_state[instance];
 
-    if (dstate.detect_started_ms > 0) {
+    if (dstate.auto_detected_baud) {
         hal.util->snprintf(buffer, buflen,
                  "GPS %d: detected as %s at %d baud",
                  instance + 1,


### PR DESCRIPTION
As discussed on the dev call this removes auto detecting NMEA instances, as it's almost always an error, and it's also the worst driver in terms of information we can reliably expect to decode with it. This also has the slight bonus that if you are using a NMEA GPS the detection time is faster, as we no longer have to wait for a complete cycle of the possible baud rates.

Second commit leveraged the fact that we no longer need a timestamp for NMEA detection reasons and transformed the detect started time stamping to instead just be a bool flag. I looked briefly at fixing the SBF/NOVA/GSOF incorrect baud rate prints, but I didn't come across a simple way to do implement that part in the same pass, so I've left that for future work.