### PR TITLE
Chase mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -947,6 +947,7 @@ private:
     ModeAutoTune mode_autotune{*this};
 #endif
     ModeBrake mode_brake{*this};
+    ModeChase mode_chase{*this};
     ModeCircle mode_circle{*this, circle_nav};
     ModeDrift mode_drift{*this};
     ModeFlip mode_flip{*this};

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -47,6 +47,7 @@ NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
     case RTL:
     case LOITER:
     case AVOID_ADSB:
+    case CHASE:
     case GUIDED:
     case CIRCLE:
     case POSHOLD:
@@ -696,6 +697,7 @@ void GCS_MAVLINK_Copter::packetReceived(const mavlink_status_t &status,
         // optional handling of GLOBAL_POSITION_INT as a MAVLink based avoidance source
         copter.avoidance_adsb.handle_msg(msg);
     }
+    copter.mode_chase.mavlink_packet_received(msg);
     GCS_MAVLINK::packetReceived(status, msg);
 }
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -107,6 +107,7 @@ enum control_mode_t {
     AVOID_ADSB =   19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
     GUIDED_NOGPS = 20,  // guided mode but only accepts attitude and altitude
     SMART_RTL =    21,  // SMART_RTL returns to home by retracing its steps
+    CHASE     =    22,  // chase attempts to follow a mavink system id
 };
 
 enum mode_reason_t {

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -27,6 +27,10 @@ Copter::Mode *Copter::mode_from_mode_num(const uint8_t mode)
             ret = &mode_auto;
             break;
 
+        case CHASE:
+            ret = &mode_chase;
+            break;
+
         case CIRCLE:
             ret = &mode_circle;
             break;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1138,3 +1138,49 @@ protected:
 private:
 
 };
+
+class ModeChase : public ModeGuided {
+
+public:
+
+    ModeChase(Copter &copter) :
+        Copter::ModeGuided(copter) {
+        target_loc.flags.relative_alt = true;
+    }
+
+    bool init(bool ignore_checks) override;
+    void run() override;
+
+    bool requires_GPS() const override { return true; }
+    bool has_manual_throttle() const override { return false; }
+    bool allows_arming(bool from_gcs) const override { return false; }
+    bool is_autopilot() const override { return true; }
+
+    bool set_velocity(const Vector3f& velocity_neu);
+
+    void mavlink_packet_received(const mavlink_message_t &msg);
+
+protected:
+
+    const char *name() const override { return "CHASE"; }
+    const char *name4() const override { return "CHSE"; }
+
+private:
+
+    uint8_t target_srcid = 255;
+
+    Location_Class target_loc;
+    Vector3f target_vel;
+    uint32_t target_last_update_ms;
+    const uint16_t target_update_timeout_ms = 1000;
+
+    float sphere_radius_min = 5; // no closer than this to target
+    float sphere_radius_max = 50; // give up when further than this
+
+    const float closure_speed = 10; // metres/second
+    const float distance_slop = 2; // metres
+
+    void run_lonely_mode();
+    Copter::Mode *lonely_mode;
+
+};

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1163,7 +1163,7 @@ public:
 protected:
 
     const char *name() const override { return "CHASE"; }
-    const char *name4() const override { return "CHSE"; }
+    const char *name4() const override { return "CHAS"; }
 
 private:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1174,11 +1174,11 @@ private:
     uint32_t target_last_update_ms;
     const uint16_t target_update_timeout_ms = 1000;
 
-    float sphere_radius_min = 5; // no closer than this to target
-    float sphere_radius_max = 50; // give up when further than this
+    float sphere_radius_min = 5.0f; // no closer than this to target
+    float sphere_radius_max = 50.0f; // give up when further than this
 
-    const float closure_speed = 10; // metres/second
-    const float distance_slop = 2; // metres
+    const float closure_speed = 10.0f; // metres/second
+    const float distance_slop = 2.0f; // metres
 
     void run_lonely_mode();
     Copter::Mode *lonely_mode;

--- a/ArduCopter/mode_chase.cpp
+++ b/ArduCopter/mode_chase.cpp
@@ -8,6 +8,7 @@
  * TODO: stick control to change sphere diameter
  * TODO: "channel 7 option" to lock onto "pointed at" target
  * TODO: do better in terms of loitering around the moving point; may need a PID?  Maybe use loiter controller somehow?
