### PR TITLE
AP_HAL_Linux : PPM support for the Intel Aero board

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -27,6 +27,7 @@
 #include "RCInput_RPI.h"
 #include "RCInput_SBUS.h"
 #include "RCInput_SoloLink.h"
+#include "RCInput_Aero.h"
 #include "RCInput_UART.h"
 #include "RCInput_UDP.h"
 #include "RCInput_115200.h"
@@ -158,7 +159,7 @@ static RCInput_DSM rcinDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
 static RCInput_Multi rcinDriver{2, new RCInput_SBUS, new RCInput_115200("/dev/uart-sumd")};
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
-static RCInput_SoloLink rcinDriver;
+static RCInput_Aero rcinDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2 || \
       CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE
 static RCInput_Navio2 rcinDriver;

--- a/libraries/AP_HAL_Linux/RCInput_Aero.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Aero.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/* feature added by Anemos Technologies : Philippe Crochat (pcrochat@anemos-technologies.com) */
+
+#include "RCInput_Aero.h"
+#include <stdio.h>
+
+#include <utility>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/sparse-endian.h>
+
+using namespace Linux;
+
+#define DEBUG 1
+
+#if DEBUG
+#define debug(fmt, args...) ::printf(fmt "\n", ##args)
+#else
+#define debug(fmt, args...)
+#endif
+
+static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+
+RCInput_Aero::RCInput_Aero()
+{
+	
+}
+
+void RCInput_Aero::init()
+{
+	const uint8_t tx_buffer[2]={CLOCK_REG, 0x00};
+	uint8_t rx_buffer[2];
+	
+	_spi = hal.spi->get_device(DEVICE_NAME);
+	
+	if (!_spi) {
+        AP_HAL::panic("Could not initialize Aero RCInput");
+    }
+	
+    if (!_spi->transfer_fullduplex(tx_buffer, rx_buffer, 2)) {
+    	AP_HAL::panic("Could not get FPGA frequency");
+    }
+    
+    _frequency=(uint8_t)rx_buffer[1];
+    
+    if (!_frequency) {
+    	AP_HAL::panic("Aero RCInput : Panic no valid FPGA frequency read for device name");
+    }
+}
+
+void RCInput_Aero::_timer_tick(void)
+{
+	uint8_t i;
+	const uint8_t buffer_size=CHANNEL_NUMBER*2+1;
+	
+	uint16_t channels[CHANNEL_NUMBER];
+	uint8_t tx_buffer[buffer_size];
+	uint8_t rx_buffer[buffer_size];
+	
+	bool good_value;
+	int8_t retry=-1;
+	
+	do {
+		good_value=true;
+		for(i=1;i<buffer_size;i++) {
+			tx_buffer[i]=0x00;
+		}
+		
+		tx_buffer[0]=CHANNEL_REG;
+		
+		if (!_spi->transfer_fullduplex(tx_buffer, rx_buffer, buffer_size)) {
+			printf("Could not get rc input value\n");
+		}
+		
+		for(i=0;i<CHANNEL_NUMBER;i++) {
+			channels[i] = ((rx_buffer[(i<<1)+1]<<8) + rx_buffer[(i<<1)+2])/_frequency; //converts counter result into microseconds
+			
+			if (channels[i]<CHANNEL_MIN_VALUE || channels[i]>CHANNEL_MAX_VALUE) {
+				good_value=false;
+			}
+		}
+		
+		retry++;
+	} while(good_value==false && retry<MAX_RETRY);
+    
+    
+    if (good_value==true) {
+    	for(i=0;i<CHANNEL_NUMBER;i++) {
+    		if (abs(channels[i]-_old_channels[i]) > MAX_DIFF_VALUE) {
+    			printf("\nOC C NC : %d	%d	%d\n", _old_channels[i], channels[i], (uint16_t) (COMPLEMENTARY_FILTER*(float)channels[i] + (1.0-COMPLEMENTARY_FILTER)*(float)_old_channels[i]));
+    			channels[i] = (uint16_t) (COMPLEMENTARY_FILTER*(float)_old_channels[i] + (1.0-COMPLEMENTARY_FILTER)*(float)channels[i]);
+    		}
+    		
+    		_old_channels[i]=channels[i];
+    	}
+    	
+    	_update_periods(channels, CHANNEL_NUMBER);
+    } else {
+    	_update_periods(_old_channels, CHANNEL_NUMBER);
+    }
+}
+
+uint16_t RCInput_Aero::_hw_read(uint16_t address)
+{
+    struct PACKED {
+        uint8_t prefix;
+        be16_t addr;
+    } tx;
+    struct PACKED {
+        uint8_t ignored[2];
+        be16_t val;
+    } rx;
+
+    address = RADDRESS(address);
+
+    // Write in the SPI buffer the address value
+    tx.prefix = WRITE_PREFIX;
+    tx.addr = htobe16(address);
+    if (!_spi->transfer((uint8_t *)&tx, sizeof(tx), nullptr, 0)) {
+        return 0;
+    }
+
+    return be16toh(rx.val);
+}

