### PR TITLE
Add support for Sololink for Linux-based boards

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -27,6 +27,7 @@
 #include "RCInput_RPI.h"
 #include "RCInput_Raspilot.h"
 #include "RCInput_SBUS.h"
+#include "RCInput_SoloLink.h"
 #include "RCInput_UART.h"
 #include "RCInput_UDP.h"
 #include "RCInput_115200.h"
@@ -163,7 +164,7 @@ static RCInput_DSM rcinDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
 static RCInput_Multi rcinDriver{2, new RCInput_SBUS, new RCInput_115200("/dev/uart-sumd")};
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
-static RCInput_SBUS rcinDriver;
+static RCInput_SoloLink rcinDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
 static RCInput_Navio2 rcinDriver;
 #else

--- a/libraries/AP_HAL_Linux/RCInput_SoloLink.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_SoloLink.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "RCInput_SoloLink.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+#include <AP_HAL/AP_HAL.h>
+
+#define DEBUG 0
+#if DEBUG
+#define debug(fmt, args...) ::printf(fmt "\n", ##args)
+#else
+#define debug(fmt, args...)
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+using namespace Linux;
+
+RCInput_SoloLink::RCInput_SoloLink()
+{
+    memset(&_packet, 0, sizeof(_packet));
+}
+
+void RCInput_SoloLink::init()
+{
+    if (!_socket.bind("0.0.0.0", PORT)) {
+        AP_HAL::panic("failed to bind UDP socket");
+    }
+
+    // timeout is handled by poll() in SocketAPM
+    _socket.set_blocking(true);
+
+    return;
+}
+
+bool RCInput_SoloLink::_check_hdr(ssize_t len)
+{
+    if (len < (ssize_t) sizeof(_packet)) {
+        hal.console->printf("RCInput: Packet too small (%zd), doesn't contain full frame\n",
+                            len);
+        return false;
+    }
+
+    uint64_t now_usec = AP_HAL::micros64();
+    uint64_t delay = now_usec - _last_usec;
+
+    if (_last_usec != 0 && delay > 40000) {
+        debug("RCInput: no rc cmds received for %llu\n", (unsigned long long)delay);
+    }
+    _last_usec = now_usec;
+
+    uint16_t seq = le16toh(_packet.seq);
+    if (seq - _last_seq > 1) {
+        debug("RCInput: gap in rc cmds : %u\n", seq - _last_seq);
+    }
+    _last_seq = seq;
+
+    return true;
+}
+
+/* TODO: this should be a PollerThread or at least stop using a SchedThread */
+void RCInput_SoloLink::_timer_tick(void)
+{
+    do {
+        uint16_t channels[8];
+        ssize_t r;
+
+        r = _socket.recv(&_packet.buf, sizeof(_packet), 20);
+        if (r < 0) {
+            break;
+        }
+
+        if (!_check_hdr(r)) {
+            break;
+        }
+
+        channels[0] = le16toh(_packet.channel[1]);
+        channels[1] = le16toh(_packet.channel[2]);
+        channels[2] = le16toh(_packet.channel[0]);
+
+        for (unsigned int i = 3; i < 8; i++) {
+            channels[i] = le16toh(_packet.channel[i]);
+        }
+
+
+
+        _update_periods(channels, 8);
+    } while (true);
+}

--- a/libraries/AP_HAL_Linux/RCInput_SoloLink.h
+++ b/libraries/AP_HAL_Linux/RCInput_SoloLink.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <unistd.h>
+
+#include <AP_HAL/utility/Socket.h>
+#include <AP_HAL/utility/sparse-endian.h>
+
+#include "RCInput.h"
+
+namespace Linux {
+
+class RCInput_SoloLink : public RCInput
+{
+public:
+    RCInput_SoloLink();
+
+    void init();
+    void _timer_tick();
+
+private:
+    static const unsigned int PACKET_LEN = 26;
+    static const unsigned int PORT = 5005;
+
+    union packet {
+        struct PACKED {
+            /* changes at every packet */
+            uint32_t _unknown0;
+            /* apparently doesn't change: version? */
+            uint32_t _unknown1;
+            le16_t seq;
+            le16_t channel[8];
+        };
+        uint8_t buf[PACKET_LEN];
+    };
+
+    bool _check_hdr(ssize_t len);
+
+    SocketAPM _socket{true};
+    uint64_t _last_usec = 0;
+    uint16_t _last_seq = 0;
+    union packet _packet;
+};
+
+}

--- a/libraries/AP_HAL_Linux/RCInput_SoloLink.h
+++ b/libraries/AP_HAL_Linux/RCInput_SoloLink.h
@@ -39,10 +39,7 @@ private:
 
     union packet {
         struct PACKED {
-            /* changes at every packet */
-            uint32_t _unknown0;
-            /* apparently doesn't change: version? */
-            uint32_t _unknown1;
+            uint64_t timestamp_usec;
             le16_t seq;
             le16_t channel[8];
         };


### PR DESCRIPTION
This adds support to use the Sololink RC as a WiFi RC for Linux-based boards. For now I'm switching Aero board (not to be confused with aerofc)  to it since there's no other way to use an RC on it nowadays.

Protocol details that I've been able to understand analyzing the network traffic are on the commit messages.

It's not so plug and play, but the effort here was to re-use the RC with little to no modifications to be easier to use it and to continue using it for Solo.
