### PR TITLE
Fix clang++ compiler warnings

### DIFF
--- a/libraries/AP_ADC/AP_ADC_ADS1115.h
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.h
@@ -31,7 +31,6 @@ private:
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 
-    uint32_t            _last_update_timestamp;
     uint16_t            _gain;
     int                 _channel_to_read;
     adc_report_s        *_samples;

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.h
@@ -54,8 +54,6 @@ private:
 
     float _temp;
     float _press;
-    float _temperature;
-    float _pressure;
     uint16_t _temp_count;
     uint16_t _press_count;
     float _temp_sum;

--- a/libraries/AP_Compass/AP_Compass_MAG3110.h
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.h
@@ -49,5 +49,4 @@ private:
 
     uint8_t _compass_instance;
     bool _initialised;
-    float compass_len;
 };

--- a/libraries/AP_Compass/Compass_PerMotor.h
+++ b/libraries/AP_Compass/Compass_PerMotor.h
@@ -53,9 +53,6 @@ private:
     // battery voltage
     float voltage;
 
-    // what rcout channel is being calibrated
-    uint8_t channel;
-
     // is calibration running?
     bool running;
 

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -72,7 +72,6 @@ private:
     const char* _port_enable = "\nSSSSSSSSSS\n";
    
     uint32_t crc_error_counter = 0;
-    uint32_t last_injected_data_ms = 0;
     uint32_t RxState;
     uint32_t RxError;
 
@@ -207,5 +206,5 @@ private:
         CPUOVERLOAD   = (1 << 9),
         INVALIDCONFIG = (1 << 10),
         OUTOFGEOFENCE = (1 << 11),
-    } RxError_bits;
+    };
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -105,8 +105,6 @@ private:
     uint8_t _gyro_instance;
     uint8_t _accel_instance;
 
-    uint16_t _error_count;
-
     float temp_sensitivity = 1.0/340; // degC/LSB
     float temp_zero = 36.53; // degC
     

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -42,7 +42,6 @@ public:
         _ekf(ahrs),
         _ahrs(ahrs),
         _state(GIMBAL_STATE_NOT_PRESENT),
-        _yaw_rate_ff_ef_filt(0.0f),
         _vehicle_yaw_rate_ef_filt(0.0f),
         _vehicle_to_gimbal_quat(),
         _vehicle_to_gimbal_quat_filt(),
@@ -119,7 +118,6 @@ private:
         Vector3f joint_angles;
     } _measurement;
 
-    float _yaw_rate_ff_ef_filt;
     float _vehicle_yaw_rate_ef_filt;
 
     static const uint8_t _compid = MAV_COMP_ID_GIMBAL;
@@ -136,8 +134,6 @@ private:
     float _max_torque;
 
     float _ang_vel_mag_filt;
-
-    mavlink_channel_t _chan;
 
     Vector3f    _ang_vel_dem_rads;       // rad/s
     Vector3f    _att_target_euler_rad;   // desired earth-frame roll, tilt and pan angles in radians

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -309,11 +309,14 @@ void AP_OpticalFlow_Pixart::timer(void)
     }
     
 #if 0
+    static uint32_t last_print_ms;
     static int fd = -1;
     if (fd == -1) {
         fd = open("/dev/ttyACM0", O_WRONLY);
     }
     // used for debugging
+    static int32_t sum_x;
+    static int32_t sum_y;
     sum_x += burst.delta_x;
     sum_y += burst.delta_y;
     

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
@@ -72,9 +72,6 @@ private:
     void timer(void);
     void motion_burst(void);
 
-    int32_t sum_x;
-    int32_t sum_y;
-    uint32_t last_print_ms;
     uint32_t last_burst_us;
     uint32_t last_update_ms;
 };

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -85,15 +85,10 @@ private:
     char _rp_systeminfo[63];
     bool _descriptor_data;
     bool _information_data;
-    bool _payload_data;
     bool _resetted;
     bool _initialised;
-    bool _skip;
-    bool _rp_reset;
     bool _sector_initialised;
 
