### PR TITLE
AP_Landing: Support CCW Deepstalls

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -34,13 +34,6 @@ void Plane::Log_Write_Attitude(void)
     DataFlash.Log_Write_PID(LOG_PIDP_MSG, pitchController.get_pid_info());
     DataFlash.Log_Write_PID(LOG_PIDY_MSG, yawController.get_pid_info());
     DataFlash.Log_Write_PID(LOG_PIDS_MSG, steerController.get_pid_info());
-    if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
-        const DataFlash_Class::PID_Info *landing_info;
-        landing_info = landing.get_pid_info();
-        if (landing_info != nullptr) { // only log LANDING PID's while in landing
-            DataFlash.Log_Write_PID(LOG_PIDL_MSG, *landing_info);
-        }
-    }
 
 #if AP_AHRS_NAVEKF_AVAILABLE
     DataFlash.Log_Write_EKF(ahrs);

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -580,6 +580,8 @@ void AP_Landing::log(void) const
         type_slope_log();
         break;
     case TYPE_DEEPSTALL:
+        deepstall.log();
+        break;
     default:
         break;
     }

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -136,6 +136,13 @@ const AP_Param::GroupInfo AP_Landing_Deepstall::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ABORTALT", 15, AP_Landing_Deepstall, min_abort_alt, 0.0f),
 
+    // @Param: AIL_SCL
+    // @DisplayName: Aileron landing gain scalaing
+    // @Description: A scalar to reduce or increase the aileron control
+    // @Range: 0 2.0
+    // @User: Advanced
+    AP_GROUPINFO("AIL_SCL", 16, AP_Landing_Deepstall, aileron_scalar, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -329,15 +336,10 @@ bool AP_Landing_Deepstall::override_servos(void)
                                              0.5f, 1.0f);
 
         float output = constrain_float(pid, -travel_limit, travel_limit);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, output*4500);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron_with_input, output*4500);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, output*4500*aileron_scalar);
         SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, output*4500);
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0); // this will normally be managed as part of landing,
                                                                      // but termination needs to set throttle control here
-    } else {
-        // allow the normal servo control of the channel
-        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron_with_input,
-                                        SRV_Channels::get_output_scaled(SRV_Channel::k_aileron));
     }
 
     // hand off rudder control to deepstall controlled

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -281,7 +281,6 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
             // that will be handled within override_servos
             initial_elevator_pwm = elevator->get_output_pwm();
         }
-        L1_xtrack_i = 0; // reset the integrators
         }
         FALLTHROUGH;
     case DEEPSTALL_STAGE_LAND:
