### PR TITLE
Update Vagrantfile and init script to work with newest version of Ubuntu

### DIFF
--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -2,6 +2,8 @@
 
 # this script is run by the root user in the virtual machine
 
+resize2fs /dev/sda1
+
 set -e
 set -x
 
@@ -13,7 +15,7 @@ PYTHON_PKGS="pymavlink MAVProxy droneapi future pexpect"
 PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
           zip genromfs cmake"
-UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.9-base:i386 libstdc++5:i386 libstdc++6:i386"
+UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.8-base:i386 libstdc++5:i386 libstdc++6:i386"
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)
@@ -25,13 +27,13 @@ ARM_HF_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # Ardupilot Tools
 ARDUPILOT_TOOLS="ardupilot/Tools/autotest"
 
-VAGRANT_USER=ubuntu
+VAGRANT_USER=vagrant
 
 usermod -a -G dialout $VAGRANT_USER
 
 apt-get -y remove modemmanager
 apt-get -y update
-apt-get -y install dos2unix g++-4.7 ccache python-lxml screen xterm gdb pkgconf
+apt-get -y install dos2unix g++-4.8 ccache python-lxml screen xterm gdb pkgconf
 apt-get -y install $BASE_PKGS $SITL_PKGS $PX4_PKGS $UBUNTU64_PKGS $ARM_HF_PKGS
 pip -q install $PYTHON_PKGS
 easy_install catkin_pkg

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/zesty32"
+  config.vm.box = "ubuntu/artful32"
   # push.app = "geeksville/ardupilot-sitl"
 
   # The following forwarding is not necessary (or possible), because our sim_vehicle.py is smart enough to send packets
@@ -18,6 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb|
+      vb.name = "ardupilot"
       # Don't boot with headless mode
       #   vb.gui = true
       #


### PR DESCRIPTION
The Zesty build no longer works. This commit is a tested and working version of the Vagrant simulator running on Artful, the latest stable version of Ubuntu.

- Some of the libraries have changed around that are no longer available in Artful, so I updated them until they worked (as close to the old versions as possible). I had to go down with gcc, as 4.9 isn't available for Artful for some reason. There is also a weird bug with the filesystem that made the main VM disk way too small, addressed with `resize2fs /dev/sda1`.
- The user changed from `ubuntu` to `vagrant`, which is standard Vagrant practice anyway.
- As a bonus, I made it so the name of the VM in virtualbox is identified as Ardupilot.

![ardupilot](https://user-images.githubusercontent.com/6226188/36058314-1b404ac4-0dda-11e8-91f9-5d43efd683ce.PNG)

