### PR TITLE
Rover: execute RTL commands from within auto mode

### DIFF
--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -32,6 +32,7 @@ Rover::Rover(void) :
     nav_controller(&L1_controller),
     control_mode(&mode_initializing),
     home(ahrs.get_home()),
-    G_Dt(0.02f)
+    G_Dt(0.02f),
+    mode_auto(mode_rtl)
 {
 }

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -211,7 +211,8 @@ bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
 
 void Rover::do_RTL(void)
 {
-    set_mode(mode_rtl, MODE_REASON_MISSION_COMMAND);
+    // start rtl in auto mode
+    mode_auto.start_RTL();
 }
 
 void Rover::do_nav_wp(const AP_Mission::Mission_Command& cmd, bool stay_active_at_dest)
@@ -307,7 +308,7 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
 bool Rover::verify_RTL()
 {
-    return mode_rtl.reached_destination();
+    return mode_auto.reached_destination();
 }
 
 bool Rover::verify_loiter_unlimited(const AP_Mission::Mission_Command& cmd)

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -6,6 +6,9 @@
 
 #define MODE_NEXT_HEADING_UNKNOWN   99999.0f    // used to indicate to set_desired_location method that next leg's heading is unknown
 
+// pre-define ModeRTL so Auto can appear higher in this file
+class ModeRTL;
+
 class Mode
 {
 public:
@@ -142,6 +145,9 @@ class ModeAuto : public Mode
 {
 public:
 
+    // constructor
+    ModeAuto(ModeRTL& mode_rtl);
+
     uint32_t mode_number() const override { return AUTO; }
 
     // methods that affect movement of the vehicle in this mode
@@ -164,6 +170,9 @@ public:
     void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed) override;
     bool reached_heading();
 
+    // start RTL (within auto)
+    void start_RTL();
+
     // execute the mission in reverse (i.e. backing up)
     void set_reversed(bool value);
 
@@ -174,12 +183,16 @@ protected:
 
     enum AutoSubMode {
         Auto_WP,                // drive to a given location
-        Auto_HeadingAndSpeed    // turn to a given heading
+        Auto_HeadingAndSpeed,   // turn to a given heading
+        Auto_RTL                // perform RTL within auto mode
     } _submode;
 
 private:
 
     bool check_trigger(void);
+
+    // references
+    ModeRTL& _mode_rtl;
 
     // this is set to true when auto has been triggered to start
     bool auto_triggered;

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -1,6 +1,12 @@
 #include "mode.h"
 #include "Rover.h"
 
+// constructor
+ModeAuto::ModeAuto(ModeRTL& mode_rtl) :
+    _mode_rtl(mode_rtl)
+{
+}
+
 bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
@@ -75,6 +81,10 @@ void ModeAuto::update()
             }
             break;
         }
+
+        case Auto_RTL:
+            _mode_rtl.update();
+            break;
     }
 }
 
@@ -93,6 +103,9 @@ bool ModeAuto::reached_destination()
 {
     if (_submode == Auto_WP) {
         return _reached_destination;
+    }
+    if (_submode == Auto_RTL) {
+        return _mode_rtl.reached_destination();
     }
     // we should never reach here but just in case, return true to allow missions to continue
     return true;
@@ -116,6 +129,14 @@ bool ModeAuto::reached_heading()
     }
     // we should never reach here but just in case, return true to allow missions to continue
     return true;
+}
+
+// start RTL (within auto)
+void ModeAuto::start_RTL()
+{
+    if (_mode_rtl.enter()) {
+        _submode = Auto_RTL;
+    }
 }
 
 // execute the mission in reverse (i.e. backing up)


### PR DESCRIPTION
This PR executes the NAV_RETURN_TO_LAUNCH mission command from within auto mode instead of switching to the separate RTL mode.  I prefer this approach because there could be commands after the RTL that should be executed upon reaching home.

I'd appreciate advice from @peterbarker as well because this is the first time we've attempted to access one mode from another since we've moved to the new class structure.