### PR TITLE
Copter: use zero_throttle_and_relax_ac in land

### DIFF
--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -108,16 +108,7 @@ void Copter::ModeLand::nogps_run()
 
     // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
-#if FRAME_CONFIG == HELI_FRAME  // Helicopters always stabilize roll/pitch/yaw
-        // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
-        attitude_control->set_throttle_out(0,false,g.throttle_filt);
-#else
-        motors->set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
-        // multicopters do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
-#endif
-
+        zero_throttle_and_relax_ac();
         // disarm when the landing detector says we've landed
         if (ap.land_complete) {
             _copter.init_disarm_motors();


### PR DESCRIPTION
This is the last patch from #7467 

Note that mode land is currently inconsistent; sometimes we do what all the other modes do - sometimes we don't.

I think we should be consistent in mode_land :-)
