### PR TITLE
Plane: AP_Arming: sanity-check fs timeout parameters

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -35,6 +35,13 @@ bool AP_Arming_Plane::pre_arm_checks(bool report)
     // Check airspeed sensor
     ret &= AP_Arming::airspeed_checks(report);
 
+    if (plane.g.long_fs_timeout < plane.g.short_fs_timeout) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
+        }
+        ret = false;
+    }
+
     if (plane.aparm.roll_limit_cd < 300) {
         if (report) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: LIM_ROLL_CD too small (%u)", plane.aparm.roll_limit_cd);


### PR DESCRIPTION
Vehicles will toggle their failsafe status if the short timeout is greater than the long timeout (https://github.com/ardupilot/ardupilot/blob/master/ArduPlane/system.cpp#L502).
