### PR TITLE
AP_Compass:Fixed the QMC5883 identification,add check ID

### DIFF
--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -96,11 +96,8 @@ bool AP_Compass_QMC5883L::init()
 
     _dev->set_retries(10);
 
-    uint8_t whoami;
-    if (!_dev->read_registers(QMC5883L_REG_ID, &whoami,1)||
-    		whoami != QMC5883_ID_VAL){
-        // not an QMC5883L
-        goto fail;
+    if(!_check_whoami()){
+    	 goto fail;
     }
 
     if (!_dev->write_register(0x0B, 0x01)||
@@ -142,6 +139,20 @@ bool AP_Compass_QMC5883L::init()
  fail:
     _dev->get_semaphore()->give();
     return false;
+}
+bool AP_Compass_QMC5883L::_check_whoami()
+{
+    uint8_t whoami;
+    //After power on 0x21 == 0x03
+    if (!_dev->read_registers(0x21, &whoami,1)||
+      		whoami != 0x03){
+    	return false;
+    }
+    if (!_dev->read_registers(QMC5883L_REG_ID, &whoami,1)||
+    		whoami != QMC5883_ID_VAL){
+    	return false;
+    }
+    return true;
 }
 
 void AP_Compass_QMC5883L::timer()

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -46,6 +46,7 @@ private:
 					   bool force_external,
                        enum Rotation rotation);
 
+    bool _check_whoami();
     void timer();
     bool init();
 

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -46,6 +46,7 @@ private:
 					   bool force_external,
                        enum Rotation rotation);
 
+    void _dump_registers();
     bool _check_whoami();
     void timer();
     bool init();


### PR DESCRIPTION
Before the ID identification error problem may come up,Add new check ID now.
testing in pixhawk,pixracer.Use HMC5983 and QMC5883,there is no course deflection problem.
@rmackay9 You can test about #6633 issues