### PR TITLE
Plane & Rover: always log mode change reason to df

### DIFF
--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -62,7 +62,7 @@ enum mode {
 #define MASK_LOG_PM             (1<<3)
 #define MASK_LOG_CTUN           (1<<4)
 #define MASK_LOG_NTUN           (1<<5)
-#define MASK_LOG_MODE           (1<<6)
+//#define MASK_LOG_MODE         (1<<6) // no longer used
 #define MASK_LOG_IMU            (1<<7)
 #define MASK_LOG_CMD            (1<<8)
 #define MASK_LOG_CURRENT        (1<<9)

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -232,10 +232,8 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
 
     old_mode.exit();
 
-    if (should_log(MASK_LOG_MODE)) {
-        control_mode_reason = reason;
-        DataFlash.Log_Write_Mode(control_mode->mode_number(), reason);
-    }
+    control_mode_reason = reason;
+    DataFlash.Log_Write_Mode(control_mode->mode_number(), control_mode_reason);
 
     notify_mode((enum mode)control_mode->mode_number());
     return true;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -884,10 +884,7 @@ void Plane::set_flight_stage(AP_Vehicle::FixedWing::FlightStage fs)
     }
 
     flight_stage = fs;
-
-    if (should_log(MASK_LOG_MODE)) {
-        Log_Write_Status();
-    }
+    Log_Write_Status();
 }
 
 void Plane::update_alt()

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -402,7 +402,7 @@ void Plane::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by DataFlash
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
-    DataFlash.Log_Write_Mode(control_mode);
+    DataFlash.Log_Write_Mode(control_mode, control_mode_reason);
     DataFlash.Log_Write_Rally(rally);
     Log_Write_Home_And_Origin();
     gps.Write_DataFlash_Log_Startup_messages();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -346,8 +346,7 @@ void Plane::do_RTL(int32_t rtl_altitude)
     setup_glide_slope();
     setup_turn_angle();
 
-    if (should_log(MASK_LOG_MODE))
-        DataFlash.Log_Write_Mode(control_mode);
+    DataFlash.Log_Write_Mode(control_mode, control_mode_reason);
 }
 
 void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -134,7 +134,7 @@ enum log_messages {
 #define MASK_LOG_PM                     (1<<3)
 #define MASK_LOG_CTUN                   (1<<4)
 #define MASK_LOG_NTUN                   (1<<5)
-#define MASK_LOG_MODE                   (1<<6)
+//#define MASK_LOG_MODE                 (1<<6) // no longer used
 #define MASK_LOG_IMU                    (1<<7)
 #define MASK_LOG_CMD                    (1<<8)
 #define MASK_LOG_CURRENT                (1<<9)

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -152,9 +152,7 @@ void Plane::update_is_flying_5Hz(void)
 
     crash_detection_update();
 
-    if (should_log(MASK_LOG_MODE)) {
-        Log_Write_Status();
-    }
+    Log_Write_Status();
 
     // tell AHRS flying state
     ahrs.set_likely_flying(new_is_flying);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -446,8 +446,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 
     adsb.set_is_auto_mode(auto_navigation_mode);
 
-    if (should_log(MASK_LOG_MODE))
-        DataFlash.Log_Write_Mode(control_mode);
+    DataFlash.Log_Write_Mode(control_mode, control_mode_reason);
 
     // update notify with flight mode change
     notify_flight_mode(control_mode);


### PR DESCRIPTION
Always log mode change reason to df, remove the bitmask option to disable it.