### PR TITLE
Rover: add non-GPS navigation using wheel encoders

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -54,7 +54,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(update_alt,             10,   3400),
     SCHED_TASK(update_beacon,          50,     50),
     SCHED_TASK(update_visual_odom,     50,     50),
-    SCHED_TASK(update_wheel_encoder,   50,     50),
+    SCHED_TASK(update_wheel_encoder,   20,     50),
     SCHED_TASK(navigate,               10,   1600),
     SCHED_TASK(update_compass,         10,   2000),
     SCHED_TASK(update_commands,        10,   1000),

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -269,6 +269,14 @@ void Rover::send_current_waypoint(mavlink_channel_t chan)
     mavlink_msg_mission_current_send(chan, mission.get_current_nav_index());
 }
 
+void Rover::send_wheel_encoder(mavlink_channel_t chan)
+{
+    // send wheel encoder data using rpm message
+    if (g2.wheel_encoder.enabled(0) || g2.wheel_encoder.enabled(1)) {
+        mavlink_msg_rpm_send(chan, wheel_encoder_rpm[0], wheel_encoder_rpm[1]);
+    }
+}
+
 uint8_t GCS_MAVLINK_Rover::sysid_my_gcs() const
 {
     return rover.g.sysid_my_gcs;
@@ -415,6 +423,11 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         send_distance_sensor(rover.rangefinder);
         break;
 
+    case MSG_RPM:
+        CHECK_PAYLOAD_SIZE(RPM);
+        rover.send_wheel_encoder(chan);
+        break;
+
     case MSG_MOUNT_STATUS:
 #if MOUNT == ENABLED
         CHECK_PAYLOAD_SIZE(MOUNT_STATUS);
@@ -481,7 +494,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_TERRAIN:
     case MSG_OPTICAL_FLOW:
     case MSG_GIMBAL_REPORT:
-    case MSG_RPM:
     case MSG_POSITION_TARGET_GLOBAL_INT:
     case MSG_LANDING:
         break;  // just here to prevent a warning
@@ -691,6 +703,7 @@ GCS_MAVLINK_Rover::data_stream_send(void)
         send_message(MSG_MOUNT_STATUS);
         send_message(MSG_EKF_STATUS_REPORT);
         send_message(MSG_VIBRATION);
+        send_message(MSG_RPM);
     }
 }
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -415,6 +415,7 @@ private:
     float wheel_encoder_last_angle_rad[WHEELENCODER_MAX_INSTANCES];     // distance in radians at time of last update to EKF
     uint32_t wheel_encoder_last_update_ms[WHEELENCODER_MAX_INSTANCES];  // system time of last ping from each encoder
     uint32_t wheel_encoder_last_ekf_update_ms;                          // system time of last encoder data push to EKF
+    float wheel_encoder_rpm[WHEELENCODER_MAX_INSTANCES];                // for reporting to GCS
 
     // True when we are doing motor test
     bool motor_test;
