### PR TITLE
WIP - Reduce delay between camera feedback event and reported AHRS state

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -913,8 +913,8 @@ const AP_Param::Info Plane::var_info[] = {
 
 #if CAMERA == ENABLED
     // @Group: CAM_
-    // @Path: ../libraries/AP_Camera/AP_Camera.cpp
-    GOBJECT(camera,                  "CAM_", AP_Camera),
+    // @Path: ../libraries/AP_Camera/AP_Camera.cpp,../libraries/AP_Camera/AP_Camera_Vision.cpp
+    GOBJECT(camera,                  "CAM_", AP_Camera_Vision),
 #endif
 
     // @Group: ARMING_

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -49,6 +49,7 @@
 #include <AP_Buffer/AP_Buffer.h>      // APM FIFO Buffer
 #include <AP_Relay/AP_Relay.h>       // APM relay
 #include <AP_Camera/AP_Camera.h>          // Photo or video camera
+#include <AP_Camera/AP_Camera_Vision.h>   // Machine vision camera
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RPM/AP_RPM.h>
@@ -274,7 +275,7 @@ private:
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera = AP_Camera::create(&relay, MASK_LOG_CAMERA, current_loc, gps, ahrs);
+    AP_Camera_Vision camera = AP_Camera_Vision::create(&relay, MASK_LOG_CAMERA, current_loc, gps, ahrs);
 #endif
 
 #if OPTFLOW == ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -40,6 +40,8 @@ AP_AHRS_NavEKF::AP_AHRS_NavEKF(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gp
     _ekf_flags(flags)
 {
     _dcm_matrix.identity();
+    // create three entries in the summary list
+    summary.create_nodes(3);
 }
 
 // return the smoothed gyro vector corrected for drift
@@ -113,6 +115,63 @@ void AP_AHRS_NavEKF::update(bool skip_ins_update)
         // update optional alternative attitude view
         _view->update(skip_ins_update);
     }
+
+    update_summary();
+}
+
+void AP_AHRS_NavEKF::update_summary(void) {
+    for (uint8_t i = 0; i < summary.get_node_count(); i++) {
+        AP_AHRS::AHRS_Summary *active_summary = summary.active_summary;
+        // stop the consumer from reading this node
+        // this has no effect if the consumer is already reading this node
+        active_summary->set_ready_to_read(false);
+        // check to see if this node is ready to write / is not being read from currently
+        if (active_summary->get_ready_to_write()) {
+            // node is ready to be updated
+            // update the active summary with the latest values
+            active_summary->ahrs_update_time = AP_HAL::micros64();
+            active_summary->healthy = healthy();
+            active_summary->have_inertial_nav = have_inertial_nav();
+            active_summary->roll = roll;
+            active_summary->pitch = pitch;
+            active_summary->yaw = yaw;
+            active_summary->ekf_type = active_EKF_type();
+            get_location(active_summary->location);
+            if (active_summary->have_inertial_nav) {
+                get_relative_position_NED_home(active_summary->ned_pos_rel_home);
+                get_velocity_NED(active_summary->velocity);
+                active_summary->home = get_home();
+            }
+            switch (active_EKF_type()) {
+                case EKF_TYPE_NONE:
+                    active_summary->quat.from_rotation_matrix(AP_AHRS_DCM::get_rotation_body_to_ned());
+                case EKF_TYPE2:
+                    EKF2.getQuaternion(-1, active_summary->quat);
+                case EKF_TYPE3:
+                    EKF3.getQuaternion(-1, active_summary->quat);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+                case EKF_TYPE_SITL:
+                    active_summary->quat.from_rotation_matrix(AP_AHRS_DCM::get_rotation_body_to_ned());
+#endif
+            }
+            active_summary->write_errors = summary.get_write_error_count();
+            active_summary->read_errors = summary.get_read_error_count();
+            // node update is complete, allow the consumer to read
+            active_summary->set_ready_to_read(true);
+            // update the consumer index to point to this buffer
+            // the consumer now 'sees' this entry
+            summary.current_summary = active_summary;
+            summary.next();
+            return;
+        } else {
+            // summary node was not ready to be updated
+            // allow the consumer to read
+            active_summary->set_ready_to_read(true);
+            summary.next();
+        }
+    }
+    // the AHRS was unable to write into any of the summary nodes
+    summary.increment_write_error();
 }
 
 void AP_AHRS_NavEKF::update_DCM(bool skip_ins_update)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -292,6 +292,9 @@ private:
     void update_EKF2(void);
     void update_EKF3(void);
 
