### PR TITLE
Move mavlink reboot up to base class

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -660,14 +660,6 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
-        case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (is_equal(packet.param1, 1.0f) || is_equal(packet.param1, 3.0f)) {
-                // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(is_equal(packet.param1, 3.0f));
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
         case MAV_CMD_COMPONENT_ARM_DISARM:
             if (is_equal(packet.param1, 1.0f)) {
                 // run pre_arm_checks and arm_checks and display failures

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -418,16 +418,6 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
                 result = MAV_RESULT_ACCEPTED;
                 break;
 
-            case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            {
-                if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-                    // when packet.param1 == 3 we reboot to hold in bootloader
-                    hal.scheduler->reboot(is_equal(packet.param1,3.0f));
-                    result = MAV_RESULT_ACCEPTED;
-                }
-                break;
-            }
-
             case MAV_CMD_ACCELCAL_VEHICLE_POS:
                 result = MAV_RESULT_FAILED;
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -973,17 +973,6 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             break;
 
-        case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-                AP_Notify::flags.firmware_update = 1;
-                copter.notify.update();
-                hal.scheduler->delay(200);
-                // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(is_equal(packet.param1,3.0f));
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
         case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED
             result = MAV_RESULT_ACCEPTED;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -752,6 +752,11 @@ void GCS_MAVLINK_Plane::packetReceived(const mavlink_status_t &status,
     GCS_MAVLINK::packetReceived(status, msg);
 }
 
+bool GCS_MAVLINK_Plane::should_disable_overrides_on_reboot() const
+{
+    return (plane.quadplane.enable != 0);
+}
+
 void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
@@ -989,10 +994,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             } else {
                 result = MAV_RESULT_UNSUPPORTED;
             }
-            break;
-
-        case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            result = handle_preflight_reboot(packet, plane.quadplane.enable != 0);
             break;
 
         case MAV_CMD_DO_LAND_START:

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -28,6 +28,7 @@ protected:
     uint8_t sysid_my_gcs() const override;
 
     bool set_mode(uint8_t mode) override;
+    bool should_disable_overrides_on_reboot() const override;
 
     MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -940,29 +940,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
             }
             break;
 
-        case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-                // Send an invalid signal to the motors to prevent spinning due to neutral (1500) pwm pulse being cut short
-                // For that matter, send an invalid signal to all channels to prevent undesired/unexpected behavior
-                SRV_Channels::cork();
-                for (int i=0; i<NUM_RC_CHANNELS; i++) {
-                    // Set to 1 because 0 is interpreted as flag to ignore update
-                    hal.rcout->write(i, 1);
-                }
-                SRV_Channels::push();
-
-                result = MAV_RESULT_ACCEPTED;
-                // send ack before we reboot
-                mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
-
-                AP_Notify::flags.firmware_update = 1;
-                sub.notify.update();
-                hal.scheduler->delay(200);
-                // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(is_equal(packet.param1,3.0f));
-            }
-            break;
-
         case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED
             result = MAV_RESULT_ACCEPTED;

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -23,6 +23,7 @@ protected:
     uint8_t sysid_my_gcs() const override;
 
     bool set_mode(uint8_t mode) override;
+    bool should_zero_rc_outputs_on_reboot() const override { return true; }
 
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -311,6 +311,7 @@ protected:
     virtual bool should_disable_overrides_on_reboot() const { return true; }
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
     MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet);
+    void disable_overrides();
     MAV_RESULT handle_rc_bind(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet);
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -308,7 +308,9 @@ protected:
     void handle_common_message(mavlink_message_t *msg);
     void handle_set_gps_global_origin(const mavlink_message_t *msg);
     void handle_setup_signing(const mavlink_message_t *msg);
-    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet, bool disable_overrides);
+    virtual bool should_disable_overrides_on_reboot() const { return true; }
+    virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
+    MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet);
     MAV_RESULT handle_rc_bind(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet);
 
@@ -551,6 +553,8 @@ private:
     struct Location global_position_current_loc;
 
     void send_global_position_int();
