### PR TITLE
SITL - Fixed Cygwin package names and made install easier for new users

### DIFF
--- a/Tools/autotest/win_sitl/InstallDevEnvironment.ps1
+++ b/Tools/autotest/win_sitl/InstallDevEnvironment.ps1
@@ -11,11 +11,10 @@ Write-Output "Downloading Cygwin x64 (2/6)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
 Write-Output "Installing Cygwin x64 (3/6)"
-#& $PSScriptRoot\setup-x86_64.exe --root="C:\cygwin" --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site="http://cygwin.mirror.constant.com" --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode | Out-Null
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python2,python2-future,python2-libxml2,libxslt-devel,python2-devel,procps-ng --quiet-mode"
 
 Write-Output "Copying JSBSim install script Cygwin (4/6)"
-Copy-Item jsbsim_install.sh C:\cygwin\home
+Start-BitsTransfer -Source "https://github.com/ArduPilot/ardupilot/raw/master/Tools/autotest/win_sitl/jsbsim_install.sh" -Destination "C:\cygwin\home\jsbsim_install.sh"
 
 Write-Output "Downloading JSBSim Cygwin (5/6)"
 Start-Process -wait -FilePath "C:\cygwin\bin\bash" -ArgumentList "--login -i -c ../jsbsim_install.sh"

--- a/Tools/autotest/win_sitl/InstallDevEnvironmentAndAPMSource.ps1
+++ b/Tools/autotest/win_sitl/InstallDevEnvironmentAndAPMSource.ps1
@@ -11,11 +11,10 @@ Write-Output "Downloading Cygwin x64 (2/6)"
 Start-BitsTransfer -Source "https://cygwin.com/setup-x86_64.exe" -Destination "$PSScriptRoot\setup-x86_64.exe"
 
 Write-Output "Installing Cygwin x64 (3/6)"
-#& $PSScriptRoot\setup-x86_64.exe --root="C:\cygwin" --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site="http://cygwin.mirror.constant.com" --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode | Out-Null
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel, libxml2-devel,python-libxml2,libxslt-devel,python-devel,procps-ng --quiet-mode"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python2,python2-future,python2-libxml2,libxslt-devel,python2-devel,procps-ng --quiet-mode"
 
 Write-Output "Copying JSBSim APM install script Cygwin (4/6)"
-Copy-Item jsbsimAPM_install.sh C:\cygwin\home
+Start-BitsTransfer -Source "https://github.com/ArduPilot/ardupilot/raw/master/Tools/autotest/win_sitl/jsbsimAPM_install.sh" -Destination "C:\cygwin\home\jsbsimAPM_install.sh"
 
 Write-Output "Downloading JSBSim and APM (5/6)"
 Start-Process -wait -FilePath "C:\cygwin\bin\bash" -ArgumentList "--login -i -c ../jsbsimAPM_install.sh"

--- a/Tools/autotest/win_sitl/jsbsimAPM_install.sh
+++ b/Tools/autotest/win_sitl/jsbsimAPM_install.sh
@@ -2,8 +2,6 @@
 
 #A simple script to install the APM SITL environment into cygwin
 
-python -m ensurepip --user
-python -m pip install --user future
 git clone git://github.com/ArduPilot/ardupilot.git
 git clone git://github.com/tridge/jsbsim.git
 cd jsbsim

--- a/Tools/autotest/win_sitl/jsbsim_install.sh
+++ b/Tools/autotest/win_sitl/jsbsim_install.sh
@@ -2,8 +2,6 @@
 
 #A simple script to install the APM SITL environment into cygwin
 
-python -m ensurepip --user
-python -m pip install --user future
 git clone git://github.com/tridge/jsbsim.git
 cd jsbsim
 ./autogen.sh

--- a/Tools/autotest/win_sitl/readme.txt
+++ b/Tools/autotest/win_sitl/readme.txt
@@ -16,11 +16,13 @@ Prerequisites:
 
 2A) Installing just the Development Environment:
 
-    Run the script "InstallDevEnvironment.ps1" (right click -> Run in Powershell). This will install Cygwin to C:\cygwin and MAVProxy to C:\Program Files (x86)\MAVProxy
+    Download and run the script "InstallDevEnvironment.ps1" (right click -> Run in Powershell). This will install Cygwin to C:\cygwin and MAVProxy to C:\Program Files (x86)\MAVProxy
     
 2B) Installing the Development Environment and APM source code:
 
-    Run the script "InstallDevEnvironmentAndAPMSource.ps1" (right click -> Run in Powershell). This will install Cygwin to C:\cygwin and MAVProxy to C:\Program Files (x86)\MAVProxy. The APM source code will be in C:\cygwin\home\<username>\ardupilot
+    Download and run the script "InstallDevEnvironmentAndAPMSource.ps1" (right click -> Run in Powershell). This will install Cygwin to C:\cygwin and MAVProxy to C:\Program Files (x86)\MAVProxy. The APM source code will be in C:\cygwin\home\<username>\ardupilot
+    
+NOTE: When running the above script, you may recieve an error due to the default Windows security policy not allowing downloaded scripts to run. See https://www.howtogeek.com/106273/how-to-allow-the-execution-of-powershell-scripts-on-windows-7/ for details on how to disable this policy.
     
 3) Running SITL:
 


### PR DESCRIPTION
For Cygwin install scripts, corrected python2 install (Cygwin now uses "python2" rather than "python")

Based on user feedback, the Powershell script now downloads the bach install script, rhater than requiring the user to download it themselves.