### PR TITLE
Tools: ardupilotwaf: disable SLP vectorization for clang++ in SITL

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -247,6 +247,12 @@ class sitl(Board):
                 'winmm',
             ]
 
+
+        if 'clang++' in cfg.env.COMPILER_CXX:
+            print("Disabling SLP for clang++")
+            env.CXXFLAGS += [
+                '-fno-slp-vectorize' # compiler bug when trying to use SLP
+            ]
 class chibios(Board):
     toolchain = 'arm-none-eabi'
 


### PR DESCRIPTION
There appears to be a problem caused by clang++'s optimisations to do
with SLP vectorizations.

It *looks* like it doesn't push enough operands into one of the vectors,
so you end up with a division by zero when attempting to execute an SSE
instruction.