### PR TITLE
AP_Notify: Support for UAVCAN RGB LEDs

### DIFF
--- a/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
@@ -61,7 +61,7 @@ bool UAVCAN_RGB_LED::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
             if (hal.can_mgr[i] != nullptr) {
                 AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
                 if (uavcan != nullptr) {
-                    success = success || uavcan->led_write(_led_index, red, green, blue);
+                    success |= uavcan->led_write(_led_index, red, green, blue);
                 }
             }
         }

--- a/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 Emlid Ltd. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/system.h>
+
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
+#if HAL_WITH_UAVCAN
+#include "UAVCAN_RGB_LED.h"
+
+#include <AP_UAVCAN/AP_UAVCAN.h>
+
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
+
+static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+#define LED_OFF 0
+#define LED_FULL_BRIGHT 255
+#define LED_MEDIUM ((LED_FULL_BRIGHT / 5) * 4)
+#define LED_DIM ((LED_FULL_BRIGHT / 5) * 2)
+
+UAVCAN_RGB_LED::UAVCAN_RGB_LED(uint8_t led_index)
+    : UAVCAN_RGB_LED(led_index, LED_OFF,
+                     LED_FULL_BRIGHT, LED_MEDIUM, LED_DIM)
+{
+}
+
+UAVCAN_RGB_LED::UAVCAN_RGB_LED(uint8_t led_index, uint8_t led_off,
+                               uint8_t led_full, uint8_t led_medium,
+                               uint8_t led_dim)
+    : RGBLed(led_off, led_full, led_medium, led_dim)
+    , _led_index(led_index)
+{
+}
+
+bool UAVCAN_RGB_LED::hw_init()
+{
+    return true;
+}
+
+
+bool UAVCAN_RGB_LED::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
+{
+    bool success = false;
+    if (AP_BoardConfig_CAN::get_can_num_ifaces() != 0) {
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+            if (hal.can_mgr[i] != nullptr) {
+                AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+                if (uavcan != nullptr) {
+                    success = success || uavcan->led_write(_led_index, red, green, blue);
+                }
+            }
+        }
+    }
+    return success;
+}
+#endif

--- a/libraries/AP_Notify/UAVCAN_RGB_LED.h
+++ b/libraries/AP_Notify/UAVCAN_RGB_LED.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "RGBLed.h"
+
+class UAVCAN_RGB_LED: public RGBLed {
+public:
+    UAVCAN_RGB_LED(uint8_t led_index, uint8_t led_off, uint8_t led_full,
+                   uint8_t led_medium, uint8_t led_dim);
+    UAVCAN_RGB_LED(uint8_t led_index);
+
+protected:
+    bool hw_init() override;
+    virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override;
+
+private:
+    uint8_t _led_index;
+};
+

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -25,6 +25,9 @@
 #include <uavcan/equipment/actuator/Command.hpp>
 #include <uavcan/equipment/actuator/Status.hpp>
 #include <uavcan/equipment/esc/RawCommand.hpp>
+#include <uavcan/equipment/indication/LightsCommand.hpp>
+#include <uavcan/equipment/indication/SingleLightCommand.hpp>
+#include <uavcan/equipment/indication/RGB565.hpp>
 
 extern const AP_HAL::HAL& hal;
 
@@ -277,6 +280,7 @@ static void (*air_data_st_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan:
 // publisher interfaces
 static uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>* act_out_array[MAX_NUMBER_OF_CAN_DRIVERS];
 static uavcan::Publisher<uavcan::equipment::esc::RawCommand>* esc_raw[MAX_NUMBER_OF_CAN_DRIVERS];
+static uavcan::Publisher<uavcan::equipment::indication::LightsCommand>* rgb_led[MAX_NUMBER_OF_CAN_DRIVERS];
 
 AP_UAVCAN::AP_UAVCAN() :
     _node_allocator(
@@ -315,6 +319,7 @@ AP_UAVCAN::AP_UAVCAN() :
     }
 
     _rc_out_sem = hal.util->new_semaphore();
+    _led_out_sem = hal.util->new_semaphore();
 
     debug_uavcan(2, "AP_UAVCAN constructed\n\r");
 }