-    uint8_t _element_len[2];
-    uint8_t _element_num;
     uint8_t _payload_length;
     uint8_t _cnt;
     uint8_t _sync_error ;

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -131,8 +131,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
 SoaringController::SoaringController(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, const AP_Vehicle::FixedWing &parms) :
     _ahrs(ahrs),
     _spdHgt(spdHgt),
-    _aparm(parms),
-    _vario(ahrs,spdHgt,parms),
+    _vario(ahrs,parms),
     _loiter_rad(parms.loiter_radius),
     _throttle_suppressed(true)
 {

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -29,7 +29,6 @@ class SoaringController {
     ExtendedKalmanFilter _ekf{};
     AP_AHRS &_ahrs;
     AP_SpdHgtControl &_spdHgt;
-    const AP_Vehicle::FixedWing &_aparm;
     Variometer _vario;
 
     // store aircraft location at last update

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -4,9 +4,8 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 */
 #include "Variometer.h"
 
-Variometer::Variometer(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, const AP_Vehicle::FixedWing &parms) :
+Variometer::Variometer(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms) :
     _ahrs(ahrs),
-    _spdHgt(spdHgt),
     _aparm(parms),
     new_data(false)
 {

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -17,7 +17,6 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 class Variometer {
 
     AP_AHRS &_ahrs;
-    AP_SpdHgtControl &_spdHgt;
     const AP_Vehicle::FixedWing &_aparm;
 
     // store time of last update
@@ -31,7 +30,7 @@ class Variometer {
     float _last_total_E;
 
 public:
-    Variometer(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, const AP_Vehicle::FixedWing &parms);
+    Variometer(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms);
     float alt;
     float reading;
     float filtered_reading;

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -27,8 +27,7 @@ namespace SITL {
 
 SITL *_sitl;
 
-ADSB::ADSB(const struct sitl_fdm &_fdm, const char *_home_str) :
-    fdm(_fdm)
+ADSB::ADSB(const struct sitl_fdm &_fdm, const char *_home_str)
 {
     float yaw_degrees;
     Aircraft::parse_home(_home_str, home, yaw_degrees);

--- a/libraries/SITL/SIM_ADSB.h
+++ b/libraries/SITL/SIM_ADSB.h
@@ -46,7 +46,6 @@ public:
     void update(void);
 
 private:
-    const struct sitl_fdm &fdm;
     const char *target_address = "127.0.0.1";
     const uint16_t target_port = 5762;
 

--- a/libraries/SITL/SIM_Gripper_Servo.h
+++ b/libraries/SITL/SIM_Gripper_Servo.h
@@ -53,7 +53,6 @@ private:
     uint64_t last_update_us;
 
     bool should_report();
-    bool zero_report_done = false;
 
     // dangle load from a string:
     const float string_length = 2.0f; // metres

--- a/libraries/SITL/SIM_Sprayer.h
+++ b/libraries/SITL/SIM_Sprayer.h
@@ -52,7 +52,6 @@ private:
 
     double capacity = 0.25; // litres
 
-    uint64_t start_time_us;
     uint64_t last_update_us;
 
     bool should_report();

--- a/libraries/SITL/SIM_last_letter.cpp
+++ b/libraries/SITL/SIM_last_letter.cpp
@@ -32,8 +32,7 @@ namespace SITL {
 last_letter::last_letter(const char *home_str, const char *_frame_str) :
     Aircraft(home_str, _frame_str),
     last_timestamp_us(0),
-    sock(true),
-    frame_str(_frame_str)
+    sock(true)
 {
     // try to bind to a specific port so that if we restart ArduPilot
     // last_letter keeps sending us packets. Not strictly necessary but

--- a/libraries/SITL/SIM_last_letter.h
+++ b/libraries/SITL/SIM_last_letter.h
@@ -70,8 +70,6 @@ private:
 
     uint64_t last_timestamp_us;
     SocketAPM sock;
-
-    const char *frame_str;
 };
 
 } // namespace SITL


### PR DESCRIPTION
./Tools/autotest/sim_vehicle.py --waf-configure-arg="--check-cxx-compiler=clang++ --check-c-compiler=clang" -v ArduCopter --gdb --debug  -v ArduPlane

This incorporates a fix to compiler flags for clang++.

Most contentious thing here is doing as the compiler suggests and using `std::abs(...)`
