### PR TITLE
Added SERVO_DEF_RATE parameter

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -116,7 +116,7 @@ public:
     /*
       enable SBUS out at the given rate
      */
-    virtual bool     enable_sbus_out(uint16_t rate_gz) { return false; }
+    virtual bool     enable_sbus_out(uint16_t rate_hz) { return false; }
 
     /*
      * Optional method to control the update of the motors. Derived classes
@@ -133,4 +133,9 @@ public:
         MODE_PWM_BRUSHED
     };
     virtual void    set_output_mode(enum output_mode mode) {}
+
+    /*
+      set default update rate
+     */
+    virtual void    set_default_rate(uint16_t rate_hz) {}
 };

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -641,4 +641,13 @@ void PX4RCOutput::set_output_mode(enum output_mode mode)
 }
 
 
+// set default output update rate
+void PX4RCOutput::set_default_rate(uint16_t rate_hz)
+{
+    ioctl(_pwm_fd, PWM_SERVO_SET_DEFAULT_UPDATE_RATE, rate_hz);
+    if (_alt_fd != -1) {
+        ioctl(_alt_fd, PWM_SERVO_SET_DEFAULT_UPDATE_RATE, rate_hz);
+    }    
+}
+
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -40,6 +40,9 @@ public:
     void timer_tick(void) override;
     bool enable_sbus_out(uint16_t rate_hz) override;
 
+    // set default output update rate
+    void set_default_rate(uint16_t rate_hz) override;
+
 private:
     int _pwm_fd;
     int _alt_fd;

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -391,6 +391,7 @@ private:
     
     // this static arrangement is to avoid having static objects in AP_Param tables
     static SRV_Channel *channels;
+    static SRV_Channels *instance;
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];
 
     static struct srv_function {
@@ -402,6 +403,7 @@ private:
     } functions[SRV_Channel::k_nr_aux_servo_functions];
 
     AP_Int8 auto_trim;
+    AP_Int16 default_rate;
 
     // return true if passthrough is disabled
     static bool passthrough_disabled(void) {

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -151,6 +151,8 @@ void SRV_Channels::update_aux_servo_function(void)
 /// Should be called after the the servo functions have been initialized
 void SRV_Channels::enable_aux_servos()
 {
+    hal.rcout->set_default_rate(uint16_t(instance->default_rate.get()));
+    
     update_aux_servo_function();
 
     // enable all channels that are set to a valid function. This

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -25,6 +25,7 @@
 extern const AP_HAL::HAL& hal;
 
 SRV_Channel *SRV_Channels::channels;
+SRV_Channels *SRV_Channels::instance;
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;
 Bitmask SRV_Channels::function_mask{SRV_Channel::k_nr_aux_servo_functions};
@@ -102,6 +103,14 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO_FRAME("_AUTO_TRIM",  17, SRV_Channels, auto_trim, 0, AP_PARAM_FRAME_PLANE),
 
+    // @Param: _DEF_RATE
+    // @DisplayName: Default output rate
+    // @Description: This sets the default output rate in Hz for all outputs. 
+    // @Range: 25 400
+    // @User: Advanced
+    // @Units: Hz
+    AP_GROUPINFO("_DEF_RATE",  18, SRV_Channels, default_rate, 50),
+    
     AP_GROUPEND
 };
 
@@ -110,6 +119,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
  */
 SRV_Channels::SRV_Channels(void)
 {
+    instance = this;
     channels = obj_channels;
     
     // set defaults from the parameter table


### PR DESCRIPTION
this allows the default servo rate to be set, which allows for faster update rates on control surfaces for planes, and faster rates in rovers or for servo gimbals in all vehicles.
Requested by @priseborough for tailsitters
