### PR TITLE
Tools: Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/Tools/LogAnalyzer/UnitTest.py
+++ b/Tools/LogAnalyzer/UnitTest.py
@@ -56,10 +56,10 @@ try:
 	assert(lit['ATT']['RollIn']   == 11.19)
 	assert(lit['CURR']['CurrTot'] == 25.827288)
 	assert(lit['D32']['Value']    == 11122)
-	lit.next()
+	next(lit)
 	assert(lit.iterators == {'CURR': (9, 514), 'ERR': (1, 553), 'NTUN': (0, 2206), 'CTUN': (88, 502), 'GPS': (0, 552), 'CMD': (0, 607), 'D32': (0, 305), 'ATT': (83, 501), 'EV': (4, 606), 'DU32': (9, 513), 'PM': (1, 719)})
 	lit.jump(4750)
-	lit.next()
+	next(lit)
 	assert(lit.currentLine == 4751)
 	assert(lit['ATT']['Roll'] == 2.99)
 

--- a/Tools/LogAnalyzer/tests/TestPitchRollCoupling.py
+++ b/Tools/LogAnalyzer/tests/TestPitchRollCoupling.py
@@ -100,7 +100,7 @@ class TestPitchRollCoupling(Test):
                         if abs(pitch)>(maxLeanAngle+maxLeanAngleBuffer) and abs(pitch)>abs(maxPitch):
                             maxPitch = pitch
                             maxPitchLine = lit.currentLine
-                    lit.next()
+                    next(lit)
         # check for breaking max lean angles
         if maxRoll and abs(maxRoll)>abs(maxPitch):
             self.result.status = TestResult.StatusType.FAIL

--- a/Tools/PrintVersion.py
+++ b/Tools/PrintVersion.py
@@ -3,6 +3,7 @@
 """
 Extract version information for the various vehicle types, print it
 """
+from __future__ import print_function
 
 import os
 import re

--- a/Tools/Replay/CheckLogs.py
+++ b/Tools/Replay/CheckLogs.py
@@ -2,6 +2,7 @@
 '''
 run Replay over a set of logs to check for code regressions
 '''
+from __future__ import print_function
 
 import optparse, os, sys
 

--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -26,6 +26,7 @@ some of them will be rewritten, see the implementation for details).
 This tool also checks if the headers used by the source files don't use
 vehicle-related headers and fails the build if they do.
 """
+from __future__ import absolute_import
 import os
 import re
 
@@ -34,7 +35,7 @@ from waflib.Configure import conf
 from waflib.TaskGen import after_method, before_method, feature
 from waflib.Tools import c_preproc
 
-import ardupilotwaf as ap
+from . import ardupilotwaf as ap
 
 UTILITY_SOURCE_EXTS = ['utility/' + glob for glob in ap.SOURCE_EXTS]
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -2,13 +2,14 @@
 # encoding: utf-8
 
 from __future__ import print_function
+from __future__ import absolute_import
 from waflib import Build, Logs, Options, Utils
 from waflib.Configure import conf
 from waflib.TaskGen import before_method, feature
 import os.path, os
 from collections import OrderedDict
 
-import ap_persistent
+from . import ap_persistent
 
 SOURCE_EXTS = [
     '*.S',

--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -34,6 +34,7 @@ tg.build_summary['binary'] should be set as the Node object or a path relative
 to bld.bldnode for the binary file. Otherwise, size information won't be
 printed for that target.
 '''
+from __future__ import print_function
 import sys
 
 from waflib import Context, Logs, Node

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -4,11 +4,12 @@
 """
 gtest is a Waf tool for test builds in Ardupilot
 """
+from __future__ import absolute_import
 
 from waflib import Utils
 from waflib.Configure import conf
 
-import boards
+from . import boards
 
 def configure(cfg):
     cfg.env.HAS_GTEST = False

--- a/Tools/ardupilotwaf/px4.py
+++ b/Tools/ardupilotwaf/px4.py
@@ -4,6 +4,7 @@
 """
 Waf tool for PX4 build
 """
+from __future__ import print_function
 
 from waflib import Errors, Logs, Task, Utils
 from waflib.TaskGen import after_method, before_method, feature

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -1,14 +1,15 @@
 # drive APMrover2 in SITL
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import shutil
 
 import pexpect
 from pymavlink import mavutil
 
-from common import *
-from pysim import util
-from pysim import vehicleinfo
+from .common import *
+from .pysim import util
+from .pysim import vehicleinfo
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7,6 +7,7 @@
 #   switch 5 = Loiter
 #   switch 6 = Stabilize
 from __future__ import print_function
+from __future__ import absolute_import
 import math
 import os
 import shutil
@@ -15,9 +16,9 @@ import time
 import pexpect
 from pymavlink import mavutil, mavwp
 
-from common import *
-from pysim import util
-from pysim import vehicleinfo
+from .common import *
+from .pysim import util
+from .pysim import vehicleinfo
 
 vinfo = vehicleinfo.VehicleInfo()
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1,5 +1,6 @@
 # Fly ArduPlane in SITL
 from __future__ import print_function
+from __future__ import absolute_import
 import math
 import os
 import shutil
@@ -7,8 +8,8 @@ import shutil
 import pexpect
 from pymavlink import mavutil
 
-from common import *
-from pysim import util
+from .common import *
+from .pysim import util
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1,13 +1,14 @@
 # drive APMrover2 in SITL
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import shutil
 
 import pexpect
 from pymavlink import mavutil
 
-from common import *
-from pysim import util
+from .common import *
+from .pysim import util
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -4,6 +4,7 @@
  Andrew Tridgell, October 2011
 """
 from __future__ import print_function
