### PR TITLE
Create Copter::Mode::_TakeOff

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -362,15 +362,6 @@ private:
         uint8_t count;
         uint8_t ch_flag;
     } aux_debounce[(CH_12 - CH_7)+1];
-
-    typedef struct {
-        bool running;
-        float max_speed;
-        float alt_delta;
-        uint32_t start_ms;
-    } takeoff_state_t;
-    takeoff_state_t takeoff_state;
-
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
 
@@ -924,9 +915,6 @@ private:
     const char* get_frame_string();
     void allocate_motors(void);
 
-    void takeoff_timer_start(float alt_cm);
-    void takeoff_stop();
-    void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);
     void auto_takeoff_set_start_alt(void);
     void auto_takeoff_attitude_run(float target_yaw_rate);
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -924,7 +924,6 @@ private:
     const char* get_frame_string();
     void allocate_motors(void);
 
-    bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
     void takeoff_timer_start(float alt_cm);
     void takeoff_stop();
     void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -924,8 +924,6 @@ private:
     const char* get_frame_string();
     void allocate_motors(void);
 
-    // takeoff.cpp
-    bool current_mode_has_user_takeoff(bool must_navigate);
     bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
     void takeoff_timer_start(float alt_cm);
     void takeoff_stop();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -816,7 +816,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
             float takeoff_alt = packet.param7 * 100;      // Convert m to cm
 
-            if(copter.do_user_takeoff(takeoff_alt, is_zero(packet.param3))) {
+            if (copter.flightmode->do_user_takeoff(takeoff_alt, is_zero(packet.param3))) {
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 result = MAV_RESULT_FAILED;
@@ -1103,7 +1103,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             } else if (copter.ap.land_complete) {
                 // if armed and landed, takeoff
                 if (copter.set_mode(LOITER, MODE_REASON_GCS_COMMAND)) {
-                    copter.do_user_takeoff(packet.param1*100, true);
+                    copter.flightmode->do_user_takeoff(packet.param1*100, true);
                 }
             } else {
                 // if flying, land

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -352,9 +352,9 @@ void Copter::Mode::get_pilot_desired_lean_angles(float &roll_out, float &pitch_o
     // roll_out and pitch_out are returned
 }
 
-bool Copter::Mode::takeoff_triggered(const float target_climb_rate) const
+bool Copter::Mode::_TakeOff::triggered(const float target_climb_rate) const
 {
-    if (!ap.land_complete) {
+    if (!copter.ap.land_complete) {
         // can't take off if we're already flying
         return false;
     }
@@ -363,7 +363,7 @@ bool Copter::Mode::takeoff_triggered(const float target_climb_rate) const
         return false;
     }
 #if FRAME_CONFIG == HELI_FRAME
-    if (!motors->rotor_runup_complete()) {
+    if (!copter.motors->rotor_runup_complete()) {
         // hold heli on the ground until rotor speed runup has finished
         return false;
     }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -24,7 +24,6 @@ Copter::Mode::Mode(void) :
     channel_yaw(copter.channel_yaw),
     G_Dt(copter.G_Dt),
     ap(copter.ap),
-    takeoff_state(copter.takeoff_state),
     ekfGndSpdLimit(copter.ekfGndSpdLimit),
 #if FRAME_CONFIG == HELI_FRAME
     heli_flags(copter.heli_flags),
@@ -281,7 +280,7 @@ void Copter::exit_mode(Copter::Mode *&old_flightmode,
     }
 
     // cancel any takeoffs in progress
-    takeoff_stop();
+    old_flightmode->takeoff_stop();
 
 #if MODE_SMARTRTL_ENABLED == ENABLED
     // call smart_rtl cleanup
@@ -599,21 +598,6 @@ void Copter::Mode::Log_Write_Event(uint8_t id)
 void Copter::Mode::set_throttle_takeoff()
 {
     return copter.set_throttle_takeoff();
-}
-
-void Copter::Mode::takeoff_timer_start(float alt_cm)
-{
-    return copter.takeoff_timer_start(alt_cm);
-}
-
-void Copter::Mode::takeoff_stop()
-{
-    return copter.takeoff_stop();
-}
-
-void Copter::Mode::takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate)
-{
-    return copter.takeoff_get_climb_rates(pilot_climb_rate, takeoff_climb_rate);
 }
 
 float Copter::Mode::get_avoidance_adjusted_climbrate(float target_rate)

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -71,6 +71,8 @@ public:
     };
     static AutoYaw auto_yaw;
 
+    bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
+
 protected:
 
     virtual bool init(bool ignore_checks) = 0;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -133,6 +133,10 @@ protected:
     ap_t &ap;
     takeoff_state_t &takeoff_state;
 
+    // takeoff support
+    bool takeoff_triggered(float target_climb_rate) const;
+    virtual bool do_user_takeoff_start(float takeoff_alt_cm);
+
     // gnd speed limit required to observe optical flow sensor limits
     float &ekfGndSpdLimit;
 
@@ -781,7 +785,7 @@ public:
     void limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
     bool limit_check();
 
-    bool takeoff_start(float final_alt_above_home);
+    bool do_user_takeoff_start(float final_alt_above_home) override;
 
     GuidedMode mode() const { return guided_mode; }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -133,21 +133,27 @@ protected:
     ap_t &ap;
 
     // auto-takeoff support; takeoff state is shared across all mode instances
-    typedef struct {
-        bool running;
+    class _TakeOff {
+    public:
+        void start(float alt_cm);
+        void stop();
+        void get_climb_rates(float& pilot_climb_rate,
+                             float& takeoff_climb_rate);
+        bool triggered(float target_climb_rate) const;
+
+        bool running() const { return _running; }
+    private:
+        bool _running;
         float max_speed;
         float alt_delta;
         uint32_t start_ms;
-    } takeoff_state_t;
+    };
 
-    static takeoff_state_t takeoff_state;
+    static _TakeOff takeoff;
 
-    void takeoff_timer_start(float alt_cm);
-    void takeoff_stop();
-    void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);
+    static void takeoff_stop() { takeoff.stop(); }
 
     // takeoff support
-    bool takeoff_triggered(float target_climb_rate) const;
     virtual bool do_user_takeoff_start(float takeoff_alt_cm);
 
     // gnd speed limit required to observe optical flow sensor limits

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -131,7 +131,20 @@ protected:
     RC_Channel *&channel_yaw;
     float &G_Dt;
     ap_t &ap;
-    takeoff_state_t &takeoff_state;
+
+    // auto-takeoff support; takeoff state is shared across all mode instances
+    typedef struct {
+        bool running;
+        float max_speed;
+        float alt_delta;
+        uint32_t start_ms;
+    } takeoff_state_t;
+
+    static takeoff_state_t takeoff_state;
+
+    void takeoff_timer_start(float alt_cm);
+    void takeoff_stop();
+    void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);
 
     // takeoff support
     bool takeoff_triggered(float target_climb_rate) const;
