### PR TITLE
EKF3: Improve stability of covariance matrix processing

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -21,7 +21,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -45,7 +45,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -69,7 +69,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
@@ -93,7 +93,7 @@
 #define GYRO_P_NSE_DEFAULT      1.5E-02f
 #define ACC_P_NSE_DEFAULT       3.5E-01f
 #define GBIAS_P_NSE_DEFAULT     1.0E-03f
-#define ABIAS_P_NSE_DEFAULT     3.0E-03f
+#define ABIAS_P_NSE_DEFAULT     6.0E-03f
 #define MAGB_P_NSE_DEFAULT      1.0E-04f
 #define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -864,15 +864,10 @@ void NavEKF3_core::CovariancePrediction()
     }
 
     if (!inhibitDelVelBiasStates) {
+        // default process noise (m/s)^2
         float dVelBiasVar = sq(sq(dt) * constrain_float(frontend->_accelBiasProcessNoise, 0.0f, 1.0f));
         for (uint8_t i=3; i<=5; i++) {
-            uint8_t stateIndex = i + 10;
-            if (P[stateIndex][stateIndex] > 1E-8f) {
-                processNoiseVariance[i] = dVelBiasVar;
-            } else {
-                // increase the process noise variance up to a maximum of 100 x the nominal value if the variance is below the target minimum
-                processNoiseVariance[i] = 10.0f * dVelBiasVar * (1e-8f / fmaxf(P[stateIndex][stateIndex],1e-9f));
-            }
+            processNoiseVariance[i] = dVelBiasVar;
         }
     }
 
@@ -1422,20 +1417,28 @@ void NavEKF3_core::ConstrainVariances()
     }
 
     if (!inhibitDelVelBiasStates) {
-        // limit delta velocity bias state variance levels and request a reset if below the safe minimum
+
+        // Find the maximum delta velocity bias state variance and request a covariance reset if any variance is below the safe minimum
+        const float minSafeStateVar = 1e-9f;
+        float maxStateVar = minSafeStateVar;
         bool resetRequired = false;
-        for (uint8_t i=13; i<=15; i++) {
-            if (P[i][i] > 1E-9f) {
-                // variance is above the safe minimum
-                P[i][i] = fminf(P[i][i], sq(10.0f * dtEkfAvg));
-            } else {
-                // Set the variance to the target minimum and request a covariance reset
-                P[i][i] = 1E-8f;
+        for (uint8_t stateIndex=13; stateIndex<=15; stateIndex++) {
+            if (P[stateIndex][stateIndex] > maxStateVar) {
+                maxStateVar = P[stateIndex][stateIndex];
+            } else if (P[stateIndex][stateIndex] < minSafeStateVar) {
                 resetRequired = true;
             }
         }
 
-        // If any one axis is below the safe minimum, all delta velocity covariance terms must be reset to zero
+        // To ensure stability of the covariance matrix operations, the ratio of a max and min variance must
+        // not exceed 100 and the minimum variance must not fall below the target minimum
+        const float minStateVarTarget = 1E-8f;
+        float minAllowedStateVar = fmaxf(0.01f * maxStateVar, minStateVarTarget);
+        for (uint8_t stateIndex=13; stateIndex<=15; stateIndex++) {
+            P[stateIndex][stateIndex] = constrain_float(P[stateIndex][stateIndex], minAllowedStateVar, sq(10.0f * dtEkfAvg));
+        }
+
+        // If any one axis has fallen below the safe minimum, all delta velocity covariance terms must be reset to zero
         if (resetRequired) {
             float delVelBiasVar[3];
             // store all delta velocity bias variances


### PR DESCRIPTION
1) Variances for each axis  are increased to prevent the ratio of the largest to smallest value exceeding 100. Large ratios can result in poor stability of the delta velocity bias state covariance prediction and update operations.

2) The covariance prediction step explicitly constrains the variance from falling below the target minimum of 1E-8 which is equivalent to about 0.01 m/sec^2 of accel bias uncertainty. 

These changes improve the protection against badly conditioned IMU delta velocity bias state variances. This is necessary due to the limitations associated with single precision arithmetic that limits the range of values that can be used for the EK3_ABIAS_P_NSE parameter. The order and rate that different sensors are fused changes the minimum safe value for this parameter meaning that the safe minimum parameter value varies between board types. This requires active protection measures.

The symptons of badly conditioned delta velocity bias variances are:

1) The accel bias variance for the sensor axis aligned with the vertical collapses to the minimum value allowed by the ConstrainVariances() function.
2) Delta velocity bias states  fail to converge on correct values and in extreme cases can even go to the limits imposed by the ConstrainStates()  function.

This is most likely to happen during static operation.