### PR TITLE
Rover: Minor fixes for the Windows build

### DIFF
--- a/APMrover2/make.inc
+++ b/APMrover2/make.inc
@@ -47,3 +47,5 @@ LIBRARIES += AP_Beacon
 LIBRARIES += AP_VisualOdom
 LIBRARIES += AP_WheelEncoder
 LIBRARIES += AP_AdvancedFailsafe
+LIBRARIES += AP_Proximity
+LIBRARIES += AC_Fence

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -22,6 +22,8 @@ def build(bld):
             'AP_VisualOdom',
             'AP_AdvancedFailsafe',
             'AP_WheelEncoder',
+            'AP_Proximity',
+            'AC_Fence',
         ],
     )
 


### PR DESCRIPTION
With the recent inclusions of these libraries (AC_Fence and AP_Proximity) the build configuration needed to be updated so waf worked on Windows.  Linux was unaffected.