### PR TITLE
 Copter: split init() into ok_to_enter and enter()

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -1,6 +1,8 @@
 #include "mode.h"
 #include "Rover.h"
 
+#include <stdio.h>
+
 Mode::Mode() :
     ahrs(rover.ahrs),
     g(rover.g),
@@ -19,7 +21,7 @@ void Mode::exit()
 }
 
 // these are basically the same checks as in AP_Arming:
-bool Mode::ok_to_enter() const
+bool Mode::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     const bool ignore_checks = !hal.util->get_soft_armed();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
     if (!ignore_checks) {
@@ -34,11 +36,13 @@ bool Mode::ok_to_enter() const
                                 (filt_status.flags.horiz_pos_abs || filt_status.flags.pred_horiz_pos_abs ||
                                  filt_status.flags.horiz_pos_rel || filt_status.flags.pred_horiz_pos_rel);
         if (requires_position() && !position_ok) {
+            snprintf(failure_reason, failure_reason_len, "Position required");
             return false;
         }
 
         // check velocity estimate (if we have position estimate, we must have velocity estimate)
         if (requires_velocity() && !position_ok && !filt_status.flags.horiz_vel) {
+            snprintf(failure_reason, failure_reason_len, "Velocity required");
             return false;
         }
     }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -18,7 +18,8 @@ void Mode::exit()
     _exit();
 }
 
-bool Mode::enter()
+// these are basically the same checks as in AP_Arming:
+bool Mode::ok_to_enter() const
 {
     const bool ignore_checks = !hal.util->get_soft_armed();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
     if (!ignore_checks) {
@@ -42,14 +43,13 @@ bool Mode::enter()
         }
     }
 
-    bool ret = _enter();
+    return true;
+}
 
+void Mode::enter()
+{
     // initialisation common to all modes
-    if (ret) {
-        set_reversed(false);
-    }
-
-    return ret;
+    set_reversed(false);
 }
 
 // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -37,7 +37,7 @@ public:
     Mode();
 
     // returns true of it s OK to enter this mode
-    virtual bool ok_to_enter() const;
+    virtual bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const;
 
     // enter this mode
     virtual void enter();
@@ -258,7 +258,7 @@ public:
 
 protected:
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void _exit() override;
 
@@ -404,7 +404,7 @@ public:
 
 protected:
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
 
 };
@@ -438,7 +438,7 @@ protected:
         SmartRTL_Failure
     } smart_rtl_state;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
 
     bool _load_point;

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -36,8 +36,11 @@ public:
     // Constructor
     Mode();
 
-    // enter this mode, returns false if we failed to enter
-    bool enter();
+    // returns true of it s OK to enter this mode
+    virtual bool ok_to_enter() const;
+
+    // enter this mode
+    virtual void enter();
 
     // perform any cleanups required:
     void exit();
@@ -118,10 +121,7 @@ public:
 
 protected:
 
-    // subclasses override this to perform checks before entering the mode
-    virtual bool _enter() { return true; }
-
-    // subclasses override this to perform any required cleanup when exiting the mode
+     // subclasses override this to perform any required cleanup when exiting the mode
     virtual void _exit() { return; }
 
     // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments
@@ -258,7 +258,8 @@ public:
 
 protected:
 
-    bool _enter() override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void _exit() override;
 
     enum AutoSubMode {
@@ -313,7 +314,7 @@ protected:
         Guided_TurnRateAndSpeed
     };
 
-    bool _enter() override;
+    void enter() override;
 
     GuidedMode _guided_mode;    // stores which GUIDED mode the vehicle is in
 
@@ -357,7 +358,7 @@ public:
 
 protected:
 
-    bool _enter() override;
+    void enter() override;
 };
 
 class ModeManual : public Mode
@@ -386,6 +387,7 @@ protected:
 
 class ModeRTL : public Mode
 {
+    friend class ModeAuto; // for access to enter() and ok_to_enter()
 public:
 
     uint32_t mode_number() const override { return RTL; }
@@ -402,7 +404,9 @@ public:
 
 protected:
 
-    bool _enter() override;
+    bool ok_to_enter() const override;
+    void enter() override;
+
 };
 
 class ModeSmartRTL : public Mode
@@ -434,7 +438,9 @@ protected:
         SmartRTL_Failure
     } smart_rtl_state;
 
-    bool _enter() override;
+    bool ok_to_enter() const override;
+    void enter() override;
+
     bool _load_point;
 };
 
@@ -484,7 +490,8 @@ public:
 
 protected:
 
-    bool _enter() override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
+    void enter() override;
 };
 
 class ModeSimple : public Mode

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -7,7 +7,7 @@ ModeAuto::ModeAuto(ModeRTL& mode_rtl) :
 {
 }
 
-bool ModeAuto::_enter()
+bool ModeAuto::ok_to_enter() const
 {
     // fail to enter auto if no mission commands
     if (mission.num_commands() == 0) {
@@ -15,6 +15,11 @@ bool ModeAuto::_enter()
         return false;
     }
 
+    return Mode::ok_to_enter();
+}
+
+void ModeAuto::enter()
+{
     // initialise waypoint speed
     set_desired_speed_to_default();
 
@@ -26,7 +31,6 @@ bool ModeAuto::_enter()
 
     // restart mission processing
     mission.start_or_resume();
-    return true;
 }
 
 void ModeAuto::_exit()