+    // attempt to update the AHRS summary
+    void update_summary(void);
+
     // get the index of the current primary IMU
     uint8_t get_primary_IMU_index(void) const;
     

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -35,7 +35,7 @@ public:
                             uint32_t _log_camera_bit,
                             const struct Location &_loc,
                             const AP_GPS &_gps,
-                            const AP_AHRS &_ahrs) {
+                            AP_AHRS &_ahrs) {
         return AP_Camera{obj_relay, _log_camera_bit, _loc, _gps, _ahrs};
     }
 
@@ -68,8 +68,8 @@ public:
 
     static const struct AP_Param::GroupInfo        var_info[];
 
-private:
-    AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_GPS &_gps, const AP_AHRS &_ahrs)
+protected:
+    AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_GPS &_gps, AP_AHRS &_ahrs)
         : _trigger_counter(0) // count of number of cycles shutter has been held open
         , _image_index(0)
         , log_camera_bit(_log_camera_bit)
@@ -119,7 +119,7 @@ private:
     uint32_t log_camera_bit;
     const struct Location &current_loc;
     const AP_GPS &gps;
-    const AP_AHRS &ahrs;
+    AP_AHRS &ahrs;
 
     // entry point to trip local shutter (e.g. by relay or servo)
     void trigger_pic();

