### PR TITLE
Parameters: Fix bad parameter link in rover parameters

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -543,7 +543,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(visual_odom, "VISO", 7, ParametersG2, AP_VisualOdom),
 
     // @Group: MOT_
-    // @Path: MotorsUGV.cpp
+    // @Path: AP_MotorsUGV.cpp
     AP_SUBGROUPINFO(motors, "MOT_", 8, ParametersG2, AP_MotorsUGV),
 
     // @Group: WENC_

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -47,6 +47,7 @@ known_units = {
              'ms'      : 'milliseconds'          ,
              'PWM'     : 'PWM in microseconds'   , # should be microseconds, this is NOT a SI unit, but follows https://github.com/ArduPilot/ardupilot/pull/5538#issuecomment-271943061
              'Hz'      : 'hertz'                 ,
+             'kHz'     : 'kilohertz'             ,
 # distance
              'km'      : 'kilometers'                , # metre is the SI unit name, meter is the american spelling of it
              'm'       : 'meters'                    , # metre is the SI unit name, meter is the american spelling of it


### PR DESCRIPTION
The path for MotorsUGV was wrong, once I fixed that the parameter script broke, as kHz wasn't a permitted unit.

Apparently param generation isn't yet part of CI, I will take a stab at trying to get it included in the CI suite.