### PR TITLE
AP_HAL: support lightware i2c rangefinder for pixhawk2

### DIFF
--- a/libraries/AP_HAL/board/px4.h
+++ b/libraries/AP_HAL/board/px4.h
@@ -20,6 +20,7 @@
 #define HAL_HAVE_IMU_HEATER         1 // for Pixhawk2
 #define HAL_IMU_TEMP_DEFAULT       -1 // disabled
 #define HAL_WITH_UAVCAN             1
+#define HAL_RANGEFINDER_LIGHTWARE_I2C_BUS 0
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
 #define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_PX4_V2
 #define HAL_STORAGE_SIZE            16384


### PR DESCRIPTION
fix (part of) #5831 with minimum code changed. Other boards will not be affected

Because we use "make px4-v3" for pixhawk2 now. Most likely, lightware i2c rangefinder is attached to "i2c 2" connector.