### PR TITLE
Plane: Remove redundant status text on MAV_CMD_DO_GO_AROUND

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1397,12 +1397,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_ACCEPTED;
                 }
             }
-
-            if (result == MAV_RESULT_ACCEPTED) {
-                plane.gcs_send_text(MAV_SEVERITY_INFO,"Go around command accepted");
-            } else {
-                plane.gcs_send_text(MAV_SEVERITY_NOTICE,"Rejected go around command");
-            }
             break;
 
         case MAV_CMD_DO_FENCE_ENABLE:


### PR DESCRIPTION
We already ACK/NACK the packets correctly, statustexts are redundant as the GCS already has the information, and there are already a ton of other abort related prints.