### PR TITLE
AP_GPS: Change GPS switching conditions with dual GPS.

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -717,7 +717,7 @@ void AP_GPS::update(void)
 
                     bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
 
-                    if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
+                    if (state[i].status >= state[primary_instance].status && another_gps_has_1_or_more_sats) {
 
                         bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
 


### PR DESCRIPTION
GPS status is enum value.
For GPS positioning accuracy, the enum value should be large.
When converting GPS to primary, I think that it is better to have status than the status.
===
     /// GPS status codes
     enum GPS_Status {
         NO_GPS = GPS_FIX_TYPE_NO_GPS, /// <No GPS connected / detected
         NO_FIX = GPS_FIX_TYPE_NO_FIX, /// <Receiving valid GPS messages but no lock
         GPS_OK_FIX_ 2 D = GPS_FIX_TYPE_ 2 D_FIX, /// <Receiving valid messages and 2 D lock
         GPS_OK_FIX_ 3 D = GPS_FIX_TYPE_ 3 D_FIX, /// <Receiving valid messages and 3D lock
         GPS_OK_FIX_3D_DGPS = GPS_FIX_TYPE_DGPS, /// <Receiving valid messages and 3D lock with a differential improvementments
         GPS_OK_FIX_3D_RTK_FLOAT = GPS_FIX_TYPE_RTK_FLOAT, /// <Receiving valid messages and 3D RTK Float
         GPS_OK_FIX_3D_RTK_FIXED = GPS_FIX_TYPE_RTK_FIXED, /// <Receiving valid messages and 3D RTK Fixed
     };

＝＝＝
typedef enum GPS_FIX_TYPE
{
   GPS_FIX_TYPE_NO_GPS=0, /* No GPS connected | */
   GPS_FIX_TYPE_NO_FIX=1, /* No position information, GPS is connected | */
   GPS_FIX_TYPE_2D_FIX=2, /* 2D position | */
   GPS_FIX_TYPE_3D_FIX=3, /* 3D position | */
   GPS_FIX_TYPE_DGPS=4, /* DGPS/SBAS aided 3D position | */
   GPS_FIX_TYPE_RTK_FLOAT=5, /* RTK float, 3D position | */
   GPS_FIX_TYPE_RTK_FIXED=6, /* RTK Fixed, 3D position | */
   GPS_FIX_TYPE_STATIC=7, /* Static fixed, typically used for base stations | */
   GPS_FIX_TYPE_PPP=8, /* PPP, 3D position. | */
   GPS_FIX_TYPE_ENUM_END=9, /*  | */
} GPS_FIX_TYPE;