### PR TITLE
WIP: simple example of adding vendor-specific UAVCAN datatype

### DIFF
--- a/Tools/ardupilotwaf/uavcangen.py
+++ b/Tools/ardupilotwaf/uavcangen.py
@@ -21,7 +21,9 @@ class uavcangen(Task.Task):
         out = self.env.get_flat('OUTPUT_DIR')
         src = self.env.get_flat('SRC')
         dsdlc = self.env.get_flat("DSDL_COMPILER")
-        input_dir = os.path.dirname(self.inputs[0].abspath())
+        dir = os.path.dirname(self.inputs[0].abspath())
+        root_dir = dir.rfind('uavcan')
+        input_dir = dir[0:root_dir+6]
         ret = self.exec_command('{} {} {} -O{}'.format(
                                 python, dsdlc, input_dir, out))
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -94,6 +94,17 @@ public:
     uint8_t register_mag_listener_to_node(AP_Compass_Backend* new_listener, uint8_t node);
     void update_mag_state(uint8_t node);
 
+    struct Example_Data {
+        float value;
+        uint8_t error_flags;
+    };
+
+    uint8_t register_example_listener_to_id(AP_Example_Backend* new_listener, uint8_t id);
+    void remove_example_listener(AP_BattMonitor_Backend* rem_listener);
+    uint8_t find_smallest_free_example_id();
+    GenericBatteryInfo_Data* getptrto_example_data(uint8_t id);
+    void update_example_data(uint8_t id);
+
     // synchronization for RC output
     bool rc_out_sem_take();
     void rc_out_sem_give();
@@ -125,6 +136,13 @@ private:
     Mag_Info _mag_node_state[AP_UAVCAN_MAX_MAG_NODES];
     uint8_t _mag_listener_to_node[AP_UAVCAN_MAX_LISTENERS];
     AP_Compass_Backend* _mag_listeners[AP_UAVCAN_MAX_LISTENERS];
+
+    // ------------------------- EXAMPLE
+    uint8_t _example_nodes[AP_UAVCAN_MAX_EXAMPLE_NODES];
+    uint8_t _example_node_taken[AP_UAVCAN_MAX_EXAMPLE_NODES];
+    Example_Info _example_node_state[AP_UAVCAN_MAX_EXAMPLE_NODES];
+    uint8_t _example_listener_to_node[AP_UAVCAN_MAX_LISTENERS];
+    AP_Example_Backend* _example_listeners[AP_UAVCAN_MAX_LISTENERS];
 
     struct {
         uint16_t pulse;

--- a/libraries/AP_UAVCAN/dsdl/ap_uavcan/20000.Example.uavcan
+++ b/libraries/AP_UAVCAN/dsdl/ap_uavcan/20000.Example.uavcan
@@ -1,0 +1,9 @@
+#
+# Generic device example
+#
+
+uint16 device_id
+
+float16 value
+
+uint8 error_flags

--- a/wscript
+++ b/wscript
@@ -271,11 +271,24 @@ def _build_dynamic_sources(bld):
     if bld.get_board().with_uavcan:
         bld(
             features='uavcangen',
+            # standard uavcan datatypes
             source=bld.srcnode.ant_glob('modules/uavcan/dsdl/uavcan/**/*.uavcan'),
             output_dir='modules/uavcan/libuavcan/include/dsdlc_generated',
             name='uavcan',
             export_includes=[
                 bld.bldnode.make_node('modules/uavcan/libuavcan/include/dsdlc_generated').abspath(),
+                bld.bldnode.make_node('libraries/AP_UAVCAN/include/dsdlc_generated').abspath(),
+            ]
+        )
+        bld(
+            features='uavcangen',
+            # vendor-specific datatypes
+            source=bld.srcnode.ant_glob('libraries/AP_UAVCAN/dsdl/ap_uavcan/**/*.uavcan'),
+            output_dir='libraries/AP_UAVCAN/include/dsdlc_generated',
+            name='uavcan',
+            export_includes=[
+                bld.bldnode.make_node('modules/uavcan/libuavcan/include/dsdlc_generated').abspath(),
+                bld.bldnode.make_node('libraries/AP_UAVCAN/include/dsdlc_generated').abspath(),
             ]
         )
 


### PR DESCRIPTION
@tridge @EShamaev This places a single vendor specific .uavcan file in  AP_UAVCAN/dsdl/ap_uavcan
and the namespace for the resulting datatype is then ap_uavcan::Example

wscript and uavcangen.py are modified to also parse the files in this directory and the resulting header files are written to libraries/AP_UAVCAN/include/dsdlc_generated in the build folder.

Please let me know if there are any obvious problems with these choices, and advise whether writing a new AP_Example_Backend is the best approach for an example, and if so where it should live.