### PR TITLE
Remove create() methods in objects

### DIFF
--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -8,11 +8,11 @@
 class AP_Arming_Rover : public AP_Arming
 {
 public:
-    static AP_Arming_Rover create(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass, const AP_BattMonitor &battery) {
-        return AP_Arming_Rover{ahrs_ref, baro, compass, battery};
+    AP_Arming_Rover(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+                    const AP_BattMonitor &battery)
+        : AP_Arming(ahrs_ref, baro, compass, battery)
+    {
     }
-
-    constexpr AP_Arming_Rover(AP_Arming_Rover &&other) = default;
 
     /* Do not allow copies */
     AP_Arming_Rover(const AP_Arming_Rover &other) = delete;
@@ -23,11 +23,5 @@ public:
     bool gps_checks(bool display_failure) override;
 
 protected:
-    AP_Arming_Rover(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                    const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
-    {
-    }
-
     enum HomeState home_status() const override;
 };

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -27,7 +27,7 @@ Rover::Rover(void) :
     channel_steer(nullptr),
     channel_throttle(nullptr),
     channel_aux(nullptr),
-    DataFlash(DataFlash_Class::create(fwver.fw_string, g.log_bitmask)),
+    DataFlash{fwver.fw_string, g.log_bitmask},
     modes(&g.mode1),
     nav_controller(&L1_controller),
     control_mode(&mode_initializing),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -133,17 +133,17 @@ private:
     ParametersG2 g2;
 
     // main loop scheduler
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_Scheduler scheduler;
 
     // mapping between input channels
-    RCMapper rcmap = RCMapper::create();
+    RCMapper rcmap;
 
     // board specific config
-    AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+    AP_BoardConfig BoardConfig;
 
 #if HAL_WITH_UAVCAN
     // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN = AP_BoardConfig_CAN::create();
+    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // primary control channels
@@ -154,11 +154,11 @@ private:
     DataFlash_Class DataFlash;
 
     // sensor drivers
-    AP_GPS gps = AP_GPS::create();
-    AP_Baro barometer = AP_Baro::create();
-    Compass compass = Compass::create();
-    AP_InertialSensor ins = AP_InertialSensor::create();
-    RangeFinder rangefinder = RangeFinder::create(serial_manager, ROTATION_NONE);
+    AP_GPS gps;
+    AP_Baro barometer;
+    Compass compass;
+    AP_InertialSensor ins;
+    RangeFinder rangefinder{serial_manager, ROTATION_NONE};
     AP_Button button;
 
     // flight modes convenience array
@@ -166,61 +166,61 @@ private:
 
     // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rangefinder);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rangefinder);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3);
+    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
+    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs = AP_AHRS_DCM::create(ins, barometer, gps);
+    AP_AHRS_DCM ahrs{ins, barometer, gps};
 #endif
 
     // Arming/Disarming management class
-    AP_Arming_Rover arming = AP_Arming_Rover::create(ahrs, barometer, compass, battery);
+    AP_Arming_Rover arming{ahrs, barometer, compass, battery};
 
-    AP_L1_Control L1_controller = AP_L1_Control::create(ahrs, nullptr);
+    AP_L1_Control L1_controller{ahrs, nullptr};
 
     // selected navigation controller
     AP_Navigation *nav_controller;
 
     // Mission library
-    AP_Mission mission = AP_Mission::create(ahrs,
+    AP_Mission mission{ahrs,
             FUNCTOR_BIND_MEMBER(&Rover::start_command, bool, const AP_Mission::Mission_Command&),
             FUNCTOR_BIND_MEMBER(&Rover::verify_command_callback, bool, const AP_Mission::Mission_Command&),
-            FUNCTOR_BIND_MEMBER(&Rover::exit_mission, void));
+            FUNCTOR_BIND_MEMBER(&Rover::exit_mission, void)};
 
 #if AP_AHRS_NAVEKF_AVAILABLE
-    OpticalFlow optflow = OpticalFlow::create(ahrs);
+    OpticalFlow optflow{ahrs};
 #endif
 
     // RSSI
-    AP_RSSI rssi = AP_RSSI::create();
+    AP_RSSI rssi;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
 #endif
 
-    AP_SerialManager serial_manager = AP_SerialManager::create();
+    AP_SerialManager serial_manager;
 
     // GCS handling
     GCS_Rover _gcs;  // avoid using this; use gcs()
     GCS_Rover &gcs() { return _gcs; }
 
     // relay support
-    AP_Relay relay = AP_Relay::create();
+    AP_Relay relay;
 
-    AP_ServoRelayEvents ServoRelayEvents = AP_ServoRelayEvents::create(relay);
+    AP_ServoRelayEvents ServoRelayEvents{relay};
 
     // The rover's current location
     struct Location current_loc;
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera = AP_Camera::create(&relay, MASK_LOG_CAMERA, current_loc, ahrs);
+    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps solution for altitude rather than gps only.
-    AP_Mount camera_mount = AP_Mount::create(ahrs, current_loc);
+    AP_Mount camera_mount{ahrs, current_loc};
 #endif
 
     // true if initialisation has completed
@@ -258,7 +258,7 @@ private:
     } failsafe;
 
     // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
-    AP_Notify notify = AP_Notify::create();
+    AP_Notify notify;
 
     // true if we have a position estimate from AHRS
     bool have_position;
@@ -289,11 +289,11 @@ private:
     aux_switch_pos aux_ch7;
 
     // Battery Sensors
-    AP_BattMonitor battery = AP_BattMonitor::create();
+    AP_BattMonitor battery;
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry = AP_Frsky_Telem::create(ahrs, battery, rangefinder);
+    AP_Frsky_Telem frsky_telemetry{ahrs, battery, rangefinder};
 #endif
 
     uint32_t control_sensors_present;

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -135,7 +135,7 @@ void Tracker::ten_hz_logging_loop()
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 Tracker::Tracker(void)
-    : DataFlash(DataFlash_Class::create(fwver.fw_string, g.log_bitmask))
+    : DataFlash(fwver.fw_string, g.log_bitmask)
 {
     memset(&current_loc, 0, sizeof(current_loc));
     memset(&vehicle, 0, sizeof(vehicle));

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -93,10 +93,10 @@ private:
     Parameters g;
 
     // main loop scheduler
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_Scheduler scheduler;
 
     // notification object for LEDs, buzzers etc
-    AP_Notify notify = AP_Notify::create();
+    AP_Notify notify;
 
     uint32_t start_time_ms = 0;
 
@@ -104,23 +104,23 @@ private:
 
     DataFlash_Class DataFlash;
 
-    AP_GPS gps = AP_GPS::create();
+    AP_GPS gps;
 
-    AP_Baro barometer = AP_Baro::create();
+    AP_Baro barometer;
 
-    Compass compass = Compass::create();
+    Compass compass;
 
-    AP_InertialSensor ins = AP_InertialSensor::create();
+    AP_InertialSensor ins;
 
-    RangeFinder rng = RangeFinder::create(serial_manager, ROTATION_NONE);
+    RangeFinder rng{serial_manager, ROTATION_NONE};
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rng);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rng);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3);
+    NavEKF2 EKF2{&ahrs, barometer, rng};
+    NavEKF3 EKF3{&ahrs, barometer, rng};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs = AP_AHRS_DCM::create(ins, barometer, gps);
+    AP_AHRS_DCM ahrs{ins, barometer, gps};
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -139,19 +139,19 @@ private:
     bool yaw_servo_out_filt_init = false;
     bool pitch_servo_out_filt_init = false;
 
-    AP_SerialManager serial_manager = AP_SerialManager::create();
+    AP_SerialManager serial_manager;
     GCS_Tracker _gcs; // avoid using this; use gcs()
     GCS_Tracker &gcs() { return _gcs; }
 
-    AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+    AP_BoardConfig BoardConfig;
 
 #if HAL_WITH_UAVCAN
     // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN = AP_BoardConfig_CAN::create();
+    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // Battery Sensors
-    AP_BattMonitor battery = AP_BattMonitor::create();
+    AP_BattMonitor battery;
 
     struct Location current_loc;
 

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -5,13 +5,15 @@
 class AP_Arming_Copter : public AP_Arming
 {
 public:
-    static AP_Arming_Copter create(const AP_AHRS_NavEKF &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                                   const AP_BattMonitor &battery, const AP_InertialNav_NavEKF &inav,
-                                   const AP_InertialSensor &ins) {
-        return AP_Arming_Copter{ahrs_ref, baro, compass, battery, inav, ins};
+    AP_Arming_Copter(const AP_AHRS_NavEKF &ahrs_ref, const AP_Baro &baro, Compass &compass,
+                     const AP_BattMonitor &battery, const AP_InertialNav_NavEKF &inav,
+                     const AP_InertialSensor &ins)
+        : AP_Arming(ahrs_ref, baro, compass, battery)
+        , _inav(inav)
+        , _ins(ins)
+        , _ahrs_navekf(ahrs_ref)
+    {
     }
-
-    constexpr AP_Arming_Copter(AP_Arming_Copter &&other) = default;
 
     /* Do not allow copies */
     AP_Arming_Copter(const AP_Arming_Copter &other) = delete;
@@ -48,15 +50,6 @@ protected:
     enum HomeState home_status() const override;
 
 private:
-    AP_Arming_Copter(const AP_AHRS_NavEKF &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                     const AP_BattMonitor &battery, const AP_InertialNav_NavEKF &inav,
-                     const AP_InertialSensor &ins)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
-        , _inav(inav)
-        , _ins(ins)
-        , _ahrs_navekf(ahrs_ref)
-    {
-    }
 
     const AP_InertialNav_NavEKF &_inav;
     const AP_InertialSensor &_ins;

--- a/ArduCopter/AP_Rally.h
+++ b/ArduCopter/AP_Rally.h
@@ -20,18 +20,12 @@
 class AP_Rally_Copter : public AP_Rally
 {
 public:
-    static AP_Rally_Copter create(AP_AHRS &ahrs) {
-        return AP_Rally_Copter{ahrs};
-    }
-
-    constexpr AP_Rally_Copter(AP_Rally_Copter &&other) = default;
+    AP_Rally_Copter(AP_AHRS &ahrs) : AP_Rally(ahrs) { }
 
     /* Do not allow copies */
     AP_Rally_Copter(const AP_Rally_Copter &other) = delete;
     AP_Rally_Copter &operator=(const AP_Rally_Copter&) = delete;
 
 private:
-    AP_Rally_Copter(AP_AHRS &ahrs) : AP_Rally(ahrs) { }
-
     bool is_valid(const Location &rally_point) const override;
 };

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -24,7 +24,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
   constructor for main Copter class
  */
 Copter::Copter(void)
-    : DataFlash(DataFlash_Class::create(fwver.fw_string, g.log_bitmask)),
+    : DataFlash(fwver.fw_string, g.log_bitmask),
     flight_modes(&g.flight_mode1),
     control_mode(STABILIZE),
     scaleLongDown(1),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -168,10 +168,10 @@ private:
     ParametersG2 g2;
 
     // main loop scheduler
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_Scheduler scheduler;
 
     // AP_Notify instance
-    AP_Notify notify = AP_Notify::create();
+    AP_Notify notify;
 
     // used to detect MAVLink acks from GCS to stop compassmot
     uint8_t command_ack_counter;
@@ -185,16 +185,16 @@ private:
     // Dataflash
     DataFlash_Class DataFlash;
 
-    AP_GPS gps = AP_GPS::create();
+    AP_GPS gps;
 
     // flight modes convenience array
     AP_Int8 *flight_modes;
 
-    AP_Baro barometer = AP_Baro::create();
-    Compass compass = Compass::create();
-    AP_InertialSensor ins = AP_InertialSensor::create();
+    AP_Baro barometer;
+    Compass compass;
+    AP_InertialSensor ins;
 
-    RangeFinder rangefinder = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
+    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
@@ -204,29 +204,29 @@ private:
         int8_t glitch_count;
     } rangefinder_state = { false, false, 0, 0 };
 
-    AP_RPM rpm_sensor = AP_RPM::create();
+    AP_RPM rpm_sensor;
 
     // Inertial Navigation EKF
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rangefinder);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rangefinder);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF);
+    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
+    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
 #endif
 
     // Mission library