+from __future__ import absolute_import
 import atexit
 import fnmatch
 import glob
@@ -15,12 +16,12 @@ import sys
 import time
 import traceback
 
-import apmrover2
-import arducopter
-import arduplane
-import quadplane
-import ardusub
-from pysim import util
+from . import apmrover2
+from . import arducopter
+from . import arduplane
+from . import quadplane
+from . import ardusub
+from .pysim import util
 from pymavlink import mavutil
 from pymavlink.generator import mavtemplate
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import math
 import time
 
 from pymavlink import mavwp
 
-from pysim import util
+from .pysim import util
 
 # a list of pexpect objects to read while waiting for
 # messages. This keeps the output to stdout flowing

--- a/Tools/autotest/dump_logs.py
+++ b/Tools/autotest/dump_logs.py
@@ -4,11 +4,12 @@
  Andrew Tridgell, April 2013
 """
 from __future__ import print_function
+from __future__ import absolute_import
 import optparse
 import os
 import sys
 
-from pysim import util
+from .pysim import util
 
 
 ############## main program #############

--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -2,9 +2,10 @@
 """
 Emit docs in a form acceptable to the old Ardupilot wordpress docs site
 """
+from __future__ import absolute_import
 
-from param import known_param_fields, known_units
-from emit import Emit
+from .param import known_param_fields, known_units
+from .emit import Emit
 import cgi
 
 

--- a/Tools/autotest/param_metadata/mdemit.py
+++ b/Tools/autotest/param_metadata/mdemit.py
@@ -2,9 +2,10 @@
 """
 Emit parameter documentation in markdown format
 """
+from __future__ import absolute_import
 
-from param import known_param_fields
-from emit import Emit
+from .param import known_param_fields
+from .emit import Emit
 import re
 import os
 

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import absolute_import
 import glob
 import os
 import re
 import sys
 from optparse import OptionParser
 
-from param import (Library, Parameter, Vehicle, known_group_fields,
+from .param import (Library, Parameter, Vehicle, known_group_fields,
                    known_param_fields, required_param_fields, known_units)
-from htmlemit import HtmlEmit
-from rstemit import RSTEmit
-from wikiemit import WikiEmit
-from xmlemit import XmlEmit
-from mdemit import MDEmit
+from .htmlemit import HtmlEmit
+from .rstemit import RSTEmit
+from .wikiemit import WikiEmit
+from .xmlemit import XmlEmit
+from .mdemit import MDEmit
 
 parser = OptionParser("param_parse.py [options]")
 parser.add_option("-v", "--verbose", dest='verbose', action='store_true', default=False, help="show debugging output")

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import absolute_import
 import re
-from param import known_param_fields, known_units
-from emit import Emit
+from .param import known_param_fields, known_units
+from .emit import Emit
 import cgi
 
 

--- a/Tools/autotest/param_metadata/wikiemit.py
+++ b/Tools/autotest/param_metadata/wikiemit.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import re
 
-from emit import Emit
-from param import known_param_fields, known_units
+from .emit import Emit
+from .param import known_param_fields, known_units
 
 
 # Emit docs in a form acceptable to the APM wiki site

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from xml.sax.saxutils import escape, quoteattr
 
-from emit import Emit
-from param import known_param_fields, known_units
+from .emit import Emit
+from .param import known_param_fields, known_units
 
 
 # Emit APM documentation in an machine readable XML format

--- a/Tools/autotest/pysim/aircraft.py
+++ b/Tools/autotest/pysim/aircraft.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import math
 import random
 import time
-import util
+from . import util
 
-from rotmat import Vector3, Matrix3
+from .rotmat import Vector3, Matrix3
 
 
 class Aircraft(object):

--- a/Tools/autotest/pysim/fg_display.py
+++ b/Tools/autotest/pysim/fg_display.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import errno
 import socket
 import sys
@@ -76,7 +77,7 @@ while True:
         print("%u FPS len=%u" % (count, len(udp_buffer)))
         count = 0
         tlast = time.time()
-        print(fg.get('latitude', units='degrees'),
+        print((fg.get('latitude', units='degrees'),
               fg.get('longitude', units='degrees'),
               fg.get('altitude', units='meters'),
-              fg.get('vcas', units='mps'))
+              fg.get('vcas', units='mps')))

--- a/Tools/autotest/pysim/iris_ros.py
+++ b/Tools/autotest/pysim/iris_ros.py
@@ -3,6 +3,7 @@
 Python interface to euroc ROS multirotor simulator
 See https://pixhawk.org/dev/ros/sitl
 """
