### PR TITLE
Travis CI: Add flake8 testing on Python 2, Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,6 @@ matrix:
     - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
     - language: python
-      cpp:
       compiler:
       python: 2.7
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ matrix:
     - language: python
       compiler:
       python: 2.7
-      install:
+      before_install:
         - pip install flake8
       script:
         # stop the build if there are Python syntax errors
@@ -96,7 +96,7 @@ matrix:
     - language: python
       compiler:
       python: 3.6
-      install:
+      before_install:
         - pip install flake8
       script:
         # stop the build if there are Python syntax errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ matrix:
         - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
         # warn only if there are undefined names
         - flake8 . --count --exit-zero --select=F821 --show-source --statistics
+  allow_failures:
     - language: python
       compiler:
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,12 @@ env:
 matrix:
   fast_finish: true
   include:
-    #- compiler: "gcc"
-    #  env: CI_BUILD_TARGET="sitl minlure linux navio2 bebop"
-    #- compiler: "gcc"
-    #  env: CI_BUILD_TARGET="px4-v2 px4-v4"
-    #- compiler: "gcc"
-    #  env: CI_BUILD_TARGET="px4-v3"
+    - compiler: "gcc"
+      env: CI_BUILD_TARGET="sitl minlure linux navio2 bebop"
+    - compiler: "gcc"
+      env: CI_BUILD_TARGET="px4-v2 px4-v4"
+    - compiler: "gcc"
+      env: CI_BUILD_TARGET="px4-v3"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
     - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,3 +83,23 @@ matrix:
       env: CI_BUILD_TARGET="px4-v3"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
+    - language: python
+      cpp:
+      python: 2.7
+      install:
+        - pip install flake8
+      script:
+        # stop the build if there are Python syntax errors
+        - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+        # warn only if there are undefined names
+        - flake8 . --count --exit-zero --select=F821 --show-source --statistics
+    - language: python
+      cpp:
+      python: 3.6
+      install:
+        - pip install flake8
+      script:
+        # stop the build if there are Python syntax errors
+        - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+        # warn only if there are undefined names
+        - flake8 . --count --exit-zero --select=F821 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ matrix:
       env: CI_BUILD_TARGET="sitltest"
     - language: python
       cpp:
+      compiler:
       python: 2.7
       install:
         - pip install flake8
@@ -94,7 +95,7 @@ matrix:
         # warn only if there are undefined names
         - flake8 . --count --exit-zero --select=F821 --show-source --statistics
     - language: python
-      cpp:
+      compiler:
       python: 3.6
       install:
         - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,14 +93,13 @@ matrix:
         - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
         # warn only if there are undefined names
         - flake8 . --count --exit-zero --select=F821 --show-source --statistics
-    allow_failures:
     - language: python
       compiler:
       python: 3.6
       before_install:
         - pip install flake8
       script:
-        # stop the build if there are Python syntax errors
-        - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+        # warn only if there are Python syntax errors
+        - flake8 . --count --exit-zero --select=E901,E999,F822,F823 --show-source --statistics
         # warn only if there are undefined names
         - flake8 . --count --exit-zero --select=F821 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,12 @@ env:
 matrix:
   fast_finish: true
   include:
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="sitl minlure linux navio2 bebop"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="px4-v2 px4-v4"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="px4-v3"
+    #- compiler: "gcc"
+    #  env: CI_BUILD_TARGET="sitl minlure linux navio2 bebop"
+    #- compiler: "gcc"
+    #  env: CI_BUILD_TARGET="px4-v2 px4-v4"
+    #- compiler: "gcc"
+    #  env: CI_BUILD_TARGET="px4-v3"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
     - language: python
@@ -93,7 +93,7 @@ matrix:
         - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
         # warn only if there are undefined names
         - flake8 . --count --exit-zero --select=F821 --show-source --statistics
-  allow_failures:
+    allow_failures:
     - language: python
       compiler:
       python: 3.6


### PR DESCRIPTION
A better approach to #7023. Adds two new parallel execution tasks to Travis CI for doing flake8 testing on Python 2 and Python 3.  Each task runs flake8 twice: The first fails the build on Python syntax errors. The second treats undefined names as warnings only.