### PR TITLE
TradHeli - Default ACCEL_Z_P and Comment Fix for Dynamic Flight Speed

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -69,6 +69,7 @@
   # define WP_YAW_BEHAVIOR_DEFAULT              WP_YAW_BEHAVIOR_LOOK_AHEAD
   # define THR_MIN_DEFAULT                      0
   # define AUTOTUNE_ENABLED                     DISABLED
+  # define ACCEL_Z_P				0.30f
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -69,7 +69,7 @@
   # define WP_YAW_BEHAVIOR_DEFAULT              WP_YAW_BEHAVIOR_LOOK_AHEAD
   # define THR_MIN_DEFAULT                      0
   # define AUTOTUNE_ENABLED                     DISABLED
-  # define ACCEL_Z_P				0.30f
+  # define ACCEL_Z_P                            0.30f
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -5,7 +5,7 @@
 #if FRAME_CONFIG == HELI_FRAME
 
 #ifndef HELI_DYNAMIC_FLIGHT_SPEED_MIN
- #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      500     // we are in "dynamic flight" when the speed is over 1m/s for 2 seconds
+ #define HELI_DYNAMIC_FLIGHT_SPEED_MIN      500     // we are in "dynamic flight" when the speed is over 5m/s for 2 seconds
 #endif
 
 // counter to control dynamic flight profile


### PR DESCRIPTION
This changes the default ACCEL_Z_P for helicopters to prevent collective pitch oscillation in altitude controlled flight modes.

And fixes a comment for the dynamic flight speed definition in heli.cpp