### PR TITLE
AP_GPS: bypass the baudrate auto-detection code, it does not work for…

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -472,7 +472,9 @@ void AP_GPS::detect_instance(uint8_t instance)
     switch (_type[instance]) {
     // by default the sbf/trimble gps outputs no data on its port, until configured.
     case GPS_TYPE_SBF:
+        dstate->auto_detected_baud = false; // specified, not detected
         new_gps = new AP_GPS_SBF(*this, state[instance], _port[instance]);
+        goto found_gps; // bypass the baudrate auto-detection code, it does not work for AsteRX-M2 UAS FW 4.2.2
         break;
 
     case GPS_TYPE_GSOF:


### PR DESCRIPTION
… AsteRX-M2 UAS FW 4.2.2

This does not fix the issue that AsteRX-M2 UAS FW 4.2.2 do not get proper configured out-of-the-box, but it is maybee a start