### PR TITLE
Copter: default allow RC_Override

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -313,7 +313,7 @@ private:
             uint8_t in_arming_delay         : 1; // 24      // true while we are armed but waiting to spin motors
             uint8_t initialised_params      : 1; // 25      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
             uint8_t compass_init_location   : 1; // 26      // true when the compass's initial location has been set
-            uint8_t rc_override_enable      : 1; // 27      // aux switch rc_override is allowed
+            uint8_t rc_override_disable     : 1; // 27      // aux switch rc_override is allowed
         };
         uint32_t value;
     } ap_t;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -755,7 +755,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         // or for complete GCS control of switch position
         // and RC PWM values.
         if(msg->sysid != copter.g.sysid_my_gcs) break;                         // Only accept control from our gcs
-        if (!copter.ap.rc_override_enable) {
+        if (copter.ap.rc_override_disable) {
             if (copter.failsafe.rc_override_active) {  // if overrides were active previously, disable them
                 copter.failsafe.rc_override_active = false;
                 hal.rcin->clear_overrides();

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -74,7 +74,7 @@ enum aux_sw_func {
     AUXSW_INVERTED  =           43,  // enable inverted flight
     AUXSW_WINCH_ENABLE =        44, // winch enable/disable
     AUXSW_WINCH_CONTROL =       45, // winch control
-    AUXSW_RC_OVERRIDE_ENABLE =  46, // enable RC Override
+    AUXSW_RC_OVERRIDE_DISABLE = 46, // disable RC Override
     AUXSW_SWITCH_MAX,
 };
 

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -203,7 +203,7 @@ void Copter::init_aux_switch_function(int8_t ch_option, uint8_t ch_flag)
         case AUXSW_AVOID_PROXIMITY:
         case AUXSW_INVERTED:
         case AUXSW_WINCH_ENABLE:
-        case AUXSW_RC_OVERRIDE_ENABLE:
+        case AUXSW_RC_OVERRIDE_DISABLE:
             do_aux_switch_function(ch_option, ch_flag);
             break;
     }
@@ -670,15 +670,15 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
 #endif
             break;
 
-        case AUXSW_RC_OVERRIDE_ENABLE:
+        case AUXSW_RC_OVERRIDE_DISABLE:
             // Allow or disallow RC_Override
             switch (ch_flag) {
                 case AUX_SWITCH_HIGH: {
-                    ap.rc_override_enable = true;
+                    ap.rc_override_disable = false;
                     break;
                 }
                 case AUX_SWITCH_LOW: {
-                    ap.rc_override_enable = false;
+                    ap.rc_override_disable = true;
                     break;
                 }
             }


### PR DESCRIPTION
#7597 add rc_override_enable and it is default 0. It makes user need to assign a aux switch to enable rc oveerride. It makes joystick flight not possible for copters with no RC (for example, parrot bebop)