@@ -135,7 +139,8 @@ bool ModeAuto::reached_heading()
 // start RTL (within auto)
 void ModeAuto::start_RTL()
 {
-    if (_mode_rtl.enter()) {
+    if (_mode_rtl.ok_to_enter()) {
+        _mode_rtl.enter();
         _submode = Auto_RTL;
     }
 }

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -2,20 +2,22 @@
 #include "Rover.h"
 
 // initialize follow mode
-bool ModeFollow::_enter()
+bool ModeFollow::ok_to_enter() const
 {
     if (!g2.follow.enabled()) {
         return false;
     }
+    return true;
+}
 
+void ModeFollow::enter()
+{
     // initialise waypoint speed
     set_desired_speed_to_default();
 
     // initialise heading to current heading
     _desired_yaw_cd = ahrs.yaw_sensor;
     _yaw_error_cd = 0.0f;
-
-    return true;
 }
 
 void ModeFollow::update()

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -2,9 +2,10 @@
 #include "Rover.h"
 
 // initialize follow mode
-bool ModeFollow::ok_to_enter() const
+bool ModeFollow::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     if (!g2.follow.enabled()) {
+        snprintf(failure_reason, failure_reason_len, "Follow not enabled");
         return false;
     }
     return true;

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -1,7 +1,7 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeGuided::_enter()
+void ModeGuided::enter()
 {
     // initialise waypoint speed
     set_desired_speed_to_default();
@@ -9,8 +9,6 @@ bool ModeGuided::_enter()
     // set desired location to reasonable stopping point
     calc_stopping_location(_destination);
     set_desired_location(_destination);
-
-    return true;
 }
 
 void ModeGuided::update()

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -1,7 +1,7 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeLoiter::_enter()
+void ModeLoiter::enter()
 {
     // set _destination to reasonable stopping point
     calc_stopping_location(_destination);
@@ -14,8 +14,6 @@ bool ModeLoiter::_enter()
     // initialise heading to current heading
     _desired_yaw_cd = ahrs.yaw_sensor;
     _yaw_error_cd = 0.0f;
-
-    return true;
 }
 
 void ModeLoiter::update()

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -1,13 +1,17 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeRTL::_enter()
+bool ModeRTL::ok_to_enter() const
 {
     // refuse RTL if home has not been set
     if (!AP::ahrs().home_is_set()) {
         return false;
     }
+    return Mode::ok_to_enter();
+}
 
+void ModeRTL::enter()
+{
     // initialise waypoint speed
     set_desired_speed_to_default(true);
 
@@ -19,7 +23,7 @@ bool ModeRTL::_enter()
     set_desired_location(rover.home);
 #endif
 
-    return true;
+    Mode::enter();
 }
 
 void ModeRTL::update()

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -1,13 +1,16 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeRTL::ok_to_enter() const
+#include <stdio.h>
+
+bool ModeRTL::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // refuse RTL if home has not been set
     if (!AP::ahrs().home_is_set()) {
+        snprintf(failure_reason, failure_reason_len, "Home not set");
         return false;
     }
-    return Mode::ok_to_enter();
+    return Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void ModeRTL::enter()

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -1,20 +1,24 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeSmartRTL::ok_to_enter() const
+#include <stdio.h>
+
+bool ModeSmartRTL::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // SmartRTL requires EKF (not DCM)
     Location ekf_origin;
     if (!ahrs.get_origin(ekf_origin)) {
+        snprintf(failure_reason, failure_reason_len, "Origin not set");
         return false;
     }
 
     // refuse to enter SmartRTL if smart RTL's home has not been set
     if (!g2.smart_rtl.is_active()) {
+        snprintf(failure_reason, failure_reason_len, "Inactive");
         return false;
     }
 
-    return Mode::ok_to_enter();
+    return Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void ModeSmartRTL::enter()

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -1,7 +1,7 @@
 #include "mode.h"
 #include "Rover.h"
 
-bool ModeSmartRTL::_enter()
+bool ModeSmartRTL::ok_to_enter() const
 {
     // SmartRTL requires EKF (not DCM)
     Location ekf_origin;
@@ -14,6 +14,11 @@ bool ModeSmartRTL::_enter()
         return false;
     }
 
+    return Mode::ok_to_enter();
+}
+
+void ModeSmartRTL::enter()
+{
     // initialise waypoint speed
     set_desired_speed_to_default(true);
 
@@ -24,7 +29,7 @@ bool ModeSmartRTL::_enter()
     smart_rtl_state = SmartRTL_WaitForPathCleanup;
     _reached_destination = false;
 
-    return true;
+    Mode::enter();
 }
 
 void ModeSmartRTL::update()

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -235,12 +235,14 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
     }
 
     Mode &old_mode = *control_mode;
-    if (!new_mode.enter()) {
+    if (!new_mode.ok_to_enter()) {
         // Log error that we failed to enter desired flight mode
         Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE, new_mode.mode_number());
         gcs().send_text(MAV_SEVERITY_WARNING, "Flight mode change failed");
         return false;
     }
+
+    new_mode.enter();
 
     control_mode = &new_mode;
 

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -235,10 +235,14 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
     }
 
     Mode &old_mode = *control_mode;
