### PR TITLE
Copter: change pre-arm checks to allow interlock to be enabled

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -49,7 +49,6 @@ bool AP_Arming_Copter::pre_arm_checks(bool display_failure)
         if (display_failure) {
             gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Motor Interlock Enabled");
         }
-        return false;
     }
 
     // succeed if pre arm checks are disabled


### PR DESCRIPTION
With this change we will continue to tell the user their interlock is
enabled, but we will not fail the pre-arm checks.

This will mean that the blinking-LED indicators will show the vehicle as
armable (flashing green / flashing blue), even if the interlock would
prevent arming.

This has the advantage that you don't need your vehicle in the
"dangerous" state to work out whether arming will work when you attempt
to arm it.

Note that we repeat the interlock switch check in the arming checks, and
it WILL fail if the interlock switch is enabled.