### PR TITLE
Create and use a check_failed function

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -20,33 +20,23 @@ bool AP_Arming_Rover::pre_arm_rc_checks(const bool display_failure)
         const char *channel_name = channel_names[i];
         // check if radio has been calibrated
         if (!channel->min_max_configured()) {
-            if (display_failure) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: RC %s not configured", channel_name);
-            }
+            check_failed(ARMING_CHECK_RC, display_failure, "RC %s not configured", channel_name);
             return false;
         }
         if (channel->get_radio_min() > 1300) {
-            if (display_failure) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio min too high", channel_name);
-            }
+            check_failed(ARMING_CHECK_RC, display_failure, "%s radio min too high", channel_name);
             return false;
         }
         if (channel->get_radio_max() < 1700) {
-            if (display_failure) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio max too low", channel_name);
-            }
+            check_failed(ARMING_CHECK_RC, display_failure, "%s radio max too low", channel_name);
             return false;
         }
         if (channel->get_radio_trim() < channel->get_radio_min()) {
-            if (display_failure) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim below min", channel_name);
-            }
+            check_failed(ARMING_CHECK_RC, display_failure, "%s radio trim below min", channel_name);
             return false;
         }
         if (channel->get_radio_trim() > channel->get_radio_max()) {
-            if (display_failure) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s radio trim above max", channel_name);
-            }
+            check_failed(ARMING_CHECK_RC, display_failure, "%s radio trim above max", channel_name);
             return false;
         }
     }

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -22,80 +22,61 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
   additional arming checks for plane
 
  */
-bool AP_Arming_Plane::pre_arm_checks(bool report)
+bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
 {
     // call parent class checks
-    bool ret = AP_Arming::pre_arm_checks(report);
+    bool ret = AP_Arming::pre_arm_checks(display_failure);
 
     // Check airspeed sensor
-    ret &= AP_Arming::airspeed_checks(report);
+    ret &= AP_Arming::airspeed_checks(display_failure);
 
     if (plane.g.fs_timeout_long < plane.g.fs_timeout_short && plane.g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
         ret = false;
     }
 
     if (plane.aparm.roll_limit_cd < 300) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: LIM_ROLL_CD too small (%u)", plane.aparm.roll_limit_cd);
-        }
-        ret = false;        
+        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_ROLL_CD too small (%u)", plane.aparm.roll_limit_cd);
+        ret = false;
     }
 
     if (plane.aparm.pitch_limit_max_cd < 300) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: LIM_PITCH_MAX too small (%u)", plane.aparm.pitch_limit_max_cd);
-        }
-        ret = false;        
+        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_PITCH_MAX too small (%u)", plane.aparm.pitch_limit_max_cd);
+        ret = false;
     }
 
     if (plane.aparm.pitch_limit_min_cd > -300) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: LIM_PITCH_MIN too large (%u)", plane.aparm.pitch_limit_min_cd);
-        }
-        ret = false;        
+        check_failed(ARMING_CHECK_NONE, display_failure, "LIM_PITCH_MIN too large (%u)", plane.aparm.pitch_limit_min_cd);
+        ret = false;
     }
 
     if (plane.channel_throttle->get_reverse() && 
         plane.g.throttle_fs_enabled &&
         plane.g.throttle_fs_value < 
         plane.channel_throttle->get_radio_max()) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Invalid THR_FS_VALUE for rev throttle");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "Invalid THR_FS_VALUE for rev throttle");
         ret = false;
     }
 
     if (plane.quadplane.available() && plane.scheduler.get_loop_rate_hz() < 100) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: quadplane needs SCHED_LOOP_RATE > 100");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "quadplane needs SCHED_LOOP_RATE >= 100");
         ret = false;
     }
 
     if (plane.control_mode == AUTO && plane.mission.num_commands() <= 1) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: No mission loaded");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "No mission loaded");
         ret = false;
     }
 
     // check adsb avoidance failsafe
     if (plane.failsafe.adsb) {
-        if (report) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: ADSB threat detected");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "ADSB threat detected");
         ret = false;
     }
 
 #if HAVE_PX4_MIXER
     if (plane.last_mixer_crc == -1) {
-        if (report) {
-            // if you ever get this error, a reboot is recommended.
-            gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Mixer error");
-        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "Mixer error");
         ret = false;
     }
 #endif // CONFIG_HAL_BOARD
@@ -103,10 +84,10 @@ bool AP_Arming_Plane::pre_arm_checks(bool report)
     return ret;
 }
 
