### PR TITLE
AP_Compass: Add break to prevent fallthrough of PIXRACER to PIXHAWK_PRO

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -657,6 +657,7 @@ void Compass::_detect_backends(void)
                     AP_Compass_HMC5843::name, false);
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_ROLL_180_YAW_90),
                     AP_Compass_AK8963::name, false);
+        break;
 
     case AP_BoardConfig::PX4_BOARD_PIXHAWK_PRO:
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_ROLL_180_YAW_90),


### PR DESCRIPTION
PIXRACER and PIXHAWK_PRO use different compasses hence the initialization of PIXRACER compass should not fallthrough to that of PIXHAWK_PRO