### PR TITLE
Arming check function

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -205,6 +205,33 @@ bool AP_Arming::ins_accels_consistent(const AP_InertialSensor &ins)
     return true;
 }
 
+bool AP_Arming::ins_gyros_consistent(const AP_InertialSensor &ins)
+{
+    if (ins.get_gyro_count() <= 1) {
+        return true;
+    }
+
+    const Vector3f &prime_gyro_vec = ins.get_gyro();
+    for(uint8_t i=0; i<ins.get_gyro_count(); i++) {
+        if (!ins.use_gyro(i)) {
+            continue;
+        }
+        // get next gyro vector
+        const Vector3f &gyro_vec = ins.get_gyro(i);
+        Vector3f vec_diff = gyro_vec - prime_gyro_vec;
+        // allow for up to 5 degrees/s difference. Pass if it has
+        // been OK in last 10 seconds
+        if (vec_diff.length() <= radians(5)) {
+            last_gyro_pass_ms[i] = AP_HAL::millis();
+        }
+        if (AP_HAL::millis() - last_gyro_pass_ms[i] > 10000) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool AP_Arming::ins_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
@@ -252,27 +279,11 @@ bool AP_Arming::ins_checks(bool report)
         }
 
         // check all gyros are giving consistent readings
-        if (ins.get_gyro_count() > 1) {
-            const Vector3f &prime_gyro_vec = ins.get_gyro();
-            for(uint8_t i=0; i<ins.get_gyro_count(); i++) {
-                if (!ins.use_gyro(i)) {
-                    continue;
-                }
-                // get next gyro vector
-                const Vector3f &gyro_vec = ins.get_gyro(i);
-                Vector3f vec_diff = gyro_vec - prime_gyro_vec;
-                // allow for up to 5 degrees/s difference. Pass if it has
-                // been OK in last 10 seconds
-                if (vec_diff.length() <= radians(5)) {
-                    last_gyro_pass_ms[i] = AP_HAL::millis();
-                }
-                if (AP_HAL::millis() - last_gyro_pass_ms[i] > 10000) {
-                    if (report) {
-                        gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Gyros inconsistent");
-                    }
-                    return false;
-                }
+        if (!ins_gyros_consistent(ins)) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Gyros inconsistent");
             }
+            return false;
         }
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -166,6 +166,45 @@ bool AP_Arming::logging_checks(bool report)
     return true;
 }
 
+bool AP_Arming::ins_accels_consistent(const AP_InertialSensor &ins)
+{
+    if (ins.get_accel_count() <= 1) {
+        return true;
+    }
+
+    const Vector3f &prime_accel_vec = ins.get_accel();
+    for(uint8_t i=0; i<ins.get_accel_count(); i++) {
+        if (!ins.use_accel(i)) {
+            continue;
+        }
+        // get next accel vector
+        const Vector3f &accel_vec = ins.get_accel(i);
+        Vector3f vec_diff = accel_vec - prime_accel_vec;
+        // allow for user-defined difference, typically 0.75 m/s/s. Has to pass in last 10 seconds
+        float threshold = accel_error_threshold;
+        if (i >= 2) {
+            /*
+              we allow for a higher threshold for IMU3 as it
+              runs at a different temperature to IMU1/IMU2,
+              and is not used for accel data in the EKF
+            */
+            threshold *= 3;
+        }
+
+        // EKF is less sensitive to Z-axis error
+        vec_diff.z *= 0.5f;
+
+        if (vec_diff.length() <= threshold) {
+            last_accel_pass_ms[i] = AP_HAL::millis();
+        }
+        if (AP_HAL::millis() - last_accel_pass_ms[i] > 10000) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool AP_Arming::ins_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
@@ -205,39 +244,11 @@ bool AP_Arming::ins_checks(bool report)
         }
 
         // check all accelerometers point in roughly same direction
-        if (ins.get_accel_count() > 1) {
-            const Vector3f &prime_accel_vec = ins.get_accel();
-            for(uint8_t i=0; i<ins.get_accel_count(); i++) {
-                if (!ins.use_accel(i)) {
-                    continue;
-                }
-                // get next accel vector
-                const Vector3f &accel_vec = ins.get_accel(i);
-                Vector3f vec_diff = accel_vec - prime_accel_vec;
-                // allow for user-defined difference, typically 0.75 m/s/s. Has to pass in last 10 seconds
-                float threshold = accel_error_threshold;
-                if (i >= 2) {
-                    /*
-                      we allow for a higher threshold for IMU3 as it
-                      runs at a different temperature to IMU1/IMU2,
-                      and is not used for accel data in the EKF
-                     */
-                    threshold *= 3;
-                }
-
-                // EKF is less sensitive to Z-axis error
-                vec_diff.z *= 0.5f;
-
-                if (vec_diff.length() <= threshold) {
-                    last_accel_pass_ms[i] = AP_HAL::millis();
-                }
-                if (AP_HAL::millis() - last_accel_pass_ms[i] > 10000) {
-                    if (report) {
-                        gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accels inconsistent");
-                    }
-                    return false;
-                }
+        if (!ins_accels_consistent(ins)) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accels inconsistent");
             }
+            return false;
         }
 
         // check all gyros are giving consistent readings

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -104,4 +104,8 @@ protected:
 
     virtual enum HomeState home_status() const = 0;
 
+private:
+
+    bool ins_accels_consistent(const AP_InertialSensor &ins);
+
 };

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -104,6 +104,9 @@ protected:
 
     virtual enum HomeState home_status() const = 0;
 
+    bool check_enabled(const enum AP_Arming::ArmingChecks check) const;
+    bool check(bool success, bool report, AP_Arming::ArmingChecks check, const char *failmsg, ...) const;
+
 private:
 
     bool ins_accels_consistent(const AP_InertialSensor &ins);

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -107,5 +107,6 @@ protected:
 private:
 
     bool ins_accels_consistent(const AP_InertialSensor &ins);
+    bool ins_gyros_consistent(const AP_InertialSensor &ins);
 
 };


### PR DESCRIPTION
I'm after feedback on this check() function.

This accomplishes two things
 - allows us to sneak up on the always-do-arming-checks patches from a different direction
 - will allow us to easily have a bitmask of arming checks which have failed

Once concern I have is the signature of the check function; the first argument is a boolean which says if the check is passing, the third is a message to emit if the check fails.  that feels a little inconsistent, but having check take a failure boolean doesn't seem right, and I can't see ways to reword the error messages satisfactorily.
