### PR TITLE
Copter: support MAV_CMD_DO_GO_AROUND

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -974,6 +974,8 @@ private:
     Mode *mode_from_mode_num(const uint8_t mode);
     void exit_mode(Mode *&old_flightmode, Mode *&new_flightmode);
 
+    void do_go_around(int32_t go_around_alt_cm);
+
 public:
     void mavlink_delay_cb();    // GCS_Mavlink.cpp
     void failsafe_check();      // failsafe.cpp

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1134,6 +1134,15 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             }
             break;
 
+        case MAV_CMD_DO_GO_AROUND:
+            if (packet.param1 > 0) {
+                copter.do_go_around((int32_t)(packet.param1*100));
+            } else {
+                copter.do_go_around(300); //if GCS send go_around with param #1 = 0, we climb to 3m above ground
+            }
+            result = MAV_RESULT_ACCEPTED;
+            break;
+
         case MAV_CMD_DO_FENCE_ENABLE:
 #if AC_FENCE == ENABLED
             result = MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
rework of #6877 

GCS can send MAV_CMD_DO_GO_AROUND to order the copter to abort landing. Copter will change mode to loiter or guided and climbing up to desired altitude. 
There is a "abort landing" button on Mission Planner which send MAV_CMD_DO_GO_AROUND. For example, when the copter auto landing on a boat, user can use GCS to abort landing, If user think the copter is not going to make it. To avoid the copter from falling into water.