### PR TITLE
Rover: improved dataflash logging for steering and throttle

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -253,8 +253,8 @@ void Rover::update_logging1(void)
         Log_Write_Attitude();
     }
 
-    if (should_log(MASK_LOG_CTUN)) {
-        Log_Write_Control_Tuning();
+    if (should_log(MASK_LOG_THR)) {
+        Log_Write_Throttle();
         Log_Write_Beacon();
     }
 

--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -269,9 +269,7 @@ void Rover::update_logging1(void)
 void Rover::update_logging2(void)
 {
     if (should_log(MASK_LOG_STEERING)) {
-        if (!control_mode->manual_steering()) {
-            Log_Write_Steering();
-        }
+        Log_Write_Steering();
     }
 
     if (should_log(MASK_LOG_RC)) {

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -131,7 +131,7 @@ void Rover::send_nav_controller_output(mavlink_channel_t chan)
 {
     mavlink_msg_nav_controller_output_send(
         chan,
-        control_mode->lateral_acceleration,  // use nav_roll to hold demanded Y accel
+        g2.attitude_control.get_desired_lat_accel(),
         ahrs.groundspeed() * ins.get_gyro().z,  // use nav_pitch to hold actual Y accel
         nav_controller->nav_bearing_cd() * 0.01f,
         nav_controller->target_bearing_cd() * 0.01f,

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -129,7 +129,6 @@ struct PACKED log_Nav_Tuning {
     float    wp_distance;
     uint16_t target_bearing_cd;
     uint16_t nav_bearing_cd;
-    int8_t   throttle;
     float xtrack_error;
 };
 
@@ -143,7 +142,6 @@ void Rover::Log_Write_Nav_Tuning()
         wp_distance         : control_mode->get_distance_to_destination(),
         target_bearing_cd   : static_cast<uint16_t>(abs(nav_controller->target_bearing_cd())),
         nav_bearing_cd      : static_cast<uint16_t>(abs(nav_controller->nav_bearing_cd())),
-        throttle            : int8_t(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)),
         xtrack_error        : nav_controller->crosstrack_error()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
@@ -353,7 +351,7 @@ const LogStructure Rover::log_structure[] = {
     { LOG_THR_MSG, sizeof(log_Throttle),
       "THR", "Qhffff", "TimeUS,ThrIn,ThrOut,DesSpeed,Speed,AccY", "s--nno", "F--000" },
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),
-      "NTUN", "QHfHHbf",    "TimeUS,Yaw,WpDist,TargBrg,NavBrg,Thr,XT", "sdmdd-m", "FB0BB-0" },
+      "NTUN", "QHfHHf", "TimeUS,Yaw,WpDist,TargBrg,NavBrg,XT", "sdmddm", "FB0BB0" },
     { LOG_RANGEFINDER_MSG, sizeof(log_Rangefinder),
       "RGFD", "QfHHHbHCb",  "TimeUS,LatAcc,R1Dist,R2Dist,DCnt,TAng,TTim,Spd,Thr", "somm-hsm-", "F0BB-0CB-" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -180,7 +180,7 @@ void Rover::Log_Write_Rangefinder()
     struct log_Rangefinder pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RANGEFINDER_MSG),
         time_us               : AP_HAL::micros64(),
-        lateral_accel         : control_mode->lateral_acceleration,
+        lateral_accel         : g2.attitude_control.get_desired_lat_accel(),
         rangefinder1_distance : s0 ? s0->distance_cm() : (uint16_t)0,
         rangefinder2_distance : s1 ? s1->distance_cm() : (uint16_t)0,
         detected_count        : obstacle.detected_count,

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -28,7 +28,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in dataflash. This values is made up of the sum of each of the log types you want to be saved on dataflash. On a PX4 or Pixhawk the large storage size of a microSD card means it is usually best just to enable all log types by setting this to 65535. On APM2 the smaller 4 MByte dataflash means you need to be more selective in your logging or you may run out of log space while flying (in which case it will wrap and overwrite the start of the log). The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Rangefinder=16384, Arming=32768, FullLogs=65535
     // @Values: 0:Disabled,5190:APM2-Default,65535:PX4/Pixhawk-Default
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:MODE,7:IMU,8:CMD,9:CURRENT,10:COMPASS,11:TECS,12:CAMERA,13:RC,14:RANGEFINDER,15:ARM/DISARM,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,7:IMU,8:CMD,9:CURRENT,10:RANGEFINDER,11:COMPASS,12:CAMERA,13:STEERING,14:RC,15:ARM/DISARM,19:IMU_RAW
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -28,7 +28,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in dataflash. This values is made up of the sum of each of the log types you want to be saved on dataflash. On a PX4 or Pixhawk the large storage size of a microSD card means it is usually best just to enable all log types by setting this to 65535. On APM2 the smaller 4 MByte dataflash means you need to be more selective in your logging or you may run out of log space while flying (in which case it will wrap and overwrite the start of the log). The individual bits are ATTITUDE_FAST=1, ATTITUDE_MEDIUM=2, GPS=4, PerformanceMonitoring=8, ControlTuning=16, NavigationTuning=32, Mode=64, IMU=128, Commands=256, Battery=512, Compass=1024, TECS=2048, Camera=4096, RCandServo=8192, Rangefinder=16384, Arming=32768, FullLogs=65535
     // @Values: 0:Disabled,5190:APM2-Default,65535:PX4/Pixhawk-Default
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,7:IMU,8:CMD,9:CURRENT,10:RANGEFINDER,11:COMPASS,12:CAMERA,13:STEERING,14:RC,15:ARM/DISARM,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:THR,5:NTUN,7:IMU,8:CMD,9:CURRENT,10:RANGEFINDER,11:COMPASS,12:CAMERA,13:STEERING,14:RC,15:ARM/DISARM,19:IMU_RAW
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -501,7 +501,7 @@ private:
     void Log_Write_Steering();
     void Log_Write_Beacon();
     void Log_Write_Startup(uint8_t type);
-    void Log_Write_Control_Tuning();
+    void Log_Write_Throttle();
     void Log_Write_Nav_Tuning();
     void Log_Write_Attitude();
     void Log_Write_Rangefinder();

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -53,7 +53,7 @@ enum mode {
 #define FAILSAFE_EVENT_RC       (1<<2)
 
 //  Logging parameters
-#define LOG_CTUN_MSG            0x01
+#define LOG_THR_MSG             0x01
 #define LOG_NTUN_MSG            0x02
 #define LOG_PERFORMANCE_MSG     0x03
 #define LOG_STARTUP_MSG         0x06
@@ -71,7 +71,7 @@ enum mode {
 #define MASK_LOG_ATTITUDE_MED   (1<<1)
 #define MASK_LOG_GPS            (1<<2)
 #define MASK_LOG_PM             (1<<3)
-#define MASK_LOG_CTUN           (1<<4)
+#define MASK_LOG_THR            (1<<4)
 #define MASK_LOG_NTUN           (1<<5)
 //#define MASK_LOG_MODE         (1<<6) // no longer used
 #define MASK_LOG_IMU            (1<<7)

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -95,10 +95,6 @@ public:
     // rtl argument should be true if called from RTL or SmartRTL modes (handled here to avoid duplication)
     void set_desired_speed_to_default(bool rtl = false);
 
-    // Navigation control variables
-    // The instantaneous desired lateral acceleration in m/s/s
-    float lateral_acceleration;
-
 protected:
 
     // subclasses override this to perform checks before entering the mode
@@ -153,6 +149,7 @@ protected:
     Location _destination;      // destination Location when in Guided_WP
     float _distance_to_destination; // distance from vehicle to final destination in meters
     bool _reached_destination;  // true once the vehicle has reached the destination
+    float _desired_lat_accel;   // desired lateral acceleration in m/s/s
     float _desired_yaw_cd;      // desired yaw in centi-degrees
     float _yaw_error_cd;        // error between desired yaw and actual yaw in centi-degrees
     float _desired_speed;       // desired speed in m/s

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -60,7 +60,7 @@ void ModeAuto::update()
             } else {
                 // we have reached the destination so stop
                 stop_vehicle();
-                lateral_acceleration = 0.0f;
+                _desired_lat_accel = 0.0f;
             }
             break;
         }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -7,7 +7,7 @@ bool ModeGuided::_enter()
     set_desired_speed_to_default();
 
     // when entering guided mode we set the target as the current location.
-    lateral_acceleration = 0.0f;
+    _desired_lat_accel = 0.0f;
     set_desired_location(rover.current_loc);
 
     // guided mode never travels in reverse

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -37,6 +37,6 @@ void ModeRTL::update()
     } else {
         // we've reached destination so stop
         stop_vehicle();
-        lateral_acceleration = 0.0f;
+        _desired_lat_accel = 0.0f;
     }
 }

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -15,7 +15,7 @@ void ModeSteering::update()
         // no valid speed so stop
         g2.motors.set_throttle(0.0f);
         g2.motors.set_steering(0.0f);
