### PR TITLE
Copter: Continue in LAND mode on failsafe event

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1027,6 +1027,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("PILOT_SPEED_DN", 24, ParametersG2, pilot_speed_dn, 0),
 
+    // @Param: FS_LAND_CONTINUE
+    // @DisplayName: Failsafe land continue
+    // @Description: If FS_LAND_CONTINUE is set for 1 (enabled) and the copter is in Land Mode when radio, battery, or GCS failsafe activates, Copter will continue to land. 0 = (default) Disabled (Always take failafe action).  1 = Enabled (Continue with Land Mode).
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("FS_LAND_CONTINUE", 25, ParametersG2, fs_land_continue, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -577,6 +577,9 @@ public:
 
     // Additional pilot velocity items
     AP_Int16    pilot_speed_dn;
+    
+    // Continune land mode on radio failsafe
+    AP_Int8 fs_land_continue;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -17,7 +17,9 @@ void Copter::failsafe_radio_on_event()
         if (control_mode == AUTO && g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION) {
             // continue mission
         } else if (control_mode == LAND && g.failsafe_battery_enabled == FS_BATT_LAND && failsafe.battery) {
-            // continue landing
+            // continue landing because we're already in the battery failsafe landing phase
+        } else if (control_mode == LAND && g2.fs_land_continue) {
+            // continue landing because FS_LAND_CONTINUE is true
         } else {
             if (g.failsafe_throttle == FS_THR_ENABLED_ALWAYS_LAND) {
                 set_mode_land_with_pause(MODE_REASON_RADIO_FAILSAFE);
@@ -54,7 +56,9 @@ void Copter::failsafe_battery_event(void)
         if (should_disarm_on_failsafe()) {
             init_disarm_motors();
         } else {
-            if (g.failsafe_battery_enabled == FS_BATT_RTL || control_mode == AUTO) {
+            if (control_mode == LAND && g2.fs_land_continue) {
+                // continue landing because FS_LAND_CONTINUE is true
+            } else if (g.failsafe_battery_enabled == FS_BATT_RTL || control_mode == AUTO) {
                 set_mode_RTL_or_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
             } else {
                 set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
@@ -115,6 +119,10 @@ void Copter::failsafe_gcs_check()
     } else {
         if (control_mode == AUTO && g.failsafe_gcs == FS_GCS_ENABLED_CONTINUE_MISSION) {
             // continue mission
+        } else if (control_mode == LAND && g.failsafe_battery_enabled == FS_BATT_LAND && failsafe.battery) {
+            // continue landing because we're already in the battery failsafe landing phase
+        } else if (control_mode == LAND && g2.fs_land_continue) {
+            // continue landing because FS_LAND_CONTINUE is true
         } else if (g.failsafe_gcs != FS_GCS_DISABLED) {
             set_mode_RTL_or_land_with_pause(MODE_REASON_GCS_FAILSAFE);
         }


### PR DESCRIPTION
Adds new copter parameter `FS_LAND_CONTINUE` to enable/disable this feature.

If `FS_LAND_CONTINUE` is set for 1 (enabled) and the copter is in _Land Mode_ when radio, battery, or GCS failsafe activates, Copter will continue to land. If set for 0, Copter will carry out the failsafe action as usual.

The logic behind this is that if the vehicle is already in LAND mode, the operator has already positively decided to land at the given location. If a radio, GCS, or battery failsafe event happens _during that landing_, the vehicle should continue with the landing rather than carrying out the failsafe action.  Continuing to land gets the vehicle safely on the ground immediately. Whereas the full failsafe action, if set for RTL, at that point would just waste time and battery. The less time the vehicle spends in the air during a failsafe condition, the better. And if it's already trying to land, we might as well let it do that.

This was recently raised in https://github.com/ArduPilot/ardupilot/issues/6390.  

_Description updated 2017-11-22_