### PR TITLE
Create AHRS singleton

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -311,11 +311,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         rover.send_location(chan);
         break;
 
-    case MSG_LOCAL_POSITION:
-        CHECK_PAYLOAD_SIZE(LOCAL_POSITION_NED);
-        send_local_position(rover.ahrs);
-        break;
-
     case MSG_NAV_CONTROLLER_OUTPUT:
         if (rover.control_mode->is_autopilot_mode()) {
             CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
@@ -356,11 +351,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
         send_sensor_offsets(rover.ins, rover.compass, rover.barometer);
-        break;
-
-    case MSG_AHRS:
-        CHECK_PAYLOAD_SIZE(AHRS);
-        send_ahrs(rover.ahrs);
         break;
 
     case MSG_SIMSTATE:

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -180,11 +180,6 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
         tracker.send_location(chan);
         break;
 
-    case MSG_LOCAL_POSITION:
-        CHECK_PAYLOAD_SIZE(LOCAL_POSITION_NED);
-        send_local_position(tracker.ahrs);
-        break;
-
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         tracker.send_nav_controller_output(chan);
@@ -213,11 +208,6 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
         send_sensor_offsets(tracker.ins, tracker.compass, tracker.barometer);
-        break;
-
-    case MSG_AHRS:
-        CHECK_PAYLOAD_SIZE(AHRS);
-        send_ahrs(tracker.ahrs);
         break;
 
     case MSG_SIMSTATE:

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -569,7 +569,7 @@ private:
 #endif
 
 #if ADSB_ENABLED == ENABLED
-    AP_ADSB adsb{ahrs};
+    AP_ADSB adsb;
 
     // avoidance of adsb enabled vehicles (normally manned vehicles)
     AP_Avoidance_Copter avoidance_adsb{ahrs, adsb};

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -317,11 +317,6 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         copter.send_location(chan);
         break;
 
-    case MSG_LOCAL_POSITION:
-        CHECK_PAYLOAD_SIZE(LOCAL_POSITION_NED);
-        send_local_position(copter.ahrs);
-        break;
-
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         copter.send_nav_controller_output(chan);
@@ -388,18 +383,13 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 #endif
         break;
 
-    case MSG_AHRS:
-        CHECK_PAYLOAD_SIZE(AHRS);
-        send_ahrs(copter.ahrs);
-        break;
-
     case MSG_SIMSTATE:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         CHECK_PAYLOAD_SIZE(SIMSTATE);
         copter.send_simstate(chan);
 #endif
         CHECK_PAYLOAD_SIZE(AHRS2);
-        send_ahrs2(copter.ahrs);
+        send_ahrs2();
         break;
 
     case MSG_MOUNT_STATUS:
@@ -417,7 +407,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     case MSG_OPTICAL_FLOW:
 #if OPTFLOW == ENABLED
         CHECK_PAYLOAD_SIZE(OPTICAL_FLOW);
-        send_opticalflow(copter.ahrs, copter.optflow);
+        send_opticalflow(copter.optflow);
 #endif
         break;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -424,11 +424,6 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         plane.send_location(chan);
         break;
 
-    case MSG_LOCAL_POSITION:
-        CHECK_PAYLOAD_SIZE(LOCAL_POSITION_NED);
-        send_local_position(plane.ahrs);
-        break;
-
     case MSG_NAV_CONTROLLER_OUTPUT:
         if (plane.control_mode != MANUAL) {
             CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
@@ -493,16 +488,11 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
 #endif
         break;
 
-    case MSG_AHRS:
-        CHECK_PAYLOAD_SIZE(AHRS);
-        send_ahrs(plane.ahrs);
-        break;
-
     case MSG_SIMSTATE:
         CHECK_PAYLOAD_SIZE(SIMSTATE);
         plane.send_simstate(chan);
         CHECK_PAYLOAD_SIZE2(AHRS2);
-        send_ahrs2(plane.ahrs);
+        send_ahrs2();
         break;
 
     case MSG_RANGEFINDER:
@@ -540,7 +530,7 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
 #if OPTFLOW == ENABLED
         if (plane.optflow.enabled()) {        
             CHECK_PAYLOAD_SIZE(OPTICAL_FLOW);
-            send_opticalflow(plane.ahrs, plane.optflow);
+            send_opticalflow(plane.optflow);
         }
 #endif
         break;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -626,7 +626,7 @@ private:
             FUNCTOR_BIND_MEMBER(&Plane::disarm_if_autoland_complete, void),
             FUNCTOR_BIND_MEMBER(&Plane::update_flight_stage, void)};
 
-    AP_ADSB adsb{ahrs};
+    AP_ADSB adsb;
 
     // avoidance of adsb enabled vehicles (normally manned vheicles)
     AP_Avoidance_Plane avoidance_adsb{ahrs, adsb};

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -517,11 +517,6 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
         sub.send_location(chan);
         break;
 
-    case MSG_LOCAL_POSITION:
-        CHECK_PAYLOAD_SIZE(LOCAL_POSITION_NED);
-        send_local_position(sub.ahrs);
-        break;
-
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         sub.send_nav_controller_output(chan);
@@ -588,18 +583,13 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
 #endif
         break;
 
-    case MSG_AHRS:
-        CHECK_PAYLOAD_SIZE(AHRS);
-        send_ahrs(sub.ahrs);
-        break;
-
     case MSG_SIMSTATE:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         CHECK_PAYLOAD_SIZE(SIMSTATE);
         sub.send_simstate(chan);
 #endif
         CHECK_PAYLOAD_SIZE(AHRS2);
-        send_ahrs2(sub.ahrs);
+        send_ahrs2();
         break;
 
     case MSG_MOUNT_STATUS:
@@ -617,7 +607,7 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
     case MSG_OPTICAL_FLOW:
 #if OPTFLOW == ENABLED
         CHECK_PAYLOAD_SIZE(OPTICAL_FLOW);
-        send_opticalflow(sub.ahrs, sub.optflow);
+        send_opticalflow(sub.optflow);
 #endif
         break;
 

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -161,7 +161,7 @@ void AP_ADSB::deinit(void)
 void AP_ADSB::update(void)
 {
     // update _my_loc
-    if (!_ahrs.get_position(_my_loc)) {
+    if (!AP::ahrs().get_position(_my_loc)) {
         _my_loc.zero();
     }
 
@@ -506,7 +506,7 @@ void AP_ADSB::send_dynamic_out(const mavlink_channel_t chan)
     const uint64_t gps_time = gps.time_epoch_usec();
     const uint32_t utcTime = gps_time / 1000000ULL;
 
-    const AP_Baro &baro = _ahrs.get_baro();
+    const AP_Baro &baro = AP::ahrs().get_baro();
     int32_t altPres = INT_MAX;
     if (baro.healthy()) {
         // Altitude difference between 101325 (Pascals) and current pressure. Result in millimeters

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -31,8 +31,7 @@
 
 class AP_ADSB {
 public:
-    AP_ADSB(const AP_AHRS &ahrs)
-        : _ahrs(ahrs)
+    AP_ADSB()
     {
         AP_Param::setup_object_defaults(this, var_info);
     }
@@ -108,10 +107,6 @@ private:
 
     // handle ADS-B transceiver report for ping2020
     void handle_transceiver_report(mavlink_channel_t chan, const mavlink_message_t* msg);
-
-    // reference to AHRS, so we can ask for our position,
-    // heading and speed
-    const AP_AHRS &_ahrs;
 
     AP_Int8     _enabled;
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -411,3 +411,15 @@ Vector2f AP_AHRS::rotate_body_to_earth2D(const Vector2f &bf) const
     return Vector2f(bf.x * _cos_yaw - bf.y * _sin_yaw,
                     bf.x * _sin_yaw + bf.y * _cos_yaw);
 }
+
+// singleton instance
+AP_AHRS *AP_AHRS::_singleton;
+
+namespace AP {
+
+AP_AHRS &ahrs()
+{
+    return *AP_AHRS::get_singleton();
+}
+
+}

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -76,6 +76,8 @@ public:
         _sin_yaw(0.0f),
         _active_accel_instance(0)
     {
+        _singleton = this;
+
         // load default values from var_info table
         AP_Param::setup_object_defaults(this, var_info);
 
@@ -99,6 +101,11 @@ public:
 
     // empty virtual destructor
     virtual ~AP_AHRS() {}
+
+    // get singleton instance
+    static AP_AHRS *get_singleton() {
+        return _singleton;
+    }
 
     // init sets up INS board orientation
     virtual void init() {
@@ -670,6 +677,10 @@ protected:
     // AOA and SSA
     float _AOA, _SSA;
     uint32_t _last_AOA_update_ms;
+
+private:
+    static AP_AHRS *_singleton;
+
 };
 
 #include "AP_AHRS_DCM.h"
@@ -680,3 +691,7 @@ protected:
 #else
 #define AP_AHRS_TYPE AP_AHRS
 #endif
+
+namespace AP {
+    AP_AHRS &ahrs();
+};

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -303,6 +303,8 @@ public:
     // otherwise false. This call fills in lat, lng and alt
     virtual bool get_position(struct Location &loc) const = 0;
 
+    virtual bool get_hagl(float &height) const { return false; }
+
     // return a wind estimation vector, in m/s
     virtual Vector3f wind_estimate(void) const = 0;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -72,7 +72,7 @@ public:
     bool get_position(struct Location &loc) const override;
 
     // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const;
+    bool get_hagl(float &hagl) const override;
 
     // status reporting of estimated error
     float           get_error_rp() const override;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1023,7 +1023,7 @@ bool NavEKF2::getHAGL(float &HAGL) const
 }
 
 // return the Euler roll, pitch and yaw angle in radians for the specified instance
-void NavEKF2::getEulerAngles(int8_t instance, Vector3f &eulers)
+void NavEKF2::getEulerAngles(int8_t instance, Vector3f &eulers) const
 {
     if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -182,7 +182,7 @@ public:
 
     // return the Euler roll, pitch and yaw angle in radians for the specified instance
     // An out of range instance (eg -1) returns data for the the primary instance
-    void getEulerAngles(int8_t instance, Vector3f &eulers);
+    void getEulerAngles(int8_t instance, Vector3f &eulers) const;
 
     // return the transformation matrix from XYZ (body) to NED axes
     void getRotationBodyToNED(Matrix3f &mat) const;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -160,19 +160,19 @@ public:
     void send_distance_sensor_downward(const RangeFinder &rangefinder) const;
     void send_rangefinder_downward(const RangeFinder &rangefinder) const;
     bool send_proximity(const AP_Proximity &proximity) const;
-    void send_ahrs2(AP_AHRS &ahrs);
+    void send_ahrs2();
     void send_system_time();
     void send_radio_in(uint8_t receiver_rssi);
     void send_raw_imu(const AP_InertialSensor &ins, const Compass &compass);
     void send_scaled_pressure(AP_Baro &barometer);
     void send_sensor_offsets(const AP_InertialSensor &ins, const Compass &compass, AP_Baro &barometer);
-    void send_ahrs(AP_AHRS &ahrs);
+    void send_ahrs();
     void send_battery2(const AP_BattMonitor &battery);
 #if AP_AHRS_NAVEKF_AVAILABLE
-    void send_opticalflow(AP_AHRS_NavEKF &ahrs, const OpticalFlow &optflow);
+    void send_opticalflow(const OpticalFlow &optflow);
 #endif
     void send_autopilot_version() const;
-    void send_local_position(const AP_AHRS &ahrs) const;
+    void send_local_position() const;
     void send_vibration(const AP_InertialSensor &ins) const;
     void send_home(const Location &home) const;
     void send_ekf_origin(const Location &ekf_origin) const;


### PR DESCRIPTION
I have a concern with this approach - basically, how many more libraries will be modified to take a specific `AP_AHRS_View` in place of an `AP_AHRS` object - like `AC_Circle`.  If, for some reason, you wanted to change ADSB to use a view all lines referencing the ahrs would have to be changed.

One option would be to have an `ahrs()` call on `AP_ADSB` - which would at this point just return `AP::adsb()` but could later return a view instead (constructor would have to change but calls on the ahrs object would not need to).

For this PR I just went with `AP::ahrs()`
