### PR TITLE
Airspeed: added SDP33 driver and dual-airspeed support

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1030,9 +1030,9 @@ const AP_Param::Info Plane::var_info[] = {
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),
 
-    // @Group: ARSPD_
+    // @Group: ARSPD
     // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
-    GOBJECT(airspeed,                               "ARSPD_",   AP_Airspeed),
+    GOBJECT(airspeed,                               "ARSPD",   AP_Airspeed),
 
     // @Group: NAVL1_
     // @Path: ../libraries/AP_L1_Control/AP_L1_Control.cpp

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -321,7 +321,7 @@ void Plane::update_sensor_status_flags(void)
     if (!ins.get_accel_health_all()) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_3D_ACCEL;
     }
-    if (airspeed.healthy()) {
+    if (airspeed.all_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
     }
 #if GEOFENCE_ENABLED

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -27,7 +27,9 @@
 #include "AP_Airspeed.h"
 #include "AP_Airspeed_MS4525.h"
 #include "AP_Airspeed_MS5525.h"
+#include "AP_Airspeed_SDP3X.h"
 #include "AP_Airspeed_analog.h"
+#include "AP_Airspeed_Backend.h"
 
 extern const AP_HAL::HAL &hal;
 
@@ -53,7 +55,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Airspeed type
     // @Description: Type of airspeed sensor
-    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77)
+    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 0, AP_Airspeed, _type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
 
@@ -112,7 +114,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Param: BUS
     // @DisplayName: Airspeed I2C bus
     // @Description: The bus number of the I2C bus to look for the sensor on
-    // @Values: 0:Bus0,1:Bus1
+    // @Values: 0:Bus0(internal),1:Bus1(external),2:Bus2(auxillary)
     // @User: Advanced
     AP_GROUPINFO("BUS",  9, AP_Airspeed, _bus, 1),
     
@@ -165,6 +167,9 @@ void AP_Airspeed::init()
         break;
     case TYPE_I2C_MS5525_ADDRESS_2:
         sensor = new AP_Airspeed_MS5525(*this, AP_Airspeed_MS5525::MS5525_ADDR_2);
