### PR TITLE
Plane: Allow a second activation of parachute

### DIFF
--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -18,12 +18,15 @@ void Plane::parachute_check()
 */
 void Plane::parachute_release()
 {
-    if (parachute.released()) {
+    if (parachute.release_in_progress()) {
         return;
     }
-    
     // send message to gcs and dataflash
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released");
+    if (parachute.released()) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released again");
+    } else {
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released");
+    }
 
     // release parachute
     parachute.release();

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -52,6 +52,9 @@ public:
     
     /// release_initiated - true if the parachute release sequence has been initiated (may wait before actual release)
     bool release_initiated() const { return _release_initiated; }
+
+    /// release_in_progress - true if the parachute release sequence is in progress
+    bool release_in_progress() const { return _release_in_progress; }
     
     /// update - shuts off the trigger should be called at about 10hz
     void update();


### PR DESCRIPTION
The hardware can fail in the first activation,
this patch allow a second chance to active the parachute successfully.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>