### PR TITLE
Copter, Sub: consolidate set-home functions

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -179,16 +179,6 @@ void Copter::setup()
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
- */
-void Copter::compass_accumulate(void)
-{
-    if (g.compass_enabled) {
-        compass.accumulate();
-    }
-}
-
-/*
   try to accumulate a baro reading
  */
 void Copter::barometer_accumulate(void)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -762,10 +762,8 @@ private:
     void userhook_SuperSlowLoop();
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location();
-    bool set_home_to_current_location_and_lock();
-    bool set_home_and_lock(const Location& loc);
-    bool set_home(const Location& loc);
+    bool set_home_to_current_location(bool lock);
+    bool set_home(const Location& loc, bool lock);
     bool far_from_EKF_origin(const Location& loc);
     void set_system_time_from_GPS();
     void exit_mission();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -285,6 +285,7 @@ private:
             uint8_t motor_interlock_switch  : 1; // 23      // true if pilot is requesting motor interlock enable
             uint8_t in_arming_delay         : 1; // 24      // true while we are armed but waiting to spin motors
             uint8_t initialised_params      : 1; // 25      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
+            uint8_t compass_init_location   : 1; // 26      // true when the compass's initial location has been set
         };
         uint32_t value;
     } ap;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1156,7 +1156,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             // param7 : altitude (absolute)
             result = MAV_RESULT_FAILED; // assume failure
             if(is_equal(packet.param1,1.0f) || (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7))) {
-                if (copter.set_home_to_current_location_and_lock()) {
+                if (copter.set_home_to_current_location(true)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
             } else {
@@ -1168,7 +1168,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                if (copter.set_home_and_lock(new_home_loc)) {
+                if (copter.set_home(new_home_loc, true)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
             }
@@ -2005,7 +2005,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         mavlink_set_home_position_t packet;
         mavlink_msg_set_home_position_decode(msg, &packet);
         if((packet.latitude == 0) && (packet.longitude == 0) && (packet.altitude == 0)) {
-            copter.set_home_to_current_location_and_lock();
+            copter.set_home_to_current_location(true);
         } else {
             // sanity check location
             if (!check_latlng(packet.latitude, packet.longitude)) {
@@ -2015,7 +2015,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             new_home_loc.lat = packet.latitude;
             new_home_loc.lng = packet.longitude;
             new_home_loc.alt = packet.altitude / 10;
-            copter.set_home_and_lock(new_home_loc);
+            copter.set_home(new_home_loc, true);
         }
         break;
     }

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -72,10 +72,6 @@ bool Copter::set_home(const Location& loc, bool lock)
 
     // init inav and compass declination
     if (ap.home_state == HOME_UNSET) {
-        // Set compass declination automatically
-        if (g.compass_enabled) {
-            compass.set_initial_location(gps.location().lat, gps.location().lng);
-        }
         // update navigation scalers.  used to offset the shrinking longitude as we go towards the poles
         scaleLongDown = longitude_scale(loc);
         // record home is set

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -20,7 +20,7 @@ void Copter::update_home_from_EKF()
         set_home_to_current_location_inflight();
     } else {
         // move home to current ekf location (this will set home_state to HOME_SET)
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     }
 }
 
@@ -31,37 +31,16 @@ void Copter::set_home_to_current_location_inflight() {
     if (inertial_nav.get_location(temp_loc)) {
         const struct Location &ekf_origin = inertial_nav.get_origin();
         temp_loc.alt = ekf_origin.alt;
-        set_home(temp_loc);
+        set_home(temp_loc, false);
     }
 }
 
 // set_home_to_current_location - set home to current GPS location
-bool Copter::set_home_to_current_location() {
+bool Copter::set_home_to_current_location(bool lock) {
     // get current location from EKF
     Location temp_loc;
     if (inertial_nav.get_location(temp_loc)) {
-        return set_home(temp_loc);
-    }
-    return false;
-}
-
-// set_home_to_current_location_and_lock - set home to current location and lock so it cannot be moved
-bool Copter::set_home_to_current_location_and_lock()
-{
-    if (set_home_to_current_location()) {
-        set_home_state(HOME_SET_AND_LOCKED);
-        return true;
-    }
-    return false;
-}
-
-// set_home_and_lock - sets ahrs home (used for RTL) to specified location and locks so it cannot be moved
-//  unless this function is called again
-bool Copter::set_home_and_lock(const Location& loc)
-{
-    if (set_home(loc)) {
-        set_home_state(HOME_SET_AND_LOCKED);
-        return true;
+        return set_home(temp_loc, lock);
     }
     return false;
 }
@@ -69,7 +48,7 @@ bool Copter::set_home_and_lock(const Location& loc)
 // set_home - sets ahrs home (used for RTL) to specified location
 //  initialises inertial nav and compass on first call
 //  returns true if home location set successfully
-bool Copter::set_home(const Location& loc)
+bool Copter::set_home(const Location& loc, bool lock)
 {
     // check location is valid
     if (loc.lat == 0 && loc.lng == 0) {
@@ -109,6 +88,11 @@ bool Copter::set_home(const Location& loc)
                 DataFlash.Log_Write_Mission_Cmd(mission, temp_cmd);
             }
         }
+    }
+
+    // lock home position
+    if (lock) {
+        set_home_state(HOME_SET_AND_LOCKED);
     }
 
     // log ahrs home and ekf origin dataflash

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -1102,9 +1102,9 @@ void Copter::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Copter::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if(cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     } else {
-        set_home(cmd.content.location);
+        set_home(cmd.content.location, false);
     }
 }
 

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -175,7 +175,7 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
         Log_Write_Event(DATA_EKF_ALT_RESET);
     } else if (ap.home_state == HOME_SET_NOT_LOCKED) {
         // Reset home position if it has already been set before (but not locked)
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     }
     calc_distance_and_bearing();
 

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -109,6 +109,28 @@ void Copter::init_compass()
     ahrs.set_compass(&compass);
 }
 
