### PR TITLE
Copter: support SET_GPS_GLOBAL_ORIGIN message

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -121,7 +121,7 @@ void Rover::send_location(mavlink_channel_t chan)
         current_loc.lat,                    // in 1E7 degrees
         current_loc.lng,                    // in 1E7 degrees
         current_loc.alt * 10UL,             // millimeters above sea level
-        (current_loc.alt - home.alt) * 10,  // millimeters above ground
+        (current_loc.alt - home.alt) * 10,  // millimeters above home
         vel.x * 100,   // X speed cm/s (+ve North)
         vel.y * 100,   // Y speed cm/s (+ve East)
         vel.z * -100,  // Z speed cm/s (+ve up)

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -643,6 +643,23 @@ void GCS_MAVLINK_Rover::handle_change_alt_request(AP_Mission::Mission_Command &c
 void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
+
+    case MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN:
+    {
+        mavlink_set_gps_global_origin_t packet;
+        mavlink_msg_set_gps_global_origin_decode(msg, &packet);
+        // sanity check location
+        if (!check_latlng(packet.latitude, packet.longitude)) {
+            break;
+        }
+        Location ekf_origin {};
+        ekf_origin.lat = packet.latitude;
+        ekf_origin.lng = packet.longitude;
+        ekf_origin.alt = packet.altitude / 10;
+        rover.set_ekf_origin(ekf_origin);
+        break;
+    }
+
     case MAVLINK_MSG_ID_REQUEST_DATA_STREAM:
         {
             handle_request_data_stream(msg, true);
@@ -854,6 +871,10 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_GET_HOME_POSITION:
             if (rover.home_is_set != HOME_UNSET) {
                 send_home(rover.ahrs.get_home());
+                Location ekf_origin;
+                if (rover.ahrs.get_origin(ekf_origin)) {
+                    send_ekf_origin(ekf_origin);
+                }
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 result = MAV_RESULT_FAILED;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -451,6 +451,7 @@ private:
     void update_home_from_EKF();
     bool set_home_to_current_location(bool lock);
     bool set_home(const Location& loc, bool lock);
+    void set_ekf_origin(const Location& loc);
     void set_system_time_from_GPS();
     void update_home();
 

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -35,10 +35,10 @@ bool Rover::set_home(const Location& loc, bool lock)
         return false;
     }
 
-    // set EKF origin to home if it hasn't been set yet
+    // check if EKF origin has been set
     Location ekf_origin;
     if (!ahrs.get_origin(ekf_origin)) {
-        ahrs.set_origin(loc);
+        return false;
     }
 
     // set ahrs home
@@ -69,8 +69,9 @@ bool Rover::set_home(const Location& loc, bool lock)
     // log ahrs home and ekf origin dataflash
     Log_Write_Home_And_Origin();
 
-    // send new home location to GCS
+    // send new home and ekf origin to GCS
     gcs().send_home(loc);
+    gcs().send_ekf_origin(loc);
 
     // send text of home position to ground stations
     gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
@@ -80,6 +81,32 @@ bool Rover::set_home(const Location& loc, bool lock)
 
     // return success
     return true;
+}
+
+// sets ekf_origin if it has not been set.
+//  should only be used when there is no GPS to provide an absolute position
+void Rover::set_ekf_origin(const Location& loc)
+{
+    // check location is valid
+    if (!check_latlng(loc)) {
+        return;
+    }
+
+    // check if EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send ekf origin to GCS
+    gcs().send_ekf_origin(loc);
 }
 
 // checks if we should update ahrs/RTL home position from GPS

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -17,7 +17,7 @@ bool Rover::set_home_to_current_location(bool lock)
 {
     // use position from EKF if available otherwise use GPS
     Location temp_loc;
-    if (ahrs.get_position(temp_loc)) {
+    if (ahrs.have_inertial_nav() && ahrs.get_position(temp_loc)) {
         return set_home(temp_loc, lock);
     }
     return false;

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -250,6 +250,7 @@ private:
     bool get_home_eeprom(struct Location &loc);
     void set_home_eeprom(struct Location temp);
     void set_home(struct Location temp);
+    void set_ekf_origin(const Location& loc);
     void arm_servos();
     void disarm_servos();
     void prepare_servos();

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -166,6 +166,33 @@ void Tracker::set_home(struct Location temp)
     set_home_eeprom(temp);
     current_loc = temp;
     gcs().send_home(temp);
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        gcs().send_ekf_origin(ekf_origin);
+    }
+}
+
+// sets ekf_origin if it has not been set.
+//  should only be used when there is no GPS to provide an absolute position
+void Tracker::set_ekf_origin(const Location& loc)
+{
+    // check location is valid
+    if (!check_latlng(loc)) {
+        return;
+    }
+
+    // check EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+    // send ekf origin to GCS
+    gcs().send_ekf_origin(loc);
 }
 
 void Tracker::arm_servos()

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -772,6 +772,7 @@ private:
     void set_home_to_current_location_inflight();
     bool set_home_to_current_location(bool lock);
     bool set_home(const Location& loc, bool lock);
+    void set_ekf_origin(const Location& loc);
     bool far_from_EKF_origin(const Location& loc);
     void set_system_time_from_GPS();
     void exit_mission();

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -55,11 +55,10 @@ bool Copter::set_home(const Location& loc, bool lock)
         return false;
     }
 
