### PR TITLE
probe external ist8310 compass on I2C1

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -578,6 +578,9 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_QMC5883, AP_Compass_QMC5883L::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_QMC5883L_I2C_ADDR),
                 								both_i2c_external, both_i2c_external?ROTATION_ROLL_180:ROTATION_YAW_270),
         			AP_Compass_QMC5883L::name,both_i2c_external);
+		//external i2c bus
+		ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_IST8310_I2C_ADDR),
+                                                ROTATION_PITCH_180_YAW_270), AP_Compass_IST8310::name, true);
         
 #if !HAL_MINIMIZE_FEATURES
         // AK09916 on ICM20948


### PR DESCRIPTION
HMC5883/5983 is difficult to purchase right now. IST8310 can be used as a external compass to instead of HMC5883.

I has tested it with a pixhawk flight controller. It works well. The I2C address of IST8310 is 0x0E.