### PR TITLE
Travis CI: Add flake8 testing to the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
       - libxslt1-dev
       - python-pip
       - python-dev
+      - python3-pip
+      - python3-dev
       - zlib1g-dev
       - gcc-4.9
       - g++-4.9
@@ -44,11 +46,17 @@ before_install:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
 before_script:
+  # Python 2.7
   - pip install --user flake8
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  
+  # Python 3
+  - python3 -m pip install --user flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
 script:
   - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
 before_script:
-  - pip install flake8
+  - pip install --user flake8
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,13 @@ before_install:
   - Tools/scripts/configure-ci.sh
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 script:
   - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2
   - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle AntennaTracker

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,15 +48,19 @@ before_install:
 before_script:
   # Python 2.7
   - pip install --user flake8
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # stop the build if there are Python syntax errors
+  - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+  # warn if there are undefined names
+  - flake8 . --count --exit-zero --select=F821 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   
   # Python 3
   - python3 -m pip install --user flake8
-  # stop the build if there are Python syntax errors or undefined names
-  - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # stop the build if there are Python syntax errors
+  - python3 -m flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+  # warn if there are undefined names
+  - python3 -m flake8 . --count --exit-zero --select=F821 --show-source --statistics
 
 script:
   - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ before_script:
   - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
   # warn if there are undefined names
   - flake8 . --count --exit-zero --select=F821 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   
   # Python 3
   - python3 -m pip install --user flake8


### PR DESCRIPTION
The tests will only be run on Python 2 for now.  Python 3 could be added in a future PR.  Flake8 is run in two passes.  The first looks at a handful of crucial issues which can raise exceptions at runtime.  The second lists out all issues but in warning-only mode.

Either #6924 or #5568 would need to be resolved for the build to pass these tests.