+from __future__ import absolute_import
 
 import time
 
@@ -12,8 +13,8 @@ import rosgraph_msgs.msg as rosgraph_msgs
 import rospy
 import sensor_msgs.msg as sensor_msgs
 
-from aircraft import Aircraft
-from rotmat import Vector3, Matrix3
+from .aircraft import Aircraft
+from .rotmat import Vector3, Matrix3
 
 
 def quat_to_dcm(q1, q2, q3, q4):

--- a/Tools/autotest/pysim/testwind.py
+++ b/Tools/autotest/pysim/testwind.py
@@ -3,9 +3,10 @@
 simple test of wind generation code
 """
 from __future__ import print_function
+from __future__ import absolute_import
 import time
-import util
-from rotmat import Vector3
+from . import util
+from .rotmat import Vector3
 
 wind = util.Wind('7,90,0.1')
 

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 class VehicleInfo(object):
 
     def __init__(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1,12 +1,13 @@
 # fly ArduPlane QuadPlane in SITL
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import pexpect
 import shutil
 from pymavlink import mavutil
 
-from common import *
-from pysim import util
+from .common import *
+from .pysim import util
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -7,6 +7,7 @@ Peter Barker, April 2016
 based on sim_vehicle.sh by Andrew Tridgell, October 2011
 """
 from __future__ import print_function
+from __future__ import absolute_import
 
 import atexit
 import errno
@@ -274,7 +275,7 @@ def wait_unlimited():
     """Wait until signal received"""
     time.sleep(987654321987654321)
 
-from pysim import vehicleinfo
+from .pysim import vehicleinfo
 vinfo = vehicleinfo.VehicleInfo()
 
 def do_build_waf(opts, frame_options):

--- a/Tools/mavproxy_modules/lib/magcal_graph_ui.py
+++ b/Tools/mavproxy_modules/lib/magcal_graph_ui.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (C) 2016  Intel Corporation. All rights reserved.
 #
 # This file is free software: you can redistribute it and/or modify it
@@ -21,7 +22,7 @@ from pymavlink.mavutil import mavlink
 from MAVProxy.modules.lib import wx_processguard
 from MAVProxy.modules.lib.wx_loader import wx
 
