### PR TITLE
AP_AdvancedFailsafe: Report MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION

### DIFF
--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -156,6 +156,9 @@ AP_AdvancedFailsafe::check(uint32_t last_heartbeat_ms, bool geofence_breached, u
     if (!_enable) {
         return;
     }
+    // only set the termination capability, clearing it can mess up copter and sub which can always be terminated
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION);
+
     // we always check for fence breach
     if(_enable_geofence_fs) {
         if (geofence_breached || check_altlimit()) {


### PR DESCRIPTION
Any vehicle that enables AFS is capable of MAVLink flight termination, but only copter and sub were reporting the capability, which left a GCS that was wondering if a connected plane/rover could be terminated unable to tell without requesting parameters.