### PR TITLE
Fix fall-through warnings

### DIFF
--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -748,14 +748,14 @@ bool Copter::verify_payload_place()
         // we're there; set loiter target
         auto_payload_place_start(wp_nav->get_wp_destination());
         nav_payload_place.state = PayloadPlaceStateType_Calibrating_Hover_Start;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Calibrating_Hover_Start:
         // hover for 1 second to get an idea of what our hover
         // throttle looks like
         debug("Calibrate start");
         nav_payload_place.hover_start_timestamp = now;
         nav_payload_place.state = PayloadPlaceStateType_Calibrating_Hover;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Calibrating_Hover: {
         if (now - nav_payload_place.hover_start_timestamp < hover_throttle_calibrate_time) {
             // still calibrating...
@@ -768,13 +768,13 @@ bool Copter::verify_payload_place()
         gcs().send_text(MAV_SEVERITY_INFO, "hover throttle delta: %f", static_cast<double>(hover_throttle_delta));
         nav_payload_place.state = PayloadPlaceStateType_Descending_Start;
         }
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Descending_Start:
         nav_payload_place.descend_start_timestamp = now;
         nav_payload_place.descend_start_altitude = inertial_nav.get_altitude();
         nav_payload_place.descend_throttle_level = 0;
         nav_payload_place.state = PayloadPlaceStateType_Descending;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Descending:
         // make sure we don't descend too far:
         debug("descended: %f cm (%f cm max)", (nav_payload_place.descend_start_altitude - inertial_nav.get_altitude()), nav_payload_place.descend_max);
@@ -808,7 +808,7 @@ bool Copter::verify_payload_place()
             return false;
         }
         nav_payload_place.state = PayloadPlaceStateType_Releasing_Start;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Releasing_Start:
 #if GRIPPER_ENABLED == ENABLED
         if (g2.gripper.valid()) {
@@ -823,7 +823,7 @@ bool Copter::verify_payload_place()
         gcs().send_text(MAV_SEVERITY_INFO, "Gripper code disabled");
 #endif
         nav_payload_place.state = PayloadPlaceStateType_Releasing;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Releasing:
 #if GRIPPER_ENABLED == ENABLED
         if (g2.gripper.valid() && !g2.gripper.released()) {
@@ -831,24 +831,24 @@ bool Copter::verify_payload_place()
         }
 #endif
         nav_payload_place.state = PayloadPlaceStateType_Released;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Released: {
         nav_payload_place.state = PayloadPlaceStateType_Ascending_Start;
         }
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Ascending_Start: {
         Location_Class target_loc = inertial_nav.get_position();
         target_loc.alt = nav_payload_place.descend_start_altitude;
         auto_wp_start(target_loc);
         nav_payload_place.state = PayloadPlaceStateType_Ascending;
         }
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Ascending:
         if (!wp_nav->reached_wp_destination()) {
             return false;
         }
         nav_payload_place.state = PayloadPlaceStateType_Done;
-        // no break
+        FALLTHROUGH;
     case PayloadPlaceStateType_Done:
         return true;
     default:

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -183,7 +183,8 @@ bool Copter::autotune_init(bool ignore_checks)
         case AUTOTUNE_MODE_FAILED:
             // autotune has been run but failed so reset state to uninitialized
             autotune_state.mode = AUTOTUNE_MODE_UNINITIALISED;
-            // no break to allow fall through to restart the tuning
+            // fall through to restart the tuning
+            FALLTHROUGH;
 
         case AUTOTUNE_MODE_UNINITIALISED:
             // autotune has never been run

--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -40,7 +40,7 @@ void Copter::calc_wp_distance()
             wp_distance = wp_nav->get_wp_distance_to_destination();
             break;
         }
-        // no break
+        FALLTHROUGH;
     default:
         wp_distance = 0;
         break;
@@ -67,7 +67,7 @@ void Copter::calc_wp_bearing()
             wp_bearing = wp_nav->get_wp_bearing_to_destination();
             break;
         }
