### PR TITLE
Copter: move proximity to common

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -709,7 +709,6 @@ private:
     void send_hwstatus(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
-    void send_proximity(mavlink_channel_t chan, uint16_t count_max);
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();
     void button_update();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -207,58 +207,6 @@ void NOINLINE Copter::send_current_waypoint(mavlink_channel_t chan)
     mavlink_msg_mission_current_send(chan, mission.get_current_nav_index());
 }
 
-void NOINLINE Copter::send_proximity(mavlink_channel_t chan, uint16_t count_max)
-{
-#if PROXIMITY_ENABLED == ENABLED
-    // return immediately if no proximity sensor is present
-    if (g2.proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
-        return;
-    }
-
-    // return immediately if no tx buffer room to send messages
-    if (count_max == 0) {
-        return;
-    }
-
-    bool send_upwards = true;
-
-    // send horizontal distances
-    AP_Proximity::Proximity_Distance_Array dist_array;
-    const uint8_t horiz_count = MIN(count_max, PROXIMITY_MAX_DIRECTION);  // send at most PROXIMITY_MAX_DIRECTION horizontal distances
-    if (g2.proximity.get_horizontal_distances(dist_array)) {
-        for (uint8_t i = 0; i < horiz_count; i++) {
-            mavlink_msg_distance_sensor_send(
-                chan,
-                AP_HAL::millis(),                               //  time since system boot
-                (uint16_t)(g2.proximity.distance_min() * 100),  // minimum distance the sensor can measure in centimeters
-                (uint16_t)(g2.proximity.distance_max() * 100),  // maximum distance the sensor can measure in centimeters
-                (uint16_t)(dist_array.distance[i] * 100),       // current distance reading (in cm?)
-                MAV_DISTANCE_SENSOR_LASER,                      // type from MAV_DISTANCE_SENSOR enum
-                PROXIMITY_SENSOR_ID_START + i,                  // onboard ID of the sensor
-                dist_array.orientation[i],                      //  direction the sensor faces from MAV_SENSOR_ORIENTATION enum
-                0);                                             // Measurement covariance in centimeters, 0 for unknown / invalid readings
-        }
-        // check if we still have room to send upwards distance
-        send_upwards = (count_max > 8);
-    }
-
-    // send upward distance
-    float dist_up;
-    if (send_upwards && g2.proximity.get_upward_distance(dist_up)) {
-        mavlink_msg_distance_sensor_send(
-            chan,
-            AP_HAL::millis(),                                        //  time since system boot
-            (uint16_t)(g2.proximity.distance_min() * 100),           // minimum distance the sensor can measure in centimeters
-            (uint16_t)(g2.proximity.distance_max() * 100),           // maximum distance the sensor can measure in centimeters
-            (uint16_t)(dist_up * 100),                               // current distance reading
-            MAV_DISTANCE_SENSOR_LASER,                               // type from MAV_DISTANCE_SENSOR enum
-            PROXIMITY_SENSOR_ID_START + PROXIMITY_MAX_DIRECTION +1,  // onboard ID of the sensor
-            MAV_SENSOR_ROTATION_PITCH_90,                            // direction upwards
-            0);                                                      // Measurement covariance in centimeters, 0 for unknown / invalid readings
-    }
-#endif
-}
-
 /*
   send RPM packet
  */
@@ -467,8 +415,10 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(DISTANCE_SENSOR);
         send_distance_sensor_downward(copter.rangefinder);
 #endif
+#if PROXIMITY_ENABLED == ENABLED
         CHECK_PAYLOAD_SIZE(DISTANCE_SENSOR);
-        copter.send_proximity(chan, comm_get_txspace(chan) / (packet_overhead()+9));
+        send_proximity(copter.g2.proximity, comm_get_txspace(chan) / (packet_overhead()+9));
+#endif
         break;
 
     case MSG_RPM:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -416,8 +416,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         send_distance_sensor_downward(copter.rangefinder);
 #endif
 #if PROXIMITY_ENABLED == ENABLED
