### PR TITLE
AP_Compass: add LIS3MDL probe for Pixracer

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -676,6 +676,10 @@ void Compass::_detect_backends(void)
         ADD_BACKEND(DRIVER_HMC5883, AP_Compass_HMC5843::probe(*this, hal.spi->get_device(HAL_COMPASS_HMC5843_NAME),
                                                               false, ROTATION_PITCH_180),
                     AP_Compass_HMC5843::name, false);
+        // R15 has LIS3MDL on spi bus instead of HMC; same CS pin
+        ADD_BACKEND(DRIVER_LIS3MDL, AP_Compass_LIS3MDL::probe(*this, hal.spi->get_device(HAL_COMPASS_LIS3MDL_NAME),
+                                                              false, ROTATION_NONE),
+                    AP_Compass_LIS3MDL::name, false);
         ADD_BACKEND(DRIVER_AK8963, AP_Compass_AK8963::probe_mpu9250(*this, 0, ROTATION_ROLL_180_YAW_90),
                     AP_Compass_AK8963::name, false);
         break;

--- a/libraries/AP_HAL_PX4/SPIDevice.cpp
+++ b/libraries/AP_HAL_PX4/SPIDevice.cpp
@@ -84,6 +84,10 @@ SPIDesc SPIDeviceManager::device_table[] = {
 #endif
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_PX4_V4
     SPIDesc("ms5611_int",   PX4_SPI_BUS_BARO, (spi_dev_e)PX4_SPIDEV_BARO, SPIDEV_MODE3, 20*MHZ, 20*MHZ),
+#ifdef PX4_SPIDEV_HMC
+    // r15 has LIS3MDL in place of HMC
+	SPIDesc("lis3mdl",      PX4_SPI_BUS_SENSORS, (spi_dev_e)PX4_SPIDEV_HMC, SPIDEV_MODE3, 500*KHZ, 500*KHZ),
+#endif
 #endif
 #ifdef PX4_SPIDEV_BARO
     SPIDesc("ms5611",       PX4_SPI_BUS_SENSORS, (spi_dev_e)PX4_SPIDEV_BARO, SPIDEV_MODE3, 20*MHZ, 20*MHZ),


### PR DESCRIPTION
depends on https://github.com/ArduPilot/PX4Firmware/pull/83