### PR TITLE
Copter: eliminate MAIN_LOOP_SECONDS macro

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -45,7 +45,6 @@ Copter::Copter(void)
     yaw_look_at_heading(0),
     yaw_look_at_heading_slew(0),
     yaw_look_ahead_bearing(0.0f),
-    G_Dt(MAIN_LOOP_SECONDS),
     inertial_nav(ahrs),
     pmTest1(0),
     fast_loopTimer(0),

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -490,7 +490,7 @@ public:
         pi_vel_xy               (VEL_XY_P,        VEL_XY_I,                         VEL_XY_IMAX,        VEL_XY_FILT_HZ,     WPNAV_LOITER_UPDATE_TIME),
 
         p_vel_z                 (VEL_Z_P),
-        pid_accel_z             (ACCEL_Z_P,       ACCEL_Z_I,        ACCEL_Z_D,      ACCEL_Z_IMAX,       ACCEL_Z_FILT_HZ,    MAIN_LOOP_SECONDS),
+        pid_accel_z             (ACCEL_Z_P,       ACCEL_Z_I,        ACCEL_Z_D,      ACCEL_Z_IMAX,       ACCEL_Z_FILT_HZ,    0),
 
         // P controller	        initial P
         //----------------------------------------------------------------------

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -48,9 +48,6 @@
 
 #define MAGNETOMETER ENABLED
 
-// run at 400Hz on all systems
-# define MAIN_LOOP_SECONDS 0.0025f
-
 #ifndef ARMING_DELAY_SEC
     # define ARMING_DELAY_SEC 2.0f
 #endif

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -16,7 +16,7 @@ void Copter::update_land_and_crash_detectors()
     // update 1hz filtered acceleration
     Vector3f accel_ef = ahrs.get_accel_ef_blended();
     accel_ef.z += GRAVITY_MSS;
-    land_accel_ef_filter.apply(accel_ef, MAIN_LOOP_SECONDS);
+    land_accel_ef_filter.apply(accel_ef, scheduler.get_loop_period_s());
 
     update_land_detector();
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -602,25 +602,25 @@ void Copter::ModeAutoTune::autotune_attitude_control()
         switch (axis) {
         case ROLL:
             if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().x) * 100.0f), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().x) * 100.0f), _copter.scheduler.get_loop_period_s());
             } else {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().x) * 100.0f - start_rate), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().x) * 100.0f - start_rate), _copter.scheduler.get_loop_period_s());
             }
             lean_angle = direction_sign * (ahrs.roll_sensor - (int32_t)start_angle);
             break;
         case PITCH:
             if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().y) * 100.0f), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().y) * 100.0f), _copter.scheduler.get_loop_period_s());
             } else {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().y) * 100.0f - start_rate), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().y) * 100.0f - start_rate), _copter.scheduler.get_loop_period_s());
             }
             lean_angle = direction_sign * (ahrs.pitch_sensor - (int32_t)start_angle);
             break;
         case YAW:
             if ((tune_type == SP_DOWN) || (tune_type == SP_UP)) {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().z) * 100.0f), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().z) * 100.0f), _copter.scheduler.get_loop_period_s());
             } else {
-                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().z) * 100.0f - start_rate), MAIN_LOOP_SECONDS);
+                rotation_rate = rotation_rate_filt.apply(direction_sign * (ToDeg(ahrs.get_gyro().z) * 100.0f - start_rate), _copter.scheduler.get_loop_period_s());
             }
             lean_angle = direction_sign * wrap_180_cd(ahrs.yaw_sensor-(int32_t)start_angle);
             break;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -48,6 +48,8 @@ void Copter::init_ardupilot()
     // load parameters from EEPROM
     load_parameters();
 
+    G_Dt = scheduler.get_loop_period_s();
+
     // initialise stats module
     g2.stats.init();
 
@@ -174,7 +176,9 @@ void Copter::init_ardupilot()
 #endif
 
     attitude_control->parameter_sanity_check();
-    pos_control->set_dt(MAIN_LOOP_SECONDS);
+    pos_control->set_dt(scheduler.get_loop_period_s());
+
+    g.pid_accel_z.set_dt(scheduler.get_loop_period_s());
 
     // init the optical flow sensor
     init_optflow();
@@ -582,10 +586,10 @@ void Copter::allocate_motors(void)
     const struct AP_Param::GroupInfo *ac_var_info;
 
 #if FRAME_CONFIG != HELI_FRAME
-    attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, MAIN_LOOP_SECONDS);
+    attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
     ac_var_info = AC_AttitudeControl_Multi::var_info;
 #else
