### PR TITLE
init_ardupilot cleanup and improvements

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -104,8 +104,6 @@ void Rover::setup()
 
     in_auto_reverse = false;
 
-    rssi.init();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -121,10 +121,19 @@ void Rover::init_ardupilot()
     // used to detect in-flight resets
     g.num_resets.set_and_save(g.num_resets + 1);
 
-    set_control_channels();
 
+    rc_override_active = hal.rcin->set_overrides(rc_override, 8);
+
+    set_control_channels();
+    // sets up rc channels from radio
+    init_rc_in();
     // sets up motors and output to escs
     init_rc_out();
+    /*
+      setup the 'main loop is dead' check. Note that this relies on
+      the RC library being initialised.
+     */
+    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
     // initialise which outputs Servo and Relay events can use
     // allow servo set on all channels except first 4
@@ -170,15 +179,6 @@ void Rover::init_ardupilot()
 
     // Do GPS init
     gps.init(&DataFlash, serial_manager);
-
-    rc_override_active = hal.rcin->set_overrides(rc_override, 8);
-
-    init_rc_in();        // sets up rc channels from radio
-    /*
-      setup the 'main loop is dead' check. Note that this relies on
-      the RC library being initialised.
-     */
-    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
 #if CLI_ENABLED == ENABLED
     // If the switch is in 'menu' mode, run the main menu.

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -150,8 +150,15 @@ void Copter::init_ardupilot()
     // allocate the motors class
     allocate_motors();
 
+    // sets up rc channels from radio
+    init_rc_in();
     // sets up motors and output to escs
     init_rc_out();
+    /*
+    *  setup the 'main loop is dead' check. Note that this relies on
+    *  the RC library being initialised.
+    */
+    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
     // motors initialised so parameters can be sent
     ap.initialised_params = true;
@@ -195,13 +202,6 @@ void Copter::init_ardupilot()
 
     // Do GPS init
     gps.init(&DataFlash, serial_manager);
-
-    init_rc_in();  // sets up rc channels from radio
-    /*
-     *  setup the 'main loop is dead' check. Note that this relies on
-     *  the RC library being initialised.
-     */
-    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
 #if CLI_ENABLED == ENABLED
     if (g.cli_enabled) {

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -101,10 +101,6 @@ void Plane::setup()
     // load the default values of variables listed in var_info[]
     AP_Param::setup_sketch_defaults();
 
-    AP_Notify::flags.failsafe_battery = false;
-
-    rssi.init();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -152,7 +152,14 @@ void Plane::init_ardupilot()
     // used to detect in-flight resets
     g.num_resets.set_and_save(g.num_resets + 1);
 
+    // sets up rc channels from radio
+    init_rc_in();
     init_rc_out_main();
+    /*
+    *  setup the 'main loop is dead' check. Note that this relies on
+    *  the RC library being initialised.
+    */
+    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
     // initialise which outputs Servo and Relay events can use
     // allow servo set on all channels except first 4
@@ -198,13 +205,6 @@ void Plane::init_ardupilot()
 
     // GPS Initialization
     gps.init(&DataFlash, serial_manager);
-
-    init_rc_in();               // sets up rc channels from radio
-    /*
-     *  setup the 'main loop is dead' check. Note that this relies on
-     *  the RC library being initialised.
-     */
-    hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
 
 #if CLI_ENABLED == ENABLED
     gcs().handle_interactive_setup();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -82,6 +82,8 @@ void Plane::init_ardupilot()
                          "\n\nFree RAM: %u\n",
                       (unsigned)hal.util->available_memory());
 
+    // init vehicle capabilties
+    init_capabilities();
 
     //
     // Check the EEPROM format version before loading any parameters from EEPROM
@@ -101,7 +103,7 @@ void Plane::init_ardupilot()
 #endif
 
     set_control_channels();
