### PR TITLE
Fix reentrant GCS::update()

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -426,6 +426,8 @@ private:
     ///
     uint16_t                    packet_drops;
 
+    bool _in_update;
+
     // waypoints
     uint16_t        waypoint_dest_sysid; // where to send requests
     uint16_t        waypoint_dest_compid; // "

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -888,6 +888,21 @@ void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
 void
 GCS_MAVLINK::update(uint32_t max_time_us)
 {
+    if (_in_update) {
+        /*
+         * We are currently processing a mavlink packet that triggered another
+         * call to update() - don't let this happen: we will just process it
+         * when this one finishes.
+         *
+         * Notice that this only happens if we are currently handling a
+         * mavlink packet, not from any other places like during
+         * initialization in which delay() calls this method.
+         */
+        return;
+    }
+
+    _in_update = true;
+
     // receive new packets
     mavlink_message_t msg;
     mavlink_status_t status;
@@ -969,7 +984,8 @@ GCS_MAVLINK::update(uint32_t max_time_us)
         }
     }
 
-    hal.util->perf_end(_perf_update);    
+    hal.util->perf_end(_perf_update);
+    _in_update = false;
 }
 
 


### PR DESCRIPTION
See commit message with detailed backtrace.

This also changes the Scheduler::delay() call in AP_HAL_Linux so it only allows calls from the main thread.