### PR TITLE
mk: l is an undefined name; use orig_line instead

### DIFF
--- a/mk/PX4/Tools/genmsg/src/genmsg/msg_loader.py
+++ b/mk/PX4/Tools/genmsg/src/genmsg/msg_loader.py
@@ -198,7 +198,7 @@ def _load_constant_line(orig_line):
     else:
         line_splits = [x.strip() for x in ' '.join(line_splits[1:]).split(CONSTCHAR)] #resplit on '='
         if len(line_splits) != 2:
-            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
+            raise InvalidMsgSpec("Invalid constant declaration: %s"%orig_line)
         name = line_splits[0]
         val = line_splits[1]
 

--- a/mk/VRBRAIN/Tools/genmsg/src/genmsg/msg_loader.py
+++ b/mk/VRBRAIN/Tools/genmsg/src/genmsg/msg_loader.py
@@ -198,7 +198,7 @@ def _load_constant_line(orig_line):
     else:
         line_splits = [x.strip() for x in ' '.join(line_splits[1:]).split(CONSTCHAR)] #resplit on '='
         if len(line_splits) != 2:
-            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
+            raise InvalidMsgSpec("Invalid constant declaration: %s"%orig_line)
         name = line_splits[0]
         val = line_splits[1]
 


### PR DESCRIPTION
Without this change, a `NameError` is raised instead of the expected `InvalidMsgSpec`.

flake8 testing of https://github.com/ArduPilot/ardupilot on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mk/PX4/Tools/genmsg/src/genmsg/msg_loader.py:201:69: F821 undefined name 'l'
            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
                                                                    ^
./mk/VRBRAIN/Tools/genmsg/src/genmsg/msg_loader.py:201:69: F821 undefined name 'l'
            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
                                                                    ^
```