+        break;
+    case TYPE_I2C_SDP3X:
+        sensor = new AP_Airspeed_SDP3X(*this);
         break;
     }
     if (sensor && !sensor->init()) {

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -52,80 +52,154 @@ extern const AP_HAL::HAL &hal;
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
-    // @Param: TYPE
+    // @Param: _TYPE
     // @DisplayName: Airspeed type
     // @Description: Type of airspeed sensor
     // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X
     // @User: Standard
-    AP_GROUPINFO_FLAGS("TYPE", 0, AP_Airspeed, _type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
 
-    // @Param: USE
+    // @Param: _USE
     // @DisplayName: Airspeed use
     // @Description: use airspeed for flight control. When set to 0 airspeed sensor can be logged and displayed on a GCS but won't be used for flight. When set to 1 it will be logged and used. When set to 2 it will be only used when the throttle is zero, which can be useful in gliders with airspeed sensors behind a propeller
     // @Values: 0:Don't Use,1:use,2:UseWhenZeroThrottle
     // @User: Standard
-    AP_GROUPINFO("USE",    1, AP_Airspeed, _use, 0),
+    AP_GROUPINFO("_USE",    1, AP_Airspeed, param[0].use, 0),
 
-    // @Param: OFFSET
+    // @Param: _OFFSET
     // @DisplayName: Airspeed offset
     // @Description: Airspeed calibration offset
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("OFFSET", 2, AP_Airspeed, _offset, 0),
+    AP_GROUPINFO("_OFFSET", 2, AP_Airspeed, param[0].offset, 0),
 
-    // @Param: RATIO
+    // @Param: _RATIO
     // @DisplayName: Airspeed ratio
     // @Description: Airspeed calibration ratio
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("RATIO",  3, AP_Airspeed, _ratio, 1.9936f),
+    AP_GROUPINFO("_RATIO",  3, AP_Airspeed, param[0].ratio, 1.9936f),
 
-    // @Param: PIN
+    // @Param: _PIN
     // @DisplayName: Airspeed pin
     // @Description: The pin number that the airspeed sensor is connected to for analog sensors. Set to 15 on the Pixhawk for the analog airspeed port. 
     // @User: Advanced
-    AP_GROUPINFO("PIN",  4, AP_Airspeed, _pin, ARSPD_DEFAULT_PIN),
+    AP_GROUPINFO("_PIN",  4, AP_Airspeed, param[0].pin, ARSPD_DEFAULT_PIN),
 
-    // @Param: AUTOCAL
+    // @Param: _AUTOCAL
     // @DisplayName: Automatic airspeed ratio calibration
     // @Description: If this is enabled then the APM will automatically adjust the ARSPD_RATIO during flight, based upon an estimation filter using ground speed and true airspeed. The automatic calibration will save the new ratio to EEPROM every 2 minutes if it changes by more than 5%. This option should be enabled for a calibration flight then disabled again when calibration is complete. Leaving it enabled all the time is not recommended.
     // @User: Advanced
-    AP_GROUPINFO("AUTOCAL",  5, AP_Airspeed, _autocal, 0),
+    AP_GROUPINFO("_AUTOCAL",  5, AP_Airspeed, param[0].autocal, 0),
 
-    // @Param: TUBE_ORDER
+    // @Param: _TUBE_ORDER
     // @DisplayName: Control pitot tube order
     // @Description: This parameter allows you to control whether the order in which the tubes are attached to your pitot tube matters. If you set this to 0 then the top connector on the sensor needs to be the dynamic pressure. If set to 1 then the bottom connector needs to be the dynamic pressure. If set to 2 (the default) then the airspeed driver will accept either order. The reason you may wish to specify the order is it will allow your airspeed sensor to detect if the aircraft it receiving excessive pressure on the static port, which would otherwise be seen as a positive airspeed.
     // @User: Advanced
-    AP_GROUPINFO("TUBE_ORDER",  6, AP_Airspeed, _tube_order, 2),
+    AP_GROUPINFO("_TUBE_ORDER",  6, AP_Airspeed, param[0].tube_order, 2),
 
-    // @Param: SKIP_CAL
+    // @Param: _SKIP_CAL
     // @DisplayName: Skip airspeed calibration on startup
     // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
-    AP_GROUPINFO("SKIP_CAL",  7, AP_Airspeed, _skip_cal, 0),
+    AP_GROUPINFO("_SKIP_CAL",  7, AP_Airspeed, param[0].skip_cal, 0),
 
-    // @Param: PSI_RANGE
+    // @Param: _PSI_RANGE
     // @DisplayName: The PSI range of the device
     // @Description: This parameter allows you to to set the PSI (pounds per square inch) range for your sensor. You should not change this unless you examine the datasheet for your device
     // @User: Advanced
-    AP_GROUPINFO("PSI_RANGE",  8, AP_Airspeed, _psi_range, PSI_RANGE_DEFAULT),
+    AP_GROUPINFO("_PSI_RANGE",  8, AP_Airspeed, param[0].psi_range, PSI_RANGE_DEFAULT),
 
-    // @Param: BUS
+    // @Param: _BUS
     // @DisplayName: Airspeed I2C bus
     // @Description: The bus number of the I2C bus to look for the sensor on
     // @Values: 0:Bus0(internal),1:Bus1(external),2:Bus2(auxillary)
     // @User: Advanced
-    AP_GROUPINFO("BUS",  9, AP_Airspeed, _bus, 1),
+    AP_GROUPINFO("_BUS",  9, AP_Airspeed, param[0].bus, 1),
+
+    // @Param: _PRIMARY
+    // @DisplayName: Primary airspeed sensor
+    // @Description: This selects which airspeed sensor will be the primary if multiple sensors are found
+    // @Values: 0:FirstSensor,1:2ndSensor
+    // @User: Advanced
+    AP_GROUPINFO("_PRIMARY", 10, AP_Airspeed, primary_sensor, 0),
+
+    // @Param: 2_TYPE
+    // @DisplayName: Second Airspeed type
+    // @Description: Type of 2nd airspeed sensor
+    // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-SDP3X
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("2_TYPE", 11, AP_Airspeed, param[1].type, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: 2_USE
+    // @DisplayName: Enable use of 2nd airspeed sensor
+    // @Description: use airspeed for flight control. When set to 0 airspeed sensor can be logged and displayed on a GCS but won't be used for flight. When set to 1 it will be logged and used. When set to 2 it will be only used when the throttle is zero, which can be useful in gliders with airspeed sensors behind a propeller
+    // @Values: 0:Don't Use,1:use,2:UseWhenZeroThrottle
+    // @User: Standard
+    AP_GROUPINFO("2_USE",    12, AP_Airspeed, param[1].use, 0),
+
+    // @Param: 2_OFFSET
+    // @DisplayName: Airspeed offset for 2nd airspeed sensor
+    // @Description: Airspeed calibration offset
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("2_OFFSET", 13, AP_Airspeed, param[1].offset, 0),
+
+    // @Param: 2_RATIO
+    // @DisplayName: Airspeed ratio for 2nd airspeed sensor
+    // @Description: Airspeed calibration ratio
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("2_RATIO",  14, AP_Airspeed, param[1].ratio, 2),
+
+    // @Param: 2_PIN
+    // @DisplayName: Airspeed pin for 2nd airspeed sensor
+    // @Description: The pin number that the airspeed sensor is connected to for analog sensors. Set to 15 on the Pixhawk for the analog airspeed port. 
+    // @User: Advanced
+    AP_GROUPINFO("2_PIN",  15, AP_Airspeed, param[1].pin, 0),
+
+    // @Param: 2_AUTOCAL
+    // @DisplayName: Automatic airspeed ratio calibration for 2nd airspeed sensor
+    // @Description: If this is enabled then the APM will automatically adjust the ARSPD_RATIO during flight, based upon an estimation filter using ground speed and true airspeed. The automatic calibration will save the new ratio to EEPROM every 2 minutes if it changes by more than 5%. This option should be enabled for a calibration flight then disabled again when calibration is complete. Leaving it enabled all the time is not recommended.
+    // @User: Advanced
+    AP_GROUPINFO("2_AUTOCAL",  16, AP_Airspeed, param[1].autocal, 0),
+
+    // @Param: 2_TUBE_ORDR
+    // @DisplayName: Control pitot tube order of 2nd airspeed sensor
+    // @Description: This parameter allows you to control whether the order in which the tubes are attached to your pitot tube matters. If you set this to 0 then the top connector on the sensor needs to be the dynamic pressure. If set to 1 then the bottom connector needs to be the dynamic pressure. If set to 2 (the default) then the airspeed driver will accept either order. The reason you may wish to specify the order is it will allow your airspeed sensor to detect if the aircraft it receiving excessive pressure on the static port, which would otherwise be seen as a positive airspeed.
+    // @User: Advanced
+    AP_GROUPINFO("2_TUBE_ORDR",  17, AP_Airspeed, param[1].tube_order, 2),
+
+    // @Param: 2_SKIP_CAL
+    // @DisplayName: Skip airspeed calibration on startup for 2nd sensor
+    // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
+    // @Values: 0:Disable,1:Enable
+    // @User: Advanced
+    AP_GROUPINFO("2_SKIP_CAL",  18, AP_Airspeed, param[1].skip_cal, 0),
+
+    // @Param: 2_PSI_RANGE
+    // @DisplayName: The PSI range of the device for 2nd sensor
+    // @Description: This parameter allows you to to set the PSI (pounds per square inch) range for your sensor. You should not change this unless you examine the datasheet for your device
+    // @User: Advanced
+    AP_GROUPINFO("2_PSI_RANGE",  19, AP_Airspeed, param[1].psi_range, PSI_RANGE_DEFAULT),
+
+    // @Param: 2_BUS
+    // @DisplayName: Airspeed I2C bus for 2nd sensor
+    // @Description: The bus number of the I2C bus to look for the sensor on
+    // @Values: 0:Bus0(internal),1:Bus1(external),2:Bus2(auxillary)
+    // @User: Advanced
+    AP_GROUPINFO("2_BUS",  20, AP_Airspeed, param[1].bus, 1),
     
     AP_GROUPEND
 };
 
 
 AP_Airspeed::AP_Airspeed()
-    : _EAS2TAS(1.0f)
-    , _calibration()
 {
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        state[i].EAS2TAS = 1;
+    }
     AP_Param::setup_object_defaults(this, var_info);
 }
 
@@ -140,188 +214,238 @@ AP_Airspeed::AP_Airspeed()
 void AP_Airspeed::init()
 {
     // cope with upgrade from old system
-    if (_pin.load() && _pin.get() != 65) {
-        _type.set_default(TYPE_ANALOG);
+    if (param[0].pin.load() && param[0].pin.get() != 65) {
+        param[0].type.set_default(TYPE_ANALOG);
     }
 
-    _last_pressure = 0;
-    _calibration.init(_ratio);
-    _last_saved_ratio = _ratio;
-    _counter = 0;
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        state[i].calibration.init(param[i].ratio);
+        state[i].last_saved_ratio = param[i].ratio;
 
-    switch ((enum airspeed_type)_type.get()) {
-    case TYPE_NONE:
-        // nothing to do
-        break;
-    case TYPE_I2C_MS4525:
-        sensor = new AP_Airspeed_MS4525(*this);
-        break;
-    case TYPE_ANALOG:
-        sensor = new AP_Airspeed_Analog(*this);
-        break;
-    case TYPE_I2C_MS5525:
-        sensor = new AP_Airspeed_MS5525(*this, AP_Airspeed_MS5525::MS5525_ADDR_AUTO);
-        break;
-    case TYPE_I2C_MS5525_ADDRESS_1:
-        sensor = new AP_Airspeed_MS5525(*this, AP_Airspeed_MS5525::MS5525_ADDR_1);
-        break;
-    case TYPE_I2C_MS5525_ADDRESS_2:
-        sensor = new AP_Airspeed_MS5525(*this, AP_Airspeed_MS5525::MS5525_ADDR_2);
-        break;
-    case TYPE_I2C_SDP3X:
-        sensor = new AP_Airspeed_SDP3X(*this);
-        break;
-    }
-    if (sensor && !sensor->init()) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Airspeed init failed");
-        delete sensor;
-        sensor = nullptr;
+        switch ((enum airspeed_type)param[i].type.get()) {
+        case TYPE_NONE:
+            // nothing to do
+            break;
+        case TYPE_I2C_MS4525:
+            sensor[i] = new AP_Airspeed_MS4525(*this, i);
+            break;
+        case TYPE_ANALOG:
+            sensor[i] = new AP_Airspeed_Analog(*this, i);
+            break;
+        case TYPE_I2C_MS5525:
+            sensor[i] = new AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_AUTO);
+            break;
+        case TYPE_I2C_MS5525_ADDRESS_1:
+            sensor[i] = new AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_1);
+            break;
+        case TYPE_I2C_MS5525_ADDRESS_2:
+            sensor[i] = new AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_2);
+            break;
+        case TYPE_I2C_SDP3X:
+            sensor[i] = new AP_Airspeed_SDP3X(*this, i);
+            break;
+        }
+        if (sensor[i] && !sensor[i]->init()) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Airspeed[%u] init failed", i);
+            delete sensor[i];
+            sensor[i] = nullptr;
+        }
     }
 }
 
 // read the airspeed sensor
