### PR TITLE
SITL: Model blocked pitot tubes

### DIFF
--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -33,6 +33,13 @@ void SITL_State::_update_airspeed(float airspeed)
     // Add noise
     airspeed = airspeed + (_sitl->arspd_noise * rand_float());
 
+    if (!is_zero(_sitl->arspd_fail_pressure)) {
+        // compute a realistic pressure report given some level of trapper air pressure in the tube abd our current altitude
+        // algorithim taken from https://en.wikipedia.org/wiki/Calibrated_airspeed#Calculation_from_impact_pressure
+        float tube_pressure = abs(_sitl->arspd_fail_pressure - _barometer->get_pressure() + _sitl->arspd_fail_pitot_pressure);
+        airspeed = 340.29409348 * sqrt(5 * (pow((tube_pressure / 101325.01576 + 1), 2.0/7.0) - 1.0));
+    }
+
     const float airspeed_pressure = (airspeed * airspeed) / airspeed_ratio;
     float airspeed_raw = airspeed_pressure + airspeed_offset;
     if (airspeed_raw / 4 > 0xFFFF) {

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -104,6 +104,8 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("TEMP_TCONST",  3, SITL,  temp_tconst, 30),
     AP_GROUPINFO("TEMP_BFACTOR", 4, SITL,  temp_baro_factor, 0),
     AP_GROUPINFO("GPS_LOCKTIME", 5, SITL,  gps_lock_time, 0),
+    AP_GROUPINFO("ARSPD_FAIL_P", 6, SITL,  arspd_fail_pressure, 0),
+    AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -82,6 +82,8 @@ public:
     AP_Vector3f accel2_bias; // in m/s/s
     AP_Float arspd_noise;  // in m/s
     AP_Float arspd_fail;   // pitot tube failure
+    AP_Float arspd_fail_pressure; // pitot tube failure pressure
+    AP_Float arspd_fail_pitot_pressure; // pitot tube failure pressure
     AP_Float gps_noise; // amplitude of the gps altitude error
     AP_Int16 gps_lock_time; // delay in seconds before GPS gets lock
 


### PR DESCRIPTION
The target of this is to model the effect of a blocked pitot tube in SITL. The simulation is based on a 100% block of the pitot tube, with no leakage or equalization happening as the altitude/airspeed changes. `SIM_AIRSPD_FAIL_P` is a bit of a poor parameter name, but short of inventing a new abbreviation for airspeed I didn't see a great option.

I'm not 100% sold I have the physics quite right with this, it does work, but it is honestly more sensitive to altitude change then I expected it to be.