### PR TITLE
AP_GPS: set have_vertical_velocity if MAVLink GPS report it

### DIFF
--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -80,8 +80,10 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t *msg)
 
             if (have_vel_h) {
                 Vector3f vel(packet.vn, packet.ve, 0);
-                if (have_vel_v)
+                if (have_vel_v) {
                     vel.z = packet.vd;
+                    state.have_vertical_velocity = true;
+                }
 
                 state.velocity = vel;
                 state.ground_course = wrap_360(degrees(atan2f(vel.y, vel.x)));


### PR DESCRIPTION
Currently. MAVLink GPS driver do not set have_vertical_velocity = true when it get vertical velocity. It makes ekf will not use vd filed in GPS_INPUT mavlink message.