### PR TITLE
Plane: Parameterize the home altitude reset conditions

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1176,6 +1176,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("MANUAL_RCMASK", 10, ParametersG2, manual_rc_mask, 0),
     
+    // @Param: HOME_RESET_ALT
+    // @DisplayName: Home reset altitude threshold
+    // @Description: When the aircraft is within this altitude of the home waypoint, while disarmed it will automatically update the home position. Set to 0 to continously reset it.
+    // @Values: -1:Never reset,0:Always reset
+    // @Range: -1 127
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("HOME_RESET_ALT", 11, ParametersG2, home_reset_threshold, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -541,6 +541,10 @@ public:
 
     // mask of channels to do manual pass-thru for
     AP_Int32 manual_rc_mask;
+
+    // home reset altitude threshold
+    AP_Int8 home_reset_threshold;
+
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -126,7 +126,9 @@ void Plane::init_home()
 */
 void Plane::update_home()
 {
-    if (fabsf(barometer.get_altitude()) > 2) {
+    if ((g2.home_reset_threshold == -1) ||
+        ((g2.home_reset_threshold > 0) &&
+         (fabsf(barometer.get_altitude()) > g2.home_reset_threshold))) {
         // don't auto-update if we have changed barometer altitude
         // significantly. This allows us to cope with slow baro drift
         // but not re-do home and the baro if we have changed height


### PR DESCRIPTION
This allows the user to control what threshold is used for deciding if the home position/baro should be updated. This also represents a behaviour change, but it is actually rolling back to the old behavior we used to have (of always updating when disarmed).

This also fixes a problem with PH2.1 with Plane where the baro heater could cause such a large ramp that the barometer was considered to be >2 meters before we got back to the calibration update, which can lead to very large baro errors before takeoff, unless a manual airspeed calibration was triggered.