### PR TITLE
AP_RangeFinder: Clarify the purpose of input registers

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -47,7 +47,7 @@ bool AP_RangeFinder_LeddarOne::detect(AP_SerialManager &serial_manager)
 // read - return last value measured by sensor
 bool AP_RangeFinder_LeddarOne::get_reading(uint16_t &reading_cm)
 {
-    uint8_t number_detections;
+    uint16_t number_detections;
     LeddarOne_Status leddarone_status;
 
     if (uart == nullptr) {
@@ -186,7 +186,7 @@ bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCh
      24: CRC High
     -----------------------------------------------
   */
-LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detections)
+LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint16_t &number_detections)
 {
     uint8_t index;
     uint8_t index_offset = LEDDARONE_DETECTION_DATA_INDEX_OFFSET;
@@ -219,8 +219,8 @@ LeddarOne_Status AP_RangeFinder_LeddarOne::parse_response(uint8_t &number_detect
         return LEDDARONE_STATE_ERR_BAD_CRC;
     }
 
-    // number of detections (index:10)
-    number_detections = read_buffer[LEDDARONE_DETECTION_DATA_NUMBER_INDEX];
+    // number of detections (index:9, 10)
+    number_detections = static_cast<uint16_t>(read_buffer[LEDDARONE_DETECTION_DATA_NUMBER_HIGH_INDEX]) << 8 | read_buffer[LEDDARONE_DETECTION_DATA_NUMBER_LOW_INDEX];
 
     // if the number of detection is over or zero , it is false
     if (number_detections > LEDDARONE_DETECTIONS_MAX || number_detections == 0) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -172,11 +172,10 @@ bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCh
     -----------------------------------------------
       0: slave address (LEDDARONE_DEFAULT_ADDRESS)
       1: functions code
-      2: ?
-3-4-5-6: timestamp
+      2: byte count
+5-6-3-4: timestamp
     7-8: internal temperature
-      9: ?
-     10: number of detections
+   9-10: number of distance
   11-12: first distance
   13-14: first amplitude
   15-16: second distance

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -13,7 +13,8 @@
 #define LEDDARONE_READ_BUFFER_SIZE 25
 
 #define LEDDARONE_DETECTIONS_MAX 3
-#define LEDDARONE_DETECTION_DATA_NUMBER_INDEX 10
+#define LEDDARONE_DETECTION_DATA_NUMBER_HIGH_INDEX 9
+#define LEDDARONE_DETECTION_DATA_NUMBER_LOW_INDEX  10
 #define LEDDARONE_DETECTION_DATA_INDEX_OFFSET 11
 #define LEDDARONE_DETECTION_DATA_OFFSET 4
 
@@ -65,7 +66,7 @@ private:
     bool CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCheck);
 
     // parse a response message from ModBus
-    LeddarOne_Status parse_response(uint8_t &number_detections);
+    LeddarOne_Status parse_response(uint16_t &number_detections);
 
     AP_HAL::UARTDriver *uart = nullptr;
     uint32_t last_reading_ms;


### PR DESCRIPTION
1. I clarified the unknown register from the following specification.
2. I fixed the byte order of the timestamp.

Byte 2: MODBUS specification "Byte Count" is defined in the response table on page 16.
Byte 3-6: "20: Least significant 16 bits of timestamp." "21: Most significant 16 bits of timestamp." Is defined on page 23 of the Leddar One User Guide.
Byte 9-10: "23: Number of detections" is defined on page 23 of the Leddar One User Guide.

MODBUS SPEC:
http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf

Leddar One User Guide
http://www.robotshop.com/media/files/pdf2/rb-led-02-04_-_54a0025-2_leddar_one_user_guide_-_2016-09-01.pdf
