### PR TITLE
AP_HAL: fix warning from having undefined HAL_WITH_IO_MCU

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -190,6 +190,10 @@
 #define HAL_WITH_UAVCAN 0
 #endif
 
+#ifndef HAL_WITH_IO_MCU
+#define HAL_WITH_IO_MCU 0
+#endif
+
 // this is used as a general mechanism to make a 'small' build by
 // dropping little used features. We use this to allow us to keep
 // FMUv2 going for as long as possible


### PR DESCRIPTION
In file included from ../../libraries/AP_IOMCU/AP_IOMCU.cpp:8:0:
../../libraries/AP_IOMCU/AP_IOMCU.h:10:5: warning: "HAL_WITH_IO_MCU" is not defined [-Wundef]
 #if HAL_WITH_IO_MCU
     ^
../../libraries/AP_IOMCU/AP_IOMCU.cpp:10:5: warning: "HAL_WITH_IO_MCU" is not defined [-Wundef]
 #if HAL_WITH_IO_MCU
     ^
And so on.