### PR TITLE
GCS_MAVLink: Correct a bug in the FOR_EACH_ACTIVE_CHANNEL macro

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -22,12 +22,12 @@ void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
             if (!chan(i).initialised) {              \
                 continue;                            \
             }                                        \
-            if (!(GCS_MAVLINK::active_channel_mask() & (chan(i).get_chan()-MAVLINK_COMM_0))) { \
+            if (!(GCS_MAVLINK::active_channel_mask() & (1 << (chan(i).get_chan()-MAVLINK_COMM_0)))) { \
                 continue;                            \
             }                                        \
             chan(i).methodcall;                      \
         }                                            \
-    } while (0);
+    } while (0)
 
 void GCS::send_home(const Location &home) const
 {


### PR DESCRIPTION
Without the bit shift the home updates won't be sent out to the correct GCS channels leaving a GCS to miss the HOME_POSITION updates that are meant to inform it that home moved.