-        lateral_acceleration = 0.0f;
+        _desired_lat_accel = 0.0f;
         return;
     }
 
@@ -36,13 +36,13 @@ void ModeSteering::update()
     max_g_force = constrain_float(max_g_force, 0.1f, g.turn_max_g * GRAVITY_MSS);
 
     // convert pilot steering input to desired lateral acceleration
-    lateral_acceleration = max_g_force * (desired_steering / 4500.0f);
+    _desired_lat_accel = max_g_force * (desired_steering / 4500.0f);
 
     // reverse target lateral acceleration if backing up
     bool reversed = false;
     if (is_negative(target_speed)) {
         reversed = true;
-        lateral_acceleration = -lateral_acceleration;
+        _desired_lat_accel = -_desired_lat_accel;
     }
 
     // mark us as in_reverse when using a negative throttle

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -18,6 +18,7 @@
 #define AR_ATTCONTROL_THR_SPEED_D       0.00f
 #define AR_ATTCONTROL_THR_SPEED_FILT    5.00f
 #define AR_ATTCONTROL_DT                0.02f
+#define AR_ATTCONTROL_TIMEOUT           0.1f
 
 // throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
 #define AR_ATTCONTROL_THR_ACCEL_MAX     5.00f
@@ -50,6 +51,15 @@ public:
     // desired yaw rate in radians/sec. Positive yaw is to the right.
     float get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reverse);
 
