### PR TITLE
libraries: add AP_LandingProximityi which use APDS-9930 proximity sen…

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -361,6 +361,7 @@ void Copter::ten_hz_logging_loop()
 #if FRAME_CONFIG == HELI_FRAME
     Log_Write_Heli();
 #endif
+    Log_Write_LandProx();
 }
 
 // twentyfive_hz_logging - should be run at 25hz

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -84,6 +84,7 @@
 #include <AP_Arming/AP_Arming.h>
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <AP_TempCalibration/AP_TempCalibration.h>
+#include <AP_LandingProximity/AP_LandingProximity.h>
 
 // Configuration
 #include "defines.h"
@@ -248,6 +249,8 @@ private:
 #if RPM_ENABLED == ENABLED
     AP_RPM rpm_sensor;
 #endif
+
+    AP_LandingProximity landing_proximity;
 
     // Inertial Navigation EKF
     NavEKF2 EKF2{&ahrs, rangefinder};
@@ -815,6 +818,7 @@ private:
     void Log_Write_Heli(void);
 #endif
     void Log_Write_Precland();
+    void Log_Write_LandProx();
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_Vehicle_Startup_Messages();
     void log_init(void);
@@ -875,6 +879,7 @@ private:
     // sensors.cpp
     void read_barometer(void);
     void init_rangefinder(void);
+    void init_landing_proximity();
     void read_rangefinder(void);
     bool rangefinder_alt_ok();
     void rpm_update();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -450,6 +450,26 @@ void Copter::Log_Write_Precland()
  #endif     // PRECISION_LANDING == ENABLED
 }
 
+struct PACKED log_LandProx {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t proximity;
+};
+
+void Copter::Log_Write_LandProx()
+{
+    if (!landing_proximity.enabled()) {
+        return;
+    }
+
+    struct log_LandProx pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_LANDPROX_MSG),
+        time_us : AP_HAL::micros64(),
+        proximity : landing_proximity.proximity
+    };
+    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
 // precision landing logging
 struct PACKED log_GuidedTarget {
     LOG_PACKET_HEADER;
@@ -525,6 +545,8 @@ const struct LogStructure Copter::log_structure[] = {
 #endif
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },
+    { LOG_LANDPROX_MSG, sizeof(log_LandProx),
+      "LPRO",    "QB",    "TimeUS,Proxi", "s-","F-" },
 };
 
 void Copter::Log_Write_Vehicle_Startup_Messages()
@@ -562,6 +584,7 @@ void Copter::Log_Write_Error(uint8_t sub_system, uint8_t error_code) {}
 void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, int16_t control_in, int16_t tune_low, int16_t tune_high) {}
 void Copter::Log_Sensor_Health() {}
 void Copter::Log_Write_Precland() {}
+void Copter::Log_Write_LandProx() {}
 void Copter::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
 void Copter::Log_Write_Vehicle_Startup_Messages() {}
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -732,6 +732,8 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AC_PrecLand/AC_PrecLand.cpp
     GOBJECT(precland, "PLND_", AC_PrecLand),
 #endif
+    
+    GOBJECT(landing_proximity, "LPRO_", AP_LandingProximity),
 
 #if RPM_ENABLED == ENABLED
     // @Group: RPM

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -152,6 +152,8 @@ public:
         k_param_single_servo_3,         // remove
         k_param_single_servo_4,         // 78 - remove
 
+        k_param_landing_proximity = 79,  
+               
         //
         // 80: Heli
         //

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -309,6 +309,7 @@ enum LoggingParameters {
      LOG_HELI_MSG,
      LOG_PRECLAND_MSG,
      LOG_GUIDEDTARGET_MSG,
+     LOG_LANDPROX_MSG,
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -83,6 +83,11 @@ void Copter::update_land_detector()
             // we've sensed movement up or down so reset land_detector
             land_detector_count = 0;
         }
+
+        if ((control_mode == LAND || control_mode == RTL || (control_mode == AUTO && (mode_auto.mode() == Auto_Land || mode_auto.mode() == Auto_RTL)))
+            && landing_proximity.proximity && rangefinder_check) {
+             set_land_complete(true);
+         }
     }
 
     set_land_complete_maybe(ap.land_complete || (land_detector_count >= LAND_DETECTOR_MAYBE_TRIGGER_SEC*scheduler.get_loop_rate_hz()));