-bool AP_Arming_Plane::ins_checks(bool report)
+bool AP_Arming_Plane::ins_checks(bool display_failure)
 {
     // call parent class checks
-    if (!AP_Arming::ins_checks(report)) {
+    if (!AP_Arming::ins_checks(display_failure)) {
         return false;
     }
 
@@ -114,14 +95,11 @@ bool AP_Arming_Plane::ins_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
         if (!ahrs.healthy()) {
-            if (report) {
-                const char *reason = ahrs.prearm_failure_reason();
-                if (reason) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s", reason);
-                } else {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: AHRS not healthy");
-                }
+            const char *reason = ahrs.prearm_failure_reason();
+            if (reason == nullptr) {
+                reason = "AHRS not healthy";
             }
+            check_failed(ARMING_CHECK_INS, display_failure, "%s", reason);
             return false;
         }
     }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -12,19 +12,19 @@ bool AP_Arming_Sub::rc_calibration_checks(bool display_failure)
     return rc_checks_copter_sub(display_failure, channels, false /* check_min_max */);
 }
 
-bool AP_Arming_Sub::pre_arm_checks(bool report)
+bool AP_Arming_Sub::pre_arm_checks(bool display_failure)
 {
     if (armed) {
         return true;
     }
 
-    return AP_Arming::pre_arm_checks(report);
+    return AP_Arming::pre_arm_checks(display_failure);
 }
 
-bool AP_Arming_Sub::ins_checks(bool report)
+bool AP_Arming_Sub::ins_checks(bool display_failure)
 {
     // call parent class checks
-    if (!AP_Arming::ins_checks(report)) {
+    if (!AP_Arming::ins_checks(display_failure)) {
         return false;
     }
 
@@ -32,14 +32,11 @@ bool AP_Arming_Sub::ins_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
         if (!ahrs.healthy()) {
-            if (report) {
-                const char *reason = ahrs.prearm_failure_reason();
-                if (reason) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s", reason);
-                } else {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: AHRS not healthy");
-                }
+            const char *reason = ahrs.prearm_failure_reason();
+            if (reason == nullptr) {
+                reason = "AHRS not healthy";
             }
+            check_failed(ARMING_CHECK_INS, display_failure, "%s", reason);
             return false;
         }
     }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -47,6 +47,7 @@ public:
     // get bitmask of enabled checks
     uint16_t get_enabled_checks();
 
+
     // pre_arm_checks() is virtual so it can be modified in a vehicle specific subclass
     virtual bool pre_arm_checks(bool report);
 
@@ -106,6 +107,13 @@ protected:
 
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4], const bool check_min_max = true) const;
+
+    // returns true if a particular check is enabled
+    bool check_enabled(const enum AP_Arming::ArmingChecks check) const;
+    // returns a mavlink severity which should be used if a specific check fails
+    MAV_SEVERITY check_severity(const enum AP_Arming::ArmingChecks check) const;
+    // handle the case where a check fails
+    void check_failed(const enum AP_Arming::ArmingChecks check, bool report, const char *fmt, ...) const;
 
 private:
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -5,15 +5,19 @@ extern const AP_HAL::HAL& hal;
 /*
   send a text message to all GCS
  */
-void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
+void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
     char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+    hal.util->vsnprintf((char *)text, sizeof(text)-1, fmt, arg_list);
+    send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
+}
+
+void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
+{
     va_list arg_list;
     va_start(arg_list, fmt);
-    hal.util->vsnprintf((char *)text, sizeof(text)-1, fmt, arg_list);
+    send_textv(severity, fmt, arg_list);
     va_end(arg_list);
-    text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = 0;
-    send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
 }
 
 #define FOR_EACH_ACTIVE_CHANNEL(methodcall)          \

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -109,6 +109,7 @@ public:
     void        setup_uart(const AP_SerialManager& serial_manager, AP_SerialManager::SerialProtocol protocol, uint8_t instance);
     void        send_message(enum ap_message id);
     void        send_text(MAV_SEVERITY severity, const char *fmt, ...);
+    void        send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
     void        data_stream_send();
     void        queued_param_send();
     void        queued_waypoint_send();
@@ -580,6 +581,7 @@ public:
     }
 
     void send_text(MAV_SEVERITY severity, const char *fmt, ...);
+    void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
     virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
     void service_statustext(void);
     virtual GCS_MAVLINK &chan(const uint8_t ofs) = 0;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -606,15 +606,18 @@ void GCS_MAVLINK::handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) 
 }
 
 
-void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...)
+void GCS_MAVLINK::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
     char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+    hal.util->vsnprintf((char *)text, sizeof(text)-1, fmt, arg_list);
+    gcs().send_statustext(severity, (1<<chan), text);
+}
+void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...)
+{
     va_list arg_list;
     va_start(arg_list, fmt);
-    hal.util->vsnprintf((char *)text, sizeof(text), fmt, arg_list);
+    send_textv(severity, fmt, arg_list);
     va_end(arg_list);
-    text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = 0;
-    gcs().send_statustext(severity, (1<<chan), text);
 }
 
 void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &dataflash, bool log_radio)


### PR DESCRIPTION
@OXINARF A somewhat less intrusive patch than the `check` function.

Thoughts on this one?  Worth doing if we're not e.g. keeping a bitmask of failed checks?