--- a/libraries/AP_Camera/AP_Camera_Vision.cpp
+++ b/libraries/AP_Camera/AP_Camera_Vision.cpp
@@ -1,0 +1,188 @@
+/*
+ *  Camera wrapper class for optional tight camera autopilot synchronization
+ *  Camera Vision overloads the camera functions to add behaviors suited to machine vision
+ *
+ *  Samuel Dudley 28/10/2017
+ *
+ *  dudley.samuel@gmail.com
+ *
+ */
+#include "AP_Camera_Vision.h"
+
+#define CAM_DEBUG_VISION true
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Camera_Vision::var_info[] = {
+    // parameters from parent class
+    AP_NESTEDGROUPINFO(AP_Camera, 0),
+
+    // @Param: FEEDBACK_ID
+    // @DisplayName: Camera feedback target component ID
+    // @Description: Target ID of the component which handles camera feedback AHRS MAVLink messages
+    // @User: Standard
+    AP_GROUPINFO("FEEDBACK_ID",  1, AP_Camera_Vision, _vision_feedback_target_component, AP_CAMERA_VISION_DEFAULT_FEEDBACK_COMPONENT_ID),
+
+    // @Param: MAX_SAMP_AGE
+    // @DisplayName: Max camera trigger and AHRS sample time delta
+    // @Description: Maximum acceptable delta between camera trigger time and AHRS sample time in us before the AHRS sample is unhealthy
+    // @Units: us
+    // @Range: 0 1000000
+    // @User: Advanced
+    AP_GROUPINFO("MAX_SAMP_AGE", 2, AP_Camera_Vision, _maximum_ahrs_sample_age_us, AP_CAMERA_VISION_DEFAULT_MAX_SAMPLE_AGE),
+
+    // @Param: MAX_GCS_RATE
+    // @DisplayName: Max camera feedback message Hz
+    // @Description: Maximum rate that camera feedback messages will be sent to the GCS (Hz). 0 = suppress all feedback messages to the GCS, -1 = send all feedback messages to the GCS
+    // @Units: Hz
+    // @Range: -1 100
+    // @User: Advanced
+    AP_GROUPINFO("MAX_GCS_RATE", 3, AP_Camera_Vision, _gcs_feedback_hz, AP_CAMERA_VISION_DEFAULT_GCS_FEEDBACK_HZ),
+
+    AP_GROUPEND
+};
+
+// check the camera trigger status and action
+// this function is called by Arduplane.cpp at 50Hz by default but needs to be called
+// at 2 x frame rate of camera to ensure all frames are reported
+void AP_Camera_Vision::update_trigger() {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && CAM_DEBUG_VISION
+    snapshot_ahrs();
+#endif
+    // if the hardware trigger has not been installed then do it now
+    setup_feedback_callback();
+    if (check_trigger_pin()) {
+        // registered that a photo was taken (via the feedback pin)
+        if (_ahrs_data_good) {
+            read_ahrs_summary();
+        }
+        _image_index++;
+
+        // TODO use the flag bit fields to indicate what the errors are
+        if (_ahrs_data_good) {
+            _flags = 1;
+        } else {
+            _flags = 0;
+        }
+
+        // send a low rate message feedback to the GCS while sending full rate to the CC
+        if (should_send_feedback_to_gcs()) {
+            gcs().send_message(MSG_CAMERA_FEEDBACK); // this calls send_feedback in the standard camera library
+            _last_gcs_feedback_time = AP_HAL::millis();
+        }
+        // send feedback info and AHRS state to the CC
+        send_feedback_ahrs();
+
+        // store the image capture info to dataflash
+        DataFlash_Class *df = DataFlash_Class::instance();
+        if (df != nullptr) {
+            if (df->should_log(log_camera_bit)) {
+                // log the AHRS synchronised camera data
+                df->Log_Write_Camera_Vision1(_ahrs_summary, _flags, _camera_feedback_time, _image_index);
+                df->Log_Write_Camera_Vision2(_ahrs_summary, _flags, _camera_feedback_time, _image_index);
+                // log the default camera data
+                df->Log_Write_Camera(ahrs, gps, current_loc);
+            }
+        }
+    }
+}
+
+// send camera feedback to message to components of this system
+void AP_Camera_Vision::send_feedback_ahrs() {
+    mavlink_message_t msg;
+    mavlink_camera_feedback_ahrs_t camera_feedback_ahrs = { };
+
+    camera_feedback_ahrs.trigger_time = _camera_feedback_time;
+    camera_feedback_ahrs.sample_time = _ahrs_summary.ahrs_update_time;
+    camera_feedback_ahrs.x = _ahrs_summary.ned_pos_rel_home.x;
+    camera_feedback_ahrs.y = _ahrs_summary.ned_pos_rel_home.y;
+    camera_feedback_ahrs.z = _ahrs_summary.ned_pos_rel_home.z;
+    camera_feedback_ahrs.vx = _ahrs_summary.velocity.x;
+    camera_feedback_ahrs.vy = _ahrs_summary.velocity.y;
+    camera_feedback_ahrs.vz = _ahrs_summary.velocity.z;
+    camera_feedback_ahrs.q1 = _ahrs_summary.quat.q1;
+    camera_feedback_ahrs.q2 = _ahrs_summary.quat.q2;
+    camera_feedback_ahrs.q3 = _ahrs_summary.quat.q3;
+    camera_feedback_ahrs.q4 = _ahrs_summary.quat.q4;
+    camera_feedback_ahrs.home_lat = _ahrs_summary.home.lat;
+    camera_feedback_ahrs.home_lon = _ahrs_summary.home.lng;
+    camera_feedback_ahrs.home_alt = _ahrs_summary.home.alt;
+    camera_feedback_ahrs.lat = _ahrs_summary.location.lat;
+    camera_feedback_ahrs.lon = _ahrs_summary.location.lng;
+    camera_feedback_ahrs.alt = _ahrs_summary.location.alt;
+    camera_feedback_ahrs.img_idx = _image_index;
+    camera_feedback_ahrs.ekf_type = _ahrs_summary.ekf_type;
+    camera_feedback_ahrs.target_component = _vision_feedback_target_component;
+    camera_feedback_ahrs.status = _flags;
+
+    // encode camera feedback ahrs into MAVLink msg
+    mavlink_msg_camera_feedback_ahrs_encode(0, 0, &msg, &camera_feedback_ahrs);
+
+    // send to all components
+    GCS_MAVLINK::send_to_components(&msg);
+}
+
+// read the AHRS summary
+void AP_Camera_Vision::read_ahrs_summary(void) {
+    // make sure the AHRS summary is ready to read
+    if (_current_summary->get_ready_to_read()) {
+        // copy the data locally
+        memcpy(&_ahrs_summary, _current_summary, sizeof(_ahrs_summary));
+        // check the health of the data copied
+        // we expect _camera_feedback_time to be close to ahrs_summary.ahrs_update_time
+        // the delta is used to check health
+        _ahrs_sample_age = abs(_camera_feedback_time - _ahrs_summary.ahrs_update_time);
+
+        if (_ahrs_sample_age > _maximum_ahrs_sample_age_us) {
+            // the AHRS summary was too old
+            _ahrs_data_good = false;
+        } else {
+            _ahrs_data_good = true;
+        }
+    } else {
+        // the AHRS summary was not ready to read
+        _ahrs_data_good = false;
+    }
+    // release the summary for writing
+    _current_summary->set_ready_to_write(true);
+}
+
+bool AP_Camera_Vision::should_send_feedback_to_gcs(void) {
+    if (is_negative(_gcs_feedback_hz)) {
+        return true;
+    } else if (is_zero(_gcs_feedback_hz)) {
+        // handle the zero case here to avoid the divide by zero in the next case
+        return false;
+    } else if (AP_HAL::millis() - _last_gcs_feedback_time > (1.0/_gcs_feedback_hz)*1000) {
+        // sufficient time has passed since we last sent a msg to the GCS
+       return true;
+    } else {
+        // insufficient time has passed, don't send a message to the GCS this image
+       return false;
+    }
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+// callback for hardware timer capture on PX4.
+// machine vision camera exposure output is connected to this pin
+void AP_Camera_Vision::capture_callback(void *context, uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow) {
+    snapshot_ahrs();
+}
+#endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+void AP_Camera_Vision::snapshot_ahrs(void) {
+    _camera_feedback_time = AP_HAL::micros64();
+    _camera_triggered = true;
+    // snapshot the memory address of the summary
+    _current_summary = ahrs.summary.current_summary;
+    // make sure the AHRS summary is valid
+    if (_current_summary != nullptr) {
+        // lock the summary from being over written
+        _current_summary->set_ready_to_write(false);
+        _ahrs_data_good = true;
+    } else {
+        // valid current summary does not yet exist
+        _ahrs_data_good = false;
+    }
+}
+#endif

