### PR TITLE
Implement slew rate limiting and failure recovery for Solo ESC's (revised)

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1025,6 +1025,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("PILOT_SPEED_DN", 24, ParametersG2, pilot_speed_dn, 0),
 
+    AP_SUBGROUPINFO(motors_slew_rate_parameters, "MOT_SLW", 25, ParametersG2, AP_MotorsSlewRateParameters),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -577,6 +577,9 @@ public:
 
     // Additional pilot velocity items
     AP_Int16    pilot_speed_dn;
+
+    // motor slew rate limiter parameters
+    AP_MotorsSlewRateParameters motors_slew_rate_parameters;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -528,7 +528,14 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_OCTAQUAD:
         case AP_Motors::MOTOR_FRAME_DODECAHEXA:
         default:
-            motors = new AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
+            if (g2.motors_slew_rate_parameters._enabled)
+            {
+                motors = new AP_MotorsMatrixSlewRateLimited(g2.motors_slew_rate_parameters, copter.scheduler.get_loop_rate_hz());
+            }
+            else
+            {
+                motors = new AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
+            }
             motors_var_info = AP_MotorsMatrix::var_info;
             break;
         case AP_Motors::MOTOR_FRAME_TRI:

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -48,6 +48,7 @@ known_units = {
              'cs'      : 'centiseconds'          ,
              'ms'      : 'milliseconds'          ,
              'PWM'     : 'PWM in microseconds'   , # should be microseconds, this is NOT a SI unit, but follows https://github.com/ArduPilot/ardupilot/pull/5538#issuecomment-271943061
+             'PWM/s'     : 'PWM rate of chamge, in microseconds per second'   , # Rate of change of PWM value in microseconds
              'Hz'      : 'hertz'                 ,
              'kHz'     : 'kilohertz'             ,
 # distance

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -3,6 +3,8 @@
 #include "AP_Motors_Class.h"
 #include "AP_MotorsMulticopter.h"
 #include "AP_MotorsMatrix.h"
+#include "AP_MotorsMatrixSlewRateLimited.h"
+#include "AP_MotorsSlewRateParameters.h"
 #include "AP_MotorsTri.h"
 #include "AP_MotorsHeli_Single.h"
 #include "AP_MotorsHeli_Dual.h"

--- a/libraries/AP_Motors/AP_MotorsMatrixSlewRateLimited.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixSlewRateLimited.cpp
@@ -1,0 +1,300 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * AP_MotorsMatrixSlewRateLimited.cpp - ArduCopter motors library
+ *
+ * Original code by Jonathan Challinger
+ *
+ * Refactored / adapted to AC3.5 by Hugh Eaves
+ *
+ * Description:
+ *
+ * AP_MotorsMatrixSlewRateLimited is an AP_MotorsMatrix, but with the
+ * additional capability of limiting the rate of change of the motor
+ * outputs. (i.e. slew rate limiting) This is primarily to workaround
+ * an issue with signal propogation with the 3DR Solo ESC controllers,
+ * but could be applied to other applications where limiting the
+ * output slew rate could be useful.
+ *
+ */
+ 
+#include <AP_HAL/AP_HAL.h>
+#include "AP_MotorsMatrixSlewRateLimited.h"
+
+/**
+ * Constructor
+ */
+AP_MotorsMatrixSlewRateLimited::AP_MotorsMatrixSlewRateLimited(AP_MotorsSlewRateParameters& parameters, uint16_t loop_rate, uint16_t speed_hz) :
+     AP_MotorsMatrix(loop_rate, speed_hz),
+    _recovery_state(MOTOR_STATE_NORMAL),
+    _params(parameters)
+{
+
+    memset(_motor_out_pwm_actual, 0, sizeof(_motor_out_pwm_actual));
+    memset(_motor_out_pwm_max, 0, sizeof(_motor_out_pwm_max));
+    memset(_motor_out_pwm_requested, 0, sizeof(_motor_out_pwm_requested));
+    memset(_motor_out_filtered, 0, sizeof(_motor_out_filtered));
+}
+
+/**
+ * Re-initialize some state variables after the parameters have been set
+ */
+void AP_MotorsMatrixSlewRateLimited::init(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    AP_MotorsMatrix::init(frame_class, frame_type);
+    _next_state_transition_time = 0;
+    _recovery_state = MOTOR_STATE_NORMAL;
+    set_slew_rate(_params._normal_slew_rate);
+}
+
+/**
+ * Override output_to_motors, just so we can call update_recovery_state()
+ * once per loop iteration.
+ */
+void AP_MotorsMatrixSlewRateLimited::output_to_motors()
+{
+    AP_MotorsMatrix::output_to_motors();
+    update_recovery_state();
+    log_state(false);
+}
+
+/**
+ * Override rc_write so we can constrain the output
+ * based on the slew rate (if needed),
+ * and keep a record of motor output state
+ */
+void AP_MotorsMatrixSlewRateLimited::rc_write(uint8_t chan, uint16_t pwm)
+{
+   // record the requested output value
+   _motor_out_pwm_requested[chan] = pwm;
+   
+   // ensure _motor_out_pwm_max[chan] is never below activation threshold
+   _motor_out_pwm_max[chan] = MAX(_motor_out_pwm_max[chan], out_to_pwm(_params._limiter_low_threshold) - _slew_per_iteration);
+
+   // calculate difference between requested output and current max output
+   float output_delta = pwm - _motor_out_pwm_max[chan];
+
+   // adjust the max output, based on the requested output
+   if (output_delta > _slew_per_iteration) {
+       output_delta = _slew_per_iteration;
+   } else if (output_delta < -_slew_per_iteration) {
+       output_delta = -_slew_per_iteration;
+   }
+   _motor_out_pwm_max[chan] += output_delta;
+
+   // constrain output to be less than or equal to max output
+   pwm = MIN(pwm, _motor_out_pwm_max[chan]);
+
+   // Now that we've done all the calculations, call the parent
+   // class rc_write to actually output the new values.
+   // The parent method handles channel remapping, etc.
+   AP_MotorsMatrix::rc_write(chan, pwm);
+
+   // record the actual output value
+   _motor_out_pwm_actual[chan] = pwm;
+}
+
+void AP_MotorsMatrixSlewRateLimited::update_recovery_state()
+{
+    uint64_t current_time = AP_HAL::micros64();
+
+    if (!armed())
+    {
+        reset_failure_detector(current_time);
+        return;
+    }
+
+    // check to see if we need to re-examine the recovery state
+    if (current_time >= _next_state_transition_time)
+    {
+        switch (_recovery_state)
+        {
+        case MOTOR_STATE_NORMAL:
+            if (detect_motor_failure(current_time)) {
+                ++_failure_count;
+                set_state(MOTOR_STATE_RECOVERY);
+                start_motor_recovery(current_time);
+            }
+            break;
+
+        case MOTOR_STATE_RECOVERY:
+            set_state(MOTOR_STATE_POST_RECOVERY);
+            set_slew_rate(_params._normal_slew_rate);
+            reset_failure_detector(current_time);
+            _next_state_transition_time = current_time + _params._post_recovery_time_ms * 1000;
+            break;
+
+        case MOTOR_STATE_POST_RECOVERY:
+            set_state(MOTOR_STATE_NORMAL);
+            set_slew_rate(_params._normal_slew_rate);
+            reset_failure_detector(current_time);
+            _next_state_transition_time = 0;
+            break;
+        }
+    }
+}
+
+bool AP_MotorsMatrixSlewRateLimited::detect_motor_failure(uint64_t current_time)
+{
+    // find highest motor and motor average
+    uint8_t highest_motor_index = 0;
+    float highest_motor = 0.0f;
+    float motor_avg = 0.0f;
+    uint8_t motor_count = 0;
+    bool failed = false;
+
+    // calculate alpha value for motor failure detection low pass filter
+    float motor_filt_alpha = constrain_float((2.0f*M_PI*_params._detection_filter_frequency) /
+       ((2.0f*M_PI*_params._detection_filter_frequency) + _loop_rate),0.0f,1.0f);
+
+    for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        _motor_out_filtered[i] += (get_requested_motor_out(i) - _motor_out_filtered[i]) * motor_filt_alpha;
+
+        if (motor_enabled[i]) {
+            if (_motor_out_filtered[i] > highest_motor) {
+                highest_motor = _motor_out_filtered[i];
+                highest_motor_index = i;
+            }
+
+            motor_avg += _motor_out_filtered[i];
+            motor_count++;
+        }
+    }
+
+    motor_avg /= motor_count;
+
+
+    bool motor_fail_criteria_met = (highest_motor_index == _last_highest_motor) &&
+       (highest_motor >= _params._detection_high_threshold) && (motor_avg <= _params._detection_low_threshold);
+
+    if (!motor_fail_criteria_met) {
+        _last_motor_good_time = current_time;
+    } else if(current_time - _last_motor_good_time > ((uint32_t)_params._detection_time_ms) * 1000) {
+        // if criteria for a motor failure are met continuously for _detection_time seconds
+       failed = true;
+    }
+
+    _last_highest_motor = highest_motor_index;
+
+    return failed;
+}
+
+/**
+ * Start a motor recovery
+ */
+void AP_MotorsMatrixSlewRateLimited::start_motor_recovery(uint64_t current_time)
+{
+    set_slew_rate(_params._recovery_slew_rate);
+
+    // Set the last motor output based on the recovery percentage
+    // The slew rate limiter will force the actual outputs to be this
+    // value +- one slew rate increment during the next loop iteration.
+    float recovery_pwm = out_to_pwm(_params._recovery_output) - _slew_per_iteration;
+    for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            _motor_out_pwm_max[i] = recovery_pwm;
+        }
+    }
+
+    // calculate the total recovery time, in seconds
+    float recovery_time_length = (get_pwm_output_max() - out_to_pwm(_params._recovery_output)) / _params._recovery_slew_rate;
+    // set the state transition time after recovery is complete
+    _next_state_transition_time = current_time + (recovery_time_length * 1000 * 1000);
+}
+
+/**
+ * Get the motor output as a percentage
+ */
+float AP_MotorsMatrixSlewRateLimited::get_requested_motor_out(uint8_t mot)
+{
+    return (mot<AP_MOTORS_MAX_NUM_MOTORS) ? pwm_to_out(_motor_out_pwm_requested[mot]) : 0.0f;
+}
+
+/**
+ * Convert a PWM value to a proportion of full output, using the
+ * configured pwm_output_max and pwm_output_min.
+ */
+float AP_MotorsMatrixSlewRateLimited::pwm_to_out(uint16_t pwm)
+{
+    return ((float)pwm - get_pwm_output_min()) / (get_pwm_output_max()-get_pwm_output_min());
+}
+
+/**
+ * Convert a proportion of full output to a PWM value, using the
+ * configured pwm_output_max and pwm_output_min.
+ */
+float AP_MotorsMatrixSlewRateLimited::out_to_pwm(float out)
+{
+    return (get_pwm_output_min() + ((get_pwm_output_max()-get_pwm_output_min()) * out));
+}
+
+/**
+ * Set the slew per iteration value based on a slew rate in slew per seconds
+ */
+void AP_MotorsMatrixSlewRateLimited::set_slew_rate(float slew_per_second)
+{
+    _slew_per_iteration = slew_per_second / _loop_rate;
+}
+
+/**
+ * Clears / resets the motor failure detection state
+ */
+void AP_MotorsMatrixSlewRateLimited::reset_failure_detector(uint64_t current_time)
+{
+    _last_motor_good_time = current_time;
+    for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        _motor_out_filtered[i] = get_requested_motor_out(i);
+    }
+}
+
+void AP_MotorsMatrixSlewRateLimited::set_state(motor_recovery_state new_state)
+{
+    _recovery_state = new_state;
+    log_state(true);
+}
+
+void AP_MotorsMatrixSlewRateLimited::log_state(bool force)
+{
+    uint64_t current_time = AP_HAL::micros64();
+
+    if (force || current_time > _next_log_time) {
+        _next_log_time = current_time + (_params._log_interval_ms * 1000);
+
+        DataFlash_Class::instance()->Log_Write("SLW1",
+            "TimeUS,State,FailCnt,NxtTrans,SlwRt", "QIHIf",
+            current_time, _recovery_state,
+            _failure_count, _next_state_transition_time, _slew_per_iteration);
+
+        if (_params._debug != 0) {
+            for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+                if (motor_enabled[i]) {
+                    DataFlash_Class::instance()->Log_Write("SLW2",
+                        "TimeUS,Motor,Req,Act,Max,Filt",
+                        "QIffIf", current_time, i,
+                        _motor_out_pwm_requested[i], _motor_out_pwm_actual[i],
+                        _motor_out_pwm_max[i], _motor_out_filtered[i]);
+                }
+            }
+
+            DataFlash_Class::instance()->Log_Write("SLW3",
+                "TimeUS,LstHstMtr,LstGdTm",
+                "QIII", current_time, _last_highest_motor, _last_motor_good_time);
+        }
+    }
+}
+
+

