### PR TITLE
Rover: allow to use slew rate limit on all output

### DIFF
--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -83,9 +83,6 @@ protected:
     // output throttle (-100 ~ +100) to a throttle channel.  Sets relays if required
     void output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle);
 
-    // slew limit throttle for one iteration
-    void slew_limit_throttle(float dt);
-
     // set limits based on steering and throttle input
     void set_limits_from_input(bool armed, float steering, float throttle);
 
@@ -104,6 +101,5 @@ protected:
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500
     float   _throttle;  // requested throttle as a value from -100 to 100
-    float   _last_throttle;
     bool    _use_slew_rate; // true if we should slew limit the throttle for one interation
 };

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -49,7 +49,7 @@ public:
     void output(bool armed, float dt);
 
     // set when to use slew rate limiter
-    void slew_limit_throttle(bool value) { _use_slew_rate = value; }
+    void slew_limit_motors(bool value) { _use_slew_rate = value; }
 
     // test steering or throttle output as a percentage of the total (range -100 to +100)
     // used in response to DO_MOTOR_TEST mavlink command

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -37,7 +37,7 @@ void Rover::set_servos(void)
 {
     // send output signals to motors
     if (motor_test) {
-        g2.motors.slew_limit_throttle(false);
+        g2.motors.slew_limit_motors(false);
         motor_test_output();
     } else {
         g2.motors.output(arming.is_armed() && hal.util->get_soft_armed(), G_Dt);

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -21,7 +21,7 @@ void Mode::exit()
 
 bool Mode::enter()
 {
-    g2.motors.slew_limit_throttle(false);
+    g2.motors.slew_limit_motors(false);
     return _enter();
 }
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -298,6 +298,10 @@ public:
 
     // attributes for mavlink system status reporting
     bool has_manual_input() const override { return true; }
+
+protected:
+
+    bool _enter() override;
 };
 
 class ModeInitializing : public Mode

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -14,7 +14,7 @@ bool ModeAuto::_enter()
 
     // other initialisation
     auto_triggered = false;
-    g2.motors.slew_limit_throttle(true);
+    g2.motors.slew_limit_motors(true);
 
     // initialise reversed to be false
     set_reversed(false);

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -13,7 +13,7 @@ bool ModeGuided::_enter()
     // guided mode never travels in reverse
     rover.set_reverse(false);
 
-    g2.motors.slew_limit_throttle(true);
+    g2.motors.slew_limit_motors(true);
     return true;
 }
 

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -14,7 +14,7 @@ bool ModeRTL::_enter()
     // RTL never reverses
     rover.set_reverse(false);
 
-    g2.motors.slew_limit_throttle(true);
+    g2.motors.slew_limit_motors(true);
     return true;
 }
 

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -3,7 +3,7 @@
 
 bool ModeSteering::_enter()
 {
-    g2.motors.slew_limit_throttle(true);
+    g2.motors.slew_limit_motors(true);
     return true;
 }
 

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -1,6 +1,12 @@
 #include "mode.h"
 #include "Rover.h"
 
+bool ModeSteering::_enter()
+{
+    g2.motors.slew_limit_throttle(true);
+    return true;
+}
+
 void ModeSteering::update()
 {
     // convert pilot throttle input to desired speed (up to twice the cruise speed)


### PR DESCRIPTION
This will allow to prevent instant change on output when motor controllers aren't smart enough to handle it.
It should also, when use, prevent the discontinuity on pivot turn