-        // no break
+        FALLTHROUGH;
     default:
         wp_bearing = 0;
         break;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -607,7 +607,7 @@ void Plane::update_flight_mode(void)
             quadplane.guided_update();
             break;
         }
-        // no break
+        FALLTHROUGH;
 
     case RTL:
     case LOITER:
@@ -835,7 +835,8 @@ void Plane::update_navigation()
         if (radius > 0) {
             loiter.direction = (g.rtl_radius < 0) ? -1 : 1;
         }
-        // no break, fall through to LOITER
+        // fall through to LOITER
+        FALLTHROUGH;
 
     case LOITER:
     case AVOID_ADSB:

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -495,6 +495,7 @@ class px4(Board):
             '-Wlogical-op',
             '-Wframe-larger-than=1300',
             '-fsingle-precision-constant',
+            '-Wno-attributes',
             '-Wno-error=double-promotion',
             '-Wno-error=missing-declarations',
             '-Wno-error=float-equal',

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -263,7 +263,7 @@ void AP_Airspeed::read(void)
     switch ((enum pitot_tube_order)_tube_order.get()) {
     case PITOT_TUBE_ORDER_NEGATIVE:
         airspeed_pressure = -airspeed_pressure;
-        // no break
+        FALLTHROUGH;
     case PITOT_TUBE_ORDER_POSITIVE:
         if (airspeed_pressure < -32) {
             // we're reading more than about -8m/s. The user probably has

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -98,6 +98,7 @@ bool AP_Baro_MS56XX::_init()
     switch (_ms56xx_type) {
     case BARO_MS5607:
         name = "MS5607";
+        FALLTHROUGH;
     case BARO_MS5611:
         prom_read_ok = _read_prom_5611(prom);
         break;

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -39,6 +39,17 @@
 #define FMT_PRINTF(a,b) __attribute__((format(printf, a, b)))
 #define FMT_SCANF(a,b) __attribute__((format(scanf, a, b)))
 
+#ifdef __has_cpp_attribute
+#  if __has_cpp_attribute(fallthrough)
+#    define FALLTHROUGH [[fallthrough]]
+#  elif __has_cpp_attribute(gnu::fallthrough)
+#    define FALLTHROUGH [[gnu::fallthrough]]
+#  endif
+#endif
+#ifndef FALLTHROUGH
+#  define FALLTHROUGH
+#endif
+
 #define ToRad(x) radians(x)	// *pi/180
 #define ToDeg(x) degrees(x)	// *180/pi
 

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -79,7 +79,7 @@ AP_GPS_ERB::read(void)
             }
             _step = 0;
             Debug("reset %u", __LINE__);
-            /* no break */
+            FALLTHROUGH;
         case 0:
             if(PREAMBLE1 == data)
                 _step++;
@@ -238,7 +238,7 @@ reset:
                 break;
             }
             state.step = 0;
-            /* no break */
+            FALLTHROUGH;
         case 0:
             if (PREAMBLE1 == data)
                 state.step++;

--- a/libraries/AP_GPS/AP_GPS_MTK.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK.cpp
@@ -176,6 +176,7 @@ AP_GPS_MTK::_detect(struct MTK_detect_state &state, uint8_t data)
                 break;
             }
             state.step = 0;
