### PR TITLE
ArduPlane: tailsitter thrust boost proportional to pitch/yaw error

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -762,13 +762,9 @@ void Plane::update_flight_mode(void)
         nav_roll_cd  = (channel_roll->get_control_in() / 4500.0) * roll_limit;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
         float pitch_input = channel_pitch->norm_input();
-        // Scale from normalized input [-1,1] to centidegrees
-        if (quadplane.tailsitter_active()) {
-            // For tailsitters, the pitch range is symmetrical: [-Q_ANGLE_MAX,Q_ANGLE_MAX]
+        if (quadplane.is_tailsitter()) {
             nav_pitch_cd = pitch_input * quadplane.aparm.angle_max;
         } else {
-            // pitch is further constrained by LIM_PITCH_MIN/MAX which may impose
-            // tighter (possibly asymmetrical) limits than Q_ANGLE_MAX
             if (pitch_input > 0) {
                 nav_pitch_cd = pitch_input * MIN(aparm.pitch_limit_max_cd, quadplane.aparm.angle_max);
             } else {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -762,9 +762,13 @@ void Plane::update_flight_mode(void)
         nav_roll_cd  = (channel_roll->get_control_in() / 4500.0) * roll_limit;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
         float pitch_input = channel_pitch->norm_input();
-        if (quadplane.is_tailsitter()) {
+        // Scale from normalized input [-1,1] to centidegrees
+        if (quadplane.tailsitter_active()) {
+            // For tailsitters, the pitch range is symmetrical: [-Q_ANGLE_MAX,Q_ANGLE_MAX]
             nav_pitch_cd = pitch_input * quadplane.aparm.angle_max;
         } else {
+            // pitch is further constrained by LIM_PITCH_MIN/MAX which may impose
+            // tighter (possibly asymmetrical) limits than Q_ANGLE_MAX
             if (pitch_input > 0) {
                 nav_pitch_cd = pitch_input * MIN(aparm.pitch_limit_max_cd, quadplane.aparm.angle_max);
             } else {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -400,6 +400,13 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Values: 0:AUTO,1:FIXED_WING,2:QUADROTOR,3:COAXIAL,4:HELICOPTER,7:AIRSHIP,8:FREE_BALLOON,9:ROCKET,10:GROUND_ROVER,11:SURFACE_BOAT,12:SUBMARINE,16:FLAPPING_WING,17:KITE,19:VTOL_DUOROTOR,20:VTOL_QUADROTOR,21:VTOL_TILTROTOR
     AP_GROUPINFO("MAV_TYPE", 57, QuadPlane, mav_type, 0),
     
+    // @Param: TAILSIT_TCOMP
+    // @DisplayName: Tailsitter pitch error thrust gain in hover
+    // @Description: This sets the ratio of thrust boost to pitch error used in hover for a tailsitter
+    // @Range: 0 1
+    // @Increment: 0.01
+    AP_GROUPINFO("TAILSIT_TCGAIN", 57, QuadPlane, tailsitter.tcomp_gain, 0.5),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -405,7 +405,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: This sets the ratio of thrust boost to pitch error used in hover for a tailsitter
     // @Range: 0 1
     // @Increment: 0.01
-    AP_GROUPINFO("TAILSIT_TCGAIN", 57, QuadPlane, tailsitter.tcomp_gain, 0.5),
+    AP_GROUPINFO("TAILSIT_TCGAIN", 58, QuadPlane, tailsitter.tcomp_gain, 0.5),
 
     AP_GROUPEND
 };

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -383,6 +383,7 @@ private:
         AP_Float vectored_forward_gain;
         AP_Float vectored_hover_gain;
         AP_Float vectored_hover_power;
+        AP_Float tcomp_gain;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -125,7 +125,6 @@ void QuadPlane::tailsitter_output(void)
             int16_t thr_scaledL = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft);
             int16_t thr_scaledR = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight);
 
-            // boost throttle only if throttle stick is above 10%
             if (enable_boost) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, thr_boost * thr_scaledL);
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, thr_boost * thr_scaledR);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -67,12 +67,16 @@ void QuadPlane::tailsitter_output(void)
     const float throttle_servo_max = 100.0f;
 
     static float orig_pkP = -1.0f;
+    static float orig_pkD = -1.0f;
     static float orig_rkP = -1.0f;
     static float orig_ykP = -1.0f;
 
     if (tailsitter.tcomp_gain > 0) {
         if (orig_pkP < 0.0f) {
             orig_pkP = attitude_control->get_rate_pitch_pid().kP();
+        }
+        if (orig_pkD < 0.0f) {
+            orig_pkD = attitude_control->get_rate_pitch_pid().kD();
         }
         if (orig_rkP < 0.0f) {
             orig_rkP = attitude_control->get_rate_roll_pid().kP();
@@ -156,13 +160,15 @@ void QuadPlane::tailsitter_output(void)
 
         // reduce PID gains in proportion to throttle level
         float pitch_kP = orig_pkP;
+        float pitch_kD = orig_pkD;
         float roll_kP = orig_rkP;
         float yaw_kP = orig_rkP;
 
         float gain_scale = 1.0;
-        if (true && avg_thr_norm > 0.5f) { //motors->get_throttle_hover()) {
-            gain_scale = 0.5f / avg_thr_norm;
+        if (avg_thr_norm > 0.5f) { //motors->get_throttle_hover()) {
+            gain_scale = fmaxf(1.0f, 0.35f / avg_thr_norm);
             pitch_kP *= gain_scale;
+            pitch_kD *= gain_scale;
             roll_kP *= gain_scale;
             yaw_kP *= gain_scale;
         }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -98,8 +98,11 @@ void QuadPlane::tailsitter_output(void)
         // assume that k_throttle will not be assigned for twin_engine tailsitters
         bool twin_engine = !SRV_Channels::function_assigned(SRV_Channel::k_throttle);
 
-        // allow throttle boost only if throttle stick is above 10%
-        bool enable_boost = plane.channel_throttle->get_control_in() > 10;
+        // assume that k_tiltMotorLeft will be assigned for tilt-vectored dual-motor vehicles
+        bool vectored_thrust = SRV_Channels::function_assigned(SRV_Channel::k_tiltMotorLeft);
+
+        // allow throttle boost only if not tilt-vectored and throttle stick is above 10%
+        bool enable_boost = !vectored_thrust && plane.channel_throttle->get_control_in() > 10;
 
         float avg_thr_norm = 0;
         if (twin_engine) {

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -172,12 +172,12 @@ void QuadPlane::tailsitter_output(void)
 
         // temporary debug logging
         static int dec_count=0;
-        if ((dec_count++ >= 3) && (thr_boost > 1.05f)) {
+        if ((dec_count++ >= 40) && (thr_boost > 1.05f)) {
             dec_count = 0;
-//            hal.console->printf("roll_error_norm: %5.3f, thr_boosted: %5.3f, thr_scaled: %5.3f\n",
-//                    (double) roll_error_norm,
-//                    (double) thr_boosted,
-//                    (double) thr_scaled);
+            hal.console->printf("norm_err_max: %5.3f, thr_boost: %5.3f, ail_scale: %5.3f\n",
+                    (double) norm_err_max,
+                    (double) thr_boost,
+                    (double) ail_scale);
             DataFlash_Class::instance()->Log_Write("TCOM", "TimeUS,Perr,YErr,ThrA,ElvD,AilS,PkP,DesY,Yaw,Gscl", "Qfffffffff",
                                                    AP_HAL::micros64(),
                                                    (double) pitch_error_norm,

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -62,6 +62,36 @@ void QuadPlane::tailsitter_output(void)
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
 
+    if (tailsitter.tcomp_gain > 0) {
+        // boost throttle when pitch or yaw error is large
+        float pitch_error_cd = (plane.nav_pitch_cd - ahrs_view->pitch_sensor) * 0.5;
+        float pitch_error_norm = constrain_float(fabsf(pitch_error_cd), 0, 4500) / 4500.0;
+
+        float yaw_error_cd = (attitude_control->get_att_target_euler_cd().z - ahrs_view->yaw_sensor) * 0.5;
+        float yaw_error_norm = constrain_float(fabsf(yaw_error_cd), 0, 4500) / 4500.0;
+
+        float norm_err_max = fmaxf(yaw_error_norm, pitch_error_norm);
+        float thr_boost = 1.0f + norm_err_max * tailsitter.tcomp_gain;
+
+        int16_t thr_scaledL = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft);
+        int16_t thr_scaledR = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight);
+
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, thr_boost * thr_scaledL);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, thr_boost * thr_scaledR);
+
+        // temporary debug logging
+        static int dec_count=0;
+        if (dec_count++ >= 3) {
+            dec_count = 0;
+            DataFlash_Class::instance()->Log_Write("TCOM", "TimeUS,Perr,YErr,ThrB", "Qfff",
+                                                   AP_HAL::micros64(),
+                                                   (double) pitch_error_norm,
+                                                   (double) yaw_error_norm,
+                                                   (double) thr_boost);
+        }
+
+    }
+
     if (tailsitter.vectored_hover_gain > 0) {
         // thrust vectoring VTOL modes
         float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -70,6 +70,7 @@ Plane::Plane(const char *home_str, const char *frame_str) :
     }
    if (strstr(frame_str, "-tailsitter")) {
        tailsitter = true;
+       elevons = true;
        ground_behavior = GROUND_BEHAVIOR_TAILSITTER;
        thrust_scale *= 1.5;
    }


### PR DESCRIPTION
implemented in tailsitter.cpp in order to have access to attitude target values

Observation: there must be sufficient thrust margin available to boost pitch/yaw thrust with application of throttle boost. The Stryker becomes marginal on pitch authority if, for example, one uses a weak LiPo battery. Servo performance is also important, the original servos were probably overstressed since they both failed at the same time. 

The following plot shows that throttle boost is coming in each time the elevons saturate, and that this is effective in reducing tracking error:

![thrcomp4](https://cloud.githubusercontent.com/assets/2300221/26726910/0a5c6916-4762-11e7-8d4d-f78122c334bc.png)

log file: https://drive.google.com/open?id=0Bw3digSMQXDuZGJ3aE1GekZMQWc