### PR TITLE
Plane: change format of reset alt target message

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -747,7 +747,7 @@ void QuadPlane::run_z_controller(void)
     if (now - last_pidz_active_ms > 2000) {
         // set alt target to current height on transition. This
         // starts the Z controller off with the right values
-        gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)inertial_nav.get_altitude());
+        gcs().send_text(MAV_SEVERITY_INFO, "Reset alt target to %.1f", (double)inertial_nav.get_altitude() / 100);
         set_alt_target_current();
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
 


### PR DESCRIPTION
A message with a format of centimeters.millimeters is confusing here. This PR will change the format to meters.millimeters.