### PR TITLE
Plane: Report the primary magnetometer health rather then the first

### DIFF
--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -303,7 +303,7 @@ void Plane::update_sensor_status_flags(void)
     if (barometer.all_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
     }
-    if (g.compass_enabled && compass.healthy(0) && ahrs.use_compass()) {
+    if (g.compass_enabled && compass.healthy() && ahrs.use_compass()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
     if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {


### PR DESCRIPTION
If we sent 3D_MAG2 health then sending the first compass would make sense, but as we only support sending one MAG report reporting the primary is more consistent, and for a plane use case we only care if the primary compass is healthy anyways. This enables better reporting if the second or third compass is primary.