### PR TITLE
Improved Battery resistance estimation

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -170,6 +170,8 @@ void Copter::read_battery(void)
     }
     if (battery.has_current()) {
         motors->set_current(battery.current_amps());
+        motors->set_resistance(battery.get_resistance());
+        motors->set_voltage_resting_estimate(battery.voltage_resting_estimate());
     }
 
     // check for low voltage or current if the low voltage check hasn't already been triggered

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -243,12 +243,8 @@ bool AP_BattMonitor::is_powering_off(uint8_t instance) const {
 /// has_current - returns true if battery monitor instance provides current info
 bool AP_BattMonitor::has_current(uint8_t instance) const
 {
-    // check for analog voltage and current monitor or smbus monitor
-    if (instance < _num_instances && drivers[instance] != nullptr) {
-        return (_monitoring[instance] == BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT ||
-                _monitoring[instance] == BattMonitor_TYPE_SOLO ||
-                _monitoring[instance] == BattMonitor_TYPE_BEBOP ||
-                _monitoring[instance] == BattMonitor_TYPE_MAXELL);
+    if (instance < _num_instances && drivers[instance] != nullptr && _monitoring[instance] != BattMonitor_TYPE_NONE) {
+        return drivers[instance]->has_current();
     }
 
     // not monitoring current

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -143,15 +143,15 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
 
 #endif // AP_BATT_MONITOR_MAX_INSTANCES > 1
 
-    // @Param: _VOLT_TIMER
+    // @Param: _LOW_TIMER
     // @DisplayName: Low voltage timeout
     // @Description: This is the timeout in seconds before a low voltage event will be triggered. For aircraft with low C batteries it may be necessary to raise this in order to cope with low voltage on long takeoffs. A value of zero disables low voltage errors.
     // @Units: s
     // @Increment: 1
     // @Range: 0 120
     // @User: Advanced
-    AP_GROUPINFO("_VOLT_TIMER", 21, AP_BattMonitor, _volt_timeout, AP_BATT_LOW_VOLT_TIMEOUT_DEFAULT),
-        
+    AP_GROUPINFO("_LOW_TIMER", 21, AP_BattMonitor, _low_voltage_timeout, AP_BATT_LOW_VOLT_TIMEOUT_DEFAULT),
+
     AP_GROUPEND
 };
 
@@ -312,7 +312,7 @@ bool AP_BattMonitor::exhausted(uint8_t instance, float low_voltage, float min_ca
         // this is the first time our voltage has dropped below minimum so start timer
         if (state[instance].low_voltage_start_ms == 0) {
             state[instance].low_voltage_start_ms = AP_HAL::millis();
-        } else if (_volt_timeout > 0 && AP_HAL::millis() - state[instance].low_voltage_start_ms > uint32_t(_volt_timeout.get())*1000U) {
+        } else if (_low_voltage_timeout > 0 && AP_HAL::millis() - state[instance].low_voltage_start_ms > uint32_t(_low_voltage_timeout.get())*1000U) {
             return true;
         }
     } else {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -365,7 +365,7 @@ bool AP_BattMonitor::exhausted(uint8_t instance, float low_voltage, float min_ca
 bool AP_BattMonitor::overpower_detected() const
 {
     bool result = false;
-    for (int instance = 0; instance < _num_instances; instance++) {
+    for (uint8_t instance = 0; instance < _num_instances; instance++) {
         result |= overpower_detected(instance);
     }
     return result;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -227,6 +227,7 @@ AP_BattMonitor::read()
     for (uint8_t i=0; i<_num_instances; i++) {
         if (drivers[i] != nullptr && _monitoring[i] != BattMonitor_TYPE_NONE) {
             drivers[i]->read();
+            drivers[i]->update_resistance_estimate();
         }
     }
 }
@@ -256,6 +257,17 @@ float AP_BattMonitor::voltage(uint8_t instance) const
 {
     if (instance < _num_instances) {
         return _BattMonitor_STATE(instance).voltage;
+    } else {
+        return 0.0f;
+    }
+}
+
+/// get voltage with sag removed (based on battery current draw and resistance)
+float AP_BattMonitor::voltage_resting_estimate(uint8_t instance) const
+{
+    if (instance < _num_instances) {
+        // resting voltage should always be greater than or equal to the raw voltage
+        return MAX(_BattMonitor_STATE(instance).voltage, _BattMonitor_STATE(instance).voltage_resting_estimate);
     } else {
         return 0.0f;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -384,6 +384,15 @@ bool AP_BattMonitor::overpower_detected(uint8_t instance) const
 #endif
 }
 
+bool AP_BattMonitor::has_cell_voltages(const uint8_t instance) const
+{
+    if (instance < _num_instances && drivers[instance] != nullptr) {
+        return drivers[instance]->has_cell_voltages();
+    }
+
+    return false;
+}
+
 // return the current cell voltages, returns the first monitor instances cells if the instance is out of range
 const AP_BattMonitor::cells & AP_BattMonitor::get_cell_voltages(const uint8_t instance) const
 {

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -18,6 +18,9 @@
 
 #define AP_BATT_MONITOR_TIMEOUT             5000
 
+#define AP_BATT_MONITOR_RES_EST_TC_1        0.5f
+#define AP_BATT_MONITOR_RES_EST_TC_2        0.1f
+
 // declare backend class
 class AP_BattMonitor_Backend;
 class AP_BattMonitor_Analog;
@@ -65,6 +68,8 @@ public:
         cells       cell_voltages;      // battery cell voltages in millivolts, 10 cells matches the MAVLink spec
         float       temperature;        // battery temperature in celsius
         uint32_t    temperature_time;   // timestamp of the last recieved temperature message
+        float       voltage_resting_estimate; // voltage with sag removed based on current and resistance estimate
+        float       resistance;         // resistance calculated by comparing resting voltage vs in flight voltage
     };
 
     // Return the number of battery monitor instances
@@ -92,6 +97,10 @@ public:
     /// voltage - returns battery voltage in millivolts
     float voltage(uint8_t instance) const;
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
+
+    /// get voltage with sag removed (based on battery current draw and resistance)
+    float voltage_resting_estimate(uint8_t instance) const;
+    float voltage_resting_estimate() const { return voltage_resting_estimate(AP_BATT_PRIMARY_INSTANCE); }
 
     /// current_amps - returns the instantaneous current draw in amperes
     float current_amps(uint8_t instance) const;
@@ -134,6 +143,10 @@ public:
     // temperature
     bool get_temperature(float &temperature) const { return get_temperature(temperature, AP_BATT_PRIMARY_INSTANCE); };
     bool get_temperature(float &temperature, const uint8_t instance) const;
+
+    // get battery resistance estimate in ohms
+    float get_resistance() const { return get_resistance(AP_BATT_PRIMARY_INSTANCE); }
+    float get_resistance(uint8_t instance) const { return state[instance].resistance; }
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -144,7 +144,9 @@ public:
     bool overpower_detected(uint8_t instance) const;
 
     // cell voltages
-    const cells & get_cell_voltages() { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); };
+    bool has_cell_voltages() { return has_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
+    bool has_cell_voltages(const uint8_t instance) const;
+    const cells & get_cell_voltages() const { return get_cell_voltages(AP_BATT_PRIMARY_INSTANCE); }
     const cells & get_cell_voltages(const uint8_t instance) const;
 
     // temperature

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -149,8 +149,7 @@ protected:
     AP_Int32    _pack_capacity[AP_BATT_MONITOR_MAX_INSTANCES];      /// battery pack capacity less reserve in mAh
     AP_Int16    _watt_max[AP_BATT_MONITOR_MAX_INSTANCES];           /// max battery power allowed. Reduce max throttle to reduce current to satisfy this limit
     AP_Int32    _serial_numbers[AP_BATT_MONITOR_MAX_INSTANCES];     /// battery serial number, automatically filled in on SMBus batteries
-
-    AP_Int8     _volt_timeout;
+    AP_Int8     _low_voltage_timeout;                               /// timeout in seconds before a low voltage event will be triggered
 
 private:
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -51,6 +51,12 @@ public:
         BattMonitor_TYPE_MAXELL                     = 7
     };
 
+    // low voltage sources (used for BATT_LOW_TYPE parameter)
+    enum BattMonitor_LowVoltage_Source {
+        BattMonitor_LowVoltageSource_Raw            = 0,
+        BattMonitor_LowVoltageSource_SagCompensated = 1
+    };
+
     struct cells {
         uint16_t cells[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
     };
@@ -99,6 +105,7 @@ public:
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
 
     /// get voltage with sag removed (based on battery current draw and resistance)
+    /// this will always be greater than or equal to the raw voltage
     float voltage_resting_estimate(uint8_t instance) const;
     float voltage_resting_estimate() const { return voltage_resting_estimate(AP_BATT_PRIMARY_INSTANCE); }
 
@@ -163,6 +170,7 @@ protected:
     AP_Int16    _watt_max[AP_BATT_MONITOR_MAX_INSTANCES];           /// max battery power allowed. Reduce max throttle to reduce current to satisfy this limit
     AP_Int32    _serial_numbers[AP_BATT_MONITOR_MAX_INSTANCES];     /// battery serial number, automatically filled in on SMBus batteries
     AP_Int8     _low_voltage_timeout;                               /// timeout in seconds before a low voltage event will be triggered
+    AP_Int8     _low_voltage_source;                                /// voltage type used for detection of low voltage event
 
 private:
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -28,7 +28,7 @@ AP_BattMonitor_Analog::read()
     _state.voltage = _volt_pin_analog_source->voltage_average() * _mon._volt_multiplier[_state.instance];
 
     // read current
-    if (_mon.has_current(_state.instance)) {
+    if (has_current()) {
         // calculate time since last current read
         uint32_t tnow = AP_HAL::micros();
         float dt = tnow - _state.last_time_micros;
@@ -48,4 +48,10 @@ AP_BattMonitor_Analog::read()
         // record time
         _state.last_time_micros = tnow;
     }
+}
+
+/// return true if battery provides current info
+bool AP_BattMonitor_Analog::has_current() const
+{
+    return (_mon.get_type(_state.instance) == AP_BattMonitor::BattMonitor_TYPE_ANALOG_VOLTAGE_AND_CURRENT);
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -87,6 +87,9 @@ public:
     /// Read the battery voltage and current.  Should be called at 10hz
     void read();
 
+    /// returns true if battery monitor provides current info
+    bool has_current() const override;
+
 protected:
 
     AP_HAL::AnalogSource *_volt_pin_analog_source;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -44,3 +44,54 @@ int32_t AP_BattMonitor_Backend::get_capacity() const
 {
     return _mon.pack_capacity_mah(_state.instance);
 }
+
+// update battery resistance estimate
+// faster rates of change of the current and voltage readings cause faster updates to the resistance estimate
+// the battery resistance is calculated by comparing the latest current and voltage readings to a low-pass filtered current and voltage
+// high current steps are integrated into the resistance estimate by varying the time constant of the resistance filter
+void AP_BattMonitor_Backend::update_resistance_estimate()
+{
+    // return immediately if no current
+    if (!has_current() || !is_positive(_state.current_amps)) {
+        return;
+    }
+
+    // update maximum current seen since startup and protect against divide by zero
+    _current_max_amps = MAX(_current_max_amps, _state.current_amps);
+    float current_delta = _state.current_amps - _current_filt_amps;
+    if (is_zero(current_delta)) {
+        return;
+    }
+
+    // update reference voltage and current
+    if (_state.voltage > _resistance_voltage_ref) {
+        _resistance_voltage_ref = _state.voltage;
+        _resistance_current_ref = _state.current_amps;
+    }
+
+    // calculate time since last update
+    uint32_t now = AP_HAL::millis();
+    float loop_interval = (now - _resistance_timer_ms) / 1000.0f;
+    _resistance_timer_ms = now;
+
+    // estimate short-term resistance
+    float filt_alpha = constrain_float(loop_interval/(loop_interval + AP_BATT_MONITOR_RES_EST_TC_1), 0.0f, 0.5f);
+    float resistance_alpha = MIN(1, AP_BATT_MONITOR_RES_EST_TC_2*fabsf((_state.current_amps-_current_filt_amps)/_current_max_amps));
+    float resistance_estimate = -(_state.voltage-_voltage_filt)/current_delta;
+    if (is_positive(resistance_estimate)) {
+        _state.resistance = _state.resistance*(1-resistance_alpha) + resistance_estimate*resistance_alpha;
+    }
+
+    // calculate maximum resistance
+    if ((_resistance_voltage_ref > _state.voltage) && (_state.current_amps > _resistance_current_ref)) {
+        float resistance_max = (_resistance_voltage_ref - _state.voltage) / (_state.current_amps - _resistance_current_ref);
+        _state.resistance = MIN(_state.resistance, resistance_max);
+    }
+
+    // update the filtered voltage and currents
+    _voltage_filt = _voltage_filt*(1-filt_alpha) + _state.voltage*filt_alpha;
+    _current_filt_amps = _current_filt_amps*(1-filt_alpha) + _state.current_amps*filt_alpha;
+
+    // update estimated voltage without sag
+    _state.voltage_resting_estimate = _state.voltage + _state.current_amps * _state.resistance;
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -34,6 +34,9 @@ public:
     // read the latest battery voltage
     virtual void read() = 0;
 
+    /// returns true if battery monitor instance provides current info
+    virtual bool has_current() const = 0;
+
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -43,7 +43,19 @@ public:
     /// get capacity for this instance
     int32_t get_capacity() const;
 
+    // update battery resistance estimate and voltage_resting_estimate
+    void update_resistance_estimate();
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)
+
+private:
+    // resistance estimate
+    uint32_t    _resistance_timer_ms;    // system time of last resistance estimate update
+    float       _voltage_filt;           // filtered voltage
+    float       _current_max_amps;       // maximum current since start-up
+    float       _current_filt_amps;      // filtered current
+    float       _resistance_voltage_ref; // voltage used for maximum resistance calculation
+    float       _resistance_current_ref; // current used for maximum resistance calculation
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -37,6 +37,9 @@ public:
     /// returns true if battery monitor instance provides current info
     virtual bool has_current() const = 0;
 
+    // returns true if battery monitor provides individual cell voltages
+    virtual bool has_cell_voltages() const { return false; }
+
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     uint8_t capacity_remaining_pct() const;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
@@ -37,6 +37,9 @@ public:
     // read the latest battery voltage
     void read() override;
 
+    // bebop provides current info
+    bool has_current() const override { return true; };
+
 private:
     float _prev_vbat_raw;
     float _prev_vbat;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -23,6 +23,8 @@ public:
     // virtual destructor to reduce compiler warnings
     virtual ~AP_BattMonitor_SMBus() {}
 
+    // all smart batteries provide current info
+    bool has_current() const override { return true; }
 
 protected:
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -23,8 +23,9 @@ public:
     // virtual destructor to reduce compiler warnings
     virtual ~AP_BattMonitor_SMBus() {}
 
-    // all smart batteries provide current info
+    // all smart batteries provide current and individual cell voltages
     bool has_current() const override { return true; }
+    bool has_cell_voltages() const override { return true; }
 
 protected:
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -72,9 +72,6 @@ public:
     // get_batt_voltage_filt - get battery voltage ratio - for logging purposes only
     float               get_batt_voltage_filt() const { return _batt_voltage_filt.get(); }
 
-    // get_batt_resistance - get battery resistance approximation - for logging purposes only
-    float               get_batt_resistance() const { return _batt_resistance; }
-
     // get throttle limit imposed by battery current limiting.  This is a number from 0 ~ 1 where 0 means hover throttle, 1 means full throttle (i.e. not limited)
     float               get_throttle_limit() const { return _throttle_limit; }
 
@@ -121,9 +118,6 @@ protected:
 
     // update_lift_max_from_batt_voltage - used for voltage compensation
     void                update_lift_max_from_batt_voltage();
-
-    // update_battery_resistance - calculate battery resistance when throttle is above hover_out
-    void                update_battery_resistance();
 
     // return gain scheduling gain based on voltage and air density
     float               get_compensation_gain() const;
@@ -185,11 +179,7 @@ protected:
     float               _spin_up_ratio;      // throttle percentage (0 ~ 1) between zero and throttle_min
 
     // battery voltage, current and air pressure compensation variables
-    float               _batt_voltage_resting;  // battery voltage reading at minimum throttle
     LowPassFilterFloat  _batt_voltage_filt;     // filtered battery voltage expressed as a percentage (0 ~ 1.0) of batt_voltage_max
-    float               _batt_current_resting;  // battery's current when motors at minimum
-    float               _batt_resistance;       // battery's resistance calculated by comparing resting voltage vs in flight voltage
-    int16_t             _batt_timer;            // timer used in battery resistance calcs
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
     float               _throttle_thrust_max;   // the maximum allowed throttle thrust 0.0 to 1.0 in the range throttle_min to throttle_max

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -107,9 +107,14 @@ public:
     //
     // set_voltage - set voltage to be used for output scaling
     void                set_voltage(float volts){ _batt_voltage = volts; }
+    void                set_voltage_resting_estimate(float volts) { _batt_voltage_resting_estimate = volts; }
 
     // set_current - set current to be used for output scaling
     void                set_current(float current){ _batt_current = current; }
+
+    // get and set battery resistance estimate
+    float               get_batt_resistance() const { return _batt_resistance; }
+    void                set_resistance(float resistance){ _batt_resistance = resistance; }
 
     // set_density_ratio - sets air density as a proportion of sea level density
     void                set_air_density_ratio(float ratio) { _air_density_ratio = ratio; }
@@ -207,7 +212,9 @@ protected:
 
     // battery voltage, current and air pressure compensation variables
     float               _batt_voltage;          // latest battery voltage reading
+    float               _batt_voltage_resting_estimate; // estimated battery voltage with sag removed
     float               _batt_current;          // latest battery current reading
+    float               _batt_resistance;       // latest battery resistance estimate in ohms
     float               _air_density_ratio;     // air density / sea level density - decreases in altitude
 
     // mapping to output channels

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -928,9 +928,9 @@ Format characters in the format string for binary log messages
     { LOG_ARSP_MSG, sizeof(log_AIRSPEED), \
       "ARSP",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U" }, \
     { LOG_CURRENT_MSG, sizeof(log_Current), \
-      "CURR", CURR_FMT,CURR_LABELS }, \
+      "BAT", CURR_FMT,CURR_LABELS }, \
     { LOG_CURRENT2_MSG, sizeof(log_Current), \
-      "CUR2", CURR_FMT,CURR_LABELS }, \
+      "BAT2", CURR_FMT,CURR_LABELS }, \
     { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
       "BCL", CURR_CELL_FMT, CURR_CELL_LABELS }, \
     { LOG_CURRENT_CELLS2_MSG, sizeof(log_Current_Cells), \

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -513,10 +513,18 @@ struct PACKED log_PID {
 struct PACKED log_Current {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    float    battery_voltage;
+    float    voltage;
+    float    voltage_resting;
     float    current_amps;
     float    current_total;
     int16_t  temperature; // degrees C * 100
+    float    resistance;
+};
+
+struct PACKED log_Current_Cells {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float    voltage;
     uint16_t cell_voltages[10];
 };
 
@@ -848,8 +856,11 @@ struct PACKED log_Beacon {
 #define QUAT_LABELS "TimeUS,Q1,Q2,Q3,Q4"
 #define QUAT_FMT    "Qffff"
 
-#define CURR_LABELS "TimeUS,Volt,Curr,CurrTot,Temp,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
-#define CURR_FMT    "QfffcHHHHHHHHHH"
+#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,Temp,Res"
+#define CURR_FMT    "Qffffcf"
+
+#define CURR_CELL_LABELS "TimeUS,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
+#define CURR_CELL_FMT    "QfHHHHHHHHHH"
 
 /*
 Format characters in the format string for binary log messages
@@ -920,6 +931,10 @@ Format characters in the format string for binary log messages
       "CURR", CURR_FMT,CURR_LABELS }, \
     { LOG_CURRENT2_MSG, sizeof(log_Current), \
       "CUR2", CURR_FMT,CURR_LABELS }, \
+    { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
+      "BCL", CURR_CELL_FMT, CURR_CELL_LABELS }, \
+    { LOG_CURRENT_CELLS2_MSG, sizeof(log_Current_Cells), \
+      "BCL2", CURR_CELL_FMT, CURR_CELL_LABELS }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
@@ -1136,6 +1151,8 @@ enum LogMessages {
     LOG_ATTITUDE_MSG,
     LOG_CURRENT_MSG,
     LOG_CURRENT2_MSG,
+    LOG_CURRENT_CELLS_MSG,
+    LOG_CURRENT_CELLS2_MSG,
     LOG_COMPASS_MSG,
     LOG_COMPASS2_MSG,
     LOG_COMPASS3_MSG,


### PR DESCRIPTION
This PR does the following:

- moves the battery resistance estimation from the copter AP_Motors library into the Battery monitor library so it can be used by all vehicles
- improves the resistance estimation by looking for short-term changes in current and voltage.  The magic behind this is all in the AP_BattMonitor_Backend::update_resistance_estimate.  @lthall is the designer so please ask your questions about how this works to him!
- optionally allows the battery failsafe to use the estimated resting voltage (i.e. voltage with sag caused by current draw removed)
- Dataflash logging of Current adds new resting voltage and resistance fields.
- Dataflash Current logging is split into two messages so that individual cell voltages appear in a new message called "CUC" and "CUC2" (CUrrent Cell).  This was done primarily because the CURR message column names were getting too long.  It also reduces the amount of logging for most users slightly.

Here's is a graph from Leonard showing how the new resistance learning performs better than the older method.
![batt_resistance_estimate](https://cloud.githubusercontent.com/assets/1498098/26615905/7d1378e0-4605-11e7-9dc5-8ed62fee699f.png)

Notice how in the top graph, the new resting voltage estimate (light-green line) is much smoother than with the older method (dark blue line).  Also notice in the bottom graph that the new resistance estimate (dark blue) is also much smoother than the older estimate (dark red).

I (Randy) found during testing on my IRIS that the resistance estimate early on in the flight was far too high leading to unrealistically high resting voltage estimates.  Leonard says he has a fix for this so I've marked this PR as "WIP".
![iris-battvoltandresistance](https://cloud.githubusercontent.com/assets/1498098/26615996/4bf47b3c-4606-11e7-81b7-a3f0072ca4bd.png)

One question is whether we should store the resistance values to a parameter to avoid learning at startup.