-        CHECK_PAYLOAD_SIZE(DISTANCE_SENSOR);
-        send_proximity(copter.g2.proximity, comm_get_txspace(chan) / (packet_overhead()+9));
+        send_proximity(copter.g2.proximity);
 #endif
         break;
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -765,24 +765,6 @@ void Copter::Log_Write_Throw(ThrowModeStage stage, float velocity, float velocit
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
-// proximity sensor logging
-struct PACKED log_Proximity {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t health;
-    float dist0;
-    float dist45;
-    float dist90;
-    float dist135;
-    float dist180;
-    float dist225;
-    float dist270;
-    float dist315;
-    float distup;
-    float closest_angle;
-    float closest_dist;
-};
-
 // Write proximity sensor distances
 void Copter::Log_Write_Proximity()
 {
@@ -791,42 +773,7 @@ void Copter::Log_Write_Proximity()
     if (g2.proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
         return;
     }
-
-    float sector_distance[8] = {0,0,0,0,0,0,0,0};
-    g2.proximity.get_horizontal_distance(0, sector_distance[0]);
-    g2.proximity.get_horizontal_distance(45, sector_distance[1]);
-    g2.proximity.get_horizontal_distance(90, sector_distance[2]);
-    g2.proximity.get_horizontal_distance(135, sector_distance[3]);
-    g2.proximity.get_horizontal_distance(180, sector_distance[4]);
-    g2.proximity.get_horizontal_distance(225, sector_distance[5]);
-    g2.proximity.get_horizontal_distance(270, sector_distance[6]);
-    g2.proximity.get_horizontal_distance(315, sector_distance[7]);
-
-    float dist_up;
-    if (!g2.proximity.get_upward_distance(dist_up)) {
-        dist_up = 0.0f;
-    }
-
-    float close_ang = 0.0f, close_dist = 0.0f;
-    g2.proximity.get_closest_object(close_ang, close_dist);
-
-    struct log_Proximity pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
-        time_us         : AP_HAL::micros64(),
-        health          : (uint8_t)g2.proximity.get_status(),
-        dist0           : sector_distance[0],
-        dist45          : sector_distance[1],
-        dist90          : sector_distance[2],
-        dist135         : sector_distance[3],
-        dist180         : sector_distance[4],
-        dist225         : sector_distance[5],
-        dist270         : sector_distance[6],
-        dist315         : sector_distance[7],
-        distup          : dist_up,
-        closest_angle   : close_ang,
-        closest_dist    : close_dist
-    };
-    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+    DataFlash.Log_Write_Proximity(g2.proximity);
 #endif
 }
 
@@ -882,8 +829,6 @@ const struct LogStructure Copter::log_structure[] = {
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
     { LOG_THROW_MSG, sizeof(log_Throw),
       "THRO",  "QBffffbbbb",  "TimeUS,Stage,Vel,VelZ,Acc,AccEfZ,Throw,AttOk,HgtOk,PosOk" },
-    { LOG_PROXIMITY_MSG, sizeof(log_Proximity),
-      "PRX",   "QBfffffffffff","TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis" },
 };
 
 #if CLI_ENABLED == ENABLED

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -769,10 +769,6 @@ void Copter::Log_Write_Throw(ThrowModeStage stage, float velocity, float velocit
 void Copter::Log_Write_Proximity()
 {
 #if PROXIMITY_ENABLED == ENABLED
-    // exit immediately if not enabled
-    if (g2.proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
-        return;
-    }
     DataFlash.Log_Write_Proximity(g2.proximity);
 #endif
 }

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -318,7 +318,7 @@ enum DevOptions {
 #define LOG_PRECLAND_MSG                0x21
 #define LOG_GUIDEDTARGET_MSG            0x22
 #define LOG_THROW_MSG                   0x23
-#define LOG_PROXIMITY_MSG               0x24
+
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -21,6 +21,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <AP_Rally/AP_Rally.h>
 #include <AP_Beacon/AP_Beacon.h>
+#include <AP_Proximity/AP_Proximity.h>
 #include <stdint.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
@@ -153,6 +154,7 @@ public:
     void Log_Write_VisualOdom(float time_delta, const Vector3f &angle_delta, const Vector3f &position_delta, float confidence);
     void Log_Write_AOA_SSA(AP_AHRS &ahrs);
     void Log_Write_Beacon(AP_Beacon &beacon);
+    void Log_Write_Proximity(AP_Proximity &proximity);
 
     void Log_Write(const char *name, const char *labels, const char *fmt, ...);
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1926,3 +1926,43 @@ void DataFlash_Class::Log_Write_Beacon(AP_Beacon &beacon)
     };
     WriteBlock(&pkt_beacon, sizeof(pkt_beacon));
 }
