### PR TITLE
SITL: fix pthread_setname_np to build on mac

### DIFF
--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -103,7 +103,11 @@ void *FlightAxis::update_thread(void *arg)
 {
     FlightAxis *flightaxis = (FlightAxis *)arg;
 
-#ifndef __CYGWIN__
+#ifdef __CYGWIN__
+    //Cygwin doesn't support pthread_setname_np
+#elif defined(__APPLE__) && defined(__MACH__)
+    pthread_setname_np("ardupilot-flightaxis");
+#else
     pthread_setname_np(pthread_self(), "ardupilot-flightaxis");
 #endif
     


### PR DESCRIPTION
This fixes #7178 (SITL build failing)