### PR TITLE
AP_HAL_Linux: Add Raspberry Pi Zero support 

### DIFF
--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -174,8 +174,8 @@ int Util::read_file(const char *path, const char *fmt, ...)
 }
 
 const char *Linux::Util::_hw_names[UTIL_NUM_HARDWARES] = {
-    [UTIL_HARDWARE_RPI1]   = "BCM2708",
-    [UTIL_HARDWARE_RPI2]   = "BCM2709",
+    [UTIL_HARDWARE_RPI1]   = "BCM2708,BCM2835",
+    [UTIL_HARDWARE_RPI2]   = "BCM2709,BCM2836,BCM2837",
     [UTIL_HARDWARE_BEBOP]  = "Mykonos3 board",
     [UTIL_HARDWARE_BEBOP2] = "Milos board",
     [UTIL_HARDWARE_DISCO]  = "Evinrude board",
@@ -190,15 +190,22 @@ int Util::get_hw_arm32()
         return -errno;
     }
 
+    char hw_names[MAX_SIZE_LINE];
     while (fgets(buffer, MAX_SIZE_LINE, f) != nullptr) {
         if (strstr(buffer, "Hardware") == nullptr) {
             continue;
         }
         for (uint8_t i = 0; i < UTIL_NUM_HARDWARES; i++) {
-            if (strstr(buffer, _hw_names[i]) == nullptr) {
-                continue;
+            strcpy(hw_names, _hw_names[i]);
+            char *hw_name = strtok(hw_names, ",");
+            while (hw_name != NULL) {
+                if (strstr(buffer, hw_name) == nullptr) {
+                    hw_name = strtok(NULL, ",");
+                    continue;
+                }
+                fclose(f);
+                break;
             }
-            fclose(f);
             return i;
         }
     }

--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -37,7 +37,7 @@ int UtilRPI::_check_rpi_version()
         printf("Raspberry Pi 2/3 with BCM2709!\n");
         _rpi_version = 2;
     } else if (hw == UTIL_HARDWARE_RPI1) {
-        printf("Raspberry Pi 1 with BCM2708!\n");
+        printf("Raspberry Pi 0/1 with BCM2708!\n");
         _rpi_version = 1;
     } else {
         /* defaults to RPi version 2/3 */


### PR DESCRIPTION
Using kernel 4.7.79-2 the cpuinfo hardware tag have the processor name.

```
[pi@companion ~]$ cat /proc/cpuinfo
processor	: 0
model name	: ARMv6-compatible processor rev 7 (v6l)
BogoMIPS	: 697.95
Features	: half thumb fastmult vfp edsp java tls 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xb76
CPU revision	: 7

Hardware	: BCM2835
Revision	: 9000c1
Serial		: 0000000050f9d54a
```
This patch allows multiple string checks per boards