### PR TITLE
AP_NavEKF3: correctly use wheel odometry speed for pitched rovers

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1589,7 +1589,7 @@ void NavEKF3_core::SelectBodyOdomFusion()
             unitVec.x = prevTnb.a.x;
             unitVec.y = prevTnb.a.y;
             unitVec.z = 0.0f;
-            unitVec.normalized();
+            unitVec.normalize();
 
             // multiply by forward speed to get velocity vector measured by wheel encoders
             Vector3f velNED = unitVec * fwdSpd;


### PR DESCRIPTION
Fixes error not detected during testing that will cause rovers with significant pitch angles to underestimate the distance travelled when using wheel odometer fusion.