@@ -460,6 +461,7 @@ private:
     void send_pid_tuning(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
+    void send_wheel_encoder(mavlink_channel_t chan);
     void gcs_data_stream_send(void);
     void gcs_update(void);
     void gcs_retry_deferred(void);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -411,6 +411,11 @@ private:
     // last visual odometry update time
     uint32_t visual_odom_last_update_ms;
 
+    // last wheel encoder update times
+    float wheel_encoder_last_angle_rad[WHEELENCODER_MAX_INSTANCES];     // distance in radians at time of last update to EKF
+    uint32_t wheel_encoder_last_update_ms[WHEELENCODER_MAX_INSTANCES];  // system time of last ping from each encoder
+    uint32_t wheel_encoder_last_ekf_update_ms;                          // system time of last encoder data push to EKF
+
     // True when we are doing motor test
     bool motor_test;
 

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -95,7 +95,63 @@ void Rover::update_visual_odom()
 // update wheel encoders
 void Rover::update_wheel_encoder()
 {
+    // exit immediately if not enabled
+    if (g2.wheel_encoder.num_sensors() == 0) {
+        return;
+    }
+
+    // update encoders
     g2.wheel_encoder.update();
+
+    // initialise on first iteration
+    uint32_t now = AP_HAL::millis();
+    if (wheel_encoder_last_ekf_update_ms == 0) {
+        wheel_encoder_last_ekf_update_ms = now;
+        for (uint8_t i = 0; i<g2.wheel_encoder.num_sensors(); i++) {
+            wheel_encoder_last_angle_rad[i] = g2.wheel_encoder.get_delta_angle(i);
+            wheel_encoder_last_update_ms[i] = g2.wheel_encoder.get_last_reading_ms(i);
+        }
+        return;
+    }
+
+    // calculate delta angle and delta time and send to EKF
+    // use time of last ping from wheel encoder
+    // send delta time (time between this wheel encoder time and previous wheel encoder time)
+    // in case where wheel hasn't moved, count = 0 (cap the delta time at 50ms - or system time)
+    //     use system clock of last update instead of time of last ping
+    float system_dt = (now - wheel_encoder_last_ekf_update_ms) / 1000.0f;
+    for (uint8_t i = 0; i<g2.wheel_encoder.num_sensors(); i++) {
+
+        // calculate angular change (in radians)
+        float curr_angle_rad = g2.wheel_encoder.get_delta_angle(i);
+        float delta_angle = curr_angle_rad - wheel_encoder_last_angle_rad[i];
+        wheel_encoder_last_angle_rad[i] = curr_angle_rad;
+
+        // calculate delta time
+        float delta_time;
+        uint32_t latest_sensor_update_ms = g2.wheel_encoder.get_last_reading_ms(i);
+        uint32_t sensor_diff_ms = latest_sensor_update_ms - wheel_encoder_last_update_ms[i];
+
+        // if we have not received any sensor updates, or time difference is too high then use time since last update to the ekf
+        // check for old or insane sensor update times
+        if (sensor_diff_ms == 0 || sensor_diff_ms > 100) {
+            delta_time = system_dt;
+            wheel_encoder_last_update_ms[i] = wheel_encoder_last_ekf_update_ms;
+        } else {
+            delta_time = sensor_diff_ms / 1000.0f;
+            wheel_encoder_last_update_ms[i] = latest_sensor_update_ms;
+        }
+
+        /* delAng is the measured change in angular position from the previous measurement where a positive rotation is produced by forward motion of the vehicle (rad)
+         * delTime is the time interval for the measurement of delAng (sec)
+         * timeStamp_ms is the time when the rotation was last measured (msec)
+         * posOffset is the XYZ body frame position of the wheel hub (m)
+         */
+        EKF3.writeWheelOdom(delta_angle, delta_time, wheel_encoder_last_update_ms[i], g2.wheel_encoder.get_position(i), g2.wheel_encoder.get_wheel_radius(i));
+    }
+
+    // record system time update for next iteration
+    wheel_encoder_last_ekf_update_ms = now;
 }
 
 // read_battery - reads battery voltage and current and invokes failsafe

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -148,6 +148,14 @@ void Rover::update_wheel_encoder()
          * posOffset is the XYZ body frame position of the wheel hub (m)
          */
         EKF3.writeWheelOdom(delta_angle, delta_time, wheel_encoder_last_update_ms[i], g2.wheel_encoder.get_position(i), g2.wheel_encoder.get_wheel_radius(i));
+
+        // calculate rpm for reporting to GCS
+        if (is_positive(delta_time)) {
+            wheel_encoder_rpm[i] = (delta_angle / M_2PI) / (delta_time / 60.0f);
+        } else {
+            wheel_encoder_rpm[i] = 0.0f;
+        }
+
     }
 
     // record system time update for next iteration

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1163,6 +1163,23 @@ void NavEKF3::writeBodyFrameOdom(float quality, const Vector3f &delPos, const Ve
     }
 }
 
