### PR TITLE
EK2: added option to set earth field state from tables

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -544,6 +544,13 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("OGN_HGT_MASK", 49, NavEKF2, _originHgtMode, 0),
 
+    // @Param: MAG_EF_TYPE
+    // @DisplayName: Mag earth-field type
+    // @Description: This sets the source of the earth field vector for magnetometer fusion. When set to MeasuredField the declination is obtained from the declination tables and the inclination and intensity comes from the current sensor value. When set to Tables all 3 components of the earth-field come from the world magnetic model tables.
+    // @Values: 0:MeasuredField,1:Tables
+    // @User: Advanced
+    AP_GROUPINFO("MAG_EF_TYPE", 50, NavEKF2, _mag_ef_type, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -395,6 +395,7 @@ private:
     AP_Float _useRngSwSpd;          // Maximum horizontal ground speed to use range finder as the primary height source (m/s)
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
+    AP_Int8 _mag_ef_type;           // source of earth-field vactor.
 
     // Tuning parameters
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -89,6 +89,16 @@ void NavEKF2_core::controlMagYawReset()
     // Perform a reset of magnetic field states and reset yaw to corrected magnetic heading
     if (magYawResetRequest || magStateResetRequest || extNavYawResetRequest) {
 
+        if (doneFieldFromTables && frontend->_mag_ef_type == 1) {
+            // we need to re-do the field from the tables
+            if (AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
+                setEarthFieldFromTables();
+            } else {
+                // we've lost GPS lock. re-do when we regain 3D lock
+                doneFieldFromTables = false;
+            }
+        }
+        
         // if a yaw reset has been requested, apply the updated quaternion to the current state
         if (extNavYawResetRequest) {
             // get the euler angles from the current state estimate

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -538,6 +538,14 @@ void NavEKF2_core::readGpsData()
                 gpsNotAvailable = false;
             }
 
+            // if we are initialising earth field from tables and we
+            // haven't done that yet then do it now that we have a
+            // position
+            if (!doneFieldFromTables && frontend->_mag_ef_type == 1) {
+                doneFieldFromTables = true;
+                setEarthFieldFromTables();
+            }
+            
             frontend->logging.log_gps = true;
 
         } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1351,6 +1351,14 @@ void NavEKF2_core::zeroCols(Matrix24 &covMat, uint8_t first, uint8_t last)
     }
 }
 
+// set a diagonal range to a value
+void NavEKF2_core::setDiagonal(Matrix24 &covMat, uint8_t first, uint8_t last, float value)
+{
+    for (uint8_t i=first; i<=last; i++) {
+        covMat[i][i] = value;
+    }
+}
+
 // reset the output data to the current EKF state
 void NavEKF2_core::StoreOutputReset()
 {
@@ -1537,14 +1545,11 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
             // and set the corresponding variances and covariances
             alignMagStateDeclination();
 
-            // set the remaining variances and covariances
+            // set the remaining variances and covariances. elements
+            // 16 and 17 are set in alignMagStateDeclination()
             zeroRows(P,18,21);
             zeroCols(P,18,21);
-            P[18][18] = sq(frontend->_magNoise);
-            P[19][19] = P[18][18];
-            P[20][20] = P[18][18];
-            P[21][21] = P[18][18];
-
+            setDiagonal(P,18,21,sq(frontend->_magNoise));
         }
 
         // record the fact we have initialised the magnetic field states

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -750,6 +750,9 @@ private:
 
     // update timing statistics structure
     void updateTimingStatistics(void);
+
+    // set some diagonal elements of a Matrix24
+    void setDiagonal(Matrix24 &covMat, uint8_t first, uint8_t last, float value);
     
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -621,6 +621,9 @@ private:
     // and return attitude quaternion
     Quaternion calcQuatAndFieldStates(float roll, float pitch);
 
+    // set earth magnetic field states from intensity, inclination and declination tables
+    void setEarthFieldFromTables(void);
+    
     // zero stored variables
     void InitialiseVariables();
 
@@ -1104,6 +1107,8 @@ private:
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
     bool extNavYawResetRequest;         // true when a reset of vehicle yaw using the external nav data is requested
 
+    bool doneFieldFromTables;       // have we initialised earth field from tables
+    
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {
         bool bad_xmag:1;


### PR DESCRIPTION
This adds tables for intensity and incliination and updates our declination tables.

It also adds a new EK2 option EK2_MAG_EF_TYPE, which can be used to ask the EKF to setup the earth field state from the new tables. 

This allows the user to request that the full earth field state comes from the inclination, declination and intensity tables instead of coming from a sample from the sensor.

The advantage of this technique is that for vehicles that may be flown close to metal structures it is less likely to get a bad initial earth field state.
    
The disadvantage is that it relies on the WMM tables being a good estimate of the earths field where the user is flying. This may not be true if the user is flying in a building which reduces the field intensity, or if the tables don't accurately represent a local magnetic field deviation from the tables.
    
The primary use is for small copters that may be hovered close to buildings or vehicles. In that case the in-flight yaw alignment and estimation of earth field may result in a very poor earth field estimate, which can lead to very poor navigation (or even a fly away).
