### PR TITLE
Consolidate battery logging, and make AP_BattMonitor a singleton.

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -299,9 +299,6 @@ void Rover::update_aux(void)
  */
 void Rover::one_second_loop(void)
 {
-    if (should_log(MASK_LOG_CURRENT)) {
-        Log_Write_Current();
-    }
     // send a heartbeat
     gcs().send_message(MSG_HEARTBEAT);
 

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -202,14 +202,6 @@ void Rover::Log_Write_Rangefinder()
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
-void Rover::Log_Write_Current()
-{
-    DataFlash.Log_Write_Current(battery);
-
-    // also write power status
-    DataFlash.Log_Write_Power();
-}
-
 struct PACKED log_Arm_Disarm {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -390,7 +382,6 @@ void Rover::Log_Write_Vehicle_Startup_Messages()
 
 // dummy functions
 void Rover::Log_Write_Startup(uint8_t type) {}
-void Rover::Log_Write_Current() {}
 void Rover::Log_Write_Nav_Tuning() {}
 void Rover::Log_Write_Performance() {}
 void Rover::Log_Write_Throttle() {}

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -292,7 +292,7 @@ private:
     aux_switch_pos aux_ch7;
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
@@ -513,7 +513,6 @@ private:
     void Log_Write_Nav_Tuning();
     void Log_Write_Attitude();
     void Log_Write_Rangefinder();
-    void Log_Write_Current();
     void Log_Arm_Disarm();
     void Log_Write_RC(void);
     void Log_Write_Error(uint8_t sub_system, uint8_t error_code);

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -270,8 +270,8 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable
-    // @Values: 63:Default,0:Disabled
-    // @Bitmask: 0:ATTITUDE,1:GPS,2:RCIN,3:IMU,4:RCOUT,5:COMPASS
+    // @Values: 127:Default,0:Disabled
+    // @Bitmask: 0:ATTITUDE,1:GPS,2:RCIN,3:IMU,4:RCOUT,5:COMPASS,6:Battery
     // @User: Standard
     GSCALAR(log_bitmask, "LOG_BITMASK", DEFAULT_LOG_BITMASK),
 
@@ -385,6 +385,9 @@ const AP_Param::Info Tracker::var_info[] = {
     // @User: Advanced
     GSCALAR(command_total,          "CMD_TOTAL",      0),
 
+    // @Group: BATT
+    // @Path: ../libraries/AP_BattMonitor/AP_BattMonitor.cpp
+    GOBJECT(battery,                "BATT", AP_BattMonitor),
 
     AP_VAREND
 };

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -93,6 +93,7 @@ public:
         k_param_log_bitmask,        // 140
         k_param_notify,
         k_param_BoardConfig_CAN,
+        k_param_battery,
 
         //
         // 150: Telemetry control

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -151,7 +151,7 @@ private:
 #endif
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
     struct Location current_loc;
 

--- a/AntennaTracker/config.h
+++ b/AntennaTracker/config.h
@@ -76,5 +76,6 @@
     MASK_LOG_RCIN | \
     MASK_LOG_IMU | \
     MASK_LOG_RCOUT | \
-    MASK_LOG_COMPASS
+    MASK_LOG_COMPASS | \
+    MASK_LOG_CURRENT
 #endif

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -40,6 +40,7 @@ enum AltSource {
 #define MASK_LOG_IMU                    (1<<3)
 #define MASK_LOG_RCOUT                  (1<<4)
 #define MASK_LOG_COMPASS                (1<<5)
+#define MASK_LOG_CURRENT                (1<<6)
 #define MASK_LOG_ANY                    0xFFFF
 
 //  Logging messages

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -387,7 +387,7 @@ private:
     int32_t initial_armed_bearing;
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
@@ -755,7 +755,6 @@ private:
     void update_notify();
 
     // Log.cpp
-    void Log_Write_Current();
     void Log_Write_Optflow();
     void Log_Write_Nav_Tuning();
     void Log_Write_Control_Tuning();

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -59,15 +59,6 @@ void Copter::ModeAutoTune::Log_Write_AutoTuneDetails(float angle_cd, float rate_
 }
 #endif
 
-// Write a Current data packet
-void Copter::Log_Write_Current()
-{
-    DataFlash.Log_Write_Current(battery);
-
-    // also write power status
-    DataFlash.Log_Write_Power();
-}
-
 struct PACKED log_Optflow {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -700,7 +691,6 @@ void Copter::Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_targ
                                 float meas_min, float meas_max, float new_gain_rp, \
                                 float new_gain_rd, float new_gain_sp, float new_ddt) {}
 void Copter::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds) {}
-void Copter::Log_Write_Current() {}
 void Copter::Log_Write_Nav_Tuning() {}
 void Copter::Log_Write_Control_Tuning() {}
 void Copter::Log_Write_Performance() {}

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -185,17 +185,14 @@ void Copter::read_battery(void)
 {
     battery.read();
 
-    // update compass with current value
-    if (battery.has_current()) {
-        compass.set_current(battery.current_amps());
-    }
-
     // update motors with voltage and current
     if (battery.get_type() != AP_BattMonitor_Params::BattMonitor_TYPE_NONE) {
         motors->set_voltage(battery.voltage());
-        AP_Notify::flags.battery_voltage = battery.voltage();
     }
+
     if (battery.has_current()) {
+        compass.set_current(battery.current_amps());
+
         motors->set_current(battery.current_amps());
         motors->set_resistance(battery.get_resistance());
         motors->set_voltage_resting_estimate(battery.voltage_resting_estimate());
@@ -205,11 +202,6 @@ void Copter::read_battery(void)
     // we only check when we're not powered by USB to avoid false alarms during bench tests
     if (!ap.usb_connected && !failsafe.battery && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah)) {
         failsafe_battery_event();
-    }
-
-    // log battery info to the dataflash
-    if (should_log(MASK_LOG_CURRENT)) {
-        Log_Write_Current();
     }
 }
 

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -263,14 +263,6 @@ struct PACKED log_Arm_Disarm {
     uint16_t arm_checks;
 };
 
-void Plane::Log_Write_Current()
-{
-    DataFlash.Log_Write_Current(battery);
-
-    // also write power status
-    DataFlash.Log_Write_Power();
-}
-
 void Plane::Log_Arm_Disarm() {
     struct log_Arm_Disarm pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
@@ -439,7 +431,6 @@ void Plane::Log_Write_Sonar() {}
 void Plane::Log_Write_Optflow() {}
  #endif
 
-void Plane::Log_Write_Current() {}
 void Plane::Log_Arm_Disarm() {}
 void Plane::Log_Write_GPS(uint8_t instance) {}
 void Plane::Log_Write_IMU() {}

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -391,7 +391,7 @@ private:
     int32_t altitude_error_cm;
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
@@ -834,7 +834,6 @@ private:
     void Log_Write_Status();
     void Log_Write_Sonar();
     void Log_Write_Optflow();
-    void Log_Write_Current();
     void Log_Arm_Disarm();
     void Log_Write_GPS(uint8_t instance);
     void Log_Write_IMU();

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -127,13 +127,6 @@ void Plane::read_battery(void)
         battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah)) {
         low_battery_event();
     }
-    if (battery.get_type() != AP_BattMonitor_Params::BattMonitor_TYPE_NONE) {
-        AP_Notify::flags.battery_voltage = battery.voltage();
-    }
-    
-    if (should_log(MASK_LOG_CURRENT)) {
-        Log_Write_Current();
-    }
 }
 
 // read the receiver RSSI as an 8 bit number for MAVLink

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -12,15 +12,6 @@ void Sub::do_erase_logs(void)
     gcs().send_text(MAV_SEVERITY_INFO, "Log erase complete");
 }
 