-    if (!new_mode.ok_to_enter()) {
+    char fail_reason[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
+    if (!new_mode.ok_to_enter(fail_reason, sizeof(fail_reason))) {
         // Log error that we failed to enter desired flight mode
         Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE, new_mode.mode_number());
         gcs().send_text(MAV_SEVERITY_WARNING, "Flight mode change failed");
+        if (strlen(fail_reason)) {
+            gcs().send_text(MAV_SEVERITY_WARNING, "%s", fail_reason);
+        }
         return false;
     }
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -80,7 +80,7 @@ float Copter::Mode::get_pilot_desired_throttle(int16_t throttle_control, float t
         thr_mid = motors->get_throttle_hover();
     }
 
-    int16_t mid_stick = get_throttle_mid();
+    int16_t mid_stick = copter.get_throttle_mid();
     // protect against unlikely divide by zero
     if (mid_stick <= 0) {
         mid_stick = 500;
@@ -126,7 +126,7 @@ float Copter::get_pilot_desired_climb_rate(float throttle_control)
 #endif
     
     float desired_rate = 0.0f;
-    float mid_stick = get_throttle_mid();
+    float mid_stick = copter.get_throttle_mid();
     float deadband_top = mid_stick + g.throttle_deadzone;
     float deadband_bottom = mid_stick - g.throttle_deadzone;
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -152,7 +152,7 @@ float Copter::get_pilot_desired_climb_rate(float throttle_control)
 }
 
 // get_non_takeoff_throttle - a throttle somewhere between min and mid throttle which should not lead to a takeoff
-float Copter::get_non_takeoff_throttle()
+float Copter::Mode::get_non_takeoff_throttle() const
 {
     return MAX(0,motors->get_throttle_hover()/2.0f);
 }

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -74,7 +74,7 @@ void Copter::set_throttle_takeoff()
 // used only for manual throttle modes
 // thr_mid should be in the range 0 to 1
 // returns throttle output 0 to 1
-float Copter::get_pilot_desired_throttle(int16_t throttle_control, float thr_mid)
+float Copter::Mode::get_pilot_desired_throttle(int16_t throttle_control, float thr_mid) const
 {
     if (thr_mid <= 0.0f) {
         thr_mid = motors->get_throttle_hover();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -668,7 +668,6 @@ private:
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     void update_throttle_hover();
     void set_throttle_takeoff();
-    float get_pilot_desired_throttle(int16_t throttle_control, float thr_mid = 0.0f);
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle();
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -930,7 +930,7 @@ private:
 #endif
     ModeAltHold mode_althold;
 #if MODE_AUTO_ENABLED == ENABLED
-    ModeAuto mode_auto;
+    ModeAuto mode_auto{mission};
 #endif
 #if AUTOTUNE_ENABLED == ENABLED
     ModeAutoTune mode_autotune;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -669,7 +669,6 @@ private:
     void update_throttle_hover();
     void set_throttle_takeoff();
     float get_pilot_desired_climb_rate(float throttle_control);
-    float get_non_takeoff_throttle();
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
     float get_avoidance_adjusted_climbrate(float target_rate);
     void set_accel_throttle_I_from_pilot_throttle();

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -47,10 +47,10 @@ void Copter::update_land_detector()
     } else if (ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME
         // if rotor speed and collective pitch are high then clear landing flag
-        if (motors->get_throttle() > get_non_takeoff_throttle() && !motors->limit.throttle_lower && motors->rotor_runup_complete()) {
+        if (motors->get_throttle() > flightmode->get_non_takeoff_throttle() && !motors->limit.throttle_lower && motors->rotor_runup_complete()) {
 #else
         // if throttle output is high then clear landing flag
-        if (motors->get_throttle() > get_non_takeoff_throttle()) {
+        if (motors->get_throttle() > flightmode->get_non_takeoff_throttle()) {
 #endif
             set_land_complete(false);
         }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -558,11 +558,6 @@ float Copter::Mode::get_pilot_desired_climb_rate(float throttle_control)
     return copter.get_pilot_desired_climb_rate(throttle_control);
 }
 
-float Copter::Mode::get_pilot_desired_throttle(int16_t throttle_control, float thr_mid)
-{
-    return copter.get_pilot_desired_throttle(throttle_control, thr_mid);
-}
-
 float Copter::Mode::get_non_takeoff_throttle()
 {
     return copter.get_non_takeoff_throttle();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -75,7 +75,8 @@ public:
 
 protected:
 
-    virtual bool init(bool ignore_checks) = 0;
+    virtual bool ok_to_enter() const;
+    virtual void enter() = 0;
     virtual void run() = 0;
 
     virtual bool is_autopilot() const { return false; }
@@ -186,7 +187,6 @@ protected:
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     float get_pilot_desired_climb_rate(float throttle_control);
-    float get_non_takeoff_throttle(void);
     void update_simple_mode(void);
     bool set_mode(control_mode_t mode, mode_reason_t reason);
     void set_land_complete(bool b);
@@ -197,6 +197,10 @@ protected:
     uint16_t get_pilot_speed_dn(void);
 
     // end pass-through functions
+
+private:
+
+    bool ok_to_enter_gps_checks() const;
 };
 
 
@@ -204,10 +208,12 @@ protected:
 class ModeAcro : public Mode {
 
 public:
+
     // inherit constructor
     using Copter::Mode::Mode;
 
-    virtual bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     virtual void run() override;
 
     bool is_autopilot() const override { return false; }
@@ -234,7 +240,7 @@ public:
     // inherit constructor
     using Copter::ModeAcro::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
 protected:
@@ -249,7 +255,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -273,10 +279,13 @@ private:
 class ModeAuto : public Mode {
 
 public:
-    // inherit constructor
-    using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    ModeAuto(AP_Mission &_mission) :
+        mission(_mission),
+        Mode() {}
+
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool is_autopilot() const override { return true; }
@@ -329,6 +338,8 @@ protected:
     void run_autopilot() override;
 
 private:
+
+    bool ok_to_enter_check_takeoff_cmd() const;
 
     bool verify_command(const AP_Mission::Mission_Command& cmd);
 
@@ -433,6 +444,7 @@ private:
         float descend_max; // centimetres
     } nav_payload_place;
 
+    AP_Mission &mission;
 };
 
 #if AUTOTUNE_ENABLED == ENABLED
@@ -442,7 +454,8 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -597,7 +610,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -626,7 +639,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -655,7 +668,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -681,7 +694,8 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -713,7 +727,8 @@ public:
     // need a constructor for parameters
     ModeFlowHold(void);
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run(void) override;
 
     bool requires_GPS() const override { return false; }
@@ -795,7 +810,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -857,7 +872,7 @@ public:
     // inherit constructor
     using Copter::ModeGuided::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -881,7 +896,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -910,7 +925,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -951,7 +966,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -984,7 +999,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override {
         return run(true);
     }
@@ -1055,7 +1070,8 @@ public:
     // inherit constructor
     using Copter::ModeRTL::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -1092,7 +1108,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -1119,7 +1135,8 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    virtual bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     virtual void run() override;
 
     bool requires_GPS() const override { return false; }
@@ -1143,7 +1160,7 @@ public:
     // inherit constructor
     using Copter::ModeStabilize::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
 protected:
@@ -1160,7 +1177,8 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -1211,7 +1229,8 @@ public:
     // inherit constructor
     using Copter::ModeGuided::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -1237,7 +1256,7 @@ public:
     // inherit constructor
     using Copter::ModeGuided::Mode;
 
-    bool init(bool ignore_checks) override;
+    bool ok_to_enter() const override;
     void run() override;
 
     bool requires_GPS() const override { return true; }
@@ -1260,7 +1279,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool init(bool ignore_checks) override;
+    void enter() override;
     void run() override;
 
     bool requires_GPS() const override { return true; }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -177,13 +177,14 @@ protected:
     heli_flags_t &heli_flags;
 #endif
 
+    float get_pilot_desired_throttle(int16_t throttle_control, float thr_mid = 0.0f) const;
+
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
     float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     float get_pilot_desired_climb_rate(float throttle_control);
-    float get_pilot_desired_throttle(int16_t throttle_control, float thr_mid = 0.0f);
     float get_non_takeoff_throttle(void);
     void update_simple_mode(void);
     bool set_mode(control_mode_t mode, mode_reason_t reason);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -75,7 +75,7 @@ public:
 
 protected:
 
-    virtual bool ok_to_enter() const;
+    virtual bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const;
     virtual void enter() = 0;
     virtual void run() = 0;
 
@@ -200,7 +200,7 @@ protected:
 
 private:
 
-    bool ok_to_enter_gps_checks() const;
+    bool ok_to_enter_gps_checks(char *failure_reason, uint8_t failure_reason_len) const;
 };
 
 
@@ -212,7 +212,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *reason, uint8_t reason_len) const override;
     void enter() override;
     virtual void run() override;
 
@@ -284,7 +284,7 @@ public:
         mission(_mission),
         Mode() {}
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *reason, uint8_t reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -339,7 +339,7 @@ protected:
 
 private:
 
-    bool ok_to_enter_check_takeoff_cmd() const;
+    bool ok_to_enter_check_takeoff_cmd(char *failure_reason, uint8_t failure_reason_len) const;
 
     bool verify_command(const AP_Mission::Mission_Command& cmd);
 
@@ -454,7 +454,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -694,7 +694,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -727,7 +727,7 @@ public:
     // need a constructor for parameters
     ModeFlowHold(void);
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run(void) override;
 
@@ -1070,7 +1070,7 @@ public:
     // inherit constructor
     using Copter::ModeRTL::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -1135,7 +1135,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     virtual void run() override;
 
@@ -1177,7 +1177,7 @@ public:
     // inherit constructor
     using Copter::Mode::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -1229,7 +1229,7 @@ public:
     // inherit constructor
     using Copter::ModeGuided::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void enter() override;
     void run() override;
 
@@ -1256,7 +1256,7 @@ public:
     // inherit constructor
     using Copter::ModeGuided::Mode;
 
-    bool ok_to_enter() const override;
+    bool ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const override;
     void run() override;
 
     bool requires_GPS() const override { return true; }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -178,6 +178,7 @@ protected:
 #endif
 
     float get_pilot_desired_throttle(int16_t throttle_control, float thr_mid = 0.0f) const;
+    float get_non_takeoff_throttle() const;
 
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -8,14 +8,15 @@
  * Init and run calls for acro flight mode
  */
 
-bool Copter::ModeAcro::ok_to_enter() const
+bool Copter::ModeAcro::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
    // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
    if (motors->armed() && ap.land_complete && !copter.flightmode->has_manual_throttle() &&
            (get_pilot_desired_throttle(channel_throttle->get_control_in(), copter.g2.acro_thr_mid) > get_non_takeoff_throttle())) {
+       snprintf(failure_reason, failure_reason_len, "Throttle too high");
        return false;
    }
-   return Copter::Mode::ok_to_enter();
+   return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeAcro::enter()

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -8,17 +8,20 @@
  * Init and run calls for acro flight mode
  */
 
-bool Copter::ModeAcro::init(bool ignore_checks)
+bool Copter::ModeAcro::ok_to_enter() const
 {
    // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
    if (motors->armed() && ap.land_complete && !copter.flightmode->has_manual_throttle() &&
            (get_pilot_desired_throttle(channel_throttle->get_control_in(), copter.g2.acro_thr_mid) > get_non_takeoff_throttle())) {
        return false;
    }
+   return Copter::Mode::ok_to_enter();
+}
+
+void Copter::ModeAcro::enter()
+{
    // set target altitude to zero for reporting
    pos_control->set_alt_target(0);
-
-   return true;
 }
 
 void Copter::ModeAcro::run()

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -12,7 +12,7 @@ bool Copter::ModeAcro::init(bool ignore_checks)
 {
    // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
    if (motors->armed() && ap.land_complete && !copter.flightmode->has_manual_throttle() &&
-           (get_pilot_desired_throttle(channel_throttle->get_control_in(), copter.g2.acro_thr_mid) > copter.get_non_takeoff_throttle())) {
+           (get_pilot_desired_throttle(channel_throttle->get_control_in(), copter.g2.acro_thr_mid) > get_non_takeoff_throttle())) {
        return false;
    }
    // set target altitude to zero for reporting

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -8,7 +8,7 @@
  */
 
 // heli_acro_init - initialise acro controller
-bool Copter::ModeAcro_Heli::init(bool ignore_checks)
+void Copter::ModeAcro_Heli::enter()
 {
     // if heli is equipped with a flybar, then tell the attitude controller to pass through controls directly to servos
     attitude_control->use_flybar_passthrough(motors->has_flybar(), motors->supports_yaw_passthrough());
@@ -17,9 +17,6 @@ bool Copter::ModeAcro_Heli::init(bool ignore_checks)
     
     // set stab collective false to use full collective pitch range
     copter.input_manager.set_use_stab_col(false);
-
-    // always successfully enter acro
-    return true;
 }
 
 // heli_acro_run - runs the acro controller

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -5,16 +5,14 @@
  * Init and run calls for althold, flight mode
  */
 
-// althold_init - initialise althold controller
-bool Copter::ModeAltHold::init(bool ignore_checks)
+// enter - initialise althold controller
+void Copter::ModeAltHold::enter()
 {
     // initialise position and desired velocity
     if (!pos_control->is_active_z()) {
         pos_control->set_alt_target_to_current_alt();
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
     }
-
-    return true;
 }
 
 // althold_run - runs the althold controller

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -19,7 +19,7 @@
  *  Code in this file implements the navigation commands
  */
 
-bool Copter::ModeAuto::ok_to_enter_check_takeoff_cmd() const
+bool Copter::ModeAuto::ok_to_enter_check_takeoff_cmd(char *failure_reason, uint8_t failure_reason_len) const
 {
     if (!ap.land_complete) {
         // we're already flying, so we don't need a takeoff_cmd
@@ -27,14 +27,14 @@ bool Copter::ModeAuto::ok_to_enter_check_takeoff_cmd() const
     }
 
     if (!mission.starts_with_takeoff_cmd()) {
-            // gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: Missing Takeoff Cmd");
+        snprintf(failure_reason, failure_reason_len, "Missing Takeoff Cmd");
         return false;
     }
     return true;
 }
 
 // auto_init - initialise auto controller
-bool Copter::ModeAuto::ok_to_enter() const
+bool Copter::ModeAuto::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // allow changing into auto mode if disarmed, regardless of
     // the mission having a takeoff.  Arming is not permitted in
@@ -44,13 +44,14 @@ bool Copter::ModeAuto::ok_to_enter() const
             // can't enter auto without at least one non-home-position
             // command.  Note our home position counts towards
             // num_commands()!
+            snprintf(failure_reason, failure_reason_len, "Too few mission items");
             return false;
         }
-        if (!ok_to_enter_check_takeoff_cmd()) {
+        if (!ok_to_enter_check_takeoff_cmd(failure_reason, failure_reason_len)) {
             return false;
         }
     }
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeAuto::enter()

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -21,13 +21,6 @@
 
 bool Copter::ModeAuto::ok_to_enter_check_takeoff_cmd() const
 {
-    if (!motors->armed()) {
-        // allow changing into auto mode if disarmed, regardless of
-        // the mission having a takeoff.  Arming is not permitted in
-        // auto mode, otherwise we would need a pre-arm check.
-        return true;
-    }
-
     if (!ap.land_complete) {
         // we're already flying, so we don't need a takeoff_cmd
         return true;
@@ -43,14 +36,19 @@ bool Copter::ModeAuto::ok_to_enter_check_takeoff_cmd() const
 // auto_init - initialise auto controller
 bool Copter::ModeAuto::ok_to_enter() const
 {
-    if (mission.num_commands() < 2) {
-        // can't enter auto without at least one non-home-position
-        // command.  Note our home position counts towards
-        // num_commands()!
-        return false;
-    }
-    if (!ok_to_enter_check_takeoff_cmd()) {
-        return false;
+    // allow changing into auto mode if disarmed, regardless of
+    // the mission having a takeoff.  Arming is not permitted in
+    // auto mode, otherwise we would need a pre-arm check.
+    if (motors->armed()) {
+        if (mission.num_commands() < 2) {
+            // can't enter auto without at least one non-home-position
+            // command.  Note our home position counts towards
+            // num_commands()!
+            return false;
+        }
+        if (!ok_to_enter_check_takeoff_cmd()) {
+            return false;
+        }
     }
     return Copter::Mode::ok_to_enter();
 }

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -162,25 +162,30 @@ void Copter::ModeAutoTune::stop()
 }
 
 // start - Initialize autotune flight mode
-bool Copter::ModeAutoTune::ok_to_enter() const
+bool Copter::ModeAutoTune::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
-    // only allow flip from Stabilize, AltHold,  PosHold or Loiter modes
-    if (copter.control_mode != STABILIZE && copter.control_mode != ALT_HOLD &&
-        copter.control_mode != LOITER && copter.control_mode != POSHOLD) {
+    // only allow autotune from Stabilize, AltHold,  PosHold or Loiter modes
+    if (copter.control_mode != STABILIZE &&
+        copter.control_mode != ALT_HOLD &&
+        copter.control_mode != LOITER &&
+        copter.control_mode != POSHOLD) {
+        snprintf(failure_reason, failure_reason_len, "Must enter from stabilize, alt_hold, loiter or poshold");
         return false;
     }
 
     // ensure throttle is above zero
     if (ap.throttle_zero) {
+        snprintf(failure_reason, failure_reason_len, "Throttle too low");
         return false;
     }
 
     // ensure we are flying
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        snprintf(failure_reason, failure_reason_len, "Must be flying");
         return false;
     }
 
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 const char *Copter::ModeAutoTune::level_issue_string() const

--- a/ArduCopter/mode_avoid_adsb.cpp
+++ b/ArduCopter/mode_avoid_adsb.cpp
@@ -9,11 +9,18 @@
  * each source are only accepted and processed in the appropriate flight mode.
  */
 
-// initialise avoid_adsb controller
-bool Copter::ModeAvoidADSB::init(const bool ignore_checks)
+// ok_to-enter - returns true if it is OK to enter this mode
+bool Copter::ModeAvoidADSB::ok_to_enter() const
 {
     // re-use guided mode
-    return Copter::ModeGuided::init(ignore_checks);
+    return Copter::ModeGuided::ok_to_enter();
+}
+
+// initialise avoid_adsb controller
+void Copter::ModeAvoidADSB::enter()
+{
+    // re-use guided mode
+    return Copter::ModeGuided::enter();
 }
 
 bool Copter::ModeAvoidADSB::set_velocity(const Vector3f& velocity_neu)

--- a/ArduCopter/mode_avoid_adsb.cpp
+++ b/ArduCopter/mode_avoid_adsb.cpp
@@ -10,10 +10,10 @@
  */
 
 // ok_to-enter - returns true if it is OK to enter this mode
-bool Copter::ModeAvoidADSB::ok_to_enter() const
+bool Copter::ModeAvoidADSB::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // re-use guided mode
-    return Copter::ModeGuided::ok_to_enter();
+    return Copter::ModeGuided::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 // initialise avoid_adsb controller

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -4,10 +4,9 @@
  * Init and run calls for brake flight mode
  */
 
-// brake_init - initialise brake controller
-bool Copter::ModeBrake::init(bool ignore_checks)
+// enter - enter brake mode
+void Copter::ModeBrake::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
 
         // set target to current position
         wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
@@ -23,11 +22,6 @@ bool Copter::ModeBrake::init(bool ignore_checks)
         }
 
         _timeout_ms = 0;
-
-        return true;
-    }else{
-        return false;
-    }
 }
 
 // brake_run - runs the brake controller

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -6,10 +6,8 @@
  * Init and run calls for circle flight mode
  */
 
-// circle_init - initialise circle controller flight mode
-bool Copter::ModeCircle::init(bool ignore_checks)
+void Copter::ModeCircle::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
         pilot_yaw_override = false;
 
         // initialize speeds and accelerations
@@ -20,11 +18,6 @@ bool Copter::ModeCircle::init(bool ignore_checks)
 
         // initialise circle controller including setting the circle center based on vehicle speed
         copter.circle_nav->init();
-
-        return true;
-    }else{
-        return false;
-    }
 }
 
 // circle_run - runs the circle flight mode

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -28,14 +28,9 @@
  # define DRIFT_THR_MAX         0.787f  // throttle assist will be active when pilot's throttle is below this value
 #endif
 
