### PR TITLE
AP_HAL_ChibiOS: add #ifdef around toneAlarm thread stack declaration

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -37,7 +37,9 @@ using namespace ChibiOS;
 extern const AP_HAL::HAL& hal;
 THD_WORKING_AREA(_timer_thread_wa, 2048);
 THD_WORKING_AREA(_rcin_thread_wa, 512);
+#ifdef HAL_PWM_ALARM
 THD_WORKING_AREA(_toneAlarm_thread_wa, 512);
+#endif
 THD_WORKING_AREA(_io_thread_wa, 2048);
 THD_WORKING_AREA(_storage_thread_wa, 2048);
 #if HAL_WITH_UAVCAN


### PR DESCRIPTION
don't allocate space for stack if ALARM pin is not defined in hwdef.dat