### PR TITLE
Plane: don't start a transition while disarmed

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1190,6 +1190,7 @@ void QuadPlane::update_transition(void)
     if (have_airspeed &&
         assistance_needed(aspeed) &&
         !is_tailsitter() &&
+        hal.util->get_soft_armed() &&
         (plane.auto_throttle_mode ||
          plane.channel_throttle->get_control_in()>0 ||
          plane.is_flying())) {


### PR DESCRIPTION
this can caused flooding of the GCS console while disarmed in FBWA
mode