### PR TITLE
Copter:TradHeli - Default ACCEL_Z_P

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -71,6 +71,7 @@
   # define WP_YAW_BEHAVIOR_DEFAULT              WP_YAW_BEHAVIOR_LOOK_AHEAD
   # define THR_MIN_DEFAULT                      0
   # define AUTOTUNE_ENABLED                     DISABLED
+  # define ACCEL_Z_P                            0.30f
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
change default ACCEL_Z_P to 0.3 for traditional helicopters to prevent collective pitch oscillation in altitude controlled flight modes
Change Type: enhancement - partially resolves issue #2974
merged with Copter master #7127