@@ -161,9 +174,6 @@ protected:
     GCS_Copter &gcs();
     void Log_Write_Event(uint8_t id);
     void set_throttle_takeoff(void);
-    void takeoff_timer_start(float alt_cm);
-    void takeoff_stop(void);
-    void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);
     float get_avoidance_adjusted_climbrate(float target_rate);
     uint16_t get_pilot_speed_dn(void);
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -85,6 +85,8 @@ protected:
 
     virtual const char *name() const = 0;
 
+    virtual bool has_user_takeoff(bool must_navigate) const { return false; }
+
     // returns a string for this flightmode, exactly 4 bytes
     virtual const char *name4() const = 0;
 
@@ -219,6 +221,9 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; };
     bool is_autopilot() const override { return false; }
+    bool has_user_takeoff(bool must_navigate) const override {
+        return !must_navigate;
+    }
 
 protected:
 
@@ -262,6 +267,10 @@ public:
     void nav_guided_start();
 
     bool landing_gear_should_be_deployed() const override;
+
+    // return true if this flight mode supports user takeoff
+    //  must_nagivate is true if mode must also control horizontal position
+    virtual bool has_user_takeoff(bool must_navigate) const { return false; }
 
     void payload_place_start();
 
@@ -673,6 +682,9 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; };
     bool is_autopilot() const override { return false; }
+    bool has_user_takeoff(bool must_navigate) const override {
+        return !must_navigate;
+    }
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -753,6 +765,7 @@ public:
     bool allows_arming(bool from_gcs) const override { return from_gcs; }
     bool is_autopilot() const override { return true; }
     bool in_guided_mode() const { return true; }
