### PR TITLE
GPS: Log and maintain the delta time between the last position update

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -349,6 +349,14 @@ bool AP_Arming::gps_checks(bool report)
             }
             return false;
         }
+
+        //GPS update rate acceptable
+        if (!gps.is_healthy()) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS is not healthy");
+            }
+            return false;
+        }
     }
 
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -357,23 +357,8 @@ bool AP_Arming::gps_checks(bool report)
             }
             return false;
         }
-    }
 
-    if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
-        uint8_t first_unconfigured = gps.first_unconfigured_gps();
-        if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
-            if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL,
-                                                 "PreArm: GPS %d failing configuration checks",
-                                                  first_unconfigured + 1);
-                gps.broadcast_first_configuration_failure_reason();
-            }
-            return false;
-        }
-    }
-
-    // check GPSs are within 50m of each other and that blending is healthy
-    if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS)) {
+        // check GPSs are within 50m of each other and that blending is healthy
         float distance_m;
         if (!gps.all_consistent(distance_m)) {
             if (report) {
@@ -386,6 +371,19 @@ bool AP_Arming::gps_checks(bool report)
         if (!gps.blend_health_check()) {
             if (report) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS blending unhealthy");
+            }
+            return false;
+        }
+    }
+
+    if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
+        uint8_t first_unconfigured = gps.first_unconfigured_gps();
+        if (first_unconfigured != AP_GPS::GPS_ALL_CONFIGURED) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL,
+                                                 "PreArm: GPS %d failing configuration checks",
+                                                  first_unconfigured + 1);
+                gps.broadcast_first_configuration_failure_reason();
             }
             return false;
         }

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -282,7 +282,8 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, uint64_t time_
         vacc          : (uint16_t)MIN((vacc*100), UINT16_MAX),
         sacc          : (uint16_t)MIN((sacc*100), UINT16_MAX),
         have_vv       : (uint8_t)gps.have_vertical_velocity(i),
-        sample_ms     : gps.last_message_time_ms(i)
+        sample_ms     : gps.last_message_time_ms(i),
+        delta_ms      : gps.last_message_delta_time_ms(i)
     };
     WriteBlock(&pkt2, sizeof(pkt2));
 }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -79,6 +79,7 @@ struct PACKED log_GPA {
     uint16_t sacc;
     uint8_t  have_vv;
     uint32_t sample_ms;
+    uint16_t delta_ms;
 };
 
 struct PACKED log_Message {
@@ -897,8 +898,8 @@ struct PACKED log_Proximity {
 #define ESC_LABELS "TimeUS,RPM,Volt,Curr,Temp"
 #define ESC_FMT   "Qcccc"
 
-#define GPA_LABELS "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS"
-#define GPA_FMT   "QCCCCBI"
+#define GPA_LABELS "TimeUS,VDop,HAcc,VAcc,SAcc,VV,SMS,Delta"
+#define GPA_FMT   "QCCCCBIH"
 
 // see "struct GPS_State" and "Log_Write_GPS":
 #define GPS_LABELS "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,U"


### PR DESCRIPTION
This logs the delta time between GPS position updates, and uses it as an arming check.

The arming check was selected to limit us to 5Hz updates as a minimum, @priseborough  if this is felt to be to strict we can change it, but from memory this is what we were requiring.

The logging should be highlighted as a fixing a frequent problem I encounter with users logs when things start going wrong. When I'm trying to tell if the GPS driver made an error/the GPS is misconfigured at the time it's hard to tell if we lost GPS (and thus aren't getting any logged messages) or if we just had to drop some logging messages. With the delta time from the GPS lib, we can tell if the GPS actually experienced a miss, or if we just lost some messages.

This implements #5749, however @rmackay9 I don't know how to emit ERR messages, so I'm hoping you can either take it on later/separately or point me at how to do it.