### PR TITLE
COPTER | WIP: Energy, distance, and altitude based battery failsafe

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -754,6 +754,7 @@ private:
     void Log_Write_Proximity();
     void Log_Write_Beacon();
     void Log_Write_Vehicle_Startup_Messages();
+    void Log_Write_FS_Energy(float wClm, float wCrs, float wHov, float wDesc, float wFin, float wRTL, uint32_t mahRTL, uint32_t mahWR, uint32_t secRTL);
     void load_parameters(void);
     void convert_pid_parameters(void);
     void userhook_init();
@@ -1024,6 +1025,7 @@ private:
     void init_disarm_motors();
     void motors_output();
     void lost_vehicle_check();
+    void save_params_on_disarm();
     void run_nav_updates(void);
     void calc_distance_and_bearing();
     void calc_wp_distance();
@@ -1065,6 +1067,8 @@ private:
     void init_precland();
     void update_precland();
     void read_battery(void);
+    float rtl_mah_calc(void);
+    float calc_hover_watts(void);
     void read_receiver_rssi(void);
     void epm_update();
     void gripper_update();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -629,6 +629,39 @@ void Copter::Log_Write_Beacon()
     DataFlash.Log_Write_Beacon(g2.beacon);
 }
 
+struct PACKED log_FS_Energy {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float watts_climb;
+    float watts_cruise;
+    float watts_hover;
+    float watts_desc;
+    float watts_final;
+    float watts_rtl_total;
+    uint32_t mah_rtl_total;
+    uint32_t mah_rtl_plus_res;
+    uint32_t sec_total;
+};
+
+// Failsage Energy Packet
+void Copter::Log_Write_FS_Energy(float wClm, float wCrs, float wHov, float wDesc, float wFin, float wRTL, uint32_t mahRTL, uint32_t mahWR, uint32_t secRTL)
+{
+    struct log_FS_Energy pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_FS_ENERGY_MSG),
+        time_us             : AP_HAL::micros64(),
+        watts_climb         : wClm,
+        watts_cruise        : wCrs,
+        watts_hover         : wHov,
+        watts_desc          : wDesc,
+        watts_final         : wFin,
+        watts_rtl_total     : wRTL,
+        mah_rtl_total       : mahRTL,
+        mah_rtl_plus_res    : mahWR,
+        sec_total           : secRTL
+    };
+    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
 const struct LogStructure Copter::log_structure[] = {
     LOG_COMMON_STRUCTURES,
 #if AUTOTUNE_ENABLED == ENABLED
@@ -671,6 +704,8 @@ const struct LogStructure Copter::log_structure[] = {
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ" },
     { LOG_THROW_MSG, sizeof(log_Throw),
       "THRO",  "QBffffbbbb",  "TimeUS,Stage,Vel,VelZ,Acc,AccEfZ,Throw,AttOk,HgtOk,PosOk" },
+    { LOG_FS_ENERGY_MSG, sizeof(log_FS_Energy), \
+      "FSEN", "QffffffIII","wClm,wCrs,wHov,wDesc,wFin,wRTL,mahRTL,mahWR,secRTL" }, \
 };
 
 void Copter::Log_Write_Vehicle_Startup_Messages()
@@ -721,6 +756,7 @@ void Copter::Log_Write_Throw(ThrowModeStage stage, float velocity, float velocit
 void Copter::Log_Write_Proximity() {}
 void Copter::Log_Write_Beacon() {}
 void Copter::Log_Write_Vehicle_Startup_Messages() {}
+void Copter::Log_Write_FS_Energy(float wClm, float wCrs, float wHov, float wDesc, float wFin, float wRTL, uint32_t mahRTL, uint32_t mahWR, uint32_t secRTL){}
 
 #if FRAME_CONFIG == HELI_FRAME
 void Copter::Log_Write_Heli() {}

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1010,6 +1010,54 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_SmartRTL/AP_SmartRTL.cpp
     AP_SUBGROUPINFO(smart_rtl, "SRTL_", 21, ParametersG2, AP_SmartRTL),
 
+    //ID 22 & 23 reserved for FS Land mode PR
+
+    // @Param: HOVER_WATT
+    // @DisplayName: Hover Watts
+    // @Description: The watts required to hover
+    // @Range: 0 2000
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("HOVER_WATT", 24, ParametersG2, hover_watt, 0),
+
+    // @Param: HOVER_WATT_LEARN
+    // @DisplayName: Hover Watts Learning
+    // @Description: Enable/Disable automatic learning of hover wattage
+    // @Values: 0:Disabled, 1:Learn, 2:LearnAndSave
+    // @User: Advanced
+    AP_GROUPINFO("HOVER_WATT_LEARN", 25, ParametersG2, hover_watt_learn, HOVER_WATT_LEARN_DISABLED),
+
+    // @Param: FS_BATT_RESERVE
+    // @DisplayName: Battery reserve % remaining on landing
+    // @Description: Sets the desired battery percent remaining on landing after a battery failsafe, and enables the energy based battery failsafe. When not zero, ArduCopter will calculate the watts requried to RTL based on distance and altitude, then calculate a live MAH value for the battery failsafe and low battery alarm to use. This will be used instead of the traditional FS_BATT_MAH value.
+    // @Range: 0 100
+    // @User: Advanced
+    AP_GROUPINFO("FS_BATT_RESERVE", 26, ParametersG2, fs_batt_reserve, 0),
+
+    // @Param:FS_BATT_MULT_CLM
+    // @DisplayName: Climb power multiplier
+    // @Description: Multiplier for power required to climb compared to hover. Default is a climb using 20% more power than hovering, for a value of 1.2.
+    // @Range: 0.1 2
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("FS_BATT_MULT_CLM", 27, ParametersG2, fs_batt_mult_clm, 1.2),
+
+    // @Param:FS_BATT_MULT_DSC
+    // @DisplayName: Desent power multiplier
+    // @Description: Multiplier for power required to descend compared to hover. Default is a descent using 10% less power than hovering, for a value of 0.9.
+    // @Range: 0.1 2
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("FS_BATT_MULT_DSC", 28, ParametersG2, fs_batt_mult_dsc, 0.9),
+
+    // @Param:FS_BATT_MULT_CRS
+    // @DisplayName: Cruise power multiplier
+    // @Description: Multiplier for power required in level cruise compared to hover. Default is cruise using 10% more power than hovering, for a value of 1.1.
+    // @Range: 0.1 2
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("FS_BATT_MULT_CRS", 29, ParametersG2, fs_batt_mult_crs, 1.1),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -568,8 +568,16 @@ public:
     // control over servo output ranges
     SRV_Channels servo_channels;
 
-    // Safe RTL library
+    // Smart RTL library
     AP_SmartRTL smart_rtl;
+    
+    // Energy based battery failsafe
+    AP_Int16 hover_watt;
+    AP_Int16 hover_watt_learn;
+    AP_Int16 fs_batt_reserve;
+    AP_Float fs_batt_mult_clm;
+    AP_Float fs_batt_mult_dsc;
+    AP_Float fs_batt_mult_crs;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -304,6 +304,13 @@ enum DevOptions {
     DevOptionADSBMAVLink = 1,
 };
 
+// enum values for HOVER_WATT_LEARN parameter
+enum HoverWattLearn {
+    HOVER_WATT_LEARN_DISABLED = 0,
+    HOVER_WATT_LEARN_ONLY = 1,
+    HOVER_WATT_LEARN_AND_SAVE = 2
+};
+
 //  Logging parameters
 #define TYPE_AIRSTART_MSG               0x00
 #define TYPE_GROUNDSTART_MSG            0x01
@@ -329,6 +336,7 @@ enum DevOptions {
 #define LOG_PRECLAND_MSG                0x21
 #define LOG_GUIDEDTARGET_MSG            0x22
 #define LOG_THROW_MSG                   0x23
+#define LOG_FS_ENERGY_MSG               0x24
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -249,6 +249,9 @@ void Copter::init_disarm_motors()
     autotune_save_tuning_gains();
 #endif
 
+    // save copter parameters on disarm
+    save_params_on_disarm();
+
     // we are not in the air
     set_land_complete(true);
     set_land_complete_maybe(true);
@@ -344,5 +347,12 @@ void Copter::lost_vehicle_check()
         if (AP_Notify::flags.vehicle_lost == true) {
             AP_Notify::flags.vehicle_lost = false;
         }
+    }
+}
+
+void Copter::save_params_on_disarm()
+{
+    if (g2.hover_watt_learn == HOVER_WATT_LEARN_AND_SAVE) {
+        g2.hover_watt.save();
     }
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -413,3 +413,21 @@ bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance)
         return (AP_HAL::millis() - state[instance].temperature_time) <= AP_BATT_MONITOR_TIMEOUT;
     }
 }
