### PR TITLE
add library AP_SBusOut

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -63,6 +63,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Relay',
     'AP_ServoRelayEvents',
     'AP_Volz_Protocol',
+    'AP_SBusOut',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -176,8 +176,8 @@ void AP_BoardConfig::px4_setup_sbus(void)
                 rate = rates[i].rate;
             }
         }
-        if (!hal.rcout->enable_sbus_out(rate)) {
-            hal.console->printf("Failed to enable SBUS out\n");
+        if (!hal.rcout->enable_px4io_sbus_out(rate)) {
+            hal.console->printf("Failed to enable PX4IO SBUS out\n");
         }
     }
 #endif

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AP_HAL_Namespace.h"
+#include <stdint.h>
 
 #define RC_OUTPUT_MIN_PULSEWIDTH 400
 #define RC_OUTPUT_MAX_PULSEWIDTH 2100
@@ -114,9 +115,9 @@ public:
     virtual float    scale_esc_to_unity(uint16_t pwm) { return 0; }
 
     /*
-      enable SBUS out at the given rate
+      enable PX4IO SBUS out at the given rate
      */
-    virtual bool     enable_sbus_out(uint16_t rate_hz) { return false; }
+    virtual bool enable_px4io_sbus_out(uint16_t rate_hz) { return false; }
 
     /*
      * Optional method to control the update of the motors. Derived classes

--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -18,7 +18,7 @@
 #include "utility/print_vprintf.h"
 #include "UARTDriver.h"
 
-/* 
+/*
    BetterStream method implementations
    These are implemented in AP_HAL to ensure consistent behaviour on
    all boards, although they can be overridden by a port

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -45,6 +45,14 @@ public:
     virtual void set_flow_control(enum flow_control flow_control_setting) {};
     virtual enum flow_control get_flow_control(void) { return FLOW_CONTROL_DISABLE; }
 
+    virtual void configure_parity(uint8_t v){};
+    virtual void set_stop_bits(int n){};
+
+    /* unbuffered writes bypass the ringbuffer and go straight to the
+     * file descriptor
+     */
+    virtual bool set_unbuffered_writes(bool on){ return false; };
+
     /* Implementations of BetterStream virtual methods. These are
      * provided by AP_HAL to ensure consistency between ports to
      * different boards

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -574,7 +574,7 @@ void PX4RCOutput::timer_tick(void)
 /*
   enable sbus output
  */
