### PR TITLE
Deepstall: Require a minimum altitude before allowing an abort

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -955,11 +955,11 @@ void Plane::update_flight_stage(void)
             } else if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_TAKEOFF);
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
-
                 if (landing.is_commanded_go_around() || flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
                     // abort mode is sticky, it must complete while executing NAV_LAND
                     set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND);
-                } else if (landing.get_abort_throttle_enable() && channel_throttle->get_control_in() >= 90) {
+                } else if (landing.get_abort_throttle_enable() && channel_throttle->get_control_in() >= 90 &&
+                           landing.request_go_around()) {
                     gcs().send_text(MAV_SEVERITY_INFO,"Landing aborted via throttle");
                     set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND);
                 } else {

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -128,6 +128,14 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @Path: ../PID/PID.cpp
     AP_SUBGROUPINFO(ds_PID, "", 14, AP_Landing_Deepstall, PID),
 
+    // @Param: ABORTALT
+    // @DisplayName: Deepstall minimum abort altitude
+    // @Description: The minimum altitude which the aircraft must be above to abort a deepstall landing
+    // @Range: 0 50
+    // @Units meters
+    // @User: Advanced
+    AP_GROUPINFO("ABORTALT", 15, AP_Landing_Deepstall, min_abort_alt, 0.0f),
+
     AP_GROUPEND
 };
 
@@ -336,8 +344,15 @@ bool AP_Landing_Deepstall::override_servos(void)
 
 bool AP_Landing_Deepstall::request_go_around(void)
 {
-    landing.flags.commanded_go_around = true;
-    return true;
+    float current_altitude_d;
+    landing.ahrs.get_relative_position_D_home(current_altitude_d);
+
+    if (is_zero(min_abort_alt) || -current_altitude_d > min_abort_alt) {
+        landing.flags.commanded_go_around = true;
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool AP_Landing_Deepstall::is_throttle_suppressed(void) const

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
 
     // @Group: DS_
     // @Path: ../PID/PID.cpp
-    AP_SUBGROUPINFO(ds_PID, "", 13, AP_Landing_Deepstall, PID),
+    AP_SUBGROUPINFO(ds_PID, "", 14, AP_Landing_Deepstall, PID),
 
     AP_GROUPEND
 };
@@ -504,13 +504,13 @@ float AP_Landing_Deepstall::update_steering()
     Location current_loc;
     if (!landing.ahrs.get_position(current_loc)) {
         // panic if no position source is available
-        // continue the  but target just holding the wings held level as deepstall should be a minimal energy
-        // configuration on the aircraft, and if a position isn't available aborting would be worse
+        // continue the stall but target just holding the wings held level as deepstall should be a minimal
+        // energy configuration on the aircraft, and if a position isn't available aborting would be worse
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Deepstall: No position available. Attempting to hold level");
         memcpy(&current_loc, &landing_point, sizeof(Location));
     }
     uint32_t time = AP_HAL::millis();
-    float dt = constrain_float(time - last_time, (uint32_t)10UL, (uint32_t)200UL) / 1000.0;
+    float dt = constrain_float(time - last_time, (uint32_t)10UL, (uint32_t)200UL) * 1e-3;
     last_time = time;
 
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -67,6 +67,7 @@ private:
     AP_Float L1_i;
     AP_Float yaw_rate_limit;
     AP_Float time_constant;
+    AP_Float min_abort_alt;
     int32_t loiter_sum_cd;         // used for tracking the progress on loitering
     deepstall_stage stage;
     Location landing_point;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -165,6 +165,11 @@ bool AP_Param::check_group_info(const struct AP_Param::GroupInfo *  group_info,
             // great idx 0 as 63 for duplicates. See group_id()
             idx = 63;
         }
+        if (used_mask & (1ULL<<idx)) {
+            Debug("Duplicate group idx %u for %s", idx, group_info[i].name);
+            return false;
+        }
+        used_mask |= (1ULL<<idx);
         if (type == AP_PARAM_GROUP) {
             // a nested group
             if (group_shift + _group_level_shift >= _group_bits) {
@@ -180,11 +185,6 @@ bool AP_Param::check_group_info(const struct AP_Param::GroupInfo *  group_info,
             }
             continue;
         }
-        if (used_mask & (1ULL<<idx)) {
-            Debug("Duplicate group idx %u for %s", idx, group_info[i].name);
-            return false;
-        }
-        used_mask |= (1ULL<<idx);
         uint8_t size = type_size((enum ap_var_type)type);
         if (size == 0) {
             Debug("invalid type in %s", group_info[i].name);


### PR DESCRIPTION
This allows the aircraft to reject any aborts when in close proximity to the ground. This is useful as an abort that is begun to low, will result in a full throttle nose first impact at much higher speed then if the deepstall was continued.

This also addressed the fact that throttle based landing aborts should be asking AP_Landing for permission to execute an abort, rather then just always applying them. This was an error missed in the refactoring to AP_Landing, as the GCS based ones did correctly call AP_Landing. This makes the behavior more consistent.

Depends on #6602 