### PR TITLE
AC_Avoid: correct alt_diff calculation in adjust_velocity_z

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -139,7 +139,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         float veh_alt;
         _ahrs.get_relative_position_D_home(veh_alt);
         // _fence.get_safe_alt_max() is UP, veh_alt is DOWN:
-        alt_diff = _fence.get_safe_alt_max() + veh_alt;
+        alt_diff = _fence.get_safe_alt_max() - veh_alt;
         limit_alt = true;
     }
 


### PR DESCRIPTION
To calculate the distance between the vehicle altitude and the maximum fence, the altitude of the vehicle should be subtracted rather than added.