--- a/ArduCopter/make.inc
+++ b/ArduCopter/make.inc
@@ -65,3 +65,4 @@ LIBRARIES += AP_Winch
 LIBRARIES += AP_WheelEncoder
 LIBRARIES += AP_Follow
 LIBRARIES += AP_Devo_Telem
+LIBRARIES += AP_LandingProximity

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -11,6 +11,11 @@ void Copter::read_barometer(void)
     motors->set_air_density_ratio(barometer.get_air_density_ratio());
 }
 
+void Copter::init_landing_proximity()
+{
+    landing_proximity.init();
+}
+
 void Copter::init_rangefinder(void)
 {
 #if RANGEFINDER_ENABLED == ENABLED

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -221,6 +221,8 @@ void Copter::init_ardupilot()
     // initialise rangefinder
     init_rangefinder();
 
+    init_landing_proximity();
+
     // init proximity sensor
     init_proximity();
 

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -34,6 +34,7 @@ def build(bld):
             'AP_Winch',
             'AP_Follow',
             'AP_Devo_Telem',
+            'AP_LandingProximity',
         ],
     )
 

--- a/libraries/AP_LandingProximity/AP_LandingProximity.cpp
+++ b/libraries/AP_LandingProximity/AP_LandingProximity.cpp
@@ -1,0 +1,212 @@
+#include "AP_LandingProximity.h"
+
+extern const AP_HAL::HAL &hal;
+
+const AP_Param::GroupInfo AP_LandingProximity::var_info[] = {
+    // @Param: ENABLED
+    // @DisplayName: enable land proximity
+    // @Values: 0:Disabled, 1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLED", 0, AP_LandingProximity, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: THRESHOLD
+    // @DisplayName: proximity threshold
+    // @User: Advanced
+    AP_GROUPINFO("THRESHOLD", 1, AP_LandingProximity, _thd, DEFAULT_PIHT),
+
+    // @Param: GAIN
+    // @DisplayName: proximity gain
+    // @User: Advanced
+    AP_GROUPINFO("GAIN", 2, AP_LandingProximity, _gain, DEFAULT_PGAIN),
+
+    // @Param: PERSISTENCE
+    // @DisplayName: proximity persistence
+    // @User: Advanced
+    AP_GROUPINFO("PERSISTENCE", 3, AP_LandingProximity, _pers, DEFAULT_PPERS),
+
+    AP_GROUPEND
+};
+
+AP_LandingProximity::AP_LandingProximity()
+{
+    proximity = false;
+}
+
+bool AP_LandingProximity::setProximityGain(uint8_t drive)
+{
+    uint8_t val;
+    uint8_t send = APDS9930_CONTROL | AUTO_INCREMENT;
+    
+    /* Read value from CONTROL register */
+    if (!_dev->transfer(&send, 1, &val, 1)) {
+        return false;
+    }
+    
+    /* Set bits in register to given value */
+    drive &= 0b00000011;
+    drive = drive << 2;
+    val &= 0b11110011;
+    val |= drive;
+    
+    /* Write register value back into CONTROL register */
+    if (!_dev->write_register(APDS9930_CONTROL | AUTO_INCREMENT, val)) {
+        return false;
+    }
+    
+    return true;
+}
+
+bool AP_LandingProximity::setLEDDrive(uint8_t drive)
+{
+    uint8_t val;
+    uint8_t send = APDS9930_CONTROL | AUTO_INCREMENT;
+    
+    /* Read value from CONTROL register */
+    if (!_dev->transfer(&send, 1, &val, 1)) {
+        return false;
+    }
+    
+    /* Set bits in register to given value */
+    drive &= 0b00000011;
+    drive = drive << 6;
+    val &= 0b00111111;
+    val |= drive;
+    
+    /* Write register value back into CONTROL register */
+    if (!_dev->write_register(APDS9930_CONTROL | AUTO_INCREMENT, val)) {
+        return false;
+    }
+    
+    return true;
+}
+
+bool AP_LandingProximity::setProximityDiode(uint8_t drive)
+{
+    uint8_t val;
+    uint8_t send = APDS9930_CONTROL | AUTO_INCREMENT;
+    
+    /* Read value from CONTROL register */
+    if (!_dev->transfer(&send, 1, &val, 1)) {
+        return false;
+    }
+    
+    /* Set bits in register to given value */
+    drive &= 0b00000011;
+    drive = drive << 4;
+    val &= 0b11001111;
+    val |= drive;
+    
+    /* Write register value back into CONTROL register */
+    if (!_dev->write_register(APDS9930_CONTROL | AUTO_INCREMENT, val)) {
+        return false;
+    }
+    
+    return true;
+}
+
+bool AP_LandingProximity::enableProximitySensor()
+{
+    /* Set default gain, LED, interrupts, enable power, and enable sensor */
+    if( !setProximityGain(_gain) ) {
+        return false;
+    }
+    if( !setLEDDrive(DEFAULT_PDRIVE) ) {
+        return false;
+    }
+    if (!_dev->write_register(APDS9930_ENABLE | AUTO_INCREMENT, 0x25)) {//power, proximity, proximity interrupt
+        return false;
+    }
+    
+    return true;
+}
+
+bool AP_LandingProximity::checkId() {
+    uint8_t send = APDS9930_ID | AUTO_INCREMENT;
+    uint8_t val;
+    if (_dev->transfer(&send, 1, &val, 1) && val == 0x39) return true;
+    return false;
+}
+
+void AP_LandingProximity::timer() {
+    uint8_t send = APDS9930_STATUS | AUTO_INCREMENT;
+    uint8_t val;
+    proximity = false;
+    if (!_enabled) return;
+    if (!_dev->transfer(&send, 1, &val, 1)) return;
+    if (val & 0x20) {
+        proximity = true;
+        send = CLEAR_PROX_INT;
+        _dev->transfer(&send, 1, 0, 0);
+    }
+}
+
+bool AP_LandingProximity::setProximityIntHighThreshold(uint16_t threshold)
+{
+    uint8_t lo;
+    uint8_t hi;
+    hi = threshold >> 8;
+    lo = threshold & 0x00FF;
+
+    if( !_dev->write_register(APDS9930_PIHTL | AUTO_INCREMENT, lo) ) {
+        return false;
+    }
+    if( !_dev->write_register(APDS9930_PIHTH | AUTO_INCREMENT, hi) ) {
+        return false;
+    }
+    
+    return true;
+}
+
+void AP_LandingProximity::init()
+{
+    if (!_enabled) return;
+    _dev = hal.i2c_mgr->get_device(0, 0x39);
+    if (_dev && _dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        if (!checkId()) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_ENABLE | AUTO_INCREMENT, 0)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_ATIME | AUTO_INCREMENT, DEFAULT_ATIME)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_WTIME | AUTO_INCREMENT, DEFAULT_WTIME)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_PPULSE | AUTO_INCREMENT, DEFAULT_PPULSE)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_POFFSET | AUTO_INCREMENT, DEFAULT_POFFSET)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!_dev->write_register(APDS9930_CONFIG | AUTO_INCREMENT, DEFAULT_CONFIG)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!setProximityDiode(DEFAULT_PDIODE)) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if( !setProximityIntHighThreshold(_thd) ) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if( !_dev->write_register(APDS9930_PERS | AUTO_INCREMENT, _pers << 4) ) {
+            _dev->get_semaphore()->give();
+            return;
+        }
+        if (!enableProximitySensor()) {
+            _dev->get_semaphore()->give();
+            return;
+        }            
+        _dev->get_semaphore()->give();
+        _dev->register_periodic_callback(100000, FUNCTOR_BIND_MEMBER(&AP_LandingProximity::timer, void));
+    }    
+}

