### PR TITLE
AP_Camera: option to do trigging in AUTO mode only 

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -229,6 +229,9 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
 #if FRSKY_TELEM_ENABLED == ENABLED
     frsky_telemetry.update_control_mode(control_mode->mode_number());
 #endif
+#if CAMERA == ENABLED
+    camera.set_is_auto_mode(control_mode->mode_number() == AUTO);
+#endif
 
     old_mode.exit();
 

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -155,6 +155,9 @@ failed:
 #if FRSKY_TELEM_ENABLED == ENABLED
         frsky_telemetry.update_control_mode(control_mode);
 #endif
+#if CAMERA == ENABLED
+        camera.set_is_auto_mode(control_mode == AUTO);
+#endif
         
     } else {
         // Log error that we failed to enter desired flight mode

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -295,7 +295,10 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 #if FRSKY_TELEM_ENABLED == ENABLED
     frsky_telemetry.update_control_mode(control_mode);
 #endif
-    
+#if CAMERA == ENABLED
+    camera.set_is_auto_mode(control_mode == AUTO);
+#endif
+
     if (previous_mode == AUTOTUNE && control_mode != AUTOTUNE) {
         // restore last gains
         autotune_restore();

--- a/ArduSub/flight_mode.cpp
+++ b/ArduSub/flight_mode.cpp
@@ -75,6 +75,10 @@ bool Sub::set_mode(control_mode_t mode, mode_reason_t reason)
         // update notify object
         notify_flight_mode(control_mode);
 
+#if CAMERA == ENABLED
+        camera.set_is_auto_mode(control_mode == AUTO);
+#endif
+
 #if AC_FENCE == ENABLED
         // pilot requested flight mode change during a fence breach indicates pilot is attempting to manually recover
         // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -92,6 +92,13 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("FEEDBACK_POL",  9, AP_Camera, _feedback_polarity, 1),
     
+    // @Param: AUTO_ONLY
+    // @DisplayName: Distance-trigging in AUTO mode only
+    // @Description: When enabled, trigging by distance is done in AUTO mode only.
+    // @Values: 0:Always,1:Only when in AUTO
+    // @User: Standard
+    AP_GROUPINFO("AUTO_ONLY",  10, AP_Camera, _auto_mode_only, 0),
+
     AP_GROUPEND
 };
 
@@ -281,6 +288,10 @@ void AP_Camera::update()
 
     if (_max_roll > 0 && labs(ahrs.roll_sensor*1e-2) > _max_roll) {
         return;
+    }
+
+    if (_is_in_auto_mode != true && _auto_mode_only != 0) {
+            return;
     }
 
     uint32_t tnow = AP_HAL::millis();

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -68,6 +68,9 @@ public:
 
     static const struct AP_Param::GroupInfo        var_info[];
 
+    // set if vehicle is in AUTO mode
+    void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
+
 private:
     AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_GPS &_gps, const AP_AHRS &_ahrs)
         : _trigger_counter(0) // count of number of cycles shutter has been held open
@@ -88,6 +91,8 @@ private:
     AP_Int16        _servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
     uint8_t         _trigger_counter;   // count of number of cycles shutter has been held open
     AP_Relay       *_apm_relay;         // pointer to relay object from the base class Relay.
+    AP_Int8         _auto_mode_only;    // if 1: trigger by distance only if in AUTO mode.
+    bool            _is_in_auto_mode;   // true if in AUTO mode
 
     void            servo_pic();        // Servo operated camera
     void            relay_pic();        // basic relay activation


### PR DESCRIPTION
Useful in scenarios:
ArduPlane, going into into circle at lower altitude by ATC request due to traffic. 
ArduCopter, flying a survey, needs to land for battery swap.

- no need to continue to shoot photos all the time.  This option inhibits shooting in non-auto mode.