### PR TITLE
AP_AHRS: Do not revert to DCM if GPS is lost but we have healthy airspeed sensor

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -987,11 +987,14 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
             get_filter_status(filt_state);
 #endif
         }
-        if (hal.util->get_soft_armed() && !filt_state.flags.using_gps && _gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+        if (hal.util->get_soft_armed() &&
+            (!filt_state.flags.using_gps && _gps.status() >= AP_GPS::GPS_OK_FIX_3D &&
+             _airspeed != nullptr && !_airspeed->healthy())) {
             // if the EKF is not fusing GPS and we have a 3D lock, then
             // plane and rover would prefer to use the GPS position from
             // DCM. This is a safety net while some issues with the EKF
-            // get sorted out
+            // get sorted out. If there is a healthy airspeed sensor,
+            // do not revert to DCM.
             return EKF_TYPE_NONE;
         }
         if (hal.util->get_soft_armed() && filt_state.flags.const_pos_mode) {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -971,7 +971,9 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
       DCM is very robust. Note that we also check the filter status
       when fly_forward is false and we are disarmed. This is to ensure
       that the arming checks do wait for good GPS position on fixed
-      wing and rover
+      wing and rover.
+      If there is a healthy airspeed sensor, do not revert to DCM on
+      plane during flight.
      */
     if (ret != EKF_TYPE_NONE &&
         (_vehicle_class == AHRS_VEHICLE_FIXED_WING ||


### PR DESCRIPTION
Refers to https://github.com/ArduPilot/ardupilot/pull/6497 and https://github.com/ArduPilot/ardupilot/pull/6288 to prevent sudden altitude change if GPS is lost on plane while correction on baro is active.