### PR TITLE
Copter: add Landing gear startup parameter

### DIFF
--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -4,8 +4,8 @@
 // Run landing gear controller at 10Hz
 void Copter::landinggear_update()
 {
-    // exit immediately if no landing gear switch is enabled
-    if (!check_if_auxsw_mode_used(AUXSW_LANDING_GEAR)) {
+    // exit immediately if no landing gear output has been enabled
+    if (!SRV_Channels::function_assigned(SRV_Channel::k_landing_gear_control)) {
         return;
     }
 

--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -4,30 +4,31 @@
 // Run landing gear controller at 10Hz
 void Copter::landinggear_update()
 {
-    // If landing gear control is active, run update function.
-    if (check_if_auxsw_mode_used(AUXSW_LANDING_GEAR)){
-
-        // last status (deployed or retracted) used to check for changes, initialised to startup state of landing gear
-        static bool last_deploy_status = landinggear.deployed();
-
-        // if we are doing an automatic landing procedure, force the landing gear to deploy.
-        // To-Do: should we pause the auto-land procedure to give time for gear to come down?
-        if (control_mode == LAND ||
-           (control_mode == RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent)) ||
-           (control_mode == AUTO && auto_mode == Auto_Land) ||
-           (control_mode == AUTO && auto_mode == Auto_RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent))) {
-            landinggear.set_position(AP_LandingGear::LandingGear_Deploy_And_Keep_Deployed);
-        }
-
-        // send event message to datalog if status has changed
-        if (landinggear.deployed() != last_deploy_status){
-            if (landinggear.deployed()) {
-                Log_Write_Event(DATA_LANDING_GEAR_DEPLOYED);
-            } else {
-                Log_Write_Event(DATA_LANDING_GEAR_RETRACTED);
-            }
-        }
-
-        last_deploy_status = landinggear.deployed();        
+    // exit immediately if no landing gear switch is enabled
+    if (!check_if_auxsw_mode_used(AUXSW_LANDING_GEAR)) {
+        return;
     }
+
+    // last status (deployed or retracted) used to check for changes, initialised to startup state of landing gear
+    static bool last_deploy_status = landinggear.deployed();
+
+    // if we are doing an automatic landing procedure, force the landing gear to deploy.
+    // To-Do: should we pause the auto-land procedure to give time for gear to come down?
+    if (control_mode == LAND ||
+       (control_mode == RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent)) ||
+       (control_mode == AUTO && auto_mode == Auto_Land) ||
+       (control_mode == AUTO && auto_mode == Auto_RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent))) {
+        landinggear.set_position(AP_LandingGear::LandingGear_Deploy_And_Keep_Deployed);
+    }
+
+    // send event message to datalog if status has changed
+    if (landinggear.deployed() != last_deploy_status) {
+        if (landinggear.deployed()) {
+            Log_Write_Event(DATA_LANDING_GEAR_DEPLOYED);
+        } else {
+            Log_Write_Event(DATA_LANDING_GEAR_RETRACTED);
+        }
+    }
+
+    last_deploy_status = landinggear.deployed();
 }

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -250,6 +250,9 @@ void Copter::init_ardupilot()
     init_precland();
 #endif
 
+    // initialise landing gear position
+    landinggear.init();
+
 #ifdef USERHOOK_INIT
     USERHOOK_INIT
 #endif

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -26,8 +26,32 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("SERVO_DEPLOY", 1, AP_LandingGear, _servo_deploy_pwm, AP_LANDINGGEAR_SERVO_DEPLOY_PWM_DEFAULT),
 
+    // @Param: STARTUP
+    // @DisplayName: Landing Gear Startup position
+    // @Description: Landing Gear Startup behaviour control
+    // @Values: 0:WaitForPilotInput, 1:Retract, 2:Deploy
+    // @User: Standard
+    AP_GROUPINFO("STARTUP", 2, AP_LandingGear, _startup_behaviour, (uint8_t)AP_LandingGear::LandingGear_Startup_WaitForPilotInput),
+
     AP_GROUPEND
 };
+
+/// initialise state of landing gear
+void AP_LandingGear::init()
+{
+    switch ((enum LandingGearStartupBehaviour)_startup_behaviour.get()) {
+        default:
+        case LandingGear_Startup_WaitForPilotInput:
+            // do nothing
+            break;
+        case LandingGear_Startup_Retract:
+            retract();
+            break;
+        case LandingGear_Startup_Deploy:
+            deploy();
+            break;
+    }
+}
 
 /// set landing gear position to retract, deploy or deploy-and-keep-deployed
 void AP_LandingGear::set_position(LandingGearCommand cmd)

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -21,12 +21,22 @@ public:
         LandingGear_Deploy_And_Keep_Deployed,
     };
 
+    // Gear command modes
+    enum LandingGearStartupBehaviour {
+        LandingGear_Startup_WaitForPilotInput = 0,
+        LandingGear_Startup_Retract = 1,
+        LandingGear_Startup_Deploy = 2,
+    };
+
     /// Constructor
     AP_LandingGear()
     {
         // setup parameter defaults
         AP_Param::setup_object_defaults(this, var_info);
     }
+
+    /// initialise state of landing gear
+    void init();
 
     /// returns true if the landing gear is deployed
     bool deployed() const { return _deployed; }
@@ -41,6 +51,7 @@ private:
     // Parameters
     AP_Int16    _servo_retract_pwm;     // PWM value to move servo to when gear is retracted
     AP_Int16    _servo_deploy_pwm;      // PWM value to move servo to when gear is deployed
+    AP_Int8     _startup_behaviour;     // start-up behaviour (see LandingGearStartupBehaviour)
 
     // internal variables
     bool        _deployed;              // true if the landing gear has been deployed, initialized false


### PR DESCRIPTION
This PR adds a LGR_STARTUP parameter that allows the user to set the startup behaviour of the landing to:

- wait for pilot input (i.e. output no PWM until the pilot moves the transmitter's auxiliary switch)
- deploy landing gear on startup
- retract landing gear on startup

This PR also includes an unrelated change to enable the landing gear based on whether the SERVOx_FUNCTION has been set (to 29) instead of based on whether the transmitter's auxiliary switch has been setup.  In practice both must be setup to use the landing gear but basing it on the output channel function is more consistent with other features.

This fixes #6651

