### PR TITLE
Rover: add pwm to thrust compensation for motors

### DIFF
--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -86,6 +86,9 @@ protected:
     // set limits based on steering and throttle input
     void set_limits_from_input(bool armed, float steering, float throttle);
 
+    // scale a throttle using the _thrust_curve_expo parameter.  throttle should be in the range -100 to +100
+    float get_scaled_throttle(float throttle) const;
+
     // external references
     AP_ServoRelayEvents &_relayEvents;
 
@@ -97,6 +100,7 @@ protected:
     AP_Int8 _throttle_min; // throttle minimum percentage
     AP_Int8 _throttle_max; // throttle maximum percentage
     AP_Float _skid_friction;    // skid steering vehicle motor output compensation for friction while stopped
+    AP_Float _thrust_curve_expo; // thrust curve exponent from -1 to +1 with 0 being linear
 
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -303,8 +303,10 @@ struct PACKED log_WheelEncoder {
     uint64_t time_us;
     float distance_0;
     uint8_t quality_0;
+    float rpm_0;
     float distance_1;
     uint8_t quality_1;
+    float rpm_1;
 };
 
 // log wheel encoder information
@@ -319,8 +321,10 @@ void Rover::Log_Write_WheelEncoder()
         time_us     : AP_HAL::micros64(),
         distance_0  : g2.wheel_encoder.get_distance(0),
         quality_0   : (uint8_t)constrain_float(g2.wheel_encoder.get_signal_quality(0), 0.0f, 100.0f),
+        rpm_0       : wheel_encoder_rpm[0],
         distance_1  : g2.wheel_encoder.get_distance(1),
-        quality_1   : (uint8_t)constrain_float(g2.wheel_encoder.get_signal_quality(1), 0.0f, 100.0f)
+        quality_1   : (uint8_t)constrain_float(g2.wheel_encoder.get_signal_quality(1), 0.0f, 100.0f),
+        rpm_1       : wheel_encoder_rpm[1]
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -349,7 +353,7 @@ const LogStructure Rover::log_structure[] = {
     { LOG_ERROR_MSG, sizeof(log_Error),
       "ERR",   "QBB",         "TimeUS,Subsys,ECode", "s--", "F--" },
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder),
-      "WENC",  "Qfbfb",       "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" },
+      "WENC",  "Qfbffbf", "TimeUS,Dist0,Qual0,RPM0,Dist1,Qual1,RPM1", "sm-qm-q", "F0--0--" },
 };
 
 void Rover::log_init(void)


### PR DESCRIPTION
This PR adds:

- pwm to thrust compensation to the Rover's motors library.  This is important because for good control, we ideally want a linear response (i.e. input to motors library doubles, motor output also doubles).  The shape of the compensation curve is controlled with a new MOT_THST_EXPO parameter which can be -1 to +1.  By default it is zero which turns off compensation.  The curve formula is borrowed from copter by the way.
- add RPM output to the WENC dataflash logging message.
- non-functional change to make the order of the method implementations in AP_MotorsUGV.cpp match the header order.

Here is a graph of the pwm output (expressed as a percentage) vs the RPM (also expressed as a percentage of the maximum achievable rpm on my frame):
![dcmotor_pwmvsrpm](https://user-images.githubusercontent.com/1498098/33510148-ee57c8d0-d74b-11e7-9ca2-8dad3332d204.png).  A MOT_THST_EXPO value of between -0.5 to -1.0 linearises the response quite a bit although it's still not perfect.  Still it's much better.