-bool PX4RCOutput::enable_sbus_out(uint16_t rate_hz)
+bool PX4RCOutput::enable_px4io_sbus_out(uint16_t rate_hz)
 {
     int fd = open("/dev/px4io", 0);
     if (fd == -1) {

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -38,7 +38,7 @@ public:
     void set_output_mode(enum output_mode mode) override;
 
     void timer_tick(void) override;
-    bool enable_sbus_out(uint16_t rate_hz) override;
+    bool enable_px4io_sbus_out(uint16_t rate_hz) override;
 
     // set default output update rate
     void set_default_rate(uint16_t rate_hz) override;

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -28,7 +28,8 @@ PX4UARTDriver::PX4UARTDriver(const char *devpath, const char *perf_name) :
     _in_timer(false),
     _perf_uart(perf_alloc(PC_ELAPSED, perf_name)),
     _os_start_auto_space(-1),
-    _flow_control(FLOW_CONTROL_DISABLE)
+    _flow_control(FLOW_CONTROL_DISABLE),
+    _unbuffered_writes(false)
 {
 }
 
@@ -153,6 +154,44 @@ void PX4UARTDriver::set_flow_control(enum flow_control fcontrol)
     _flow_control = fcontrol;
 }
 
+void PX4UARTDriver::configure_parity(uint8_t v) {
+    if (_fd == -1) {
+        return;
+    }
+    struct termios t;
+    tcgetattr(_fd, &t);
+    if (v != 0) {
+        // enable parity
+        t.c_cflag |= PARENB;
+        if (v == 1) {
+            t.c_cflag |= PARODD;
+        } else {
+            t.c_cflag &= ~PARODD;
+        }
+    }
+    else {
+        // disable parity
+        t.c_cflag &= ~PARENB;
+    }
+    tcsetattr(_fd, TCSANOW, &t);
+}
+
+void PX4UARTDriver::set_stop_bits(int n) {
+    if (_fd == -1) {
+        return;
+    }
+    struct termios t;
+    tcgetattr(_fd, &t);
+    if (n > 1) t.c_cflag |= CSTOPB;
+    else t.c_cflag &= ~CSTOPB;
+    tcsetattr(_fd, TCSANOW, &t);
+}
+
+bool PX4UARTDriver::set_unbuffered_writes(bool on) {
+    _unbuffered_writes = on;
+    return _unbuffered_writes;
+}
+
 void PX4UARTDriver::begin(uint32_t b)
 {
 	begin(b, 0, 0);
@@ -256,7 +295,7 @@ int16_t PX4UARTDriver::read()
 }
 
 /*
-   write one byte to the buffer
+   write one byte
  */
 size_t PX4UARTDriver::write(uint8_t c)
 {
@@ -266,6 +305,11 @@ size_t PX4UARTDriver::write(uint8_t c)
     if (!_initialised) {
         try_initialise();
         return 0;
+    }
+
+    if (_unbuffered_writes) {
+        // write one byte to the file descriptor
+        return _write_fd(&c, 1);
     }
 
     while (_writebuf.space() == 0) {
@@ -278,14 +322,14 @@ size_t PX4UARTDriver::write(uint8_t c)
 }
 
 /*
-  write size bytes to the write buffer
+ * write size bytes
  */
 size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
 {
     if (_uart_owner_pid != getpid()){
         return 0;
     }
-	if (!_initialised) {
+    if (!_initialised) {
         try_initialise();
 		return 0;
 	}
@@ -300,6 +344,11 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
             ret++;
         }
         return ret;
+    }
+
+    if (_unbuffered_writes) {
+        // write buffer straight to the file descriptor
+        return _write_fd(buffer, size);
     }
 
     return _writebuf.write(buffer, size);

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -331,8 +331,8 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
     }
     if (!_initialised) {
         try_initialise();
-		return 0;
-	}
+        return 0;
+    }
 
     if (!_nonblocking_writes) {
         /*

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -39,6 +39,10 @@ public:
     void set_flow_control(enum flow_control flow_control);
     enum flow_control get_flow_control(void) { return _flow_control; }
 
+    void configure_parity(uint8_t v);
+    void set_stop_bits(int n);
+    bool set_unbuffered_writes(bool on);
+
 private:
     const char *_devpath;
     int _fd;
@@ -47,6 +51,7 @@ private:
     volatile bool _in_timer;
 
     bool _nonblocking_writes;
+    bool _unbuffered_writes;
 
     // we use in-task ring buffers to reduce the system call cost
     // of ::read() and ::write() in the main loop

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -35,6 +35,7 @@
 #include <netinet/tcp.h>
 #include <sys/select.h>
 #include <termios.h>
+#include <sys/time.h>
 
 #include "UARTDriver.h"
 #include "SITL_State.h"
@@ -152,7 +153,19 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
     if (size <= 0) {
         return 0;
     }
-    _writebuffer.write(buffer, size);
+    if (_unbuffered_writes) {
+        struct timeval tp;
+        gettimeofday(&tp, nullptr);
+        uint64_t time = 1.0e6 * (tp.tv_sec + (tp.tv_usec * 1.0e-6));
+        DataFlash_Class::instance()->Log_Write("SBUS", "TimeUS,ToD", "QQ",
+                                               AP_HAL::micros64(), time);
+        // write buffer straight to the file descriptor
+        ::write(_fd, buffer, size);
+        // these have no effect
+        tcdrain(_fd);
+    } else {
+        _writebuffer.write(buffer, size);
+    }
     return size;
 }
 
@@ -335,9 +348,7 @@ void UARTDriver::_uart_start_connection(void)
     tcsetattr(_fd, TCSANOW, &t);
 
     // set baudrate
-    tcgetattr(_fd, &t);
-    cfsetspeed(&t, _uart_baudrate);
-    tcsetattr(_fd, TCSANOW, &t);
+    set_speed(_uart_baudrate);
 
     _connected = true;
     _use_send_recv = false;
@@ -392,6 +403,20 @@ void UARTDriver::_set_nonblocking(int fd)
 {
     unsigned v = fcntl(fd, F_GETFL, 0);
     fcntl(fd, F_SETFL, v | O_NONBLOCK);
+}
+
+bool UARTDriver::set_unbuffered_writes(bool on) {
+    if (_fd == -1) {
+        return false;
+    }
+    _unbuffered_writes = on;
+
+    // this has no effect
+    unsigned v = fcntl(_fd, F_GETFL, 0);
+    v &= ~O_NONBLOCK;
+    fcntl(_fd, F_SETFL, v | O_DIRECT | O_SYNC);
+
+    return _unbuffered_writes;
 }
 
 void UARTDriver::_check_reconnect(void)

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -57,7 +57,14 @@ public:
     // file descriptor, exposed so SITL_State::loop_hook() can use it
     int _fd;
 
+    bool _unbuffered_writes;
+
     enum flow_control get_flow_control(void) { return FLOW_CONTROL_ENABLE; }
+
+    virtual bool set_speed(int speed);
+    virtual void configure_parity(uint8_t v);
+    virtual void set_stop_bits(int n);
+    bool set_unbuffered_writes(bool on);
 
     void _timer_tick(void);
     

--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_HAL/AP_HAL.h>
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include "UARTDriver.h"
+
+#include <asm/termbits.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+bool HALSITL::UARTDriver::set_speed(int speed)
+{
+    struct termios2 tc;
+
+    if (_fd < 0) {
+        return false;
+    }
+
+    memset(&tc, 0, sizeof(tc));
+    if (ioctl(_fd, TCGETS2, &tc) == -1) {
+        return false;
+    }
+
+    /* speed is configured by c_[io]speed */
+    tc.c_cflag &= ~CBAUD;
+    tc.c_cflag |= BOTHER;
+    tc.c_ispeed = speed;
+    tc.c_ospeed = speed;
+
+    if (ioctl(_fd, TCSETS2, &tc) == -1) {
+        return false;
+    }
+
+    if (ioctl(_fd, TCFLSH, TCIOFLUSH) == -1) {
+        return false;
+    }
+
+    return true;
+}
+
+void HALSITL::UARTDriver::configure_parity(uint8_t v) {
+    if (_fd < 0) {
+        return;
+    }
+    struct termios2 tc;
+
+    memset(&tc, 0, sizeof(tc));
+    if (ioctl(_fd, TCGETS2, &tc) == -1) {
+        return;
+    }
+    if (v != 0) {
+        // enable parity
+        tc.c_cflag |= PARENB;
+        if (v == 1) {
+            tc.c_cflag |= PARODD;
+        } else {
+            tc.c_cflag &= ~PARODD;
+        }
+    }
+    else {
+        // disable parity
+        tc.c_cflag &= ~PARENB;
+    }
+    if (ioctl(_fd, TCSETS2, &tc) == -1) {
+        return;
+    }
+
+    if (ioctl(_fd, TCFLSH, TCIOFLUSH) == -1) {
+        return;
+    }
+}
+
+void HALSITL::UARTDriver::set_stop_bits(int n) {
+    if (_fd < 0) {
+        return;
+    }
+    struct termios2 tc;
+
+    memset(&tc, 0, sizeof(tc));
+    if (ioctl(_fd, TCGETS2, &tc) == -1) {
+        return;
+    }
+    if (n > 1) tc.c_cflag |= CSTOPB;
+    else tc.c_cflag &= ~CSTOPB;
+
+    if (ioctl(_fd, TCSETS2, &tc) == -1) {
+        return;
+    }
+
+    if (ioctl(_fd, TCFLSH, TCIOFLUSH) == -1) {
+        return;
+    }
+}
+
+#endif

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -559,7 +559,7 @@ void VRBRAINRCOutput::_timer_tick(void)
 /*
   enable sbus output
  */