-    // set EKF origin to home if it hasn't been set yet and vehicle is disarmed
-    // this is required to allowing flying in AUTO and GUIDED with only an optical flow
+    // check EKF origin has been set
     Location ekf_origin;
-    if (!motors->armed() && !ahrs.get_origin(ekf_origin)) {
-        ahrs.set_origin(loc);
+    if (!ahrs.get_origin(ekf_origin)) {
+        return false;
     }
 
     // check home is close to EKF origin
@@ -94,11 +93,38 @@ bool Copter::set_home(const Location& loc, bool lock)
     // log ahrs home and ekf origin dataflash
     Log_Write_Home_And_Origin();
 
-    // send new home location to GCS
+    // send new home and ekf origin to GCS
     gcs().send_home(loc);
+    gcs().send_ekf_origin(ekf_origin);
 
     // return success
     return true;
+}
+
+// sets ekf_origin if it has not been set.
+//  should only be used when there is no GPS to provide an absolute position
+void Copter::set_ekf_origin(const Location& loc)
+{
+    // check location is valid
+    if (!check_latlng(loc)) {
+        return;
+    }
+
+    // check EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send ekf origin to GCS
+    gcs().send_ekf_origin(loc);
 }
 
 // far_from_EKF_origin - checks if a location is too far from the EKF origin

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -895,6 +895,22 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
 
+    case MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN:
+    {
+        mavlink_set_gps_global_origin_t packet;
+        mavlink_msg_set_gps_global_origin_decode(msg, &packet);
+        // sanity check location
+        if (!check_latlng(packet.latitude, packet.longitude)) {
+            break;
+        }
+        Location ekf_origin {};
+        ekf_origin.lat = packet.latitude;
+        ekf_origin.lng = packet.longitude;
+        ekf_origin.alt = packet.altitude / 10;
+        plane.set_ekf_origin(ekf_origin);
+        break;
+    }
+
     case MAVLINK_MSG_ID_REQUEST_DATA_STREAM:
     {
         handle_request_data_stream(msg, true);
@@ -1185,6 +1201,10 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_GET_HOME_POSITION:
             if (plane.home_is_set != HOME_UNSET) {
                 send_home(plane.ahrs.get_home());
+                Location ekf_origin;
+                if (plane.ahrs.get_origin(ekf_origin)) {
+                    send_ekf_origin(ekf_origin);
+                }
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 result = MAV_RESULT_FAILED;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -885,6 +885,7 @@ private:
     void set_guided_WP(void);
     void init_home();
     void update_home();
+    void set_ekf_origin(const Location& loc);
     void do_RTL(int32_t alt);
     bool verify_takeoff();
     bool verify_loiter_unlim();

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -145,3 +145,29 @@ void Plane::update_home()
     }
     barometer.update_calibration();
 }
+
+// sets ekf_origin if it has not been set.
+//  should only be used when there is no GPS to provide an absolute position
+void Plane::set_ekf_origin(const Location& loc)
+{
+    // check location is valid
+    if (!check_latlng(loc)) {
+        return;
+    }
+
+    // check if EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send ekf origin to GCS
+    gcs().send_ekf_origin(loc);
+}

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -906,6 +906,11 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
         home_is_set = HOME_SET_NOT_LOCKED;
         Log_Write_Home_And_Origin();
         gcs().send_home(cmd.content.location);
+        // send ekf origin if set
+        Location ekf_origin;
+        if (ahrs.get_origin(ekf_origin)) {
+            gcs().send_ekf_origin(ekf_origin);
+        }
     }
 }
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -891,6 +891,22 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN:
+    {
+        mavlink_set_gps_global_origin_t packet;
+        mavlink_msg_set_gps_global_origin_decode(msg, &packet);
+        // sanity check location
+        if (!check_latlng(packet.latitude, packet.longitude)) {
+            break;
+        }
+        Location ekf_origin {};
+        ekf_origin.lat = packet.latitude;
+        ekf_origin.lng = packet.longitude;
+        ekf_origin.alt = packet.altitude / 10;
+        sub.set_ekf_origin(ekf_origin);
+        break;
+    }
+
     case MAVLINK_MSG_ID_REQUEST_DATA_STREAM: {  // MAV ID: 66
         handle_request_data_stream(msg, false);
         break;
@@ -1167,6 +1183,10 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_GET_HOME_POSITION:
             if (sub.ap.home_state != HOME_UNSET) {
                 send_home(sub.ahrs.get_home());
+                Location ekf_origin;
+                if (sub.ahrs.get_origin(ekf_origin)) {
+                    send_ekf_origin(ekf_origin);
+                }
                 result = MAV_RESULT_ACCEPTED;
             }
             break;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -542,6 +542,7 @@ private:
     void set_home_to_current_location_inflight();
     bool set_home_to_current_location(bool lock);
     bool set_home(const Location& loc, bool lock);
+    void set_ekf_origin(const Location& loc);
     bool far_from_EKF_origin(const Location& loc);
     void set_system_time_from_GPS();
     void exit_mission();

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -63,6 +63,12 @@ bool Sub::set_home(const Location& loc, bool lock)
         return false;
     }
 
