### PR TITLE
waf: fixed ChibiOS build with waf under cygwin

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -266,6 +266,7 @@ class sitl(Board):
             env.LIB += [
                 'winmm',
             ]
+            env.CXXFLAGS += ['-DCYGWIN_BUILD']
 
 
         if 'clang++' in cfg.env.COMPILER_CXX:
@@ -345,6 +346,9 @@ class chibios(Board):
             '-mfpu=fpv4-sp-d16',
             '-mfloat-abi=hard'
         ]
+
+        if sys.platform == 'cygwin':
+            env.CXXFLAGS += ['-DCYGWIN_BUILD']
 
         bldnode = cfg.bldnode.make_node(self.name)
         env.BUILDROOT = bldnode.make_node('').abspath()

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -375,9 +375,10 @@ class chibios(Board):
             '-mfpu=fpv4-sp-d16',
             '-mno-thumb-interwork',
             '-mthumb',
+            '-L%s' % env.BUILDROOT,
             '-L%s' % cfg.srcnode.make_node('modules/ChibiOS/os/common/startup/ARMCMx/compilers/GCC/ld/').abspath(),
             '-L%s' % cfg.srcnode.make_node('libraries/AP_HAL_ChibiOS/hwdef/common/').abspath(),
-            '-Wl,--gc-sections,--no-warn-mismatch,--library-path=/ld,--script=%s/ldscript.ld,--defsym=__process_stack_size__=0x400,--defsym=__main_stack_size__=0x400' % env.BUILDROOT,
+            '-Wl,--gc-sections,--no-warn-mismatch,--library-path=/ld,--script=ldscript.ld,--defsym=__process_stack_size__=0x400,--defsym=__main_stack_size__=0x400',
         ]
 
         env.LIB += ['gcc', 'm']

--- a/libraries/AP_Common/missing/cmath
+++ b/libraries/AP_Common/missing/cmath
@@ -29,6 +29,26 @@
 #  endif
 #endif
 
+
+#ifdef WAF_BUILD
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
+// cygwin path length issues in configure mean these come out wrong,
+// so fix them here
+#ifndef HAVE_CMATH_ISFINITE
+# define HAVE_CMATH_ISFINITE
+# define NEED_CMATH_ISFINITE_STD_NAMESPACE
+#endif
+#ifndef HAVE_CMATH_ISINF
+# define HAVE_CMATH_ISINF
+# define NEED_CMATH_ISINF_STD_NAMESPACE
+#endif
+#ifndef HAVE_CMATH_ISNAN
+# define HAVE_CMATH_ISNAN
+# define NEED_CMATH_ISNAN_STD_NAMESPACE
+#endif
+#endif
+#endif
+
 #if defined(HAVE_CMATH_ISFINITE) && defined(NEED_CMATH_ISFINITE_STD_NAMESPACE)
 using std::isfinite;
 #endif

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -30,9 +30,9 @@
 
 #if HAL_USE_I2C == TRUE
 
