### PR TITLE
ArduCopter: AP_Baro new sensor addition (LPS25H)

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -34,6 +34,7 @@
 #include "AP_Baro_HIL.h"
 #include "AP_Baro_KellerLD.h"
 #include "AP_Baro_MS5611.h"
+#include "AP_Baro_LPS25H.h"
 #include "AP_Baro_qflight.h"
 #include "AP_Baro_QURT.h"
 #if HAL_WITH_UAVCAN
@@ -479,6 +480,9 @@ void AP_Baro::init(void)
 #elif HAL_BARO_DEFAULT == HAL_BARO_QURT
     drivers[0] = new AP_Baro_QURT(*this);
     _num_drivers = 1;
+#elif HAL_BARO_DEFAULT == HAL_BARO_LPS25H
+ADD_BACKEND(AP_Baro_LPS25H::probe(*this,
+                                      std::move(hal.i2c_mgr->get_device(HAL_BARO_LPS25H_I2C_BUS, HAL_BARO_LPS25H_I2C_ADDR))));
 #endif
 
     // can optionally have baro on I2C too

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -481,7 +481,7 @@ void AP_Baro::init(void)
     drivers[0] = new AP_Baro_QURT(*this);
     _num_drivers = 1;
 #elif HAL_BARO_DEFAULT == HAL_BARO_LPS25H
-ADD_BACKEND(AP_Baro_LPS25H::probe(*this,
+	ADD_BACKEND(AP_Baro_LPS25H::probe(*this,
                                       std::move(hal.i2c_mgr->get_device(HAL_BARO_LPS25H_I2C_BUS, HAL_BARO_LPS25H_I2C_ADDR))));
 #endif
 

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -117,8 +117,8 @@ void AP_Baro_LPS25H::_update_temperature(void)
 	int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
 	if (_sem->take_nonblocking()) {
 		_temperature=((float)(Temp_Reg_s16/480)+42.5);
-	}
 	_sem->give();
+	}
 	
 }
 
@@ -131,6 +131,6 @@ void AP_Baro_LPS25H::_update_pressure(void)
 	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
 	if (_sem->take_nonblocking()) {
 		_pressure=Pressure_mb;
-	}
 	_sem->give();
+	}
 }

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -19,8 +19,8 @@
 extern const AP_HAL::HAL &hal;
 
 
-#define LPS25H_ID            0xBD
-#define LPS25H_REG_ID		0x0F
+#define LPS25H_ID            	  0xBD
+#define LPS25H_REG_ID			  0x0F
 #define LPS25H_CTRL_REG1_ADDR     0x20
 #define LPS25H_CTRL_REG2_ADDR     0x21
 #define LPS25H_CTRL_REG3_ADDR     0x22
@@ -96,14 +96,12 @@ void AP_Baro_LPS25H::_timer(void)
 // transfer data to the frontend
 void AP_Baro_LPS25H::update(void)
 {
-//printf("here  :-) \n");
-
     if (_sem->take_nonblocking()) {
         if (!_has_sample) {
             _sem->give();
             return;
         }
-//printf("here  :-)2 \n");
+
         _copy_to_frontend(_instance, _pressure, _temperature);
         _has_sample = false;
         _sem->give();
@@ -116,12 +114,8 @@ void AP_Baro_LPS25H::_update_temperature(void)
 	uint8_t pu8[2];
 	_dev->read_registers(LPS25H_TEMP_OUT_ADDR, pu8, 1);
 	_dev->read_registers(0x2c, pu8+1, 1);
-	/*printf("high value is value are: 0x%X \n",pu8[1]);
-	printf("low value is value are: 0x%X \n",pu8[0]);*/
 	int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
-	//printf("read value is value are: %d \n",Temp_Reg_s16);
 	Temp_Reg_s16=(int16_t)((float)(Temp_Reg_s16/480)+42.5);
-	//printf("temp is: %d\n",Temp_Reg_s16);
 	_temperature=Temp_Reg_s16;
 	
 }
@@ -133,13 +127,8 @@ void AP_Baro_LPS25H::_update_pressure(void)
 	_dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 1);
 	_dev->read_registers(0x29, pressure+1, 1);
 	_dev->read_registers(0x2a, pressure+2,1);
-	
-	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|pressure[0]; // make a
-	/*printf("pressure is : 0x%X\n",pressure[2]);
-	printf("pressure is : 0x%X\n",pressure[1]);
-	printf("pressure is : 0x%X\n",pressure[0]);*/
+	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|pressure[0];
 	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
