### PR TITLE
EKF timing initialisation fix

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -160,7 +160,7 @@ AP_AHRS_DCM::reset(bool recover_eulers)
         initAccVec = _ins.get_accel();
 
         // the first vector may be invalid as the filter starts up
-        while (initAccVec.length() <= 5.0f && counter++ < 10) {
+        while ((initAccVec.length() < 9.0f || initAccVec.length() > 11) && counter++ < 20) {
             _ins.wait_for_sample();
             _ins.update();
             initAccVec = _ins.get_accel();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -173,7 +173,7 @@ public:
     /* get_delta_time returns the time period in seconds
      * overwhich the sensor data was collected
      */
-    float get_delta_time() const { return _delta_time; }
+    float get_delta_time() const { return MIN(_delta_time, _loop_delta_t_max); }
 
     // return the maximum gyro drift rate in radians/s/s. This
     // depends on what gyro chips are being used
@@ -378,6 +378,7 @@ private:
     // the selected sample rate
     uint16_t _sample_rate;
     float _loop_delta_t;
+    float _loop_delta_t_max;
 
     // Most recent accelerometer reading
     Vector3f _accel[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -136,6 +136,13 @@ void AP_InertialSensor_SITL::generate_gyro(uint8_t instance)
 void AP_InertialSensor_SITL::timer_update(void)
 {
     uint64_t now = AP_HAL::micros64();
+#if 0
+    // insert a 1s pause in IMU data. This triggers a pause in EK2
+    // processing that leads to some interesting issues
+    if (now > 5e6 && now < 6e6) {
+        return;
+    }
+#endif
     for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
         if (now >= next_accel_sample[i]) {
             generate_accel(i);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Buffer.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Buffer.h
@@ -147,6 +147,13 @@ public:
         buffer[_youngest].element = element;
         // set oldest data index
         _oldest = (_youngest+1)%_size;
+        if (_oldest == 0) {
+            _filled = true;
+        }
+    }
+
+    inline bool is_filled(void) const {
+        return _filled;
     }
 
     // retrieve the oldest data from the ring buffer tail
@@ -185,4 +192,5 @@ public:
     }
 private:
     uint8_t _size,_oldest,_youngest;
+    bool _filled;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -396,7 +396,7 @@ bool NavEKF2_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &d
     if (ins_index < ins.get_accel_count()) {
         ins.get_delta_velocity(ins_index,dVel);
         dVel_dt = MAX(ins.get_delta_velocity_dt(ins_index),1.0e-4f);
-        dVel_dt = MIN(ins.get_delta_velocity_dt(ins_index),1.0e-1f);
+        dVel_dt = MIN(dVel_dt,1.0e-1f);
         return true;
     }
     return false;
@@ -539,7 +539,7 @@ bool NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng
         ins.get_delta_angle(ins_index,dAng);
         frontend->logging.log_imu = true;
         dAng_dt = MAX(ins.get_delta_angle_dt(imu_index),1.0e-4f);
-        dAng_dt = MIN(dt,1.0e-1f);
+        dAng_dt = MIN(dAng_dt,1.0e-1f);
         return true;
     }
     return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -341,6 +341,17 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
         return false;
     }
 
+    if (statesInitialised) {
+        // we are initialised, but we don't return true until the IMU
+        // buffer has been filled. This prevents a timing
+        // vulnerability with a pause in IMU data during filter startup
+        readIMUData();
+        readMagData();
+        readGpsData();
+        readBaroData();
+        return storedIMU.is_filled();
+    }
+
     // set re-used variables to zero
     InitialiseVariables();
 
@@ -410,7 +421,8 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
     // set to true now that states have be initialised
     statesInitialised = true;
 
-    return true;
+    // we initially return false to wait for the IMU buffer to fill
+    return false;
 }
 
 // initialise the covariance matrix

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -544,7 +544,7 @@ private:
 
     // helper functions for readIMUData
     bool readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt);
-    bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng);
+    bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt);
 
     // helper functions for correcting IMU data
     void correctDeltaAngle(Vector3f &delAng, float delAngDT);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Buffer.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Buffer.h
@@ -147,8 +147,16 @@ public:
         buffer[_youngest].element = element;
         // set oldest data index
         _oldest = (_youngest+1)%_size;
+        if (_oldest == 0) {
+            _filled = true;
+        }
     }
 
+    // return true if the buffer has been filled at least once
+    inline bool is_filled(void) const {
+        return _filled;
+    }
+    
     // retrieve the oldest data from the ring buffer tail
     inline element_type pop_oldest_element() {
         element_type ret = buffer[_oldest].element;
@@ -185,4 +193,5 @@ public:
     }
 private:
     uint8_t _size,_oldest,_youngest;
+    bool _filled;
 };

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -408,6 +408,13 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
     readGpsData();
     readBaroData();
 
+    if (statesInitialised) {
+        // we are initialised, but we don't return true until the IMU
+        // buffer has been filled. This prevents a timing
+        // vulnerability with a pause in IMU data during filter startup
+        return storedIMU.is_filled();
+    }
+
     // accumulate enough sensor data to fill the buffers
     if (firstInitTime_ms == 0) {
         firstInitTime_ms = imuSampleTime_ms;
@@ -469,7 +476,8 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
     statesInitialised = true;
     gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u initialised",(unsigned)imu_index);
 
-    return true;
+    // we initially return false to wait for the IMU buffer to fill
+    return false;
 }
 
 // initialise the covariance matrix


### PR DESCRIPTION
This prevents a problem where EK2 can diverge if there is a pause in INS data during EK2 startup. The IMU buffer is not filled yet, and the same sample gets used multiple times.
Paul and I have discussed this, and while it does fix the vulnerability, we think there may be an additional issue that is still happening. 
This PR is for us to discuss the right fix and diagnose the issue
