### PR TITLE
build:  add rsync command + --upload option for linux boards

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -269,6 +269,12 @@ class linux(Board):
             'AP_HAL_Linux',
         ]
 
+    def build(self, bld):
+        super(linux, self).build(bld)
+        if bld.options.upload:
+            waflib.Options.commands.append('rsync')
+            # Avoid infinite recursion
+            bld.options.upload = False
 
 class minlure(linux):
     def configure_env(self, cfg, env):

--- a/wscript
+++ b/wscript
@@ -397,3 +397,18 @@ for program_group in ('all', 'bin', 'tools', 'examples', 'tests', 'benchmarks'):
         program_group_list=program_group,
         doc='builds all programs of %s group' % program_group,
     )
+
+class LocalInstallContext(Build.InstallContext):
+    """runs install using BLD/install as destdir, where BLD is the build variant directory"""
+    cmd = 'linstall'
+
+    def __init__(self, **kw):
+        super(LocalInstallContext, self).__init__(**kw)
+        self.local_destdir = os.path.join(self.variant_dir, 'install')
+
+    def execute(self):
+        old_destdir = self.options.destdir
+        self.options.destdir = self.local_destdir
+        r = super(LocalInstallContext, self).execute()
+        self.options.destdir = old_destdir
+        return r


### PR DESCRIPTION
Hi all,

This PR tries to address #6283. It does so by creating a more general `rsync` command and making `linux` boards add it to the command chain when the user passes the `--upload` build option.

One not so good side-effect of this approach is that a command like `waf copter --upload` is executed actually as two commands (`copter` and `rsync`) and the build summary is output twice to the user.

@lucasdemarchi, does that somehow addresses your issue?

Best,
Gustavo Sousa