-// drift_init - initialise drift controller
-bool Copter::ModeDrift::init(bool ignore_checks)
+void Copter::ModeDrift::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
-        return true;
-    }else{
-        return false;
-    }
+    // TODO: insert missing initialisations here
 }
 
 // drift_run - runs the drift controller

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -38,7 +38,7 @@ int8_t    flip_roll_dir;            // roll direction (-1 = roll left, 1 = roll 
 int8_t    flip_pitch_dir;           // pitch direction (-1 = pitch forward, 1 = pitch back)
 
 // flip_init - initialise flip controller
-bool Copter::ModeFlip::init(bool ignore_checks)
+bool Copter::ModeFlip::ok_to_enter() const
 {
     // only allow flip from ACRO, Stabilize, AltHold or Drift flight modes
     if (copter.control_mode != ACRO &&
@@ -62,7 +62,11 @@ bool Copter::ModeFlip::init(bool ignore_checks)
     if (!motors->armed() || ap.land_complete) {
         return false;
     }
+    return Copter::Mode::ok_to_enter();
+}
 
+void Copter::ModeFlip::enter()
+{
     // capture original flight mode so that we can return to it after completion
     flip_orig_control_mode = copter.control_mode;
 
@@ -91,8 +95,6 @@ bool Copter::ModeFlip::init(bool ignore_checks)
     flip_orig_attitude.x = constrain_float(ahrs.roll_sensor, -angle_max, angle_max);
     flip_orig_attitude.y = constrain_float(ahrs.pitch_sensor, -angle_max, angle_max);
     flip_orig_attitude.z = ahrs.yaw_sensor;
-
-    return true;
 }
 
 // flip_run - runs the flip controller

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -38,31 +38,35 @@ int8_t    flip_roll_dir;            // roll direction (-1 = roll left, 1 = roll 
 int8_t    flip_pitch_dir;           // pitch direction (-1 = pitch forward, 1 = pitch back)
 
 // flip_init - initialise flip controller
-bool Copter::ModeFlip::ok_to_enter() const
+bool Copter::ModeFlip::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // only allow flip from ACRO, Stabilize, AltHold or Drift flight modes
     if (copter.control_mode != ACRO &&
         copter.control_mode != STABILIZE &&
         copter.control_mode != ALT_HOLD &&
         copter.control_mode != FLOWHOLD) {
+        snprintf(failure_reason, failure_reason_len, "Must enter from Acro, Stabilize, FlowHold or Alt Hold");
         return false;
     }
 
     // if in acro or stabilize ensure throttle is above zero
     if (ap.throttle_zero && (copter.control_mode == ACRO || copter.control_mode == STABILIZE)) {
+        snprintf(failure_reason, failure_reason_len, "Throttle too low");
         return false;
     }
 
     // ensure roll input is less than 40deg
     if (abs(channel_roll->get_control_in()) >= 4000) {
+        snprintf(failure_reason, failure_reason_len, "Not level");
         return false;
     }
 
     // only allow flip when flying
     if (!motors->armed() || ap.land_complete) {
+        snprintf(failure_reason, failure_reason_len, "Not armed");
         return false;
     }
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeFlip::enter()

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -75,11 +75,11 @@ Copter::ModeFlowHold::ModeFlowHold(void) : Mode()
 #define CONTROL_FLOWHOLD_EARTH_FRAME 0
 
 // flowhold_init - initialise flowhold controller
-bool Copter::ModeFlowHold::init(bool ignore_checks)
+bool Copter::ModeFlowHold::ok_to_enter() const
 {
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter Flow Hold if the Rotor Runup is not complete
-    if (!ignore_checks && !motors->rotor_runup_complete()){
+    if (!motors->rotor_runup_complete()){
         return false;
     }
 #endif
@@ -88,6 +88,11 @@ bool Copter::ModeFlowHold::init(bool ignore_checks)
         return false;
     }
 
+    return true;
+}
+
+void Copter::ModeFlowHold::enter()
+{
     // initialize vertical speeds and leash lengths
     copter.pos_control->set_max_speed_z(-copter.g2.pilot_speed_dn, copter.g.pilot_speed_up);
     copter.pos_control->set_max_accel_z(copter.g.pilot_accel_z);
@@ -109,8 +114,6 @@ bool Copter::ModeFlowHold::init(bool ignore_checks)
     // start with INS height
     last_ins_height = copter.inertial_nav.get_altitude() * 0.01;
     height_offset = 0;
-    
-    return true;
 }
 
 /*

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -75,16 +75,18 @@ Copter::ModeFlowHold::ModeFlowHold(void) : Mode()
 #define CONTROL_FLOWHOLD_EARTH_FRAME 0
 
 // flowhold_init - initialise flowhold controller
-bool Copter::ModeFlowHold::ok_to_enter() const
+bool Copter::ModeFlowHold::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter Flow Hold if the Rotor Runup is not complete
     if (!motors->rotor_runup_complete()){
+        snprintf(failure_reason, failure_reason_len, "Rotor runup not complete");
         return false;
     }
 #endif
 
     if (!copter.optflow.enabled() || !copter.optflow.healthy()) {
+        snprintf(failure_reason, failure_reason_len, "Optical flow not healthy");
         return false;
     }
 

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -25,14 +25,13 @@
 #endif
 
 // initialise follow mode
-bool Copter::ModeFollow::init(const bool ignore_checks)
+bool Copter::ModeFollow::ok_to_enter() const
 {
     // re-use guided mode
-    gcs().send_text(MAV_SEVERITY_WARNING, "Follow-mode init");
     if (!g2.follow.enabled()) {
         return false;
     }
-    return Copter::ModeGuided::init(ignore_checks);
+    return Copter::ModeGuided::ok_to_enter();
 }
 
 void Copter::ModeFollow::run()

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -25,13 +25,14 @@
 #endif
 
 // initialise follow mode
-bool Copter::ModeFollow::ok_to_enter() const
+bool Copter::ModeFollow::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // re-use guided mode
     if (!g2.follow.enabled()) {
+        snprintf(failure_reason, failure_reason_len, "Follow not enabled");
         return false;
     }
-    return Copter::ModeGuided::ok_to_enter();
+    return Copter::ModeGuided::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeFollow::run()

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -35,16 +35,10 @@ struct Guided_Limit {
     Vector3f start_pos; // start position as a distance from home in cm.  used for checking horiz_max limit
 } guided_limit;
 
-// guided_init - initialise guided controller
-bool Copter::ModeGuided::init(bool ignore_checks)
+void Copter::ModeGuided::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
         // start in position control mode
         pos_control_start();
-        return true;
-    }else{
-        return false;
-    }
 }
 
 

--- a/ArduCopter/mode_guided_nogps.cpp
+++ b/ArduCopter/mode_guided_nogps.cpp
@@ -5,11 +5,10 @@
  */
 
 // initialise guided_nogps controller
-bool Copter::ModeGuidedNoGPS::init(bool ignore_checks)
+void Copter::ModeGuidedNoGPS::enter()
 {
     // start in angle control mode
     Copter::ModeGuided::angle_control_start();
-    return true;
 }
 
 // guided_run - runs the guided controller

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -6,8 +6,8 @@ static bool land_with_gps;
 static uint32_t land_start_time;
 static bool land_pause;
 
-// land_init - initialise land controller
-bool Copter::ModeLand::init(bool ignore_checks)
+// enter - start landing
+void Copter::ModeLand::enter()
 {
     // check if we have GPS and decide which LAND we're going to do
     land_with_gps = copter.position_ok();
@@ -34,8 +34,6 @@ bool Copter::ModeLand::init(bool ignore_checks)
 
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     ap.land_repo_active = false;
-
-    return true;
 }
 
 // land_run - runs the land controller

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -4,10 +4,8 @@
  * Init and run calls for loiter flight mode
  */
 
-// loiter_init - initialise loiter controller
-bool Copter::ModeLoiter::init(bool ignore_checks)
+void Copter::ModeLoiter::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
         if (!copter.failsafe.radio) {
             float target_roll, target_pitch;
             // apply SIMPLE mode transform to pilot inputs
@@ -22,6 +20,7 @@ bool Copter::ModeLoiter::init(bool ignore_checks)
             // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
             loiter_nav->clear_pilot_desired_acceleration();
         }
+        // set target to current position
         loiter_nav->init_target();
 
         // initialise position and desired velocity
@@ -29,11 +28,6 @@ bool Copter::ModeLoiter::init(bool ignore_checks)
             pos_control->set_alt_target_to_current_alt();
             pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
         }
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 #if PRECISION_LANDING == ENABLED

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -69,14 +69,9 @@ static struct {
     int16_t pitch;  // final pitch angle sent to attitude controller
 } poshold;
 
