### PR TITLE
EKF: reduce final compass reset to 2.5m

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -100,16 +100,24 @@ bool Copter::ekf_over_threshold()
     }
 
     // use EKF to get variance
-    float posVar, hgtVar, tasVar;
-    Vector3f magVar;
+    float position_variance, vel_variance, height_variance, tas_variance;
+    Vector3f mag_variance;
     Vector2f offset;
-    float compass_variance;
-    float vel_variance;
-    ahrs.get_variances(vel_variance, posVar, hgtVar, magVar, tasVar, offset);
-    compass_variance = magVar.length();
+    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset);
 
-    // return true if compass and velocity variance over the threshold
-    return (compass_variance >= g.fs_ekf_thresh && vel_variance >= g.fs_ekf_thresh);
+    // return true if two of compass, velocity and position variances are over the threshold
+    uint8_t over_thresh_count = 0;
+    if (mag_variance.length() >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+    if (vel_variance >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+    if (position_variance >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+
+    return (over_thresh_count >= 2);
 }
 
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -58,7 +58,7 @@ void NavEKF2_core::controlMagYawReset()
     if (flightResetAllowed && !assume_zero_sideslip()) {
         // check that we have reached a height where ground magnetic interference effects are insignificant
         // and can perform a final reset of the yaw and field states
-        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
+        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -EKF2_MAG_FINAL_RESET_ALT;
 
         // check for increasing height
         bool hgtIncreasing = (posDownAtLastMagReset-stateStruct.position.z) > 0.5f;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -50,6 +50,9 @@
 // target EKF update time step
 #define EKF_TARGET_DT 0.01f
 
+// mag fusion final reset altitude
+#define EKF2_MAG_FINAL_RESET_ALT 2.5f
+
 class AP_AHRS;
 
 class NavEKF2_core

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -56,7 +56,7 @@ void NavEKF3_core::controlMagYawReset()
     if (flightResetAllowed && !assume_zero_sideslip()) {
         // check that we have reached a height where ground magnetic interference effects are insignificant
         // and can perform a final reset of the yaw and field states
-        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -5.0f;
+        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -EKF3_MAG_FINAL_RESET_ALT;
 
         // check for increasing height
         bool hgtIncreasing = (posDownAtLastMagReset-stateStruct.position.z) > 0.5f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -61,6 +61,9 @@
 #define EKF_TARGET_DT_MS 12
 #define EKF_TARGET_DT    0.012f
 
+// mag fusion final reset altitude (using NED frame so altitude is negative)
+#define EKF3_MAG_FINAL_RESET_ALT 2.5f
+
 class AP_AHRS;
 
 class NavEKF3_core


### PR DESCRIPTION
This PR does two things to try and improve the chance that a bad heading estimate (normally caused by interference on the compass) will be caught more quickly:

- reduce the altitude of the EKF's final compass reset from 5m to 2.5m.  Above this altitude, all 3-axis of the compass are used when calculating the compass variance (below this altitude only a projection onto the earth-frame horizontal plane is used).  With all 3-axis used, a bad compass will be detected more quickly.
- trigger Copter's ekf variance when any two of three variances (position, velocity and compass) are over the threshold.  Previously only velocity and compass were used.

These changes were made after consulting with @priseborough.

The intention is to merge the two EKF changes into Copter-3.5 but the ekf-check will only be merged to master for now and will go out with a future release after more developer testing has been completed.

This is in response to this issue found during AC3.5.0 beta testing: http://discuss.ardupilot.org/t/dji-s1000-frame-pixhawk-2-1-flight-controller-mission-planner-beta-gcs-firmware-3-5-0-rc7-crash/18920/3
