### PR TITLE
AP_GPS: Start/Stop logging when armed/disarmed

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -509,6 +509,14 @@ bool AP_Arming::pre_arm_checks(bool report)
 
 bool AP_Arming::arm_checks(uint8_t method)
 {
+    // ensure the GPS drivers are ready on any final changes
+    if ((checks_to_perform & ARMING_CHECK_ALL) ||
+        (checks_to_perform & ARMING_CHECK_GPS_CONFIG)) {
+        if (!AP_GPS::gps().prepare_for_arming()) {
+            return false;
+        }
+    }
+
     // note that this will prepare DataFlash to start logging
     // so should be the last check to be done before arming
     if ((checks_to_perform & ARMING_CHECK_ALL) ||

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -61,6 +61,8 @@ const uint32_t AP_GPS::_baudrates[] = {4800U, 19200U, 38400U, 115200U, 57600U, 9
 // right mode
 const char AP_GPS::_initialisation_blob[] = UBLOX_SET_BINARY MTK_SET_BINARY SIRF_SET_BINARY;
 
+AP_GPS *AP_GPS::_singleton;
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Param: TYPE
@@ -267,6 +269,11 @@ AP_GPS::AP_GPS()
                     "GPS initilisation blob is to large to be completely sent before the baud rate changes");
 
     AP_Param::setup_object_defaults(this, var_info);
+
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AP_GPS must be singleton");
+    }
+    _singleton = this;
 }
 
 /// Startup initialisation.

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -132,8 +132,8 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 
     // @Param: RAW_DATA
     // @DisplayName: Raw data logging
-    // @Description: Enable logging of RXM raw data from uBlox which includes carrier phase and pseudo range information. This allows for post processing of dataflash logs for more precise positioning. Note that this requires a raw capable uBlox such as the 6P or 6T.
-    // @Values: 0:Disabled,1:log every sample,5:log every 5 samples
+    // @Description: Handles logging raw data; on uBlox chips that support raw data this will log RXM messages into dataflash log; on Septentrio this will log on the equipment's SD card and when set to 2, the autopilot will try to stop logging after disarming and restart after arming
+    // @Values: 0:Ignore,1:Always log,2:Stop logging when disarmed (SBF only),5:Only log every five samples (uBlox only)
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("RAW_DATA", 9, AP_GPS, _raw_data, 0),
@@ -1505,4 +1505,14 @@ bool AP_GPS::is_healthy(uint8_t instance) const {
     return drivers[instance] != nullptr &&
            last_message_delta_time_ms(instance) < GPS_MAX_DELTA_MS &&
            drivers[instance]->is_healthy();
+}
+
+bool AP_GPS::prepare_for_arming(void) {
+    bool all_passed = true;
+    for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+        if (drivers[i] != nullptr) {
+            all_passed &= drivers[i]->prepare_for_arming();
+        }
+    }
+    return all_passed;
 }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -72,6 +72,10 @@ public:
     AP_GPS(const AP_GPS &other) = delete;
     AP_GPS &operator=(const AP_GPS&) = delete;
 