-// poshold_init - initialise PosHold controller
-bool Copter::ModePosHold::init(bool ignore_checks)
+// enter - initialise PosHold controller
+void Copter::ModePosHold::enter()
 {
-    // fail to initialise PosHold mode if no GPS lock
-    if (!copter.position_ok() && !ignore_checks) {
-        return false;
-    }
-    
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
     pos_control->set_max_accel_z(g.pilot_accel_z);
@@ -113,8 +108,6 @@ bool Copter::ModePosHold::init(bool ignore_checks)
     poshold.wind_comp_roll = 0;
     poshold.wind_comp_pitch = 0;
     poshold.wind_comp_timer = 0;
-
-    return true;
 }
 
 // poshold_run - runs the PosHold controller

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -7,18 +7,12 @@
  * and the lower implementation of the waypoint or landing controllers within those states
  */
 
-// rtl_init - initialise rtl controller
-bool Copter::ModeRTL::init(bool ignore_checks)
+void Copter::ModeRTL::enter()
 {
-    if (copter.position_ok() || ignore_checks) {
-        // initialise waypoint and spline controller
-        wp_nav->wp_and_spline_init();
-        build_path(!copter.failsafe.terrain);
-        climb_start();
-        return true;
-    }else{
-        return false;
-    }
+    // initialise waypoint and spline controller
+    wp_nav->wp_and_spline_init();
+    build_path(!copter.failsafe.terrain);
+    climb_start();
 }
 
 // re-start RTL with terrain following disabled

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -9,12 +9,13 @@
  * Once the copter is close to home, it will run a standard land controller.
  */
 
