### PR TITLE
AP_HAL_SITL: correct _unbuffered_writes usage

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -160,7 +160,12 @@ size_t UARTDriver::write(const uint8_t *buffer, size_t size)
         DataFlash_Class::instance()->Log_Write("SBUS", "TimeUS,ToD", "QQ",
                                                AP_HAL::micros64(), time);
         // write buffer straight to the file descriptor
-        ::write(_fd, buffer, size);
+        ssize_t nwritten = ::write(_fd, buffer, size);
+        if (nwritten == -1 && errno != EAGAIN && _uart_path) {
+            close(_fd);
+            _fd = -1;
+            _connected = false;
+        }
         // these have no effect
         tcdrain(_fd);
     } else {


### PR DESCRIPTION
This correct a compilation warning from https://github.com/ArduPilot/ardupilot/pull/7270: 
````
../../libraries/AP_HAL_SITL/UARTDriver.cpp: In member function ‘virtual size_t HALSITL::UARTDriver::write(const uint8_t*, size_t)’:
../../libraries/AP_HAL_SITL/UARTDriver.cpp:148:35: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
         ::write(_fd, buffer, size);
````