### PR TITLE
Plane: fixed VTOL transition issue in TECS

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1631,6 +1631,8 @@ bool QuadPlane::in_vtol_auto(void)
         return true;
     case MAV_CMD_NAV_LOITER_UNLIM:
     case MAV_CMD_NAV_LOITER_TIME:
+    case MAV_CMD_NAV_LOITER_TURNS:
+    case MAV_CMD_NAV_LOITER_TO_ALT:
         return plane.auto_state.vtol_loiter;
     default:
         return false;
@@ -1814,8 +1816,19 @@ void QuadPlane::vtol_position_controller(void)
     // now height control
     switch (poscontrol.state) {
     case QPOS_POSITION1:
-    case QPOS_POSITION2:
-        if (plane.control_mode == QRTL || plane.control_mode == GUIDED) {
+    case QPOS_POSITION2: {
+        bool vtol_loiter_auto = false;
+        if (plane.control_mode == AUTO) {
+            switch (plane.mission.get_current_nav_cmd().id) {
+            case MAV_CMD_NAV_LOITER_UNLIM:
+            case MAV_CMD_NAV_LOITER_TIME:
+            case MAV_CMD_NAV_LOITER_TURNS:
+            case MAV_CMD_NAV_LOITER_TO_ALT:
+                vtol_loiter_auto = true;
+                break;
+            }
+        }
+        if (plane.control_mode == QRTL || plane.control_mode == GUIDED || vtol_loiter_auto) {
             plane.ahrs.get_position(plane.current_loc);
             float target_altitude = plane.next_WP_loc.alt;
             if (poscontrol.slow_descent) {
@@ -1832,6 +1845,7 @@ void QuadPlane::vtol_position_controller(void)
             pos_control->set_alt_target_from_climb_rate(0, plane.G_Dt, false);
         }
         break;
+    }
 
     case QPOS_LAND_DESCEND: {
         float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
@@ -1957,6 +1971,8 @@ void QuadPlane::control_auto(const Location &loc)
     case MAV_CMD_NAV_VTOL_LAND:
     case MAV_CMD_NAV_LOITER_UNLIM:
     case MAV_CMD_NAV_LOITER_TIME:
+    case MAV_CMD_NAV_LOITER_TURNS:
+    case MAV_CMD_NAV_LOITER_TO_ALT:
         vtol_position_controller();
         break;
     default:

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -589,6 +589,15 @@ void AP_TECS::_update_throttle_with_airspeed(void)
     float SPE_err_max = 0.5f * _TASmax * _TASmax - _SKE_dem;
     float SPE_err_min = 0.5f * _TASmin * _TASmin - _SKE_dem;
 
+    if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_VTOL) {
+        /*
+          when we are in a VTOL state then we ignore potential energy
+          errors as we have vertical motors that interfere with the
+          total energy calculation.
+         */
+        SPE_err_max = SPE_err_min = 0;
+    }
+    
     // Calculate total energy error
     _STE_error = constrain_float((_SPE_dem - _SPE_est), SPE_err_min, SPE_err_max) + _SKE_dem - _SKE_est;
     float STEdot_dem = constrain_float((_SPEdot_dem + _SKEdot_dem), _STEdot_min, _STEdot_max);
@@ -770,6 +779,12 @@ void AP_TECS::_update_pitch(void)
     float SKE_weighting = constrain_float(_spdWeight, 0.0f, 2.0f);
     if (!_ahrs.airspeed_sensor_enabled()) {
         SKE_weighting = 0.0f;
+    } else if (_flight_stage == AP_Vehicle::FixedWing::FLIGHT_VTOL) {
+        // if we are in VTOL mode then control pitch without regard to
+        // speed. Speed is also taken care of independently of
+        // height. This is needed as the usual relationship of speed
+        // and height is broken by the VTOL motors
+        SKE_weighting = 0.0f;        
     } else if ( _flags.underspeed || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
         SKE_weighting = 2.0f;
     } else if (_flags.is_doing_auto_land) {


### PR DESCRIPTION
This fixes a problem with VTOL transitions where the target altitude is well below the current altitude. The use of TECS for throttle control can lead to low throttle, which can mean the aircraft doesn't reach transition speed.
Thanks to @priseborough for the suggested fix, which separates pitch and throttle control in AP_TECS in VTOL mode by not using potential energy in the speed controller and using a speed weight of zero in the height controller.
This fixes issue #7062 