+/*
+  if the compass is enabled then try to accumulate a reading
+  also update initial location used for declination
+ */
+void Copter::compass_accumulate(void)
+{
+    if (!g.compass_enabled) {
+        return;
+    }
+
+    compass.accumulate();
+
+    // update initial location used for declination
+    if (!ap.compass_init_location) {
+        Location loc;
+        if (ahrs.get_position(loc)) {
+            compass.set_initial_location(loc.lat, loc.lng);
+            ap.compass_init_location = true;
+        }
+    }
+}
+
 // initialise optical flow sensor
 void Copter::init_optflow()
 {

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -94,16 +94,6 @@ void Sub::setup()
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
- */
-void Sub::compass_accumulate(void)
-{
-    if (g.compass_enabled) {
-        compass.accumulate();
-    }
-}
-
-/*
   try to accumulate a baro reading
  */
 void Sub::barometer_accumulate(void)

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1138,7 +1138,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
             // param7 : altitude (absolute)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1,1.0f) || (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7))) {
-                if (sub.set_home_to_current_location_and_lock()) {
+                if (sub.set_home_to_current_location(true)) {
                     result = MAV_RESULT_ACCEPTED;
                 }
             } else {
@@ -1151,7 +1151,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
                 if (!sub.far_from_EKF_origin(new_home_loc)) {
-                    if (sub.set_home_and_lock(new_home_loc)) {
+                    if (sub.set_home(new_home_loc, true)) {
                         result = MAV_RESULT_ACCEPTED;
                     }
                 }
@@ -1789,7 +1789,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         mavlink_set_home_position_t packet;
         mavlink_msg_set_home_position_decode(msg, &packet);
         if ((packet.latitude == 0) && (packet.longitude == 0) && (packet.altitude == 0)) {
-            sub.set_home_to_current_location_and_lock();
+            sub.set_home_to_current_location(true);
         } else {
             // sanity check location
             if (!check_latlng(packet.latitude, packet.longitude)) {
@@ -1802,7 +1802,7 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
             if (sub.far_from_EKF_origin(new_home_loc)) {
                 break;
             }
-            sub.set_home_and_lock(new_home_loc);
+            sub.set_home(new_home_loc, true);
         }
         break;
     }

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -234,6 +234,7 @@ private:
             uint8_t at_bottom           : 1; // true if we are at the bottom
             uint8_t at_surface          : 1; // true if we are at the surface
             uint8_t depth_sensor_present: 1; // true if there is a depth sensor detected at boot
+            uint8_t compass_init_location:1; // true when the compass's initial location has been set
         };
         uint32_t value;
     } ap;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -525,10 +525,8 @@ private:
     void userhook_SuperSlowLoop();
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location();
-    bool set_home_to_current_location_and_lock();
-    bool set_home_and_lock(const Location& loc);
-    bool set_home(const Location& loc);
+    bool set_home_to_current_location(bool lock);
+    bool set_home(const Location& loc, bool lock);
     bool far_from_EKF_origin(const Location& loc);
     void set_system_time_from_GPS();
     void exit_mission();

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -20,7 +20,7 @@ void Sub::update_home_from_EKF()
         set_home_to_current_location_inflight();
     } else {
         // move home to current ekf location (this will set home_state to HOME_SET)
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     }
 }
 