-    AP_Mission mission = AP_Mission::create(ahrs,
+    AP_Mission mission{ahrs,
             FUNCTOR_BIND_MEMBER(&Copter::start_command, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&Copter::verify_command_callback, bool, const AP_Mission::Mission_Command &),
-            FUNCTOR_BIND_MEMBER(&Copter::exit_mission, void));
+            FUNCTOR_BIND_MEMBER(&Copter::exit_mission, void)};
 
     // Arming/Disarming mangement class
-    AP_Arming_Copter arming = AP_Arming_Copter::create(ahrs, barometer, compass, battery, inertial_nav, ins);
+    AP_Arming_Copter arming{ahrs, barometer, compass, battery, inertial_nav, ins};
 
     // Optical flow sensor
 #if OPTFLOW == ENABLED
-    OpticalFlow optflow = OpticalFlow::create(ahrs);
+    OpticalFlow optflow{ahrs};
 #endif
 
     // gnd speed limit required to observe optical flow sensor limits
@@ -239,7 +239,7 @@ private:
     uint32_t ekfYawReset_ms = 0;
     int8_t ekf_primary_core;
 
-    AP_SerialManager serial_manager = AP_SerialManager::create();
+    AP_SerialManager serial_manager;
 
     // GCS selection
     GCS_Copter _gcs; // avoid using this; use gcs()
@@ -310,14 +310,14 @@ private:
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
 
-    RCMapper rcmap = RCMapper::create();
+    RCMapper rcmap;
 
     // board specific config
-    AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+    AP_BoardConfig BoardConfig;
 
 #if HAL_WITH_UAVCAN
     // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN = AP_BoardConfig_CAN::create();
+    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // receiver RSSI
@@ -404,11 +404,11 @@ private:
     uint32_t nav_delay_time_start;
 
     // Battery Sensors
-    AP_BattMonitor battery = AP_BattMonitor::create();
+    AP_BattMonitor battery;
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry = AP_Frsky_Telem::create(ahrs, battery, rangefinder);
+    AP_Frsky_Telem frsky_telemetry{ahrs, battery, rangefinder};
 #endif
 
     // Variables for extended status MAVLink messages
@@ -428,7 +428,7 @@ private:
     LowPassFilterFloat rc_throttle_control_in_filter;
 
     // loop performance monitoring:
-    AP::PerfInfo perf_info = AP::PerfInfo::create();
+    AP::PerfInfo perf_info;
 
     // 3D Location vectors
     // Current location of the vehicle (altitude is relative to home)
@@ -496,72 +496,72 @@ private:
     uint8_t auto_trim_counter;
 
     // Reference to the relay object
-    AP_Relay relay = AP_Relay::create();
+    AP_Relay relay;
 
     // handle repeated servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents = AP_ServoRelayEvents::create(relay);
+    AP_ServoRelayEvents ServoRelayEvents{relay};
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera = AP_Camera::create(&relay, MASK_LOG_CAMERA, current_loc, ahrs);
+    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
-    AP_Mount camera_mount = AP_Mount::create(ahrs, current_loc);
+    AP_Mount camera_mount{ahrs, current_loc};
 #endif
 
     // AC_Fence library to reduce fly-aways
 #if AC_FENCE == ENABLED
-    AC_Fence fence = AC_Fence::create(ahrs);
+    AC_Fence fence{ahrs};
 #endif
 
 #if AC_AVOID_ENABLED == ENABLED
-    AC_Avoid avoid = AC_Avoid::create(ahrs, fence, g2.proximity, &g2.beacon);
+    AC_Avoid avoid{ahrs, fence, g2.proximity, &g2.beacon};
 #endif
 
     // Rally library
 #if AC_RALLY == ENABLED
-    AP_Rally_Copter rally = AP_Rally_Copter::create(ahrs);
+    AP_Rally_Copter rally{ahrs};
 #endif
 
     // RSSI
-    AP_RSSI rssi = AP_RSSI::create();
+    AP_RSSI rssi;
 
     // Crop Sprayer
 #if SPRAYER == ENABLED
-    AC_Sprayer sprayer = AC_Sprayer::create(&inertial_nav);
+    AC_Sprayer sprayer{&inertial_nav};
 #endif
 
     // Parachute release
 #if PARACHUTE == ENABLED
-    AP_Parachute parachute = AP_Parachute::create(relay);
+    AP_Parachute parachute{relay};
 #endif
 
     // Landing Gear Controller
-    AP_LandingGear landinggear = AP_LandingGear::create();
+    AP_LandingGear landinggear;
 
     // terrain handling
 #if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    AP_Terrain terrain = AP_Terrain::create(ahrs, mission, rally);
+    AP_Terrain terrain{ahrs, mission, rally};
 #endif
 
     // Precision Landing
 #if PRECISION_LANDING == ENABLED
-    AC_PrecLand precland = AC_PrecLand::create(ahrs, inertial_nav);
+    AC_PrecLand precland{ahrs, inertial_nav};
 #endif
 
     // Pilot Input Management Library
     // Only used for Helicopter for now
 #if FRAME_CONFIG == HELI_FRAME
-    AC_InputManager_Heli input_manager = AC_InputManager_Heli::create();
+    AC_InputManager_Heli input_manager;
 #endif
 
-    AP_ADSB adsb = AP_ADSB::create(ahrs);
+    AP_ADSB adsb{ahrs};
 
     // avoidance of adsb enabled vehicles (normally manned vehicles)
-    AP_Avoidance_Copter avoidance_adsb = AP_Avoidance_Copter::create(ahrs, adsb);
+    AP_Avoidance_Copter avoidance_adsb{ahrs, adsb};
 
     // use this to prevent recursion during sensor init
     bool in_mavlink_delay;

