### PR TITLE
Rover: skid-steer mixing fixes

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -367,6 +367,9 @@ private:
     // set if the users asks for auto reverse
     bool in_auto_reverse;
 
+    // true if pivoting (set by use_pivot_steering)
+    bool pivot_steering_active;
+
     static const AP_Scheduler::Task scheduler_tasks[];
 
     // use this to prevent recursion during sensor init


### PR DESCRIPTION
This PR makes two improvements:

- once triggered, pivot-steering (which involves the vehicle stopping and turning towards a target) stays active until the vehicle is within 10 degrees of the target.  Previously it would stop pivot steering once the vehicle was back within PIVOT_TURN_ANGLE degrees of the target meaning the vehicle would often stop pivoting even though it was still far from the target heading especially if PIVOT_TURN_ANGLE was set to a large value like 90.  Pivot steering only applies to vehicles which have skid steering (like tank tracks) and is triggered in AUTO mode when the vehicle's heading is more than PIVOT_TURN_ANGLE from the desired heading. 
- improve motor mixing when the throttle and steering inputs means the motors will saturate (i.e. we cannot achieve both the desired turn and throttle).  Previously throttle was prioritised over steering, now they are both proportionally reduced until there is no more saturation.
- turning direction while in reverse is consistent with non-skid-steering vehicles.

Before fix: https://www.youtube.com/watch?v=XzxjosAf034
after fix: https://youtu.be/24RTlu4SojI
