### PR TITLE
HAL - i2c detect mask

### DIFF
--- a/libraries/AP_HAL/I2CDevice.h
+++ b/libraries/AP_HAL/I2CDevice.h
@@ -78,6 +78,7 @@ class I2CDeviceManager {
 public:
     /* Get a device handle */
     virtual OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address) = 0;
+    virtual uint32_t bus_detect_mask() const = 0;
 };
 
 }

--- a/libraries/AP_HAL_PX4/I2CDevice.h
+++ b/libraries/AP_HAL_PX4/I2CDevice.h
@@ -24,6 +24,7 @@
 #include "Semaphores.h"
 #include "I2CWrapper.h"
 #include "Device.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 namespace PX4 {
 
@@ -91,6 +92,23 @@ public:
     }
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address) override;
+
+    uint32_t bus_detect_mask() const override {
+#if   defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
+        return 0x3;
+#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
+#if defined HAL_BOARD_SUBTYPE_PX4_V3
+        // also probe on bus 2 on The Cube
+        return 0x7;
+#endif
+        return 0x3;
+#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
+        return 0x3;
+#else
+#error "Unrecognised board"
+#endif
+    }
+
 };
 
 }

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -30,9 +30,9 @@ static RCInput  sitlRCInput(&sitlState);
 static RCOutput sitlRCOutput(&sitlState);
 static AnalogIn sitlAnalogIn(&sitlState);
 static GPIO sitlGPIO(&sitlState);
+static I2CDeviceManager i2c_mgr_instance;
 
 // use the Empty HAL for hardware we don't emulate
-static Empty::I2CDeviceManager i2c_mgr_instance;
 static Empty::SPIDeviceManager emptySPI;
 static Empty::OpticalFlow emptyOpticalFlow;
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -16,6 +16,7 @@
 #include "GPIO.h"
 #include "SITL_State.h"
 #include "Util.h"
+#include "I2CDevice.h"
 
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -1,0 +1,11 @@
+#include <AP_HAL/I2CDevice.h>
+#include <AP_HAL_Empty/I2CDevice.h>
+
+namespace HALSITL {
+
+class I2CDeviceManager : public Empty::I2CDeviceManager {
+public:
+    uint32_t bus_detect_mask() const override { return 0; }
+};
+
+}


### PR DESCRIPTION
@OXINARF asked me to pull this out as a separate PR for discussion from the original PR (https://github.com/ArduPilot/ardupilot/pull/6741)

This PR is incomplete - I've only done two HALs, and I'm pretty sure the detect masks for the PX4 HAL aren't correct.

An example of using the mask is here: https://github.com/ArduPilot/ardupilot/pull/6741/commits/c8da760ed9efe4de89c01d7a1dabe78df3620169#diff-6a46a6784670624eeb9f22a28da031a3R26  . I'm not sure we couldn't do this iteration/ownership-checking in the HAL i2c-mgr itself - in the future...
