### PR TITLE
COPTER: Landing gear mavlink control & remove lock state

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -928,6 +928,21 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         return MAV_RESULT_FAILED;
 #endif
 
+        case MAV_CMD_AIRFRAME_CONFIGURATION: {
+            // Param 1: Select which gear, not used in ArduPilot
+            // Param 2: 0 = Deploy, 1 = Retract
+            // For safety, anything other than 1 will deploy
+            switch ((uint8_t)packet.param2) {
+                case 1:
+                    copter.landinggear.set_position(AP_LandingGear::LandingGear_Retract);
+                    return MAV_RESULT_ACCEPTED;
+                default:
+                    copter.landinggear.set_position(AP_LandingGear::LandingGear_Deploy);
+                    return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+
         /* Solo user presses Fly button */
     case MAV_CMD_SOLO_BTN_FLY_CLICK: {
         if (copter.failsafe.radio) {

--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -15,7 +15,7 @@ void Copter::landinggear_update()
     // if we are doing an automatic landing procedure, force the landing gear to deploy.
     // To-Do: should we pause the auto-land procedure to give time for gear to come down?
     if (flightmode->landing_gear_should_be_deployed()) {
-        landinggear.set_position(AP_LandingGear::LandingGear_Deploy_And_Keep_Deployed);
+        landinggear.set_position(AP_LandingGear::LandingGear_Deploy);
     }
 
     // send event message to datalog if status has changed

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -58,17 +58,10 @@ void AP_LandingGear::set_position(LandingGearCommand cmd)
 {
     switch (cmd) {
         case LandingGear_Retract:
-            if (!_deploy_lock) {
-                retract();
-            }
+            retract();
             break;
         case LandingGear_Deploy:
             deploy();
-            _deploy_lock = false;
-            break;
-        case LandingGear_Deploy_And_Keep_Deployed:
-            deploy();
-            _deploy_lock = true;
             break;
     }
 }

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -25,7 +25,6 @@ public:
     enum LandingGearCommand {
         LandingGear_Retract,
         LandingGear_Deploy,
-        LandingGear_Deploy_And_Keep_Deployed,
     };
 
     // Gear command modes
@@ -54,7 +53,6 @@ private:
 
     // internal variables
     bool        _deployed;              // true if the landing gear has been deployed, initialized false
-    bool        _deploy_lock;           // used to force landing gear to remain deployed until another regular Deploy command is received to reduce accidental retraction
     
     /// retract - retract landing gear
     void retract();


### PR DESCRIPTION
This does a few things related to landing gear in copter.  What prompted me to do this was adding landing gear functionality to the Solo. I found that there was no mavlink landing gear functionality in ArduPilot.  And that stumbled into the auto deploy vs switch position conundrum.  I think I've come up with a method to safely handle all of this, and make the operation easier and cleaner for the operator.

- **COPTER GCS_Mavlink:** Adds mavlink control of landing gear. This will allow you to control the landing gear via GCS and companion computers communicating via mavlink.  Previously, the only way to control landing gear, was using the CH7/8 options, which is very limiting.
  - Add  MAV_CMD_AIRFRAME_CONFIGURATION (# 2520), which is for landing gear control
  - Param 1 is to select specific gear, which is not used in ArduPilot.
  - Param 2 is deploy/retract. 0 is deploy, 1 is Retract
  - My implementation uses 1 to retract and anything other than 1 to deploy to make it error-safe
.
- **COPTER Landing_Gear:** This allows you to programmatically and safely release the "deployed and locked" state that is set when in an automatic landing mode. This locked state prevents the gear from inadvertently retracting after and auto-deploy if the gear switch happens to still be in the up position.  However, this also means the operator has to cycle the gear switch to down (or send the mavlink or mission down command) in order to regain manual control of the gear.  This is confusing and cumbersome.  So I've modified this to be simpler, safe, and easy to operate.
  - Added neutral to the gear switch handling, and added `gear_sw_up` to know when it's up
  - When exiting a mode that auto-deployed the gear, _it checks if the gear switch is up first_.
  - If the gear switch is up, the gear stays in a locked state and the operator is warned.
  - If the gear switch is neutral or down, the lock is released and the gear will operate normally.
  - This prevents the operator from having to unnecessarily cycle the gear switch or commands.
.
- **AP_LANDING_GEAR:** 
  - Add GCS message for deploy & retract.
  - Add an unlock command. Mainly so we can unlock when exiting an auto landing mode.
  - Add a locked bool so the copter code can see if the gear is locked down or not.
.
- **Changes to existing operation:**
  - If the landing gear automatically deploys in an automatic landing mode, _and the RC gear switch is in the neutral or down position_, you no longer need to cycle the switch to regain manual control of the landing gear after the automatic landing terminates. 
  - If the landing gear automatically deploys in an automatic landing mode, _and the RC gear switch is in the up position_, the gear will remain locked down until you take the switch out of the up position. You can go to neutral or down. Either way, the gear will unlock and resume operating normally.
  - You can now use MAV_CMD_AIRFRAME_CONFIGURATION to retract/deploy the gear without needing the CH7/8 option or any RC switch at all.
  - The existing auto-deploy in RTL or land mode, and auto mission rtl/land remains unchanged and will still happen. 


**And it even worked!**
Mavlink commanded gear up and down verified on Mission Planner. The servo PWM out changed appropriately, and the GCS messages came through to tell the operator what it's doing.
![capture](https://user-images.githubusercontent.com/8234496/29747618-6c78cbd0-8ace-11e7-825a-e973eddf7138.JPG)
