### PR TITLE
Copter: fix Battery FailSafe action with auto mode

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -62,7 +62,7 @@ void Copter::failsafe_battery_event(void)
                 set_mode_SmartRTL_or_RTL(MODE_REASON_BATTERY_FAILSAFE);
             } else if (g.failsafe_battery_enabled == FS_BATT_SMARTRTL_OR_LAND) {
                 set_mode_SmartRTL_or_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
-            } else if (g.failsafe_battery_enabled == FS_BATT_RTL || control_mode == AUTO) {
+            } else if (g.failsafe_battery_enabled == FS_BATT_RTL) {
                 set_mode_RTL_or_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);
             } else { // g.failsafe_battery_enabled == FS_BATT_LAND
                 set_mode_land_with_pause(MODE_REASON_BATTERY_FAILSAFE);


### PR DESCRIPTION
I noticed that Copter change to RTL when battery failsafe trigger in Auto mode and FS_BATT_ENABLE=1 (Land).
It was confused because the copter was behaving differently from the setting.

So, I changed the following:
in Auto mode
 FS_BATT_ENABLE=1 (Land) -> Land
 FS_BATT_ENABLE=2 (RTL)   -> RTL