-bool VRBRAINRCOutput::enable_sbus_out(uint16_t rate_hz)
+bool VRBRAINRCOutput::enable_px4io_sbus_out(uint16_t rate_hz)
 {
     int fd = open("/dev/px4io", 0);
     if (fd == -1) {

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.h
@@ -35,7 +35,7 @@ public:
     void set_output_mode(enum output_mode mode) override;
     
     void _timer_tick(void);
-    bool enable_sbus_out(uint16_t rate_hz) override;
+    bool enable_px4io_sbus_out(uint16_t rate_hz) override;
 
 private:
     int _pwm_fd;

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -43,7 +43,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define SBUS_DEBUG 1
+#define SBUS_DEBUG 0
 
 // SBUS1 constant definitions
 // pulse widths measured using FrSky Sbus/PWM converter

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -155,7 +155,7 @@ void AP_SBusOut::init() {
     hal.console->printf("AP_SBusOut: init %d Hz\n", rate);
 #endif
 
-    // subtract 500msec from requested frame interval to allow for latency
+    // subtract 500usec from requested frame interval to allow for latency
     sbus_frame_interval = (1000UL * 1000UL) / rate - 500;
     // at 100,000 bps, a 300 bit sbus frame takes 3msec to transfer
     // require a minimum 700usec interframe gap

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -152,7 +152,7 @@ void AP_SBusOut::init() {
     uint16_t rate = sbus_rate.get();
 
 #if SBUS_DEBUG
-    ::printf("AP_SBusOut: init %d Hz\n", rate);
+    hal.console->printf("AP_SBusOut: init %d Hz\n", rate);
 #endif
 
     // subtract 500msec from requested frame interval to allow for latency

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -1,0 +1,172 @@
+/*
+ * AP_SBusOut.cpp
+ *
+ *  Created on: Aug 19, 2017
+ *      Author: Mark Whitehorn
+ *
+ * method sbus1_out was ported from ardupilot/modules/PX4Firmware/src/lib/rc/sbus.c
+ * which has the following license:
+ *
+ *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "AP_SBusOut.h"
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <SRV_Channel/SRV_Channel.h>
+
+extern const AP_HAL::HAL& hal;
+
+#define SBUS_DEBUG 1
+
+// SBUS1 constant definitions
+// pulse widths measured using FrSky Sbus/PWM converter
+#define SBUS_BSIZE    25
+#define SBUS_CHANNELS 16
+#define SBUS_MIN 880.0f
+#define SBUS_MAX 2156.0f
+#define SBUS_SCALE (2048.0f / (SBUS_MAX - SBUS_MIN))
+
+const AP_Param::GroupInfo AP_SBusOut::var_info[] = {
+    // @Param: SBUS_RATE
+    // @DisplayName: SBUS default output rate
+    // @Description: This sets the SBUS output frame rate in Hz.
+    // @Range: 25 250
+    // @User: Advanced
+    // @Units: Hz
+    AP_GROUPINFO("RATE",  1, AP_SBusOut, sbus_rate, 50),
+
+    AP_GROUPEND
+};
+
+
+// constructor
+AP_SBusOut::AP_SBusOut(void)
+{
+    // set defaults from the parameter table
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+
+/*
+ * build and send sbus1 frame representing first 16 servo channels
+ * input arg is pointer to uart
+ */
+void
+AP_SBusOut::update()
+{
+    if (!initialised) {
+        initialised = true;
+        init();
+    }
+
+    if (sbus1_uart == nullptr) {
+        return;
+    }
+
+    // constrain output rate using sbus_frame_interval
+    static uint32_t last_micros = 0;
+    uint32_t now = AP_HAL::micros();
+    if ((now - last_micros) > sbus_frame_interval) {
+        last_micros = now;
+        uint8_t buffer[SBUS_BSIZE] = { 0x0f };  // first byte is always 0x0f
+        uint8_t index = 1;
+        uint8_t offset = 0;
+        uint16_t value;
+
+        /* construct sbus frame representing channels 1 through 16 (max) */
+        uint8_t nchan = MIN(NUM_SERVO_CHANNELS, SBUS_CHANNELS);
+        for (unsigned i = 0; i < nchan; ++i) {
+            SRV_Channel *ch = SRV_Channels::srv_channel(i);
+            if (ch == nullptr) {
+                continue;
+            }
+            /*protect from out of bounds values and limit to 11 bits*/
+            uint16_t pwmval = MAX(ch->get_output_pwm(), SBUS_MIN);
+            value = (uint16_t)((pwmval - SBUS_MIN) * SBUS_SCALE);
+            if (value > 0x07ff) {
+                value = 0x07ff;
+            }
+
+#if SBUS_DEBUG
+            static uint16_t lastch9 = 0;
+            if ((i==8) && (pwmval != lastch9)) {
+                lastch9 = pwmval;
+                hal.console->printf("channel 9 pwm: %04d\n", pwmval);
+            }
+#endif
+
+            while (offset >= 8) {
+                ++index;
+                offset -= 8;
+            }
+
+            buffer[index] |= (value << (offset)) & 0xff;
+            buffer[index + 1] |= (value >> (8 - offset)) & 0xff;
+            buffer[index + 2] |= (value >> (16 - offset)) & 0xff;
+            offset += 11;
+        }
+
+#if SBUS_DEBUG
+        hal.gpio->pinMode(55, HAL_GPIO_OUTPUT);
+        hal.gpio->write(55, 1);
+#endif
+
+    sbus1_uart->write(buffer, sizeof(buffer));
+
+#if SBUS_DEBUG
+        hal.gpio->pinMode(55, HAL_GPIO_OUTPUT);
+        hal.gpio->write(55, 0);
+#endif
+
+    }
+}
+
+void AP_SBusOut::init() {
+    uint16_t rate = sbus_rate.get();
+
+#if SBUS_DEBUG
+    ::printf("AP_SBusOut: init %d Hz\n", rate);
+#endif
+
+    // subtract 500msec from requested frame interval to allow for latency
+    sbus_frame_interval = (1000UL * 1000UL) / rate - 500;
+    // at 100,000 bps, a 300 bit sbus frame takes 3msec to transfer
+    // require a minimum 700usec interframe gap
+    if (sbus_frame_interval < 3700) {
+        sbus_frame_interval = 3700;
+    }
+
+    AP_SerialManager *serial_manager = AP_SerialManager::get_instance();
+    if (!serial_manager) {
+        return;
+    }
+    sbus1_uart = serial_manager->find_serial(AP_SerialManager::SerialProtocol_Sbus1,0);
+}
+

--- a/libraries/AP_SBusOut/AP_SBusOut.h
+++ b/libraries/AP_SBusOut/AP_SBusOut.h
@@ -1,0 +1,40 @@
+/*
+ * AP_SBusOut.h
+ *
+ *  Created on: Aug 19, 2017
+ *      Author: Mark Whitehorn
+ */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_Param/AP_Param.h>
+
+class AP_SBusOut {
+public:
+    static const struct AP_Param::GroupInfo var_info[];
+
+    static AP_SBusOut create() {
+        return AP_SBusOut{};
+    }
+
+    constexpr AP_SBusOut(AP_SBusOut &&other) = default;
+
+    /* Do not allow copies */
+    AP_SBusOut(const AP_SBusOut &other) = delete;
+    AP_SBusOut &operator=(const AP_SBusOut&) = delete;
+
+    void update();
+
+private:
+    AP_SBusOut();
+    AP_HAL::UARTDriver *sbus1_uart;
+
+    void init(void);
+
+    uint16_t sbus_frame_interval;   // microseconds
+
+    AP_Int16 sbus_rate;
+    bool initialised;
+};

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -225,7 +225,6 @@ void AP_SerialManager::init()
                                          AP_SERIALMANAGER_ULANDING_BUFSIZE_RX,
                                          AP_SERIALMANAGER_ULANDING_BUFSIZE_TX);
                     break;
-
                 case SerialProtocol_Volz:
                                     // Note baudrate is hardcoded to 115200
                                     state[i].baud = AP_SERIALMANAGER_VOLZ_BAUD;   // update baud param in case user looks at it
@@ -233,6 +232,15 @@ void AP_SerialManager::init()
                                     		AP_SERIALMANAGER_VOLZ_BUFSIZE_RX,
 											AP_SERIALMANAGER_VOLZ_BUFSIZE_TX);
                                     break;
+                case SerialProtocol_Sbus1:
+                    state[i].baud = AP_SERIALMANAGER_SBUS1_BAUD / 1000;   // update baud param in case user looks at it
+                    state[i].uart->begin(map_baudrate(state[i].baud),
+                                         AP_SERIALMANAGER_SBUS1_BUFSIZE_RX,
+                                         AP_SERIALMANAGER_SBUS1_BUFSIZE_TX);
+                    state[i].uart->configure_parity(2);    // enable even parity
+                    state[i].uart->set_stop_bits(2);
+                    state[i].uart->set_unbuffered_writes(true);
+                    break;
             }
         }
     }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -73,6 +73,11 @@
 #define AP_SERIALMANAGER_VOLZ_BUFSIZE_RX     128
 #define AP_SERIALMANAGER_VOLZ_BUFSIZE_TX     128
 
