### PR TITLE
AP_HAL_ChibiOS: Add realloc support

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -85,6 +85,22 @@ void free(void *ptr)
     }
 }
 
+void *realloc(void *ptr, size_t size) {
+    if (size == 0) {
+       free(ptr);
+       return NULL;
+    }
+    if (ptr == NULL) {
+        return malloc(size);
+    }
+    void *new_mem = malloc(size);
+    if (new_mem != NULL) {
+        memcpy(new_mem, ptr, size);
+        free(ptr);
+    }
+    return new_mem;
+}
+
 /*
   return total available memory in bytes
  */

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -36,6 +36,7 @@ int sscanf (const char *buf, const char *fmt, ...);
 int vsscanf (const char *buf, const char *s, va_list ap);
 void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
 void free(void *ptr);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is needed for supporting scripting. Sending in standalone because discussion at the unconference lead to the opinion anything that is common/hal layer for scripting should probably just be sent in earlier to reduce the odds of it being redone by @bugobliterator or @tridge.

I'm not sure why git thinks I've made a line change on the #endif.