### PR TITLE
AP_HAL_Linux: reset duty cycle before setting period

### DIFF
--- a/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
@@ -94,6 +94,8 @@ bool PWM_Sysfs_Base::is_enabled()
 
 void PWM_Sysfs_Base::set_period(uint32_t nsec_period)
 {
+    set_duty_cycle(0);
+
     if (Util::from(hal.util)->write_file(_period_path, "%u", nsec_period) < 0) {
         hal.console->printf("LinuxPWM_Sysfs: %s Unable to set period\n",
                             _period_path);


### PR DESCRIPTION
On kernels 4.7+ [duty_cycle should always be less than period](https://elixir.free-electrons.com/linux/v4.7/source/drivers/pwm/core.c#L461).
Otherways, we'll get a EINVAL.

It makes sense to set duty_cycle to 0, as
duty_cycle doesn't really make sense without a proper period.

A proper way to handle these errors might be to call pwm_adjust_config
in every pwmchip backend but it's unrealistic to hope that all vendors
will do it quickly.

Either way, we'll just set duty_cycle on the next iteration, so I guess we're good. I'll be glad if anyone would pitch in and give a feedback! Thanks.