### PR TITLE
Plane: attitude.cpp roll limit clarification / tweak to close https://github.com/ArduPilot/ardupilot/issues/6747

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -621,7 +621,7 @@ void Plane::update_flight_mode(void)
     case TRAINING: {
         training_manual_roll = false;
         training_manual_pitch = false;
-        update_load_factor();
+        update_stall_factor();
         
         // if the roll is past the set roll limit, then
         // we set target roll to the limit
@@ -670,7 +670,7 @@ void Plane::update_flight_mode(void)
         // set nav_roll and nav_pitch using sticks
         nav_roll_cd  = channel_roll->norm_input() * roll_limit_cd;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
-        update_load_factor();
+        update_stall_factor();
         float pitch_input = channel_pitch->norm_input();
         if (pitch_input > 0) {
             nav_pitch_cd = pitch_input * aparm.pitch_limit_max_cd;
@@ -705,7 +705,7 @@ void Plane::update_flight_mode(void)
         // Thanks to Yury MonZon for the altitude limit code!
         nav_roll_cd = channel_roll->norm_input() * roll_limit_cd;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
-        update_load_factor();
+        update_stall_factor();
         update_fbwb_speed_height();
         break;
         
@@ -724,7 +724,7 @@ void Plane::update_flight_mode(void)
         if (!cruise_state.locked_heading) {
             nav_roll_cd = channel_roll->norm_input() * roll_limit_cd;
             nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
-            update_load_factor();
+            update_stall_factor();
         } else {
             calc_nav_roll();
         }
@@ -743,7 +743,7 @@ void Plane::update_flight_mode(void)
         // holding altitude at the altitude we set when we
         // switched into the mode
         nav_roll_cd  = roll_limit_cd / 3;
-        update_load_factor();
+        update_stall_factor();
         calc_nav_pitch();
         calc_throttle();
         break;
@@ -930,7 +930,7 @@ void Plane::update_alt()
                                                  get_takeoff_pitch_min_cd(),
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
-                                                 aerodynamic_load_factor);
+                                                 stall_factor);
     }
 }
 

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -556,7 +556,7 @@ void Plane::calc_nav_roll()
     }
 
     nav_roll_cd = constrain_int32(commanded_roll, -roll_limit_cd, roll_limit_cd);
-    update_load_factor();
+    update_stall_factor();
 }
 
 
@@ -653,15 +653,15 @@ void Plane::adjust_nav_pitch_throttle(void)
   calculate a new aerodynamic_load_factor and limit nav_roll_cd to
   ensure that the aircraft can achieve required airspeed to maintain altitude in turns
  */