+ * TODO: extrapolate target vehicle position using its velocity and acceleration
  */
 
 #if 1

--- a/ArduCopter/mode_chase.cpp
+++ b/ArduCopter/mode_chase.cpp
@@ -1,0 +1,141 @@
+#include "Copter.h"
+
+/*
+ * mode_chase.cpp - chase another mavlink-enabled vehicle by system id
+ *
+ * TODO: set ROI yaw mode / point camera at target
+ * TODO: stick control to move around on sphere
+ * TODO: stick control to change sphere diameter
+ * TODO: "channel 7 option" to lock onto "pointed at" target
+ * TODO: do better in terms of loitering around the moving point; may need a PID?  Maybe use loiter controller somehow?
+ */
+
+#if 1
+#define Debug(fmt, args ...)  do {::fprintf(stderr, "%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); hal.scheduler->delay(1); } while(0)
+#else
+#define Debug(fmt, args ...)
+#endif
+
+// initialise avoid_adsb controller
+bool Copter::ModeChase::init(const bool ignore_checks)
+{
+    // re-use guided mode
+    return Copter::ModeGuided::init(ignore_checks);
+}
+
+bool Copter::ModeChase::set_velocity(const Vector3f& velocity_neu)
+{
+    // check flight mode
+    if (_copter.flightmode != &_copter.mode_chase) {
+        return false;
+    }
+
+    return true;
+}
+
+void Copter::ModeChase::run_lonely_mode()
+{
+    if (lonely_mode == nullptr) {
+        if (copter.mode_loiter.init(false)) {
+            lonely_mode = &copter.mode_loiter;
+        } else if(copter.mode_rtl.init(false)) {
+            lonely_mode = &copter.mode_rtl;
+        } else {
+            copter.mode_land.init(false);
+            lonely_mode = &copter.mode_land;
+        }
+
+        gcs().send_text(MAV_SEVERITY_INFO, "Chase: Lonely; %s", lonely_mode->name());
+    }
+
+    lonely_mode->run();
+}
+
+
+void Copter::ModeChase::run()
+{
+    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
+#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
+        // call attitude controller
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
+        attitude_control->set_throttle_out(0,false,g.throttle_filt);
+#else   // multicopters do not stabilize roll/pitch/yaw when disarmed
+        motors->set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
+        // reset attitude control targets
+        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
+#endif
+        return;
+    }
+
+    // re-use guided mode's velocity controller
+    // Note: this is safe from interference from GCSs and companion computer's whose guided mode
+    //       position and velocity requests will be ignored while the vehicle is not in guided mode
+
+    const uint32_t now = AP_HAL::millis();
+    if (now - target_last_update_ms > target_update_timeout_ms) {
+        return run_lonely_mode();
+    }
+
+    Vector3f to_vehicle = location_3d_diff_NED(_copter.current_loc, target_loc);
+    Debug("to_vehicle: %f %f %f", to_vehicle.x, to_vehicle.y, to_vehicle.z);
+    const float distance_to_vehicle = to_vehicle.length();
+
+    if (distance_to_vehicle > sphere_radius_max) {
+        return run_lonely_mode();
+    }
+    lonely_mode = nullptr;
+
+    const float distance_to_stop = pos_control->get_stopping_distance_xyz() * .01f;
+
+    const float distance_to_move = distance_to_vehicle - sphere_radius_min;
+    Debug("distance_to_vehicle=%f move=%f stop=%f",
+          distance_to_vehicle,
+          distance_to_move,
+          distance_to_stop);
+    to_vehicle.normalize();
+    if (fabsf(distance_to_move) > distance_to_stop) {
+        to_vehicle *= closure_speed * 100; // m/s to cm/s (which set_velocity takes)
+        to_vehicle.z = -to_vehicle.z; // translate to NEU
+        if (distance_to_move < 0) {
+            to_vehicle = -to_vehicle; // too close!  back up!
+        }
+    } else {
+        to_vehicle.x = 0;
+        to_vehicle.y = 0;
+        to_vehicle.z = 0;
+    }
+    to_vehicle += target_vel;
+
+    // re-use guided mode's velocity controller (takes NEU)
+    Copter::ModeGuided::set_velocity(to_vehicle);
+
+    Copter::ModeGuided::run();
+}
+
+
+
+void Copter::ModeChase::mavlink_packet_received(const mavlink_message_t &msg)
+{
+    if (copter.flightmode != &copter.mode_chase) {
+        return;
+    }
+    if (msg.sysid != target_srcid) {
+        return;
+    }
+    if (msg.msgid != MAVLINK_MSG_ID_GLOBAL_POSITION_INT) {
+        // handle position only for now
+        return;
+    }
+
+    mavlink_global_position_int_t packet;
+    mavlink_msg_global_position_int_decode(&msg, &packet);
+    target_loc.lat = packet.lat;
+    target_loc.lng = packet.lon;
+    target_loc.alt = packet.relative_alt / 10; // mm -> cm
+    target_vel.x = packet.vx/100.0f; // cm/s to m/s
+    target_vel.y = packet.vy/100.0f; // cm/s to m/s
+    target_vel.z = packet.vz/100.0f; // cm/s to m/s
+
+    target_last_update_ms = AP_HAL::millis();
+}

