### PR TITLE
AP_Arming: Add a check for the minimum satellite count

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -71,6 +71,14 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     AP_GROUPINFO("MIN_VOLT2",     5,     AP_Arming,  _min_voltage[1],  0),
 #endif
 
+    // @Param: GPS_SATS
+    // @DisplayName: Minimum number of GPS satellites
+    // @Description: The minimum number of GPS satellites on the primary GPS to arm the aircraft, set to 0 to disable the check.
+    // @Increment: 1
+    // @Range: 6 15
+    // @User: Standard
+    AP_GROUPINFO("GPS_SATS",      6,     AP_Arming,  _gps_minimum_sats,  6),
+
     AP_GROUPEND
 };
 
@@ -348,6 +356,14 @@ bool AP_Arming::gps_checks(bool report)
             gps.status() < AP_GPS::GPS_OK_FIX_3D) {
             if (report) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Bad GPS Position");
+            }
+            return false;
+        }
+
+        // satellite count
+        if (_gps_minimum_sats > 0 && gps.num_sats() < _gps_minimum_sats) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS too few sats (has %d, needs %d)", gps.num_sats(), _gps_minimum_sats);
             }
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -68,6 +68,7 @@ protected:
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Float                _min_voltage[AP_BATT_MONITOR_MAX_INSTANCES];
+    AP_Int8                 _gps_minimum_sats;
 
     // references
     const AP_AHRS           &ahrs;


### PR DESCRIPTION
This adds a check that the primary GPS instance has at least the minimum number of satellites before arming. This is different then the EKF check that there are 6 satellites before aligning the GPS. Once the EKF has aligned the first time, you no longer need 6 satellites to arm the aircraft, and you could be arming with fewer satellites. The other use case this is meant to cover is that when using multiple GNSS constellations that there should be far more satellites in view then 6, and if there isn't then something is wrong or marginal and the aircraft shouldn't be armed.