### PR TITLE
AP_Mission: Use a static assert to check content size

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -41,10 +41,8 @@ void AP_Mission::init()
     // command list will be cleared if they do not match
     check_eeprom_version();
 
-    // prevent an easy programming error, this will be optimised out
-    if (sizeof(union Content) != 12) {
-        AP_HAL::panic("AP_Mission Content must be 12 bytes");
-    }
+    // changes in Content size break the storage
+    static_assert(sizeof(union Content) == 12, "AP_Mission: Content must be 12 bytes");
 
     _last_change_time_ms = AP_HAL::millis();
 }


### PR DESCRIPTION
Rather then waiting for a panic at boot time it makes far more sense to simply break the compile process cleanly.