### PR TITLE
Copter: improved sqrt controller

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -283,7 +283,7 @@ float Copter::get_surface_tracking_climb_rate(int16_t target_rate, float current
 float Copter::get_avoidance_adjusted_climbrate(float target_rate)
 {
 #if AC_AVOID_ENABLED == ENABLED
-    avoid.adjust_velocity_z(pos_control->get_pos_z_kP(), pos_control->get_accel_z(), target_rate);
+    avoid.adjust_velocity_z(pos_control->get_pos_z_kP(), pos_control->get_accel_z(), target_rate, G_Dt);
     return target_rate;
 #else
     return target_rate;

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -653,7 +653,7 @@ void Copter::ModeGuided::set_desired_velocity_with_accel_and_fence_limits(const 
 
 #if AC_AVOID_ENABLED
     // limit the velocity to prevent fence violations
-    _copter.avoid.adjust_velocity(pos_control->get_pos_xy_kP(), pos_control->get_accel_xy(), curr_vel_des);
+    _copter.avoid.adjust_velocity(pos_control->get_pos_xy_kP(), pos_control->get_accel_xy(), curr_vel_des, G_Dt);
     // get avoidance adjusted climb rate
     curr_vel_des.z = get_avoidance_adjusted_climbrate(curr_vel_des.z);    
 #endif

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -184,7 +184,7 @@ void Copter::land_run_vertical_control(bool pause_descent)
         max_land_descent_velocity = MIN(max_land_descent_velocity, -abs(g.land_speed));
 
         // Compute a vertical velocity demand such that the vehicle approaches LAND_START_ALT. Without the below constraint, this would cause the vehicle to hover at LAND_START_ALT.
-        cmb_rate = AC_AttitudeControl::sqrt_controller(LAND_START_ALT-alt_above_ground, g.p_alt_hold.kP(), pos_control->get_accel_z());
+        cmb_rate = AC_AttitudeControl::sqrt_controller(LAND_START_ALT-alt_above_ground, g.p_alt_hold.kP(), pos_control->get_accel_z(), G_Dt);
 
         // Constrain the demanded vertical velocity so that it is between the configured maximum descent speed and the configured minimum descent speed.
         cmb_rate = constrain_float(cmb_rate, max_land_descent_velocity, -abs(g.land_speed));

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -714,25 +714,35 @@ float AC_AttitudeControl::get_althold_lean_angle_max() const
 // Proportional controller with piecewise sqrt sections to constrain second derivative
 float AC_AttitudeControl::sqrt_controller(float error, float p, float second_ord_lim, float dt)
 {
-    if (second_ord_lim < 0.0f || is_zero(second_ord_lim)) {
-        return error*p;
-    }else if (is_zero(p)) {
-        if (error > 0.0f && !is_zero(dt)) {
-            return MIN(safe_sqrt(2.0f*error*second_ord_lim), error*dt);
-        } else if (error < 0.0f && !is_zero(dt)) {
-            return MAX(-safe_sqrt(2.0f*error*second_ord_lim), error*dt);
+    float correction_rate;
+    if (is_negative(second_ord_lim) || is_zero(second_ord_lim)) {
+        // second order limit is zero or negative.
+        correction_rate = error*p;
+    } else if (is_zero(p)) {
+        // P term is zero but we have a second order limit.
+        if (is_positive(error)) {
+            correction_rate = safe_sqrt(2.0f*second_ord_lim*(error));
+        } else if (is_negative(error)) {
+            correction_rate = -safe_sqrt(2.0f*second_ord_lim*(-error));
+        } else {
+            correction_rate = 0.0f;
         }
-        return 0.0f;
-    }
-
-    float linear_dist = second_ord_lim/sq(p);
-
-    if (error > linear_dist) {
-        return safe_sqrt(2.0f*second_ord_lim*(error-(linear_dist/2.0f)));
-    } else if (error < -linear_dist) {
-        return -safe_sqrt(2.0f*second_ord_lim*(-error-(linear_dist/2.0f)));
     } else {
-        return error*p;
+        // Both the P and second order limit have been defined.
+        float linear_dist = second_ord_lim/sq(p);
+        if (error > linear_dist) {
+            correction_rate = safe_sqrt(2.0f*second_ord_lim*(error-(linear_dist/2.0f)));
+        } else if (error < -linear_dist) {
+            correction_rate = -safe_sqrt(2.0f*second_ord_lim*(-error-(linear_dist/2.0f)));
+        } else {
+            correction_rate = error*p;
+        }
+    }
+    if (!is_zero(dt)) {
+        // this ensures we do not get small oscillations by over shooting the error correction in the last time step.
+        return constrain_float(correction_rate, -fabsf(error)/dt, fabsf(error)/dt);
+    } else {
+        return correction_rate;
     }
 }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -220,14 +220,14 @@ public:
     float lean_angle_max() const { return _aparm.angle_max; }
 
     // Proportional controller with piecewise sqrt sections to constrain second derivative
-    static float sqrt_controller(float error, float p, float second_ord_lim);
+    static float sqrt_controller(float error, float p, float second_ord_lim, float dt);
 
     // Inverse proportional controller with piecewise sqrt sections to constrain second derivative
     static float stopping_point(float first_ord_mag, float p, float second_ord_lim);
 
     // calculates the velocity correction from an angle error. The angular velocity has acceleration and
     // deceleration limits including basic jerk limiting using smoothing_gain
-    float input_shaping_angle(float error_angle, float smoothing_gain, float accel_max, float target_ang_vel);
+    static float input_shaping_angle(float error_angle, float smoothing_gain, float accel_max, float target_ang_vel, float dt);
 
     // limits the acceleration and deceleration of a velocity request
     float input_shaping_ang_vel(float target_ang_vel, float desired_ang_vel, float accel_max);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -378,7 +378,7 @@ void AC_PosControl::pos_to_rate_z()
     }
 
     // calculate _vel_target.z using from _pos_error.z using sqrt controller
-    _vel_target.z = AC_AttitudeControl::sqrt_controller(_pos_error.z, _p_pos_z.kP(), _accel_z_cms);
+    _vel_target.z = AC_AttitudeControl::sqrt_controller(_pos_error.z, _p_pos_z.kP(), _accel_z_cms, _dt);
 
     // check speed limits
     // To-Do: check these speed limits here or in the pos->rate controller

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -39,11 +39,11 @@ public:
      * before the fence/object.
      * Note: Vector3f version is for convenience and only adjusts x and y axis
      */
-    void adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel);
-    void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel);
+    void adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel, float dt);
+    void adjust_velocity(float kP, float accel_cmss, Vector3f &desired_vel, float dt);
 
     // adjust vertical climb rate so vehicle does not break the vertical fence
-    void adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_cms);
+    void adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_cms, float dt);
 
     // adjust roll-pitch to push vehicle away from objects
     // roll and pitch value are in centi-degrees
