### PR TITLE
AP_Notify: Fix for Oreo LED gyro init indication

### DIFF
--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -163,36 +163,15 @@ bool OreoLED_PX4::mode_firmware_update()
 }
 
 
-// Procedure for when Pixhawk is booting up and initializing
-// Makes all LEDs rapidly strobe blue. Returns LED_INIT_STAGE
-// 1 = Default, initialization has not yet begun
-// 2 = Initialization flag found, initialization in progress
-// 3 = Initialization flag no longer found, initialization complete
+// Makes all LEDs rapidly strobe blue while gyros initialize.
 bool OreoLED_PX4::mode_init()
 {
-    static uint16_t stage = 1;
-
-    // Pixhawk has not begun initializing yet. Strobe all blue
-    if ((!AP_Notify::flags.initialising) && ((stage == 1))) {
+    if (AP_Notify::flags.initialising) {
         set_rgb(OREOLED_INSTANCE_ALL, OREOLED_PATTERN_STROBE, 0, 0, 255,0,0,0,PERIOD_SUPER,0);
-
-    // Pixhawk has begun initializing
-    } else if ((AP_Notify::flags.initialising) && ((stage == 1))) { 
-        stage = 2;
-        set_rgb(OREOLED_INSTANCE_ALL, OREOLED_PATTERN_STROBE, 0, 0, 255,0,0,0,PERIOD_SUPER,0);
-
-    // Pixhawk still initializing
-    } else if ((AP_Notify::flags.initialising) && ((stage == 2))) { 
-        set_rgb(OREOLED_INSTANCE_ALL, OREOLED_PATTERN_STROBE, 0, 0, 255,0,0,0,PERIOD_SUPER,0);
-
-    // Pixhawk has completed initialization
-    } else if((!AP_Notify::flags.initialising) && ((stage == 2))) {
-        stage = 0;
-        set_rgb(OREOLED_INSTANCE_ALL, OREOLED_PATTERN_SOLID, 0, 0, 255);
-
-    } else { stage = 0; }
-
-    return stage;
+        return true;
+    } else { 
+        return false;
+    }
 }
 
 


### PR DESCRIPTION
If parameter `INS_GYR_CAL` is disabled, usually because operator is arming on a moving vehicle such as a boat, the Oreo LEDs would wait indefinitely for a gyro calibration that will never happen. This gives false indication to the operator.  As reported in https://github.com/ArduPilot/ardupilot/issues/6511. 

This commit removes the blue strobing stage where it is waiting for gyo initialization to begin. Instead, the LEDs will strobe blue only when gyros are actually initializing. Consequently, this greatly simplifies that portion of the code.

If this can go into 3.5-RC9, that would be great.