### PR TITLE
tools: fix compiler warning

### DIFF
--- a/Tools/Replay/DataFlashFileReader.cpp
+++ b/Tools/Replay/DataFlashFileReader.cpp
@@ -7,6 +7,10 @@
 #include <unistd.h>
 #include <time.h>
 
+#ifndef PRIu64
+#define PRIu64 "llu"
+#endif
+
 // flogged from AP_Hal_Linux/system.cpp; we don't want to use stopped clock here
 uint64_t now() {
     struct timespec ts;
@@ -22,8 +26,8 @@ DataFlashFileReader::~DataFlashFileReader()
 {
     const uint64_t micros = now();
     const uint64_t delta = micros - start_micros;
-    ::printf("Replay counts: %ld bytes  %u entries\n", bytes_read, message_count);
-    ::printf("Replay rates: %ld bytes/second  %ld messages/second\n", bytes_read*1000000/delta, message_count*1000000/delta);
+    ::printf("Replay counts: %" PRIu64 " bytes  %u entries\n", bytes_read, message_count);
+    ::printf("Replay rates: %" PRIu64 " bytes/second  %" PRIu64 " messages/second\n", bytes_read*1000000/delta, message_count*1000000/delta);
 }
 
 bool DataFlashFileReader::open_log(const char *logfile)

--- a/Tools/Replay/DataFlashFileReader.cpp
+++ b/Tools/Replay/DataFlashFileReader.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <time.h>
+#include <cinttypes>
 
 #ifndef PRIu64
 #define PRIu64 "llu"


### PR DESCRIPTION
format ‘%ld’ expects argument of type ‘long int’, but argument has type ‘uint64_t {aka long long unsigned int}’