### PR TITLE
Rover: add motor test

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -5,3 +5,55 @@ enum HomeState AP_Arming_Rover::home_status() const
 {
     return rover.home_is_set;
 }
+
+// perform pre_arm_rc_checks checks
+bool AP_Arming_Rover::pre_arm_rc_checks(const bool display_failure)
+{
+    // set rc-checks to success if RC checks are disabled
+    if ((checks_to_perform != ARMING_CHECK_ALL) && !(checks_to_perform & ARMING_CHECK_RC)) {
+        return true;
+    }
+
+    const RC_Channel *channels[] = {
+            rover.channel_steer,
+            rover.channel_throttle,
+    };
+    const char *channel_names[] = {"Steer", "Throttle"};
+
+    for (uint8_t i= 0 ; i < ARRAY_SIZE(channels); i++) {
+        const RC_Channel *channel = channels[i];
+        const char *channel_name = channel_names[i];
+        // check if radio has been calibrated
+        if (!channel->min_max_configured()) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: RC %s not configured", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_min() > 1300) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio min too high", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_max() < 1700) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio max too low", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_trim() < channel->get_radio_min()) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim below min", channel_name);
+            }
+            return false;
+        }
+        if (channel->get_radio_trim() > channel->get_radio_max()) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim above max", channel_name);
+            }
+            return false;
+        }
+    }
+    return true;
+}

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -14,6 +14,8 @@ public:
         AP_Arming(ahrs_ref, baro, compass, battery) {
     }
 
+    bool pre_arm_rc_checks(const bool display_failure);
+
 protected:
 
     enum HomeState home_status() const override;

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -184,16 +184,53 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
             motor_left += dir * steering_scaled;
         }
     }
-    if (_pwm_type == PWM_TYPE_BRUSHED) {
-        const bool dirLeft = is_positive(motor_left);
-        const bool dirRight = is_positive(motor_right);
-        _relayEvents.do_set_relay(0, dirLeft);
-        _relayEvents.do_set_relay(1, dirRight);
-        motor_left = fabsf(motor_left);
-        motor_right = fabsf(motor_right);
+
+    // send pwm value to each motor
+    output_throttle(SRV_Channel::k_throttleLeft, 100.0f * motor_left);
+    output_throttle(SRV_Channel::k_throttleRight, 100.0f * motor_right);
+}
+
+// output throttle value to main throttle channel, left throttle or right throttle.  throttle should be scaled from -100 to 100
+void AP_MotorsUGV::output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle)
+{
+    // sanity check servo function
+    if (function != SRV_Channel::k_throttle && function != SRV_Channel::k_throttleLeft && function != SRV_Channel::k_throttleRight) {
+        return;
     }
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft,  1000.0f * motor_left);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000.0f * motor_right);
+
+    // constrain output
+    throttle = constrain_float(throttle, -100.0f, 100.0f);
+
+    // set relay if necessary
+    if (_pwm_type == PWM_TYPE_BRUSHED) {
+        switch (function) {
+            case SRV_Channel::k_throttle:
+            case SRV_Channel::k_throttleLeft:
+                _relayEvents.do_set_relay(0, is_negative(throttle));
+                break;
+            case SRV_Channel::k_throttleRight:
+                _relayEvents.do_set_relay(1, is_negative(throttle));
+                break;
+            default:
+                // do nothing
+                break;
+        }
+        throttle = fabsf(throttle);
+    }
+
+    // output to servo channel
+    switch (function) {
+        case SRV_Channel::k_throttle:
+            SRV_Channels::set_output_scaled(function,  throttle);
+            break;
+        case SRV_Channel::k_throttleLeft:
+        case SRV_Channel::k_throttleRight:
+            SRV_Channels::set_output_scaled(function,  throttle*10.0f);
+            break;
+        default:
+            // do nothing
+            break;
+    }
 }
 
 // slew limit throttle for one iteration

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -312,3 +312,52 @@ void AP_MotorsUGV::setup_safety_output()
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
 }
