### PR TITLE
Plane: Fix deepstall land detect disarming in flight

### DIFF
--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -70,10 +70,6 @@ void Plane::update_is_flying_5Hz(void)
                 crash_state.impact_detected = false;
             }
 
-            if (landing.is_on_approach() && fabsf(auto_state.sink_rate) > 0.2f) {
-                is_flying_bool = true;
-            }
-
             switch (flight_stage)
             {
             case AP_Vehicle::FixedWing::FLIGHT_TAKEOFF:
@@ -91,6 +87,12 @@ void Plane::update_is_flying_5Hz(void)
 
             case AP_Vehicle::FixedWing::FLIGHT_VTOL:
                 // TODO: detect ground impacts
+                break;
+
+            case AP_Vehicle::FixedWing::FLIGHT_LAND:
+                if (landing.is_on_approach() && fabsf(auto_state.sink_rate) > 0.2f) {
+                    is_flying_bool = true;
+                }
                 break;
 
             case AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND:

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -308,6 +308,7 @@ bool AP_Landing::is_on_approach(void) const
     case TYPE_STANDARD_GLIDE_SLOPE:
         return type_slope_is_on_approach();
     case TYPE_DEEPSTALL:
+        return deepstall.is_on_approach();
     default:
         return false;
     }

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -367,6 +367,11 @@ bool AP_Landing_Deepstall::is_flying_forward(void) const
     return stage != DEEPSTALL_STAGE_LAND;
 }
 
+bool AP_Landing_Deepstall::is_on_approach(void) const
+{
+    return stage == DEEPSTALL_STAGE_LAND;
+}
+
 bool AP_Landing_Deepstall::get_target_altitude_location(Location &location)
 {
     memcpy(&location, &landing_point, sizeof(Location));

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -102,6 +102,7 @@ private:
     int32_t get_target_airspeed_cm(void) const;
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
+    bool is_on_approach(void) const;
     bool terminate(void);
     void log(void) const;
 


### PR DESCRIPTION
Deepstall never implemented is_on_approach() which can lead to is_flying determining that the aircraft is no longer flying and disarm.

Also corrects is_flying to only check for the landing stage on approach when in FLIGHT_LAND.