### PR TITLE
Tools: runplanetest.py: Remove redundant opening parenthesis

### DIFF
--- a/Tools/scripts/runplanetest.py
+++ b/Tools/scripts/runplanetest.py
@@ -9,7 +9,7 @@ def wait_heartbeat(mav, timeout=10):
     while time.time() < start_time+timeout:
         if mav.recv_match(type='HEARTBEAT', blocking=True, timeout=0.5) is not None:
             return
-    raise Exception(("Failed to get heartbeat")    
+    raise Exception("Failed to get heartbeat")    
 
 def wait_mode(mav, modes, timeout=10):
     '''wait for one of a set of flight modes'''


### PR DESCRIPTION
This syntax error was mistakenly introduced in #6999.