@@ -296,7 +295,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
 
 bool AP_Landing_Deepstall::override_servos(void)
 {
-    if (!(stage == DEEPSTALL_STAGE_LAND)) {
+    if (stage != DEEPSTALL_STAGE_LAND) {
         return false;
     }
 
@@ -304,8 +303,7 @@ bool AP_Landing_Deepstall::override_servos(void)
 
     if (elevator == nullptr) {
         // deepstalls are impossible without these channels, abort the process
-        gcs().send_text(MAV_SEVERITY_CRITICAL,
-                                         "Deepstall: Unable to find the elevator channels");
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Deepstall: Unable to find the elevator channels");
         request_go_around();
         return false;
     }
@@ -314,7 +312,6 @@ bool AP_Landing_Deepstall::override_servos(void)
     float slew_progress = 1.0f;
     if (slew_speed > 0) {
         slew_progress  = (AP_HAL::millis() - stall_entry_time) / (100.0f * slew_speed);
-        slew_progress = constrain_float (slew_progress, 0.0f, 1.0f);
     }
 
     // mix the elevator to the correct value

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -103,6 +103,7 @@ private:
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
     bool terminate(void);
+    void log(void) const;
 
     bool send_deepstall_message(mavlink_channel_t chan) const;
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -68,6 +68,7 @@ private:
     AP_Float yaw_rate_limit;
     AP_Float time_constant;
     AP_Float min_abort_alt;
+    AP_Float aileron_scalar;
     int32_t loiter_sum_cd;         // used for tracking the progress on loitering
     deepstall_stage stage;
     Location landing_point;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -604,6 +604,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_NAV_LAND:                              // MAV ID: 21
         copy_location = true;
         cmd.p1 = packet.param1;                         // abort target altitude(m)  (plane only)
+        cmd.content.location.flags.loiter_ccw = is_negative(packet.param4); // yaw direction, (plane deepstall only)
         break;
 
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22
@@ -1058,6 +1059,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_NAV_LAND:                              // MAV ID: 21
         copy_location = true;
         packet.param1 = cmd.p1;                        // abort target altitude(m)  (plane only)
+        packet.param4 = cmd.content.location.flags.loiter_ccw ? -1 : 1; // yaw direction, (plane deepstall only)
         break;
 
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -898,6 +898,24 @@ struct PACKED log_SRTL {
     float D;
 };
 
+struct PACKED log_DSTL {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t stage;
+    float target_heading;
+    int32_t target_lat;
+    int32_t target_lng;
+    int32_t target_alt;
+    int16_t crosstrack_error;
+    int16_t travel_distance;
+    float l1_i;
+    int32_t loiter_sum_cd;
+    float desired;
+    float P;
+    float I;
+    float D;
+};
+
 // #endif // SBP_HW_LOGGING
 
 #define ACC_LABELS "TimeUS,SampleUS,AccX,AccY,AccZ"
@@ -1153,8 +1171,8 @@ Format characters in the format string for binary log messages
       "PIDA", PID_FMT,  PID_LABELS }, \
     { LOG_PIDS_MSG, sizeof(log_PID), \
       "PIDS", PID_FMT,  PID_LABELS }, \
-    { LOG_PIDL_MSG, sizeof(log_PID), \
-      "PIDL", PID_FMT,  PID_LABELS }, \
+    { LOG_DSTL_MSG, sizeof(log_DSTL), \
+      "DSTL", "QBfLLeccfeffff", "TimeUS,Stg,THdg,Lat,Lng,Alt,XT,Travel,L1I,Loiter,Des,P,I,D" }, \
     { LOG_BAR2_MSG, sizeof(log_BARO), \
       "BAR2",  BARO_FMT, BARO_LABELS }, \
     { LOG_BAR3_MSG, sizeof(log_BARO), \
@@ -1264,7 +1282,7 @@ enum LogMessages {
     LOG_PIDY_MSG,
     LOG_PIDA_MSG,
     LOG_PIDS_MSG,
-    LOG_PIDL_MSG,
+    LOG_DSTL_MSG,
     LOG_VIBE_MSG,
     LOG_IMUDT_MSG,
     LOG_IMUDT2_MSG,

--- a/libraries/PID/PID.cpp
+++ b/libraries/PID/PID.cpp
@@ -119,6 +119,11 @@ PID::reset_I()
     _pid_info.I = 0;
 }
 
+void PID::reset() {
+    memset(&_pid_info, 0, sizeof(_pid_info));
+    reset_I();
+}
+
 void
 PID::load_gains()
 {

--- a/libraries/PID/PID.h
+++ b/libraries/PID/PID.h
@@ -39,6 +39,10 @@ public:
     ///
     float        get_pid(float error, float scaler = 1.0);
 
+    /// Reset the whole PID state
+    //
+    void        reset();
+
     /// Reset the PID integrator
     ///
     void        reset_I();


### PR DESCRIPTION
This is a number of small deepstall enhancements:

- Support CCW deepstall loiters approaches
- Allow scaling aileron response up/down compared to the rudder when in deepstall. (Needed for some aircraft with ailerons)
- Rework the deepstall logging messages to improve the log analysis of deepstall approaches. (PIDL was only used for deepstall reasons, and a proper deepstall message made more sense then having the pair of messages)
- Cleanup some redundant code, remove k_aileron_with_input handling since it is no longer supported

SITL testing appears to be well behaved, however I'd like to get a real world test flight in before merging, as SITL testing can't test anything after the flare. Should be able to do the test flight tomorrow, but the code is ready for review (despite the WIP tag).