### PR TITLE
Count and log consumed energy in Wh

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -196,6 +196,17 @@ bool AP_BattMonitor::healthy(uint8_t instance) const {
     return instance < _num_instances && state[instance].healthy;
 }
 
+/// has_consumed_energy - returns true if battery monitor instance provides consumed energy info
+bool AP_BattMonitor::has_consumed_energy(uint8_t instance) const
+{
+    if (instance < _num_instances && drivers[instance] != nullptr && _params[instance].type() != AP_BattMonitor_Params::BattMonitor_TYPE_NONE) {
+        return drivers[instance]->has_consumed_energy();
+    }
+
+    // not monitoring current
+    return false;
+}
+
 /// has_current - returns true if battery monitor instance provides current info
 bool AP_BattMonitor::has_current(uint8_t instance) const
 {
@@ -242,6 +253,15 @@ float AP_BattMonitor::current_amps(uint8_t instance) const {
 float AP_BattMonitor::current_total_mah(uint8_t instance) const {
     if (instance < _num_instances) {
         return state[instance].current_total_mah;
+    } else {
+        return 0.0f;
+    }
+}
+
+/// consumed_wh - returns energy consumed since start-up in watt-hours
+float AP_BattMonitor::consumed_wh(uint8_t instance) const {
+    if (instance < _num_instances) {
+        return state[instance].consumed_wh;
     } else {
         return 0.0f;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -55,6 +55,7 @@ public:
         float       voltage;            // voltage in volts
         float       current_amps;       // current in amperes
         float       current_total_mah;  // total current draw since start-up
+        float       consumed_wh;        // total energy consumed in Wh since start-up
         uint32_t    last_time_micros;   // time when voltage and current was last read
         uint32_t    low_voltage_start_ms;  // time when voltage dropped below the minimum
         float       temperature;        // battery temperature in celsius
@@ -77,6 +78,10 @@ public:
     bool healthy(uint8_t instance) const;
     bool healthy() const { return healthy(AP_BATT_PRIMARY_INSTANCE); }
 
+    /// has_consumed_energy - returns true if battery monitor instance provides consumed energy info
+    bool has_consumed_energy(uint8_t instance) const;
+    bool has_consumed_energy() const { return has_consumed_energy(AP_BATT_PRIMARY_INSTANCE); }
+
     /// has_current - returns true if battery monitor instance provides current info
     bool has_current(uint8_t instance) const;
     bool has_current() const { return has_current(AP_BATT_PRIMARY_INSTANCE); }
@@ -97,6 +102,10 @@ public:
     /// current_total_mah - returns total current drawn since start-up in amp-hours
     float current_total_mah(uint8_t instance) const;
     float current_total_mah() const { return current_total_mah(AP_BATT_PRIMARY_INSTANCE); }
+
+    /// consumed_wh - returns total energy drawn since start-up in watt-hours
+    float consumed_wh(uint8_t instance) const;
+    float consumed_wh() const { return consumed_wh(AP_BATT_PRIMARY_INSTANCE); }
 
     /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
     virtual uint8_t capacity_remaining_pct(uint8_t instance) const;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -44,7 +44,9 @@ AP_BattMonitor_Analog::read()
         // update total current drawn since startup
         if (_state.last_time_micros != 0 && dt < 2000000.0f) {
             // .0002778 is 1/3600 (conversion to hours)
-            _state.current_total_mah += _state.current_amps * dt * 0.0000002778f;
+            float mah = _state.current_amps * dt * 0.0000002778f;
+            _state.current_total_mah += mah;
+            _state.consumed_wh  += 0.001f * mah * _state.voltage;
         }
 
         // record time

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -115,6 +115,9 @@ public:
     /// Read the battery voltage and current.  Should be called at 10hz
     void read();
 
+    /// returns true if battery monitor provides consumed energy info
+    bool has_consumed_energy() const override { return has_current(); }
+
     /// returns true if battery monitor provides current info
     bool has_current() const override;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -34,6 +34,9 @@ public:
     // read the latest battery voltage
     virtual void read() = 0;
 
+    /// returns true if battery monitor instance provides consumed energy info
+    virtual bool has_consumed_energy() const { return false; }
+
     /// returns true if battery monitor instance provides current info
     virtual bool has_current() const = 0;
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1562,6 +1562,7 @@ void DataFlash_Class::Log_Write_Current_instance(const uint64_t time_us,
         voltage_resting     : battery.voltage_resting_estimate(battery_instance),
         current_amps        : battery.current_amps(battery_instance),
         current_total       : battery.current_total_mah(battery_instance),
+        consumed_wh         : battery.consumed_wh(battery_instance),
         temperature         : (int16_t)(has_temp ? (temp * 100) : 0),
         resistance          : battery.get_resistance(battery_instance)
     };

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -84,6 +84,7 @@ const struct UnitStructure log_Units[] = {
     { 'G', "Gauss" },         // Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
     { 'h', "degheading" },    // 0.? to 359.?
     { 'i', "A.s" },           // Ampere second
+    { 'J', "W.s" },           // Joule (Watt second)
     // { 'l', "l" },          // litres
     { 'L', "rad/s/s" },       // radians per second per second
     { 'm', "m" },             // metres
@@ -126,6 +127,7 @@ const struct MultiplierStructure log_Multipliers[] = {
     { 'G', 1e-7 },
 // <leave a gap here, just in case....>
     { '!', 3.6 }, // (ampere*second => milliampere*hour) and (km/h => m/s)
+    { '/', 3600 }, // (ampere*second => ampere*hour)
 };
 
 struct PACKED log_Parameter {
@@ -666,6 +668,7 @@ struct PACKED log_Current {
     float    voltage_resting;
     float    current_amps;
     float    current_total;
+    float    consumed_wh;
     int16_t  temperature; // degrees C * 100
     float    resistance;
 };
@@ -1110,10 +1113,10 @@ struct PACKED log_DSTL {
 #define QUAT_UNITS  "s????"
 #define QUAT_MULTS  "F????"
 
-#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,Temp,Res"
-#define CURR_FMT    "Qffffcf"
-#define CURR_UNITS  "sv?A?Ow"
-#define CURR_MULTS  "F??????"
+#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res"
+#define CURR_FMT    "Qfffffcf"
+#define CURR_UNITS  "sv?A?JOw"
+#define CURR_MULTS  "F????/??"
 
 #define CURR_CELL_LABELS "TimeUS,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
 #define CURR_CELL_FMT    "QfHHHHHHHHHH"

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -197,7 +197,7 @@ void GCS_MAVLINK::send_battery_status(const AP_BattMonitor &battery, const uint8
                                     battery.get_cell_voltages(instance).cells, // cell voltages
                                     battery.has_current(instance) ? battery.current_amps(instance) * 100 : -1, // current
                                     battery.has_current(instance) ? battery.current_total_mah(instance) : -1, // total current
-                                    -1, // joules used
+                                    battery.has_consumed_energy(instance) ? battery.consumed_wh(instance) * 36 : -1, // consumed energy in hJ (hecto-Joules)
                                     battery.capacity_remaining_pct(instance));
 }
 


### PR DESCRIPTION
Currently, we do our remaining battery calculations on capacity, i.E. spent mAh. This works well with high-C LiPo batteries, that have a prominent plateau of constant voltage during 70-80% of the flight. 

Modern alternatives with better engergy-to-weight ratio, like 18650 LiIon cells or low-C LiPos, do not have this characteristics. Instead, the voltage is (nearly) constantly decreasing from 4.2V before takeoff to 2.7V at during landing. Periods of heavy load might change the battery temperature, causing arbitrary steps in the voltage. With the voltage going down and the average current going up by 50%, the remaining shown battery percentage is far too optimistic.

![18650](https://user-images.githubusercontent.com/3057137/34245717-8a5f6786-e62b-11e7-8091-4d2445d6f026.png)

As a first step, this PR adds calculation and logging of the consumed ernergy in mWh (as an addition to the capacity in mAh).