### PR TITLE
AP_Terrain: cast to int32_t to avoid warning about signedness

### DIFF
--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -171,9 +171,9 @@ void AP_Terrain::open_file(void)
     }
     snprintf(p, 13, "/%c%02u%c%03u.DAT",
              block.lat_degrees<0?'S':'N',
-             abs(block.lat_degrees),
+             abs((int32_t)block.lat_degrees),
              block.lon_degrees<0?'W':'E',
-             abs(block.lon_degrees));
+             abs((int32_t)block.lon_degrees));
 
     // create directory if need be
     if (!directory_created) {


### PR DESCRIPTION
../../libraries/AP_Terrain/TerrainIO.cpp: In member function ‘void
AP_Terrain::open_file()’:
../../libraries/AP_Terrain/TerrainIO.cpp:176:46: warning: format ‘%u’
expects argument of type ‘unsigned int’, but argument 5 has type
‘__gnu_cxx::__enable_if<true, double>::__type {aka double}’ [-Wformat=]
              abs((uint32_t)block.lon_degrees));
                                              ^
../../libraries/AP_Terrain/TerrainIO.cpp:176:46: warning: format ‘%u’
expects argument of type ‘unsigned int’, but argument 7 has type
‘__gnu_cxx::__enable_if<true, double>::__type {aka double}’ [-Wformat=]