### PR TITLE
Tools: TestPitchRollCoupling.py: Change usage of next()

### DIFF
--- a/Tools/LogAnalyzer/tests/TestPitchRollCoupling.py
+++ b/Tools/LogAnalyzer/tests/TestPitchRollCoupling.py
@@ -100,7 +100,7 @@ class TestPitchRollCoupling(Test):
                         if abs(pitch)>(maxLeanAngle+maxLeanAngleBuffer) and abs(pitch)>abs(maxPitch):
                             maxPitch = pitch
                             maxPitchLine = lit.currentLine
-                    lit.next()
+                    next(lit)
         # check for breaking max lean angles
         if maxRoll and abs(maxRoll)>abs(maxPitch):
             self.result.status = TestResult.StatusType.FAIL
@@ -115,10 +115,3 @@ class TestPitchRollCoupling(Test):
 
         # TODO: use numpy/scipy to check Roll+RollIn curves for fitness (ignore where we're not airborne)
         # ...
-
-
-
-
-
-
-


### PR DESCRIPTION
__lit.next()__ is not Python 3 compatible but __next(lit)__ is compatible with both Python 2 and 3.