-	//printf("pressure is : %d\n",Pressure_mb);
 	_pressure=Pressure_mb;
 	_has_sample=true;
 }

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -27,11 +27,9 @@ extern const AP_HAL::HAL &hal;
 #define LPS25H_CTRL_REG3_ADDR     0x22
 #define LPS25H_CTRL_REG4_ADDR     0x23
 #define LPS25H_FIFO_CTRL          0x2E
-#define LPS25H_TEMP_OUT_ADDR      0x2B
-#define PRESS_OUT_XL_ADDR		  0x28
-#define TEMP_OUT_H_ADDR			  0x2C
-#define PRESS_OUT_L_ADDR		  0x29
-#define PRESS_OUT_H_ADDR		  0x2A
+#define LPS25H_TEMP_OUT_ADDR      0xAB	//Regsiter address is 0x2B in 2's compliment.
+#define PRESS_OUT_XL_ADDR		  0xA8	//Regsiter address is 0x28 in 2's compliment.
+//putting 1 in the MSB of those two registers turns on Auto increment for faster reading. 
 
 AP_Baro_LPS25H::AP_Baro_LPS25H(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
     : AP_Baro_Backend(baro)
@@ -115,8 +113,7 @@ void AP_Baro_LPS25H::update(void)
 void AP_Baro_LPS25H::_update_temperature(void)
 {
 	uint8_t pu8[2];
-	_dev->read_registers(LPS25H_TEMP_OUT_ADDR, pu8, 1);
-	_dev->read_registers(TEMP_OUT_H_ADDR, pu8+1, 1);
+	_dev->read_registers(LPS25H_TEMP_OUT_ADDR, pu8, 2);
 	int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
 	_temperature=((float)(Temp_Reg_s16/480)+42.5);
 	
@@ -126,10 +123,8 @@ void AP_Baro_LPS25H::_update_temperature(void)
 void AP_Baro_LPS25H::_update_pressure(void)
 {
 	uint8_t pressure[3];
-	_dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 1);
-	_dev->read_registers(PRESS_OUT_L_ADDR, pressure + 1, 1);
-	_dev->read_registers(PRESS_OUT_H_ADDR, pressure + 2,1);
-	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|pressure[0];
+	_dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 3);
+	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|(uint32_t)pressure[0];
 	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
 	_pressure=Pressure_mb;
 	_has_sample=true;

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -13,6 +13,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "AP_Baro_LPS25H.h"
+
 #include <unistd.h>
 #include <utility>
 #include <stdio.h>
@@ -20,15 +21,17 @@ extern const AP_HAL::HAL &hal;
 
 
 #define LPS25H_ID            	  0xBD
-#define LPS25H_REG_ID			  0x0F
+#define LPS25H_REG_ID		      0x0F
 #define LPS25H_CTRL_REG1_ADDR     0x20
 #define LPS25H_CTRL_REG2_ADDR     0x21
 #define LPS25H_CTRL_REG3_ADDR     0x22
 #define LPS25H_CTRL_REG4_ADDR     0x23
-#define LPS25H_FIFO_CTRL          0x2e
-#define LPS25H_TEMP_OUT_ADDR      (uint8_t)0x2B
+#define LPS25H_FIFO_CTRL          0x2E
+#define LPS25H_TEMP_OUT_ADDR      0x2B
 #define PRESS_OUT_XL_ADDR		  0x28
-
+#define TEMP_OUT_H_ADDR			  0x2C
+#define PRESS_OUT_L_ADDR		  0x29
+#define PRESS_OUT_H_ADDR		  0x2A
 
 AP_Baro_LPS25H::AP_Baro_LPS25H(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
     : AP_Baro_Backend(baro)
@@ -52,7 +55,7 @@ AP_Baro_Backend *AP_Baro_LPS25H::probe(AP_Baro &baro,
 
 bool AP_Baro_LPS25H::_init()
 {
-    if (!_dev | !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (!_dev || !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
     _has_sample = false;
@@ -69,7 +72,7 @@ bool AP_Baro_LPS25H::_init()
 
 	//init control registers.
 	_dev->write_register(LPS25H_CTRL_REG1_ADDR,0x00); // turn off for config 
-	_dev->write_register(LPS25H_CTRL_REG2_ADDR,0x40); 
+	_dev->write_register(LPS25H_CTRL_REG2_ADDR,0x00); //FIFO Disabled
 	_dev->write_register(LPS25H_FIFO_CTRL, 0x01);
 	_dev->write_register(LPS25H_CTRL_REG1_ADDR,0xc0); 
 	
@@ -113,10 +116,9 @@ void AP_Baro_LPS25H::_update_temperature(void)
 {
 	uint8_t pu8[2];
 	_dev->read_registers(LPS25H_TEMP_OUT_ADDR, pu8, 1);
-	_dev->read_registers(0x2c, pu8+1, 1);
+	_dev->read_registers(TEMP_OUT_H_ADDR, pu8+1, 1);
 	int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
-	Temp_Reg_s16=(int16_t)((float)(Temp_Reg_s16/480)+42.5);
-	_temperature=Temp_Reg_s16;
+	_temperature=((float)(Temp_Reg_s16/480)+42.5);
 	
 }
 
@@ -125,8 +127,8 @@ void AP_Baro_LPS25H::_update_pressure(void)
 {
 	uint8_t pressure[3];
 	_dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 1);
-	_dev->read_registers(0x29, pressure+1, 1);
-	_dev->read_registers(0x2a, pressure+2,1);
+	_dev->read_registers(PRESS_OUT_L_ADDR, pressure + 1, 1);
+	_dev->read_registers(PRESS_OUT_H_ADDR, pressure + 2,1);
 	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|pressure[0];
 	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
 	_pressure=Pressure_mb;

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -89,9 +89,12 @@ bool AP_Baro_LPS25H::_init()
 //  acumulate a new sensor reading
 void AP_Baro_LPS25H::_timer(void)
 {
-    _update_temperature();
-    _update_pressure();
-
+	if (_sem->take_nonblocking()) {
+		_update_temperature();
+		_update_pressure();
+		_has_sample = true;
+		_sem->give();
+	}
 }
 
 // transfer data to the frontend
@@ -127,5 +130,4 @@ void AP_Baro_LPS25H::_update_pressure(void)
 	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|(uint32_t)pressure[0];
 	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
 	_pressure=Pressure_mb;
-	_has_sample=true;
 }

--- a/libraries/AP_Baro/AP_Baro_LPS25H.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.cpp
@@ -1,0 +1,145 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "AP_Baro_LPS25H.h"
+#include <unistd.h>
+#include <utility>
+#include <stdio.h>
+extern const AP_HAL::HAL &hal;
+
+
+#define LPS25H_ID            0xBD
+#define LPS25H_REG_ID		0x0F
+#define LPS25H_CTRL_REG1_ADDR     0x20
+#define LPS25H_CTRL_REG2_ADDR     0x21
+#define LPS25H_CTRL_REG3_ADDR     0x22
+#define LPS25H_CTRL_REG4_ADDR     0x23
+#define LPS25H_FIFO_CTRL          0x2e
+#define LPS25H_TEMP_OUT_ADDR      (uint8_t)0x2B
+#define PRESS_OUT_XL_ADDR		  0x28
+
+
+AP_Baro_LPS25H::AP_Baro_LPS25H(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+    : AP_Baro_Backend(baro)
+    , _dev(std::move(dev))
+{
+}
+
+AP_Baro_Backend *AP_Baro_LPS25H::probe(AP_Baro &baro,
+                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+{
+    if (!dev) {
+        return nullptr;
+    }
+    AP_Baro_LPS25H *sensor = new AP_Baro_LPS25H(baro, std::move(dev));
+    if (!sensor || !sensor->_init()) {
+        delete sensor;
+        return nullptr;
+    }
+    return sensor;
+}
+
+bool AP_Baro_LPS25H::_init()
+{
+    if (!_dev | !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        return false;
+    }
+    _has_sample = false;
+
+    _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
+
+    uint8_t whoami;
+    if (!_dev->read_registers(LPS25H_REG_ID, &whoami, 1)  ||
+        whoami != LPS25H_ID) {
+        // not a LPS25H
+        _dev->get_semaphore()->give();
+        return false;
+    }
+
+	//init control registers.
+	_dev->write_register(LPS25H_CTRL_REG1_ADDR,0x00); // turn off for config 
+	_dev->write_register(LPS25H_CTRL_REG2_ADDR,0x40); 
+	_dev->write_register(LPS25H_FIFO_CTRL, 0x01);
+	_dev->write_register(LPS25H_CTRL_REG1_ADDR,0xc0); 
+	
+    _instance = _frontend.register_sensor();
+
+    _dev->get_semaphore()->give();
+
+    // request 25Hz update (maximum refresh Rate according to datasheet)
+    _dev->register_periodic_callback(40 * AP_USEC_PER_MSEC, FUNCTOR_BIND_MEMBER(&AP_Baro_LPS25H::_timer, void));
+
+    return true;
+}
+
+
+
+//  acumulate a new sensor reading
+void AP_Baro_LPS25H::_timer(void)
+{
+    _update_temperature();
+    _update_pressure();
+
+}
+
+// transfer data to the frontend
+void AP_Baro_LPS25H::update(void)
+{
+//printf("here  :-) \n");
+
+    if (_sem->take_nonblocking()) {
+        if (!_has_sample) {
+            _sem->give();
+            return;
+        }
+//printf("here  :-)2 \n");
+        _copy_to_frontend(_instance, _pressure, _temperature);
+        _has_sample = false;
+        _sem->give();
+    }
+}
+
+// calculate temperature
+void AP_Baro_LPS25H::_update_temperature(void)
+{
+	uint8_t pu8[2];
+	_dev->read_registers(LPS25H_TEMP_OUT_ADDR, pu8, 1);
+	_dev->read_registers(0x2c, pu8+1, 1);
+	/*printf("high value is value are: 0x%X \n",pu8[1]);
+	printf("low value is value are: 0x%X \n",pu8[0]);*/
+	int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
+	//printf("read value is value are: %d \n",Temp_Reg_s16);
+	Temp_Reg_s16=(int16_t)((float)(Temp_Reg_s16/480)+42.5);
+	//printf("temp is: %d\n",Temp_Reg_s16);
+	_temperature=Temp_Reg_s16;
+	
+}
+
+// calculate pressure
+void AP_Baro_LPS25H::_update_pressure(void)
+{
+	uint8_t pressure[3];
+	_dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 1);
+	_dev->read_registers(0x29, pressure+1, 1);
+	_dev->read_registers(0x2a, pressure+2,1);
+	
+	int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|pressure[0]; // make a
+	/*printf("pressure is : 0x%X\n",pressure[2]);
+	printf("pressure is : 0x%X\n",pressure[1]);
+	printf("pressure is : 0x%X\n",pressure[0]);*/
+	int32_t Pressure_mb = Pressure_Reg_s32 / 4096; // scale
+	//printf("pressure is : %d\n",Pressure_mb);
+	_pressure=Pressure_mb;
+	_has_sample=true;
+}

--- a/libraries/AP_Baro/AP_Baro_LPS25H.h
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.h
@@ -32,11 +32,6 @@ private:
 
     bool _has_sample;
     uint8_t _instance;
-    int32_t _t_fine;
     float _pressure;
     float _temperature;
-
-    // Internal calibration registers
-    int16_t _t2, _t3, _p2, _p3, _p4, _p5, _p6, _p7, _p8, _p9;
-    uint16_t _t1, _p1;
 };

--- a/libraries/AP_Baro/AP_Baro_LPS25H.h
+++ b/libraries/AP_Baro/AP_Baro_LPS25H.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Device.h>
+#include <AP_HAL/utility/OwnPtr.h>
+
+#include "AP_Baro_Backend.h"
+
+#define HAL_BARO_LPS25H_I2C_BUS 0
+#define HAL_BARO_LPS25H_I2C_ADDR 0x5D
+
+
+class AP_Baro_LPS25H : public AP_Baro_Backend
+{
+public:
+    AP_Baro_LPS25H(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+
+    /* AP_Baro public interface: */
+    void update();
+
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+
+private:
+    virtual ~AP_Baro_LPS25H(void) {};
+
+    bool _init(void);
+    void _timer(void);
+    void _update_temperature(void);
+    void _update_pressure(void);
+
+    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+
+    bool _has_sample;
+    uint8_t _instance;
+    int32_t _t_fine;
+    float _pressure;
+    float _temperature;
+
+    // Internal calibration registers
+    int16_t _t2, _t3, _p2, _p3, _p4, _p5, _p6, _p7, _p8, _p9;
+    uint16_t _t1, _p1;
+};


### PR DESCRIPTION
the following is the driver for the LPS25H Barometer sensor to support the 96boards STM32 Sensor mezzanine board with the Qualcomm DragonBoard 410c Board running AP.
the sensor was written and being submitted as part of a project involving porting the AP Code to the db410c. it was written and designed with the LPS25H datasheet and application note.
i hope this request qualifies under the AP project rules, if not i will be happy to answer any questions and receive any feedback regarding the commit.
BR,
Lior
[LPS25HB_DataSheet.pdf](https://github.com/ArduPilot/ardupilot/files/1272249/LPS25HB_DataSheet.pdf)
[LPS25HB APP_NOTE.pdf](https://github.com/ArduPilot/ardupilot/files/1272250/LPS25HB.APP_NOTE.pdf)