--- a/libraries/AP_Camera/AP_Camera_Vision.cpp
+++ b/libraries/AP_Camera/AP_Camera_Vision.cpp
@@ -141,6 +141,7 @@ void AP_Camera_Vision::read_ahrs_summary(void) {
     } else {
         // the AHRS summary was not ready to read
         _ahrs_data_good = false;
+        ahrs.summary.increment_read_error();
     }
     // release the summary for writing
     _current_summary->set_ready_to_write(true);

--- a/libraries/AP_Camera/AP_Camera_Vision.h
+++ b/libraries/AP_Camera/AP_Camera_Vision.h
@@ -1,0 +1,101 @@
+/*
+ *  Camera wrapper class for optional tight camera autopilot synchronization
+ *  Camera Vision overloads the camera functions to add behaviors suited to machine vision
+ *
+ *  Samuel Dudley 28/10/2017
+ *
+ *  dudley.samuel@gmail.com
+ *
+ */
+
+#pragma once
+
+#include "AP_Camera.h"
+#include <AP_AHRS/AP_AHRS.h>
+
+// with a 400Hz AHRS update rate we expect the data to be no older than 2500us
+// TODO assess the logged values to determine a suitable default time
+#define AP_CAMERA_VISION_DEFAULT_MAX_SAMPLE_AGE          100000 // set to 100ms for now
+#define AP_CAMERA_VISION_DEFAULT_FEEDBACK_COMPONENT_ID   191
+#define AP_CAMERA_VISION_DEFAULT_GCS_FEEDBACK_HZ         1 // 1 message per second
+
+class AP_Camera_Vision: public AP_Camera {
+public:
+    static AP_Camera_Vision create(AP_Relay *obj_relay,
+                            uint32_t _log_camera_bit,
+                            const struct Location &_loc,
+                            const AP_GPS &_gps,
+                            AP_AHRS &_ahrs) {
+        return AP_Camera_Vision{obj_relay, _log_camera_bit, _loc, _gps, _ahrs};
+    }
+
+    constexpr AP_Camera_Vision(AP_Camera_Vision &&other) = default;
+
+    /* Do not allow copies */
+    AP_Camera_Vision(const AP_Camera_Vision &other) = delete;
+    AP_Camera_Vision &operator=(const AP_Camera_Vision&) = delete;
+
+    // overloaded function from the standard AP_Camera class
+    // check to see if a trigger event has occurred and action accordingly
+    void update_trigger();
+
+
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+    AP_Camera_Vision(AP_Relay *obj_relay, uint32_t _log_camera_bit,
+            const struct Location &_loc, const AP_GPS &_gps, AP_AHRS &_ahrs)
+            : AP_Camera(obj_relay, _log_camera_bit, _loc, _gps, _ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+        _last_gcs_feedback_time = 0;
+    }
+
+    // determine if the GCS should be informed about this image capture event
+    bool should_send_feedback_to_gcs(void);
+
+    // send AHRS summary MAVLink message to attached components
+    void send_feedback_ahrs(void);
+
+    // read the AHRS summary captured at the feedback event
+    void read_ahrs_summary(void);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+    // overloaded function from the standard AP_Camera class
+    // called on hardware trigger event
+    void capture_callback(void *context, uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);
+#endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    void snapshot_ahrs(void);
+#endif
+
+    // component ID of the CC which will receive the AHRS summary MAVLink message
+    AP_Int16 _vision_feedback_target_component;
+
+    // maximum time difference between the AHRS data sample time and the camera trigger time
+    // before the sampled AHRS data is considered unhealthy
+    AP_Int32 _maximum_ahrs_sample_age_us;
+
+    uint32_t _last_gcs_feedback_time;
+
+    // the cameras local copy of the AHRS summary structure
+    AP_AHRS::AHRS_Summary _ahrs_summary;
+
+    AP_AHRS::AHRS_Summary *_current_summary;
+
+    // the time that the last hardware trigger event occurred
+    uint64_t _camera_feedback_time;
+
+    // the absolute difference between the camera feedback time and the AHRS sample time
+    AP_Int32 _ahrs_sample_age;
+
+    // maximum rate at which the GCS will receive camera feedback infomation
+    AP_Float _gcs_feedback_hz;
+
+    volatile bool _ahrs_data_good;
+
+    uint8_t _flags;
+
+};

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -137,6 +137,8 @@ public:
     void Log_Write_MessageF(const char *fmt, ...);
     void Log_Write_CameraInfo(enum LogMessages msg, const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);
     void Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);