+    static AP_GPS &gps() {
+        return *_singleton;
+    }
+
     // GPS driver types
     enum GPS_Type {
         GPS_TYPE_NONE  = 0,
@@ -435,6 +439,8 @@ protected:
 
 private:
     AP_GPS();
+
+    static AP_GPS *_singleton;
 
     // returns the desired gps update rate in milliseconds
     // this does not provide any guarantee that the GPS is updating at the requested

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -406,6 +406,9 @@ public:
     bool is_healthy(uint8_t instance) const;
     bool is_healthy(void) const { return is_healthy(primary_instance); }
 
+    // returns true if all GPS instances have passed all final arming checks/state changes
+    bool prepare_for_arming(void);
+
 protected:
 
     // configuration parameters

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -64,30 +64,43 @@ AP_GPS_SBF::AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
 bool
 AP_GPS_SBF::read(void)
 {
-    uint32_t now = AP_HAL::millis();
-
-    if (gps._auto_config != AP_GPS::GPS_AUTO_CONFIG_DISABLE &&
-        _init_blob_index < ARRAY_SIZE(_initialisation_blob)) {
-        const char *init_str = _initialisation_blob[_init_blob_index];
-
-        if (now > _init_blob_time) {
-            if (now > _config_last_ack_time + 2500) {
-                // try to enable input on the GPS port if we have not made progress on configuring it
-                Debug("SBF Sending port enable");
-                port->write((const uint8_t*)_port_enable, strlen(_port_enable));
-                _config_last_ack_time = now;
-            } else {
-                Debug("SBF sending init string: %s", init_str);
-                port->write((const uint8_t*)init_str, strlen(init_str));
-            }
-            _init_blob_time = now + 1000;
-        }
-    }
-
     bool ret = false;
-    while (port->available() > 0) {
+    uint32_t available_bytes = port->available();
+    for (uint32_t i = 0; i < available_bytes; i++) {
         uint8_t temp = port->read();
         ret |= parse(temp);
+    }
+
+    if (gps._auto_config != AP_GPS::GPS_AUTO_CONFIG_DISABLE) {
+        if (_init_blob_index < ARRAY_SIZE(_initialisation_blob)) {
+            uint32_t now = AP_HAL::millis();
+            const char *init_str = _initialisation_blob[_init_blob_index];
+
+            if (now > _init_blob_time) {
+                if (now > _config_last_ack_time + 2500) {
+                    // try to enable input on the GPS port if we have not made progress on configuring it
+                    Debug("SBF Sending port enable");
+                    port->write((const uint8_t*)_port_enable, strlen(_port_enable));
+                    _config_last_ack_time = now;
+                } else {
+                    Debug("SBF sending init string: %s", init_str);
+                    port->write((const uint8_t*)init_str, strlen(init_str));
+                }
+                _init_blob_time = now + 1000;
+            }
+        } else if (gps._raw_data == 2) { // only manage disarm/rearms when the user opts into it
+            if (hal.util->get_soft_armed()) {
+                _has_been_armed = true;
+            } else if (_has_been_armed && (RxState & SBF_DISK_MOUNTED)) {
+                // since init is done at this point and unmounting should be rate limited,
+                // take over the _init_blob_time variable
+                uint32_t now = AP_HAL::millis();
+                if (now > _init_blob_time) {
+                    unmount_disk();
+                    _init_blob_time = now + 1000;
+                }
+            }
+        }
     }
 
     return ret;
@@ -380,18 +393,6 @@ AP_GPS_SBF::process_message(void)
 
 void AP_GPS_SBF::broadcast_configuration_failure_reason(void) const
 {
-    if (gps._raw_data) {
-        if (!(RxState & SBF_DISK_MOUNTED)){
-            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF disk is not mounted", state.instance + 1);
-        }
-        else if (RxState & SBF_DISK_FULL) {
-            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF disk is full", state.instance + 1);
-        }
-        else if (!(RxState & SBF_DISK_ACTIVITY)) {
-            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF is not currently logging", state.instance + 1);
-        }
-    }
-
     if (gps._auto_config != AP_GPS::GPS_AUTO_CONFIG_DISABLE &&
         _init_blob_index < ARRAY_SIZE(_initialisation_blob)) {
         gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF is not fully configured (%d/%d)", state.instance + 1,
@@ -400,11 +401,49 @@ void AP_GPS_SBF::broadcast_configuration_failure_reason(void) const
 }
 
 bool AP_GPS_SBF::is_configured (void) {
-    return (!gps._raw_data || (RxState & SBF_DISK_ACTIVITY)) &&
-            (gps._auto_config == AP_GPS::GPS_AUTO_CONFIG_DISABLE ||
+    return (gps._auto_config == AP_GPS::GPS_AUTO_CONFIG_DISABLE ||
              _init_blob_index >= ARRAY_SIZE(_initialisation_blob));
 }
 
 bool AP_GPS_SBF::is_healthy (void) const {
     return (RxError & RX_ERROR_MASK) == 0;
+}
+
+void AP_GPS_SBF::mount_disk (void) const {
+    const char* command = "emd, DSK1, Mount\n";
+    Debug("Mounting disk");
+    port->write((const uint8_t*)command, strlen(command));
+}
+
+void AP_GPS_SBF::unmount_disk (void) const {
+    const char* command = "emd, DSK1, Unmount\n";
+    Debug("Unmounting disk");
+    port->write((const uint8_t*)command, strlen(command));
+}
+
+bool AP_GPS_SBF::prepare_for_arming(void) {
+    bool is_logging = true; // assume that its logging until proven otherwise
+    if (gps._raw_data) {
+        if (!(RxState & SBF_DISK_MOUNTED)){
+            is_logging = false;
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF disk is not mounted", state.instance + 1);
+
+            // simply attempt to mount the disk, no need to check if the command was
+            // ACK/NACK'd as we don't continously attempt to remount the disk
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: Attempting to mount disk", state.instance + 1);
+            mount_disk();
+            // reset the flag to indicate if we should be logging
+            _has_been_armed = false;
+        }
+        else if (RxState & SBF_DISK_FULL) {
+            is_logging = false;
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF disk is full", state.instance + 1);
+        }
+        else if (!(RxState & SBF_DISK_ACTIVITY)) {
+            is_logging = false;
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF is not currently logging", state.instance + 1);
+        }
+    }
+
+    return is_logging;
 }

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -48,6 +48,8 @@ public:
 
     bool is_healthy(void) const override;
 
+    bool prepare_for_arming(void) override;
+
 
 private:
 
@@ -73,6 +75,10 @@ private:
     uint32_t last_injected_data_ms = 0;
     uint32_t RxState;
     uint32_t RxError;
+
+    void mount_disk(void) const;
+    void unmount_disk(void) const;
+    bool _has_been_armed;
 
     enum sbf_ids {
         DOP = 4001,

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -64,6 +64,8 @@ public:
     void broadcast_gps_type() const;
     virtual void Write_DataFlash_Log_Startup_messages() const;
 
+    virtual bool prepare_for_arming(void) { return true; }
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
Septentrio GPS's have a SD card they can log raw data to which is typically used for PPK. This SD card is quite prone to filesystem corruption when power is removed from the system, and can sometimes result in the loss of some or all data. This PR allows the autopilot to automatically stop logging to the SD card when they system is powered off.

The primary controller of this is `GPS_RAW_DATA`, with this set to 1 we will attempt to start logging on boot up and continue logging the whole time. If the GPS is not logging to it's SD card then it will fail an arming check. If this is set to 2 we start logging on boot, and will continue logging until we transition from armed to disarmed. At this point we will stop logging to the SD card. If the user then attempts to arm again the first arming attempt will fail, but we will restart logging to the SD card. The subsequent attempt to arm should succeed.

A key note is that the behavior as described above is true for an AsteRx-M2. On a AsteRx-M the disk cannot be remounted after it was unmounted, and the system must be power cycled. This is acceptable as it's an opt in behaviour, and it takes the pressure off of the user to remember to press the button on the GPS that controls the logging everytime.

Other changes in this PR:
- We shouldn't parse an arbitrary number of bytes out of the buffer, it's better to only read however many were available on entry.
- Because running the `AP_GPS::prepare_for_arming(void)` needs to modify internal state in the backend I needed a non const version of it, which is why all the noise on AP_Arming in each vehicle occured. The alternate solution is to give `AP_AHRS`a non const ref and then `AP_AHRS::get_gps(void)` would still work. I think this is in some manner the better solution, but I wanted to minimize the large behavior changes. I also left all the normal GPS checks in AP_Arming using the const ref.
- `GPS_RAW_DATA` now has different meanings for u-blox vs Septentrio GPS units. Because from what I've seen the Septentrio use case is actually more common then the u-blox usage, I've changed the values field to refer to the Septentrio use case rather then u-blox. I could put both use cases in the values field, but this would make a very long drop down in a GCS.

Primarily ground tested on a AsteRx-M2 w/ FW 4.2.2, initial testing was preformed on a AsteRx-M w/ FW 3.6.3.