-bool Copter::ModeSmartRTL::ok_to_enter() const
+bool Copter::ModeSmartRTL::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     if (!g2.smart_rtl.is_active()) {
+        snprintf(failure_reason, failure_reason_len, "SmartRTL inactive");
         return false;
     }
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeSmartRTL::enter()

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -9,9 +9,16 @@
  * Once the copter is close to home, it will run a standard land controller.
  */
 
-bool Copter::ModeSmartRTL::init(bool ignore_checks)
+bool Copter::ModeSmartRTL::ok_to_enter() const
 {
-    if ((copter.position_ok() || ignore_checks) && g2.smart_rtl.is_active()) {
+    if (!g2.smart_rtl.is_active()) {
+        return false;
+    }
+    return Copter::Mode::ok_to_enter();
+}
+
+void Copter::ModeSmartRTL::enter()
+{
         // initialise waypoint and spline controller
         wp_nav->wp_and_spline_init();
 
@@ -26,10 +33,6 @@ bool Copter::ModeSmartRTL::init(bool ignore_checks)
 
         // wait for cleanup of return path
         smart_rtl_state = SmartRTL_WaitForPathCleanup;
-        return true;
-    }
-
-    return false;
 }
 
 // perform cleanup required when leaving smart_rtl

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -5,7 +5,7 @@
  */
 
 // sport_init - initialise sport controller
