### PR TITLE
Rover: add control-mode class

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -7,7 +7,6 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
 {
     uint8_t base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
     uint8_t system_status = MAV_STATE_ACTIVE;
-    const uint32_t custom_mode = control_mode;
 
     if (failsafe.triggered != 0) {
         system_status = MAV_STATE_CRITICAL;
@@ -21,30 +20,16 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
     // only get useful information from the custom_mode, which maps to
     // the APM flight mode and has a well defined meaning in the
     // ArduPlane documentation
-    switch (control_mode) {
-    case MANUAL:
-    case LEARNING:
-    case STEERING:
-        base_mode = MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
-        break;
-    case AUTO:
-    case RTL:
-    case GUIDED:
-        base_mode = MAV_MODE_FLAG_GUIDED_ENABLED;
-        // note that MAV_MODE_FLAG_AUTO_ENABLED does not match what
-        // APM does in any mode, as that is defined as "system finds its own goal
-        // positions", which APM does not currently do
-        break;
-    case INITIALISING:
-        system_status = MAV_STATE_CALIBRATING;
-        break;
-    case HOLD:
-        system_status = 0;
-        break;
+    if (control_mode->has_manual_input()) {
+        base_mode |= MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
     }
 
-#if defined(ENABLE_STICK_MIXING) && (ENABLE_STICK_MIXING == ENABLED)
-    if (control_mode != INITIALISING) {
+    if (control_mode->is_autopilot_mode()) {
+        base_mode |= MAV_MODE_FLAG_GUIDED_ENABLED;
+    }
+
+#if defined(ENABLE_STICK_MIXING) && (ENABLE_STICK_MIXING == ENABLED) // TODO ???? Remove !
+    if (control_mode->stick_mixing_enabled()) {
         // all modes except INITIALISING have some form of manual
         // override if stick mixing is enabled
         base_mode |= MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
@@ -54,9 +39,14 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
 #if HIL_MODE != HIL_MODE_DISABLED
     base_mode |= MAV_MODE_FLAG_HIL_ENABLED;
 #endif
-
+    if (control_mode == &mode_initializing) {
+        system_status = MAV_STATE_CALIBRATING;
+    }
+    if (control_mode == &mode_hold) {
+        system_status = MAV_STATE_STANDBY;
+    }
     // we are armed if we are not initialising
-    if (control_mode != INITIALISING && arming.is_armed()) {
+    if (control_mode != &mode_initializing && arming.is_armed()) {
         base_mode |= MAV_MODE_FLAG_SAFETY_ARMED;
     }
 
@@ -65,7 +55,7 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
 
     gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(MAV_TYPE_GROUND_ROVER,
                                             base_mode,
-                                            custom_mode,
+                                            control_mode->mode_number(),
                                             system_status);
 }
 
@@ -140,7 +130,7 @@ void Rover::send_nav_controller_output(mavlink_channel_t chan)
 {
     mavlink_msg_nav_controller_output_send(
         chan,
-        lateral_acceleration,  // use nav_roll to hold demanded Y accel
+        control_mode->lateral_acceleration,  // use nav_roll to hold demanded Y accel
         ahrs.groundspeed() * ins.get_gyro().z,  // use nav_pitch to hold actual Y accel
         nav_controller->nav_bearing_cd() * 0.01f,
         nav_controller->target_bearing_cd() * 0.01f,
@@ -343,7 +333,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         break;
 
     case MSG_NAV_CONTROLLER_OUTPUT:
-        if (rover.control_mode != MANUAL) {
+        if (rover.control_mode->is_autopilot_mode()) {
             CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
             rover.send_nav_controller_output(chan);
         }
@@ -672,7 +662,7 @@ GCS_MAVLINK_Rover::data_stream_send(void)
     if (stream_trigger(STREAM_EXTRA1)) {
         send_message(MSG_ATTITUDE);
         send_message(MSG_SIMSTATE);
-        if (rover.control_mode != MANUAL) {
+        if (rover.control_mode->is_autopilot_mode()) {
             send_message(MSG_PID_TUNING);
         }
     }
@@ -708,13 +698,10 @@ GCS_MAVLINK_Rover::data_stream_send(void)
 
 bool GCS_MAVLINK_Rover::handle_guided_request(AP_Mission::Mission_Command &cmd)
 {
-    if (rover.control_mode != GUIDED) {
+    if (rover.control_mode != &rover.mode_guided) {
         // only accept position updates when in GUIDED mode
         return false;
     }
-
-    // This method is only called when we are in Guided WP GUIDED mode
-    rover.guided_mode = Guided_WP;
 
     // make any new wp uploaded instant (in case we are already in Guided mode)
     rover.set_guided_WP(cmd.content.location);
@@ -796,7 +783,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             switch (packet.command) {
 
             case MAV_CMD_NAV_RETURN_TO_LAUNCH:
-                rover.set_mode(RTL);
+                rover.set_mode(rover.mode_rtl);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
@@ -863,7 +850,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                 break;
 
             case MAV_CMD_MISSION_START:
-                rover.set_mode(AUTO);
+                rover.set_mode(rover.mode_auto);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
@@ -920,19 +907,19 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             switch (static_cast<uint16_t>(packet.param1)) {
             case MAV_MODE_MANUAL_ARMED:
             case MAV_MODE_MANUAL_DISARMED:
-                rover.set_mode(MANUAL);
+                rover.set_mode(rover.mode_manual);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
             case MAV_MODE_AUTO_ARMED:
             case MAV_MODE_AUTO_DISARMED:
-                rover.set_mode(AUTO);
+                rover.set_mode(rover.mode_auto);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
             case MAV_MODE_STABILIZE_DISARMED:
             case MAV_MODE_STABILIZE_ARMED:
-                rover.set_mode(LEARNING);
+                rover.set_mode(rover.mode_learning);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
@@ -1014,11 +1001,11 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             // param2 : Speed - normalized to 0 .. 1
 
             // exit if vehicle is not in Guided mode
-            if (rover.control_mode != GUIDED) {
+            if (rover.control_mode != &rover.mode_guided) {
                 break;
             }
 
-            rover.guided_mode = Guided_Angle;
+            rover.mode_guided.guided_mode = ModeGuided::Guided_Angle;
             rover.guided_control.msg_time_ms = AP_HAL::millis();
             rover.guided_control.turn_angle = packet.param1;
             rover.guided_control.target_speed = constrain_float(packet.param2, 0.0f, 1.0f);
@@ -1132,7 +1119,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             mavlink_msg_set_attitude_target_decode(msg, &packet);
 
             // exit if vehicle is not in Guided mode
-            if (rover.control_mode != GUIDED) {
+            if (rover.control_mode != &rover.mode_guided) {
                 break;
             }
             // record the time when the last message arrived
@@ -1173,7 +1160,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             mavlink_msg_set_position_target_local_ned_decode(msg, &packet);
 
             // exit if vehicle is not in Guided mode
-            if (rover.control_mode != GUIDED) {
+            if (rover.control_mode != &rover.mode_guided) {
                 break;
             }
 
@@ -1258,7 +1245,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             mavlink_msg_set_position_target_global_int_decode(msg, &packet);
 
             // exit if vehicle is not in Guided mode
-            if (rover.control_mode != GUIDED) {
+            if (rover.control_mode != &rover.mode_guided) {
                 break;
             }
             // check for supported coordinate frames

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -329,13 +329,13 @@ void Rover::Log_Write_Rangefinder()
     struct log_Rangefinder pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RANGEFINDER_MSG),
         time_us               : AP_HAL::micros64(),
-        lateral_accel   : control_mode->lateral_acceleration,
+        lateral_accel         : control_mode->lateral_acceleration,
         rangefinder1_distance : rangefinder.distance_cm(0),
         rangefinder2_distance : rangefinder.distance_cm(1),
         detected_count        : obstacle.detected_count,
         turn_angle            : static_cast<int8_t>(obstacle.turn_angle),
         turn_time             : turn_time,
-        ground_speed          : static_cast<uint16_t>(fabsf(ground_speed * 100)),
+        ground_speed          : static_cast<uint16_t>(fabsf(ground_speed * 100.0f)),
         throttle              : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -197,7 +197,7 @@ void Rover::Log_Write_Steering()
     struct log_Steering pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STEERING_MSG),
         time_us        : AP_HAL::micros64(),
-        demanded_accel : lateral_acceleration,
+        demanded_accel : control_mode->lateral_acceleration,
         achieved_accel : ahrs.groundspeed() * ins.get_gyro().z,
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -329,7 +329,7 @@ void Rover::Log_Write_Rangefinder()
     struct log_Rangefinder pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RANGEFINDER_MSG),
         time_us               : AP_HAL::micros64(),
-        lateral_accel         : lateral_acceleration,
+        lateral_accel   : control_mode->lateral_acceleration,
         rangefinder1_distance : rangefinder.distance_cm(0),
         rangefinder2_distance : rangefinder.distance_cm(1),
         detected_count        : obstacle.detected_count,
@@ -529,7 +529,7 @@ void Rover::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by DataFlash
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
-    DataFlash.Log_Write_Mode(control_mode);
+    DataFlash.Log_Write_Mode(control_mode->mode_number());
     Log_Write_Home_And_Origin();
     gps.Write_DataFlash_Log_Startup_messages();
 }

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -40,7 +40,7 @@ Rover::Rover(void) :
 #if MOUNT == ENABLED
     camera_mount(ahrs, current_loc),
 #endif
-    control_mode(INITIALISING),
+    control_mode(&mode_initializing),
     throttle(500),
 #if FRSKY_TELEM_ENABLED == ENABLED
     frsky_telemetry(ahrs, battery, rangefinder),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -271,9 +271,6 @@ private:
     // ground speed error in m/s
     float groundspeed_error;
 
-    // 0-(throttle_max - throttle_cruise) : throttle nudge in Auto mode using top 1/2 of throttle stick travel
-    int16_t     throttle_nudge;
-
     // receiver RSSI
     uint8_t receiver_rssi;
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -65,6 +65,8 @@
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include "AP_MotorsUGV.h"
 
+#include "mode.h"
+
 #include "AP_Arming.h"
 #include "compat.h"
 
@@ -106,6 +108,13 @@ public:
     friend class AP_AdvancedFailsafe_Rover;
 #endif
     friend class GCS_Rover;
+    friend class Mode;
+    friend class ModeAuto;
+    friend class ModeGuided;
+    friend class ModeHold;
+    friend class ModeSteering;
+    friend class ModeManual;
+    friend class ModeRTL;
 
     Rover(void);
 
@@ -221,10 +230,9 @@ private:
     // if USB is connected
     bool usb_connected;
 
-    // Radio
     // This is the state of the flight control system
-    // There are multiple states defined such as MANUAL, FBW-A, AUTO
-    enum mode control_mode;
+    // There are multiple states defined such as MANUAL, AUTO, ...
+    Mode *control_mode;
 
     // Used to maintain the state of the previous control switch position
     // This is set to -1 when we need to re-read the switch
@@ -284,9 +292,6 @@ private:
         uint32_t detected_time_ms;
     } obstacle;
 
-    // this is set to true when auto has been triggered to start
-    bool auto_triggered;
-
     // Ground speed
     // The amount current ground speed is below min ground speed.  meters per second
     float ground_speed;
@@ -309,10 +314,6 @@ private:
     uint32_t control_sensors_present;
     uint32_t control_sensors_enabled;
     uint32_t control_sensors_health;
-
-    // Navigation control variables
-    // The instantaneous desired lateral acceleration in m/s/s
-    float lateral_acceleration;
 
     // Waypoint distances
     // Distance between rover and next waypoint.  Meters
@@ -399,12 +400,6 @@ private:
     // time that rudder/steering arming has been running
     uint32_t rudder_arm_timer;
 
-    // true if we are in an auto-throttle mode, which means
-    // we need to run the speed controller
-    bool auto_throttle_mode;
-
-    // Guided control
-    GuidedMode guided_mode;             // controls which controller is run (waypoint or velocity)
     // Store parameters from Guided msg
     struct {
       float turn_angle;          // target heading in centi-degrees
@@ -421,6 +416,15 @@ private:
 
     // True when we are doing motor test
     bool motor_test;
+
+    ModeInitializing mode_initializing;
+    ModeHold mode_hold;
+    ModeManual mode_manual;
+    ModeGuided mode_guided;
+    ModeAuto mode_auto;
+    ModeLearning mode_learning;
+    ModeSteering mode_steering;
+    ModeRTL mode_rtl;
 
 private:
     // private member functions
@@ -458,6 +462,10 @@ private:
     void gcs_update(void);
     void gcs_retry_deferred(void);
 
+    Mode *control_mode_from_num(enum mode num);
+    bool set_mode(Mode &mode);
+    bool mavlink_set_mode(uint8_t mode);
+
     void do_erase_logs(void);
     void Log_Write_Performance();
     void Log_Write_Steering();
@@ -481,11 +489,7 @@ private:
     void Log_Arm_Disarm();
 
     void load_parameters(void);
-    bool auto_check_trigger(void);
     bool use_pivot_steering(void);
-    void calc_throttle(float target_speed);
-    void calc_lateral_acceleration();
-    void calc_nav_steer();
     void set_servos(void);
     void set_auto_WP(const struct Location& loc);
     void set_guided_WP(const struct Location& loc);
@@ -539,8 +543,7 @@ private:
     void init_ardupilot();
     void startup_ground(void);
     void set_reverse(bool reverse);
-    void set_mode(enum mode mode);
-    bool mavlink_set_mode(uint8_t mode);
+
     void failsafe_trigger(uint8_t failsafe_type, bool on);
     void startup_INS_ground(void);
     void update_notify();

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -1,58 +1,12 @@
 #include "Rover.h"
 
 /*
-    check for triggering of start of auto mode
-*/
-bool Rover::auto_check_trigger(void) {
-    // only applies to AUTO mode
-    if (control_mode != AUTO) {
-        return true;
-    }
-
-    // check for user pressing the auto trigger to off
-    if (auto_triggered && g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 1) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "AUTO triggered off");
-        auto_triggered = false;
-        return false;
-    }
-
-    // if already triggered, then return true, so you don't
-    // need to hold the switch down
-    if (auto_triggered) {
-        return true;
-    }
-
-    if (g.auto_trigger_pin == -1 && is_zero(g.auto_kickstart)) {
-        // no trigger configured - let's go!
-        auto_triggered = true;
-        return true;
-    }
-
-    if (g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
-        auto_triggered = true;
-        return true;
-    }
-
-    if (!is_zero(g.auto_kickstart)) {
-        const float xaccel = ins.get_accel().x;
-        if (xaccel >= g.auto_kickstart) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
-            auto_triggered = true;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/*
     work out if we are going to use pivot steering
 */
 bool Rover::use_pivot_steering(void)
 {
     // check cases where we clearly cannot use pivot steering
-    if (control_mode < AUTO || !g2.motors.have_skid_steering() || g.pivot_turn_angle <= 0) {
+    if (control_mode->is_autopilot_mode() || !g2.motors.have_skid_steering() || g.pivot_turn_angle <= 0) {
         pivot_steering_active = false;
         return false;
     }
@@ -82,7 +36,7 @@ bool Rover::use_pivot_steering(void)
 bool Rover::in_stationary_loiter()
 {
     // Confirm we are in AUTO mode and need to loiter for a time period
-    if ((loiter_start_time > 0) && (control_mode == AUTO)) {
+    if ((loiter_start_time > 0) && (control_mode == &mode_auto)) {
         // Check if active loiter is enabled AND we are outside the waypoint loiter radius
         // then the vehicle still needs to move so return false
         if (active_loiter && (wp_distance > g.waypoint_radius)) {
@@ -94,156 +48,12 @@ bool Rover::in_stationary_loiter()
     return false;
 }
 
-/*
-    calculate the throtte for auto-throttle modes
-*/
-void Rover::calc_throttle(float target_speed) {
-    // If not autostarting OR we are loitering at a waypoint
-    // then set the throttle to minimum
-    if (!auto_check_trigger() || in_stationary_loiter()) {
-        g2.motors.set_throttle(g.throttle_min.get());
-        // Stop rotation in case of loitering and skid steering
-        if (g2.motors.have_skid_steering()) {
-            g2.motors.set_steering(0.0f);
-        }
-        return;
-    }
-
-    const float throttle_base = (fabsf(target_speed) / g.speed_cruise) * g.throttle_cruise;
-    const int throttle_target = throttle_base + throttle_nudge;
-
-    /*
-        reduce target speed in proportion to turning rate, up to the
-        SPEED_TURN_GAIN percentage.
-    */
-    float steer_rate = fabsf(lateral_acceleration / (g.turn_max_g*GRAVITY_MSS));
-    steer_rate = constrain_float(steer_rate, 0.0f, 1.0f);
-
-    // use g.speed_turn_gain for a 90 degree turn, and in proportion
-    // for other turn angles
-    const int32_t turn_angle = wrap_180_cd(next_navigation_leg_cd - ahrs.yaw_sensor);
-    const float speed_turn_ratio = constrain_float(fabsf(turn_angle / 9000.0f), 0.0f, 1.0f);
-    const float speed_turn_reduction = (100 - g.speed_turn_gain) * speed_turn_ratio * 0.01f;
-
-    float reduction = 1.0f - steer_rate * speed_turn_reduction;
-
-    if (control_mode >= AUTO && guided_mode != Guided_Velocity && wp_distance <= g.speed_turn_dist) {
-        // in auto-modes we reduce speed when approaching waypoints
-        const float reduction2 = 1.0f - speed_turn_reduction;
-        if (reduction2 < reduction) {
-            reduction = reduction2;
-        }
-    }
-
-    // reduce the target speed by the reduction factor
-    target_speed *= reduction;
-
-    groundspeed_error = fabsf(target_speed) - ground_speed;
-
-    throttle = throttle_target + (g.pidSpeedThrottle.get_pid(groundspeed_error * 100.0f) / 100.0f);
-
-    // also reduce the throttle by the reduction factor. This gives a
-    // much faster response in turns
-    throttle *= reduction;
-
-    if (in_reverse) {
-        g2.motors.set_throttle(constrain_int16(-throttle, -g.throttle_max, -g.throttle_min));
-    } else {
-        g2.motors.set_throttle(constrain_int16(throttle, g.throttle_min, g.throttle_max));
-    }
-
-    if (!in_reverse && g.braking_percent != 0 && groundspeed_error < -g.braking_speederr) {
-        // the user has asked to use reverse throttle to brake. Apply
-        // it in proportion to the ground speed error, but only when
-        // our ground speed error is more than BRAKING_SPEEDERR.
-        //
-        // We use a linear gain, with 0 gain at a ground speed error
-        // of braking_speederr, and 100% gain when groundspeed_error
-        // is 2*braking_speederr
-        const float brake_gain = constrain_float(((-groundspeed_error)-g.braking_speederr)/g.braking_speederr, 0.0f, 1.0f);
-        const int16_t braking_throttle = g.throttle_max * (g.braking_percent * 0.01f) * brake_gain;
-        g2.motors.set_throttle(constrain_int16(-braking_throttle, -g.throttle_max, -g.throttle_min));
-
-        // temporarily set us in reverse to allow the PWM setting to
-        // go negative
-        set_reverse(true);
-    }
-
-    if (guided_mode != Guided_Velocity) {
-        if (use_pivot_steering()) {
-            // In Guided Velocity, only the steering input is used to calculate the pivot turn.
-            g2.motors.set_throttle(0.0f);
-        }
-    }
-}
-
-/*****************************************
-    Calculate desired turn angles (in medium freq loop)
- *****************************************/
-
-void Rover::calc_lateral_acceleration() {
-    switch (control_mode) {
-    case AUTO:
-        // If we have reached the waypoint previously navigate
-        // back to it from our current position
-        if (previously_reached_wp && (loiter_duration > 0)) {
-            nav_controller->update_waypoint(current_loc, next_WP);
-        } else {
-            nav_controller->update_waypoint(prev_WP, next_WP);
-        }
-        break;
-
-    case RTL:
-    case GUIDED:
-    case STEERING:
-        nav_controller->update_waypoint(current_loc, next_WP);
-        break;
-    default:
-        return;
-    }
-
-    // Calculate the required turn of the wheels
-
-    // negative error = left turn
-    // positive error = right turn
-    lateral_acceleration = nav_controller->lateral_acceleration();
-    if (use_pivot_steering()) {
-        const int16_t bearing_error = wrap_180_cd(nav_controller->target_bearing_cd() - ahrs.yaw_sensor) / 100;
-        if (bearing_error > 0) {
-            lateral_acceleration = g.turn_max_g * GRAVITY_MSS;
-        } else {
-            lateral_acceleration = -g.turn_max_g * GRAVITY_MSS;
-        }
-    }
-}
-
-/*
-    calculate steering angle given lateral_acceleration
-*/
-void Rover::calc_nav_steer() {
-    // check to see if the rover is loitering
-    if (in_stationary_loiter()) {
-        g2.motors.set_steering(0.0f);
-        return;
-    }
-
-    // add in obstacle avoidance
-    if (!in_reverse) {
-        lateral_acceleration += (obstacle.turn_angle/45.0f) * g.turn_max_g;
-    }
-
-    // constrain to max G force
-    lateral_acceleration = constrain_float(lateral_acceleration, -g.turn_max_g * GRAVITY_MSS, g.turn_max_g * GRAVITY_MSS);
-
-    g2.motors.set_steering(steerController.get_steering_out_lat_accel(lateral_acceleration));
-}
-
 /*****************************************
     Set the flight control servos based on the current calculated values
 *****************************************/
 void Rover::set_servos(void) {
     // Apply slew rate limit on non Manual modes
-    if (control_mode == MANUAL || control_mode == LEARNING) {
+    if (control_mode == &mode_manual || control_mode == &mode_learning) {
         g2.motors.slew_limit_throttle(false);
         if (failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
             g2.motors.set_throttle(0.0f);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -54,13 +54,10 @@ bool Rover::in_stationary_loiter()
 void Rover::set_servos(void) {
     // Apply slew rate limit on non Manual modes
     if (control_mode == &mode_manual || control_mode == &mode_learning) {
-        g2.motors.slew_limit_throttle(false);
         if (failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
             g2.motors.set_throttle(0.0f);
             g2.motors.set_steering(0.0f);
         }
-    } else {
-        g2.motors.slew_limit_throttle(true);
     }
 
     // send output signals to motors

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -51,15 +51,8 @@ bool Rover::in_stationary_loiter()
 /*****************************************
     Set the flight control servos based on the current calculated values
 *****************************************/
-void Rover::set_servos(void) {
-    // Apply slew rate limit on non Manual modes
-    if (control_mode == &mode_manual || control_mode == &mode_learning) {
-        if (failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
-            g2.motors.set_throttle(0.0f);
-            g2.motors.set_steering(0.0f);
-        }
-    }
-
+void Rover::set_servos(void)
+{
     // send output signals to motors
     if (motor_test) {
         g2.motors.slew_limit_throttle(false);

--- a/APMrover2/afs_rover.cpp
+++ b/APMrover2/afs_rover.cpp
@@ -17,28 +17,11 @@ AP_AdvancedFailsafe_Rover::AP_AdvancedFailsafe_Rover(AP_Mission &_mission, AP_Ba
  */
 void AP_AdvancedFailsafe_Rover::terminate_vehicle(void)
 {
-    // stop motors
-    SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_steering, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
-    rover.lateral_acceleration = 0;
-
     // disarm as well
     rover.disarm_motors();
 
     // Set to HOLD mode
-    rover.set_mode(HOLD);
-    // and set all aux channels
-    SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-
-    SRV_Channels::output_ch_all();
-}
-
-void AP_AdvancedFailsafe_Rover::setup_IO_failsafe(void)
-{
-    // setup failsafe for all aux channels
-    SRV_Channels::set_failsafe_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_failsafe_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+    rover.set_mode(rover.mode_hold);
 }
 
 /*
@@ -46,13 +29,8 @@ void AP_AdvancedFailsafe_Rover::setup_IO_failsafe(void)
  */
 AP_AdvancedFailsafe::control_mode AP_AdvancedFailsafe_Rover::afs_mode(void)
 {
-    switch (rover.control_mode) {
-    case AUTO:
-    case GUIDED:
-    case RTL:
+    if (rover.control_mode->is_autopilot_mode()) {
         return AP_AdvancedFailsafe::AFS_AUTO;
-    default:
-        break;
     }
     return AP_AdvancedFailsafe::AFS_STABILIZED;
 }

--- a/APMrover2/afs_rover.h
+++ b/APMrover2/afs_rover.h
@@ -30,14 +30,14 @@ public:
     AP_AdvancedFailsafe_Rover(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap);
 
     // called to set all outputs to termination state
-    void terminate_vehicle(void);
+    void terminate_vehicle(void) override;
 
 protected:
-    // setup failsafe values for if FMU firmware stops running
-    void setup_IO_failsafe(void);
+    // setup failsafe values - this is handled by motors library
+    void setup_IO_failsafe(void) override {}
 
     // return the AFS mapped control mode
-    enum control_mode afs_mode(void);
+    enum control_mode afs_mode(void) override;
 };
 
 #endif  // ADVANCED_FAILSAFE

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -29,7 +29,7 @@ void Rover::set_auto_WP(const struct Location& loc)
 
 void Rover::set_guided_WP(const struct Location& loc)
 {
-    guided_mode = Guided_WP;
+    rover.mode_guided.guided_mode = ModeGuided::Guided_WP;
     // copy the current location into the OldWP slot
     // ---------------------------------------
     prev_WP = current_loc;
@@ -47,12 +47,11 @@ void Rover::set_guided_WP(const struct Location& loc)
 
 void Rover::set_guided_velocity(float target_steer_speed, float target_speed)
 {
-    guided_mode = Guided_Velocity;
+    rover.mode_guided.guided_mode = ModeGuided::Guided_Velocity;
     rover.guided_control.target_steer_speed = target_steer_speed;
     rover.guided_control.target_speed = target_speed;
 
     next_WP = current_loc;
-    lateral_acceleration = 0.0f;
     // this is handy for the groundstation
     wp_totalDistance = 0;
     wp_distance      = 0.0f;

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -10,11 +10,6 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
         DataFlash.Log_Write_Mission_Cmd(mission, cmd);
     }
 
-    // exit immediately if not in AUTO mode
-    if (control_mode != &mode_auto) {
-        return false;
-    }
-
     gcs().send_text(MAV_SEVERITY_INFO, "Executing command ID #%i", cmd.id);
 
     // remember the course of our next navigation leg
@@ -130,27 +125,22 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
 //      we double check that the flight mode is AUTO to avoid the possibility of ap-mission triggering actions while we're not in AUTO mode
 void Rover::exit_mission()
 {
-    if (control_mode == &mode_auto) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "No commands. Can't set AUTO. Setting HOLD");
-        set_mode(mode_hold);
-    }
+    gcs().send_text(MAV_SEVERITY_NOTICE, "No commands. Can't set AUTO. Setting HOLD");
+    set_mode(mode_hold);
 }
 
 // verify_command_callback - callback function called from ap-mission at 10hz or higher when a command is being run
 //      we double check that the flight mode is AUTO to avoid the possibility of ap-mission triggering actions while we're not in AUTO mode
 bool Rover::verify_command_callback(const AP_Mission::Mission_Command& cmd)
 {
-    if (control_mode == &mode_auto) {
-        const bool cmd_complete = verify_command(cmd);
+    const bool cmd_complete = verify_command(cmd);
 
-        // send message to GCS
-        if (cmd_complete) {
-            gcs().send_mission_item_reached_message(cmd.index);
-        }
-
-        return cmd_complete;
+    // send message to GCS
+    if (cmd_complete) {
+        gcs().send_mission_item_reached_message(cmd.index);
     }
-    return false;
+
+    return cmd_complete;
 }
 
 /*******************************************************************************

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -215,9 +215,7 @@ bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
 
 void Rover::do_RTL(void)
 {
-    prev_WP = current_loc;
-    control_mode = &mode_rtl;
-    next_WP = home;
+    set_mode(mode_rtl);
 }
 
 void Rover::do_nav_wp(const AP_Mission::Mission_Command& cmd)

--- a/APMrover2/commands_process.cpp
+++ b/APMrover2/commands_process.cpp
@@ -4,7 +4,7 @@
 // --------------------
 void Rover::update_commands(void)
 {
-    if (control_mode == AUTO) {
+    if (control_mode == &mode_auto) {
         if (home_is_set != HOME_UNSET && mission.num_commands() > 1) {
             mission.update();
         }

--- a/APMrover2/crash_check.cpp
+++ b/APMrover2/crash_check.cpp
@@ -13,7 +13,7 @@ void Rover::crash_check()
   static uint16_t crash_counter;  // number of iterations vehicle may have been crashed
 
   // return immediately if disarmed, or crash checking disabled or in HOLD mode
-  if (!arming.is_armed() || g.fs_crash_check == FS_CRASH_DISABLE || (control_mode != GUIDED && control_mode != AUTO)) {
+  if (!arming.is_armed() || g.fs_crash_check == FS_CRASH_DISABLE || (!control_mode->is_autopilot_mode())) {
     crash_counter = 0;
     return;
   }
@@ -38,7 +38,7 @@ void Rover::crash_check()
     // send message to gcs
     gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
     // change mode to hold and disarm
-    set_mode(HOLD);
+    set_mode(mode_hold);
     if (g.fs_crash_check == FS_CRASH_HOLD_AND_DISARM) {
       disarm_motors();
     }

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -40,12 +40,6 @@ enum mode {
     INITIALISING = 16
 };
 
-enum GuidedMode {
-    Guided_WP,
-    Guided_Angle,
-    Guided_Velocity
-};
-
 // types of failsafe events
 #define FAILSAFE_EVENT_THROTTLE (1<<0)
 #define FAILSAFE_EVENT_GCS      (1<<1)

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -74,18 +74,18 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
     if (failsafe.triggered == 0 &&
         failsafe.bits != 0 &&
         millis() - failsafe.start_time > g.fs_timeout * 1000 &&
-        control_mode != RTL &&
-        control_mode != HOLD) {
+        control_mode != &mode_rtl &&
+        control_mode != &mode_hold) {
         failsafe.triggered = failsafe.bits;
         gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", static_cast<uint32_t>(failsafe.triggered));
         switch (g.fs_action) {
             case 0:
                 break;
             case 1:
-                set_mode(RTL);
+                set_mode(mode_rtl);
                 break;
             case 2:
-                set_mode(HOLD);
+                set_mode(mode_hold);
                 break;
         }
     }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -1,0 +1,149 @@
+#include "mode.h"
+#include "Rover.h"
+
+Mode::Mode() :
+    g(rover.g),
+    g2(rover.g2),
+    channel_steer(rover.channel_steer),
+    channel_throttle(rover.channel_throttle),
+    mission(rover.mission)
+{ }
+
+void Mode::exit()
+{
+    // call sub-classes exit
+    _exit();
+
+    lateral_acceleration = 0.0f;
+    rover.throttle = 500;
+    rover.g.pidSpeedThrottle.reset_I();
+    if (!rover.in_auto_reverse) {
+        rover.set_reverse(false);
+    }
+    rover.rtl_complete = false;
+}
+
+bool Mode::enter()
+{
+    return _enter();
+}
+
+void Mode::calc_throttle(float target_speed)
+{
+    const int16_t &throttle_nudge = rover.throttle_nudge;
+    int16_t &throttle = rover.throttle;
+    const int32_t next_navigation_leg_cd = rover.next_navigation_leg_cd;
+    const AP_AHRS &ahrs = rover.ahrs;
+    const float wp_distance = rover.wp_distance;
+    float &groundspeed_error = rover.groundspeed_error;
+    const float ground_speed = rover.ground_speed;
+
+    const float throttle_base = (fabsf(target_speed) / g.speed_cruise) * g.throttle_cruise;
+    const int throttle_target = throttle_base + throttle_nudge;
+
+    /*
+        reduce target speed in proportion to turning rate, up to the
+        SPEED_TURN_GAIN percentage.
+    */
+    float steer_rate = fabsf(lateral_acceleration / (g.turn_max_g * GRAVITY_MSS));
+    steer_rate = constrain_float(steer_rate, 0.0f, 1.0f);
+
+    // use g.speed_turn_gain for a 90 degree turn, and in proportion
+    // for other turn angles
+    const int32_t turn_angle = wrap_180_cd(next_navigation_leg_cd - ahrs.yaw_sensor);
+    const float speed_turn_ratio = constrain_float(fabsf(turn_angle / 9000.0f), 0.0f, 1.0f);
+    const float speed_turn_reduction = (100 - g.speed_turn_gain) * speed_turn_ratio * 0.01f;
+
+    float reduction = 1.0f - steer_rate * speed_turn_reduction;
+
+    if (is_autopilot_mode() && rover.mode_guided.guided_mode != ModeGuided::Guided_Velocity && wp_distance <= g.speed_turn_dist) {
+        // in auto-modes we reduce speed when approaching waypoints
+        const float reduction2 = 1.0f - speed_turn_reduction;
+        if (reduction2 < reduction) {
+            reduction = reduction2;
+        }
+    }
+
+    // reduce the target speed by the reduction factor
+    target_speed *= reduction;
+
+    groundspeed_error = fabsf(target_speed) - ground_speed;
+
+    throttle = throttle_target + (g.pidSpeedThrottle.get_pid(groundspeed_error * 100.0f) / 100.0f);
+
+    // also reduce the throttle by the reduction factor. This gives a
+    // much faster response in turns
+    throttle *= reduction;
+
+    if (rover.in_reverse) {
+        g2.motors.set_throttle(constrain_int16(-throttle, -g.throttle_max, -g.throttle_min));
+    } else {
+        g2.motors.set_throttle(constrain_int16(throttle, g.throttle_min, g.throttle_max));
+    }
+
+    if (!rover.in_reverse && g.braking_percent != 0 && groundspeed_error < -g.braking_speederr) {
+        // the user has asked to use reverse throttle to brake. Apply
+        // it in proportion to the ground speed error, but only when
+        // our ground speed error is more than BRAKING_SPEEDERR.
+        //
+        // We use a linear gain, with 0 gain at a ground speed error
+        // of braking_speederr, and 100% gain when groundspeed_error
+        // is 2*braking_speederr
+        const float brake_gain = constrain_float(((-groundspeed_error)-g.braking_speederr)/g.braking_speederr, 0.0f, 1.0f);
+        const int16_t braking_throttle = g.throttle_max * (g.braking_percent * 0.01f) * brake_gain;
+        g2.motors.set_throttle(constrain_int16(-braking_throttle, -g.throttle_max, -g.throttle_min));
+
+        // temporarily set us in reverse to allow the PWM setting to
+        // go negative
+        rover.set_reverse(true);
+    }
+
+    if (rover.mode_guided.guided_mode != ModeGuided::Guided_Velocity) {
+        if (rover.use_pivot_steering()) {
+            // In Guided Velocity, only the steering input is used to calculate the pivot turn.
+            g2.motors.set_throttle(0.0f);
+        }
+    }
+}
+
+void Mode::calc_lateral_acceleration()
+{
+    calc_lateral_acceleration(rover.current_loc, rover.next_WP);
+}
+
+/*
+ * Calculate desired turn angles (in medium freq loop)
+ */
+void Mode::calc_lateral_acceleration(const struct Location &last_WP, const struct Location &next_WP)
+{
+    // Calculate the required turn of the wheels
+    // negative error = left turn
+    // positive error = right turn
+    rover.nav_controller->update_waypoint(last_WP, next_WP);
+    lateral_acceleration = rover.nav_controller->lateral_acceleration();
+    if (rover.use_pivot_steering()) {
+        const int16_t bearing_error = wrap_180_cd(rover.nav_controller->target_bearing_cd() - rover.ahrs.yaw_sensor) / 100;
+        if (bearing_error > 0) {
+            lateral_acceleration = g.turn_max_g * GRAVITY_MSS;
+        } else {
+            lateral_acceleration = -g.turn_max_g * GRAVITY_MSS;
+        }
+    }
+}
+
+/*
+    calculate steering angle given lateral_acceleration
+*/
+void Mode::calc_nav_steer()
+{
+    // add in obstacle avoidance
+    if (!rover.in_reverse) {
+        lateral_acceleration += (rover.obstacle.turn_angle / 45.0f) * g.turn_max_g;
+    }
+
+    // constrain to max G force
+    lateral_acceleration = constrain_float(lateral_acceleration, -g.turn_max_g * GRAVITY_MSS, g.turn_max_g * GRAVITY_MSS);
+
+    // send final steering command to motor library
+    g2.motors.set_steering(rover.steerController.get_steering_out_lat_accel(lateral_acceleration));
+}

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -25,6 +25,7 @@ void Mode::exit()
 
 bool Mode::enter()
 {
+    g2.motors.slew_limit_throttle(false);
     return _enter();
 }
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -82,6 +82,9 @@ protected:
     // calculate desired lateral acceleration
     void calc_lateral_acceleration(const struct Location &last_wp, const struct Location &next_WP);
 
+    // calculate pilot input to nudge throttle up or down
+    int16_t calc_throttle_nudge();
+
     // references to avoid code churn:
     class Parameters &g;
     class ParametersG2 &g2;

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -1,0 +1,242 @@
+#pragma once
+
+#include <stdint.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>  // for MAV_SEVERITY
+#include "defines.h"
+
+class Mode
+{
+public:
+
+    // Constructor
+    Mode();
+
+    // enter this mode, returns false if we failed to enter
+    bool enter();
+
+    // perform any cleanups required:
+    void exit();
+
+    // returns a unique number specific to this mode
+    virtual uint32_t mode_number() const = 0;
+
+    //
+    // methods that sub classes should override to affect movement of the vehicle in this mode
+    //
+
+    // convert user input to targets, implement high level control for this mode
+    virtual void update() = 0;
+
+    // calculates the amount of throttle that should be output based
+    // on things like proximity to corners and current speed
+    virtual void calc_throttle(float target_speed);
+
+    // called to determine where the vehicle should go next, and how it should get there
+    virtual void update_navigation() { }  // most modes don't navigate
+
+    //
+    // attributes of the mode
+    //
+
+    // return if in non-manual mode : AUTO, GUIDED, RTL
+    virtual bool is_autopilot_mode() const { return false; }
+
+    // returns true if steering is directly controlled by RC
+    virtual bool manual_steering() const { return false; }
+
+    // returns true if the throttle is controlled automatically
+    virtual bool auto_throttle() { return is_autopilot_mode(); }
+
+    // return true if throttle should be supressed in event of a
+    // FAILSAFE_EVENT_THROTTLE
+    virtual bool failsafe_throttle_suppress() const { return true; }
+
+    //
+    // attributes for mavlink system status reporting
+    //
+
+    // returns true if any RC input is used
+    virtual bool has_manual_input() const { return false; }
+
+    // true if heading is controlled
+    virtual bool attitude_stabilized() const { return true; }
+
+    // Navigation control variables
+    // The instantaneous desired lateral acceleration in m/s/s
+    float lateral_acceleration;
+
+protected:
+
+    // subclasses override this to perform checks before entering the mode
+    virtual bool _enter() { return true; }
+
+    // subclasses override this to perform any required cleanup when exiting the mode
+    virtual void _exit() { return; }
+
+    // calculate steering angle given a desired lateral acceleration
+    virtual void calc_nav_steer();
+
+    // calculate desired lateral acceleration using current location and target held in next_WP
+    virtual void calc_lateral_acceleration();
+
+    // calculate desired lateral acceleration
+    void calc_lateral_acceleration(const struct Location &last_wp, const struct Location &next_WP);
+
+    // references to avoid code churn:
+    class Parameters &g;
+    class ParametersG2 &g2;
+    class RC_Channel *&channel_steer;  // TODO : Pointer reference ?
+    class RC_Channel *&channel_throttle;
+    class AP_Mission &mission;
+};
+
+
+class ModeAuto : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return AUTO; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+    void calc_throttle(float target_speed) override;
+    void update_navigation() override;
+
+    // attributes of the mode
+    bool is_autopilot_mode() const override { return true; }
+    bool failsafe_throttle_suppress() const override { return false; }
+
+protected:
+
+    bool _enter() override;
+    void _exit() override;
+    void calc_nav_steer() override;
+    void calc_lateral_acceleration() override;
+
+private:
+
+    bool check_trigger(void);
+
+    // this is set to true when auto has been triggered to start
+    bool auto_triggered;
+};
+
+
+class ModeGuided : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return GUIDED; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+    void update_navigation() override;
+
+    // attributes of the mode
+    bool is_autopilot_mode() const override { return true; }
+    bool failsafe_throttle_suppress() const override { return false; }
+
+    enum GuidedMode {
+        Guided_WP,
+        Guided_Angle,
+        Guided_Velocity
+    };
+
+    // Guided
+    GuidedMode guided_mode;  // stores which GUIDED mode the vehicle is in
+
+protected:
+
+    bool _enter() override;
+};
+
+
+class ModeHold : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return HOLD; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+
+    // attributes for mavlink system status reporting
+    bool attitude_stabilized() const override { return false; }
+};
+
+
+class ModeManual : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return MANUAL; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+
+    // attributes of the mode
+    bool manual_steering() const override { return true; }
+
+    // attributes for mavlink system status reporting
+    bool has_manual_input() const override { return true; }
+    bool attitude_stabilized() const override { return false; }
+};
+
+
+class ModeLearning : public ModeManual
+{
+public:
+
+    uint32_t mode_number() const override { return LEARNING; }
+
+    // attributes for mavlink system status reporting
+    bool has_manual_input() const override { return true; }
+};
+
+
+class ModeRTL : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return RTL; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+    void update_navigation() override;
+
+    // attributes of the mode
+    bool is_autopilot_mode() const override { return true; }
+    bool failsafe_throttle_suppress() const override { return false; }
+
+protected:
+
+    bool _enter() override;
+};
+
+
+class ModeSteering : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return STEERING; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+
+    // attributes for mavlink system status reporting
+    bool has_manual_input() const override { return true; }
+};
+
+class ModeInitializing : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return INITIALISING; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override { }
+
+    // attributes for mavlink system status reporting
+    bool has_manual_input() const override { return true; }
+    bool attitude_stabilized() const override { return false; }
+};

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -1,0 +1,123 @@
+#include "mode.h"
+#include "Rover.h"
+
+bool ModeAuto::_enter()
+{
+    auto_triggered = false;
+    rover.restart_nav();
+    rover.loiter_start_time = 0;
+    return true;
+}
+
+void ModeAuto::_exit()
+{
+    // If we are changing out of AUTO mode reset the loiter timer
+    rover.loiter_start_time = 0;
+    // ... and stop running the mission
+    if (mission.state() == AP_Mission::MISSION_RUNNING) {
+        mission.stop();
+    }
+}
+
+void ModeAuto::update()
+{
+    if (!rover.in_auto_reverse) {
+        rover.set_reverse(false);
+    }
+    if (!rover.do_auto_rotation) {
+        calc_lateral_acceleration();
+        calc_nav_steer();
+        calc_throttle(g.speed_cruise);
+    } else {
+        rover.do_yaw_rotation();
+    }
+}
+
+void ModeAuto::update_navigation()
+{
+    mission.update();
+    if (rover.do_auto_rotation) {
+        rover.do_yaw_rotation();
+    }
+}
+
+/*
+    check for triggering of start of auto mode
+*/
+bool ModeAuto::check_trigger(void)
+{
+    // check for user pressing the auto trigger to off
+    if (auto_triggered && g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 1) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "AUTO triggered off");
+        auto_triggered = false;
+        return false;
+    }
+
+    // if already triggered, then return true, so you don't
+    // need to hold the switch down
+    if (auto_triggered) {
+        return true;
+    }
+
+    // return true if auto trigger and kickstart are disabled
+    if (g.auto_trigger_pin == -1 && is_zero(g.auto_kickstart)) {
+        // no trigger configured - let's go!
+        auto_triggered = true;
+        return true;
+    }
+
+    // check if trigger pin has been pushed
+    if (g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 0) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
+        auto_triggered = true;
+        return true;
+    }
+
+    // check if mission is started by giving vehicle a kick with acceleration > AUTO_KICKSTART
+    if (!is_zero(g.auto_kickstart)) {
+        const float xaccel = rover.ins.get_accel().x;
+        if (xaccel >= g.auto_kickstart) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
+            auto_triggered = true;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ModeAuto::calc_throttle(float target_speed)
+{
+    // If not autostarting OR we are loitering at a waypoint
+    // then set the throttle to minimum
+    if (!check_trigger() || rover.in_stationary_loiter()) {
+        g2.motors.set_throttle(g.throttle_min.get());
+        // Stop rotation in case of loitering and skid steering
+        if (g2.motors.have_skid_steering()) {
+            g2.motors.set_steering(0.0f);
+        }
+        return;
+    }
+    Mode::calc_throttle(target_speed);
+}
+
+void ModeAuto::calc_lateral_acceleration()
+{
+    // If we have reached the waypoint previously navigate
+    // back to it from our current position
+    if (rover.previously_reached_wp && (rover.loiter_duration > 0)) {
+        Mode::calc_lateral_acceleration(rover.current_loc, rover.next_WP);
+    } else {
+        Mode::calc_lateral_acceleration(rover.prev_WP, rover.next_WP);
+    }
+}
+
+void ModeAuto::calc_nav_steer()
+{
+    // check to see if the rover is loitering
+    if (rover.in_stationary_loiter()) {
+        g2.motors.set_steering(0.0f);
+        return;
+    }
+    Mode::calc_nav_steer();
+}

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -3,6 +3,12 @@
 
 bool ModeAuto::_enter()
 {
+    // fail to enter auto if no mission commands
+    if (mission.num_commands() == 0) {
+        gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
+        return false;
+    }
+
     auto_triggered = false;
     rover.restart_nav();
     rover.loiter_start_time = 0;

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -12,6 +12,7 @@ bool ModeAuto::_enter()
     auto_triggered = false;
     rover.restart_nav();
     rover.loiter_start_time = 0;
+    g2.motors.slew_limit_throttle(true);
     return true;
 }
 

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -43,9 +43,6 @@ void ModeAuto::update()
 void ModeAuto::update_navigation()
 {
     mission.update();
-    if (rover.do_auto_rotation) {
-        rover.do_yaw_rotation();
-    }
 }
 
 /*

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -9,6 +9,7 @@ bool ModeGuided::_enter()
     */
     lateral_acceleration = 0.0f;
     rover.set_guided_WP(rover.current_loc);
+    g2.motors.slew_limit_throttle(true);
     return true;
 }
 

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -1,0 +1,82 @@
+#include "mode.h"
+#include "Rover.h"
+
+bool ModeGuided::_enter()
+{
+    /*
+      when entering guided mode we set the target as the current
+      location. This matches the behaviour of the copter code.
+    */
+    lateral_acceleration = 0.0f;
+    rover.set_guided_WP(rover.current_loc);
+    return true;
+}
+
+void ModeGuided::update()
+{
+    if (!rover.in_auto_reverse) {
+        rover.set_reverse(false);
+    }
+
+    switch (guided_mode) {
+        case Guided_Angle:
+            rover.nav_set_yaw_speed();
+            break;
+
+        case Guided_WP:
+            if (rover.rtl_complete || rover.verify_RTL()) {
+                // we have reached destination so stop where we are
+                if (fabsf(g2.motors.get_throttle()) > g.throttle_min.get()) {
+                    rover.gcs().send_mission_item_reached_message(0);
+                }
+                g2.motors.set_throttle(g.throttle_min.get());
+                g2.motors.set_steering(0.0f);
+                lateral_acceleration = 0.0f;
+            } else {
+                calc_lateral_acceleration();
+                calc_nav_steer();
+                calc_throttle(rover.guided_control.target_speed);
+                rover.Log_Write_GuidedTarget(guided_mode, Vector3f(rover.next_WP.lat, rover.next_WP.lng, rover.next_WP.alt),
+                                       Vector3f(rover.guided_control.target_speed, g2.motors.get_throttle(), 0.0f));
+            }
+            break;
+
+        case Guided_Velocity:
+            rover.nav_set_speed();
+            break;
+
+        default:
+            gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
+            break;
+    }
+}
+
+void ModeGuided::update_navigation()
+{
+    switch (guided_mode) {
+        case Guided_Angle:
+            rover.nav_set_yaw_speed();
+            break;
+
+        case Guided_WP:
+            // no loitering around the wp with the rover, goes direct to the wp position
+            if (rover.rtl_complete || rover.verify_RTL()) {
+                // we have reached destination so stop where we are
+                g2.motors.set_throttle(g.throttle_min.get());
+                g2.motors.set_steering(0.0f);
+                lateral_acceleration = 0.0f;
+            } else {
+                calc_lateral_acceleration();
+                calc_nav_steer();
+            }
+            break;
+
+        case Guided_Velocity:
+            rover.nav_set_speed();
+            break;
+
+        default:
+            gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
+            break;
+    }
+}

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -54,30 +54,11 @@ void ModeGuided::update()
 
 void ModeGuided::update_navigation()
 {
-    switch (guided_mode) {
-        case Guided_Angle:
-            rover.nav_set_yaw_speed();
-            break;
-
-        case Guided_WP:
-            // no loitering around the wp with the rover, goes direct to the wp position
-            if (rover.rtl_complete || rover.verify_RTL()) {
-                // we have reached destination so stop where we are
-                g2.motors.set_throttle(g.throttle_min.get());
-                g2.motors.set_steering(0.0f);
-                lateral_acceleration = 0.0f;
-            } else {
-                calc_lateral_acceleration();
-                calc_nav_steer();
-            }
-            break;
-
-        case Guided_Velocity:
-            rover.nav_set_speed();
-            break;
-
-        default:
-            gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
-            break;
+    // no loitering around the wp with the rover, goes direct to the wp position
+    if (guided_mode == Guided_WP && (rover.rtl_complete || rover.verify_RTL())) {
+        // we have reached destination so stop where we are
+        g2.motors.set_throttle(g.throttle_min.get());
+        g2.motors.set_steering(0.0f);
+        lateral_acceleration = 0.0f;
     }
 }

--- a/APMrover2/mode_hold.cpp
+++ b/APMrover2/mode_hold.cpp
@@ -1,0 +1,12 @@
+#include "mode.h"
+#include "Rover.h"
+
+void ModeHold::update()
+{
+    // hold position - stop motors and center steering
+    g2.motors.set_throttle(0.0f);
+    g2.motors.set_steering(0.0f);
+    if (!rover.in_auto_reverse) {
+        rover.set_reverse(false);
+    }
+}

--- a/APMrover2/mode_learning.cpp
+++ b/APMrover2/mode_learning.cpp
@@ -1,0 +1,2 @@
+#include "mode.h"
+#include "Rover.h"

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -3,7 +3,10 @@
 
 void ModeManual::update()
 {
-    // mark us as in_reverse when using a negative throttle to
-    // stop AHRS getting off
+    // copy RC scaled inputs to outputs
+    g2.motors.set_throttle(channel_throttle->get_control_in());
+    g2.motors.set_steering(channel_steer->get_control_in());
+
+    // mark us as in_reverse when using a negative throttle to stop AHRS getting off
     rover.set_reverse(is_negative(g2.motors.get_throttle()));
 }

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -1,0 +1,9 @@
+#include "mode.h"
+#include "Rover.h"
+
+void ModeManual::update()
+{
+    // mark us as in_reverse when using a negative throttle to
+    // stop AHRS getting off
+    rover.set_reverse(is_negative(g2.motors.get_throttle()));
+}

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -3,9 +3,15 @@
 
 void ModeManual::update()
 {
-    // copy RC scaled inputs to outputs
-    g2.motors.set_throttle(channel_throttle->get_control_in());
-    g2.motors.set_steering(channel_steer->get_control_in());
+    // check for radio failsafe
+    if (rover.failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
+        g2.motors.set_throttle(0.0f);
+        g2.motors.set_steering(0.0f);
+    } else {
+        // copy RC scaled inputs to outputs
+        g2.motors.set_throttle(channel_throttle->get_control_in());
+        g2.motors.set_steering(channel_steer->get_control_in());
+    }
 
     // mark us as in_reverse when using a negative throttle to stop AHRS getting off
     rover.set_reverse(is_negative(g2.motors.get_throttle()));

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -4,6 +4,7 @@
 bool ModeRTL::_enter()
 {
     rover.do_RTL();
+    g2.motors.slew_limit_throttle(true);
     return true;
 }
 

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -1,0 +1,30 @@
+#include "mode.h"
+#include "Rover.h"
+
+bool ModeRTL::_enter()
+{
+    rover.do_RTL();
+    return true;
+}
+
+void ModeRTL::update()
+{
+    if (!rover.in_auto_reverse) {
+        rover.set_reverse(false);
+    }
+    calc_lateral_acceleration();
+    calc_nav_steer();
+    calc_throttle(g.speed_cruise);
+}
+
+void ModeRTL::update_navigation()
+{
+    // no loitering around the wp with the rover, goes direct to the wp position
+    if (rover.verify_RTL()) {
+        g2.motors.set_throttle(g.throttle_min.get());
+        rover.set_mode(rover.mode_hold);
+    } else {
+        calc_lateral_acceleration();
+        calc_nav_steer();
+    }
+}

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -3,7 +3,8 @@
 
 bool ModeRTL::_enter()
 {
-    rover.do_RTL();
+    rover.prev_WP = rover.current_loc;
+    rover.next_WP = rover.home;
     g2.motors.slew_limit_throttle(true);
     return true;
 }

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -23,10 +23,6 @@ void ModeRTL::update_navigation()
 {
     // no loitering around the wp with the rover, goes direct to the wp position
     if (rover.verify_RTL()) {
-        g2.motors.set_throttle(g.throttle_min.get());
         rover.set_mode(rover.mode_hold);
-    } else {
-        calc_lateral_acceleration();
-        calc_nav_steer();
     }
 }

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -1,0 +1,34 @@
+#include "mode.h"
+#include "Rover.h"
+
+void ModeSteering::update() {
+    /*
+        in steering mode we control lateral acceleration
+        directly. We first calculate the maximum lateral
+        acceleration at full steering lock for this speed. That is
+        V^2/R where R is the radius of turn. We get the radius of
+        turn from half the STEER2SRV_P.
+    */
+    const float ground_speed = rover.ground_speed;
+    float max_g_force = ground_speed * ground_speed / rover.steerController.get_turn_radius();
+
+    // constrain to user set TURN_MAX_G
+    max_g_force = constrain_float(max_g_force, 0.1f, g.turn_max_g * GRAVITY_MSS);
+
+    // convert pilot steering input to desired lateral acceleration
+    lateral_acceleration = max_g_force * (channel_steer->get_control_in() / 4500.0f);
+
+    // run steering controller
+    calc_nav_steer();
+
+    // convert pilot throttle input to desired speed
+    // speed in proportion to cruise speed, up to 50% throttle, then uses nudging above that.
+    float target_speed = channel_throttle->get_control_in() * 0.01f * 2.0f * g.speed_cruise;
+    target_speed = constrain_float(target_speed, -g.speed_cruise, g.speed_cruise);
+
+    // mark us as in_reverse when using a negative throttle to stop AHRS getting off
+    rover.set_reverse(is_negative(target_speed));
+
+    // run speed to throttle output controller
+    calc_throttle(target_speed);
+}

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -156,17 +156,6 @@ void Rover::read_radio()
     g2.motors.set_throttle(channel_throttle->get_control_in());
     g2.motors.set_steering(channel_steer->get_control_in());
 
-    // Check if the throttle value is above 50% and we need to nudge
-    // Make sure its above 50% in the direction we are travelling
-    if ((fabsf(g2.motors.get_throttle()) > 50.0f) &&
-        ((is_negative(g2.motors.get_throttle()) && in_reverse) ||
-         (is_positive(g2.motors.get_throttle()) && !in_reverse))) {
-        throttle_nudge = (g.throttle_max - g.throttle_cruise) *
-                         ((fabsf(channel_throttle->norm_input()) - 0.5f) / 0.5f);
-    } else {
-        throttle_nudge = 0;
-    }
-
     // check if we try to do RC arm/disarm
     rudder_arm_disarm_check();
 }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -152,10 +152,6 @@ void Rover::read_radio()
         channel_throttle->set_pwm(thr);
     }
 
-    // copy RC scaled inputs to outputs
-    g2.motors.set_throttle(channel_throttle->get_control_in());
-    g2.motors.set_steering(channel_steer->get_control_in());
-
     // check if we try to do RC arm/disarm
     rudder_arm_disarm_check();
 }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -53,7 +53,7 @@ void Rover::rudder_arm_disarm_check()
     }
 
     // if not in a manual throttle mode then disallow rudder arming/disarming
-    if (auto_throttle_mode) {
+    if (control_mode->auto_throttle()) {
         rudder_arm_timer = 0;
         return;
     }

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -239,29 +239,13 @@ void Rover::update_sensor_status_flags(void)
                                                          ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
                                                          ~MAV_SYS_STATUS_LOGGING);
-
-    switch (control_mode) {
-    case MANUAL:
-    case HOLD:
-        break;
-
-    case LEARNING:
-    case STEERING:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL;    // 3D angular rate control
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;  // attitude stabilisation
-        break;
-
-    case AUTO:
-    case RTL:
-    case GUIDED:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL;    // 3D angular rate control
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;  // attitude stabilisation
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_YAW_POSITION;            // yaw position
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;     // X/Y position control
-        break;
-
-    case INITIALISING:
-        break;
+    if (control_mode->attitude_stabilized()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL; // 3D angular rate control
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION; // 3D angular rate control
+    }
+    if (control_mode->is_autopilot_mode()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_YAW_POSITION; // yaw position
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL; // X/Y position control
     }
 
     if (rover.DataFlash.logging_enabled()) {

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -121,7 +121,7 @@ void Rover::init_ardupilot()
     // initialise notify system
     notify.init(false);
     AP_Notify::flags.failsafe_battery = false;
-    notify_mode(control_mode);
+    notify_mode((enum mode)control_mode->mode_number());
 
     ServoRelayEvents.set_channel_mask(0xFFF0);
 
@@ -209,7 +209,12 @@ void Rover::init_ardupilot()
 
     startup_ground();
 
-    set_mode((enum mode)g.initial_mode.get());
+    Mode *initial_mode = control_mode_from_num((enum mode)g.initial_mode.get());
+    if (initial_mode == nullptr) {
+        initial_mode = &mode_initializing;
+    }
+    set_mode(*initial_mode);
+
 
     // set the correct flight mode
     // ---------------------------
@@ -227,7 +232,7 @@ void Rover::init_ardupilot()
 //*********************************************************************************
 void Rover::startup_ground(void)
 {
-    set_mode(INITIALISING);
+    set_mode(mode_initializing);
 
     gcs().send_text(MAV_SEVERITY_INFO, "<startup_ground> Ground start");
 
@@ -278,75 +283,32 @@ void Rover::set_reverse(bool reverse)
     in_reverse = reverse;
 }
 
-void Rover::set_mode(enum mode mode)
+bool Rover::set_mode(Mode &new_mode)
 {
-    if (control_mode == mode) {
+    if (control_mode == &new_mode) {
         // don't switch modes if we are already in the correct mode.
-        return;
+        return true;
     }
 
-    // If we are changing out of AUTO mode reset the loiter timer and stop current mission
-    if (control_mode == AUTO) {
-        loiter_start_time = 0;
-        if (mission.state() == AP_Mission::MISSION_RUNNING) {
-            mission.stop();
-        }
+    Mode &old_mode = *control_mode;
+    if (!new_mode.enter()) {
+        return false;
     }
 
-    control_mode = mode;
-    throttle = 500;
-    if (!in_auto_reverse) {
-        set_reverse(false);
-    }
-    g.pidSpeedThrottle.reset_I();
+    control_mode = &new_mode;
 
 #if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.update_control_mode(control_mode);
+    frsky_telemetry.update_control_mode(control_mode->mode_number());
 #endif
 
-    if (control_mode != AUTO) {
-        auto_triggered = false;
-    }
-
-    switch (control_mode) {
-    case MANUAL:
-    case HOLD:
-    case LEARNING:
-    case STEERING:
-        auto_throttle_mode = false;
-        break;
-
-    case AUTO:
-        auto_throttle_mode = true;
-        rtl_complete = false;
-        restart_nav();
-        break;
-
-    case RTL:
-        auto_throttle_mode = true;
-        do_RTL();
-        break;
-
-    case GUIDED:
-        auto_throttle_mode = true;
-        /*
-           when entering guided mode we set the target as the current
-           location. This matches the behaviour of the copter code.
-           */
-        set_guided_WP(current_loc);
-        break;
-
-    default:
-        auto_throttle_mode = true;
-        do_RTL();
-        break;
-    }
+    old_mode.exit();
 
     if (should_log(MASK_LOG_MODE)) {
-        DataFlash.Log_Write_Mode(control_mode);
+        DataFlash.Log_Write_Mode(control_mode->mode_number());
     }
 
-    notify_mode(control_mode);
+    notify_mode((enum mode)control_mode->mode_number());
+    return true;
 }
 
 /*
@@ -354,18 +316,11 @@ void Rover::set_mode(enum mode mode)
  */
 bool Rover::mavlink_set_mode(uint8_t mode)
 {
-    switch (mode) {
-    case MANUAL:
-    case HOLD:
-    case LEARNING:
-    case STEERING:
-    case GUIDED:
-    case AUTO:
-    case RTL:
-        set_mode((enum mode)mode);
-        return true;
+    Mode *new_mode = control_mode_from_num((enum mode)mode);
+    if (new_mode == nullptr) {
+        return false;
     }
-    return false;
+    return set_mode(*new_mode);
 }
 
 void Rover::startup_INS_ground(void)
@@ -536,7 +491,7 @@ bool Rover::disarm_motors(void)
     if (!arming.disarm()) {
         return false;
     }
-    if (control_mode != AUTO) {
+    if (control_mode != &mode_auto) {
         // reset the mission on disarm if we are not in auto
         mission.reset();
     }


### PR DESCRIPTION
This is a replacement PR for: https://github.com/ArduPilot/ardupilot/pull/6575

This PR does the following:

- new Mode class (see mode.h, mode.cpp, mode_manual.cpp, etc files) consolidates much of the control mode code into objects.  The mode class has "enter" and "exit" methods which are called when the vehicle switches in/out of these modes.  an "update" method performs the parsing of user input, calling navigation functions and passing the outputs to the motors.  "is_autopilot_mode()", "auto_throttle()", etc methods try to characterise the modes for decision making in other parts of the vehicle code
- transmitter input is copied to motor outputs only in manual and learning mode (the only valid place to do this).
- advanced failsafe is fixed and simplified to remove direct setting of outputs to motors.  output to the motors is the responsibility of the AP_MotorsUGV class now.
- remove RTL's redundant navigation calls (calc_lateral_acceleration and calc_nav_steer)
- vehicle will not switch to AUTO mode if there is no mission

These changes are mostly architectural changes with no really significant functional changes.  The new structure is not yet perfect, in particular there is still a lot of calling back into the vehicle code from the flight mode objects which we will hopefully remove in follow up PRs.

This has been tested in SITL and on a skid-steering vehicle.

