### PR TITLE
AP_Mission: Added MIS_RETAIN Parameter to clear Mission on boot Issue…

### DIFF
--- a/APMrover2/release-notes.txt
+++ b/APMrover2/release-notes.txt
@@ -1,3 +1,30 @@
+APMrover2 Release Notes:
+========================
+APM:Rover V3.2.0-rc1 25-Aug-2017
+Changes from 3.1.2:
+1) Skid-steering vehicle support added (i.e. tank track or R2D2 style vehicles)
+2) Brushless motor support
+3) Improved speed/throttle and steering controllers:
+    a) layered P and PID controllers with optional feedforward, input filtering and saturation handling (reduces unnecessary I-term build-up) 
+    b) forward-back acceleration limited (see ATC_ACCEL_MAX parameter)
+    c) pro-active slowing before waypoint in order to keep overshoot at or below WP_OVERSHOOT distance
+    d) proper output scaling for skid-steering vs regular car steering controls
+    e) TURN_RADIUS parameter added to allow better control of turn in Steering mode
+    f) speed along forward-back axis used instead of total ground speed (resolves unusual behaviour for boats being washed downstream)
+4) Auxiliary switch changes (see CH7_OPTION parameter):
+    a) "Save Waypoint" saves the current location as a waypoint in all modes except AUTO if the vehicle is armed.  If disarmed the mission is cleared and home is set to the current location.
+    b) "Learn Cruise" sets the THROTTLE_CRUISE and SPEED_CRUISE parameter values to the vehicle's current speed and throttle level 
+5) Wheel encoder supported for non-GPS navigation (can also be used with GPS)
+6) Visual Odometry support for non-GPS navigation (can also be used with GPS)
+7) Guided mode improvements:
+    a) for SET_ATTITUDE_TARGET accepts quaternions for target heading, valid thrust changed to -1 ~ +1 range (was previously 0 ~ 1)
+    b) COMMAND_LONG.SET_YAW_SPEED support fixes (thrust field accepted as target speed in m/s)
+    c) SET_POSITION_TARGET_GLOBAL_INT, _LOCAL_NED fixes and added support for yaw and yaw-rate fields
+8) Bug Fixes:
+    a) resolve occasional start of motors after power-on
+    b) steering mode turn direction fix while reversing
+    c) reversing in auto mode fixes (see DO_REVERSE mission command)
+----------------------------------------------------------
 Release 3.1.2, 15 March 2017
 ============================
 Minor bugfix release.

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -22,6 +22,13 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RESTART",  1, AP_Mission, _restart, AP_MISSION_RESTART_DEFAULT),
 
+    // @Param: RETAIN
+    // @DisplayName: Mission retained after reboot
+    // @Description: Controls mission if the mission is retained after a reboot, 0 to clear, 1 to retain.
+    // @Values: 0:Clear Mission, 1:Retain Mission
+    // @User: Advanced
+    AP_GROUPINFO("RETAIN",  2, AP_Mission, _retain, AP_MISSION_RETAIN_DEFAULT),
+
     AP_GROUPEND
 };
 
@@ -44,6 +51,12 @@ void AP_Mission::init()
     // prevent an easy programming error, this will be optimised out
     if (sizeof(union Content) != 12) {
         AP_HAL::panic("AP_Mission Content must be 12 bytes");
+    }
+    
+    // If _retain equals 0 then it should clear the mission
+    if(_retain == 0) {
+    	gcs().send_text(MAV_SEVERITY_INFO, "Clearing Mission");
+    	clear();	
     }
 
     _last_change_time_ms = AP_HAL::millis();

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -24,8 +24,8 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: Mission options bitmask
-    // @Description: Bitmap of what options to use. This values is made up of the sum of each of the mission options you require.  The individual bits are CLEAR_MISSION=1
-    // @Values: 0:Clear Mission, 1:Retain Mission
+    // @Description: Bitmap of what options to use. This values is made up of the sum of each of the mission options you require.
+    // @Bitmask: 0:Clear Mission
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 
@@ -53,8 +53,8 @@ void AP_Mission::init()
         AP_HAL::panic("AP_Mission Content must be 12 bytes");
     }
     
-    // If Mission retain bit is not set then it should clear the mission
-    if(!is_option(MASK_MISSION_RETAIN)) {
+    // If Mission Clear bit is set then it should clear the mission, otherwise retain the mission.
+    if(MASK_MISSION_CLEAR & _options) {
     	gcs().send_text(MAV_SEVERITY_INFO, "Clearing Mission");
     	clear();	
     }
@@ -1688,14 +1688,3 @@ bool AP_Mission::jump_to_landing_sequence(void)
     gcs().send_text(MAV_SEVERITY_WARNING, "Unable to start landing sequence");
     return false;
 }
-
-bool AP_Mission::is_option(const uint8_t mask)
-{
-	if (!(mask & _options)) {
-        return false;
-    }
-
-	return true;
-}
-
-

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -22,12 +22,12 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RESTART",  1, AP_Mission, _restart, AP_MISSION_RESTART_DEFAULT),
 
