### PR TITLE
Rover: allow disarming from transmitter on skid-steering vehicles

### DIFF
--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -186,13 +186,22 @@ void Rover::read_aux_switch()
     }
 }
 
+// return true if motors are moving
 bool Rover::motor_active()
 {
-    // Check if armed and output throttle servo is not neutral
-    if (hal.util->get_soft_armed()) {
-        if (!is_zero(g2.motors.get_throttle())) {
-            return true;
-        }
+    // if soft disarmed, motors not active
+    if (!hal.util->get_soft_armed()) {
+        return false;
+    }
+
+    // check throttle is active
+    if (!is_zero(g2.motors.get_throttle())) {
+        return true;
+    }
+
+    // skid-steering vehicles active when steering
+    if (g2.motors.have_skid_steering() && !is_zero(g2.motors.get_steering())) {
+        return true;
     }
 
     return false;

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -77,10 +77,8 @@ void Rover::rudder_arm_disarm_check()
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if (!motor_active() && !g2.motors.have_skid_steering()) {
+    } else if (!motor_active()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
-        // This is disabled for skid steering otherwise when tring to turn a skid steering rover around
-        // the rover would disarm
         if (channel_steer->get_control_in() < -4000) {
             const uint32_t now = millis();
 


### PR DESCRIPTION
This PR allows skid-steering vehicles to be disarmed from the transmitter.  This can be in any mode as long as the safety switch is on (i.e. motors can't move because it's "soft disarmed") or if the vehicle is in HOLD mode.