### PR TITLE
Allow to embed parameters in ROMFS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -568,3 +568,4 @@ class aerofc_v1(px4):
         self.board_name = 'aerofc-v1'
         self.romfs_exclude(['oreoled.bin'])
         self.board_rc = True
+        self.param_defaults = '../../../Tools/Frame_params/intel-aero-rtf.param'

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -460,6 +460,12 @@ class px4(Board):
         # be searched for in sources and installed in ROMFS as rc.board. This
         # init script is used to change the init behavior among different boards.
         self.board_rc = False
+
+        # Path relative to the ROMFS directory where to find a file with default
+        # parameters. If set this file will be copied to /etc/defaults.parm
+        # inside the ROMFS
+        self.param_defaults = None
+
         self.ROMFS_EXCLUDE = []
 
     def configure(self, cfg):
@@ -504,6 +510,7 @@ class px4(Board):
         env.PX4_BOARD_NAME = self.board_name
         env.PX4_BOARD_RC = self.board_rc
         env.PX4_PX4IO_NAME = self.px4io_name
+        env.PX4_PARAM_DEFAULTS = self.param_defaults
 
         env.AP_PROGRAM_AS_STLIB = True
 

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -200,6 +200,9 @@ def _process_romfs(self):
         board_rc = 'init.d/rc.%s' % bld.env.get_flat('PX4_BOARD_NAME')
         file_list.append((board_rc, 'init.d/rc.board'))
 
+    if bld.env.PX4_PARAM_DEFAULTS:
+        file_list.append((bld.env.PX4_PARAM_DEFAULTS, 'defaults.parm'))
+
     romfs_src = bld.srcnode.find_dir(bld.env.PX4_ROMFS_SRC)
     romfs_bld = bld.bldnode.make_node(bld.env.PX4_ROMFS_BLD)
 

--- a/libraries/AP_HAL/board/px4.h
+++ b/libraries/AP_HAL/board/px4.h
@@ -35,7 +35,8 @@
 #define HAL_STORAGE_SIZE            16384
 #define USE_FLASH_STORAGE           1
 // we don't have any sdcard
-#undef HAL_OS_POSIX_IO
+#undef HAL_BOARD_LOG_DIRECTORY
+#undef HAL_BOARD_TERRAIN_DIRECTORY
 #else
 #error "Unknown PX4 board type"
 #endif


### PR DESCRIPTION
This allows PX4-based boards to embed default parameters in the ROMFS, saving them as /etc/defaults.parm. This sets the defaults for aerofc, to be used in the Intel Aero RTF.