### PR TITLE
AP_GPS: Fix MAVLink message field SYSTEM_TIME.time_unix_usec when GPS_AUTO_SWITCH = blend

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1423,6 +1423,8 @@ void AP_GPS::calc_blended_state(void)
             _last_time_updated[i] = state[i].last_gps_time_ms;
         }
     }
+    state[GPS_BLENDED_INSTANCE].last_gps_time_ms = state[best_index].last_gps_time_ms;
+
 
     // Calculate the offset from each GPS solution to the blended solution
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {


### PR DESCRIPTION
The mavlink message field [SYSTEM_TIME.time_unix_usec](http://mavlink.org/messages/common#SYSTEM_TIME) works fine with GPS_AUTO_SWITCH == 0 (no switch) or ==1 (usebest)

But when [GPS_AUTO_SWITCH](http://ardupilot.org/copter/docs/parameters.html#gps-auto-switch) == 2 (blend) then state[GPS_BLENDED_INSTANCE].last_gps_time_ms gets initialized with 0 and never rewritten.
The consequence: [SYSTEM_TIME.time_unix_usec](http://mavlink.org/messages/common#SYSTEM_TIME) gets stuck at zero.

This patch fixes that