-import geodesic_grid as grid
+from . import geodesic_grid as grid
 
 class MagcalPanel(wx.Panel):
     _status_markup_strings = {

--- a/Tools/scripts/add_git_hashes.py
+++ b/Tools/scripts/add_git_hashes.py
@@ -3,6 +3,7 @@
 Add git hashes to .px4 file for PX4/Pixhawk build
 Written by Jon Challinger January 2015
 '''
+from __future__ import print_function
 
 import json
 import sys

--- a/Tools/scripts/build_examples.py
+++ b/Tools/scripts/build_examples.py
@@ -5,6 +5,7 @@
 # Peter Barker, June 2016
 # based on build_examples.sh,  Andrew Tridgell, November 2012
 
+from __future__ import print_function
 import os
 import sys
 import optparse

--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -5,6 +5,7 @@ decode a device ID, such as used for COMPASS_DEV_ID, INS_ACC_ID etc
 To understand the devtype you should look at the backend headers for
 the sensor library, such as libraries/AP_Compass/AP_Compass_Backend.h
 '''
+from __future__ import print_function
 
 import sys
 import optparse

--- a/Tools/scripts/frame_sizes.py
+++ b/Tools/scripts/frame_sizes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import re, sys, operator, os
 
 code_line = re.compile("^\s*\d+:/")

--- a/Tools/scripts/magfit_flashlog.py
+++ b/Tools/scripts/magfit_flashlog.py
@@ -3,6 +3,7 @@
 ''' fit best estimate of magnetometer offsets from ArduCopter flashlog
 using the algorithm from Bill Premerlani
 '''
+from __future__ import print_function
 
 import sys, time, os, math
 
@@ -87,7 +88,7 @@ def find_offsets(data, ofs):
         ofs = ofs - delta
 
         if opts.verbose:
-            print ofs
+            print(ofs)
     return ofs
 
 

--- a/Tools/scripts/runplanetest.py
+++ b/Tools/scripts/runplanetest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import pexpect, time, sys
 from pymavlink import mavutil
 

--- a/Tools/scripts/update_wiki.py
+++ b/Tools/scripts/update_wiki.py
@@ -6,6 +6,7 @@ May 2013
 
 See http://codex.wordpress.org/XML-RPC_WordPress_API/Posts
 '''
+from __future__ import print_function
 
 import xmlrpclib, sys
 
@@ -87,5 +88,5 @@ r = server.wp.editPost(opts.blog_id, opts.username, opts.password, post_id, { 'p
 if r == True:
     print("Upload OK")
     sys.exit(0)
-print 'result: ', r
+print('result: ', r)
 sys.exit(1)

--- a/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_gentools.py
+++ b/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_gentools.py
@@ -31,7 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
 import os
 import sys 
         
@@ -107,13 +106,13 @@ def test_compute_md5_text():
     tests = _load_md5_tests('md5text')
     # text file #1 is the reference
     for k, files in tests.items():
-        print(("running tests", k))
+        print("running tests", k)
         ref_file = [f for f in files if f.endswith('%s1.txt'%k)]
         if not ref_file:
             assert False, "failed to load %s"%k
         ref_file = ref_file[0]
         ref_text = open(ref_file, 'r').read().strip()
-        print(("KEY", k))
+        print("KEY", k)
         files = [f for f in files if not f.endswith('%s1.txt'%k)]
         for f in files[1:]:
             f_text = _compute_md5_text(msg_context, f)
@@ -126,7 +125,7 @@ def test_md5_equals():
     search_path = get_search_path()
     tests = _load_md5_tests('same')
     for k, files in tests.items():
-        print(("running tests", k))
+        print("running tests", k)
         md5sum = _compute_md5(msg_context, files[0])
         for f in files[1:]:
             assert md5sum == _compute_md5(msg_context, f), "failed on %s: \n[%s]\nvs.\n[%s]\n"%(k, _compute_md5_text(msg_context, files[0]), _compute_md5_text(msg_context, f))
@@ -137,7 +136,7 @@ def test_md5_not_equals():
 
     tests = _load_md5_tests('different')
     for k, files in tests.items():
-        print(("running tests", k))
+        print("running tests", k)
         md5s = set()
         md6md5sum = _compute_md5(msg_context, files[0])
         for f in files:

--- a/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_gentools.py
+++ b/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_gentools.py
@@ -31,6 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import os
 import sys 
         
@@ -106,13 +107,13 @@ def test_compute_md5_text():
     tests = _load_md5_tests('md5text')
     # text file #1 is the reference
     for k, files in tests.items():
-        print("running tests", k)
+        print(("running tests", k))
         ref_file = [f for f in files if f.endswith('%s1.txt'%k)]
         if not ref_file:
             assert False, "failed to load %s"%k
         ref_file = ref_file[0]
         ref_text = open(ref_file, 'r').read().strip()
-        print("KEY", k)
+        print(("KEY", k))
         files = [f for f in files if not f.endswith('%s1.txt'%k)]
         for f in files[1:]:
             f_text = _compute_md5_text(msg_context, f)
@@ -125,7 +126,7 @@ def test_md5_equals():
     search_path = get_search_path()
     tests = _load_md5_tests('same')
     for k, files in tests.items():
-        print("running tests", k)
+        print(("running tests", k))
         md5sum = _compute_md5(msg_context, files[0])
         for f in files[1:]:
             assert md5sum == _compute_md5(msg_context, f), "failed on %s: \n[%s]\nvs.\n[%s]\n"%(k, _compute_md5_text(msg_context, files[0]), _compute_md5_text(msg_context, f))
@@ -136,7 +137,7 @@ def test_md5_not_equals():
 
     tests = _load_md5_tests('different')
     for k, files in tests.items():
-        print("running tests", k)
+        print(("running tests", k))
         md5s = set()
         md6md5sum = _compute_md5(msg_context, files[0])
         for f in files:

--- a/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_msg_loader.py
+++ b/mk/VRBRAIN/Tools/genmsg/test/test_genmsg_msg_loader.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2009, Willow Garage, Inc.


### PR DESCRIPTION
Use http://python-future.org code to take a more automated and complete approach than #6833

Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _definitely_ be much more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py` # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`
