### PR TITLE
Rover: add WP_SPEED, RTL_SPEED

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -926,7 +926,8 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             }
 
             // send yaw change and target speed to guided mode controller
-            float target_speed = constrain_float(packet.param2 * rover.g.speed_cruise, -rover.g.speed_cruise, rover.g.speed_cruise);
+            const float speed_max = rover.control_mode->get_speed_default();
+            const float target_speed = constrain_float(packet.param2 * speed_max, -speed_max, speed_max);
             rover.mode_guided.set_desired_heading_delta_and_speed(packet.param1, target_speed);
             result = MAV_RESULT_ACCEPTED;
             break;
@@ -1043,7 +1044,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
             // convert thrust to ground speed
             packet.thrust = constrain_float(packet.thrust, -1.0f, 1.0f);
-            float target_speed = rover.g.speed_cruise * packet.thrust;
+            const float target_speed = rover.control_mode->get_speed_default() * packet.thrust;
 
             // if the body_yaw_rate field is ignored, convert quaternion to heading
             if ((packet.type_mask & MAVLINK_SET_ATT_TYPE_MASK_YAW_RATE_IGNORE) != 0) {
@@ -1114,8 +1115,9 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
             // consume velocity and convert to target speed and heading
             if (!vel_ignore) {
+                const float speed_max = rover.control_mode->get_speed_default();
                 // convert vector length into a speed
-                target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), -rover.g.speed_cruise, rover.g.speed_cruise);
+                target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), -speed_max, speed_max);
                 // convert vector direction to target yaw
                 target_yaw_cd = degrees(atan2f(packet.vy, packet.vx)) * 100.0f;
 
@@ -1215,8 +1217,9 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
             // consume velocity and convert to target speed and heading
             if (!vel_ignore) {
+                const float speed_max = rover.control_mode->get_speed_default();
                 // convert vector length into a speed
-                target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), -rover.g.speed_cruise, rover.g.speed_cruise);
+                target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), -speed_max, speed_max);
                 // convert vector direction to target yaw
                 target_yaw_cd = degrees(atan2f(packet.vy, packet.vx)) * 100.0f;
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -517,6 +517,24 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_SmartRTL/AP_SmartRTL.cpp
     AP_SUBGROUPINFO(smart_rtl, "SRTL_", 13, ParametersG2, AP_SmartRTL),
 
+    // @Param: WP_SPEED
+    // @DisplayName: Waypoint speed default
+    // @Description: Waypoint speed default.  If zero use CRUISE_SPEED.
+    // @Units: m/s
+    // @Range: 0 100
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("WP_SPEED", 14, ParametersG2, wp_speed, 0.0f),
+
+    // @Param: RTL_SPEED
+    // @DisplayName: Return-to-Launch speed default
+    // @Description: Return-to-Launch speed default.  If zero use WP_SPEED or CRUISE_SPEED.
+    // @Units: m/s
+    // @Range: 0 100
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("RTL_SPEED", 15, ParametersG2, rtl_speed, 0.0f),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -322,6 +322,10 @@ public:
 
     // Safe RTL library
     AP_SmartRTL smart_rtl;
+
+    // default speeds for auto, rtl
+    AP_Float wp_speed;
+    AP_Float rtl_speed;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -268,7 +268,8 @@ void Rover::do_nav_set_yaw_speed(const AP_Mission::Mission_Command& cmd)
     }
 
     // set auto target
-    mode_auto.set_desired_heading_and_speed(desired_heading_cd, constrain_float(cmd.content.set_yaw_speed.speed, -g.speed_cruise, g.speed_cruise));
+    const float speed_max = control_mode->get_speed_default();
+    mode_auto.set_desired_heading_and_speed(desired_heading_cd, constrain_float(cmd.content.set_yaw_speed.speed, -speed_max, speed_max));
 }
 
 /********************************************************************************/
@@ -378,14 +379,10 @@ bool Rover::verify_within_distance()
 
 void Rover::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
-    if (cmd.content.speed.target_ms > 0.0f) {
-        g.speed_cruise.set(cmd.content.speed.target_ms);
-        gcs().send_text(MAV_SEVERITY_INFO, "Cruise speed: %.1f m/s", static_cast<double>(g.speed_cruise.get()));
-    }
-
-    if (cmd.content.speed.throttle_pct > 0.0f && cmd.content.speed.throttle_pct <= 100.0f) {
-        g.throttle_cruise.set(cmd.content.speed.throttle_pct);
-        gcs().send_text(MAV_SEVERITY_INFO, "Cruise throttle: %.1f", static_cast<double>(g.throttle_cruise.get()));
+    // set speed for active mode
+    if ((cmd.content.speed.target_ms >= 0.0f) && (cmd.content.speed.target_ms <= rover.control_mode->get_speed_default())) {
+        control_mode->set_desired_speed(cmd.content.speed.target_ms);
+        gcs().send_text(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
     }
 }
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -130,7 +130,6 @@ void Mode::set_desired_location(const struct Location& destination, float next_l
     // record targets
     _origin = rover.current_loc;
     _destination = destination;
-    _desired_speed = g.speed_cruise;
 
     // initialise distance
     _distance_to_destination = get_distance(_origin, _destination);
@@ -175,6 +174,24 @@ void Mode::set_desired_heading_and_speed(float yaw_angle_cd, float target_speed)
     // record targets
     _desired_yaw_cd = yaw_angle_cd;
     _desired_speed = target_speed;
+}
+
+// get default speed for this mode (held in (CRUISE_SPEED, WP_SPEED or RTL_SPEED)
+float Mode::get_speed_default(bool rtl) const
+{
+    if (rtl && is_positive(g2.rtl_speed)) {
+        return g2.rtl_speed;
+    } else if (is_positive(g2.wp_speed)) {
+        return g2.wp_speed;
+    } else {
+        return g.speed_cruise;
+    }
+}
+
+// restore desired speed to default from parameter values (CRUISE_SPEED or WP_SPEED)
+void Mode::set_desired_speed_to_default(bool rtl)
+{
+    _desired_speed = get_speed_default(rtl);
 }
 
 void Mode::calc_throttle(float target_speed, bool nudge_allowed)

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -82,7 +82,7 @@ public:
     virtual void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed);
 
     // get speed error in m/s, returns zero for modes that do not control speed