-    attitude_control = new AC_AttitudeControl_Heli(*ahrs_view, aparm, *motors, MAIN_LOOP_SECONDS);
+    attitude_control = new AC_AttitudeControl_Heli(*ahrs_view, aparm, *motors, scheduler.get_loop_period_s());
     ac_var_info = AC_AttitudeControl_Heli::var_info;
 #endif
     if (attitude_control == nullptr) {

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -57,7 +57,6 @@ const AP_Param::GroupInfo AP_Scheduler::var_info[] = {
 // constructor
 AP_Scheduler::AP_Scheduler(void)
 {
-    _loop_rate_hz.set(SCHEDULER_DEFAULT_LOOP_RATE);
     AP_Param::setup_object_defaults(this, var_info);
 
     // only allow 50 to 2000 Hz
@@ -189,7 +188,7 @@ uint16_t AP_Scheduler::time_available_usec(void)
 /*
   calculate load average as a number from 0 to 1
  */
-float AP_Scheduler::load_average() const
+float AP_Scheduler::load_average()
 {
     if (_spare_ticks == 0) {
         return 0.0f;

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -22,6 +22,7 @@
 
 #include <AP_Param/AP_Param.h>
 #include <AP_HAL/Util.h>
+#include <AP_Math/AP_Math.h>
 
 #define AP_SCHEDULER_NAME_INITIALIZER(_name) .name = #_name,
 
@@ -96,6 +97,13 @@ public:
     uint32_t get_loop_period_us() const {
         return 1000000UL / _loop_rate_hz;
     }
+    // get the time-allowed-per-loop:
+    float get_loop_period_s() {
+        if (is_zero(_loop_period_s)) {
+            _loop_period_s = 1.0 / _loop_rate_hz;
+        }
+        return _loop_period_s;
+    }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -107,7 +115,13 @@ private:
     AP_Int8 _debug;
 
     // overall scheduling rate in Hz
-    AP_Int16 _loop_rate_hz;  // The value of this variable can be changed with the non-initialization. (Ex. Tuning by GDB)
+    // The value of this variable can be changed with the
+    // non-initialization. (Ex. Tuning by GDB).  However, if you do,
+    // make sure you update _loop_period_us at the same time.  And all
+    // the other places which take a copy of this at startup and don't
+    // get refreshed.  So, really, don't.
+    AP_Int16 _loop_rate_hz;
+    float _loop_period_s;
 
     // progmem list of tasks to run
     const struct Task *_tasks;

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -87,19 +87,28 @@ public:
     // return load average, as a number between 0 and 1. 1 means
     // 100% load. Calculated from how much spare time we have at the
     // end of a run()
-    float load_average() const;
+    float load_average();
 
-    // get the configured main loop rate
-    uint16_t get_loop_rate_hz(void) const {
-        return _loop_rate_hz;
+    // get the active main loop rate
+    uint16_t get_loop_rate_hz(void) {
+        if (_active_loop_rate_hz == 0) {
+            _active_loop_rate_hz = _loop_rate_hz;
+        }
+        return _active_loop_rate_hz;
     }
-    // get the time-allowed-per-loop:
-    uint32_t get_loop_period_us() const {
-        return 1000000UL / _loop_rate_hz;
+    // get the time-allowed-per-loop in microseconds
+    uint32_t get_loop_period_us() {
+        if (_loop_period_us == 0) {
+            _loop_period_us = 1000000UL / _loop_rate_hz;
+        }
+        return _loop_period_us;
     }
-    // get the time-allowed-per-loop:
-    float get_loop_period_s() const {
-        return 1.0 / _loop_rate_hz;
+    // get the time-allowed-per-loop in seconds
+    float get_loop_period_s() {
+        if (is_zero(_loop_period_s)) {
+            _loop_period_s = 1.0 / _loop_rate_hz;
+        }
+        return _loop_period_s;
     }
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -112,13 +121,17 @@ private:
     AP_Int8 _debug;
 
     // overall scheduling rate in Hz
-    // The value of this variable can be changed with the
-    // non-initialization. (Ex. Tuning by GDB).  However, if you do,
-    // make sure you update _loop_period_us at the same time.  And all
-    // the other places which take a copy of this at startup and don't
-    // get refreshed.  So, really, don't.
     AP_Int16 _loop_rate_hz;
 
+    // loop rate in Hz as set at startup
+    AP_Int16 _active_loop_rate_hz;
+    
+    // calculated loop period in usec
+    uint16_t _loop_period_us;
+
+    // calculated loop period in seconds
+    float _loop_period_s;
+    
     // progmem list of tasks to run
     const struct Task *_tasks;
 

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -98,11 +98,8 @@ public:
         return 1000000UL / _loop_rate_hz;
     }
     // get the time-allowed-per-loop:
-    float get_loop_period_s() {
-        if (is_zero(_loop_period_s)) {
-            _loop_period_s = 1.0 / _loop_rate_hz;
-        }
-        return _loop_period_s;
+    float get_loop_period_s() const {
+        return 1.0 / _loop_rate_hz;
     }
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -121,7 +118,6 @@ private:
     // the other places which take a copy of this at startup and don't
     // get refreshed.  So, really, don't.
     AP_Int16 _loop_rate_hz;
-    float _loop_period_s;
 
     // progmem list of tasks to run
     const struct Task *_tasks;


### PR DESCRIPTION
The main loop rate is no longer constant; stop using a constant
for its period!