+    // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only
+    float get_desired_turn_rate() const;
+
+    // get latest desired lateral acceleration in m/s/s recorded during calls to get_steering_out_lat_accel.  For reporting purposes only
+    float get_desired_lat_accel() const;
+
+    // get actual lateral acceleration in m/s/s.  returns true on success.  For reporting purposes only
+    bool get_lat_accel(float &lat_accel) const;
+
     //
     // throttle / speed controller
     //
@@ -78,6 +88,9 @@ public:
     // get throttle/speed controller maximum acceleration (also used for deceleration)
     float get_accel_max() const { return MAX(_throttle_accel_max, 0.0f); }
 
+    // get latest desired speed recorded during call to get_throttle_out_speed.  For reporting purposes only
+    float get_desired_speed() const;
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -95,7 +108,10 @@ private:
     AP_Float _stop_speed;           // speed control stop speed.  Motor outputs to zero once vehicle speed falls below this value
 
     // steering control
+    uint32_t _steer_lat_accel_last_ms;  // system time of last call to lateral acceleration controller (i.e. get_steering_out_lat_accel)
     uint32_t _steer_turn_last_ms;   // system time of last call to steering rate controller
+    float    _desired_lat_accel;    // desired lateral acceleration from latest call to get_steering_out_lat_accel (for reporting purposes)
+    float    _desired_turn_rate;    // desired turn rate either from external caller or from lateral acceleration controller (for reporting purpose)
 
     // throttle control
     uint32_t _speed_last_ms;        // system time of last call to get_throttle_out_speed

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -26,10 +26,10 @@ PX4UARTDriver::PX4UARTDriver(const char *devpath, const char *perf_name) :
     _baudrate(57600),
     _initialised(false),
     _in_timer(false),
+    _unbuffered_writes(false),
     _perf_uart(perf_alloc(PC_ELAPSED, perf_name)),
     _os_start_auto_space(-1),
-    _flow_control(FLOW_CONTROL_DISABLE),
-    _unbuffered_writes(false)
+    _flow_control(FLOW_CONTROL_DISABLE)
 {
 }
 


### PR DESCRIPTION
This PR improves the logging of steering and throttle controller output which should make support easier.

- the STR message get desired and achieved values, side-by-side for the things support people most often want to see:
  -  steering in (from the pilot), steering output (final output sent into the motor library), 
  -  desired and actual lateral acceleration (so we can see how well the attitude controller is achieving what's been requested by the navigation controller)
  -  desired and actual turn rate (so we can see how well the attitude controller's lowest level control is working)
- the CTUN message has been renamed to THR which is hopefully more intuitive.  It also gets desired and achieved values, side-by-side:
  -  throttle in (from the pilot) and output (what's sent into the motors library)
  -  desired and achieved speed (so we can easily see the speed->throttle controller's performance)
- NTUN messages loses the redundant throttle field
- unrelated fix to the LOG_BITMASK's parameter description

Here's an example of how a support person can now more easily check the performance of the attitude controller's low-level turn-rate controller:
![mp_ster_msg](https://user-images.githubusercontent.com/1498098/33747793-592745b2-dc08-11e7-8212-338085cd62e6.png)

