### PR TITLE
AP_Frsky_Telem: dual battery support

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -567,13 +567,13 @@ uint32_t AP_Frsky_Telem::calc_param(void)
     uint32_t param = 0;
 
     // cycle through paramIDs
-    if (_paramID >= 4) {
+    if (_paramID >= 5) {
         _paramID = 0;
     }
     _paramID++;
     switch(_paramID) {
     case 1:
-        param = _params.mav_type;                                    // frame type (see MAV_TYPE in Mavlink definition file common.h)
+        param = _params.mav_type; // frame type (see MAV_TYPE in Mavlink definition file common.h)
         break;
     case 2:
         if (_params.fs_batt_voltage != nullptr) {
@@ -582,15 +582,18 @@ uint32_t AP_Frsky_Telem::calc_param(void)
         break;
     case 3:
         if (_params.fs_batt_mah != nullptr) {
-            param = (uint32_t)roundf((*_params.fs_batt_mah));              // battery failsafe capacity in mAh
+            param = (uint32_t)roundf((*_params.fs_batt_mah)); // battery failsafe capacity in mAh
         }
         break;
     case 4:
-        param = (uint32_t)roundf(_battery.pack_capacity_mah());      // battery pack capacity in mAh as configured by user
+        param = (uint32_t)roundf(_battery.pack_capacity_mah(0)); // battery pack capacity in mAh
+        break;
+    case 5:
+        param = (uint32_t)roundf(_battery.pack_capacity_mah(1)); // battery pack capacity in mAh
         break;
     }
     //Reserve first 8 bits for param ID, use other 24 bits to store parameter value
-    param = (_paramID << 24) | (param & 0xFFFFFF);
+    param = (_paramID << PARAM_ID_OFFSET) | (param & PARAM_VALUE_LIMIT);
     
     return param;
 }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -71,6 +71,9 @@ for FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
 for FrSky SPort Passthrough
 */
 // data bits preparation
+// for parameter data
+#define PARAM_ID_OFFSET             24
+#define PARAM_VALUE_LIMIT           0xFFFFFF
 // for gps status data
 #define GPS_SATS_LIMIT              0xF
 #define GPS_STATUS_LIMIT            0x3

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -198,6 +198,7 @@ private:
         uint32_t params_timer;
         uint32_t ap_status_timer;
         uint32_t batt_timer;
+        uint32_t batt_timer2;
         uint32_t gps_status_timer;
         uint32_t home_timer;
         uint32_t velandyaw_timer;
@@ -249,7 +250,7 @@ private:
     uint32_t calc_param(void);
     uint32_t calc_gps_latlng(bool *send_latitude);
     uint32_t calc_gps_status(void);
-    uint32_t calc_batt(void);
+    uint32_t calc_batt(uint8_t instance);
     uint32_t calc_ap_status(void);
     uint32_t calc_home(void);
     uint32_t calc_velandyaw(void);


### PR DESCRIPTION
Provides telemetry information through the FrSky link for the second battery instance.

Tested working.