### PR TITLE
Compass: disable QMC5883 on pixhawk by default

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -520,12 +520,16 @@ void Compass::_detect_backends(void)
         return;
     }
 
+
+    // default mask to disable some compasses
+    int32_t mask_default = 1U<<DRIVER_QMC5883;
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2) {
         // default to disabling LIS3MDL on pixhawk2 due to hardware issue
-        _driver_type_mask.set_default(1U<<DRIVER_LIS3MDL);
+        mask_default |= 1U<<DRIVER_LIS3MDL;
     }
 #endif
+    _driver_type_mask.set_default(mask_default);
     
 /*
   macro to add a backend with check for too many backends or compass


### PR DESCRIPTION
This driver causes occasional heading issues so disabling until these are resolved.  This issue was discussed and agreed with @tridge before I made this change.

The issue are discussed here: https://github.com/ArduPilot/ardupilot/issues/6633