+    void Log_Write_Camera_Vision1(const AP_AHRS::AHRS_Summary &ahrs_summary, const uint8_t &flags, const uint64_t &feedback_time, const uint16_t &image_index);
+    void Log_Write_Camera_Vision2(const AP_AHRS::AHRS_Summary &ahrs_summary, const uint8_t &flags, const uint64_t &feedback_time, const uint16_t &image_index);
     void Log_Write_Trigger(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);    
     void Log_Write_ESC(void);
     void Log_Write_Airspeed(AP_Airspeed &airspeed);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1448,6 +1448,52 @@ void DataFlash_Class::Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, c
     Log_Write_CameraInfo(LOG_CAMERA_MSG, ahrs, gps, current_loc);
 }
 
+// Write a Camera Vision packet 1
+void DataFlash_Class::Log_Write_Camera_Vision1(const AP_AHRS::AHRS_Summary &ahrs_summary, const uint8_t &flags, const uint64_t &feedback_time, const uint16_t &image_index )
+{
+    struct log_Camera_Vision1 pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_CAMERA_VISION_MSG1),
+        time_us         : AP_HAL::micros64(),
+        feedback_time_us: (uint64_t)feedback_time,
+        ahrs_time_us    : (uint64_t)ahrs_summary.ahrs_update_time,
+        feedback_flags  : (uint8_t)flags,
+        image_index     : (uint16_t)image_index,
+        latitude        : ahrs_summary.location.lat,
+        longitude       : ahrs_summary.location.lng,
+        altitude        : ahrs_summary.location.alt,
+        north_rel_home  : ahrs_summary.ned_pos_rel_home.x,
+        east_rel_home   : ahrs_summary.ned_pos_rel_home.y,
+        down_rel_home   : ahrs_summary.ned_pos_rel_home.z,
+        home_latitude   : ahrs_summary.home.lat,
+        home_longitude  : ahrs_summary.home.lng,
+        home_altitude   : ahrs_summary.home.alt
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write a Camera Vision packet 2
+void DataFlash_Class::Log_Write_Camera_Vision2(const AP_AHRS::AHRS_Summary &ahrs_summary, const uint8_t &flags, const uint64_t &feedback_time, const uint16_t &image_index )
+{
+    struct log_Camera_Vision2 pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_CAMERA_VISION_MSG2),
+        time_us         : AP_HAL::micros64(),
+        feedback_time_us: (uint64_t)feedback_time,
+        feedback_flags  : (uint8_t)flags,
+        image_index     : (uint16_t)image_index,
+        north_velocity  : ahrs_summary.velocity.x,
+        east_velocity   : ahrs_summary.velocity.y,
+        down_velocity   : ahrs_summary.velocity.z,
+        q1              : ahrs_summary.quat.q1,
+        q2              : ahrs_summary.quat.q2,
+        q3              : ahrs_summary.quat.q3,
+        q4              : ahrs_summary.quat.q4,
+        ekf_type        : ahrs_summary.ekf_type,
+        read_errors     : ahrs_summary.read_errors,
+        write_errors    : ahrs_summary.write_errors
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
 // Write a Trigger packet
 void DataFlash_Class::Log_Write_Trigger(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc)
 {

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -541,6 +541,42 @@ struct PACKED log_Camera {
     uint16_t yaw;
 };
 
+struct PACKED log_Camera_Vision1 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint64_t feedback_time_us;
+    uint64_t ahrs_time_us;
+    uint8_t  feedback_flags;
+    uint16_t image_index;
+    int32_t  latitude;
+    int32_t  longitude;
+    int32_t  altitude;
+    float    north_rel_home;
+    float    east_rel_home;
+    float    down_rel_home;
+    int32_t  home_latitude;
+    int32_t  home_longitude;
+    int32_t  home_altitude;
+};
+
+struct PACKED log_Camera_Vision2 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint64_t feedback_time_us;
+    uint8_t  feedback_flags;
+    uint16_t image_index;
+    float  north_velocity;
+    float  east_velocity;
+    float  down_velocity;
+    float  q1;
+    float  q2;
+    float  q3;
+    float  q4;
+    int8_t ekf_type;
+    uint8_t read_errors;
+    uint8_t write_errors;
+};
+
 struct PACKED log_Attitude {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1052,6 +1088,10 @@ Format characters in the format string for binary log messages
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed" }, \
     { LOG_CAMERA_MSG, sizeof(log_Camera), \
       "CAM", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw" }, \
