### PR TITLE
AP_Baro: AP_Baro_SITL more accurately simulates real sensor backend.

### DIFF
--- a/libraries/AP_Baro/AP_Baro_SITL.h
+++ b/libraries/AP_Baro/AP_Baro_SITL.h
@@ -28,7 +28,12 @@ private:
 
     // adjust for simulated board temperature
     void temperature_adjustment(float &p, float &T);
-    
+
+    void _timer();
+    bool _has_sample;
+    uint32_t _last_sample_time;
+    float _recent_temp;
+    float _recent_press;
+
 };
 #endif // CONFIG_HAL_BOARD
-


### PR DESCRIPTION
@tridge This is the fix we discussed about. Now `update()` will only copy to frontend if it has a sample instead of every call to it.