### PR TITLE
Rover: boats hold position in Auto, Guided, RTL, SmartRTL

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -535,6 +535,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RTL_SPEED", 15, ParametersG2, rtl_speed, 0.0f),
 
+    // @Param: FRAME_CLASS
+    // @DisplayName: Frame Class
+    // @Description: Frame Class
+    // @Values: 0:Undefined,1:Rover,2:Boat
+    // @User: Standard
+    AP_GROUPINFO("FRAME_CLASS", 16, ParametersG2, frame_class, 1),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -326,6 +326,9 @@ public:
     // default speeds for auto, rtl
     AP_Float wp_speed;
     AP_Float rtl_speed;
+
+    // frame class for vehicle
+    AP_Int8 frame_class;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -572,6 +572,7 @@ private:
     bool arm_motors(AP_Arming::ArmingMethod method);
     bool disarm_motors(void);
     void smart_rtl_update();
+    bool is_boat() const;
 
     // test.cpp
     void print_hit_enter();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -423,9 +423,7 @@ private:
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     void do_RTL(void);
-    void do_nav_wp(const AP_Mission::Mission_Command& cmd, bool stay_active_at_dest);
-    void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
-    void do_loiter_time(const AP_Mission::Mission_Command& cmd);
+    void do_nav_wp(const AP_Mission::Mission_Command& cmd, bool always_stop_at_destination);
     void do_nav_set_yaw_speed(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
     bool verify_RTL();

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -139,5 +139,12 @@ enum pilot_steer_type_t {
     PILOT_STEER_TYPE_DIR_UNCHANGED_WHEN_REVERSING = 3,
 };
 
+// frame class enum used for FRAME_CLASS parameter
+enum frame_class {
+    FRAME_UNDEFINED = 0,
+    FRAME_ROVER = 1,
+    FRAME_BOAT = 2
+};
+
 #define AUX_SWITCH_PWM_TRIGGER_HIGH 1800   // pwm value above which the ch7 or ch8 option will be invoked
 #define AUX_SWITCH_PWM_TRIGGER_LOW  1200   // pwm value below which the ch7 or ch8 option will be disabled

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -200,8 +200,7 @@ public:
     float get_distance_to_destination() const override { return _distance_to_destination; }
 
     // set desired location, heading and speed
-    // set stay_active_at_dest if the vehicle should attempt to maintain it's position at the destination (mostly for boats)
-    void set_desired_location(const struct Location& destination, float next_leg_bearing_cd = MODE_NEXT_HEADING_UNKNOWN, bool stay_active_at_dest = false);
+    void set_desired_location(const struct Location& destination, float next_leg_bearing_cd = MODE_NEXT_HEADING_UNKNOWN);
     bool reached_destination() override;
 
     // heading and speed control
@@ -236,7 +235,6 @@ private:
     bool auto_triggered;
 
     bool _reached_heading;      // true when vehicle has reached desired heading in TurnToHeading sub mode
-    bool _stay_active_at_dest;  // true when we should actively maintain position even after reaching the destination
     bool _reversed;             // execute the mission by backing up
 };
 

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -53,11 +53,9 @@ void ModeAuto::update()
                     _reached_destination = true;
                 }
             }
-            // stay active at destination if caller requested this behaviour and outside the waypoint radius
-            bool active_at_destination = _reached_destination && _stay_active_at_dest && (_distance_to_destination > rover.g.waypoint_radius);
-            if (!_reached_destination || active_at_destination) {
+            if (!_reached_destination || rover.is_boat()) {
                 // continue driving towards destination
-                calc_steering_to_waypoint(active_at_destination ? rover.current_loc : _origin, _destination, _reversed);
+                calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination, _reversed);
                 calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true);
             } else {
                 // we have reached the destination so stop
@@ -90,13 +88,12 @@ void ModeAuto::update()
 }
 
 // set desired location to drive to
-void ModeAuto::set_desired_location(const struct Location& destination, float next_leg_bearing_cd, bool stay_active_at_dest)
+void ModeAuto::set_desired_location(const struct Location& destination, float next_leg_bearing_cd)
 {
     // call parent
     Mode::set_desired_location(destination, next_leg_bearing_cd);
 
     _submode = Auto_WP;
-    _stay_active_at_dest = stay_active_at_dest;
 }
 
 // return true if vehicle has reached or even passed destination

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -21,16 +21,15 @@ void ModeGuided::update()
     switch (_guided_mode) {
         case Guided_WP:
         {
-            if (!_reached_destination) {
+            if (!_reached_destination || rover.is_boat()) {
                 // check if we've reached the destination
                 _distance_to_destination = get_distance(rover.current_loc, _destination);
-                if (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination)) {
-                    // trigger reached
+                if (!_reached_destination && (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination))) {
                     _reached_destination = true;
                     rover.gcs().send_mission_item_reached_message(0);
                 }
                 // drive towards destination
-                calc_steering_to_waypoint(_origin, _destination);
+                calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination);
                 calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
             } else {
                 stop_vehicle();

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -22,17 +22,17 @@ bool ModeRTL::_enter()
 
 void ModeRTL::update()
 {
-    if (!_reached_destination) {
+    if (!_reached_destination || rover.is_boat()) {
         // calculate distance to home
         _distance_to_destination = get_distance(rover.current_loc, _destination);
         // check if we've reached the destination
-        if (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination)) {
+        if (!_reached_destination && (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination))) {
             // trigger reached
             _reached_destination = true;
             gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
         }
         // continue driving towards destination
-        calc_steering_to_waypoint(_origin, _destination);
+        calc_steering_to_waypoint(_reached_destination ? rover.current_loc :_origin, _destination);
         calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
     } else {
         // we've reached destination so stop

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -367,3 +367,10 @@ void Rover::smart_rtl_update()
     const bool save_position = hal.util->get_soft_armed() && (control_mode != &mode_smartrtl);
     mode_smartrtl.save_position(save_position);
 }
+
+// returns true if vehicle is a boat
+// this affects whether the vehicle tries to maintain position after reaching waypoints
+bool Rover::is_boat() const
+{
+    return ((enum frame_class)g2.frame_class.get() == FRAME_BOAT);
+}


### PR DESCRIPTION
This PR does the following:

- adds a FRAME_CLASS which allows the user to specify if the vehicle is a rover or a boat (defaults to Rover)
- boats always stay active at the waypoint in AUTO mode.
- boats always stay active in Guided mode when they reach the specified location
- boats always stay active when they reach home in RTL or SmartRTL

Previously the user specified if they wanted this behaviour by using the LOITER_UNLIMITED or LOITER_TIME commands but personally I found this unintuitive and meant that these LOITER_xx commands couldn't be used for regular Rovers (at least not without having this additional behaviour added).  Also a WAYPOINT command with a delay would not maintain position.