### PR TITLE
EKF: prevent sending terrain report when not using rangefinder

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -579,7 +579,7 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
     // height estimation or optical flow operation. This prevents false alarms at the GCS if a
     // range finder is fitted for other applications
     float temp;
-    if ((frontend->_useRngSwHgt > 0) || PV_AidingMode == AID_RELATIVE || flowDataValid) {
+    if (((frontend->_useRngSwHgt > 0) && activeHgtSource == HGT_SOURCE_RNG) || (PV_AidingMode == AID_RELATIVE && flowDataValid)) {
         temp = sqrtf(auxRngTestRatio);
     } else {
         temp = 0.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -589,7 +589,7 @@ void NavEKF3_core::send_status_report(mavlink_channel_t chan)
     // height estimation or optical flow operation. This prevents false alarms at the GCS if a
     // range finder is fitted for other applications
     float temp;
-    if ((frontend->_useRngSwHgt > 0) || PV_AidingMode == AID_RELATIVE || flowDataValid) {
+    if (((frontend->_useRngSwHgt > 0) && activeHgtSource == HGT_SOURCE_RNG) || (PV_AidingMode == AID_RELATIVE && flowDataValid)) {
         temp = sqrtf(auxRngTestRatio);
     } else {
         temp = 0.0f;


### PR DESCRIPTION
This address a problem where the terrain estimator is send even if the rangefinder value is not use.

This was found by using a rangefinder with 100m limit and setting _useRngSwHgt to 15% . Going upper that 100m trigger the terrain alt variance on mission planner, probably because of the discontinuity on rangefinder mesurement when passing from valid range to max limit.

I not sure about the fix