### PR TITLE
Copter: add MIN_VOLT arming check by calling AP_Arming

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -53,10 +53,9 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ACCTHRESH",    3,     AP_Arming,  accel_error_threshold,  AP_ARMING_ACCEL_ERROR_THRESHOLD),
 
-#if !APM_BUILD_TYPE(APM_BUILD_ArduCopter)
     // @Param: MIN_VOLT
     // @DisplayName: Minimum arming voltage on the first battery
-    // @Description: The minimum voltage on the first battery to arm, 0 disables the check.  This parameter is relevant for ArduPlane only.
+    // @Description: The minimum voltage on the first battery to arm, 0 disables the check
     // @Units: V
     // @Increment: 0.1 
     // @User: Standard
@@ -64,12 +63,11 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
 
     // @Param: MIN_VOLT2
     // @DisplayName: Minimum arming voltage on the second battery
-    // @Description: The minimum voltage on the first battery to arm, 0 disables the check. This parameter is relevant for ArduPlane only.
+    // @Description: The minimum voltage on the first battery to arm, 0 disables the check
     // @Units: V
     // @Increment: 0.1 
     // @User: Standard
     AP_GROUPINFO("MIN_VOLT2",     5,     AP_Arming,  _min_voltage[1],  0),
-#endif
 
     AP_GROUPEND
 };

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -398,7 +398,7 @@ bool AP_Arming::battery_checks(bool report)
             return false;
         }
 
-        for (int i = 0; i < _battery.num_instances(); i++) {
+        for (uint8_t i = 0; i < _battery.num_instances(); i++) {
             if ((_min_voltage[i] > 0.0f) && (_battery.voltage(i) < _min_voltage[i])) {
                 if (report) {
                     gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Battery %d voltage %.1f below minimum %.1f",

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -53,21 +53,21 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ACCTHRESH",    3,     AP_Arming,  accel_error_threshold,  AP_ARMING_ACCEL_ERROR_THRESHOLD),
 
-    // @Param: MIN_VOLT
-    // @DisplayName: Minimum arming voltage on the first battery
+    // @Param: VOLT_MIN
+    // @DisplayName: Arming voltage minimum on the first battery
     // @Description: The minimum voltage on the first battery to arm, 0 disables the check
     // @Units: V
     // @Increment: 0.1 
     // @User: Standard
-    AP_GROUPINFO("MIN_VOLT",      4,     AP_Arming,  _min_voltage[0],  0),
+    AP_GROUPINFO("VOLT_MIN",      4,     AP_Arming,  _min_voltage[0],  0),
 
-    // @Param: MIN_VOLT2
-    // @DisplayName: Minimum arming voltage on the second battery
+    // @Param: VOLT2_MIN
+    // @DisplayName: Arming voltage minimum on the second battery
     // @Description: The minimum voltage on the first battery to arm, 0 disables the check
     // @Units: V
     // @Increment: 0.1 
     // @User: Standard
-    AP_GROUPINFO("MIN_VOLT2",     5,     AP_Arming,  _min_voltage[1],  0),
+    AP_GROUPINFO("VOLT2_MIN",     5,     AP_Arming,  _min_voltage[1],  0),
 
     AP_GROUPEND
 };


### PR DESCRIPTION
This PR adds an arming check to Copter that the battery voltage is above the ARMING_MIN_VOLT and ARMING_MIN_VOLT2 parameter values.

In addition the following changes are made:

- the check of battery voltage vs _MIN_VOLT/_MIN_VOLT2 is disabled if the flight controller is connected via USB.  If this is controversial we can move the "is-usb-connected" call up into AP_Arming_Copter.
- rename ARMING_MIN_VOLT to ARMING_VOLT_MIN.  This is a nice-to-have for me but if there are strong objections I don't mind this commit being skipped.
- minor change of "int" to "uint8_t"