### PR TITLE
Plane: Don't log SONR if there are no rangefinders

### DIFF
--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -46,8 +46,9 @@ void Plane::read_rangefinder(void)
 
     rangefinder.update();
 
-    if (should_log(MASK_LOG_SONAR))
+    if ((rangefinder.num_sensors() > 0) && should_log(MASK_LOG_SONAR)) {
         Log_Write_Sonar();
+    }
 
     rangefinder_height_update();
 }


### PR DESCRIPTION
Logging rangefinders without one present is just a waste of dataflash log space, and makes logs harder to handle.

I looked at skipping the entire rangefinder update however I couldn't quite convince myself that skipping it wouldn't risk having a piece of state wrong.