-bool Copter::ModeSport::init(bool ignore_checks)
+void Copter::ModeSport::enter()
 {
     // initialize vertical speed and acceleration
     pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
@@ -16,8 +16,6 @@ bool Copter::ModeSport::init(bool ignore_checks)
         pos_control->set_alt_target_to_current_alt();
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
     }
-
-    return true;
 }
 
 // sport_run - runs the sport controller

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -5,17 +5,21 @@
  */
 
 // stabilize_init - initialise stabilize controller
-bool Copter::ModeStabilize::init(bool ignore_checks)
+bool Copter::ModeStabilize::ok_to_enter() const
 {
     // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
     if (motors->armed() && ap.land_complete && !copter.flightmode->has_manual_throttle() &&
             (get_pilot_desired_throttle(channel_throttle->get_control_in()) > get_non_takeoff_throttle())) {
         return false;
     }
+
+    return Copter::Mode::ok_to_enter();
+}
+
+void Copter::ModeStabilize::enter()
+{
     // set target altitude to zero for reporting
     pos_control->set_alt_target(0);
-
-    return true;
 }
 
 // stabilize_run - runs the main stabilize controller

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -5,15 +5,16 @@
  */
 
 // stabilize_init - initialise stabilize controller
-bool Copter::ModeStabilize::ok_to_enter() const
+bool Copter::ModeStabilize::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
     // if landed and the mode we're switching from does not have manual throttle and the throttle stick is too high
     if (motors->armed() && ap.land_complete && !copter.flightmode->has_manual_throttle() &&
             (get_pilot_desired_throttle(channel_throttle->get_control_in()) > get_non_takeoff_throttle())) {
+        snprintf(failure_reason, failure_reason_len, "Throttle too high");
         return false;
     }
 
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeStabilize::enter()

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -5,8 +5,8 @@
  * Init and run calls for stabilize flight mode for trad heli
  */
 
