### PR TITLE
Copter: deploy/retract landing gear once switch moves

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -146,7 +146,7 @@ void Copter::parachute_release()
     parachute.release();
 
     // deploy landing gear
-    landinggear.set_cmd_mode(LandingGear_Deploy);
+    landinggear.set_position(AP_LandingGear::LandingGear_Deploy);
 }
 
 // parachute_manual_release - trigger the release of the parachute, after performing some checks for pilot error

--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -2,13 +2,13 @@
 
 
 // Run landing gear controller at 10Hz
-void Copter::landinggear_update(){
-
+void Copter::landinggear_update()
+{
     // If landing gear control is active, run update function.
     if (check_if_auxsw_mode_used(AUXSW_LANDING_GEAR)){
 
-        // last status (deployed or retracted) used to check for changes
-        static bool last_deploy_status;
+        // last status (deployed or retracted) used to check for changes, initialised to startup state of landing gear
+        static bool last_deploy_status = landinggear.deployed();
 
         // if we are doing an automatic landing procedure, force the landing gear to deploy.
         // To-Do: should we pause the auto-land procedure to give time for gear to come down?
@@ -16,10 +16,8 @@ void Copter::landinggear_update(){
            (control_mode == RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent)) ||
            (control_mode == AUTO && auto_mode == Auto_Land) ||
            (control_mode == AUTO && auto_mode == Auto_RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent))) {
-            landinggear.force_deploy(true);
+            landinggear.set_position(AP_LandingGear::LandingGear_Deploy_And_Keep_Deployed);
         }
-
-        landinggear.update();
 
         // send event message to datalog if status has changed
         if (landinggear.deployed() != last_deploy_status){

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -191,7 +191,6 @@ void Copter::init_aux_switch_function(int8_t ch_option, uint8_t ch_flag)
         case AUXSW_MISSION_RESET:
         case AUXSW_ATTCON_FEEDFWD:
         case AUXSW_ATTCON_ACCEL_LIM:
-        case AUXSW_LANDING_GEAR:
         case AUXSW_MOTOR_ESTOP:
         case AUXSW_MOTOR_INTERLOCK:
         case AUXSW_AVOID_ADSB:
@@ -492,13 +491,10 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
        case AUXSW_LANDING_GEAR:
             switch (ch_flag) {
                 case AUX_SWITCH_LOW:
-                    landinggear.set_cmd_mode(LandingGear_Deploy);
-                    break;
-                case AUX_SWITCH_MIDDLE:
-                    landinggear.set_cmd_mode(LandingGear_Auto);
+                    landinggear.set_position(AP_LandingGear::LandingGear_Deploy);
                     break;
                 case AUX_SWITCH_HIGH:
-                    landinggear.set_cmd_mode(LandingGear_Retract);
+                    landinggear.set_position(AP_LandingGear::LandingGear_Retract);
                     break;
             }
             break;

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -29,10 +29,24 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     AP_GROUPEND
 };
 
-/// enable - enable or disable land gear retraction
-void AP_LandingGear::enable(bool on_off)
+/// set landing gear position to retract, deploy or deploy-and-keep-deployed
+void AP_LandingGear::set_position(LandingGearCommand cmd)
 {
-    _retract_enabled = on_off;
+    switch (cmd) {
+        case LandingGear_Retract:
+            if (!_deploy_lock) {
+                retract();
+            }
+            break;
+        case LandingGear_Deploy:
+            deploy();
+            _deploy_lock = false;
+            break;
+        case LandingGear_Deploy_And_Keep_Deployed:
+            deploy();
+            _deploy_lock = true;
+            break;
+    }
 }
 
 /// deploy - deploy landing gear
@@ -42,43 +56,15 @@ void AP_LandingGear::deploy()
     SRV_Channels::set_output_pwm(SRV_Channel::k_landing_gear_control, _servo_deploy_pwm);
 
     // set deployed flag
-    _deployed = true;    
+    _deployed = true;
 }
 
 /// retract - retract landing gear
 void AP_LandingGear::retract()
