### PR TITLE
DataFlash: use const char * rather than fixed array lengths in LogStructure

### DIFF
--- a/libraries/DataFlash/DataFlash_Backend.cpp
+++ b/libraries/DataFlash/DataFlash_Backend.cpp
@@ -146,15 +146,20 @@ void DataFlash_Backend::WriteMoreStartupMessages()
 bool DataFlash_Backend::Log_Write_Emit_FMT(uint8_t msg_type)
 {
     // get log structure from front end:
+    char ls_name[LS_NAME_SIZE] = {};
+    char ls_format[LS_FORMAT_SIZE] = {};
+    char ls_labels[LS_LABELS_SIZE] = {};
+    char ls_units[LS_UNITS_SIZE] = {};
+    char ls_multipliers[LS_MULTIPLIERS_SIZE] = {};
     struct LogStructure logstruct = {
         // these will be overwritten, but need to keep the compiler happy:
         0,
         0,
-        "IGNO",
-        "",
-        "",
-        "",
-        ""
+        ls_name,
+        ls_format,
+        ls_labels,
+        ls_units,
+        ls_multipliers
     };
     if (!_front.fill_log_write_logstructure(logstruct, msg_type)) {
         // this is a bug; we've been asked to write out the FMT

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -17,12 +17,19 @@
 struct LogStructure {
     uint8_t msg_type;
     uint8_t msg_len;
-    const char name[5];
-    const char format[16];
-    const char labels[64];
-    const char units[16];
-    const char multipliers[16];
+    const char *name;
+    const char *format;
+    const char *labels;
+    const char *units;
+    const char *multipliers;
 };
+
+// maximum lengths of fields in LogStructure, including trailing nulls
+static const uint8_t LS_NAME_SIZE = 5;
+static const uint8_t LS_FORMAT_SIZE = 17;
+static const uint8_t LS_LABELS_SIZE = 65;
+static const uint8_t LS_UNITS_SIZE = 17;
+static const uint8_t LS_MULTIPLIERS_SIZE = 17;
 
 /*
   log structures common to all vehicle types


### PR DESCRIPTION

Previously tridge found that using const char * here meant that the
data segment (and thus RAM usage) would increase.

This doesn't seem to be a problem now.
