### PR TITLE
AP_Landing: Support absolute altitude deepstalls

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -87,6 +87,7 @@ private:
     float crosstrack_error; // current crosstrack error
     float predicted_travel_distance; // distance the aircraft is perdicted to travel during deepstall
     bool hold_level; // locks the target yaw rate of the aircraft to 0, serves to hold the aircraft level at all times
+    float approach_alt_offset;     // approach altitude offset
 
     //public AP_Landing interface
     void do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude);


### PR DESCRIPTION
This adds support for deepstall landings being aimed at a lat/lon that doesn't match the home altitude. Because of mission storage reasons using this mode forces the approach altitude and abort altitude to be the same. This has been flight tested.