### PR TITLE
Rover, Copter, Global: delete \n from the log using gcs().send_text

### DIFF
--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -319,7 +319,7 @@ bool Rover::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
 {
     const bool result = verify_nav_wp(cmd);
     if (result) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Finished active loiter\n");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Finished active loiter");
     }
     return result;
 }

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -209,7 +209,7 @@ void Copter::check_ekf_reset()
     if ((EKF2.getPrimaryCoreIndex() != ekf_primary_core) && (EKF2.getPrimaryCoreIndex() != -1)) {
         ekf_primary_core = EKF2.getPrimaryCoreIndex();
         Log_Write_Error(ERROR_SUBSYSTEM_EKF_PRIMARY, ekf_primary_core);
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d\n", (unsigned)ekf_primary_core);
+        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
     }
 #endif
 }

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -372,18 +372,18 @@ void AP_Camera::setup_feedback_callback(void)
         int fd = open("/dev/px4fmu", 0);
         if (fd != -1) {
             if (ioctl(fd, PWM_SERVO_SET_MODE, PWM_SERVO_MODE_3PWM1CAP) != 0) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Camera: unable to setup 3PWM1CAP\n");
+                gcs().send_text(MAV_SEVERITY_WARNING, "Camera: unable to setup 3PWM1CAP");
                 close(fd);
                 goto failed;
             }   
             if (up_input_capture_set(3, _feedback_polarity==1?Rising:Falling, 0, capture_callback, this) != 0) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "Camera: unable to setup timer capture\n");
+                gcs().send_text(MAV_SEVERITY_WARNING, "Camera: unable to setup timer capture");
                 close(fd);
                 goto failed;
             }
             close(fd);
             _timer_installed = true;
-            gcs().send_text(MAV_SEVERITY_WARNING, "Camera: setup fast trigger capture\n");
+            gcs().send_text(MAV_SEVERITY_WARNING, "Camera: setup fast trigger capture");
         }
     }
 failed:

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -41,7 +41,7 @@ bool PX4RCInput::new_input()
     _override_valid = false;
     pthread_mutex_unlock(&rcin_mutex);
     if (_rcin.input_source != last_input_source) {
-        gcs().send_text(MAV_SEVERITY_DEBUG, "RCInput: decoding %s\n", input_source_name(_rcin.input_source));
+        gcs().send_text(MAV_SEVERITY_DEBUG, "RCInput: decoding %s", input_source_name(_rcin.input_source));
         last_input_source = _rcin.input_source;
     }
     return valid;

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -182,10 +182,10 @@ bool SoaringController::check_cruise_criteria()
     float alt = _vario.alt;
 
     if (soar_active && (AP_HAL::micros64() - _thermal_start_time_us) > ((unsigned)min_thermal_s * 1e6) && thermalability < McCready(alt)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Thermal weak, recommend quitting: W %f R %f th %f alt %f Mc %f\n", (double)_ekf.X[0], (double)_ekf.X[1], (double)thermalability, (double)alt, (double)McCready(alt));
+        gcs().send_text(MAV_SEVERITY_INFO, "Thermal weak, recommend quitting: W %f R %f th %f alt %f Mc %f", (double)_ekf.X[0], (double)_ekf.X[1], (double)thermalability, (double)alt, (double)McCready(alt));
         return true;
     } else if (soar_active && (alt>alt_max || alt<alt_min)) {
-        gcs().send_text(MAV_SEVERITY_ALERT, "Out of allowable altitude range, beginning cruise. Alt = %f\n", (double)alt);
+        gcs().send_text(MAV_SEVERITY_ALERT, "Out of allowable altitude range, beginning cruise. Alt = %f", (double)alt);
         return true;
     }
 

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -75,6 +75,6 @@ float Variometer::correct_netto_rate(float climb_rate,
     //float temp_netto = netto_rate;
     //float dVdt = SpdHgt_Controller->get_VXdot();
     //netto_rate = netto_rate + aspd*dVdt/GRAVITY_MSS;
-    //gcs().send_text(MAV_SEVERITY_INFO, "%f %f %f %f\n",temp_netto,dVdt,netto_rate,barometer.get_altitude());
+    //gcs().send_text(MAV_SEVERITY_INFO, "%f %f %f %f",temp_netto,dVdt,netto_rate,barometer.get_altitude());
     return netto_rate;
 }


### PR DESCRIPTION
I discovered that there is another string that is the same as this PR #7638  .
GCS messages are used for OpenTX, smartphone voice messages, warning decisions, and error decisions.
I think blank lines are unnecessary.