### PR TITLE
Travis: prepare for Trusty and other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,11 @@ before_install:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
 script:
-  - python Tools/autotest/param_metadata/param_parse.py
+  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2
+  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle AntennaTracker
+  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduCopter
+  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduPlane
+  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduSub
   - Tools/scripts/build_ci.sh
 
 before_cache:

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -17,6 +17,7 @@ from mdemit import MDEmit
 parser = OptionParser("param_parse.py [options]")
 parser.add_option("-v", "--verbose", dest='verbose', action='store_true', default=False, help="show debugging output")
 parser.add_option("--vehicle", default='*',  help="Vehicle type to generate for")
+parser.add_option("--no-emit", dest='emit_params', action='store_false', default=True, help="don't emit parameter documention, just validate")
 (opts, args) = parser.parse_args()
 
 
@@ -230,10 +231,11 @@ def do_emit(emit):
 
     emit.close()
 
-do_emit(XmlEmit())
-do_emit(WikiEmit())
-do_emit(HtmlEmit())
-do_emit(RSTEmit())
-do_emit(MDEmit())
+if opts.emit_params:
+    do_emit(XmlEmit())
+    do_emit(WikiEmit())
+    do_emit(HtmlEmit())
+    do_emit(RSTEmit())
+    do_emit(MDEmit())
 
 sys.exit(error_count)

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -3,9 +3,9 @@
 # This helps when doing large merges
 # Andrew Tridgell, November 2011
 
-set -ex
-
 . ~/.profile
+
+set -ex
 
 # CXX and CC are exported by default by travis
 c_compiler=${CC:-gcc}

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -19,10 +19,6 @@ export NUTTX_GIT_VERSION="ci_test"
 export PX4_GIT_VERSION="ci_test"
 export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
 
-if [[ "$cxx_compiler" == "clang++" ]]; then
-  export CCACHE_CPP2="true"
-fi
-
 # If CI_BUILD_TARGET is not set, build 3 different ones
 if [ -z "$CI_BUILD_TARGET" ]; then
     CI_BUILD_TARGET="sitl linux px4-v2"

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -12,7 +12,7 @@ ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
 RPI_ROOT="master"
 RPI_TARBALL="$RPI_ROOT.tar.gz"
 
-CCACHE_ROOT="ccache-3.2.5"
+CCACHE_ROOT="ccache-3.3.4"
 CCACHE_TARBALL="$CCACHE_ROOT.tar.bz2"
 
 mkdir -p $HOME/opt
@@ -32,9 +32,12 @@ if [ ! -d "$HOME/opt/$dir" ]; then
   tar -xf $RPI_TARBALL -C opt $dir
 fi
 
-# CCache
+# ccache
 dir=$CCACHE_ROOT
 if [ ! -d "$HOME/opt/$dir" ]; then
+  # if version 3 isn't there, try to remove older v2 folders from CI cache
+  rm -rf "$HOME/opt"/ccache-3.2*
+
   wget https://www.samba.org/ftp/ccache/$CCACHE_TARBALL
   tar -xf $CCACHE_TARBALL
   pushd $CCACHE_ROOT


### PR DESCRIPTION
Tomorrow Travis will start changing the default image from Ubuntu Precise (12.04) to Ubuntu Trusty (14.04) so I spent a bit of time testing if our builds worked with it.

The only thing I discovered was that the *.profile* script in Trusty is way bigger than in Precise and it was making even the Linux builds exceed the log size (we can always view the raw log, but the colorful one is better). We include the profile both in configure and build phases, so I simply changed the build phase to do `set -x` after profile is included: we still log what the profile does, but only one time.

I've also updated the ccache version from 3.2.5 to 3.3.4, which supposedly does an even better job.

Last, but not least, I've split the param parse check for each vehicle. @WickedShell found out that Travis wasn't complaining even when a parameter group path was wrote wrong and didn't exist, but calling the script individually for each vehicle works - it is known that the param_parse.py script has issues with doing all vehicles at once, so this wasn't completely surprising. The test this is now working is at https://travis-ci.org/OXINARF/ardupilot/jobs/254582098#L1571
I've added a `--no-emit` option to the script so that in CI we don't lose time emitting the documentation, we only need validation.

P.S.: I also played a bit with the new stage feature of Travis, but I think it has more disadvantages than advantages and, being in beta, doesn't look to work well yet: https://travis-ci.org/OXINARF/ardupilot/builds/254589573