@@ -60,29 +60,29 @@ private:
     /*
      * Adjusts the desired velocity for the circular fence.
      */
-    void adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f &desired_vel, float dt);
 
     /*
      * Adjusts the desired velocity for the polygon fence.
      */
-    void adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2f &desired_vel, float dt);
 
     /*
      * Adjusts the desired velocity for the beacon fence.
      */
-    void adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_beacon_fence(float kP, float accel_cmss, Vector2f &desired_vel, float dt);
 
     /*
      * Adjusts the desired velocity based on output from the proximity sensor
      */
-    void adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel);
+    void adjust_velocity_proximity(float kP, float accel_cmss, Vector2f &desired_vel, float dt);
 
     /*
      * Adjusts the desired velocity given an array of boundary points
      *   earth_frame should be true if boundary is in earth-frame, false for body-frame
      *   margin is the distance (in meters) that the vehicle should stop short of the polygon
      */
-    void adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f* boundary, uint16_t num_points, bool earth_frame, float margin);
+    void adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f* boundary, uint16_t num_points, bool earth_frame, float margin, float dt);
 
     /*
      * Limits the component of desired_vel in the direction of the unit vector
@@ -91,13 +91,13 @@ private:
      * Uses velocity adjustment idea from Randy's second email on this thread:
      * https://groups.google.com/forum/#!searchin/drones-discuss/obstacle/drones-discuss/QwUXz__WuqY/qo3G8iTLSJAJ
      */
-    void limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance) const;
+    void limit_velocity(float kP, float accel_cmss, Vector2f &desired_vel, const Vector2f& limit_direction, float limit_distance, float dt) const;
 
     /*
      * Computes the speed such that the stopping distance
      * of the vehicle will be exactly the input distance.
      */
-    float get_max_speed(float kP, float accel_cmss, float distance) const;
+    float get_max_speed(float kP, float accel_cmss, float distance, float dt) const;
 
     /*
      * Computes distance required to stop, given current speed.

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -302,7 +302,7 @@ void AC_WPNav::calc_loiter_desired_velocity(float nav_dt, float ekfGndSpdLimit)
 
     // Limit the velocity to prevent fence violations
     if (_avoid != nullptr) {
-        _avoid->adjust_velocity(_pos_control.get_pos_xy_kP(), _loiter_accel_cmss, desired_vel);
+        _avoid->adjust_velocity(_pos_control.get_pos_xy_kP(), _loiter_accel_cmss, desired_vel, nav_dt);
     }
 
     // send adjusted feed forward velocity back to position controller


### PR DESCRIPTION
This PR includes the following improvements to the sqrt controller:

- sqrt-controller accepts "dt" so that it can be used in various parts of the code which may operate at different rates
- sqrt controller gets protection against overshoot

Knock-on effect of requiring dt to be passed to the sqrt controller is that avoidance, AC_WPNav and a couple of places in the Copter vehicle code need to pass in their update rates.

These changes are pre-requisites for @lthall's upcoming "New Loiter" changes