+
+    void zero_rc_outputs();
 };
 
 /// @class GCS

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1779,6 +1779,25 @@ void GCS_MAVLINK::zero_rc_outputs()
     SRV_Channels::push();
 }
 
+void GCS_MAVLINK::disable_overrides()
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+    int px4io_fd = open("/dev/px4io", 0);
+    if (px4io_fd < 0) {
+        return;
+    }
+    // disable OVERRIDES so we don't run the mixer while
+    // rebooting
+    if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_OK, 0) != 0) {
+        hal.console->printf("SET_OVERRIDE_OK failed\n");
+    }
+    if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_IMMEDIATE, 0) != 0) {
+        hal.console->printf("SET_OVERRIDE_IMMEDIATE failed\n");
+    }
+    close(px4io_fd);
+#endif
+}
+
 /*
   handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
 
@@ -1789,46 +1808,37 @@ void GCS_MAVLINK::zero_rc_outputs()
  */
 MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packet)
 {
-    if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-        if (should_disable_overrides_on_reboot()) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-            // disable overrides while rebooting
-            int px4io_fd = open("/dev/px4io", 0);
-            if (px4io_fd >= 0) {
-                // disable OVERRIDES so we don't run the mixer while
-                // rebooting
-                if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_OK, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_OK failed\n");
-                }
-                if (ioctl(px4io_fd, PWM_SERVO_SET_OVERRIDE_IMMEDIATE, 0) != 0) {
-                    hal.console->printf("SET_OVERRIDE_IMMEDIATE failed\n");
-                }
-                close(px4io_fd);
-            }
-#endif
-        }
-        if (should_zero_rc_outputs_on_reboot()) {
-            reboot_zero_rc_outputs();
-        }
-        // send ack before we reboot
-        mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED);
-        // Notify might want to blink some LEDs:
-        AP_Notify *notify = AP_Notify::instance();
-        if (notify) {
-            AP_Notify::flags.firmware_update = 1;
-            notify->update();
-        }
-        // force safety on 
-        hal.rcout->force_safety_on();
-        hal.rcout->force_safety_no_wait();
-        hal.scheduler->delay(200);
-
-        // when packet.param1 == 3 we reboot to hold in bootloader
-        bool hold_in_bootloader = is_equal(packet.param1,3.0f);
-        hal.scheduler->reboot(hold_in_bootloader);
-        return MAV_RESULT_FAILED;
+    if (!(is_equal(packet.param1, 1.0f) || is_equal(packet.param1, 3.0f))) {
+        // param1 must be 1 or 3 - 1 being reboot, 3 being reboot-to-bootloader
+        return MAV_RESULT_UNSUPPORTED;
     }
-    return MAV_RESULT_UNSUPPORTED;
+
+    if (should_disable_overrides_on_reboot()) {
+        // disable overrides while rebooting
+        disable_overrides();
+    }
+    if (should_zero_rc_outputs_on_reboot()) {
+        zero_rc_outputs();
+    }
+
+    // send ack before we reboot
+    mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED);
+    // Notify might want to blink some LEDs:
+    AP_Notify *notify = AP_Notify::instance();
+    if (notify) {
+        AP_Notify::flags.firmware_update = 1;
+        notify->update();
+    }
+    // force safety on
+    hal.rcout->force_safety_on();
+    hal.rcout->force_safety_no_wait();
+    hal.scheduler->delay(200);
+
+    // when packet.param1 == 3 we reboot to hold in bootloader
+    const bool hold_in_bootloader = is_equal(packet.param1, 3.0f);
+    hal.scheduler->reboot(hold_in_bootloader);
+
+    return MAV_RESULT_FAILED;
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1773,8 +1773,7 @@ void GCS_MAVLINK::zero_rc_outputs()
     // For that matter, send an invalid signal to all channels to prevent undesired/unexpected behavior
     SRV_Channels::cork();
     for (int i=0; i<NUM_RC_CHANNELS; i++) {
-        // Set to 1 because 0 is interpreted as flag to ignore update
-        hal.rcout->write(i, 1);
+        hal.rcout->write(i, 0);
     }
     SRV_Channels::push();
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1795,7 +1795,8 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
             }
 #endif
         }
