### PR TITLE
AP_HAL_SITL: suppress output until initialization is finished

### DIFF
--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -45,6 +45,7 @@ void RCOutput::disable_ch(uint8_t ch)
 
 void RCOutput::write(uint8_t ch, uint16_t period_us)
 {
+    _sitlState->output_ready = true;
     if (ch < SITL_NUM_CHANNELS && (_enable_mask & (1U<<ch))) {
         if (_corked) {
             _pending[ch] = period_us;

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -323,7 +323,7 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
      * to change */
     uint8_t i;
 
-    if (last_update_usec == 0) {
+    if (last_update_usec == 0 || !output_ready) {
         for (i=0; i<SITL_NUM_CHANNELS; i++) {
             pwm_output[i] = 1000;
         }

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -44,6 +44,7 @@ public:
     ssize_t gps_read(int fd, void *buf, size_t count);
     uint16_t pwm_output[SITL_NUM_CHANNELS];
     uint16_t pwm_input[SITL_RC_INPUT_CHANNELS];
+    bool output_ready = false;
     bool new_rc_input;
     void loop_hook(void);
     uint16_t base_port(void) const {


### PR DESCRIPTION
Taken from https://github.com/ArduPilot/ardupilot/pull/6734

This intend to prevent to update SITL model until SITL instance send the first motors cmd