### PR TITLE
AP_BattMonitor: Aggregate the commands defined in the SMBUS specification.

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -2,11 +2,6 @@
 
 #define AP_BATTMONITOR_SMBUS_PEC_POLYNOME 0x07 // Polynome for CRC generation
 
-#define BATTMONITOR_SMBUS_TEMP                 0x08 // temperature register
-#define BATTMONITOR_SMBUS_REMAINING_CAPACITY   0x0F // remaining capacity
-#define BATTMONITOR_SMBUS_FULL_CHARGE_CAPACITY 0x10 // full charge capacity
-#define BATTMONITOR_SMBUS_SERIAL               0x1C // serial number
-
 AP_BattMonitor_SMBus::AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                                            AP_BattMonitor::BattMonitor_State &mon_state,
                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -15,6 +15,19 @@ class AP_BattMonitor_SMBus : public AP_BattMonitor_Backend
 {
 public:
 
+    // Smart Battery Data Specification Revision 1.1
+    enum BATTMONITOR_SMBUS {
+        BATTMONITOR_SMBUS_TEMP = 0x08,                 // Temperature
+        BATTMONITOR_SMBUS_VOLTAGE = 0x09,              // Voltage
+        BATTMONITOR_SMBUS_CURRENT = 0x0A,              // Current
+        BATTMONITOR_SMBUS_REMAINING_CAPACITY = 0x0F,   // Remaining Capacity
+        BATTMONITOR_SMBUS_FULL_CHARGE_CAPACITY = 0x10, // Full Charge Capacity
+        BATTMONITOR_SMBUS_SPECIFICATION_INFO = 0x1A,   // Specification Info
+        BATTMONITOR_SMBUS_SERIAL = 0x1C,               // Serial Number
+        BATTMONITOR_SMBUS_MANUFACTURE_NAME = 0x20,     // Manufacture Name
+        BATTMONITOR_SMBUS_MANUFACTURE_DATA = 0x23,     // Manufacture Data
+    };
+
     /// Constructor
     AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                     AP_BattMonitor::BattMonitor_State &mon_state,

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -5,11 +5,6 @@
 #include "AP_BattMonitor_SMBus_Maxell.h"
 #include <utility>
 
-#define BATTMONITOR_SMBUS_MAXELL_VOLTAGE    0x09    // voltage register
-#define BATTMONITOR_SMBUS_MAXELL_CURRENT    0x0a    // current register
-#define BATTMONITOR_SMBUS_MAXELL_SPECIFICATION_INFO    0x1a    // specification info
-#define BATTMONITOR_SMBUS_MAXELL_MANUFACTURE_NAME  0x20    // manufacturer name
-
 #define BATTMONITOR_SMBUS_MAXELL_NUM_CELLS 6
 uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
                               0x3e,  // cell 2
@@ -53,7 +48,7 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     uint32_t tnow = AP_HAL::micros();
 
     // read voltage (V)
-    if (read_word(BATTMONITOR_SMBUS_MAXELL_VOLTAGE, data)) {
+    if (read_word(BATTMONITOR_SMBUS_VOLTAGE, data)) {
         _state.voltage = (float)data / 1000.0f;
         _state.last_time_micros = tnow;
         _state.healthy = true;
@@ -76,7 +71,7 @@ void AP_BattMonitor_SMBus_Maxell::timer()
     }
 
     // read current (A)
-    if (read_word(BATTMONITOR_SMBUS_MAXELL_CURRENT, data)) {
+    if (read_word(BATTMONITOR_SMBUS_CURRENT, data)) {
         _state.current_amps = -(float)((int16_t)data) / 1000.0f;
         _state.last_time_micros = tnow;
     }
@@ -146,7 +141,7 @@ bool AP_BattMonitor_SMBus_Maxell::check_pec_support()
 
     // specification info
     uint16_t data;
-    if (!read_word(BATTMONITOR_SMBUS_MAXELL_SPECIFICATION_INFO, data)) {
+    if (!read_word(BATTMONITOR_SMBUS_SPECIFICATION_INFO, data)) {
         return false;
     }
 
@@ -162,7 +157,7 @@ bool AP_BattMonitor_SMBus_Maxell::check_pec_support()
 
     // check manufacturer name
     uint8_t buff[SMBUS_READ_BLOCK_MAXIMUM_TRANSFER + 1];
-    if (read_block(BATTMONITOR_SMBUS_MAXELL_MANUFACTURE_NAME, buff, true)) {
+    if (read_block(BATTMONITOR_SMBUS_MANUFACTURE_NAME, buff, true)) {
         // Hitachi maxell batteries do not support PEC
         if (strcmp((char*)buff, "Hitachi maxell") == 0) {
             _pec_supported = false;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -6,7 +6,6 @@
 #include "AP_BattMonitor_SMBus_Solo.h"
 #include <utility>
 
-#define BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA     0x23    /// manufacturer data
 #define BATTMONITOR_SMBUS_SOLO_CELL_VOLTAGE         0x28    // cell voltage register
 #define BATTMONITOR_SMBUS_SOLO_CURRENT              0x2a    // current register
 #define BATTMONITOR_SMBUS_SOLO_BUTTON_DEBOUNCE      3       // button held down for 3 intervals will cause a power off event
@@ -77,7 +76,7 @@ void AP_BattMonitor_SMBus_Solo::timer()
     read_remaining_capacity();
 
     // read the button press indicator
-    if (read_block(BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA, buff, 6, false) == 6) {
+    if (read_block(BATTMONITOR_SMBUS_MANUFACTURE_DATA, buff, 6, false) == 6) {
         bool pressed = (buff[1] >> 3) & 0x01;
 
         if (_button_press_count >= BATTMONITOR_SMBUS_SOLO_BUTTON_DEBOUNCE) {


### PR DESCRIPTION
I think that it is better to define SMBUS specification commands in the SMBUS class.
I have SMBUS specification commands defined in SOLO, Maxell class.