### PR TITLE
AP_InertialSensor: fix parameter desc for notch and log

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -85,6 +85,7 @@ known_units = {
              '%'       : 'percent'               ,
              '%/s'     : 'percent per second'    ,
              'd%'      : 'decipercent'           , # decipercent is strange, but "per-mille" is even more exotic
+             'dB'      : 'decibel'               ,
 # compound
              'm.m/s/s' : 'square meter per square second',
              'deg/m/s' : 'degrees per meter per second'  ,

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -425,16 +425,12 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FAST_SAMPLE",  36, AP_InertialSensor, _fast_sampling_mask,   0),
 
-    // @Param: NOTCH_
-    // @DisplayName: Notch filter
-    // @Description: Gyro notch filter
-    // @User: Advanced
+    // @Group: NOTCH_
+    // @Path: ../Filter/NotchFilter.cpp
     AP_SUBGROUPINFO(_notch_filter, "NOTCH_",  37, AP_InertialSensor, NotchFilterVector3fParam),
 
-    // @Param: LOG_
-    // @DisplayName: Log Settings
-    // @Description: Log Settings
-    // @User: Advanced
+    // @Group: LOG_
+    // @Path: ../AP_InertialSensor/BatchSampler.cpp
     AP_SUBGROUPINFO(batchsampler, "LOG_",  39, AP_InertialSensor, AP_InertialSensor::BatchSampler),
 
     /*


### PR DESCRIPTION
This fixes the parameter descriptions for the INS_NOTCH_ and INS_LOG_ parameters and added "dB" as a valid unit.