@@ -32,12 +32,12 @@ void Sub::set_home_to_current_location_inflight()
     if (inertial_nav.get_location(temp_loc)) {
         const struct Location &ekf_origin = inertial_nav.get_origin();
         temp_loc.alt = ekf_origin.alt;
-        set_home(temp_loc);
+        set_home(temp_loc, false);
     }
 }
 
 // set_home_to_current_location - set home to current GPS location
-bool Sub::set_home_to_current_location()
+bool Sub::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
     Location temp_loc;
@@ -48,28 +48,7 @@ bool Sub::set_home_to_current_location()
         // This also ensures that mission items with relative altitude frame, are always
         // relative to the water's surface, whether in a high elevation lake, or at sea level.
         temp_loc.alt -= barometer.get_altitude() * 100.0f;
-        return set_home(temp_loc);
-    }
-    return false;
-}
-
-// set_home_to_current_location_and_lock - set home to current location and lock so it cannot be moved
-bool Sub::set_home_to_current_location_and_lock()
-{
-    if (set_home_to_current_location()) {
-        set_home_state(HOME_SET_AND_LOCKED);
-        return true;
-    }
-    return false;
-}
-
-// set_home_and_lock - sets ahrs home (used for RTL) to specified location and locks so it cannot be moved
-//  unless this function is called again
-bool Sub::set_home_and_lock(const Location& loc)
-{
-    if (set_home(loc)) {
-        set_home_state(HOME_SET_AND_LOCKED);
-        return true;
+        return set_home(temp_loc, lock);
     }
     return false;
 }
@@ -77,7 +56,7 @@ bool Sub::set_home_and_lock(const Location& loc)
 // set_home - sets ahrs home (used for RTL) to specified location
 //  initialises inertial nav and compass on first call
 //  returns true if home location set successfully
-bool Sub::set_home(const Location& loc)
+bool Sub::set_home(const Location& loc, bool lock)
 {
     // check location is valid
     if (loc.lat == 0 && loc.lng == 0) {
@@ -105,6 +84,11 @@ bool Sub::set_home(const Location& loc)
                 DataFlash.Log_Write_Mission_Cmd(mission, temp_cmd);
             }
         }
+    }
+
+    // lock home position
+    if (lock) {
+        set_home_state(HOME_SET_AND_LOCKED);
     }
 
     // log ahrs home and ekf origin dataflash

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -68,10 +68,6 @@ bool Sub::set_home(const Location& loc, bool lock)
 
     // init inav and compass declination
     if (ap.home_state == HOME_UNSET) {
-        // Set compass declination automatically
-        if (g.compass_enabled) {
-            compass.set_initial_location(gps.location().lat, gps.location().lng);
-        }
         // update navigation scalers.  used to offset the shrinking longitude as we go towards the poles
         scaleLongDown = longitude_scale(loc);
         // record home is set

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -840,10 +840,10 @@ void Sub::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Sub::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     } else {
         if (!far_from_EKF_origin(cmd.content.location)) {
-            set_home(cmd.content.location);
+            set_home(cmd.content.location, false);
         }
     }
 }

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -55,7 +55,7 @@ bool Sub::init_arm_motors(bool arming_from_gcs)
         // Log_Write_Event(DATA_EKF_ALT_RESET);
     } else if (ap.home_state == HOME_SET_NOT_LOCKED) {
         // Reset home position if it has already been set before (but not locked)
-        set_home_to_current_location();
+        set_home_to_current_location(false);
     }
 	
     // enable gps velocity based centrefugal force compensation

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -102,6 +102,28 @@ void Sub::init_compass()
     ahrs.set_compass(&compass);
 }
 
+/*
+  if the compass is enabled then try to accumulate a reading
+  also update initial location used for declination
+ */
+void Sub::compass_accumulate(void)
+{
+    if (!g.compass_enabled) {
+        return;
+    }
+
+    compass.accumulate();
+
+    // update initial location used for declination
+    if (!ap.compass_init_location) {
+        Location loc;
+        if (ahrs.get_position(loc)) {
+            compass.set_initial_location(loc.lat, loc.lng);
+            ap.compass_init_location = true;
+        }
+    }
+}
+
 // initialise optical flow sensor
 #if OPTFLOW == ENABLED
 void Sub::init_optflow()


### PR DESCRIPTION
This PR does two things but only one of them is a functional change:

- reduce the number of set-home-ish methods by adding a "lock" argument.  this is a non-functional change.
- set the compass's initial location using the home location instead of the current GPS location.

This second change resolves a problem in cases where we are not using the GPS (i.e. when using optical flow or visual-odometry).  We resolve this by using the home location instead of the current GPS location.  Now, there is a reasonable argument that we should instead use the ahrs.get_position() (i.e. the vehicle's current position) instead of the home position although they are normally close together.  If people feel it would be best, I could change it to the current location (according to the EKF).