--- a/libraries/AP_Motors/AP_MotorsMatrixSlewRateLimited.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixSlewRateLimited.h
@@ -1,0 +1,100 @@
+/// @file	AP_MotorsMatrixSlewRateLimited.h
+/// @brief	Motor control class for Matrixcopters with output slew rate limiting
+#pragma once
+
+#include <DataFlash/DataFlash.h>
+#include "AP_MotorsMatrix.h"
+#include "AP_MotorsSlewRateParameters.h"
+
+/// @class      AP_MotorsMatrixSlewRateLimited
+class AP_MotorsMatrixSlewRateLimited : public AP_MotorsMatrix {
+public:
+    AP_MotorsMatrixSlewRateLimited(AP_MotorsSlewRateParameters& parameters, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
+
+    // override of init from parent class
+    void init(motor_frame_class frame_class, motor_frame_type frame_type);
+
+    // override of output_to_motors
+    void output_to_motors();
+
+    // override of rc_write
+    void rc_write(uint8_t chan, uint16_t pwm);
+
+protected:
+    // Motor recovery states
+    enum motor_recovery_state {
+        MOTOR_STATE_NORMAL = 0,
+        MOTOR_STATE_RECOVERY = 1,
+        MOTOR_STATE_POST_RECOVERY = 2
+    };
+
+    // check and update the current recovery state
+    void update_recovery_state();
+
+    // checks for motor failure, returns true of a failure has been detected
+    bool detect_motor_failure(uint64_t current_time);
+
+    // resets the recovery state
+    void reset_failure_detector(uint64_t current_time);
+
+    // start a motor recovery
+    void start_motor_recovery(uint64_t current_time);
+
+    // return the requested output level for the given motor as a
+    // proportion of full output (0.0 - 1.0)
+    float get_requested_motor_out(uint8_t mot);
+
+    // convert the given pwm value to a proportion of full output (0.0 - 1.0)
+    float pwm_to_out(uint16_t pwm);
+
+    // convert a value representing the proportion of full output (0.0 - 1.0)
+    // to a pwm value
+    float out_to_pwm(float output);
+
+    // set the slew rate per interation value based on a slew per second rate
+    void set_slew_rate(float slew_per_second);
+
+    AP_MotorsSlewRateParameters& _params;
+
+    // Next time that the system should check for a state change. 0 indicates right away.
+    uint64_t _next_state_transition_time = 0;
+
+    // Current state
+    motor_recovery_state _recovery_state = MOTOR_STATE_NORMAL;
+
+    // Current slew rate in PWM change / loop iteration
+    float _slew_per_iteration = 0;
+
+    /***
+     * Motor state information
+     */
+
+    // last pwm output sent to motor
+    float _motor_out_pwm_actual[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // current maximum allowed pwm output - adjusted up and down by slew rate limiter
+    float _motor_out_pwm_max[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // last requested pwm output (not always equal to actual about, if slew rate is limited)
+    uint16_t _motor_out_pwm_requested[AP_MOTORS_MAX_NUM_MOTORS];
+
+    /*****
+    * Motor failure detector state
+    */
+    uint8_t _last_highest_motor = 0;
+    uint64_t _last_motor_good_time = 0;
+    float _motor_out_filtered[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // track total number of failure events since start
+    uint16_t _failure_count = 0;
+
+    // time of next log message for log message throttling
+    uint64_t _next_log_time = 0;
+
+private:
+    // set the motor recovery state
+    void set_state(motor_recovery_state new_state);
+
+    // log the current state of the slew rate limiter
+    void log_state(bool force);
+};

--- a/libraries/AP_Motors/AP_MotorsSlewRateParameters.cpp
+++ b/libraries/AP_Motors/AP_MotorsSlewRateParameters.cpp
@@ -1,0 +1,133 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/**
+ *
+ * AP_MotorsSlewRateParameters.cpp - ArduCopter motors library
+ *
+ * Description:
+ *
+ * As there doesn't seem to be a straightforward way to define 
+ * parameters for subclasses, this class provides a parameter "container"
+ * holding all the parameters for AP_MotorsMatrixSlewRateLimited, which
+ * is a subclass of AP_MotorsMatrix.
+ *
+ */
+ 
+#include "AP_MotorsSlewRateParameters.h"
+
+// parameters for the AP_MotorsMatrixSlewRateLimited class
+const AP_Param::GroupInfo AP_MotorsSlewRateParameters::var_info[] = {
+    // @Param: ENABLED
+    // @DisplayName: Slew rate limiter enabled or disabled
+    // @Description: Slew rate limiter enabled or disabled
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLED", 0, AP_MotorsSlewRateParameters, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    
+    // @Param: RT_NORM
+    // @DisplayName: Normal Motor Slew Rate
+    // @Description: Maximum allowed change in motor PWM output per second, during normal operation
+    // @Units: PWM/s
+    // @Range: 0 25000
+    // @User: Advanced
+    AP_GROUPINFO("RT_NORM", 1, AP_MotorsSlewRateParameters, _normal_slew_rate, AP_MOTORS_NORMAL_SLEW_RATE_DEFAULT),
+
+    // @Param: RT_RCOV
+    // @DisplayName: Recovery Motor Slew Rate
+    // @Description: Maximum allowed change in motor PWM output per second, during recovery / restart
+    // @Units: PWM/s
+    // @Range: 0 25000
+    // @User: Advanced
+    AP_GROUPINFO("RT_RCOV", 2, AP_MotorsSlewRateParameters, _recovery_slew_rate, AP_MOTORS_RECOVERY_SLEW_RATE_DEFAULT),
+
+    // @Param: RCOV_OUT
+    // @DisplayName: Motor Recovery Output Power
+    // @Description: Motor output level to use when starting motor recovery (proportion of max pwm output)
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("RCOV_OUT", 3, AP_MotorsSlewRateParameters, _recovery_output, AP_MOTORS_RECOVERY_OUTPUT_DEFAULT),
+
+    // @Param: DET_HIGH
+    // @DisplayName: Motor Failure Detection High Threshold
+    // @Description: Motor output level high threshold for failure detection (proportion of max pwm output)
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("DET_HIGH", 4, AP_MotorsSlewRateParameters, _detection_high_threshold, AP_MOTORS_RECOVERY_HIGH_MOTOR_THRESHOLD_DEFAULT),
+
+    // @Param: DET_LOW
+    // @DisplayName: Motor Failure Detection Low Threshold
+    // @Description: Motor output level low threshold for failure detection (proportion of max pwm output)
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("DET_LOW", 5, AP_MotorsSlewRateParameters, _detection_low_threshold, AP_MOTORS_RECOVERY_LOW_AVG_THRESHOLD_DEFAULT),
+
+    // @Param: DET_TIME
+    // @DisplayName: Motor Failure Detection Time
+    // @Description: Minimum time exceeding threshold to trigger failure detection
+    // @Units: ms
+    // @Range: 0 2000
+    // @User: Advanced
+    AP_GROUPINFO("DET_TIME", 6, AP_MotorsSlewRateParameters, _detection_time_ms, AP_MOTORS_RECOVERY_DETECTION_TIME_DEFAULT),
+
+    // @Param: DET_FREQ
+    // @DisplayName: Motor Failure Detection Filter Frequency
+    // @Description: Frequency used in failure detection low pass filter
+    // @Units: Hz
+    // @Range: 0 10
+    // @User: Advanced
+    AP_GROUPINFO("DET_FREQ", 7, AP_MotorsSlewRateParameters, _detection_filter_frequency, AP_MOTORS_RECOVERY_MOT_FILT_HZ_DEFAULT),
+
+    // @Param: DLY_TIME
+    // @DisplayName: Motor Failure Post Recovery Delay Time
+    // @Description: Time after motor recovery during which failure detection is disabled
+    // @Units: ms
+    // @Range: 0 2000
+    // @User: Advanced
+    AP_GROUPINFO("DLY_TIME", 8, AP_MotorsSlewRateParameters, _post_recovery_time_ms, AP_MOTORS_RECOVERY_POST_DELAY_DEFAULT),
+
+    // @Param: LIM_LOW
+    // @DisplayName: Lower Output Power Threshold for Limiter
+    // @Description: Output power above which the slew rate limiter becomes active.
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("LIM_LOW", 9, AP_MotorsSlewRateParameters, _limiter_low_threshold, AP_MOTORS_SLEW_RATE_LIMITER_LOW_THRESHOLD_DEFAULT),
+
+    // @Param: LOG_INT
+    // @DisplayName: Slew Rate Limiter Logging Interval
+    // @Description: Minimum time between slew rate limiter log messages.
+    // @Units: ms
+    // @Range: 0 2000
+    // @User: Advanced
+    AP_GROUPINFO("LOG_INT", 10, AP_MotorsSlewRateParameters, _log_interval_ms, AP_MOTORS_LOG_INTERVAL_DEFAULT),
+
+    // @Param: DEBUG
+    // @DisplayName: Slew Rate Limiter Debug Enable
+    // @Description: Enable debugging for slew rate limiter.
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("DEBUG", 11, AP_MotorsSlewRateParameters, _debug, 0),
+
+    AP_GROUPEND
+};
+
+
+/**
+ * Constructor
+ */
+AP_MotorsSlewRateParameters::AP_MotorsSlewRateParameters()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}

--- a/libraries/AP_Motors/AP_MotorsSlewRateParameters.h
+++ b/libraries/AP_Motors/AP_MotorsSlewRateParameters.h
@@ -1,0 +1,78 @@
+/// @file	AP_MotorsSlewRateParameters.h
+/// @brief	Parameters for AP_MotorsMatrixSlewRateLimited
+
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+// Default normal slew rate (change in PWM output / sec)
+#define AP_MOTORS_NORMAL_SLEW_RATE_DEFAULT 2400
+
+// Default recovery slew rate (change in PWM output / sec)
+#define AP_MOTORS_RECOVERY_SLEW_RATE_DEFAULT 3600
+
+// Default motor recovery output level
+#define AP_MOTORS_RECOVERY_OUTPUT_DEFAULT 0.5f
+
+// Default logging interval
+#define AP_MOTORS_LOG_INTERVAL_DEFAULT 50
+
+/*****
+* Motor failure detection parameters
+*/
+#define AP_MOTORS_RECOVERY_HIGH_MOTOR_THRESHOLD_DEFAULT 0.95f
+#define AP_MOTORS_RECOVERY_LOW_AVG_THRESHOLD_DEFAULT 0.77f
+#define AP_MOTORS_RECOVERY_DETECTION_TIME_DEFAULT 200
+#define AP_MOTORS_RECOVERY_POST_DELAY_DEFAULT 750
+#define AP_MOTORS_RECOVERY_MOT_FILT_HZ_DEFAULT 5.0f
+#define AP_MOTORS_SLEW_RATE_LIMITER_LOW_THRESHOLD_DEFAULT 0.36f
+
+
+/// @class      AP_MotorsSlewRateParameters
+class AP_MotorsSlewRateParameters {
+public:
+    AP_MotorsSlewRateParameters();
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo        var_info[];
+    
+   /****
+     * Parameter values
+     */
+
+    // slew rate limiter enabled
+    AP_Int8 _enabled;
+
+    // the slew rate used during normal motor operation (PWM us/sec)
+    AP_Float _normal_slew_rate;
+
+    // the slew rate used when a motor recovery is underway (PWM us/sec)
+    AP_Float _recovery_slew_rate;
+
+    // the initial motor output level when a recovery is started (proportion of full output, 0-1.0)
+    AP_Float _recovery_output;
+
+    // motor failure detection high threshold (proportion of full output, 0-1.0)
+    AP_Float _detection_high_threshold;
+
+    // motor failure detection low threshold (proportion of full output, 0-1.0)
+    AP_Float _detection_low_threshold;
+
+    // amount of time output imbalance must be present before triggering failure recovery
+    AP_Int32 _detection_time_ms;
+
+    // amount of time after a failure recovery before a new failure recovery can be initated
+    AP_Int32 _post_recovery_time_ms;
+
+    // failure detection low pass filter frequncy (Hz)
+    AP_Float _detection_filter_frequency;
+
+    // output power at which slew rate limiter becomes active
+    AP_Float _limiter_low_threshold;
+
+    // minimum time between log messages
+    AP_Int32 _log_interval_ms;
+
+    // debug slew rate limiter
+    AP_Int8 _debug;
+};


### PR DESCRIPTION
This is my rebase of the slew rate limiting and motor failure detection recovery code from ardupilot-solo onto AC3.5 to resolve issue #5988 .

In ardupilot-solo the slew rate and recovery code was sprinkled throughout a number of core files. As Solo is only a small part of the AC user base, I attempted to extract and decouple (as much as possible) the slew rate code from the rest of the AC code. I evaluated different ways of doing this, but the best approach seemed to be to create a new subclass of AC_MotorsMatrix that is swapped in and out based on a top level parameter.

Please take a look at these changes, and let me know what you think.

Thanks,
Hugh

Note: this is a replacement for my orginal PR #6356, which was incorrectly based on the Copter branch.