-
+        // send ack before we reboot
+        mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED);
         // force safety on 
         hal.rcout->force_safety_on();
         hal.rcout->force_safety_no_wait();
@@ -1804,7 +1805,7 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
         // when packet.param1 == 3 we reboot to hold in bootloader
         bool hold_in_bootloader = is_equal(packet.param1,3.0f);
         hal.scheduler->reboot(hold_in_bootloader);
-        return MAV_RESULT_ACCEPTED;
+        return MAV_RESULT_FAILED;
     }
     return MAV_RESULT_UNSUPPORTED;
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1767,6 +1767,18 @@ void GCS_MAVLINK::send_vfr_hud()
         vfr_hud_climbrate());
 }
 
+void GCS_MAVLINK::zero_rc_outputs()
+{
+    // Send an invalid signal to the motors to prevent spinning due to neutral (1500) pwm pulse being cut short
+    // For that matter, send an invalid signal to all channels to prevent undesired/unexpected behavior
+    SRV_Channels::cork();
+    for (int i=0; i<NUM_RC_CHANNELS; i++) {
+        // Set to 1 because 0 is interpreted as flag to ignore update
+        hal.rcout->write(i, 1);
+    }
+    SRV_Channels::push();
+}
+
 /*
   handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
 
@@ -1775,10 +1787,10 @@ void GCS_MAVLINK::send_vfr_hud()
   motors. That can be dangerous when a preflight reboot is done with
   the pilot close to the aircraft and can also damage the aircraft
  */
-MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packet, bool disable_overrides)
+MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packet)
 {
     if (is_equal(packet.param1,1.0f) || is_equal(packet.param1,3.0f)) {
-        if (disable_overrides) {
+        if (should_disable_overrides_on_reboot()) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
             // disable overrides while rebooting
             int px4io_fd = open("/dev/px4io", 0);
@@ -1795,8 +1807,17 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
             }
 #endif
         }
+        if (should_zero_rc_outputs_on_reboot()) {
+            reboot_zero_rc_outputs();
+        }
         // send ack before we reboot
         mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED);
+        // Notify might want to blink some LEDs:
+        AP_Notify *notify = AP_Notify::instance();
+        if (notify) {
+            AP_Notify::flags.firmware_update = 1;
+            notify->update();
+        }
         // force safety on 
         hal.rcout->force_safety_on();
         hal.rcout->force_safety_no_wait();
@@ -2642,6 +2663,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
 
     case MAV_CMD_DO_SEND_BANNER:
         result = handle_command_do_send_banner(packet);
+        break;
+
+    case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
+        result = handle_preflight_reboot(packet);
         break;
 
     case MAV_CMD_DO_START_MAG_CAL:


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/6640 solved a bug for Sub only; making the code common means everybody can benefit from this sort of fix.

However, the different vehicles currently have several things different between them:
 - Sub and Copter both poked AP_Notify that a reboot was occurring.  No harm in the other vehicles also getting that behaviour
- Plane pokes px4io to disable the mixers.  I've assumed that that is still only relevant for Plane and controlled it with a boolean "should" callback.
 - Sub had some interesting code which iterated through all of the outputs (badly; should be using _servo_count or similar in RCOutput, not NUM_RC_CHANNELS!)
   - I've retained this, also protected by a callback.

We need to work out what everybody should be doing here.  Should all vehicles be doing the same thing when rebooting in terms of mixing and Sub's "no short pwm signal" code?

If these should be the same on every vehicle, should we have a call on AP_HAL to do this "reboot safing"?  Possibly `AP_HAL::reboot` would call that?  At the moment a CLI reboot won't do any of these "safing" procedures, so a reboot in the middle of a motor-test might do interesting things...