+    bool has_user_takeoff(bool must_navigate) const override { return true; }
 
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_cd = 0.0, bool use_yaw_rate = false, float yaw_rate_cds = 0.0, bool yaw_relative = false);
@@ -865,6 +878,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; };
     bool is_autopilot() const override { return false; }
+    bool has_user_takeoff(bool must_navigate) const override { return true; }
 
 #if PRECISION_LANDING == ENABLED
     void set_precision_loiter_enabled(bool value) { _precision_loiter_enabled = value; }
@@ -905,6 +919,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; };
     bool is_autopilot() const override { return false; }
+    bool has_user_takeoff(bool must_navigate) const override { return true; }
 
 protected:
 
@@ -1043,6 +1058,9 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; };
     bool is_autopilot() const override { return false; }
+    bool has_user_takeoff(bool must_navigate) const override {
+        return !must_navigate;
+    }
 
 protected:
 

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -45,7 +45,7 @@ void Copter::ModeAltHold::run()
     // Alt Hold State Machine Determination
     if (!motors->armed() || !motors->get_interlock()) {
         althold_state = AltHold_MotorStopped;
-    } else if (takeoff_state.running || takeoff_triggered(target_climb_rate)) {
+    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
         althold_state = AltHold_Takeoff;
     } else if (!ap.auto_armed || ap.land_complete) {
         althold_state = AltHold_Landed;
@@ -85,8 +85,8 @@ void Copter::ModeAltHold::run()
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
-        if (!takeoff_state.running) {
-            takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
+        if (!takeoff.running()) {
+            takeoff.start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             // indicate we are taking off
             set_land_complete(false);
             // clear i terms
@@ -94,7 +94,7 @@ void Copter::ModeAltHold::run()
         }
 
         // get take-off adjusted pilot and takeoff climb rates
-        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff.get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -244,7 +244,7 @@ void Copter::ModeFlowHold::run()
     
     if (!copter.motors->armed() || !copter.motors->get_interlock()) {
         flowhold_state = FlowHold_MotorStopped;
-    } else if (takeoff_state.running || takeoff_triggered(target_climb_rate)) {
+    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
         flowhold_state = FlowHold_Takeoff;
     } else if (!copter.ap.auto_armed || copter.ap.land_complete) {
         flowhold_state = FlowHold_Landed;
@@ -304,8 +304,8 @@ void Copter::ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
-        if (!takeoff_state.running) {
-            takeoff_timer_start(constrain_float(copter.g.pilot_takeoff_alt,0.0f,1000.0f));
+        if (!takeoff.running()) {
+            takeoff.start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             // indicate we are taking off
             copter.set_land_complete(false);
             // clear i terms
@@ -313,7 +313,7 @@ void Copter::ModeFlowHold::run()
         }
 
         // get take-off adjusted pilot and takeoff climb rates
-        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff.get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = copter.get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -244,7 +244,7 @@ void Copter::ModeFlowHold::run()
     
     if (!copter.motors->armed() || !copter.motors->get_interlock()) {
         flowhold_state = FlowHold_MotorStopped;
-    } else if (copter.takeoff_state.running || takeoff_triggered(target_climb_rate)) {
+    } else if (takeoff_state.running || takeoff_triggered(target_climb_rate)) {
         flowhold_state = FlowHold_Takeoff;
     } else if (!copter.ap.auto_armed || copter.ap.land_complete) {
         flowhold_state = FlowHold_Landed;
@@ -304,8 +304,8 @@ void Copter::ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
-        if (!copter.takeoff_state.running) {
-            copter.takeoff_timer_start(constrain_float(copter.g.pilot_takeoff_alt,0.0f,1000.0f));
+        if (!takeoff_state.running) {
+            takeoff_timer_start(constrain_float(copter.g.pilot_takeoff_alt,0.0f,1000.0f));
             // indicate we are taking off
             copter.set_land_complete(false);
             // clear i terms
@@ -313,7 +313,7 @@ void Copter::ModeFlowHold::run()
         }
 
         // get take-off adjusted pilot and takeoff climb rates
-        copter.takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = copter.get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -50,8 +50,8 @@ bool Copter::ModeGuided::init(bool ignore_checks)
 }
 
 
-// guided_takeoff_start - initialises waypoint controller to implement take-off
-bool Copter::ModeGuided::takeoff_start(float final_alt_above_home)
+// do_user_takeoff_start - initialises waypoint controller to implement take-off
+bool Copter::ModeGuided::do_user_takeoff_start(float final_alt_above_home)
 {
     guided_mode = Guided_TakeOff;
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -105,7 +105,7 @@ void Copter::ModeLoiter::run()
     // Loiter State Machine Determination
     if (!motors->armed() || !motors->get_interlock()) {
         loiter_state = Loiter_MotorStopped;
-    } else if (takeoff_state.running || takeoff_triggered(target_climb_rate)) {
+    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
         loiter_state = Loiter_Takeoff;
     } else if (!ap.auto_armed || ap.land_complete) {
         loiter_state = Loiter_Landed;
@@ -141,8 +141,8 @@ void Copter::ModeLoiter::run()
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
-        if (!takeoff_state.running) {
-            takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
+        if (!takeoff.running()) {
+            takeoff.start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             // indicate we are taking off
             set_land_complete(false);
             // clear i term when we're taking off
@@ -150,7 +150,7 @@ void Copter::ModeLoiter::run()
         }
 
         // get takeoff adjusted pilot and takeoff climb rates
-        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff.get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -155,17 +155,17 @@ void Copter::ModePosHold::run()
         target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
         // get takeoff adjusted pilot and takeoff climb rates
-        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff.get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // check for take-off
 #if FRAME_CONFIG == HELI_FRAME
         // helicopters are held on the ground until rotor speed runup has finished
-        if (ap.land_complete && (takeoff_state.running || (target_climb_rate > 0.0f && motors->rotor_runup_complete()))) {
+        if (ap.land_complete && (takeoff.running() || (target_climb_rate > 0.0f && motors->rotor_runup_complete()))) {
 #else
-        if (ap.land_complete && (takeoff_state.running || target_climb_rate > 0.0f)) {
+        if (ap.land_complete && (takeoff.running() || target_climb_rate > 0.0f)) {
 #endif
-            if (!takeoff_state.running) {
-                takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
+            if (!takeoff.running()) {
+                takeoff.start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             }
 
             // indicate we are taking off

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -74,7 +74,7 @@ void Copter::ModeSport::run()
     // State Machine Determination
     if (!motors->armed() || !motors->get_interlock()) {
         sport_state = Sport_MotorStopped;
-    } else if (takeoff_state.running || takeoff_triggered(target_climb_rate)) {
+    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
         sport_state = Sport_Takeoff;
     } else if (!ap.auto_armed || ap.land_complete) {
         sport_state = Sport_Landed;
@@ -106,8 +106,8 @@ void Copter::ModeSport::run()
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
-        if (!takeoff_state.running) {
-            takeoff_timer_start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
+        if (!takeoff.running()) {
+            takeoff.start(constrain_float(g.pilot_takeoff_alt,0.0f,1000.0f));
             // indicate we are taking off
             set_land_complete(false);
             // clear i terms
@@ -115,7 +115,7 @@ void Copter::ModeSport::run()
         }
 
         // get take-off adjusted pilot and takeoff climb rates
-        takeoff_get_climb_rates(target_climb_rate, takeoff_climb_rate);
+        takeoff.get_climb_rates(target_climb_rate, takeoff_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -1,6 +1,6 @@
 #include "Copter.h"
 
-Copter::Mode::takeoff_state_t Copter::Mode::takeoff_state;
+Copter::Mode::_TakeOff Copter::Mode::takeoff;
 
 // This file contains the high-level takeoff logic for Loiter, PosHold, AltHold, Sport modes.
 //   The take-off can be initiated from a GCS NAV_TAKEOFF command which includes a takeoff altitude
@@ -9,7 +9,7 @@ Copter::Mode::takeoff_state_t Copter::Mode::takeoff_state;
 
 bool Copter::Mode::do_user_takeoff_start(float takeoff_alt_cm)
 {
-    takeoff_timer_start(takeoff_alt_cm);
+    copter.flightmode->takeoff.start(takeoff_alt_cm);
     return true;
 }
 
@@ -48,60 +48,61 @@ bool Copter::Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
 }
 
 // start takeoff to specified altitude above home in centimeters
-void Copter::Mode::takeoff_timer_start(float alt_cm)
+void Copter::Mode::_TakeOff::start(float alt_cm)
 {
     // calculate climb rate
-    float speed = MIN(wp_nav->get_speed_up(), MAX(g.pilot_speed_up*2.0f/3.0f, g.pilot_speed_up-50.0f));
+    const float speed = MIN(copter.wp_nav->get_speed_up(), MAX(copter.g.pilot_speed_up*2.0f/3.0f, copter.g.pilot_speed_up-50.0f));
 
     // sanity check speed and target
-    if (takeoff_state.running || speed <= 0.0f || alt_cm <= 0.0f) {
+    if (running() || speed <= 0.0f || alt_cm <= 0.0f) {
         return;
     }
 
     // initialise takeoff state
-    takeoff_state.running = true;
-    takeoff_state.max_speed = speed;
-    takeoff_state.start_ms = millis();
-    takeoff_state.alt_delta = alt_cm;
+    _running = true;
+    max_speed = speed;
+    start_ms = millis();
+    alt_delta = alt_cm;
 }
 
 // stop takeoff
-void Copter::Mode::takeoff_stop()
+void Copter::Mode::_TakeOff::stop()
 {
-    takeoff_state.running = false;
-    takeoff_state.start_ms = 0;
+    _running = false;
+    start_ms = 0;
 }
 
 // returns pilot and takeoff climb rates
 //  pilot_climb_rate is both an input and an output
 //  takeoff_climb_rate is only an output
 //  has side-effect of turning takeoff off when timeout as expired
-void Copter::Mode::takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate)
+void Copter::Mode::_TakeOff::get_climb_rates(float& pilot_climb_rate,
+                                                  float& takeoff_climb_rate)
 {
     // return pilot_climb_rate if take-off inactive
-    if (!takeoff_state.running) {
+    if (!_running) {
         takeoff_climb_rate = 0.0f;
         return;
     }
 
     // acceleration of 50cm/s/s
-    static const float takeoff_accel = 50.0f;
-    float takeoff_minspeed = MIN(50.0f,takeoff_state.max_speed);
-    float time_elapsed = (millis()-takeoff_state.start_ms)*1.0e-3f;
-    float speed = MIN(time_elapsed*takeoff_accel+takeoff_minspeed, takeoff_state.max_speed);
+    static constexpr float TAKEOFF_ACCEL = 50.0f;
+    const float takeoff_minspeed = MIN(50.0f, max_speed);
+    const float time_elapsed = (millis() - start_ms) * 1.0e-3f;
+    const float speed = MIN(time_elapsed * TAKEOFF_ACCEL + takeoff_minspeed, max_speed);
 
-    float time_to_max_speed = (takeoff_state.max_speed-takeoff_minspeed)/takeoff_accel;
+    const float time_to_max_speed = (max_speed - takeoff_minspeed) / TAKEOFF_ACCEL;
     float height_gained;
     if (time_elapsed <= time_to_max_speed) {
-        height_gained = 0.5f*takeoff_accel*sq(time_elapsed) + takeoff_minspeed*time_elapsed;
+        height_gained = 0.5f * TAKEOFF_ACCEL * sq(time_elapsed) + takeoff_minspeed * time_elapsed;
     } else {
-        height_gained = 0.5f*takeoff_accel*sq(time_to_max_speed) + takeoff_minspeed*time_to_max_speed +
-                        (time_elapsed-time_to_max_speed)*takeoff_state.max_speed;
+        height_gained = 0.5f * TAKEOFF_ACCEL * sq(time_to_max_speed) + takeoff_minspeed * time_to_max_speed +
+                        (time_elapsed - time_to_max_speed) * max_speed;
     }
 
     // check if the takeoff is over
-    if (height_gained >= takeoff_state.alt_delta) {
-        takeoff_stop();
+    if (height_gained >= alt_delta) {
+        stop();
     }
 
     // if takeoff climb rate is zero return
@@ -118,7 +119,7 @@ void Copter::Mode::takeoff_get_climb_rates(float& pilot_climb_rate, float& takeo
         // if overall climb rate is still positive, move to take-off climb rate
         if (takeoff_climb_rate + pilot_climb_rate > 0.0f) {
             takeoff_climb_rate = takeoff_climb_rate + pilot_climb_rate;
-            pilot_climb_rate = 0;
+            pilot_climb_rate = 0.0f;
         } else {
             // if overall is negative, move to pilot climb rate
             pilot_climb_rate = pilot_climb_rate + takeoff_climb_rate;

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -6,22 +6,22 @@
 //   the pos_control target is then slowly increased until time_ms expires
 
 // initiate user takeoff - called when MAVLink TAKEOFF command is received
-bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
+bool Copter::Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
 {
-    if (motors->armed() && ap.land_complete && flightmode->has_user_takeoff(must_navigate) && takeoff_alt_cm > current_loc.alt) {
+    if (copter.motors->armed() && ap.land_complete && has_user_takeoff(must_navigate) && takeoff_alt_cm > copter.current_loc.alt) {
 
 #if FRAME_CONFIG == HELI_FRAME
         // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning
-        if (!motors->rotor_runup_complete()) {
+        if (!copter.motors->rotor_runup_complete()) {
             return false;
         }
 #endif
 
-        switch(control_mode) {
+        switch(copter.control_mode) {
 #if MODE_GUIDED_ENABLED == ENABLED
             case GUIDED:
-                if (mode_guided.takeoff_start(takeoff_alt_cm)) {
-                    set_auto_armed(true);
+                if (copter.mode_guided.takeoff_start(takeoff_alt_cm)) {
+                    copter.set_auto_armed(true);
                     return true;
                 }
                 return false;
@@ -31,7 +31,7 @@ bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
             case ALT_HOLD:
             case SPORT:
             case FLOWHOLD:
-                set_auto_armed(true);
+                copter.set_auto_armed(true);
                 takeoff_timer_start(takeoff_alt_cm);
                 return true;
             default:

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -1,5 +1,7 @@
 #include "Copter.h"
 
+Copter::Mode::takeoff_state_t Copter::Mode::takeoff_state;
+
 // This file contains the high-level takeoff logic for Loiter, PosHold, AltHold, Sport modes.
 //   The take-off can be initiated from a GCS NAV_TAKEOFF command which includes a takeoff altitude
 //   A safe takeoff speed is calculated and used to calculate a time_ms
@@ -46,7 +48,7 @@ bool Copter::Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
 }
 
 // start takeoff to specified altitude above home in centimeters
-void Copter::takeoff_timer_start(float alt_cm)
+void Copter::Mode::takeoff_timer_start(float alt_cm)
 {
     // calculate climb rate
     float speed = MIN(wp_nav->get_speed_up(), MAX(g.pilot_speed_up*2.0f/3.0f, g.pilot_speed_up-50.0f));
@@ -64,7 +66,7 @@ void Copter::takeoff_timer_start(float alt_cm)
 }
 
 // stop takeoff
-void Copter::takeoff_stop()
+void Copter::Mode::takeoff_stop()
 {
     takeoff_state.running = false;
     takeoff_state.start_ms = 0;
@@ -74,7 +76,7 @@ void Copter::takeoff_stop()
 //  pilot_climb_rate is both an input and an output
 //  takeoff_climb_rate is only an output
 //  has side-effect of turning takeoff off when timeout as expired
-void Copter::takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate)
+void Copter::Mode::takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate)
 {
     // return pilot_climb_rate if take-off inactive
     if (!takeoff_state.running) {

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -5,28 +5,10 @@
 //   A safe takeoff speed is calculated and used to calculate a time_ms
 //   the pos_control target is then slowly increased until time_ms expires
 
-// return true if this flight mode supports user takeoff
-//  must_nagivate is true if mode must also control horizontal position
-bool Copter::current_mode_has_user_takeoff(bool must_navigate)
-{
-    switch (control_mode) {
-        case GUIDED:
-        case LOITER:
-        case POSHOLD:
-            return true;
-        case ALT_HOLD:
-        case SPORT:
-        case FLOWHOLD:
-            return !must_navigate;
-        default:
-            return false;
-    }
-}
-
 // initiate user takeoff - called when MAVLink TAKEOFF command is received
 bool Copter::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
 {
-    if (motors->armed() && ap.land_complete && current_mode_has_user_takeoff(must_navigate) && takeoff_alt_cm > current_loc.alt) {
+    if (motors->armed() && ap.land_complete && flightmode->has_user_takeoff(must_navigate) && takeoff_alt_cm > current_loc.alt) {
 
 #if FRAME_CONFIG == HELI_FRAME
         // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning


### PR DESCRIPTION
This isn't an actual mode - thus the leading `_`.

It's re-encapsulation of the existing `takeoff_state` stuff which is used by `alt_hold` etc etc.

Perhaps we could say `Copter::Mode::_FunctionTakeOff` or `Copter::Mode::_FunctionLand` instead?
