### PR TITLE
Compass: implement per-motor compass compensation

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -356,6 +356,7 @@ void Copter::update_batt_compass(void)
     if(g.compass_enabled) {
         // update compass with throttle value - used for compassmot
         compass.set_throttle(motors->get_throttle());
+        compass.set_voltage(battery.voltage());
         compass.read();
         // log compass information
         if (should_log(MASK_LOG_COMPASS) && !ahrs.have_ekf_logging()) {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1003,7 +1003,7 @@ private:
     void update_notify();
     void motor_test_output();
     bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc);
-    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec);
+    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec, uint8_t motor_count);
     void motor_test_stop();
     void arm_motors_check();
     void auto_disarm_check();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1410,7 +1410,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
             // param3 : throttle (range depends upon param2)
             // param4 : timeout (in seconds)
-            result = copter.mavlink_motor_test_start(chan, (uint8_t)packet.param1, (uint8_t)packet.param2, (uint16_t)packet.param3, packet.param4);
+            // param5 : num_motors (in sequence)
+            result = copter.mavlink_motor_test_start(chan, (uint8_t)packet.param1, (uint8_t)packet.param2, (uint16_t)packet.param3,
+                                                     packet.param4, (uint8_t)packet.param5);
             break;
 
 #if GRIPPER_ENABLED == ENABLED

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1411,6 +1411,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             // param3 : throttle (range depends upon param2)
             // param4 : timeout (in seconds)
             // param5 : num_motors (in sequence)
+            // param6 : compass learning (0: disabled, 1: enabled)
             result = copter.mavlink_motor_test_start(chan, (uint8_t)packet.param1, (uint8_t)packet.param2, (uint16_t)packet.param3,
                                                      packet.param4, (uint8_t)packet.param5);
             break;

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -10,11 +10,12 @@
 #define MOTOR_TEST_PWM_MAX              2200    // max pwm value accepted by the test
 #define MOTOR_TEST_TIMEOUT_MS_MAX       30000   // max timeout is 30 seconds
 
-static uint32_t motor_test_start_ms = 0;        // system time the motor test began
-static uint32_t motor_test_timeout_ms = 0;      // test will timeout this many milliseconds after the motor_test_start_ms
-static uint8_t motor_test_seq = 0;              // motor sequence number of motor being tested
-static uint8_t motor_test_throttle_type = 0;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
-static uint16_t motor_test_throttle_value = 0;  // throttle to be sent to motor, value depends upon it's type
+static uint32_t motor_test_start_ms;        // system time the motor test began
+static uint32_t motor_test_timeout_ms;      // test will timeout this many milliseconds after the motor_test_start_ms
+static uint8_t motor_test_seq;              // motor sequence number of motor being tested
+static uint8_t motor_test_count;            // number of motors to test
+static uint8_t motor_test_throttle_type;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
+static uint16_t motor_test_throttle_value;  // throttle to be sent to motor, value depends upon it's type
 
 // motor_test_output - checks for timeout and sends updates to motors objects
 void Copter::motor_test_output()
@@ -25,7 +26,23 @@ void Copter::motor_test_output()
     }
 
     // check for test timeout
