### PR TITLE
DataFlash: tighten types up to save flash space

### DIFF
--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -339,7 +339,7 @@ private:
     // possibly expensive calls to start log system:
     void Prep();
 
-    bool _writes_enabled;
+    bool _writes_enabled:1;
 
     /* support for retrieving logs via mavlink: */
     uint8_t  _log_listing:1; // sending log list

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -60,7 +60,7 @@ struct PACKED log_Format_Units {
 
 struct UnitStructure {
     const char ID;
-    const char unit[64];
+    const char *unit;
 };
 
 struct MultiplierStructure {
@@ -113,9 +113,9 @@ const struct UnitStructure log_Units[] = {
 // tl;dr a GCS shouldn't/mustn't infer any scaling from the unit name
 
 const struct MultiplierStructure log_Multipliers[] = {
-// <leave a gap here, just in case....>
     { '-', 0 },       // no multiplier e.g. a string
     { '?', 1 },       // multipliers which haven't been worked out yet....
+// <leave a gap here, just in case....>
     { '2', 1e2 },
     { '1', 1e1 },
     { '0', 1e0 },


### PR DESCRIPTION
Saves about 1,500 bytes!

Also, move a comment into correct position.
