### PR TITLE
Set FW compile date in AUTOPILOT_VERSION.os_sw_version

### DIFF
--- a/APMrover2/version.cpp
+++ b/APMrover2/version.cpp
@@ -13,8 +13,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Rover.h"
-
 #define FORCE_VERSION_H_INCLUDE
 #include "version.h"
 #undef FORCE_VERSION_H_INCLUDE
@@ -28,14 +26,24 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_type = FW_TYPE,
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
+    .fw_hash_str = "",
 #else
     .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-#ifdef CHIBIOS_GIT_VERSION
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
+#ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,
+#else
+    .os_name = nullptr,
+    .os_hash_str = nullptr,
+#endif
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
 #endif
 };

--- a/AntennaTracker/version.cpp
+++ b/AntennaTracker/version.cpp
@@ -12,7 +12,6 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "Tracker.h"
 
 #define FORCE_VERSION_H_INCLUDE
 #include "version.h"
@@ -27,14 +26,24 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_type = FW_TYPE,
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
+    .fw_hash_str = "",
 #else
     .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-#ifdef CHIBIOS_GIT_VERSION
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
+#ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,
+#else
+    .os_name = nullptr,
+    .os_hash_str = nullptr,
+#endif
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
 #endif
 };

--- a/ArduCopter/version.cpp
+++ b/ArduCopter/version.cpp
@@ -13,8 +13,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Copter.h"
-
 #define FORCE_VERSION_H_INCLUDE
 #include "version.h"
 #undef FORCE_VERSION_H_INCLUDE
@@ -28,14 +26,24 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_type = FW_TYPE,
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
+    .fw_hash_str = "",
 #else
     .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-#ifdef CHIBIOS_GIT_VERSION
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
+#ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,
+#else
+    .os_name = nullptr,
+    .os_hash_str = nullptr,
+#endif
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
 #endif
 };

--- a/ArduPlane/version.cpp
+++ b/ArduPlane/version.cpp
@@ -13,8 +13,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Plane.h"
-
 #define FORCE_VERSION_H_INCLUDE
 #include "version.h"
 #undef FORCE_VERSION_H_INCLUDE
@@ -25,17 +23,27 @@ const AP_FWVersion AP_FWVersion::fwver{
     .major = FW_MAJOR,
     .minor = FW_MINOR,
     .patch = FW_PATCH,
-    .fw_type = (enum FIRMWARE_VERSION_TYPE)(FW_TYPE),
+    .fw_type = FW_TYPE,
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
+    .fw_hash_str = "",
 #else
     .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-#ifdef CHIBIOS_GIT_VERSION
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
+#ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,
+#else
+    .os_name = nullptr,
+    .os_hash_str = nullptr,
+#endif
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
 #endif
 };

--- a/ArduSub/version.cpp
+++ b/ArduSub/version.cpp
@@ -13,8 +13,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Sub.h"
-
 #define FORCE_VERSION_H_INCLUDE
 #include "version.h"
 #undef FORCE_VERSION_H_INCLUDE
@@ -28,14 +26,24 @@ const AP_FWVersion AP_FWVersion::fwver{
     .fw_type = FW_TYPE,
 #ifndef GIT_VERSION
     .fw_string = THISFIRMWARE,
+    .fw_hash_str = "",
 #else
     .fw_string = THISFIRMWARE " (" GIT_VERSION ")",
     .fw_hash_str = GIT_VERSION,
 #endif
-#ifdef CHIBIOS_GIT_VERSION
     .middleware_name = nullptr,
     .middleware_hash_str = nullptr,
+#ifdef CHIBIOS_GIT_VERSION
     .os_name = "ChibiOS",
     .os_hash_str = CHIBIOS_GIT_VERSION,
+#else
+    .os_name = nullptr,
+    .os_hash_str = nullptr,
+#endif
+#ifdef BUILD_DATE_YEAR
+    // encode build date in os_sw_version
+   .os_sw_version = (BUILD_DATE_YEAR*100*100) + (BUILD_DATE_MONTH*100) + BUILD_DATE_DAY,
+#else
+   .os_sw_version = 0,
 #endif
 };

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -246,6 +246,9 @@ class Board:
                 cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath()
             ]
 
