### PR TITLE
Fix GPS backend instance number

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -624,6 +624,7 @@ void AP_GPS::update_instance(uint8_t instance)
             delete drivers[instance];
             drivers[instance] = nullptr;
             memset(&state[instance], 0, sizeof(state[instance]));
+            state[instance].instance = instance;
             state[instance].status = NO_GPS;
             state[instance].hdop = GPS_UNKNOWN_DOP;
             state[instance].vdop = GPS_UNKNOWN_DOP;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1107,7 +1107,7 @@ const Vector3f &AP_GPS::get_antenna_offset(uint8_t instance) const
 
 /*
   returns the desired gps update rate in milliseconds
-  this does not provide any gurantee that the GPS is updating at the requested
+  this does not provide any guarantee that the GPS is updating at the requested
   rate it is simply a helper for use in the backends for determining what rate
   they should be configuring the GPS to run at
 */
@@ -1121,7 +1121,7 @@ uint16_t AP_GPS::get_rate_ms(uint8_t instance) const
 }
 
 /*
- calculate the weightings used to blend GPs location and velocity data
+ calculate the weightings used to blend GPSs location and velocity data
 */
 bool AP_GPS::calc_blend_weights(void)
 {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -403,7 +403,7 @@ void AP_GPS::detect_instance(uint8_t instance)
 {
     AP_GPS_Backend *new_gps = nullptr;
     struct detect_state *dstate = &detect_state[instance];
-    uint32_t now = AP_HAL::millis();
+    const uint32_t now = AP_HAL::millis();
 
     state[instance].status = NO_GPS;
     state[instance].hdop = GPS_UNKNOWN_DOP;
@@ -612,7 +612,7 @@ void AP_GPS::update_instance(uint8_t instance)
 
     // we have an active driver for this instance
     bool result = drivers[instance]->read();
-    uint32_t tnow = AP_HAL::millis();
+    const uint32_t tnow = AP_HAL::millis();
 
     // if we did not get a message, and the idle timer of 2 seconds
     // has expired, re-initialise the GPS. This will cause GPS
@@ -786,7 +786,7 @@ void AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms
     if (instance >= GPS_MAX_RECEIVERS) {
         return;
     }
-    uint32_t tnow = AP_HAL::millis();
+    const uint32_t tnow = AP_HAL::millis();
     GPS_State &istate = state[instance];
     istate.status = _status;
     istate.location = _location;
@@ -951,7 +951,7 @@ uint8_t AP_GPS::first_unconfigured_gps(void) const
 
 void AP_GPS::broadcast_first_configuration_failure_reason(void) const
 {
-    uint8_t unconfigured = first_unconfigured_gps();
+    const uint8_t unconfigured = first_unconfigured_gps();
     if (drivers[unconfigured] == nullptr) {
         gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: was not found", unconfigured + 1);
     } else {


### PR DESCRIPTION
I see that sometimes after initialization the GPS_backend.cpp file always gets 0 when accessing it's state.instance variable.

This PR tries to fix that. Some testing is required.
