### PR TITLE
use gcc/g++ for SITL build on mac osx

### DIFF
--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -16,6 +16,7 @@ from waflib import Errors, Context, Utils
 from waflib.Configure import conf
 from waflib.Tools import compiler_c, compiler_cxx
 from waflib.Tools import clang, clangxx, gcc, gxx
+from waflib import Logs
 
 import os
 import re
@@ -126,12 +127,15 @@ def find_toolchain_program(cfg, filename, **kw):
     return cfg.find_program(filename, **kw)
 
 def configure(cfg):
-    if cfg.env.TOOLCHAIN == 'native':
-        cfg.load('compiler_cxx compiler_c')
-        return
-
     _filter_supported_c_compilers('gcc', 'clang')
     _filter_supported_cxx_compilers('g++', 'clang++')
+
+    if cfg.env.TOOLCHAIN == 'native':
+        cfg.load('compiler_cxx compiler_c')
+        if cfg.env.COMPILER_CC == 'clang' or cfg.env.COMPILER_CXX == 'clang++':
+            Logs.warn("Warning! Native clang builds can be unstable, please use gcc/g++. \
+\nRefer ardupilot.org docs for more details.")
+        return
 
     cfg.find_toolchain_program('ar')
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -240,7 +240,8 @@ def kill_tasks():
 
         if under_cygwin():
             return kill_tasks_cygwin(victim_names)
-        if under_macos():
+        if under_macos() and os.environ.get('DISPLAY'):
+            #use special macos kill routine if Display is on
             return kill_tasks_macos()
 
         try:
@@ -464,7 +465,7 @@ def run_in_terminal_window(autotest, name, cmd):
     runme.extend(cmd)
     progress_cmd("Run " + name, runme)
 
-    if under_macos():
+    if under_macos() and os.environ.get('DISPLAY'):
         # on MacOS record the window IDs so we can close them later
         out = subprocess.Popen(runme, stdout=subprocess.PIPE).communicate()[0]
         import re
@@ -478,7 +479,8 @@ def run_in_terminal_window(autotest, name, cmd):
                 break
 
             time.sleep(0.1)
-
+        #sleep for extra 2 seconds for application to start
+        time.sleep(2)
         if len(tabs) > 0:
             windowID.append(tabs[0])
         else:


### PR DESCRIPTION
the default clang produces a build that crashes at startup. This patch forces user to use gcc on their mac system for build else throws an error.

Steps for getting gcc over mac (ensure brew is already installed):
`brew install gcc`
check location of installation using `brew list gcc`
```
echo 'export PATH=/usr/local/Cellar/gcc/7.2.0_1/bin:$PATH' >> ~/.bash_profile
cp /usr/local/Cellar/gcc/7.2.0_1/bin/gcc-7 /usr/local/Cellar/gcc/7.2.0_1/bin/gcc
cp /usr/local/Cellar/gcc/7.2.0_1/bin/g++-7 /usr/local/Cellar/gcc/7.2.0_1/bin/g++
source ~/.bash_profile
```
Note: Replace `/usr/local/Cellar/gcc/7.2.0_1/bin/gcc-7` with the one you got from `brew list gcc`