### PR TITLE
AHRS: provide takeoff state for use by EKF

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -106,6 +106,9 @@ void Copter::set_land_complete(bool b)
 
     g2.stats.set_flying(!b);
 
+    // tell AHRS flying state
+    ahrs.set_likely_flying(!b);
+    
     // trigger disarm-on-land if configured
     bool disarm_on_land_configured = (g.throttle_behavior & THR_BEHAVE_DISARM_ON_LAND_DETECT) != 0;
     bool mode_disarms_on_land = mode_allows_arming(control_mode,false) && !mode_has_manual_throttle(control_mode);

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -155,6 +155,9 @@ void Plane::update_is_flying_5Hz(void)
     if (should_log(MASK_LOG_MODE)) {
         Log_Write_Status();
     }
+
+    // tell AHRS flying state
+    ahrs.set_likely_flying(new_is_flying);
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -115,6 +115,38 @@ public:
         return _flags.fly_forward;
     }
 
+    /*
+      set the "likely flying" flag. This is not guaranteed to be
+      accurate, but is the vehicle codes best guess as to the whether
+      the vehicle is currently flying
+     */
+    void set_likely_flying(bool b) {
+        if (b && !_flags.likely_flying) {
+            _last_flying_ms = AP_HAL::millis();
+        }
+        _flags.likely_flying = b;
+    }
+
+    /*
+      get the likely flying status. Returns true if the vehicle code
+      thinks we are flying at the moment. Not guaranteed to be
+      accurate
+     */
+    bool get_likely_flying(void) const {
+        return _flags.likely_flying;
+    }
+
+    /*
+      return time in milliseconds since likely_flying was set
+      true. Returns zero if likely_flying is currently false
+    */
+    uint32_t get_time_flying_ms(void) const {
+        if (!_flags.likely_flying) {
+            return 0;
+        }
+        return AP_HAL::millis() - _last_flying_ms;
+    }
+    
     AHRS_VehicleClass get_vehicle_class(void) const {
         return _vehicle_class;
     }
@@ -551,7 +583,11 @@ protected:
         uint8_t fly_forward             : 1;    // 1 if we can assume the aircraft will be flying forward on its X axis
         uint8_t correct_centrifugal     : 1;    // 1 if we should correct for centrifugal forces (allows arducopter to turn this off when motors are disarmed)
         uint8_t wind_estimation         : 1;    // 1 if we should do wind estimation
+        uint8_t likely_flying           : 1;    // 1 if vehicle is probably flying
     } _flags;
+
+    // time when likely_flying last went true
+    uint32_t _last_flying_ms;
 
     // calculate sin/cos of roll/pitch/yaw from rotation
     void calc_trig(const Matrix3f &rot,

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -368,11 +368,11 @@ void NavEKF2_core::detectFlight()
                 inFlight = true;
             }
 
-            // If more than 15 seconds armed since exiting on-ground, then we definitely are flying
-            if ((imuSampleTime_ms - timeAtArming_ms) > 15000) {
+            // If more than 5 seconds since likely_flying was set
+            // true, then set inFlight true
+            if (_ahrs->get_time_flying_ms() > 5000) {
                 inFlight = true;
             }
-
         }
 
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -367,11 +367,11 @@ void NavEKF3_core::detectFlight()
                 inFlight = true;
             }
 
-            // If more than 15 seconds armed since exiting on-ground, then we definitely are flying
-            if ((imuSampleTime_ms - timeAtArming_ms) > 15000) {
+            // If more than 5 seconds since likely_flying was set
+            // true, then set inFlight true
+            if (_ahrs->get_time_flying_ms() > 5000) {
                 inFlight = true;
             }
-
         }
 
     }


### PR DESCRIPTION
This adds takeoff state from vehicle code in AHRS, allowing the EKF to base inFlight decisions on the vehicles knowledge of the takeoff state.
The recent "15s since armed" EKF condition is replaced with "5s since takeoff"
