### PR TITLE
is_healthy AP_GPS methods

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -299,6 +299,23 @@ uint8_t AP_GPS::num_sensors(void) const
     }
 }
 
+bool AP_GPS::is_healthy() const {
+    return is_healthy(primary_instance); //could be overloaded with defaults
+}
+
+bool AP_GPS::is_healthy(uint8_t instance) const {
+    if (instance >= GPS_MAX_RECEIVERS)
+        return false;
+
+    uint32_t tnow = AP_HAL::millis();
+    if (drivers[instance] != nullptr && state[instance].status != NO_GPS &&
+      tnow - timing[instance].last_message_time_ms < get_rate_ms(instance) &&
+      drivers[instance]->is_healthy())
+        return true;
+
+    return false;
+}
+
 bool AP_GPS::speed_accuracy(uint8_t instance, float &sacc) const
 {
     if (state[instance].have_speed_accuracy) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -176,6 +176,8 @@ public:
         return status(primary_instance);
     }
 
+    bool is_healthy() const;
+    bool is_healthy(uint8_t instance) const;
     // Query the highest status this GPS supports (always reports GPS_OK_FIX_3D for the blended GPS)
     GPS_Status highest_supported_status(uint8_t instance) const;
 

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -61,6 +61,7 @@ public:
     void broadcast_gps_type() const;
     virtual void Write_DataFlash_Log_Startup_messages() const;
 
+    virtual bool is_healthy() const { return true; }
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
According to this issue, #2879, I provide the patch stub for what are my ideas for implementing a is_healthy method.

According to my interpretation of the issue 2879, I created a is_healthy method that when called, verifies if given a valid primary instance the last update rate is withing an acceptable value. It also checks if the primary driver's health status.

Considerations:
The is_healthy method takes 2 boolean arguments that command a log write on unhealty or command a mavlink unhealthy message sending.
The reason the is_healthy does these 2 additional tasks is that this way the actual messages structures would be internal to the AP_GPS library

Otherwise I guess we could get a method like getHealthStatus which would return a const pointer with a message, and this message would be null if health was good.

It is my first attempt at AP_GPS code so let me know of your higher level considerations.

Paulo Neves