### PR TITLE
COPTER: Don't log battery failsafe error when failsafe disabled

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -93,7 +93,7 @@ void Copter::set_failsafe_radio(bool b)
 
 
 // ---------------------------------------------
-void Copter::set_failsafe_battery(bool b)
+void Copter::set_low_battery(bool b)
 {
     failsafe.battery = b;
     AP_Notify::flags.failsafe_battery = b;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -599,7 +599,7 @@ private:
     void set_auto_armed(bool b);
     void set_simple_mode(uint8_t b);
     void set_failsafe_radio(bool b);
-    void set_failsafe_battery(bool b);
+    void set_low_battery(bool b);
     void set_failsafe_gcs(bool b);
     void update_using_interlock();
     void set_motor_emergency_stop(bool b);

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -68,14 +68,15 @@ void Copter::failsafe_battery_event(void)
                 set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
             }
         }
+    Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
     }
 
     // set the low battery flag
-    set_failsafe_battery(true);
+    set_low_battery(true);
 
     // warn the ground station and log to dataflash
     gcs().send_text(MAV_SEVERITY_WARNING,"Low battery");
-    Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
+    
 
 }
 

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -150,7 +150,7 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
     failsafe_disable();
 
     // reset battery failsafe
-    set_failsafe_battery(false);
+    set_low_battery(false);
 
     // notify that arming will occur (we do this early to give plenty of warning)
     AP_Notify::flags.armed = true;


### PR DESCRIPTION
This moves setting the `ERROR_SUBSYSTEM_FAILSAFE_BATT` logging call up to the if block so the failsafe error it is only set if the battery failsafe is enabled. Previously, you would get the error logging and GCS warning for failsafe even if the failsafe was disabled.

The low battery GCS message and AP_Notify stuff still goes through as normal, since those are only notifying of the low battery condition, not the failsafe itself.  Also renamed the function from `set_failsafe_battery` to `set_low_battery` since it actually is only handling the low battery notification, not the failsafe notification.

This should close https://github.com/ArduPilot/ardupilot/issues/7619