### PR TITLE
Do not merge: Plane: hack to always send AIRSPEED_AUTOCAL msg at 10Hz

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -67,7 +67,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(check_long_failsafe,     3,    400),
     SCHED_TASK(read_receiver_rssi,     10,    100),
     SCHED_TASK(rpm_update,             10,    100),
-    SCHED_TASK(airspeed_ratio_update,   1,    100),
+    SCHED_TASK(airspeed_ratio_update,  10,    100),
     SCHED_TASK(update_mount,           50,    100),
     SCHED_TASK(update_trigger,         50,    100),
     SCHED_TASK(log_perf_info,         0.2,    100),
@@ -415,6 +415,9 @@ void Plane::dataflash_periodic(void)
  */
 void Plane::airspeed_ratio_update(void)
 {
+    const Vector3f &vg = gps.velocity();
+    gcs_send_airspeed_calibration(vg);
+
     if (!airspeed.enabled() ||
         gps.status() < AP_GPS::GPS_OK_FIX_3D ||
         gps.ground_speed() < 4) {
@@ -435,7 +438,7 @@ void Plane::airspeed_ratio_update(void)
         // don't calibrate when going beyond normal flight envelope
         return;
     }
-    const Vector3f &vg = gps.velocity();
+//    const Vector3f &vg = gps.velocity();
     airspeed.update_calibration(vg, aparm.airspeed_max);
     gcs_send_airspeed_calibration(vg);
 }

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -152,12 +152,15 @@ void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspe
 // log airspeed calibration data to MAVLink
 void AP_Airspeed::log_mavlink_send(mavlink_channel_t chan, const Vector3f &vground)
 {
+    float temp;
+    get_temperature(temp);
     mavlink_msg_airspeed_autocal_send(chan,
                                       vground.x,
                                       vground.y,
                                       vground.z,
                                       get_differential_pressure(),
-                                      _EAS2TAS,
+//                                      _EAS2TAS,
+                                      temp,
                                       _ratio.get(),
                                       _calibration.state.x,
                                       _calibration.state.y,


### PR DESCRIPTION
for testing airspeed sensors

MS5525 is sensitive to device orientation. This plot shows a +/-4 Pascal offset between ports oriented upwards and downwards:
![orientation_sensitivity](https://user-images.githubusercontent.com/2300221/30784423-15f9460e-a112-11e7-9d63-efd2255d7fb9.png)
