### PR TITLE
Update HAL_PX4_Class.cpp

### DIFF
--- a/libraries/AP_HAL_PX4/HAL_PX4_Class.cpp
+++ b/libraries/AP_HAL_PX4/HAL_PX4_Class.cpp
@@ -152,7 +152,6 @@ static int main_loop(int argc, char **argv)
     hal.uartC->begin(57600);
     hal.uartD->begin(57600);
     hal.uartE->begin(57600);
-    hal.uartF->begin(57600);
     hal.scheduler->init();
 
     /*


### PR DESCRIPTION
"ttys5" should not be  used both for console and common usart at the same time ,it should be initialized and managed by AP_SerialManager ;