### PR TITLE
Downward-facing rangefinder based low altitude fence

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -191,6 +191,9 @@ public:
 #endif
     friend class AP_Arming_Copter;
     friend class ToyMode;
+#if AC_AVOID_ENABLED == ENABLED
+    friend class AC_PosControl; // position control needs to access a AC_Avoid function
+#endif
 
     Copter(void);
 

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -22,19 +22,19 @@ void Copter::fence_check()
     if (new_breaches) {
 
         // if the user wants some kind of response and motors are armed
-        if(fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY ) {
+        if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
 
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down
-            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))){
+            if (ap.land_complete || (flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))) {
                 init_disarm_motors();
-            }else{
+            } else {
                 // if we are within 100m of the fence, RTL
                 if (fence.get_breach_distance(new_breaches) <= AC_FENCE_GIVE_UP_DISTANCE) {
                     if (!set_mode(RTL, MODE_REASON_FENCE_BREACH)) {
                         set_mode(LAND, MODE_REASON_FENCE_BREACH);
                     }
-                }else{
+                } else {
                     // if more than 100m outside the fence just force a land
                     set_mode(LAND, MODE_REASON_FENCE_BREACH);
                 }

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -2,6 +2,7 @@
 #include "AC_PosControl.h"
 #include <AP_Math/AP_Math.h>
 #include <DataFlash/DataFlash.h>
+#include "../ArduCopter/Copter.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -534,8 +535,14 @@ void AC_PosControl::run_z_controller()
     // To-Do: check these speed limits here or in the pos->rate controller
     _limit.vel_up = false;
     _limit.vel_down = false;
-    if (_vel_target.z < _speed_down_cms) {
-        _vel_target.z = _speed_down_cms;
+
+    // adjust z-acceleration based on fence FORCE FIELD
+    float target_descend_rate = _speed_down_cms;
+
+    copter.avoid.adjust_velocity_z(_p_pos_z.kP(), _vel_target.z, target_descend_rate);
+
+    if (_vel_target.z < target_descend_rate) {
+        _vel_target.z = target_descend_rate;
         _limit.vel_down = true;
     }
     if (_vel_target.z > _speed_up_cms) {

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Range: -100 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO_FRAME("ALT_MIN",     7,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT, AP_PARAM_FRAME_SUB),
+    AP_GROUPINFO_FRAME("ALT_MIN",     7,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_SUB | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -420,7 +420,35 @@ bool AP_Proximity::get_upward_distance(uint8_t instance, float &distance) const
     return drivers[instance]->get_upward_distance(distance);
 }
 
+bool AP_Proximity::get_downward_distance(uint8_t instance, float &distance) const
+{
+    if ((drivers[instance] == nullptr) || (_type[instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get downward distance from backend
+    return drivers[instance]->get_downward_distance(distance);
+}
+
+
+
+
 bool AP_Proximity::get_upward_distance(float &distance) const
 {
-    return get_upward_distance(primary_instance, distance);
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (get_orientation(i) == ROTATION_PITCH_90) {
+            return get_upward_distance(i, distance);
+        }
+    }
+    return false;
+}
+
+
+bool AP_Proximity::get_downward_distance(float &distance) const
+{
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (get_orientation(i) == ROTATION_PITCH_270) {
+            return get_downward_distance(i, distance);
+        }
+    }
+    return false;
 }

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -122,7 +122,9 @@ public:
 
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(uint8_t instance, float &distance) const;
+    bool get_downward_distance(uint8_t instance, float &distance) const;
     bool get_upward_distance(float &distance) const;
+    bool get_downward_distance(float &distance) const;
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -41,6 +41,8 @@ public:
 
     // get distance upwards in meters. returns true on success
     virtual bool get_upward_distance(float &distance) const { return false; }
+    // get distance downward in meters. returns true on success
+    virtual bool get_downward_distance(float &distance) const { return false; }
 
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(mavlink_message_t *msg) {}

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -60,7 +60,15 @@ void AP_Proximity_RangeFinder::update(void)
             if (sensor->orientation() == ROTATION_PITCH_90) {
                 _distance_upward = sensor->distance_cm() / 100.0f;
                 _last_upward_update_ms = AP_HAL::millis();
+                _last_update_ms = AP_HAL::millis();
             }
+            // check downward facing range finder
+            if (sensor->orientation() == ROTATION_PITCH_270) {
+                _distance_downward = sensor->distance_cm() / 100.0f;
+                _last_downward_update_ms = AP_HAL::millis();
+                _last_update_ms = AP_HAL::millis();
+            }
+
         }
     }
 
@@ -81,3 +89,14 @@ bool AP_Proximity_RangeFinder::get_upward_distance(float &distance) const
     }
     return false;
 }
