### PR TITLE
Implement receiver based RSSI

### DIFF
--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -32,6 +32,9 @@ public:
     /* Read an array of channels, return the valid count */
     virtual uint8_t read(uint16_t* periods, uint8_t len) = 0;
 
+    /* get receiver based RSSI if available. -1 for unknown, 0 for no link, 255 for maximum link */
+    virtual int16_t get_rssi(void) { return -1; }
+    
     /**
      * Overrides: these are really grody and don't belong here but we need
      * them at the moment to make the port work.

--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -448,6 +448,7 @@ bool RCInput::add_sumd_input(const uint8_t *bytes, size_t nbytes)
             _num_channels = channel_count;
             rc_input_count++;
             ret = true;
+            _rssi = rssi;
         }
         nbytes--;
     }
@@ -478,6 +479,7 @@ bool RCInput::add_st24_input(const uint8_t *bytes, size_t nbytes)
             _num_channels = channel_count;
             rc_input_count++;
             ret = true;
+            _rssi = rssi;
         }
         nbytes--;
     }

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -22,6 +22,10 @@ public:
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
+    int16_t get_rssi(void) override {
+        return _rssi;
+    }
+    
     bool set_overrides(int16_t *overrides, uint8_t len);
     bool set_override(uint8_t channel, int16_t override);
     void clear_overrides();
@@ -93,6 +97,8 @@ protected:
         uint8_t partial_frame_count;
         uint32_t last_input_ms;
     } sbus;
+
+    int16_t _rssi = -1;
 };
 
 }

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -118,6 +118,10 @@ void PX4RCInput::_timer_tick(void)
     if (orb_check(_rc_sub, &rc_updated) == 0 && rc_updated) {
         pthread_mutex_lock(&rcin_mutex);
         orb_copy(ORB_ID(input_rc), _rc_sub, &_rcin);
+        if (_rcin.rssi != 0 || _rssi != -1) {
+            // always zero means not supported
+            _rssi = _rcin.rssi;
+        }
         pthread_mutex_unlock(&rcin_mutex);
     }
     // note, we rely on the vehicle code checking new_input()

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -18,6 +18,11 @@ public:
     uint16_t read(uint8_t ch) override;
     uint8_t read(uint16_t* periods, uint8_t len) override;
 
+    int16_t get_rssi(void) override {
+        return _rssi;
+    }
+        
+    
     bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
@@ -35,4 +40,5 @@ private:
     bool _override_valid;
     perf_counter_t _perf_rcin;
     pthread_mutex_t rcin_mutex;
+    int16_t _rssi = -1;
 };

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Param: TYPE
     // @DisplayName: RSSI Type
     // @Description: Radio Receiver RSSI type. If your radio receiver supports RSSI of some kind, set it here, then set its associated RSSI_XXXXX parameters, if any.
-    // @Values: 0:Disabled,1:AnalogPin,2:RCChannelPwmValue
+    // @Values: 0:Disabled,1:AnalogPin,2:RCChannelPwmValue,3:ReceiverProtocol
     // @User: Standard
     AP_GROUPINFO("TYPE", 0, AP_RSSI, rssi_type,  BOARD_RSSI_DEFAULT),
 
@@ -128,6 +128,13 @@ float AP_RSSI::read_receiver_rssi()
         case RssiType::RSSI_RC_CHANNEL_VALUE :
             receiver_rssi = read_channel_rssi();
             break;
+        case RssiType::RSSI_RECEIVER : {
+            int16_t rssi = hal.rcin->get_rssi();
+            if (rssi != -1) {
+                receiver_rssi = rssi / 255.0;
+            }
+            break;
+        }
         default :   
             receiver_rssi = 0.0f;
             break;

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -24,7 +24,8 @@ public:
     enum RssiType {
         RSSI_DISABLED           = 0,
         RSSI_ANALOG_PIN         = 1,
-        RSSI_RC_CHANNEL_VALUE   = 2
+        RSSI_RC_CHANNEL_VALUE   = 2,
+        RSSI_RECEIVER           = 3
     };
 
     // constructor


### PR DESCRIPTION
This allows for RSSI for receiver based RSSI protocols. This includes ST24, SUMD and the nice sbus method that @StewLG has done
This replaces:
https://github.com/ArduPilot/ardupilot/pull/3274