+    // check if EKF origin has been set
+    Location ekf_origin;
+    if (!ahrs.get_origin(ekf_origin)) {
+        return false;
+    }
+
     // set ahrs home (used for RTL)
     ahrs.set_home(loc);
 
@@ -90,11 +96,38 @@ bool Sub::set_home(const Location& loc, bool lock)
     // log ahrs home and ekf origin dataflash
     Log_Write_Home_And_Origin();
 
-    // send new home location to GCS
+    // send new home and ekf origin to GCS
     gcs().send_home(loc);
+    gcs().send_ekf_origin(loc);
 
     // return success
     return true;
+}
+
+// sets ekf_origin if it has not been set.
+//  should only be used when there is no GPS to provide an absolute position
+void Sub::set_ekf_origin(const Location& loc)
+{
+    // check location is valid
+    if (!check_latlng(loc)) {
+        return;
+    }
+
+    // check if EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send ekf origin to GCS
+    gcs().send_ekf_origin(loc);
 }
 
 // far_from_EKF_origin - checks if a location is too far from the EKF origin

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -23,6 +23,7 @@
 #define AP_ARMING_BOARD_VOLTAGE_MIN     4.3f
 #define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
 #define AP_ARMING_ACCEL_ERROR_THRESHOLD 0.75f
+#define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS
 
 extern const AP_HAL::HAL& hal;
 
@@ -373,6 +374,19 @@ bool AP_Arming::gps_checks(bool report)
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS blending unhealthy");
             }
             return false;
+        }
+
+        // check AHRS and GPS are within 10m of each other
+        Location gps_loc = ahrs.get_gps().location();
+        Location ahrs_loc;
+        if (ahrs.get_position(ahrs_loc)) {
+            float distance = location_3d_diff_NED(gps_loc, ahrs_loc).length();
+            if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
+                if (report) {
+                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS and AHRS differ by %4.1fm", (double)distance);
+                }
+                return false;
+            }
         }
     }
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -34,4 +34,9 @@ void GCS::send_home(const Location &home) const
     FOR_EACH_ACTIVE_CHANNEL(send_home(home));
 }
 
+void GCS::send_ekf_origin(const Location &ekf_origin) const
+{
+    FOR_EACH_ACTIVE_CHANNEL(send_ekf_origin(ekf_origin));
+}
+
 #undef FOR_EACH_ACTIVE_CHANNEL

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -176,6 +176,7 @@ public:
     void send_local_position(const AP_AHRS &ahrs) const;
     void send_vibration(const AP_InertialSensor &ins) const;
     void send_home(const Location &home) const;
+    void send_ekf_origin(const Location &ekf_origin) const;
     void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
@@ -473,6 +474,7 @@ public:
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_home(const Location &home) const;
+    void send_ekf_origin(const Location &ekf_origin) const;
     // push send_message() messages and queued statustext messages etc:
     void retry_deferred();
     void data_stream_send();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1467,6 +1467,17 @@ void GCS_MAVLINK::send_home(const Location &home) const
     }
 }
 
+void GCS_MAVLINK::send_ekf_origin(const Location &ekf_origin) const
+{
+    if (HAVE_PAYLOAD_SPACE(chan, GPS_GLOBAL_ORIGIN)) {
+        mavlink_msg_gps_global_origin_send(
+            chan,
+            ekf_origin.lat,
+            ekf_origin.lng,
+            ekf_origin.alt * 10);
+    }
+}
+
 /*
   wrapper for sending heartbeat
  */


### PR DESCRIPTION
This PR resolves an issue that could cause vehicles to fly to extremely high altitudes during autonomous modes including RTL, Auto, Guided in cases where the ground station has sent an inaccurate altitude in a DO_SET_HOME message before the vehicle's EKF origin has been set (i.e. before a good GPS lock).

The following changes are included:

- DO_SET_HOME commands (received either within a COMMAND_LONG message or SET_HOME_POSITION messages) only set the AHRS home, they no longer set the EKF origin.
- SET_GPS_GLOBAL_ORIGIN messages are consumed and used to set the EKF origin.  When the origin is set a GPS_GLOBAL_ORIGIN message is sent to the ground station
- GET_HOME commands return both home and EKF origin to the caller (there is currently no command that allows requesting the origin)
- when home is set (either automatically or when specified by the user) both the home and origin are sent to all mavlink channels
- a new arming check is added that checks that the AHRS's reported position is within 10m of the GPS position.  This check is within the GPS arming checks so the check will not run in cases where the user is not using a GPS (i.e. a manual flight mode or GPS is not being used)

These changes mostly only affect Copter (the AP_Arming check affects all vehicles) but I will extend the changes to at least Rover and Tracker (and Plane if people want) if the peer review is happy with them.