-    float speed_error() { return _speed_error; }
+    float speed_error() const { return _speed_error; }
 
     // Navigation control variables
     // The instantaneous desired lateral acceleration in m/s/s

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -84,6 +84,17 @@ public:
     // get speed error in m/s, returns zero for modes that do not control speed
     float speed_error() const { return _speed_error; }
 
+    // get default speed for this mode (held in CRUISE_SPEED, WP_SPEED or RTL_SPEED)
+    // rtl argument should be true if called from RTL or SmartRTL modes (handled here to avoid duplication)
+    float get_speed_default(bool rtl = false) const;
+
+    // set desired speed
+    void set_desired_speed(float speed) { _desired_speed = speed; }
+
+    // restore desired speed to default from parameter values (CRUISE_SPEED or WP_SPEED)
+    // rtl argument should be true if called from RTL or SmartRTL modes (handled here to avoid duplication)
+    void set_desired_speed_to_default(bool rtl = false);
+
     // Navigation control variables
     // The instantaneous desired lateral acceleration in m/s/s
     float lateral_acceleration;

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -17,13 +17,13 @@ void ModeAcro::update()
     get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
 
     // convert pilot throttle input to desired speed (up to twice the cruise speed)
-    float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
+    const float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
 
     // convert pilot steering input to desired turn rate in radians/sec
-    float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
+    const float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
 
     // determine if pilot is requesting pivot turn
-    bool is_pivot_turning = g2.motors.have_skid_steering() && is_zero(target_speed) && (!is_zero(desired_steering));
+    const bool is_pivot_turning = g2.motors.have_skid_steering() && is_zero(target_speed) && (!is_zero(desired_steering));
 
     // stop vehicle if target speed is zero and not pivot turning
     if (is_zero(target_speed) && !is_pivot_turning) {
@@ -32,11 +32,11 @@ void ModeAcro::update()
     }
 
     // set reverse flag backing up
-    bool reversed = is_negative(target_speed);
+    const bool reversed = is_negative(target_speed);
     rover.set_reverse(reversed);
 
     // run steering turn rate controller and throttle controller
-    float steering_out = attitude_control.get_steering_out_rate(target_turn_rate, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    const float steering_out = attitude_control.get_steering_out_rate(target_turn_rate, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
     calc_throttle(target_speed, false);
 }

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -15,6 +15,9 @@ bool ModeAuto::_enter()
         return false;
     }
 
+    // initialise waypoint speed
+    set_desired_speed_to_default();
+
     // init location target
     set_desired_location(rover.current_loc);
 

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -3,10 +3,10 @@
 
 bool ModeGuided::_enter()
 {
-    /*
-      when entering guided mode we set the target as the current
-      location. This matches the behaviour of the copter code.
-    */
+    // initialise waypoint speed
+    set_desired_speed_to_default();
+
+    // when entering guided mode we set the target as the current location.
     lateral_acceleration = 0.0f;
     set_desired_location(rover.current_loc);
 

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -8,6 +8,9 @@ bool ModeRTL::_enter()
         return false;
     }
 
+    // initialise waypoint speed
+    set_desired_speed_to_default(true);
+
     // set destination
     set_desired_location(rover.home);
 

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -14,6 +14,9 @@ bool ModeSmartRTL::_enter()
         return false;
     }
 
+    // initialise waypoint speed
+    set_desired_speed_to_default(true);
+
     // RTL never reverses
     rover.set_reverse(false);
 


### PR DESCRIPTION
This PR makes the following changes to resolve issue #7351:

- adds the WP_SPEED parameter which contains the default speed to be used during missions.  If left as zero, the CRUISE_SPEED is used which matches the current behaviour in master.
- adds the RTL_SPEED parameter which holds the default speed to be used during RTL.  If left as zero, the WP_SPEED is used, and if that is also zero, then the CRUISE_SPEED is used (which matches what master does at the moment).  Setting the RTL_SPEED parameter is important in cases where the mission contains a DO_CHANGE_SPEED parameter which sets the vehicle to a very low speed.  If, after the execution of this DO_CHANGE_SPEED parameter, a failsafe triggered an RTL, the vehicle could return very slowly.
- the desired speed is reset whenever the vehicle enters AUTO, Guided, RTL or SmartRTL.
- the DO_CHANGE_SPEED command handler only changes the current mode's desired speed.  It no longer changes the CRUISE_THROTTLE.  I think most users expect this command to modify the vehicle's speed, they don't intend for it to affect the speed->throttle controller so there's no need to modify CRUISE_THROTTLE.

There is one unlikely but unintuitive edge case.  If the mission has an RTL in the middle, the vehicle will change to the RTL_SPEED as it executes this command.  If there is a waypoint command after the RTL, the vehicle will execute the waypoint command using the RTL_SPEED.  I.e. it's not currently smart enough to recognise that after completing and RTL command (within AUTO) that it should set the speed back to the WP_SPEED.  Still, this behaviour is nothing compared to the bad behaviour we see in master at the moment where any changes in speed persist across modes and affect the throttle tuning.

This PR also contains a couple of small changes to add const in a few places in Rover.