### PR TITLE
mk: l is an undefined name; use orig_line instead (round two)

### DIFF
--- a/mk/VRBRAIN/Tools/genmsg/src/genmsg/msg_loader.py
+++ b/mk/VRBRAIN/Tools/genmsg/src/genmsg/msg_loader.py
@@ -198,7 +198,7 @@ def _load_constant_line(orig_line):
     else:
         line_splits = [x.strip() for x in ' '.join(line_splits[1:]).split(CONSTCHAR)] #resplit on '='
         if len(line_splits) != 2:
-            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
+            raise InvalidMsgSpec("Invalid constant declaration: %s"%orig_line)
         name = line_splits[0]
         val = line_splits[1]
 


### PR DESCRIPTION
#6838 was closed because of #6923 but the latter only solved half of the former.

This is a recreation of the __second commit__ of #6838 which is is still required because the VRBRAIN directory still contains a `msg_loader.py` that contains an undefined name.