### PR TITLE
DataFlash: log critical messages while disarmed

### DIFF
--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -136,7 +136,7 @@ protected:
                           print_mode_fn print_mode,
                           AP_HAL::BetterStream *port);
 
-    bool ShouldLog() const;
+    bool ShouldLog(bool is_critical);
     virtual bool WritesOK() const = 0;
     virtual bool StartNewLogOK() const;
 
@@ -166,5 +166,5 @@ private:
 
     uint32_t _last_periodic_1Hz;
     uint32_t _last_periodic_10Hz;
-
+    bool have_logged_armed;
 };


### PR DESCRIPTION
this logs critical messages while disarmed if we have logged any
messages while armed. This fixes issue #7010 where log files show the
incorrect mode if the log includes any portions where the user
disarmed. It makes analysing users logs very difficult. It also
affects parameters, so we don't always know the true parameter values
in logs from users.