--- a/ArduCopter/avoidance_adsb.h
+++ b/ArduCopter/avoidance_adsb.h
@@ -8,11 +8,10 @@
 // functionality - for example, not doing anything while landed.
 class AP_Avoidance_Copter : public AP_Avoidance {
 public:
-    static AP_Avoidance_Copter create(AP_AHRS &ahrs, class AP_ADSB &adsb) {
-        return AP_Avoidance_Copter{ahrs, adsb};
+    AP_Avoidance_Copter(AP_AHRS &ahrs, class AP_ADSB &adsb)
+        : AP_Avoidance(ahrs, adsb)
+    {
     }
-
-    constexpr AP_Avoidance_Copter(AP_Avoidance_Copter &&other) = default;
 
     /* Do not allow copies */
     AP_Avoidance_Copter(const AP_Avoidance_Copter &other) = delete;
@@ -23,11 +22,6 @@ private:
     void set_mode_else_try_RTL_else_LAND(control_mode_t mode);
 
 protected:
-    AP_Avoidance_Copter(AP_AHRS &ahrs, class AP_ADSB &adsb)
-        : AP_Avoidance(ahrs, adsb)
-    {
-    }
-
     // override avoidance handler
     MAV_COLLISION_ACTION handle_avoidance(const AP_Avoidance::Obstacle *obstacle, MAV_COLLISION_ACTION requested_action) override;
 

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -8,17 +8,18 @@
 class AP_Arming_Plane : public AP_Arming
 {
 public:
+    AP_Arming_Plane(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+                    const AP_BattMonitor &battery)
+        : AP_Arming(ahrs_ref, baro, compass, battery)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+    }
+
     enum ArmingRudder {
         ARMING_RUDDER_DISABLED  = 0,
         ARMING_RUDDER_ARMONLY   = 1,
         ARMING_RUDDER_ARMDISARM = 2
     };
-
-    static AP_Arming_Plane create(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass, const AP_BattMonitor &battery) {
-        return AP_Arming_Plane{ahrs_ref, baro, compass, battery};
-    }
-
-    constexpr AP_Arming_Plane(AP_Arming_Plane &&other) = default;
 
     /* Do not allow copies */
     AP_Arming_Plane(const AP_Arming_Plane &other) = delete;
@@ -32,13 +33,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
-    AP_Arming_Plane(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                    const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     bool ins_checks(bool report);
     enum HomeState home_status() const override;
 

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -24,7 +24,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
   constructor for main Plane class
  */
 Plane::Plane(void)
-    : DataFlash(DataFlash_Class::create(fwver.fw_string, g.log_bitmask))
+    : DataFlash(fwver.fw_string, g.log_bitmask)
 {
     // C++11 doesn't allow in-class initialisation of bitfields
     auto_state.takeoff_complete = true;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -166,17 +166,17 @@ private:
     ParametersG2 g2;
 
     // main loop scheduler
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_Scheduler scheduler;
 
     // mapping between input channels
-    RCMapper rcmap = RCMapper::create();
+    RCMapper rcmap;
 
     // board specific config
-    AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+    AP_BoardConfig BoardConfig;
 
     // board specific config for CAN bus
 #if HAL_WITH_UAVCAN
-    AP_BoardConfig_CAN BoardConfig_CAN = AP_BoardConfig_CAN::create();
+    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // primary input channels
@@ -186,7 +186,7 @@ private:
     RC_Channel *channel_rudder;
 
     // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
-    AP_Notify notify = AP_Notify::create();
+    AP_Notify notify;
 
     DataFlash_Class DataFlash;
 
@@ -195,39 +195,39 @@ private:
     int32_t pitch_limit_min_cd;
 
     // Sensors
-    AP_GPS gps = AP_GPS::create();
+    AP_GPS gps;
 
     // flight modes convenience array
     AP_Int8 *flight_modes = &g.flight_mode1;
 
-    AP_Baro barometer = AP_Baro::create();
-    Compass compass = Compass::create();
+    AP_Baro barometer;
+    Compass compass;
 
-    AP_InertialSensor ins = AP_InertialSensor::create();
+    AP_InertialSensor ins;
 
-    RangeFinder rangefinder = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
+    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
 
     AP_Vehicle::FixedWing::Rangefinder_State rangefinder_state;
 
-    AP_RPM rpm_sensor = AP_RPM::create();
+    AP_RPM rpm_sensor;
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rangefinder);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rangefinder);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3);
+    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
+    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs = AP_AHRS_DCM::create(ins, barometer, gps);
+    AP_AHRS_DCM ahrs{ins, barometer, gps};
 #endif
 
-    AP_TECS TECS_controller = AP_TECS::create(ahrs, aparm, landing, g2.soaring_controller);
-    AP_L1_Control L1_controller = AP_L1_Control::create(ahrs, &TECS_controller);
+    AP_TECS TECS_controller{ahrs, aparm, landing, g2.soaring_controller};
+    AP_L1_Control L1_controller{ahrs, &TECS_controller};
 
     // Attitude to servo controllers
-    AP_RollController rollController = AP_RollController::create(ahrs, aparm, DataFlash);
-    AP_PitchController pitchController = AP_PitchController::create(ahrs, aparm, DataFlash);
-    AP_YawController yawController = AP_YawController::create(ahrs, aparm);
-    AP_SteerController steerController = AP_SteerController::create(ahrs);
+    AP_RollController rollController{ahrs, aparm, DataFlash};
+    AP_PitchController pitchController{ahrs, aparm, DataFlash};
+    AP_YawController yawController{ahrs, aparm};
+    AP_SteerController steerController{ahrs};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
@@ -254,7 +254,7 @@ private:
     // external failsafe boards during baro and airspeed calibration
     bool in_calibration;
 
-    AP_SerialManager serial_manager = AP_SerialManager::create();
+    AP_SerialManager serial_manager;
 
     // GCS selection
     GCS_Plane _gcs; // avoid using this; use gcs()
@@ -267,26 +267,26 @@ private:
     AP_SpdHgtControl *SpdHgt_Controller = &TECS_controller;
 
     // Relay
-    AP_Relay relay = AP_Relay::create();
+    AP_Relay relay;
 
     // handle servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents = AP_ServoRelayEvents::create(relay);
+    AP_ServoRelayEvents ServoRelayEvents{relay};
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera = AP_Camera::create(&relay, MASK_LOG_CAMERA, current_loc, ahrs);
+    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
 #endif
 
 #if OPTFLOW == ENABLED
     // Optical flow sensor
-    OpticalFlow optflow = OpticalFlow::create(ahrs);
+    OpticalFlow optflow{ahrs};
 #endif
 
     // Rally Ponints
-    AP_Rally rally = AP_Rally::create(ahrs);
+    AP_Rally rally{ahrs};
 
     // RSSI
-    AP_RSSI rssi = AP_RSSI::create();
+    AP_RSSI rssi;
 
     // This is the state of the flight control system
     // There are multiple states defined such as MANUAL, FBW-A, AUTO
@@ -391,11 +391,11 @@ private:
     int32_t altitude_error_cm;
 
     // Battery Sensors
-    AP_BattMonitor battery = AP_BattMonitor::create();
+    AP_BattMonitor battery;
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry = AP_Frsky_Telem::create(ahrs, battery, rangefinder);
+    AP_Frsky_Telem frsky_telemetry{ahrs, battery, rangefinder};
 #endif
 
     // Variables for extended status MAVLink messages
@@ -599,33 +599,33 @@ private:
     float smoothed_airspeed;
 
     // Mission library
-    AP_Mission mission = AP_Mission::create(ahrs,
+    AP_Mission mission{ahrs,
             FUNCTOR_BIND_MEMBER(&Plane::start_command_callback, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&Plane::verify_command_callback, bool, const AP_Mission::Mission_Command &),
-            FUNCTOR_BIND_MEMBER(&Plane::exit_mission_callback, void));
+            FUNCTOR_BIND_MEMBER(&Plane::exit_mission_callback, void)};
 
 
 #if PARACHUTE == ENABLED
-    AP_Parachute parachute = AP_Parachute::create(relay);
+    AP_Parachute parachute{relay};
 #endif
 
     // terrain handling
 #if AP_TERRAIN_AVAILABLE
-    AP_Terrain terrain = AP_Terrain::create(ahrs, mission, rally);
+    AP_Terrain terrain{ahrs, mission, rally};
 #endif
 
-    AP_Landing landing = AP_Landing::create(mission,ahrs,SpdHgt_Controller,nav_controller,aparm,
-        FUNCTOR_BIND_MEMBER(&Plane::set_target_altitude_proportion, void, const Location&, float),
-        FUNCTOR_BIND_MEMBER(&Plane::constrain_target_altitude_location, void, const Location&, const Location&),
-        FUNCTOR_BIND_MEMBER(&Plane::adjusted_altitude_cm, int32_t),
-        FUNCTOR_BIND_MEMBER(&Plane::adjusted_relative_altitude_cm, int32_t),
-        FUNCTOR_BIND_MEMBER(&Plane::disarm_if_autoland_complete, void),
-        FUNCTOR_BIND_MEMBER(&Plane::update_flight_stage, void));
+    AP_Landing landing{mission,ahrs,SpdHgt_Controller,nav_controller,aparm,
+            FUNCTOR_BIND_MEMBER(&Plane::set_target_altitude_proportion, void, const Location&, float),
+            FUNCTOR_BIND_MEMBER(&Plane::constrain_target_altitude_location, void, const Location&, const Location&),
+            FUNCTOR_BIND_MEMBER(&Plane::adjusted_altitude_cm, int32_t),
+            FUNCTOR_BIND_MEMBER(&Plane::adjusted_relative_altitude_cm, int32_t),
+            FUNCTOR_BIND_MEMBER(&Plane::disarm_if_autoland_complete, void),
+            FUNCTOR_BIND_MEMBER(&Plane::update_flight_stage, void)};
 
-    AP_ADSB adsb = AP_ADSB::create(ahrs);
+    AP_ADSB adsb{ahrs};
 
     // avoidance of adsb enabled vehicles (normally manned vheicles)
-    AP_Avoidance_Plane avoidance_adsb = AP_Avoidance_Plane::create(ahrs, adsb);
+    AP_Avoidance_Plane avoidance_adsb{ahrs, adsb};
 
     // Outback Challenge Failsafe Support
     AP_AdvancedFailsafe_Plane afs {mission, barometer, gps, rcmap};
@@ -768,11 +768,11 @@ private:
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
-    AP_Mount camera_mount = AP_Mount::create(ahrs, current_loc);
+    AP_Mount camera_mount{ahrs, current_loc};
 #endif
 
     // Arming/Disarming mangement class
-    AP_Arming_Plane arming = AP_Arming_Plane::create(ahrs, barometer, compass, battery);
+    AP_Arming_Plane arming{ahrs, barometer, compass, battery};
 
     AP_Param param_loader {var_info};
 

--- a/ArduPlane/avoidance_adsb.h
+++ b/ArduPlane/avoidance_adsb.h
@@ -8,22 +8,16 @@
 // functionality - for example, not doing anything while landed.
 class AP_Avoidance_Plane : public AP_Avoidance {
 public:
-    static AP_Avoidance_Plane create(AP_AHRS &ahrs, class AP_ADSB &adsb) {
-        return AP_Avoidance_Plane{ahrs, adsb};
+    AP_Avoidance_Plane(AP_AHRS &ahrs, class AP_ADSB &adsb)
+        : AP_Avoidance(ahrs, adsb)
+    {
     }
-
-    constexpr AP_Avoidance_Plane(AP_Avoidance_Plane &&other) = default;
 
     /* Do not allow copies */
     AP_Avoidance_Plane(const AP_Avoidance_Plane &other) = delete;
     AP_Avoidance_Plane &operator=(const AP_Avoidance_Plane&) = delete;
 
 protected:
-    AP_Avoidance_Plane(AP_AHRS &ahrs, class AP_ADSB &adsb)
-        : AP_Avoidance(ahrs, adsb)
-    {
-    }
-
     // override avoidance handler
     MAV_COLLISION_ACTION handle_avoidance(const AP_Avoidance::Obstacle *obstacle, MAV_COLLISION_ACTION requested_action) override;
 

--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -4,11 +4,11 @@
 
 class AP_Arming_Sub : public AP_Arming {
 public:
-    static AP_Arming_Sub create(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass, const AP_BattMonitor &battery) {
-        return AP_Arming_Sub{ahrs_ref, baro, compass, battery};
+    AP_Arming_Sub(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+                  const AP_BattMonitor &battery)
+        : AP_Arming(ahrs_ref, baro, compass, battery)
+    {
     }
-
-    constexpr AP_Arming_Sub(AP_Arming_Sub &&other) = default;
 
     /* Do not allow copies */
     AP_Arming_Sub(const AP_Arming_Sub &other) = delete;
@@ -18,12 +18,6 @@ public:
     bool pre_arm_checks(bool report) override;
 
 protected:
-    AP_Arming_Sub(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                  const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
-    {
-    }
-
     bool ins_checks(bool report) override;
     enum HomeState home_status() const override;
 };

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -24,7 +24,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
   constructor for main Sub class
  */
 Sub::Sub(void)
-    : DataFlash(DataFlash_Class::create(fwver.fw_string, g.log_bitmask)),
+    : DataFlash(fwver.fw_string, g.log_bitmask),
           control_mode(MANUAL),
           motors(MAIN_LOOP_RATE),
           scaleLongDown(1),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -146,10 +146,10 @@ private:
     ParametersG2 g2;
 
     // main loop scheduler
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_Scheduler scheduler;
 
     // AP_Notify instance
-    AP_Notify notify = AP_Notify::create();
+    AP_Notify notify;
 
     // primary input control channels
     RC_Channel *channel_roll;
@@ -162,16 +162,16 @@ private:
     // Dataflash
     DataFlash_Class DataFlash;
 
-    AP_GPS gps = AP_GPS::create();
+    AP_GPS gps;
 
-    AP_LeakDetector leak_detector = AP_LeakDetector::create();
+    AP_LeakDetector leak_detector;
 
     TSYS01 celsius;
-    AP_Baro barometer = AP_Baro::create();
-    Compass compass = Compass::create();
-    AP_InertialSensor ins = AP_InertialSensor::create();
+    AP_Baro barometer;
+    Compass compass;
+    AP_InertialSensor ins;
 
-    RangeFinder rangefinder = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
+    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder
@@ -181,27 +181,27 @@ private:
     } rangefinder_state = { false, false, 0, 0 };
 
 #if RPM_ENABLED == ENABLED
-    AP_RPM rpm_sensor = AP_RPM::create();
+    AP_RPM rpm_sensor;
 #endif
 
     // Inertial Navigation EKF
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rangefinder);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rangefinder);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF);
+    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
+    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
 #endif
 
     // Mission library
-    AP_Mission mission = AP_Mission::create(ahrs,
+    AP_Mission mission{ahrs,
             FUNCTOR_BIND_MEMBER(&Sub::start_command, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&Sub::verify_command_callback, bool, const AP_Mission::Mission_Command &),
-            FUNCTOR_BIND_MEMBER(&Sub::exit_mission, void));
+            FUNCTOR_BIND_MEMBER(&Sub::exit_mission, void)};
 
     // Optical flow sensor
 #if OPTFLOW == ENABLED
-    OpticalFlow optflow = OpticalFlow::create(ahrs);
+    OpticalFlow optflow{ahrs};
 #endif
 
     // gnd speed limit required to observe optical flow sensor limits
@@ -213,7 +213,7 @@ private:
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms = 0;
 
-    AP_SerialManager serial_manager = AP_SerialManager::create();
+    AP_SerialManager serial_manager;
 
     // GCS selection
     GCS_Sub _gcs; // avoid using this; use gcs()
@@ -252,15 +252,15 @@ private:
     mode_reason_t prev_control_mode_reason = MODE_REASON_UNKNOWN;
 
 #if RCMAP_ENABLED == ENABLED
-    RCMapper rcmap = RCMapper::create();
+    RCMapper rcmap;
 #endif
 
     // board specific config
-    AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+    AP_BoardConfig BoardConfig;
 
 #if HAL_WITH_UAVCAN
     // board specific config for CAN bus
-    AP_BoardConfig_CAN BoardConfig_CAN = AP_BoardConfig_CAN::create();
+    AP_BoardConfig_CAN BoardConfig_CAN;
 #endif
 
     // Failsafe
@@ -327,9 +327,9 @@ private:
     uint32_t nav_delay_time_start;
 
     // Battery Sensors
-    AP_BattMonitor battery = AP_BattMonitor::create();
+    AP_BattMonitor battery;
 
-    AP_Arming_Sub arming = AP_Arming_Sub::create(ahrs, barometer, compass, battery);
+    AP_Arming_Sub arming{ahrs, barometer, compass, battery};
 
     // Altitude
     // The cm/s we are moving up or down based on filtered data - Positive = UP
@@ -347,7 +347,7 @@ private:
     bool input_hold_engaged;
 
     // loop performance monitoring:
-    AP::PerfInfo perf_info = AP::PerfInfo::create();
+    AP::PerfInfo perf_info;
 
     // 3D Location vectors
     // Current location of the Sub (altitude is relative to home)
@@ -408,39 +408,39 @@ private:
     uint16_t mainLoop_count;
 
     // Reference to the relay object
-    AP_Relay relay = AP_Relay::create();
+    AP_Relay relay;
 
     // handle repeated servo and relay events
-    AP_ServoRelayEvents ServoRelayEvents = AP_ServoRelayEvents::create(relay);
+    AP_ServoRelayEvents ServoRelayEvents{relay};
 
     // Camera
 #if CAMERA == ENABLED
-    AP_Camera camera = AP_Camera::create(&relay, MASK_LOG_CAMERA, current_loc, ahrs);
+    AP_Camera camera{&relay, MASK_LOG_CAMERA, current_loc, ahrs};
 #endif
 
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
-    AP_Mount camera_mount = AP_Mount::create(ahrs, current_loc);
+    AP_Mount camera_mount{ahrs, current_loc};
 #endif
 
     // AC_Fence library to reduce fly-aways
 #if AC_FENCE == ENABLED
-    AC_Fence fence = AC_Fence::create(ahrs);
+    AC_Fence fence{ahrs};
 #endif
 
 #if AVOIDANCE_ENABLED == ENABLED
-    AC_Avoid avoid = AC_Avoid::create(ahrs, inertial_nav, fence, g2.proximity, &g2.beacon);
+    AC_Avoid avoid{ahrs, inertial_nav, fence, g2.proximity, &g2.beacon};
 #endif
 
     // Rally library
 #if AC_RALLY == ENABLED
-    AP_Rally rally = AP_Rally::create(ahrs);
+    AP_Rally rally{ahrs};
 #endif
 
     // terrain handling
 #if AP_TERRAIN_AVAILABLE && AC_TERRAIN
-    AP_Terrain terrain = AP_Terrain::create(ahrs, mission, rally);
+    AP_Terrain terrain{ahrs, mission, rally};
 #endif
 
     // use this to prevent recursion during sensor init

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -58,20 +58,20 @@ public:
     void setup();
     void load_parameters(void);
 
-    AP_InertialSensor ins = AP_InertialSensor::create();
-    AP_Baro barometer = AP_Baro::create();
-    AP_GPS gps = AP_GPS::create();
-    Compass compass = Compass::create();
-    AP_SerialManager serial_manager = AP_SerialManager::create();
-    RangeFinder rng = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rng);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rng);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3);
+    AP_InertialSensor ins;
+    AP_Baro barometer;
+    AP_GPS gps;
+    Compass compass;
+    AP_SerialManager serial_manager;
+    RangeFinder rng{serial_manager, ROTATION_PITCH_270};
+    NavEKF2 EKF2{&ahrs, barometer, rng};
+    NavEKF3 EKF3{&ahrs, barometer, rng};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3};
     AP_InertialNav_NavEKF inertial_nav{ahrs};
     AP_Vehicle::FixedWing aparm;
     AP_Airspeed airspeed;
     AP_Int32 unused; // logging is magic for Replay; this is unused