-using namespace ChibiOS;
+namespace ChibiOS {
 
-class ChibiOS::I2CBus : public ChibiOS::DeviceBus {
+class I2CBus : public DeviceBus {
 public:
     I2CConfig i2ccfg;
     uint8_t busnum;
@@ -46,7 +46,7 @@ public:
     static void clear_bus(ioline_t scl_line, uint8_t scl_af);
 };
     
-class ChibiOS::I2CDevice : public AP_HAL::I2CDevice {
+class I2CDevice : public AP_HAL::I2CDevice {
 public:
     static I2CDevice *from(AP_HAL::I2CDevice *dev)
     {
@@ -102,7 +102,7 @@ private:
     uint32_t _timeout_ms;
 };
 
-class ChibiOS::I2CDeviceManager : public AP_HAL::I2CDeviceManager {
+class I2CDeviceManager : public AP_HAL::I2CDeviceManager {
 public:
     friend class I2CDevice;
 
@@ -121,6 +121,7 @@ public:
                                                  bool use_smbus = false,
                                                  uint32_t timeout_ms=4) override;
 };
+}
 
 #endif // HAL_USE_I2C
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -23,9 +23,9 @@
 
 #if HAL_USE_SPI == TRUE
 
-using namespace ChibiOS;
+namespace ChibiOS {
 
-class ChibiOS::SPIBus : public ChibiOS::DeviceBus {
+class SPIBus : public DeviceBus {
 public:
     SPIBus(uint8_t bus);
     struct spi_dev_s *dev;
@@ -36,7 +36,7 @@ public:
     bool spi_started;
 };
 
-struct ChibiOS::SPIDesc {
+struct SPIDesc {
     SPIDesc(const char *_name, uint8_t _bus,
             uint8_t _device, ioline_t _pal_line,
             uint16_t _mode, uint32_t _lowspeed, uint32_t _highspeed)
@@ -56,7 +56,7 @@ struct ChibiOS::SPIDesc {
 };
 
 
-class ChibiOS::SPIDevice : public AP_HAL::SPIDevice {
+class SPIDevice : public AP_HAL::SPIDevice {
 public:
     SPIDevice(SPIBus &_bus, SPIDesc &_device_desc);
 
@@ -101,7 +101,7 @@ private:
     uint16_t derive_freq_flag(uint32_t _frequency);
 };
 
-class ChibiOS::SPIDeviceManager : public AP_HAL::SPIDeviceManager {
+class SPIDeviceManager : public AP_HAL::SPIDeviceManager {
 public:
     friend class SPIDevice;
 
@@ -116,6 +116,6 @@ private:
     static SPIDesc device_table[];
     SPIBus *buses;
 };
-
+}
 
 #endif // HAL_USE_SPI

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -362,7 +362,7 @@ MEMORY
     ram0  : org = 0x20000000, len = %uk
 }
 
-INCLUDE common.ld
+INCLUDE ../../libraries/AP_HAL_ChibiOS/hwdef/common/common.ld
 ''' % (flash_base, flash_length, ram_size))
 
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -63,7 +63,7 @@ void SITL_State::_sitl_setup(const char *home_str)
 {
     _home_str = home_str;
 
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(__CYGWIN64__)
     _parent_pid = getppid();
 #endif
     _rcout_addr.sin_family = AF_INET;

--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -19,7 +19,11 @@
 
 #include "UARTDriver.h"
 
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(__APPLE__)
+#define USE_TERMIOS
+#endif
+
+#ifdef USE_TERMIOS
 #include <termios.h>
 #else
 #include <asm/termbits.h>
@@ -35,7 +39,7 @@ bool HALSITL::UARTDriver::set_speed(int speed)
     if (_fd < 0) {
         return false;
     }
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#ifdef USE_TERMIOS
     struct termios t;
     tcgetattr(_fd, &t);
     cfsetspeed(&t, speed);
@@ -68,7 +72,7 @@ void HALSITL::UARTDriver::configure_parity(uint8_t v)
     if (_fd < 0) {
         return;
     }
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#ifdef USE_TERMIOS
     struct termios t;
 
     tcgetattr(_fd, &t);
@@ -93,7 +97,7 @@ void HALSITL::UARTDriver::configure_parity(uint8_t v)
         t.c_cflag &= ~PARENB;
     }
 
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#ifdef USE_TERMIOS
     tcsetattr(_fd, TCSANOW, &t);
 #else
     ioctl(_fd, TCSETS2, &t);
@@ -105,7 +109,7 @@ void HALSITL::UARTDriver::set_stop_bits(int n)
     if (_fd < 0) {
         return;
     }
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#ifdef USE_TERMIOS
     struct termios t;
 
     tcgetattr(_fd, &t);
@@ -123,7 +127,7 @@ void HALSITL::UARTDriver::set_stop_bits(int n)
         t.c_cflag &= ~CSTOPB;
     }
 
-#if defined(__CYGWIN__) || defined(__APPLE__)
+#ifdef USE_TERMIOS
     tcsetattr(_fd, TCSANOW, &t);
 #else
     ioctl(_fd, TCSETS2, &t);

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -23,7 +23,7 @@
 #include <unistd.h>
 
 
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(__CYGWIN64__)
 #include <windows.h>
 #include <time.h>
 #include <mmsystem.h>
@@ -54,7 +54,7 @@ Aircraft::Aircraft(const char *home_str, const char *frame_str) :
     rate_hz(1200.0f),
     autotest_dir(nullptr),
     frame(frame_str),
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(__CYGWIN64__)
     min_sleep_time(20000)
 #else
     min_sleep_time(5000)
@@ -429,7 +429,7 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
 
 uint64_t Aircraft::get_wall_time_us() const
 {
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(__CYGWIN64__)
     static DWORD tPrev;
     static uint64_t last_ret_us;
     if (tPrev == 0) {

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -103,7 +103,7 @@ void *FlightAxis::update_thread(void *arg)
 {
     FlightAxis *flightaxis = (FlightAxis *)arg;
 
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(__CYGWIN64__)
     //Cygwin doesn't support pthread_setname_np
 #elif defined(__APPLE__) && defined(__MACH__)
     pthread_setname_np("ardupilot-flightaxis");


### PR DESCRIPTION
we needed to use relative paths to avoid very short path name length restrictions with the cross compiler on cygwin