--- a/ArduCopter/mode_chase.cpp
+++ b/ArduCopter/mode_chase.cpp
@@ -78,7 +78,7 @@ void Copter::ModeChase::run()
     }
     lonely_mode = nullptr;
 
-    const float distance_to_stop = pos_control->get_stopping_distance_xyz() * .01f;
+    const float distance_to_stop = pos_control->get_stopping_distance_xyz() * 0.01f;
 
     const float distance_to_move = distance_to_vehicle - sphere_radius_min;
     Debug("distance_to_vehicle=%f move=%f stop=%f",

--- a/ArduCopter/mode_chase.cpp
+++ b/ArduCopter/mode_chase.cpp
@@ -56,15 +56,7 @@ void Copter::ModeChase::run()
 {
     // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
-        // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0, get_smoothing_gain());
-        attitude_control->set_throttle_out(0,false,g.throttle_filt);
-#else   // multicopters do not stabilize roll/pitch/yaw when disarmed
-        motors->set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-        // reset attitude control targets
-        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
-#endif
+        zero_throttle_and_relax_ac();
         return;
     }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -582,11 +582,11 @@ float AC_PosControl::get_stopping_distance_xyz() const
     }
 
     // calculate point at which velocity switches from linear to sqrt
-    const float linear_velocity = _accel_cms/kP;
+    const float linear_velocity = _accel_cms / kP;
 
     // calculate distance within which we can stop
     if (vel_total < linear_velocity) {
-        return vel_total/kP;
+        return vel_total / kP;
     }
 
     const float linear_distance = _accel_cms/(2.0f*kP*kP);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -252,6 +252,10 @@ public:
     /// set_target_to_stopping_point_xy - sets horizontal target to reasonable stopping position in cm from home
     void set_target_to_stopping_point_xy();
 
+    /// get_stopping_distance_xyz - returns metres travelled before
+    /// vehicle will be stopped.
+    float get_stopping_distance_xyz() const;
+
     /// get_stopping_point_xy - calculates stopping point based on current position, velocity, vehicle acceleration
     ///     distance_max allows limiting distance to stopping point
     ///     results placed in stopping_position vector


### PR DESCRIPTION
The intent is to allow a vehicle to be used as a "chase" vehicle for aerial photography of another vehicle.

The "TODO" list is quite long, but the current code will move the vehicle to the nearest point on a sphere around the target vehicle.

Tested only in SITL.

Relatively easily tested in SITL, something like this:
```
module load message
alias add chase mode 22
alias add m2 message GLOBAL_POSITION_INT 0 -353633519 1491655464 586000 15000 0 0 0 0
arm throttle
rc 3 1600
chase
m2
m2
m2
m2
m2
m2
m2
```

The aliases (and `module load`) can go in `.mavinit.scr`.  EKF must be using GPS before the mode change is permitted.

The `GLOBAL_POSITION_INT` must be sent at >1Hz for the vehicle to continue moving.

This could be used as a "follow me" if the phone-based GCS were to send `GLOBAL_POSITION_INT` messages.
