### PR TITLE
AP_GPS: Update comment on get_rate_ms()

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1068,7 +1068,10 @@ const Vector3f &AP_GPS::get_antenna_offset(uint8_t instance) const
 }
 
 /*
-  return gps update rate in milliseconds
+  returns the desired gps update rate in milliseconds
+  this does not provide any gurantee that the GPS is updating at the requested
+  rate it is simply a helper for use in the backends for determining what rate
+  they should be configuring the GPS to run at
 */
 uint16_t AP_GPS::get_rate_ms(uint8_t instance) const
 {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -392,7 +392,10 @@ protected:
     AP_Float _blend_tc;
 
 private:
-    // return gps update rate in milliseconds
+    // returns the desired gps update rate in milliseconds
+    // this does not provide any gurantee that the GPS is updating at the requested
+    // rate it is simply a helper for use in the backends for determining what rate
+    // they should be configuring the GPS to run at
     uint16_t get_rate_ms(uint8_t instance) const;
 
     struct GPS_timing {


### PR DESCRIPTION
AP_GPS::get_rate_ms() is only meant to help the GPS backends, and it provides no guarantees about how fast the driver is actually running. This is just intended to help make it more obvious to developers that they can't base any logic on this backend.