### PR TITLE
Camera: Report number of feedback events over MAVLink

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -258,7 +258,7 @@ void AP_Camera::send_feedback(mavlink_channel_t chan)
         current_loc.lat, current_loc.lng,
         altitude*1e-2, altitude_rel*1e-2,
         ahrs.roll_sensor*1e-2, ahrs.pitch_sensor*1e-2, ahrs.yaw_sensor*1e-2,
-        0.0f,CAMERA_FEEDBACK_PHOTO);
+        0.0f, CAMERA_FEEDBACK_PHOTO, _feedback_events);
 }
 
 
@@ -441,6 +441,7 @@ void AP_Camera::update_trigger()
 {
     trigger_pic_cleanup();
     if (check_trigger_pin()) {
+        _feedback_events++;
         gcs().send_message(MSG_CAMERA_FEEDBACK);
         DataFlash_Class *df = DataFlash_Class::instance();
         if (df != nullptr) {

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -98,6 +98,7 @@ private:
     uint32_t        _last_photo_time;   // last time a photo was taken
     struct Location _last_location;
     uint16_t        _image_index;       // number of pictures taken since boot
+    uint16_t        _feedback_events;   // number of feedback events since boot
 
     // pin number for accurate camera feedback messages
     AP_Int8         _feedback_pin;


### PR DESCRIPTION
Implements #3903. For a mapping mission you routinely want to know both how many times you've tried to trigger the camera (which we already report) and how many times you succeeded in triggering the camera (what this PR adds). Otherwise it's quite difficult to assess if the camera is meeting an acceptable level of performance.

*CAUTION* Do not merge as is, https://github.com/ArduPilot/mavlink/pull/65 must be merged first, then the MAVLink commit here needs to be updated before merging.