### PR TITLE
OptFlow: add retry to px4flow init

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -146,11 +146,7 @@ void Rover::Log_Write_Attitude()
     DataFlash.Log_Write_Attitude(ahrs, targets);
 
 #if AP_AHRS_NAVEKF_AVAILABLE
-  #if defined(OPTFLOW) and (OPTFLOW == ENABLED)
-    DataFlash.Log_Write_EKF(ahrs, optflow.enabled());
-  #else
-    DataFlash.Log_Write_EKF(ahrs, false);
-  #endif
+    DataFlash.Log_Write_EKF(ahrs);
     DataFlash.Log_Write_AHRS2(ahrs);
 #endif
     DataFlash.Log_Write_POS(ahrs);

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -11,7 +11,7 @@ void Tracker::Log_Write_Attitude()
     targets.y = nav_status.pitch * 100.0f;
     targets.z = wrap_360_cd(nav_status.bearing * 100.0f);
     DataFlash.Log_Write_Attitude(ahrs, targets);
-    DataFlash.Log_Write_EKF(ahrs,false);
+    DataFlash.Log_Write_EKF(ahrs);
     DataFlash.Log_Write_AHRS2(ahrs);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE(&DataFlash);

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -239,11 +239,7 @@ void Copter::Log_Write_Attitude()
 // Write an EKF and POS packet
 void Copter::Log_Write_EKF_POS()
 {
- #if OPTFLOW == ENABLED
-    DataFlash.Log_Write_EKF(ahrs,optflow.enabled());
- #else
-    DataFlash.Log_Write_EKF(ahrs,false);
- #endif
+    DataFlash.Log_Write_EKF(ahrs);
     DataFlash.Log_Write_AHRS2(ahrs);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE(&DataFlash);

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -139,11 +139,6 @@ void Copter::compass_accumulate(void)
 void Copter::init_optflow()
 {
 #if OPTFLOW == ENABLED
-    // exit immediately if not enabled
-    if (!optflow.enabled()) {
-        return;
-    }
-
     // initialise optical flow sensor
     optflow.init();
 #endif      // OPTFLOW == ENABLED

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -44,11 +44,7 @@ void Plane::Log_Write_Attitude(void)
     }
 
 #if AP_AHRS_NAVEKF_AVAILABLE
- #if OPTFLOW == ENABLED
-    DataFlash.Log_Write_EKF(ahrs,optflow.enabled());
- #else
-    DataFlash.Log_Write_EKF(ahrs,false);
- #endif
+    DataFlash.Log_Write_EKF(ahrs);
     DataFlash.Log_Write_AHRS2(ahrs);
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -179,11 +179,7 @@ void Sub::Log_Write_Attitude()
     targets.z = wrap_360_cd(targets.z);
     DataFlash.Log_Write_Attitude(ahrs, targets);
 
-#if OPTFLOW == ENABLED
-    DataFlash.Log_Write_EKF(ahrs,optflow.enabled());
-#else
-    DataFlash.Log_Write_EKF(ahrs,false);
-#endif
+    DataFlash.Log_Write_EKF(ahrs);
     DataFlash.Log_Write_AHRS2(ahrs);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     sitl.Log_Write_SIMSTATE(&DataFlash);

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -128,11 +128,6 @@ void Sub::compass_accumulate(void)
 #if OPTFLOW == ENABLED
 void Sub::init_optflow()
 {
-    // exit immediately if not enabled
-    if (!optflow.enabled()) {
-        return;
-    }
-
     // initialise optical flow sensor
     optflow.init();
 }

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -613,7 +613,7 @@ void Replay::set_signal_handlers(void)
 void Replay::write_ekf_logs(void)
 {
     if (!LogReader::in_list("EKF", nottypes)) {
-        _vehicle.dataflash.Log_Write_EKF(_vehicle.ahrs,false);
+        _vehicle.dataflash.Log_Write_EKF(_vehicle.ahrs);
     }
     if (!LogReader::in_list("AHRS2", nottypes)) {
         _vehicle.dataflash.Log_Write_AHRS2(_vehicle.ahrs);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -27,7 +27,8 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define PX4FLOW_BASE_I2C_ADDR 0x42
+#define PX4FLOW_BASE_I2C_ADDR   0x42
+#define PX4FLOW_INIT_RETRIES    10      // attempt to initialise the sensor up to 10 times at startup
 
 // constructor
 AP_OpticalFlow_PX4Flow::AP_OpticalFlow_PX4Flow(OpticalFlow &_frontend) :
@@ -55,30 +56,39 @@ AP_OpticalFlow_PX4Flow *AP_OpticalFlow_PX4Flow::detect(OpticalFlow &_frontend)
  */
 bool AP_OpticalFlow_PX4Flow::scan_buses(void)
 {
-    for (uint8_t bus = 0; bus < 3; bus++) {
-#ifdef HAL_OPTFLOW_PX4FLOW_I2C_BUS
-        // only one bus from HAL
-        if (bus != HAL_OPTFLOW_PX4FLOW_I2C_BUS) {
-            continue;
+    bool success = false;
+    uint8_t retry_attempt = 0;
+
+    while (!success && retry_attempt < PX4FLOW_INIT_RETRIES) {
+        for (uint8_t bus = 0; bus < 3; bus++) {
+    #ifdef HAL_OPTFLOW_PX4FLOW_I2C_BUS
+            // only one bus from HAL
+            if (bus != HAL_OPTFLOW_PX4FLOW_I2C_BUS) {
+                continue;
+            }
+    #endif
+            AP_HAL::OwnPtr<AP_HAL::Device> tdev = hal.i2c_mgr->get_device(bus, PX4FLOW_BASE_I2C_ADDR + get_address());
+            if (!tdev) {
+                continue;
+            }
+            if (!tdev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+                continue;
+            }
+            struct i2c_integral_frame frame;
+            success = tdev->read_registers(REG_INTEGRAL_FRAME, (uint8_t *)&frame, sizeof(frame));
+            tdev->get_semaphore()->give();
+            if (success) {
+                printf("Found PX4Flow on bus %u\n", bus);
+                dev = std::move(tdev);
+                break;
+            }
         }
-#endif
-        AP_HAL::OwnPtr<AP_HAL::Device> tdev = hal.i2c_mgr->get_device(bus, PX4FLOW_BASE_I2C_ADDR + get_address());
-        if (!tdev) {
-            continue;
-        }
-        if (!tdev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-            continue;
-        }
-        struct i2c_integral_frame frame;
-        bool ok = tdev->read_registers(REG_INTEGRAL_FRAME, (uint8_t *)&frame, sizeof(frame));
-        tdev->get_semaphore()->give();
-        if (ok) {
-            printf("Found PX4Flow on bus %u\n", bus);
-            dev = std::move(tdev);
-            break;
+        retry_attempt++;
+        if (!success) {
+            hal.scheduler->delay(10);
         }
     }
-    return !!dev;
+    return success;
 }
 
 // setup the device

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -62,7 +62,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
             continue;
         }
 #endif
-        AP_HAL::OwnPtr<AP_HAL::Device> tdev = hal.i2c_mgr->get_device(bus, PX4FLOW_BASE_I2C_ADDR + get_bus_id());
+        AP_HAL::OwnPtr<AP_HAL::Device> tdev = hal.i2c_mgr->get_device(bus, PX4FLOW_BASE_I2C_ADDR + get_address());
         if (!tdev) {
             continue;
         }
@@ -106,7 +106,7 @@ void AP_OpticalFlow_PX4Flow::timer(void)
         return;
     }
     struct OpticalFlow::OpticalFlow_state state {};
-    state.device_id = get_bus_id();
+    state.device_id = get_address();
 
     if (frame.integration_timespan > 0) {
         const Vector2f flowScaler = _flowScaler();

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -104,8 +104,6 @@ void OpticalFlow::init(void)
 
     if (backend != nullptr) {
         backend->init();
-    } else {
-        _enabled = 0;
     }
 }
 

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -58,12 +58,12 @@ const AP_Param::GroupInfo OpticalFlow::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_POS", 4, OpticalFlow, _pos_offset, 0.0f),
 
-    // @Param: _BUS_ID
-    // @DisplayName: ID on the bus
-    // @Description: This is used to select between multiple possible bus IDs for some sensor types. For PX4Flow you can choose 0 to 7 for the 8 possible addresses on the I2C bus.
+    // @Param: _ADDR
+    // @DisplayName: Address on the bus
+    // @Description: This is used to select between multiple possible I2C addresses for some sensor types. For PX4Flow you can choose 0 to 7 for the 8 possible addresses on the I2C bus.
     // @Range: 0 127
     // @User: Advanced
-    AP_GROUPINFO("_BUS_ID", 5,  OpticalFlow, _bus_id,   0),
+    AP_GROUPINFO("_ADDR", 5,  OpticalFlow, _address,   0),
     
     AP_GROUPEND
 };

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -83,6 +83,11 @@ OpticalFlow::OpticalFlow(AP_AHRS_NavEKF &ahrs)
 
 void OpticalFlow::init(void)
 {
+    // return immediately if not enabled
+    if (!_enabled) {
+        return;
+    }
+
     if (!backend) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
         if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK) {

--- a/libraries/AP_OpticalFlow/OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow.h
@@ -89,7 +89,7 @@ private:
     AP_Int16 _flowScalerY;          // Y axis flow scale factor correction - parts per thousand
     AP_Int16 _yawAngle_cd;          // yaw angle of sensor X axis with respect to vehicle X axis - centi degrees
     AP_Vector3f _pos_offset;        // position offset of the flow sensor in the body frame
-    AP_Int8  _bus_id;               // ID on bus (some sensors only)
+    AP_Int8  _address;              // address on the bus (allows selecting between 8 possible I2C addresses for px4flow)
 
     // state filled in by backend
     struct OpticalFlow_state _state;

--- a/libraries/AP_OpticalFlow/OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow.h
@@ -60,9 +60,6 @@ public:
     // last_update() - returns system time of last sensor update
     uint32_t last_update() const { return _last_update_ms; }
 
-    // parameter var info table
-    static const struct AP_Param::GroupInfo var_info[];
-
     struct OpticalFlow_state {
         uint8_t device_id;          // device id
         uint8_t  surface_quality;   // image quality (below TBD you can't trust the dx,dy values returned)
@@ -74,6 +71,9 @@ public:
     const Vector3f &get_pos_offset(void) const {
         return _pos_offset;
     }
+
+    // parameter var info table
+    static const struct AP_Param::GroupInfo var_info[];
 
 private:
     AP_AHRS_NavEKF &_ahrs;

--- a/libraries/AP_OpticalFlow/OpticalFlow_backend.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow_backend.h
@@ -54,8 +54,8 @@ protected:
     // get access to AHRS object
     AP_AHRS_NavEKF &get_ahrs(void) { return frontend._ahrs; }
 
-    // get bus ID parameter
-    uint8_t get_bus_id(void) const { return frontend._bus_id; }
+    // get ADDR parameter value
+    uint8_t get_address(void) const { return frontend._address; }
     
     // semaphore for access to shared frontend data
     AP_HAL::Semaphore *_sem;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -123,7 +123,7 @@ public:
     void Log_Write_AHRS2(AP_AHRS &ahrs);
     void Log_Write_POS(AP_AHRS &ahrs);
 #if AP_AHRS_NAVEKF_AVAILABLE
-    void Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled);
+    void Log_Write_EKF(AP_AHRS_NavEKF &ahrs);
 #endif
     bool Log_Write_MavCmd(uint16_t cmd_total, const mavlink_mission_item_t& mav_cmd);
     void Log_Write_Radio(const mavlink_radio_t &packet);
@@ -274,8 +274,8 @@ private:
     bool _armed;
 
 #if AP_AHRS_NAVEKF_AVAILABLE
-    void Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled);
-    void Log_Write_EKF3(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled);
+    void Log_Write_EKF2(AP_AHRS_NavEKF &ahrs);
+    void Log_Write_EKF3(AP_AHRS_NavEKF &ahrs);
 #endif
 
     void backend_starting_new_log(const DataFlash_Backend *backend);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -684,15 +684,15 @@ void DataFlash_Class::Log_Write_POS(AP_AHRS &ahrs)
 }
 
 #if AP_AHRS_NAVEKF_AVAILABLE
-void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
+void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs)
 {
     // only log EKF2 if enabled
     if (ahrs.get_NavEKF2().activeCores() > 0) {
-        Log_Write_EKF2(ahrs, optFlowEnabled);
+        Log_Write_EKF2(ahrs);
     }
     // only log EKF3 if enabled
     if (ahrs.get_NavEKF3().activeCores() > 0) {
-        Log_Write_EKF3(ahrs, optFlowEnabled);
+        Log_Write_EKF3(ahrs);
     }
 }
 
@@ -716,7 +716,7 @@ void DataFlash_Class::Log_Write_EKF_Timing(const char *name, uint64_t time_us, c
               (double)timing.delVelDT_max);
 }
 
