### PR TITLE
Tools: define reduce() for Python 3

### DIFF
--- a/Tools/LogAnalyzer/tests/TestCompass.py
+++ b/Tools/LogAnalyzer/tests/TestCompass.py
@@ -1,12 +1,8 @@
 from LogAnalyzer import Test,TestResult
 import DataflashLog
 
+from functools import reduce
 import math
-
-try:               # Python 2
-    reduce
-except NameError:  # Python 3
-    from functools import reduce
 
 
 class TestCompass(Test):
@@ -117,13 +113,3 @@ class TestCompass(Test):
         except KeyError as e:
             self.result.status = TestResult.StatusType.FAIL
             self.result.statusMessage = str(e) + ' not found'
-
-
-
-
-
-
-
-
-
-

--- a/Tools/LogAnalyzer/tests/TestCompass.py
+++ b/Tools/LogAnalyzer/tests/TestCompass.py
@@ -3,6 +3,11 @@ import DataflashLog
 
 import math
 
+try:               # Python 2
+    reduce
+except NameError:  # Python 3
+    from functools import reduce
+
 
 class TestCompass(Test):
     '''test for compass offsets and throttle interference'''


### PR DESCRIPTION
`reduce()` is called on line 55.  Python 3 dropped reduce() as a builtin.  https://docs.python.org/3/whatsnew/3.0.html#builtins encourages the rewriting of reduce() calls as explicit for loops or list comprehensions but I am not confident to attempt that in this context.