+
+/// watts - returns current watthour consumption
+float AP_BattMonitor::watts(uint8_t instance) const {
+    if (instance < _num_instances) {
+        return _BattMonitor_STATE(instance).watts;
+    } else {
+        return 0.0f;
+    }
+}
+
+/// watts_used - returns total watts since start-up
+float AP_BattMonitor::watts_used(uint8_t instance) const {
+    if (instance < _num_instances) {
+        return _BattMonitor_STATE(instance).watts_used;
+    } else {
+        return 0.0f;
+    }
+}

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -80,6 +80,8 @@ public:
         uint32_t    temperature_time;   // timestamp of the last recieved temperature message
         float       voltage_resting_estimate; // voltage with sag removed based on current and resistance estimate
         float       resistance;         // resistance calculated by comparing resting voltage vs in flight voltage
+        float       watts;              // watts based on current * estimated resting voltage
+        float       watts_used;         // total watts used
     };
 
     // Return the number of battery monitor instances
@@ -160,6 +162,14 @@ public:
     // get battery resistance estimate in ohms
     float get_resistance() const { return get_resistance(AP_BATT_PRIMARY_INSTANCE); }
     float get_resistance(uint8_t instance) const { return state[instance].resistance; }
+    
+    // watts
+    float watts(uint8_t instance) const;
+    float watts() const { return watts(AP_BATT_PRIMARY_INSTANCE); }
+    
+    // watts used
+    float watts_used(uint8_t instance) const;
+    float watts_used() const { return watts_used(AP_BATT_PRIMARY_INSTANCE); }
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -38,11 +38,15 @@ AP_BattMonitor_Analog::read()
 
         // read current
         _state.current_amps = (_curr_pin_analog_source->voltage_average()-_mon._curr_amp_offset[_state.instance])*_mon._curr_amp_per_volt[_state.instance];
