### PR TITLE
AP_GPS: don't consider uBlox PVT time correct unless we have 2D fix

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1012,8 +1012,10 @@ AP_GPS_UBLOX::_parse_gps(void)
             state.hdop        = _buffer.pvt.p_dop;
             state.vdop        = _buffer.pvt.p_dop;
         }
-                    
-        state.last_gps_time_ms = AP_HAL::millis();
+
+        if (_buffer.pvt.fix_type >= 2) {
+            state.last_gps_time_ms = AP_HAL::millis();
+        }
         
         // time
         state.time_week_ms    = _buffer.pvt.itow;


### PR DESCRIPTION
the time may be set by an offline assistance client and may not be
accurate