+            FALLTHROUGH;
         case 0:
 			state.ck_b = state.ck_a = state.payload_counter = 0;
             if(PREAMBLE1 == data)

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -140,7 +140,7 @@ bool AP_GPS_NMEA::_decode(char c)
     switch (c) {
     case ',': // term terminators
         _parity ^= c;
-        /* no break */
+        FALLTHROUGH;
     case '\r':
     case '\n':
     case '*':

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -204,48 +204,48 @@ AP_GPS_SIRF::_accumulate(uint8_t val)
 /*
   detect a SIRF GPS
  */
-bool
-AP_GPS_SIRF::_detect(struct SIRF_detect_state &state, uint8_t data)
+bool AP_GPS_SIRF::_detect(struct SIRF_detect_state &state, uint8_t data)
 {
-	switch (state.step) {
-	case 1:
-		if (PREAMBLE2 == data) {
-			state.step++;
-			break;
-		}
-		state.step = 0;
-	case 0:
-		state.payload_length = state.payload_counter = state.checksum = 0;
-		if (PREAMBLE1 == data)
-			state.step++;
-		break;
-	case 2:
-		state.step++;
-		if (data != 0) {
-			// only look for short messages
-			state.step = 0;
-		}
-		break;
-	case 3:
-		state.step++;
-		state.payload_length = data;
-		break;
-	case 4:
-		state.checksum = (state.checksum + data) & 0x7fff;
-		if (++state.payload_counter == state.payload_length)
-			state.step++;
-		break;
-	case 5:
-		state.step++;
-		if ((state.checksum >> 8) != data) {
-			state.step = 0;
-		}
-		break;
-	case 6:
-		state.step = 0;
-		if ((state.checksum & 0xff) == data) {
-			return true;
-		}
+    switch (state.step) {
+    case 1:
+        if (PREAMBLE2 == data) {
+            state.step++;
+            break;
+        }
+        state.step = 0;
+    case 0:
+        state.payload_length = state.payload_counter = state.checksum = 0;
+        if (PREAMBLE1 == data)
+            state.step++;
+        break;
+    case 2:
+        state.step++;
+        if (data != 0) {
+            // only look for short messages
+            state.step = 0;
+        }
+        break;
+    case 3:
+        state.step++;
+        state.payload_length = data;
+        break;
+    case 4:
+        state.checksum = (state.checksum + data) & 0x7fff;
+        if (++state.payload_counter == state.payload_length) {
+            state.step++;
+        }
+        break;
+    case 5:
+        state.step++;
+        if ((state.checksum >> 8) != data) {
+            state.step = 0;
+        }
+        break;
+    case 6:
+        state.step = 0;
+        if ((state.checksum & 0xff) == data) {
+            return true;
+        }
     }
     return false;
 }

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -83,7 +83,7 @@ AP_GPS_SIRF::read(void)
                 break;
             }
             _step = 0;
-        // FALLTHROUGH
+            FALLTHROUGH;
         case 0:
             if(PREAMBLE1 == data)
                 _step++;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -398,7 +398,7 @@ AP_GPS_UBLOX::read(void)
             }
             _step = 0;
             Debug("reset %u", __LINE__);
-            /* no break */
+            FALLTHROUGH;
         case 0:
             if(PREAMBLE1 == data)
                 _step++;
@@ -1215,7 +1215,7 @@ reset:
                 break;
             }
             state.step = 0;
-            /* no break */
+            FALLTHROUGH;
         case 0:
             if (PREAMBLE1 == data)
                 state.step++;

--- a/libraries/AP_HAL/utility/print_vprintf.cpp
+++ b/libraries/AP_HAL/utility/print_vprintf.cpp
@@ -428,7 +428,8 @@ flt_oper:
                     goto ultoa;
                 case 'p':
                     flags |= FL_ALT;
-                    /* no break */
+
+                    FALLTHROUGH;
                 case 'x':
                     if (flags & FL_ALT)
                         flags |= FL_ALTHEX;

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -177,7 +177,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         }
         stage = DEEPSTALL_STAGE_ESTIMATE_WIND;
         loiter_sum_cd = 0; // reset the loiter counter
-        // no break
+        FALLTHROUGH;
     case DEEPSTALL_STAGE_ESTIMATE_WIND:
         {
         landing.nav_controller->update_loiter(landing_point, landing.aparm.loiter_radius, 1);
@@ -199,7 +199,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         }
         stage = DEEPSTALL_STAGE_WAIT_FOR_BREAKOUT;
         loiter_sum_cd = 0; // reset the loiter counter
-        // no break
+        FALLTHROUGH;
         }
     case DEEPSTALL_STAGE_WAIT_FOR_BREAKOUT:
         // rebuild the approach path if we have done less then a full circle to allow it to be
@@ -221,14 +221,14 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         }
         stage = DEEPSTALL_STAGE_FLY_TO_ARC;
         memcpy(&breakout_location, &current_loc, sizeof(Location));
