### PR TITLE
Rover: send pid tuning message to GCS regarless of mode

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -222,7 +222,8 @@ void Rover::send_rangefinder(mavlink_channel_t chan)
 void Rover::send_pid_tuning(mavlink_channel_t chan)
 {
     const DataFlash_Class::PID_Info *pid_info;
-    if ((g.gcs_pid_mask & 1) && (!control_mode->manual_steering())) {
+    // steering PID
+    if (g.gcs_pid_mask & 1) {
         pid_info = &g2.attitude_control.get_steering_rate_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_STEER,
                                     degrees(pid_info->desired),
@@ -235,7 +236,8 @@ void Rover::send_pid_tuning(mavlink_channel_t chan)
             return;
         }
     }
-    if ((g.gcs_pid_mask & 2) && (control_mode->auto_throttle())) {
+    // speed to throttle PID
+    if (g.gcs_pid_mask & 2) {
         pid_info = &g2.attitude_control.get_throttle_speed_pid().get_pid_info();
         float speed = 0.0f;
         g2.attitude_control.get_forward_speed(speed);

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -225,7 +225,8 @@ bool Mode::stop_vehicle()
 }
 
 // estimate maximum vehicle speed (in m/s)
-float Mode::calc_speed_max(float cruise_speed, float cruise_throttle)
+// cruise_speed is in m/s, cruise_throttle should be in the range -1 to +1
+float Mode::calc_speed_max(float cruise_speed, float cruise_throttle) const
 {
     float speed_max;
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -42,9 +42,6 @@ public:
     // return if in non-manual mode : AUTO, GUIDED, RTL
     virtual bool is_autopilot_mode() const { return false; }
 
-    // returns true if steering is directly controlled by RC
-    virtual bool manual_steering() const { return false; }
-
     // returns true if the throttle is controlled automatically
     virtual bool auto_throttle() { return is_autopilot_mode(); }
 
@@ -308,9 +305,6 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
-
-    // attributes of the mode
-    bool manual_steering() const override { return true; }
 
     // attributes for mavlink system status reporting
     bool has_manual_input() const override { return true; }

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -39,11 +39,11 @@ public:
     // attributes of the mode
     //
 
-    // return if in non-manual mode : AUTO, GUIDED, RTL
+    // return if in non-manual mode : Auto, Guided, RTL, SmartRTL
     virtual bool is_autopilot_mode() const { return false; }
 
-    // returns true if the throttle is controlled automatically
-    virtual bool auto_throttle() { return is_autopilot_mode(); }
+    // returns true if vehicle can be armed or disarmed from the transmitter in this mode
+    virtual bool allows_arming_from_transmitter() { return !is_autopilot_mode(); }
 
     //
     // attributes for mavlink system status reporting

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -121,7 +121,8 @@ protected:
     bool stop_vehicle();
 
     // estimate maximum vehicle speed (in m/s)
-    float calc_speed_max(float cruise_speed, float cruise_throttle);
+    // cruise_speed is in m/s, cruise_throttle should be in the range -1 to +1
+    float calc_speed_max(float cruise_speed, float cruise_throttle) const;
 
     // calculate pilot input to nudge speed up or down
     //  target_speed should be in meters/sec

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -52,8 +52,8 @@ void Rover::rudder_arm_disarm_check()
         return;
     }
 
-    // if not in a manual throttle mode then disallow rudder arming/disarming
-    if (control_mode->auto_throttle()) {
+    // check if arming/disarming allowed from this mode
+    if (!control_mode->allows_arming_from_transmitter()) {
         rudder_arm_timer = 0;
         return;
     }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _STR_RAT_P
     // @DisplayName: Steering control rate P gain
     // @Description: Steering control rate P gain.  Converts the turn rate error (in radians/sec) to a steering control output (in the range -1 to +1)
-    // @Range: 0.100 2.000
+    // @Range: 0.000 2.000
     // @Increment: 0.01
     // @User: Standard
 
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _STR_RAT_FF
     // @DisplayName: Steering control feed forward
     // @Description: Steering control feed forward
-    // @Range: 0 0.5
+    // @Range: 0.000 3.000
     // @Increment: 0.001
     // @User: Standard
 
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _SPEED_FF
     // @DisplayName: Speed control feed forward
     // @Description: Speed control feed forward
-    // @Range: 0 0.5
+    // @Range: 0.000 0.500
     // @Increment: 0.001
     // @User: Standard
 
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _ACCEL_MAX
     // @DisplayName: Speed control acceleration (and deceleration) maximum in m/s/s
     // @Description: Speed control acceleration (and deceleration) maximum in m/s/s.  0 to disable acceleration limiting
-    // @Range: 0 10
+    // @Range: 0.0 10.0
     // @Increment: 0.1
     // @Units: m/s/s
     // @User: Standard
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _STOP_SPEED
     // @DisplayName: Speed control stop speed
     // @Description: Speed control stop speed.  Motor outputs to zero once vehicle speed falls below this value
-    // @Range: 0 0.5
+    // @Range: 0.00 0.50
     // @Increment: 0.01
     // @Units: m/s
     // @User: Standard


### PR DESCRIPTION
This PR addresses two issues found during Rover-3.2.0-rc4 beta testing:

- always send the PID_TUNING message to the GCS (if enabled) regardless of mode.  The specific issue found was that the steering rate PID info was not being sent in Acro or Steering mode.  We could have addressed this specific issue but it is simpler and more consistent with other vehicles to simply send the PID info if the GCS_PID_MASK parameter is configured to do so regardless of mode.  Worst case if the user is in a mode that doesn't use that particular PID, the graph won't update and a little bit more telemetry band width is consumed than is required.
- increase the expected range of the ATC_STR_RAT_P and ATC_STR_RAT_FF parameters

.. and two additional changes unrelated to beta testing:
- const-ify the calc_speed_max method
- rename a method of the Mode class to make it's use more clear