### PR TITLE
Travis: Move a number of builds to Semaphore CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,10 @@ matrix:
   fast_finish: true
   include:
     - compiler: "gcc"
-      env: CI_BUILD_TARGET="sitl minlure linux navio2 bebop"
+      env: CI_BUILD_TARGET="px4-v2"
     - compiler: "gcc"
-      env: CI_BUILD_TARGET="px4-v2 px4-v4"
+      env: CI_BUILD_TARGET="px4-v4"
     - compiler: "gcc"
-      env: CI_BUILD_TARGET="fmuv3 px4-v3"
+      env: CI_BUILD_TARGET="sitltest-copter"
     - compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest"
+      env: CI_BUILD_TARGET="sitltest-quadplane sitltest-rover"


### PR DESCRIPTION
We have 6 boxes on SemaphoreCI now, the removed tasks are all running on SemaphoreCI now. The next future step will be to split `sitltest` into a copter and others test and split it over two tasks, for now this just removes duplicate work and speeds travis up a bit.