+
+// Write proximity sensor distances
+void DataFlash_Class::Log_Write_Proximity(AP_Proximity &proximity)
+{
+    float sector_distance[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    proximity.get_horizontal_distance(0.0f, sector_distance[0]);
+    proximity.get_horizontal_distance(45.0f, sector_distance[1]);
+    proximity.get_horizontal_distance(90.0f, sector_distance[2]);
+    proximity.get_horizontal_distance(135.0f, sector_distance[3]);
+    proximity.get_horizontal_distance(180.0f, sector_distance[4]);
+    proximity.get_horizontal_distance(225.0f, sector_distance[5]);
+    proximity.get_horizontal_distance(270.0f, sector_distance[6]);
+    proximity.get_horizontal_distance(315.0f, sector_distance[7]);
+
+    float dist_up;
+    if (!proximity.get_upward_distance(dist_up)) {
+        dist_up = 0.0f;
+    }
+
+    float close_ang = 0.0f, close_dist = 0.0f;
+    proximity.get_closest_object(close_ang, close_dist);
+
+    struct log_Proximity pkt_proximity = {
+            LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
+            time_us         : AP_HAL::micros64(),
+            health          : (uint8_t)proximity.get_status(),
+            dist0           : sector_distance[0],
+            dist45          : sector_distance[1],
+            dist90          : sector_distance[2],
+            dist135         : sector_distance[3],
+            dist180         : sector_distance[4],
+            dist225         : sector_distance[5],
+            dist270         : sector_distance[6],
+            dist315         : sector_distance[7],
+            distup          : dist_up,
+            closest_angle   : close_ang,
+            closest_dist    : close_dist
+    };
+    WriteBlock(&pkt_proximity, sizeof(pkt_proximity));
+}

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1930,15 +1930,12 @@ void DataFlash_Class::Log_Write_Beacon(AP_Beacon &beacon)
 // Write proximity sensor distances
 void DataFlash_Class::Log_Write_Proximity(AP_Proximity &proximity)
 {
-    float sector_distance[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
-    proximity.get_horizontal_distance(0.0f, sector_distance[0]);
-    proximity.get_horizontal_distance(45.0f, sector_distance[1]);
-    proximity.get_horizontal_distance(90.0f, sector_distance[2]);
-    proximity.get_horizontal_distance(135.0f, sector_distance[3]);
-    proximity.get_horizontal_distance(180.0f, sector_distance[4]);
-    proximity.get_horizontal_distance(225.0f, sector_distance[5]);
-    proximity.get_horizontal_distance(270.0f, sector_distance[6]);
-    proximity.get_horizontal_distance(315.0f, sector_distance[7]);
+    // exit immediately if not enabled
+    if (proximity.get_status() == AP_Proximity::Proximity_NotConnected) {
+        return;
+    }
+    AP_Proximity::Proximity_Distance_Array dist_array {};
+    proximity.get_horizontal_distances(dist_array);
 
     float dist_up;
     if (!proximity.get_upward_distance(dist_up)) {
@@ -1952,14 +1949,14 @@ void DataFlash_Class::Log_Write_Proximity(AP_Proximity &proximity)
             LOG_PACKET_HEADER_INIT(LOG_PROXIMITY_MSG),
             time_us         : AP_HAL::micros64(),
             health          : (uint8_t)proximity.get_status(),
-            dist0           : sector_distance[0],
-            dist45          : sector_distance[1],
-            dist90          : sector_distance[2],
-            dist135         : sector_distance[3],
-            dist180         : sector_distance[4],
-            dist225         : sector_distance[5],
-            dist270         : sector_distance[6],
-            dist315         : sector_distance[7],
+            dist0           : dist_array.distance[0],
+            dist45          : dist_array.distance[1],
+            dist90          : dist_array.distance[2],
+            dist135         : dist_array.distance[3],
+            dist180         : dist_array.distance[4],
+            dist225         : dist_array.distance[5],
+            dist270         : dist_array.distance[6],
+            dist315         : dist_array.distance[7],
             distup          : dist_up,
             closest_angle   : close_ang,
             closest_dist    : close_dist

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -855,6 +855,24 @@ struct PACKED log_Beacon {
     float posz;
 };
 
+// proximity sensor logging
+struct PACKED log_Proximity {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t health;
+    float dist0;
+    float dist45;
+    float dist90;
+    float dist135;
+    float dist180;
+    float dist225;
+    float dist270;
+    float dist315;
+    float distup;
+    float closest_angle;
+    float closest_dist;
+};
+
 // #endif // SBP_HW_LOGGING
 
 #define ACC_LABELS "TimeUS,SampleUS,AccX,AccY,AccZ"
@@ -982,7 +1000,9 @@ Format characters in the format string for binary log messages
     { LOG_DF_MAV_STATS, sizeof(log_DF_MAV_Stats), \
       "DMS", "IIIIIBBBBBBBBBB",         "TimeMS,N,Dp,RT,RS,Er,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \
-      "BCN", "QBBfffffff",  "TimeUS,Health,Cnt,D0,D1,D2,D3,PosX,PosY,PosZ" }
+      "BCN", "QBBfffffff",  "TimeUS,Health,Cnt,D0,D1,D2,D3,PosX,PosY,PosZ" }, \
+    { LOG_PROXIMITY_MSG, sizeof(log_Proximity), \
+      "PRX", "QBfffffffffff", "TimeUS,Health,D0,D45,D90,D135,D180,D225,D270,D315,DUp,CAn,CDis" }
 
 // messages for more advanced boards
 #define LOG_EXTRA_STRUCTURES \
@@ -1274,6 +1294,7 @@ enum LogMessages {
     LOG_VISUALODOM_MSG,
     LOG_AOA_SSA_MSG,
     LOG_BEACON_MSG,
+    LOG_PROXIMITY_MSG,
 };
 
 enum LogOriginType {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -14,6 +14,7 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Mount/AP_Mount.h>
 #include <AP_Avoidance/AP_Avoidance.h>
+#include <AP_Proximity/AP_Proximity.h>
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 
@@ -155,6 +156,7 @@ public:
     bool send_distance_sensor(const RangeFinder &rangefinder) const;
     void send_distance_sensor_downward(const RangeFinder &rangefinder) const;
     void send_rangefinder_downward(const RangeFinder &rangefinder) const;
+    void send_proximity(const AP_Proximity &proximity, uint16_t count_max) const;
     void send_ahrs2(AP_AHRS &ahrs);
     bool send_gps_raw(AP_GPS &gps);
     void send_system_time(AP_GPS &gps);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -156,7 +156,7 @@ public:
     bool send_distance_sensor(const RangeFinder &rangefinder) const;
     void send_distance_sensor_downward(const RangeFinder &rangefinder) const;
     void send_rangefinder_downward(const RangeFinder &rangefinder) const;
-    void send_proximity(const AP_Proximity &proximity, uint16_t count_max) const;
+    bool send_proximity(const AP_Proximity &proximity) const;
     void send_ahrs2(AP_AHRS &ahrs);
     bool send_gps_raw(AP_GPS &gps);
     void send_system_time(AP_GPS &gps);


### PR DESCRIPTION
This PR move proximity message to GCS_common and logging to Dataflash in order to share them with Rover 