### PR TITLE
AP_RangeFinder: update uLanding driver

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
@@ -51,9 +51,9 @@ bool AP_RangeFinder_uLanding::detect(AP_SerialManager &serial_manager)
 /*
    detect uLanding Firmware Version
 */
-bool AP_RangeFinder_uLanding::detect_uLanding_version(void)
+bool AP_RangeFinder_uLanding::detect_version(void)
 {
-    if (_uLanding_version_check) {
+    if (_version_known) {
         // return true if we've already detected the uLanding version
         return true;
     } else if (uart == nullptr) {
@@ -84,9 +84,9 @@ bool AP_RangeFinder_uLanding::detect_uLanding_version(void)
                 } else {
                     if (c == byte1) {
                         // if header byte is recurring, set uLanding Version
-                        _uLanding_version = 0;
-                        _uLanding_hdr = ULANDING_HDR_V0;
-                        _uLanding_version_check = true;
+                        _version = 0;
+                        _header = ULANDING_HDR_V0;
+                        _version_known = true;
                         return true;
                     } else {
                         /* if V0 header byte didn't occur again on 4th byte,
@@ -113,9 +113,9 @@ bool AP_RangeFinder_uLanding::detect_uLanding_version(void)
                     /* if this second byte passes the above if statement, this byte
                      * is the version number
                      */
-                    _uLanding_version = c;
-                    _uLanding_hdr = ULANDING_HDR;
-                    _uLanding_version_check = true;
+                    _version = c;
+                    _header = ULANDING_HDR;
+                    _version_known = true;
                     return true;
                 }
             }
@@ -137,7 +137,7 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
     }
 
     
-    if (!detect_uLanding_version()) {
+    if (!detect_version()) {
         // return false if uLanding version check failed
         return false;
     }
@@ -152,37 +152,37 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
     while (nbytes-- > 0) {
         uint8_t c = uart->read();
         
-        if ((c == _uLanding_hdr) && !hdr_found) {
+        if ((c == _header) && !hdr_found) {
             // located header byte
-            linebuf_len = 0;
+            _linebuf_len = 0;
             hdr_found   = true;
         }
         // decode index information
         if (hdr_found) {
-            linebuf[linebuf_len++] = c;
+            _linebuf[_linebuf_len++] = c;
 
-            /* don't process linebuf until we've collected six bytes of data
-             * (or 3 bytes for Version 0 firmware)
-             */
-            if ((linebuf_len < (sizeof(linebuf)/sizeof(linebuf[0]))) ||
-                (_uLanding_version == 0 && linebuf_len < 3)) {
+            if ((_linebuf_len < (sizeof(_linebuf)/sizeof(_linebuf[0]))) ||
+                (_version == 0 && _linebuf_len < 3)) {
+                /* don't process _linebuf until we've collected six bytes of data
+                 * (or 3 bytes for Version 0 firmware)
+                 */
                 continue;
             } else {
-                if (_uLanding_version == 0) {
-                    // parse data from Firmware Version #0
-                    sum += (linebuf[2]&0x7F)*128 + (linebuf[1]&0x7F);
+                if (_version == 0) {
+                    // parse data for Firmware Version #0
+                    sum += (_linebuf[2]&0x7F)*128 + (_linebuf[1]&0x7F);
                     count++;
                 } else {
                     // evaluate checksum
-                    if (((linebuf[1] + linebuf[2] + linebuf[3] + linebuf[4]) & 0xFF) == linebuf[5]) {
-                        // if checksum passed, parse data from Firmware Version #1
-                        sum += linebuf[3]*256 + linebuf[2];
+                    if (((_linebuf[1] + _linebuf[2] + _linebuf[3] + _linebuf[4]) & 0xFF) == _linebuf[5]) {
+                        // if checksum passed, parse data for Firmware Version #1
+                        sum += _linebuf[3]*256 + _linebuf[2];
                         count++;
                     }
                 }
 
                 hdr_found = false;
-                linebuf_len = 0;
+                _linebuf_len = 0;
             }
         }
     }
@@ -193,7 +193,7 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
 
     reading_cm = sum / count;
 
-    if (_uLanding_version == 0) {
+    if (_version == 0) {
         reading_cm *= 2.5f;
     }
 
@@ -207,9 +207,9 @@ void AP_RangeFinder_uLanding::update(void)
 {
     if (get_reading(state.distance_cm)) {
         // update range_valid state based on distance measured
-        last_reading_ms = AP_HAL::millis();
+        _last_reading_ms = AP_HAL::millis();
         update_status();
-    } else if (AP_HAL::millis() - last_reading_ms > 200) {
+    } else if (AP_HAL::millis() - _last_reading_ms > 200) {
         set_status(RangeFinder::RangeFinder_NoData);
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
@@ -18,6 +18,8 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <ctype.h>
 
+#define ULANDING_HDR 254 // Header Byte from uLanding (0xFE)
+
 extern const AP_HAL::HAL& hal;
 
 /*
@@ -55,25 +57,31 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
     // read any available lines from the uLanding
     float sum = 0;
     uint16_t count = 0;
-    uint8_t  index = 0;
+    bool hdr_found = false;
 
     int16_t nbytes = uart->available();
     while (nbytes-- > 0) {
         uint8_t c = uart->read();
-        // ok, we have located start byte
-        if (c == 72 && index == 0) {
+        
+        if (c == ULANDING_HDR && !hdr_found) {
+            // located header byte
             linebuf_len = 0;
-            index       = 1;
+            hdr_found   = true;
         }
-        // now it is ready to decode index information
-        if (index == 1) {
-            linebuf[linebuf_len] = c;
-            linebuf_len ++;
-            if (linebuf_len == 3) {
-                index = 0;
-                sum += (linebuf[2]&0x7F) *128 + (linebuf[1]&0x7F);
+        // decode index information
+        if (hdr_found) {
+            linebuf[linebuf_len++] = c;
+
+            // process linebuf once we've collected six bytes of data
+            if (linebuf_len == 6) {
+                // evaluate checksum
+                if (((linebuf[1] + linebuf[2] + linebuf[3] + linebuf[4]) & 0xFF) == linebuf[5]) {
+                    sum += linebuf[3]*256 + linebuf[2];
+                    count++;
+                }
+
+                hdr_found = false;
                 linebuf_len = 0;
-                count ++;
             }
         }
     }
@@ -82,7 +90,8 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
         return false;
     }
 
-    reading_cm = 2.5f * sum / count;
+    reading_cm = sum / count;
+
     return true;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
@@ -25,16 +25,16 @@ protected:
 
 private:
     // detect uLanding Firmware Version
-    bool detect_uLanding_version(void);
+    bool detect_version(void);
 
     // get a reading
     bool get_reading(uint16_t &reading_cm);
 
     AP_HAL::UARTDriver *uart = nullptr;
-    uint32_t last_reading_ms = 0;
-    uint8_t linebuf[6];
-    uint8_t linebuf_len = 0;
-    bool _uLanding_version_check = false;
-    uint8_t _uLanding_hdr;
-    uint8_t _uLanding_version;
+    uint8_t  _linebuf[6];
+    uint8_t  _linebuf_len = 0;
+    uint32_t _last_reading_ms = 0;
+    bool     _version_known;
+    uint8_t  _header;
+    uint8_t  _version;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
@@ -24,11 +24,17 @@ protected:
     }
 
 private:
+    // detect uLanding Firmware Version
+    bool detect_uLanding_version(void);
+
     // get a reading
     bool get_reading(uint16_t &reading_cm);
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms = 0;
-    uint8_t linebuf[10];
+    uint8_t linebuf[6];
     uint8_t linebuf_len = 0;
+    bool _uLanding_version_check = false;
+    uint8_t _uLanding_hdr;
+    uint8_t _uLanding_version;
 };


### PR DESCRIPTION
Firmware on the uLanding radar altimeter was updated to a 6-byte data format. The legacy 3-byte data format (matching the current AP_RangeFinder driver) was present on initial evaluation units of the sensor, but all production units utilize the updated firmware. This PR updates the AP_RangeFinder_uLanding driver to match the firmware update.