### PR TITLE
Add GPS_RTK and GPS2_RTK MAVLink messages support in Emlid reach

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -920,17 +920,13 @@ void AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
         rtk_age_ms(1));
 }
 
-void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan)
+void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)
 {
-    if (drivers[0] != nullptr && drivers[0]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
-        drivers[0]->send_mavlink_gps_rtk(chan);
+    if (inst >= GPS_MAX_RECEIVERS) {
+        return;
     }
-}
-
-void AP_GPS::send_mavlink_gps2_rtk(mavlink_channel_t chan)
-{
-    if (drivers[1] != nullptr && drivers[1]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
-        drivers[1]->send_mavlink_gps_rtk(chan);
+    if (drivers[inst] != nullptr && drivers[inst]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
+        drivers[inst]->send_mavlink_gps_rtk(chan);
     }
 }
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -144,8 +144,16 @@ public:
         uint32_t last_gps_time_ms;          ///< the system time we got the last GPS timestamp, milliseconds
 
         // all the following fields must only all be filled by RTK capable backend drivers
+        uint32_t rtk_time_week_ms;         ///< GPS Time of Week of last baseline in milliseconds
+        uint16_t rtk_week_number;          ///< GPS Week Number of last baseline
         uint32_t rtk_age_ms;               ///< GPS age of last baseline correction in milliseconds  (0 when no corrections, 0xFFFFFFFF indicates overflow)
         uint8_t  rtk_num_sats;             ///< Current number of satellites used for RTK calculation
+        uint8_t  rtk_baseline_coords_type; ///< Coordinate system of baseline. 0 == ECEF, 1 == NED
+        int32_t  rtk_baseline_x_mm;        ///< Current baseline in ECEF x or NED north component in mm
+        int32_t  rtk_baseline_y_mm;        ///< Current baseline in ECEF y or NED east component in mm
+        int32_t  rtk_baseline_z_mm;        ///< Current baseline in ECEF z or NED down component in mm
+        uint32_t rtk_accuracy;             ///< Current estimate of 3D baseline accuracy (receiver dependent, typical 0 to 9999)
+        int32_t  rtk_iar_num_hypotheses;   ///< Current number of integer ambiguity hypotheses
     };
 
     /// Startup initialisation.

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -350,8 +350,7 @@ public:
     void send_mavlink_gps_raw(mavlink_channel_t chan);
     void send_mavlink_gps2_raw(mavlink_channel_t chan);
 
-    void send_mavlink_gps_rtk(mavlink_channel_t chan);
-    void send_mavlink_gps2_rtk(mavlink_channel_t chan);
+    void send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst);
 
     // Returns the index of the first unconfigured GPS (returns GPS_ALL_CONFIGURED if all instances report as being configured)
     uint8_t first_unconfigured_gps(void) const;

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -189,6 +189,25 @@ AP_GPS_ERB::_parse_gps(void)
             state.time_week_ms    = _buffer.stat.time;
             state.time_week       = _buffer.stat.week;
         }
+        if (   _buffer.ver.ver_high > 0
+           ||  _buffer.ver.ver_medium >= 2) {
+            state.rtk_baseline_coords_type = 1;
+            state.rtk_num_sats      = _buffer.stat.base_num_sats;
+            if (_buffer.stat.age_cs == 0xFFFF) {
+                state.rtk_age_ms    = 0xFFFFFFFF;
+            } else {
+                state.rtk_age_ms    = _buffer.stat.age_cs * 10;
+            }
+            state.rtk_baseline_x_mm = _buffer.stat.baseline_N_mm;
+            state.rtk_baseline_y_mm = _buffer.stat.baseline_E_mm;
+            state.rtk_baseline_z_mm = _buffer.stat.baseline_D_mm;
+            state.rtk_accuracy      = _buffer.stat.ar_ratio;
+
+            state.rtk_week_number   = _buffer.stat.week;
+            state.rtk_time_week_ms  = _buffer.stat.time;
+            state.rtk_iar_num_hypotheses = _buffer.stat.iar_num_hypotheses;
+            // state.num_leap_seconds = _buffer.stat.num_leap_seconds; // leap seconds (0x7F indicates invalid)
+        }
         break;
     case MSG_DOPS:
         Debug("Message DOPS");

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -66,6 +66,17 @@ private:
         uint8_t fix_type;   ///< see erb_fix_type enum
         uint8_t fix_status;
         uint8_t satellites;
