### PR TITLE
Vagrant issues

### DIFF
--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -40,7 +40,7 @@ easy_install catkin_pkg
 # ARM toolchain
 if [ ! -d /opt/$ARM_ROOT ]; then
     (
-        sudo -u $VAGRANT_USER wget -nv $ARM_TARBALL_URL
+        wget -nv $ARM_TARBALL_URL
         pushd /opt
         tar xjf ${OLDPWD}/${ARM_TARBALL}
         popd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/zesty32"
+  config.vm.box = "ubuntu/xenial32"
   # push.app = "geeksville/ardupilot-sitl"
 
   # The following forwarding is not necessary (or possible), because our sim_vehicle.py is smart enough to send packets


### PR DESCRIPTION
Some issues were corrected for the VM:

1. Zesty32 is no longer available on http://archive.ubuntu.com/ubuntu/dists/.
2. On initvagrant.sh "wget" was called with sudo and it stopped the execution of the script