### PR TITLE
Rover: add aux function features, remove learning mode

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -63,7 +63,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(gcs_update,             50,   1700),
     SCHED_TASK(gcs_data_stream_send,   50,   3000),
     SCHED_TASK(read_control_switch,     7,   1000),
-    SCHED_TASK(read_trim_switch,       10,   1000),
+    SCHED_TASK(read_aux_switch,        10,    100),
     SCHED_TASK(read_battery,           10,   1000),
     SCHED_TASK(read_receiver_rssi,     10,   1000),
     SCHED_TASK(update_events,          50,   1000),

--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -80,6 +80,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(button_update,           5,    100),
     SCHED_TASK(stats_update,            1,    100),
     SCHED_TASK(crash_check,            10,   1000),
+    SCHED_TASK(cruise_learn_update,    50,     50),
 #if ADVANCED_FAILSAFE == ENABLED
     SCHED_TASK(afs_fs_check,           10,    100),
 #endif

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -815,7 +815,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
             case MAV_MODE_STABILIZE_DISARMED:
             case MAV_MODE_STABILIZE_ARMED:
-                rover.set_mode(rover.mode_learning, MODE_REASON_GCS_COMMAND);
+                rover.set_mode(rover.mode_steering, MODE_REASON_GCS_COMMAND);
                 result = MAV_RESULT_ACCEPTED;
                 break;
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -241,45 +241,45 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: MODE1
     // @DisplayName: Mode1
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
     // @Description: Driving mode for switch position 1 (910 to 1230 and above 2049)
-    GSCALAR(mode1,           "MODE1",         MODE_1),
+    GSCALAR(mode1,           "MODE1",         MANUAL),
 
     // @Param: MODE2
     // @DisplayName: Mode2
     // @Description: Driving mode for switch position 2 (1231 to 1360)
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
-    GSCALAR(mode2,           "MODE2",         MODE_2),
+    GSCALAR(mode2,           "MODE2",         MANUAL),
 
     // @Param: MODE3
     // @DisplayName: Mode3
     // @Description: Driving mode for switch position 3 (1361 to 1490)
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
-    GSCALAR(mode3,           "MODE3",         MODE_3),
+    GSCALAR(mode3,           "MODE3",         MANUAL),
 
     // @Param: MODE4
     // @DisplayName: Mode4
     // @Description: Driving mode for switch position 4 (1491 to 1620)
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
-    GSCALAR(mode4,           "MODE4",         MODE_4),
+    GSCALAR(mode4,           "MODE4",         MANUAL),
 
     // @Param: MODE5
     // @DisplayName: Mode5
     // @Description: Driving mode for switch position 5 (1621 to 1749)
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
-    GSCALAR(mode5,           "MODE5",         MODE_5),
+    GSCALAR(mode5,           "MODE5",         MANUAL),
 
     // @Param: MODE6
     // @DisplayName: Mode6
     // @Description: Driving mode for switch position 6 (1750 to 2049)
-    // @Values: 0:Manual,2:LEARNING,3:STEERING,4:HOLD,10:Auto,11:RTL,15:Guided
+    // @Values: 0:Manual,3:Steering,4:Hold,10:Auto,11:RTL,15:Guided
     // @User: Standard
-    GSCALAR(mode6,           "MODE6",         MODE_6),
+    GSCALAR(mode6,           "MODE6",         MANUAL),
 
     // @Param: WP_RADIUS
     // @DisplayName: Waypoint radius

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -129,7 +129,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CH7_OPTION
     // @DisplayName: Channel 7 option
     // @Description: What to do use channel 7 for
-    // @Values: 0:Nothing,1:LearnWaypoint
+    // @Values: 0:Nothing,1:SaveWaypoint
     // @User: Standard
     GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
 
@@ -227,11 +227,11 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Standard
     GSCALAR(rangefinder_debounce,   "RNGFND_DEBOUNCE",    2),
 
-    // @Param: LEARN_CH
-    // @DisplayName: Learning channel
-    // @Description: RC Channel to use for learning waypoints
+    // @Param: AUX_CH
+    // @DisplayName: Auxiliary switch channel
+    // @Description: RC Channel to use for auxiliary functions including saving waypoints
     // @User: Advanced
-    GSCALAR(learn_channel,    "LEARN_CH",       7),
+    GSCALAR(aux_channel,    "AUX_CH",       7),
 
     // @Param: MODE_CH
     // @DisplayName: Mode channel

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -129,7 +129,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CH7_OPTION
     // @DisplayName: Channel 7 option
     // @Description: What to do use channel 7 for
