### PR TITLE
Rover: report GPS healthy even without 3D lock, remove autotrim at startup

### DIFF
--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -141,7 +141,7 @@ void Rover::trim_control_surfaces()
     read_radio();
     // Store control surface trim values
     // ---------------------------------
-    if (channel_steer->get_radio_in() > 1400) {
+    if ((channel_steer->get_radio_in() > 1400) && (channel_steer->get_radio_in() < 1600)) {
         channel_steer->set_radio_trim(channel_steer->get_radio_in());
         // save to eeprom
         channel_steer->save_eeprom();

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -362,7 +362,7 @@ void Rover::update_sensor_status_flags(void)
         control_sensors_health &= ~MAV_SYS_STATUS_LOGGING;
     }
 
-    if (AP_Notify::flags.initialising) {
+    if (!initialised || ins.calibrating()) {
         // while initialising the gyros and accels are not enabled
         control_sensors_enabled &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
         control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -329,7 +329,7 @@ void Rover::update_sensor_status_flags(void)
     if (g.compass_enabled && compass.healthy(0) && ahrs.use_compass()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
-    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.is_healthy()) {
+    if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }
     if (g2.visual_odom.enabled() && !g2.visual_odom.healthy()) {

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -179,10 +179,6 @@ void Rover::startup_ground(void)
 
     startup_INS_ground();
 
-    // read the radio to set trims
-    // ---------------------------
-    trim_radio();
-
     // initialise mission library
     mission.init();
 


### PR DESCRIPTION
This PR makes three somewhat unrelated changes:

- system status reporting to the GCS will only report the GCS as unhealthy when it's actually "!healthy()" instead of when it simply doesn't have a 3D Lock.
- gyros and accelerometers are reported as *not* enabled during vehicle initialisation and during INS calibration.  This behaviour is unchanged from master but we use different flags.  We really shouldn't be using the notify flags as a way to pass state around the system.  Notify is there to blink LEDs and buzz at the user, it is not a data bus.
- remove auto trim at startup and add an additional sanity check of the trim value.  A few users have complained that their rover suddenly starts moving if they've accidentally had the sticks off from center during startup.