### PR TITLE
Autotest: Skip unnecessary log downloads

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1333,8 +1333,7 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
     util.pexpect_close(sitl)
 
     # copy DF log
-    if not is_CI_test():
-        move_most_recent_log("../buildlogs/ArduCopter-log.bin")
+    move_most_recent_log("../buildlogs/ArduCopter-log.bin")
 
     valgrind_log = util.valgrind_log_filepath(binary=binary, model='+')
     if os.path.exists(valgrind_log):
@@ -1467,8 +1466,7 @@ def fly_CopterAVC(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fals
     util.pexpect_close(sitl)
 
     # copy DF log
-    if not is_CI_test():
-        move_most_recent_log("../buildlogs/CopterAVC-log.bin")
+    move_most_recent_log("../buildlogs/CopterAVC-log.bin")
 
     valgrind_log = util.valgrind_log_filepath(binary=binary, model='heli')
     if os.path.exists(valgrind_log):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -29,7 +29,7 @@ AVCHOME = mavutil.location(40.072842, -105.230575, 1586, 0)
 
 homeloc = None
 num_wp = 0
-speedup_default = 10
+speedup_default = 20
 
 
 def wait_ready_to_arm(mavproxy):
@@ -1004,6 +1004,30 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
     util.pexpect_close(mavproxy)
     util.pexpect_close(sitl)
 
+    # test a log download
+    sitl = util.start_SITL(binary, model=frame, home=home, speedup=speedup_default, valgrind=valgrind, gdb=gdb, gdbserver=gdbserver)
+    mavproxy = util.start_MAVProxy_SITL('ArduCopter', options='--sitl=127.0.0.1:5501 --out=127.0.0.1:19550 --quadcopter')
+    mavproxy.expect('Received [0-9]+ parameters')
+    # get a mavlink connection going
+    try:
+        mav = mavutil.mavlink_connection('127.0.0.1:19550', robust_parsing=True)
+    except Exception as msg:
+        print("Failed to start mavlink connection on 127.0.0.1:19550" % msg)
+        raise
+    mav.message_hooks.append(message_hook)
+    mav.idle_hooks.append(idle_hook)
+    # give the log some time to fill up
+    time.sleep(10 / speedup_default)
+    print("# Log Download")
+    if not log_download(mavproxy, mav, util.reltopdir("../buildlogs/ArduCopter-log-download.bin")):
+        print("Failed log download")
+        failed = True
+
+    # reboot for the remainint testing
+    mav.close()
+    util.pexpect_close(mavproxy)
+    util.pexpect_close(sitl)
+
     sitl = util.start_SITL(binary, model=frame, home=home, speedup=speedup_default, valgrind=valgrind, gdb=gdb, gdbserver=gdbserver)
     options = '--sitl=127.0.0.1:5501 --out=127.0.0.1:19550 --quadcopter --streamrate=5'
     if viewerip:
@@ -1300,11 +1324,6 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
         # wait for disarm
         mav.motors_disarmed_wait()
 
-        if not log_download(mavproxy, mav, util.reltopdir("../buildlogs/ArduCopter-log.bin")):
-            failed_test_msg = "log_download failed"
-            print(failed_test_msg)
-            failed = True
-
     except pexpect.TIMEOUT as failed_test_msg:
         failed_test_msg = "Timeout"
         failed = True
@@ -1312,6 +1331,10 @@ def fly_ArduCopter(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fal
     mav.close()
     util.pexpect_close(mavproxy)
     util.pexpect_close(sitl)
+
+    # copy DF log
+    if not is_CI_test():
+        move_most_recent_log("../buildlogs/ArduCopter-log.bin")
 
     valgrind_log = util.valgrind_log_filepath(binary=binary, model='+')
     if os.path.exists(valgrind_log):
@@ -1434,10 +1457,6 @@ def fly_CopterAVC(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fals
         mavproxy.send('rc 8 1000\n')
 
         # mission includes disarm at end so should be ok to download logs now
-        if not log_download(mavproxy, mav, util.reltopdir("../buildlogs/CopterAVC-log.bin")):
-            failed_test_msg = "log_download failed"
-            print(failed_test_msg)
-            failed = True
 
     except pexpect.TIMEOUT as failed_test_msg:
         failed_test_msg = "Timeout"
@@ -1446,6 +1465,10 @@ def fly_CopterAVC(binary, viewerip=None, use_map=False, valgrind=False, gdb=Fals
     mav.close()
     util.pexpect_close(mavproxy)
     util.pexpect_close(sitl)
+
+    # copy DF log
+    if not is_CI_test():
+        move_most_recent_log("../buildlogs/CopterAVC-log.bin")
 
     valgrind_log = util.valgrind_log_filepath(binary=binary, model='heli')
     if os.path.exists(valgrind_log):

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -290,7 +290,3 @@ def move_most_recent_log(dest):
         log_path = util.reltopdir("logs/%08d.BIN" % log_num)
         print("Moving log %s to %s" % (log_path, dest))
         os.rename(log_path, dest)
-
-def is_CI_test():
-    """Returns true if the test is running as part of a CI build"""
-    return os.environ.get('CI') == 'true'

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import math
+import os
 import time
 
 from pymavlink import mavwp
@@ -281,3 +282,15 @@ def log_download(mavproxy, mav, filename, timeout=360):
     mav.wait_heartbeat()
     mav.wait_heartbeat()
     return True
+
+def move_most_recent_log(dest):
+    """Move the most recent log file"""
+    with open("logs/LASTLOG.TXT") as log_num_file:
+        log_num = int(log_num_file.read().strip())
+        log_path = util.reltopdir("logs/%08d.BIN" % log_num)
+        print("Moving log %s to %s" % (log_path, dest))
+        os.rename(log_path, dest)
+
+def is_CI_test():
+    """Returns true if the test is running as part of a CI build"""
+    return os.environ.get('CI') == 'true'


### PR DESCRIPTION
Downloading logs over MAVLink represents 20% of the run time of the fly.ArduCopter runtime. This is used to both test log downloading and copy the log for the autotest server. However the log file that is selected is a large log file, which takes quite a long time to process (it's speed limited by MAVProxy). This PR moves log downloading to it's own test which is run once, and directly copies the log file on the disk for autotest server.

The CI environment variable is used to flag if logs should be copied (was selected because Semaphore defaults to setting it true). It could potentially be passed down from autotest.py as an option instead if that is preferred, it just meant more modifications to the CI sides to pass it in. I'm fine with changing it to whichever approach is preferred.

This isn't expected to be merged as is, I'm presenting it here for review before I duplicate the same logic into plane/rover/sub scripts. This is meant to live along with #6821 