@@ -418,6 +423,12 @@ bool AP_UAVCAN::try_init(void)
                     esc_raw[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
                     esc_raw[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
 
+                    rgb_led[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::indication::LightsCommand>(*node);
+                    rgb_led[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+                    rgb_led[_uavcan_i]->setPriority(uavcan::TransferPriority::OneHigherThanLowest);
+
+                    _led_conf.devices_count = 0;
+
                     /*
                      * Informing other nodes that we're ready to work.
                      * Default mode is INITIALIZING.
@@ -453,6 +464,20 @@ bool AP_UAVCAN::rc_out_sem_take()
 void AP_UAVCAN::rc_out_sem_give()
 {
     _rc_out_sem->give();
+}
+
+bool AP_UAVCAN::led_out_sem_take()
+{
+    bool sem_ret = _led_out_sem->take(10);
+    if (!sem_ret) {
+        debug_uavcan(1, "AP_UAVCAN LEDOut semaphore fail\n\r");
+    }
+    return sem_ret;
+}
+
+void AP_UAVCAN::led_out_sem_give()
+{
+    _led_out_sem->give();
 }
 
 void AP_UAVCAN::do_cyclic(void)
@@ -566,6 +591,27 @@ void AP_UAVCAN::do_cyclic(void)
                 }
 
                 rc_out_sem_give();
+            }
+            
+            if (led_out_sem_take()) {
+                
+                if (_led_conf.broadcast_enabled && ((AP_HAL::micros64() - _led_conf.last_update) > (AP_UAVCAN_LED_DELAY_MILLISECONDS * 1000))) {
+                    uavcan::equipment::indication::LightsCommand msg;
+                    uavcan::equipment::indication::SingleLightCommand cmd;
+
+                    for (uint8_t i = 0; i < _led_conf.devices_count; i++) {
+                        if (_led_conf.devices[i].enabled) {
+                            cmd.light_id =_led_conf.devices[i].led_index;
+                            cmd.color = _led_conf.devices[i].rgb565_color;
+                            msg.commands.push_back(cmd);
+                        }
+                    }
+
+                    rgb_led[_uavcan_i]->broadcast(msg);
+                    _led_conf.last_update = AP_HAL::micros64();
+                }
+                
+                led_out_sem_give();
             }
         }
     } else {
@@ -1033,6 +1079,39 @@ void AP_UAVCAN::update_mag_state(uint8_t node)
             }
         }
     }
+}
+
+bool AP_UAVCAN::led_write(uint8_t led_index, uint8_t red, uint8_t green, uint8_t blue) {
+    uavcan::equipment::indication::RGB565 color;
+    color.red = (red >> 3);
+    color.green = (green >> 2);
+    color.blue = (blue >> 3);
+    
+    if (!led_out_sem_take()) return false;
+    
+    for (uint8_t i = 0; i < _led_conf.devices_count; i++) {
+        if (!_led_conf.devices[i].enabled || (_led_conf.devices[i].led_index == led_index)) {
+            _led_conf.devices[i].led_index = led_index;
+            _led_conf.devices[i].rgb565_color = color;
+            _led_conf.devices[i].enabled = true;
+            _led_conf.broadcast_enabled = true;
+            led_out_sem_give();
+            return true;
+        }
+    }
+    
+    if (_led_conf.devices_count >= AP_UAVCAN_MAX_LED_DEVICES) {
+        led_out_sem_give();
+        return false;
+    }
+    
+    _led_conf.devices[_led_conf.devices_count].led_index = led_index;
+    _led_conf.devices[_led_conf.devices_count].rgb565_color = color;
+    _led_conf.devices[_led_conf.devices_count].enabled = true;
+    _led_conf.devices_count++;
+    _led_conf.broadcast_enabled = true;
+    led_out_sem_give();
+    return true;
 }
 
 #endif // HAL_WITH_UAVCAN


### PR DESCRIPTION
Hello all,

This PR adds support for new notification device, UAVCAN RGB LED. This utilizes broadcasting ```1081.LightsCommand.uavcan``` message with a single ```SingleLightCommand```. Then UAVCAN LED-powered device can hear the message and update its LED to the status that ArduPilot has.
The message is sent each 50 ms.

The reason for this is that this will allow Edge GNSS to provide the user with the same ArduPilot status information as the Edge's default onboard LED.

Please note that internally the ```SingleLightCommand``` features ```RGB565``` color, not ```RGB888``` color. All the necessary conversions are implemented.

This was tested on Edge with custom firmware on Edge GNSS and everything was fine.

Best,
Nikita Tomilov