### PR TITLE
Rangefinder detection cleanups + i2c bus_detect_mask

### DIFF
--- a/libraries/AP_HAL/I2CDevice.h
+++ b/libraries/AP_HAL/I2CDevice.h
@@ -78,6 +78,7 @@ class I2CDeviceManager {
 public:
     /* Get a device handle */
     virtual OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address) = 0;
+    virtual uint32_t bus_detect_mask() const = 0;
 };
 
 }

--- a/libraries/AP_HAL_PX4/I2CDevice.h
+++ b/libraries/AP_HAL_PX4/I2CDevice.h
@@ -24,6 +24,7 @@
 #include "Semaphores.h"
 #include "I2CWrapper.h"
 #include "Device.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 namespace PX4 {
 
@@ -91,6 +92,19 @@ public:
     }
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address) override;
+
+    uint32_t bus_detect_mask() const override {
+#if   defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
+        return 0x3;
+#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
+        return 0x3;
+#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
+        return 0x3;
+#else
+#error "Unrecognised board"
+#endif
+    }
+
 };
 
 }

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -30,9 +30,9 @@ static RCInput  sitlRCInput(&sitlState);
 static RCOutput sitlRCOutput(&sitlState);
 static AnalogIn sitlAnalogIn(&sitlState);
 static GPIO sitlGPIO(&sitlState);
+static I2CDeviceManager i2c_mgr_instance;
 
 // use the Empty HAL for hardware we don't emulate
-static Empty::I2CDeviceManager i2c_mgr_instance;
 static Empty::SPIDeviceManager emptySPI;
 static Empty::OpticalFlow emptyOpticalFlow;
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -16,6 +16,7 @@
 #include "GPIO.h"
 #include "SITL_State.h"
 #include "Util.h"
