### PR TITLE
AP_HAL - RingBuffer: Fixed off by one in space() method.

### DIFF
--- a/libraries/AP_HAL/utility/RingBuffer.cpp
+++ b/libraries/AP_HAL/utility/RingBuffer.cpp
@@ -66,7 +66,9 @@ uint32_t ByteBuffer::space(void) const
         ret = size;
     }
 
-    ret += _head - tail - 1;
+	if(_head != tail) {
+		ret += _head - tail - 1;
+	}
 
     return ret;
 }


### PR DESCRIPTION
Whenever the head and tail indexes were equal space() would be off by
one. This happens in particular right after construction.