### PR TITLE
RFC: Rover motor lib

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -105,8 +105,6 @@ void Rover::setup()
 
     in_auto_reverse = false;
 
-    rssi.init();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -43,6 +43,7 @@ Rover rover;
   time they are expected to take (in microseconds)
 */
 const AP_Scheduler::Task Rover::scheduler_tasks[] = {
+    //         Function name,          Hz,     us,
     SCHED_TASK(read_radio,             50,   1000),
     SCHED_TASK(ahrs_update,            50,   6400),
     SCHED_TASK(read_sonars,            50,   2000),

--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -5,3 +5,22 @@ enum HomeState AP_Arming_Rover::home_status() const
 {
     return rover.home_is_set;
 }
+
+bool AP_Arming_Rover::pre_arm_checks(bool report)
+{
+    if (rover.motor_type_class == Rover::UGV_TYPE_UNDEFINED) {
+        if (report) {
+            rover.gcs_send_text(MAV_SEVERITY_WARNING, "PreArm: FRAME_TYPE unset");
+        }
+        return false;
+    }
+    return hardware_safety_check(report)
+           &  barometer_checks(report)
+           &  ins_checks(report)
+           &  compass_checks(report)
+           &  gps_checks(report)
+           &  battery_checks(report)
+           &  logging_checks(report)
+           &  manual_transmitter_checks(report)
+           &  board_voltage_checks(report);
+}

--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -6,8 +6,8 @@ enum HomeState AP_Arming_Rover::home_status() const
     return rover.home_is_set;
 }
 
-bool AP_Arming_Rover::pre_arm_checks(bool report)
-{
+
+bool AP_Arming_Rover::pre_arm_checks(bool report) {
     if (rover.motor_type_class == Rover::UGV_TYPE_UNDEFINED) {
         if (report) {
             rover.gcs_send_text(MAV_SEVERITY_WARNING, "PreArm: FRAME_TYPE unset");
@@ -15,12 +15,64 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
         return false;
     }
     return hardware_safety_check(report)
-           &  barometer_checks(report)
-           &  ins_checks(report)
-           &  compass_checks(report)
-           &  gps_checks(report)
-           &  battery_checks(report)
-           &  logging_checks(report)
-           &  manual_transmitter_checks(report)
-           &  board_voltage_checks(report);
+           & barometer_checks(report)
+           & ins_checks(report)
+           & compass_checks(report)
+           & gps_checks(report)
+           & battery_checks(report)
+           & logging_checks(report)
+           & manual_transmitter_checks(report)
+           & board_voltage_checks(report);
+}
+
+// perform pre_arm_rc_checks checks and set ap.pre_arm_rc_check flag
+bool AP_Arming_Rover::pre_arm_rc_checks(const bool display_failure)
+{
+    // set rc-checks to success if RC checks are disabled
+    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_RC)) {
+        return true;
+    }
+
+    const RC_Channel *channels[] = {
+            rover.channel_steer,
+            rover.channel_throttle,
+    };
+    const char *channel_names[] = {"Steer", "Throttle"};
+
+    for (uint8_t i= 0 ; i < ARRAY_SIZE(channels); i++) {
+        const RC_Channel *channel = channels[i];
+        const char *channel_name = channel_names[i];
+        // check if radio has been calibrated
+        if (!channel->min_max_configured()) {
+            if (display_failure) {
+                rover.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "PreArm: RC %s not configured", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_min() > 1300) {
+            if (display_failure) {
+                rover.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "PreArm: %s radio min too high", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_max() < 1700) {
+            if (display_failure) {
+                rover.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "PreArm: %s radio max too low", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_trim() < channel->get_radio_min()) {
+            if (display_failure) {
+                rover.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim below min", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_trim() > channel->get_radio_max()) {
+            if (display_failure) {
+                rover.gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim above max", channel_name);
+            }
+            return false;
+        }
+    }
+    return true;
 }

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -14,6 +14,8 @@ public:
         AP_Arming(ahrs_ref, baro, compass, battery) {
     }
 
+    bool pre_arm_checks(bool report) override ;
+
 protected:
 
     enum HomeState home_status() const override;

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -15,6 +15,7 @@ public:
     }
 
     bool pre_arm_checks(bool report) override ;
+    bool pre_arm_rc_checks(const bool display_failure);
 
 protected:
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -162,7 +162,7 @@ void Rover::send_servo_out(mavlink_channel_t chan)
         0,  // port 0
         10000 * channel_steer->norm_output(),
         0,
-        10000 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle),
+        100 * SRV_Channels::get_output_scaled(SRV_Channel::k_throttle),
         0,
         0,
         0,
@@ -179,7 +179,7 @@ void Rover::send_vfr_hud(mavlink_channel_t chan)
         gps.ground_speed(),
         ahrs.groundspeed(),
         (ahrs.yaw_sensor / 100) % 360,
-        static_cast<uint16_t>(100 * fabsf(SRV_Channels::get_output_norm(SRV_Channel::k_throttle))),
+        SRV_Channels::get_output_scaled(SRV_Channel::k_throttle),
         current_loc.alt / 100.0f,
         0);
 }

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1093,7 +1093,16 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
-
+        case MAV_CMD_DO_MOTOR_TEST:
+            // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
+            // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
+            // param3 : throttle (range depends upon param2)
+            // param4 : timeout (in seconds)
+            result = rover.mavlink_motor_test_start(chan, static_cast<uint8_t>(packet.param1),
+                                                    static_cast<uint8_t>(packet.param2),
+                                                    static_cast<uint16_t>(packet.param3),
+                                                    packet.param4);
+            break;
 
         default:
                 break;

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -278,7 +278,7 @@ void Rover::Log_Write_Nav_Tuning()
         wp_distance         : wp_distance,
         target_bearing_cd   : static_cast<uint16_t>(fabsf(nav_controller->target_bearing_cd())),
         nav_bearing_cd      : static_cast<uint16_t>(fabsf(nav_controller->nav_bearing_cd())),
-        throttle            : static_cast<int8_t>(100 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle)),
+        throttle            : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)),
         xtrack_error        : nav_controller->crosstrack_error()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -336,7 +336,7 @@ void Rover::Log_Write_Sonar()
         turn_angle      : static_cast<int8_t>(obstacle.turn_angle),
         turn_time       : turn_time,
         ground_speed    : static_cast<uint16_t>(fabsf(ground_speed * 100)),
