### PR TITLE
DataFlash: add ? and - to multiplier table

### DIFF
--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -273,19 +273,11 @@ bool DataFlash_Class::validate_structure(const struct LogStructure *logstructure
         }
     }
 
-    // ensure the FMTU messages reference valid units
+    // ensure the FMTU messages reference valid multipliers
     for (uint8_t j=0; j<strlen(logstructure->multipliers); j++) {
         char logmultiplier = logstructure->multipliers[j];
         uint8_t k;
         for (k=0; k<_num_multipliers; k++) {
-            if (logmultiplier == '-') {
-                // no sensible multiplier
-                break;
-            }
-            if (logmultiplier == '?') {
-                // currently unknown multiplier....
-                break;
-            }
             if (logmultiplier == _multipliers[k].ID) {
                 // found this one
                 break;

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -112,6 +112,8 @@ const struct UnitStructure log_Units[] = {
 
 const struct MultiplierStructure log_Multipliers[] = {
 // <leave a gap here, just in case....>
+    { '-', 0 },       // no multiplier e.g. a string
+    { '?', 1 },       // multipliers which haven't been worked out yet....
     { '2', 1e2 },
     { '1', 1e1 },
     { '0', 1e0 },


### PR DESCRIPTION
This allows a consumer to expect referential integrity for the
multipliers