-        // no break
+        FALLTHROUGH;
     case DEEPSTALL_STAGE_FLY_TO_ARC:
         if (get_distance(current_loc, arc_entry) > 2 * landing.aparm.loiter_radius) {
             landing.nav_controller->update_waypoint(breakout_location, arc_entry);
             return false;
         }
         stage = DEEPSTALL_STAGE_ARC;
-        // no break
+        FALLTHROUGH;
     case DEEPSTALL_STAGE_ARC:
         {
         Vector2f groundspeed = landing.ahrs.groundspeed_vector();
@@ -240,7 +240,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         }
         stage = DEEPSTALL_STAGE_APPROACH;
         }
-        // no break
+        FALLTHROUGH;
     case DEEPSTALL_STAGE_APPROACH:
         {
         Location entry_point;
@@ -274,7 +274,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         }
         L1_xtrack_i = 0; // reset the integrators
         }
-        // no break
+        FALLTHROUGH;
     case DEEPSTALL_STAGE_LAND:
         // while in deepstall the only thing verify needs to keep the extended approach point sufficently far away
         landing.nav_controller->update_waypoint(current_loc, extended_approach);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -71,14 +71,17 @@ bool AP_RangeFinder_LeddarOne::get_reading(uint16_t &reading_cm)
         read_len = 0;
         modbus_status = LEDDARONE_MODBUS_STATE_PRE_SEND_REQUEST;
         }
-        // no break to fall through to next state LEDDARONE_MODBUS_STATE_PRE_SEND_REQUEST immediately
+
+        // fall through to next state LEDDARONE_MODBUS_STATE_PRE_SEND_REQUEST
+        // immediately
+        FALLTHROUGH;
 
     case LEDDARONE_MODBUS_STATE_PRE_SEND_REQUEST:
         // send a request message for Modbus function 4
         uart->write(send_request_buffer, sizeof(send_request_buffer));
         modbus_status = LEDDARONE_MODBUS_STATE_SENT_REQUEST;
         last_sending_request_ms = AP_HAL::millis();
-        // no break
+        FALLTHROUGH;
 
     case LEDDARONE_MODBUS_STATE_SENT_REQUEST:
         if (uart->available()) {

--- a/libraries/DataFlash/DFMessageWriter.cpp
+++ b/libraries/DataFlash/DFMessageWriter.cpp
@@ -30,7 +30,7 @@ void DFMessageWriter_DFLogStart::process()
     switch(stage) {
     case ls_blockwriter_stage_init:
         stage = ls_blockwriter_stage_formats;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_formats:
         // write log formats so the log is self-describing
@@ -42,7 +42,7 @@ void DFMessageWriter_DFLogStart::process()
         }
         _fmt_done = true;
         stage = ls_blockwriter_stage_parms;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_parms:
         while (ap) {
@@ -53,7 +53,7 @@ void DFMessageWriter_DFLogStart::process()
         }
 
         stage = ls_blockwriter_stage_sysinfo;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_sysinfo:
         _writesysinfo.process();
@@ -61,7 +61,7 @@ void DFMessageWriter_DFLogStart::process()
             return;
         }
         stage = ls_blockwriter_stage_write_entire_mission;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_write_entire_mission:
         _writeentiremission.process();
@@ -69,7 +69,7 @@ void DFMessageWriter_DFLogStart::process()
             return;
         }
         stage = ls_blockwriter_stage_vehicle_messages;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_vehicle_messages:
         // we guarantee 200 bytes of space for the vehicle startup
@@ -82,7 +82,7 @@ void DFMessageWriter_DFLogStart::process()
             (_dataflash_backend->vehicle_message_writer())();
         }
         stage = ls_blockwriter_stage_done;
-        // no break
+        FALLTHROUGH;
 
     case ls_blockwriter_stage_done:
         break;
