### PR TITLE
Added motor mixing and mode for direct force control - new vehicle configuration for hexarotor and octarotors

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -867,6 +867,8 @@ private:
     void circle_run();
     bool drift_init(bool ignore_checks);
     void drift_run();
+    bool dfc_init(bool ignore_checks); // dfc controller
+    void dfc_run(); //dfc controller
     float get_throttle_assist(float velz, float pilot_throttle_scaled);
     bool flip_init(bool ignore_checks);
     void flip_run();

--- a/ArduCopter/control_dfc.cpp
+++ b/ArduCopter/control_dfc.cpp
@@ -1,0 +1,80 @@
+#include "Copter.h"
+
+/*
+ * Init and run calls for dfc-stabilize flight mode
+ */
+
+// dfc_init - initialise dfc-stabilize controller
+bool Copter::dfc_init(bool ignore_checks)
+{
+    // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
+    if (motors->armed() && ap.land_complete && !mode_has_manual_throttle(control_mode) &&
+            (get_pilot_desired_throttle(channel_throttle->get_control_in()) > get_non_takeoff_throttle())) {
+        return false;
+    }
+    // set target altitude to zero for reporting
+    pos_control->set_alt_target(0);
+
+    return true;
+}
+
+// dfc_run - runs the main dfc-stabilize controller
+// should be called at 100hz or more
+void Copter::dfc_run()
+{
+    float target_roll, target_pitch;
+    float target_yaw_rate;
+    float pilot_throttle_scaled;
+    float target_fx, target_fy;
+
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || ap.throttle_zero || !motors->get_interlock()) {
+        motors->set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
+        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        return;
+    }
+
+    // clear landing flag
+    set_land_complete(false);
+
+    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+
+    // apply SIMPLE mode transform to pilot inputs
+    update_simple_mode();
+    
+    // SEE if DFC is enabled
+    if(g.frame_type >= AP_Motors::MOTOR_FRAME_TYPE_DFC_15)
+    {
+
+      target_roll  = 0.0f + 1500.0*(RC_Channels::rc_channel(CH_6)->norm_input()); //S1
+      target_pitch = 0.0f + 1500.0*(RC_Channels::rc_channel(CH_7)->norm_input()); //S2
+    
+      target_fx = (float)(channel_pitch->get_control_in()*-1); // X is backwards -push forward on pitch stick is negative --to generate forward accel-need it to be positive
+      target_fy = (float)channel_roll->get_control_in();	  
+
+      motors->set_FX( target_fx/4500.0f ); //scale down to +-1
+      motors->set_FY( target_fy/4500.0f );
+      
+    }else{
+      
+      get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, aparm.angle_max);	
+      //target roll/pitch range +- 4500
+      target_fx = 0.0f;
+      target_fy = 0.0f;
+      
+    }
+
+    // get pilot's desired yaw rate
+    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+
+    // get pilot's desired throttle
+    pilot_throttle_scaled = get_pilot_desired_throttle(channel_throttle->get_control_in());
+
+    // call attitude controller
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
+
+    // body-frame rate controller is run directly from 100hz loop
+
+    // output pilot's throttle
+    attitude_control->set_throttle_out(pilot_throttle_scaled, true, g.throttle_filt);
+}

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -90,7 +90,7 @@ enum control_mode_t {
     ACRO =          1,  // manual body-frame angular rate with manual throttle
     ALT_HOLD =      2,  // manual airframe angle with automatic throttle
     AUTO =          3,  // fully automatic waypoint control using mission commands
-    DFC           = 4,  // direct force control mode - essential three force commands(body-x,body-y and body-z)
+    GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
     LOITER =        5,  // automatic horizontal acceleration with automatic throttle
     RTL =           6,  // automatic return to launching point
     CIRCLE =        7,  // automatic circular flight with automatic throttle
@@ -104,7 +104,7 @@ enum control_mode_t {
     THROW =        18,  // throw to launch mode using inertial/GPS system, no pilot input
     AVOID_ADSB =   19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
     GUIDED_NOGPS = 20,  // guided mode but only accepts attitude and altitude
-    GUIDED =        21,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    DFC =          21,  // direct force control mode - essential three force commands(body-x,body-y and body-z)
 };
 
 enum mode_reason_t {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -90,7 +90,7 @@ enum control_mode_t {
     ACRO =          1,  // manual body-frame angular rate with manual throttle
     ALT_HOLD =      2,  // manual airframe angle with automatic throttle
     AUTO =          3,  // fully automatic waypoint control using mission commands
-    GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    DFC           = 4,  // direct force control mode - essential three force commands(body-x,body-y and body-z)
     LOITER =        5,  // automatic horizontal acceleration with automatic throttle
     RTL =           6,  // automatic return to launching point
     CIRCLE =        7,  // automatic circular flight with automatic throttle
@@ -104,6 +104,7 @@ enum control_mode_t {
     THROW =        18,  // throw to launch mode using inertial/GPS system, no pilot input
     AVOID_ADSB =   19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
     GUIDED_NOGPS = 20,  // guided mode but only accepts attitude and altitude
+    GUIDED =        21,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
 };
 
 enum mode_reason_t {

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -51,6 +51,10 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
 
         case CIRCLE:
             success = circle_init(ignore_checks);
+            break;    
+
+        case DFC:
+            success = dfc_init(ignore_checks);
             break;
 
         case LOITER:
@@ -190,6 +194,10 @@ void Copter::update_flight_mode()
             circle_run();
             break;
 
+        case DFC:
+            dfc_run();
+            break;
+
         case LOITER:
             loiter_run();
             break;
@@ -325,6 +333,7 @@ bool Copter::mode_has_manual_throttle(control_mode_t mode)
     switch (mode) {
         case ACRO:
         case STABILIZE:
+	case DFC:
             return true;
         default:
             return false;
@@ -376,6 +385,9 @@ void Copter::notify_flight_mode(control_mode_t mode)
             break;
         case AUTO:
             notify.set_flight_mode_str("AUTO");
+            break;
+        case DFC:
+            notify.set_flight_mode_str("DFC");
             break;
         case GUIDED:
             notify.set_flight_mode_str("GUID");
@@ -442,6 +454,9 @@ void Copter::print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode)
         break;
     case AUTO:
         port->printf("AUTO");
+        break;
+    case DFC:
+        port->printf("DFC");
         break;
     case GUIDED:
         port->printf("GUIDED");

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -56,6 +56,10 @@ protected:
 
     // add_motor using separate roll and pitch factors (for asymmetrical frames) and prop direction
     void                add_motor(int8_t motor_num, float roll_factor_in_degrees, float pitch_factor_in_degrees, float yaw_factor, uint8_t testing_order);
+    
+        // add_dfc_motor - multiple factors to take into account
+    void add_dfc_motor(int8_t motor_num, float roll_factor_in_degrees, float pitch_factor_in_degrees, float yaw_factor,
+                       float fx_factor, float fy_factor, uint8_t testing_order);
 
     // remove_motor
     void                remove_motor(int8_t motor_num);
@@ -76,4 +80,6 @@ protected:
     uint8_t             _test_order[AP_MOTORS_MAX_NUM_MOTORS];  // order of the motors in the test sequence
     motor_frame_class   _last_frame_class; // most recently requested frame class (i.e. quad, hexa, octa, etc)
     motor_frame_type    _last_frame_type; // most recently requested frame type (i.e. plus, x, v, etc)
+    float               _fx_factor[AP_MOTORS_MAX_NUM_MOTORS];   // each motors dfc x force contribution
+    float               _fy_factor[AP_MOTORS_MAX_NUM_MOTORS];   // each motors dfc y force contribution
 };

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -32,6 +32,8 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     _roll_in(0.0f),
     _pitch_in(0.0f),
     _yaw_in(0.0f),
+    _x_control_input(0.0f),
+    _y_control_input(0.0f),
     _throttle_in(0.0f),
     _throttle_avg_max(0.0f),
     _throttle_filter(),

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -52,7 +52,11 @@ public:
         MOTOR_FRAME_TYPE_VTAIL = 4,
         MOTOR_FRAME_TYPE_ATAIL = 5,
         MOTOR_FRAME_TYPE_Y6B = 10,
-        MOTOR_FRAME_TYPE_Y6F = 11 // for FireFlyY6
+        MOTOR_FRAME_TYPE_Y6F = 11, // for FireFlyY6
+        MOTOR_FRAME_TYPE_DFC_15 = 12, // for direct force control  = 15 deg motor tilt
+        MOTOR_FRAME_TYPE_DFC_30 = 13, // for direct force control  = 30 deg motor tilt
+        MOTOR_FRAME_TYPE_DFC_45 = 14, // for direct force control  = 45 deg motor tilt
+        MOTOR_FRAME_TYPE_DFC_60 = 15 // for direct force control  = 60 deg motor tilt
     };
 
     // Constructor
@@ -80,6 +84,8 @@ public:
     void                set_throttle_filter_cutoff(float filt_hz) { _throttle_filter.set_cutoff_frequency(filt_hz); }
     void                set_forward(float forward_in) { _forward_in = forward_in; }; // range -1 ~ +1
     void                set_lateral(float lateral_in) { _lateral_in = lateral_in; };     // range -1 ~ +1
+    void                set_FX(float fx_in){ _x_control_input = fx_in; }; // range -1 to 1   
+    void 		set_FY(float fy_in){ _y_control_input = fy_in; }; // range -1 to 1  
 
     // accessors for roll, pitch, yaw and throttle inputs to motors
     float               get_roll() const { return _roll_in; }
@@ -90,6 +96,8 @@ public:
     float               get_forward() const { return _forward_in; }
     float               get_lateral() const { return _lateral_in; }
     virtual float       get_throttle_hover() const = 0;
+    float               get_FX() const { return _x_control_input; } 
+    float 		get_FY() const { return _y_control_input; } 
 
     // spool up states
     enum spool_up_down_desired {
@@ -209,6 +217,8 @@ protected:
     float               _throttle_avg_max;          // last throttle input from set_throttle_avg_max
     LowPassFilterFloat  _throttle_filter;           // throttle input filter
     spool_up_down_desired _spool_desired;           // desired spool state
+    float               _x_control_input;           // desired x accel from DFC controller , +/- 1   
+    float 		_y_control_input;           // desired y accel from DFC controller , +/- 1   
 
     // battery voltage, current and air pressure compensation variables
     float               _batt_voltage;          // latest battery voltage reading


### PR DESCRIPTION
Direct force control - changes underactuated vehicle to 5.5dof. Rotors are tilted such that they generate body-x,y accelerations. DFC mode fixes the attitude to level and the pitch/roll stick become force commands in the body.

videos here: https://www.youtube.com/watch?v=lFs92gbW1xM
and
https://www.youtube.com/watch?v=weNZHS55-Cw