### PR TITLE
AP_HAL_SITL: Fixes bug with uartF.

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -70,7 +70,7 @@ public:
         "tcp:2",
         "tcp:3",
         "GPS2",
-        "tcp:4",
+        "tcp:5",
     };
     
 private:

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -210,6 +210,7 @@ void Scheduler::_run_io_procs(bool called_from_isr)
     UARTDriver::from(hal.uartC)->_timer_tick();
     UARTDriver::from(hal.uartD)->_timer_tick();
     UARTDriver::from(hal.uartE)->_timer_tick();
+    UARTDriver::from(hal.uartF)->_timer_tick();
 }
 
 /*


### PR DESCRIPTION
uartF `_timer_tick()` was not being called in the SITL scheduler. All other schedulers are behaving correctly.
`tcp:4` to `tcp:5` is to fix inconsistency with `AP_SerialManager`.

This also fixes the SITL problem mentioned in issue https://github.com/ArduPilot/ardupilot/issues/5829