### PR TITLE
DataFlash: POS.RelOriginAlt should be NaN if unknown

### DIFF
--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -667,7 +667,6 @@ void DataFlash_Class::Log_Write_POS(AP_AHRS &ahrs)
     }
     float home, origin;
     ahrs.get_relative_position_D_home(home);
-    ahrs.get_relative_position_D_origin(origin);
     struct log_POS pkt = {
         LOG_PACKET_HEADER_INIT(LOG_POS_MSG),
         time_us        : AP_HAL::micros64(),
@@ -675,7 +674,7 @@ void DataFlash_Class::Log_Write_POS(AP_AHRS &ahrs)
         lng            : loc.lng,
         alt            : loc.alt*1.0e-2f,
         rel_home_alt   : -home,
-        rel_origin_alt : -origin
+        rel_origin_alt : ahrs.get_relative_position_D_origin(origin) ? -origin : nanf("ARDUPILOT")
     };
     WriteBlock(&pkt, sizeof(pkt));
 }


### PR DESCRIPTION
We ignored the return value of `get_relative_position_D_origin()` which results in seeing an insnae range of values from +/- infinity, near 0 values, and random NaN's. From a log analysis perspective since we've already been emitting NaN's it makes more sense to just standardize that NaN is the output when it is unknown.

This is following a conversation between @peterbarker and myself on gitter.