### PR TITLE
Vehicles: Document minimum/maximum loop time as being in microseconds

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -358,7 +358,7 @@ private:
     // Performance monitoring
     // Timer used to accrue data and trigger recording of the performance monitoring log message
     int32_t perf_mon_timer;
-    // The maximum main loop execution time recorded in the current performance monitoring interval
+    // The maximum main loop execution time, in microseconds, recorded in the current performance monitoring interval
     uint32_t G_Dt_max;
 
     // System Timers

--- a/ArduCopter/perf_info.cpp
+++ b/ArduCopter/perf_info.cpp
@@ -10,8 +10,8 @@
 #define PERF_INFO_OVERTIME_THRESHOLD_MICROS 3000
 
 static uint16_t perf_info_loop_count;
-static uint32_t perf_info_max_time;
-static uint32_t perf_info_min_time;
+static uint32_t perf_info_max_time; // in microseconds
+static uint32_t perf_info_min_time; // in microseconds
 static uint16_t perf_info_long_running;
 static uint32_t perf_info_log_dropped;
 static bool perf_ignore_loop = false;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -735,7 +735,7 @@ private:
         // Timer used to accrue data and trigger recording of the performanc monitoring log message
         uint32_t start_ms;
 
-        // The maximum and minimum main loop execution time recorded in the current performance monitoring interval
+        // The maximum and minimum main loop execution time, in microseconds, recorded in the current performance monitoring interval
         uint32_t G_Dt_max;
         uint32_t G_Dt_min;
 

--- a/ArduSub/perf_info.cpp
+++ b/ArduSub/perf_info.cpp
@@ -10,8 +10,8 @@
 #define PERF_INFO_OVERTIME_THRESHOLD_MICROS 3000
 
 static uint16_t perf_info_loop_count;
-static uint32_t perf_info_max_time;
-static uint32_t perf_info_min_time;
+static uint32_t perf_info_max_time; // in microseconds
+static uint32_t perf_info_min_time; // in microseconds
 static uint16_t perf_info_long_running;
 static uint32_t perf_info_log_dropped;
 static bool perf_ignore_loop = false;


### PR DESCRIPTION
It wasn't entirely obvious to me from a DF log what time unit was actually being used for the min/max times in a performance message, and it wasn't actually noted where the storage variables were declared...