### PR TITLE
AP_GPS: Fix SBF race condition on start

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -65,7 +65,8 @@ AP_GPS_SBF::read(void)
 
         if (now > _init_blob_time) {
             port->write((const uint8_t*)init_str, strlen(init_str));
-            _init_blob_time = now + 1000;
+            // if this is to low a race condition on stat occurs and the GPS isn't detected
+            _init_blob_time = now + 2000;
         }
     }
 


### PR DESCRIPTION
Unsure what the underlying problem is, but the length of the first string in
the initilisation_blob increasing resulted in a race condition on startup, waiting
longer before retrying the message resolves it, but we still need to identify
the underlying problem. This patch just results in the GPS working with current
configurations. Tested against AsteRx-M firmware 3.6.3

Interestingly the race condition interacts  with how long the system takes to start, so removing or adding external components (IE airspeed) can result in the system finding the GPS or not.