### PR TITLE
Plane/Copter: Allow Landing to terminate the vehicle

### DIFF
--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -17,20 +17,24 @@ AP_AdvancedFailsafe_Copter::AP_AdvancedFailsafe_Copter(AP_Mission &_mission, AP_
  */
 void AP_AdvancedFailsafe_Copter::terminate_vehicle(void)
 {
-    // stop motors
-    copter.motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
-    copter.motors->output();
+    if (_terminate_action == TERMINATE_ACTION_LAND) {
+        copter.set_mode(LAND, MODE_REASON_TERMINATE);
+    } else {
+        // stop motors
+        copter.motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+        copter.motors->output();
 
-    // disarm as well
-    copter.init_disarm_motors();
+        // disarm as well
+        copter.init_disarm_motors();
     
-    // and set all aux channels
-    SRV_Channels::set_output_limit(SRV_Channel::k_heli_rsc, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_heli_tail_rsc, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_ignition, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        // and set all aux channels
+        SRV_Channels::set_output_limit(SRV_Channel::k_heli_rsc, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_heli_tail_rsc, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_ignition, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+    }
 
     SRV_Channels::output_ch_all();
 }

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -122,6 +122,7 @@ enum mode_reason_t {
     MODE_REASON_AVOIDANCE,
     MODE_REASON_AVOIDANCE_RECOVERY,
     MODE_REASON_THROW_COMPLETE,
+    MODE_REASON_TERMINATE,
 };
 
 // Tuning enumeration

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -17,14 +17,18 @@ void AP_AdvancedFailsafe_Plane::terminate_vehicle(void)
 {
     plane.g2.servo_channels.disable_passthrough(true);
     
-    // and all aux channels
-    SRV_Channels::set_output_scaled(SRV_Channel::k_flap_auto, 100);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_flap, 100);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, SERVO_MAX);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, SERVO_MAX);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, SERVO_MAX);
-    SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+    if (_terminate_action == TERMINATE_ACTION_LAND) {
+        plane.landing.terminate();
+    } else {
+        // aerodynamic termination is the default approach to termination
+        SRV_Channels::set_output_scaled(SRV_Channel::k_flap_auto, 100);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_flap, 100);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, SERVO_MAX);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, SERVO_MAX);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, SERVO_MAX);
+        SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+    }
 
     plane.servos_output();
 

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -45,6 +45,11 @@ public:
         STATE_GPS_LOSS        = 3
     };
 
+    enum terminate_action {
+        TERMINATE_ACTION_TERMINATE = 42,
+        TERMINATE_ACTION_LAND      = 43
+    };
+
     // Constructor
     AP_AdvancedFailsafe(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap) :
         mission(_mission),

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -621,3 +621,17 @@ bool AP_Landing::is_flying_forward(void) const
         return true;
     }
 }
+
+/*
+ * attempt to terminate flight with an immediate landing
+ * returns true if the landing library can and is terminating the landing
+ */
+bool AP_Landing::terminate(void) {
+    switch (type) {
+    case TYPE_DEEPSTALL:
+        return deepstall.terminate();
+    case TYPE_STANDARD_GLIDE_SLOPE:
+    default:
+        return false;
+    }
+}

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -75,6 +75,9 @@ public:
     bool get_target_altitude_location(Location &location);
     bool send_landing_message(mavlink_channel_t chan);
 
+    // terminate the flight with an immediate landing, returns false if unable to be used for termination
+    bool terminate(void);
+
     // helper functions
     bool restart_landing_sequence(void);
     float wind_alignment(const float heading_deg);

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -85,6 +85,7 @@ private:
     int32_t last_target_bearing;   // used for tracking the progress on loitering
     float crosstrack_error; // current crosstrack error
     float predicted_travel_distance; // distance the aircraft is perdicted to travel during deepstall
+    bool hold_level; // locks the target yaw rate of the aircraft to 0, serves to hold the aircraft level at all times
 
     //public AP_Landing interface
     void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);
@@ -100,13 +101,14 @@ private:
     int32_t get_target_airspeed_cm(void) const;
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
+    bool terminate(void);
 
     bool send_deepstall_message(mavlink_channel_t chan) const;
 
     const DataFlash_Class::PID_Info& get_pid_info(void) const;
 
     //private helpers
-    void build_approach_path();
+    void build_approach_path(bool use_current_heading);
     float predict_travel_distance(const Vector3f wind, const float height, const bool print);
     bool verify_breakout(const Location &current_loc, const Location &target_loc, const float height_error) const;
     float update_steering(void);


### PR DESCRIPTION
This adds support for using AP_Landing to terminate the vehicle in flight. At the moment the only landing type allowed to terminate the vehicle is deepstall landings. If AP_Landing doesn't handle the termination request then the behavior is unchanged.

This PR is an extension of #6666 

This has been flight tested and works as expected. The deepstall landing also has a couple of small enhancements, primarily the actual landing code is capable of handling the EKF blowing up on it (and then only relying on the gyro to stabilize the aircraft to the ground). 

The main open question on this is that I added a parameter to deepstall to signify if deepstall landings could be used for terminations. I'm wondering if this should just be a common AP_Landing parameter that must be true, then AP_Landing can ask the landing type if it can actually perform the landing. The advantage of this approach is that it avoids more and more parameters as we create more landing types. The downside is someone might thing they could do a glide slope termination. I've flagged this as a dev call topic to get an answer to this question.