### PR TITLE
Copter : Continue LAND of BATT FS

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -54,7 +54,7 @@ void Copter::failsafe_battery_event(void)
         if (should_disarm_on_failsafe()) {
             init_disarm_motors();
         } else {
-            if (g.failsafe_battery_enabled == FS_BATT_RTL || control_mode == AUTO) {
+            if (g.failsafe_battery_enabled == FS_BATT_RTL && control_mode != LAND || control_mode == AUTO) {
                 set_mode_RTL_or_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
             } else {
                 set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);


### PR DESCRIPTION
If Coper is already landing and the FS_BATT kicks in, do not change mode to RTL and let the land continue.