### PR TITLE
Rover: Fix pivot turns in auto mode

### DIFF
--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -6,7 +6,7 @@
 bool Rover::use_pivot_steering(float yaw_error_cd)
 {
     // check cases where we clearly cannot use pivot steering
-    if (control_mode->is_autopilot_mode() || !g2.motors.have_skid_steering() || g.pivot_turn_angle <= 0) {
+    if (!g2.motors.have_skid_steering() || g.pivot_turn_angle <= 0) {
         pivot_steering_active = false;
         return false;
     }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -228,6 +228,6 @@ void Mode::calc_nav_steer(bool reversed)
     lateral_acceleration = constrain_float(lateral_acceleration, -g.turn_max_g * GRAVITY_MSS, g.turn_max_g * GRAVITY_MSS);
 
     // send final steering command to motor library
-    float steering_out = attitude_control.get_steering_out_lat_accel(lateral_acceleration, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right);
+    float steering_out = attitude_control.get_steering_out_lat_accel(lateral_acceleration, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
 }

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -65,7 +65,7 @@ void ModeAuto::update()
             if (!_reached_heading) {
                 // run steering and throttle controllers
                 const float yaw_error = wrap_PI(radians((_desired_yaw_cd - ahrs.yaw_sensor) * 0.01f));
-                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right);
+                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true);
                 // check if we have reached target

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -50,7 +50,7 @@ void ModeGuided::update()
             if (have_attitude_target) {
                 // run steering and throttle controllers
                 const float yaw_error = wrap_PI(radians((_desired_yaw_cd - ahrs.yaw_sensor) * 0.01f));
-                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right);
+                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true);
             } else {
@@ -69,7 +69,7 @@ void ModeGuided::update()
             }
             if (have_attitude_target) {
                 // run steering and throttle controllers
-                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right);
+                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true);
             } else {

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -131,7 +131,7 @@ AR_AttitudeControl::AR_AttitudeControl(AP_AHRS &ahrs) :
 
 // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
 // positive lateral acceleration is to the right.
-float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right)
+float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // get speed forward
     float speed;
@@ -141,32 +141,37 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool s
         return 0.0f;
     }
 
+    // only use positive speed. Use reverse flag instead of negative speeds.
+    speed = fabsf(speed);
+
     // enforce minimum speed to stop oscillations when first starting to move
-    if (fabsf(speed) < AR_ATTCONTROL_STEER_SPEED_MIN) {
-        if (is_negative(speed)) {
-            speed = -AR_ATTCONTROL_STEER_SPEED_MIN;
-        } else {
-            speed = AR_ATTCONTROL_STEER_SPEED_MIN;
-        }
+    if (speed < AR_ATTCONTROL_STEER_SPEED_MIN) {
+        speed = AR_ATTCONTROL_STEER_SPEED_MIN;
     }
 
     // Calculate the desired steering rate given desired_accel and speed
     float desired_rate = desired_accel / speed;
-    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right);
+
+    // invert rate if we are going backwards
+    if (reversed) {
+        desired_rate *= -1.0f;
+    }
+
+    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
 }
 
 // return a steering servo output from -1 to +1 given a yaw error in radians
-float AR_AttitudeControl::get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right)
+float AR_AttitudeControl::get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
     float desired_rate = _steer_angle_p.get_p(angle_err);
 
-    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right);
+    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
 }
 
 // return a steering servo output from -1 to +1 given a
 // desired yaw rate in radians/sec. Positive yaw is to the right.
-float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right)
+float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // calculate dt
     uint32_t now = AP_HAL::millis();
@@ -187,15 +192,14 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_st
         return 0.0f;
     }
 
+    // only use positive speed. Use reverse flag instead of negative speeds.
+    speed = fabsf(speed);
+
     // enforce minimum speed to stop oscillations when first starting to move
     bool low_speed = false;
-    if (fabsf(speed) < AR_ATTCONTROL_STEER_SPEED_MIN) {
+    if (speed < AR_ATTCONTROL_STEER_SPEED_MIN) {
         low_speed = true;
-        if (is_negative(speed)) {
-            speed = -AR_ATTCONTROL_STEER_SPEED_MIN;
-        } else {
-            speed = AR_ATTCONTROL_STEER_SPEED_MIN;
-        }
+        speed = AR_ATTCONTROL_STEER_SPEED_MIN;
     }
 
     // scaler to linearize output because turn rate increases as vehicle speed increases on non-skid steering vehicles
@@ -208,7 +212,7 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_st
     // We do this in earth frame to allow for rover leaning over in hard corners
     float yaw_rate_earth = _ahrs.get_yaw_rate_earth();
     // check if reversing
-    if (is_negative(speed)) {
+    if (reversed) {
         yaw_rate_earth *= -1.0f;
     }
     float rate_error = (desired_rate - yaw_rate_earth) * scaler;

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -41,14 +41,14 @@ public:
 
     // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
     // positive lateral acceleration is to the right.
-	float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right);
+	float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reverse);
 
     // return a steering servo output from -1 to +1 given a yaw error in radians
-    float get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right);
+    float get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
 	// return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.
-	float get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right);
+	float get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reverse);
 
 	//
 	// throttle / speed controller


### PR DESCRIPTION
This pull-request enables pivot turns (turning on the spot) in auto mode and introduces an explicit `reversed` flag to decide if steering needs to be inverted.

AR_AttitudeControl uses the measured speed (GPS speed) to detect if the rover is currently reversing. If it is reversing the steering is inverted. But during a pivot turn, the speed is close to zero. Noise in the speed measurements can cause the speed to be a small but negative value, which will invert the steering.

See https://discuss.ardupilot.org/t/pivot-turn-with-skid-steer-enabled

I tested it in SITL and on a real rover and it works fine as far as I can tell.


