### PR TITLE
INS: added INS_ENABLE_MASK and allow for over 1kHz IMUs

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -860,7 +860,7 @@ AP_InertialSensor::detect_backends(void)
     _enable_mask.set(found_mask);
 
     if (_backend_count == 0) {
-        AP_HAL::panic("No INS backends available");
+        AP_BoardConfig::sensor_config_error("INS: unable to initialise driver");
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -460,6 +460,9 @@ private:
     // control enable of fast sampling
     AP_Int8     _fast_sampling_mask;
 
+    // control enable of detected sensors
+    AP_Int8     _enable_mask;
+    
     // board orientation from AHRS
     enum Rotation _board_orientation;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -144,11 +144,21 @@ protected:
         return _imu._accel_raw_sample_rates[instance];
     }
 
+    // set accelerometer raw sample rate
+    void _set_accel_raw_sample_rate(uint8_t instance, uint16_t rate_hz) {
+        _imu._accel_raw_sample_rates[instance] = rate_hz;
+    }
+    
     // get gyroscope raw sample rate
     uint32_t _gyro_raw_sample_rate(uint8_t instance) const {
         return _imu._gyro_raw_sample_rates[instance];
     }
 
+    // set gyro raw sample rate
+    void _set_gyro_raw_sample_rate(uint8_t instance, uint16_t rate_hz) {
+        _imu._gyro_raw_sample_rates[instance] = rate_hz;
+    }
+    
     // publish a temperature value
     void _publish_temperature(uint8_t instance, float temperature);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -125,6 +125,12 @@ private:
     // are we doing more than 1kHz sampling?
     bool _fast_sampling;
 
+    // what downsampling rate are we using from the FIFO?
+    uint8_t _fifo_downsample_rate;
+
+    // what rate are we generating samples into the backend?
+    uint16_t _backend_rate_hz;
+
     // Last status from register user control
     uint8_t _last_stat_user_ctrl;    
 


### PR DESCRIPTION
This adds INS_ENABLE_MASK to allow users to choose what IMUs to enable on their board. That is useful when pushing for maximum loop rate on boards with more than 1 IMU
It also adds code to allow for invensense sensors to provide over 1kHz output rate
This code is also in the pr-chibios PR #7540 but is given separately here for easier review
