### PR TITLE
AP_HAL_PX4 - UART_Driver: Fixed likely race condition on writing.

### DIFF
--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -4,6 +4,7 @@
 
 #include "AP_HAL_PX4.h"
 #include <systemlib/perf_counter.h>
+#include "Semaphores.h"
 
 class PX4::PX4UARTDriver : public AP_HAL::UARTDriver {
 public:
@@ -68,5 +69,5 @@ private:
     enum flow_control _flow_control;
 
     pid_t _uart_owner_pid;
-
+	Semaphore _write_sem;
 };


### PR DESCRIPTION
Sending Data over UART seemed to strangely not work. In particular this
problem was encountered when trying to configure a TeraRanger Tower
from the pixhawk. Adding a semaphore around accesses of the internal
writebuffer fixed the issue.

This is related to #6595