### PR TITLE
AP_GPS: parse RTK status in NMEA GGA message

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -305,11 +305,6 @@ bool AP_GPS_NMEA::_term_complete()
                     state.ground_course    = wrap_360(_new_course*0.01f);
                     make_gps_time(_new_date, _new_time * 10);
                     state.last_gps_time_ms = now;
-                    // To-Do: add support for proper reporting of 2D and 3D fix
-                    if (_gga_gps_status > 0) //use GGA quality indicator if available
-                        state.status = _gga_gps_status;
-                    else
-                        state.status = AP_GPS::GPS_OK_FIX_3D;
                     fill_3d_velocity();
                     break;
                 case _GPS_SENTENCE_GGA:
@@ -339,10 +334,10 @@ bool AP_GPS_NMEA::_term_complete()
                         state.status = AP_GPS::GPS_OK_FIX_3D_RTK_FLOAT;
                         break;
                     case 6: // Estimated (dead reckoning) Mode
-                        state.status = AP_GPS::GPS_OK_FIX_3D;
-                        break;
-                    default:
                         state.status = AP_GPS::NO_FIX;
+                        break;
+                    default://to maintain compatibility with MAV_GPS_INPUT and others
+                        state.status = AP_GPS::GPS_OK_FIX_3D;
                         break;
                     }
                     _gga_gps_status = state.status;

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -340,7 +340,6 @@ bool AP_GPS_NMEA::_term_complete()
                         state.status = AP_GPS::GPS_OK_FIX_3D;
                         break;
                     }
-                    _gga_gps_status = state.status;
                     break;
                 case _GPS_SENTENCE_VTG:
                     _last_VTG_ms = now;

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -140,7 +140,7 @@ private:
     uint16_t _new_hdop;                                                 ///< HDOP parsed from a term
     uint8_t _new_satellite_count;                       ///< satellite count parsed from a term
     uint8_t _new_quality_indicator;                                     ///< GPS quality indicator parsed from a term
-    AP_GPS::GPS_Status _gga_gps_status = AP_GPS::NO_FIX;
+    AP_GPS::GPS_Status _gga_gps_status = AP_GPS::NO_GPS;
 
     uint32_t _last_RMC_ms = 0;
     uint32_t _last_GGA_ms = 0;

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -140,7 +140,6 @@ private:
     uint16_t _new_hdop;                                                 ///< HDOP parsed from a term
     uint8_t _new_satellite_count;                       ///< satellite count parsed from a term
     uint8_t _new_quality_indicator;                                     ///< GPS quality indicator parsed from a term
-    AP_GPS::GPS_Status _gga_gps_status = AP_GPS::NO_GPS;
 
     uint32_t _last_RMC_ms = 0;
     uint32_t _last_GGA_ms = 0;

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -139,6 +139,8 @@ private:
     int32_t _new_course;                                        ///< course parsed from a term
     uint16_t _new_hdop;                                                 ///< HDOP parsed from a term
     uint8_t _new_satellite_count;                       ///< satellite count parsed from a term
+    uint8_t _new_quality_indicator;                                     ///< GPS quality indicator parsed from a term
+    AP_GPS::GPS_Status _gga_gps_status = AP_GPS::NO_FIX;
 
     uint32_t _last_RMC_ms = 0;
     uint32_t _last_GGA_ms = 0;


### PR DESCRIPTION
It parse NMEA GGA message field  6 "GPS Quality indicator" to get RTK float / fix status

Some code are part of #3602 by @Regelink. #3602 was closed and seems replaced by #4166. But #4166 do not contain RTK status parsing code. 
However, in #3602 if a GPS send both RMC and GGA. it status may be switched between RTK and 3D fix unpredictably.  Because in NMEA standard. RMC field 3 only indicate "Active" or "Void". This PR use GGA field 6  (which is documented in standard about RTK status)

Tested with NavSpark/SkyTraq S2525F8-BD-RTK