-// stabilize_init - initialise stabilize controller
-bool Copter::ModeStabilize_Heli::init(bool ignore_checks)
+// enter - initialise stabilize controller
+void Copter::ModeStabilize_Heli::enter()
 {
     // set target altitude to zero for reporting
     // To-Do: make pos controller aware when it's active/inactive so it can always report the altitude error?
@@ -14,8 +14,6 @@ bool Copter::ModeStabilize_Heli::init(bool ignore_checks)
 
     // set stab collective true to use stabilize scaled collective pitch range
     copter.input_manager.set_use_stab_col(true);
-
-    return true;
 }
 
 // stabilize_run - runs the main stabilize controller

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -3,19 +3,21 @@
 #if MODE_THROW_ENABLED == ENABLED
 
 // throw_init - initialise throw controller
-bool Copter::ModeThrow::ok_to_enter() const
+bool Copter::ModeThrow::ok_to_enter(char *failure_reason, uint8_t failure_reason_len) const
 {
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to use throw to start
+    snprintf(failure_reason, failure_reason_len, "Not available for helicopters");
     return false;
 #endif
 
     // do not enter the mode when already armed or when flying
     if (motors->armed()) {
+        snprintf(failure_reason, failure_reason_len, "Must be disarmed");
         return false;
     }
 
-    return Copter::Mode::ok_to_enter();
+    return Copter::Mode::ok_to_enter(failure_reason, failure_reason_len);
 }
 
 void Copter::ModeThrow::enter()

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -3,7 +3,7 @@
 #if MODE_THROW_ENABLED == ENABLED
 
 // throw_init - initialise throw controller
-bool Copter::ModeThrow::init(bool ignore_checks)
+bool Copter::ModeThrow::ok_to_enter() const
 {
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to use throw to start
@@ -15,11 +15,14 @@ bool Copter::ModeThrow::init(bool ignore_checks)
         return false;
     }
 
+    return Copter::Mode::ok_to_enter();
+}
+
+void Copter::ModeThrow::enter()
+{
     // init state
     stage = Throw_Disarmed;
     nextmode_attempted = false;
-
-    return true;
 }
 
 // runs the throw to start controller

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -9,12 +9,8 @@
 #define ZIGZAG_WP_RADIUS_CM 300
 
 // initialise zigzag controller
-bool Copter::ModeZigZag::init(bool ignore_checks)
+void Copter::ModeZigZag::enter()
 {
-    if (!copter.position_ok() && !ignore_checks) {
-        return false;
-    }
-
     // initialize's loiter position and velocity on xy-axes from current pos and velocity
     loiter_nav->clear_pilot_desired_acceleration();
     loiter_nav->init_target();
@@ -29,8 +25,6 @@ bool Copter::ModeZigZag::init(bool ignore_checks)
     stage = STORING_POINTS;
     dest_A.zero();
     dest_B.zero();
-
-    return true;
 }
 
 // run the zigzag controller


### PR DESCRIPTION
This change allows the base mode object to do some checks for the derived classes.

It also ensures we either don't play with the controllers or switch modes.

I'm looking for suggestions on `gcs().send_text(...)` in a const function!