-    if ((AP_HAL::millis() - motor_test_start_ms) >= motor_test_timeout_ms) {
+    uint32_t now = AP_HAL::millis();
+    if ((now - motor_test_start_ms) >= motor_test_timeout_ms) {
+        if (motor_test_count > 1) {
+            if (now - motor_test_start_ms < motor_test_timeout_ms*1.5) {
+                // output zero for 50% of the test time
+                motors->output_min();
+            } else {
+                // move onto next motor
+                motor_test_seq++;
+                motor_test_count--;
+                motor_test_start_ms = now;
+                if (!motors->armed()) {
+                    motors->armed(true);
+                }
+            }
+            return;
+        }
         // stop motor test
         motor_test_stop();
     } else {
@@ -103,8 +120,12 @@ bool Copter::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
 
 // mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
 //  returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
-uint8_t Copter::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec)
+uint8_t Copter::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value,
+                                         float timeout_sec, uint8_t motor_count)
 {
+    if (motor_count == 0) {
+        motor_count = 1;
+    }
     // if test has not started try to start it
     if (!ap.motor_test) {
         /* perform checks that it is ok to start test
@@ -140,6 +161,7 @@ uint8_t Copter::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_s
 
     // store required output
     motor_test_seq = motor_seq;
+    motor_test_count = motor_count;
     motor_test_throttle_type = throttle_type;
     motor_test_throttle_value = throttle_value;
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -418,6 +418,10 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("OFFS_MAX", 31, Compass, _offset_max, AP_COMPASS_OFFSETS_MAX_DEFAULT),
+
+    // @Group: PMOT
+    // @Path: Compass_PerMotor.cpp
+    AP_SUBGROUPINFO(_per_motor, "PMOT", 32, Compass, Compass_PerMotor),
     
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -1,0 +1,224 @@
+/*
+  per-motor compass compensation
+ */
+
+#include "AP_Compass.h"
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL &hal;
+
+const AP_Param::GroupInfo Compass_PerMotor::var_info[] = {
+    // @Param: _EN
+    // @DisplayName: per-motor compass correction enable
+    // @Description: This enables per-motor compass corrections
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("_EN",  1, Compass_PerMotor, enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: _EXP
+    // @DisplayName: per-motor exponential correction
+    // @Description: This is the exponential correction for the power output of the motor for per-motor compass correction
+    // @Range: 0 2
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("_EXP", 2, Compass_PerMotor, expo, 0.65),
+
+    // @Param: 1_X
+    // @DisplayName: Compass per-motor1 X
+    // @Description: Compensation for X axis of motor1
+    // @User: Advanced
+
+    // @Param: 1_Y
+    // @DisplayName: Compass per-motor1 Y
+    // @Description: Compensation for Y axis of motor1
+    // @User: Advanced
+
+    // @Param: 1_Z
+    // @DisplayName: Compass per-motor1 Z
+    // @Description: Compensation for Z axis of motor1
+    // @User: Advanced
+    AP_GROUPINFO("1",  3, Compass_PerMotor, compensation[0], 0),
+
+    // @Param: 2_X
+    // @DisplayName: Compass per-motor2 X
+    // @Description: Compensation for X axis of motor2
+    // @User: Advanced
+
+    // @Param: 2_Y
+    // @DisplayName: Compass per-motor2 Y
+    // @Description: Compensation for Y axis of motor2
+    // @User: Advanced
+
+    // @Param: 2_Z
+    // @DisplayName: Compass per-motor2 Z
+    // @Description: Compensation for Z axis of motor2
+    // @User: Advanced
+    AP_GROUPINFO("2",  4, Compass_PerMotor, compensation[1], 0),
+
+    // @Param: 3_X
+    // @DisplayName: Compass per-motor3 X
+    // @Description: Compensation for X axis of motor3
+    // @User: Advanced
+
+    // @Param: 3_Y
+    // @DisplayName: Compass per-motor3 Y
+    // @Description: Compensation for Y axis of motor3
+    // @User: Advanced
+
+    // @Param: 3_Z
+    // @DisplayName: Compass per-motor3 Z
+    // @Description: Compensation for Z axis of motor3
+    // @User: Advanced
+    AP_GROUPINFO("3",  5, Compass_PerMotor, compensation[2], 0),
+
+    // @Param: 4_X
+    // @DisplayName: Compass per-motor4 X
+    // @Description: Compensation for X axis of motor4
+    // @User: Advanced
+
+    // @Param: 4_Y
+    // @DisplayName: Compass per-motor4 Y
+    // @Description: Compensation for Y axis of motor4
+    // @User: Advanced
+
+    // @Param: 4_Z
+    // @DisplayName: Compass per-motor4 Z
+    // @Description: Compensation for Z axis of motor4
+    // @User: Advanced
+    AP_GROUPINFO("4",  6, Compass_PerMotor, compensation[3], 0),
+    
+    AP_GROUPEND
+};
+
+// constructor
+Compass_PerMotor::Compass_PerMotor(Compass &_compass) :
+    compass(_compass)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+// return current scaled motor output
+float Compass_PerMotor::scaled_output(uint8_t motor)
+{
+    if (!have_motor_map) {
+        if (SRV_Channels::find_channel(SRV_Channel::k_motor1, motor_map[0]) &&
+            SRV_Channels::find_channel(SRV_Channel::k_motor2, motor_map[1]) &&
+            SRV_Channels::find_channel(SRV_Channel::k_motor3, motor_map[2]) &&
+            SRV_Channels::find_channel(SRV_Channel::k_motor4, motor_map[3])) {
+            have_motor_map = true;
+        }
+    }
+    if (!have_motor_map) {
+        return 0;
+    }
+    
+    // this currently assumes first 4 channels. 
+    uint16_t pwm = hal.rcout->read_last_sent(motor_map[motor]);
+
+    // get 0 to 1 motor demand
+    float output = (hal.rcout->scale_esc_to_unity(pwm)+1) * 0.5;
+
+    if (output <= 0) {
+        return 0;
+    }
+    
+    // scale for voltage
+    output *= voltage;
+
+    // apply expo correction
+    output = powf(output, expo);
+    return output;
+}
+
+// per-motor calibration update
+void Compass_PerMotor::calibration_start(void)
+{
+    for (uint8_t i=0; i<4; i++) {
+        field_sum[i].zero();
+        output_sum[i] = 0;
+        count[i] = 0;
+        start_ms[i] = 0;
+    }
+    base_field = compass.get_field(0);
+    running = true;
+
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "PMOT starting");
+}
+
+// per-motor calibration update
+void Compass_PerMotor::calibration_update(void)
+{
+    uint32_t now = AP_HAL::millis();
+    
+    // accumulate per-motor sums
+    for (uint8_t i=0; i<4; i++) {
+        float output = scaled_output(i);
+
+        if (output <= 0) {
+            // motor is off
+            start_ms[i] = 0;
+            continue;
+        }
+        if (start_ms[i] == 0) {
+            start_ms[i] = now;
+        }
+        if (now - start_ms[i] < 500) {
+            // motor must run for 0.5s to settle
+            continue;
+        }
+
+        // accumulate a sample
+        field_sum[i] += compass.get_field(0);
+        output_sum[i] += output;
+        count[i]++;
+    }
+}
+
+// calculate per-motor calibration values
+void Compass_PerMotor::calibration_end(void)
+{
+    for (uint8_t i=0; i<4; i++) {
+        if (count[i] == 0) {
+            continue;
+        }
+
+        // calculate effective output
+        float output = output_sum[i] / count[i];
+
+        // calculate amount that field changed from base field
+        Vector3f field_change = base_field - (field_sum[i] / count[i]);
+        if (output <= 0) {
+            continue;
+        }
+        
+        Vector3f c = field_change / output;
+        compensation[i].set_and_save(c);
+    }
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "PMOT finished");
+
+    // enable per-motor compensation
+    enable.set_and_save(1);
+    
+    running = false;
+}
+
+/*
+  calculate total offset for per-motor compensation
+ */
+void Compass_PerMotor::compensate(Vector3f &offset)
+{
+    offset.zero();
+
+    if (running) {
+        // don't compensate while calibrating
+        return;
+    }
+
+    for (uint8_t i=0; i<4; i++) {
+        float output = scaled_output(i);
+
+        const Vector3f &c = compensation[i].get();
+
+        offset += c * output;
+    }
+}

--- a/libraries/AP_Compass/Compass_PerMotor.h
+++ b/libraries/AP_Compass/Compass_PerMotor.h
@@ -1,0 +1,68 @@
+/*
+  per-motor compass compensation
+ */
+
+#include <AP_Math/AP_Math.h>
+
+
+class Compass;
+
+// per-motor compass compensation class. Currently tied to quadcopters
+// only, and single magnetometer
+class Compass_PerMotor {
+public:
+    static const struct AP_Param::GroupInfo var_info[];
+
+    Compass_PerMotor(Compass &_compass);
+
+    bool enabled(void) const {
+        return enable.get() != 0;
+    }
+    
+    void set_voltage(float _voltage) {
+        voltage = _voltage;
+    }
+
+    void calibration_start(void);
+    void calibration_update(void);
+    void calibration_end(void);
+    void compensate(Vector3f &offset);
+    
+private:
+    Compass &compass;
+    AP_Int8 enable;
+    AP_Float expo;
+    AP_Vector3f compensation[4];
+
+    // base field on test start
+    Vector3f base_field;
+        
+    // sum of calibration field samples
+    Vector3f field_sum[4];
+
+    // sum of output (voltage*scaledpwm) in calibration
+    float output_sum[4];
+        
+    // count of calibration accumulation
+    uint16_t count[4];
+
+    // time a motor started in milliseconds
+    uint32_t start_ms[4];
+        
+    // battery voltage
+    float voltage;
+
+    // what rcout channel is being calibrated
+    uint8_t channel;
+
+    // is calibration running?
+    bool running;
+
+    // get scaled motor ouput
+    float scaled_output(uint8_t motor);
+
+    // map of motors
+    bool have_motor_map;
+    uint8_t motor_map[4];
+};
+


### PR DESCRIPTION
This implements an alternative form of motor interference compass compensation for small vehicles. It learns offsets per-motor, which makes for much more accurate compensation, and uses a scaling factor between demanded output, voltage and magnetic interference. 
The result is remarkably good compass compensation when motors and wiring are very close to a compass in a small quadcopter.
The code is quadcopter specific (though could work on a quadplane). It could be extended to work for other multicopters with more parameters, although the need isn't clear as other multirotor types tend to be larger and it is easier to move the compass to a better location.
The calibration process uses the existing motortest code, which is very convenient, and also provides for a simple way to test the results.
