### PR TITLE
Fix a couple of memory corruptions on Linux

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -67,13 +67,6 @@ static Util utilInstance;
 
 // 3 serial ports on Linux for now
 static UARTDriver uartADriver(true);
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO || \
-    CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2 || \
-    CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
-static SPIUARTDriver uartBDriver;
-#else
-static UARTDriver uartBDriver(false);
-#endif
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
 static RPIOUARTDriver uartCDriver;
 #else
@@ -85,6 +78,14 @@ static UARTDriver uartFDriver(false);
 
 static I2CDeviceManager i2c_mgr_instance;
 static SPIDeviceManager spi_mgr_instance;
+
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO || \
+    CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2 || \
+    CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
+static SPIUARTDriver uartBDriver;
+#else
+static UARTDriver uartBDriver(false);
+#endif
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO || \
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2 || \

--- a/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
@@ -46,10 +46,8 @@ PWM_Sysfs_Base::~PWM_Sysfs_Base()
 {
     ::close(_duty_cycle_fd);
 
-    free(_export_path);
     free(_polarity_path);
     free(_enable_path);
-    free(_duty_path);
     free(_period_path);
 }
 

--- a/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
@@ -37,7 +37,7 @@ RCOutput_Sysfs::~RCOutput_Sysfs()
         delete _pwm_channels[i];
     }
 
-    delete _pwm_channels;
+    delete [] _pwm_channels;
 }
 
 void RCOutput_Sysfs::init()


### PR DESCRIPTION
There was a couple of memory corruptions that resulted in segmentation faults on SIGINT on Navio 2 and corresponding fixes for those.

I guess there might be a better way to fix `SPIUARTDriver` but the fix is better than a crash.