### PR TITLE
AP_COMPASS.CPP/PX4.h: probe external Ist8310 for px4fmu_v2

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -551,6 +551,11 @@ void Compass::_detect_backends(void)
 #if HAL_COMPASS_DEFAULT == HAL_COMPASS_HIL
     ADD_BACKEND(DRIVER_SITL, AP_Compass_HIL::detect(*this), nullptr, false);
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_PX4 || HAL_COMPASS_DEFAULT == HAL_COMPASS_VRBRAIN
+    if(AP_BoardConfig::get_board_type()== AP_BoardConfig::PX4_BOARD_PIXHAWK2){
+	//external i2c bus
+			ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_IST8310_I2C_ADDR),
+													ROTATION_PITCH_180_YAW_270), AP_Compass_IST8310::name, true);
+    }
     switch (AP_BoardConfig::get_board_type()) {
     case AP_BoardConfig::PX4_BOARD_PX4V1:
     case AP_BoardConfig::PX4_BOARD_PIXHAWK:
@@ -578,9 +583,6 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_QMC5883, AP_Compass_QMC5883L::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_QMC5883L_I2C_ADDR),
                 								both_i2c_external, both_i2c_external?ROTATION_ROLL_180:ROTATION_YAW_270),
         			AP_Compass_QMC5883L::name,both_i2c_external);
-		//external i2c bus
-		ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_IST8310_I2C_ADDR),
-                                                ROTATION_PITCH_180_YAW_270), AP_Compass_IST8310::name, true);
         
 #if !HAL_MINIMIZE_FEATURES
         // AK09916 on ICM20948

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -578,6 +578,9 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_QMC5883, AP_Compass_QMC5883L::probe(*this, hal.i2c_mgr->get_device(0, HAL_COMPASS_QMC5883L_I2C_ADDR),
                 								both_i2c_external, both_i2c_external?ROTATION_ROLL_180:ROTATION_YAW_270),
         			AP_Compass_QMC5883L::name,both_i2c_external);
+		//external i2c bus
+		ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(*this, hal.i2c_mgr->get_device(1, HAL_COMPASS_IST8310_I2C_ADDR),
+                                                ROTATION_PITCH_180_YAW_270), AP_Compass_IST8310::name, true);
         
 #if !HAL_MINIMIZE_FEATURES
         // AK09916 on ICM20948

--- a/libraries/AP_HAL/board/px4.h
+++ b/libraries/AP_HAL/board/px4.h
@@ -85,6 +85,11 @@
 #define HAL_PX4_HAVE_PWM_INPUT 0
 #endif
 
+/* px4fmu-v2 */
+#ifdef CONFIG_ARCH_BOARD_PX4FMU_V2
+#define HAL_COMPASS_IST8310_I2C_ADDR 0x0E
+#endif
+
 /* px4fmu-v4 */
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V4
 #define HAL_PX4_HAVE_PX4IO 0


### PR DESCRIPTION
IST8310 can be used as a external compass to insttead of HMC5883/5983.  I build the project and flash ArduCopter-v2.px4 firmware into a PX4FMU-V2.4.6 FC board.  I can calibrate the external IST8310 compass in mission planner.  I fly in PosHold flight mode. It looks good. 