### PR TITLE
Landing: Allow auto disarm for deepstall landings

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -270,6 +270,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
     case DEEPSTALL_STAGE_LAND:
         // while in deepstall the only thing verify needs to keep the extended approach point sufficently far away
         landing.nav_controller->update_waypoint(current_loc, extended_approach);
+        landing.disarm_if_autoland_complete_fn();
         return false;
     default:
         return true;


### PR DESCRIPTION
This really should have gone in with the original deepstall code, but I had missed it. Flight tested today, works as expected.