### PR TITLE
AP_Landing: Fix missing doc for LAND_TYPE

### DIFF
--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -134,7 +134,7 @@ const AP_Param::GroupInfo AP_Landing::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Auto-landing type
     // @Description: Specifies the auto-landing type to use
-    // @Values: 0:Standard Glide Slope
+    // @Values: 0:Standard Glide Slope, 1:Deepstall
     // @User: Standard
     AP_GROUPINFO("TYPE",    14, AP_Landing, type, TYPE_STANDARD_GLIDE_SLOPE),
 


### PR DESCRIPTION
Apparently when I added deepstall as a landing type I never added it to the param metadata.