+        
+        // Calculate watts_used as amps * estimated resting voltage
+        _state.watts = (_state.current_amps * _state.voltage_resting_estimate);
 
-        // update total current drawn since startup
+        // update total current and watts used since startup
         if (_state.last_time_micros != 0 && dt < 2000000.0f) {
             // .0002778 is 1/3600 (conversion to hours)
             _state.current_total_mah += _state.current_amps * dt * 0.0000002778f;
+            _state.watts_used += (_state.watts/3600) * (dt/1000000);
         }
 
         // record time

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -95,6 +95,25 @@ bool AP_BattMonitor_SMBus::read_serial_number(void) {
     return false;
 }
 
+// Watt caclulations for SMBUS smart batteries
+// Watts is calculated using current and estimated resting voltage
+void AP_BattMonitor_SMBus::calc_watts(void) {
+    // calculate time since last current read
+    uint32_t tnow = AP_HAL::micros();
+    float dt = tnow - _state.last_time_micros;
+
+    // Calculate watts as amps * estimated resting voltage
+    _state.watts = (_state.current_amps * _state.voltage_resting_estimate);
+
+    // update total watts since startup
+    if (_state.last_time_micros != 0 && dt < 2000000.0f) {
+        _state.watts_used += float(_state.watts/3600) * float(dt/1000000);
+    }
+
+    // record time
+    _state.last_time_micros = tnow;
+}
+
 // read word from register
 // returns true if read was successful, false if failed
 bool AP_BattMonitor_SMBus::read_word(uint8_t reg, uint16_t& data) const

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -48,6 +48,8 @@ protected:
     // reads the serial number if it's not already known
     // returns true if the read was successful, or the number was already known
     bool read_serial_number(void);
+    
+    void calc_watts(void);
 
      // read word from register
      // returns true if read was successful, false if failed

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -91,6 +91,8 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     read_temp();
 
     read_serial_number();
+    
+    calc_watts();
 }
 
 // read_block - returns number of characters read if successful, zero if unsuccessful

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -76,6 +76,7 @@ void AP_BattMonitor_SMBus_Solo::timer()
 
     read_full_charge_capacity();
     read_remaining_capacity();