+// SBUS servo outputs
+#define AP_SERIALMANAGER_SBUS1_BAUD           100000
+#define AP_SERIALMANAGER_SBUS1_BUFSIZE_RX     16
+#define AP_SERIALMANAGER_SBUS1_BUFSIZE_TX     32
+
 
 class AP_SerialManager {
 public:
@@ -93,6 +98,7 @@ public:
         SerialProtocol_Aerotenna_uLanding      = 12, // Ulanding support
         SerialProtocol_Beacon = 13,
         SerialProtocol_Volz = 14,                    // Volz servo protocol
+        SerialProtocol_Sbus1 = 15
     };
 
     // get singleton instance

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -18,6 +18,7 @@
 #include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_Common/Bitmask.h>
 #include <AP_Volz_Protocol/AP_Volz_Protocol.h>
+#include <AP_SBusOut/AP_SBusOut.h>
 
 #define NUM_SERVO_CHANNELS 16
 
@@ -439,6 +440,10 @@ private:
     // support for Volz protocol
     AP_Volz_Protocol volz = AP_Volz_Protocol::create();
     static AP_Volz_Protocol *volz_ptr;
+
+    // support for SBUS protocol
+    AP_SBusOut sbus = AP_SBusOut::create();
+    static AP_SBusOut *sbus_ptr;
 
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -27,6 +27,7 @@ extern const AP_HAL::HAL& hal;
 SRV_Channel *SRV_Channels::channels;
 SRV_Channels *SRV_Channels::instance;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
