### PR TITLE
Rover: add pre-arm failure if both regular and skid steering outputs configured

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -69,3 +69,8 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
     // call parent gps checks
     return AP_Arming::gps_checks(display_failure);
 }
+
+bool AP_Arming_Rover::pre_arm_checks(bool report)
+{
+    return rover.g2.motors.pre_arm_check(report) & AP_Arming::pre_arm_checks(report);
+}

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -18,6 +18,7 @@ public:
     AP_Arming_Rover(const AP_Arming_Rover &other) = delete;
     AP_Arming_Rover &operator=(const AP_Baro&) = delete;
 
+    bool pre_arm_checks(bool report) override;
     bool pre_arm_rc_checks(const bool display_failure);
     bool gps_checks(bool display_failure) override;
 

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -299,6 +299,36 @@ bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
     return true;
 }
 
+//  returns true if checks pass, false if they fail.  report should be true to send text messages to GCS
+bool AP_MotorsUGV::pre_arm_check(bool report) const
+{
+    // check if both regular and skid steering functions have been defined
+    if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) &&
+        SRV_Channels::function_assigned(SRV_Channel::k_throttleRight) &&
+        SRV_Channels::function_assigned(SRV_Channel::k_throttle) &&
+        SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: regular AND skid steering configured");
+        }
+        return false;
+    }
+    // check if only one of skid-steering output has been configured
+    if (SRV_Channels::function_assigned(SRV_Channel::k_throttleLeft) != SRV_Channels::function_assigned(SRV_Channel::k_throttleRight)) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: check skid steering config");
+        }
+        return false;
+    }
+    // check if only one of throttle or steering outputs has been configured
+    if (SRV_Channels::function_assigned(SRV_Channel::k_throttle) != SRV_Channels::function_assigned(SRV_Channel::k_steering)) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: check steering and throttle config");
+        }
+        return false;
+    }
+    return true;
+}
+
 // setup pwm output type
 void AP_MotorsUGV::setup_pwm_type()
 {

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -55,6 +55,9 @@ public:
     // test steering or throttle output using a pwm value
     bool output_test_pwm(motor_test_order motor_seq, float pwm);
 
+    //  returns true if checks pass, false if they fail.  display_failure argument should be true to send text messages to GCS
+    bool pre_arm_check(bool report) const;
+
     // structure for holding motor limit flags
     struct AP_MotorsUGV_limit {
         uint8_t steer_left      : 1; // we have reached the steering controller's left most limit


### PR DESCRIPTION
We do not support having both skid-steering and regular steering at the same time so I have added a pre-arm check to protect against this kind of misconfiguration.

It would perhaps be nice to support both at the same time but it's not at all trivial because the steering turn-rate response depends upon the vehicle speed for regular rovers, but stays constant or even decreases with speed for skid-steer vehicles.

This fix is in response to a problem I found on my own vehicle in which I had accidentally setup both regular and skid-steering.  This caused the vehicle to simply stop when it reached sharp corners and the pivot-turn feature kicked in and stopped the vehicle and then attempted to turn it .. with the skid-steer motors that were not connected.