### PR TITLE
GCS_MAVLink: fix non static perf counter

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -363,6 +363,8 @@ private:
     // perf counters
     AP_HAL::Util::perf_counter_t _perf_packet;
     AP_HAL::Util::perf_counter_t _perf_update;
+    char _perf_packet_name[16];
+    char _perf_update_name[16];
 
     // deferred message handling.  We size the deferred_message
     // ringbuffer so we can defer every message type

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -59,13 +59,11 @@ GCS_MAVLINK::init(AP_HAL::UARTDriver *port, mavlink_channel_t mav_chan)
     initialised = true;
     _queued_parameter = nullptr;
 
-    char perf_name[16];
+    snprintf(_perf_packet_name, sizeof(_perf_packet_name), "GCS_Packet_%u", chan);
+    _perf_packet = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, _perf_packet_name);
 
-    snprintf(perf_name, sizeof(perf_name), "GCS_Packet_%u", chan);
-    _perf_packet = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, perf_name);
-
-    snprintf(perf_name, sizeof(perf_name), "GCS_Update_%u", chan);
-    _perf_update = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, perf_name);
+    snprintf(_perf_update_name, sizeof(_perf_update_name), "GCS_Update_%u", chan);
+    _perf_update = hal.util->perf_alloc(AP_HAL::Util::PC_ELAPSED, _perf_update_name);
 }
 
 


### PR DESCRIPTION
Commit b9877e0d3850223ae6c2df3a68c3d888ca5be628
(GCS_MAVLink: make per channel perf counter non-static) made the
perf counters to be available per instance but missed the fact that
the perf infra doesn't copy the string.

Fix this by maintaining a the string inside the object.