+#include "I2CDevice.h"
 
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -1,0 +1,11 @@
+#include <AP_HAL/I2CDevice.h>
+#include <AP_HAL_Empty/I2CDevice.h>
+
+namespace HALSITL {
+
+class I2CDeviceManager : public Empty::I2CDeviceManager {
+public:
+    uint32_t bus_detect_mask() const override { return 0; }
+};
+
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_I2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_I2C.cpp
@@ -1,0 +1,17 @@
+#include "AP_RangeFinder_I2C.h"
+#include <utility>
+#include <AP_HAL/AP_HAL.h>
+
+extern const AP_HAL::HAL &hal;
+
+bool AP_RangeFinder_I2C::probe_buses()
+{
+    uint8_t _addr = addr();
+    for (uint8_t i=0; i<2; i++) {
+        _dev = std::move(hal.i2c_mgr->get_device(i, _addr));
+        if (probe()) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_I2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_I2C.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "RangeFinder_Backend.h"
+#include <AP_HAL/I2CDevice.h>
+
+class AP_RangeFinder_I2C : public AP_RangeFinder_Backend
+{
+
+public:
+
+protected:
+
+    virtual uint8_t addr() const = 0;
+    virtual bool probe() = 0;
+
+    // constructor
+    AP_RangeFinder_I2C(RangeFinder::RangeFinder_State &_state) :
+        AP_RangeFinder_Backend(_state)
+        { }
+
+    bool probe_buses();
+
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+
+private:
+
+};

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -1,34 +1,33 @@
 #pragma once
 
 #include "RangeFinder.h"
-#include "RangeFinder_Backend.h"
-#include <AP_HAL/I2CDevice.h>
+#include "AP_RangeFinder_I2C.h"
 
-class AP_RangeFinder_LightWareI2C : public AP_RangeFinder_Backend
+class AP_RangeFinder_LightWareI2C : public AP_RangeFinder_I2C
 {
+    using AP_RangeFinder_I2C::AP_RangeFinder_I2C;
 
 public:
     // static detection function
-    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state,
-                                          AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state);
 
     // update state
     void update(void);
 
 protected:
 
+    uint8_t addr() const override;
+    bool probe() override;
+
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
         return MAV_DISTANCE_SENSOR_LASER;
     }
 
 private:
-    // constructor
-    AP_RangeFinder_LightWareI2C(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     void init();
     void timer();
 
     // get a reading
     bool get_reading(uint16_t &reading_cm);
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include "RangeFinder.h"
-#include "RangeFinder_Backend.h"
+#include "AP_RangeFinder_I2C.h"
 #include <AP_HAL/I2CDevice.h>
 
-class AP_RangeFinder_TeraRangerI2C : public AP_RangeFinder_Backend
+class AP_RangeFinder_TeraRangerI2C : public AP_RangeFinder_I2C
 {
+    using AP_RangeFinder_I2C::AP_RangeFinder_I2C;
+
 public:
     // static detection function
-    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state,
-                                          AP_HAL::OwnPtr<AP_HAL::I2CDevice> i2c_dev);
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state);
 
     // update state
     void update(void);
@@ -20,17 +21,15 @@ protected:
         return MAV_DISTANCE_SENSOR_LASER;
     }
 
+    uint8_t addr() const override { return 0x30; }
+    bool probe() override;
+
 private:
-    // constructor
-    AP_RangeFinder_TeraRangerI2C(RangeFinder::RangeFinder_State &_state,
-                                 AP_HAL::OwnPtr<AP_HAL::I2CDevice> i2c_dev);
 
     bool measure(void);
     bool collect(uint16_t &distance_cm);
-    
-    bool init(void);    
+
     void timer(void);
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
 
     struct {
         uint32_t sum;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "RangeFinder.h"
-#include "RangeFinder_Backend.h"
+#include "AP_RangeFinder_I2C.h"
 #include <AP_HAL/I2CDevice.h>
 
-class AP_RangeFinder_VL53L0X : public AP_RangeFinder_Backend
+class AP_RangeFinder_VL53L0X : public AP_RangeFinder_I2C
 {
+    using AP_RangeFinder_I2C::AP_RangeFinder_I2C;
 
 public:
+
     // static detection function
-    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state);
 
     // update state
     void update(void);
@@ -20,9 +21,10 @@ protected:
         return MAV_DISTANCE_SENSOR_LASER;
     }
 
+    uint8_t addr() const override { return 0x29; }
+    bool probe() override;
+
 private:
-    // constructor
-    AP_RangeFinder_VL53L0X(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     void init();
     void timer();

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -607,6 +607,7 @@ typedef struct {
 
 static const detect_function_for_type_t detect_functions[] = {
     { RangeFinder::RangeFinder_TYPE_LWI2C, AP_RangeFinder_LightWareI2C::detect },
+    { RangeFinder::RangeFinder_TYPE_VL53L0X, AP_RangeFinder_VL53L0X::detect }
 };
 
 /*
@@ -639,13 +640,6 @@ void RangeFinder::detect_instance(uint8_t instance)
                 _add_backend(AP_RangeFinder_TeraRangerI2C::detect(state[instance],
                                                                   hal.i2c_mgr->get_device(0, state[instance].address)));
             }
-        }
-        break;
-    case RangeFinder_TYPE_VL53L0X:
-        if (!_add_backend(AP_RangeFinder_VL53L0X::detect(state[instance],
-                                                         hal.i2c_mgr->get_device(1, 0x29)))) {
-            _add_backend(AP_RangeFinder_VL53L0X::detect(state[instance],
-                                                        hal.i2c_mgr->get_device(0, 0x29)));
         }
         break;
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4  || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -607,7 +607,8 @@ typedef struct {
 
 static const detect_function_for_type_t detect_functions[] = {
     { RangeFinder::RangeFinder_TYPE_LWI2C, AP_RangeFinder_LightWareI2C::detect },
-    { RangeFinder::RangeFinder_TYPE_VL53L0X, AP_RangeFinder_VL53L0X::detect }
+    { RangeFinder::RangeFinder_TYPE_VL53L0X, AP_RangeFinder_VL53L0X::detect },
+    { RangeFinder::RangeFinder_TYPE_TRI2C, AP_RangeFinder_TeraRangerI2C::detect },
 };
 
 /*
@@ -632,15 +633,6 @@ void RangeFinder::detect_instance(uint8_t instance)
         break;
     case RangeFinder_TYPE_MBI2C:
         _add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance]));
-        break;
-    case RangeFinder_TYPE_TRI2C:
-        if (state[instance].address) {
-            if (!_add_backend(AP_RangeFinder_TeraRangerI2C::detect(state[instance],
-                                                                   hal.i2c_mgr->get_device(1, state[instance].address)))) {
-                _add_backend(AP_RangeFinder_TeraRangerI2C::detect(state[instance],
-                                                                  hal.i2c_mgr->get_device(0, state[instance].address)));
-            }
-        }
         break;
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4  || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     case RangeFinder_TYPE_PX4_PWM:

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -606,6 +606,7 @@ typedef struct {
 }  detect_function_for_type_t;
 
 static const detect_function_for_type_t detect_functions[] = {
+    { RangeFinder::RangeFinder_TYPE_LWI2C, AP_RangeFinder_LightWareI2C::detect },
 };
 
 /*
@@ -630,12 +631,6 @@ void RangeFinder::detect_instance(uint8_t instance)
         break;
     case RangeFinder_TYPE_MBI2C:
         _add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance]));
-        break;
-    case RangeFinder_TYPE_LWI2C:
-        if (state[instance].address) {
-            _add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance],
-                hal.i2c_mgr->get_device(HAL_RANGEFINDER_LIGHTWARE_I2C_BUS, state[instance].address)));
-        }
         break;
     case RangeFinder_TYPE_TRI2C:
         if (state[instance].address) {

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -600,12 +600,27 @@ bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend)
     return true;
 }
 
+typedef struct {
+    uint8_t type; // type narrowed from uint32_t
+    AP_RangeFinder_Backend *(*detect)(RangeFinder::RangeFinder_State &);
+}  detect_function_for_type_t;
+
+static const detect_function_for_type_t detect_functions[] = {
+};
+
 /*
   detect if an instance of a rangefinder is connected. 
  */
 void RangeFinder::detect_instance(uint8_t instance)
 {
     enum RangeFinder_Type _type = (enum RangeFinder_Type)state[instance].type.get();
+    for (uint8_t i=0;i<ARRAY_SIZE(detect_functions);i++) {
+        if (detect_functions[i].type != _type) {
+            continue;
+        }
+        _add_backend(detect_functions[i].detect(state[instance]));
+    }
+
     switch (_type) {
     case RangeFinder_TYPE_PLI2C:
     case RangeFinder_TYPE_PLI2CV3:


### PR DESCRIPTION
This a RFC WIP PR.

It contains patches from previous PRs, the topmost being #6738 

The patch consists of three changes:
(1) Make the RangeFinder class unaware of how a backend is constructed, what resources it needs.  In this case the i2c backends use AP_HAL to retrieve the i2c devices they require
(2) Require all HALs to provide a bus_detect_mask describing which buses it is sensible to probe for drivers on
(3) Allow detection of multiple instances of each backend type, at least one on each bus but more if the specific backend understands an address parameter.

The patches are obviously not complete:
 - each of the i2c backends would want to move the just having their detect function in `RangeFinder.cpp`
 - the Serial backends have a lot of duplicated code, so creating an `AP_RangeFinder_Serial` and  moving them to the same detect mechanism will save text
 - HALs other than SITL and px4 need to specify the bus detect mask (does it need to be 64-bit for Linux?)
 - notionally the i2c manager could handle the iteration across the bus mask, and thus driver ownership of an I2CDevice
