### PR TITLE
Plane: Log flight stage

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -145,6 +145,7 @@ struct PACKED log_Nav_Tuning {
     float   xtrack_error;
     float   xtrack_error_i;
     float   airspeed_error;
+    uint8_t flight_stage;
 };
 
 // Write a navigation tuning packet
@@ -159,7 +160,8 @@ void Plane::Log_Write_Nav_Tuning()
         altitude_error_cm   : (int16_t)altitude_error_cm,
         xtrack_error        : nav_controller->crosstrack_error(),
         xtrack_error_i      : nav_controller->crosstrack_error_integrator(),
-        airspeed_error      : airspeed_error
+        airspeed_error      : airspeed_error,
+        flight_stage        : flight_stage
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -376,7 +378,7 @@ const struct LogStructure Plane::log_structure[] = {
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qcccchhh",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThrOut,RdrOut,ThrDem" },
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
-      "NTUN", "Qfcccfff",  "TimeUS,WpDist,TargBrg,NavBrg,AltErr,XT,XTi,ArspdErr" },
+      "NTUN", "QfcccfffB",  "TimeUS,WpDist,TargBrg,NavBrg,AltErr,XT,XTi,ArspdErr,Stage" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
       "SONR", "QffBf",   "TimeUS,Dist,Volt,Cnt,Corr" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),


### PR DESCRIPTION
When trying to do log analysis not knowing the flight stage that the plane was on is causing problems, particularly related to land/land abort.