### PR TITLE
Copter: support MAV_CMD_DO_GO_AROUND

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1084,6 +1084,7 @@ private:
     const char* get_frame_string();
     bool current_mode_has_user_takeoff(bool must_navigate);
     bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
+    bool do_user_go_around(float go_around_alt_cm);
     void takeoff_timer_start(float alt_cm);
     void takeoff_stop();
     void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1366,6 +1366,14 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             break;
 
+        case MAV_CMD_DO_GO_AROUND:
+            if (copter.do_user_go_around(300)) {
+                result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
+            }
+            break;
+
         case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED
             result = MAV_RESULT_ACCEPTED;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1366,13 +1366,16 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             break;
 
-        case MAV_CMD_DO_GO_AROUND:
-            if (copter.do_user_go_around(300)) {
+        case MAV_CMD_DO_GO_AROUND: {
+            float go_around_alt = 300.0f;
+            if (packet.param1 > 0) go_around_alt = packet.param1 * 100; //MP send go_around with 0 alt param
+            if (copter.do_user_go_around(go_around_alt)) {
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 result = MAV_RESULT_FAILED;
             }
             break;
+        }
 
         case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -55,6 +55,15 @@ bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
     return false;
 }
 
+bool Copter::do_user_go_around(float go_around_alt_cm) 
+{
+    if (motors->armed() && control_mode == LAND && set_mode(LOITER, MODE_REASON_GCS_COMMAND)) {
+        takeoff_timer_start(go_around_alt_cm);
+        return true;
+    }
+    return false;
+}
+
 // start takeoff to specified altitude above home in centimeters
 void Copter::takeoff_timer_start(float alt_cm)
 {


### PR DESCRIPTION
GCS can send MAV_CMD_DO_GO_AROUND to order copter to abort landing. Copter will change mode to loiter and climbing up to desired altitude. There is a "abort landing" button on Mission Planner which send MAV_CMD_DO_GO_AROUND.  For example, when the copter auto landing on a boat, user can use GCS to abort landing, If user think the copter is not going to make it. 