### PR TITLE
AP_GPS: SBF Enhancements

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -329,7 +329,7 @@ void Rover::update_sensor_status_flags(void)
     if (g.compass_enabled && compass.healthy(0) && ahrs.use_compass()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }
     if (g2.visual_odom.enabled() && !g2.visual_odom.healthy()) {

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -399,7 +399,7 @@ void Copter::update_sensor_status_flags(void)
     if (!g.compass_enabled || !compass.healthy() || !ahrs.use_compass()) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (gps.status() == AP_GPS::NO_GPS) {
+    if (!gps.is_healthy()) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_GPS;
     }
     if (!ap.rc_receiver_present || failsafe.radio) {

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -306,7 +306,7 @@ void Plane::update_sensor_status_flags(void)
     if (g.compass_enabled && compass.healthy() && ahrs.use_compass()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }
 #if OPTFLOW == ENABLED

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -164,7 +164,7 @@ NOINLINE void Sub::send_extended_status1(mavlink_channel_t chan)
     if (g.compass_enabled && compass.healthy() && ahrs.use_compass()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (gps.status() > AP_GPS::NO_GPS) {
+    if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }
 #if OPTFLOW == ENABLED

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -501,12 +501,12 @@ void AP_GPS::detect_instance(uint8_t instance)
         _port[instance]->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
         dstate->last_baud_change_ms = now;
 
-        if (_auto_config == GPS_AUTO_CONFIG_ENABLE) {
+        if (_auto_config == GPS_AUTO_CONFIG_ENABLE && new_gps == nullptr) {
             send_blob_start(instance, _initialisation_blob, sizeof(_initialisation_blob));
         }
     }
 
-    if (_auto_config == GPS_AUTO_CONFIG_ENABLE) {
+    if (_auto_config == GPS_AUTO_CONFIG_ENABLE && new_gps == nullptr) {
         send_blob_update(instance);
     }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1499,3 +1499,9 @@ void AP_GPS::calc_blended_state(void)
     timing[GPS_BLENDED_INSTANCE].last_fix_time_ms = (uint32_t)temp_time_1;
     timing[GPS_BLENDED_INSTANCE].last_message_time_ms = (uint32_t)temp_time_2;
 }
+
+bool AP_GPS::is_healthy(uint8_t instance) const {
+    return drivers[instance] != nullptr &&
+           last_message_delta_time_ms(instance) < GPS_MAX_DELTA_MS &&
+           drivers[instance]->is_healthy();
+}

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -397,8 +397,9 @@ public:
     // indicate which bit in LOG_BITMASK indicates gps logging enabled
     void set_log_gps_bit(uint32_t bit) { _log_gps_bit = bit; }
 
-    // report if the gps is healthy (this is defined as having received an update at a rate greater than 4Hz)
-    bool is_healthy(uint8_t instance) const { return last_message_delta_time_ms(instance) < GPS_MAX_DELTA_MS; }
+    // report if the gps is healthy (this is defined as existing, an update at a rate greater than 4Hz,
+    // as well as any driver specific behaviour)
+    bool is_healthy(uint8_t instance) const;
     bool is_healthy(void) const { return is_healthy(primary_instance); }
 
 protected:

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -41,6 +41,14 @@ do {                                            \
 
 #define SBF_EXCESS_COMMAND_BYTES 5 // 2 start bytes + validity byte + space byte + endline byte
 
+#define RX_ERROR_MASK (SOFTWARE      | \
+                       CONGESTION    | \
+                       MISSEDEVENT   | \
+                       CPUOVERLOAD   | \
+                       INVALIDCONFIG | \
+                       OUTOFGEOFENCE)
+
+
 AP_GPS_SBF::AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                        AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
@@ -339,6 +347,7 @@ AP_GPS_SBF::process_message(void)
     {
         const msg4014 &temp = sbf_msg.data.msg4014u;
         RxState = temp.RxState;
+        RxError = temp.RxError;
         break;
     }
     case VelCovGeodetic:
@@ -386,4 +395,8 @@ bool AP_GPS_SBF::is_configured (void) {
     return (!gps._raw_data || (RxState & SBF_DISK_ACTIVITY)) &&
             (gps._auto_config == AP_GPS::GPS_AUTO_CONFIG_DISABLE ||
              _init_blob_index >= ARRAY_SIZE(_initialisation_blob));
+}
+
+bool AP_GPS_SBF::is_healthy (void) const {
+    return (RxError & RX_ERROR_MASK) == 0;
 }

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -55,7 +55,8 @@ AP_GPS_SBF::read(void)
 {
     uint32_t now = AP_HAL::millis();
 
-    if (_init_blob_index < (sizeof(_initialisation_blob) / sizeof(_initialisation_blob[0]))) {
+    if (gps._auto_config != AP_GPS::GPS_AUTO_CONFIG_DISABLE &&
+        _init_blob_index < (sizeof(_initialisation_blob) / sizeof(_initialisation_blob[0]))) {
         const char *init_str = _initialisation_blob[_init_blob_index];
         if (validcommand) {
             _init_blob_index++;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -46,6 +46,9 @@ public:
     // get the velocity lag, returns true if the driver is confident in the returned value
     bool get_lag(float &lag_sec) const override { lag_sec = 0.08f; return true; } ;
 
+    bool is_healthy(void) const override;
+
+
 private:
 
     bool parse(uint8_t temp);
@@ -66,6 +69,7 @@ private:
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;
     uint32_t RxState;
+    uint32_t RxError;
 
     enum sbf_ids {
         DOP = 4001,
@@ -185,4 +189,14 @@ private:
     } sbf_msg;
 
     void log_ExtEventPVTGeodetic(const msg4007 &temp);
+
+    enum {
+        SOFTWARE      = (1 << 3),
+        WATCHDOG      = (1 << 4),
+        CONGESTION    = (1 << 6),
+        MISSEDEVENT   = (1 << 8),
+        CPUOVERLOAD   = (1 << 9),
+        INVALIDCONFIG = (1 << 10),
+        OUTOFGEOFENCE = (1 << 11),
+    } RxError_bits;
 };

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -65,6 +65,9 @@ private:
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
     "sso, Stream2, Dsk1, postprocess+event, msec100\n"};
+    uint32_t _config_last_ack_time;
+
+    const char* _port_enable = "\nSSSSSSSSSS\n";
    
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -60,7 +60,7 @@ private:
     "sso, Stream1, COM1, PVTGeodetic+DOP+ExtEventPVTGeodetic+ReceiverStatus+VelCovGeodetic, msec100\n",
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
-    "spm, Rover, StandAlone+SBAS+DGPS+RTK\n",
+    "spm, Rover, all\n",
     "sso, Stream2, Dsk1, postprocess+event, msec100\n"};
    
     uint32_t crc_error_counter = 0;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -39,7 +39,7 @@ public:
 
     const char *name() const override { return "SBF"; }
 
-    bool is_configured (void) override { return (!gps._raw_data || (RxState & SBF_DISK_ACTIVITY)); }
+    bool is_configured (void) override;
 
     void broadcast_configuration_failure_reason(void) const override;
 
@@ -65,7 +65,6 @@ private:
    
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;
-    bool validcommand = false;
     uint32_t RxState;
 
     enum sbf_ids {
@@ -174,7 +173,8 @@ private:
             BLOCKID2,
             LENGTH1,
             LENGTH2,
-            DATA
+            DATA,
+            COMMAND_LINE // used to parse command responses
         } sbf_state;
         uint16_t preamble;
         uint16_t crc;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -64,7 +64,7 @@ private:
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
-    "sso, Stream2, Dsk1, postprocess+event, msec100\n"};
+    "sso, Stream2, Dsk1, postprocess+event+comment, msec100\n"};
     uint32_t _config_last_ack_time;
 
     const char* _port_enable = "\nSSSSSSSSSS\n";

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -56,6 +56,9 @@ public:
     // driver specific lag, returns true if the driver is confident in the provided lag
     virtual bool get_lag(float &lag) const { lag = 0.2f; return true; }
 
+    // driver specific health, returns true if the driver is healthy
+    virtual bool is_healthy(void) const { return true; }
+
     virtual const char *name() const = 0;
 
     void broadcast_gps_type() const;


### PR DESCRIPTION
This is a fairly significant overhaul of the Septentrio GPS driver.

- Respects GPS_AUTO_CONFIG in case someone wants to be running custom settings
- Validates that a configuration command was actually accepted instead of rejected
- Fix an invalid PVT configuration (if your board did not support RTK, then the PVT config command would fail)
- Check the receiver status for errors and report this as part of the GPS health. (Reciever errors include but aren't limited to CPU overload, uart congestion leading to delayed/lost data (a user has hit this by accident and experienced a terrifying copter flight)
- In the vehicles when evaluating GPS health actually check GPS::is_healthy() rather then just fix type
- Do not spam the SBF, GSOF, NOVA gps drivers with config strings not meant for them. This only caused configuration to take longer, and more overhead as we had to handle the invalid config messages
- Send a string to enable input on the SBF uart port in case it was disabled. This should resolve most cases of not allowing auto configuration to succeed
- Log comment blocks to the GPS SD card (intended to let the GCS inject markers/data to the GPS log for layer analysis).

I've only tested on a AsteRx-M with FW 3.6.3 (which in general was not suffering from auto config failures). But this did detect/report the bad errors with PVT mode, and pass sanity checks.

@amilcarlucas this still leaves the GPS auto bauding, but bypasses the other GPS init blobs, which is part of what you were doing in #6869

The GPS commits can be squashed in the end, I left them in the order as is, as they represent a feature on the above list, and might make for easier/clearer reviewing as there are less changes in one round.