### PR TITLE
SBF GPS driver: Use the COG calculated by the GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -285,12 +285,12 @@ AP_GPS_SBF::process_message(void)
 
         state.last_gps_time_ms = AP_HAL::millis();
 
-        // Update COG (don't use −2·10^10)
+        // Update COG (don't use -2�10^10)
         if (temp.COG > -200000) {
             state.ground_course = (float)temp.COG;
          }
 
-        // Update velocity state (don't use −2·10^10)
+        // Update velocity state (don't use -2�10^10)
         if (temp.Vn > -200000) {
             state.velocity.x = (float)(temp.Vn);
             state.velocity.y = (float)(temp.Ve);
@@ -310,7 +310,7 @@ AP_GPS_SBF::process_message(void)
             state.have_vertical_accuracy = true;
         }
 
-        // Update position state (don't use −2·10^10)
+        // Update position state (don't use -2�10^10)
         if (temp.Latitude > -200000) {
             state.location.lat = (int32_t)(temp.Latitude * RAD_TO_DEG_DOUBLE * (double)1e7);
             state.location.lng = (int32_t)(temp.Longitude * RAD_TO_DEG_DOUBLE * (double)1e7);
@@ -379,8 +379,8 @@ AP_GPS_SBF::process_message(void)
     {
         const msg5908 &temp = sbf_msg.data.msg5908u;
 
-        // select the maximum variance, as the EKF will apply it to all the columnds in it's estimate
-        // FIXME: Support returning the covariance matric to the EKF
+        // select the maximum variance, as the EKF will apply it to all the columns in it's estimate
+        // FIXME: Support returning the covariance matrix to the EKF
         float max_variance_squared = MAX(temp.Cov_VnVn, MAX(temp.Cov_VeVe, temp.Cov_VuVu));
         if (is_positive(max_variance_squared)) {
             state.have_speed_accuracy = true;
@@ -433,7 +433,7 @@ bool AP_GPS_SBF::prepare_for_arming(void) {
             gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF disk is not mounted", state.instance + 1);
 
             // simply attempt to mount the disk, no need to check if the command was
-            // ACK/NACK'd as we don't continously attempt to remount the disk
+            // ACK/NACK'd as we don't continuously attempt to remount the disk
             gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: Attempting to mount disk", state.instance + 1);
             mount_disk();
             // reset the flag to indicate if we should be logging

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -285,6 +285,11 @@ AP_GPS_SBF::process_message(void)
 
         state.last_gps_time_ms = AP_HAL::millis();
 
+        // Update COG (don't use −2·10^10)
+        if (temp.COG > -200000) {
+            state.ground_course = (float)temp.COG;
+         }
+
         // Update velocity state (don't use −2·10^10)
         if (temp.Vn > -200000) {
             state.velocity.x = (float)(temp.Vn);
@@ -296,7 +301,6 @@ AP_GPS_SBF::process_message(void)
             float ground_vector_sq = state.velocity[0] * state.velocity[0] + state.velocity[1] * state.velocity[1];
             state.ground_speed = (float)safe_sqrt(ground_vector_sq);
 
-            state.ground_course = wrap_360(degrees(atan2f(state.velocity[1], state.velocity[0])));
             state.rtk_age_ms = temp.MeanCorrAge * 10;
 
             // value is expressed as twice the rms error = int16 * 0.01/2


### PR DESCRIPTION
 Instead of calculating atan with potentialy small noisy velocity vectors, use the one provided by the GPS.
It only gets updated at speeds > 0.1 m/s and it saves us the atan() operation.