### PR TITLE
build: fix link check

### DIFF
--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -182,7 +182,7 @@ def check_package(cfg, env, libname):
         fragment='''int main() { return 0; }''',
         msg='Testing link with %s' % libname,
         mandatory=False,
-        lib='dl'
+        lib=libname
     )
 
     if ret:
@@ -192,6 +192,8 @@ def check_package(cfg, env, libname):
         env.LIBPATH += cfg.env['LIBPATH_%s' % capsname]
 
     cfg.env.revert()
+
+    return ret
 
 @conf
 def check_lttng(cfg, env):
@@ -203,8 +205,12 @@ def check_lttng(cfg, env):
         cfg.msg("Checking for 'lttng-ust':", 'disabled', color='YELLOW')
         return False
 
-    check_package(cfg, env, 'lttng-ust')
-    return True
+    ret = check_package(cfg, env, 'lttng-ust')
+    if ret:
+        cfg.define('HAVE_LTTNG_UST', 1)
+        return True
+
+    return False
 
 @conf
 def check_libiio(cfg, env):

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -161,39 +161,33 @@ def check_package(cfg, env, libname):
     '''use pkg-config to look for an installed library that has a LIBNAME.pc file'''
     capsname = libname.upper()
 
-    # we don't want check_cfg() changing the global environment during
-    # this test, in case it fails in the 2nd link step
     cfg.env.stash()
 
-    cfg.check_cfg(package=libname, mandatory=False, global_define=True,
-                  args=['--libs', '--cflags'], uselib_store=capsname)
+    if not cfg.check_cfg(package=libname, mandatory=False, global_define=True,
+                         args=['--libs', '--cflags'], uselib_store=capsname):
+        # Don't even try to link if check_cfg fails
+        cfg.env.revert()
+        return False
 
-    # we need to also check that we can link against the lib. We may
-    # have a pc file for the package, but its the wrong
-    # architecture. This can happen as PKG_CONFIG_PATH is not
-    # architecture specific
-    cfg.env.LIB += cfg.env['LIB_%s' % capsname]
-    cfg.env.INCLUDES += cfg.env['INCLUDES_%s' % capsname]
-    cfg.env.CFLAGS += cfg.env['CFLAGS_%s' % capsname]
-    cfg.env.LIBPATH += cfg.env['LIBPATH_%s' % capsname]
+    if not cfg.check(compiler='cxx',
+            fragment='''int main() { return 0; }''',
+            msg='Checking link with %s' % libname,
+            mandatory=False,
+            lib=libname,
+            use=capsname):
+        cfg.env.revert()
+        return False
 
-    ret = cfg.check(
-        compiler='cxx',
-        fragment='''int main() { return 0; }''',
-        msg='Testing link with %s' % libname,
-        mandatory=False,
-        lib=libname
-    )
+    cfg.env.commit()
 
-    if ret:
-        env.LIB += cfg.env['LIB_%s' % capsname]
-        env.INCLUDES += cfg.env['INCLUDES_%s' % capsname]
-        env.CFLAGS += cfg.env['CFLAGS_%s' % capsname]
-        env.LIBPATH += cfg.env['LIBPATH_%s' % capsname]
+    # Add to global environment:
+    # we always want to use the library for all targets
+    env.LIB += cfg.env['LIB_%s' % capsname]
+    env.INCLUDES += cfg.env['INCLUDES_%s' % capsname]
+    env.CFLAGS += cfg.env['CFLAGS_%s' % capsname]
+    env.LIBPATH += cfg.env['LIBPATH_%s' % capsname]
 
-    cfg.env.revert()
-
-    return ret
+    return True
 
 @conf
 def check_lttng(cfg, env):
@@ -205,12 +199,7 @@ def check_lttng(cfg, env):
         cfg.msg("Checking for 'lttng-ust':", 'disabled', color='YELLOW')
         return False
 
-    ret = check_package(cfg, env, 'lttng-ust')
-    if ret:
-        cfg.define('HAVE_LTTNG_UST', 1)
-        return True
-
-    return False
+    return check_package(cfg, env, 'lttng-ust')
 
 @conf
 def check_libiio(cfg, env):
@@ -222,8 +211,7 @@ def check_libiio(cfg, env):
         cfg.msg("Checking for 'libiio':", 'disabled', color='YELLOW')
         return False
 
-    check_package(cfg, env, 'libiio')
-    return True
+    return check_package(cfg, env, 'libiio')
 
 @conf
 def check_libdl(cfg, env):

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -133,9 +133,6 @@ echo $githash > "buildlogs/history/$hdate/githash.txt"
 
 killall -9 JSBSim || /bin/true
 
-# setup for libiio on Parrot boards
-export PKG_CONFIG_PATH=$HOME/APM/ParrotLib/lib
-
 # raise core limit
 ulimit -c 10000000
 


### PR DESCRIPTION
This reverts commit 6747f42986f4110a2e279fe72dd3126a4e278634.

This broke the link to external libraries since it won't define the
HAVE_* variable anymore. When we call the check method from pkg-config
it defines this variable for us, but it's reverted by the call to
cfg.env.revert().  We could define it again, but the whole check
defeats the purpose of relying on the pkg-config module from waf. If the
module is not sufficient, it should be fixed in the proper place.

This however points a deficiency on our infra: we don't have support for
the user to point to a sysroot. This would make it much easier to
cross-compile the packages and not have issues regarding wrong
libraries.  For now only the revert is done.

Thanks to Miguel Arroyo for help debugging it.