+        if cfg.env.build_dates:
+            env.build_dates = True
+
         # We always want to use PRI format macros
         cfg.define('__STDC_FORMAT_MACROS', 1)
 
@@ -259,9 +262,10 @@ class Board:
         bld.ap_version_append_str('GIT_VERSION', bld.git_head_hash(short=True))
         import time
         ltime = time.localtime()
-        bld.ap_version_append_int('BUILD_DATE_YEAR', ltime.tm_year)
-        bld.ap_version_append_int('BUILD_DATE_MONTH', ltime.tm_mon)
-        bld.ap_version_append_int('BUILD_DATE_DAY', ltime.tm_mday)
+        if bld.env.build_dates:
+            bld.ap_version_append_int('BUILD_DATE_YEAR', ltime.tm_year)
+            bld.ap_version_append_int('BUILD_DATE_MONTH', ltime.tm_mon)
+            bld.ap_version_append_int('BUILD_DATE_DAY', ltime.tm_mday)
 
     def embed_ROMFS_files(self, ctx):
         '''embed some files using AP_ROMFS'''

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -17,6 +17,7 @@ public:
     const char *middleware_hash_str;
     const char *os_name;
     const char *os_hash_str;
+    const uint32_t os_sw_version;
 
     static const AP_FWVersion &get_fwverz() { return fwver; }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2391,7 +2391,6 @@ void GCS_MAVLINK::send_autopilot_version() const
 {
     uint32_t flight_sw_version;
     uint32_t middleware_sw_version = 0;
-    uint32_t os_sw_version = 0;
     uint32_t board_version = 0;
     char flight_custom_version[MAVLINK_MSG_AUTOPILOT_VERSION_FIELD_FLIGHT_CUSTOM_VERSION_LEN]{};
     char middleware_custom_version[MAVLINK_MSG_AUTOPILOT_VERSION_FIELD_MIDDLEWARE_CUSTOM_VERSION_LEN]{};
@@ -2427,7 +2426,7 @@ void GCS_MAVLINK::send_autopilot_version() const
         capabilities(),
         flight_sw_version,
         middleware_sw_version,
-        os_sw_version,
+        version.os_sw_version,
         board_version,
         (uint8_t *)flight_custom_version,
         (uint8_t *)middleware_custom_version,

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -7,7 +7,11 @@ const AP_FWVersion AP_FWVersion::fwver
     minor: 1,
     patch: 4,
     fw_type: FIRMWARE_VERSION_TYPE_DEV,
-    fw_string: "Dummy GCS"
+    fw_string: "Dummy GCS",
+    fw_hash_str: "",
+    middleware_hash_str: "",
+    os_hash_str: "",
+    os_sw_version: 0
 };
 
 const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] {};

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -9,7 +9,9 @@ const AP_FWVersion AP_FWVersion::fwver
     fw_type: FIRMWARE_VERSION_TYPE_DEV,
     fw_string: "Dummy GCS",
     fw_hash_str: "",
+    middleware_name: "",
     middleware_hash_str: "",
+    os_name: "",
     os_hash_str: "",
     os_sw_version: 0
 };

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -18,7 +18,13 @@ const AP_FWVersion AP_FWVersion::fwver
     minor: 1,
     patch: 4,
     fw_type: FIRMWARE_VERSION_TYPE_DEV,
-    fw_string: "routing example"
+    fw_string: "routing example",
+    fw_hash_str: "",
+    middleware_name: "",
+    middleware_hash_str: "",
+    os_name: "",
+    os_hash_str: "",
+    os_sw_version: 0
 };
 
 const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] {};

--- a/wscript
+++ b/wscript
@@ -196,6 +196,10 @@ configuration in order to save typing.
                  default=False,
                  help="Enable SITL RGBLed")
 
+    g.add_option('--build-dates', action='store_true',
+                 default=False,
+                 help="Include build date in binaries.  Appears in AUTOPILOT_VERSION.os_sw_version")
+
     g.add_option('--sitl-flash-storage',
         action='store_true',
         default=False,


### PR DESCRIPTION
We're well-OOB standards-wise on this.

But we haven't used this field for anything in the past, and it has proved extremely useful to have this information available in AUTOPILOT_VERSION.