-        throttle        : static_cast<int8_t>(100 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle))
+        throttle        : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -623,9 +623,6 @@ void Rover::load_parameters(void)
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_ROVER);
 
-    SRV_Channels::set_default_function(CH_1, SRV_Channel::k_steering);
-    SRV_Channels::set_default_function(CH_3, SRV_Channel::k_throttle);
-
     const uint8_t old_rc_keys[14] = { Parameters::k_param_rc_1_old,  Parameters::k_param_rc_2_old,
                                       Parameters::k_param_rc_3_old,  Parameters::k_param_rc_4_old,
                                       Parameters::k_param_rc_5_old,  Parameters::k_param_rc_6_old,

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -552,6 +552,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_VisualOdom/AP_VisualOdom.cpp
     AP_SUBGROUPINFO(visual_odom, "VISO", 7, ParametersG2, AP_VisualOdom),
 
+    // @Param: TYPE_CLASS
+    // @DisplayName: Type Class
+    // @Description: Controls major type class for rover component
+    // @Values: 0:Undefined, 1:Rover, 2:Robot, 3:Boat
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("TYPE_CLASS", 8, ParametersG2, type_class, Rover::UGV_TYPE_UNDEFINED),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -322,6 +322,9 @@ public:
 
     // Visual Odometry camera
     AP_VisualOdom visual_odom;
+
+    // type class
+    AP_Int8 type_class;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -408,6 +408,9 @@ private:
     // last visual odometry update time
     uint32_t visual_odom_last_update_ms;
 
+    // True when we are doing motor test
+    bool motor_test;
+    bool initialised;
 
     // Motors
     enum ugv_type_class {
@@ -599,6 +602,11 @@ private:
     void set_loiter_active(const AP_Mission::Mission_Command& cmd);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void crash_check();
+    // Motor test
+    void motor_test_output();
+    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc);
+    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec);
+    void motor_test_stop();
     // Motor
     bool setup_type_class(ugv_type_class type_class);
     // output_to_motors - sends minimum values out to the motors

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -487,7 +487,6 @@ private:
     void calc_throttle(float target_speed);
     void calc_lateral_acceleration();
     void calc_nav_steer();
-    bool have_skid_steering();
     void mix_skid_steering();
     void set_servos(void);
     void set_auto_WP(const struct Location& loc);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -408,6 +408,18 @@ private:
     // last visual odometry update time
     uint32_t visual_odom_last_update_ms;
 
+
+    // Motors
+    enum ugv_type_class {
+        UGV_TYPE_UNDEFINED = 0,
+        UGV_TYPE_ROVER = 1,
+        UGV_TYPE_TANK = 2,
+        UGV_TYPE_BOAT = 3,
+    };
+
+    ugv_type_class motor_type_class{UGV_TYPE_UNDEFINED};  // init undefined to make the correct setup at start
+    bool isTypeTank = false;
+
 private:
     // private member functions
     void ahrs_update();
@@ -588,6 +600,13 @@ private:
     void set_loiter_active(const AP_Mission::Mission_Command& cmd);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void crash_check();
+    // Motor
+    bool setup_type_class(ugv_type_class type_class);
+    // output_to_motors - sends minimum values out to the motors
+    void output_to_motors();
+    void set_freq_group(uint8_t group, uint16_t freq_hz);
+    void setup_default_function(ugv_type_class type_class);
+    void setup_motors();
 #if ADVANCED_FAILSAFE == ENABLED
     void afs_fs_check(void);
 #endif

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -281,7 +281,6 @@ private:
     // Ground speed
     // The amount current ground speed is below min ground speed.  meters per second
     float ground_speed;
-    int16_t throttle_last;
     int16_t throttle;
 
     // CH7 control

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -469,7 +469,7 @@ private:
     void Log_Arm_Disarm();
 
     void load_parameters(void);
-    void throttle_slew_limit(int16_t last_throttle);
+    void throttle_slew_limit(void);
     bool auto_check_trigger(void);
     bool use_pivot_steering(void);
     void calc_throttle(float target_speed);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -475,6 +475,8 @@ private:
     void calc_throttle(float target_speed);
     void calc_lateral_acceleration();
     void calc_nav_steer();
