### PR TITLE
AP_BoardConfig: separation of parameter groups

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -58,19 +58,19 @@ const AP_Param::GroupInfo AP_BoardConfig_CAN::var_info[] = {
 
 #if MAX_NUMBER_OF_CAN_DRIVERS > 0
     // @Group: D1_
-    // @Path: ../AP_BoardConfig/canbus.cpp
+    // @Path: ../AP_BoardConfig/canbus_driver.cpp
     AP_SUBGROUPINFO(_var_info_can_protocol[0], "D1_", 4, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
 #endif
 
 #if MAX_NUMBER_OF_CAN_DRIVERS > 1
     // @Group: D2_
-    // @Path: ../AP_BoardConfig/canbus.cpp
+    // @Path: ../AP_BoardConfig/canbus_driver.cpp
     AP_SUBGROUPINFO(_var_info_can_protocol[1], "D2_", 5, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
 #endif
 
 #if MAX_NUMBER_OF_CAN_DRIVERS > 2
     // @Group: D3_
-    // @Path: ../AP_BoardConfig/canbus.cpp
+    // @Path: ../AP_BoardConfig/canbus_driver.cpp
     AP_SUBGROUPINFO(_var_info_can_protocol[2], "D3_", 6, AP_BoardConfig_CAN, AP_BoardConfig_CAN::CAN_driver_var_info),
 #endif
 

--- a/libraries/AP_BoardConfig/canbus.cpp
+++ b/libraries/AP_BoardConfig/canbus.cpp
@@ -48,19 +48,4 @@ const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_if_var_info::var_info[] = {
     AP_GROUPEND
 };
 
-const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_driver_var_info::var_info[] = {
-    // @Param: PROTOCOL
-    // @DisplayName: Enable use of specific protocol over virtual driver
-    // @Description: Enabling this option starts selected protocol that will use this virtual driver
-    // @Values: 0:Disabled,1:UAVCAN
-    // @User: Advanced
-    // @RebootRequired: True
-    AP_GROUPINFO("PROTOCOL", 1, AP_BoardConfig_CAN::CAN_driver_var_info, _protocol, UAVCAN_PROTOCOL_ENABLE),
-
-    // @Group: UC_
-    // @Path: ../AP_UAVCAN/AP_UAVCAN.cpp
-    AP_SUBGROUPPTR(_uavcan, "UC_", 2, AP_BoardConfig_CAN::CAN_driver_var_info, AP_UAVCAN),
-
-    AP_GROUPEND
-};
 #endif

--- a/libraries/AP_BoardConfig/canbus_driver.cpp
+++ b/libraries/AP_BoardConfig/canbus_driver.cpp
@@ -1,0 +1,40 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include "AP_BoardConfig.h"
+
+#if HAL_WITH_UAVCAN
+#include "AP_BoardConfig_CAN.h"
+#include <AP_UAVCAN/AP_UAVCAN.h>
+
+// table of user settable CAN bus parameters
+const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_driver_var_info::var_info[] = {
+    // @Param: PROTOCOL
+    // @DisplayName: Enable use of specific protocol over virtual driver
+    // @Description: Enabling this option starts selected protocol that will use this virtual driver
+    // @Values: 0:Disabled,1:UAVCAN
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("PROTOCOL", 1, AP_BoardConfig_CAN::CAN_driver_var_info, _protocol, UAVCAN_PROTOCOL_ENABLE),
+
+    // @Group: UC_
+    // @Path: ../AP_UAVCAN/AP_UAVCAN.cpp
+    AP_SUBGROUPPTR(_uavcan, "UC_", 2, AP_BoardConfig_CAN::CAN_driver_var_info, AP_UAVCAN),
+
+    AP_GROUPEND
+};
+#endif


### PR DESCRIPTION
The separation of parameter groups into different files seems to be needed to correctly build the wiki's parameter list.