@@ -108,14 +108,14 @@ void DFMessageWriter_WriteSysInfo::process() {
 
     case ws_blockwriter_stage_init:
         stage = ws_blockwriter_stage_firmware_string;
-        // no break
+        FALLTHROUGH;
 
     case ws_blockwriter_stage_firmware_string:
         if (! _dataflash_backend->Log_Write_Message(_firmware_string)) {
             return; // call me again
         }
         stage = ws_blockwriter_stage_git_versions;
-        // no break
+        FALLTHROUGH;
 
     case ws_blockwriter_stage_git_versions:
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
@@ -124,7 +124,7 @@ void DFMessageWriter_WriteSysInfo::process() {
         }
 #endif
         stage = ws_blockwriter_stage_system_id;
-        // no break
+        FALLTHROUGH;
 
     case ws_blockwriter_stage_system_id:
         char sysid[40];
@@ -133,7 +133,7 @@ void DFMessageWriter_WriteSysInfo::process() {
                 return; // call me again
             }
         }
-        // no break
+        FALLTHROUGH;
     }
 
     _finished = true;  // all done!
@@ -149,14 +149,14 @@ void DFMessageWriter_WriteEntireMission::process() {
         } else {
             stage = em_blockwriter_stage_write_new_mission_message;
         }
-        // no break
+        FALLTHROUGH;
 
     case em_blockwriter_stage_write_new_mission_message:
         if (! _dataflash_backend->Log_Write_Message("New mission")) {
             return; // call me again
         }
         stage = em_blockwriter_stage_write_mission_items;
-        // no break
+        FALLTHROUGH;
 
     case em_blockwriter_stage_write_mission_items:
         AP_Mission::Mission_Command cmd;
@@ -171,7 +171,7 @@ void DFMessageWriter_WriteEntireMission::process() {
             _mission_number_to_send++;
         }
         stage = em_blockwriter_stage_done;
-        // no break
+        FALLTHROUGH;
 
     case em_blockwriter_stage_done:
         break;

--- a/mk/px4_targets.mk
+++ b/mk/px4_targets.mk
@@ -51,7 +51,7 @@ PX4_V4PRO_CONFIG_FILE=$(MK_DIR)/PX4/config_px4fmu-v4pro_APM.mk
 # because this platform lacks most of the standard library and STL. Hence we need to force C++03 mode.
 SKETCHFLAGS=$(SKETCHLIBINCLUDES) -DUAVCAN_CPP_VERSION=UAVCAN_CPP03 -DUAVCAN_NO_ASSERTIONS -DUAVCAN_NULLPTR=nullptr -DARDUPILOT_BUILD -DTESTS_MATHLIB_DISABLE -DCONFIG_HAL_BOARD=HAL_BOARD_PX4 -DSKETCHNAME="\\\"$(SKETCH)\\\"" -DSKETCH_MAIN=ArduPilot_main -DAPM_BUILD_DIRECTORY=APM_BUILD_$(SKETCH)
 
-WARNFLAGS = -Wall -Wextra -Wlogical-op -Werror -Wno-unknown-pragmas -Wno-redundant-decls -Wno-psabi -Wno-packed -Wno-error=double-promotion -Wno-error=unused-variable -Wno-error=reorder -Wno-error=float-equal -Wno-error=pmf-conversions -Wno-error=missing-declarations -Wno-error=unused-function
+WARNFLAGS = -Wall -Wextra -Wlogical-op -Werror -Wno-attributes -Wno-unknown-pragmas -Wno-redundant-decls -Wno-psabi -Wno-packed -Wno-error=double-promotion -Wno-error=unused-variable -Wno-error=reorder -Wno-error=float-equal -Wno-error=pmf-conversions -Wno-error=missing-declarations -Wno-error=unused-function
 OPTFLAGS = -fsingle-precision-constant
 
 # avoid PX4 submodules


### PR DESCRIPTION
GCC 7 turned the fallthrough warning on by default. These are the ways
to handle them on the cases it should fallthrough:

```c++
    switch (cond) {
    case 1:
        bar (1);
        __attribute__ ((fallthrough)); // C and C++03
    case 2:
        bar (2);
        [[gnu::fallthrough]]; // C++11 and C++14
    case 3:
        bar (3);
        [[fallthrough]]; // C++17 and above
    /* ... */
    }
```

More info: https://dzone.com/articles/implicit-fallthrough-in-gcc-7
And it **does** work with clang as well.