### PR TITLE
AP_Compass: probe for LIS3MDL in mRo Neo-M8N GPS module

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -593,21 +593,22 @@ void Compass::_detect_backends(void)
                                                                         both_i2c_external, ROTATION_NONE),
                      AP_Compass_AK09916::name, true);
         
-        // lis3mdl
-        ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR),
-                                                              true, ROTATION_YAW_90),
-                    AP_Compass_LIS3MDL::name, true);
-
+        // lis3mdl on bus 0 with default address
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_LIS3MDL_I2C_ADDR),
                                                               both_i2c_external, both_i2c_external?ROTATION_YAW_90:ROTATION_NONE),
                     AP_Compass_LIS3MDL::name, both_i2c_external);
 
-        // external lis3mdl in mRo Neo-M8N GPS module
+        // lis3mdl on bus 0 with alternate address
+        ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_LIS3MDL_I2C_ADDR2),
+                                                              both_i2c_external, both_i2c_external?ROTATION_YAW_90:ROTATION_NONE),
+                    AP_Compass_LIS3MDL::name, both_i2c_external);
+
+        // external lis3mdl on bus 1 with default address
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR),
                                                               true, ROTATION_YAW_90),
                     AP_Compass_LIS3MDL::name, true);
 
-        // external lis3mdl in mRo Neo-M8N GPS module (alternate I2C address)
+        // external lis3mdl on bus 1 with alternate address
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR2),
                                                               true, ROTATION_YAW_90),
                     AP_Compass_LIS3MDL::name, true);

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -597,9 +597,20 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR),
                                                               true, ROTATION_YAW_90),
                     AP_Compass_LIS3MDL::name, true);
+
         ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_LIS3MDL_I2C_ADDR),
                                                               both_i2c_external, both_i2c_external?ROTATION_YAW_90:ROTATION_NONE),
                     AP_Compass_LIS3MDL::name, both_i2c_external);
+
+        // external lis3mdl in mRo Neo-M8N GPS module
+        ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR),
+                                                              true, ROTATION_YAW_90),
+                    AP_Compass_LIS3MDL::name, true);
+
+        // external lis3mdl in mRo Neo-M8N GPS module (alternate I2C address)
+        ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_LIS3MDL_I2C_ADDR2),
+                                                              true, ROTATION_YAW_90),
+                    AP_Compass_LIS3MDL::name, true);
         
         // AK09916
         ADD_BACKEND(DRIVER_AK09916, AP_Compass_AK09916::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_AK09916_I2C_ADDR),

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.h
@@ -25,6 +25,7 @@
 #ifndef HAL_COMPASS_LIS3MDL_I2C_ADDR
 // this can also be on 0x1e
 # define HAL_COMPASS_LIS3MDL_I2C_ADDR 0x1c
+# define HAL_COMPASS_LIS3MDL_I2C_ADDR2 0x1e
 #endif
 
 class AP_Compass_LIS3MDL : public AP_Compass_Backend

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.h
@@ -23,8 +23,10 @@
 #include "AP_Compass_Backend.h"
 
 #ifndef HAL_COMPASS_LIS3MDL_I2C_ADDR
-// this can also be on 0x1e
 # define HAL_COMPASS_LIS3MDL_I2C_ADDR 0x1c
+#endif
+
+#ifndef HAL_COMPASS_LIS3MDL_I2C_ADDR2
 # define HAL_COMPASS_LIS3MDL_I2C_ADDR2 0x1e
 #endif
 


### PR DESCRIPTION
This seems to calibrate and work properly with a prototype GPS module connected to a PixRacer, but I don't understand why I needed to specify ROTATION_YAW_90 in the ADD_BACKEND call.

```
AP_I2C_6 on I2C bus 1 at 0x1e (bus: 100 KHz, max: 100 KHz)
Found a LIS3MDL on 0x1e09 as compass 0

```