-// Write a Current data packet
-void Sub::Log_Write_Current()
-{
-    DataFlash.Log_Write_Current(battery);
-
-    // also write power status
-    DataFlash.Log_Write_Power();
-}
-
 struct PACKED log_Optflow {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -472,7 +463,6 @@ void Sub::log_init(void)
 #else // LOGGING_ENABLED
 
 void Sub::do_erase_logs(void) {}
-void Sub::Log_Write_Current() {}
 void Sub::Log_Write_Nav_Tuning() {}
 void Sub::Log_Write_Control_Tuning() {}
 void Sub::Log_Write_Performance() {}

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -328,7 +328,7 @@ private:
     uint32_t nav_delay_time_start;
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
     AP_Arming_Sub arming{ahrs, barometer, compass, battery};
 
@@ -507,7 +507,6 @@ private:
     void gcs_data_stream_send(void);
     void gcs_check_input(void);
     void do_erase_logs(void);
-    void Log_Write_Current();
     void Log_Write_Optflow();
     void Log_Write_Nav_Tuning();
     void Log_Write_Control_Tuning();

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -174,11 +174,6 @@ void Sub::read_battery(void)
 {
     battery.read();
 
-    // update compass with current value
-    if (battery.has_current()) {
-        compass.set_current(battery.current_amps());
-    }
-
     // update motors with voltage and current
     if (battery.get_type() != AP_BattMonitor_Params::BattMonitor_TYPE_NONE) {
         motors.set_voltage(battery.voltage());
@@ -186,14 +181,10 @@ void Sub::read_battery(void)
 
     if (battery.has_current()) {
         motors.set_current(battery.current_amps());
+        compass.set_current(battery.current_amps());
     }
 
     failsafe_battery_check();
-
-    // log battery info to the dataflash
-    if (should_log(MASK_LOG_CURRENT)) {
-        Log_Write_Current();
-    }
 }
 
 void Sub::compass_cal_update()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -35,11 +35,15 @@ class AP_BattMonitor
     friend class AP_BattMonitor_SMBus_Maxell;
 
 public:
-    AP_BattMonitor();
+    AP_BattMonitor(uint32_t log_battery_bit);
 
     /* Do not allow copies */
     AP_BattMonitor(const AP_BattMonitor &other) = delete;
     AP_BattMonitor &operator=(const AP_BattMonitor&) = delete;
+
+    static AP_BattMonitor &battery() {
+        return *_singleton;
+    }
 
     struct cells {
         uint16_t cells[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
@@ -139,10 +143,17 @@ protected:
     AP_BattMonitor_Params _params[AP_BATT_MONITOR_MAX_INSTANCES];
 
 private:
+    static AP_BattMonitor *_singleton;
+
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];
     AP_BattMonitor_Backend *drivers[AP_BATT_MONITOR_MAX_INSTANCES];
+    uint32_t    _log_battery_bit;
     uint8_t     _num_instances;                                     /// number of monitors
 
     void convert_params(void);
 
+};
+
+namespace AP {
+    AP_BattMonitor &battery();
 };

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
@@ -11,7 +11,7 @@ void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_BattMonitor battery_mon;
+static AP_BattMonitor battery_mon{1<<9};
 uint32_t timer;
 
 void setup() {

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -139,7 +139,7 @@ public:
     void Log_Write_Airspeed(AP_Airspeed &airspeed);
     void Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Log_Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
-    void Log_Write_Current(const AP_BattMonitor &battery);
+    void Log_Write_Current();
     void Log_Write_Compass(const Compass &compass, uint64_t time_us=0);
     void Log_Write_Mode(uint8_t mode, uint8_t reason = 0);
 
@@ -304,8 +304,7 @@ private:
                                     uint64_t time_us,
                                     uint8_t mag_instance,
                                     enum LogMessages type);
-    void Log_Write_Current_instance(const AP_BattMonitor &battery,
-                                    uint64_t time_us,
+    void Log_Write_Current_instance(uint64_t time_us,
                                     uint8_t battery_instance,
                                     enum LogMessages type,
                                     enum LogMessages celltype);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1547,12 +1547,12 @@ void DataFlash_Class::Log_Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f 
     WriteBlock(&pkt, sizeof(pkt));
 }
 
-void DataFlash_Class::Log_Write_Current_instance(const AP_BattMonitor &battery,
-                                                 const uint64_t time_us,
+void DataFlash_Class::Log_Write_Current_instance(const uint64_t time_us,
                                                  const uint8_t battery_instance,
                                                  const enum LogMessages type,
                                                  const enum LogMessages celltype)
 {
+    AP_BattMonitor &battery = AP::battery();
     float temp;
     bool has_temp = battery.get_temperature(temp, battery_instance);
     struct log_Current pkt = {
@@ -1587,20 +1587,19 @@ void DataFlash_Class::Log_Write_Current_instance(const AP_BattMonitor &battery,
 }
 
 // Write an Current data packet
-void DataFlash_Class::Log_Write_Current(const AP_BattMonitor &battery)
+void DataFlash_Class::Log_Write_Current()
 {
     const uint64_t time_us = AP_HAL::micros64();
-    if (battery.num_instances() >= 1) {
-        Log_Write_Current_instance(battery,
-                                   time_us,
+    const uint8_t num_instances = AP::battery().num_instances();
+    if (num_instances >= 1) {
+        Log_Write_Current_instance(time_us,
                                    0,
                                    LOG_CURRENT_MSG,
                                    LOG_CURRENT_CELLS_MSG);
     }
 
-    if (battery.num_instances() >= 2) {
-        Log_Write_Current_instance(battery,
-                                   time_us,
+    if (num_instances >= 2) {
+        Log_Write_Current_instance(time_us,
                                    1,
                                    LOG_CURRENT2_MSG,
                                    LOG_CURRENT_CELLS2_MSG);


### PR DESCRIPTION
This does a couple of things:
- Makes AP_BattMonitor a singleton available via `AP::battery()` (which is the same interface we settled on for the GPS)
- Centralizes all the logging of the battery to be driven by the AP_BattMonitor, which is not a behaviour change for any of the vehicles
- Centralizes the publishing of battery voltage to AP_Notify (which also means Sub, Tracker, Rover all support battery voltage in notify now)
- Fixes AntennaTracker not allowing users to configure the battery parameters, and never logging any battery information. (This doesn't chase anything further with AntennaTracker, it just aims to ensure that a user can start to configure the battery and actually log useful data, IE tracker never logged the board power levels)