### PR TITLE
Travis CI: Add flake8 testing on Python 2, Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,3 +83,23 @@ matrix:
       env: CI_BUILD_TARGET="px4-v3"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest"
+    - language: python
+      compiler:
+      python: 2.7
+      before_install:
+        - pip install flake8
+      script:
+        # stop the build if there are Python syntax errors
+        - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+        # warn only if there are undefined names
+        - flake8 . --count --exit-zero --select=F821 --show-source --statistics
+    - language: python
+      compiler:
+      python: 3.6
+      before_install:
+        - pip install flake8
+      script:
+        # warn only if there are Python syntax errors
+        - flake8 . --count --exit-zero --select=E901,E999,F822,F823 --show-source --statistics
+        # warn only if there are undefined names
+        - flake8 . --count --exit-zero --select=F821 --show-source --statistics


### PR DESCRIPTION
A better approach to #7023. Adds two new parallel execution tasks to Travis CI for doing flake8 testing on Python 2 and Python 3. Each task runs flake8 twice: The first fails the build on Python syntax errors. The second treats undefined names as warnings only.

Can someone please help me to understand why this test is failing.  It seems unrelated to my changes but my knowledge is limited.  https://travis-ci.org/ArduPilot/ardupilot/builds/293014878