### PR TITLE
SBP driver v2

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -476,7 +476,17 @@ AP_GPS_SBP2::logging_log_raw_sbp(uint16_t msg_type,
             time_us         : time_us,
             msg_type        : msg_type,
         };
-        memcpy(pkt2.data2, &msg_buff[64], MIN(msg_len - 64,192));
+        memcpy(pkt2.data2, &msg_buff[64], MIN(msg_len - 64,104));
         gps._DataFlash->WriteBlock(&pkt2, sizeof(pkt2));
+
+        if (msg_len > 168) {
+            struct log_SbpRAW2 pkt3 = {
+                LOG_PACKET_HEADER_INIT(LOG_MSG_SBPRAW2),
+                time_us         : time_us,
+                msg_type        : msg_type,
+            };
+            memcpy(pkt3.data2, &msg_buff[168], MIN(msg_len - 168,104));
+            gps._DataFlash->WriteBlock(&pkt3, sizeof(pkt3));
+        }
     }
 };

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -198,12 +198,17 @@ AP_GPS_SBP2::_sbp_process_message() {
             last_dops = *((struct sbp_dops_t*)parser_state.msg_buff);
             break;
 
+        case SBP_EXT_EVENT_MSGTYPE:
+            last_event = *((struct sbp_ext_event_t*)parser_state.msg_buff);
+            logging_ext_event();
+            break;
+
         default:
             break;
     }
 
     // send all messages we receive to log, even if it's an unsupported message,
-    // so we can do annditional post-processing from Dataflash logs.
+    // so we can do additional post-processing from Dataflash logs.
     // The log mask will be used to adjust or suppress logging
     logging_log_raw_sbp(parser_state.msg_type, parser_state.sender_id, parser_state.msg_len, parser_state.msg_buff);
 }
@@ -489,4 +494,22 @@ AP_GPS_SBP2::logging_log_raw_sbp(uint16_t msg_type,
             gps._DataFlash->WriteBlock(&pkt3, sizeof(pkt3));
         }
     }