+
+// get distance downwards in meters. returns true on success
+bool AP_Proximity_RangeFinder::get_downward_distance(float &distance) const
+{
+    if ((_last_downward_update_ms != 0) && (AP_HAL::millis() - _last_downward_update_ms <= PROXIMITY_RANGEFIDER_TIMEOUT_MS)) {
+        distance = _distance_downward;
+        return true;
+    }
+    return false;
+}
+

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
@@ -22,6 +22,10 @@ public:
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(float &distance) const;
 
+    // get distance downward in meters. returns true on success
+    bool get_downward_distance(float &distance) const;
+
+
 private:
 
     // horizontal distance support
@@ -32,4 +36,8 @@ private:
     // upward distance support
     uint32_t _last_upward_update_ms;    // system time of last update distance
     float _distance_upward;             // upward distance in meters
+
+    // downward distance support
+    uint32_t _last_downward_update_ms;    // system time of last update distance
+    float _distance_downward;             // downward distance in meters
 };

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -42,6 +42,10 @@ AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
     if (fence_alt_max == nullptr || ptype != AP_PARAM_FLOAT) {
         AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MAX");
     }
+    fence_alt_min = (AP_Float *)AP_Param::find("FENCE_ALT_MIN", &ptype);
+    if (fence_alt_min == nullptr || ptype != AP_PARAM_FLOAT) {
+        AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MIN");
+    }
 }
 
 // update the state of the sensor
@@ -134,6 +138,13 @@ bool AP_Proximity_SITL::get_upward_distance(float &distance) const
 {
     // return distance to fence altitude
     distance = MAX(0.0f, fence_alt_max->get() - sitl->height_agl);
+    return true;
+}
+
+bool AP_Proximity_SITL::get_downward_distance(float &distance) const
+{
+    // return distance to fence altitude
+    distance = MAX(0.0f, sitl->height_agl - fence_alt_min->get());
     return true;
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -22,12 +22,15 @@ public:
 
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(float &distance) const;
+    // get distance downward in meters. returns true on success
+    bool get_downward_distance(float &distance) const;
 
 private:
     SITL::SITL *sitl;
     Vector2l *fence;
     AP_Int8 *fence_count;
     AP_Float *fence_alt_max;
+    AP_Float *fence_alt_min;
     uint32_t last_load_ms;
     AC_PolyFence_loader fence_loader;
     Location current_loc;


### PR DESCRIPTION
This fence prevents the copter from hitting the ground in all flight modes except STABALIZE, RTL and LAND.
If for some reason it does manage to go bellow the fence then RTL is triggered (RTL_ALT http://ardupilot.org/copter/docs/parameters.html#rtl-alt-rtl-altitude should be bigger than FENCE_ALT_MIN parameter).
RTL and LAND flight modes completely ignore this fence.

If no range finder is present it will use the height sensor selected in the EK2_ALT_SOURCE or EK3_ALT_SOURCE parameter ( http://ardupilot.org/copter/docs/parameters.html#ek2-alt-source-primary-altitude-sensor-source )

It contains CI tests.
![laf_log](https://user-images.githubusercontent.com/24453563/31894603-39a279d6-b80f-11e7-8bb0-0a2172cd8b92.png)
