### PR TITLE
AP_Arming: Compass calibration running is a pre arm failure, rather then an arming failure

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -295,7 +295,7 @@ bool AP_Arming::compass_checks(bool report)
         //check if compass is calibrating
         if (_compass.is_calibrating()) {
             if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "Arm: Compass calibration running");
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Compass calibration running");
             }
             return false;
         }


### PR DESCRIPTION
This is part of pre arm checks rather then arming checks, meaning the status text was wrong.