### PR TITLE
Rover: ch7 switch option for arming/disarming and each drive mode

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -129,7 +129,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CH7_OPTION
     // @DisplayName: Channel 7 option
     // @Description: What to do use channel 7 for
-    // @Values: 0:Nothing,1:SaveWaypoint,2:LearnCruiseSpeed,3:ArmDisarm
+    // @Values: 0:Nothing,1:SaveWaypoint,2:LearnCruiseSpeed,3:ArmDisarm,4:Manual,5:Acro,6:Steering,7:Hold,8:Auto,9:RTL,10:SmartRTL,11:Guided
     // @User: Standard
     GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -129,7 +129,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: CH7_OPTION
     // @DisplayName: Channel 7 option
     // @Description: What to do use channel 7 for
-    // @Values: 0:Nothing,1:SaveWaypoint,2:LearnCruiseSpeed
+    // @Values: 0:Nothing,1:SaveWaypoint,2:LearnCruiseSpeed,3:ArmDisarm
     // @User: Standard
     GSCALAR(ch7_option,             "CH7_OPTION",          CH7_OPTION),
 

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -60,6 +60,9 @@
   #define MAV_SYSTEM_ID    1
 #endif
 
+#ifndef ARM_DELAY_MS
+  #define ARM_DELAY_MS  2000
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 // FrSky telemetry support

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -189,6 +189,15 @@ void Rover::read_aux_switch()
             cruise_learn_complete();
         }
         break;
+
+    // arm or disarm the motors
+    case CH7_ARM_DISARM:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            arm_motors(AP_Arming::RUDDER);
+        } else if (aux_ch7 == AUX_SWITCH_LOW) {
+            disarm_motors();
+        }
+        break;
     }
 }
 

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -198,6 +198,78 @@ void Rover::read_aux_switch()
             disarm_motors();
         }
         break;
+
+    // set mode to Manual
+    case CH7_MANUAL:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_manual, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_manual)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to Acro
+    case CH7_ACRO:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_acro, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_acro)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to Steering
+    case CH7_STEERING:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_steering, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_steering)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to Hold
+    case CH7_HOLD:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_hold, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_hold)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to Auto
+    case CH7_AUTO:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_auto, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_auto)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to RTL
+    case CH7_RTL:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_rtl, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_rtl)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to SmartRTL
+    case CH7_SMART_RTL:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_smartrtl, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_smartrtl)) {
+            reset_control_switch();
+        }
+        break;
+
+    // set mode to Guided
+    case CH7_GUIDED:
+        if (aux_ch7 == AUX_SWITCH_HIGH) {
+            set_mode(mode_guided, MODE_REASON_TX_COMMAND);
+        } else if ((aux_ch7 == AUX_SWITCH_LOW) && (control_mode == &mode_guided)) {
+            reset_control_switch();
+        }
+        break;
     }
 }
 

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -17,7 +17,8 @@
 enum ch7_option {
     CH7_DO_NOTHING      = 0,
     CH7_SAVE_WP         = 1,
-    CH7_LEARN_CRUISE    = 2
+    CH7_LEARN_CRUISE    = 2,
+    CH7_ARM_DISARM      = 3
 };
 
 // HIL enumerations

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -18,7 +18,15 @@ enum ch7_option {
     CH7_DO_NOTHING      = 0,
     CH7_SAVE_WP         = 1,
     CH7_LEARN_CRUISE    = 2,
-    CH7_ARM_DISARM      = 3
+    CH7_ARM_DISARM      = 3,
+    CH7_MANUAL          = 4,
+    CH7_ACRO            = 5,
+    CH7_STEERING        = 6,
+    CH7_HOLD            = 7,
+    CH7_AUTO            = 8,
+    CH7_RTL             = 9,
+    CH7_SMART_RTL       = 10,
+    CH7_GUIDED          = 11
 };
 
 // HIL enumerations

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -48,10 +48,6 @@ public:
     // returns true if the throttle is controlled automatically
     virtual bool auto_throttle() { return is_autopilot_mode(); }
 
-    // return true if throttle should be supressed in event of a
-    // FAILSAFE_EVENT_THROTTLE
-    virtual bool failsafe_throttle_suppress() const { return true; }
-
     //
     // attributes for mavlink system status reporting
     //
@@ -188,7 +184,6 @@ public:
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
-    bool failsafe_throttle_suppress() const override { return false; }
 
     // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
@@ -247,7 +242,6 @@ public:
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
-    bool failsafe_throttle_suppress() const override { return false; }
 
     // return distance (in meters) to destination
     float get_distance_to_destination() const override;
@@ -328,7 +322,6 @@ public:
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
-    bool failsafe_throttle_suppress() const override { return false; }
 
     float get_distance_to_destination() const override { return _distance_to_destination; }
     bool reached_destination() override { return _reached_destination; }
@@ -350,7 +343,6 @@ public:
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
-    bool failsafe_throttle_suppress() const override { return false; }
 
     float get_distance_to_destination() const override { return _distance_to_destination; }
     bool reached_destination() override { return smart_rtl_state == SmartRTL_StopAtHome; }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -64,7 +64,7 @@ void Rover::rudder_arm_disarm_check()
             const uint32_t now = millis();
 
             if (rudder_arm_timer == 0 ||
-                now - rudder_arm_timer < 3000) {
+                now - rudder_arm_timer < ARM_DELAY_MS) {
                 if (rudder_arm_timer == 0) {
                     rudder_arm_timer = now;
                 }
@@ -83,7 +83,7 @@ void Rover::rudder_arm_disarm_check()
             const uint32_t now = millis();
 
             if (rudder_arm_timer == 0 ||
-                now - rudder_arm_timer < 3000) {
+                now - rudder_arm_timer < ARM_DELAY_MS) {
                 if (rudder_arm_timer == 0) {
                     rudder_arm_timer = now;
                 }

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -331,6 +331,7 @@ void Rover::change_arm_state(void)
 bool Rover::arm_motors(AP_Arming::ArmingMethod method)
 {
     if (!arming.arm(method)) {
+        AP_Notify::events.arming_failed = true;
         return false;
     }
 


### PR DESCRIPTION
This PR makes the following changes/enhancements to Rover:

- arming/disarming with the throttle/steering stick takes 2 seconds instead of 3.  This is consistent with Copter.
- new ch7 option for arming/disarming
- new ch7 options to switch into each of the existing drive modes (manual, acro, steering, hold, auto, rtl, smart_rtl and guided)
- play a sad tune from the buzzer if arming the vehicle fails
- removed an unused method from the mode class