-void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
+void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs)
 {
     uint64_t time_us = AP_HAL::micros64();
     // Write first EKF packet
@@ -1058,7 +1058,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
 }
 
 
-void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
+void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs)
 {
     uint64_t time_us = AP_HAL::micros64();
 	// Write first EKF packet


### PR DESCRIPTION
This PR should resolve these two issues:

- Copter: FLOW_ENABLE should remain "1" even if we fail to connect to flow sensor (https://github.com/ArduPilot/ardupilot/issues/6243)
- PX4Flow only works after boot via USB connection (https://github.com/ArduPilot/ardupilot/issues/3084)

The first issue is resolved by simply leaving the _enabled parameter as 1 if initialisation fails.  I've checked where optflow.enabled() is called from and it appears to me that this should be safe.  All calls rely just on the optical flow's front end state.

The second issue was caused by the sensor starting up slowly if it is not receiving enough power.  It's easy to argue that this is really a hardware issues but enough users have complained that it worked on Copter-3.4.6 but fails to work on Copter-3.5.x that it's probably worth fixing.  It's resolved by attempting to read from the px4flow sensor up to 10times for a total of 100ms.

This PR also includes a few unrelated changes:

- add an _enabled check to optflow's init call (reduces a couple of lines from copter and sub)
- remove Log_Write_EKF's unused 2nd "optflowEnabled" argument
- minor format change
- rename the _BUS_ID parameter to _ADDR which makes it more consistent with the RangeFinder class.  The parameter controls the I2C address, not the bus being used so I think the name is better.

