### PR TITLE
Plane: use control_mode explicitly by index making the enum order arbitrary

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -561,6 +561,9 @@ private:
     // with STICK_MIXING=0
     bool auto_navigation_mode:1;
     
+    // this allows certain flight modes to mix RC input with throttle depending on airspeed_nudge_cm
+    bool throttle_allows_nudging:1;
+
     // this controls throttle suppression in auto modes
     bool throttle_suppressed;
 	

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -163,6 +163,8 @@ void Plane::calc_gndspeed_undershoot()
             float gndSpdFwd = yawVect * gndVel;
             groundspeed_undershoot = (aparm.min_gndspeed_cm > 0) ? (aparm.min_gndspeed_cm - gndSpdFwd*100) : 0;
         }
+    } else {
+    	groundspeed_undershoot = 0;
     }
 }
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -127,7 +127,9 @@ void Plane::calc_airspeed_errors()
     // Set target to current airspeed + ground speed undershoot,
     // but only when this is faster than the target airspeed commanded
     // above.
-    if (control_mode >= FLY_BY_WIRE_B && (aparm.min_gndspeed_cm > 0)) {
+    if (auto_throttle_mode &&
+    	aparm.min_gndspeed_cm > 0 &&
+    	control_mode != CIRCLE) {
         int32_t min_gnd_target_airspeed = airspeed_measured*100 + groundspeed_undershoot;
         if (min_gnd_target_airspeed > target_airspeed_cm) {
             target_airspeed_cm = min_gnd_target_airspeed;

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -135,7 +135,7 @@ void Plane::calc_airspeed_errors()
     }
 
     // Bump up the target airspeed based on throttle nudging
-    if (control_mode >= AUTO && airspeed_nudge_cm > 0) {
+    if (throttle_allows_nudging && airspeed_nudge_cm > 0) {
         target_airspeed_cm += airspeed_nudge_cm;
     }
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -581,7 +581,7 @@ void Plane::set_servos(void)
     // setup flap outputs
     set_servos_flaps();
     
-    if (control_mode >= FLY_BY_WIRE_B ||
+    if (auto_throttle_mode ||
         quadplane.in_assisted_flight() ||
         quadplane.in_vtol_mode()) {
         /* only do throttle slew limiting in modes where throttle

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -327,6 +327,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     switch(control_mode)
     {
     case INITIALISING:
+        throttle_allows_nudging = true;
         auto_throttle_mode = true;
         auto_navigation_mode = false;
         break;
@@ -335,17 +336,20 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     case STABILIZE:
     case TRAINING:
     case FLY_BY_WIRE_A:
+        throttle_allows_nudging = false;
         auto_throttle_mode = false;
         auto_navigation_mode = false;
         break;
 
     case AUTOTUNE:
+        throttle_allows_nudging = false;
         auto_throttle_mode = false;
         auto_navigation_mode = false;
         autotune_start();
         break;
 
     case ACRO:
+        throttle_allows_nudging = false;
         auto_throttle_mode = false;
         auto_navigation_mode = false;
         acro_state.locked_roll = false;
@@ -353,6 +357,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         break;
         
     case CRUISE:
+        throttle_allows_nudging = false;
         auto_throttle_mode = true;
         auto_navigation_mode = false;
         cruise_state.locked_heading = false;
@@ -365,6 +370,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         break;
 
     case FLY_BY_WIRE_B:
+        throttle_allows_nudging = false;
         auto_throttle_mode = true;
         auto_navigation_mode = false;
         
@@ -376,12 +382,14 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 
     case CIRCLE:
         // the altitude to circle at is taken from the current altitude
+        throttle_allows_nudging = false;
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         next_WP_loc.alt = current_loc.alt;
         break;
 
     case AUTO:
+        throttle_allows_nudging = true;
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         if (quadplane.available() && quadplane.enable == 2) {
@@ -397,6 +405,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         break;
 
     case RTL:
+        throttle_allows_nudging = true;
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         prev_WP_loc = current_loc;
@@ -404,6 +413,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         break;
 
     case LOITER:
+        throttle_allows_nudging = true;
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         do_loiter_at_location();
@@ -418,6 +428,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 
     case AVOID_ADSB:
     case GUIDED:
+        throttle_allows_nudging = true;
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         guided_throttle_passthru = false;
@@ -434,6 +445,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     case QLOITER:
     case QLAND:
     case QRTL:
+        throttle_allows_nudging = true;
         auto_navigation_mode = false;
         if (!quadplane.init_mode()) {
             control_mode = previous_mode;


### PR DESCRIPTION
This is a final cleanup to close https://github.com/ArduPilot/ardupilot/issues/4656

This is a non-functional change except for one tiny thing. Flight mode AUTOTUNE will no longer enforce a minimum ground speed which it was not supposed to be doing anyway. AUTOTUNE should be like FBWA which doesn't respect it (where FBWB would).

throttle_allows_nudging matches auto_navigation_mode in all cases except CIRCLE and Q* modes, and I don't think the throttle nudging does anything in Q but I wasn't sure. Anyway, a 1 bit-wide flag won't hurt.
