### PR TITLE
Plane: Only update home when not armed, rather then not soft armed

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -349,9 +349,9 @@ void Plane::one_second_loop()
     }
 #endif
 
-    // update home position if soft armed and gps position has
+    // update home position if armed and gps position has
     // changed. Update every 5s at most
-    if (!hal.util->get_soft_armed() &&
+    if (!arming.is_armed() &&
         gps.last_message_time_ms() - last_home_update_ms > 5000 &&
         gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
             last_home_update_ms = gps.last_message_time_ms();


### PR DESCRIPTION
Plane supports being armed, in takeoff logic and not spinning the motor
until the moment the safety button has been pressed. Unfortunately
because the safety button is required to be pressed for soft arming this
results in the plane updating home position while the user moves the
vehicle or is holding it to throw the vehicle which will can result in
several meters of altitude error from where the user expected home to
be.

Because the normal approach to plane is to have activated the safety
button before arming the aircraft this is not expected to be a behaviour
change for most users, but an improvement for people who use the button
to initiate a takeoff.