### PR TITLE
COPTER: Fix MOUNT_CONTROL command yaw response

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1016,6 +1016,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_DO_MOUNT_CONTROL:
 #if MOUNT == ENABLED
+            if(!copter.camera_mount.has_pan_control()) {
+                copter.set_auto_yaw_look_at_heading((float)packet.param3 / 100.0f,0.0f,0,0);
+            }
             copter.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
             result = MAV_RESULT_ACCEPTED;
 #endif
@@ -1655,6 +1658,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
     //deprecated. Use MAV_CMD_DO_MOUNT_CONTROL
     case MAVLINK_MSG_ID_MOUNT_CONTROL:
+        if(!copter.camera_mount.has_pan_control()) {
+            copter.set_auto_yaw_look_at_heading(mavlink_msg_mount_control_get_input_c(msg)/100.0f, 0.0f, 0, 0);
+        }
         copter.camera_mount.control_msg(msg);
         break;
 #endif // MOUNT == ENABLED

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -1182,6 +1182,9 @@ void Copter::ModeAuto::do_digicam_control(const AP_Mission::Mission_Command& cmd
 void Copter::ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
 {
 #if MOUNT == ENABLED
+    if(!_copter.camera_mount.has_pan_control()) {
+        _copter.set_auto_yaw_look_at_heading(cmd.content.mount_control.yaw,0.0f,0,0);
+    }
     _copter.camera_mount.set_angle_targets(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw);
 #endif
 }


### PR DESCRIPTION
In response to MAV_CMD_DO_MOUNT_CONTROL or MSG_MOUNT_CONTROL in guided mode, or DO_MOUNT_CONTROL in missions.... If the mount instance doesn't support camera panning, the copter is supposed to yaw instead.  For some reason, this was missing from the GCS and Mission commands handling.  So in both guided and missions, the gimbal would tilt correctly, but copter yaw never moved.  I'm surprised nobody noticed this bug, but MOUNT_CONTROL probably has a fairly limited set of users.

These two patches implement the copter yaw when the mount instance does not have panning support.  It does so by calling the same yaw controller that CONDITION_YAW uses.  I've tested this repeatedly, and it worked as intended.

This will close https://github.com/ArduPilot/ardupilot/issues/6272