+
+bool AP_MotorsUGV::output_test(motor_test_order motor_seq)
+{
+    // check if the motor_seq is valid
+    if (motor_seq > THROTTLE_RIGHT) {
+        return false;
+    }
+    _throttle = constrain_float(_throttle, -100.0f, 100.0f);
+
+    switch (motor_seq) {
+        case THROTTLE: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
+                return false;
+            }
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, _throttle);
+            break;
+        }
+        case STEERING: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
+                return false;
+            }
+            SRV_Channels::set_output_scaled(SRV_Channel::k_steering, _throttle);
+            break;
+        }
+        case THROTTLE_LEFT: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
+                return false;
+            }
+            const float motorLeft = brushed_scaler((_throttle * 0.01f), _throttleLeft_servo);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, 1000.0f * motorLeft);
+            break;
+        }
+        case THROTTLE_RIGHT: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+                return false;
+            }
+            const float motorRight = brushed_scaler((_throttle * 0.01f), _throttleRight_servo);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000.0f * motorRight);
+            break;
+        }
+        default:
+            return false;
+    }
+    SRV_Channels::calc_pwm();
+    hal.rcout->cork();
+    SRV_Channels::output_ch_all();
+    hal.rcout->push();
+    return true;
+}

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -313,43 +313,89 @@ void AP_MotorsUGV::setup_safety_output()
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
 }
 
-bool AP_MotorsUGV::output_test(motor_test_order motor_seq)
+// test steering or throttle output as a percentage of the total (range -100 to +100)
+// used in response to DO_MOTOR_TEST mavlink command
+bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
 {
     // check if the motor_seq is valid
     if (motor_seq > THROTTLE_RIGHT) {
         return false;
     }
-    _throttle = constrain_float(_throttle, -100.0f, 100.0f);
+    pct = constrain_float(pct, -100.0f, 100.0f);
 
     switch (motor_seq) {
         case THROTTLE: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
                 return false;
             }
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, _throttle);
+            output_throttle(SRV_Channel::k_throttle, pct);
             break;
         }
         case STEERING: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
                 return false;
             }
-            SRV_Channels::set_output_scaled(SRV_Channel::k_steering, _throttle);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_steering, pct * 45.0f);
             break;
         }
         case THROTTLE_LEFT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
                 return false;
             }
-            const float motorLeft = brushed_scaler((_throttle * 0.01f), _throttleLeft_servo);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, 1000.0f * motorLeft);
+            output_throttle(SRV_Channel::k_throttleLeft, pct);
             break;
         }
         case THROTTLE_RIGHT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
                 return false;
             }
-            const float motorRight = brushed_scaler((_throttle * 0.01f), _throttleRight_servo);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, 1000.0f * motorRight);
+            output_throttle(SRV_Channel::k_throttleRight, pct);
+            break;
+        }
+        default:
+            return false;
+    }
+    SRV_Channels::calc_pwm();
+    hal.rcout->cork();
+    SRV_Channels::output_ch_all();
+    hal.rcout->push();
+    return true;
+}
+
+// test steering or throttle output using a pwm value
+bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
+{
+    // check if the motor_seq is valid
+    if (motor_seq > THROTTLE_RIGHT) {
+        return false;
+    }
+    switch (motor_seq) {
+        case THROTTLE: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
+                return false;
+            }
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, pwm);
+            break;
+        }
+        case STEERING: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
+                return false;
+            }
+            SRV_Channels::set_output_pwm(SRV_Channel::k_steering, pwm);
+            break;
+        }
+        case THROTTLE_LEFT: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
+                return false;
+            }
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, pwm);
+            break;
+        }
+        case THROTTLE_RIGHT: {
+            if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+                return false;
+            }
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, pwm);
             break;
         }
         default:

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -318,34 +318,34 @@ void AP_MotorsUGV::setup_safety_output()
 bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
 {
     // check if the motor_seq is valid
-    if (motor_seq > THROTTLE_RIGHT) {
+    if (motor_seq > MOTOR_TEST_THROTTLE_RIGHT) {
         return false;
     }
     pct = constrain_float(pct, -100.0f, 100.0f);
 
     switch (motor_seq) {
-        case THROTTLE: {
+        case MOTOR_TEST_THROTTLE: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
                 return false;
             }
             output_throttle(SRV_Channel::k_throttle, pct);
             break;
         }
-        case STEERING: {
+        case MOTOR_TEST_STEERING: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
                 return false;
             }
             SRV_Channels::set_output_scaled(SRV_Channel::k_steering, pct * 45.0f);
             break;
         }
-        case THROTTLE_LEFT: {
+        case MOTOR_TEST_THROTTLE_LEFT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
                 return false;
             }
             output_throttle(SRV_Channel::k_throttleLeft, pct);
             break;
         }
