### PR TITLE
waf: added --disable-header-checks

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -167,6 +167,7 @@ class ap_library_check_headers(Task.Task):
     def scan(self):
         r = []
         self.headers = []
+
         srcnode_path = self.generator.bld.srcnode.abspath()
 
         # force dependency scan, if necessary
@@ -196,6 +197,9 @@ class ap_library_check_headers(Task.Task):
 @after_method('process_source')
 def ap_library_register_for_check(self):
     if not hasattr(self, 'compiled_tasks'):
+        return
+
+    if self.env.DISABLE_HEADER_CHECKS:
         return
 
     for t in self.compiled_tasks:

--- a/wscript
+++ b/wscript
@@ -108,6 +108,10 @@ order to save typing.
         default=False,
         help="Disable compilation and test execution")
 
+    g.add_option('--disable-header-checks', action='store_true',
+        default=False,
+        help="Disable checking of headers")
+
     g.add_option('--static',
         action='store_true',
         default=False,
@@ -204,6 +208,12 @@ def configure(cfg):
     if cfg.options.rsync_dest:
         cfg.msg('Setting rsync destination to', cfg.options.rsync_dest)
         cfg.env.RSYNC_DEST = cfg.options.rsync_dest
+
+    if cfg.options.disable_header_checks:
+        cfg.msg('Disabling header checks', cfg.options.disable_header_checks)
+        cfg.env.DISABLE_HEADER_CHECKS = True
+    else:
+        cfg.env.DISABLE_HEADER_CHECKS = False
 
     # TODO: Investigate if code could be changed to not depend on the
     # source absolute path.


### PR DESCRIPTION
the headers checks are most of the re-build time when editing class
headers. Disabling them makes development much faster