### PR TITLE
AP_HAL_Linux: fixed RPi version detection on kernel 4.9

### DIFF
--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -28,9 +28,34 @@ UtilRPI::UtilRPI()
     _check_rpi_version();
 }
 
+#define MAX_SIZE_LINE 50
 int UtilRPI::_check_rpi_version()
 {
     int hw;
+
+    char buffer[MAX_SIZE_LINE] = { 0 };
+    FILE* f = fopen("/sys/firmware/devicetree/base/model", "r");
+    if (f != nullptr && fgets(buffer, MAX_SIZE_LINE, f) != nullptr) {
+    	int ret = sscanf(buffer+12, "%d", &_rpi_version);
+		fclose(f);
+		if (ret != EOF) {
+
+			// Preserving old behavior.
+			if (_rpi_version > 2) {
+				_rpi_version = 2;
+			}
+			// RPi 1 doesn't have a number there, so sscanf() won't have read anything.
+			else if (_rpi_version == 0) {
+				_rpi_version = 1;
+			}
+
+			printf("%s. (intern: %d)\n", buffer, _rpi_version);
+
+			return _rpi_version;
+		}
+	}
+
+    // Attempting old method if the version couldn't be read with the new one.
     hw = Util::from(hal.util)->get_hw_arm32();
 
     if (hw == UTIL_HARDWARE_RPI2) {


### PR DESCRIPTION
This should fix #6639 and #7091 . The RPi version is now being read from `/sys/firmware/devicetree/base/model` instead of `/proc/cpuinfo`. Tested with RPi 1/2/3/Zero/Zero W, on Jessie with kernel 4.4 on RPi 1, Jessie with kernel 4.9 on RPi 2 and Stretch with kernel 4.9 on all other boards.