### PR TITLE
Fix System Time to GPS sync inaccuracy due to bad data types for operations

### DIFF
--- a/libraries/AP_HAL/Util.cpp
+++ b/libraries/AP_HAL/Util.cpp
@@ -62,7 +62,7 @@ uint64_t AP_HAL::Util::get_system_clock_ms() const
     clock_gettime(CLOCK_REALTIME, &ts);
     const uint64_t seconds = ts.tv_sec;
     const uint64_t nanoseconds = ts.tv_nsec;
-    return (seconds * 1000UL + nanoseconds/1000000UL);
+    return (seconds * 1000ULL + nanoseconds/1000000ULL);
 #endif
 }
 

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -98,8 +98,8 @@ void Util::set_system_clock(uint64_t time_utc_usec)
 {
 #if CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_NONE
     timespec ts;
-    ts.tv_sec = time_utc_usec/1.0e6;
-    ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
+    ts.tv_sec = time_utc_usec/1000000ULL;
+    ts.tv_nsec = (time_utc_usec % 1000000ULL) * 1000ULL;
     clock_settime(CLOCK_REALTIME, &ts);    
 #endif    
 }

--- a/libraries/AP_HAL_PX4/Util.cpp
+++ b/libraries/AP_HAL_PX4/Util.cpp
@@ -99,8 +99,8 @@ enum PX4Util::safety_state PX4Util::safety_switch_state(void)
 void PX4Util::set_system_clock(uint64_t time_utc_usec)
 {
     timespec ts;
-    ts.tv_sec = time_utc_usec/1.0e6f;
-    ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
+    ts.tv_sec = time_utc_usec/1000000ULL;
+    ts.tv_nsec = (time_utc_usec % 1000000ULL) * 1000ULL;
     clock_settime(CLOCK_REALTIME, &ts);    
 }
 

--- a/libraries/AP_HAL_VRBRAIN/Util.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Util.cpp
@@ -95,8 +95,8 @@ enum VRBRAINUtil::safety_state VRBRAINUtil::safety_switch_state(void)
 void VRBRAINUtil::set_system_clock(uint64_t time_utc_usec)
 {
     timespec ts;
-    ts.tv_sec = time_utc_usec/1.0e6f;
-    ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
+    ts.tv_sec = time_utc_usec/1000000ULL;
+    ts.tv_nsec = (time_utc_usec % 1000000ULL) * 1000UL;
     clock_settime(CLOCK_REALTIME, &ts);    
 }
 


### PR DESCRIPTION
Division by `float` datatype was causing inaccurate conversion resulting in 10s of seconds of offset between the two times. I have made the changes in all HAL libs wherever its used.