### PR TITLE
ardupilotwaf: AeroFC: Remove unused tools

### DIFF
--- a/Tools/ardupilotwaf/px4/cmake/configs/nuttx_aerofc-v1_apm.cmake
+++ b/Tools/ardupilotwaf/px4/cmake/configs/nuttx_aerofc-v1_apm.cmake
@@ -12,6 +12,10 @@ list(APPEND config_module_list
 list(REMOVE_ITEM config_module_list
     drivers/stm32/adc
     drivers/stm32/tone_alarm
+    systemcmds/bl_update
+    systemcmds/mtd
+    systemcmds/usb_connected
+    systemcmds/otp
 )
 
 list(REMOVE_ITEM config_extra_builtin_cmds


### PR DESCRIPTION
before
```
BUILD SUMMARY
Build directory: /home/zehortigoza/dev/ardupilot/build/aerofc-v1
Target               Text    Data  BSS    Total
------------------------------------------------
bin/arducopter       860324  2032  55220  917576
bin/arducopter-heli  844204  2028  55028  901260
```

after
```
BUILD SUMMARY
Build directory: /home/zehortigoza/dev/ardupilot/build/aerofc-v1
Target               Text    Data  BSS    Total
------------------------------------------------
bin/arducopter       852248  2024  55156  909428
bin/arducopter-heli  836120  2020  54964  893104
```