### PR TITLE
AP_Notify: Avoid nullptr init

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -69,9 +69,11 @@ void RGBLed::set_rgb(uint8_t red, uint8_t green, uint8_t blue)
     if (!_healthy) {
         return;
     }
-    if (pNotify->_rgb_led_override) {
-        // don't set if in override mode
-        return;
+    if (pNotify) {
+        if (pNotify->_rgb_led_override) {
+            // don't set if in override mode
+            return;
+        }
     }
     _set_rgb(red, green, blue);
 }
@@ -82,19 +84,21 @@ void RGBLed::update_colours(void)
 {
     uint8_t brightness = _led_bright;
 
-    switch (pNotify->_rgb_led_brightness) {
-    case RGB_LED_OFF:
-        brightness = _led_off;
-        break;
-    case RGB_LED_LOW:
-        brightness = _led_dim;
-        break;
-    case RGB_LED_MEDIUM:
-        brightness = _led_medium;
-        break;
-    case RGB_LED_HIGH:
-        brightness = _led_bright;
-        break;
+    if (pNotify) {
+        switch (pNotify->_rgb_led_brightness) {
+        case RGB_LED_OFF:
+            brightness = _led_off;
+            break;
+        case RGB_LED_LOW:
+            brightness = _led_dim;
+            break;
+        case RGB_LED_MEDIUM:
+            brightness = _led_medium;
+            break;
+        case RGB_LED_HIGH:
+            brightness = _led_bright;
+            break;
+        }
     }
 
     // slow rate from 50Hz to 10hz
@@ -342,11 +346,13 @@ void RGBLed::update()
     if (!_healthy) {
         return;
     }
-    if (!pNotify->_rgb_led_override) {
+    if (pNotify) {
+        if (pNotify->_rgb_led_override) {
+            update_override();
+        }
+    } else {
         update_colours();
         set_rgb(_red_des, _green_des, _blue_des);
-    } else {
-        update_override();
     }
 }
 
@@ -355,9 +361,11 @@ void RGBLed::update()
 */
 void RGBLed::handle_led_control(mavlink_message_t *msg)
 {
-    if (!pNotify->_rgb_led_override) {
-        // ignore LED_CONTROL commands if not in LED_OVERRIDE mode
-        return;
+    if (pNotify) {
+        if (!pNotify->_rgb_led_override) {
+            // ignore LED_CONTROL commands if not in LED_OVERRIDE mode
+            return;
+        }
     }
 
     // decode mavlink message

--- a/libraries/AP_Notify/ToneAlarm_Linux.cpp
+++ b/libraries/AP_Notify/ToneAlarm_Linux.cpp
@@ -66,9 +66,11 @@ void ToneAlarm_Linux::update()
         return;
     }
 
-    // exit if buzzer is not enabled
-    if (pNotify->buzzer_enabled() == false) {
-        return;
+    if (pNotify) {
+        // exit if buzzer is not enabled
+        if (pNotify->buzzer_enabled() == false) {
+            return;
+        }
     }
 
     // check for arming failure

--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -160,9 +160,11 @@ void ToneAlarm_PX4::update()
         return;
     }
 
-    // exit if buzzer is not enabled
-    if (pNotify->buzzer_enabled() == false) {
-        return;
+    if (pNotify) {
+        // exit if buzzer is not enabled
+        if (pNotify->buzzer_enabled() == false) {
+            return;
+        }
     }
 
     check_cont_tone();

--- a/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
@@ -21,7 +21,7 @@ void setup(void)
 
     // check if healthy
     if (!toshiba_led.healthy()) {
-        hal.console->printf("Failed to initialise Toshiba LED\n");
+        AP_HAL::panic("Failed to initialise Toshiba LED\n");
     }
 
     // turn on initialising notification


### PR DESCRIPTION
- Avoid nullptr on init only, with or without AP_Notify init.
- Updated Toshiba Led example.

This solve https://github.com/ArduPilot/ardupilot/issues/7375

Tested with SITL and URUS.