### PR TITLE
from math import sqrt  # fix undefined name

### DIFF
--- a/Tools/LogAnalyzer/tests/TestIMUMatch.py
+++ b/Tools/LogAnalyzer/tests/TestIMUMatch.py
@@ -98,7 +98,7 @@ class TestIMUMatch(Test):
             ydiff_filtered += (ydiff-ydiff_filtered)*dt/filter_tc
             zdiff_filtered += (zdiff-zdiff_filtered)*dt/filter_tc
 
-            diff_filtered = math.sqrt(xdiff_filtered**2+ydiff_filtered**2+zdiff_filtered**2)
+            diff_filtered = sqrt(xdiff_filtered**2+ydiff_filtered**2+zdiff_filtered**2)
             max_diff_filtered = max(max_diff_filtered,diff_filtered)
             #print(max_diff_filtered)
             last_t = t

--- a/Tools/LogAnalyzer/tests/TestOptFlow.py
+++ b/Tools/LogAnalyzer/tests/TestOptFlow.py
@@ -1,7 +1,7 @@
 from LogAnalyzer import Test,TestResult
 import DataflashLog
 
-import math
+from math import sqrt
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
flake8 testing of https://github.com/ArduPilot/ardupilot on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Tools/LogAnalyzer/tests/TestIMUMatch.py:101:29: F821 undefined name 'math'
            diff_filtered = math.sqrt(xdiff_filtered**2+ydiff_filtered**2+zdiff_filtered**2)
                            ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:198:16: F821 undefined name 'sqrt'
            if sqrt(cov_x[0][0]) > param_std_threshold or sqrt(cov_y[0][0]) > param_std_threshold:
               ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:198:59: F821 undefined name 'sqrt'
            if sqrt(cov_x[0][0]) > param_std_threshold or sqrt(cov_y[0][0]) > param_std_threshold:
                                                          ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:200:170: F821 undefined name 'sqrt'
                self.result.statusMessage = "FAIL: inaccurate fit - poor quality or insufficient data\nFLOW_FXSCALER 1STD = %u\nFLOW_FYSCALER 1STD = %u\n" % (round(1000*sqrt(cov_x[0][0])),round(1000*sqrt(cov_y[0][0])))
                                                                                                                                                                         ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:200:200: F821 undefined name 'sqrt'
                self.result.statusMessage = "FAIL: inaccurate fit - poor quality or insufficient data\nFLOW_FXSCALER 1STD = %u\nFLOW_FYSCALER 1STD = %u\n" % (round(1000*sqrt(cov_x[0][0])),round(1000*sqrt(cov_y[0][0])))
                                                                                                                                                                                                       ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:208:287: F821 undefined name 'sqrt'
            self.result.statusMessage = "Set FLOW_FXSCALER to %i\nSet FLOW_FYSCALER to %i\n\nCal plots saved to flow_calibration.pdf\nCal parameters saved to flow_calibration.param\n\nFLOW_FXSCALER 1STD = %u\nFLOW_FYSCALER 1STD = %u\n" % (flow_fxscaler_new,flow_fyscaler_new,round(1000*sqrt(cov_x[0][0])),round(1000*sqrt(cov_y[0][0])))
                                                                                                                                                                                                                                                                                              ^

./Tools/LogAnalyzer/tests/TestOptFlow.py:208:317: F821 undefined name 'sqrt'
            self.result.statusMessage = "Set FLOW_FXSCALER to %i\nSet FLOW_FYSCALER to %i\n\nCal plots saved to flow_calibration.pdf\nCal parameters saved to flow_calibration.param\n\nFLOW_FXSCALER 1STD = %u\nFLOW_FYSCALER 1STD = %u\n" % (flow_fxscaler_new,flow_fyscaler_new,round(1000*sqrt(cov_x[0][0])),round(1000*sqrt(cov_y[0][0])))
                                                                                                                                                                                                                                                                                                                            ^
```