-    // @Values: 0:Nothing,1:SaveWaypoint
+    // @Values: 0:Nothing,1:SaveWaypoint,2:LearnCruiseSpeed
     // @User: Standard
     GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -264,7 +264,7 @@ public:
     AP_Int8     mode4;
     AP_Int8     mode5;
     AP_Int8     mode6;
-    AP_Int8     learn_channel;
+    AP_Int8     aux_channel;
 
     // Waypoints
     //

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -160,7 +160,7 @@ public:
         k_param_mode4,
         k_param_mode5,
         k_param_mode6,
-        k_param_learn_channel,
+        k_param_aux_channel,
 
         //
         // 220: Waypoint data

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -23,7 +23,7 @@ Rover::Rover(void) :
     param_loader(var_info),
     channel_steer(nullptr),
     channel_throttle(nullptr),
-    channel_learn(nullptr),
+    channel_aux(nullptr),
     DataFlash{FIRMWARE_STRING, g.log_bitmask},
     modes(&g.mode1),
     L1_controller(ahrs, nullptr),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -510,7 +510,6 @@ private:
     void rudder_arm_disarm_check();
     void read_radio();
     void control_failsafe(uint16_t pwm);
-    bool throttle_failsafe_active();
     void trim_control_surfaces();
     void trim_radio();
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -144,7 +144,7 @@ private:
     // primary control channels
     RC_Channel *channel_steer;
     RC_Channel *channel_throttle;
-    RC_Channel *channel_learn;
+    RC_Channel *channel_aux;
 
     DataFlash_Class DataFlash;
 
@@ -276,11 +276,8 @@ private:
     // The amount current ground speed is below min ground speed.  meters per second
     float ground_speed;
 
-    // CH7 control
-    // Used to track the CH7 toggle state.
-    // When CH7 goes LOW PWM from HIGH PWM, this value will have been set true
-    // This allows advanced functionality to know when to execute
-    bool ch7_flag;
+    // CH7 auxiliary switches last known position
+    aux_switch_pos aux_ch7;
 
     // Battery Sensors
     AP_BattMonitor battery;
@@ -448,7 +445,9 @@ private:
     void read_control_switch();
     uint8_t readSwitch(void);
     void reset_control_switch();
-    void read_trim_switch();
+    aux_switch_pos read_aux_switch_pos();
+    void init_aux_switch();
+    void read_aux_switch();
     bool motor_active();
 
     // crash_check.cpp

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -377,7 +377,6 @@ private:
     ModeManual mode_manual;
     ModeGuided mode_guided;
     ModeAuto mode_auto;
-    ModeLearning mode_learning;
     ModeSteering mode_steering;
     ModeRTL mode_rtl;
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -71,6 +71,7 @@
 #include <Filter/AverageFilter.h>                   // Mode Filter from Filter library
 #include <Filter/Butter.h>                          // Filter library - butterworth filter
 #include <Filter/Filter.h>                          // Filter library
+#include <Filter/LowPassFilter.h>
 #include <Filter/ModeFilter.h>                      // Mode Filter from Filter library
 #include <RC_Channel/RC_Channel.h>                  // RC Channel Library
 #include <StorageManager/StorageManager.h>
@@ -380,6 +381,13 @@ private:
     ModeSteering mode_steering;
     ModeRTL mode_rtl;
 
+    // cruise throttle and speed learning
+    struct {
+        bool learning;
+        LowPassFilterFloat speed_filt = LowPassFilterFloat(2.0f);
+        LowPassFilterFloat throttle_filt = LowPassFilterFloat(2.0f);
+    } cruise_learn;
+
 private:
 
     // APMrover2.cpp
@@ -451,6 +459,11 @@ private:
 
     // crash_check.cpp
     void crash_check();
+
+    // cruise_learn.cpp
+    void cruise_learn_start();
+    void cruise_learn_update();
+    void cruise_learn_complete();
 
     // events.cpp
     void update_events(void);

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -93,26 +93,6 @@
   #error XXX
 #endif
 
