### PR TITLE
Update UART_test.cpp

### DIFF
--- a/libraries/AP_HAL/examples/UART_test/UART_test.cpp
+++ b/libraries/AP_HAL/examples/UART_test/UART_test.cpp
@@ -30,7 +30,10 @@ void setup(void)
 {
     /*
       start all UARTs at 57600 with default buffer sizes
-     */
+    */
+
+    hal.scheduler->delay(1000); //Ensure that the uartA can be initialized
+
     setup_uart(hal.uartA, "uartA");  // console
     setup_uart(hal.uartB, "uartB");  // 1st GPS
     setup_uart(hal.uartC, "uartC");  // telemetry 1


### PR DESCRIPTION
For AC3.5 and higher version, the sketches "UART_test" and "Printf", serial uartA-USBconsole cannot work. Maybe the code before "setup" has been changed. This change ensure that the uartA can be initialized.