### PR TITLE
Tools: runplanetest.py: Resolve undefined name

### DIFF
--- a/Tools/scripts/runplanetest.py
+++ b/Tools/scripts/runplanetest.py
@@ -9,7 +9,7 @@ def wait_heartbeat(mav, timeout=10):
     while time.time() < start_time+timeout:
         if mav.recv_match(type='HEARTBEAT', blocking=True, timeout=0.5) is not None:
             return
-    failure("Failed to get heartbeat")    
+    raise Exception(("Failed to get heartbeat")    
 
 def wait_mode(mav, modes, timeout=10):
     '''wait for one of a set of flight modes'''
@@ -53,4 +53,3 @@ mavproxy.send('module load map\n')
 mavproxy.send('map set showsimpos 1\n')
 mavproxy.logfile = None
 mavproxy.interact()
-


### PR DESCRIPTION
Fixes: #6839

Undefined names can raise [NameError](https://docs.python.org/2/library/exceptions.html#exceptions.NameError) at runtime.