### PR TITLE
Tools: SyntaxError: print() is a function in Python 3

### DIFF
--- a/Tools/scripts/magfit_flashlog.py
+++ b/Tools/scripts/magfit_flashlog.py
@@ -87,7 +87,7 @@ def find_offsets(data, ofs):
         ofs = ofs - delta
 
         if opts.verbose:
-            print ofs
+            print(ofs)
     return ofs
 
 

--- a/Tools/scripts/update_wiki.py
+++ b/Tools/scripts/update_wiki.py
@@ -7,6 +7,7 @@ May 2013
 See http://codex.wordpress.org/XML-RPC_WordPress_API/Posts
 '''
 
+fron __future__ import print_function
 import xmlrpclib, sys
 
 from optparse import OptionParser

--- a/Tools/scripts/update_wiki.py
+++ b/Tools/scripts/update_wiki.py
@@ -87,5 +87,5 @@ r = server.wp.editPost(opts.blog_id, opts.username, opts.password, post_id, { 'p
 if r == True:
     print("Upload OK")
     sys.exit(0)
-print 'result: ', r
+print('result: ', r)
 sys.exit(1)

--- a/Tools/scripts/update_wiki.py
+++ b/Tools/scripts/update_wiki.py
@@ -7,7 +7,7 @@ May 2013
 See http://codex.wordpress.org/XML-RPC_WordPress_API/Posts
 '''
 
-fron __future__ import print_function
+from __future__ import print_function
 import xmlrpclib, sys
 
 from optparse import OptionParser


### PR DESCRIPTION
Tools: Fix two SyntaxErrors that will halt execution on Python 3

flake8 testing of https://github.com/ArduPilot/ardupilot on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Tools/scripts/magfit_flashlog.py:90:21: E999 SyntaxError: invalid syntax
            print ofs
                    ^

E999 SyntaxError: invalid syntax
```