+};
+
+void
+AP_GPS_SBP2::logging_ext_event() {
+    if (gps._DataFlash == nullptr || !gps._DataFlash->logging_started()) {
+      return;
+    }
+
+    struct log_SbpEvent pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_MSG_SBPEVENT),
+        time_us            : AP_HAL::micros64(),
+        wn                 : last_event.wn,
+        tow                : last_event.tow,
+        ns_residual        : last_event.ns_residual,
+        level              : last_event.flags.level,
+        quality            : last_event.flags.quality,
+    };
+    gps._DataFlash->WriteBlock(&pkt, sizeof(pkt));
 };

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -178,28 +178,28 @@ AP_GPS_SBP2::_sbp_process_message() {
     //Here, we copy messages into local structs.
     switch (parser_state.msg_type) {
         case SBP_HEARTBEAT_MSGTYPE:
-            last_heartbeat = *((struct sbp_heartbeat_t*)parser_state.msg_buff);
+            memcpy(&last_heartbeat, parser_state.msg_buff, sizeof(struct sbp_heartbeat_t));
             last_heartbeat_received_ms = AP_HAL::millis();
             break;
 
         case SBP_GPS_TIME_MSGTYPE:
-            last_gps_time = *((struct sbp_gps_time_t*)parser_state.msg_buff);
+            memcpy(&last_gps_time, parser_state.msg_buff, sizeof(struct sbp_gps_time_t));
             break;
 
         case SBP_VEL_NED_MSGTYPE:
-            last_vel_ned = *((struct sbp_vel_ned_t*)parser_state.msg_buff);
+            memcpy(&last_vel_ned, parser_state.msg_buff, sizeof(struct sbp_vel_ned_t));
             break;
 
         case SBP_POS_LLH_MSGTYPE:
-            last_pos_llh = *((struct sbp_pos_llh_t*)parser_state.msg_buff);
+            memcpy(&last_pos_llh, parser_state.msg_buff, sizeof(struct sbp_pos_llh_t));
             break;
 
         case SBP_DOPS_MSGTYPE:
-            last_dops = *((struct sbp_dops_t*)parser_state.msg_buff);
+            memcpy(&last_dops, parser_state.msg_buff, sizeof(struct sbp_dops_t));
             break;
 
         case SBP_EXT_EVENT_MSGTYPE:
-            last_event = *((struct sbp_ext_event_t*)parser_state.msg_buff);
+            memcpy(&last_event, parser_state.msg_buff, sizeof(struct sbp_ext_event_t));
             logging_ext_event();
             break;
 

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -78,6 +78,7 @@ private:
     static const uint16_t SBP_VEL_NED_MSGTYPE        = 0x020E;
     static const uint16_t SBP_TRACKING_STATE_MSGTYPE = 0x0013;
     static const uint16_t SBP_IAR_STATE_MSGTYPE      = 0x0019;
+    static const uint16_t SBP_EXT_EVENT_MSGTYPE      = 0x0101;
 
     // Heartbeat
     struct PACKED sbp_heartbeat_t {
@@ -148,6 +149,18 @@ private:
         } flags;
     }; // 22 bytes
 
+    // Messages reporting accurately-timestamped external events, e.g. camera shutter time.
+    struct PACKED sbp_ext_event_t {
+        uint16_t wn;           //< GPS week number (unit: weeks)
+        uint32_t tow;          //< GPS Time of Week (unit: ms)
+        int32_t ns_residual;   //< Nanosecond residual of millisecond-rounded TOW (ranges from -500000 to 500000)
+        struct PACKED flags {
+            uint8_t level:1;       //< New level of pin values (0: Low (falling edge), 1: High (rising edge))
+            uint8_t quality:1;     //< Time quality values (0: Unknown - don't have nav solution, 1: Good (< 1 microsecond))
+            uint8_t res:6;         //< Reserved
+        } flags;
+    }; // 12 bytes
+
     void _sbp_process();
     void _sbp_process_message();
     bool _attempt_state_update();
@@ -163,6 +176,7 @@ private:
     struct sbp_dops_t      last_dops;
     struct sbp_pos_llh_t   last_pos_llh;
     struct sbp_vel_ned_t   last_vel_ned;
+    struct sbp_ext_event_t last_event;
 
     uint32_t               last_full_update_tow;
     uint16_t               last_full_update_wn;
@@ -178,6 +192,7 @@ private:
     // ************************************************************************
 
     void logging_log_full_update();
+    void logging_ext_event();
     void logging_log_raw_sbp(uint16_t msg_type, uint16_t sender_id, uint8_t msg_len, uint8_t *msg_buff);
 
     int32_t distMod(int32_t tow1_ms, int32_t tow2_ms, int32_t mod);

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -780,6 +780,16 @@ struct PACKED log_SbpRAW2 {
     uint8_t data2[104];
 };
 
+struct PACKED log_SbpEvent {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint16_t wn;
+    uint32_t tow;
+    int32_t ns_residual;
+    uint8_t level;
+    uint8_t quality;
+};
+
 struct PACKED log_Rally {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1089,7 +1099,9 @@ Format characters in the format string for binary log messages
     { LOG_MSG_SBPRAW1, sizeof(log_SbpRAW1), \
       "SBR1", "QHHBQQQQQQQQ", "TimeUS,msg_type,sender_id,msg_len,1,2,3,4,5,6,7,8" }, \
     { LOG_MSG_SBPRAW2, sizeof(log_SbpRAW2), \
-      "SBR2", "QHQQQQQQQQQQQQQ", "TimeUS,msg_type,1,2,3,4,5,6,7,8,9,10,11,12,13" }
+      "SBR2", "QHQQQQQQQQQQQQQ", "TimeUS,msg_type,1,2,3,4,5,6,7,8,9,10,11,12,13" }, \
+    { LOG_MSG_SBPEVENT, sizeof(log_SbpEvent), \
+      "SBRE", "QHIiBB", "TimeUS,GWk,GMS,ns_residual,level,quality" }
 // #endif
 
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES, LOG_SBP_STRUCTURES
@@ -1202,7 +1214,7 @@ enum LogMessages {
     LOG_MSG_SBPTRACKING2,
     LOG_MSG_SBPRAW1,
     LOG_MSG_SBPRAW2,
-    LOG_MSG_SBPRAWx,
+    LOG_MSG_SBPEVENT,
     LOG_TRIGGER_MSG,
 
     LOG_GIMBAL1_MSG,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -777,7 +777,7 @@ struct PACKED log_SbpRAW2 {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint16_t msg_type;
-    uint8_t data2[192];
+    uint8_t data2[104];
 };
 
 struct PACKED log_Rally {
@@ -1085,11 +1085,11 @@ Format characters in the format string for binary log messages
 // #if SBP_HW_LOGGING
 #define LOG_SBP_STRUCTURES \
     { LOG_MSG_SBPHEALTH, sizeof(log_SbpHealth), \
-      "SBPH", "QIII",   "TimeUS,CrcError,LastInject,IARhyp" }, \
+      "SBPH", "QIII", "TimeUS,CrcError,LastInject,IARhyp" }, \
     { LOG_MSG_SBPRAW1, sizeof(log_SbpRAW1), \
-      "SBR1", "QHHBZ",      "TimeUS,msg_type,sender_id,msg_len,d1" }, \
+      "SBR1", "QHHBQQQQQQQQ", "TimeUS,msg_type,sender_id,msg_len,1,2,3,4,5,6,7,8" }, \
     { LOG_MSG_SBPRAW2, sizeof(log_SbpRAW2), \
-      "SBR2", "QHZZZ",      "TimeUS,msg_type,d2,d3,d4" }
+      "SBR2", "QHQQQQQQQQQQQQQ", "TimeUS,msg_type,1,2,3,4,5,6,7,8,9,10,11,12,13" }
 // #endif
 
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES, LOG_SBP_STRUCTURES

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -764,20 +764,28 @@ struct PACKED log_SbpHealth {
     uint32_t last_iar_num_hypotheses;
 };
 
