### PR TITLE
Rover: skid steering always uses full range

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -63,15 +63,6 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("THR_MAX", 6, AP_MotorsUGV, _throttle_max, 100),
 
-    // @Param: SKID_FRIC
-    // @DisplayName: Motor skid steering friction compensation
-    // @Description: Motor output for skid steering vehicles will be increased by this percentage to overcome friction when stopped
-    // @Units: %
-    // @Range: 0 100
-    // @Increment: 1
-    // @User: Standard
-    AP_GROUPINFO("SKID_FRIC", 7, AP_MotorsUGV, _skid_friction, 0.0f),
-
     // @Param: SLEWRATE
     // @DisplayName: Throttle slew rate
     // @Description: Throttle slew rate as a percentage of total range per second. A value of 100 allows the motor to change over its full range in one second.  A value of zero disables the limit.  Note some NiMH powered rovers require a lower setting of 40 to reduce current demand to avoid brownouts.
@@ -389,27 +380,12 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
         throttle_scaled = throttle_scaled / saturation_value;
     }
 
-    // add in throttle
-    float motor_left = throttle_scaled;
-    float motor_right = throttle_scaled;
+    // reverse steering direction if throttle is negative to mimic regular rovers
+    const float steering_dir = is_negative(throttle_scaled) ? -1.0f : 1.0f;
 
-    // deal with case of turning on the spot
-    if (is_zero(throttle_scaled)) {
-        // steering output split evenly between left and right motors and compensated for friction
-        const float friction_comp = MAX(0.0f, 1.0f + (_skid_friction * 0.01f));
-        motor_left += steering_scaled * 0.5f * friction_comp;
-        motor_right -= steering_scaled * 0.5f * friction_comp;
-    } else {
-        // add in steering
-        const float dir = is_positive(throttle_scaled) ? 1.0f : -1.0f;
-        if (is_negative(steering_scaled)) {
-            // moving left all steering to right wheel
-            motor_right -= dir * steering_scaled;
-        } else {
-            // turning right, all steering to left wheel
-            motor_left += dir * steering_scaled;
-        }
-    }
+    // add in throttle and steering
+    const float motor_left = throttle_scaled + (steering_dir * steering_scaled);
+    const float motor_right = throttle_scaled - (steering_dir * steering_scaled);
 
     // send pwm value to each motor
     output_throttle(SRV_Channel::k_throttleLeft, 100.0f * motor_left);

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -99,7 +99,6 @@ protected:
     AP_Int16 _slew_rate; // slew rate expressed as a percentage / second
     AP_Int8 _throttle_min; // throttle minimum percentage
     AP_Int8 _throttle_max; // throttle maximum percentage
-    AP_Float _skid_friction;    // skid steering vehicle motor output compensation for friction while stopped
     AP_Float _thrust_curve_expo; // thrust curve exponent from -1 to +1 with 0 being linear
 
     // internal variables

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -285,6 +285,9 @@ public:
 
     // attributes for mavlink system status reporting
     bool attitude_stabilized() const override { return false; }
+
+    // hold mode does not require GPS
+    bool requires_gps() const override { return false; }
 };
 
 
@@ -305,8 +308,8 @@ public:
     bool has_manual_input() const override { return true; }
     bool attitude_stabilized() const override { return false; }
 
+    // manual mode does not require GPS
     bool requires_gps() const override { return false; }
-
 };
 
 


### PR DESCRIPTION
This change affects the mixer and steering gains for skid steering vehicles which leads to the following improvements:

- removes the motor jumps when the vehicle transitions between a pivot-turn (i.e. vehicle is rotating on the spot) and a turn-while-moving.
- removes the need for the MOT_SKID_FRICT parameter which was used to increase steering output when the vehicle was stopped.

The fundamental difference vs the current mixer is the current mixer handles the pivot-turn case differently than the turn-while-moving case.  When not moving, the current mixer sends the steering command to both wheels but when moving the steering command is only sent to one wheel  With the new mixer, the steering command is always sent to both wheels.

The behaviour in the old mixer came from the mistaken belief that the speed of the vehicle is the minimum speed of the left and right motors.  So for example, if one motor is not moving, then the vehicle must not be moving forward.  This is not true however, the speed of the vehicle is the average of the speed of the two wheels.  Even if a motor is stopped (or moving backwards) it's still possible that the vehicle is moving forward, it's just that the path it is moving on will be extremely curved. 

![mixer-change-pic](https://user-images.githubusercontent.com/1498098/33590592-dc1a915a-d9c3-11e7-8743-02f333f99528.png)

In my testing it seems the ATC_STR_RAT_P, I and D terms should be reduced to about half the value used with the current mixer.