### PR TITLE
Tools: magfit_flashlog.py: fix syntax errors

### DIFF
--- a/Tools/scripts/magfit_flashlog.py
+++ b/Tools/scripts/magfit_flashlog.py
@@ -87,7 +87,7 @@ def find_offsets(data, ofs):
         ofs = ofs - delta
 
         if opts.verbose:
-            print ofs
+            print(ofs)
     return ofs
 
 


### PR DESCRIPTION
SyntaxError: print() is a function in Python 3