--- a/libraries/AP_HAL_Linux/RCInput_Aero.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Aero.cpp
@@ -27,7 +27,17 @@
 
 using namespace Linux;
 
-#define DEBUG 1
+#define DEBUG 0
+
+#define DEVICE_NAME "aeroio"
+
+#define CHANNEL_MIN_VALUE 970
+#define CHANNEL_MAX_VALUE 2000
+#define MAX_DIFF_VALUE 300
+#define MAX_RETRY 10
+#define CLOCK_REG 0x4a
+#define CHANNEL_REG 0x4b
+#define COMPLEMENTARY_FILTER 0.93
 
 #if DEBUG
 #define debug(fmt, args...) ::printf(fmt "\n", ##args)
@@ -43,8 +53,10 @@ RCInput_Aero::RCInput_Aero()
 	
 }
 
+//initialize Aero RC Input 
 void RCInput_Aero::init()
 {
+	//get the clock speed of the FPGA in MHz
 	const uint8_t tx_buffer[2]={CLOCK_REG, 0x00};
 	uint8_t rx_buffer[2];
 	
@@ -54,9 +66,15 @@ void RCInput_Aero::init()
         AP_HAL::panic("Could not initialize Aero RCInput");
     }
 	
+    if (!_spi->get_semaphore()->take_nonblocking()) {
+        return;
+    }
+    
     if (!_spi->transfer_fullduplex(tx_buffer, rx_buffer, 2)) {
     	AP_HAL::panic("Could not get FPGA frequency");
     }
+    
+    _spi->get_semaphore()->give();
     
     _frequency=(uint8_t)rx_buffer[1];
     
@@ -65,6 +83,8 @@ void RCInput_Aero::init()
     }
 }
 