-struct PACKED log_SbpRAW1 {
+struct PACKED log_SbpRAWH {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint16_t msg_type;
     uint16_t sender_id;
+    uint8_t index;
+    uint8_t pages;
     uint8_t msg_len;
-    uint8_t data1[64];
+    uint8_t res;
+    uint8_t data[48];
 };
 
-struct PACKED log_SbpRAW2 {
+struct PACKED log_SbpRAWM {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint16_t msg_type;
-    uint8_t data2[104];
+    uint16_t sender_id;
+    uint8_t index;
+    uint8_t pages;
+    uint8_t msg_len;
+    uint8_t res;
+    uint8_t data[104];
 };
 
 struct PACKED log_SbpEvent {
@@ -1096,10 +1104,10 @@ Format characters in the format string for binary log messages
 #define LOG_SBP_STRUCTURES \
     { LOG_MSG_SBPHEALTH, sizeof(log_SbpHealth), \
       "SBPH", "QIII", "TimeUS,CrcError,LastInject,IARhyp" }, \
-    { LOG_MSG_SBPRAW1, sizeof(log_SbpRAW1), \
-      "SBR1", "QHHBQQQQQQQQ", "TimeUS,msg_type,sender_id,msg_len,1,2,3,4,5,6,7,8" }, \
-    { LOG_MSG_SBPRAW2, sizeof(log_SbpRAW2), \
-      "SBR2", "QHQQQQQQQQQQQQQ", "TimeUS,msg_type,1,2,3,4,5,6,7,8,9,10,11,12,13" }, \
+    { LOG_MSG_SBPRAWH, sizeof(log_SbpRAWH), \
+      "SBRH", "QQQQQQQQ", "TimeUS,msg_flag,1,2,3,4,5,6" }, \
+    { LOG_MSG_SBPRAWM, sizeof(log_SbpRAWM), \
+      "SBRM", "QQQQQQQQQQQQQQQ", "TimeUS,msg_flag,1,2,3,4,5,6,7,8,9,10,11,12,13" }, \
     { LOG_MSG_SBPEVENT, sizeof(log_SbpEvent), \
       "SBRE", "QHIiBB", "TimeUS,GWk,GMS,ns_residual,level,quality" }
 // #endif
@@ -1212,8 +1220,8 @@ enum LogMessages {
     LOG_MSG_SBPBASELINE,
     LOG_MSG_SBPTRACKING1,
     LOG_MSG_SBPTRACKING2,
-    LOG_MSG_SBPRAW1,
-    LOG_MSG_SBPRAW2,
+    LOG_MSG_SBPRAWH,
+    LOG_MSG_SBPRAWM,
     LOG_MSG_SBPEVENT,
     LOG_TRIGGER_MSG,
 


### PR DESCRIPTION
As we were passing binary data as strings, the *.log file was "corrupted" after conversion from the *.bin file because of "end of the line" character. It now uses long integer instead.

Also, support for SBP EXT_EVENTS messages has been added for easy accurate geotagging. This new SBRE message uses the ID of the unused SBRx, so there is no impact on other messages.