### PR TITLE
GCS_MAVLink: allow statustext logging from any source system

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1704,14 +1704,24 @@ void GCS_MAVLINK::handle_statustext(mavlink_message_t *msg)
     if (df == nullptr) {
         return;
     }
-    // ignore any statustext messages not from our GCS:
-    if (msg->sysid != sysid_my_gcs()) {
-        return;
-    }
+
     mavlink_statustext_t packet;
     mavlink_msg_statustext_decode(msg, &packet);
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1+4] = { 'G','C','S',':'};
-    memcpy(&text[4], packet.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    const uint8_t max_prefix_len = 20;
+    const uint8_t text_len = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1+max_prefix_len;
+    char text[text_len] = { 'G','C','S',':'};
+    uint8_t offset = strlen(text);
+
+    if (msg->sysid != sysid_my_gcs()) {
+        offset = hal.util->snprintf(text,
+                                    max_prefix_len,
+                                    "SRC=%u/%u:",
+                                    msg->sysid,
+                                    msg->compid);
+    }
+
+    memcpy(&text[offset], packet.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+
     df->Log_Write_Message(text);
 }
 


### PR DESCRIPTION
Turns out this is terribly useful for companion computers if
you allow them to log things when they're not your GCS.

The original check was bogus; if someone is talking to you via
mavlink they can do much worse than fill your logs!