### PR TITLE
Fourier ahrs

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -290,6 +290,7 @@ void Copter::update_batt_compass(void)
     if(g.compass_enabled) {
         // update compass with throttle value - used for compassmot
         compass.set_throttle(motors->get_throttle());
+        compass.set_voltage(battery.voltage());
         compass.read();
         // log compass information
         if (should_log(MASK_LOG_COMPASS) && !ahrs.have_ekf_logging()) {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -330,6 +330,9 @@ private:
 
     RCMapper rcmap;
 
+    // intertial nav alt when we armed
+    float arming_altitude_m;
+
     // board specific config
     AP_BoardConfig BoardConfig;
 
@@ -395,7 +398,7 @@ private:
     int32_t initial_armed_bearing;
 
     // Battery Sensors
-    AP_BattMonitor battery;
+    AP_BattMonitor battery{MASK_LOG_CURRENT};
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
@@ -835,7 +838,8 @@ private:
     void set_throttle_and_failsafe(uint16_t throttle_pwm);
     void set_throttle_zero_flag(int16_t throttle_control);
     void radio_passthrough_to_motors();
-
+    int16_t get_throttle_mid(void);
+    
     // sensors.cpp
     void init_barometer(bool full_calibration);
     void read_barometer(void);
@@ -924,26 +928,26 @@ private:
 
     Mode *flightmode;
 #if FRAME_CONFIG == HELI_FRAME
-    ModeAcro_Heli mode_acro{*this};
+    ModeAcro_Heli mode_acro;
 #else
-    ModeAcro mode_acro{*this};
+    ModeAcro mode_acro;
 #endif
-    ModeAltHold mode_althold{*this};
-    ModeAuto mode_auto{*this, mission, circle_nav};
+    ModeAltHold mode_althold;
+    ModeAuto mode_auto;
 #if AUTOTUNE_ENABLED == ENABLED
-    ModeAutoTune mode_autotune{*this};
+    ModeAutoTune mode_autotune;
 #endif
-    ModeBrake mode_brake{*this};
-    ModeCircle mode_circle{*this, circle_nav};
-    ModeDrift mode_drift{*this};
-    ModeFlip mode_flip{*this};
-    ModeGuided mode_guided{*this};
-    ModeLand mode_land{*this};
-    ModeLoiter mode_loiter{*this};
-    ModePosHold mode_poshold{*this};
-    ModeRTL mode_rtl{*this};
+    ModeBrake mode_brake;
+    ModeCircle mode_circle;
+    ModeDrift mode_drift;
+    ModeFlip mode_flip;
+    ModeGuided mode_guided;
+    ModeLand mode_land;
+    ModeLoiter mode_loiter;
+    ModePosHold mode_poshold;
+    ModeRTL mode_rtl;
 #if FRAME_CONFIG == HELI_FRAME
-    ModeStabilize_Heli mode_stabilize{*this};
+    ModeStabilize_Heli mode_stabilize;
 #else
     ModeStabilize mode_stabilize;
 #endif
@@ -955,11 +959,6 @@ private:
 #if !HAL_MINIMIZE_FEATURES && OPTFLOW == ENABLED
     ModeFlowHold mode_flowhold;
 #endif
-    ModeSport mode_sport{*this};
-    ModeAvoidADSB mode_avoid_adsb{*this};
-    ModeThrow mode_throw{*this};
-    ModeGuidedNoGPS mode_guided_nogps{*this};
-    ModeSmartRTL mode_smartrtl{*this};
 
     // mode.cpp
     Mode *mode_from_mode_num(const uint8_t mode);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -157,7 +157,6 @@ public:
     friend class AP_AdvancedFailsafe_Copter;
 #endif
     friend class AP_Arming_Copter;
-    friend class ToyMode;
 
     Copter(void);
 
@@ -331,9 +330,6 @@ private:
 
     RCMapper rcmap;
 
-    // intertial nav alt when we armed
-    float arming_altitude_m;
-    
     // board specific config
     AP_BoardConfig BoardConfig;
 
@@ -399,7 +395,7 @@ private:
     int32_t initial_armed_bearing;
 
     // Battery Sensors
-    AP_BattMonitor battery{MASK_LOG_CURRENT};
+    AP_BattMonitor battery;
 
 #if FRSKY_TELEM_ENABLED == ENABLED
     // FrSky telemetry support
@@ -747,6 +743,7 @@ private:
     void landinggear_update();
 
     // Log.cpp
+    void Log_Write_Current();
     void Log_Write_Optflow();
     void Log_Write_Nav_Tuning();
     void Log_Write_Control_Tuning();
@@ -838,7 +835,6 @@ private:
     void set_throttle_and_failsafe(uint16_t throttle_pwm);
     void set_throttle_zero_flag(int16_t throttle_control);
     void radio_passthrough_to_motors();
-    int16_t get_throttle_mid(void);
 
     // sensors.cpp
     void init_barometer(bool full_calibration);
@@ -928,26 +924,26 @@ private:
 
     Mode *flightmode;
 #if FRAME_CONFIG == HELI_FRAME
-    ModeAcro_Heli mode_acro;
+    ModeAcro_Heli mode_acro{*this};
 #else
-    ModeAcro mode_acro;
+    ModeAcro mode_acro{*this};
 #endif
-    ModeAltHold mode_althold;
-    ModeAuto mode_auto;
+    ModeAltHold mode_althold{*this};
+    ModeAuto mode_auto{*this, mission, circle_nav};
 #if AUTOTUNE_ENABLED == ENABLED
-    ModeAutoTune mode_autotune;
+    ModeAutoTune mode_autotune{*this};
 #endif
-    ModeBrake mode_brake;
-    ModeCircle mode_circle;
-    ModeDrift mode_drift;
-    ModeFlip mode_flip;
-    ModeGuided mode_guided;
-    ModeLand mode_land;
-    ModeLoiter mode_loiter;
-    ModePosHold mode_poshold;
-    ModeRTL mode_rtl;
+    ModeBrake mode_brake{*this};
+    ModeCircle mode_circle{*this, circle_nav};
+    ModeDrift mode_drift{*this};
+    ModeFlip mode_flip{*this};
+    ModeGuided mode_guided{*this};
+    ModeLand mode_land{*this};
+    ModeLoiter mode_loiter{*this};
+    ModePosHold mode_poshold{*this};
+    ModeRTL mode_rtl{*this};
 #if FRAME_CONFIG == HELI_FRAME
-    ModeStabilize_Heli mode_stabilize;
+    ModeStabilize_Heli mode_stabilize{*this};
 #else
     ModeStabilize mode_stabilize;
 #endif
@@ -959,6 +955,11 @@ private:
 #if !HAL_MINIMIZE_FEATURES && OPTFLOW == ENABLED
     ModeFlowHold mode_flowhold;
 #endif
+    ModeSport mode_sport{*this};
+    ModeAvoidADSB mode_avoid_adsb{*this};
+    ModeThrow mode_throw{*this};
+    ModeGuidedNoGPS mode_guided_nogps{*this};
+    ModeSmartRTL mode_smartrtl{*this};
 
     // mode.cpp
     Mode *mode_from_mode_num(const uint8_t mode);

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -911,7 +911,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 11:Heli_Dual, 12:DodecaHexa
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 11:Heli_Dual, 12:DodecaHexa, 13:RotaryFrame
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, 0),

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -82,6 +82,7 @@ enum aux_sw_func {
 #define UNDEFINED_FRAME 0
 #define MULTICOPTER_FRAME 1
 #define HELI_FRAME 2
+#define ROT_FRAME 3
 
 // HIL enumerations
 #define HIL_MODE_DISABLED               0

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -458,6 +458,7 @@ uint8_t Copter::get_frame_mav_type()
     switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {
         case AP_Motors::MOTOR_FRAME_QUAD:
         case AP_Motors::MOTOR_FRAME_UNDEFINED:
+        case AP_Motors::MOTOR_FRAME_ROTATIONAL_DUAL:
             return MAV_TYPE_QUADROTOR;
         case AP_Motors::MOTOR_FRAME_HEXA:
         case AP_Motors::MOTOR_FRAME_Y6:
@@ -512,6 +513,8 @@ const char* Copter::get_frame_string()
             return "TAILSITTER";
         case AP_Motors::MOTOR_FRAME_DODECAHEXA:
             return "DODECA_HEXA";
+        case AP_Motors::MOTOR_FRAME_ROTATIONAL_DUAL:
+        	return "ROTATIONAL_FRAME_DUAL";
         case AP_Motors::MOTOR_FRAME_UNDEFINED:
         default:
             return "UNKNOWN";
@@ -531,6 +534,7 @@ void Copter::allocate_motors(void)
         case AP_Motors::MOTOR_FRAME_OCTA:
         case AP_Motors::MOTOR_FRAME_OCTAQUAD:
         case AP_Motors::MOTOR_FRAME_DODECAHEXA:
+        case AP_Motors::MOTOR_FRAME_ROTATIONAL_DUAL:
         default:
             motors = new AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsMatrix::var_info;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -137,6 +137,9 @@ public:
     // Run angular velocity controller and send outputs to the motors
     virtual void rate_controller_run() = 0;
 
+    // Run rate_controller_run with rotation_frame parameter added
+    virtual void rate_controller_run(bool rotational_frame, float instant_heading) = 0;
+    
     // Convert a 321-intrinsic euler angle derivative to an angular velocity vector
     void euler_rate_to_ang_vel(const Vector3f& euler_rad, const Vector3f& euler_rate_rads, Vector3f& ang_vel_rads);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -247,6 +247,12 @@ void AC_AttitudeControl_Heli::input_rate_bf_roll_pitch_yaw(float roll_rate_bf_cd
 // rate_controller_run - run lowest level rate controller and send outputs to the motors
 // should be called at 100hz or more
 void AC_AttitudeControl_Heli::rate_controller_run()
+{
+	rate_controller_run(false,0);
+}
+
+
+void AC_AttitudeControl_Heli::rate_controller_run(bool rotational_frame, float instant_heading)
 {	
     Vector3f gyro_latest = _ahrs.get_gyro_latest();
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -73,6 +73,7 @@ public:
 	// rate_controller_run - run lowest level body-frame rate controller and send outputs to the motors
 	// should be called at 100hz or more
 	virtual void rate_controller_run();
+	virtual void rate_controller_run(bool rotational_frame, float instant_heading);
 
     // Update Alt_Hold angle maximum
     void update_althold_lean_angle_max(float throttle_in) override;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -74,7 +74,8 @@ public:
 
     // run lowest level body-frame rate controller and send outputs to the motors
     void rate_controller_run();
-
+    void rate_controller_run(const bool rotational_frame, const float instant_heading);
+    
     // sanity check parameters.  should be called once before take-off
     void parameter_sanity_check();
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -21,6 +21,7 @@
  *
  */
 
+ 
 class AP_AHRS_DCM : public AP_AHRS {
 public:
     AP_AHRS_DCM(AP_InertialSensor &ins, AP_Baro &baro)
@@ -69,6 +70,11 @@ public:
     // return rotation matrix representing rotaton from body to earth axes
     const Matrix3f &get_rotation_body_to_ned() const override {
         return _body_dcm_matrix;
+    }
+    
+    // return rotation matrix representing rotaton from body to earth axes
+    const Matrix3f &get_dcm_matrix() const {
+        return _dcm_matrix;
     }
 
     // return the current drift correction integrator value
@@ -119,7 +125,8 @@ public:
 
     // time that the AHRS has been up
     uint32_t uptime_ms() const override;
-
+    
+    void resynchronize_fourier_phase(void);
 private:
     float _ki;
     float _ki_yaw;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -95,17 +95,20 @@ void AP_AHRS_NavEKF::update(bool skip_ins_update)
 #endif
 
     update_DCM(skip_ins_update);
-    if (_ekf_type == 2) {
-        // if EK2 is primary then run EKF2 first to give it CPU
-        // priority
-        update_EKF2();
-        update_EKF3();
-    } else {
-        // otherwise run EKF3 first
-        update_EKF3();
-        update_EKF2();
+    
+    if (ekf_type() != EKF_TYPE_NONE) {
+    	if (_ekf_type == 2) {
+    		// if EK2 is primary then run EKF2 first to give it CPU
+    		// priority
+    		update_EKF2();
+    		update_EKF3();
+    	} else {
+    		// otherwise run EKF3 first
+    		update_EKF3();
+    		update_EKF2();
+    	}
     }
-
+    
 #if AP_MODULE_SUPPORTED
     // call AHRS_update hook if any
     AP_Module::call_hook_AHRS_update(*this);

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -62,7 +62,7 @@ public:
     //  should be called if gyro offsets are recalculated
     void reset_gyro_drift() override;
 
-    void            update(bool skip_ins_update=false) override;
+    void            update(bool skip_ins_update=false);
     void            reset(bool recover_eulers = false) override;
 
     // reset the current attitude, used on new IMU calibration

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -168,6 +168,7 @@ public:
     float roll;
     float pitch;
     float yaw;
+    
     int32_t roll_sensor;
     int32_t pitch_sensor;
     int32_t yaw_sensor;
@@ -179,6 +180,8 @@ private:
     Matrix3f rot_view;
     Matrix3f rot_body_to_ned;
     Vector3f gyro;
+    
+    float _heading;
 
     struct {
         float cos_roll;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -618,6 +618,16 @@ void AP_InertialSensor::_start_backends()
     }
 }
 
+void AP_InertialSensor::synchronize_fourier_phase(float instant_heading)
+{
+	_backends[0]->synchronize_fourier_phase(instant_heading);
+}
+
+Vector2f AP_InertialSensor::get_pitch_yaw_FT(void)
+{
+	return _backends[0]->get_pitch_yaw_FT();
+}
+
 /* Find the N instance of the backend that has already been successfully detected */
 AP_InertialSensor_Backend *AP_InertialSensor::_find_backend(int16_t backend_id, uint8_t instance)
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -280,6 +280,10 @@ public:
         IMU_SENSOR_TYPE_GYRO = 1,
     };
 
+    Vector2f get_pitch_yaw_FT(void);
+
+    void synchronize_fourier_phase(float);
+    
     class BatchSampler {
     public:
         BatchSampler(const AP_InertialSensor &imu) :

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -328,7 +328,7 @@ Vector2f AP_InertialSensor_Backend::get_pitch_yaw_FT(void)
 	return _fourier_analysis.get_result();
 }
 
-void::AP_InertialSensor_Backend::synchronize_fourier_phase(float actual_heading)
+void AP_InertialSensor_Backend::synchronize_fourier_phase(float actual_heading)
 {
 	_fourier_analysis.synchronize_fourier_phase(actual_heading);
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -316,7 +316,21 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
         _sem->give();
     }
 
+    if (instance==0) {
+    	_fourier_analysis.accumulate_discrete(accel, dt, _imu._gyro[instance]);
+    }
+
     log_accel_raw(instance, sample_us, accel);
+}
+
+Vector2f AP_InertialSensor_Backend::get_pitch_yaw_FT(void)
+{
+	return _fourier_analysis.get_result();
+}
+
+void::AP_InertialSensor_Backend::synchronize_fourier_phase(float actual_heading)
+{
+	_fourier_analysis.synchronize_fourier_phase(actual_heading);
 }
 
 void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel)

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 
 #include <AP_Math/AP_Math.h>
+#include "AP_Math/fourier.h"
 
 #include "AP_InertialSensor.h"
 
@@ -80,6 +81,10 @@ public:
     // notify of a fifo reset
     void notify_fifo_reset(void);
     
+    Vector2f get_pitch_yaw_FT(void);
+    
+    void synchronize_fourier_phase(float);
+    
     /*
       device driver IDs. These are used to fill in the devtype field
       of the device ID, which shows up as INS*ID* parameters to
@@ -106,6 +111,9 @@ public:
     };
         
 protected:
+
+    Fourier_Analysis _fourier_analysis;
+
     // access to frontend
     AP_InertialSensor &_imu;
 

--- a/libraries/AP_Math/fourier.cpp
+++ b/libraries/AP_Math/fourier.cpp
@@ -1,0 +1,201 @@
+/*
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//designed by Philippe Crochat / Anemos Technologies : pcrochat@anemos-technologies.com
+
+/* This library is here to transform a rotational frame motion into pitch and yaw angle.
+The roll angle will always be set to 0, the pitch will be set to the one corresponding to the greatest slope swept 
+by the rotor. A more complete explanation is available at https://discuss.ardupilot.org/t/gyropter-monocopter-support-with-the-help-of-a-fourier-based-transform/25168/14
+*/
+
+
+#include "fourier.h"
+
+
+//constructor, it does initiates a filter and sets the fourier buffer size to it's default BUF_SIZE
+Fourier_Analysis::Fourier_Analysis() {
+	_result_filter.set_cutoff_frequency(RESULT_FILTER_FREQ);
+	Set_Fourier_Analysis(BUF_SIZE);
+}
+
+//sets buffer size and allocates memory
+void Fourier_Analysis::Set_Fourier_Analysis(int32_t buffer_size) {
+	_buffer_size=buffer_size;
+	
+	_signal_buffer=(Fourier_Struct *)calloc(buffer_size,sizeof(Fourier_Struct));
+}
+
+//destructor
+Fourier_Analysis::~Fourier_Analysis() {
+	if (_signal_buffer != nullptr) {
+		free(_signal_buffer);
+		_signal_buffer=nullptr;
+	}
+}
+
+//private method to add a new sample value to the filter (substract=false) or remove an old one (substract=true)
+//this method does the fourier filter calculation. Please note that only the first fundamental frequency is analysed
+void Fourier_Analysis::_add_signal(bool substract) {
+	int8_t sign = substract==true ? -1 : 1;
+	int32_t buffer_index = substract==true ? _buffer_index_inf : _buffer_index_sup;
+	
+	Vector2f fourier_coef;
+	float signal_temp[2];
+	
+	fourier_coef.x=cosf(_signal_buffer[buffer_index].phase);
+	fourier_coef.y=-sinf(_signal_buffer[buffer_index].phase);
+	
+	signal_temp[0]=_signal_buffer[buffer_index].signal.x;
+	signal_temp[1]=_signal_buffer[buffer_index].signal.y;
+	
+	while(_dtheta_sum>M_2PI || substract==false || 
+		(_buffer_index_sup==(_buffer_index_inf>0 ? _buffer_index_inf-1 : _buffer_size-1) && substract==true))
+	{
+		int32_t i;
+		
+		if (_signal_buffer[buffer_index].dtheta<0.0f) {
+			_signal_buffer[buffer_index].dtheta=-_signal_buffer[buffer_index].dtheta;
+		}
+		
+		for(i=0;i<2;i++) {
+			_fourier_transform[i].x += sign * (fourier_coef.x*signal_temp[i]) * _signal_buffer[buffer_index].dtheta;
+			_fourier_transform[i].y += sign * (fourier_coef.y*signal_temp[i]) * _signal_buffer[buffer_index].dtheta;
+		}
+		
+		_dtheta_sum += _signal_buffer[buffer_index].dtheta * sign;
+		
+		_signal_mean += _signal_buffer[buffer_index].signal * _signal_buffer[buffer_index].dtheta * sign;
+		buffer_index++;
+		
+		if (buffer_index>=_buffer_size) {
+			buffer_index=0;
+		}
+		
+		if (substract==true) {
+			_buffer_index_inf=buffer_index;
+		} else {
+			_buffer_index_sup=buffer_index;
+		}
+		
+		if (substract==false) {
+			break;
+		}
+	}
+}
+
+//acumulates a new sample into the filter. dt is the time elapsed since last accumulaton and omega are the instant gyro value
+void Fourier_Analysis::accumulate_discrete(const &Vector3f new_sample, float dt, const &Vector3f omega) {
+	int32_t last_buffer_index_sup = _buffer_index_sup-1<0 ? _buffer_size-1 : _buffer_index_sup-1;
+	
+	_add_signal(true);
+	
+	_signal_buffer[_buffer_index_sup].signal = new_sample;
+	_signal_buffer[_buffer_index_sup].dtheta = dt*omega.z;
+	
+	if (_phase_synchronized==false) {
+		_signal_buffer[_buffer_index_sup].phase = _signal_buffer[last_buffer_index_sup].phase+dt*omega.z;
+	}
+	
+	_add_signal(false);
+	_phase_synchronized=false;
+}
+
+//return the current phase of the fourier filter
+float Fourier_Analysis::get_phase(void) {
+	int32_t last_index=_buffer_index_sup-1;
+	
+	if(last_index<0){
+		last_index=_buffer_size-1;
+	}
+	
+	return _signal_buffer[last_index].phase;
+}
+
+//synchronize heading with compass value
+void Fourier_Analysis::synchronize_fourier_phase(float instant_heading) {
+	if (instant_heading>M_PI) {
+		instant_heading-=M_2PI;
+	}
+	
+	if (instant_heading<-M_PI) {
+		instant_heading+=M_2PI;
+	}
+	
+	_signal_buffer[_buffer_index_sup].phase=instant_heading;
+	_phase_synchronized=true;
+}
+
+//this methode calculates and returns the pitch and yaw angle 
+Vector2f Fourier_Analysis::get_result(void) {
+	Vector2f result;
+	
+	result.x=_get_pitch_angle();
+	result.y=_get_yaw_angle();
+	
+	if (result.x>0.0f) {
+		result.y=-result.y;
+		result.x=-result.x;
+	}
+	
+	return result;
+}
+
+//this method calculates the greatest slope of the disk area swept by the frame
+float Fourier_Analysis::_get_pitch_angle(void) {
+	Vector2f result;
+	
+	if (_dtheta_sum>0.0f) {
+		float scale=2.0/_dtheta_sum;
+		
+		
+		result.x = norm(_fourier_transform[0].x*scale, _fourier_transform[0].y*scale);
+		result.y = norm(_fourier_transform[1].x*scale, _fourier_transform[1].y*scale);
+		
+		return _signal_mean.z != 0.0f ? atanf(0.5*(result.x+result.y)/_signal_mean.z*_dtheta_sum) : 0.0f;
+	} else {
+		return 0.0f;
+	}
+}
+
+//return the calculated yaw between PI and -PI
+float Fourier_Analysis::_get_yaw_angle(void) {
+	Vector2f result;
+	
+	result.x = (_fourier_transform[0].x != 0.0f) ? atanf(_fourier_transform[0].y/_fourier_transform[0].x) : 0.0f;
+	result.y = (_fourier_transform[1].x != 0.0f) ? atanf(_fourier_transform[1].y/_fourier_transform[1].x) : 0.0f;
+	
+	if (_fourier_transform[0].x<0) {
+		result.x+=M_PI;
+		
+		if(result.x>M_PI){
+			result.x-=M_2PI;
+		}
+	}
+	
+	if (_fourier_transform[1].x<0) {
+		result.y+=M_PI;
+		
+		if(result.y>M_PI) {
+			result.y-=M_2PI;
+		}
+	}
+	
+	return result.x;
+}
+
+//sets filter buffer size
+void Fourier_Analysis::set_buffer_size(int32_t buffer_size) {
+	_buffer_size=buffer_size;
+}

--- a/libraries/AP_Math/fourier.cpp
+++ b/libraries/AP_Math/fourier.cpp
@@ -96,7 +96,7 @@ void Fourier_Analysis::_add_signal(bool substract) {
 }
 
 //acumulates a new sample into the filter. dt is the time elapsed since last accumulaton and omega are the instant gyro value
-void Fourier_Analysis::accumulate_discrete(const &Vector3f new_sample, float dt, const &Vector3f omega) {
+void Fourier_Analysis::accumulate_discrete(const Vector3f new_sample, float dt, const Vector3f omega) {
 	int32_t last_buffer_index_sup = _buffer_index_sup-1<0 ? _buffer_size-1 : _buffer_index_sup-1;
 	
 	_add_signal(true);

--- a/libraries/AP_Math/fourier.h
+++ b/libraries/AP_Math/fourier.h
@@ -52,7 +52,7 @@ public:
 	Fourier_Analysis();
 	~Fourier_Analysis();
 	void Set_Fourier_Analysis(int32_t buffer_size);
-	void accumulate_discrete(const &Vector3f new_sample, float dt, const &Vector3f omega);
+	void accumulate_discrete(const Vector3f new_sample, float dt, const Vector3f omega);
 	Vector2f get_result(void);
 	float get_phase(void);
 	void set_buffer_size(int32_t buffer_size);

--- a/libraries/AP_Math/fourier.h
+++ b/libraries/AP_Math/fourier.h
@@ -1,0 +1,78 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /* fourier class, determines the fourier magnitude and phase of the signal in case our frame is rotating fast on it's yaw axis
+ This class is absolutely mandatory to fly gyropter or monoblade like drones
+ 
+ designed by Philippe Crochat / Anemos Technologies : pcrochat@anemos-technologies.com
+ */
+ 
+#pragma once
+
+#include <AP_Math/AP_Math.h>
+#include <AP_HAL/AP_HAL.h>
+#include <Filter/LowPassFilter.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define RESULT_FILTER_FREQ 5 //in Hz
+
+struct Timing_Struct{
+	float dt;
+	Vector3f omega;
+	float T;
+};
+
+struct Fourier_Struct{
+	Vector3f signal;
+	float phase;
+	float dtheta;
+};
+
+const int32_t SAMPLE_RATE=1600;
+const int32_t MIN_FREQ=1;
+const int32_t BUF_SIZE=SAMPLE_RATE/MIN_FREQ;
+
+class Fourier_Analysis
+{
+public:
+	Fourier_Analysis();
+	~Fourier_Analysis();
+	void Set_Fourier_Analysis(int32_t buffer_size);
+	void accumulate_discrete(const &Vector3f new_sample, float dt, const &Vector3f omega);
+	Vector2f get_result(void);
+	float get_phase(void);
+	void set_buffer_size(int32_t buffer_size);
+	void synchronize_fourier_phase(float instant_heading);
+protected:
+	Vector2f _fourier_transform[2];
+	Timing_Struct *_timing;
+private:
+	void _add_signal(bool substract);
+	float _get_pitch_angle(void);
+	float _get_yaw_angle(void);
+	
+	Fourier_Struct *_signal_buffer;
+	int32_t _buffer_size;
+	float _time_elapsed;
+	int32_t _buffer_index_inf;
+	int32_t _buffer_index_sup;
+	Vector3f _signal_mean;
+	float _dtheta_sum;
+	LowPassFilterVector2f _result_filter;
+	Vector2f _last_result;
+	bool _phase_synchronized;
+};

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -1,20 +1,20 @@
 /*
- * quaternion.cpp
- * Copyright (C) Andrew Tridgell 2012
- *
- * This file is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This file is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+* quaternion.cpp
+* Copyright (C) Andrew Tridgell 2012
+*
+* This file is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This file is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #pragma GCC optimize("O3")
 
@@ -32,7 +32,7 @@ void Quaternion::rotation_matrix(Matrix3f &m) const
     float q1q3 = q1 * q3;
     float q1q4 = q1 * q4;
     float q4q4 = q4 * q4;
-
+    
     m.a.x = 1.0f-2.0f*(q3q3 + q4q4);
     m.a.y = 2.0f*(q2q3 - q1q4);
     m.a.z = 2.0f*(q2q4 + q1q3);
@@ -58,7 +58,7 @@ void Quaternion::rotation_matrix_norm(Matrix3f &m) const
     float q3q4 = q3 * q4;
     float q4q4 = q4 * q4;
     float invs = 1.0f / (q1q1 + q2q2 + q3q3 + q4q4);
-
+    
     m.a.x = ( q2q2 - q3q3 - q4q4 + q1q1)*invs;
     m.a.y = 2.0f*(q2q3 - q1q4)*invs;
     m.a.z = 2.0f*(q2q4 + q1q3)*invs;
@@ -70,7 +70,7 @@ void Quaternion::rotation_matrix_norm(Matrix3f &m) const
     m.c.z = (-q2q2 - q3q3 + q4q4 + q1q1)*invs;
 }
 
-// return the rotation matrix equivalent for this quaternion
+// return the quaternion equivalent to this rotation matrix
 // Thanks to Martin John Baker
 // http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
 void Quaternion::from_rotation_matrix(const Matrix3f &m)
@@ -88,9 +88,9 @@ void Quaternion::from_rotation_matrix(const Matrix3f &m)
     float &qx = q2;
     float &qy = q3;
     float &qz = q4;
-
+    
     float tr = m00 + m11 + m22;
-
+    
     if (tr > 0) {
         float S = sqrtf(tr+1) * 2;
         qw = 0.25f * S;
@@ -135,7 +135,7 @@ void Quaternion::from_euler(float roll, float pitch, float yaw)
     float sr2 = sinf(roll*0.5f);
     float sp2 = sinf(pitch*0.5f);
     float sy2 = sinf(yaw*0.5f);
-
+    
     q1 = cr2*cp2*cy2 + sr2*sp2*sy2;
     q2 = sr2*cp2*cy2 - cr2*sp2*sy2;
     q3 = cr2*sp2*cy2 + sr2*cp2*sy2;
@@ -147,10 +147,11 @@ void Quaternion::from_vector312(float roll ,float pitch, float yaw)
 {
     Matrix3f m;
     m.from_euler312(roll, pitch, yaw);
-
+    
     from_rotation_matrix(m);
 }
 
+// creates a quaternion from an axis vector and an angle, the angle is equal to the vector length
 void Quaternion::from_axis_angle(Vector3f v)
 {
     float theta = v.length();
@@ -163,6 +164,7 @@ void Quaternion::from_axis_angle(Vector3f v)
     from_axis_angle(v,theta);
 }
 
+// creates a quaternion from an axis vector and an angle
 void Quaternion::from_axis_angle(const Vector3f &axis, float theta)
 {
     // axis must be a unit vector as there is no check for length
@@ -172,13 +174,14 @@ void Quaternion::from_axis_angle(const Vector3f &axis, float theta)
         return;
     }
     float st2 = sinf(theta/2.0f);
-
+    
     q1 = cosf(theta/2.0f);
     q2 = axis.x * st2;
     q3 = axis.y * st2;
     q4 = axis.z * st2;
 }
 
+//rotates current quaternion by vector v with an angle = length(v)
 void Quaternion::rotate(const Vector3f &v)
 {
     Quaternion r;
@@ -186,6 +189,7 @@ void Quaternion::rotate(const Vector3f &v)
     (*this) *= r;
 }
 
+//convert quaternion to a vector with magnitude=to its angle
 void Quaternion::to_axis_angle(Vector3f &v)
 {
     float l = sqrt(sq(q2)+sq(q3)+sq(q4));
@@ -213,7 +217,7 @@ void Quaternion::from_axis_angle_fast(const Vector3f &axis, float theta)
     float t2 = theta/2.0f;
     float sqt2 = sq(t2);
     float st2 = t2-sqt2*t2/6.0f;
-
+    
     q1 = 1.0f-(sqt2/2.0f)+sq(sqt2)/24.0f;
     q2 = axis.x * st2;
     q3 = axis.y * st2;
@@ -230,19 +234,19 @@ void Quaternion::rotate_fast(const Vector3f &v)
     float sqt2 = sq(t2);
     float st2 = t2-sqt2*t2/6.0f;
     st2 /= theta;
-
+    
     //"rotation quaternion"
     float w2 = 1.0f-(sqt2/2.0f)+sq(sqt2)/24.0f;
     float x2 = v.x * st2;
     float y2 = v.y * st2;
     float z2 = v.z * st2;
-
+    
     //copy our quaternion
     float w1 = q1;
     float x1 = q2;
     float y1 = q3;
     float z1 = q4;
-
+    
     //do the multiply into our quaternion
     q1 = w1*w2 - x1*x2 - y1*y2 - z1*z2;
     q2 = w1*x2 + x1*w2 + y1*z2 - z1*y2;
@@ -313,18 +317,35 @@ Quaternion Quaternion::operator*(const Quaternion &v) const
     const float &x1 = q2;
     const float &y1 = q3;
     const float &z1 = q4;
-
+    
     float w2 = v.q1;
     float x2 = v.q2;
     float y2 = v.q3;
     float z2 = v.q4;
-
+    
     ret.q1 = w1*w2 - x1*x2 - y1*y2 - z1*z2;
     ret.q2 = w1*x2 + x1*w2 + y1*z2 - z1*y2;
     ret.q3 = w1*y2 - x1*z2 + y1*w2 + z1*x2;
     ret.q4 = w1*z2 + x1*y2 - y1*x2 + z1*w2;
-
+    
     return ret;
+}
+
+Quaternion Quaternion::operator*(const float &k) const
+{
+	Quaternion ret;
+	const float &w1 = q1;
+    const float &w2 = q2;
+    const float &w3 = q3;
+    const float &w4 = q4;
+	
+    ret.q1=w1*k;
+    ret.q2=w2*k;
+    ret.q3=w3*k;
+    ret.q4=w4*k;
+    
+	
+	return ret;
 }
 
 Quaternion &Quaternion::operator*=(const Quaternion &v)
@@ -333,17 +354,17 @@ Quaternion &Quaternion::operator*=(const Quaternion &v)
     float x1 = q2;
     float y1 = q3;
     float z1 = q4;
-
+    
     float w2 = v.q1;
     float x2 = v.q2;
     float y2 = v.q3;
     float z2 = v.q4;
-
+    
     q1 = w1*w2 - x1*x2 - y1*y2 - z1*z2;
     q2 = w1*x2 + x1*w2 + y1*z2 - z1*y2;
     q3 = w1*y2 - x1*z2 + y1*w2 + z1*x2;
     q4 = w1*z2 + x1*y2 - y1*x2 + z1*w2;
-
+    
     return *this;
 }
 
@@ -354,12 +375,12 @@ Quaternion Quaternion::operator/(const Quaternion &v) const
     const float &quat1 = q2;
     const float &quat2 = q3;
     const float &quat3 = q4;
-
+    
     float rquat0 = v.q1;
     float rquat1 = v.q2;
     float rquat2 = v.q3;
     float rquat3 = v.q4;
-
+    
     ret.q1 = (rquat0*quat0 + rquat1*quat1 + rquat2*quat2 + rquat3*quat3);
     ret.q2 = (rquat0*quat1 - rquat1*quat0 - rquat2*quat3 + rquat3*quat2);
     ret.q3 = (rquat0*quat2 + rquat1*quat3 - rquat2*quat0 - rquat3*quat1);

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -132,6 +132,7 @@ public:
     }
 
     Quaternion operator*(const Quaternion &v) const;
+    Quaternion operator*(const float &k) const;
     Quaternion &operator*=(const Quaternion &v);
     Quaternion operator/(const Quaternion &v) const;
 };

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -642,6 +642,12 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
             }
             break;
 
+        case MOTOR_FRAME_ROTATIONAL_DUAL:
+        	add_motor(AP_MOTORS_MOT_1, 0, 0, 1);
+            add_motor(AP_MOTORS_MOT_2, 180, 0, 2);
+            success = true;
+            break;
+            
         default:
             // matrix doesn't support the configured class
             break;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -44,6 +44,7 @@ public:
         MOTOR_FRAME_HELI_DUAL = 11,
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
+        MOTOR_FRAME_ROTATIONAL_DUAL = 14,
     };
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,


### PR DESCRIPTION
fourier AHRS real time roll/pitch/yaw calculation for gyropter/mono blade like drones where the IMU is mounted on the rotating frame.

With the current kalman filter, when rotating the filter becomes quickly dizzy and diverge. With a fourier like filter, like the one proposed with this PR, the pitch and yaw angle calculation is stable and is determined as if the rotor when sweeping it's area was considered as a solid disc. the gyropter/mono blade like drones are thus with this new filter fully controllable and easy to automate.