+    { LOG_CAMERA_VISION_MSG1, sizeof(log_Camera_Vision1), \
+      "CAM1", "QQQBHLLefffLLe","TimeUS,TiFB,TiAH,Fl,Img,Lat,Lng,Alt,Nh,Eh,Dh,HLat,HLng,HAlt" }, \
+    { LOG_CAMERA_VISION_MSG2, sizeof(log_Camera_Vision2), \
+      "CAM2", "QQBHfffffffbBB","TimeUS,TiFB,Fl,Img,Nv,Ev,Dv,q1,q2,q3,q4,EKFt,Re,We" }, \
     { LOG_TRIGGER_MSG, sizeof(log_Camera), \
       "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw" }, \
     { LOG_ARSP_MSG, sizeof(log_AIRSPEED), \
@@ -1064,7 +1104,7 @@ Format characters in the format string for binary log messages
       "BCL", CURR_CELL_FMT, CURR_CELL_LABELS }, \
     { LOG_CURRENT_CELLS2_MSG, sizeof(log_Current_Cells), \
       "BCL2", CURR_CELL_FMT, CURR_CELL_LABELS }, \
-	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
+    { LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
       "MAG", MAG_FMT,    MAG_LABELS }, \
@@ -1368,6 +1408,8 @@ enum LogMessages {
     LOG_MSG_SBPRAWM,
     LOG_MSG_SBPEVENT,
     LOG_TRIGGER_MSG,
+    LOG_CAMERA_VISION_MSG1,
+    LOG_CAMERA_VISION_MSG2,
 
     LOG_GIMBAL1_MSG,
     LOG_GIMBAL2_MSG,


### PR DESCRIPTION
# WIP
**Related discussion [here](https://github.com/ArduPilot/ardupilot/pull/6672)**

The existing camera hardware feedback supports high resolution detection of a camera trigger events but there is a delay between when this trigger event is detected and when the AHRS state is grabbed (for reporting and logging). This PR aims to reduce this delay as much as possible without stopping the AHRS.

With each AHRS update (~400Hz) key bits of information such as attitude and location are stored in a structure. These structures are in turn stored in 'nodes' of a forward only linked list / ring buffer. Each node is capable of being locked by a consumer for reading, which effectively locks that node out of the ring buffer for updating by the producer. If the producer encounters a locked out node it continues to move on through the list attempting to write. If a node is written to or every node has been tried the AHRS gives up, increments as write error counter and moves on. I'm still doing testing on how many nodes would be required to operate without errors but I'm currently testing node counts of 2 and 3.

On the camera end the current AHRS node and autopilot time is 'locked in' as part of the camera feedback event callback. This node is then memcpy'd to a local structure within the camera class when the next `update_trigger()` is called from within the main vehicle loop. Datalogging and MAVLink feedback also occur as part of this loop keeping the camera feedback event callback short.

One use for this module is to synchronize a high frame rate (20+FPS) machine vision camera (connected to a companion computer) with the autopilot AHRS state. In this situation the existing camera implementation would send one message per event to the GCS, using up a large quantity of radio bandwidth. As part of the new AP_Camera_Vision class the rate at which the GCS is sent messages is configurable by a parameter (default 1Hz max), while a companion computer will continue to receive one message for every trigger event.

I'm at a stage with this code where I feel that moving forward without wider (and wiser!) input to this concept will result in an unusable outcome for the greater ArduPilot community. Please note that I don't typically do a lot of work in C++  so please be gentle :)

For testing feedback to the companion computer I'm currently using the following message:
```
    <message id="10999" name="CAMERA_FEEDBACK_AHRS">
      <description>Camera feedback that is synchronised with AHRS data</description>
      <field type="uint8_t" name="target_component">Component ID</field>
      <field type="uint16_t" name="img_idx">Image index</field>
      <field type="uint64_t" name="trigger_time" units="us">Autopilot time when the feedback event occured</field>
      <field type="uint64_t" name="sample_time" units="us">Autopilot time when the AHRS data was sampled</field>
      <field type="float" name="x" units="m">X Position</field>
      <field type="float" name="y" units="m">Y Position</field>
      <field type="float" name="z" units="m">Z Position</field>
      <field type="float" name="vx" units="m/s">X Speed</field>
      <field type="float" name="vy" units="m/s">Y Speed</field>
      <field type="float" name="vz" units="m/s">Z Speed</field>
      <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
      <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
      <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
      <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
      <field type="int32_t" name="lat" units="degE7">Latitude, expressed as degrees * 1E7</field>
      <field type="int32_t" name="lon" units="degE7">Longitude, expressed as degrees * 1E7</field>
      <field type="int32_t" name="alt" units="mm">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
      <field type="int32_t" name="home_lat" units="degE7">EKF home latitude, expressed as degrees * 1E7</field>
      <field type="int32_t" name="home_lon" units="degE7">EKF home longitude, expressed as degrees * 1E7</field>
      <field type="int32_t" name="home_alt" units="mm">EKF home altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
      <field type="uint8_t" name="ekf_type">EKF type running when data was generated</field>
      <field type="uint8_t" name="status">good/bad flag for now</field>
    </message>
```
Comments, ideas and suggestions welcomed!

Thanks,
Sam