+AP_SBusOut *SRV_Channels::sbus_ptr;
 
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;
@@ -117,6 +118,10 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     // @Path: ../AP_Volz_Protocol/AP_Volz_Protocol.cpp
     AP_SUBGROUPINFO(volz, "_VOLZ_",  19, SRV_Channels, AP_Volz_Protocol),
 
+    // @Group: SBUS_
+    // @Path: ../AP_SBusOut/AP_SBusOut.cpp
+    AP_SUBGROUPINFO(sbus, "_SBUS_",  20, SRV_Channels, AP_SBusOut),
+
     AP_GROUPEND
 };
 
@@ -137,6 +142,7 @@ SRV_Channels::SRV_Channels(void)
     }
 
     volz_ptr = &volz;
+    sbus_ptr = &sbus;
 }
 
 /*
@@ -201,4 +207,7 @@ void SRV_Channels::push()
 
     // give volz library a chance to update
     volz_ptr->update();
+
+    // give sbus library a chance to update
+    sbus_ptr->update();
 }

--- a/mk/make.inc
+++ b/mk/make.inc
@@ -10,3 +10,4 @@ LIBRARIES += AP_Airspeed
 LIBRARIES += AP_Relay
 LIBRARIES += AP_ServoRelayEvents
 LIBRARIES += AP_Volz_Protocol
+LIBRARIES += AP_SBusOut


### PR DESCRIPTION
supersedes #6794

Adds support for SBUS serial output in AP_HAL for all vehicle types.

- This PR implements the UARTDriver configure_parity and set_stop_bits methods in AP_HAL_PX4 and AP_HAL_SITL.

- Tested on SITL using Prolific Technology, Inc. PL2303 Serial Port on USB.

- Flight tested on px4-v4 (PixRacer) with ArduPlane using FrSky SBUS-PWM converter on Serial2 (telem2, SERIAL2_PROTOCOL=15).

- selected UART must support baud rate of 100,000, even parity and 2 stop bits

- to implement for other board types, provide iplementations for the default empty methods in AP_HAL/UARTDriver.h; providing an unbuffered write method will reduce timing jitter on the sbus output frames
