### PR TITLE
Rover: boats always navigate when outside waypoint radius

### DIFF
--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -46,14 +46,14 @@ void ModeAuto::update()
         case Auto_WP:
         {
             _distance_to_destination = get_distance(rover.current_loc, _destination);
+            const bool near_wp = _distance_to_destination <= rover.g.waypoint_radius;
             // check if we've reached the destination
-            if (!_reached_destination) {
-                if (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination)) {
-                    // trigger reached
-                    _reached_destination = true;
-                }
+            if (!_reached_destination && (near_wp || location_passed_point(rover.current_loc, _origin, _destination))) {
+                // trigger reached
+                _reached_destination = true;
             }
-            if (!_reached_destination || rover.is_boat()) {
+            // determine if we should keep navigating
+            if (!_reached_destination || (rover.is_boat() && !near_wp)) {
                 // continue driving towards destination
                 calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination, _reversed);
                 calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true);

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -22,15 +22,17 @@ bool ModeRTL::_enter()
 
 void ModeRTL::update()
 {
-    if (!_reached_destination || rover.is_boat()) {
-        // calculate distance to home
-        _distance_to_destination = get_distance(rover.current_loc, _destination);
-        // check if we've reached the destination
-        if (!_reached_destination && (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination))) {
-            // trigger reached
-            _reached_destination = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
-        }
+    // calculate distance to home
+    _distance_to_destination = get_distance(rover.current_loc, _destination);
+    const bool near_wp = _distance_to_destination <= rover.g.waypoint_radius;
+    // check if we've reached the destination
+    if (!_reached_destination && (near_wp || location_passed_point(rover.current_loc, _origin, _destination))) {
+        // trigger reached
+        _reached_destination = true;
+        gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
+    }
+    // determine if we should keep navigating
+    if (!_reached_destination || (rover.is_boat() && !near_wp)) {
         // continue driving towards destination
         calc_steering_to_waypoint(_reached_destination ? rover.current_loc :_origin, _destination);
         calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);


### PR DESCRIPTION
This PR should resolve issue #7645 which was recently brought up during Rover-3.2.1 testing (https://discuss.ardupilot.org/t/actively-loitering-issue-with-rover-3-2/25364).

There's a nice picture in the link above but in short what this change does is mean that Boats (which have FRAME_CLASS = 2) will continue navigating in Auto, Guided and RTL towards the waypoint if they are further than WP_RADIUS meters from it.  This should lead to them reaching the target, turning off their motors and steering, drifting for a bit and then when the drift out of the waypoint radius the motors and steering control will start again.

I am slightly unsure if RTL should do this because it could lead to the motors starting up if a user picks up the boat and walks a couple of meters away from where he/she picked it up without first switching the vehicle to HOLD mode.  Still, I figure it is best to be consistent amongst all the modes and I could add a note to the RTL wiki page.