+    bool have_skid_steering();
+    void mix_skid_steering();
     void set_servos(void);
     void set_auto_WP(const struct Location& loc);
     void set_guided_WP(const struct Location& loc);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -224,8 +224,6 @@ void Rover::calc_nav_steer() {
     Set the flight control servos based on the current calculated values
 *****************************************/
 void Rover::set_servos(void) {
-    static uint16_t last_throttle;
-
     if (control_mode == MANUAL || control_mode == LEARNING) {
         // do a direct pass through of radio values
         SRV_Channels::set_output_pwm(SRV_Channel::k_steering, channel_steer->read());
@@ -266,9 +264,6 @@ void Rover::set_servos(void) {
             }
         }
     }
-
-    // record last throttle before we apply skid steering
-    SRV_Channels::get_output_pwm(SRV_Channel::k_throttle, last_throttle);
 
     if (motor_test) {
         motor_test_output();

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -3,18 +3,13 @@
 /*****************************************
     Throttle slew limit
 *****************************************/
-void Rover::throttle_slew_limit(int16_t last_throttle) {
-    // if slew limit rate is set to zero then do not slew limit
-    if (g.throttle_slewrate && last_throttle != 0) {
-        // limit throttle change by the given percentage per second
-        float temp = g.throttle_slewrate * G_Dt * 0.01f * fabsf(channel_throttle->get_radio_max() - channel_throttle->get_radio_min());
-        // allow a minimum change of 1 PWM per cycle
-        if (temp < 1) {
-            temp = 1;
-        }
-        uint16_t pwm;
-        if (SRV_Channels::get_output_pwm(SRV_Channel::k_throttle, pwm)) {
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, constrain_int16(pwm, last_throttle - temp, last_throttle + temp));
+void Rover::throttle_slew_limit(void)
+{
+    if (g.throttle_slewrate > 0) {
+        SRV_Channels::limit_slew_rate(SRV_Channel::k_throttle, g.throttle_slewrate, G_Dt);
+        if (g.skid_steer_out) {
+            // when skid steering also limit 2nd channel
+            SRV_Channels::limit_slew_rate(SRV_Channel::k_steering, g.throttle_slewrate, G_Dt);
         }
     }
 }
@@ -288,9 +283,6 @@ void Rover::set_servos(void) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
-
-        // limit throttle movement speed
-        throttle_slew_limit(last_throttle);
     }
 
     // record last throttle before we apply skid steering
@@ -322,6 +314,11 @@ void Rover::set_servos(void) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100 * motor2);
     }
 
+    if (control_mode != MANUAL && control_mode != LEARNING) {
+        // limit throttle movement speed
+        throttle_slew_limit();
+    }
+    
     if (!arming.is_armed()) {
         // Some ESCs get noisy (beep error msgs) if PWM == 0.
         // This little segment aims to avoid this.

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -252,10 +252,10 @@ void Rover::set_servos(void) {
         SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, channel_throttle->read());
         if (failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
             // suppress throttle if in failsafe and manual
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, channel_throttle->get_radio_trim());
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             // suppress steer if in failsafe and manual and skid steer mode
             if (g.skid_steer_out) {
-                SRV_Channels::set_output_pwm(SRV_Channel::k_steering, channel_steer->get_radio_trim());
+                SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
         }
         if (g.skid_steer_in) {
@@ -332,17 +332,17 @@ void Rover::set_servos(void) {
             break;
 
         case AP_Arming::YES_ZERO_PWM:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, 0);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             if (g.skid_steer_out) {
-                SRV_Channels::set_output_pwm(SRV_Channel::k_steering, 0);
+                SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             }
             break;
 
         case AP_Arming::YES_MIN_PWM:
         default:
-            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, channel_throttle->get_radio_trim());
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             if (g.skid_steer_out) {
-                SRV_Channels::set_output_pwm(SRV_Channel::k_steering, channel_steer->get_radio_trim());
+                SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
             break;
         }

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -269,5 +269,10 @@ void Rover::set_servos(void) {
 
     // record last throttle before we apply skid steering
     SRV_Channels::get_output_pwm(SRV_Channel::k_throttle, last_throttle);
-    output_to_motors();
+
+    if (motor_test) {
+        motor_test_output();
+    } else {
+        output_to_motors();
+    }
 }

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -50,7 +50,7 @@ bool Rover::auto_check_trigger(void) {
     work out if we are going to use pivot steering
 */
 bool Rover::use_pivot_steering(void) {
-    if (control_mode >= AUTO && have_skid_steering() && g.pivot_turn_angle != 0) {
+    if (control_mode >= AUTO && isTypeTank && g.pivot_turn_angle != 0) {
         const int16_t bearing_error = wrap_180_cd(nav_controller->target_bearing_cd() - ahrs.yaw_sensor) / 100;
         if (abs(bearing_error) > g.pivot_turn_angle) {
             return true;
@@ -86,7 +86,7 @@ void Rover::calc_throttle(float target_speed) {
     if (!auto_check_trigger() || in_stationary_loiter()) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, g.throttle_min.get());
         // Stop rotation in case of loitering and skid steering
-        if (g.skid_steer_out) {
+        if (isTypeTank) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
         }
         return;
@@ -234,7 +234,7 @@ void Rover::set_servos(void) {
             // suppress throttle if in failsafe and manual
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             // suppress steer if in failsafe and manual and skid steer mode
-            if (g.skid_steer_out) {
+            if (isTypeTank) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
         }
@@ -253,7 +253,7 @@ void Rover::set_servos(void) {
             // suppress throttle if in failsafe
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (have_skid_steering()) {
+            if (isTypeTank) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
@@ -261,7 +261,7 @@ void Rover::set_servos(void) {
         if (!hal.util->get_soft_armed()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (have_skid_steering()) {
+            if (isTypeTank) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -119,7 +119,7 @@ void Rover::calc_throttle(float target_speed) {
     // use g.speed_turn_gain for a 90 degree turn, and in proportion
     // for other turn angles
     const int32_t turn_angle = wrap_180_cd(next_navigation_leg_cd - ahrs.yaw_sensor);
-    const float speed_turn_ratio = constrain_float(fabsf(turn_angle / 9000.0f), 0, 1);
+    const float speed_turn_ratio = constrain_float(fabsf(turn_angle / 9000.0f), 0.0f, 1.0f);
     const float speed_turn_reduction = (100 - g.speed_turn_gain) * speed_turn_ratio * 0.01f;
 
     float reduction = 1.0f - steer_rate * speed_turn_reduction;
@@ -137,7 +137,7 @@ void Rover::calc_throttle(float target_speed) {
 
     groundspeed_error = fabsf(target_speed) - ground_speed;
 
-    throttle = throttle_target + (g.pidSpeedThrottle.get_pid(groundspeed_error * 100) / 100);
+    throttle = throttle_target + (g.pidSpeedThrottle.get_pid(groundspeed_error * 100.0f) / 100.0f);
 
     // also reduce the throttle by the reduction factor. This gives a
     // much faster response in turns
@@ -157,7 +157,7 @@ void Rover::calc_throttle(float target_speed) {
         // We use a linear gain, with 0 gain at a ground speed error
         // of braking_speederr, and 100% gain when groundspeed_error
         // is 2*braking_speederr
-        const float brake_gain = constrain_float(((-groundspeed_error)-g.braking_speederr)/g.braking_speederr, 0, 1);
+        const float brake_gain = constrain_float(((-groundspeed_error)-g.braking_speederr)/g.braking_speederr, 0.0f, 1.0f);
         const int16_t braking_throttle = g.throttle_max * (g.braking_percent * 0.01f) * brake_gain;
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, constrain_int16(-braking_throttle, -g.throttle_max, -g.throttle_min));
 

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -64,7 +64,7 @@ bool Rover::auto_check_trigger(void) {
     work out if we are going to use pivot steering
 */
 bool Rover::use_pivot_steering(void) {
-    if (control_mode >= AUTO && g.skid_steer_out && g.pivot_turn_angle != 0) {
+    if (control_mode >= AUTO && have_skid_steering() && g.pivot_turn_angle != 0) {
         const int16_t bearing_error = wrap_180_cd(nav_controller->target_bearing_cd() - ahrs.yaw_sensor) / 100;
         if (abs(bearing_error) > g.pivot_turn_angle) {
             return true;
@@ -234,12 +234,52 @@ void Rover::calc_nav_steer() {
     SRV_Channels::set_output_scaled(SRV_Channel::k_steering, steerController.get_steering_out_lat_accel(lateral_acceleration));
 }
 
+/*
+  run the skid steering mixer
+ */
+void Rover::mix_skid_steering(void)
+{
+    const float steering_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_steering) / 4500.0;
+    const float throttle_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) / 100.0;
+    float motor1 = throttle_scaled + 0.5f * steering_scaled;
+    float motor2 = throttle_scaled - 0.5f * steering_scaled;
+
+    if (fabsf(throttle_scaled) <= 0.01f) {
+        // Use full range for on spot turn
+        motor1 = steering_scaled;
+        motor2 = -steering_scaled;
+    }
+    
+    // first new-style skid steering
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft,  1000 * motor1);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000 * motor2);
+
+    // now old style skid steering with skid_steer_out
+    if (g.skid_steer_out) {
+        // convert the two radio_out values to skid steering values
+        /*
+            mixing rule:
+            steering = motor1 - motor2
+            throttle = 0.5*(motor1 + motor2)
+            motor1 = throttle + 0.5*steering
+            motor2 = throttle - 0.5*steering
+        */
+        if ((control_mode == MANUAL || control_mode == LEARNING) && g.skid_steer_in) {
+            // Mixage is already done by a controller so just pass the value to motor
+            motor1 = steering_scaled;
+            motor2 = throttle_scaled;
+        }
+
+        SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 4500 * motor1);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100 * motor2);
+    }
+}
+
 /*****************************************
     Set the flight control servos based on the current calculated values
 *****************************************/
 void Rover::set_servos(void) {
     static uint16_t last_throttle;
-    bool apply_skid_mix = true;  // Normaly true, false when the mixage is done by the controler with skid_steer_in = 1
 
     if (control_mode == MANUAL || control_mode == LEARNING) {
         // do a direct pass through of radio values
@@ -252,9 +292,6 @@ void Rover::set_servos(void) {
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
-        }
-        if (g.skid_steer_in) {
-            apply_skid_mix = false;
         }
     } else {
         if (in_reverse) {
@@ -271,7 +308,7 @@ void Rover::set_servos(void) {
             // suppress throttle if in failsafe
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (g.skid_steer_out) {
+            if (have_skid_steering()) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
@@ -279,7 +316,7 @@ void Rover::set_servos(void) {
         if (!hal.util->get_soft_armed()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (g.skid_steer_out) {
+            if (have_skid_steering()) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
@@ -288,30 +325,8 @@ void Rover::set_servos(void) {
     // record last throttle before we apply skid steering
     SRV_Channels::get_output_pwm(SRV_Channel::k_throttle, last_throttle);
 
-    if (g.skid_steer_out) {
-        // convert the two radio_out values to skid steering values
-        /*
-            mixing rule:
-            steering = motor1 - motor2
-            throttle = 0.5*(motor1 + motor2)
-            motor1 = throttle + 0.5*steering
-            motor2 = throttle - 0.5*steering
-        */
-        const float steering_scaled = SRV_Channels::get_output_norm(SRV_Channel::k_steering);
-        const float throttle_scaled = SRV_Channels::get_output_norm(SRV_Channel::k_throttle);
-        float motor1 = throttle_scaled + 0.5f * steering_scaled;
-        float motor2 = throttle_scaled - 0.5f * steering_scaled;
-
-        if (!apply_skid_mix) {  // Mixage is already done by a controller so just pass the value to motor
-            motor1 = steering_scaled;
-            motor2 = throttle_scaled;
-        } else if (fabsf(throttle_scaled) <= 0.01f) {  // Use full range for on spot turn
-            motor1 = steering_scaled;
-            motor2 = -steering_scaled;
-        }
-
-        SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 4500 * motor1);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100 * motor2);
+    if (have_skid_steering()) {
+        mix_skid_steering();
     }
 
     if (control_mode != MANUAL && control_mode != LEARNING) {
@@ -330,6 +345,8 @@ void Rover::set_servos(void) {
 
         case AP_Arming::YES_ZERO_PWM:
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             }
@@ -338,6 +355,8 @@ void Rover::set_servos(void) {
         case AP_Arming::YES_MIN_PWM:
         default:
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
@@ -354,4 +373,17 @@ void Rover::set_servos(void) {
 #endif
 }
 
-
+/*
+  work out if skid steering is available
+ */
+bool Rover::have_skid_steering(void)
+{
+    if (g.skid_steer_out) {
+        return true;
+    }
+    if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) &&
+        SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+        return true;
+    }
+    return false;
+}

--- a/APMrover2/afs_rover.cpp
+++ b/APMrover2/afs_rover.cpp
@@ -18,8 +18,8 @@ AP_AdvancedFailsafe_Rover::AP_AdvancedFailsafe_Rover(AP_Mission &_mission, AP_Ba
 void AP_AdvancedFailsafe_Rover::terminate_vehicle(void)
 {
     // stop motors
-    SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, 0);
-    SRV_Channels::set_output_pwm(SRV_Channel::k_steering, 0);
+    SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+    SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
     rover.lateral_acceleration = 0;
 
     // disarm as well

--- a/APMrover2/crash_check.cpp
+++ b/APMrover2/crash_check.cpp
@@ -23,7 +23,7 @@ void Rover::crash_check()
 
   if ((ahrs.groundspeed() >= CRASH_CHECK_VEL_MIN) ||        // Check velocity
       (fabsf(ahrs.get_gyro().z) >= CRASH_CHECK_VEL_MIN) ||  // Check turn speed
-      ((100 * fabsf(SRV_Channels::get_output_norm(SRV_Channel::k_throttle))) < CRASH_CHECK_THROTTLE_MIN)) {
+      (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)) < CRASH_CHECK_THROTTLE_MIN)) {
     crash_counter = 0;
     return;
   }

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -1,0 +1,168 @@
+#include "Rover.h"
+
+/*
+  mavlink motor test - implements the MAV_CMD_DO_MOTOR_TEST mavlink command so that the GCS/pilot can test an individual motor or flaps
+                       to ensure proper wiring, rotation.
+ */
+
+// motor test definitions
+static const int16_t MOTOR_TEST_PWM_MIN = 1000;     // min pwm value accepted by the test
+static const int16_t MOTOR_TEST_PWM_MAX = 2000;    // max pwm value accepted by the test
+static const int16_t MOTOR_TEST_TIMEOUT_MS_MAX = 30000;   // max timeout is 30 seconds
+
+static uint32_t motor_test_start_ms = 0;        // system time the motor test began
+static uint32_t motor_test_timeout_ms = 0;      // test will timeout this many milliseconds after the motor_test_start_ms
+static uint8_t motor_test_seq = 0;              // motor sequence number of motor being tested
+static uint8_t motor_test_throttle_type = 0;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
+static uint16_t motor_test_throttle_value = 0;  // throttle to be sent to motor, value depends upon it's type
+
+// motor_test_output - checks for timeout and sends updates to motors objects
+void Rover::motor_test_output()
+{
+    // exit immediately if the motor test is not running
+    if (!motor_test) {
+        return;
+    }
+
+    // check for test timeout
+    if ((AP_HAL::millis() - motor_test_start_ms) >= motor_test_timeout_ms) {
+        // stop motor test
+        motor_test_stop();
+    } else {
+        int16_t pwm = 0;   // pwm that will be output to the motors
+
+        // calculate pwm based on throttle type
+        switch (motor_test_throttle_type) {
+
+            case MOTOR_TEST_THROTTLE_PERCENT:
+                // sanity check motor_test_throttle value
+                if (motor_test_throttle_value <= 100) {  // TODO : correct that
+                    int16_t pwm_min = 1000;
+                    int16_t pwm_max = 2000;
+                    pwm = pwm_min + (pwm_max - pwm_min) * static_cast<float>(motor_test_throttle_value) / 100.0f;
+                }
+                break;
+
+            case MOTOR_TEST_THROTTLE_PWM:
+                pwm = motor_test_throttle_value;
+                break;
+
+            case MOTOR_TEST_THROTTLE_PILOT:
+                pwm = channel_throttle->get_radio_in();
+                break;
+
+            default:
+                motor_test_stop();
+                return;
+        }
+
+        // sanity check throttle values
+        motor_test_seq = motor_test_seq - 1;  // motor channel start at 0
+        const bool valid = (pwm >= MOTOR_TEST_PWM_MIN && pwm <= MOTOR_TEST_PWM_MAX) && is_bounded_int32(motor_test_seq, 0, 16);
+        if (valid) {
+            // turn on motor to specified pwm vlaue
+            SRV_Channels::set_output_pwm_chan(motor_test_seq, pwm);
+            SRV_Channels::output_ch_all();
+        } else {
+            motor_test_stop();
+        }
+    }
+}
+
+// mavlink_motor_test_check - perform checks before motor tests can begin
+// return true if tests can continue, false if not
+bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
+{
+    // check board has initialised
+    if (!initialised) {
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Motor Test: Board initialising");
+        return false;
+    }
+
+    // check rc has been calibrated
+    if (check_rc && !arming.pre_arm_rc_checks(true)) {
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Motor Test: RC not calibrated");
+        return false;
+    }
+
+    // check if safety switch has been pushed
+    if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
+        gcs_chan[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Motor Test: Safety switch");
+        return false;
+    }
+
+    // if we got this far the check was successful and the motor test can continue
+    return true;
+}
+
+// mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
+// returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
+uint8_t Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec)
+{
+    // if test has not started try to start it
+    if (!motor_test) {
+        /* perform checks that it is ok to start test
+           The RC calibrated check can be skipped if direct pwm is
+           supplied
+        */
+        if (!mavlink_motor_test_check(chan, throttle_type != 1)) {
+            return MAV_RESULT_FAILED;
+        } else {
+            // start test
+            motor_test = true;
+
+            // enable and arm motors
+            if (!arming.is_armed()) {
+                setup_motors();
+            }
+
+            // disable throttle, battery and gps failsafe action
+            g.fs_gcs_enabled = 0;
+            g.fs_throttle_enabled = 0;
+            g.fs_crash_check = 0;
+            // failsafe battery ?
+
+            // turn on notify leds
+            AP_Notify::flags.esc_calibration = true;
+        }
+    }
+
+    // set timeout
+    motor_test_start_ms = AP_HAL::millis();
+    motor_test_timeout_ms = MIN(timeout_sec * 1000, MOTOR_TEST_TIMEOUT_MS_MAX);
+
+    // store required output
+    motor_test_seq = motor_seq;
+    motor_test_throttle_type = throttle_type;
+    motor_test_throttle_value = throttle_value;
+
+    // return success
+    return MAV_RESULT_ACCEPTED;
+}
+
+// motor_test_stop - stops the motor test
+void Rover::motor_test_stop()
+{
+    // exit immediately if the test is not running
+    if (!motor_test) {
+        return;
+    }
+
+    // flag test is complete
+    motor_test = false;
+
+    // disarm motors
+    disarm_motors();
+
+    // reset timeout
+    motor_test_start_ms = 0;
+    motor_test_timeout_ms = 0;
+
+    // re-enable failsafes
+    g.fs_gcs_enabled.load();
+    g.fs_throttle_enabled.load();
+    g.fs_crash_check.load();
+
+    // turn off notify leds
+    AP_Notify::flags.esc_calibration = false;
+}

--- a/APMrover2/motors.cpp
+++ b/APMrover2/motors.cpp
@@ -1,0 +1,189 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Rover.h"
+
+/*
+  set frequency of a set of channels
+ */
+void Rover::set_freq_group(uint8_t group, uint16_t freq_hz)
+{
+    // TODO :get group mask
+    /*hal.rcout->set_freq(mask, freq_hz);
+    if ((_pwm_type == PWM_TYPE_ONESHOT ||
+         _pwm_type == PWM_TYPE_ONESHOT125) &&
+        freq_hz > 50 &&
+        mask != 0) {
+        // tell HAL to do immediate output
+        hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_ONESHOT);
+    } else if (_pwm_type == PWM_TYPE_BRUSHED16kHz) {
+        hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_BRUSHED16KHZ);
+    }*/
+
+    /*if (rover.g2.pwm_type != PWM_TYPE_NORMAL) {
+        if ((rover.g2.pwm_type == PWM_TYPE_ONESHOT || g2.pwm_type == PWM_TYPE_ONESHOT125)) {
+            // tell HAL to do immediate output
+            // hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_ONESHOT);
+        } else if (rover.g2.pwm_type == PWM_TYPE_BRUSHED16kHz) {
+            hal.rcout->set_output_mode(AP_HAL::RCOutput::MODE_PWM_BRUSHED16KHZ);
+            hal.rcout->set_freq((1UL << 0), static_cast<uint16_t>(2000.0f * 0.0625f * g2.pwm_freq));  // Steering group
+            hal.rcout->set_freq((1UL << 2), static_cast<uint16_t>(2000.0f * 0.0625f * g2.pwm_freq));  // Throttle group
+        }
+    }*/
+}
+
+// set frame class (i.e. rover, robot, etc.) and type (i.e. rover, tank, skidsteering, 6-wheels etc.)
+bool Rover::setup_type_class(ugv_type_class type_class)
+{
+    // exit immediately if no change
+    if (motor_type_class == type_class) {
+        return false;
+    }
+    if (arming.is_armed()) {
+        gcs_send_text(MAV_SEVERITY_WARNING, "Cannot change frame when armed");
+        return false;
+    }
+    motor_type_class = type_class;
+
+    if (motor_type_class == Rover::UGV_TYPE_TANK) {
+        isTypeTank = true;
+    } else {
+        isTypeTank = false;
+    }
+
+    setup_default_function(motor_type_class);
+    // setup the motors
+    setup_motors();
+
+    return true;
+}
+
+void Rover::output_to_motors()
+{
+    if (control_mode != MANUAL && control_mode != LEARNING) {
+        // limit throttle movement speed
+        if (g.throttle_slewrate > 0) {
+            SRV_Channels::limit_slew_rate(SRV_Channel::k_throttle, g.throttle_slewrate, G_Dt);
+        }
+    }
+
+    if (isTypeTank) {
+        const float steering_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_steering) / 4500.0f;
+        const float throttle_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) / 100.0f;
+        float motor1 = throttle_scaled + 0.5f * steering_scaled;
+        float motor2 = throttle_scaled - 0.5f * steering_scaled;
+
+        if ((control_mode == MANUAL || control_mode == LEARNING) && g.skid_steer_in) {
+            // Mixage is already done by a controller so just pass the value to motor
+            motor1 = steering_scaled;
+            motor2 = throttle_scaled;
+        } else if (fabsf(throttle_scaled) <= 0.01f) {  // Use full range for on spot turn
+            motor1 = steering_scaled;
+            motor2 = -steering_scaled;
+        }
+
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft,  1000.0f * motor1);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000.0f * motor2);
+    }
+
+    if (!arming.is_armed()) {
+        // Some ESCs get noisy (beep error msgs) if PWM == 0.
+        // This little segment aims to avoid this.
+        switch (arming.arming_required()) {
+            case AP_Arming::NO:
+                // keep existing behavior: do nothing to radio_out
+                // (don't disarm throttle channel even if AP_Arming class is)
+                break;
+
+            case AP_Arming::YES_ZERO_PWM:
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                if (isTypeTank) {
+                    SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+                }
+                break;
+
+            case AP_Arming::YES_MIN_PWM:
+            default:
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                if (isTypeTank) {
+                    SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+                }
+                break;
+        }
+    }
+
+    SRV_Channels::calc_pwm();
+
+    // send values to the PWM timers for output
+    // ----------------------------------------
+    SRV_Channels::output_ch_all();
+}
+
+/***
+ * Set default function for each channels if not already assigned
+ */
+void Rover::setup_default_function(ugv_type_class type_class)
+{
+    bool hasChange = false;
+    switch (type_class) {
+        case UGV_TYPE_ROVER:
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
+                SRV_Channels::set_default_function(CH_1, SRV_Channel::k_steering);
+                hasChange = true;
+            }
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
+                SRV_Channels::set_default_function(CH_3, SRV_Channel::k_throttle);
+                hasChange = true;
+            }
+            break;
+        case UGV_TYPE_TANK:
+        case UGV_TYPE_BOAT:
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
+                SRV_Channels::set_default_function(CH_1, SRV_Channel::k_throttleLeft);
+                hasChange = true;
+            }
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+                SRV_Channels::set_default_function(CH_3, SRV_Channel::k_throttleRight);
+                hasChange = true;
+            }
+            break;
+        case UGV_TYPE_UNDEFINED:
+        default:
+            break;
+    }
+    if (hasChange) {
+        gcs_send_text(MAV_SEVERITY_WARNING, "TYPE_CLASS changed, please reboot");
+    }
+}
+
+/***
+ * Associate the different ouput pins to their functions
+ * @param type_class
+ */
+void Rover::setup_motors()
+{
+    // k_steering are limited to -45;45 degree
+    SRV_Channels::set_angle(SRV_Channel::k_steering, SERVO_MAX);
+    // k_throttle are in power percent so 0 ... 100%
+    SRV_Channels::set_angle(SRV_Channel::k_throttle, 100);
+
+    // left/right throttle as -1000 to 1000 values
+    SRV_Channels::set_angle(SRV_Channel::k_throttleLeft,  1000);
+    SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 1000);
+}

--- a/APMrover2/motors.cpp
+++ b/APMrover2/motors.cpp
@@ -76,6 +76,10 @@ void Rover::output_to_motors()
         // limit throttle movement speed
         if (g.throttle_slewrate > 0) {
             SRV_Channels::limit_slew_rate(SRV_Channel::k_throttle, g.throttle_slewrate, G_Dt);
+            if (isTypeTank) {
+                // when skid steering also limit 2nd channel
+                SRV_Channels::limit_slew_rate(SRV_Channel::k_steering, g.throttle_slewrate, G_Dt);
+            }
         }
     }
 
@@ -85,11 +89,7 @@ void Rover::output_to_motors()
         float motor1 = throttle_scaled + 0.5f * steering_scaled;
         float motor2 = throttle_scaled - 0.5f * steering_scaled;
 
-        if ((control_mode == MANUAL || control_mode == LEARNING) && g.skid_steer_in) {
-            // Mixage is already done by a controller so just pass the value to motor
-            motor1 = steering_scaled;
-            motor2 = throttle_scaled;
-        } else if (fabsf(throttle_scaled) <= 0.01f) {  // Use full range for on spot turn
+        if (fabsf(throttle_scaled) <= 0.01f) {  // Use full range for on spot turn
             motor1 = steering_scaled;
             motor2 = -steering_scaled;
         }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -16,6 +16,10 @@ void Rover::set_control_channels(void)
     SRV_Channels::set_angle(SRV_Channel::k_steering, SERVO_MAX);
     SRV_Channels::set_angle(SRV_Channel::k_throttle, 100);
 
+    // left/right throttle as -1000 to 1000 values
+    SRV_Channels::set_angle(SRV_Channel::k_throttleLeft,  1000);
+    SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 1000);
+
     // For a rover safety is TRIM throttle
     if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
@@ -95,7 +99,7 @@ void Rover::rudder_arm_disarm_check()
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if (!motor_active() & !g.skid_steer_out) {
+    } else if (!motor_active() & !have_skid_steering()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
         // This is disabled for skid steering otherwise when tring to turn a skid steering rover around
         // the rover would disarm

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -5,17 +5,15 @@
  */
 void Rover::set_control_channels(void)
 {
-
-    SRV_Channels::set_angle(SRV_Channel::k_steering, SERVO_MAX);
-    SRV_Channels::set_angle(SRV_Channel::k_throttle, 100);
-
-    // left/right throttle as -1000 to 1000 values
-    SRV_Channels::set_angle(SRV_Channel::k_throttleLeft,  1000);
-    SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 1000);
+    if (!setup_type_class((ugv_type_class)rover.g2.type_class.get())) {  // handle class change and motors
+        setup_motors();  // otherwise only update motor mapping
+    }
 
     // For a rover safety is TRIM throttle
     if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         if (g.skid_steer_out) {
             SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }
@@ -59,6 +57,8 @@ void Rover::init_rc_out()
     // full speed backward.
     if (arming.arming_required() == AP_Arming::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         if (g.skid_steer_out) {
             SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -139,8 +139,9 @@ void Rover::read_radio()
     RC_Channels::set_pwm_all();
     // check that RC value are valid
     control_failsafe(channel_throttle->get_radio_in());
-    // copy RC throttle input to throttle output
+    // copy RC scaled inputs to outputs
     SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, channel_throttle->get_control_in());
+    SRV_Channels::set_output_scaled(SRV_Channel::k_steering, channel_steer->get_control_in());
 
     // Check if the throttle value is above 50% and we need to nudge
     // Make sure its above 50% in the direction we are travelling

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -5,13 +5,6 @@
  */
 void Rover::set_control_channels(void)
 {
-    channel_steer    = RC_Channels::rc_channel(rcmap.roll()-1);
-    channel_throttle = RC_Channels::rc_channel(rcmap.throttle()-1);
-    channel_learn    = RC_Channels::rc_channel(g.learn_channel-1);
-
-    // set rc channel ranges
-    channel_steer->set_angle(SERVO_MAX);
-    channel_throttle->set_angle(100);
 
     SRV_Channels::set_angle(SRV_Channel::k_steering, SERVO_MAX);
     SRV_Channels::set_angle(SRV_Channel::k_throttle, 100);
@@ -36,6 +29,15 @@ void Rover::set_control_channels(void)
 
 void Rover::init_rc_in()
 {
+    // Initialize default RC channels
+    channel_steer    = RC_Channels::rc_channel(rcmap.roll()-1);
+    channel_throttle = RC_Channels::rc_channel(rcmap.throttle()-1);
+    channel_learn    = RC_Channels::rc_channel(g.learn_channel-1);
+
+    // set rc channel ranges
+    channel_steer->set_angle(SERVO_MAX);  // -4500 to 4500 centidegrees
+    channel_throttle->set_angle(100);     // 0 - 100%
+
     // set rc dead zones
     channel_steer->set_default_dead_zone(30);
     channel_throttle->set_default_dead_zone(30);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -129,16 +129,17 @@ void Rover::rudder_arm_disarm_check()
 void Rover::read_radio()
 {
     if (!hal.rcin->new_input()) {
+        // check if we lost RC link
         control_failsafe(channel_throttle->get_radio_in());
         return;
     }
 
     failsafe.last_valid_rc_ms = AP_HAL::millis();
-
+    // read the RC value
     RC_Channels::set_pwm_all();
-
+    // check that RC value are valid
     control_failsafe(channel_throttle->get_radio_in());
-
+    // copy RC throttle input to throttle output
     SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, channel_throttle->get_control_in());
 
     // Check if the throttle value is above 50% and we need to nudge
@@ -151,7 +152,7 @@ void Rover::read_radio()
     } else {
         throttle_nudge = 0;
     }
-
+    // apply RC skid steer mixing
     if (g.skid_steer_in) {
         // convert the two radio_in values from skid steering values
         /*
@@ -182,7 +183,7 @@ void Rover::read_radio()
         channel_steer->set_pwm(steer);
         channel_throttle->set_pwm(thr);
     }
-
+    // check if we try to do RC arm/disarm
     rudder_arm_disarm_check();
 }
 

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -28,9 +28,10 @@ void Rover::set_control_channels(void)
         }
     }
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
-    // take a proportion of speed.
+    // take a proportion of speed. Default to 1000 to 2000 for systems without
+    // a k_throttle output
+    hal.rcout->set_esc_scaling(1000, 2000);
     g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttle);
-    g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_steering);
 }
 
 void Rover::init_rc_in()

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -18,14 +18,15 @@ void Rover::set_control_channels(void)
 
     // For a rover safety is TRIM throttle
     if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
-        hal.rcout->set_safety_pwm(1UL << (rcmap.throttle() - 1), channel_throttle->get_radio_trim());
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         if (g.skid_steer_out) {
-            hal.rcout->set_safety_pwm(1UL << (rcmap.roll() - 1),  channel_steer->get_radio_trim());
+            SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }
     }
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
     // take a proportion of speed.
-    hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
+    g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttle);
+    g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_steering);
 }
 
 void Rover::init_rc_in()
@@ -50,9 +51,9 @@ void Rover::init_rc_out()
     // For Rover's no throttle means TRIM as rovers can go backwards i.e. MIN throttle is
     // full speed backward.
     if (arming.arming_required() == AP_Arming::YES_MIN_PWM) {
-        hal.rcout->set_safety_pwm(1UL << (rcmap.throttle() - 1),  channel_throttle->get_radio_trim());
+        SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         if (g.skid_steer_out) {
-            hal.rcout->set_safety_pwm(1UL << (rcmap.roll() - 1),  channel_steer->get_radio_trim());
+            SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }
     }
 }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -14,7 +14,7 @@ void Rover::set_control_channels(void)
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-        if (g.skid_steer_out) {
+        if (isTypeTank) {
             SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }
     }
@@ -59,7 +59,7 @@ void Rover::init_rc_out()
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-        if (g.skid_steer_out) {
+        if (isTypeTank) {
             SRV_Channels::set_safety_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         }
     }
@@ -102,7 +102,7 @@ void Rover::rudder_arm_disarm_check()
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if (!motor_active() & !have_skid_steering()) {
+    } else if (!motor_active() & !isTypeTank) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
         // This is disabled for skid steering otherwise when tring to turn a skid steering rover around
         // the rover would disarm

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -295,7 +295,6 @@ void Rover::set_mode(enum mode mode)
     }
 
     control_mode = mode;
-    throttle_last = 0;
     throttle = 500;
     if (!in_auto_reverse) {
         set_reverse(false);

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -217,6 +217,7 @@ void Rover::init_ardupilot()
 
     // disable safety if requested
     BoardConfig.init_safety();
+    initialised = true;
 }
 
 //*********************************************************************************

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -164,7 +164,7 @@ void Rover::init_ardupilot()
     gps.init(&DataFlash, serial_manager);
 
     rc_override_active = hal.rcin->set_overrides(rc_override, 8);
-
+    setup_default_function((ugv_type_class)g2.type_class.get());
     set_control_channels();
     init_rc_in();        // sets up rc channels from radio
     init_rc_out();        // sets up the timer libs

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -115,9 +115,9 @@ void Rover::init_ardupilot()
 
     ServoRelayEvents.set_channel_mask(0xFFF0);
 
-    set_control_channels();
-
     battery.init();
+
+    rssi.init();
 
     // keep a record of how many resets have happened. This can be
     // used to detect in-flight resets
@@ -165,6 +165,7 @@ void Rover::init_ardupilot()
 
     rc_override_active = hal.rcin->set_overrides(rc_override, 8);
 
+    set_control_channels();
     init_rc_in();        // sets up rc channels from radio
     init_rc_out();        // sets up the timer libs
 
@@ -421,6 +422,7 @@ void Rover::startup_INS_ground(void)
     mavlink_delay(1000);
 
     ahrs.init();
+    // say to EKF that rover only move by goind forward
     ahrs.set_fly_forward(true);
     ahrs.set_vehicle_class(AHRS_VEHICLE_GROUND);
 

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -73,6 +73,7 @@ void PX4RCOutput::init()
     // ensure not to write zeros to disabled channels
     for (uint8_t i=0; i < PX4_NUM_OUTPUT_CHANNELS; i++) {
         _period[i] = PWM_IGNORE_THIS_CHANNEL;
+        _last_sent[i] = PWM_IGNORE_THIS_CHANNEL;
     }
 }
 
@@ -229,6 +230,7 @@ void PX4RCOutput::enable_ch(uint8_t ch)
     _enabled_channels |= (1U<<ch);
     if (_period[ch] == PWM_IGNORE_THIS_CHANNEL) {
         _period[ch] = 0;
+        _last_sent[ch] = 0;
     }
 }
 
@@ -329,7 +331,12 @@ void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
         _max_channel = ch + 1;
     }
 
+
     if (_output_mode == MODE_PWM_BRUSHED) {
+
+        // keep unscaled value
+        _last_sent[ch] = period_us;
+    
         // map from the PWM range to 0 t0 100% duty cycle. For 16kHz
         // this ends up being 0 to 500 pulse width in units of
         // 125usec.
@@ -386,7 +393,7 @@ uint16_t PX4RCOutput::read_last_sent(uint8_t ch)
         return 0;
     }
 
-    return _period[ch];
+    return _last_sent[ch];
 }
 
 void PX4RCOutput::read_last_sent(uint16_t* period_us, uint8_t len)

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -45,6 +45,9 @@ private:
     int _alt_fd;
     uint16_t _freq_hz;
     uint16_t _period[PX4_NUM_OUTPUT_CHANNELS];
+    // we keep the last_sent value separately, as we need to keep the unscaled
+    // value for systems with brushed motors which scale outputs
+    uint16_t _last_sent[PX4_NUM_OUTPUT_CHANNELS];
     volatile uint8_t _max_channel;
     volatile bool _need_update;
     bool _sbus_enabled:1;

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -583,8 +583,10 @@ void SRV_Channels::limit_slew_rate(SRV_Channel::Aux_servo_function_t function, f
                 continue;
             }
             uint16_t max_change = (ch.get_output_max() - ch.get_output_min()) * slew_rate * dt * 0.01f;
-            if (max_change == 0) {
-                // always allow some change
+            if (max_change == 0 || dt > 1) {
+                // always allow some change. If dt > 1 then assume we
+                // are just starting out, and only allow a small
+                // change for this loop
                 max_change = 1;
             }
             ch.output_pwm = constrain_int16(ch.output_pwm, last_pwm-max_change, last_pwm+max_change);


### PR DESCRIPTION
Hello,

This is a first try for a motor lib for rover !
It implement a new parameter TYPE_CLASS that will allow to separate correctly the different type of rover.
It put motor initialization and mixing in a dedicated file.
It implement a new skid steering (aka tank mode). This new mode require to change the servo function from k_throttle;k_steering to k_throttleLeft:k_throttleRight .

Other improvements:
- add some comments in various place
- correct some safety not correctly set
- always use scaled RC input and remove the need of special handling for manuals modes. It solve non-working servo/rc reverse feature
- improvement to brushed motor control
- implementation of motor test for rover
- add some pre_arm_check to prevent usage of rover without TYPE_CLASS set

It has only been tested on SITL ! 
TODO : 
- [ ] Real tests
- [ ] New autotest for new features
- [ ] implement PWM_TYPE
- [ ] implement PWM_FREQ
- [ ] impement a way to link a motor ouput with an ON/OFF pin use to switch the direction on H-Bridge
- [ ] Correct DO_REVERSE function that is broken.

Questions: 
I go on the simplier way and only add some function to ROVER class. Should we make a dedicated class for motor ? The mixing and calculus for output need some parameter from rover ...
Should I do a conversion function from SKID_STEER_OUT to TYPE_CLASS ? Currently the rover won't arm without TYPE_CLASS set. Will convert CH1 and CH3 to default of each class unless they got another function