### PR TITLE
Build: Use posixpath for compatibility with Windows PX4 Toolchain (& MSYS git)

### DIFF
--- a/Tools/scripts/add_git_hashes.py
+++ b/Tools/scripts/add_git_hashes.py
@@ -7,6 +7,7 @@ Written by Jon Challinger January 2015
 import json
 import sys
 import os
+import posixpath
 import subprocess
 import argparse
 
@@ -28,25 +29,25 @@ f.close()
 
 if args.ardupilot is not None:
     try:
-        fw_json["ardupilot_git_hash"] = subprocess.check_output(["git", "--git-dir", os.path.join(args.ardupilot,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
+        fw_json["ardupilot_git_hash"] = subprocess.check_output(["git", "--git-dir", posixpath.join(args.ardupilot,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
     except:
         print("Failed to get apm hash")
         
 if args.px4 is not None:
     try:
-        fw_json["px4_git_hash"] = subprocess.check_output(["git", "--git-dir", os.path.join(args.px4,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
+        fw_json["px4_git_hash"] = subprocess.check_output(["git", "--git-dir", posixpath.join(args.px4,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
     except:
         print("Failed to get px4 hash")
 
 if args.nuttx is not None:
     try:
-        fw_json["nuttx_git_hash"] = subprocess.check_output(["git", "--git-dir", os.path.join(args.nuttx,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
+        fw_json["nuttx_git_hash"] = subprocess.check_output(["git", "--git-dir", posixpath.join(args.nuttx,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
     except:
         print("Failed to get nuttx hash")
 
 if args.uavcan is not None:
     try:
-        fw_json["uavcan_git_hash"] = subprocess.check_output(["git", "--git-dir", os.path.join(args.uavcan,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
+        fw_json["uavcan_git_hash"] = subprocess.check_output(["git", "--git-dir", posixpath.join(args.uavcan,".git"), "rev-parse", "HEAD"]).strip().decode('ascii')
     except:
         print("Failed to get uavcan hash")
 


### PR DESCRIPTION
The `add_git_hashes.py` script used `os.path` to join filenames. When building ArduPilot from the PX4 toolchain on Windows, this resulted in a fatal error from `git` when adding hashes to the PX4 file as it assumes POSIX paths are used.

This bug only arises if the submodule's `.git` file contains a relative path. If an absolute path is used in the `.git` file, `git`'s POSIX path assumption is not reached. There seems to be some murkiness about the behaviour of `git` with submodule `.git` files. It seems that the default was absolute paths until somewhere around version 1.7.10 [[1]](https://stackoverflow.com/questions/8925564/git-submodule-absolute-worktree-path-config), later versions may default to relative paths. It is definitely the case that version `2.15.0.windows.1` results in relative paths while version `1.7.9.msysgit.0` (as contained in the PX4 toolchain for Windows) results in absolute paths.