### PR TITLE
EKF: fix bug effecting accuracy of optical flow estimated height during climb/descent

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -184,10 +184,10 @@ void NavEKF2_core::EstimateTerrainOffset()
 
             // divide velocity by range, subtract body rates and apply scale factor to
             // get predicted sensed angular optical rates relative to X and Y sensor axes
-            losPred =   relVelSensor.length()/flowRngPred;
+            losPred =   sqrtf(sq(relVelSensor.x) + sq(relVelSensor.y))/flowRngPred;
 
             // calculate innovations
-            auxFlowObsInnov = losPred - sqrtf(sq(ofDataDelayed.flowRadXYcomp[0]) + sq(ofDataDelayed.flowRadXYcomp[1]));
+            auxFlowObsInnov = losPred - sqrtf(sq(ofDataDelayed.flowRadXYcomp.x) + sq(ofDataDelayed.flowRadXYcomp.y));
 
             // calculate observation jacobian
             float t3 = sq(q0);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -187,10 +187,10 @@ void NavEKF3_core::EstimateTerrainOffset()
 
             // divide velocity by range, subtract body rates and apply scale factor to
             // get predicted sensed angular optical rates relative to X and Y sensor axes
-            losPred =   relVelSensor.length()/flowRngPred;
+            losPred =   sqrtf(sq(relVelSensor.x) + sq(relVelSensor.y))/flowRngPred;
 
             // calculate innovations
-            auxFlowObsInnov = losPred - sqrtf(sq(ofDataDelayed.flowRadXYcomp[0]) + sq(ofDataDelayed.flowRadXYcomp[1]));
+            auxFlowObsInnov = losPred - sqrtf(sq(ofDataDelayed.flowRadXYcomp.x) + sq(ofDataDelayed.flowRadXYcomp.y));
 
             // calculate observation jacobian
             float t3 = sq(q0);


### PR DESCRIPTION
The body relative velocity component along the flow sensor bore-sight should not be used when calculating the LOS rate magnitude. This will bias the terrain position estimate when the vehicle is climbing or descending or has a large tilt angle in the direction of travel. 

**TESTING**

Here are the estimated terrain height with error bounds from EKF2 and EKF3 generated from Plane SITL testing with  an auto mission with optical flow enabled. Terrain offset estimates remain within 1-sigma error bounds.

EKF2 - terrain offset estimate

![screen shot 2017-06-20 at 6 26 16 pm](https://user-images.githubusercontent.com/3596952/27323781-25a9a57a-55e6-11e7-868b-0a40acefab50.png)

EKF3 - terrain offset estimate

![screen shot 2017-06-20 at 6 27 03 pm](https://user-images.githubusercontent.com/3596952/27323783-27e9f312-55e6-11e7-9932-a1663dd23dd1.png)

Here are the optical flow  innovations in mrad/s from the terrain estimator for both EKF's

![screen shot 2017-06-20 at 6 29 06 pm](https://user-images.githubusercontent.com/3596952/27323837-5d5afa46-55e6-11e7-9c2f-331658595a23.png)
