### PR TITLE
Plane: Move takeoff state into local statics

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -419,13 +419,6 @@ private:
         uint32_t lock_timer_ms;
     } cruise_state;
 
-    struct {
-        uint32_t last_tkoff_arm_time;
-        uint32_t last_check_ms;
-        uint32_t last_report_ms;
-        bool launchTimerStarted;
-    } takeoff_state;
-    
     // ground steering controller state
     struct {
         // Direction held during phases of takeoff and landing centidegrees


### PR DESCRIPTION
This is a 0 functional change, and instead is a style change.

I found it annoying when reading through this code to have all these fields that lived in a common structure, that are only used in side a single function. To me this implies its used elsewhere in the code base, and I kept having to check that no in fact this variable is only used within this function. When the entire takeoff_state is only used inside this function I find it much easier for these to be local statics.

Not only does it clearly delimit the scope that this takeoff state is needed for, I found it improved readability by removing all the `takeoff_state.` prefixes everywhere.

As far as binary size this apparently results in a slightly smaller binary as well, although that wasn't the point.

Master:
```
Target         Text     Data  BSS    Total  
--------------------------------------------
bin/arduplane  1007048  2840  56248  1066136
```

This patch:
```
Target         Text     Data  BSS    Total  
--------------------------------------------
bin/arduplane  1007032  2840  56248  1066120
```