### PR TITLE
Rover: remove duplicate lateral_acceleration variable

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -364,3 +364,12 @@ void Mode::calc_steering_from_lateral_acceleration(bool reversed)
     float steering_out = attitude_control.get_steering_out_lat_accel(_desired_lat_accel, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
+
+// calculate steering output to drive towards desired heading
+void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
+{
+    // calculate yaw error (in radians) and pass to steering angle controller
+    const float yaw_error = wrap_PI(radians((desired_heading_cd - ahrs.yaw_sensor) * 0.01f));
+    const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    g2.motors.set_steering(steering_out * 4500.0f);
+}

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -111,7 +111,7 @@ protected:
     void calc_steering_to_waypoint(const struct Location &origin, const struct Location &destination, bool reversed = false);
 
     // calculate steering angle given a desired lateral acceleration
-    void calc_steering_from_lateral_acceleration(bool reversed = false);
+    void calc_steering_from_lateral_acceleration(float lat_accel, bool reversed = false);
 
     // calculate steering output to drive towards desired heading
     void calc_steering_to_heading(float desired_heading_cd, bool reversed = false);
@@ -152,7 +152,6 @@ protected:
     Location _destination;      // destination Location when in Guided_WP
     float _distance_to_destination; // distance from vehicle to final destination in meters
     bool _reached_destination;  // true once the vehicle has reached the destination
-    float _desired_lat_accel;   // desired lateral acceleration in m/s/s
     float _desired_yaw_cd;      // desired yaw in centi-degrees
     float _yaw_error_cd;        // error between desired yaw and actual yaw in centi-degrees
     float _desired_speed;       // desired speed in m/s

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -113,6 +113,8 @@ protected:
     // calculate steering angle given a desired lateral acceleration
     void calc_steering_from_lateral_acceleration(bool reversed = false);
 
+    // calculate steering output to drive towards desired heading
+    void calc_steering_to_heading(float desired_heading_cd, bool reversed = false);
 
     // calculates the amount of throttle that should be output based
     // on things like proximity to corners and current speed

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -60,7 +60,6 @@ void ModeAuto::update()
             } else {
                 // we have reached the destination so stop
                 stop_vehicle();
-                _desired_lat_accel = 0.0f;
             }
             break;
         }

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -69,12 +69,10 @@ void ModeAuto::update()
         {
             if (!_reached_heading) {
                 // run steering and throttle controllers
-                const float yaw_error = wrap_PI(radians((_desired_yaw_cd - ahrs.yaw_sensor) * 0.01f));
-                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
-                g2.motors.set_steering(steering_out * 4500.0f);
+                calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
                 calc_throttle(_desired_speed, true);
-                // check if we have reached target
-                _reached_heading = (fabsf(yaw_error) < radians(5));
+                // check if we have reached within 5 degrees of target
+                _reached_heading = (fabsf(_desired_yaw_cd - ahrs.yaw_sensor) < 500);
             } else {
                 stop_vehicle();
             }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -7,7 +7,6 @@ bool ModeGuided::_enter()
     set_desired_speed_to_default();
 
     // when entering guided mode we set the target as the current location.
-    _desired_lat_accel = 0.0f;
     set_desired_location(rover.current_loc);
 
     // guided mode never travels in reverse

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -46,9 +46,7 @@ void ModeGuided::update()
             }
             if (have_attitude_target) {
                 // run steering and throttle controllers
-                const float yaw_error = wrap_PI(radians((_desired_yaw_cd - ahrs.yaw_sensor) * 0.01f));
-                const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
-                g2.motors.set_steering(steering_out * 4500.0f);
+                calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
                 calc_throttle(_desired_speed, true);
             } else {
                 stop_vehicle();

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -37,6 +37,5 @@ void ModeRTL::update()
     } else {
         // we've reached destination so stop
         stop_vehicle();
-        _desired_lat_accel = 0.0f;
     }
 }

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -15,7 +15,6 @@ void ModeSteering::update()
         // no valid speed so stop
         g2.motors.set_throttle(0.0f);
         g2.motors.set_steering(0.0f);
-        _desired_lat_accel = 0.0f;
         return;
     }
 
@@ -36,13 +35,13 @@ void ModeSteering::update()
     max_g_force = constrain_float(max_g_force, 0.1f, g.turn_max_g * GRAVITY_MSS);
 
     // convert pilot steering input to desired lateral acceleration
-    _desired_lat_accel = max_g_force * (desired_steering / 4500.0f);
+    float desired_lat_accel = max_g_force * (desired_steering / 4500.0f);
 
     // reverse target lateral acceleration if backing up
     bool reversed = false;
     if (is_negative(target_speed)) {
         reversed = true;
-        _desired_lat_accel = -_desired_lat_accel;
+        desired_lat_accel = -desired_lat_accel;
     }
 
     // mark us as in_reverse when using a negative throttle
@@ -53,7 +52,7 @@ void ModeSteering::update()
         stop_vehicle();
     } else {
         // run lateral acceleration to steering controller
-        calc_steering_from_lateral_acceleration(false);
+        calc_steering_from_lateral_acceleration(desired_lat_accel, false);
         calc_throttle(target_speed, false);
     }
 }


### PR DESCRIPTION
This PR makes two mostly non-functional changes:

- remove the lateral_acceleration variable from the mode class because we already store this in the attitude controller
- move some duplicate code from Guided and Auto mode into a new calc_steering_to_heading method