### PR TITLE
Add some Sub-specific state info to telemetry stream

### DIFF
--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -488,7 +488,7 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
 
     switch (id) {
 
-    case MSG_SUB_INFO:
+    case MSG_NAMED_FLOAT:
         sub.send_info(chan);
         break;
 
@@ -777,7 +777,7 @@ GCS_MAVLINK_Sub::data_stream_send(void)
         send_message(MSG_GPS2_RTK);
         send_message(MSG_NAV_CONTROLLER_OUTPUT);
         send_message(MSG_LIMITS_STATUS);
-        send_message(MSG_SUB_INFO);
+        send_message(MSG_NAMED_FLOAT);
     }
 
     if (sub.gcs_out_of_time) {

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -357,63 +357,53 @@ void NOINLINE Sub::send_temperature(mavlink_channel_t chan)
         celsius.temperature() * 100);
 }
 
-void NOINLINE Sub::send_info(mavlink_channel_t chan)
+bool NOINLINE Sub::send_info(mavlink_channel_t chan)
 {
     // Just do this all at once, hopefully the hard-wire telemetry requirement means this is ok
     // Name is char[10]
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "CamTilt",
             1 - (SRV_Channels::get_output_norm(SRV_Channel::k_mount_tilt) / 2.0f + 0.5f));
 
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "TetherTrn",
             quarter_turn_count/4);
 
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "Lights1",
             SRV_Channels::get_output_norm(SRV_Channel::k_rcin9) / 2.0f + 0.5f);
 
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "Lights2",
             SRV_Channels::get_output_norm(SRV_Channel::k_rcin10) / 2.0f + 0.5f);
 
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "PilotGain",
             gain);
 
-    if (!HAVE_PAYLOAD_SPACE(chan, NAMED_VALUE_FLOAT)) {
-        return;
-    }
+    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
     mavlink_msg_named_value_float_send(
             chan,
             AP_HAL::millis(),
             "InputHold",
             input_hold_engaged);
+
+    return true;
 }
 
 /*

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -334,6 +334,12 @@ private:
     int32_t quarter_turn_count;
     uint8_t last_turn_state;
 
+    // Input gain
+    float gain;
+
+    // Flag indicating if we are currently using input hold
+    bool input_hold_engaged;
+
     // 3D Location vectors
     // Current location of the Sub (altitude is relative to home)
     Location_Class current_loc;
@@ -490,6 +496,7 @@ private:
     void rpm_update();
 #endif
     void send_temperature(mavlink_channel_t chan);
+    void send_info(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void gcs_data_stream_send(void);
     void gcs_check_input(void);

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -496,7 +496,7 @@ private:
     void rpm_update();
 #endif
     void send_temperature(mavlink_channel_t chan);
-    void send_info(mavlink_channel_t chan);
+    bool send_info(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void gcs_data_stream_send(void);
     void gcs_check_input(void);

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -16,7 +16,6 @@ int16_t yTrim = 0;
 int16_t video_switch = 1100;
 int16_t x_last, y_last, z_last;
 uint16_t buttons_prev;
-float gain;
 
 // Servo control output channels
 // TODO: Allow selecting output channels
@@ -324,6 +323,7 @@ void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
             zTrim = z_last-500;
             xTrim = x_last;
             yTrim = y_last;
+            input_hold_engaged = abs(zTrim) > 20 || abs(xTrim) > 20 || abs(yTrim) > 20;
             gcs().send_text(MAV_SEVERITY_INFO,"#Input Hold Set");
         }
         break;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -79,7 +79,7 @@ enum ap_message {
     MSG_BATTERY_STATUS,
     MSG_AOA_SSA,
     MSG_LANDING,
-    MSG_SUB_INFO,
+    MSG_NAMED_FLOAT,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -79,6 +79,7 @@ enum ap_message {
     MSG_BATTERY_STATUS,
     MSG_AOA_SSA,
     MSG_LANDING,
+    MSG_SUB_INFO,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };
 


### PR DESCRIPTION
This makes some values available for display in GCS to make operating easier. Sending NAMED_VALUE_FLOAT for now to avoid modifying mavlink spec.