### PR TITLE
Use calloc in preference to malloc

### DIFF
--- a/ArduPlane/px4_mixer.cpp
+++ b/ArduPlane/px4_mixer.cpp
@@ -271,7 +271,7 @@ bool Plane::setup_failsafe_mixing(void)
     unsigned mixer_status = 0;
     uint16_t manual_mask = uint16_t(g2.manual_rc_mask.get());
 
-    buf = (char *)malloc(buf_size);
+    buf = (char *)calloc(1, buf_size);
     if (buf == nullptr) {
         goto failed;
     }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -280,8 +280,7 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
 
             if (_sample_buffer == nullptr) {
                 _sample_buffer =
-                        (CompassSample*) malloc(sizeof(CompassSample) *
-                                                COMPASS_CAL_NUM_SAMPLES);
+                    (CompassSample*) calloc(COMPASS_CAL_NUM_SAMPLES, sizeof(CompassSample));
             }
 
             if(_sample_buffer != nullptr) {

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -111,7 +111,7 @@ public:
         MEM_DMA_SAFE,
         MEM_FAST
     };
-    virtual void *malloc_type(size_t size, Memory_Type mem_type) { return malloc(size); }
+    virtual void *malloc_type(size_t size, Memory_Type mem_type) { return calloc(1, size); }
     virtual void free_type(void *ptr, size_t size, Memory_Type mem_type) { return free(ptr); }
 
     /**

--- a/libraries/AP_HAL/utility/RingBuffer.cpp
+++ b/libraries/AP_HAL/utility/RingBuffer.cpp
@@ -5,7 +5,7 @@
 
 ByteBuffer::ByteBuffer(uint32_t _size)
 {
-    buf = (uint8_t*)malloc(_size);
+    buf = (uint8_t*)calloc(1, _size);
     size = buf ? _size : 0;
 }
 
@@ -22,7 +22,7 @@ bool ByteBuffer::set_size(uint32_t _size)
     head = tail = 0;
     if (_size != size) {
         free(buf);
-        buf = (uint8_t*)malloc(_size);
+        buf = (uint8_t*)calloc(1, _size);
         if (!buf) {
             size = 0;
             return false;

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -52,7 +52,7 @@ void* Util::malloc_type(size_t size, AP_HAL::Util::Memory_Type mem_type)
     if (mem_type == AP_HAL::Util::MEM_FAST) {
         return try_alloc_from_ccm_ram(size);
     } else {
-        return malloc(size);
+        return calloc(1, size);
     }
 }
 
@@ -69,7 +69,7 @@ void* Util::try_alloc_from_ccm_ram(size_t size)
     void *ret = malloc_ccm(size);
     if (ret == nullptr) {
         //we failed to allocate from CCM so we are going to try common SRAM
-        ret = malloc(size);
+        ret = calloc(1, size);
     }
     return ret;
 }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.c
@@ -217,7 +217,7 @@ static void setup_usb_string(USBDescriptor *desc, const char *str)
 {
     uint8_t len = strlen(str);
     desc->ud_size = 2+2*len;
-    uint8_t *b = (uint8_t *)malloc(desc->ud_size);
+    uint8_t *b = (uint8_t *)calloc(1, desc->ud_size);
     desc->ud_string = (const char *)b;
     b[0] = USB_DESC_BYTE(desc->ud_size);
     b[1] = USB_DESC_BYTE(USB_DESCRIPTOR_STRING);

--- a/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
+++ b/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
@@ -283,7 +283,7 @@ void OpticalFlow_Onboard::_run_optflow()
             convert_buffer_size = _width * _height;
         }
 
-        convert_buffer = (uint8_t *)malloc(convert_buffer_size);
+        convert_buffer = (uint8_t *)calloc(1, convert_buffer_size);
         if (!convert_buffer) {
             AP_HAL::panic("OpticalFlow_Onboard: couldn't allocate conversion buffer\n");
         }
@@ -293,7 +293,7 @@ void OpticalFlow_Onboard::_run_optflow()
         output_buffer_size = HAL_OPTFLOW_ONBOARD_OUTPUT_WIDTH *
             HAL_OPTFLOW_ONBOARD_OUTPUT_HEIGHT;
 
-        output_buffer = (uint8_t *)malloc(output_buffer_size);
+        output_buffer = (uint8_t *)calloc(1, output_buffer_size);
         if (!output_buffer) {
             if (convert_buffer) {
                 free(convert_buffer);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -113,8 +113,8 @@ Memory_table::Memory_table(uint32_t page_count, int version)
     uint64_t pageInfo;
     void *offset;
 
-    _virt_pages = (void **)malloc(page_count * sizeof(void *));
-    _phys_pages = (void **)malloc(page_count * sizeof(void *));
+    _virt_pages = (void **)calloc(page_count, sizeof(void *));
+    _phys_pages = (void **)calloc(page_count, sizeof(void *));
     _page_count = page_count;
 
     if ((fdMem = open("/dev/mem", O_RDWR | O_SYNC | O_CLOEXEC)) < 0) {

--- a/libraries/AP_HAL_Linux/VideoIn.cpp
+++ b/libraries/AP_HAL_Linux/VideoIn.cpp
@@ -113,7 +113,7 @@ bool VideoIn::allocate_buffers(uint32_t nbufs)
         return ret;
     }
 
-    buffers = (struct buffer *)malloc(rb.count * sizeof buffers[0]);
+    buffers = (struct buffer *)calloc(rb.count, sizeof buffers[0]);
     if (buffers == nullptr) {
         hal.console->printf("Unable to allocate buffers\n");
         return false;

--- a/libraries/AP_HAL_PX4/Util.cpp
+++ b/libraries/AP_HAL_PX4/Util.cpp
@@ -250,10 +250,10 @@ void *PX4Util::malloc_type(size_t size, AP_HAL::Util::Memory_Type mem_type)
     if (mem_type == AP_HAL::Util::MEM_DMA_SAFE) {
         return fat_dma_alloc(size);
     } else {
-        return malloc(size);
+        return calloc(1, size);
     }
 #else
-    return malloc(size);
+    return calloc(1, size);
 #endif
 }
 void PX4Util::free_type(void *ptr, size_t size, AP_HAL::Util::Memory_Type mem_type)

--- a/libraries/DataFlash/DataFlash_MAVLink.cpp
+++ b/libraries/DataFlash/DataFlash_MAVLink.cpp
@@ -35,7 +35,7 @@ void DataFlash_MAVLink::Init()
 
     _blocks = nullptr;
     while (_blockcount >= 8) { // 8 is a *magic* number
-        _blocks = (struct dm_block *) malloc(_blockcount * sizeof(_blocks[0]));
+        _blocks = (struct dm_block *) calloc(_blockcount, sizeof(_blocks[0]));
         if (_blocks != nullptr) {
             break;
         }


### PR DESCRIPTION
This fixes a bug that affects PX4 from the ChibiOS merge, where the EKF memory was not initialised. It also changes to calloc in most other places. Memory allocations are quite rare in ArduPilot so the small cpu cost increase is not significant
