### PR TITLE
AP_Terrain: fix snprintf buffer length warning

### DIFF
--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -173,9 +173,9 @@ void AP_Terrain::open_file(void)
     }
     snprintf(p, 13, "/%c%02u%c%03u.DAT",
              block.lat_degrees<0?'S':'N',
-             abs((int32_t)block.lat_degrees),
+             MAX(abs((int32_t)block.lat_degrees), 99),
              block.lon_degrees<0?'W':'E',
-             abs((int32_t)block.lon_degrees));
+             MAX(abs((int32_t)block.lon_degrees), 999));
 
     // create directory if need be
     if (!directory_created) {

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -173,9 +173,9 @@ void AP_Terrain::open_file(void)
     }
     snprintf(p, 13, "/%c%02u%c%03u.DAT",
              block.lat_degrees<0?'S':'N',
-             MAX(abs((int32_t)block.lat_degrees), 99),
+             MIN(abs((int32_t)block.lat_degrees), 99),
              block.lon_degrees<0?'W':'E',
-             MAX(abs((int32_t)block.lon_degrees), 999));
+             MIN(abs((int32_t)block.lon_degrees), 999));
 
     // create directory if need be
     if (!directory_created) {


### PR DESCRIPTION
../../libraries/AP_Terrain/TerrainIO.cpp: In member function ‘void
AP_Terrain::open_file()’:
../../libraries/AP_Terrain/TerrainIO.cpp:145:6: warning: ‘.DAT’
directive output may be truncated writing 4 bytes into a region of size
between 2 and 5 [-Wformat-truncation=]
 void AP_Terrain::open_file(void)
      ^~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from ../../libraries/AP_Common/AP_Common.h:179,
                 from ../../libraries/AP_HAL/UARTDriver.h:5,
                 from ../../libraries/AP_HAL/HAL.h:11,
                 from ../../libraries/AP_HAL/AP_HAL_Main.h:19,
                 from ../../libraries/AP_HAL/AP_HAL.h:8,
                 from ../../libraries/AP_Terrain/TerrainIO.cpp:19:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:65:44: note:
‘__builtin___snprintf_chk’ output between 13 and 16 bytes into a
destination of size 13
        __bos (__s), __fmt, __va_arg_pack ());
                                            ^