### PR TITLE
Bug Fix for SITL with No Mavproxy

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -296,7 +296,8 @@ def find_root_dir():
 
 def wait_unlimited():
     """Wait until signal received"""
-    time.sleep(987654321987654321)
+    while True:
+        time.sleep(1)
 
 
 vinfo = vehicleinfo.VehicleInfo()


### PR DESCRIPTION
sim_vehicle.py would crash if the --no-mavproxy option was specified. Did a little digging and found that hardcoded integers are bad. This should do the same thing functionality-wise but with way less crashing.