### PR TITLE
Plane: guided takeoff success should return true

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2402,5 +2402,5 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
     motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
     guided_start();
     guided_takeoff = true;
-    return false;
+    return true;
 }


### PR DESCRIPTION
Followup on https://github.com/ArduPilot/ardupilot/pull/6908

This function must return true on success for the [MAV_CMD_NAV_TAKEOFF](https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/GCS_Mavlink.cpp#L1031) message to return MAV_RESULT_ACCEPTED.