### PR TITLE
AP_GPS: Fix MAVLink message field SYSTEM_TIME.time_unix_usec when GPS…

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1300,7 +1300,6 @@ void AP_GPS::calc_blended_state(void)
     state[GPS_BLENDED_INSTANCE].have_speed_accuracy = false;
     state[GPS_BLENDED_INSTANCE].have_horizontal_accuracy = false;
     state[GPS_BLENDED_INSTANCE].have_vertical_accuracy = false;
-    state[GPS_BLENDED_INSTANCE].last_gps_time_ms = 0;
     memset(&state[GPS_BLENDED_INSTANCE].location, 0, sizeof(state[GPS_BLENDED_INSTANCE].location));
 
     _blended_antenna_offset.zero();


### PR DESCRIPTION
…_AUTO_SWITCH = blend

The mavlink message field SYSTEM_TIME.time_unix_usec works fine with GPS_AUTO_SWITCH == 0 (no switch) or ==1 (usebest)
But when GPS_AUTO_SWITCH == 2 (blend) then state[GPS_BLENDED_INSTANCE].last_gps_time_ms gets initialized with 0 and never rewritten.

The consequence: SYSTEM_TIME.time_unix_usec gets stuck at zero.
The solution: Do not reset state[GPS_BLENDED_INSTANCE].last_gps_time_ms because it would overwrite the correct value already set on line 1149

This replaces #6896