-float AP_Airspeed::get_pressure(void)
+float AP_Airspeed::get_pressure(uint8_t i)
 {
-    if (!enabled()) {
+    if (!enabled(i)) {
         return 0;
     }
-    if (_hil_set) {
-        _healthy = true;
-        return _hil_pressure;
+    if (state[i].hil_set) {
+        state[i].healthy = true;
+        return state[i].hil_pressure;
     }
     float pressure = 0;
-    if (sensor) {
-        _healthy = sensor->get_differential_pressure(pressure);
+    if (sensor[i]) {
+        state[i].healthy = sensor[i]->get_differential_pressure(pressure);
     }
     return pressure;
 }
 
 // get a temperature reading if possible
-bool AP_Airspeed::get_temperature(float &temperature)
+bool AP_Airspeed::get_temperature(uint8_t i, float &temperature)
 {
-    if (!enabled()) {
+    if (!enabled(i)) {
         return false;
     }
-    if (sensor) {
-        return sensor->get_temperature(temperature);
+    if (sensor[i]) {
+        return sensor[i]->get_temperature(temperature);
     }
     return false;
 }
 
-// calibrate the airspeed. This must be called at least once before
-// the get_airspeed() interface can be used
+// calibrate the zero offset for the airspeed. This must be called at
+// least once before the get_airspeed() interface can be used
 void AP_Airspeed::calibrate(bool in_startup)
 {
-    if (!enabled()) {
-        return;
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        if (!enabled(i)) {
+            continue;
+        }
+        if (state[i].use_zero_offset) {
+            param[i].offset.set(0);
+            continue;
+        }
+        if (in_startup && param[i].skip_cal) {
+            continue;
+        }
+        state[i].cal.start_ms = AP_HAL::millis();
+        state[i].cal.count = 0;
+        state[i].cal.sum = 0;
+        state[i].cal.read_count = 0;
     }
-    if (in_startup && _skip_cal) {
-        return;
-    }
-    _cal.start_ms = AP_HAL::millis();
-    _cal.count = 0;
-    _cal.sum = 0;
-    _cal.read_count = 0;
 }
 
 /*
-  update async airspeed calibration
+  update async airspeed zero offset calibration
 */
-void AP_Airspeed::update_calibration(float raw_pressure)
+void AP_Airspeed::update_calibration(uint8_t i, float raw_pressure)
 {
+    if (!enabled(i) || state[i].cal.start_ms == 0) {
+        return;
+    }
+    
     // consider calibration complete when we have at least 15 samples
     // over at least 1 second
-    if (AP_HAL::millis() - _cal.start_ms >= 1000 &&
-        _cal.read_count > 15) {
-        if (_cal.count == 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Airspeed sensor unhealthy");
+    if (AP_HAL::millis() - state[i].cal.start_ms >= 1000 &&
+        state[i].cal.read_count > 15) {
+        if (state[i].cal.count == 0) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Airspeed[%u] sensor unhealthy", i);
         } else {
-            gcs().send_text(MAV_SEVERITY_INFO, "Airspeed sensor calibrated");
-            _offset.set_and_save(_cal.sum / _cal.count);
+            gcs().send_text(MAV_SEVERITY_INFO, "Airspeed[%u] sensor calibrated", i);
+            param[i].offset.set_and_save(state[i].cal.sum / state[i].cal.count);
         }
-        _cal.start_ms = 0;
+        state[i].cal.start_ms = 0;
         return;
     }
     // we discard the first 5 samples
-    if (_healthy && _cal.read_count > 5) {
-        _cal.sum += raw_pressure;
-        _cal.count++;
+    if (state[i].healthy && state[i].cal.read_count > 5) {
+        state[i].cal.sum += raw_pressure;
+        state[i].cal.count++;
     }
-    _cal.read_count++;
+    state[i].cal.read_count++;
 }
 
-// read the airspeed sensor
-void AP_Airspeed::read(void)
+// read one airspeed sensor
+void AP_Airspeed::read(uint8_t i)
 {
     float airspeed_pressure;
-    if (!enabled()) {
+    if (!enabled(i) || !sensor[i]) {
         return;
     }
-    float raw_pressure = get_pressure();
-    if (_cal.start_ms != 0) {
-        update_calibration(raw_pressure);
+    float raw_pressure = get_pressure(i);
+    if (state[i].cal.start_ms != 0) {
+        update_calibration(i, raw_pressure);
     }
     
-    airspeed_pressure = raw_pressure - _offset;
+    airspeed_pressure = raw_pressure - param[i].offset;
 
     // remember raw pressure for logging
-    _corrected_pressure = airspeed_pressure;
+    state[i].corrected_pressure = airspeed_pressure;
 
     // filter before clamping positive
-    _filtered_pressure      = 0.7f * _filtered_pressure  +  0.3f * airspeed_pressure;
+    state[i].filtered_pressure = 0.7f * state[i].filtered_pressure + 0.3f * airspeed_pressure;
 
     /*
       we support different pitot tube setups so user can choose if
       they want to be able to detect pressure on the static port
      */
-    switch ((enum pitot_tube_order)_tube_order.get()) {
+    switch ((enum pitot_tube_order)param[i].tube_order.get()) {
     case PITOT_TUBE_ORDER_NEGATIVE:
-        _last_pressure          = -airspeed_pressure;
-        _raw_airspeed           = sqrtf(MAX(-airspeed_pressure, 0) * _ratio);
-        _airspeed               = sqrtf(MAX(-_filtered_pressure, 0) * _ratio);
+        state[i].last_pressure  = -airspeed_pressure;
+        state[i].raw_airspeed   = sqrtf(MAX(-airspeed_pressure, 0) * param[i].ratio);
+        state[i].airspeed       = sqrtf(MAX(-state[i].filtered_pressure, 0) * param[i].ratio);
         break;
     case PITOT_TUBE_ORDER_POSITIVE:
-        _last_pressure          = airspeed_pressure;
-        _raw_airspeed           = sqrtf(MAX(airspeed_pressure, 0) * _ratio);
-        _airspeed               = sqrtf(MAX(_filtered_pressure, 0) * _ratio);
+        state[i].last_pressure  = airspeed_pressure;
+        state[i].raw_airspeed   = sqrtf(MAX(airspeed_pressure, 0) * param[i].ratio);
+        state[i].airspeed       = sqrtf(MAX(state[i].filtered_pressure, 0) * param[i].ratio);
         if (airspeed_pressure < -32) {
             // we're reading more than about -8m/s. The user probably has
             // the ports the wrong way around
-            _healthy = false;
+            state[i].healthy = false;
         }
         break;
     case PITOT_TUBE_ORDER_AUTO:
     default:
-        _last_pressure          = fabsf(airspeed_pressure);
-        _raw_airspeed           = sqrtf(fabsf(airspeed_pressure) * _ratio);
-        _airspeed               = sqrtf(fabsf(_filtered_pressure) * _ratio);
+        state[i].last_pressure  = fabsf(airspeed_pressure);
+        state[i].raw_airspeed   = sqrtf(fabsf(airspeed_pressure) * param[i].ratio);
+        state[i].airspeed       = sqrtf(fabsf(state[i].filtered_pressure) * param[i].ratio);
         break;
     }
 
-    _last_update_ms         = AP_HAL::millis();
+    state[i].last_update_ms = AP_HAL::millis();
+}
+
+// read all airspeed sensors
+void AP_Airspeed::read(void)
+{
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        read(i);
+    }
+
+#if 1
+    // debugging until we get MAVLink support for 2nd airspeed sensor
+    if (enabled(1)) {
+        mavlink_msg_named_value_float_send(MAVLINK_COMM_0, AP_HAL::millis(), "AS2", get_airspeed(1));
+    }
+#endif
+
+    // setup primary
+    if (healthy(primary_sensor.get())) {
+        primary = primary_sensor.get();
+        return;
+    }
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        if (healthy(i)) {
+            primary = i;
+            break;
+        }
+    }
 }
 
 void AP_Airspeed::setHIL(float airspeed, float diff_pressure, float temperature)
 {
-    _raw_airspeed = airspeed;
-    _airspeed = airspeed;
-    _last_pressure = diff_pressure;
-    _last_update_ms = AP_HAL::millis();
-    _hil_pressure = diff_pressure;
-    _hil_set = true;
-    _healthy = true;
+    state[0].raw_airspeed = airspeed;
+    state[0].airspeed = airspeed;
+    state[0].last_pressure = diff_pressure;
+    state[0].last_update_ms = AP_HAL::millis();
+    state[0].hil_pressure = diff_pressure;
+    state[0].hil_set = true;
+    state[0].healthy = true;
 }
 
-bool AP_Airspeed::use(void) const
+bool AP_Airspeed::use(uint8_t i) const
 {
-    if (!enabled() || !_use) {
+    if (!enabled(i) || !param[i].use) {
         return false;
     }
-    if (_use == 2 && SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) != 0) {
+    if (param[i].use == 2 && SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) != 0) {
         // special case for gliders with airspeed sensors behind the
         // propeller. Allow airspeed to be disabled when throttle is
         // running
         return false;
+    }
+    return true;
+}
+
+/*
+  return true if all enabled sensors are healthy
+ */
+bool AP_Airspeed::all_healthy(void) const
+{
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        if (enabled(i) && !healthy(i)) {
+            return false;
+        }
     }
     return true;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -8,6 +8,8 @@
 
 class AP_Airspeed_Backend;
 
+#define AIRSPEED_MAX_SENSORS 2
+
 class Airspeed_Calibration {
 public:
     friend class AP_Airspeed;
@@ -40,84 +42,86 @@ public:
 
     void init(void);
 
-    // read the analog source and update _airspeed
-    void        read(void);
+    // read the analog source and update airspeed
+    void read(void);
 
     // calibrate the airspeed. This must be called on startup if the
     // altitude/climb_rate/acceleration interfaces are ever used
-    void            calibrate(bool in_startup);
+    void calibrate(bool in_startup);
 
     // return the current airspeed in m/s
-    float           get_airspeed(void) const {
-        return _airspeed;
+    float get_airspeed(uint8_t i) const {
+        return state[i].airspeed;
     }
+    float get_airspeed(void) const { return get_airspeed(primary); }
 
     // return the unfiltered airspeed in m/s
-    float           get_raw_airspeed(void) const {
-        return _raw_airspeed;
+    float get_raw_airspeed(uint8_t i) const {
+        return state[i].raw_airspeed;
     }
-
-    // return the current airspeed in cm/s
-    float        get_airspeed_cm(void) const {
-        return _airspeed*100;
-    }
+    float get_raw_airspeed(void) const { return get_raw_airspeed(primary); }
 
     // return the current airspeed ratio (dimensionless)
-    float        get_airspeed_ratio(void) const {
-        return _ratio;
+    float get_airspeed_ratio(uint8_t i) const {
+        return param[i].ratio;
     }
+    float get_airspeed_ratio(void) const { return get_airspeed_ratio(primary); }
 
     // get temperature if available
-    bool get_temperature(float &temperature);
+    bool get_temperature(uint8_t i, float &temperature);
+    bool get_temperature(float &temperature) { return get_temperature(primary, temperature); }
 
     // set the airspeed ratio (dimensionless)
-    void        set_airspeed_ratio(float ratio) {
-        _ratio.set(ratio);
+    void set_airspeed_ratio(uint8_t i, float ratio) {
+        param[i].ratio.set(ratio);
     }
+    void set_airspeed_ratio(float ratio) { set_airspeed_ratio(primary, ratio); }
 
     // return true if airspeed is enabled, and airspeed use is set
-    bool        use(void) const;
+    bool use(uint8_t i) const;
+    bool use(void) const { return use(primary); }
 
     // return true if airspeed is enabled
-    bool        enabled(void) const {
-        return _type.get() != TYPE_NONE;
+    bool enabled(uint8_t i) const {
+        return param[i].type.get() != TYPE_NONE;
     }
-
-    // force disable the airspeed sensor
-    void        disable(void) {
-        _type.set(TYPE_NONE);
-    }
+    bool enabled(void) const { return enabled(primary); }
 
     // used by HIL to set the airspeed
-    void        set_HIL(float airspeed) {
-        _airspeed = airspeed;
+    void set_HIL(float airspeed) {
+        state[primary].airspeed = airspeed;
     }
 
     // return the differential pressure in Pascal for the last
     // airspeed reading. Used by the calibration code
-    float get_differential_pressure(void) const {
-        return _last_pressure;
+    float get_differential_pressure(uint8_t i) const {
+        return state[i].last_pressure;
     }
+    float get_differential_pressure(void) const { return get_differential_pressure(primary); }
 
     // return the current calibration offset
-    float get_offset(void) const {
-        return _offset;
+    float get_offset(uint8_t i) const {
+        return param[i].offset;
     }
+    float get_offset(void) const { return get_offset(primary); }
 
     // return the current corrected pressure
-    float get_corrected_pressure(void) const {
-        return _corrected_pressure;
+    float get_corrected_pressure(uint8_t i) const {
+        return state[i].corrected_pressure;
     }
+    float get_corrected_pressure(void) const { return get_corrected_pressure(primary); }
 
     // set the apparent to true airspeed ratio
-    void set_EAS2TAS(float v) {
-        _EAS2TAS = v;
+    void set_EAS2TAS(uint8_t i, float v) {
+        state[i].EAS2TAS = v;
     }
+    void set_EAS2TAS(float v) { set_EAS2TAS(primary, v); }
 
     // get the apparent to true airspeed ratio
-    float get_EAS2TAS(void) const {
-        return _EAS2TAS;
+    float get_EAS2TAS(uint8_t i) const {
+        return state[i].EAS2TAS;
     }
+    float get_EAS2TAS(void) const { return get_EAS2TAS(primary); }
 
     // update airspeed ratio calibration
     void update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
@@ -126,12 +130,19 @@ public:
 	void log_mavlink_send(mavlink_channel_t chan, const Vector3f &vground);
 
     // return health status of sensor
-    bool healthy(void) const { return _healthy && (fabsf(_offset) > 0 || _allow_zero_offset) && enabled(); }
+    bool healthy(uint8_t i) const {
+        return state[i].healthy && (fabsf(param[i].offset) > 0 || state[i].use_zero_offset) && enabled(i);
+    }
+    bool healthy(void) const { return healthy(primary); }
 
-    void setHIL(float pressure) { _healthy=_hil_set=true; _hil_pressure=pressure; }
+    // return true if all enabled sensors are healthy
+    bool all_healthy(void) const;
+    
+    void setHIL(float pressure) { state[0].healthy=state[0].hil_set=true; state[0].hil_pressure=pressure; }
 
     // return time in ms of last update
-    uint32_t last_update_ms(void) const { return _last_update_ms; }
+    uint32_t last_update_ms(uint8_t i) const { return state[i].last_update_ms; }
+    uint32_t last_update_ms(void) const { return last_update_ms(primary); }
 
     void setHIL(float airspeed, float diff_pressure, float temperature);
 
@@ -150,46 +161,60 @@ public:
         TYPE_I2C_MS5525_ADDRESS_2=5,
         TYPE_I2C_SDP3X=6,
     };
+
+    // get current primary sensor
+    uint8_t get_primary(void) const { return primary; }
     
 private:
-    AP_Float        _offset;
-    AP_Float        _ratio;
-    AP_Float        _psi_range;
-    AP_Int8         _use;
-    AP_Int8         _type;
-    AP_Int8         _pin;
-    AP_Int8         _bus;
-    AP_Int8         _autocal;
-    AP_Int8         _tube_order;
-    AP_Int8         _skip_cal;
-    float           _raw_airspeed;
-    float           _airspeed;
-    float			_last_pressure;
-    float           _filtered_pressure;
-    float			_corrected_pressure;
-    float           _EAS2TAS;
-    bool		    _healthy:1;
-    bool		    _hil_set:1;
-    float           _hil_pressure;
-    uint32_t        _last_update_ms;
 
-    // state of runtime calibration
+    AP_Int8 primary_sensor;
+    
     struct {
-        uint32_t        start_ms;
-        uint16_t        count;
-        float           sum;
-        uint16_t        read_count;
-    } _cal;
+        AP_Float offset;
+        AP_Float ratio;
+        AP_Float psi_range;
+        AP_Int8  use;
+        AP_Int8  type;
+        AP_Int8  pin;
+        AP_Int8  bus;
+        AP_Int8  autocal;
+        AP_Int8  tube_order;
+        AP_Int8  skip_cal;
+    } param[AIRSPEED_MAX_SENSORS];
 
-    Airspeed_Calibration _calibration;
-    float _last_saved_ratio;
-    uint8_t _counter;
+    struct airspeed_state {
+        float   raw_airspeed;
+        float   airspeed;
+        float	last_pressure;
+        float   filtered_pressure;
+        float	corrected_pressure;
+        float   EAS2TAS;
+        bool	healthy:1;
+        bool	hil_set:1;
+        float   hil_pressure;
+        uint32_t last_update_ms;
+        bool use_zero_offset;
+        
+        // state of runtime calibration
+        struct {
+            uint32_t start_ms;
+            uint16_t count;
+            float    sum;
+            uint16_t read_count;
+        } cal;
 
-    float get_pressure(void);
-    void update_calibration(float raw_pressure);
+        Airspeed_Calibration calibration;
+        float last_saved_ratio;
+        uint8_t counter;
+    } state[AIRSPEED_MAX_SENSORS];
 
-    AP_Airspeed_Backend *sensor;
+    // current primary sensor
+    uint8_t primary;
+    
+    void read(uint8_t i);
+    float get_pressure(uint8_t i);
+    void update_calibration(uint8_t i, float raw_pressure);
+    void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
 
-    // some sensors can have zero offset and be healthy
-    bool _allow_zero_offset;
+    AP_Airspeed_Backend *sensor[AIRSPEED_MAX_SENSORS];
 };

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -4,8 +4,9 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Baro/AP_Baro.h>
 
-#include "AP_Airspeed_Backend.h"
+class AP_Airspeed_Backend;
 
 class Airspeed_Calibration {
 public:
@@ -125,7 +126,7 @@ public:
 	void log_mavlink_send(mavlink_channel_t chan, const Vector3f &vground);
 
     // return health status of sensor
-    bool healthy(void) const { return _healthy && fabsf(_offset) > 0 && enabled(); }
+    bool healthy(void) const { return _healthy && (fabsf(_offset) > 0 || _allow_zero_offset) && enabled(); }
 
     void setHIL(float pressure) { _healthy=_hil_set=true; _hil_pressure=pressure; }
 
@@ -147,6 +148,7 @@ public:
         TYPE_I2C_MS5525=3,
         TYPE_I2C_MS5525_ADDRESS_1=4,
         TYPE_I2C_MS5525_ADDRESS_2=5,
+        TYPE_I2C_SDP3X=6,
     };
     
 private:
@@ -187,4 +189,7 @@ private:
     void update_calibration(float raw_pressure);
 
     AP_Airspeed_Backend *sensor;
+
+    // some sensors can have zero offset and be healthy
+    bool _allow_zero_offset;
 };

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -24,8 +24,9 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend) :
-    frontend(_frontend)
+AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend, uint8_t _instance) :
+    frontend(_frontend),
+    instance(_instance)
 {
     sem = hal.util->new_semaphore();
 }
@@ -38,15 +39,15 @@ AP_Airspeed_Backend::~AP_Airspeed_Backend(void)
 
 int8_t AP_Airspeed_Backend::get_pin(void) const
 {
-    return frontend._pin;
+    return frontend.param[instance].pin;
 }
 
 float AP_Airspeed_Backend::get_psi_range(void) const
 {
-    return frontend._psi_range;
+    return frontend.param[instance].psi_range;
 }
 
 uint8_t AP_Airspeed_Backend::get_bus(void) const
 {
-    return frontend._bus;
+    return frontend.param[instance].bus;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -20,6 +20,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Airspeed.h"
+#include "AP_Airspeed_Backend.h"
 
 extern const AP_HAL::HAL &hal;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -24,7 +24,7 @@
 
 class AP_Airspeed_Backend {
 public:
-    AP_Airspeed_Backend(AP_Airspeed &frontend);
+    AP_Airspeed_Backend(AP_Airspeed &frontend, uint8_t instance);
     virtual ~AP_Airspeed_Backend();
     
     // probe and initialise the sensor
@@ -42,31 +42,32 @@ protected:
     uint8_t get_bus(void) const;
 
     AP_Airspeed::pitot_tube_order get_tube_order(void) const {
-        return AP_Airspeed::pitot_tube_order(frontend._tube_order.get());
+        return AP_Airspeed::pitot_tube_order(frontend.param[instance].tube_order.get());
     }
     
     // semaphore for access to shared frontend data
     AP_HAL::Semaphore *sem;
 
     float get_airspeed_ratio(void) const {
-        return frontend.get_airspeed_ratio();
+        return frontend.get_airspeed_ratio(instance);
     }
 
-    // some sensors allow zero offsets while healthy
-    void set_allow_zero_offset(void) {
-        frontend._allow_zero_offset = true;
+    // some sensors use zero offsets
+    void set_use_zero_offset(void) {
+        frontend.state[instance].use_zero_offset = true;
     }
 
     // set to no zero cal, which makes sense for some sensors
     void set_skip_cal(void) {
-        frontend._skip_cal.set(1);
+        frontend.param[instance].skip_cal.set(1);
     }
 
     // set zero offset
     void set_offset(float ofs) {
-        frontend._offset.set(ofs);
+        frontend.param[instance].offset.set(ofs);
     }
     
 private:
     AP_Airspeed &frontend;
+    uint8_t instance;
 };

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -20,8 +20,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
-
-class AP_Airspeed;
+#include "AP_Airspeed.h"
 
 class AP_Airspeed_Backend {
 public:
@@ -42,8 +41,31 @@ protected:
     float get_psi_range(void) const;
     uint8_t get_bus(void) const;
 
+    AP_Airspeed::pitot_tube_order get_tube_order(void) const {
+        return AP_Airspeed::pitot_tube_order(frontend._tube_order.get());
+    }
+    
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *sem;    
+    AP_HAL::Semaphore *sem;
+
+    float get_airspeed_ratio(void) const {
+        return frontend.get_airspeed_ratio();
+    }
+
+    // some sensors allow zero offsets while healthy
+    void set_allow_zero_offset(void) {
+        frontend._allow_zero_offset = true;
+    }
+
+    // set to no zero cal, which makes sense for some sensors
+    void set_skip_cal(void) {
+        frontend._skip_cal.set(1);
+    }
+
+    // set zero offset
+    void set_offset(float ofs) {
+        frontend._offset.set(ofs);
+    }
     
 private:
     AP_Airspeed &frontend;

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -29,8 +29,8 @@ extern const AP_HAL::HAL &hal;
 
 #define MS4525D0_I2C_ADDR 0x28
 
-AP_Airspeed_MS4525::AP_Airspeed_MS4525(AP_Airspeed &_frontend) :
-    AP_Airspeed_Backend(_frontend)
+AP_Airspeed_MS4525::AP_Airspeed_MS4525(AP_Airspeed &_frontend, uint8_t _instance) :
+    AP_Airspeed_Backend(_frontend, _instance)
 {
 }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
@@ -30,7 +30,7 @@
 class AP_Airspeed_MS4525 : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_MS4525(AP_Airspeed &frontend);
+    AP_Airspeed_MS4525(AP_Airspeed &frontend, uint8_t _instance);
     ~AP_Airspeed_MS4525(void) {}
     
     // probe and initialise the sensor

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -51,8 +51,8 @@ extern const AP_HAL::HAL &hal;
 #define REG_CONVERT_PRESSURE    REG_CONVERT_D1_OSR_1024
 #define REG_CONVERT_TEMPERATURE REG_CONVERT_D2_OSR_1024
 
-AP_Airspeed_MS5525::AP_Airspeed_MS5525(AP_Airspeed &_frontend, MS5525_ADDR address) :
-    AP_Airspeed_Backend(_frontend)
+AP_Airspeed_MS5525::AP_Airspeed_MS5525(AP_Airspeed &_frontend, uint8_t _instance, MS5525_ADDR address) :
+    AP_Airspeed_Backend(_frontend, _instance)
 {
     _address = address;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
@@ -36,7 +36,7 @@ public:
         MS5525_ADDR_AUTO = 255, // does not need to be 255, just needs to be out of the address array
     };
 
-    AP_Airspeed_MS5525(AP_Airspeed &frontend, MS5525_ADDR address);
+    AP_Airspeed_MS5525(AP_Airspeed &frontend, uint8_t _instance, MS5525_ADDR address);
     ~AP_Airspeed_MS5525(void) {}
     
     // probe and initialise the sensor

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -1,0 +1,308 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  backend driver for airspeed from a I2C SDP3X sensor
+
+  with thanks to https://github.com/PX4/Firmware/blob/master/src/drivers/sdp3x_airspeed
+ */
+#include "AP_Airspeed_SDP3X.h"
+
+#include <stdio.h>
+
+#define SDP3X_SCALE_TEMPERATURE		200.0f
+
+#define SDP3XD0_I2C_ADDR            	0x21
+#define SDP3XD1_I2C_ADDR            	0x22
+#define SDP3XD2_I2C_ADDR            	0x23
+
+#define SDP3X_CONT_MEAS_AVG_MODE    	0x3615
+#define SDP3X_CONT_MEAS_STOP        	0x3FF9
+
+#define SDP3X_SCALE_PRESSURE_SDP31	60
+#define SDP3X_SCALE_PRESSURE_SDP32	240
+#define SDP3X_SCALE_PRESSURE_SDP33	20
+
+#define CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C             1.225f                  /* kg/m^3               */
+#define CONSTANTS_AIR_GAS_CONST                         287.1f                  /* J/(kg * K)           */
+#define CONSTANTS_ABSOLUTE_NULL_CELSIUS                 -273.15f                /* °C                   */
+
+extern const AP_HAL::HAL &hal;
+
+AP_Airspeed_SDP3X::AP_Airspeed_SDP3X(AP_Airspeed &_frontend) :
+    AP_Airspeed_Backend(_frontend)
+{
+}
+
+/*
+  send a 16 bit command code
+ */
+bool AP_Airspeed_SDP3X::_send_command(uint16_t cmd)
+{
+    uint8_t b[2] {uint8_t(cmd >> 8), uint8_t(cmd & 0xFF)};
+    return _dev->transfer(b, 2, nullptr, 0);
+}
+
+// probe and initialise the sensor
+bool AP_Airspeed_SDP3X::init()
+{
+    const uint8_t addresses[3] = { SDP3XD0_I2C_ADDR,
+                                   SDP3XD1_I2C_ADDR,
+                                   SDP3XD2_I2C_ADDR
+                                 };
+    bool found = false;
+    bool ret = false;
+
+    for (uint8_t i=0; i<ARRAY_SIZE(addresses) && !found; i++) {
+        _dev = hal.i2c_mgr->get_device(get_bus(), addresses[i]);
+        if (!_dev) {
+            continue;
+        }
+        if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+            continue;
+        }
+
+        // lots of retries during probe
+        _dev->set_retries(10);
+
+        // stop any precending measurements
+        if (!_send_command(SDP3X_CONT_MEAS_STOP)) {
+            _dev->get_semaphore()->give();
+            continue;
+        }
+
+        // start continuous average mode
+        if (!_send_command(SDP3X_CONT_MEAS_AVG_MODE)) {
+            _dev->get_semaphore()->give();
+            continue;
+        }
+
+        hal.scheduler->delay_microseconds(20000);
+
+        // step 3 - get scale
+        uint8_t val[9];
+        ret = _dev->transfer(nullptr, 0, &val[0], sizeof(val));
+        if (!ret) {
+            _dev->get_semaphore()->give();
+            continue;
+        }
+
+        // Check the CRC
+        if (!_crc(&val[0], 2, val[2]) || !_crc(&val[3], 2, val[5]) || !_crc(&val[6], 2, val[8])) {
+            _dev->get_semaphore()->give();
+            continue;
+        }
+
+        _scale = (((uint16_t)val[6]) << 8) | val[7];
+
+        _dev->get_semaphore()->give();
+
+        found = true;
+
+        char c = 'X';
+        switch (_scale) {
+        case SDP3X_SCALE_PRESSURE_SDP31:
+            c = '1';
+            break;
+        case SDP3X_SCALE_PRESSURE_SDP32:
+            c = '2';
+            break;
+        case SDP3X_SCALE_PRESSURE_SDP33:
+            c = '3';
+            break;
+        }
+        hal.console->printf("SDP3%c: Found on bus %u address 0x%02x scale=%u\n",
+                            c, get_bus(), addresses[i], _scale);
+    }
+
+    if (!found) {
+        return false;
+    }
+
+    /*
+      this sensor uses zero offset and skips cal
+     */
+    set_allow_zero_offset();
+    set_skip_cal();
+    set_offset(0);
+    
+    // drop to 2 retries for runtime
+    _dev->set_retries(2);
+
+    _dev->register_periodic_callback(20000,
+                                     FUNCTOR_BIND_MEMBER(&AP_Airspeed_SDP3X::_timer, void));
+    return true;
+}
+
+// read the values from the sensor. Called at 50Hz
+void AP_Airspeed_SDP3X::_timer()
+{
+    // read 6 bytes from the sensor
+    uint8_t val[6];
+    int ret = _dev->transfer(nullptr, 0, &val[0], sizeof(val));
+    uint32_t now = AP_HAL::millis();
+    if (!ret) {
+        if (now - _last_sample_time_ms > 200) {
+            // try and re-connect
+            _send_command(SDP3X_CONT_MEAS_AVG_MODE);
+        }
+        return;
+    }
+    // Check the CRC
+    if (!_crc(&val[0], 2, val[2]) || !_crc(&val[3], 2, val[5])) {
+        return;
+    }
+
+    int16_t P = (((int16_t)val[0]) << 8) | val[1];
+    int16_t temp = (((int16_t)val[3]) << 8) | val[4];
+
+    float P_float = (float)P;
+    float temp_float = (float)temp;
+
+    float scale_float = (float)_scale;
+
+    float diff_press_pa = P_float / scale_float;
+    float temperature = temp_float / (float)SDP3X_SCALE_TEMPERATURE;
+
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        _press_sum += diff_press_pa;
+        _temp_sum += temperature;
+        _press_count++;
+        _temp_count++;
+        _last_sample_time_ms = now;
+        sem->give();
+    }
+}
+
+/*
+  correct pressure for barometric height
+  With thanks to:
+   https://github.com/PX4/Firmware/blob/master/Tools/models/sdp3x_pitot_model.py
+ */
+float AP_Airspeed_SDP3X::_correct_pressure(float press)
+{
+    const float tube_len = 0.2;
+    float temperature;
+    AP_Baro *baro = AP_Baro::get_instance();
+
+    if (baro == nullptr) {
+        return press;
+    }
+
+    // fix for tube order
+    AP_Airspeed::pitot_tube_order tube_order = get_tube_order();
+    switch (tube_order) {
+    case AP_Airspeed::PITOT_TUBE_ORDER_NEGATIVE:
+        press = -press;
+    //FALLTHROUGH;
+    case AP_Airspeed::PITOT_TUBE_ORDER_POSITIVE:
+        break;
+    case AP_Airspeed::PITOT_TUBE_ORDER_AUTO:
+    default:
+        press = fabsf(press);
+        break;
+    }
+    if (press <= 0) {
+        return 0;
+    }
+
+    get_temperature(temperature);
+    float rho_air = baro->get_pressure() / (CONSTANTS_AIR_GAS_CONST * (temperature - CONSTANTS_ABSOLUTE_NULL_CELSIUS));
+
+    // flow through sensor
+    float flow_SDP3X = (300.805f - 300.878f / (0.00344205f * (float)powf(press, 0.68698f) + 1)) * 1.29f / rho_air;
+    if (flow_SDP3X < 0.0f) {
+        flow_SDP3X = 0.0f;
+    }
+
+    // diffential pressure through pitot tube
+    float dp_pitot = 28557670.0f - 28557670.0f / (1 + (float)powf((flow_SDP3X / 5027611.0f), 1.227924f));
+
+    // pressure drop through tube
+    float dp_tube = flow_SDP3X * 0.000746124f * tube_len * rho_air;
+
+    // uncorrected pressure
+    float press_uncorrected = (press + dp_tube + dp_pitot) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C;
+
+    // correction for speed at pitot-tube tip due to flow through sensor
+    float dv = 0.0331582 * flow_SDP3X;
+
+    // airspeed ratio
+    float ratio = get_airspeed_ratio();
+
+    // calculate equivalent pressure correction
+    float press_correction = sq(sqrtf(press_uncorrected*ratio)+dv)/ratio - press_uncorrected;
+
+    return press_uncorrected + press_correction;
+}
+
+// return the current differential_pressure in Pascal
+bool AP_Airspeed_SDP3X::get_differential_pressure(float &pressure)
+{
+    uint32_t now = AP_HAL::millis();
+    if (now - _last_sample_time_ms > 100) {
+        return false;
+    }
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        if (_press_count > 0) {
+            _press = _press_sum / _press_count;
+            _press_count = 0;
+            _press_sum = 0;
+        }
+        sem->give();
+    }
+    pressure = _correct_pressure(_press);
+    return true;
+}
+
+// return the current temperature in degrees C, if available
+bool AP_Airspeed_SDP3X::get_temperature(float &temperature)
+{
+    if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
+        return false;
+    }
+    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        if (_temp_count > 0) {
+            _temp = _temp_sum / _temp_count;
+            _temp_count = 0;
+            _temp_sum = 0;
+        }
+        sem->give();
+    }
+    temperature = _temp;
+    return true;
+}
+
+/*
+  check CRC for a set of bytes
+ */
+bool AP_Airspeed_SDP3X::_crc(const uint8_t data[], unsigned size, uint8_t checksum)
+{
+    uint8_t crc_value = 0xff;
+
+    // calculate 8-bit checksum with polynomial 0x31 (x^8 + x^5 + x^4 + 1)
+    for (uint8_t i = 0; i < size; i++) {
+        crc_value ^= data[i];
+        for (uint8_t bit = 8; bit > 0; --bit) {
+            if (crc_value & 0x80) {
+                crc_value = (crc_value << 1) ^ 0x31;
+            } else {
+                crc_value = (crc_value << 1);
+            }
+        }
+    }
+    // verify checksum
+    return (crc_value == checksum);
+}

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
@@ -34,7 +34,7 @@
 class AP_Airspeed_SDP3X : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_SDP3X(AP_Airspeed &frontend);
+    AP_Airspeed_SDP3X(AP_Airspeed &frontend, uint8_t _instance);
     ~AP_Airspeed_SDP3X(void) {}
 
     // probe and initialise the sensor
@@ -47,11 +47,8 @@ public:
     bool get_temperature(float &temperature) override;
 
 private:
-    void _collect();
     void _timer();
     bool _send_command(uint16_t cmd);
-    float _get_pressure(int16_t dp_raw) const;
-    float _get_temperature(int16_t dT_raw) const;
     bool _crc(const uint8_t data[], unsigned size, uint8_t checksum);
     float _correct_pressure(float press);
 

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
@@ -1,0 +1,70 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/*
+  backend driver for airspeed from I2C
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_HAL/utility/OwnPtr.h>
+#include <AP_HAL/I2CDevice.h>
+#include <utility>
+
+#include "AP_Airspeed_Backend.h"
+#include "AP_Airspeed.h"
+
+/*
+ * Thanks to PX4 for registers definitions
+ */
+
+class AP_Airspeed_SDP3X : public AP_Airspeed_Backend
+{
+public:
+    AP_Airspeed_SDP3X(AP_Airspeed &frontend);
+    ~AP_Airspeed_SDP3X(void) {}
+
+    // probe and initialise the sensor
+    bool init() override;
+
+    // return the current differential_pressure in Pascal
+    bool get_differential_pressure(float &pressure) override;
+
+    // return the current temperature in degrees C, if available
+    bool get_temperature(float &temperature) override;
+
+private:
+    void _collect();
+    void _timer();
+    bool _send_command(uint16_t cmd);
+    float _get_pressure(int16_t dp_raw) const;
+    float _get_temperature(int16_t dT_raw) const;
+    bool _crc(const uint8_t data[], unsigned size, uint8_t checksum);
+    float _correct_pressure(float press);
+
+    float _temp;
+    float _press;
+    float _temperature;
+    float _pressure;
+    uint16_t _temp_count;
+    uint16_t _press_count;
+    float _temp_sum;
+    float _press_sum;
+    uint32_t _last_sample_time_ms;
+    uint16_t _scale;
+
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+};

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
@@ -27,8 +27,8 @@ extern const AP_HAL::HAL &hal;
 // scaling for 3DR analog airspeed sensor
 #define VOLTS_TO_PASCAL 819
 
-AP_Airspeed_Analog::AP_Airspeed_Analog(AP_Airspeed &_frontend) :
-    AP_Airspeed_Backend(_frontend)
+AP_Airspeed_Analog::AP_Airspeed_Analog(AP_Airspeed &_frontend, uint8_t _instance) :
+    AP_Airspeed_Backend(_frontend, _instance)
 {
     _source = hal.analogin->channel(get_pin());
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.h
@@ -8,7 +8,7 @@
 class AP_Airspeed_Analog : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_Analog(AP_Airspeed &frontend);
+    AP_Airspeed_Analog(AP_Airspeed &frontend, uint8_t _instance);
 
     // probe and initialise the sensor
     bool init(void) override;

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -110,9 +110,9 @@ float Airspeed_Calibration::update(float airspeed, const Vector3f &vg, int16_t m
 /*
   called once a second to do calibration update
  */
-void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal)
+void AP_Airspeed::update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal)
 {
-    if (!_autocal) {
+    if (!param[i].autocal) {
         // auto-calibration not enabled
         return;
     }
@@ -120,15 +120,15 @@ void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspe
     // set state.z based on current ratio, this allows the operator to
     // override the current ratio in flight with autocal, which is
     // very useful both for testing and to force a reasonable value.
-    float ratio = constrain_float(_ratio, 1.0f, 4.0f);
+    float ratio = constrain_float(param[i].ratio, 1.0f, 4.0f);
 
-    _calibration.state.z = 1.0f / sqrtf(ratio);
+    state[i].calibration.state.z = 1.0f / sqrtf(ratio);
 
     // calculate true airspeed, assuming a airspeed ratio of 1.0
     float dpress = MAX(get_differential_pressure(), 0);
-    float true_airspeed = sqrtf(dpress) * _EAS2TAS;
+    float true_airspeed = sqrtf(dpress) * state[i].EAS2TAS;
 
-    float zratio = _calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
+    float zratio = state[i].calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
 
     if (isnan(zratio) || isinf(zratio)) {
         return;
@@ -136,16 +136,26 @@ void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspe
 
     // this constrains the resulting ratio to between 1.0 and 4.0
     zratio = constrain_float(zratio, 0.5f, 1.0f);
-    _ratio.set(1/sq(zratio));
-    if (_counter > 60) {
-        if (_last_saved_ratio > 1.05f*_ratio ||
-            _last_saved_ratio < 0.95f*_ratio) {
-            _ratio.save();
-            _last_saved_ratio = _ratio;
-            _counter = 0;
+    param[i].ratio.set(1/sq(zratio));
+    if (state[i].counter > 60) {
+        if (state[i].last_saved_ratio > 1.05f*param[i].ratio ||
+            state[i].last_saved_ratio < 0.95f*param[i].ratio) {
+            param[i].ratio.save();
+            state[i].last_saved_ratio = param[i].ratio;
+            state[i].counter = 0;
         }
     } else {
-        _counter++;
+        state[i].counter++;
+    }
+}
+
+/*
+  called once a second to do calibration update
+ */
+void AP_Airspeed::update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal)
+{
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        update_calibration(i, vground, max_airspeed_allowed_during_cal);
     }
 }
 
@@ -156,13 +166,13 @@ void AP_Airspeed::log_mavlink_send(mavlink_channel_t chan, const Vector3f &vgrou
                                       vground.x,
                                       vground.y,
                                       vground.z,
-                                      get_differential_pressure(),
-                                      _EAS2TAS,
-                                      _ratio.get(),
-                                      _calibration.state.x,
-                                      _calibration.state.y,
-                                      _calibration.state.z,
-                                      _calibration.P.a.x,
-                                      _calibration.P.b.y,
-                                      _calibration.P.c.z);
+                                      get_differential_pressure(primary),
+                                      state[primary].EAS2TAS,
+                                      param[primary].ratio.get(),
+                                      state[primary].calibration.state.x,
+                                      state[primary].calibration.state.y,
+                                      state[primary].calibration.state.z,
+                                      state[primary].calibration.P.a.x,
+                                      state[primary].calibration.P.b.y,
+                                      state[primary].calibration.P.c.z);
 }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -136,11 +136,13 @@ bool AP_Arming::airspeed_checks(bool report)
             // not an airspeed capable vehicle
             return true;
         }
-        if (airspeed->enabled() && airspeed->use() && !airspeed->healthy()) {
-            if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Airspeed not healthy");
+        for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+            if (airspeed->enabled(i) && airspeed->use(i) && !airspeed->healthy(i)) {
+                if (report) {
+                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Airspeed[%u] not healthy", i);
+                }
+                return false;
             }
-            return false;
         }
     }
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -141,11 +141,16 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     AP_GROUPEND
 };
 
+// singleton instance
+AP_Baro *AP_Baro::_instance;
+
 /*
   AP_Baro constructor
  */
 AP_Baro::AP_Baro()
 {
+    _instance = this;
+    
     AP_Param::setup_object_defaults(this, var_info);
 }
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -45,11 +45,6 @@
 #include "AP_Baro_UAVCAN.h"
 #endif
 
-#define C_TO_KELVIN 273.15f
-// Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
-#define ISA_GAS_CONSTANT 287.26f
-#define ISA_LAPSE_RATE 0.0065f
-
 #define INTERNAL_TEMPERATURE_CLAMP 35.0f
 
 
@@ -288,7 +283,7 @@ float AP_Baro::get_EAS2TAS(void)
     // provides a more consistent reading then trying to estimate a complete
     // ISA model atmosphere
     float tempK = get_ground_temperature() + C_TO_KELVIN - ISA_LAPSE_RATE * altitude;
-    _EAS2TAS = safe_sqrt(1.225f / ((float)get_pressure() / (ISA_GAS_CONSTANT * tempK)));
+    _EAS2TAS = safe_sqrt(AIR_DENSITY_SEA_LEVEL / ((float)get_pressure() / (ISA_GAS_CONSTANT * tempK)));
     _last_altitude_EAS2TAS = altitude;
     return _EAS2TAS;
 }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -30,6 +30,11 @@ public:
     AP_Baro(const AP_Baro &other) = delete;
     AP_Baro &operator=(const AP_Baro&) = delete;
 
+    // get singleton
+    static AP_Baro *get_instance(void) {
+        return _instance;
+    }
+
     // barometer types
     typedef enum {
         BARO_TYPE_AIR,
@@ -164,6 +169,9 @@ public:
     void set_pressure_correction(uint8_t instance, float p_correction);
 
 private:
+    // singleton
+    static AP_Baro *_instance;
+    
     // how many drivers do we have?
     uint8_t _num_drivers;
     AP_Baro_Backend *drivers[BARO_MAX_DRIVERS];

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -67,6 +67,15 @@ static const double WGS84_B = (WGS84_A * (1 - WGS84_F));
 // Eccentricity of the Earth
 static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 
+// air density at 15C at sea level in kg/m^3
+#define AIR_DENSITY_SEA_LEVEL    1.225f
+
+#define C_TO_KELVIN 273.15f
+
+// Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
+#define ISA_GAS_CONSTANT 287.26f
+#define ISA_LAPSE_RATE 0.0065f
+
 /*
   use AP_ prefix to prevent conflict with OS headers, such as NuttX
   clock.h

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1721,7 +1721,9 @@ void DataFlash_Class::Log_Write_Airspeed(AP_Airspeed &airspeed)
             temperature   : (int16_t)(temperature * 100.0f),
             rawpressure   : airspeed.get_corrected_pressure(i),
             offset        : airspeed.get_offset(i),
-            use           : airspeed.use(i)
+            use           : airspeed.use(i),
+            healthy       : airspeed.healthy(i),
+            primary       : airspeed.get_primary()
         };
         WriteBlock(&pkt, sizeof(pkt));
     }

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1704,21 +1704,27 @@ void DataFlash_Class::Log_Write_ESC(void)
 // Write a AIRSPEED packet
 void DataFlash_Class::Log_Write_Airspeed(AP_Airspeed &airspeed)
 {
-    float temperature;
-    if (!airspeed.get_temperature(temperature)) {
-        temperature = 0;
+    uint64_t now = AP_HAL::micros64();
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        if (!airspeed.enabled(i)) {
+            continue;
+        }
+        float temperature;
+        if (!airspeed.get_temperature(i, temperature)) {
+            temperature = 0;
+        }
+        struct log_AIRSPEED pkt = {
+            LOG_PACKET_HEADER_INIT(i==0?LOG_ARSP_MSG:LOG_ASP2_MSG),
+            time_us       : now,
+            airspeed      : airspeed.get_raw_airspeed(i),
+            diffpressure  : airspeed.get_differential_pressure(i),
+            temperature   : (int16_t)(temperature * 100.0f),
+            rawpressure   : airspeed.get_corrected_pressure(i),
+            offset        : airspeed.get_offset(i),
+            use           : airspeed.use(i)
+        };
+        WriteBlock(&pkt, sizeof(pkt));
     }
-    struct log_AIRSPEED pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_ARSP_MSG),
-        time_us       : AP_HAL::micros64(),
-        airspeed      : airspeed.get_raw_airspeed(),
-        diffpressure  : airspeed.get_differential_pressure(),
-        temperature   : (int16_t)(temperature * 100.0f),
-        rawpressure   : airspeed.get_corrected_pressure(),
-        offset        : airspeed.get_offset(),
-        use           : airspeed.use()
-    };
-    WriteBlock(&pkt, sizeof(pkt));
 }
 
 // Write a Yaw PID packet

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -1188,6 +1188,8 @@ Format characters in the format string for binary log messages
             "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
     { LOG_ARSP_MSG, sizeof(log_AIRSPEED), \
       "ARSP",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U", "snPOPP-", "F00B00-" }, \
+    { LOG_ASP2_MSG, sizeof(log_AIRSPEED), \
+      "ASP2",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U", "snPOPP-", "F00B00-" }, \
     { LOG_CURRENT_MSG, sizeof(log_Current), \
       "BAT", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS },  \
     { LOG_CURRENT2_MSG, sizeof(log_Current), \
@@ -1517,6 +1519,7 @@ enum LogMessages {
     LOG_SRTL_MSG,
     LOG_ISBH_MSG,
     LOG_ISBD_MSG,
+    LOG_ASP2_MSG,
 
 };
 

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -828,6 +828,8 @@ struct PACKED log_AIRSPEED {
     float   rawpressure;
     float   offset;
     bool    use;
+    bool    healthy;
+    uint8_t primary;
 };
 
 struct PACKED log_ACCEL {
@@ -1116,6 +1118,11 @@ struct PACKED log_DSTL {
 #define CURR_CELL_UNITS  "svvvvvvvvvvv"
 #define CURR_CELL_MULTS  "F00000000000"
 
+#define ARSP_LABELS "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U,Health,Primary"
+#define ARSP_FMT "QffcffBBB"
+#define ARSP_UNITS "snPOPP---"
+#define ARSP_MULTS "F00B00---"
+
 /*
 Format characters in the format string for binary log messages
   a   : int16_t[32]
@@ -1186,10 +1193,8 @@ Format characters in the format string for binary log messages
       "CAM", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
     { LOG_TRIGGER_MSG, sizeof(log_Camera), \
             "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
-    { LOG_ARSP_MSG, sizeof(log_AIRSPEED), \
-      "ARSP",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U", "snPOPP-", "F00B00-" }, \
-    { LOG_ASP2_MSG, sizeof(log_AIRSPEED), \
-      "ASP2",  "QffcffB",  "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U", "snPOPP-", "F00B00-" }, \
+    { LOG_ARSP_MSG, sizeof(log_AIRSPEED), "ARSP",  ARSP_FMT, ARSP_LABELS, ARSP_UNITS, ARSP_MULTS }, \
+    { LOG_ASP2_MSG, sizeof(log_AIRSPEED), "ASP2",  ARSP_FMT, ARSP_LABELS, ARSP_UNITS, ARSP_MULTS }, \
     { LOG_CURRENT_MSG, sizeof(log_Current), \
       "BAT", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS },  \
     { LOG_CURRENT2_MSG, sizeof(log_Current), \


### PR DESCRIPTION
This adds support for the new drotek SDP33 sensor:
https://drotek.com/en/differential-pressure-sensors-sdp3x/
and also adds support for flying with dual airspeed sensors. The failover for two sensors is very simplistic, it uses ARSP_PRIMARY if it is healthy, otherwise the first healthy sensor
This has only been bench tested so far. I setup a SDP33 and a MS5525 on a t-piece so they used a common pitot tube, and found the two readings are quite close.
