### PR TITLE
SITL: move sprayer and grippers in Aircraft, disable them by default

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -278,7 +278,7 @@ void SITL_State::_output_to_flightgear(void)
  */
 void SITL_State::_fdm_input_local(void)
 {
-    SITL::Aircraft::sitl_input input;
+    SITL::SITL::sitl_input input;
 
     // check for direct RC input
     _check_rc_input();
@@ -336,7 +336,7 @@ void SITL_State::_fdm_input_local(void)
 /*
   create sitl_input structure for sending to FDM
  */
-void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
+void SITL_State::_simulator_servos(SITL::SITL::sitl_input &input)
 {
     static uint32_t last_update_usec;
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -134,7 +134,7 @@ private:
     void _check_rc_input(void);
     void _fdm_input_local(void);
     void _output_to_flightgear(void);
-    void _simulator_servos(SITL::Aircraft::sitl_input &input);
+    void _simulator_servos(SITL::SITL::sitl_input &input);
     void _simulator_output(bool synthetic_clock_mode);
     uint16_t _airspeed_sensor(float airspeed);
     uint16_t _ground_sonar();

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -84,7 +84,6 @@ Aircraft::Aircraft(const char *home_str, const char *frame_str) :
     // allow for orientation settings, such as with tailsitters
     enum ap_var_type ptype;
     ahrs_orientation = (AP_Int8 *)AP_Param::find("AHRS_ORIENTATION", &ptype);
-
     terrain = reinterpret_cast<AP_Terrain *>(AP_Param::find_object("TERRAIN_"));
 }
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -748,8 +748,9 @@ void Aircraft::update_external_payload(const struct SITL::sitl_input &input)
 
     // update gripper
     if (sitl->gripper_sim.is_enable()) {
+        sitl->gripper_sim.set_alt(hagl());
         sitl->gripper_sim.update(input);
-        external_payload_mass += sitl->gripper_sim.payload_mass(hagl());
+        external_payload_mass += sitl->gripper_sim.payload_mass();
     }
     if (sitl->gripper_epm_sim.is_enable()) {
         sitl->gripper_epm_sim.update(input);

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -739,4 +739,20 @@ void Aircraft::extrapolate_sensors(float delta_time)
 void Aircraft::update_external_payload(const struct SITL::sitl_input &input)
 {
     external_payload_mass = 0;
+
+    // update sprayer
+    if (sitl->sprayer_sim.is_enable()) {
+        sitl->sprayer_sim.update(input);
+        external_payload_mass += sitl->sprayer_sim.payload_mass();
+    }
+
+    // update gripper
+    if (sitl->gripper_sim.is_enable()) {
+        sitl->gripper_sim.update(input);
+        external_payload_mass += sitl->gripper_sim.payload_mass(hagl());
+    }
+    if (sitl->gripper_epm_sim.is_enable()) {
+        sitl->gripper_epm_sim.update(input);
+        // external_payload_mass += gripper_epm.payload_mass();
+    }
 }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -736,3 +736,8 @@ void Aircraft::extrapolate_sensors(float delta_time)
     velocity_air_ef = velocity_ef + wind_ef;
     velocity_air_bf = dcm.transposed() * velocity_air_ef;
 }
+
+void Aircraft::update_external_payload(const struct SITL::sitl_input &input)
+{
+    external_payload_mass = 0;
+}

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -576,7 +576,7 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 /*
   update wind vector
 */
-void Aircraft::update_wind(const struct sitl_input &input)
+void Aircraft::update_wind(const struct SITL::sitl_input &input)
 {
     // wind vector in earth frame
     wind_ef = Vector3f(cosf(radians(input.wind.direction))*cosf(radians(input.wind.dir_z)), 
@@ -701,7 +701,7 @@ float Aircraft::filtered_idx(float v, uint8_t idx)
   return a filtered servo input as a value from -1 to 1
   servo is assumed to be 1000 to 2000, trim at 1500
  */
-float Aircraft::filtered_servo_angle(const struct sitl_input &input, uint8_t idx)
+float Aircraft::filtered_servo_angle(const struct SITL::sitl_input &input, uint8_t idx)
 {
     const float v = (input.servos[idx] - 1500)/500.0f;
     return filtered_idx(v, idx);
@@ -711,7 +711,7 @@ float Aircraft::filtered_servo_angle(const struct sitl_input &input, uint8_t idx
   return a filtered servo input as a value from 0 to 1
   servo is assumed to be 1000 to 2000
  */
-float Aircraft::filtered_servo_range(const struct sitl_input &input, uint8_t idx)
+float Aircraft::filtered_servo_range(const struct SITL::sitl_input &input, uint8_t idx)
 {
     const float v = (input.servos[idx] - 1000)/1000.0f;
     return filtered_idx(v, idx);
@@ -736,5 +736,3 @@ void Aircraft::extrapolate_sensors(float delta_time)
     velocity_air_ef = velocity_ef + wind_ef;
     velocity_air_bf = dcm.transposed() * velocity_air_ef;
 }
-
-

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -29,8 +29,6 @@ namespace SITL {
   parent class for all simulator types
  */
 class Aircraft {
-    friend class Gripper_Servo;
-
 public:
     Aircraft(const char *home_str, const char *frame_str);
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -97,7 +97,7 @@ public:
         return mag_bf;
     }
 
-    virtual float gross_mass() const { return mass; }
+    float gross_mass() const { return mass + external_payload_mass; }
 
     const Location &get_location() const { return location; }
 
@@ -128,6 +128,7 @@ protected:
     Vector3f accel_body;            // m/s/s NED, body frame
     float airspeed;                 // m/s, apparent airspeed
     float airspeed_pitot;           // m/s, apparent airspeed, as seen by fwd pitot tube
+    float external_payload_mass = 0.0f;  // kg
     float battery_voltage = -1.0f;
     float battery_current = 0.0f;
     float rpm1 = 0;
@@ -220,6 +221,9 @@ protected:
 
     // extrapolate sensors by a given delta time in seconds
     void extrapolate_sensors(float delta_time);
+
+    // update external payload/sensor dynamic
+    void update_external_payload(const struct SITL::sitl_input &input);
 
 private:
     uint64_t last_time_us = 0;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -23,7 +23,6 @@
 #include "SITL.h"
 #include <AP_Terrain/AP_Terrain.h>
 
-
 namespace SITL {
 
 /*
@@ -115,27 +114,27 @@ protected:
     float ground_level;
     float home_yaw;
     float frame_height;
-    Matrix3f dcm;                   // rotation matrix, APM conventions, from body to earth
-    Vector3f gyro;                  // rad/s
-    Vector3f gyro_prev;             // rad/s
-    Vector3f ang_accel;             // rad/s/s
-    Vector3f velocity_ef;           // m/s, earth frame
-    Vector3f wind_ef;               // m/s, earth frame
-    Vector3f velocity_air_ef;       // velocity relative to airmass, earth frame
-    Vector3f velocity_air_bf;       // velocity relative to airmass, body frame
-    Vector3f position;              // meters, NED from origin
-    float mass;                     // kg
-    Vector3f accel_body;            // m/s/s NED, body frame
-    float airspeed;                 // m/s, apparent airspeed
-    float airspeed_pitot;           // m/s, apparent airspeed, as seen by fwd pitot tube
+    Matrix3f dcm;                        // rotation matrix, APM conventions, from body to earth
+    Vector3f gyro;                       // rad/s
+    Vector3f gyro_prev;                  // rad/s
+    Vector3f ang_accel;                  // rad/s/s
+    Vector3f velocity_ef;                // m/s, earth frame
+    Vector3f wind_ef;                    // m/s, earth frame
+    Vector3f velocity_air_ef;            // velocity relative to airmass, earth frame
+    Vector3f velocity_air_bf;            // velocity relative to airmass, body frame
+    Vector3f position;                   // meters, NED from origin
+    float mass;                          // kg
     float external_payload_mass = 0.0f;  // kg
+    Vector3f accel_body;                 // m/s/s NED, body frame
+    float airspeed;                      // m/s, apparent airspeed
+    float airspeed_pitot;                // m/s, apparent airspeed, as seen by fwd pitot tube
     float battery_voltage = -1.0f;
     float battery_current = 0.0f;
     float rpm1 = 0;
     float rpm2 = 0;
     uint8_t rcin_chan_count = 0;
     float rcin[8];
-    float range = -1.0f;            // rangefinder detection in m
+    float range = -1.0f;                 // rangefinder detection in m
 
     // Wind Turbulence simulated Data
     float turbulence_azimuth = 0.0f;
@@ -162,7 +161,7 @@ protected:
 
     // allow for AHRS_ORIENTATION
     AP_Int8 *ahrs_orientation;
-    
+
     enum {
         GROUND_BEHAVIOR_NONE = 0,
         GROUND_BEHAVIOR_NO_MOVEMENT,

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -36,20 +36,6 @@ public:
     Aircraft(const char *home_str, const char *frame_str);
 
     /*
-      structure passed in giving servo positions as PWM values in
-      microseconds
-     */
-    struct sitl_input {
-        uint16_t servos[16];
-        struct {
-            float speed;      // m/s
-            float direction;  // degrees 0..360
-            float turbulence;
-            float dir_z;	  //degrees -90..90 
-        } wind;
-    };
-
-    /*
       set simulation speedup
      */
     void set_speedup(float speedup);
@@ -74,7 +60,7 @@ public:
     /*
       step the FDM by one time step
      */
-    virtual void update(const struct sitl_input &input) = 0;
+    virtual void update(const struct SITL::sitl_input &input) = 0;
 
     /* fill a sitl_fdm structure from the simulator state */
     void fill_fdm(struct sitl_fdm &fdm);
@@ -225,16 +211,16 @@ protected:
     void update_dynamics(const Vector3f &rot_accel);
 
     // update wind vector
-    void update_wind(const struct sitl_input &input);
+    void update_wind(const struct SITL::sitl_input &input);
 
     // return filtered servo input as -1 to 1 range
     float filtered_idx(float v, uint8_t idx);
-    float filtered_servo_angle(const struct sitl_input &input, uint8_t idx);
-    float filtered_servo_range(const struct sitl_input &input, uint8_t idx);
+    float filtered_servo_angle(const struct SITL::sitl_input &input, uint8_t idx);
+    float filtered_servo_range(const struct SITL::sitl_input &input, uint8_t idx);
 
     // extrapolate sensors by a given delta time in seconds
     void extrapolate_sensors(float delta_time);
-    
+
 private:
     uint64_t last_time_us = 0;
     uint32_t frame_counter = 0;

--- a/libraries/SITL/SIM_BalanceBot.cpp
+++ b/libraries/SITL/SIM_BalanceBot.cpp
@@ -52,7 +52,7 @@ float BalanceBot::calc_yaw_rate(float steering)
  * 1) http://ctms.engin.umich.edu/CTMS/index.php?example=InvertedPendulum&section=SystemModeling
  * 2) http://journals.sagepub.com/doi/pdf/10.5772/63933
  */
-void BalanceBot::update(const struct sitl_input &input)
+void BalanceBot::update(const struct SITL::sitl_input &input)
 {
     const float length = 1.0f; //m length of body
 

--- a/libraries/SITL/SIM_BalanceBot.h
+++ b/libraries/SITL/SIM_BalanceBot.h
@@ -27,7 +27,7 @@ public:
     BalanceBot(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_Balloon.cpp
+++ b/libraries/SITL/SIM_Balloon.cpp
@@ -31,7 +31,7 @@ Balloon::Balloon(const char *home_str, const char *frame_str) :
 /*
   update the balloon simulation by one time step
  */
-void Balloon::update(const struct sitl_input &input)
+void Balloon::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_Balloon.h
+++ b/libraries/SITL/SIM_Balloon.h
@@ -30,7 +30,7 @@ public:
     Balloon(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_CRRCSim.cpp
+++ b/libraries/SITL/SIM_CRRCSim.cpp
@@ -44,7 +44,7 @@ CRRCSim::CRRCSim(const char *home_str, const char *frame_str) :
 /*
   decode and send servos for heli
 */
-void CRRCSim::send_servos_heli(const struct sitl_input &input)
+void CRRCSim::send_servos_heli(const struct SITL::sitl_input &input)
 {
     float swash1 = (input.servos[0]-1000) / 1000.0f;
     float swash2 = (input.servos[1]-1000) / 1000.0f;
@@ -70,7 +70,7 @@ void CRRCSim::send_servos_heli(const struct sitl_input &input)
 /*
   decode and send servos for fixed wing
 */
-void CRRCSim::send_servos_fixed_wing(const struct sitl_input &input)
+void CRRCSim::send_servos_fixed_wing(const struct SITL::sitl_input &input)
 {
     float roll_rate  = ((input.servos[0]-1000)/1000.0) - 0.5;
     float pitch_rate = ((input.servos[1]-1000)/1000.0) - 0.5;
@@ -90,7 +90,7 @@ void CRRCSim::send_servos_fixed_wing(const struct sitl_input &input)
 /*
   decode and send servos
 */
-void CRRCSim::send_servos(const struct sitl_input &input)
+void CRRCSim::send_servos(const struct SITL::sitl_input &input)
 {
     if (heli_servos) {
         send_servos_heli(input);
@@ -103,7 +103,7 @@ void CRRCSim::send_servos(const struct sitl_input &input)
   receive an update from the FDM
   This is a blocking function
  */
-void CRRCSim::recv_fdm(const struct sitl_input &input)
+void CRRCSim::recv_fdm(const struct SITL::sitl_input &input)
 {
     fdm_packet pkt;
 
@@ -146,7 +146,7 @@ void CRRCSim::recv_fdm(const struct sitl_input &input)
 /*
   update the CRRCSim simulation by one time step
  */
-void CRRCSim::update(const struct sitl_input &input)
+void CRRCSim::update(const struct SITL::sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);

--- a/libraries/SITL/SIM_CRRCSim.h
+++ b/libraries/SITL/SIM_CRRCSim.h
@@ -32,7 +32,7 @@ public:
     CRRCSim(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -66,10 +66,10 @@ private:
         double airspeed;
     };
 
-    void send_servos_heli(const struct sitl_input &input);
-    void send_servos_fixed_wing(const struct sitl_input &input);
-    void recv_fdm(const struct sitl_input &input);
-    void send_servos(const struct sitl_input &input);
+    void send_servos_heli(const struct SITL::sitl_input &input);
+    void send_servos_fixed_wing(const struct SITL::sitl_input &input);
+    void recv_fdm(const struct SITL::sitl_input &input);
+    void send_servos(const struct SITL::sitl_input &input);
 
     bool heli_servos;
     double last_timestamp;

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -30,7 +30,7 @@ SITL::Calibration::Calibration(const char *home_str, const char *frame_str)
     mass = 1.5f;
 }
 
-void SITL::Calibration::update(const struct sitl_input& input)
+void SITL::Calibration::update(const struct SITL::sitl_input &input)
 {
     Vector3f rot_accel{0, 0, 0};
 
@@ -54,7 +54,7 @@ void SITL::Calibration::update(const struct sitl_input& input)
     update_mag_field_bf();
 }
 
-void SITL::Calibration::_stop_control(const struct sitl_input& input,
+void SITL::Calibration::_stop_control(const struct SITL::sitl_input &input,
                                       Vector3f& rot_accel)
 {
     Vector3f desired_angvel{0, 0, 0};
@@ -65,7 +65,7 @@ void SITL::Calibration::_stop_control(const struct sitl_input& input,
     rot_accel *= 0.002f;
 }
 
-void SITL::Calibration::_attitude_control(const struct sitl_input& input,
+void SITL::Calibration::_attitude_control(const struct SITL::sitl_input &input,
                                           Vector3f& rot_accel)
 {
     float desired_roll = -M_PI + 2 * M_PI * (input.servos[5] - 1000) / 1000.f;
@@ -103,7 +103,7 @@ void SITL::Calibration::_attitude_set(float desired_roll, float desired_pitch, f
     rot_accel = error * (1.0f / dt);
 }
 
-void SITL::Calibration::_angular_velocity_control(const struct sitl_input& in,
+void SITL::Calibration::_angular_velocity_control(const struct SITL::sitl_input &in,
                                                   Vector3f& rot_accel)
 {
     Vector3f axis{(float)(in.servos[5] - 1500),

--- a/libraries/SITL/SIM_Calibration.h
+++ b/libraries/SITL/SIM_Calibration.h
@@ -66,22 +66,22 @@ class Calibration : public Aircraft {
 public:
     Calibration(const char *home_str, const char *frame_str);
 
-    void update(const struct sitl_input& input);
+    void update(const struct SITL::sitl_input &input);
 
     static Aircraft *create(const char *home_str, const char *frame_str) {
         return new Calibration(home_str, frame_str);
     }
 
 private:
-    void _stop_control(const struct sitl_input& input, Vector3f& rot_accel);
+    void _stop_control(const struct SITL::sitl_input &input, Vector3f& rot_accel);
 
     void _attitude_set(float desired_roll, float desired_pitch, float desired_yaw,
                        Vector3f& rot_accel);
 
-    void _attitude_control(const struct sitl_input& input,
+    void _attitude_control(const struct SITL::sitl_input &input,
                            Vector3f& rot_accel);
 
-    void _angular_velocity_control(const struct sitl_input& input,
+    void _angular_velocity_control(const struct SITL::sitl_input &input,
                                    Vector3f& rot_accel);
 
     void _calibration_poses(Vector3f& rot_accel);

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -138,7 +138,7 @@ void *FlightAxis::update_thread(void *arg)
 void FlightAxis::update_loop(void)
 {
     while (true) {
-        struct sitl_input new_input;
+        struct SITL::sitl_input new_input;
         mutex->take(HAL_SEMAPHORE_BLOCK_FOREVER);
         new_input = last_input;
         mutex->give();
@@ -258,7 +258,7 @@ Connection: Keep-Alive
 
 
 
-void FlightAxis::exchange_data(const struct sitl_input &input)
+void FlightAxis::exchange_data(const struct SITL::sitl_input &input)
 {
     if (!controller_started ||
         is_zero(state.m_flightAxisControllerIsActive) ||
@@ -359,7 +359,7 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
 /*
   update the FlightAxis simulation by one time step
  */
-void FlightAxis::update(const struct sitl_input &input)
+void FlightAxis::update(const struct SITL::sitl_input &input)
 {
     mutex->take(HAL_SEMAPHORE_BLOCK_FOREVER);
     

--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -32,7 +32,7 @@ public:
     FlightAxis(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -153,14 +153,14 @@ public:
 
 private:
     char *soap_request(const char *action, const char *fmt, ...);
-    void exchange_data(const struct sitl_input &input);
+    void exchange_data(const struct SITL::sitl_input &input);
     void parse_reply(const char *reply);
 
     static void *update_thread(void *arg);
     void update_loop(void);
     void report_FPS(void);
 
-    struct sitl_input last_input;
+    struct SITL::sitl_input last_input;
 
     double average_frame_time_s;
     double extrapolated_s;

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -202,7 +202,7 @@ Frame *Frame::find_frame(const char *name)
 
 // calculate rotational and linear accelerations
 void Frame::calculate_forces(const Aircraft &aircraft,
-                             const Aircraft::sitl_input &input,
+                             const struct SITL::sitl_input &input,
                              Vector3f &rot_accel,
                              Vector3f &body_accel)
 {

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -48,7 +48,7 @@ public:
 
     // calculate rotational and linear accelerations
     void calculate_forces(const Aircraft &aircraft,
-                          const Aircraft::sitl_input &input,
+                          const struct SITL::sitl_input &input,
                           Vector3f &rot_accel, Vector3f &body_accel);
     
     float terminal_velocity;

--- a/libraries/SITL/SIM_Gazebo.cpp
+++ b/libraries/SITL/SIM_Gazebo.cpp
@@ -60,7 +60,7 @@ void Gazebo::set_interface_ports(const char* address, const int port_in, const i
 /*
   decode and send servos
 */
-void Gazebo::send_servos(const struct sitl_input &input)
+void Gazebo::send_servos(const struct SITL::sitl_input &input)
 {
     servo_packet pkt;
     // should rename servo_command
@@ -76,7 +76,7 @@ void Gazebo::send_servos(const struct sitl_input &input)
   receive an update from the FDM
   This is a blocking function
  */
-void Gazebo::recv_fdm(const struct sitl_input &input)
+void Gazebo::recv_fdm(const struct SITL::sitl_input &input)
 {
     fdm_packet pkt;
 
@@ -158,7 +158,7 @@ void Gazebo::drain_sockets()
 /*
   update the Gazebo simulation by one time step
  */
-void Gazebo::update(const struct sitl_input &input)
+void Gazebo::update(const struct SITL::sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);

--- a/libraries/SITL/SIM_Gazebo.h
+++ b/libraries/SITL/SIM_Gazebo.h
@@ -31,7 +31,7 @@ public:
     Gazebo(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -62,8 +62,8 @@ private:
       double position_xyz[3];
     };
 
-    void recv_fdm(const struct sitl_input &input);
-    void send_servos(const struct sitl_input &input);
+    void recv_fdm(const struct SITL::sitl_input &input);
+    void send_servos(const struct SITL::sitl_input &input);
     void drain_sockets();
 
     double last_timestamp;

--- a/libraries/SITL/SIM_Gripper_EPM.cpp
+++ b/libraries/SITL/SIM_Gripper_EPM.cpp
@@ -17,27 +17,49 @@
 */
 
 #include "SIM_Gripper_EPM.h"
+#include "AP_HAL/AP_HAL.h"
 #include <stdio.h>
-#include <AP_Common/AP_Common.h>
 
 using namespace SITL;
+
+// table of user settable parameters
+const AP_Param::GroupInfo Gripper_EPM::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Gripper servo Sim enable/disable
+    // @Description: Allows you to enable (1) or disable (0) the gripper servo simulation
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ENABLE", 0, Gripper_EPM, gripper_emp_enable, 0),
+
+    // @Param: PIN
+    // @DisplayName: Gripper emp pin
+    // @Description: The pin number that the gripper emp is connected to. (start at 0)
+    // @Range: 0 15
+    // @User: Advanced
+    AP_GROUPINFO("PIN", 1, Gripper_EPM, gripper_emp_servo_pin, -1),
+
+    AP_GROUPEND
+};
 
 /*
   update gripper state
  */
-void Gripper_EPM::update_servobased(const Aircraft::sitl_input &input)
+void Gripper_EPM::update_servobased(int16_t gripper_pwm)
 {
     if (!servo_based) {
         return;
     }
-    demand = (input.servos[gripper_servo]-1000) * 0.001f; // 0.0 - 1.0
-    if (is_negative(demand)) { // never updated
-        demand = 0.0f;
+    if (gripper_pwm >= 0) {
+        demand = (gripper_pwm - 1000) * 0.001f; // 0.0 - 1.0
+        if (is_negative(demand)) { // never updated
+            demand = 0.0f;
+        }
     }
 }
 
 
-void Gripper_EPM::update_from_demand(const Aircraft::sitl_input &input)
+void Gripper_EPM::update_from_demand()
 {
     const uint64_t now = AP_HAL::micros64();
     const float dt = (now - last_update_us) * 1.0e-6f;
@@ -68,11 +90,13 @@ void Gripper_EPM::update_from_demand(const Aircraft::sitl_input &input)
     last_update_us = now;
 }
 
-void Gripper_EPM::update(const Aircraft::sitl_input &input)
+void Gripper_EPM::update(const struct SITL::sitl_input &input)
 {
-    update_servobased(input);
+    const int16_t gripper_pwm = gripper_emp_servo_pin >= 0 ? input.servos[gripper_emp_servo_pin] : -1;
 
-    update_from_demand(input);
+    update_servobased(gripper_pwm);
+
+    update_from_demand();
 }
 
 

--- a/libraries/SITL/SIM_Gripper_EPM.h
+++ b/libraries/SITL/SIM_Gripper_EPM.h
@@ -18,22 +18,28 @@
 
 #pragma once
 
-#include "SIM_Aircraft.h"
+#include "stdint.h"
+#include <AP_Param/AP_Param.h>
+#include "SITL.h"
 
 namespace SITL {
 
 class Gripper_EPM {
 public:
-    const uint8_t gripper_servo;
-
-    Gripper_EPM(const uint8_t _gripper_servo) :
-        gripper_servo(_gripper_servo)
-    {}
+    Gripper_EPM() {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
 
     // update field stength
-    void update(const struct Aircraft::sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
+
+    static const struct AP_Param::GroupInfo var_info[];
+    bool is_enable() const {return static_cast<bool>(gripper_emp_enable);}
 
 private:
+
+    AP_Int8  gripper_emp_enable;  // enable gripper sim
+    AP_Int8  gripper_emp_servo_pin;
 
     const uint32_t report_interval = 100000; // microseconds
     uint64_t last_report_us;
@@ -52,8 +58,8 @@ private:
 
     bool should_report();
 
-    void update_from_demand(const Aircraft::sitl_input &input);
-    void update_servobased(const struct Aircraft::sitl_input &input);
+    void update_from_demand();
+    void update_servobased(int16_t gripper_pwm);
 
     float tesla();
 

--- a/libraries/SITL/SIM_Gripper_Servo.cpp
+++ b/libraries/SITL/SIM_Gripper_Servo.cpp
@@ -17,43 +17,67 @@
 */
 
 #include "SIM_Gripper_Servo.h"
+#include "AP_HAL/AP_HAL.h"
+#include "AP_Math/AP_Math.h"
 #include <stdio.h>
 
 using namespace SITL;
 
+// table of user settable parameters
+const AP_Param::GroupInfo Gripper_Servo::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Gripper servo Sim enable/disable
+    // @Description: Allows you to enable (1) or disable (0) the gripper servo simulation
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ENABLE", 0, Gripper_Servo, gripper_enable, 0),
+
+    // @Param: PIN
+    // @DisplayName: Gripper servo pin
+    // @Description: The pin number that the gripper servo is connected to. (start at 0)
+    // @Range: 0 15
+    // @User: Advanced
+    AP_GROUPINFO("PIN", 1, Gripper_Servo, gripper_servo_pin, -1),
+
+    AP_GROUPEND
+};
+
 /*
   update gripper state
  */
-void Gripper_Servo::update(const Aircraft::sitl_input &input)
+void Gripper_Servo::update(const struct SITL::sitl_input &input)
 {
+    const int16_t gripper_pwm= gripper_servo_pin >= 0 ? input.servos[gripper_servo_pin] : -1;
+
     const uint64_t now = AP_HAL::micros64();
     const float dt = (now - last_update_us) * 1.0e-6f;
 
     // update gripper position
-
-    float position_demand = (input.servos[gripper_servo]-1000) * 0.001f;
-    if (is_negative(position_demand)) { // never updated
-        position_demand = 0.0f;
-    }
-
-    const float position_max_change = position_slew_rate/100.0f * dt;
-    position = constrain_float(position_demand, position-position_max_change, position+position_max_change);
-
-    const float jaw_gap = gap*(1.0f-position);
-    if (should_report()) {
-        ::fprintf(stderr, "position_demand=%f jaw_gap=%f load=%f\n", position_demand, jaw_gap, load_mass);
-        last_report_us = now;
-        reported_position = position;
-    }
-
-    if (jaw_gap < 5) {
-        if (aircraft->on_ground()) {
-            load_mass = 1.0f; // attach the load
+    if (gripper_pwm >=0) {
+        float position_demand = (gripper_pwm - 1000) * 0.001f;
+        if (is_negative(position_demand)) { // never updated
+            position_demand = 0.0f;
         }
-    } else if (jaw_gap > 10) {
-        load_mass = 0.0f; // detach the load
-    }
 
+        const float position_max_change = position_slew_rate / 100.0f * dt;
+        position = constrain_float(position_demand, position - position_max_change, position + position_max_change);
+
+        const float jaw_gap = gap * (1.0f - position);
+        if (should_report()) {
+            ::fprintf(stderr, "position_demand=%f jaw_gap=%f load=%f\n", position_demand, jaw_gap, load_mass);
+            last_report_us = now;
+            reported_position = position;
+        }
+
+        if (jaw_gap < 5) {
+            if (on_ground) {
+                load_mass = 1.0f; // attach the load
+            }
+        } else if (jaw_gap > 10) {
+            load_mass = 0.0f; // detach the load
+        }
+    }
     last_update_us = now;
 }
 
@@ -71,9 +95,9 @@ bool Gripper_Servo::should_report()
 }
 
 
-float Gripper_Servo::payload_mass() const
+float Gripper_Servo::payload_mass(float alt) const
 {
-    if (aircraft->hagl() < string_length) {
+    if (alt < string_length) {
         return 0.0f;
     }
     return load_mass;

--- a/libraries/SITL/SIM_Gripper_Servo.cpp
+++ b/libraries/SITL/SIM_Gripper_Servo.cpp
@@ -32,8 +32,8 @@ void Gripper_Servo::update(const Aircraft::sitl_input &input)
     // update gripper position
 
     float position_demand = (input.servos[gripper_servo]-1000) * 0.001f;
-    if (position_demand < 0) { // never updated
-        position_demand = 0;
+    if (is_negative(position_demand)) { // never updated
+        position_demand = 0.0f;
     }
 
     const float position_max_change = position_slew_rate/100.0f * dt;
@@ -55,7 +55,6 @@ void Gripper_Servo::update(const Aircraft::sitl_input &input)
     }
 
     last_update_us = now;
-    return;
 }
 
 bool Gripper_Servo::should_report()

--- a/libraries/SITL/SIM_Gripper_Servo.cpp
+++ b/libraries/SITL/SIM_Gripper_Servo.cpp
@@ -71,7 +71,7 @@ void Gripper_Servo::update(const struct SITL::sitl_input &input)
         }
 
         if (jaw_gap < 5) {
-            if (on_ground) {
+            if (altitude <= 0.0f) {
                 load_mass = 1.0f; // attach the load
             }
         } else if (jaw_gap > 10) {
@@ -95,9 +95,9 @@ bool Gripper_Servo::should_report()
 }
 
 
-float Gripper_Servo::payload_mass(float alt) const
+float Gripper_Servo::payload_mass() const
 {
-    if (alt < string_length) {
+    if (altitude < string_length) {
         return 0.0f;
     }
     return load_mass;

--- a/libraries/SITL/SIM_Gripper_Servo.h
+++ b/libraries/SITL/SIM_Gripper_Servo.h
@@ -17,30 +17,29 @@
 */
 
 #pragma once
-
-#include "SIM_Aircraft.h"
+#include "stdint.h"
+#include <AP_Param/AP_Param.h>
+#include "SITL.h"
 
 namespace SITL {
 
 class Gripper_Servo {
 public:
-    const uint8_t gripper_servo;
-
-    Gripper_Servo(const uint8_t _gripper_servo) :
-        gripper_servo(_gripper_servo)
-    {}
+    Gripper_Servo() {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
 
     // update Gripper state
-    void update(const struct Aircraft::sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
-    float payload_mass() const; // kg
+    float payload_mass(float alt) const; // kg
 
-    void set_aircraft(Aircraft *_aircraft) { aircraft = _aircraft; }
+    static const struct AP_Param::GroupInfo var_info[];
+    bool is_enable() const {return static_cast<bool>(gripper_enable);}
 
 private:
-
-    Aircraft *aircraft;
-
+    AP_Int8  gripper_enable;  // enable gripper sim
+    AP_Int8  gripper_servo_pin;
     const uint32_t report_interval = 1000000; // microseconds
     uint64_t last_report_us;
 

--- a/libraries/SITL/SIM_Gripper_Servo.h
+++ b/libraries/SITL/SIM_Gripper_Servo.h
@@ -32,8 +32,9 @@ public:
     // update Gripper state
     void update(const struct SITL::sitl_input &input);
 
-    float payload_mass(float alt) const; // kg
+    float payload_mass() const; // kg
 
+    void set_alt(float alt) {altitude = alt;};
     static const struct AP_Param::GroupInfo var_info[];
     bool is_enable() const {return static_cast<bool>(gripper_enable);}
 
@@ -44,7 +45,7 @@ private:
     uint64_t last_report_us;
 
     const float gap = 30; // mm
-
+    float altitude;
     float position; // percentage
     float position_slew_rate = 35; // percentage
     float reported_position = -1; // unlikely

--- a/libraries/SITL/SIM_Helicopter.cpp
+++ b/libraries/SITL/SIM_Helicopter.cpp
@@ -53,7 +53,7 @@ Helicopter::Helicopter(const char *home_str, const char *frame_str) :
 /*
   update the helicopter simulation by one time step
  */
-void Helicopter::update(const struct sitl_input &input)
+void Helicopter::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_Helicopter.h
+++ b/libraries/SITL/SIM_Helicopter.h
@@ -30,7 +30,7 @@ public:
     Helicopter(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_ICEngine.cpp
+++ b/libraries/SITL/SIM_ICEngine.cpp
@@ -24,7 +24,7 @@ using namespace SITL;
 /*
   update engine state, returning power output from 0 to 1
  */
-float ICEngine::update(const Aircraft::sitl_input &input)
+float ICEngine::update(const struct SITL::sitl_input &input)
 {
     bool have_ignition = ignition_servo>=0;
     bool have_choke = choke_servo>=0;

--- a/libraries/SITL/SIM_ICEngine.h
+++ b/libraries/SITL/SIM_ICEngine.h
@@ -39,7 +39,7 @@ public:
     {}
 
     // update motor state
-    float update(const struct Aircraft::sitl_input &input);
+    float update(const struct SITL::sitl_input &input);
 
 private:
     float last_output;

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -319,7 +319,7 @@ bool JSBSim::open_fdm_socket(void)
 /*
   decode and send servos
 */
-void JSBSim::send_servos(const struct sitl_input &input)
+void JSBSim::send_servos(const struct SITL::sitl_input &input)
 {
     char *buf = nullptr;
     float aileron  = filtered_servo_angle(input, 0);
@@ -396,7 +396,7 @@ void FGNetFDM::ByteSwap(void)
   receive an update from the FDM
   This is a blocking function
  */
-void JSBSim::recv_fdm(const struct sitl_input &input)
+void JSBSim::recv_fdm(const struct SITL::sitl_input &input)
 {
     FGNetFDM fdm;
     check_stdout();
@@ -452,7 +452,7 @@ void JSBSim::drain_control_socket()
 /*
   update the JSBSim simulation by one time step
  */
-void JSBSim::update(const struct sitl_input &input)
+void JSBSim::update(const struct SITL::sitl_input &input)
 {
     while (!initialised) {
         if (!create_templates() ||

--- a/libraries/SITL/SIM_JSBSim.h
+++ b/libraries/SITL/SIM_JSBSim.h
@@ -32,7 +32,7 @@ public:
     JSBSim(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -72,8 +72,8 @@ private:
     bool start_JSBSim(void);
     bool open_control_socket(void);
     bool open_fdm_socket(void);
-    void send_servos(const struct sitl_input &input);
-    void recv_fdm(const struct sitl_input &input);
+    void send_servos(const struct SITL::sitl_input &input);
+    void recv_fdm(const struct SITL::sitl_input &input);
     void check_stdout(void);
     bool expect(const char *str);
 

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -22,7 +22,7 @@
 using namespace SITL;
 
 // calculate rotational accel and thrust for a motor
-void Motor::calculate_forces(const Aircraft::sitl_input &input,
+void Motor::calculate_forces(const struct SITL::sitl_input &input,
                              const float thrust_scale,
                              uint8_t motor_offset,
                              Vector3f &rot_accel,

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -69,7 +69,7 @@ public:
         pitch_max(_pitch_max)
     {}
 
-    void calculate_forces(const Aircraft::sitl_input &input,
+    void calculate_forces(const struct SITL::sitl_input &input,
                           float thrust_scale,
                           uint8_t motor_offset,
                           Vector3f &rot_accel, // rad/sec

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -75,9 +75,6 @@ void MultiCopter::update(const struct SITL::sitl_input &input)
     // update magnetic field
     update_mag_field_bf();
 
-    // update sprayer
-    sprayer.update(input);
-
     // update gripper
     gripper.update(input);
     gripper_epm.update(input);

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -29,8 +29,6 @@ MultiCopter::MultiCopter(const char *home_str, const char *frame_str) :
 {
     mass = 1.5f;
 
-    gripper.set_aircraft(this);
-
     frame = Frame::find_frame(frame_str);
     if (frame == nullptr) {
         printf("Frame '%s' not found", frame_str);
@@ -74,8 +72,5 @@ void MultiCopter::update(const struct SITL::sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
-
-    // update gripper
-    gripper.update(input);
     gripper_epm.update(input);
 }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -72,5 +72,4 @@ void MultiCopter::update(const struct SITL::sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
-    gripper_epm.update(input);
 }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -66,6 +66,7 @@ void MultiCopter::update(const struct SITL::sitl_input &input)
     calculate_forces(input, rot_accel, accel_body);
 
     update_dynamics(rot_accel);
+    update_external_payload(input);
 
     // update lat/lon/altitude
     update_position();
@@ -80,9 +81,4 @@ void MultiCopter::update(const struct SITL::sitl_input &input)
     // update gripper
     gripper.update(input);
     gripper_epm.update(input);
-}
-
-float MultiCopter::gross_mass() const
-{
-    return Aircraft::gross_mass() + sprayer.payload_mass() + gripper.payload_mass();
 }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -48,7 +48,7 @@ MultiCopter::MultiCopter(const char *home_str, const char *frame_str) :
 }
 
 // calculate rotational and linear accelerations
-void MultiCopter::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
+void MultiCopter::calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
     frame->calculate_forces(*this, input, rot_accel, body_accel);
 }
@@ -56,7 +56,7 @@ void MultiCopter::calculate_forces(const struct sitl_input &input, Vector3f &rot
 /*
   update the multicopter simulation by one time step
  */
-void MultiCopter::update(const struct sitl_input &input)
+void MultiCopter::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -52,9 +52,6 @@ protected:
     Sprayer sprayer{6, 7};
     Gripper_Servo gripper{8};
     Gripper_EPM gripper_epm{9};
-
-    float gross_mass() const override;
-
 };
 
 }

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -36,7 +36,7 @@ public:
     MultiCopter(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -45,7 +45,7 @@ public:
 
 protected:
     // calculate rotational and linear accelerations
-    void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
+    void calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     Frame *frame;
 
     // The numbers below are the pwm output channels with "0" meaning the first output (aka RC1)

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -22,7 +22,6 @@
 #include "SIM_Motor.h"
 #include "SIM_Frame.h"
 
-#include "SIM_Sprayer.h"
 #include "SIM_Gripper_Servo.h"
 #include "SIM_Gripper_EPM.h"
 
@@ -49,7 +48,6 @@ protected:
     Frame *frame;
 
     // The numbers below are the pwm output channels with "0" meaning the first output (aka RC1)
-    Sprayer sprayer{6, 7};
     Gripper_Servo gripper{8};
     Gripper_EPM gripper_epm{9};
 };

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -22,7 +22,6 @@
 #include "SIM_Motor.h"
 #include "SIM_Frame.h"
 
-#include "SIM_Gripper_Servo.h"
 #include "SIM_Gripper_EPM.h"
 
 namespace SITL {
@@ -48,7 +47,6 @@ protected:
     Frame *frame;
 
     // The numbers below are the pwm output channels with "0" meaning the first output (aka RC1)
-    Gripper_Servo gripper{8};
     Gripper_EPM gripper_epm{9};
 };
 

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -22,8 +22,6 @@
 #include "SIM_Motor.h"
 #include "SIM_Frame.h"
 
-#include "SIM_Gripper_EPM.h"
-
 namespace SITL {
 
 /*
@@ -45,9 +43,6 @@ protected:
     // calculate rotational and linear accelerations
     void calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     Frame *frame;
-
-    // The numbers below are the pwm output channels with "0" meaning the first output (aka RC1)
-    Gripper_EPM gripper_epm{9};
 };
 
 }

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -247,7 +247,7 @@ Vector3f Plane::getForce(float inputAileron, float inputElevator, float inputRud
     return Vector3f(ax, ay, az);
 }
 
-void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
+void Plane::calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
     float aileron  = filtered_servo_angle(input, 0);
     float elevator = filtered_servo_angle(input, 1);
@@ -360,7 +360,7 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
 /*
   update the plane simulation by one time step
  */
-void Plane::update(const struct sitl_input &input)
+void Plane::update(const struct SITL::sitl_input &input)
 {
     Vector3f rot_accel;
 

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -32,7 +32,7 @@ public:
     Plane(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    virtual void update(const struct sitl_input &input);
+    virtual void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -110,7 +110,7 @@ protected:
     float dragCoeff(float alpha) const;
     Vector3f getForce(float inputAileron, float inputElevator, float inputRudder) const;
     Vector3f getTorque(float inputAileron, float inputElevator, float inputRudder, float inputThrust, const Vector3f &force) const;
-    void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
+    void calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -94,7 +94,7 @@ QuadPlane::QuadPlane(const char *home_str, const char *frame_str) :
 /*
   update the quadplane simulation by one time step
  */
-void QuadPlane::update(const struct sitl_input &input)
+void QuadPlane::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_QuadPlane.h
+++ b/libraries/SITL/SIM_QuadPlane.h
@@ -32,7 +32,7 @@ public:
     QuadPlane(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input) override;
+    void update(const struct SITL::sitl_input &input) override;
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -87,7 +87,7 @@ float SimRover::calc_lat_accel(float steering_angle, float speed)
 /*
   update the rover simulation by one time step
  */
-void SimRover::update(const struct sitl_input &input)
+void SimRover::update(const struct SITL::sitl_input &input)
 {
     float steering, throttle;
 

--- a/libraries/SITL/SIM_Rover.h
+++ b/libraries/SITL/SIM_Rover.h
@@ -30,7 +30,7 @@ public:
     SimRover(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_SingleCopter.cpp
+++ b/libraries/SITL/SIM_SingleCopter.cpp
@@ -44,7 +44,7 @@ SingleCopter::SingleCopter(const char *home_str, const char *frame_str) :
 /*
   update the copter simulation by one time step
  */
-void SingleCopter::update(const struct sitl_input &input)
+void SingleCopter::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_SingleCopter.h
+++ b/libraries/SITL/SIM_SingleCopter.h
@@ -31,7 +31,7 @@ public:
     SingleCopter(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_Sprayer.cpp
+++ b/libraries/SITL/SIM_Sprayer.cpp
@@ -66,7 +66,6 @@ void Sprayer::update(const Aircraft::sitl_input &input)
     }
 
     last_update_us = now;
-    return;
 }
 
 bool Sprayer::should_report()

--- a/libraries/SITL/SIM_Sprayer.cpp
+++ b/libraries/SITL/SIM_Sprayer.cpp
@@ -17,54 +17,88 @@
 */
 
 #include "SIM_Sprayer.h"
-#include <stdio.h>
+#include "AP_HAL/AP_HAL.h"
+#include "AP_Math/AP_Math.h"
 
 using namespace SITL;
+
+// table of user settable parameters
+const AP_Param::GroupInfo Sprayer::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Gripper servo Sim enable/disable
+    // @Description: Allows you to enable (1) or disable (0) the gripper servo simulation
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("ENABLE", 0, Sprayer, sprayer_enable, 0),
+
+    // @Param: PUMP
+    // @DisplayName: Sprayer pump pin
+    // @Description: The pin number that the Sprayer pump is connected to. (start at 0)
+    // @Range: 0 15
+    // @User: Advanced
+    AP_GROUPINFO("PUMP", 1, Sprayer, sprayer_pump_pin, -1),
+
+    // @Param: SPIN
+    // @DisplayName: Sprayer spinner servo pin
+    // @Description: The pin number that the Sprayer spinner servo is connected to. (start at 0)
+    // @Range: 0 15
+    // @User: Advanced
+    AP_GROUPINFO("SPIN", 2, Sprayer, sprayer_spin_pin, -1),
+
+    AP_GROUPEND
+};
 
 /*
   update sprayer state
  */
-void Sprayer::update(const Aircraft::sitl_input &input)
+void Sprayer::update(const struct SITL::sitl_input &input)
 {
+    const int16_t pump_pwm = sprayer_pump_pin >= 0 ? input.servos[sprayer_pump_pin] : -1;
+    const int16_t spinner_pwm = sprayer_spin_pin >= 0 ? input.servos[sprayer_spin_pin] : -1;
     const uint64_t now = AP_HAL::micros64();
     const float dt = (now - last_update_us) * 1.0e-6f;
-
-    // update remaining payload
-    if (capacity > 0) {
-        const double delta = last_pump_output * pump_max_rate * dt;
-        capacity -= delta;
-        if (capacity < 0) {
-            capacity = 0.0f;
+    if (pump_pwm >= 0) {
+        // update remaining payload
+        if (capacity > 0) {
+            const double delta = last_pump_output * pump_max_rate * dt;
+            capacity -= delta;
+            if (capacity < 0) {
+                capacity = 0.0f;
+            }
         }
-    }
 
-    // update pump
-    float pump_demand = (input.servos[pump_servo]-1000) * 0.001f;
-    // ::fprintf(stderr, "pump_demand=%f\n", pump_demand);
-    if (pump_demand < 0) { // never updated
-        pump_demand = 0;
+        // update pump
+        float pump_demand = (pump_pwm - 1000) * 0.001f;
+        // ::fprintf(stderr, "pump_demand=%f\n", pump_demand);
+        if (pump_demand < 0) { // never updated
+            pump_demand = 0;
+        }
+        const float pump_max_change = pump_slew_rate / 100.0f * dt;
+        last_pump_output =
+            constrain_float(pump_demand, last_pump_output - pump_max_change, last_pump_output + pump_max_change);
+        last_pump_output = constrain_float(last_pump_output, 0, 1);
+    } else {
+        last_pump_output = 0.0f;
     }
-    const float pump_max_change = pump_slew_rate/100.0f * dt;
-    last_pump_output = constrain_float(pump_demand, last_pump_output-pump_max_change, last_pump_output+pump_max_change);
-    last_pump_output = constrain_float(last_pump_output, 0, 1);
-
     // update spinner (if any)
-    if (spinner_servo >= 0) {
-        const float spinner_demand = (input.servos[spinner_servo]-1000) * 0.001f;
+    if (spinner_pwm >= 0) {
+        const float spinner_demand = (spinner_pwm - 1000) * 0.001f;
         const float spinner_max_change = spinner_slew_rate * 0.01f * dt;
-        last_spinner_output = constrain_float(spinner_demand, last_spinner_output-spinner_max_change, last_spinner_output+spinner_max_change);
+        last_spinner_output = constrain_float(spinner_demand,
+                                              last_spinner_output - spinner_max_change,
+                                              last_spinner_output + spinner_max_change);
         last_spinner_output = constrain_float(last_spinner_output, 0, 1);
     }
 
     if (should_report()) {
         printf("Remaining: %f litres\n", capacity);
         printf("Pump: %f l/s\n", last_pump_output * pump_max_rate);
-        if (spinner_servo >= 0) {
-            printf("Spinner: %f rev/s\n", (last_spinner_output * spinner_max_rate)/360.0f);
+        if (spinner_pwm >= 0) {
+            printf("Spinner: %f rev/s\n", (last_spinner_output * spinner_max_rate) / 360.0f);
         }
         last_report_us = now;
     }
-
     last_update_us = now;
 }
 

--- a/libraries/SITL/SIM_Sprayer.h
+++ b/libraries/SITL/SIM_Sprayer.h
@@ -18,26 +18,31 @@
 
 #pragma once
 
-#include "SIM_Aircraft.h"
+#include "stdint.h"
+#include <AP_Param/AP_Param.h>
+#include "SITL.h"
 
 namespace SITL {
 
 class Sprayer {
 public:
-    const uint8_t pump_servo;
-    const int8_t spinner_servo;
-
-    Sprayer(const uint8_t _pump_servo, int8_t _spinner_servo) :
-        pump_servo(_pump_servo),
-        spinner_servo(_spinner_servo)
-    {}
+    Sprayer() {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
 
     // update sprayer state
-    void update(const struct Aircraft::sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
-    float payload_mass() const { return capacity; }; // kg; water, so kg=l
+    float payload_mass() const { return static_cast<float>(capacity); }; // kg; water, so kg=l
 
-private:
+    static const struct AP_Param::GroupInfo var_info[];
+    bool is_enable() const {return static_cast<bool>(sprayer_enable);}
+
+ private:
+
+    AP_Int8  sprayer_enable;  // enable sprayer sim
+    AP_Int8  sprayer_pump_pin;
+    AP_Int8  sprayer_spin_pin;
 
     const uint32_t report_interval = 1000000; // microseconds
     uint64_t last_report_us;

--- a/libraries/SITL/SIM_Sprayer.h
+++ b/libraries/SITL/SIM_Sprayer.h
@@ -42,12 +42,12 @@ private:
     const uint32_t report_interval = 1000000; // microseconds
     uint64_t last_report_us;
 
-    const float pump_max_rate = 0.01; // litres/second
-    const float pump_slew_rate = 20; // percent/scond
+    const float pump_max_rate = 0.01f; // litres/second
+    const float pump_slew_rate = 20.0f; // percent/second
     float last_pump_output; // percentage
 
-    const float spinner_max_rate = 3600; // degrees/second
-    const float spinner_slew_rate = 20; // percent/second
+    const float spinner_max_rate = 3600.0f; // degrees/second
+    const float spinner_slew_rate = 20.0f; // percent/second
     float last_spinner_output; // percentage
 
     double capacity = 0.25; // litres

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -44,7 +44,7 @@ Submarine::Submarine(const char *home_str, const char *frame_str) :
 }
 
 // calculate rotational and linear accelerations
-void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
+void Submarine::calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel)
 {
     rot_accel = Vector3f(0,0,0);
 
@@ -112,7 +112,7 @@ float Submarine::calculate_buoyancy_acceleration()
 /*
   update the Submarine simulation by one time step
  */
-void Submarine::update(const struct sitl_input &input)
+void Submarine::update(const struct SITL::sitl_input &input)
 {
     // get wind vector setup
     update_wind(input);

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -34,7 +34,7 @@ public:
     Submarine(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -60,7 +60,7 @@ protected:
     bool on_ground() const override;
 
     // calculate rotational and linear accelerations
-    void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
+    void calculate_forces(const struct SITL::sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     // calculate buoyancy
     float calculate_buoyancy_acceleration();
 

--- a/libraries/SITL/SIM_Tracker.cpp
+++ b/libraries/SITL/SIM_Tracker.cpp
@@ -66,7 +66,7 @@ void Tracker::update_onoff_servos(float &yaw_rate, float &pitch_rate)
 /*
   update state of tracker
  */
-void Tracker::update(const struct sitl_input &input)
+void Tracker::update(const struct SITL::sitl_input &input)
 {
     // how much time has passed?
     float delta_time = frame_time_us * 1.0e-6f;

--- a/libraries/SITL/SIM_Tracker.h
+++ b/libraries/SITL/SIM_Tracker.h
@@ -28,7 +28,7 @@ namespace SITL {
 class Tracker : public Aircraft {
 public:
     Tracker(const char *home_str, const char *frame_str);
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -354,7 +354,7 @@ failed:
 /*
   send data to X-Plane via UDP
 */
-void XPlane::send_data(const struct sitl_input &input)
+void XPlane::send_data(const struct SITL::sitl_input &input)
 {
     float aileron  = (input.servos[0]-1500)/500.0f;
     float elevator = (input.servos[1]-1500)/500.0f;
@@ -458,7 +458,7 @@ void XPlane::send_dref(const char *name, float value)
 /*
   update the XPlane simulation by one time step
  */
-void XPlane::update(const struct sitl_input &input)
+void XPlane::update(const struct SITL::sitl_input &input)
 {
     if (receive_data()) {
         send_data(input);

--- a/libraries/SITL/SIM_XPlane.h
+++ b/libraries/SITL/SIM_XPlane.h
@@ -32,7 +32,7 @@ public:
     XPlane(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -42,7 +42,7 @@ public:
 private:
     bool receive_data(void);
     void send_dref(const char *name, float value);
-    void send_data(const struct sitl_input &input);
+    void send_data(const struct SITL::sitl_input &input);
     void select_data(uint64_t usel_mask, uint64_t sel_mask);
 
     const char *xplane_ip = "127.0.0.1";

--- a/libraries/SITL/SIM_last_letter.cpp
+++ b/libraries/SITL/SIM_last_letter.cpp
@@ -74,7 +74,7 @@ void last_letter::start_last_letter(void)
 /*
   send servos
 */
-void last_letter::send_servos(const struct sitl_input &input)
+void last_letter::send_servos(const struct SITL::sitl_input &input)
 {
     servo_packet pkt;
     memcpy(pkt.servos, input.servos, sizeof(pkt.servos));
@@ -85,7 +85,7 @@ void last_letter::send_servos(const struct sitl_input &input)
   receive an update from the FDM
   This is a blocking function
  */
-void last_letter::recv_fdm(const struct sitl_input &input)
+void last_letter::recv_fdm(const struct SITL::sitl_input &input)
 {
     fdm_packet pkt;
 
@@ -122,7 +122,7 @@ void last_letter::recv_fdm(const struct sitl_input &input)
 /*
   update the last_letter simulation by one time step
  */
-void last_letter::update(const struct sitl_input &input)
+void last_letter::update(const struct SITL::sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);

--- a/libraries/SITL/SIM_last_letter.h
+++ b/libraries/SITL/SIM_last_letter.h
@@ -32,7 +32,7 @@ public:
     last_letter(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct SITL::sitl_input &input);
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {
@@ -64,8 +64,8 @@ private:
         double airspeed;
     };
 
-    void recv_fdm(const struct sitl_input &input);
-    void send_servos(const struct sitl_input &input);
+    void recv_fdm(const struct SITL::sitl_input &input);
+    void send_servos(const struct SITL::sitl_input &input);
     void start_last_letter(void);
 
     uint64_t last_timestamp_us;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -118,6 +118,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
+    // @Group: SPR_
+    // @Path: ./SIM_Sprayer.cpp
+    AP_SUBGROUPINFO(sprayer_sim, "SPR_", 18, SITL, Sprayer),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -124,6 +124,10 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     // @Group: GRPS_
     // @Path: ./SIM_Gripper_Servo.cpp
     AP_SUBGROUPINFO(gripper_sim, "GRPS_", 19, SITL, Gripper_Servo),
+    // @Group: GRPE_
+    // @Path: ./SIM_Gripper_EPM.cpp
+    AP_SUBGROUPINFO(gripper_epm_sim, "GRPE_", 20, SITL, Gripper_EPM),
+
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -121,6 +121,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     // @Group: SPR_
     // @Path: ./SIM_Sprayer.cpp
     AP_SUBGROUPINFO(sprayer_sim, "SPR_", 18, SITL, Sprayer),
+    // @Group: GRPS_
+    // @Path: ./SIM_Gripper_Servo.cpp
+    AP_SUBGROUPINFO(gripper_sim, "GRPS_", 19, SITL, Gripper_Servo),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -3,6 +3,8 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
+#include "SIM_Sprayer.h"
+
 class DataFlash_Class;
 
 namespace SITL {
@@ -218,6 +220,8 @@ public:
 
     // convert a set of roll rates from body frame to earth frame
     static Vector3f convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro);
+
+    Sprayer sprayer_sim;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -4,6 +4,7 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 #include "SIM_Sprayer.h"
+#include "SIM_Gripper_Servo.h"
 
 class DataFlash_Class;
 
@@ -222,6 +223,8 @@ public:
     static Vector3f convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro);
 
     Sprayer sprayer_sim;
+
+    Gripper_Servo gripper_sim;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -5,6 +5,7 @@
 
 #include "SIM_Sprayer.h"
 #include "SIM_Gripper_Servo.h"
+#include "SIM_Gripper_EPM.h"
 
 class DataFlash_Class;
 
@@ -159,7 +160,7 @@ public:
     AP_Int16 pin_mask; // for GPIO emulation
     AP_Float speedup; // simulation speedup
     AP_Int8  odom_enable; // enable visual odomotry data
-    
+
     // wind control
     enum WindType {
         WIND_TYPE_SQRT = 0,
@@ -225,6 +226,7 @@ public:
     Sprayer sprayer_sim;
 
     Gripper_Servo gripper_sim;
+    Gripper_EPM gripper_epm_sim;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -31,6 +31,7 @@ struct sitl_fdm {
     Vector3f angAccel; // Angular acceleration in degrees/s/s about the XYZ body axes
 };
 
+
 // number of rc output channels
 #define SITL_NUM_CHANNELS 16
 
@@ -54,6 +55,21 @@ public:
 
     static SITL *_s_instance;
     static SITL *get_instance() { return _s_instance; }
+
+
+    /*
+      structure passed in giving servo positions as PWM values in
+      microseconds
+     */
+    struct sitl_input {
+        uint16_t servos[16];
+        struct {
+            float speed;      // m/s
+            float direction;  // degrees 0..360
+            float turbulence;
+            float dir_z;	  //degrees -90..90
+        } wind;
+    };
 
     enum GPSType {
         GPS_TYPE_NONE  = 0,


### PR DESCRIPTION
This prevent sprayer and gripper to be active when using octo on SITL. In more general way, disable sprayer and grippers by default
This allow to use those on other vehicles too
Servo assigned are now parametrable