-    // @Param: RETAIN
-    // @DisplayName: Mission retained after reboot
-    // @Description: Controls mission if the mission is retained after a reboot, 0 to clear, 1 to retain.
+    // @Param: OPTIONS
+    // @DisplayName: Mission options bitmask
+    // @Description: Bitmap of what options to use. This values is made up of the sum of each of the mission options you require.  The individual bits are CLEAR_MISSION=1
     // @Values: 0:Clear Mission, 1:Retain Mission
     // @User: Advanced
-    AP_GROUPINFO("RETAIN",  2, AP_Mission, _retain, AP_MISSION_RETAIN_DEFAULT),
+    AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 
     AP_GROUPEND
 };
@@ -54,7 +54,7 @@ void AP_Mission::init()
     }
     
     // If _retain equals 0 then it should clear the mission
-    if(_retain == 0) {
+    if(!is_option(MASK_MISSION_RETAIN)) {
     	gcs().send_text(MAV_SEVERITY_INFO, "Clearing Mission");
     	clear();	
     }
@@ -1688,3 +1688,14 @@ bool AP_Mission::jump_to_landing_sequence(void)
     gcs().send_text(MAV_SEVERITY_WARNING, "Unable to start landing sequence");
     return false;
 }
+
+bool AP_Mission::is_option(const uint8_t mask)
+{
+	if (!(mask & _options)) {
+        return false;
+    }
+
+	return true;
+}
+
+

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -53,7 +53,7 @@ void AP_Mission::init()
         AP_HAL::panic("AP_Mission Content must be 12 bytes");
     }
     
-    // If _retain equals 0 then it should clear the mission
+    // If Mission retain bit is not set then it should clear the mission
     if(!is_option(MASK_MISSION_RETAIN)) {
     	gcs().send_text(MAV_SEVERITY_INFO, "Clearing Mission");
     	clear();	

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -37,9 +37,9 @@
 
 #define AP_MISSION_RESTART_DEFAULT          0       // resume the mission from the last command run by default
 
-#define AP_MISSION_OPTIONS_DEFAULT          1       // Retain the mission when rebooting
+#define AP_MISSION_OPTIONS_DEFAULT          0       // Do not clear the mission when rebooting
 
-#define MASK_MISSION_RETAIN                 (1<<0)
+#define MASK_MISSION_CLEAR                 (1<<0)   // If set then Clear the mission on boot
 
 /// @class    AP_Mission
 /// @brief    Object managing Mission
@@ -442,10 +442,6 @@ public:
     // available.
     bool jump_to_landing_sequence(void);
 
-    // check if an option is set within the option bitmask.  Returns true if
-    // option is set.  Returns false if the option is not set.
-    bool is_option(const uint8_t mask);
-
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -512,7 +508,7 @@ private:
     // parameters
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
-    AP_Int8                _options;    // bitmask options for missions, currently for mission retention on reboot but can be expanded as required
+    AP_Int16                _options;    // bitmask options for missions, currently for mission clearing on reboot but can be expanded as required
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -37,6 +37,8 @@
 
 #define AP_MISSION_RESTART_DEFAULT          0       // resume the mission from the last command run by default
 
+#define AP_MISSION_RETAIN_DEFAULT          1       // Retain the mission when rebooting
+
 /// @class    AP_Mission
 /// @brief    Object managing Mission
 class AP_Mission {
@@ -504,6 +506,7 @@ private:
     // parameters
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
+    AP_Int8                 _retain;    // controls if the mission is retained on a reboot, 0 for clearing the mission, 1 for retaining the mission.
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -37,7 +37,9 @@
 
 #define AP_MISSION_RESTART_DEFAULT          0       // resume the mission from the last command run by default
 
-#define AP_MISSION_RETAIN_DEFAULT          1       // Retain the mission when rebooting
+#define AP_MISSION_OPTIONS_DEFAULT          1       // Retain the mission when rebooting
+
+#define MASK_MISSION_RETAIN                 (1<<0)
 
 /// @class    AP_Mission
 /// @brief    Object managing Mission
@@ -440,6 +442,10 @@ public:
     // available.
     bool jump_to_landing_sequence(void);
 
+    // check if an option is set within the option bitmask.  Returns true if
+    // option is set.  Returns false if the option is not set.
+    bool is_option(const uint8_t mask);
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -506,7 +512,7 @@ private:
     // parameters
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
-    AP_Int8                 _retain;    // controls if the mission is retained on a reboot, 0 for clearing the mission, 1 for retaining the mission.
+    AP_Int8                _options;    // bitmask options for missions, currently for mission retention on reboot but can be expanded as required
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started


### PR DESCRIPTION
… #5743 & #6383 (closed)

Added the MIS_RETAIN parameter to allow people to clear a mission on boot up if they wish.  It's default is to use current behavior which is to retain any missions that are loaded.  This has been tested on SITL (both positive and negative scenarios) but not a read device.  I can test it on either a Pixhawk or Cube (Pixhawk 2.1) if required.

As this is my first change to Ardupilot, please ensure I've followed the sytle guide correctly.

Let me know if I need to do anything extra....