+    calc_watts();
 
     // read the button press indicator
     if (read_block(BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA, buff, 6, false) == 6) {

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1506,7 +1506,9 @@ void DataFlash_Class::Log_Write_Current_instance(const AP_BattMonitor &battery,
         current_amps        : battery.current_amps(battery_instance),
         current_total       : battery.current_total_mah(battery_instance),
         temperature         : (int16_t)(has_temp ? (temp * 100) : 0),
-        resistance          : battery.get_resistance(battery_instance)
+        resistance          : battery.get_resistance(battery_instance),
+        watts               : battery.watts(battery_instance),
+        watts_used          : battery.watts_used(battery_instance)
     };
     WriteBlock(&pkt, sizeof(pkt));
 

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -550,6 +550,8 @@ struct PACKED log_Current {
     float    current_total;
     int16_t  temperature; // degrees C * 100
     float    resistance;
+    float    watts;
+    float    watts_used;
 };
 
 struct PACKED log_Current_Cells {
@@ -936,8 +938,8 @@ struct PACKED log_SRTL {
 #define QUAT_LABELS "TimeUS,Q1,Q2,Q3,Q4"
 #define QUAT_FMT    "Qffff"
 
-#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,Temp,Res"
-#define CURR_FMT    "Qffffcf"
+#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,Temp,Res,Watts,WattsTot"
+#define CURR_FMT    "Qffffcfff"
 
 #define CURR_CELL_LABELS "TimeUS,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
 #define CURR_CELL_FMT    "QfHHHHHHHHHH"


### PR DESCRIPTION
This is still a work in progress since I'm sure there will be suggested changes here for me to make. So I don't intend for this to be merged yet.  I am wide open to suggestions as always.

The idea here is to calculate on an ongoing basis in flight how much energy is required to make it back home to a safe landing with a specified % battery remaining. Then use that information rather than the arbitrary `FS_BATT_MAH` value in the triggering the battery failsafe and alarms.  This accomplishes a few things:
* Prevent flying too far away where you don't have battery capacity to make it home.
* Prevent battery alarms and failsafes from engaging unnecessarily soon when flying close in.
* Protect batteries from abuse by calculating a landing at a given safe % remaining

The changes in this PR are as follows (_updated per discussion about multiplier parameters_):
- **Added parameters:**
  - `FS_BATT_RESERVE` specifies the % battery remaining that the operator wants the copter to be on the ground. So the operator has entered 10, the calculations will run with the goal of having the copter landed on the ground with 10% battery remaining.  Valid values are 0-100, with 0 being disabled.
  - `HOVER_WATT` specifies the watts required to hover. The energy required to return home is calculated in watts rather than MAH since it is consistent regardless of battery voltage and sag.
  - `HOVER_WATT_LEARN` works just like the existing hover throttle parameter. When disabled, it will only use the hand entered value.  When set for LEARN, it will learn the watts in flight. And when set for learn and save, it will save the learned value on disarm.
  - `FS_BATT_MULT_CLM` is the multiplier for how much power is used in a climb from hover power. Default is 1.2 (20% more power than hover).
  - `FS_BATT_MULT_DSC` is the multiplier for how much power is used in a descent from hover power. Default is 0.9 (10% less power than hover).
  - `FS_BATT_MULT_CRS` is the multiplier for how much power is used in cruise from hover power. Default is 1.1 (10% more power than hover).

- **Learning hover watts in flight** Added to copter `attitude.cpp`. This happens under the same circumstances that the hover throttle value is learned.  The wattage is calculated using amps multiplied by the _estimated resting voltage_ during level hover flight when the `HOVER_WATT_LEARN` is enabled

- **Calculating watts to return home** in `sensors.cpp`. This requires the `FS_BATT_RESERVE` and `HOVER_WATT` parameters are non-zero, and the battery monitor to be reporting valid current and voltage values. If these conditions are _not_ met, the existing behavior using `FS_BATT_MAH` takes place as usual.
  - **Climb energy** is calculated at hover watts * `FS_BATT_MULT_CLM`. It looks at how high it needs to climb by comparing copter altitude and RTL altitude.  This is skipped if the failsafe is not RTL.
  - **Cruise energy** is calculated at hover watts * `FS_BATT_MULT_CRS`. It looks at the distance to home. This is skipped if the failsafe is not RTL.
  - **Loiter energy** is calculated at hover watts. It looks at the `RTL_LOIT_TIME` parameter for the time the copter loiters before beginning it's descent.
  - **Descent energy** is calculated at hover watts * `FS_BATT_MULT_DSC`. It looks at altitude to descend down to the final landing phase (10 meters)
  - **Final descent energy** is calculated at hover watts, and is the final 10 meter slow descent
  - **Total watts to RTL** is the sum of all of the above
  - **Reserve watts** is calculated as the `FS_BATT_RESERVE` percentage of `BATT_CAPCACITY` to get reserve MAH, multiplied by _estimated resting voltage_ to get watts.
  - **MAH to trigger failsafe/alarms** is the sum of RTL watts + reserve watts, then converted back to MAH by dividing by the estimated resting voltage. This MAH value is then used instead of `FS_BATT_MAH`.