### PR TITLE
SITL: Fixed build system on Cygwin

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -238,6 +238,10 @@ class sitl(Board):
             env.LIB += [
                 'winmm',
             ]
+            env.AP_LIBRARIES += [
+                'AP_Proximity',
+                'AC_Fence',
+            ]
 
 class linux(Board):
     def configure_env(self, cfg, env):

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -26,7 +26,7 @@
 #ifdef __CYGWIN__
 #include <windows.h>
 #include <time.h>
-#include <Mmsystem.h>
+#include <mmsystem.h>
 #endif
 
 #include <DataFlash/DataFlash.h>


### PR DESCRIPTION
Added required libraries needed for build SITL vehicles on cygwin.

Fixed case sensitive included file for build on cygwin. On case sensitive cygwin feature enabled with this fix it's compile ok.

All waf bin group compile ok.

Enabling case sensitive on Cygwin you need to do this two steps

## **On Cygwin:**

edit **/etc/fstab** file and change the ```posix=0``` value to ```posix=1```. This feature is only for Cygwin.
CMD, POWERSHELL and all Windows enviroment doesn't make effect.

Enabling it, you can do more stuffs like native Nuttx build separatelly out Pixhawk Toolchain and PX4 modules.

**NOTE:** You need to make the changes on the windows registry too to enable the POSIX features on Cygwin.

![cygwin1](https://user-images.githubusercontent.com/6075116/29490203-cf019fa6-8502-11e7-999c-12eaf4a54c86.png)


## **On Windows:**

Case sensitive filenames

In the Win32 subsystem filenames are only case-preserved, but not case-sensitive. You can't access two files in the same directory which only differ by case, like Abc and aBc. While NTFS (and some remote filesystems) support case-sensitivity, the NT kernel does not support it by default. Rather, you have to tweak a registry setting and reboot. For that reason, case-sensitivity can not be supported by Cygwin, unless you change that registry value.

If you really want case-sensitivity in Cygwin, you can switch it on by setting the registry value

HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel\obcaseinsensitive
to 0 and reboot the machine.

source: https://cygwin.com/cygwin-ug-net/using-specialnames.html