-        case THROTTLE_RIGHT: {
+        case MOTOR_TEST_THROTTLE_RIGHT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
                 return false;
             }
@@ -366,32 +366,32 @@ bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
 bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
 {
     // check if the motor_seq is valid
-    if (motor_seq > THROTTLE_RIGHT) {
+    if (motor_seq > MOTOR_TEST_THROTTLE_RIGHT) {
         return false;
     }
     switch (motor_seq) {
-        case THROTTLE: {
+        case MOTOR_TEST_THROTTLE: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttle)) {
                 return false;
             }
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, pwm);
             break;
         }
-        case STEERING: {
+        case MOTOR_TEST_STEERING: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
                 return false;
             }
             SRV_Channels::set_output_pwm(SRV_Channel::k_steering, pwm);
             break;
         }
-        case THROTTLE_LEFT: {
+        case MOTOR_TEST_THROTTLE_LEFT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft)) {
                 return false;
             }
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, pwm);
             break;
         }
-        case THROTTLE_RIGHT: {
+        case MOTOR_TEST_THROTTLE_RIGHT: {
             if (!SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
                 return false;
             }

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -18,6 +18,13 @@ public:
         PWM_TYPE_BRUSHEDBIPOLAR = 4,
      };
 
+    enum motor_test_order {
+        THROTTLE = 0,
+        STEERING = 1,
+        THROTTLE_LEFT = 2,
+        THROTTLE_RIGHT = 3,
+    };
+
     // initialise motors
     void init();
 
@@ -42,6 +49,8 @@ public:
 
     // set when to use slew rate limiter
     void slew_limit_throttle(bool value) { _use_slew_rate = value; }
+
+    bool output_test(motor_test_order motor_seq);
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -19,10 +19,10 @@ public:
      };
 
     enum motor_test_order {
-        THROTTLE = 0,
-        STEERING = 1,
-        THROTTLE_LEFT = 2,
-        THROTTLE_RIGHT = 3,
+        MOTOR_TEST_THROTTLE = 1,
+        MOTOR_TEST_STEERING = 2,
+        MOTOR_TEST_THROTTLE_LEFT = 3,
+        MOTOR_TEST_THROTTLE_RIGHT = 4,
     };
 
     // initialise motors

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -50,7 +50,12 @@ public:
     // set when to use slew rate limiter
     void slew_limit_throttle(bool value) { _use_slew_rate = value; }
 
-    bool output_test(motor_test_order motor_seq);
+    // test steering or throttle output as a percentage of the total (range -100 to +100)
+    // used in response to DO_MOTOR_TEST mavlink command
+    bool output_test_pct(motor_test_order motor_seq, float pct);
+
+    // test steering or throttle output using a pwm value
+    bool output_test_pwm(motor_test_order motor_seq, float pwm);
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -57,6 +57,9 @@ protected:
     // output to skid steering channels
     void output_skid_steering(bool armed, float steering, float throttle);
 
+    // output throttle (-100 ~ +100) to a throttle channel.  Sets relays if required
+    void output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle);
+
     // slew limit throttle for one iteration
     void slew_limit_throttle(float dt);
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1039,6 +1039,16 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             }
             break;
 
