### PR TITLE
Remove AP_InertialNav from AC_Fence

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -514,7 +514,7 @@ private:
 
     // AC_Fence library to reduce fly-aways
 #if AC_FENCE == ENABLED
-    AC_Fence fence = AC_Fence::create(ahrs, inertial_nav);
+    AC_Fence fence = AC_Fence::create(ahrs);
 #endif
 
 #if AC_AVOID_ENABLED == ENABLED

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -346,14 +346,19 @@ void Copter::update_sensor_status_flags(void)
     if (copter.battery.healthy()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_BATTERY;
     }
-
+#if AC_FENCE == ENABLED
+    if (copter.fence.geofence_present()) {
+        control_sensors_present |= MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
 
     // all present sensors enabled by default except altitude and position control and motors which we will set individually
     control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
                                                          ~MAV_SYS_STATUS_LOGGING &
-                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY);
+                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY &
+                                                         ~MAV_SYS_STATUS_GEOFENCE);
 
     switch (control_mode) {
     case AUTO:
@@ -393,7 +398,11 @@ void Copter::update_sensor_status_flags(void)
     if (g.fs_batt_voltage > 0 || g.fs_batt_mah > 0) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_BATTERY;
     }
-
+#if AC_FENCE == ENABLED
+    if (copter.fence.geofence_enabled()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
 
 
     // default to all healthy
@@ -483,7 +492,12 @@ void Copter::update_sensor_status_flags(void)
 
     if (copter.failsafe.battery) {
          control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_BATTERY;                                                                    }
-    
+#if AC_FENCE == ENABLED
+    if (copter.fence.geofence_failed()) {
+        control_sensors_health &= ~MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
+
 #if FRSKY_TELEM_ENABLED == ENABLED
     // give mask of error flags to Frsky_Telemetry
     frsky_telemetry.update_sensor_status_flags(~control_sensors_health & control_sensors_enabled & control_sensors_present);

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -426,7 +426,7 @@ private:
 
     // AC_Fence library to reduce fly-aways
 #if AC_FENCE == ENABLED
-    AC_Fence fence = AC_Fence::create(ahrs, inertial_nav);
+    AC_Fence fence = AC_Fence::create(ahrs);
 #endif
 
 #if AVOIDANCE_ENABLED == ENABLED

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -197,7 +197,7 @@ bool AC_Fence::check_fence_polygon()
 
     // check consistency of number of points
     if (_boundary_num_points != _total) {
-        // we have no idea where the fence is.  Can't breach it?!
+        // Fence is currently not completely loaded.  Can't breach it?!
         _boundary_loaded = false;
         load_polygon_from_eeprom();
         return false;

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -518,3 +518,32 @@ bool AC_Fence::load_polygon_from_eeprom(bool force_reload)
 
     return true;
 }
+
+// methods for mavlink SYS_STATUS message (send_extended_status1)
+bool AC_Fence::geofence_present() const
+{
+    return _enabled;
+}
+
+bool AC_Fence::geofence_enabled() const
+{
+    if (!geofence_present()) {
+        return false;
+    }
+    if (_action == AC_FENCE_ACTION_REPORT_ONLY) {
+        return false;
+    }
+    return true;
+}
+
+bool AC_Fence::geofence_failed() const
+{
+    if (!geofence_present()) {
+        // not failed if not present; can fail if present but not enabled
+        return false;
+    }
+    if (get_breaches() != 0) {
+        return true;
+    }
+    return false;
+}

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -135,7 +135,7 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
     if ((_enabled_fences & AC_FENCE_TYPE_CIRCLE) ||
         (_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
         Vector2f position;
-        if (!_ahrs.get_relative_position_NE_origin(position)) {
+        if (!_ahrs.get_relative_position_NE_home(position)) {
             fail_msg = "fence requires position";
             return false;
         }

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -130,15 +130,15 @@ bool AC_Fence::pre_arm_check(const char* &fail_msg) const
         return false;
     }
 
-    // if we have horizontal limits enabled, check inertial nav position is ok
-    nav_filter_status filt_status;
-    if (!_ahrs.get_filter_status(filt_status)) {
-        fail_msg = "AHRS status not available";
-        return false;
-    }
-    if ((_enabled_fences & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON))>0 && !filt_status.flags.horiz_pos_abs && !filt_status.flags.pred_horiz_pos_abs) {
-        fail_msg = "fence requires position";
-        return false;
+    // if we have horizontal limits enabled, check we can get a
+    // relative position from the EKF
+    if ((_enabled_fences & AC_FENCE_TYPE_CIRCLE) ||
+        (_enabled_fences & AC_FENCE_TYPE_POLYGON)) {
+        Vector2f position;
+        if (!_ahrs.get_relative_position_NE_origin(position)) {
+            fail_msg = "fence requires position";
+            return false;
+        }
     }
 
     // if we got this far everything must be ok

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -121,6 +121,11 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    // methods for mavlink SYS_STATUS message (send_extended_status1)
+    bool geofence_present() const;
+    bool geofence_enabled() const;
+    bool geofence_failed() const;
+
 private:
     AC_Fence(const AP_AHRS_NavEKF &ahrs);
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -124,6 +124,9 @@ public:
 private:
     AC_Fence(const AP_AHRS_NavEKF &ahrs);
 
+    /// check_fence_alt_max - true if alt fence has been newly breached
+    bool check_fence_alt_max(float curr_alt);
+
     /// check_fence_polygon - true if polygon fence has been newly breached
     bool check_fence_polygon();
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -124,6 +124,9 @@ public:
 private:
     AC_Fence(const AP_AHRS_NavEKF &ahrs);
 
+    /// check_fence_polygon - true if polygon fence has been newly breached
+    bool check_fence_polygon();
+
     /// record_breach - update breach bitmask, time and count
     void record_breach(uint8_t fence_type);
 

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -6,7 +6,6 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_Fence/AC_PolyFence_loader.h>
 #include <AP_Common/Location.h>
 
@@ -35,8 +34,8 @@
 class AC_Fence
 {
 public:
-    static AC_Fence create(const AP_AHRS &ahrs, const AP_InertialNav &inav) {
-        return AC_Fence{ahrs, inav};
+    static AC_Fence create(const AP_AHRS_NavEKF &ahrs) {
+        return AC_Fence{ahrs};
     }
 
     constexpr AC_Fence(AC_Fence &&other) = default;
@@ -123,7 +122,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_Fence(const AP_AHRS &ahrs, const AP_InertialNav &inav);
+    AC_Fence(const AP_AHRS_NavEKF &ahrs);
 
     /// record_breach - update breach bitmask, time and count
     void record_breach(uint8_t fence_type);
@@ -135,8 +134,7 @@ private:
     bool load_polygon_from_eeprom(bool force_reload = false);
 
     // pointers to other objects we depend upon
-    const AP_AHRS& _ahrs;
-    const AP_InertialNav& _inav;
+    const AP_AHRS_NavEKF& _ahrs;
 
     // parameters
     AP_Int8         _enabled;               // top level enable/disable control

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -127,6 +127,9 @@ private:
     /// check_fence_polygon - true if polygon fence has been newly breached
     bool check_fence_polygon();
 
+    /// check_fence_circle - true if circle fence has been newly breached
+    bool check_fence_circle();
+
     /// record_breach - update breach bitmask, time and count
     void record_breach(uint8_t fence_type);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -225,8 +225,10 @@ public:
     // it will return invalid when no limiting is required
     bool get_hgt_ctrl_limit(float &limit) const override;
 
-    // get_llh - updates the provided location with the latest calculated location including absolute altitude
-    //  returns true on success (i.e. the EKF knows it's latest position), false on failure
+    // get_location - updates the provided location with the latest
+    // calculated location including absolute altitude
+    // returns true on success (i.e. the EKF knows it's latest
+    // position), false on failure
     bool get_location(struct Location &loc) const;
 
     // get_variances - provides the innovations normalised using the innovation variance where a value of 0


### PR DESCRIPTION
Also factors out functions for each different fence type

I would prefer this to take an AP_AHRS rather than a NavEKF, but tridge bounced the idea of having get_location on AP_AHRS for the time being.

A relative position is required for running - only need an absolute position for loading.