--- a/libraries/AP_LandingProximity/AP_LandingProximity.h
+++ b/libraries/AP_LandingProximity/AP_LandingProximity.h
@@ -1,0 +1,85 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Device.h>
+#include <AP_HAL/I2CDevice.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+
+#define AUTO_INCREMENT          0xA0
+#define REPEATED_BYTE           0x80
+
+#define APDS9930_ENABLE         0x00
+#define APDS9930_ATIME          0x01
+#define APDS9930_PTIME          0x02
+#define APDS9930_WTIME          0x03
+#define APDS9930_AILTL          0x04
+#define APDS9930_AILTH          0x05
+#define APDS9930_AIHTL          0x06
+#define APDS9930_AIHTH          0x07
+#define APDS9930_PILTL          0x08
+#define APDS9930_PILTH          0x09
+#define APDS9930_PIHTL          0x0A
+#define APDS9930_PIHTH          0x0B
+#define APDS9930_PERS           0x0C
+#define APDS9930_CONFIG         0x0D
+#define APDS9930_PPULSE         0x0E
+#define APDS9930_CONTROL        0x0F
+#define APDS9930_ID             0x12
+#define APDS9930_STATUS         0x13
+#define APDS9930_Ch0DATAL       0x14
+#define APDS9930_Ch0DATAH       0x15
+#define APDS9930_Ch1DATAL       0x16
+#define APDS9930_Ch1DATAH       0x17
+#define APDS9930_PDATAL         0x18
+#define APDS9930_PDATAH         0x19
+#define APDS9930_POFFSET        0x1E
+
+#define POWER                   0
+#define AMBIENT_LIGHT           1
+#define PROXIMITY               2
+#define WAIT                    3
+#define AMBIENT_LIGHT_INT       4
+#define PROXIMITY_INT           5
+#define SLEEP_AFTER_INT         6
+#define ALL                     7
+
+#define CLEAR_PROX_INT          0xE5
+
+#define DEFAULT_ATIME           0xFF
+#define DEFAULT_WTIME           0xFF
+#define DEFAULT_PTIME           0xFF
+#define DEFAULT_PPULSE          0x01
+#define DEFAULT_POFFSET         0       // 0 offset
+#define DEFAULT_CONFIG          0
+#define DEFAULT_PDRIVE          0
+#define DEFAULT_PDIODE          2
+#define DEFAULT_PGAIN           1
+#define DEFAULT_AGAIN           0
+#define DEFAULT_PILT            0       // Low proximity threshold
+#define DEFAULT_PIHT            200      // High proximity threshold
+#define DEFAULT_PPERS           0x9
+
+class AP_LandingProximity
+{
+public:
+    AP_LandingProximity();
+    bool enabled() { return _enabled; }
+
+    void init();
+    bool proximity;
+    
+    static const struct AP_Param::GroupInfo var_info[];
+private:
+    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+    bool enableProximitySensor();
+    bool setProximityGain(uint8_t drive);
+    bool setLEDDrive(uint8_t drive);
+    bool setProximityDiode(uint8_t drive);
+    bool setProximityIntHighThreshold(uint16_t threshold);
+    bool checkId();
+    void timer();
+    
+    AP_Int8 _enabled;
+    AP_Int16 _thd;
+    AP_Int8 _pers;
+    AP_Int8 _gain;
+};


### PR DESCRIPTION
…sor for landing detection

Landing detection in copter generally works very well. But when auto landing in a windy condition, especially with precision landing enabled (PLND_ENABLED). copter may occasionally flip over like this video 
https://youtu.be/tfQmdvHvj08

APDS-9930 is a small and cheap short range (~10cm) proximity sensor. I attach it to landing gear to detect copter is very close to ground like this photo
https://discuss.ardupilot.org/uploads/default/original/2X/c/cf2dba6143a110e3b353dc5279611031b94a7684.jpg

Instead of reading proximity value, I use its persistence filter feature. apds-9930 only set proximity when several consecutive proximity value out of range. It is reliable and do not interference by irlock beacon 

I did not put it in ap_rangefinder because apds-9930 is not exactly a rangefinder. It cannot output exact distance reading. It can only tell you "there is something within detect range". Rangefinders usually have a minimum range and tends to inaccurate in very close range. By contrast, proximity sensor can only detect object in very close range.

test video is here
https://youtu.be/dFu0b_81Vzw

