### PR TITLE
GCS_Mavlink: Fix out of bounds access, CID 144337

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -229,7 +229,7 @@ void GCS_MAVLINK::handle_param_request_read(mavlink_message_t *msg)
     struct pending_param_request req;
     req.chan = chan;
     req.param_index = packet.param_index;
-    memcpy(req.param_name, packet.param_id, sizeof(req.param_name));
+    memcpy(req.param_name, packet.param_id, MIN(sizeof(packet.param_id), sizeof(req.param_name)));
     req.param_name[AP_MAX_NAME_SIZE] = 0;
 
     // queue it for processing by io timer


### PR DESCRIPTION
Found by Coverity, `req.param_name` is 17 bytes long so it can be null terminated, while the `packet.param_id` is only 16 and not necessarily null terminated.