### PR TITLE
Tools: TestParams.py: Fix undefine name VehicleType

### DIFF
--- a/Tools/LogAnalyzer/tests/TestParams.py
+++ b/Tools/LogAnalyzer/tests/TestParams.py
@@ -1,5 +1,6 @@
-from LogAnalyzer import Test,TestResult
+from LogAnalyzer import Test, TestResult
 import DataflashLog
+from VehicleType import VehicleType
 
 import math # for isnan()
 


### PR DESCRIPTION
__VehicleType__ is used on lines 47, 53, and 56 but is never defined or imported.  This could result in a NameError runtime exception.