-    DataFlash_Class dataflash = DataFlash_Class::create("Replay v0.1", unused);
+    DataFlash_Class dataflash{"Replay v0.1", unused};
 
 private:
     Parameters g;

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -28,14 +28,7 @@
  */
 class AC_Avoid {
 public:
-    static AC_Avoid create(const AP_AHRS& ahrs,
-                           const AC_Fence& fence,
-                           const AP_Proximity& proximity,
-                           const AP_Beacon* beacon = nullptr) {
-        return AC_Avoid{ahrs, fence, proximity, beacon};
-    }
-
-    constexpr AC_Avoid(AC_Avoid &&other) = default;
+    AC_Avoid(const AP_AHRS& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
 
     /* Do not allow copies */
     AC_Avoid(const AC_Avoid &other) = delete;
@@ -64,8 +57,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_Avoid(const AP_AHRS& ahrs, const AC_Fence& fence, const AP_Proximity& proximity, const AP_Beacon* beacon = nullptr);
-
     /*
      * Adjusts the desired velocity for the circular fence.
      */

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -34,11 +34,7 @@
 class AC_Fence
 {
 public:
-    static AC_Fence create(const AP_AHRS_NavEKF &ahrs) {
-        return AC_Fence{ahrs};
-    }
-
-    constexpr AC_Fence(AC_Fence &&other) = default;
+    AC_Fence(const AP_AHRS_NavEKF &ahrs);
 
     /* Do not allow copies */
     AC_Fence(const AC_Fence &other) = delete;
@@ -127,8 +123,6 @@ public:
     bool geofence_failed() const;
 
 private:
-    AC_Fence(const AP_AHRS_NavEKF &ahrs);
-
     /// check_fence_alt_max - true if alt fence has been newly breached
     bool check_fence_alt_max(float curr_alt);
 

--- a/libraries/AC_InputManager/AC_InputManager.h
+++ b/libraries/AC_InputManager/AC_InputManager.h
@@ -11,9 +11,10 @@
 /// @brief  Class managing the pilot's control inputs
 class AC_InputManager{
 public:
-    static AC_InputManager create() { return AC_InputManager{}; }
-
-    constexpr AC_InputManager(AC_InputManager &&other) = default;
+    AC_InputManager() {
+        // setup parameter defaults
+        AP_Param::setup_object_defaults(this, var_info);
+    }
 
     /* Do not allow copies */
     AC_InputManager(const AC_InputManager &other) = delete;
@@ -23,11 +24,6 @@ public:
     void set_loop_rate(uint16_t loop_rate) { _loop_rate = loop_rate; }
 
 protected:
-    AC_InputManager() {
-        // setup parameter defaults
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // internal variables
     uint16_t            _loop_rate;             // rate at which output() function is called (normally 400hz)
 

--- a/libraries/AC_InputManager/AC_InputManager_Heli.h
+++ b/libraries/AC_InputManager/AC_InputManager_Heli.h
@@ -16,9 +16,13 @@
 /// @brief  Class managing the pilot's control inputs   for Conventional Helicopter
 class AC_InputManager_Heli : public AC_InputManager {
 public:
-    static AC_InputManager_Heli create() { return AC_InputManager_Heli{}; }
-
-    constexpr AC_InputManager_Heli(AC_InputManager_Heli &&other) = default;
+    // Constructor
+    AC_InputManager_Heli()
+        : AC_InputManager()
+    {
+        // setup parameter defaults
+        AP_Param::setup_object_defaults(this, var_info);
+    }
 
     /* Do not allow copies */
     AC_InputManager_Heli(const AC_InputManager_Heli &other) = delete;
@@ -34,15 +38,6 @@ public:
     void set_stab_col_ramp(float ramp) { _stab_col_ramp = constrain_float(ramp, 0.0, 1.0); }
 
     static const struct AP_Param::GroupInfo        var_info[];
-
-protected:
-    // Constructor
-    AC_InputManager_Heli()
-        : AC_InputManager()
-    {
-        // setup parameter defaults
-        AP_Param::setup_object_defaults(this, var_info);
-    }
 
 private:
     struct InputManagerHeliFlags {

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -25,6 +25,12 @@ class AC_PrecLand
     friend class AC_PrecLand_SITL;
 
 public:
+    AC_PrecLand(const AP_AHRS& ahrs, const AP_InertialNav& inav);
+
+    /* Do not allow copies */
+    AC_PrecLand(const AC_PrecLand &other) = delete;
+    AC_PrecLand &operator=(const AC_PrecLand&) = delete;
+
     // precision landing behaviours (held in PRECLAND_ENABLED parameter)
     enum PrecLandBehaviour {
         PRECLAND_BEHAVIOUR_DISABLED,
@@ -40,16 +46,6 @@ public:
         PRECLAND_TYPE_SITL_GAZEBO,
         PRECLAND_TYPE_SITL,
     };
-
-    static AC_PrecLand create(const AP_AHRS& ahrs, const AP_InertialNav& inav) {
-        return AC_PrecLand{ahrs, inav};
-    }
-
-    constexpr AC_PrecLand(AC_PrecLand &&other) = default;
-
-    /* Do not allow copies */
-    AC_PrecLand(const AC_PrecLand &other) = delete;
-    AC_PrecLand &operator=(const AC_PrecLand&) = delete;
 
     // perform any required initialisation of landing controllers
     void init();
@@ -85,8 +81,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_PrecLand(const AP_AHRS& ahrs, const AP_InertialNav& inav);
-
     enum estimator_type_t {
         ESTIMATOR_TYPE_RAW_SENSOR = 0,
         ESTIMATOR_TYPE_KALMAN_FILTER = 1

--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -32,11 +32,7 @@
 /// @brief  Object managing a crop sprayer comprised of a spinner and a pump both controlled by pwm
 class AC_Sprayer {
 public:
-    static AC_Sprayer create(const AP_InertialNav  *inav) {
-        return AC_Sprayer{inav};
-    }
-
-    constexpr AC_Sprayer(AC_Sprayer &&other) = default;
+    AC_Sprayer(const AP_InertialNav *inav);
 
     /* Do not allow copies */
     AC_Sprayer(const AC_Sprayer &other) = delete;
@@ -65,8 +61,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AC_Sprayer(const AP_InertialNav *inav);
-
     const AP_InertialNav* const _inav;      ///< pointers to other objects we depend upon
 
     // parameters

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -9,12 +9,13 @@
 
 class AP_PitchController {
 public:
-    static AP_PitchController create(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms,
-                                    DataFlash_Class &_dataflash) {
-        return AP_PitchController{ahrs, parms, _dataflash};
+    AP_PitchController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, DataFlash_Class &_dataflash)
+        : aparm(parms)
+        , autotune(gains, AP_AutoTune::AUTOTUNE_PITCH, parms, _dataflash)
+        , _ahrs(ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_PitchController(AP_PitchController &&other) = default;
 
     /* Do not allow copies */
     AP_PitchController(const AP_PitchController &other) = delete;
@@ -38,14 +39,6 @@ public:
     AP_Float &kFF(void) { return gains.FF; }
 
 private:
-    AP_PitchController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, DataFlash_Class &_dataflash)
-        : aparm(parms)
-        , autotune(gains, AP_AutoTune::AUTOTUNE_PITCH, parms, _dataflash)
-        , _ahrs(ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     const AP_Vehicle::FixedWing &aparm;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -9,12 +9,13 @@
 
 class AP_RollController {
 public:
-    static AP_RollController create(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms,
-                                    DataFlash_Class &_dataflash) {
-        return AP_RollController{ahrs, parms, _dataflash};
+    AP_RollController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, DataFlash_Class &_dataflash)
+        : aparm(parms)
+        , autotune(gains, AP_AutoTune::AUTOTUNE_ROLL, parms, _dataflash)
+        , _ahrs(ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_RollController(AP_RollController &&other) = default;
 
     /* Do not allow copies */
     AP_RollController(const AP_RollController &other) = delete;
@@ -45,14 +46,6 @@ public:
     AP_Float &kFF(void) { return gains.FF; }
 
 private:
-    AP_RollController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, DataFlash_Class &_dataflash)
-        : aparm(parms)
-        , autotune(gains, AP_AutoTune::AUTOTUNE_ROLL, parms, _dataflash)
-        , _ahrs(ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     const AP_Vehicle::FixedWing &aparm;
     AP_AutoTune::ATGains gains;
     AP_AutoTune autotune;

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -7,11 +7,11 @@
 
 class AP_SteerController {
 public:
-    static AP_SteerController create(AP_AHRS &ahrs) {
-        return AP_SteerController{ahrs};
+    AP_SteerController(AP_AHRS &ahrs)
+        : _ahrs(ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_SteerController(AP_SteerController &&other) = default;
 
     /* Do not allow copies */
     AP_SteerController(const AP_SteerController &other) = delete;
@@ -53,12 +53,6 @@ public:
     }
 
 private:
-    AP_SteerController(AP_AHRS &ahrs)
-        : _ahrs(ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     AP_Float _tau;
 	AP_Float _K_FF;
 	AP_Float _K_P;

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -8,11 +8,15 @@
 
 class AP_YawController {
 public:
-    static AP_YawController create(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms) {
-        return AP_YawController{ahrs, parms};
+    AP_YawController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms)
+        : aparm(parms)
+        , _ahrs(ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+        _pid_info.desired = 0;
+        _pid_info.FF = 0;
+        _pid_info.P = 0;
     }
-
-    constexpr AP_YawController(AP_YawController &&other) = default;
 
     /* Do not allow copies */
     AP_YawController(const AP_YawController &other) = delete;
@@ -27,16 +31,6 @@ public:
 	static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_YawController(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms)
-        : aparm(parms)
-        , _ahrs(ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-        _pid_info.desired = 0;
-        _pid_info.FF = 0;
-        _pid_info.P = 0;
-    }
-
     const AP_Vehicle::FixedWing &aparm;
 	AP_Float _K_A;
 	AP_Float _K_I;

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -31,11 +31,11 @@
 
 class AP_ADSB {
 public:
-    static AP_ADSB create(const AP_AHRS &ahrs) {
-        return AP_ADSB{ahrs};
+    AP_ADSB(const AP_AHRS &ahrs)
+        : _ahrs(ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_ADSB(AP_ADSB &&other) = default;
 
     /* Do not allow copies */
     AP_ADSB(const AP_ADSB &other) = delete;
@@ -76,12 +76,6 @@ public:
     void handle_message(const mavlink_channel_t chan, const mavlink_message_t* msg);
 
 private:
-    AP_ADSB(const AP_AHRS &ahrs)
-        : _ahrs(ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // initialize _vehicle_list
     void init();
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -23,11 +23,38 @@
 
 class AP_AHRS_DCM : public AP_AHRS {
 public:
-    static AP_AHRS_DCM create(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps) {
-        return AP_AHRS_DCM{ins, baro, gps};
-    }
+    AP_AHRS_DCM(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps)
+        : AP_AHRS(ins, baro, gps)
+        , _omega_I_sum_time(0.0f)
+        , _renorm_val_sum(0.0f)
+        , _renorm_val_count(0)
+        , _error_rp(1.0f)
+        , _error_yaw(1.0f)
+        , _gps_last_update(0)
+        , _ra_deltat(0.0f)
+        , _ra_sum_start(0)
+        , _last_declination(0.0f)
+        , _mag_earth(1, 0)
+        , _have_gps_lock(false)
+        , _last_lat(0)
+        , _last_lng(0)
+        , _position_offset_north(0.0f)
+        , _position_offset_east(0.0f)
+        , _have_position(false)
+        , _last_wind_time(0)
+        , _last_airspeed(0.0f)
+        , _last_consistent_heading(0)
+        , _imu1_weight(0.5f)
+        , _last_failure_ms(0)
+        , _last_startup_ms(0)
+    {
+        _dcm_matrix.identity();
 
-    constexpr AP_AHRS_DCM(AP_AHRS_DCM &&other) = default;
+        // these are experimentally derived from the simulator
+        // with large drift levels
+        _ki = 0.0087f;
+        _ki_yaw = 0.01f;
+    }
 
     /* Do not allow copies */
     AP_AHRS_DCM(const AP_AHRS_DCM &other) = delete;
@@ -92,40 +119,6 @@ public:
 
     // time that the AHRS has been up
     uint32_t uptime_ms() const override;
-
-protected:
-    AP_AHRS_DCM(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps)
-        : AP_AHRS(ins, baro, gps)
-        , _omega_I_sum_time(0.0f)
-        , _renorm_val_sum(0.0f)
-        , _renorm_val_count(0)
-        , _error_rp(1.0f)
-        , _error_yaw(1.0f)
-        , _gps_last_update(0)
-        , _ra_deltat(0.0f)
-        , _ra_sum_start(0)
-        , _last_declination(0.0f)
-        , _mag_earth(1, 0)
-        , _have_gps_lock(false)
-        , _last_lat(0)
-        , _last_lng(0)
-        , _position_offset_north(0.0f)
-        , _position_offset_east(0.0f)
-        , _have_position(false)
-        , _last_wind_time(0)
-        , _last_airspeed(0.0f)
-        , _last_consistent_heading(0)
-        , _imu1_weight(0.5f)
-        , _last_failure_ms(0)
-        , _last_startup_ms(0)
-    {
-        _dcm_matrix.identity();
-
-        // these are experimentally derived from the simulator
-        // with large drift levels
-        _ki = 0.0087f;
-        _ki_yaw = 0.01f;
-    }
 
 private:
     float _ki;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -43,15 +43,9 @@ public:
         FLAG_ALWAYS_USE_EKF = 0x1,
     };
 
-    static AP_AHRS_NavEKF create(AP_InertialSensor &ins,
-                                 AP_Baro &baro,
-                                 AP_GPS &gps,
-                                 NavEKF2 &_EKF2, NavEKF3 &_EKF3,
-                                 Flags flags = FLAG_NONE) {
-        return AP_AHRS_NavEKF{ins, baro, gps, _EKF2, _EKF3, flags};
-    }
-
-    constexpr AP_AHRS_NavEKF(AP_AHRS_NavEKF &&other) = default;
+    // Constructor
+    AP_AHRS_NavEKF(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps,
+                   NavEKF2 &_EKF2, NavEKF3 &_EKF3, Flags flags = FLAG_NONE);
 
     /* Do not allow copies */
     AP_AHRS_NavEKF(const AP_AHRS_NavEKF &other) = delete;
@@ -302,10 +296,5 @@ private:
     uint32_t _last_body_odm_update_ms = 0;
     void update_SITL(void);
 #endif    
-
-private:
-    // Constructor
-    AP_AHRS_NavEKF(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps,
-                   NavEKF2 &_EKF2, NavEKF3 &_EKF3, Flags flags = FLAG_NONE);
 };
 #endif

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -14,22 +14,22 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 
-static AP_BoardConfig board_config = AP_BoardConfig::create();
-static AP_InertialSensor ins = AP_InertialSensor::create();
+static AP_BoardConfig board_config;
+static AP_InertialSensor ins;
 
-static Compass compass = Compass::create();
+static Compass compass;
 
-static AP_GPS gps = AP_GPS::create();
-static AP_Baro barometer = AP_Baro::create();
-static AP_SerialManager serial_manager = AP_SerialManager::create();
+static AP_GPS gps;
+static AP_Baro barometer;
+static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    RangeFinder sonar = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, sonar);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, sonar);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3,
-                                                 AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF);
+    RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
+    NavEKF2 EKF2{&ahrs, barometer, sonar};
+    NavEKF3 EKF3{&ahrs, barometer, sonar};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3,
+            AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -31,7 +31,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 float temperature;
 
 AP_Airspeed airspeed;
-static AP_BoardConfig board_config = AP_BoardConfig::create();
+static AP_BoardConfig board_config;
 
 namespace {
 // try to set the object value but provide diagnostic if it failed

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -24,9 +24,7 @@ class AP_Baro
     friend class AP_Baro_SITL; // for access to sensors[]
 
 public:
-    static AP_Baro create() { return AP_Baro{}; }
-
-    constexpr AP_Baro(AP_Baro &&other) = default;
+    AP_Baro();
 
     /* Do not allow copies */
     AP_Baro(const AP_Baro &other) = delete;
@@ -166,8 +164,6 @@ public:
     void set_pressure_correction(uint8_t instance, float p_correction);
 
 private:
-    AP_Baro();
-
     // how many drivers do we have?
     uint8_t _num_drivers;
     AP_Baro_Backend *drivers[BARO_MAX_DRIVERS];

--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -8,11 +8,11 @@
 
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
-static AP_Baro barometer = AP_Baro::create();
+static AP_Baro barometer;
 
 static uint32_t timer;
 static uint8_t counter;
-static AP_BoardConfig board_config = AP_BoardConfig::create();
+static AP_BoardConfig board_config;
 
 void setup();
 void loop();

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -37,9 +37,7 @@ class AP_BattMonitor
     friend class AP_BattMonitor_SMBus_Maxell;
 
 public:
-    static AP_BattMonitor create() { return AP_BattMonitor{}; }
-
-    constexpr AP_BattMonitor(AP_BattMonitor &&other) = default;
+    AP_BattMonitor();
 
     /* Do not allow copies */
     AP_BattMonitor(const AP_BattMonitor &other) = delete;
@@ -179,8 +177,6 @@ protected:
     AP_Int8     _low_voltage_source;                                /// voltage type used for detection of low voltage event
 
 private:
-    AP_BattMonitor();
-
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];
     AP_BattMonitor_Backend *drivers[AP_BATT_MONITOR_MAX_INSTANCES];
     uint8_t     _num_instances;                                     /// number of monitors

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
@@ -11,7 +11,7 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_BattMonitor battery_mon = AP_BattMonitor::create();
+static AP_BattMonitor battery_mon;
 uint32_t timer;
 
 void setup() {

--- a/libraries/AP_Beacon/examples/AP_Marvelmind_test/AP_Marvelmind_test.cpp
+++ b/libraries/AP_Beacon/examples/AP_Marvelmind_test/AP_Marvelmind_test.cpp
@@ -16,7 +16,7 @@ void set_object_value_and_report(const void *object_pointer,
                       const char *name, float value);
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
-static AP_SerialManager serial_manager = AP_SerialManager::create();
+static AP_SerialManager serial_manager;
 AP_Beacon beacon{serial_manager};
 
 // try to set the object value but provide diagnostic if it failed

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -9,9 +9,9 @@ extern "C" typedef int (*main_fn_t)(int argc, char **);
 
 class AP_BoardConfig {
 public:
-    static AP_BoardConfig create() { return AP_BoardConfig{}; }
-
-    constexpr AP_BoardConfig(AP_BoardConfig &&other) = default;
+    AP_BoardConfig() {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
 
     /* Do not allow copies */
     AP_BoardConfig(const AP_BoardConfig &other) = delete;
@@ -70,10 +70,6 @@ public:
 #endif
 
 private:
-    AP_BoardConfig() {
-        AP_Param::setup_object_defaults(this, var_info);
-    };
-
     AP_Int16 vehicleSerialNumber;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.h
@@ -11,9 +11,9 @@
 
 class AP_BoardConfig_CAN {
 public:
-    static AP_BoardConfig_CAN create() { return AP_BoardConfig_CAN{}; }
-
-    constexpr AP_BoardConfig_CAN(AP_BoardConfig_CAN &&other) = default;
+    AP_BoardConfig_CAN() {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
 
     /* Do not allow copies */
     AP_BoardConfig_CAN(const AP_BoardConfig_CAN &other) = delete;
@@ -98,10 +98,5 @@ public:
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     void px4_setup_canbus(void);
 #endif // HAL_BOARD_PX4 || HAL_BOARD_VRBRAIN
-
-private:
-    AP_BoardConfig_CAN() {
-        AP_Param::setup_object_defaults(this, var_info);
-    };
 };
 #endif

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -31,14 +31,16 @@
 class AP_Camera {
 
 public:
-    static AP_Camera create(AP_Relay *obj_relay,
-                            uint32_t _log_camera_bit,
-                            const struct Location &_loc,
-                            const AP_AHRS &_ahrs) {
-        return AP_Camera{obj_relay, _log_camera_bit, _loc, _ahrs};
+    AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_AHRS &_ahrs)
+        : _trigger_counter(0) // count of number of cycles shutter has been held open
+        , _image_index(0)
+        , log_camera_bit(_log_camera_bit)
+        , current_loc(_loc)
+        , ahrs(_ahrs)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+        _apm_relay = obj_relay;
     }
-
-    constexpr AP_Camera(AP_Camera &&other) = default;
 
     /* Do not allow copies */
     AP_Camera(const AP_Camera &other) = delete;
@@ -71,17 +73,6 @@ public:
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 
 private:
-    AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_AHRS &_ahrs)
-        : _trigger_counter(0) // count of number of cycles shutter has been held open
-        , _image_index(0)
-        , log_camera_bit(_log_camera_bit)
-        , current_loc(_loc)
-        , ahrs(_ahrs)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-        _apm_relay = obj_relay;
-    }
-
     AP_Int8         _trigger_type;      // 0:Servo,1:Relay
     AP_Int8         _trigger_duration;  // duration in 10ths of a second that the camera shutter is held open
     AP_Int8         _relay_on;          // relay value to trigger camera

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -44,9 +44,7 @@ class Compass
 {
 friend class AP_Compass_Backend;
 public:
-    static Compass create() { return Compass{}; }
-
-    constexpr Compass(Compass &&other) = default;
+    Compass();
 
     /* Do not allow copies */
     Compass(const Compass &other) = delete;
@@ -293,8 +291,6 @@ public:
     }
 
 private:
-    Compass();
-
     /// Register a new compas driver, allocating an instance number
     ///
     /// @return number of compass instances

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -9,8 +9,8 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_BoardConfig board_config = AP_BoardConfig::create();
-static Compass compass = Compass::create();
+static AP_BoardConfig board_config;
+static Compass compass;
 
 uint32_t timer;
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -113,11 +113,7 @@ for FrSky SPort Passthrough
 
 class AP_Frsky_Telem {
 public:
-    static AP_Frsky_Telem create(AP_AHRS &ahrs, const AP_BattMonitor &battery, const RangeFinder &rng) {
-        return AP_Frsky_Telem{ahrs, battery, rng};
-    }
-
-    constexpr AP_Frsky_Telem(AP_Frsky_Telem &&other) = default;
+    AP_Frsky_Telem(AP_AHRS &ahrs, const AP_BattMonitor &battery, const RangeFinder &rng);
 
     /* Do not allow copies */
     AP_Frsky_Telem(const AP_Frsky_Telem &other) = delete;
@@ -146,8 +142,6 @@ public:
     static ObjectArray<mavlink_statustext_t> _statustext_queue;
 
 private:
-    AP_Frsky_Telem(AP_AHRS &ahrs, const AP_BattMonitor &battery, const RangeFinder &rng);
-
     AP_AHRS &_ahrs;
     const AP_BattMonitor &_battery;
     const RangeFinder &_rng;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -64,9 +64,7 @@ class AP_GPS
     friend class AP_GPS_Backend;
 
 public:
-    static AP_GPS create() { return AP_GPS{}; }
-
-    constexpr AP_GPS(AP_GPS &&other) = default;
+    AP_GPS();
 
     /* Do not allow copies */
     AP_GPS(const AP_GPS &other) = delete;
@@ -445,8 +443,6 @@ protected:
     uint32_t _log_gps_bit = -1;
 
 private:
-    AP_GPS();
-
     static AP_GPS *_singleton;
 
     // returns the desired gps update rate in milliseconds

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
@@ -36,15 +36,15 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_BoardConfig board_config = AP_BoardConfig::create();
+static AP_BoardConfig board_config;
 
 // create board led object
 AP_BoardLED board_led;
 
 // This example uses GPS system. Create it.
-static AP_GPS gps = AP_GPS::create();
+static AP_GPS gps;
 // Serial manager is needed for UART comunications
-static AP_SerialManager serial_manager = AP_SerialManager::create();
+static AP_SerialManager serial_manager;
 
 
 void setup()

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -49,9 +49,7 @@ class AP_InertialSensor : AP_AccelCal_Client
     friend class AP_InertialSensor_Backend;
 
 public:
-    static AP_InertialSensor create() { return AP_InertialSensor{}; }
-
-    constexpr AP_InertialSensor(AP_InertialSensor &&other) = default;
+    AP_InertialSensor();
 
     /* Do not allow copies */
     AP_InertialSensor(const AP_InertialSensor &other) = delete;
@@ -346,8 +344,6 @@ public:
     BatchSampler batchsampler{*this};
 
 private:
-    AP_InertialSensor();
-
     // load backend drivers
     bool _add_backend(AP_InertialSensor_Backend *backend);
     void _start_backends();

--- a/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
+++ b/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
@@ -8,13 +8,13 @@
 
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
-static AP_InertialSensor ins = AP_InertialSensor::create();
+static AP_InertialSensor ins;
 
 static void display_offsets_and_scaling();
 static void run_test();
 
 // board specific config
-static AP_BoardConfig BoardConfig = AP_BoardConfig::create();
+static AP_BoardConfig BoardConfig;
 
 void setup(void);
 void loop(void);

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -21,11 +21,12 @@
 
 class AP_L1_Control : public AP_Navigation {
 public:
-    static AP_L1_Control create(AP_AHRS &ahrs, const AP_SpdHgtControl *spdHgtControl) {
-        return AP_L1_Control{ahrs, spdHgtControl};
+    AP_L1_Control(AP_AHRS &ahrs, const AP_SpdHgtControl *spdHgtControl)
+        : _ahrs(ahrs)
+        , _spdHgtControl(spdHgtControl)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_L1_Control(AP_L1_Control &&other) = default;
 
     /* Do not allow copies */
     AP_L1_Control(const AP_L1_Control &other) = delete;
@@ -75,13 +76,6 @@ public:
     }
 
 private:
-    AP_L1_Control(AP_AHRS &ahrs, const AP_SpdHgtControl *spdHgtControl)
-        : _ahrs(ahrs)
-        , _spdHgtControl(spdHgtControl)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // reference to the AHRS object
     AP_AHRS &_ahrs;
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -36,23 +36,13 @@ public:
     FUNCTOR_TYPEDEF(disarm_if_autoland_complete_fn_t, void);
     FUNCTOR_TYPEDEF(update_flight_stage_fn_t, void);
 
-    static AP_Landing create(AP_Mission &_mission, AP_AHRS &_ahrs, AP_SpdHgtControl *_SpdHgt_Controller, AP_Navigation *_nav_controller, AP_Vehicle::FixedWing &_aparm,
+    AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_SpdHgtControl *_SpdHgt_Controller, AP_Navigation *_nav_controller, AP_Vehicle::FixedWing &_aparm,
                set_target_altitude_proportion_fn_t _set_target_altitude_proportion_fn,
                constrain_target_altitude_location_fn_t _constrain_target_altitude_location_fn,
                adjusted_altitude_cm_fn_t _adjusted_altitude_cm_fn,
                adjusted_relative_altitude_cm_fn_t _adjusted_relative_altitude_cm_fn,
                disarm_if_autoland_complete_fn_t _disarm_if_autoland_complete_fn,
-               update_flight_stage_fn_t _update_flight_stage_fn) {
-        return AP_Landing{_mission, _ahrs, _SpdHgt_Controller, _nav_controller, _aparm,
-               _set_target_altitude_proportion_fn,
-               _constrain_target_altitude_location_fn,
-               _adjusted_altitude_cm_fn,
-               _adjusted_relative_altitude_cm_fn,
-               _disarm_if_autoland_complete_fn,
-               _update_flight_stage_fn};
-    }
-
-    constexpr AP_Landing(AP_Landing &&other) = default;
+               update_flight_stage_fn_t _update_flight_stage_fn);
 
     /* Do not allow copies */
     AP_Landing(const AP_Landing &other) = delete;
@@ -117,14 +107,6 @@ public:
     float alt_offset;
 
 private:
-    AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_SpdHgtControl *_SpdHgt_Controller, AP_Navigation *_nav_controller, AP_Vehicle::FixedWing &_aparm,
-               set_target_altitude_proportion_fn_t _set_target_altitude_proportion_fn,
-               constrain_target_altitude_location_fn_t _constrain_target_altitude_location_fn,
-               adjusted_altitude_cm_fn_t _adjusted_altitude_cm_fn,
-               adjusted_relative_altitude_cm_fn_t _adjusted_relative_altitude_cm_fn,
-               disarm_if_autoland_complete_fn_t _disarm_if_autoland_complete_fn,
-               update_flight_stage_fn_t _update_flight_stage_fn);
-
     struct {
         // denotes if a go-around has been commanded for landing
         bool commanded_go_around:1;

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -12,9 +12,10 @@
 /// @brief	Class managing the control of landing gear
 class AP_LandingGear {
 public:
-    static AP_LandingGear create() { return AP_LandingGear{}; }
-
-    constexpr AP_LandingGear(AP_LandingGear &&other) = default;
+    AP_LandingGear() {
+        // setup parameter defaults
+        AP_Param::setup_object_defaults(this, var_info);
+    }
 
     /* Do not allow copies */
     AP_LandingGear(const AP_LandingGear &other) = delete;
@@ -46,11 +47,6 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:
-    AP_LandingGear() {
-        // setup parameter defaults
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // Parameters
     AP_Int16    _servo_retract_pwm;     // PWM value to move servo to when gear is retracted
     AP_Int16    _servo_deploy_pwm;      // PWM value to move servo to when gear is deployed

--- a/libraries/AP_LeakDetector/AP_LeakDetector.h
+++ b/libraries/AP_LeakDetector/AP_LeakDetector.h
@@ -14,9 +14,7 @@ class AP_LeakDetector {
     friend class AP_LeakDetector_Digital;
 
 public:
-    static AP_LeakDetector create() { return AP_LeakDetector{}; }
-
-    constexpr AP_LeakDetector(AP_LeakDetector &&other) = default;
+    AP_LeakDetector();
 
     /* Do not allow copies */
     AP_LeakDetector(const AP_LeakDetector &other) = delete;
@@ -48,8 +46,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_LeakDetector();
-
     AP_LeakDetector_Backend *_drivers[LEAKDETECTOR_MAX_INSTANCES];
     LeakDetector_State _state[LEAKDETECTOR_MAX_INSTANCES];
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -280,25 +280,40 @@ public:
     FUNCTOR_TYPEDEF(mission_cmd_fn_t, bool, const Mission_Command&);
     FUNCTOR_TYPEDEF(mission_complete_fn_t, void);
 
+    // constructor
+    AP_Mission(AP_AHRS &ahrs, mission_cmd_fn_t cmd_start_fn, mission_cmd_fn_t cmd_verify_fn, mission_complete_fn_t mission_complete_fn) :
+        _ahrs(ahrs),
+        _cmd_start_fn(cmd_start_fn),
+        _cmd_verify_fn(cmd_verify_fn),
+        _mission_complete_fn(mission_complete_fn),
+        _prev_nav_cmd_id(AP_MISSION_CMD_ID_NONE),
+        _prev_nav_cmd_index(AP_MISSION_CMD_INDEX_NONE),
+        _prev_nav_cmd_wp_index(AP_MISSION_CMD_INDEX_NONE),
+        _last_change_time_ms(0)
+    {
+        // load parameter defaults
+        AP_Param::setup_object_defaults(this, var_info);
+
+        // clear commands
+        _nav_cmd.index = AP_MISSION_CMD_INDEX_NONE;
+        _do_cmd.index = AP_MISSION_CMD_INDEX_NONE;
+
+        // initialise other internal variables
+        _flags.state = MISSION_STOPPED;
+        _flags.nav_cmd_loaded = false;
+        _flags.do_cmd_loaded = false;
+    }
+
+    /* Do not allow copies */
+    AP_Mission(const AP_Mission &other) = delete;
+    AP_Mission &operator=(const AP_Mission&) = delete;    
+    
     // mission state enumeration
     enum mission_state {
         MISSION_STOPPED=0,
         MISSION_RUNNING=1,
         MISSION_COMPLETE=2
     };
-
-    static AP_Mission create(AP_AHRS &ahrs,
-                             mission_cmd_fn_t cmd_start_fn,
-                             mission_cmd_fn_t cmd_verify_fn,
-                             mission_complete_fn_t mission_complete_fn) {
-        return AP_Mission(ahrs, cmd_start_fn, cmd_verify_fn, mission_complete_fn);
-    }
-
-    constexpr AP_Mission(AP_Mission &&other) = default;
-
-    /* Do not allow copies */
-    AP_Mission(const AP_Mission &other) = delete;
-    AP_Mission &operator=(const AP_Mission&) = delete;
 
     ///
     /// public mission methods
@@ -457,30 +472,6 @@ private:
         uint8_t do_cmd_loaded   : 1; // true if a "do"/"conditional" command has been loaded into _do_cmd
         uint8_t do_cmd_all_done : 1; // true if all "do"/"conditional" commands have been completed (stops unnecessary searching through eeprom for do commands)
     } _flags;
-
-    AP_Mission(AP_AHRS &ahrs, mission_cmd_fn_t cmd_start_fn, mission_cmd_fn_t cmd_verify_fn, mission_complete_fn_t mission_complete_fn) :
-        _ahrs(ahrs),
-        _cmd_start_fn(cmd_start_fn),
-        _cmd_verify_fn(cmd_verify_fn),
-        _mission_complete_fn(mission_complete_fn),
-        _prev_nav_cmd_id(AP_MISSION_CMD_ID_NONE),
-        _prev_nav_cmd_index(AP_MISSION_CMD_INDEX_NONE),
-        _prev_nav_cmd_wp_index(AP_MISSION_CMD_INDEX_NONE),
-        _last_change_time_ms(0)
-    {
-        // load parameter defaults
-        AP_Param::setup_object_defaults(this, var_info);
-
-        // clear commands
-        _nav_cmd.index = AP_MISSION_CMD_INDEX_NONE;
-        _do_cmd.index = AP_MISSION_CMD_INDEX_NONE;
-
-        // initialise other internal variables
-        _flags.state = MISSION_STOPPED;
-        _flags.nav_cmd_loaded = false;
-        _flags.do_cmd_loaded = false;
-    }
-
 
     ///
     /// private methods

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -14,11 +14,11 @@ public:
     void loop();
 
 private:
-    AP_InertialSensor ins = AP_InertialSensor::create();
-    AP_Baro baro = AP_Baro::create();
-    AP_GPS  gps = AP_GPS::create();
-    Compass compass = Compass::create();
-    AP_AHRS_DCM ahrs = AP_AHRS_DCM::create(ins, baro, gps);
+    AP_InertialSensor ins;
+    AP_Baro baro;
+    AP_GPS  gps;
+    Compass compass;
+    AP_AHRS_DCM ahrs{ins, baro, gps};
 
     // global constants that control how many verify calls must be made for a command before it completes
     uint8_t verify_nav_cmd_iterations_to_complete = 3;
@@ -44,10 +44,10 @@ private:
     void run_replace_cmd_test();
     void run_max_cmd_test();
 
-    AP_Mission mission = AP_Mission::create(ahrs,
+    AP_Mission mission{ahrs,
             FUNCTOR_BIND_MEMBER(&MissionTest::start_cmd, bool, const AP_Mission::Mission_Command &),
             FUNCTOR_BIND_MEMBER(&MissionTest::verify_cmd, bool, const AP_Mission::Mission_Command &),
-            FUNCTOR_BIND_MEMBER(&MissionTest::mission_complete, void));
+            FUNCTOR_BIND_MEMBER(&MissionTest::mission_complete, void)};
 };
 
 static MissionTest missiontest;

--- a/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
+++ b/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
@@ -13,13 +13,13 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 // sensor declaration
-static AP_InertialSensor ins = AP_InertialSensor::create();
-static AP_GPS gps = AP_GPS::create();
-static AP_Baro baro = AP_Baro::create();
-static AP_SerialManager serial_manager = AP_SerialManager::create();
+static AP_InertialSensor ins;
+static AP_GPS gps;
+static AP_Baro baro;
+static AP_SerialManager serial_manager;
 
 // choose which AHRS system to use
-static AP_AHRS_DCM ahrs = AP_AHRS_DCM::create(ins, baro, gps);
+static AP_AHRS_DCM ahrs{ins, baro, gps};
 
 void setup(void)
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -55,11 +55,7 @@ class AP_Mount
     friend class AP_Mount_SToRM32_serial;
 
 public:
-    static AP_Mount create(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc) {
-        return AP_Mount{ahrs, current_loc};
-    }
-
-    constexpr AP_Mount(AP_Mount &&other) = default;
+    AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc);
 
     /* Do not allow copies */
     AP_Mount(const AP_Mount &other) = delete;
@@ -143,8 +139,6 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
-    AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc);
-
     // private members
     const AP_AHRS_TYPE     &_ahrs;
     const struct Location   &_current_loc;  // reference to the vehicle's current location

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -38,13 +38,7 @@ class NavEKF2 {
     friend class NavEKF2_core;
 
 public:
-    static NavEKF2 create(const AP_AHRS *ahrs,
-                          AP_Baro &baro,
-                          const RangeFinder &rng) {
-        return NavEKF2{ahrs, baro, rng};
-    }
-
-    constexpr NavEKF2(NavEKF2 &&other) = default;
+    NavEKF2(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
 
     /* Do not allow copies */
     NavEKF2(const NavEKF2 &other) = delete;
@@ -330,8 +324,6 @@ public:
     void getTimingStatistics(int8_t instance, struct ekf_timing &timing);
 
 private:
-    NavEKF2(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
-
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core
     NavEKF2_core *core = nullptr;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -35,13 +35,7 @@ class NavEKF3 {
     friend class NavEKF3_core;
 
 public:
-    static NavEKF3 create(const AP_AHRS *ahrs,
-                          AP_Baro &baro,
-                          const RangeFinder &rng) {
-        return NavEKF3{ahrs, baro, rng};
-    }
-
-    constexpr NavEKF3(NavEKF3 &&other) = default;
+    NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
 
     /* Do not allow copies */
     NavEKF3(const NavEKF3 &other) = delete;
@@ -361,8 +355,6 @@ public:
     void getTimingStatistics(int8_t instance, struct ekf_timing &timing);
 
 private:
-    NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
-
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core
     NavEKF3_core *core = nullptr;

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -40,19 +40,17 @@ class AP_Notify
     friend class RGBLed;            // RGBLed needs access to notify parameters
     friend class Display;           // Display needs access to notify parameters
 public:
-    static AP_Notify create() { return AP_Notify{}; }
-
-    // get singleton instance
-    static AP_Notify *instance(void) {
-        return _instance;
-    }
-
-    constexpr AP_Notify(AP_Notify &&other) = default;
+    AP_Notify();
 
     /* Do not allow copies */
     AP_Notify(const AP_Notify &other) = delete;
     AP_Notify &operator=(const AP_Notify&) = delete;
 
+    // get singleton instance
+    static AP_Notify *instance(void) {
+        return _instance;
+    }
+    
     // Oreo LED Themes
     enum Oreo_LED_Theme {
         OreoLED_Disabled        = 0,    // Disabled the OLED driver entirely
@@ -145,8 +143,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_Notify();
-
     static AP_Notify *_instance;
 
     // parameters

--- a/libraries/AP_OpticalFlow/OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow.h
@@ -30,9 +30,7 @@ class OpticalFlow
     friend class OpticalFlow_backend;
 
 public:
-    static OpticalFlow create(AP_AHRS_NavEKF& ahrs) { return OpticalFlow{ahrs}; }
-
-    constexpr OpticalFlow(OpticalFlow &&other) = default;
+    OpticalFlow(AP_AHRS_NavEKF& ahrs);
 
     /* Do not allow copies */
     OpticalFlow(const OpticalFlow &other) = delete;
@@ -81,8 +79,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    OpticalFlow(AP_AHRS_NavEKF& ahrs);
-
     AP_AHRS_NavEKF &_ahrs;
     OpticalFlow_backend *backend;
 

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -21,20 +21,19 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 class DummyVehicle {
 public:
-    AP_GPS gps = AP_GPS::create();
-    AP_Baro barometer = AP_Baro::create();
-    Compass compass = Compass::create();
-    AP_InertialSensor ins = AP_InertialSensor::create();
-    AP_SerialManager serial_manager = AP_SerialManager::create();
-    RangeFinder sonar = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3,
-                                                 AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF);
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, sonar);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, sonar);
+    AP_GPS gps;
+    AP_Baro barometer;
+    Compass compass;
+    AP_InertialSensor ins;
+    AP_SerialManager serial_manager;
+    RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    NavEKF2 EKF2{&ahrs, barometer, sonar};
+    NavEKF3 EKF3{&ahrs, barometer, sonar};
 };
 
 static DummyVehicle vehicle;
-static OpticalFlow optflow = OpticalFlow::create(vehicle.ahrs);
+static OpticalFlow optflow{vehicle.ahrs};
 
 void setup()
 {

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -25,11 +25,17 @@
 class AP_Parachute {
 
 public:
-    static AP_Parachute create(AP_Relay &relay) {
-        return AP_Parachute{relay};
+    /// Constructor
+    AP_Parachute(AP_Relay &relay)
+        : _relay(relay)
+        , _release_time(0)
+        , _release_initiated(false)
+        , _release_in_progress(false)
+        , _released(false)
+    {
+        // setup parameter defaults
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_Parachute(AP_Parachute &&other) = default;
 
     /* Do not allow copies */
     AP_Parachute(const AP_Parachute &other) = delete;
@@ -63,18 +69,6 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:
-    /// Constructor
-    AP_Parachute(AP_Relay &relay)
-        : _relay(relay)
-        , _release_time(0)
-        , _release_initiated(false)
-        , _release_in_progress(false)
-        , _released(false)
-    {
-        // setup parameter defaults
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // Parameters
     AP_Int8     _enabled;       // 1 if parachute release is enabled
     AP_Int8     _release_type;  // 0:Servo,1:Relay

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/AP_Parachute_test.cpp
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/AP_Parachute_test.cpp
@@ -19,10 +19,10 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 // Relay
-static AP_Relay relay = AP_Relay::create();
+static AP_Relay relay;
 
 // Parachute
-static AP_Parachute parachute = AP_Parachute::create(relay);
+static AP_Parachute parachute{relay};
 
 void setup()
 {

--- a/libraries/AP_RCMapper/AP_RCMapper.h
+++ b/libraries/AP_RCMapper/AP_RCMapper.h
@@ -6,9 +6,7 @@
 
 class RCMapper {
 public:
-    static RCMapper create() { return RCMapper{}; }
-
-    constexpr RCMapper(RCMapper &&other) = default;
+    RCMapper();
 
     /* Do not allow copies */
     RCMapper(const RCMapper &other) = delete;
@@ -35,8 +33,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    RCMapper();
-
     // channel mappings
     AP_Int8 _ch_roll;
     AP_Int8 _ch_pitch;

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -29,9 +29,7 @@ class AP_RPM
     friend class AP_RPM_Backend;
 
 public:
-    static AP_RPM create() { return AP_RPM{}; }
-
-    constexpr AP_RPM(AP_RPM &&other) = default;
+    AP_RPM();
 
     /* Do not allow copies */
     AP_RPM(const AP_RPM &other) = delete;
@@ -95,8 +93,6 @@ public:
     bool enabled(uint8_t instance) const;
 
 private:
-    AP_RPM();
-
     RPM_State state[RPM_MAX_INSTANCES];
     AP_RPM_Backend *drivers[RPM_MAX_INSTANCES];
     uint8_t num_instances:2;

--- a/libraries/AP_RPM/examples/RPM_generic/RPM_generic.cpp
+++ b/libraries/AP_RPM/examples/RPM_generic/RPM_generic.cpp
@@ -26,7 +26,7 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_RPM RPM = AP_RPM::create();
+static AP_RPM RPM;
 
 char sensor_state;
 

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -28,9 +28,7 @@ public:
         RSSI_RECEIVER           = 3
     };
 
-    static AP_RSSI create() { return AP_RSSI{}; }
-
-    constexpr AP_RSSI(AP_RSSI &&other) = default;
+    AP_RSSI();
 
     /* Do not allow copies */
     AP_RSSI(const AP_RSSI &other) = delete;
@@ -57,8 +55,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_RSSI();
-
     // RSSI parameters
     AP_Int8         rssi_type;                              // Type of RSSI being used
     AP_Int8         rssi_analog_pin;                        // Analog pin RSSI value found on

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -36,11 +36,7 @@ struct PACKED RallyLocation {
 /// @brief    Object managing Rally Points
 class AP_Rally {
 public:
-    static AP_Rally create(AP_AHRS &ahrs) {
-        return AP_Rally{ahrs};
-    }
-
-    constexpr AP_Rally(AP_Rally &&other) = default;
+    AP_Rally(AP_AHRS &ahrs);
 
     /* Do not allow copies */
     AP_Rally(const AP_Rally &other) = delete;
@@ -65,9 +61,6 @@ public:
 
     // parameter block
     static const struct AP_Param::GroupInfo var_info[];
-
-protected:
-    AP_Rally(AP_AHRS &ahrs);
 
 private:
     virtual bool is_valid(const Location &rally_point) const { return true; }

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -33,13 +33,7 @@ class RangeFinder
     friend class AP_RangeFinder_Backend;
 
 public:
-    static RangeFinder create(AP_SerialManager &_serial_manager,
-                              enum Rotation orientation_default)
-    {
-        return RangeFinder(_serial_manager, orientation_default);
-    }
-
-    constexpr RangeFinder(RangeFinder &&other) = default;
+    RangeFinder(AP_SerialManager &_serial_manager, enum Rotation orientation_default);
 
     /* Do not allow copies */
     RangeFinder(const RangeFinder &other) = delete;
@@ -166,8 +160,6 @@ public:
 
 
 private:
-    RangeFinder(AP_SerialManager &_serial_manager, enum Rotation orientation_default);
-
     RangeFinder_State state[RANGEFINDER_MAX_INSTANCES];
     AP_RangeFinder_Backend *drivers[RANGEFINDER_MAX_INSTANCES];
     uint8_t num_instances:3;

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -10,8 +10,8 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_SerialManager serial_manager = AP_SerialManager::create();
-static RangeFinder sonar = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
+static AP_SerialManager serial_manager;
+static RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
 
 void setup()
 {

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -17,9 +17,7 @@
 /// @brief	Class to manage the ArduPilot relay
 class AP_Relay {
 public:
-    static AP_Relay create() { return AP_Relay{}; }
-
-    constexpr AP_Relay(AP_Relay &&other) = default;
+    AP_Relay();
 
     /* Do not allow copies */
     AP_Relay(const AP_Relay &other) = delete;
@@ -43,8 +41,6 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:
-    AP_Relay();
-
     AP_Int8 _pin[AP_RELAY_NUM_RELAYS];
     AP_Int8 _default;
 };

--- a/libraries/AP_SBusOut/AP_SBusOut.h
+++ b/libraries/AP_SBusOut/AP_SBusOut.h
@@ -13,22 +13,17 @@
 
 class AP_SBusOut {
 public:
-    static const struct AP_Param::GroupInfo var_info[];
-
-    static AP_SBusOut create() {
-        return AP_SBusOut{};
-    }
-
-    constexpr AP_SBusOut(AP_SBusOut &&other) = default;
+    AP_SBusOut();
 
     /* Do not allow copies */
     AP_SBusOut(const AP_SBusOut &other) = delete;
     AP_SBusOut &operator=(const AP_SBusOut&) = delete;
 
+    static const struct AP_Param::GroupInfo var_info[];
+
     void update();
 
 private:
-    AP_SBusOut();
     AP_HAL::UARTDriver *sbus1_uart;
 
     void init(void);

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -51,9 +51,7 @@
 class AP_Scheduler
 {
 public:
-    static AP_Scheduler create() { return AP_Scheduler{}; }
-
-    constexpr AP_Scheduler(AP_Scheduler &&other) = default;
+    AP_Scheduler();
 
     /* Do not allow copies */
     AP_Scheduler(const AP_Scheduler &other) = delete;
@@ -105,8 +103,6 @@ public:
     static int8_t current_task;
 
 private:
-    AP_Scheduler();
-
     // used to enable scheduler debugging
     AP_Int8 _debug;
 

--- a/libraries/AP_Scheduler/PerfInfo.h
+++ b/libraries/AP_Scheduler/PerfInfo.h
@@ -4,10 +4,7 @@ namespace AP {
 
 class PerfInfo {
 public:
-
-    static PerfInfo create() { return PerfInfo{}; }
-
-    constexpr PerfInfo(PerfInfo &&other) = default;
+    PerfInfo() {}
 
     /* Do not allow copies */
     PerfInfo(const PerfInfo &other) = delete;
@@ -25,9 +22,6 @@ public:
     uint32_t get_stddev_time() const;
 
 private:
-
-    PerfInfo() {}
-
     uint16_t loop_count;
     uint32_t max_time; // in microseconds
     uint32_t min_time; // in microseconds

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -16,8 +16,8 @@ public:
 
 private:
 
-    AP_InertialSensor ins = AP_InertialSensor::create();
-    AP_Scheduler scheduler = AP_Scheduler::create();
+    AP_InertialSensor ins;
+    AP_Scheduler scheduler;
 
     uint32_t ins_counter;
     static const AP_Scheduler::Task scheduler_tasks[];
@@ -27,7 +27,7 @@ private:
     void five_second_call(void);
 };
 
-static AP_BoardConfig board_config = AP_BoardConfig::create();
+static AP_BoardConfig board_config;
 static SchedTest schedtest;
 
 #define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(SchedTest, &schedtest, func, _interval_ticks, _max_time_micros)

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -81,6 +81,12 @@
 
 class AP_SerialManager {
 public:
+    AP_SerialManager();
+
+    /* Do not allow copies */
+    AP_SerialManager(const AP_SerialManager &other) = delete;
+    AP_SerialManager &operator=(const AP_SerialManager&) = delete;
+
     enum SerialProtocol {
         SerialProtocol_None = -1,
         SerialProtocol_Console = 0, // unused
@@ -106,14 +112,6 @@ public:
         return _instance;
     }
     
-    static AP_SerialManager create() { return AP_SerialManager{}; }
-
-    constexpr AP_SerialManager(AP_SerialManager &&other) = default;
-
-    /* Do not allow copies */
-    AP_SerialManager(const AP_SerialManager &other) = delete;
-    AP_SerialManager &operator=(const AP_SerialManager&) = delete;
-
     // init_console - initialise console at default baud rate
     void init_console();
 
@@ -149,8 +147,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_SerialManager();
-
     static AP_SerialManager *_instance;
     
     // array of uart info

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
@@ -11,11 +11,17 @@
 
 class AP_ServoRelayEvents {
 public:
-    static AP_ServoRelayEvents create(AP_Relay &_relay) {
-        return AP_ServoRelayEvents{_relay};
+    AP_ServoRelayEvents(AP_Relay &_relay)
+        : relay(_relay)
+        , mask(0)
+        , type(EVENT_TYPE_RELAY)
+        , start_time_ms(0)
+        , delay_ms(0)
+        , repeat(0)
+        , channel(0)
+        , servo_value(0)
+    {
     }
-
-    constexpr AP_ServoRelayEvents(AP_ServoRelayEvents &&other) = default;
 
     /* Do not allow copies */
     AP_ServoRelayEvents(const AP_ServoRelayEvents &other) = delete;
@@ -31,18 +37,6 @@ public:
     void update_events(void);
 
 private:
-    AP_ServoRelayEvents(AP_Relay &_relay)
-        : relay(_relay)
-        , mask(0)
-        , type(EVENT_TYPE_RELAY)
-        , start_time_ms(0)
-        , delay_ms(0)
-        , repeat(0)
-        , channel(0)
-        , servo_value(0)
-    {
-    }
-
     AP_Relay &relay;
     uint16_t mask;
 

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -12,26 +12,25 @@
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
 // INS and Baro declaration
-static AP_InertialSensor ins = AP_InertialSensor::create();
-static Compass compass = Compass::create();
-static AP_GPS gps = AP_GPS::create();
-static AP_Baro barometer = AP_Baro::create();
-static AP_SerialManager serial_manager = AP_SerialManager::create();
+static AP_InertialSensor ins;
+static Compass compass;
+static AP_GPS gps;
+static AP_Baro barometer;
+static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    RangeFinder rangefinder = RangeFinder::create(serial_manager, ROTATION_PITCH_270);
-    NavEKF2 EKF2 = NavEKF2::create(&ahrs, barometer, rangefinder);
-    NavEKF3 EKF3 = NavEKF3::create(&ahrs, barometer, rangefinder);
-    AP_AHRS_NavEKF ahrs = AP_AHRS_NavEKF::create(ins, barometer, gps, EKF2, EKF3,
-                                                 AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF);
+    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
+    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
+    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;
 
 AP_AHRS_NavEKF &ahrs(vehicle.ahrs);
 AP_SmartRTL smart_rtl{ahrs, true};
-AP_BoardConfig board_config = AP_BoardConfig::create();
+AP_BoardConfig board_config;
 
 void setup();
 void loop();

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -29,13 +29,14 @@
 
 class AP_TECS : public AP_SpdHgtControl {
 public:
-    static AP_TECS create(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms,
-                          const AP_Landing &landing,
-                          const SoaringController &soaring_controller) {
-        return AP_TECS{ahrs, parms, landing, soaring_controller};
+    AP_TECS(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, const AP_Landing &landing, const SoaringController &soaring_controller)
+        : _ahrs(ahrs)
+        , aparm(parms)
+        , _landing(landing)
+        , _soaring_controller(soaring_controller)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
     }
-
-    constexpr AP_TECS(AP_TECS &&other) = default;
 
     /* Do not allow copies */
     AP_TECS(const AP_TECS &other) = delete;
@@ -122,15 +123,6 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    AP_TECS(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, const AP_Landing &landing, const SoaringController &soaring_controller)
-        : _ahrs(ahrs)
-        , aparm(parms)
-        , _landing(landing)
-        , _soaring_controller(soaring_controller)
-    {
-        AP_Param::setup_object_defaults(this, var_info);
-    }
-
     // Last time update_50Hz was called
     uint64_t _update_50hz_last_usec;
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -76,23 +76,17 @@
 
 class AP_Terrain {
 public:
+    AP_Terrain(AP_AHRS &_ahrs, const AP_Mission &_mission, const AP_Rally &_rally);
+
+    /* Do not allow copies */
+    AP_Terrain(const AP_Terrain &other) = delete;
+    AP_Terrain &operator=(const AP_Terrain&) = delete;
+
     enum TerrainStatus {
         TerrainStatusDisabled  = 0, // not enabled
         TerrainStatusUnhealthy = 1, // no terrain data for current location
         TerrainStatusOK        = 2  // terrain data available
     };
-
-    static AP_Terrain create(AP_AHRS &_ahrs,
-                             const AP_Mission &_mission,
-                             const AP_Rally &_rally) {
-        return AP_Terrain{_ahrs, _mission, _rally};
-    }
-
-    constexpr AP_Terrain(AP_Terrain &&other) = default;
-
-    /* Do not allow copies */
-    AP_Terrain(const AP_Terrain &other) = delete;
-    AP_Terrain &operator=(const AP_Terrain&) = delete;
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -184,8 +178,6 @@ public:
     void get_statistics(uint16_t &pending, uint16_t &loaded);
 
 private:
-    AP_Terrain(AP_AHRS &_ahrs, const AP_Mission &_mission, const AP_Rally &_rally);
-
     // allocate the terrain subsystem data
     bool allocate(void);
 

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
@@ -50,22 +50,17 @@
 
 class AP_Volz_Protocol {
 public:
-    static const struct AP_Param::GroupInfo var_info[];
-
-    static AP_Volz_Protocol create() {
-        return AP_Volz_Protocol{};
-    }
-
-    constexpr AP_Volz_Protocol(AP_Volz_Protocol &&other) = default;
+    AP_Volz_Protocol();
 
     /* Do not allow copies */
     AP_Volz_Protocol(const AP_Volz_Protocol &other) = delete;
     AP_Volz_Protocol &operator=(const AP_Volz_Protocol&) = delete;
 
+    static const struct AP_Param::GroupInfo var_info[];
+    
     void update();
 
 private:
-    AP_Volz_Protocol();
     AP_HAL::UARTDriver *port;
     
     void init(void);

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -53,20 +53,16 @@ public:
     FUNCTOR_TYPEDEF(print_mode_fn, void, AP_HAL::BetterStream*, uint8_t);
     FUNCTOR_TYPEDEF(vehicle_startup_message_Log_Writer, void);
 
-    static DataFlash_Class create(const char *firmware_string, const AP_Int32 &log_bitmask) {
-        return DataFlash_Class{firmware_string, log_bitmask};
-    }
+    DataFlash_Class(const char *firmware_string, const AP_Int32 &log_bitmask);
+
+    /* Do not allow copies */
+    DataFlash_Class(const DataFlash_Class &other) = delete;
+    DataFlash_Class &operator=(const DataFlash_Class&) = delete;
 
     // get singleton instance
     static DataFlash_Class *instance(void) {
         return _instance;
     }
-
-    constexpr DataFlash_Class(DataFlash_Class &&other) = default;
-
-    /* Do not allow copies */
-    DataFlash_Class(const DataFlash_Class &other) = delete;
-    DataFlash_Class &operator=(const DataFlash_Class&) = delete;
 
     void set_mission(const AP_Mission *mission);
 
@@ -248,8 +244,6 @@ protected:
                                bool is_critical);
 
 private:
-    DataFlash_Class(const char *firmware_string, const AP_Int32 &log_bitmask);
-
     #define DATAFLASH_MAX_BACKENDS 2
     uint8_t _next_backend;
     DataFlash_Backend *backends[DATAFLASH_MAX_BACKENDS];

--- a/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
+++ b/libraries/DataFlash/examples/DataFlash_AllTypes/DataFlash_AllTypes.cpp
@@ -91,7 +91,7 @@ public:
 private:
 
     AP_Int32 log_bitmask;
-    DataFlash_Class dataflash = DataFlash_Class::create("DF AllTypes 0.2", log_bitmask);
+    DataFlash_Class dataflash{"DF AllTypes 0.2", log_bitmask};
     void print_mode(AP_HAL::BetterStream *port, uint8_t mode);
 
     void Log_Write_TypeMessages();

--- a/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
+++ b/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
@@ -41,7 +41,7 @@ public:
 private:
 
     AP_Int32 log_bitmask;
-    DataFlash_Class dataflash = DataFlash_Class::create("DF Test 0.1", log_bitmask);
+    DataFlash_Class dataflash{"DF Test 0.1", log_bitmask};
     void print_mode(AP_HAL::BetterStream *port, uint8_t mode);
 };
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -438,11 +438,11 @@ private:
     static SRV_Channels *instance;
 
     // support for Volz protocol
-    AP_Volz_Protocol volz = AP_Volz_Protocol::create();
+    AP_Volz_Protocol volz;
     static AP_Volz_Protocol *volz_ptr;
 
     // support for SBUS protocol
-    AP_SBusOut sbus = AP_SBusOut::create();
+    AP_SBusOut sbus;
     static AP_SBusOut *sbus_ptr;
 
     SRV_Channel obj_channels[NUM_SERVO_CHANNELS];


### PR DESCRIPTION
See discussion here:
  https://github.com/ArduPilot/ardupilot/issues/7331
we were getting some uninitialised variables. While it only showed up in AP_SbusOut, it means we can't be sure it won't happen on other objects, so safest to remove the approach

Thanks to assistance from Lucas, Peter and Francisco
