### PR TITLE
Rover: improve skid steering

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -162,7 +162,7 @@ void Rover::send_servo_out(mavlink_channel_t chan)
         0,  // port 0
         10000 * channel_steer->norm_output(),
         0,
-        10000 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle),
+        100 * SRV_Channels::get_output_scaled(SRV_Channel::k_throttle),
         0,
         0,
         0,
@@ -179,7 +179,7 @@ void Rover::send_vfr_hud(mavlink_channel_t chan)
         gps.ground_speed(),
         ahrs.groundspeed(),
         (ahrs.yaw_sensor / 100) % 360,
-        static_cast<uint16_t>(100 * fabsf(SRV_Channels::get_output_norm(SRV_Channel::k_throttle))),
+        SRV_Channels::get_output_scaled(SRV_Channel::k_throttle),
         current_loc.alt / 100.0f,
         0);
 }

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -278,7 +278,7 @@ void Rover::Log_Write_Nav_Tuning()
         wp_distance         : wp_distance,
         target_bearing_cd   : static_cast<uint16_t>(fabsf(nav_controller->target_bearing_cd())),
         nav_bearing_cd      : static_cast<uint16_t>(fabsf(nav_controller->nav_bearing_cd())),
-        throttle            : static_cast<int8_t>(100 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle)),
+        throttle            : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)),
         xtrack_error        : nav_controller->crosstrack_error()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -336,7 +336,7 @@ void Rover::Log_Write_Sonar()
         turn_angle      : static_cast<int8_t>(obstacle.turn_angle),
         turn_time       : turn_time,
         ground_speed    : static_cast<uint16_t>(fabsf(ground_speed * 100)),
-        throttle        : static_cast<int8_t>(100 * SRV_Channels::get_output_norm(SRV_Channel::k_throttle))
+        throttle        : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -475,6 +475,8 @@ private:
     void calc_throttle(float target_speed);
     void calc_lateral_acceleration();
     void calc_nav_steer();
