### PR TITLE
AP_GPS: don't inject data to locked ports

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -867,6 +867,10 @@ void AP_GPS::inject_data(uint8_t *data, uint16_t len)
 
 void AP_GPS::inject_data(uint8_t instance, uint8_t *data, uint16_t len)
 {
+    if (locked_ports & (1U<<instance)) {
+        // the port is locked by another driver
+        return;
+    }
     if (instance < GPS_MAX_RECEIVERS && drivers[instance] != nullptr) {
         drivers[instance]->inject_data(data, len);
     }


### PR DESCRIPTION
the port may be in use by a tool like u-center