### PR TITLE
AP_HAL_Linux: UARTDevice: never be the controlling terminal

### DIFF
--- a/libraries/AP_HAL_Linux/UARTDevice.cpp
+++ b/libraries/AP_HAL_Linux/UARTDevice.cpp
@@ -33,7 +33,7 @@ bool UARTDevice::close()
 
 bool UARTDevice::open()
 {
-    _fd = ::open(_device_path, O_RDWR | O_CLOEXEC);
+    _fd = ::open(_device_path, O_RDWR | O_CLOEXEC | O_NOCTTY);
 
     if (_fd < 0) {
         ::fprintf(stderr, "Failed to open UART device %s - %s\n",


### PR DESCRIPTION
If we are the controlling terminal for a tty device we will receive a
SIGHUP when the device disappears. Currently what happens is that we
simply stop the whole process. We don't want to fall off the sky due
to a bad device. This can happen for any reason, but it's more likely
if the UART is behind a USB connection.