-{    
+{
     // set servo PWM to retracted position
     SRV_Channels::set_output_pwm(SRV_Channel::k_landing_gear_control, _servo_retract_pwm);
 
     // reset deployed flag
-    _deployed = false;   
-}
-
-/// update - should be called at 10hz
-void AP_LandingGear::update()
-{
-    // if there is a force deploy active, disable retraction, then reset force deploy to consume it
-    // gear will be deployed automatically because _retract_enabled is false.
-    // this will disable retract switch until it is cycled through deploy position
-    if (_force_deploy){
-            enable(false);
-            force_deploy(false);
-        }
-
-    if (!_retract_enabled) {
-        // force deployment if retract is not enabled
-        deploy();
-        // retract is disabled until switch is placed into deploy position to prevent accidental retraction on bootup if switch was left in retract position
-        enable(_command_mode == LandingGear_Deploy);
-        return;
-    }
-
-    if (_command_mode == LandingGear_Deploy){
-        deploy();
-    }
-
-    if (_command_mode == LandingGear_Retract){
-        retract();
-    }    
+    _deployed = false;
 }

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -8,47 +8,35 @@
 #define AP_LANDINGGEAR_SERVO_RETRACT_PWM_DEFAULT    1250    // default PWM value to move servo to when landing gear is up
 #define AP_LANDINGGEAR_SERVO_DEPLOY_PWM_DEFAULT     1750    // default PWM value to move servo to when landing gear is down
 
-// Gear command modes
-enum LandingGearCommandMode {
-    LandingGear_Deploy,
-    LandingGear_Auto,
-    LandingGear_Retract
-};
-
 /// @class	AP_LandingGear
 /// @brief	Class managing the control of landing gear
 class AP_LandingGear {
 
 public:
 
+    // Gear command modes
+    enum LandingGearCommand {
+        LandingGear_Retract,
+        LandingGear_Deploy,
+        LandingGear_Deploy_And_Keep_Deployed,
+    };
+
     /// Constructor
-    AP_LandingGear() :
-        _retract_enabled(false),
-        _deployed(false),
-        _force_deploy(false),
-        _command_mode(LandingGear_Deploy)
+    AP_LandingGear()
     {
         // setup parameter defaults
         AP_Param::setup_object_defaults(this, var_info);
     }
 
-    /// deployed - returns true if the landing gear is deployed
+    /// returns true if the landing gear is deployed
     bool deployed() const { return _deployed; }
 
-    /// update - should be called at 10hz
-    void update();
-
-    /// set_cmd_mode - set command mode to deploy, auto or retract
-    void set_cmd_mode(LandingGearCommandMode cmd) { _command_mode = cmd; }
-
-    /// force_deploy - set to true to force gear to deploy
-    void force_deploy(bool force) { _force_deploy = force;}
+    /// set landing gear position to retract, deploy or deploy-and-keep-deployed
+    void set_position(LandingGearCommand cmd);
 
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:
-
-    bool     _retract_enabled;          // true if landing gear retraction is enabled
 
     // Parameters
     AP_Int16    _servo_retract_pwm;     // PWM value to move servo to when gear is retracted
@@ -56,11 +44,7 @@ private:
 
     // internal variables
     bool        _deployed;              // true if the landing gear has been deployed, initialized false
-    bool        _force_deploy;          // used by main code to force landing gear to deploy, such as in Land mode
-    LandingGearCommandMode  _command_mode;  // pilots commanded control mode: Manual Deploy, Auto, or Manual Retract
-    
-    /// enable - enable landing gear retraction
-    void enable(bool on_off);
+    bool        _deploy_lock;           // used to force landing gear to remain deployed until another regular Deploy command is received to reduce accidental retraction
     
     /// retract - retract landing gear
     void retract();


### PR DESCRIPTION
This PR attempts to resolve an issue raised during AC3.5 beta testing: http://discuss.ardupilot.org/t/ac-3-5-landing-gear-behavior/18032

Although I was not able to recreate the exact issue described, it seems that some users find the landing gear retracts or deploys during startup when they would prefer that the gear just stays in it's current state.

This PR changes the landing gear functionality so that no pwm values are output to the servo until the pilot has moved the configured auxiliary switch or until the vehicle is switched into Land flight mode.