### PR TITLE
AP_BattMonitor: Change that the current relation value of Maxell becomes 1/2

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -38,32 +38,41 @@ void AP_BattMonitor_SMBus::read(void)
     }
 }
 
-// reads the pack full charge capacity
-// returns true if the read was successful, or if we already knew the pack capacity
-bool AP_BattMonitor_SMBus::read_full_charge_capacity(void)
+/**
+ * reads the pack full charge capacity
+ *
+ * @param [in] inMultiple A multiple to restore the original value
+ * @retval true if the read was successful, or if we already knew the pack capacity
+ * @retval false read was failure
+ */
+bool AP_BattMonitor_SMBus::read_full_charge_capacity(uint8_t inMultiple)
 {
     uint16_t data;
 
     if (_full_charge_capacity != 0) {
         return true;
     } else if (read_word(BATTMONITOR_SMBUS_FULL_CHARGE_CAPACITY, data)) {
-        _full_charge_capacity = data;
+        _full_charge_capacity = data * inMultiple;
         return true;
     }
     return false;
 }
 
-// reads the remaining capacity
-// returns true if the read was succesful, which is only considered to be the
-// we know the full charge capacity
-bool AP_BattMonitor_SMBus::read_remaining_capacity(void)
+/**
+ * reads the remaining capacity
+ *
+ * @param [in] inMultiple A multiple to restore the original value
+ * @retval true returns true if the read was succesful, which is only considered to be the we know the full charge capacity
+ * @retval false read was failure
+ */
+bool AP_BattMonitor_SMBus::read_remaining_capacity(uint8_t inMultiple)
 {
     int32_t capacity = get_capacity();
 
     if (capacity > 0) {
         uint16_t data;
         if (read_word(BATTMONITOR_SMBUS_REMAINING_CAPACITY, data)) {
-            _state.current_total_mah = MAX(0, capacity - data);
+            _state.current_total_mah = MAX(0.0f, static_cast<float>(capacity) - static_cast<float>(data * inMultiple));
             return true;
         }
     }
@@ -167,4 +176,3 @@ uint8_t AP_BattMonitor_SMBus::get_PEC(const uint8_t i2c_addr, uint8_t cmd, bool 
     // return result
     return crc;
 }
-

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -36,12 +36,12 @@ protected:
 
     // reads the pack full charge capacity
     // returns true if the read was successful, or if we already knew the pack capacity
-    bool read_full_charge_capacity(void);
+    bool read_full_charge_capacity(uint8_t inMultiple);
 
     // reads the remaining capacity
     // returns true if the read was succesful, which is only considered to be the
     // we know the full charge capacity
-    bool read_remaining_capacity(void);
+    bool read_remaining_capacity(uint8_t inMultiple);
 
     // reads the temperature word from the battery
     // returns true if the read was successful

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -77,14 +77,14 @@ void AP_BattMonitor_SMBus_Maxell::timer()
 
     // read current (A)
     if (read_word(BATTMONITOR_SMBUS_MAXELL_CURRENT, data)) {
-        _state.current_amps = -(float)((int16_t)data) / 1000.0f;
+        _state.current_amps = -static_cast<float>(static_cast<int16_t>(data)) / 1000.0f * 2.0f;
         _state.last_time_micros = tnow;
     }
 
-    read_full_charge_capacity();
+    read_full_charge_capacity(2);  // Maxell has set a value of 1/2.
 
     // FIXME: Preform current integration if the remaining capacity can't be requested
-    read_remaining_capacity();
+    read_remaining_capacity(2);  // Maxell has set a value of 1/2.
 
     read_temp();
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -73,8 +73,8 @@ void AP_BattMonitor_SMBus_Solo::timer()
         _state.last_time_micros = tnow;
     }
 
-    read_full_charge_capacity();
-    read_remaining_capacity();
+    read_full_charge_capacity(1);
+    read_remaining_capacity(1);
 
     // read the button press indicator
     if (read_block(BATTMONITOR_SMBUS_SOLO_MANUFACTURE_DATA, buff, 6, false) == 6) {


### PR DESCRIPTION
With Maxell's smart battery specification, the current relation value is 1/2.
I change according to that specification.
I change common methods.