### PR TITLE
AP_BattMonitor: Allow SMBus batteries to not have cell voltages

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ for reviewing patches on their specific area. See [CONTRIBUTING.md](.github/CONT
   - ***Subsystem***: DataFlash
   - ***Subsystem***: Tools
 - [Michael du Breuil](https://github.com/WickedShell)
+  - ***Subsystem***: SMBus Batteries
   - ***Subsystem***: GPS
 - [Francisco Ferreira](https://github.com/oxinarf)
   - ***Bug Master***

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -23,9 +23,10 @@ public:
     // virtual destructor to reduce compiler warnings
     virtual ~AP_BattMonitor_SMBus() {}
 
-    // all smart batteries provide current and individual cell voltages
+    bool has_cell_voltages() const override { return _has_cell_voltages; }
+
+    // all smart batteries are expected to provide current
     bool has_current() const override { return true; }
-    bool has_cell_voltages() const override { return true; }
 
 protected:
 
@@ -61,6 +62,8 @@ protected:
 
     int32_t _serial_number = -1;    // battery serial number
     uint16_t _full_charge_capacity; // full charge capacity, used to stash the value before setting the parameter
+
+    bool _has_cell_voltages;        // smbus backends flag this as true once they have recieved a valid cell voltage report
 
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -64,6 +64,7 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     // read cell voltages
     for (uint8_t i = 0; i < BATTMONITOR_SMBUS_MAXELL_NUM_CELLS; i++) {
         if (read_word(maxell_cell_ids[i], data)) {
+            _has_cell_voltages = true;
             _state.cell_voltages.cells[i] = data;
         } else {
             _state.cell_voltages.cells[i] = UINT16_MAX;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -50,6 +50,8 @@ void AP_BattMonitor_SMBus_Solo::timer()
             _state.cell_voltages.cells[i] = cell;
             pack_voltage_mv += (float)cell;
         }
+        _has_cell_voltages = true;
+
         // accumulate the pack voltage out of the total of the cells
         // because the Solo's I2C bus is so noisy, it's worth not spending the
         // time and bus bandwidth to request the pack voltage as a seperate


### PR DESCRIPTION
Despite @rmackay9's [comments](https://github.com/ArduPilot/ardupilot/pull/6351#issuecomment-306383952) about not really caring about checking for cell voltages actually being present in the Maxell driver I think this definitely matters, especially for some planned use cases for this helper functions. (On my near term to implement list is failsafes based on cell voltage spread, which I would be using this helper to determine if the failsafe is even possible to check for).

Anyways the reason this check is needed is there is no guarantee that a SMBus battery will actually respond to the requested cell voltages as they are fetched from registers that aren't a part of the formal SMBus spec (although it does appear to be part of the defacto one)

Also took the moment to tag myself as the SMBus battery maintainer, if that's alright with others .