+/*
+ * Write odometry data from a wheel encoder. The axis of rotation is assumed to be parallel to the vehicle body axis
+ *
+ * delAng is the measured change in angular position from the previous measurement where a positive rotation is produced by forward motion of the vehicle (rad)
+ * delTime is the time interval for the measurement of delAng (sec)
+ * timeStamp_ms is the time when the rotation was last measured (msec)
+ * posOffset is the XYZ body frame position of the wheel hub (m)
+*/
+void NavEKF3::writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset, float radius)
+{
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].writeWheelOdom(delAng, delTime, timeStamp_ms, posOffset, radius);
+        }
+    }
+}
+
 // return data for debugging body frame odometry fusion
 uint32_t NavEKF3::getBodyFrameOdomDebug(int8_t instance, Vector3f &velInnov, Vector3f &velInnovVar)
 {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -548,6 +548,33 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("OGN_HGT_MASK", 50, NavEKF3, _originHgtMode, 0),
 
+    // @Param: VIS_VERR_MIN
+    // @DisplayName: Visual odometry minimum velocity error
+    // @Description: This is the 1-STD odometry velocity observation error that will be assumed when maximum quality is reported by the sensor. When quality is between max and min, the error will be calculated using linear interpolation between VIS_VERR_MIN and VIS_VERR_MAX.
+    // @Range: 0.05 0.5
+    // @Increment: 0.05
+    // @User: Advanced
+    // @Units: m/s
+    AP_GROUPINFO("VIS_VERR_MIN", 51, NavEKF3, _visOdmVelErrMin, 0.1f),
+
+    // @Param: VIS_VERR_MAX
+    // @DisplayName: Visual odometry maximum velocity error
+    // @Description: This is the 1-STD odometry velocity observation error that will be assumed when minimum quality is reported by the sensor. When quality is between max and min, the error will be calculated using linear interpolation between VIS_VERR_MIN and VIS_VERR_MAX.
+    // @Range: 0.5 5.0
+    // @Increment: 0.1
+    // @User: Advanced
+    // @Units: m/s
+    AP_GROUPINFO("VIS_VERR_MAX", 52, NavEKF3, _visOdmVelErrMax, 0.9f),
+
+    // @Param: WENC_VERR
+    // @DisplayName: Wheel odometry velocity error
+    // @Description: This is the 1-STD odometry velocity observation error that will be assumed when wheel encoder data is being fused.
+    // @Range: 0.01 1.0
+    // @Increment: 0.1
+    // @User: Advanced
+    // @Units: m/s
+    AP_GROUPINFO("WENC_VERR", 53, NavEKF3, _wencOdmVelErr, 0.1f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -406,6 +406,10 @@ private:
     AP_Float _accBiasLim;           // Accelerometer bias limit (m/s/s)
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
+    AP_Float _visOdmVelErrMax;      // Observation 1-STD velocity error assumed for visual odometry sensor at lowest reported quality (m/s)
+    AP_Float _visOdmVelErrMin;      // Observation 1-STD velocity error assumed for visual odometry sensor at highest reported quality (m/s)
+    AP_Float _wencOdmVelErr;        // Observation 1-STD velocity error assumed for wheel odometry sensor (m/s)
+
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -213,6 +213,17 @@ public:
     void writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset);
 
     /*
+     * Write odometry data from a wheel encoder. The axis of rotation is assumed to be parallel to the vehicle body axis
+     *
+     * delAng is the measured change in angular position from the previous measurement where a positive rotation is produced by forward motion of the vehicle (rad)
+     * delTime is the time interval for the measurement of delAng (sec)
+     * timeStamp_ms is the time when the rotation was last measured (msec)
+     * posOffset is the XYZ body frame position of the wheel hub (m)
+     * radius is the effective rolling radius of the wheel (m)
+    */
+    void writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset, float radius);
+
+    /*
      * Return data for debugging body frame odometry fusion:
      *
      * velInnov are the XYZ body frame velocity innovations (m/s)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -418,9 +418,16 @@ bool NavEKF3_core::readyToUseOptFlow(void) const
 // return true if the filter is ready to start using body frame odometry measurements
 bool NavEKF3_core::readyToUseBodyOdm(void) const
 {
-    // We need stable roll/pitch angles and gyro bias estimates but do not need the yaw angle aligned to use these measurements
-    return (imuSampleTime_ms - bodyOdmMeasTime_ms < 200)
-            && bodyOdmDataNew.velErr < 1.0f
+
+    // Check for fresh visual odometry data that meets the accuracy required for alignment
+    bool visoDataGood = (imuSampleTime_ms - bodyOdmMeasTime_ms < 200) && (bodyOdmDataNew.velErr < 1.0f);
+
+    // Check for fresh wheel encoder data
+    bool wencDataGood = (imuSampleTime_ms - wheelOdmMeasTime_ms < 200);
+
+    // We require stable roll/pitch angles and gyro bias estimates but do not need the yaw angle aligned to use odometry measurements
+    // becasue they are in a body frame of reference
+    return (visoDataGood || wencDataGood)
             && tiltAlignComplete
             && delAngBiasLearned;
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -214,19 +214,15 @@ void NavEKF3_core::setAidingMode()
             PV_AidingMode = AID_RELATIVE;
         }
     } else if (PV_AidingMode == AID_RELATIVE) {
-         // Check if the optical flow sensor has timed out
-         bool flowSensorTimeout = ((imuSampleTime_ms - flowValidMeaTime_ms) > 5000);
          // Check if the fusion has timed out (flow measurements have been rejected for too long)
          bool flowFusionTimeout = ((imuSampleTime_ms - prevFlowFuseTime_ms) > 5000);
-         // Check if the body odometry flow sensor has timed out
-         bool bodyOdmSensorTimeout = ((imuSampleTime_ms - bodyOdmMeasTime_ms) > 5000);
          // Check if the fusion has timed out (body odometry measurements have been rejected for too long)
          bool bodyOdmFusionTimeout = ((imuSampleTime_ms - prevBodyVelFuseTime_ms) > 5000);
          // Enable switch to absolute position mode if GPS or range beacon data is available
          // If GPS or range beacons data is not available and flow fusion has timed out, then fall-back to no-aiding
          if(readyToUseGPS() || readyToUseRangeBeacon()) {
              PV_AidingMode = AID_ABSOLUTE;
-         } else if ((flowSensorTimeout || flowFusionTimeout) && (bodyOdmSensorTimeout || bodyOdmFusionTimeout)) {
+         } else if (flowFusionTimeout && bodyOdmFusionTimeout) {
              PV_AidingMode = AID_NONE;
          }
      } else if (PV_AidingMode == AID_ABSOLUTE) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -122,9 +122,7 @@ void NavEKF3_core::writeBodyFrameOdom(float quality, const Vector3f &delPos, con
 
     // simple model of accuracy
     // TODO move this calculation outside of EKF into the sensor driver
-    const float minVelErr = 0.5f;
-    const float maxVelErr = 10.0f;
-    bodyOdmDataNew.velErr = minVelErr + (maxVelErr - minVelErr) * (1.0f - 0.01f * quality);
+    bodyOdmDataNew.velErr = frontend->_visOdmVelErrMin + (frontend->_visOdmVelErrMax - frontend->_visOdmVelErrMin) * (1.0f - 0.01f * quality);
 
     storedBodyOdm.push(bodyOdmDataNew);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -136,7 +136,7 @@ void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStam
 
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
-    if (((timeStamp_ms - bodyOdmMeasTime_ms) < frontend->sensorIntervalMin_ms) || (delTime < dtEkfAvg) || !statesInitialised) {
+    if (((timeStamp_ms - wheelOdmMeasTime_ms) < frontend->sensorIntervalMin_ms) || (delTime < dtEkfAvg) || !statesInitialised) {
         return;
     }
 
@@ -145,6 +145,7 @@ void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStam
     wheelOdmDataNew.radius = radius;
     wheelOdmDataNew.delTime = delTime;
     wheelOdmDataNew.time_ms = timeStamp_ms - (uint32_t)(500.0f * delTime);
+    wheelOdmMeasTime_ms = timeStamp_ms;
 
     // becasue we are currently converting to an equivalent velocity measurement before fusing
     // the measurement time is moved back to the middle of the sampling period

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -133,7 +133,7 @@ void NavEKF3_core::writeBodyFrameOdom(float quality, const Vector3f &delPos, con
 void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset, float radius)
 {
     // This is a simple hack to get wheel encoder data into the EKF and verify the interface sign conventions and units
-    // autopilot needs to close to level with road surface.
+    // autopilot needs to be close to level with road surface.
 
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
@@ -150,6 +150,8 @@ void NavEKF3_core::writeWheelOdom(float delAng, float delTime, uint32_t timeStam
     bodyOdmDataNew.velErr = 0.05f;
 
     storedBodyOdm.push(bodyOdmDataNew);
+
+    usingWheelSensors = true; // activates processing that corrrects data for the vehicle pitch when it is fused
 
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -74,7 +74,7 @@ uint32_t NavEKF3_core::getBodyFrameOdomDebug(Vector3f &velInnov, Vector3f &velIn
     velInnovVar.x = varInnovBodyVel[0];
     velInnovVar.y = varInnovBodyVel[1];
     velInnovVar.z = varInnovBodyVel[2];
-    return bodyOdmDataDelayed.time_ms;
+    return MAX(bodyOdmDataDelayed.time_ms,wheelOdmDataDelayed.time_ms);
 }
 
 // return data for debugging range beacon fusion one beacon at a time, incrementing the beacon index after each call

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -958,7 +958,7 @@ void NavEKF3_core::FuseBodyVel()
             }
 
             // calculate intermediate expressions for X axis Kalman gains
-            float R_VEL = bodyOdmDataDelayed.velErr;
+            float R_VEL = sq(bodyOdmDataDelayed.velErr);
             float t2 = q0*q3*2.0f;
             float t3 = q1*q2*2.0f;
             float t4 = t2+t3;
@@ -1130,7 +1130,7 @@ void NavEKF3_core::FuseBodyVel()
             }
 
             // calculate intermediate expressions for Y axis Kalman gains
-            float R_VEL = bodyOdmDataDelayed.velErr;
+            float R_VEL = sq(bodyOdmDataDelayed.velErr);
             float t2 = q0*q3*2.0f;
             float t9 = q1*q2*2.0f;
             float t3 = t2-t9;
@@ -1302,7 +1302,7 @@ void NavEKF3_core::FuseBodyVel()
             }
 
             // calculate intermediate expressions for Z axis Kalman gains
-            float R_VEL = bodyOdmDataDelayed.velErr;
+            float R_VEL = sq(bodyOdmDataDelayed.velErr);
             float t2 = q0*q2*2.0f;
             float t3 = q1*q3*2.0f;
             float t4 = t2+t3;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1564,6 +1564,18 @@ void NavEKF3_core::SelectBodyOdomFusion()
         // start performance timer
         hal.util->perf_begin(_perf_FuseBodyOdom);
 
+        // If wheel encoders are being used, correct the data for the vehicle tilt
+        // using a flat terrain assumption. Wheel encoder data cannot observe any
+        // movement perpendicular to the ground.
+        if (usingWheelSensors) {
+            // rotate the velocity into nav frame
+            Vector3f velNED = prevTnb.mul_transpose(bodyOdmDataDelayed.vel);
+            // zero the vertical component
+            velNED.z = 0.0f;
+            // rotate back into body frame
+            bodyOdmDataDelayed.vel = prevTnb * velNED;
+        }
+
         // Fuse data into the main filter
         FuseBodyVel();
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1595,7 +1595,7 @@ void NavEKF3_core::SelectBodyOdomFusion()
             usingWheelSensors = true;
             bodyOdmDataDelayed.vel = prevTnb * velNED;
             bodyOdmDataDelayed.body_offset = wheelOdmDataNew.hub_offset;
-            bodyOdmDataDelayed.velErr = 0.1f;
+            bodyOdmDataDelayed.velErr = frontend->_wencOdmVelErr;
 
             // Fuse data into the main filter
             FuseBodyVel();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1564,23 +1564,44 @@ void NavEKF3_core::SelectBodyOdomFusion()
         // start performance timer
         hal.util->perf_begin(_perf_FuseBodyOdom);
 
-        // If wheel encoders are being used, correct the data for the vehicle tilt
-        // using a flat terrain assumption. Wheel encoder data cannot observe any
-        // movement perpendicular to the ground.
-        if (usingWheelSensors) {
-            // rotate the velocity into nav frame
-            Vector3f velNED = prevTnb.mul_transpose(bodyOdmDataDelayed.vel);
-            // zero the vertical component
-            velNED.z = 0.0f;
-            // rotate back into body frame
-            bodyOdmDataDelayed.vel = prevTnb * velNED;
-        }
+        usingWheelSensors = false;
 
         // Fuse data into the main filter
         FuseBodyVel();
 
         // stop the performance timer
         hal.util->perf_end(_perf_FuseBodyOdom);
+
+    } else if (storedWheelOdm.recall(wheelOdmDataDelayed, imuDataDelayed.time_ms)) {
+
+        // check if the delta time is too small to calculate a velocity
+        if (wheelOdmDataNew.delTime > EKF_TARGET_DT) {
+
+            // get the forward velocity
+            float fwdSpd = wheelOdmDataNew.delAng * wheelOdmDataNew.radius * (1.0f / wheelOdmDataNew.delTime);
+
+            // get the unit vector from the projection of the X axis onto the horizontal
+            Vector3f unitVec;
+            unitVec.x = prevTnb.a.x;
+            unitVec.y = prevTnb.a.y;
+            unitVec.z = 0.0f;
+            unitVec.normalized();
+
+            // multiply by forward speed to get velocity vector measured by wheel encoders
+            Vector3f velNED = unitVec * fwdSpd;
+
+            // This is a hack to enable use of the existing body frame velocity fusion method
+            // TODO write a dedicated observation model for wheel encoders
+            usingWheelSensors = true;
+            bodyOdmDataDelayed.vel = prevTnb * velNED;
+            bodyOdmDataDelayed.body_offset = wheelOdmDataNew.hub_offset;
+            bodyOdmDataDelayed.velErr = 0.1f;
+
+            // Fuse data into the main filter
+            FuseBodyVel();
+
+        }
+
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -374,6 +374,7 @@ void NavEKF3_core::InitialiseVariables()
     bodyOdmMeasTime_ms = 0;
     bodyVelFusionDelayed = false;
     bodyVelFusionActive = false;
+    usingWheelSensors = false;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -122,7 +122,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOF.init(obs_buffer_length)) {
         return false;
     }
-    if(!storedBodyOdm.init(obs_buffer_length)) {
+    if(!storedBodyOdm.init(imu_buffer_length)) { // initialise to same length of IMU to allow for multiple wheel sensors
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of data to be stored

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -377,6 +377,7 @@ void NavEKF3_core::InitialiseVariables()
     bodyVelFusionDelayed = false;
     bodyVelFusionActive = false;
     usingWheelSensors = false;
+    wheelOdmMeasTime_ms = 0;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -122,7 +122,10 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOF.init(obs_buffer_length)) {
         return false;
     }
-    if(!storedBodyOdm.init(imu_buffer_length)) { // initialise to same length of IMU to allow for multiple wheel sensors
+    if(!storedBodyOdm.init(obs_buffer_length)) {
+        return false;
+    }
+    if(!storedWheelOdm.init(imu_buffer_length)) { // initialise to same length of IMU to allow for multiple wheel sensors
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of data to be stored
@@ -365,7 +368,6 @@ void NavEKF3_core::InitialiseVariables()
     // body frame displacement fusion
     memset(&bodyOdmDataNew, 0, sizeof(bodyOdmDataNew));
     memset(&bodyOdmDataDelayed, 0, sizeof(bodyOdmDataDelayed));
-    bodyOdmStoreIndex = 0;
     lastbodyVelPassTime_ms = 0;
     memset(&bodyVelTestRatio, 0, sizeof(bodyVelTestRatio));
     memset(&varInnovBodyVel, 0, sizeof(varInnovBodyVel));
@@ -386,6 +388,7 @@ void NavEKF3_core::InitialiseVariables()
     storedOutput.reset();
     storedRangeBeacon.reset();
     storedBodyOdm.reset();
+    storedWheelOdm.reset();
 }
 
 // Initialise the states from accelerometer and magnetometer data (if present)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1079,7 +1079,8 @@ private:
     bool bodyVelFusionActive;           // true when body frame velocity fusion is active
 
     // wheel sensor fusion
-    bool usingWheelSensors;             // true when wheel odometry sensors are being used
+    uint32_t wheelOdmMeasTime_ms;       // time wheel odometry measurements were accepted for input to the data buffer (msec)
+    bool usingWheelSensors;             // true when the body frame velocity fusion method should take onbservation data from the wheel odometry buffer
     obs_ring_buffer_t<wheel_odm_elements> storedWheelOdm;    // body velocity data buffer
     wheel_odm_elements wheelOdmDataNew;       // Body frame odometry data at the current time horizon
     wheel_odm_elements wheelOdmDataDelayed;   // Body  frame odometry data at the fusion time horizon

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -498,6 +498,14 @@ private:
         uint32_t        time_ms;    // measurement timestamp (msec)
     };
 
+    struct wheel_odm_elements {
+        float           delAng;     // wheel rotation angle measured in body frame - positive is forward movement of vehicle (rad/s)
+        float           radius;     // wheel radius (m)
+        const Vector3f *hub_offset; // pointer to XYZ position of the wheel hub in body frame (m)
+        float           delTime;    // time interval that the measurement was accumulated over (sec)
+        uint32_t        time_ms;    // measurement timestamp (msec)
+    };
+
     // update the navigation filter status
     void updateFilterStatus(void);
 
@@ -1061,7 +1069,6 @@ private:
     obs_ring_buffer_t<vel_odm_elements> storedBodyOdm;    // body velocity data buffer
     vel_odm_elements bodyOdmDataNew;       // Body frame odometry data at the current time horizon
     vel_odm_elements bodyOdmDataDelayed;  // Body  frame odometry data at the fusion time horizon
-    uint8_t bodyOdmStoreIndex;          // Body  frame odometry  data storage index
     uint32_t lastbodyVelPassTime_ms;    // time stamp when the body velocity measurement last passed innovation consistency checks (msec)
     Vector3 bodyVelTestRatio;           // Innovation test ratios for body velocity XYZ measurements
     Vector3 varInnovBodyVel;            // Body velocity XYZ innovation variances (rad/sec)^2
@@ -1070,7 +1077,12 @@ private:
     uint32_t bodyOdmMeasTime_ms;        // time body velocity measurements were accepted for input to the data buffer (msec)
     bool bodyVelFusionDelayed;          // true when body frame velocity fusion has been delayed
     bool bodyVelFusionActive;           // true when body frame velocity fusion is active
+
+    // wheel sensor fusion
     bool usingWheelSensors;             // true when wheel odometry sensors are being used
+    obs_ring_buffer_t<wheel_odm_elements> storedWheelOdm;    // body velocity data buffer
+    wheel_odm_elements wheelOdmDataNew;       // Body frame odometry data at the current time horizon
+    wheel_odm_elements wheelOdmDataDelayed;   // Body  frame odometry data at the fusion time horizon
 
 
     // Range Beacon Sensor Fusion

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1070,6 +1070,7 @@ private:
     uint32_t bodyOdmMeasTime_ms;        // time body velocity measurements were accepted for input to the data buffer (msec)
     bool bodyVelFusionDelayed;          // true when body frame velocity fusion has been delayed
     bool bodyVelFusionActive;           // true when body frame velocity fusion is active
+    bool usingWheelSensors;             // true when wheel odometry sensors are being used
 
 
     // Range Beacon Sensor Fusion

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -224,6 +224,17 @@ public:
     void writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset);
 
     /*
+     * Write odometry data from a wheel encoder. The axis of rotation is assumed to be parallel to the vehicle body axis
+     *
+     * delAng is the measured change in angular position from the previous measurement where a positive rotation is produced by forward motion of the vehicle (rad)
+     * delTime is the time interval for the measurement of delAng (sec)
+     * timeStamp_ms is the time when the rotation was last measured (msec)
+     * posOffset is the XYZ body frame position of the wheel hub (m)
+     * radius is the effective rolling radius of the wheel (m)
+    */
+    void writeWheelOdom(float delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset, float radius);
+
+    /*
      * Return data for debugging body frame odometry fusion:
      *
      * velInnov are the XYZ body frame velocity innovations (m/s)
@@ -479,7 +490,7 @@ private:
         const Vector3f *body_offset;// pointer to XYZ position of the optical flow sensor in body frame (m)
     };
 
-    struct bfodm_elements {
+    struct vel_odm_elements {
         Vector3f        vel;        // XYZ velocity measured in body frame (m/s)
         float           velErr;     // velocity measurement error 1-std (m/s)
         const Vector3f *body_offset;// pointer to XYZ position of the velocity sensor in body frame (m)
@@ -1047,9 +1058,9 @@ private:
     uint32_t terrainHgtStableSet_ms;        // system time at which terrainHgtStable was set
 
     // body frame odometry fusion
-    obs_ring_buffer_t<bfodm_elements> storedBodyOdm;    // body velocity data buffer
-    bfodm_elements bodyOdmDataNew;       // Body frame odometry data at the current time horizon
-    bfodm_elements bodyOdmDataDelayed;  // Body  frame odometry data at the fusion time horizon
+    obs_ring_buffer_t<vel_odm_elements> storedBodyOdm;    // body velocity data buffer
+    vel_odm_elements bodyOdmDataNew;       // Body frame odometry data at the current time horizon
+    vel_odm_elements bodyOdmDataDelayed;  // Body  frame odometry data at the fusion time horizon
     uint8_t bodyOdmStoreIndex;          // Body  frame odometry  data storage index
     uint32_t lastbodyVelPassTime_ms;    // time stamp when the body velocity measurement last passed innovation consistency checks (msec)
     Vector3 bodyVelTestRatio;           // Innovation test ratios for body velocity XYZ measurements

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -237,8 +237,8 @@ Vector3f AP_WheelEncoder::get_position(uint8_t instance) const
     return _pos_offset[instance];
 }
 
-// get the total distance traveled in meters
-float AP_WheelEncoder::get_distance(uint8_t instance) const
+// get total delta angle (in radians) measured by the wheel encoder
+float AP_WheelEncoder::get_delta_angle(uint8_t instance) const
 {
     // for invalid instances return zero
     if (instance >= WHEELENCODER_MAX_INSTANCES) {
@@ -248,7 +248,14 @@ float AP_WheelEncoder::get_distance(uint8_t instance) const
     if (_counts_per_revolution[instance] == 0) {
         return 0.0f;
     }
-    return M_2PI * _wheel_radius[instance] * state[instance].distance_count / _counts_per_revolution[instance];
+    return M_2PI * state[instance].distance_count / _counts_per_revolution[instance];
+}
+
+// get the total distance traveled in meters
+float AP_WheelEncoder::get_distance(uint8_t instance) const
+{
+    // for invalid instances return zero
+    return get_delta_angle(instance) * _wheel_radius[instance];
 }
 
 // get the total number of sensor reading from the encoder

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -35,18 +35,26 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     AP_GROUPINFO("_SCALING", 1, AP_WheelEncoder, _scaling[0], WHEELENCODER_SCALING_DEFAULT),
 
     // @Param: _POS_X
-    // @DisplayName: WheelEncoder X position
-    // @Description: X position of the first wheel encoder in body frame. Positive X is forward of the origin
+    // @DisplayName: Wheel's X position offset
+    // @Description: X position of the center of the wheel in body frame. Positive X is forward of the origin.
     // @Units: m
-    // @User: Standard
-    AP_GROUPINFO("_POS_X",   2, AP_WheelEncoder, _pos_x[0], 0.0f),
+    // @Increment: 0.01
+    // @User: Advanced
 
     // @Param: _POS_Y
-    // @DisplayName: WheelEncoder Y position
-    // @Description: Y position of the first wheel encoder accelerometer in body frame. Positive Y is to the right of the origin
+    // @DisplayName: Wheel's Y position offset
+    // @Description: Y position of the center of the wheel in body frame. Positive Y is to the right of the origin.
     // @Units: m
-    // @User: Standard
-    AP_GROUPINFO("_POS_Y",   3, AP_WheelEncoder, _pos_y[0], 0.0f),
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS_Z
+    // @DisplayName: Wheel's Z position offset
+    // @Description: Z position of the center of the wheel in body frame. Positive Z is down from the origin.
+    // @Units: m
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("_POS",     3, AP_WheelEncoder, _pos_offset[0], 0.0f),
 
     // @Param: _PINA
     // @DisplayName: Input Pin A
@@ -78,18 +86,26 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     AP_GROUPINFO("2_SCALING",7, AP_WheelEncoder, _scaling[1], WHEELENCODER_SCALING_DEFAULT),
 
     // @Param: 2_POS_X
-    // @DisplayName: WheelEncoder X position
-    // @Description: X position of the first wheel encoder in body frame. Positive X is forward of the origin
+    // @DisplayName: Wheel2's X position offset
+    // @Description: X position of the center of the second wheel in body frame. Positive X is forward of the origin.
     // @Units: m
-    // @User: Standard
-    AP_GROUPINFO("2_POS_X",  8, AP_WheelEncoder, _pos_x[1], 0.0f),
+    // @Increment: 0.01
+    // @User: Advanced
 
-    // @Param: _POS_Y
-    // @DisplayName: WheelEncoder Y position
-    // @Description: Y position of the first wheel encoder accelerometer in body frame. Positive Y is to the right of the origin
+    // @Param: 2_POS_Y
+    // @DisplayName: Wheel2's Y position offset
+    // @Description: Y position of the center of the second wheel in body frame. Positive Y is to the right of the origin.
     // @Units: m
-    // @User: Standard
-    AP_GROUPINFO("2_POS_Y",  9, AP_WheelEncoder, _pos_y[1], 0.0f),
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: 2_POS_Z
+    // @DisplayName: Wheel2's Z position offset
+    // @Description: Z position of the center of the second wheel in body frame. Positive Z is down from the origin.
+    // @Units: m
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("2_POS",    9, AP_WheelEncoder, _pos_offset[1], 0.0f),
 
     // @Param: 2_PINA
     // @DisplayName: Second Encoder Input Pin A
@@ -187,6 +203,15 @@ Vector2f AP_WheelEncoder::get_position(uint8_t instance) const
     return Vector2f(_pos_x[instance],_pos_y[instance]);
 }
 
+// get the total distance travelled in meters
+Vector3f AP_WheelEncoder::get_position(uint8_t instance) const
+{
+    // for invalid instances return zero vector
+    if (instance >= WHEELENCODER_MAX_INSTANCES) {
+        return Vector3f();
+    }
+    return _pos_offset[instance];
+}
 
 // get the total distance traveled in meters
 float AP_WheelEncoder::get_distance(uint8_t instance) const

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -21,7 +21,8 @@
 
 // Maximum number of WheelEncoder measurement instances available on this platform
 #define WHEELENCODER_MAX_INSTANCES      2
-#define WHEELENCODER_SCALING_DEFAULT    0.05f   // default scaling between sensor readings and millimeters
+#define WHEELENCODER_CPR_DEFAULT        3200    // default encoder counts per full revolution of the wheel
+#define WHEELENCODER_RADIUS_DEFAULT     0.05f   // default wheel radius of 5cm (0.05m)
 
 class AP_WheelEncoder_Backend; 
  
@@ -64,6 +65,12 @@ public:
     // return true if the instance is enabled
     bool enabled(uint8_t instance) const;
 
+    // get the counts per revolution of the encoder
+    uint16_t get_counts_per_revolution(uint8_t instance) const;
+
+    // get the wheel radius in meters
+    float get_wheel_radius(uint8_t instance) const;
+
     // get the position of the wheel associated with the wheel encoder
     Vector3f get_position(uint8_t instance) const;
 
@@ -87,7 +94,8 @@ public:
 protected:
     // parameters for each instance
     AP_Int8  _type[WHEELENCODER_MAX_INSTANCES];
-    AP_Float _scaling[WHEELENCODER_MAX_INSTANCES];
+    AP_Int16 _counts_per_revolution[WHEELENCODER_MAX_INSTANCES];
+    AP_Float _wheel_radius[WHEELENCODER_MAX_INSTANCES];
     AP_Vector3f _pos_offset[WHEELENCODER_MAX_INSTANCES];
     AP_Int8  _pina[WHEELENCODER_MAX_INSTANCES];
     AP_Int8  _pinb[WHEELENCODER_MAX_INSTANCES];

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -74,7 +74,10 @@ public:
     // get the position of the wheel associated with the wheel encoder
     Vector3f get_position(uint8_t instance) const;
 
-    // get the total distance traveled in meters
+    // get total delta angle (in radians) measured by the wheel encoder
+    float get_delta_angle(uint8_t instance) const;
+
+    // get the total distance traveled in meters or radians
     float get_distance(uint8_t instance) const;
 
     // get the total number of sensor reading from the encoder

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -65,7 +65,7 @@ public:
     bool enabled(uint8_t instance) const;
 
     // get the position of the wheel associated with the wheel encoder
-    Vector2f get_position(uint8_t instance) const;
+    Vector3f get_position(uint8_t instance) const;
 
     // get the total distance traveled in meters
     float get_distance(uint8_t instance) const;
@@ -88,8 +88,7 @@ protected:
     // parameters for each instance
     AP_Int8  _type[WHEELENCODER_MAX_INSTANCES];
     AP_Float _scaling[WHEELENCODER_MAX_INSTANCES];
-    AP_Float _pos_x[WHEELENCODER_MAX_INSTANCES];
-    AP_Float _pos_y[WHEELENCODER_MAX_INSTANCES];
+    AP_Vector3f _pos_offset[WHEELENCODER_MAX_INSTANCES];
     AP_Int8  _pina[WHEELENCODER_MAX_INSTANCES];
     AP_Int8  _pinb[WHEELENCODER_MAX_INSTANCES];
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
@@ -77,7 +77,7 @@ void AP_WheelEncoder_Quadrature::update(void)
     _state.distance_count = irq_state[instance].distance_count;
     _state.total_count = irq_state[instance].total_count;
     _state.error_count = irq_state[instance].error_count;
-    _state.last_reading_ms = AP_HAL::millis();
+    _state.last_reading_ms = irq_state[instance].last_reading_ms;
 
     // restore interrupts
     irqrestore(istate);
@@ -190,6 +190,9 @@ void AP_WheelEncoder_Quadrature::irq_handler(uint8_t instance, bool pin_a)
 
     // update distance and error counts
     update_phase_and_error_count(pin_a_high, pin_b_high, irq_state[instance].phase, irq_state[instance].distance_count, irq_state[instance].total_count, irq_state[instance].error_count);
+
+    // record update time
+    irq_state[instance].last_reading_ms = AP_HAL::millis();
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
@@ -53,6 +53,7 @@ private:
         int32_t  distance_count;    // distance measured by cumulative steps forward or backwards
         uint32_t total_count;       // total number of successful readings from sensor (used for sensor quality calcs)
         uint32_t error_count;       // total number of errors reading from sensor (used for sensor quality calcs)
+        uint32_t last_reading_ms;   // system time of last update from encoder
     };
     static struct IrqState irq_state[WHEELENCODER_MAX_INSTANCES];
 


### PR DESCRIPTION
This PR allows non-GPS navigation using wheel encoders in place of (or in addition to) a GPS.

The changes to the wheel encoder library include:

- adding _POS_X, Y, Z parameters to the wheel encoder library to allow users to specify the location of the wheels
- replace the _SCALING parameter (which allowed scaling the "pings" from the wheel encoder to a distance travelled) with two parameters:
 - _RADIUS which holds the wheel's radius in meters
 - _CPR which is the counts per revolution (aka "pings" from the wheel encoder per full revolution of the wheel)
- add a "get-delta-angle" method to return the amount the vehicle has rotated since the last update

Changes to the EKF include:

- consume the wheel encoder data (aka wheel odometry) in a similar way to how visual odometry data is consumed.
- new parameters to control when the odometry data is fused
- bug fix to allow the EKF to initialise when only odometry data is provided (i.e. no GPS)

Vehicle changes include:

- reporting the wheel encoder output to the GCS as an RPM
- feed data from wheel encoder into the EKF
- update EKF constructor so the EKF is used by default instead of DCM.  The AHRS can still fall back to DCM in cases where the EKF completely fails (i.e. NaNs appear) but in general it sticks with the EKF.  This is necessary or DCM is constantly used at startup until a GPS position is provided.