+
+//reads all channels in a raw from the SPI bus
 void RCInput_Aero::_timer_tick(void)
 {
 	uint8_t i;
@@ -77,13 +97,17 @@ void RCInput_Aero::_timer_tick(void)
 	bool good_value;
 	int8_t retry=-1;
 	
+	if (!_spi->get_semaphore()->take_nonblocking()) {
+        return;
+    }
+	
 	do {
 		good_value=true;
 		for(i=1;i<buffer_size;i++) {
 			tx_buffer[i]=0x00;
 		}
 		
-		tx_buffer[0]=CHANNEL_REG;
+		tx_buffer[0]=CHANNEL_REG; //first CHANNEL SPI reg address
 		
 		if (!_spi->transfer_fullduplex(tx_buffer, rx_buffer, buffer_size)) {
 			printf("Could not get rc input value\n");
@@ -100,11 +124,11 @@ void RCInput_Aero::_timer_tick(void)
 		retry++;
 	} while(good_value==false && retry<MAX_RETRY);
     
-    
+    _spi->get_semaphore()->give();
+	
     if (good_value==true) {
     	for(i=0;i<CHANNEL_NUMBER;i++) {
     		if (abs(channels[i]-_old_channels[i]) > MAX_DIFF_VALUE) {
-    			printf("\nOC C NC : %d	%d	%d\n", _old_channels[i], channels[i], (uint16_t) (COMPLEMENTARY_FILTER*(float)channels[i] + (1.0-COMPLEMENTARY_FILTER)*(float)_old_channels[i]));
     			channels[i] = (uint16_t) (COMPLEMENTARY_FILTER*(float)_old_channels[i] + (1.0-COMPLEMENTARY_FILTER)*(float)channels[i]);
     		}
     		
@@ -112,30 +136,5 @@ void RCInput_Aero::_timer_tick(void)
     	}
     	
     	_update_periods(channels, CHANNEL_NUMBER);
-    } else {
-    	_update_periods(_old_channels, CHANNEL_NUMBER);
     }
-}
-
-uint16_t RCInput_Aero::_hw_read(uint16_t address)
-{
-    struct PACKED {
-        uint8_t prefix;
-        be16_t addr;
-    } tx;
-    struct PACKED {
-        uint8_t ignored[2];
-        be16_t val;
-    } rx;
-
-    address = RADDRESS(address);
-
-    // Write in the SPI buffer the address value
-    tx.prefix = WRITE_PREFIX;
-    tx.addr = htobe16(address);
-    if (!_spi->transfer((uint8_t *)&tx, sizeof(tx), nullptr, 0)) {
-        return 0;
-    }
-
-    return be16toh(rx.val);
 }

--- a/libraries/AP_HAL_Linux/RCInput_Aero.h
+++ b/libraries/AP_HAL_Linux/RCInput_Aero.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/* feature added by Anemos Technologies : Philippe Crochat (pcrochat@anemos-technologies.com) */
+
+#pragma once
+
+#define DEVICE_NAME "aeroio"
+#define CHANNEL_NUMBER 8
+
+#define CHANNEL_MIN_VALUE 970
+#define CHANNEL_MAX_VALUE 2000
+#define MAX_DIFF_VALUE 300
+#define MAX_RETRY 10
+#define CLOCK_REG 0x4a
+#define CHANNEL_REG 0x4b
+#define COMPLEMENTARY_FILTER 0.93
+
+#define RADDRESS(x) ((x) & 0x7FFF)
+
+// Variables to perform ongoing tests
+#define READ_PREFIX 0x80
+#define WRITE_PREFIX 0x40
+
+#include <unistd.h>
+#include "AP_HAL_Linux.h"
+
+#include "RCInput.h"
+
+namespace Linux {
+
+class RCInput_Aero : public RCInput
+{
+public:
+    RCInput_Aero();
+
+    void init();
+    void _timer_tick();
+
+private:
+	AP_HAL::OwnPtr<AP_HAL::SPIDevice> _spi;
+	uint8_t _frequency;
+	uint16_t _hw_read(uint16_t address);
+	uint16_t _old_channels[CHANNEL_NUMBER];
+};
+
+}

--- a/libraries/AP_HAL_Linux/RCInput_Aero.h
+++ b/libraries/AP_HAL_Linux/RCInput_Aero.h
@@ -19,18 +19,8 @@
 
 #pragma once
 
-#define DEVICE_NAME "aeroio"
-#define CHANNEL_NUMBER 8
-
-#define CHANNEL_MIN_VALUE 970
-#define CHANNEL_MAX_VALUE 2000
-#define MAX_DIFF_VALUE 300
-#define MAX_RETRY 10
-#define CLOCK_REG 0x4a
-#define CHANNEL_REG 0x4b
-#define COMPLEMENTARY_FILTER 0.93
-
 #define RADDRESS(x) ((x) & 0x7FFF)
+#define CHANNEL_NUMBER 8
 
 // Variables to perform ongoing tests
 #define READ_PREFIX 0x80
@@ -43,6 +33,7 @@
 
 namespace Linux {
 
+	
 class RCInput_Aero : public RCInput
 {
 public:
@@ -54,7 +45,6 @@ public:
 private:
 	AP_HAL::OwnPtr<AP_HAL::SPIDevice> _spi;
 	uint8_t _frequency;
-	uint16_t _hw_read(uint16_t address);
 	uint16_t _old_channels[CHANNEL_NUMBER];
 };
 

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -125,7 +125,7 @@ SPIDesc SPIDeviceManager::_device[] = {
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
 SPIDesc SPIDeviceManager::_device[] = {
-    SPIDesc("aeroio", 1, 1, SPI_MODE_0, 8, SPI_CS_KERNEL,  10*MHZ, 10*MHZ),
+    SPIDesc("aeroio", 1, 1, SPI_MODE_0, 8, SPI_CS_KERNEL,  4*MHZ, 4*MHZ),
     SPIDesc("bmi160", 3, 0, SPI_MODE_3, 8, SPI_CS_KERNEL, 1*MHZ, 10*MHZ),
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE


### PR DESCRIPTION
we change the default RC input to PPM for the intel Aero board, former rcinput was the 3dr solo input which is pretty useless for the common need.
PPM values are read with the spi bus from the embedded FPGA