-void Plane::update_load_factor(void)
+void Plane::update_stall_factor(void)
 {
     float demanded_roll = fabsf(nav_roll_cd*0.01f);
     if (demanded_roll > 85) {
         // limit to 85 degrees to prevent numerical errors
         demanded_roll = 85;
     }
-    aerodynamic_load_factor = 1.0f / cosf(radians(demanded_roll)); // limited to ~11.5g at 85 deg
-    stall_factor = safe_sqrt(aerodynamic_load_factor); // stall speed increases with sqrt of load factor
+        stall_factor = safe_sqrt(1.0f / cosf(radians(demanded_roll))); // limited to ~11.5g at 85 deg
+        // stall speed increases with sqrt of aerodynamic load factor
 
     if (!aparm.stall_prevention) {
         // stall prevention is disabled

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -651,8 +651,7 @@ void Plane::adjust_nav_pitch_throttle(void)
 
 /*
   calculate a new aerodynamic_load_factor and limit nav_roll_cd to
-  ensure that the load factor does not take us below the sustainable
-  airspeed
+  ensure that the aircraft can achieve required airspeed to maintain altitude in turns
  */
 void Plane::update_load_factor(void)
 {
@@ -661,7 +660,8 @@ void Plane::update_load_factor(void)
         // limit to 85 degrees to prevent numerical errors
         demanded_roll = 85;
     }
-    aerodynamic_load_factor = 1.0f / safe_sqrt(cosf(radians(demanded_roll)));
+    aerodynamic_load_factor = 1.0f / cosf(radians(demanded_roll)); // limited to ~11.5g at 85 deg
+    stall_factor = safe_sqrt(aerodynamic_load_factor); // stall speed increases with sqrt of load factor
 
     if (!aparm.stall_prevention) {
         // stall prevention is disabled
@@ -677,23 +677,17 @@ void Plane::update_load_factor(void)
     }
        
 
-    float max_load_factor = smoothed_airspeed / aparm.airspeed_min;
-    if (max_load_factor <= 1) {
-        // our airspeed is below the minimum airspeed. Limit roll to
-        // 25 degrees
+    float stall_ratio = smoothed_airspeed / (aparm.airspeed_min * stall_factor); // airspeed / corrected stall speed
+    if (stall_ratio <= 1.1) { //conditions for stall plus 10% margin.
+        //We always allow at least 25 degrees of roll however, to ensure the
+        // aircraft can be maneuvered with a bad airspeed estimate. At
+        // 25 degrees the stall ratio is 1.1 (10%)
         nav_roll_cd = constrain_int32(nav_roll_cd, -2500, 2500);
         roll_limit_cd = constrain_int32(roll_limit_cd, -2500, 2500);
-    } else if (max_load_factor < aerodynamic_load_factor) {
-        // the demanded nav_roll would take us past the aerodymamic
-        // load limit. Limit our roll to a bank angle that will keep
-        // the load within what the airframe can handle. We always
-        // allow at least 25 degrees of roll however, to ensure the
-        // aircraft can be maneuvered with a bad airspeed estimate. At
-        // 25 degrees the load factor is 1.1 (10%)
-        int32_t roll_limit = degrees(acosf(sq(1.0f / max_load_factor)))*100;
-        if (roll_limit < 2500) {
-            roll_limit = 2500;
-        }
+    } else if (stall_ratio > 1.1) {
+        // Flight envelope protection to limit our roll to a bank angle that will keep
+        // the aircraft above stall at turn entry speed.
+        int32_t roll_limit = degrees(acosf(sq(1.0f / stall_ratio)))*100;
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
         roll_limit_cd = constrain_int32(roll_limit_cd, -roll_limit, roll_limit);
     }    

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -590,9 +590,9 @@ private:
     // we separate out rudder input to allow for RUDDER_ONLY=1
     int16_t rudder_input;
 
-    // the aerodymamic load factor. This is calculated from the demanded
-    // roll before the roll is clipped, using 1/sqrt(cos(nav_roll))
-    float aerodynamic_load_factor = 1.0f;
+    // the increase in stall speed due to G force in turns. This is calculated from the demanded
+    // roll before the roll is clipped, using sqrt(aerodynamic_load_factor)
+    float stall_factor = 1.0f;
 
     // a smoothed airspeed estimate, used for limiting roll angle
     float smoothed_airspeed;
@@ -801,7 +801,7 @@ private:
 #endif // CONFIG_HAL_BOARD
     
     void adjust_nav_pitch_throttle(void);
-    void update_load_factor(void);
+    void update_stall_factor(void);
     void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);


### PR DESCRIPTION
Clarification for load factor to close https://github.com/ArduPilot/ardupilot/issues/6747
This is not a sophisticated flight envelope protection implementation, as structural limits are unknown and unbounded, stall speed is based on user param, and aircraft configuration is assumed to be that for which aparm.airspeed_min applies (ie flap/crow state is unknown).
I've left the 85 degree limit alone, although suggest that 75 degrees (2 x stall speed, 4G load factor) is probably safer, and suggest that a user defined "G Limit" param would be useful in the future.  Ultimately this upper bound is going to be arbitrarily defined for most ArduPilot implementations, but high end users/manufacturers should be advised that this is the case.