### PR TITLE
Emlid Reach FW >= 2.7.4 outputs GPS2 _RTK mavlink message

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -926,17 +926,13 @@ void AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
         rtk_age_ms(1));
 }
 
-void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan)
+void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)
 {
-    if (drivers[0] != nullptr && drivers[0]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
-        drivers[0]->send_mavlink_gps_rtk(chan);
+    if (inst >= GPS_MAX_RECEIVERS) {
+        return;
     }
-}
-
-void AP_GPS::send_mavlink_gps2_rtk(mavlink_channel_t chan)
-{
-    if (drivers[1] != nullptr && drivers[1]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
-        drivers[1]->send_mavlink_gps_rtk(chan);
+    if (drivers[inst] != nullptr && drivers[inst]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
+        drivers[inst]->send_mavlink_gps_rtk(chan);
     }
 }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -931,7 +931,7 @@ void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)
     if (inst >= GPS_MAX_RECEIVERS) {
         return;
     }
-    if (drivers[inst] != nullptr && drivers[inst]->highest_supported_status() > AP_GPS::GPS_OK_FIX_3D) {
+    if (drivers[inst] != nullptr && drivers[inst]->supports_mavlink_gps_rtk_message()) {
         drivers[inst]->send_mavlink_gps_rtk(chan);
     }
 }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -363,8 +363,7 @@ public:
     void send_mavlink_gps_raw(mavlink_channel_t chan);
     void send_mavlink_gps2_raw(mavlink_channel_t chan);
 
-    void send_mavlink_gps_rtk(mavlink_channel_t chan);
-    void send_mavlink_gps2_rtk(mavlink_channel_t chan);
+    void send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst);
 
     // Returns the index of the first unconfigured GPS (returns GPS_ALL_CONFIGURED if all instances report as being configured)
     uint8_t first_unconfigured_gps(void) const;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -149,8 +149,16 @@ public:
         uint32_t last_gps_time_ms;          ///< the system time we got the last GPS timestamp, milliseconds
 
         // all the following fields must only all be filled by RTK capable backend drivers
+        uint32_t rtk_time_week_ms;         ///< GPS Time of Week of last baseline in milliseconds
+        uint16_t rtk_week_number;          ///< GPS Week Number of last baseline
         uint32_t rtk_age_ms;               ///< GPS age of last baseline correction in milliseconds  (0 when no corrections, 0xFFFFFFFF indicates overflow)
         uint8_t  rtk_num_sats;             ///< Current number of satellites used for RTK calculation
+        uint8_t  rtk_baseline_coords_type; ///< Coordinate system of baseline. 0 == ECEF, 1 == NED
+        int32_t  rtk_baseline_x_mm;        ///< Current baseline in ECEF x or NED north component in mm
+        int32_t  rtk_baseline_y_mm;        ///< Current baseline in ECEF y or NED east component in mm
+        int32_t  rtk_baseline_z_mm;        ///< Current baseline in ECEF z or NED down component in mm
+        uint32_t rtk_accuracy;             ///< Current estimate of 3D baseline accuracy (receiver dependent, typical 0 to 9999)
+        int32_t  rtk_iar_num_hypotheses;   ///< Current number of integer ambiguity hypotheses
     };
 
     /// Startup initialisation.

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -209,6 +209,23 @@ AP_GPS_ERB::_parse_gps(void)
         state.speed_accuracy = _buffer.vel.speed_accuracy * 0.01f;
         _new_speed = true;
         break;
+    case MSG_RTK:
+        Debug("Message RTK");
+        state.rtk_baseline_coords_type = RTK_BASELINE_COORDINATE_SYSTEM_NED;
+        state.rtk_num_sats      = _buffer.rtk.base_num_sats;
+        if (_buffer.rtk.age_cs == 0xFFFF) {
+            state.rtk_age_ms    = 0xFFFFFFFF;
+        } else {
+            state.rtk_age_ms    = _buffer.rtk.age_cs * 10;
+        }
+        state.rtk_baseline_x_mm = _buffer.rtk.baseline_N_mm;
+        state.rtk_baseline_y_mm = _buffer.rtk.baseline_E_mm;
+        state.rtk_baseline_z_mm = _buffer.rtk.baseline_D_mm;
+        state.rtk_accuracy      = _buffer.rtk.ar_ratio;
+
+        state.rtk_week_number   = _buffer.rtk.base_week_number;
+        state.rtk_time_week_ms  = _buffer.rtk.base_time_week_ms;
+        break;
     default:
         Debug("Unexpected message 0x%02x", (unsigned)_msg_id);
         return false;

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -83,6 +83,16 @@ private:
         int32_t heading_2d; ///< Heading of motion 2-D [1e5 deg]
         uint32_t speed_accuracy; ///< Speed accuracy Estimate [cm/s]
     };