+        case MAV_CMD_DO_MOTOR_TEST:
+            // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
+            // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
+            // param3 : throttle (range depends upon param2)
+            // param4 : timeout (in seconds)
+            result = rover.mavlink_motor_test_start(chan, static_cast<uint8_t>(packet.param1),
+                                                    static_cast<uint8_t>(packet.param2),
+                                                    static_cast<uint16_t>(packet.param3),
+                                                    packet.param4);
+            break;
 
         default:
             result = handle_command_long_message(packet);

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1046,7 +1046,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             // param4 : timeout (in seconds)
             result = rover.mavlink_motor_test_start(chan, static_cast<uint8_t>(packet.param1),
                                                     static_cast<uint8_t>(packet.param2),
-                                                    static_cast<uint16_t>(packet.param3),
+                                                    static_cast<int16_t>(packet.param3),
                                                     packet.param4);
             break;
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -419,6 +419,9 @@ private:
     // last visual odometry update time
     uint32_t visual_odom_last_update_ms;
 
+    // True when we are doing motor test
+    bool motor_test;
+
 private:
     // private member functions
     void ahrs_update();
@@ -630,6 +633,11 @@ public:
 
     void dataflash_periodic(void);
     void update_soft_armed();
+    // Motor test
+    void motor_test_output();
+    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc);
+    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec);
+    void motor_test_stop();
 };
 
 #define MENU_FUNC(func) FUNCTOR_BIND(&rover, &Rover::func, int8_t, uint8_t, const Menu::arg *)

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -635,8 +635,8 @@ public:
     void update_soft_armed();
     // Motor test
     void motor_test_output();
-    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value);
-    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec);
+    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value);
+    uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec);
     void motor_test_stop();
 };
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -635,7 +635,7 @@ public:
     void update_soft_armed();
     // Motor test
     void motor_test_output();
-    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc);
+    bool mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value);
     uint8_t mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec);
     void motor_test_stop();
 };

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -254,5 +254,10 @@ void Rover::set_servos(void) {
     }
 
     // send output signals to motors
-    g2.motors.output(arming.is_armed() && hal.util->get_soft_armed(), G_Dt);
+    if (motor_test) {
+        g2.motors.slew_limit_throttle(false);
+        motor_test_output();
+    } else {
+        g2.motors.output(arming.is_armed() && hal.util->get_soft_armed(), G_Dt);
+    }
 }

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -41,7 +41,7 @@ void Rover::motor_test_output()
 
             case MOTOR_TEST_THROTTLE_PILOT:
                 if ((AP_MotorsUGV::motor_test_order)motor_test_seq == AP_MotorsUGV::MOTOR_TEST_STEERING) {
-                    test_result = g2.motors.output_test_pct((AP_MotorsUGV::motor_test_order)motor_test_seq, channel_steer->get_control_in());
+                    test_result = g2.motors.output_test_pct((AP_MotorsUGV::motor_test_order)motor_test_seq, channel_steer->norm_input_dz() * 100.0f);
                 } else {
                     test_result = g2.motors.output_test_pct((AP_MotorsUGV::motor_test_order)motor_test_seq, channel_throttle->get_control_in());
                 }

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -40,7 +40,7 @@ void Rover::motor_test_output()
                 break;
 
             case MOTOR_TEST_THROTTLE_PILOT:
-                if ((AP_MotorsUGV::motor_test_order)motor_test_seq == AP_MotorsUGV::STEERING) {
+                if ((AP_MotorsUGV::motor_test_order)motor_test_seq == AP_MotorsUGV::MOTOR_TEST_STEERING) {
                     test_result = g2.motors.output_test_pct((AP_MotorsUGV::motor_test_order)motor_test_seq, channel_steer->get_control_in());
                 } else {
                     test_result = g2.motors.output_test_pct((AP_MotorsUGV::motor_test_order)motor_test_seq, channel_throttle->get_control_in());
@@ -83,7 +83,7 @@ bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint
     }
 
     // check motor_seq
-    if (motor_seq > AP_MotorsUGV::THROTTLE_RIGHT) {
+    if (motor_seq > AP_MotorsUGV::MOTOR_TEST_THROTTLE_RIGHT) {
         gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Motor Test: invalid motor (%d)", (int)motor_seq);
         return false;
     }

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -1,0 +1,158 @@
+#include "Rover.h"
+
+/*
+  mavlink motor test - implements the MAV_CMD_DO_MOTOR_TEST mavlink command so that the GCS/pilot can test an individual motor or flaps
+                       to ensure proper wiring, rotation.
+ */
+
+// motor test definitions
+static const int16_t MOTOR_TEST_PWM_MIN = 1000;     // min pwm value accepted by the test
+static const int16_t MOTOR_TEST_PWM_MAX = 2000;     // max pwm value accepted by the test
+static const int16_t MOTOR_TEST_TIMEOUT_MS_MAX = 30000;   // max timeout is 30 seconds
+
+static uint32_t motor_test_start_ms = 0;        // system time the motor test began
+static uint32_t motor_test_timeout_ms = 0;      // test will timeout this many milliseconds after the motor_test_start_ms
+static uint8_t motor_test_seq = 0;              // motor sequence number of motor being tested
+static uint8_t motor_test_throttle_type = 0;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
+static uint16_t motor_test_throttle_value = 0;  // throttle to be sent to motor, value depends upon it's type
+
+// motor_test_output - checks for timeout and sends updates to motors objects
+void Rover::motor_test_output()
+{
+    // exit immediately if the motor test is not running
+    if (!motor_test) {
+        return;
+    }
+
+    // check for test timeout
+    if ((AP_HAL::millis() - motor_test_start_ms) >= motor_test_timeout_ms) {
+        // stop motor test
+        motor_test_stop();
+    } else {
+        // calculate pwm based on throttle type
+        switch (motor_test_throttle_type) {
+            case MOTOR_TEST_THROTTLE_PERCENT:
+                // sanity check motor_test_throttle value
+                if (motor_test_throttle_value <= 100) {
+                    g2.motors.set_throttle(motor_test_throttle_value);
+                }
+                break;
+
+            case MOTOR_TEST_THROTTLE_PWM:
+                channel_throttle->set_pwm(motor_test_throttle_value);
+                g2.motors.set_throttle(channel_throttle->get_control_in());
+                break;
+
+            case MOTOR_TEST_THROTTLE_PILOT:
+                g2.motors.set_throttle(channel_throttle->get_control_in());
+                break;
+
+            default:
+                motor_test_stop();
+                return;
+        }
+        const bool test_result = g2.motors.output_test((AP_MotorsUGV::motor_test_order)motor_test_seq);
+        if (!test_result) {
+            motor_test_stop();
+        }
+    }
+}
+
+// mavlink_motor_test_check - perform checks before motor tests can begin
+// return true if tests can continue, false if not
+bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
+{
+    GCS_MAVLINK_Rover &gcs_chan = gcs().chan(chan-MAVLINK_COMM_0);
+
+    // check board has initialised
+    if (!initialised) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Motor Test: Board initialising");
+        return false;
+    }
+
+    // check rc has been calibrated
+    if (check_rc && !arming.pre_arm_rc_checks(true)) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Motor Test: RC not calibrated");
+        return false;
+    }
+
+    // check if safety switch has been pushed
+    if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
+        gcs_chan.send_text(MAV_SEVERITY_CRITICAL, "Motor Test: Safety switch");
+        return false;
+    }
+
+    // if we got this far the check was successful and the motor test can continue
+    return true;
+}
+
+// mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
+// returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
+uint8_t Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec)
+{
+    // if test has not started try to start it
+    if (!motor_test) {
+        /* perform checks that it is ok to start test
+           The RC calibrated check can be skipped if direct pwm is
+           supplied
+        */
+        if (!mavlink_motor_test_check(chan, throttle_type != 1)) {
+            return MAV_RESULT_FAILED;
+        } else {
+            // start test
+            motor_test = true;
+
+            // arm motors
+            if (!arming.is_armed()) {
+                arm_motors(AP_Arming::NONE);
+            }
+
+            // disable failsafes
+            g.fs_gcs_enabled = 0;
+            g.fs_throttle_enabled = 0;
+            g.fs_crash_check = 0;
+
+            // turn on notify leds
+            AP_Notify::flags.esc_calibration = true;
+        }
+    }
+
+    // set timeout
+    motor_test_start_ms = AP_HAL::millis();
+    motor_test_timeout_ms = MIN(timeout_sec * 1000, MOTOR_TEST_TIMEOUT_MS_MAX);
+
+    // store required output
+    motor_test_seq = motor_seq;
+    motor_test_throttle_type = throttle_type;
+    motor_test_throttle_value = throttle_value;
+
+    // return success
+    return MAV_RESULT_ACCEPTED;
+}
+
+// motor_test_stop - stops the motor test
+void Rover::motor_test_stop()
+{
+    // exit immediately if the test is not running
+    if (!motor_test) {
+        return;
+    }
+
+    // disarm motors
+    disarm_motors();
+
+    // reset timeout
+    motor_test_start_ms = 0;
+    motor_test_timeout_ms = 0;
+
+    // re-enable failsafes
+    g.fs_gcs_enabled.load();
+    g.fs_throttle_enabled.load();
+    g.fs_crash_check.load();
+
+    // turn off notify leds
+    AP_Notify::flags.esc_calibration = false;
+
+    // flag test is complete
+    motor_test = false;
+}

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -13,7 +13,7 @@ static uint32_t motor_test_start_ms = 0;        // system time the motor test be
 static uint32_t motor_test_timeout_ms = 0;      // test will timeout this many milliseconds after the motor_test_start_ms
 static uint8_t motor_test_seq = 0;              // motor sequence number of motor being tested
 static uint8_t motor_test_throttle_type = 0;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
