### PR TITLE
Added simple accelcal

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -838,6 +838,9 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                     } else {
                         result = MAV_RESULT_FAILED;
                     }
+                } else if (is_equal(packet.param5,4.0f)) {
+                    // simple accel calibration
+                    result = rover.ins.simple_accel_cal(rover.ahrs);
                 } else {
                     send_text(MAV_SEVERITY_WARNING, "Unsupported preflight calibration");
                 }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1074,6 +1074,11 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 } else {
                     result = MAV_RESULT_FAILED;
                 }
+                
+            } else if (is_equal(packet.param5,4.0f)) {
+                // simple accel calibration
+                result = copter.ins.simple_accel_cal(copter.ahrs);
+
             } else if (is_equal(packet.param6,1.0f)) {
                 // compassmot calibration
                 result = copter.mavlink_compassmot(chan);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1204,6 +1204,9 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 } else {
                     result = MAV_RESULT_FAILED;
                 }
+            } else if (is_equal(packet.param5,4.0f)) {
+                // simple accel calibration
+                result = plane.ins.simple_accel_cal(plane.ahrs);
             }
             else {
                     send_text(MAV_SEVERITY_WARNING, "Unsupported preflight calibration");

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1187,6 +1187,9 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
                 } else {
                     result = MAV_RESULT_FAILED;
                 }
+            } else if (is_equal(packet.param5,4.0f)) {
+                // simple accel calibration
+                result = sub.ins.simple_accel_cal(sub.ahrs);
             } else if (is_equal(packet.param6,1.0f)) {
                 // compassmot calibration
                 //result = sub.mavlink_compassmot(chan);

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -981,11 +981,6 @@ bool AP_InertialSensor::accel_calibrated_ok_all() const
         if (_accel_offset[i].get().is_zero()) {
             return false;
         }
-        // exactly 1.0 scaling is extremely unlikely
-        const Vector3f &scaling = _accel_scale[i].get();
-        if (is_equal(scaling.x,1.0f) && is_equal(scaling.y,1.0f) && is_equal(scaling.z,1.0f)) {
-            return false;
-        }
         // zero scaling also indicates not calibrated
         if (_accel_scale[i].get().is_zero()) {
             return false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -27,6 +27,7 @@
 
 class AP_InertialSensor_Backend;
 class AuxiliaryBus;
+class AP_AHRS;
 
 /*
   forward declare DataFlash class. We can't include DataFlash.h
@@ -263,6 +264,9 @@ public:
     // update accel calibrator
     void acal_update();
 
+    // simple accel calibration
+    uint8_t simple_accel_cal(AP_AHRS &ahrs);
+    
     bool accel_cal_requires_reboot() const { return _accel_cal_requires_reboot; }
 
     // return time in microseconds of last update() call

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -94,6 +94,8 @@ void AP_InertialSensor_SITL::generate_accel(uint8_t instance)
 
     Vector3f accel = Vector3f(xAccel, yAccel, zAccel) + _imu.get_accel_offsets(instance);
 
+    _rotate_and_correct_accel(accel_instance[instance], accel);
+    
     _notify_new_accel_raw_sample(accel_instance[instance], accel, AP_HAL::micros64());
 }
 
@@ -126,6 +128,8 @@ void AP_InertialSensor_SITL::generate_gyro(uint8_t instance)
     gyro.y *= (1 + scale.y*0.01);
     gyro.z *= (1 + scale.z*0.01);
 
+    _rotate_and_correct_gyro(gyro_instance[instance], gyro);
+    
     _notify_new_gyro_raw_sample(gyro_instance[instance], gyro, AP_HAL::micros64());
 }
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -73,6 +73,11 @@ Aircraft::Aircraft(const char *home_str, const char *frame_str) :
     last_wall_time_us = get_wall_time_us();
     frame_counter = 0;
 
+    // support rotated IMUs for testing
+    if (strstr(frame_str, "-roll180")) {
+        imu_rotation = ROTATION_ROLL_180;
+    }
+    
     terrain = (AP_Terrain *)AP_Param::find_object("TERRAIN_");
 }
 
@@ -379,6 +384,20 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
         fdm.altitude  = smoothing.location.alt * 1.0e-2;
     }
 
+    if (imu_rotation != ROTATION_NONE) {
+        Vector3f accel(fdm.xAccel, fdm.yAccel, fdm.zAccel);
+        accel.rotate(imu_rotation);
+        fdm.xAccel    = accel.x;
+        fdm.yAccel    = accel.y;
+        fdm.zAccel    = accel.z;
+
+        Vector3f rgyro(fdm.rollRate, fdm.pitchRate, fdm.yawRate);
+        rgyro.rotate(imu_rotation);
+        fdm.rollRate  = degrees(rgyro.x);
+        fdm.pitchRate = degrees(rgyro.y);
+        fdm.yawRate   = degrees(rgyro.z);
+    }
+    
     if (last_speedup != sitl->speedup && sitl->speedup > 0) {
         set_speedup(sitl->speedup);
         last_speedup = sitl->speedup;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -164,6 +164,8 @@ protected:
     bool use_time_sync = true;
     float last_speedup = -1.0f;
 
+    enum Rotation imu_rotation = ROTATION_NONE;
+
     enum {
         GROUND_BEHAVIOR_NONE = 0,
         GROUND_BEHAVIOR_NO_MOVEMENT,


### PR DESCRIPTION
This is a "back to the future" PR. We had simple 1-D accelcal a long time ago, but removed it as it didn't work well with the EKF.
Now that we have EKF3 which can learn accel offsets on 3 axes, using a simple "vehicle level" accelcal becomes more practical, and is much simpler for consumer vehicles.
