### PR TITLE
AC_Avoid - remove use of inertialnav

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -513,7 +513,7 @@ private:
 #endif
 
 #if AC_AVOID_ENABLED == ENABLED
-    AC_Avoid avoid = AC_Avoid::create(ahrs, inertial_nav, fence, g2.proximity, &g2.beacon);
+    AC_Avoid avoid = AC_Avoid::create(ahrs, fence, g2.proximity, &g2.beacon);
 #endif
 
     // Rally library

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
 };
 
 /// Constructor
-AC_Avoid::AC_Avoid(const AP_AHRS_NavEKF& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon)
+AC_Avoid::AC_Avoid(const AP_AHRS& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon)
     : _ahrs(ahrs),
       _fence(fence),
       _proximity(proximity),

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -103,12 +103,6 @@ private:
     void limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance) const;
 
     /*
-     * Gets the current position or altitude, relative to home (not relative to EKF origin) in cm
-     */
-    Vector2f get_position() const;
-    float get_alt_above_home() const;
-
-    /*
      * Computes the speed such that the stopping distance
      * of the vehicle will be exactly the input distance.
      */

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -4,7 +4,6 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>     // AHRS library
-#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude controller library for sqrt controller
 #include <AC_Fence/AC_Fence.h>         // Failsafe fence library
 #include <AP_Proximity/AP_Proximity.h>
@@ -29,12 +28,11 @@
  */
 class AC_Avoid {
 public:
-    static AC_Avoid create(const AP_AHRS& ahrs,
-                           const AP_InertialNav& inav,
+    static AC_Avoid create(const AP_AHRS_NavEKF& ahrs,
                            const AC_Fence& fence,
                            const AP_Proximity& proximity,
                            const AP_Beacon* beacon = nullptr) {
-        return AC_Avoid{ahrs, inav, fence, proximity, beacon};
+        return AC_Avoid{ahrs, fence, proximity, beacon};
     }
 
     constexpr AC_Avoid(AC_Avoid &&other) = default;
@@ -66,7 +64,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_Avoid(const AP_AHRS& ahrs, const AP_InertialNav& inav, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
+    AC_Avoid(const AP_AHRS_NavEKF& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
 
     /*
      * Adjusts the desired velocity for the circular fence.
@@ -132,8 +130,7 @@ private:
     void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
 
     // external references
-    const AP_AHRS& _ahrs;
-    const AP_InertialNav& _inav;
+    const AP_AHRS_NavEKF& _ahrs;
     const AC_Fence& _fence;
     const AP_Proximity& _proximity;
     const AP_Beacon* _beacon;

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -28,7 +28,7 @@
  */
 class AC_Avoid {
 public:
-    static AC_Avoid create(const AP_AHRS_NavEKF& ahrs,
+    static AC_Avoid create(const AP_AHRS& ahrs,
                            const AC_Fence& fence,
                            const AP_Proximity& proximity,
                            const AP_Beacon* beacon = nullptr) {
@@ -64,7 +64,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_Avoid(const AP_AHRS_NavEKF& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
+    AC_Avoid(const AP_AHRS& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
 
     /*
      * Adjusts the desired velocity for the circular fence.
@@ -124,7 +124,7 @@ private:
     void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
 
     // external references
-    const AP_AHRS_NavEKF& _ahrs;
+    const AP_AHRS& _ahrs;
     const AC_Fence& _fence;
     const AP_Proximity& _proximity;
     const AP_Beacon* _beacon;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -563,6 +563,11 @@ public:
 
     virtual void update_AOA_SSA(void);
 
+    // get_hgt_ctrl_limit - get maximum height to be observed by the
+    // control loops in meters and a validity flag.  It will return
+    // false when no limiting is required
+    virtual bool get_hgt_ctrl_limit(float &limit) const { return false; };
+
 protected:
     AHRS_VehicleClass _vehicle_class;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1436,7 +1436,7 @@ bool AP_AHRS_NavEKF::get_origin(Location &ret) const
 
 // get_hgt_ctrl_limit - get maximum height to be observed by the control loops in metres and a validity flag
 // this is used to limit height during optical flow navigation
-// it will return invalid when no limiting is required
+// it will return false when no limiting is required
 bool AP_AHRS_NavEKF::get_hgt_ctrl_limit(float& limit) const
 {
     switch (ekf_type()) {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -223,7 +223,7 @@ public:
     // get_hgt_ctrl_limit - get maximum height to be observed by the control loops in meters and a validity flag
     // this is used to limit height during optical flow navigation
     // it will return invalid when no limiting is required
-    bool get_hgt_ctrl_limit(float &limit) const;
+    bool get_hgt_ctrl_limit(float &limit) const override;
 
     // get_llh - updates the provided location with the latest calculated location including absolute altitude
     //  returns true on success (i.e. the EKF knows it's latest position), false on failure

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -105,14 +105,6 @@ public:
     virtual float       get_altitude() const = 0;
 
     /**
-     * get_hgt_ctrl_limit - get maximum height to be observed by the control loops in cm and a validity flag
-     * this is used to limit height during optical flow navigation
-     * it will return invalid when no limiting is required
-     * @return
-     */
-    virtual bool       get_hgt_ctrl_limit(float& limit) const = 0;
-
-    /**
      * get_velocity_z - returns the current climbrate.
      *
      * @see get_velocity().z

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -159,23 +159,6 @@ bool AP_InertialNav_NavEKF::get_hagl(float &height) const
 }
 
 /**
- * get_hgt_ctrl_limit - get maximum height to be observed by the control loops in cm and a validity flag
- * this is used to limit height during optical flow navigation
- * it will return invalid when no limiting is required
- * @return
- */
-bool AP_InertialNav_NavEKF::get_hgt_ctrl_limit(float& limit) const
-{
-    // true when estimate is valid
-    if (_ahrs_ekf.get_hgt_ctrl_limit(limit)) {
-        // convert height from m to cm
-        limit *= 100.0f;
-        return true;
-    }
-    return false;
-}
-
-/**
  * get_velocity_z - returns the current climbrate.
  *
  * @see get_velocity().z

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -95,14 +95,6 @@ public:
     bool       get_hagl(float &hagl) const;
 
     /**
-     * get_hgt_ctrl_limit - get maximum height to be observed by the control loops in cm and a validity flag
-     * this is used to limit height during optical flow navigation
-     * it will return invalid when no limiting is required
-     * @return
-     */
-    bool       get_hgt_ctrl_limit(float& limit) const;
-
-    /**
      * get_velocity_z - returns the current climbrate.
      *
      * @see get_velocity().z


### PR DESCRIPTION
This is an excerpt from #7345 

I expect these commits to be squashed when pushed.

Changes from the original are basically to start to work in metres where possible, to take an AP_AHRS rather than an AP_AHRS_NavEKF and to check the results of the AHRS calls.
