### PR TITLE
Copter: report polygon fence breach

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -65,7 +65,7 @@ void Copter::fence_send_mavlink_status(mavlink_channel_t chan)
         if ((breaches & AC_FENCE_TYPE_ALT_MAX) != 0) {
             mavlink_breach_type = FENCE_BREACH_MAXALT;
         }
-        if ((breaches & AC_FENCE_TYPE_CIRCLE) != 0) {
+        if ((breaches & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) != 0) {
             mavlink_breach_type = FENCE_BREACH_BOUNDARY;
         }
 


### PR DESCRIPTION
Otherwise, in case of polygon fence breach, the field mavlink_breach_type isn't filled