-    
+
 #if HAVE_PX4_MIXER
     if (!quadplane.enable) {
         // this must be before BoardConfig.init() so if
@@ -118,12 +120,14 @@ void Plane::init_ardupilot()
 
     gcs().set_dataflash(&DataFlash);
 
+    // identify ourselves correctly with the ground station
     mavlink_system.sysid = g.sysid_this_mav;
 
     // initialise serial ports
     serial_manager.init();
-    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
+    // setup first port early to allow BoardConfig to report errors
+    gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
     // specify callback function for CLI menu system
 #if CLI_ENABLED == ENABLED
@@ -139,31 +143,22 @@ void Plane::init_ardupilot()
     // setup any board specific drivers
     BoardConfig.init();
 
-    relay.init();
-
     // initialise notify system
     notify.init(false);
+    AP_Notify::flags.failsafe_battery = false;
     notify_flight_mode(control_mode);
-
-    init_rc_out_main();
-    
-    // allow servo set on all channels except first 4
-    ServoRelayEvents.set_channel_mask(0xFFF0);
 
     // keep a record of how many resets have happened. This can be
     // used to detect in-flight resets
-    g.num_resets.set_and_save(g.num_resets+1);
+    g.num_resets.set_and_save(g.num_resets + 1);
 
-    // init baro before we start the GCS, so that the CLI baro test works
-    barometer.init();
+    init_rc_out_main();
 
-    // initialise rangefinder
-    init_rangefinder();
+    // initialise which outputs Servo and Relay events can use
+    // allow servo set on all channels except first 4
+    ServoRelayEvents.set_channel_mask(0xFFF0);
 
-    // initialise battery monitoring
-    battery.init();
-
-    rpm_sensor.init();
+    relay.init();
 
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
@@ -179,11 +174,14 @@ void Plane::init_ardupilot()
 #if LOGGING_ENABLED == ENABLED
     log_init();
 #endif
+    // initialise battery monitor
+    battery.init();
+    // init baro before we start the GCS, so that the CLI baro test works
+    barometer.init();
+    // Init RSSI
+    rssi.init();
 
-    // initialise airspeed sensor
-    airspeed.init();
-
-    if (g.compass_enabled==true) {
+    if (g.compass_enabled == true) {
         bool compass_ok = compass.init() && compass.read();
 #if HIL_SUPPORT
     if (g.hil_mode != 0) {
@@ -197,32 +195,11 @@ void Plane::init_ardupilot()
             ahrs.set_compass(&compass);
         }
     }
-    
-#if OPTFLOW == ENABLED
-    // make optflow available to libraries
-    if (optflow.enabled()) {
-        ahrs.set_optflow(&optflow);
-    }
-#endif
-
-    // give AHRS the airspeed sensor
-    ahrs.set_airspeed(&airspeed);
 
     // GPS Initialization
     gps.init(&DataFlash, serial_manager);
 
     init_rc_in();               // sets up rc channels from radio
-
-#if MOUNT == ENABLED
-    // initialise camera mount
-    camera_mount.init(&DataFlash, serial_manager);
-#endif
-
-#if FENCE_TRIGGERED_PIN > 0
-    hal.gpio->pinMode(FENCE_TRIGGERED_PIN, HAL_GPIO_OUTPUT);
-    hal.gpio->write(FENCE_TRIGGERED_PIN, 0);
-#endif
-
     /*
      *  setup the 'main loop is dead' check. Note that this relies on
      *  the RC library being initialised.
@@ -233,9 +210,36 @@ void Plane::init_ardupilot()
     gcs().handle_interactive_setup();
 #endif // CLI_ENABLED
 
-    init_capabilities();
-
     quadplane.setup();
+
+    // initialise sensor
+#if OPTFLOW == ENABLED
+    // make optflow available to libraries
+    if (optflow.enabled()) {
+        optflow.init();
+        ahrs.set_optflow(&optflow);
+    }
+#endif
+    // initialise airspeed sensor
+    airspeed.init();
+
+    // give AHRS the airspeed sensor
+    ahrs.set_airspeed(&airspeed);
+
+    // initialise rangefinder
+    init_rangefinder();
+
+    rpm_sensor.init();
+
+#if MOUNT == ENABLED
+    // initialise camera mount
+    camera_mount.init(&DataFlash, serial_manager);
+#endif
+
+#if FENCE_TRIGGERED_PIN > 0
+    hal.gpio->pinMode(FENCE_TRIGGERED_PIN, HAL_GPIO_OUTPUT);
+    hal.gpio->write(FENCE_TRIGGERED_PIN, 0);
+#endif
 
     AP_Param::reload_defaults_file();
     
@@ -253,13 +257,6 @@ void Plane::init_ardupilot()
     // set the correct flight mode
     // ---------------------------
     reset_control_switch();
-
-    // initialise sensor
-#if OPTFLOW == ENABLED
-    if (optflow.enabled()) {
-        optflow.init();
-    }
-#endif
 
     // disable safety if requested
     BoardConfig.init_safety();


### PR DESCRIPTION
Hello, 
I am working on new motor lib for rover, and the initlization sequence was pretty hard to understand for newcomer, and things were mixed up.
So, I try to comment and make thing similar on all vehicle as there should be much different.
I moved things in setup() that should be in init_ardupilot()
In init_ardupilot(), I try to keep the same sequence for all, I think we should comment the sequence steps to prevent further mixing. What I do is : 
-init generic vehicle stuff
- load param
- init board
- init servo out and relay
- init usb, serial, telem
- init mandatory sensors : battery, compas, baro, gps
- init rc_in
- finish init with other stuff .

I think that good initialisation order should be : 
- vehicle + boad indentifiation
- motor ouput : should be fast to prevent unexpected move
Then, can message be send during init_ardupilot() ? I don't think, but I think that the next step should be to init the communication and logging stuff. With that we can analyze how the initilisation is going.
- init communication and logging
- init sensors : should it be all ? or only mandatory ? Should we feed directly ahrs with sensors as soon as init ? Currently it isn't, as sensors are init and later the pointer is passed to ahrs.
- lately, init rc_in to prevent unexpected thing from RC radio.
- lastly, mission and high level things

What do you think?

Other things : Copter doesn't have g.num_resets.set_and_save(g.num_resets + 1), should we add it ?

Edit: Other motivation for these change is that I try to implement a new motor lib for rover and correct the mess in rover ... but it seems to me that it is not only related to rover, cleaning those stuff on all vehicles will be a good thing !