+    bool have_skid_steering();
+    void mix_skid_steering();
     void set_servos(void);
     void set_auto_WP(const struct Location& loc);
     void set_guided_WP(const struct Location& loc);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -69,7 +69,7 @@ bool Rover::auto_check_trigger(void) {
     work out if we are going to use pivot steering
 */
 bool Rover::use_pivot_steering(void) {
-    if (control_mode >= AUTO && g.skid_steer_out && g.pivot_turn_angle != 0) {
+    if (control_mode >= AUTO && have_skid_steering() && g.pivot_turn_angle != 0) {
         const int16_t bearing_error = wrap_180_cd(nav_controller->target_bearing_cd() - ahrs.yaw_sensor) / 100;
         if (abs(bearing_error) > g.pivot_turn_angle) {
             return true;
@@ -239,12 +239,52 @@ void Rover::calc_nav_steer() {
     SRV_Channels::set_output_scaled(SRV_Channel::k_steering, steerController.get_steering_out_lat_accel(lateral_acceleration));
 }
 
+/*
+  run the skid steering mixer
+ */
+void Rover::mix_skid_steering(void)
+{
+    const float steering_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_steering) / 4500.0;
+    const float throttle_scaled = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) / 100.0;
+    float motor1 = throttle_scaled + 0.5f * steering_scaled;
+    float motor2 = throttle_scaled - 0.5f * steering_scaled;
+
+    if (fabsf(throttle_scaled) <= 0.01f) {
+        // Use full range for on spot turn
+        motor1 = steering_scaled;
+        motor2 = -steering_scaled;
+    }
+
+    // first new-style skid steering
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft,  1000 * motor1);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000 * motor2);
+
+    // now old style skid steering with skid_steer_out
+    if (g.skid_steer_out) {
+        // convert the two radio_out values to skid steering values
+        /*
+            mixing rule:
+            steering = motor1 - motor2
+            throttle = 0.5*(motor1 + motor2)
+            motor1 = throttle + 0.5*steering
+            motor2 = throttle - 0.5*steering
+        */
+        if ((control_mode == MANUAL || control_mode == LEARNING) && g.skid_steer_in) {
+            // Mixage is already done by a controller so just pass the value to motor
+            motor1 = steering_scaled;
+            motor2 = throttle_scaled;
+        }
+
+        SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 4500 * motor1);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100 * motor2);
+    }
+}
+
 /*****************************************
     Set the flight control servos based on the current calculated values
 *****************************************/
 void Rover::set_servos(void) {
     static uint16_t last_throttle;
-    bool apply_skid_mix = true;  // Normaly true, false when the mixage is done by the controler with skid_steer_in = 1
 
     if (control_mode == MANUAL || control_mode == LEARNING) {
         // do a direct pass through of radio values
@@ -257,9 +297,6 @@ void Rover::set_servos(void) {
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
-        }
-        if (g.skid_steer_in) {
-            apply_skid_mix = false;
         }
     } else {
         if (in_reverse) {
@@ -276,7 +313,7 @@ void Rover::set_servos(void) {
             // suppress throttle if in failsafe
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (g.skid_steer_out) {
+            if (have_skid_steering()) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
@@ -284,7 +321,7 @@ void Rover::set_servos(void) {
         if (!hal.util->get_soft_armed()) {
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             // suppress steer if in failsafe and skid steer mode
-            if (g.skid_steer_out) {
+            if (have_skid_steering()) {
                 SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 0);
             }
         }
@@ -296,31 +333,9 @@ void Rover::set_servos(void) {
     // record last throttle before we apply skid steering
     SRV_Channels::get_output_pwm(SRV_Channel::k_throttle, last_throttle);
 
-    if (g.skid_steer_out) {
-        // convert the two radio_out values to skid steering values
-        /*
-            mixing rule:
-            steering = motor1 - motor2
-            throttle = 0.5*(motor1 + motor2)
-            motor1 = throttle + 0.5*steering
-            motor2 = throttle - 0.5*steering
-        */
-        const float steering_scaled = SRV_Channels::get_output_norm(SRV_Channel::k_steering);
-        const float throttle_scaled = SRV_Channels::get_output_norm(SRV_Channel::k_throttle);
-        float motor1 = throttle_scaled + 0.5f * steering_scaled;
-        float motor2 = throttle_scaled - 0.5f * steering_scaled;
-
-        if (!apply_skid_mix) {  // Mixage is already done by a controller so just pass the value to motor
-            motor1 = steering_scaled;
-            motor2 = throttle_scaled;
-        } else if (fabsf(throttle_scaled) <= 0.01f) {  // Use full range for on spot turn
-            motor1 = steering_scaled;
-            motor2 = -steering_scaled;
+    if (have_skid_steering()) {
+        mix_skid_steering();
         }
-
-        SRV_Channels::set_output_scaled(SRV_Channel::k_steering, 4500 * motor1);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 100 * motor2);
-    }
 
     if (!arming.is_armed()) {
         // Some ESCs get noisy (beep error msgs) if PWM == 0.
@@ -333,6 +348,8 @@ void Rover::set_servos(void) {
 
         case AP_Arming::YES_ZERO_PWM:
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             }
@@ -341,6 +358,8 @@ void Rover::set_servos(void) {
         case AP_Arming::YES_MIN_PWM:
         default:
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             if (g.skid_steer_out) {
                 SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
             }
@@ -357,4 +376,17 @@ void Rover::set_servos(void) {
 #endif
 }
 
-
+/*
+  work out if skid steering is available
+ */
+bool Rover::have_skid_steering(void)
+{
+    if (g.skid_steer_out) {
+        return true;
+    }
+    if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) &&
+        SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+        return true;
+    }
+    return false;
+}

--- a/APMrover2/crash_check.cpp
+++ b/APMrover2/crash_check.cpp
@@ -23,7 +23,7 @@ void Rover::crash_check()
 
   if ((ahrs.groundspeed() >= CRASH_CHECK_VEL_MIN) ||        // Check velocity
       (fabsf(ahrs.get_gyro().z) >= CRASH_CHECK_VEL_MIN) ||  // Check turn speed
-      ((100 * fabsf(SRV_Channels::get_output_norm(SRV_Channel::k_throttle))) < CRASH_CHECK_THROTTLE_MIN)) {
+      (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)) < CRASH_CHECK_THROTTLE_MIN)) {
     crash_counter = 0;
     return;
   }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -28,8 +28,10 @@ void Rover::set_control_channels(void)
         }
     }
     // setup correct scaling for ESCs like the UAVCAN PX4ESC which
-    // take a proportion of speed.
-    hal.rcout->set_esc_scaling(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
+    // take a proportion of speed. Default to 1000 to 2000 for systems without
+    // a k_throttle output
+    hal.rcout->set_esc_scaling(1000, 2000);
+    g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttle);
 }
 
 void Rover::init_rc_in()

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -16,6 +16,10 @@ void Rover::set_control_channels(void)
     SRV_Channels::set_angle(SRV_Channel::k_steering, SERVO_MAX);
     SRV_Channels::set_angle(SRV_Channel::k_throttle, 100);
 
+    // left/right throttle as -1000 to 1000 values
+    SRV_Channels::set_angle(SRV_Channel::k_throttleLeft,  1000);
+    SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 1000);
+
     // For a rover safety is TRIM throttle
     if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
         hal.rcout->set_safety_pwm(1UL << (rcmap.throttle() - 1), channel_throttle->get_radio_trim());
@@ -94,7 +98,7 @@ void Rover::rudder_arm_disarm_check()
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if (!motor_active() & !g.skid_steer_out) {
+    } else if (!motor_active() & !have_skid_steering()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
         // This is disabled for skid steering otherwise when tring to turn a skid steering rover around
         // the rover would disarm


### PR DESCRIPTION
This PR improves/fixes the skid steering control in Rover by introducing a new method for controlling "skid steering" in Rovers (the older method still remains).

- To use the new method, the user defines the output channels to use for left and right motors by setting the appropriate SERVOx_FUNCTION to k_throttleLeft (73) and k_throttleRight (74).  As a side note, these same enums are used in dual engine tailsitters.
- the skid steering logic for both old and new methods is more consolidated into a Steering.cpp's mix_skid_steering function and it's fairly straight forward.
- a new function "has_skid_steering" has been added to replace the simple check of the "SKID_STEER_OUT" parameter and makes setting this parameter optional if the new method is used.

Some thoughts from Randy:

- in my testing, the old skid-steering method was broken for some users (including me) because it was not properly using the SERVOx_REVERSED parameter value.  The new method does not have this problem and maybe the older method is also fixed because "mix_skid_steering" uses "get_output_scaled" instead of "get_output_norm". 
- we should consider removing the old method because I can't see any advantage of using it.  This would of course inconvenience some users who would have to change their parameters as they upgrade.

This PR also included a non-functional change to replace 100*get_output_norm() ("get_output_norm" returns a number from 0 ~ 1 for throttle) with get_output_scaled() which returns the throttle value as a number from 0 ~ 100.

By the way, I've tested these changes on both my skid-steering and traditional rover.