### PR TITLE
Add SIM_WIND_PITCH parameter for SITL

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -343,12 +343,12 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     float altitude = _barometer?_barometer->get_altitude():0;
     float wind_speed = 0;
     float wind_direction = 0;
-	float wind_pitch = 0;
+    float wind_pitch = 0;
     if (_sitl) {
         // The EKF does not like step inputs so this LPF keeps it happy.
         wind_speed =     _sitl->wind_speed_active     = (0.95f*_sitl->wind_speed_active)     + (0.05f*_sitl->wind_speed);
         wind_direction = _sitl->wind_direction_active = (0.95f*_sitl->wind_direction_active) + (0.05f*_sitl->wind_direction);
-		wind_pitch =     _sitl->wind_pitch_active     = (0.95f*_sitl->wind_pitch_active)     + (0.05f*_sitl->wind_pitch);
+        wind_pitch =     _sitl->wind_pitch_active     = (0.95f*_sitl->wind_pitch_active)     + (0.05f*_sitl->wind_pitch);
     }
 
     if (altitude < 0) {
@@ -361,7 +361,7 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     input.wind.speed = wind_speed;
     input.wind.direction = wind_direction;
     input.wind.turbulence = _sitl?_sitl->wind_turbulance:0;
-	input.wind.pitch = wind_pitch;
+    input.wind.pitch = wind_pitch;
 
     for (i=0; i<SITL_NUM_CHANNELS; i++) {
         if (pwm_output[i] == 0xFFFF) {

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -343,12 +343,12 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     float altitude = _barometer?_barometer->get_altitude():0;
     float wind_speed = 0;
     float wind_direction = 0;
-    float wind_pitch = 0;
+    float wind_dir_z = 0;
     if (_sitl) {
         // The EKF does not like step inputs so this LPF keeps it happy.
         wind_speed =     _sitl->wind_speed_active     = (0.95f*_sitl->wind_speed_active)     + (0.05f*_sitl->wind_speed);
         wind_direction = _sitl->wind_direction_active = (0.95f*_sitl->wind_direction_active) + (0.05f*_sitl->wind_direction);
-        wind_pitch =     _sitl->wind_pitch_active     = (0.95f*_sitl->wind_pitch_active)     + (0.05f*_sitl->wind_pitch);
+        wind_dir_z =     _sitl->wind_dir_z_active     = (0.95f*_sitl->wind_dir_z_active)     + (0.05f*_sitl->wind_dir_z);
     }
 
     if (altitude < 0) {
@@ -361,7 +361,7 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     input.wind.speed = wind_speed;
     input.wind.direction = wind_direction;
     input.wind.turbulence = _sitl?_sitl->wind_turbulance:0;
-    input.wind.pitch = wind_pitch;
+    input.wind.dir_z = wind_dir_z;
 
     for (i=0; i<SITL_NUM_CHANNELS; i++) {
         if (pwm_output[i] == 0xFFFF) {

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -343,10 +343,12 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     float altitude = _barometer?_barometer->get_altitude():0;
     float wind_speed = 0;
     float wind_direction = 0;
+	float wind_pitch = 0;
     if (_sitl) {
         // The EKF does not like step inputs so this LPF keeps it happy.
-        wind_speed = _sitl->wind_speed_active = (0.95f*_sitl->wind_speed_active) + (0.05f*_sitl->wind_speed);
+        wind_speed =     _sitl->wind_speed_active     = (0.95f*_sitl->wind_speed_active)     + (0.05f*_sitl->wind_speed);
         wind_direction = _sitl->wind_direction_active = (0.95f*_sitl->wind_direction_active) + (0.05f*_sitl->wind_direction);
+		wind_pitch =     _sitl->wind_pitch_active     = (0.95f*_sitl->wind_pitch_active)     + (0.05f*_sitl->wind_pitch);
     }
 
     if (altitude < 0) {
@@ -359,6 +361,7 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     input.wind.speed = wind_speed;
     input.wind.direction = wind_direction;
     input.wind.turbulence = _sitl?_sitl->wind_turbulance:0;
+	input.wind.pitch = wind_pitch;
 
     for (i=0; i<SITL_NUM_CHANNELS; i++) {
         if (pwm_output[i] == 0xFFFF) {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -565,7 +565,9 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 void Aircraft::update_wind(const struct sitl_input &input)
 {
     // wind vector in earth frame
-    wind_ef = Vector3f(cosf(radians(input.wind.direction)), sinf(radians(input.wind.direction)), 0) * input.wind.speed;
+    wind_ef = Vector3f(cosf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
+						sinf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
+						sinf(radians(input.wind.pitch))) * input.wind.speed;
 
     const float wind_turb = input.wind.turbulence * 10.0f;  // scale input.wind.turbulence to match standard deviation when using iir_coef=0.98
     const float iir_coef = 0.98f;  // filtering high frequencies from turbulence

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -566,8 +566,8 @@ void Aircraft::update_wind(const struct sitl_input &input)
 {
     // wind vector in earth frame
     wind_ef = Vector3f(cosf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
-						sinf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
-						sinf(radians(input.wind.pitch))) * input.wind.speed;
+                       sinf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
+                       sinf(radians(input.wind.pitch))) * input.wind.speed;
 
     const float wind_turb = input.wind.turbulence * 10.0f;  // scale input.wind.turbulence to match standard deviation when using iir_coef=0.98
     const float iir_coef = 0.98f;  // filtering high frequencies from turbulence

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -565,9 +565,9 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 void Aircraft::update_wind(const struct sitl_input &input)
 {
     // wind vector in earth frame
-    wind_ef = Vector3f(cosf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
-                       sinf(radians(input.wind.direction))*cosf(radians(input.wind.pitch)), 
-                       sinf(radians(input.wind.pitch))) * input.wind.speed;
+    wind_ef = Vector3f(cosf(radians(input.wind.direction))*cosf(radians(input.wind.dir_z)), 
+                       sinf(radians(input.wind.direction))*cosf(radians(input.wind.dir_z)), 
+                       sinf(radians(input.wind.dir_z))) * input.wind.speed;
 
     const float wind_turb = input.wind.turbulence * 10.0f;  // scale input.wind.turbulence to match standard deviation when using iir_coef=0.98
     const float iir_coef = 0.98f;  // filtering high frequencies from turbulence

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -45,7 +45,7 @@ public:
             float speed;      // m/s
             float direction;  // degrees 0..360
             float turbulence;
-            float pitch;	   //-90..90
+            float dir_z;	   //-90..90
         } wind;
     };
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -45,7 +45,7 @@ public:
             float speed;      // m/s
             float direction;  // degrees 0..360
             float turbulence;
-			float pitch;	   //-90..90
+            float pitch;	   //-90..90
         } wind;
     };
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -45,7 +45,7 @@ public:
             float speed;      // m/s
             float direction;  // degrees 0..360
             float turbulence;
-            float dir_z;	   //-90..90
+            float dir_z;	  //degrees -90..90 
         } wind;
     };
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -45,6 +45,7 @@ public:
             float speed;      // m/s
             float direction;  // degrees 0..360
             float turbulence;
+			float pitch;	   //-90..90
         } wind;
     };
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -108,6 +108,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPINFO("GPS_ALT_OFS",  8, SITL,  gps_alt_offset, 0),
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
+	AP_GROUPINFO("WIND_PITCH",	10, SITL,  wind_pitch,     0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPINFO("GPS_ALT_OFS",  8, SITL,  gps_alt_offset, 0),
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
-    AP_GROUPINFO("WIND_PITCH",	10, SITL,  wind_pitch,     0),
+    AP_GROUPINFO("WIND_DIR_Z",	10, SITL,  wind_dir_z,     0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPINFO("GPS_ALT_OFS",  8, SITL,  gps_alt_offset, 0),
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
-    AP_GROUPINFO("WIND_DIR_Z",	10, SITL,  wind_dir_z,     0),
+    AP_GROUPINFO("WIND_DIR_Z",  10, SITL,  wind_dir_z,     0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
     AP_GROUPINFO("GPS_ALT_OFS",  8, SITL,  gps_alt_offset, 0),
     AP_GROUPINFO("ARSPD_SIGN",   9, SITL,  arspd_signflip, 0),
-	AP_GROUPINFO("WIND_PITCH",	10, SITL,  wind_pitch,     0),
+    AP_GROUPINFO("WIND_PITCH",	10, SITL,  wind_pitch,     0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -128,10 +128,12 @@ public:
     // wind control
     float wind_speed_active;
     float wind_direction_active;
+    float wind_pitch_active;
     AP_Float wind_speed;
     AP_Float wind_direction;
     AP_Float wind_turbulance;
     AP_Float gps_drift_alt;
+    AP_Float wind_pitch;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -128,12 +128,12 @@ public:
     // wind control
     float wind_speed_active;
     float wind_direction_active;
-    float wind_pitch_active;
+    float wind_dir_z_active;
     AP_Float wind_speed;
     AP_Float wind_direction;
     AP_Float wind_turbulance;
     AP_Float gps_drift_alt;
-    AP_Float wind_pitch;
+    AP_Float wind_dir_z;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms


### PR DESCRIPTION
This param controls the vertical pitch of the 3d wind vector, allowing further control of the wind
using systems like dronekit.   This change directly effects the calculation of the wind vector
on line 568 of SITL\SIM_Aircraft.cpp, along with other changes to fully implement the param.

In the current version there is no way for the user to directly effect the vertical component of the wind. To simulate environmental conditions such as updrafts, this ability is needed.