### PR TITLE
Ekf notify fix - LCD display can display "fail" on bad EKF

### DIFF
--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -178,7 +178,7 @@ void Buzzer::update()
     // check ekf bad
     if (_flags.ekf_bad != AP_Notify::flags.ekf_bad) {
         _flags.ekf_bad = AP_Notify::flags.ekf_bad;
-        if (_flags.ekf_bad) {
+        if (_flags.ekf_bad && AP_Notify::flags.armed) {
             // ekf bad warning buzz
             play_pattern(EKF_BAD);
         }


### PR DESCRIPTION
This is apparently an important issue for 3.5; the LCD displays always display "OK".

I think removing the EKF line altogether instead of applying this PR is also a valid way to "fix" the problem.

For 3.6 we should instead simply display whether the vehicle could be armed right now if the user attempted it.
