### PR TITLE
ArduPlane: Fix missing break in GCS_MAVLink

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -699,6 +699,7 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
     case MSG_AOA_SSA:
         CHECK_PAYLOAD_SIZE(AOA_SSA);
         plane.send_aoa_ssa(chan);
+        break;
     case MSG_LANDING:
         plane.landing.send_landing_message(chan);
         break;


### PR DESCRIPTION
Was causing AOA_SSA to send a landing message as well.

Coverity reported it.