### PR TITLE
DataFlash: add debug for io thread failure

### DIFF
--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -172,6 +172,8 @@ private:
     AP_HAL::Util::perf_counter_t  _perf_fsync;
     AP_HAL::Util::perf_counter_t  _perf_errors;
     AP_HAL::Util::perf_counter_t  _perf_overruns;
+
+    const char *last_io_operation = "";
 };
 
 #endif // HAL_OS_POSIX_IO


### PR DESCRIPTION
I'm quite sure this will show write() is never returning
