### PR TITLE
Copter: re-order methods in Copter.h

### DIFF
--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -10,6 +10,7 @@ void Copter::run_nav_updates(void)
     flightmode->update_navigation();
 }
 
+// distance between vehicle and home in cm
 uint32_t Copter::home_distance()
 {
     if (position_ok()) {
@@ -20,6 +21,7 @@ uint32_t Copter::home_distance()
     return _home_distance;
 }
 
+// The location of home in relation to the vehicle in centi-degrees
 int32_t Copter::home_bearing()
 {
     if (position_ok()) {


### PR DESCRIPTION
This is a non-functional change to re-order the methods listed in Copter.h so they are grouped by file and order within the file.

This will likely cause some merge conflicts for people but I think/hope that longer term it will make the code a little bit easier to understand.

Doing this organisation also highlighted some functions that were defined but never called nor implemented.  Also when looking through the list it makes me think we have some methods in the wrong .cpp files.