### PR TITLE
Map flight modes to their mavlink representations

### DIFF
--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
+
 // Internal defines, don't edit and expect things to work
 // -------------------------------------------------------
 
@@ -35,16 +37,17 @@ enum ch7_option {
 
 // Auto Pilot modes
 // ----------------
+// map flight modes to the MAVLink representation
 enum mode {
-    MANUAL       = 0,
-    ACRO         = 1,
-    STEERING     = 3,
-    HOLD         = 4,
-    AUTO         = 10,
-    RTL          = 11,
-    SMART_RTL    = 12,
-    GUIDED       = 15,
-    INITIALISING = 16
+    MANUAL       = ROVER_FLIGHT_MODE_MANUAL,
+    ACRO         = ROVER_FLIGHT_MODE_ACRO,
+    STEERING     = ROVER_FLIGHT_MODE_STEERING,
+    HOLD         = ROVER_FLIGHT_MODE_HOLD,
+    AUTO         = ROVER_FLIGHT_MODE_AUTO,
+    RTL          = ROVER_FLIGHT_MODE_RTL,
+    SMART_RTL    = ROVER_FLIGHT_MODE_SMART_RTL,
+    GUIDED       = ROVER_FLIGHT_MODE_GUIDED,
+    INITIALISING = ROVER_FLIGHT_MODE_INITIALISING
 };
 
 // types of failsafe events

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
+
 // Command/Waypoint/Location Options Bitmask
 //--------------------
 #define MASK_OPTIONS_RELATIVE_ALT       (1<<0)          // 1 = Relative
@@ -8,13 +10,14 @@
 // Controller modes
 // ----------------
 
+// map flight modes to the MAVLink representation
 enum ControlMode {
-    MANUAL=0,
-    STOP=1,
-    SCAN=2,
-    SERVO_TEST=3,
-    AUTO=10,
-    INITIALISING=16
+    MANUAL       = TRACKER_FLIGHT_MODE_MANUAL,
+    STOP         = TRACKER_FLIGHT_MODE_STOP,
+    SCAN         = TRACKER_FLIGHT_MODE_SCAN,
+    SERVO_TEST   = TRACKER_FLIGHT_MODE_SERVO_TEST,
+    AUTO         = TRACKER_FLIGHT_MODE_AUTO,
+    INITIALISING = TRACKER_FLIGHT_MODE_INITIALISING
 };
 
 enum ServoType {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
+#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
 
 // Just so that it's completely clear...
 #define ENABLED                 1
@@ -87,26 +88,27 @@ enum aux_sw_func {
 #define HIL_MODE_SENSORS                1
 
 // Auto Pilot Modes enumeration
+// map flight modes to the MAVLink representation
 enum control_mode_t {
-    STABILIZE =     0,  // manual airframe angle with manual throttle
-    ACRO =          1,  // manual body-frame angular rate with manual throttle
-    ALT_HOLD =      2,  // manual airframe angle with automatic throttle
-    AUTO =          3,  // fully automatic waypoint control using mission commands
-    GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
-    LOITER =        5,  // automatic horizontal acceleration with automatic throttle
-    RTL =           6,  // automatic return to launching point
-    CIRCLE =        7,  // automatic circular flight with automatic throttle
-    LAND =          9,  // automatic landing with horizontal position control
-    DRIFT =        11,  // semi-automous position, yaw and throttle control
-    SPORT =        13,  // manual earth-frame angular rate control with manual throttle
-    FLIP =         14,  // automatically flip the vehicle on the roll axis
-    AUTOTUNE =     15,  // automatically tune the vehicle's roll and pitch gains
-    POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
-    BRAKE =        17,  // full-brake using inertial/GPS system, no pilot input
-    THROW =        18,  // throw to launch mode using inertial/GPS system, no pilot input
-    AVOID_ADSB =   19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
-    GUIDED_NOGPS = 20,  // guided mode but only accepts attitude and altitude
-    SMART_RTL =    21,  // SMART_RTL returns to home by retracing its steps
+    STABILIZE =    COPTER_FLIGHT_MODE_STABILIZE,     // manual airframe angle with manual throttle
+    ACRO =         COPTER_FLIGHT_MODE_ACRO,           // manual body-frame angular rate with manual throttle
+    ALT_HOLD =     COPTER_FLIGHT_MODE_ALT_HOLD,       // manual airframe angle with automatic throttle
+    AUTO =         COPTER_FLIGHT_MODE_AUTO,           // fully automatic waypoint control using mission commands
+    GUIDED =       COPTER_FLIGHT_MODE_GUIDED,         // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    LOITER =       COPTER_FLIGHT_MODE_LOITER,         // automatic horizontal acceleration with automatic throttle
+    RTL =          COPTER_FLIGHT_MODE_RTL,            // automatic return to launching point
+    CIRCLE =       COPTER_FLIGHT_MODE_CIRCLE,         // automatic circular flight with automatic throttle
+    LAND =         COPTER_FLIGHT_MODE_LAND,           // automatic landing with horizontal position control
+    DRIFT =        COPTER_FLIGHT_MODE_DRIFT,          // semi-automous position, yaw and throttle control
+    SPORT =        COPTER_FLIGHT_MODE_SPORT,          // manual earth-frame angular rate control with manual throttle
+    FLIP =         COPTER_FLIGHT_MODE_FLIP,           // automatically flip the vehicle on the roll axis
+    AUTOTUNE =     COPTER_FLIGHT_MODE_AUTOTUNE,       // automatically tune the vehicle's roll and pitch gains
+    POSHOLD =      COPTER_FLIGHT_MODE_POSHOLD,        // automatic position hold with manual override, with automatic throttle
+    BRAKE =        COPTER_FLIGHT_MODE_BRAKE,          // full-brake using inertial/GPS system, no pilot input
+    THROW =        COPTER_FLIGHT_MODE_THROW,          // throw to launch mode using inertial/GPS system, no pilot input
+    AVOID_ADSB =   COPTER_FLIGHT_MODE_AVOID_ADSB,     // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
+    GUIDED_NOGPS = COPTER_FLIGHT_MODE_GUIDED_NOGPS, // guided mode but only accepts attitude and altitude
+    SMART_RTL =    COPTER_FLIGHT_MODE_SMART_RTL,      // SMART_RTL returns to home by retracing its steps
 };
 
 enum mode_reason_t {

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
+
 // Internal defines, don't edit and expect things to work
 // -------------------------------------------------------
 
@@ -45,27 +47,28 @@ enum failsafe_action_long {
     FS_ACTION_LONG_PARACHUTE = 3,
 };
 
+// map flight modes to the MAVLink representation
 enum FlightMode {
-    MANUAL        = 0,
-    CIRCLE        = 1,
-    STABILIZE     = 2,
-    TRAINING      = 3,
-    ACRO          = 4,
-    FLY_BY_WIRE_A = 5,
-    FLY_BY_WIRE_B = 6,
-    CRUISE        = 7,
-    AUTOTUNE      = 8,
-    AUTO          = 10,
-    RTL           = 11,
-    LOITER        = 12,
-    AVOID_ADSB    = 14,
-    GUIDED        = 15,
-    INITIALISING  = 16,
-    QSTABILIZE    = 17,
-    QHOVER        = 18,
-    QLOITER       = 19,
-    QLAND         = 20,
-    QRTL          = 21
+    MANUAL        = PLANE_FLIGHT_MODE_MANUAL,
+    CIRCLE        = PLANE_FLIGHT_MODE_CIRCLE,
+    STABILIZE     = PLANE_FLIGHT_MODE_STABILIZE,
+    TRAINING      = PLANE_FLIGHT_MODE_TRAINING,
+    ACRO          = PLANE_FLIGHT_MODE_ACRO,
+    FLY_BY_WIRE_A = PLANE_FLIGHT_MODE_FLY_BY_WIRE_A,
+    FLY_BY_WIRE_B = PLANE_FLIGHT_MODE_FLY_BY_WIRE_B,
+    CRUISE        = PLANE_FLIGHT_MODE_CRUISE,
+    AUTOTUNE      = PLANE_FLIGHT_MODE_AUTOTUNE,
+    AUTO          = PLANE_FLIGHT_MODE_AUTO,
+    RTL           = PLANE_FLIGHT_MODE_RTL,
+    LOITER        = PLANE_FLIGHT_MODE_LOITER,
+    AVOID_ADSB    = PLANE_FLIGHT_MODE_AVOID_ADSB,
+    GUIDED        = PLANE_FLIGHT_MODE_GUIDED,
+    INITIALISING  = PLANE_FLIGHT_MODE_INITIALISING,
+    QSTABILIZE    = PLANE_FLIGHT_MODE_QSTABILIZE,
+    QHOVER        = PLANE_FLIGHT_MODE_QHOVER,
+    QLOITER       = PLANE_FLIGHT_MODE_QLOITER,
+    QLAND         = PLANE_FLIGHT_MODE_QLAND,
+    QRTL          = PLANE_FLIGHT_MODE_QRTL
 };
 
 enum mode_reason_t {

--- a/ArduSub/defines.h
+++ b/ArduSub/defines.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
+#include "include/mavlink/v2.0/ardupilotmega/mavlink.h"
 
 // Just so that it's completely clear...
 #define ENABLED                 1
@@ -30,16 +31,17 @@ enum autopilot_yaw_mode {
 };
 
 // Auto Pilot Modes enumeration
+// map flight modes to the MAVLink representation
 enum control_mode_t {
-    STABILIZE =     0,  // manual angle with manual depth/throttle
-    ACRO =          1,  // manual body-frame angular rate with manual depth/throttle
-    ALT_HOLD =      2,  // manual angle with automatic depth/throttle
-    AUTO =          3,  // fully automatic waypoint control using mission commands
-    GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
-    CIRCLE =        7,  // automatic circular flight with automatic throttle
-    SURFACE =       9,  // automatically return to surface, pilot maintains horizontal control
-    POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
-    MANUAL =       19   // Pass-through input with no stabilization
+    STABILIZE = SUB_FLIGHT_MODE_STABILIZE, // manual angle with manual depth/throttle
+    ACRO =      SUB_FLIGHT_MODE_ACRO,      // manual body-frame angular rate with manual depth/throttle
+    ALT_HOLD =  SUB_FLIGHT_MODE_ALT_HOLD,  // manual angle with automatic depth/throttle
+    AUTO =      SUB_FLIGHT_MODE_AUTO,      // fully automatic waypoint control using mission commands
+    GUIDED =    SUB_FLIGHT_MODE_GUIDED,    // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    CIRCLE =    SUB_FLIGHT_MODE_CIRCLE,    // automatic circular flight with automatic throttle
+    SURFACE =   SUB_FLIGHT_MODE_SURFACE,   // automatically return to surface, pilot maintains horizontal control
+    POSHOLD =   SUB_FLIGHT_MODE_POSHOLD,   // automatic position hold with manual override, with automatic throttle
+    MANUAL =    SUB_FLIGHT_MODE_MANUAL     // Pass-through input with no stabilization
 };
 
 enum mode_reason_t {


### PR DESCRIPTION
This is intended to allow ground control stations to have a direct enum to use when interpreting the `custom_mode` of heartbeat, as well as when requesting the vehicle change to a given flight mode. This could be done as pure MAVLink without changing the headers, however by forcing the `defines.h` to all match we ensure a consistent representation (and hint to people to update the mavlink xml files when they add new flight modes)

Loosely implements #3788 and is probably as good as we can ever get on that without breaking backwards compatibility with GCS's which is not worth it.