-#if !defined(MODE_1)
-  #define MODE_1    LEARNING
-#endif
-#if !defined(MODE_2)
-  #define MODE_2    LEARNING
-#endif
-#if !defined(MODE_3)
-  #define MODE_3    LEARNING
-#endif
-#if !defined(MODE_4)
-  #define MODE_4    LEARNING
-#endif
-#if !defined(MODE_5)
-  #define MODE_5    LEARNING
-#endif
-#if !defined(MODE_6)
-  #define MODE_6    MANUAL
-#endif
-
-
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 // STARTUP BEHAVIOUR

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -9,9 +9,6 @@ Mode *Rover::control_mode_from_num(const enum mode num)
     case MANUAL:
         ret = &mode_manual;
         break;
-    case LEARNING:
-        ret = &mode_learning;
-        break;
     case STEERING:
         ret = &mode_steering;
         break;

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -110,49 +110,69 @@ void Rover::reset_control_switch()
     read_control_switch();
 }
 
-// read at 10 hz
-// set this to your trainer switch
-void Rover::read_trim_switch()
+// ready auxiliary switch's position
+aux_switch_pos Rover::read_aux_switch_pos()
 {
+    uint16_t radio_in = channel_aux->get_radio_in();
+    if (radio_in < AUX_SWITCH_PWM_TRIGGER_LOW) return AUX_SWITCH_LOW;
+    if (radio_in > AUX_SWITCH_PWM_TRIGGER_HIGH) return AUX_SWITCH_HIGH;
+    return AUX_SWITCH_MIDDLE;
+}
+
+// initialise position of auxiliary switch
+void Rover::init_aux_switch()
+{
+    aux_ch7 = read_aux_switch_pos();
+}
+
+// read ch7 aux switch
+void Rover::read_aux_switch()
+{
+    // do not consume input during rc or throttle failsafe
+    if (failsafe.bits & FAILSAFE_EVENT_THROTTLE || failsafe.bits & FAILSAFE_EVENT_RC) {
+        return;
+    }
+
+    // get ch7's current position
+    aux_switch_pos aux_ch7_pos = read_aux_switch_pos();
+
+    // return if no change to switch position
+    if (aux_ch7_pos == aux_ch7) {
+        return;
+    }
+    aux_ch7 = aux_ch7_pos;
+
     switch ((enum ch7_option)g.ch7_option.get()) {
     case CH7_DO_NOTHING:
         break;
     case CH7_SAVE_WP:
-        if (channel_learn->get_radio_in() > CH_7_PWM_TRIGGER) {
-            // switch is engaged
-            ch7_flag = true;
-        } else {  // switch is disengaged
-            if (ch7_flag) {
-                ch7_flag = false;
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            // do nothing if in AUTO mode
+            if (control_mode == &mode_auto) {
+                return;
+            }
 
-                if (control_mode == &mode_manual) {
-                    hal.console->printf("Erasing waypoints\n");
-                    // if SW7 is ON in MANUAL = Erase the Flight Plan
-                    mission.clear();
-                    if (channel_steer->get_control_in() > 3000) {
-                        // if roll is full right store the current location as home
-                        set_home_to_current_location(false);
-                    }
-                } else if (control_mode == &mode_learning || control_mode == &mode_steering) {
-                    // if SW7 is ON in LEARNING = record the Wp
+            // if disarmed clear mission and set home to current location
+            if (!arming.is_armed()) {
+                mission.clear();
+                set_home_to_current_location(false);
+                return;
+            }
 
-                    // create new mission command
-                    AP_Mission::Mission_Command cmd = {};
+            // record the waypoint if in manual or steering modes
+            if (control_mode == &mode_manual || control_mode == &mode_steering) {
+                // create new mission command
+                AP_Mission::Mission_Command cmd = {};
 
-                    // set new waypoint to current location
-                    cmd.content.location = current_loc;
+                // set new waypoint to current location
+                cmd.content.location = current_loc;
 
-                    // make the new command to a waypoint
-                    cmd.id = MAV_CMD_NAV_WAYPOINT;
+                // make the new command to a waypoint
+                cmd.id = MAV_CMD_NAV_WAYPOINT;
 
-                    // save command
-                    if (mission.add_cmd(cmd)) {
-                        hal.console->printf("Learning waypoint %u", static_cast<uint32_t>(mission.num_commands()));
-                    }
-                } else if (control_mode == &mode_auto) {
-                    // if SW7 is ON in AUTO = set to RTL
-                    set_mode(mode_rtl, MODE_REASON_TX_COMMAND);
-                    break;
+                // save command
+                if (mission.add_cmd(cmd)) {
+                    hal.console->printf("Added waypoint %u", static_cast<uint32_t>(mission.num_commands()));
                 }
             }
         }

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -110,7 +110,7 @@ void Rover::reset_control_switch()
 // ready auxiliary switch's position
 aux_switch_pos Rover::read_aux_switch_pos()
 {
-    uint16_t radio_in = channel_aux->get_radio_in();
+    const uint16_t radio_in = channel_aux->get_radio_in();
     if (radio_in < AUX_SWITCH_PWM_TRIGGER_LOW) return AUX_SWITCH_LOW;
     if (radio_in > AUX_SWITCH_PWM_TRIGGER_HIGH) return AUX_SWITCH_HIGH;
     return AUX_SWITCH_MIDDLE;
@@ -126,7 +126,7 @@ void Rover::init_aux_switch()
 void Rover::read_aux_switch()
 {
     // do not consume input during rc or throttle failsafe
-    if (failsafe.bits & FAILSAFE_EVENT_THROTTLE || failsafe.bits & FAILSAFE_EVENT_RC) {
+    if ((failsafe.bits & FAILSAFE_EVENT_THROTTLE) || (failsafe.bits & FAILSAFE_EVENT_RC)) {
         return;
     }
 

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -174,6 +174,15 @@ void Rover::read_aux_switch()
             }
         }
         break;
+
+    // learn cruise speed and throttle
+    case CH7_LEARN_CRUISE:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            cruise_learn_start();
+        } else if (aux_ch7 == AUX_SWITCH_LOW) {
+            cruise_learn_complete();
+        }
+        break;
     }
 }
 

--- a/APMrover2/cruise_learn.cpp
+++ b/APMrover2/cruise_learn.cpp
@@ -1,0 +1,51 @@
+#include "Rover.h"
+
+// start cruise throttle and speed learning
+void Rover::cruise_learn_start()
+{
+    // if disarmed do nothing
+    if (!arming.is_armed()) {
+        cruise_learn.learning = false;
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning NOT stated");
+        return;
+    }
+    // when switch is high, start learning
+    float speed;
+    if (g2.attitude_control.get_forward_speed(speed)) {
+        cruise_learn.learning = true;
+        cruise_learn.speed_filt.reset(speed);
+        cruise_learn.throttle_filt.reset(g2.motors.get_throttle());
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning started");
+    }
+}
+
+// update cruise learning with latest speed and throttle
+// should be called at 50hz
+void Rover::cruise_learn_update()
+{
+    float speed;
+    if (cruise_learn.learning && g2.attitude_control.get_forward_speed(speed)) {
+        // update filters with latest speed and throttle
+        cruise_learn.speed_filt.apply(speed, 0.02f);
+        cruise_learn.throttle_filt.apply(g2.motors.get_throttle(), 0.02f);
+        return;
+    }
+}
+
+// complete cruise learning and save results
+void Rover::cruise_learn_complete()
+{
+    // when switch is moved low, save learned cruise value
+    if (cruise_learn.learning) {
+        float thr = cruise_learn.throttle_filt.get();
+        float speed = cruise_learn.speed_filt.get();
+        if (thr >= 10.0f && thr <= 100.0f && is_positive(speed)) {
+            g.throttle_cruise.set_and_save(thr);
+            g.speed_cruise.set_and_save(speed);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learned: Thr:%d Speed:%3.1f", (int)g.throttle_cruise, (double)g.speed_cruise);
+        } else {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning failed");
+        }
+        cruise_learn.learning = false;
+    }
+}

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -15,8 +15,9 @@
 
 // CH 7 control
 enum ch7_option {
-    CH7_DO_NOTHING = 0,
-    CH7_SAVE_WP    = 1
+    CH7_DO_NOTHING      = 0,
+    CH7_SAVE_WP         = 1,
+    CH7_LEARN_CRUISE    = 2
 };
 
 // HIL enumerations

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -113,3 +113,13 @@ enum mode_reason_t {
     MODE_REASON_CRASH_FAILSAFE,
     MODE_REASON_MISSION_COMMAND
 };
+
+// values used by the ap.ch7_opt and ap.ch8_opt flags
+enum aux_switch_pos {
+    AUX_SWITCH_LOW,
+    AUX_SWITCH_MIDDLE,
+    AUX_SWITCH_HIGH
+};
+
+#define AUX_SWITCH_PWM_TRIGGER_HIGH 1800   // pwm value above which the ch7 or ch8 option will be invoked
+#define AUX_SWITCH_PWM_TRIGGER_LOW  1200   // pwm value below which the ch7 or ch8 option will be disabled

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -27,7 +27,6 @@ enum ch7_option {
 // ----------------
 enum mode {
     MANUAL       = 0,
-    LEARNING     = 2,
     STEERING     = 3,
     HOLD         = 4,
     AUTO         = 10,

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -265,17 +265,6 @@ public:
 };
 
 
-class ModeLearning : public ModeManual
-{
-public:
-
-    uint32_t mode_number() const override { return LEARNING; }
-
-    // attributes for mavlink system status reporting
-    bool has_manual_input() const override { return true; }
-};
-
-
 class ModeRTL : public Mode
 {
 public:

--- a/APMrover2/mode_learning.cpp
+++ b/APMrover2/mode_learning.cpp
@@ -1,2 +1,0 @@
-#include "mode.h"
-#include "Rover.h"

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -8,7 +8,7 @@ void Rover::set_control_channels(void)
     // check change on RCMAP
     channel_steer    = RC_Channels::rc_channel(rcmap.roll()-1);
     channel_throttle = RC_Channels::rc_channel(rcmap.throttle()-1);
-    channel_learn    = RC_Channels::rc_channel(g.learn_channel-1);
+    channel_aux      = RC_Channels::rc_channel(g.aux_channel-1);
 
     // set rc channel ranges
     channel_steer->set_angle(SERVO_MAX);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -175,25 +175,6 @@ void Rover::control_failsafe(uint16_t pwm)
     }
 }
 
-/*
-  return true if throttle level is below throttle failsafe threshold
-  or RC input is invalid
- */
-bool Rover::throttle_failsafe_active(void)
-{
-    if (!g.fs_throttle_enabled) {
-        return false;
-    }
-    if (millis() - failsafe.last_valid_rc_ms > 1000) {
-        // we haven't had a valid RC frame for 1 seconds
-        return true;
-    }
-    if (channel_throttle->get_reverse()) {
-        return channel_throttle->get_radio_in() >= g.fs_throttle_value;
-    }
-    return channel_throttle->get_radio_in() <= g.fs_throttle_value;
-}
-
 void Rover::trim_control_surfaces()
 {
     read_radio();

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -189,7 +189,7 @@ void Rover::trim_control_surfaces()
 
 void Rover::trim_radio()
 {
-    for (int y = 0; y < 30; y++) {
+    for (uint8_t y = 0; y < 30; y++) {
         read_radio();
     }
     trim_control_surfaces();

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -148,6 +148,7 @@ void Rover::init_ardupilot()
     // set the correct flight mode
     // ---------------------------
     reset_control_switch();
+    init_aux_switch();
 
     // disable safety if requested
     BoardConfig.init_safety();

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -289,9 +289,6 @@ void Rover::notify_mode(enum mode new_mode)
     case MANUAL:
         notify.set_flight_mode_str("MANU");
         break;
-    case LEARNING:
-        notify.set_flight_mode_str("LERN");
-        break;
     case STEERING:
         notify.set_flight_mode_str("STER");
         break;


### PR DESCRIPTION
This PR makes the following changes:

- aux switch feature refactor a little to allow new features to be added more easily.  @peterbarker has a more complete change crossing over multiple vehicles but I think he will be OK to rebase upon this change.
- aux switch "save waypoint" feature is changed so that it: erases all waypoints and saves the current position as home if the vehicle is disarmed otherwise it saves the current position as a waypoint.  This works in all modes except AUTO.  I think this behaviour is easier to understand than the current behaviour which was:
  - erases the mission if in manual mode
  - sets home if in manual and steering is to the far right
  - saves waypoints in learning and steering mode
  - switches the vehicle to RTL if the vehicle is in auto
- removes the Learning mode which was just Manual mode and is no longer required with the modified "save waypoint" feature listed above.
- add aux switch feature to learn of the THROTTLE_CRUISE and SPEED_CRUISE parameters to simplify vehicle setup.  These parameters are used as the base for the throttle control so it's somewhat important that when driving at "SPEED_CRUISE" it requires "THROTTLE_CRUISE".  The user will set the CH7_OPTION parameter to "2", then drive in manual mode (although it works in other modes) up to a comfortable speed, hold the switch high for a few seconds, then pull it back low.
- two small unrelated fixes to replace an "int" with "uint8_t" and to remove an unused method.