+        // Introduced in ERB version 0.2.0
+        uint8_t base_num_sats;       ///< Current number of satellites used for RTK calculation.
+        uint16_t age_cs;             ///< Age of the corrections in centiseconds (0 when no corrections, 0xFFFF indicates overflow)
+        int32_t baseline_N_mm;       ///< distance between base and rover along the north axis in millimeters
+        int32_t baseline_E_mm;       ///< distance between base and rover along the east axis in millimeters
+        int32_t baseline_D_mm;       ///< distance between base and rover along the down axis in millimeters
+        uint16_t ar_ratio;           ///< AR ratio multiplied by 10
+        uint16_t base_week_number;   ///< GPS Week Number of last baseline
+        uint32_t base_time_week_ms;  ///< GPS Time of Week of last baseline in milliseconds
+        int32_t iar_num_hypotheses;  ///< Current number of integer ambiguity hypotheses.
+        int8_t num_leap_seconds;     ///< leap seconds (0x7F indicates invalid)
     };
     struct PACKED erb_dops {
         uint32_t time;      ///< GPS time of week of the navigation epoch [ms]

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -289,6 +289,7 @@ AP_GPS_SBP::_attempt_state_update()
 
         last_full_update_tow = last_vel_ned.tow;
         last_full_update_cpu_ms = now;
+        state.rtk_iar_num_hypotheses = last_iar_num_hypotheses;
 
         logging_log_full_update();
         ret = true;

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -184,3 +184,45 @@ bool AP_GPS_Backend::should_df_log() const
     }
     return true;
 }
+
+
+void AP_GPS_Backend::send_mavlink_gps_rtk(mavlink_channel_t chan)
+{
+    const uint8_t instance = state.instance;
+    // send status
+    switch (instance) {
+        case 0:
+            mavlink_msg_gps_rtk_send(chan,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_week_number,
+                                 state.rtk_time_week_ms,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_num_sats,
+                                 state.rtk_baseline_coords_type,
+                                 state.rtk_baseline_x_mm,
+                                 state.rtk_baseline_y_mm,
+                                 state.rtk_baseline_z_mm,
+                                 state.rtk_accuracy,
+                                 state.rtk_iar_num_hypotheses);
+            break;
+        case 1:
+            mavlink_msg_gps2_rtk_send(chan,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_week_number,
+                                 state.rtk_time_week_ms,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_num_sats,
+                                 state.rtk_baseline_coords_type,
+                                 state.rtk_baseline_x_mm,
+                                 state.rtk_baseline_y_mm,
+                                 state.rtk_baseline_z_mm,
+                                 state.rtk_accuracy,
+                                 state.rtk_iar_num_hypotheses);
+            break;
+    }
+}
+

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -44,9 +44,7 @@ public:
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
     //MAVLink methods
-    virtual void send_mavlink_gps_rtk(mavlink_channel_t chan) { return ; }
-
-    virtual void send_mavlink_gps2_rtk(mavlink_channel_t chan) { return ; }
+    virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2099,7 +2099,7 @@ bool GCS_MAVLINK::try_send_gps_message(const enum ap_message id)
         break;
     case MSG_GPS_RTK:
         CHECK_PAYLOAD_SIZE(GPS_RTK);
-        gps->send_mavlink_gps_rtk(chan);
+        gps->send_mavlink_gps_rtk(chan, 0);
         ret = true;
         break;
     case MSG_GPS2_RAW:
@@ -2109,7 +2109,7 @@ bool GCS_MAVLINK::try_send_gps_message(const enum ap_message id)
         break;
     case MSG_GPS2_RTK:
         CHECK_PAYLOAD_SIZE(GPS2_RTK);
-        gps->send_mavlink_gps2_rtk(chan);
+        gps->send_mavlink_gps_rtk(chan, 1);
         ret = true;
         break;
     default:


### PR DESCRIPTION
This requires #6534 and #6424 PRs in that order

This is just a small part of it (been working and testing this since May 9th) , the rest of the related work is at #6534 #6424 ArduPilot/mavlink#48 ArduPilot/mavlink#49 ArduPilot/pymavlink#88 emlid/reach-docs#26 emlid/RTKLIB#21 emlid/RTKLIB#28