### PR TITLE
Copter: Two stage battery failsafe, force land on critical low voltage

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -523,6 +523,9 @@ private:
     // handle repeated servo and relay events
     AP_ServoRelayEvents ServoRelayEvents;
 
+    // Failsafe low batt landing
+    bool fs_low_batt_land = false;
+
     // Reference to the camera object (it uses the relay object inside it)
 #if CAMERA == ENABLED
     AP_Camera camera;
@@ -957,6 +960,7 @@ private:
     void failsafe_radio_on_event();
     void failsafe_radio_off_event();
     void failsafe_battery_event(void);
+    void failsafe_severe_battery_event(void);
     void failsafe_gcs_check();
     void failsafe_gcs_off_event(void);
     void failsafe_terrain_check();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -960,7 +960,7 @@ private:
     void failsafe_radio_on_event();
     void failsafe_radio_off_event();
     void failsafe_battery_event(void);
-    void failsafe_severe_battery_event(void);
+    void failsafe_critical_battery_event(void);
     void failsafe_gcs_check();
     void failsafe_gcs_off_event(void);
     void failsafe_terrain_check();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -172,14 +172,6 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", FS_BATT_VOLTAGE_DEFAULT),
 
-    // @Param: FS_SEVERE_BATT_VOLTAGE
-    // @DisplayName: Failsafe severe battery voltage
-    // @Description: Battery voltage to trigger landing. If the battery voltage drops below this voltage then the copter will LAND
-    // @Units: Volts
-    // @Increment: 0.1
-    // @User: Standard
-    GSCALAR(fs_severe_batt_volt,    "FS_SEVERE_VOLT", FS_BATT_VOLTAGE_DEFAULT),
-
     // @Param: FS_BATT_MAH
     // @DisplayName: Failsafe battery milliAmpHours
     // @Description: Battery capacity remaining to trigger failsafe. Set to 0 to disable battery remaining failsafe. If the battery remaining drops below this level then the copter will RTL
@@ -1011,6 +1003,22 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_VisualOdom/AP_VisualOdom.cpp
     AP_SUBGROUPINFO(visual_odom, "VISO", 18, ParametersG2, AP_VisualOdom),
 #endif
+
+    // @Param: FS_CRITICAL_VOLT
+    // @DisplayName: Failsafe severe battery voltage
+    // @Description: Battery voltage to trigger landing. If the battery voltage drops below this voltage then the copter will LAND
+    // @Units: Volts
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("FS_CRITICAL_VOLT", 19, ParametersG2, fs_critical_batt_volt, 0),
+
+    // @Param: FS_CRITICAL_VOLT
+    // @DisplayName: Failsafe severe battery mah
+    // @Description: Battery mah to trigger landing. If the battery capacity drops below this mAh then the copter will LAND
+    // @Units: mAh
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("FS_CRITICAL_MAH", 20, ParametersG2, fs_critical_batt_mah, 0),
 
     AP_GROUPEND
 };

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -172,6 +172,14 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(fs_batt_voltage,        "FS_BATT_VOLTAGE", FS_BATT_VOLTAGE_DEFAULT),
 
+    // @Param: FS_SEVERE_BATT_VOLTAGE
+    // @DisplayName: Failsafe severe battery voltage
+    // @Description: Battery voltage to trigger landing. If the battery voltage drops below this voltage then the copter will LAND
+    // @Units: Volts
+    // @Increment: 0.1
+    // @User: Standard
+    GSCALAR(fs_severe_batt_volt,    "FS_SEVERE_VOLT", FS_BATT_VOLTAGE_DEFAULT),
+
     // @Param: FS_BATT_MAH
     // @DisplayName: Failsafe battery milliAmpHours
     // @Description: Battery capacity remaining to trigger failsafe. Set to 0 to disable battery remaining failsafe. If the battery remaining drops below this level then the copter will RTL

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -367,8 +367,6 @@ public:
 
         // 254,255: reserved
 
-        k_param_fs_severe_batt_volt = 256,
-
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -569,6 +567,10 @@ public:
 
     // RC input channels
     RC_Channels rc_channels;
+
+    // Critical battery volt/mah to trigger landing
+    AP_Int32 fs_critical_batt_volt;
+    AP_Int32 fs_critical_batt_mah;
     
     // control over servo output ranges
     SRV_Channels servo_channels;

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -367,6 +367,8 @@ public:
 
         // 254,255: reserved
 
+        k_param_fs_severe_batt_volt = 256,
+
         // the k_param_* space is 9-bits in size
         // 511: reserved
     };
@@ -396,6 +398,7 @@ public:
     AP_Int8         failsafe_battery_enabled;   // battery failsafe enabled
     AP_Float        fs_batt_voltage;            // battery voltage below which failsafe will be triggered
     AP_Float        fs_batt_mah;                // battery capacity (in mah) below which failsafe will be triggered
+    AP_Float        fs_severe_batt_volt;
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -71,6 +71,32 @@ void Copter::failsafe_battery_event(void)
 
 }
 
+void Copter::failsafe_severe_battery_event(void)
+{
+    // return immediately if low battery event has already been triggered
+    if (fs_low_batt_land) {
+        return;
+    }
+    if (g.failsafe_battery_enabled != FS_BATT_DISABLED && motors->armed()) {
+        if (should_disarm_on_failsafe()) {
+            init_disarm_motors();
+        } else {
+            if (g.failsafe_battery_enabled == FS_BATT_RTL || control_mode == AUTO) {
+                set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
+            } else {
+                set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
+            }
+        }
+    }
+
+    fs_low_batt_land = true;
+
+    // warn the ground station and log to dataflash
+    gcs_send_text(MAV_SEVERITY_WARNING,"Severely Low battery: LANDING");
+    Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
+
+}
+
 // failsafe_gcs_check - check for ground station failsafe
 void Copter::failsafe_gcs_check()
 {

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -71,7 +71,7 @@ void Copter::failsafe_battery_event(void)
 
 }
 
-void Copter::failsafe_severe_battery_event(void)
+void Copter::failsafe_critical_battery_event(void)
 {
     // return immediately if low battery event has already been triggered
     if (fs_low_batt_land) {

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -173,6 +173,13 @@ void Copter::read_battery(void)
         failsafe_battery_event();
     }
 
+    // Check for severely low voltage. Failsafe battery event must be triggered before and 
+    // land command must not triggered before.
+    // USB must not be connected, or might cause false alarm.
+    if (!ap.usb_connected && failsafe.battery && !fs_low_batt_land && battery.exhausted(g.fs_severe_batt_volt, g.fs_batt_mah)) {
+        failsafe_severe_battery_event();
+    }
+
     // log battery info to the dataflash
     if (should_log(MASK_LOG_CURRENT)) {
         Log_Write_Current();

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -176,8 +176,8 @@ void Copter::read_battery(void)
     // Check for severely low voltage. Failsafe battery event must be triggered before and 
     // land command must not triggered before.
     // USB must not be connected, or might cause false alarm.
-    if (!ap.usb_connected && failsafe.battery && !fs_low_batt_land && battery.exhausted(g.fs_severe_batt_volt, g.fs_batt_mah)) {
-        failsafe_severe_battery_event();
+    if (!ap.usb_connected && failsafe.battery && !fs_low_batt_land && battery.exhausted(g2.fs_critical_batt_volt, g2.fs_critical_batt_mah)) {
+        failsafe_critical_battery_event();
     }
 
     // log battery info to the dataflash


### PR DESCRIPTION
This added failsafe parameter will enable a copter to land at a specified voltage. In case that the copter is in RTL, but still too far away from home and might not make it to home.