+    struct PACKED erb_rtk {
+        uint8_t base_num_sats;       ///< Current number of satellites used for RTK calculation
+        uint16_t age_cs;             ///< Age of the corrections in centiseconds (0 when no corrections, 0xFFFF indicates overflow)
+        int32_t baseline_N_mm;       ///< distance between base and rover along the north axis in millimeters
+        int32_t baseline_E_mm;       ///< distance between base and rover along the east axis in millimeters
+        int32_t baseline_D_mm;       ///< distance between base and rover along the down axis in millimeters
+        uint16_t ar_ratio;           ///< AR ratio multiplied by 10
+        uint16_t base_week_number;   ///< GPS Week Number of last baseline
+        uint32_t base_time_week_ms;  ///< GPS Time of Week of last baseline in milliseconds
+    };
 
     // Receive buffer
     union PACKED {
@@ -92,6 +102,7 @@ private:
         erb_stat stat;
         erb_dops dops;
         erb_vel vel;
+        erb_rtk rtk;
     } _buffer;
 
     enum erb_protocol_bytes {
@@ -102,6 +113,7 @@ private:
         MSG_STAT = 0x03,
         MSG_DOPS = 0x04,
         MSG_VEL = 0x05,
+        MSG_RTK = 0x07,
     };
 
     enum erb_fix_type {

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -34,6 +34,8 @@ public:
 
     AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
+    bool supports_mavlink_gps_rtk_message() { return true; }
+
     static bool _detect(struct ERB_detect_state &state, uint8_t data);
 
     const char *name() const override { return "ERB"; }

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -289,6 +289,7 @@ AP_GPS_SBP::_attempt_state_update()
 
         last_full_update_tow = last_vel_ned.tow;
         last_full_update_cpu_ms = now;
+        state.rtk_iar_num_hypotheses = last_iar_num_hypotheses;
 
         logging_log_full_update();
         ret = true;

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -31,6 +31,8 @@ public:
 
     AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
+    bool supports_mavlink_gps_rtk_message() { return true; }
+
     // Methods
     bool read();
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -184,3 +184,45 @@ bool AP_GPS_Backend::should_df_log() const
     }
     return true;
 }
+
+
+void AP_GPS_Backend::send_mavlink_gps_rtk(mavlink_channel_t chan)
+{
+    const uint8_t instance = state.instance;
+    // send status
+    switch (instance) {
+        case 0:
+            mavlink_msg_gps_rtk_send(chan,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_week_number,
+                                 state.rtk_time_week_ms,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_num_sats,
+                                 state.rtk_baseline_coords_type,
+                                 state.rtk_baseline_x_mm,
+                                 state.rtk_baseline_y_mm,
+                                 state.rtk_baseline_z_mm,
+                                 state.rtk_accuracy,
+                                 state.rtk_iar_num_hypotheses);
+            break;
+        case 1:
+            mavlink_msg_gps2_rtk_send(chan,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_week_number,
+                                 state.rtk_time_week_ms,
+                                 0,  // Not implemented yet
+                                 0,  // Not implemented yet
+                                 state.rtk_num_sats,
+                                 state.rtk_baseline_coords_type,
+                                 state.rtk_baseline_x_mm,
+                                 state.rtk_baseline_y_mm,
+                                 state.rtk_baseline_z_mm,
+                                 state.rtk_accuracy,
+                                 state.rtk_iar_num_hypotheses);
+            break;
+    }
+}
+

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -44,9 +44,7 @@ public:
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
     //MAVLink methods
-    virtual void send_mavlink_gps_rtk(mavlink_channel_t chan) { return ; }
-
-    virtual void send_mavlink_gps2_rtk(mavlink_channel_t chan) { return ; }
+    virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }
 

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -44,6 +44,7 @@ public:
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
     //MAVLink methods
+    virtual bool supports_mavlink_gps_rtk_message() { return false; }
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);
 
     virtual void broadcast_configuration_failure_reason(void) const { return ; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2224,7 +2224,7 @@ bool GCS_MAVLINK::try_send_gps_message(const enum ap_message id)
         break;
     case MSG_GPS_RTK:
         CHECK_PAYLOAD_SIZE(GPS_RTK);
-        gps->send_mavlink_gps_rtk(chan);
+        gps->send_mavlink_gps_rtk(chan, 0);
         ret = true;
         break;
     case MSG_GPS2_RAW:
@@ -2234,7 +2234,7 @@ bool GCS_MAVLINK::try_send_gps_message(const enum ap_message id)
         break;
     case MSG_GPS2_RTK:
         CHECK_PAYLOAD_SIZE(GPS2_RTK);
-        gps->send_mavlink_gps2_rtk(chan);
+        gps->send_mavlink_gps_rtk(chan, 1);
         ret = true;
         break;
     default:


### PR DESCRIPTION
Emlid released an official version (2.7.4) that can support some of the data fields in the GPS_RTK and GPS2_RTK mavlink messages

It extends #6424
It obsoletes #6541