-static uint16_t motor_test_throttle_value = 0;  // throttle to be sent to motor, value depends upon it's type
+static int16_t motor_test_throttle_value = 0;   // throttle to be sent to motor, value depends upon it's type
 
 // motor_test_output - checks for timeout and sends updates to motors objects
 void Rover::motor_test_output()
@@ -60,7 +60,7 @@ void Rover::motor_test_output()
 
 // mavlink_motor_test_check - perform checks before motor tests can begin
 // return true if tests can continue, false if not
-bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value)
+bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value)
 {
     GCS_MAVLINK_Rover &gcs_chan = gcs().chan(chan-MAVLINK_COMM_0);
 
@@ -110,7 +110,7 @@ bool Rover::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc, uint
 
 // mavlink_motor_test_start - start motor test - spin a single motor at a specified pwm
 // returns MAV_RESULT_ACCEPTED on success, MAV_RESULT_FAILED on failure
-uint8_t Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, uint16_t throttle_value, float timeout_sec)
+uint8_t Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_seq, uint8_t throttle_type, int16_t throttle_value, float timeout_sec)
 {
     // if test has not started try to start it
     if (!motor_test) {


### PR DESCRIPTION
This is a replacement for this PR: https://github.com/ArduPilot/ardupilot/pull/6569

The PR includes these changes:

- adds support for the MAVLink DO_MOTOR_TEST command including all three methods (percentage, pwm and pass through from Pilot's transmitter).
- the ground stations can specify which motor (aka motor sequence) they want to test.  0 = throttle, 1 = steering, 2 = left motor throttle (for vehicles with skid steering) or 3 = right motor throttle.

The PR also includes two mostly unrelated changes:

- add pre-arm checks that the RC input is configured
- AP_MotorsUGV gets new method to abstract away scaling differences between the main throttle output (which uses a -100 ~ +100 range) and the skid-steering throttle outputs (which use 0 to 1000 range).  At some point we should consolidate these to use the same range but this at least reduces the number of places we need to handle the difference.