### PR TITLE
Use baro singleton

### DIFF
--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -9,9 +9,9 @@
 class AP_Arming_Rover : public AP_Arming
 {
 public:
-    AP_Arming_Rover(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+    AP_Arming_Rover(const AP_AHRS &ahrs_ref, Compass &compass,
                     const AP_BattMonitor &battery, const AC_Fence &fence)
-        : AP_Arming(ahrs_ref, baro, compass, battery),
+        : AP_Arming(ahrs_ref, compass, battery),
           _fence(fence)
     {
     }

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -18,7 +18,7 @@ public:
 
     /* Do not allow copies */
     AP_Arming_Rover(const AP_Arming_Rover &other) = delete;
-    AP_Arming_Rover &operator=(const AP_Baro&) = delete;
+    AP_Arming_Rover &operator=(const AP_Arming_Rover&) = delete;
 
     bool pre_arm_checks(bool report) override;
     bool pre_arm_rc_checks(const bool display_failure);

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -345,12 +345,12 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
 
     case MSG_RAW_IMU2:
         CHECK_PAYLOAD_SIZE(SCALED_PRESSURE);
-        send_scaled_pressure(rover.barometer);
+        send_scaled_pressure();
         break;
 
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
-        send_sensor_offsets(rover.ins, rover.compass, rover.barometer);
+        send_sensor_offsets(rover.ins, rover.compass);
         break;
 
     case MSG_SIMSTATE:

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -216,7 +216,7 @@ void Rover::Log_Write_Error(uint8_t sub_system, uint8_t error_code)
 
 void Rover::Log_Write_Baro(void)
 {
-    DataFlash.Log_Write_Baro(barometer);
+    DataFlash.Log_Write_Baro();
 }
 
 // log ahrs home and EKF origin to dataflash

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -169,15 +169,15 @@ private:
 
     // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
-    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs{ins, barometer};
+    AP_AHRS_DCM ahrs{ins};
 #endif
 
     // Arming/Disarming management class
-    AP_Arming_Rover arming{ahrs, barometer, compass, battery, g2.fence};
+    AP_Arming_Rover arming{ahrs, compass, battery, g2.fence};
 
     AP_L1_Control L1_controller{ahrs, nullptr};
 

--- a/APMrover2/afs_rover.cpp
+++ b/APMrover2/afs_rover.cpp
@@ -7,8 +7,8 @@
 #if ADVANCED_FAILSAFE == ENABLED
 
 // Constructor
-AP_AdvancedFailsafe_Rover::AP_AdvancedFailsafe_Rover(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap) :
-    AP_AdvancedFailsafe(_mission, _baro, _gps, _rcmap)
+AP_AdvancedFailsafe_Rover::AP_AdvancedFailsafe_Rover(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap) :
+    AP_AdvancedFailsafe(_mission, _gps, _rcmap)
 {}
 
 

--- a/APMrover2/afs_rover.h
+++ b/APMrover2/afs_rover.h
@@ -27,7 +27,7 @@
 class AP_AdvancedFailsafe_Rover : public AP_AdvancedFailsafe
 {
 public:
-    AP_AdvancedFailsafe_Rover(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap);
+    AP_AdvancedFailsafe_Rover(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap);
 
     // called to set all outputs to termination state
     void terminate_vehicle(void) override;

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -202,12 +202,12 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
 
     case MSG_RAW_IMU2:
         CHECK_PAYLOAD_SIZE(SCALED_PRESSURE);
-        send_scaled_pressure(tracker.barometer);
+        send_scaled_pressure();
         break;
 
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
-        send_sensor_offsets(tracker.ins, tracker.compass, tracker.barometer);
+        send_sensor_offsets(tracker.ins, tracker.compass);
         break;
 
     case MSG_SIMSTATE:

--- a/AntennaTracker/Log.cpp
+++ b/AntennaTracker/Log.cpp
@@ -21,7 +21,7 @@ void Tracker::Log_Write_Attitude()
 
 void Tracker::Log_Write_Baro(void)
 {
-    DataFlash.Log_Write_Baro(barometer);
+    DataFlash.Log_Write_Baro();
 }
 
 struct PACKED log_Vehicle_Baro {

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -116,11 +116,11 @@ private:
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2{&ahrs, barometer, rng};
-    NavEKF3 EKF3{&ahrs, barometer, rng};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3};
+    NavEKF2 EKF2{&ahrs, rng};
+    NavEKF3 EKF3{&ahrs, rng};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs{ins, barometer};
+    AP_AHRS_DCM ahrs{ins};
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -7,10 +7,10 @@ class AP_Arming_Copter : public AP_Arming
 public:
     friend class Copter;
     friend class ToyMode;
-    AP_Arming_Copter(const AP_AHRS_NavEKF &ahrs_ref, const AP_Baro &baro, Compass &compass,
+    AP_Arming_Copter(const AP_AHRS_NavEKF &ahrs_ref, Compass &compass,
                      const AP_BattMonitor &battery, const AP_InertialNav_NavEKF &inav,
                      const AP_InertialSensor &ins)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
+        : AP_Arming(ahrs_ref, compass, battery)
         , _inav(inav)
         , _ins(ins)
         , _ahrs_navekf(ahrs_ref)

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -19,7 +19,7 @@ public:
 
     /* Do not allow copies */
     AP_Arming_Copter(const AP_Arming_Copter &other) = delete;
-    AP_Arming_Copter &operator=(const AP_Baro&) = delete;
+    AP_Arming_Copter &operator=(const AP_Arming_Copter&) = delete;
 
     void update(void);
     bool all_checks_passing(bool arming_from_gcs);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -239,9 +239,9 @@ private:
     AP_RPM rpm_sensor;
 
     // Inertial Navigation EKF
-    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
-    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
@@ -266,7 +266,7 @@ private:
 #endif
 
     // Arming/Disarming mangement class
-    AP_Arming_Copter arming{ahrs, barometer, compass, battery, inertial_nav, ins};
+    AP_Arming_Copter arming{ahrs, compass, battery, inertial_nav, ins};
 
     // Optical flow sensor
 #if OPTFLOW == ENABLED

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -345,12 +345,12 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 
     case MSG_RAW_IMU2:
         CHECK_PAYLOAD_SIZE(SCALED_PRESSURE);
-        send_scaled_pressure(copter.barometer);
+        send_scaled_pressure();
         break;
 
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
-        send_sensor_offsets(copter.ins, copter.compass, copter.barometer);
+        send_sensor_offsets(copter.ins, copter.compass);
         break;
 
     case MSG_RANGEFINDER:
@@ -1652,7 +1652,7 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 
         ins.set_accel(0, accels);
 
-        copter.barometer.setHIL(packet.alt*0.001f);
+        AP::baro().setHIL(packet.alt*0.001f);
         copter.compass.setHIL(0, packet.roll, packet.pitch, packet.yaw);
         copter.compass.setHIL(1, packet.roll, packet.pitch, packet.yaw);
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -380,7 +380,7 @@ void Copter::Log_Write_Error(uint8_t sub_system, uint8_t error_code)
 void Copter::Log_Write_Baro(void)
 {
     if (!ahrs.have_ekf_logging()) {
-        DataFlash.Log_Write_Baro(barometer);
+        DataFlash.Log_Write_Baro();
     }
 }
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1002,7 +1002,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
   constructor for g2 object
  */
 ParametersG2::ParametersG2(void)
-    : temp_calibration(copter.barometer, copter.ins)
+    : temp_calibration(copter.ins)
 #if BEACON_ENABLED == ENABLED
     , beacon(copter.serial_manager)
 #endif

--- a/ArduCopter/afs_copter.cpp
+++ b/ArduCopter/afs_copter.cpp
@@ -7,7 +7,7 @@
 #if ADVANCED_FAILSAFE == ENABLED
 
 // Constructor
-AP_AdvancedFailsafe_Copter::AP_AdvancedFailsafe_Copter(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap) :
+AP_AdvancedFailsafe_Copter::AP_AdvancedFailsafe_Copter(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap) :
     AP_AdvancedFailsafe(_mission, _baro, _gps, _rcmap)
 {}
 

--- a/ArduCopter/afs_copter.h
+++ b/ArduCopter/afs_copter.h
@@ -27,7 +27,7 @@
 class AP_AdvancedFailsafe_Copter : public AP_AdvancedFailsafe
 {
 public:
-    AP_AdvancedFailsafe_Copter(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap);
+    AP_AdvancedFailsafe_Copter(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap);
 
     // called to set all outputs to termination state
     void terminate_vehicle(void);

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -23,7 +23,7 @@ public:
 
     /* Do not allow copies */
     AP_Arming_Plane(const AP_Arming_Plane &other) = delete;
-    AP_Arming_Plane &operator=(const AP_Baro&) = delete;
+    AP_Arming_Plane &operator=(const AP_Arming_Plane&) = delete;
 
     bool pre_arm_checks(bool report);
 

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -8,9 +8,9 @@
 class AP_Arming_Plane : public AP_Arming
 {
 public:
-    AP_Arming_Plane(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+    AP_Arming_Plane(const AP_AHRS &ahrs_ref, Compass &compass,
                     const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
+        : AP_Arming(ahrs_ref, compass, battery)
     {
         AP_Param::setup_object_defaults(this, var_info);
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -473,12 +473,12 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
 
     case MSG_RAW_IMU2:
         CHECK_PAYLOAD_SIZE(SCALED_PRESSURE);
-        send_scaled_pressure(plane.barometer);
+        send_scaled_pressure();
         break;
 
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
-        send_sensor_offsets(plane.ins, plane.compass, plane.barometer);
+        send_sensor_offsets(plane.ins, plane.compass);
         break;
 
     case MSG_FENCE_STATUS:

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -297,7 +297,7 @@ void Plane::Log_Write_RC(void)
 void Plane::Log_Write_Baro(void)
 {
     if (!ahrs.have_ekf_logging()) {
-        DataFlash.Log_Write_Baro(barometer);
+        DataFlash.Log_Write_Baro();
     }
 }
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -122,7 +122,7 @@
 class AP_AdvancedFailsafe_Plane : public AP_AdvancedFailsafe
 {
 public:
-    AP_AdvancedFailsafe_Plane(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap);
+    AP_AdvancedFailsafe_Plane(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap);
 
     // called to set all outputs to termination state
     void terminate_vehicle(void);
@@ -214,11 +214,11 @@ private:
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE
-    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
-    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3};
 #else
-    AP_AHRS_DCM ahrs{ins, barometer};
+    AP_AHRS_DCM ahrs{ins};
 #endif
 
     AP_TECS TECS_controller{ahrs, aparm, landing, g2.soaring_controller};
@@ -632,7 +632,7 @@ private:
     AP_Avoidance_Plane avoidance_adsb{ahrs, adsb};
 
     // Outback Challenge Failsafe Support
-    AP_AdvancedFailsafe_Plane afs {mission, barometer, gps, rcmap};
+    AP_AdvancedFailsafe_Plane afs {mission, gps, rcmap};
 
     /*
       meta data to support counting the number of circles in a loiter
@@ -752,7 +752,7 @@ private:
 #endif
 
     // Arming/Disarming mangement class
-    AP_Arming_Plane arming{ahrs, barometer, compass, battery};
+    AP_Arming_Plane arming{ahrs, compass, battery};
 
     AP_Param param_loader {var_info};
 

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -5,8 +5,8 @@
 #include "Plane.h"
 
 // Constructor
-AP_AdvancedFailsafe_Plane::AP_AdvancedFailsafe_Plane(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap) :
-    AP_AdvancedFailsafe(_mission, _baro, _gps, _rcmap)
+AP_AdvancedFailsafe_Plane::AP_AdvancedFailsafe_Plane(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap) :
+    AP_AdvancedFailsafe(_mission, _gps, _rcmap)
 {}
 
 

--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -4,9 +4,9 @@
 
 class AP_Arming_Sub : public AP_Arming {
 public:
-    AP_Arming_Sub(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+    AP_Arming_Sub(const AP_AHRS &ahrs_ref, Compass &compass,
                   const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, baro, compass, battery)
+        : AP_Arming(ahrs_ref, compass, battery)
     {
     }
 

--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -12,7 +12,7 @@ public:
 
     /* Do not allow copies */
     AP_Arming_Sub(const AP_Arming_Sub &other) = delete;
-    AP_Arming_Sub &operator=(const AP_Baro&) = delete;
+    AP_Arming_Sub &operator=(const AP_Arming_Sub&) = delete;
 
     bool rc_calibration_checks(bool report) override;
     bool pre_arm_checks(bool report) override;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -544,13 +544,13 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
 
     case MSG_RAW_IMU2:
         CHECK_PAYLOAD_SIZE(SCALED_PRESSURE);
-        send_scaled_pressure(sub.barometer);
+        send_scaled_pressure();
         sub.send_temperature(chan);
         break;
 
     case MSG_RAW_IMU3:
         CHECK_PAYLOAD_SIZE(SENSOR_OFFSETS);
-        send_sensor_offsets(sub.ins, sub.compass, sub.barometer);
+        send_sensor_offsets(sub.ins, sub.compass);
         break;
 
     case MSG_RANGEFINDER:

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -318,7 +318,7 @@ void Sub::Log_Write_Error(uint8_t sub_system, uint8_t error_code)
 void Sub::Log_Write_Baro(void)
 {
     if (!ahrs.have_ekf_logging()) {
-        DataFlash.Log_Write_Baro(barometer);
+        DataFlash.Log_Write_Baro();
     }
 }
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -186,9 +186,9 @@ private:
 #endif
 
     // Inertial Navigation EKF
-    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
-    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL sitl;
@@ -330,7 +330,7 @@ private:
     // Battery Sensors
     AP_BattMonitor battery{MASK_LOG_CURRENT};
 
-    AP_Arming_Sub arming{ahrs, barometer, compass, battery};
+    AP_Arming_Sub arming{ahrs, compass, battery};
 
     // Altitude
     // The cm/s we are moving up or down based on filtered data - Positive = UP

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -105,7 +105,7 @@ void LR_MsgHandler_BARO::process_message(uint8_t *msg)
     if (!field_value(msg, "SMS", last_update_ms)) {
         last_update_ms = 0;
     }
-    baro.setHIL(0,
+    AP::baro().setHIL(0,
 		require_field_float(msg, "Press"),
 		require_field_int16_t(msg, "Temp") * 0.01f,
 		require_field_float(msg, "Alt"),

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -113,13 +113,12 @@ class LR_MsgHandler_BARO : public LR_MsgHandler
 {
 public:
     LR_MsgHandler_BARO(log_Format &_f, DataFlash_Class &_dataflash,
-                    uint64_t &_last_timestamp_usec, AP_Baro &_baro)
-        : LR_MsgHandler(_f, _dataflash, _last_timestamp_usec), baro(_baro) { };
+                    uint64_t &_last_timestamp_usec)
+        : LR_MsgHandler(_f, _dataflash, _last_timestamp_usec)
+        { };
 
     virtual void process_message(uint8_t *msg);
 
-private:
-    AP_Baro &baro;
 };
 
 

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -39,13 +39,12 @@ const struct LogStructure log_structure[] = {
       "FBBBGGB000"}
 };
 
-LogReader::LogReader(AP_AHRS &_ahrs, AP_InertialSensor &_ins, AP_Baro &_baro, Compass &_compass, AP_GPS &_gps, 
+LogReader::LogReader(AP_AHRS &_ahrs, AP_InertialSensor &_ins, Compass &_compass, AP_GPS &_gps, 
                      AP_Airspeed &_airspeed, DataFlash_Class &_dataflash, const char **&_nottypes):
     DataFlashFileReader(),
     vehicle(VehicleType::VEHICLE_UNKNOWN),
     ahrs(_ahrs),
     ins(_ins),
-    baro(_baro),
     compass(_compass),
     gps(_gps),
     airspeed(_airspeed),
@@ -231,7 +230,7 @@ bool LogReader::handle_log_format_msg(const struct log_Format &f)
 						 sim_attitude);
 	} else if (streq(name, "BARO")) {
 	  msgparser[f.type] = new LR_MsgHandler_BARO(formats[f.type], dataflash,
-                                                  last_timestamp_usec, baro);
+                                                  last_timestamp_usec);
 	} else if (streq(name, "ARM")) {
 	  msgparser[f.type] = new LR_MsgHandler_ARM(formats[f.type], dataflash,
                                                   last_timestamp_usec);

--- a/Tools/Replay/LogReader.h
+++ b/Tools/Replay/LogReader.h
@@ -6,7 +6,7 @@
 class LogReader : public DataFlashFileReader
 {
 public:
-    LogReader(AP_AHRS &_ahrs, AP_InertialSensor &_ins, AP_Baro &_baro, Compass &_compass, AP_GPS &_gps, AP_Airspeed &_airspeed, DataFlash_Class &_dataflash, const char **&nottypes);
+    LogReader(AP_AHRS &_ahrs, AP_InertialSensor &_ins, Compass &_compass, AP_GPS &_gps, AP_Airspeed &_airspeed, DataFlash_Class &_dataflash, const char **&nottypes);
     bool wait_type(const char *type);
 
     const Vector3f &get_attitude(void) const { return attitude; }
@@ -37,7 +37,6 @@ protected:
 private:
     AP_AHRS &ahrs;
     AP_InertialSensor &ins;
-    AP_Baro &baro;
     Compass &compass;
     AP_GPS &gps;
     AP_Airspeed &airspeed;

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -64,9 +64,9 @@ public:
     Compass compass;
     AP_SerialManager serial_manager;
     RangeFinder rng{serial_manager, ROTATION_PITCH_270};
-    NavEKF2 EKF2{&ahrs, barometer, rng};
-    NavEKF3 EKF3{&ahrs, barometer, rng};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3};
+    NavEKF2 EKF2{&ahrs, rng};
+    NavEKF3 EKF3{&ahrs, rng};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3};
     AP_InertialNav_NavEKF inertial_nav{ahrs};
     AP_Vehicle::FixedWing aparm;
     AP_Airspeed airspeed;
@@ -121,7 +121,7 @@ private:
     SITL::SITL sitl;
 #endif
 
-    LogReader logreader{_vehicle.ahrs, _vehicle.ins, _vehicle.barometer, _vehicle.compass, _vehicle.gps, _vehicle.airspeed, _vehicle.dataflash, nottypes};
+    LogReader logreader{_vehicle.ahrs, _vehicle.ins, _vehicle.compass, _vehicle.gps, _vehicle.airspeed, _vehicle.dataflash, nottypes};
 
     FILE *ekf1f;
     FILE *ekf2f;

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -506,7 +506,7 @@ void AP_ADSB::send_dynamic_out(const mavlink_channel_t chan)
     const uint64_t gps_time = gps.time_epoch_usec();
     const uint32_t utcTime = gps_time / 1000000ULL;
 
-    const AP_Baro &baro = AP::ahrs().get_baro();
+    const AP_Baro &baro = AP::baro();
     int32_t altPres = INT_MAX;
     if (baro.healthy()) {
         // Altitude difference between 101325 (Pascals) and current pressure. Result in millimeters

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -53,7 +53,7 @@ public:
     friend class AP_AHRS_View;
     
     // Constructor
-    AP_AHRS(AP_InertialSensor &ins, AP_Baro &baro) :
+    AP_AHRS(AP_InertialSensor &ins) :
         roll(0.0f),
         pitch(0.0f),
         yaw(0.0f),
@@ -67,7 +67,6 @@ public:
         _beacon(nullptr),
         _compass_last_update(0),
         _ins(ins),
-        _baro(baro),
         _cos_roll(1.0f),
         _cos_pitch(1.0f),
         _cos_yaw(1.0f),
@@ -209,10 +208,6 @@ public:
 
     const AP_InertialSensor &get_ins() const {
         return _ins;
-    }
-
-    const AP_Baro &get_baro() const {
-        return _baro;
     }
 
     // get the index of the current primary accelerometer sensor
@@ -639,7 +634,6 @@ protected:
     // note: we use ref-to-pointer here so that our caller can change the GPS without our noticing
     //       IMU under us without our noticing.
     AP_InertialSensor   &_ins;
-    AP_Baro             &_baro;
 
     // a vector to capture the difference between the controller and body frames
     AP_Vector3f         _trim;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -956,7 +956,7 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
 {
     loc.lat = _last_lat;
     loc.lng = _last_lng;
-    loc.alt = _baro.get_altitude() * 100 + _home.alt;
+    loc.alt = AP::baro().get_altitude() * 100 + _home.alt;
     loc.flags.relative_alt = 0;
     loc.flags.terrain_alt = 0;
     location_offset(loc, _position_offset_north, _position_offset_east);
@@ -1010,7 +1010,7 @@ void AP_AHRS_DCM::set_home(const Location &loc)
 //  a relative ground position to home in meters, Down
 void AP_AHRS_DCM::get_relative_position_D_home(float &posD) const
 {
-    posD = -_baro.get_altitude();
+    posD = -AP::baro().get_altitude();
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -23,8 +23,8 @@
 
 class AP_AHRS_DCM : public AP_AHRS {
 public:
-    AP_AHRS_DCM(AP_InertialSensor &ins, AP_Baro &baro)
-        : AP_AHRS(ins, baro)
+    AP_AHRS_DCM(AP_InertialSensor &ins)
+        : AP_AHRS(ins)
         , _omega_I_sum_time(0.0f)
         , _renorm_val_sum(0.0f)
         , _renorm_val_count(0)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -31,11 +31,10 @@ extern const AP_HAL::HAL& hal;
 
 // constructor
 AP_AHRS_NavEKF::AP_AHRS_NavEKF(AP_InertialSensor &ins,
-                               AP_Baro &baro,
                                NavEKF2 &_EKF2,
                                NavEKF3 &_EKF3,
                                Flags flags) :
-    AP_AHRS_DCM(ins, baro),
+    AP_AHRS_DCM(ins),
     EKF2(_EKF2),
     EKF3(_EKF3),
     _ekf2_started(false),
@@ -903,7 +902,7 @@ void AP_AHRS_NavEKF::get_relative_position_D_home(float &posD) const
     float originD;
     if (!get_relative_position_D_origin(originD) ||
         !get_origin(originLLH)) {
-        posD = -_baro.get_altitude();
+        posD = -AP::baro().get_altitude();
         return;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -44,7 +44,7 @@ public:
     };
 
     // Constructor
-    AP_AHRS_NavEKF(AP_InertialSensor &ins, AP_Baro &baro,
+    AP_AHRS_NavEKF(AP_InertialSensor &ins,
                    NavEKF2 &_EKF2, NavEKF3 &_EKF3, Flags flags = FLAG_NONE);
 
     /* Do not allow copies */

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -26,9 +26,9 @@ static AP_SerialManager serial_manager;
 class DummyVehicle {
 public:
     RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
-    NavEKF2 EKF2{&ahrs, barometer, sonar};
-    NavEKF3 EKF3{&ahrs, barometer, sonar};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3,
+    NavEKF2 EKF2{&ahrs, sonar};
+    NavEKF3 EKF3{&ahrs, sonar};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3,
             AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -325,6 +325,7 @@ AP_AdvancedFailsafe::check_altlimit(void)
     }
 
     // see if the barometer is dead
+    const AP_Baro &baro = AP::baro();
     if (AP_HAL::millis() - baro.get_last_update() > 5000) {
         // the barometer has been unresponsive for 5 seconds. See if we can switch to GPS
         if (_amsl_margin_gps != -1 &&

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -51,9 +51,8 @@ public:
     };
 
     // Constructor
-    AP_AdvancedFailsafe(AP_Mission &_mission, AP_Baro &_baro, const AP_GPS &_gps, const RCMapper &_rcmap) :
+    AP_AdvancedFailsafe(AP_Mission &_mission, const AP_GPS &_gps, const RCMapper &_rcmap) :
         mission(_mission),
-        baro(_baro),
         gps(_gps),
         rcmap(_rcmap),
         _gps_loss_count(0),
@@ -96,7 +95,6 @@ protected:
     enum state _state;
 
     AP_Mission &mission;
-    AP_Baro &baro;
     const AP_GPS &gps;
     const RCMapper &rcmap;
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -77,10 +77,9 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
 
 //The function point is particularly hacky, hacky, tacky
 //but I don't want to reimplement messaging to GCS at the moment:
-AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, Compass &compass,
                      const AP_BattMonitor &battery) :
     ahrs(ahrs_ref),
-    barometer(baro),
     _compass(compass),
     _battery(battery),
     armed(false),
@@ -116,7 +115,7 @@ bool AP_Arming::barometer_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BARO)) {
-        if (!barometer.all_healthy()) {
+        if (!AP::baro().all_healthy()) {
             if (report) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Barometer not healthy");
             }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -61,7 +61,7 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
-    AP_Arming(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
+    AP_Arming(const AP_AHRS &ahrs_ref, Compass &compass,
               const AP_BattMonitor &battery);
 
     // Parameters
@@ -72,7 +72,6 @@ protected:
 
     // references
     const AP_AHRS           &ahrs;
-    const AP_Baro           &barometer;
     Compass                 &_compass;
     const AP_BattMonitor    &_battery;
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -679,3 +679,11 @@ void AP_Baro::set_pressure_correction(uint8_t instance, float p_correction)
     }
 }
 
+namespace AP {
+
+AP_Baro &baro()
+{
+    return *AP_Baro::get_instance();
+}
+
+};

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -219,3 +219,7 @@ private:
 
     bool _add_backend(AP_Baro_Backend *backend);
 };
+
+namespace AP {
+    AP_Baro &baro();
+};

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -18,7 +18,7 @@ private:
     AP_Baro baro;
     AP_GPS  gps;
     Compass compass;
-    AP_AHRS_DCM ahrs{ins, baro};
+    AP_AHRS_DCM ahrs{ins};
 
     // global constants that control how many verify calls must be made for a command before it completes
     uint8_t verify_nav_cmd_iterations_to_complete = 3;

--- a/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
+++ b/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
@@ -19,7 +19,7 @@ static AP_Baro baro;
 static AP_SerialManager serial_manager;
 
 // choose which AHRS system to use
-static AP_AHRS_DCM ahrs{ins, baro};
+static AP_AHRS_DCM ahrs{ins};
 
 void setup(void)
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -555,9 +555,8 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     AP_GROUPEND
 };
 
-NavEKF2::NavEKF2(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng) :
+NavEKF2::NavEKF2(const AP_AHRS *ahrs, const RangeFinder &rng) :
     _ahrs(ahrs),
-    _baro(baro),
     _rng(rng)
 {
     AP_Param::setup_object_defaults(this, var_info);
@@ -580,7 +579,7 @@ void NavEKF2::check_log_write(void)
         logging.log_gps = false;
     }
     if (logging.log_baro) {
-        DataFlash_Class::instance()->Log_Write_Baro(_baro, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_Baro(imuSampleTime_us);
         logging.log_baro = false;
     }
     if (logging.log_imu) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -38,7 +38,7 @@ class NavEKF2 {
     friend class NavEKF2_core;
 
 public:
-    NavEKF2(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
+    NavEKF2(const AP_AHRS *ahrs, const RangeFinder &rng);
 
     /* Do not allow copies */
     NavEKF2(const NavEKF2 &other) = delete;
@@ -328,7 +328,6 @@ private:
     uint8_t primary;   // current primary core
     NavEKF2_core *core = nullptr;
     const AP_AHRS *_ahrs;
-    AP_Baro &_baro;
     const RangeFinder &_rng;
 
     uint32_t _frameTimeUsec;        // time per IMU frame

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -556,10 +556,11 @@ void NavEKF2_core::readBaroData()
 {
     // check to see if baro measurement has changed so we know if a new measurement has arrived
     // do not accept data at a faster rate than 14Hz to avoid overflowing the FIFO buffer
-    if (frontend->_baro.get_last_update() - lastBaroReceived_ms > 70) {
+    const AP_Baro &baro = AP::baro();
+    if (baro.get_last_update() - lastBaroReceived_ms > 70) {
         frontend->logging.log_baro = true;
 
-        baroDataNew.hgt = frontend->_baro.get_altitude();
+        baroDataNew.hgt = baro.get_altitude();
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
@@ -568,7 +569,7 @@ void NavEKF2_core::readBaroData()
         }
 
         // time stamp used to check for new measurement
-        lastBaroReceived_ms = frontend->_baro.get_last_update();
+        lastBaroReceived_ms = baro.get_last_update();
 
         // estimate of time height measurement was taken, allowing for delays
         baroDataNew.time_ms = lastBaroReceived_ms - frontend->_hgtDelay_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -204,7 +204,7 @@ bool NavEKF2_core::resetHeightDatum(void)
     // record the old height estimate
     float oldHgt = -stateStruct.position.z;
     // reset the barometer so that it reads zero at the current height
-    frontend->_baro.update_calibration();
+    AP::baro().update_calibration();
     // reset the height state
     stateStruct.position.z = 0.0f;
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -579,9 +579,8 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     AP_GROUPEND
 };
 
-NavEKF3::NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng) :
+NavEKF3::NavEKF3(const AP_AHRS *ahrs, const RangeFinder &rng) :
     _ahrs(ahrs),
-    _baro(baro),
     _rng(rng),
     gpsNEVelVarAccScale(0.05f),     // Scale factor applied to horizontal velocity measurement variance due to manoeuvre acceleration - used when GPS doesn't report speed error
     gpsDVelVarAccScale(0.07f),      // Scale factor applied to vertical velocity measurement variance due to manoeuvre acceleration - used when GPS doesn't report speed error
@@ -634,7 +633,7 @@ void NavEKF3::check_log_write(void)
         logging.log_gps = false;
     }
     if (logging.log_baro) {
-        DataFlash_Class::instance()->Log_Write_Baro(_baro, imuSampleTime_us);
+        DataFlash_Class::instance()->Log_Write_Baro(imuSampleTime_us);
         logging.log_baro = false;
     }
     if (logging.log_imu) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -35,7 +35,7 @@ class NavEKF3 {
     friend class NavEKF3_core;
 
 public:
-    NavEKF3(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng);
+    NavEKF3(const AP_AHRS *ahrs, const RangeFinder &rng);
 
     /* Do not allow copies */
     NavEKF3(const NavEKF3 &other) = delete;
@@ -359,7 +359,6 @@ private:
     uint8_t primary;   // current primary core
     NavEKF3_core *core = nullptr;
     const AP_AHRS *_ahrs;
-    AP_Baro &_baro;
     const RangeFinder &_rng;
 
     uint32_t _frameTimeUsec;        // time per IMU frame

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -603,10 +603,11 @@ void NavEKF3_core::readBaroData()
 {
     // check to see if baro measurement has changed so we know if a new measurement has arrived
     // limit update rate to avoid overflowing the FIFO buffer
-    if (frontend->_baro.get_last_update() - lastBaroReceived_ms > frontend->sensorIntervalMin_ms) {
+    const AP_Baro &baro = AP::baro();
+    if (baro.get_last_update() - lastBaroReceived_ms > frontend->sensorIntervalMin_ms) {
         frontend->logging.log_baro = true;
 
-        baroDataNew.hgt = frontend->_baro.get_altitude();
+        baroDataNew.hgt = baro.get_altitude();
 
         // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
         // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
@@ -615,7 +616,7 @@ void NavEKF3_core::readBaroData()
         }
 
         // time stamp used to check for new measurement
-        lastBaroReceived_ms = frontend->_baro.get_last_update();
+        lastBaroReceived_ms = baro.get_last_update();
 
         // estimate of time height measurement was taken, allowing for delays
         baroDataNew.time_ms = lastBaroReceived_ms - frontend->_hgtDelay_ms;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -208,7 +208,7 @@ bool NavEKF3_core::resetHeightDatum(void)
     // record the old height estimate
     float oldHgt = -stateStruct.position.z;
     // reset the barometer so that it reads zero at the current height
-    frontend->_baro.update_calibration();
+    AP::baro().update_calibration();
     // reset the height state
     stateStruct.position.z = 0.0f;
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -27,9 +27,9 @@ public:
     AP_InertialSensor ins;
     AP_SerialManager serial_manager;
     RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
-    NavEKF2 EKF2{&ahrs, barometer, sonar};
-    NavEKF3 EKF3{&ahrs, barometer, sonar};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    NavEKF2 EKF2{&ahrs, sonar};
+    NavEKF3 EKF3{&ahrs, sonar};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -21,9 +21,9 @@ static AP_SerialManager serial_manager;
 class DummyVehicle {
 public:
     RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
-    NavEKF2 EKF2{&ahrs, barometer, rangefinder};
-    NavEKF3 EKF3{&ahrs, barometer, rangefinder};
-    AP_AHRS_NavEKF ahrs{ins, barometer, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
+    NavEKF2 EKF2{&ahrs, rangefinder};
+    NavEKF3 EKF3{&ahrs, rangefinder};
+    AP_AHRS_NavEKF ahrs{ins, EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 };
 
 static DummyVehicle vehicle;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -296,7 +296,7 @@ void AP_TECS::update_50hz(void)
           use a complimentary filter to calculate climb_rate. This is
           designed to minimise lag
          */
-        float baro_alt = _ahrs.get_baro().get_altitude();
+        const float baro_alt = AP::baro().get_altitude();
         // Get height acceleration
         float hgt_ddot_mea = -(_ahrs.get_accel_ef().z + GRAVITY_MSS);
         // Perform filter calculation using backwards Euler integration

--- a/libraries/AP_TempCalibration/AP_TempCalibration.cpp
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.cpp
@@ -77,9 +77,8 @@ const AP_Param::GroupInfo AP_TempCalibration::var_info[] = {
     AP_GROUPEND
 };
 
-AP_TempCalibration::AP_TempCalibration(AP_Baro &_baro, AP_InertialSensor &_ins) :
-    baro(_baro)
-    ,ins(_ins)
+AP_TempCalibration::AP_TempCalibration(AP_InertialSensor &_ins) :
+    ins(_ins)
 {
 }
 
@@ -101,7 +100,7 @@ float AP_TempCalibration::calculate_correction(float temp, float exponent) const
  */
 void AP_TempCalibration::setup_learning(void)
 {
-    learn_temp_start = baro.get_temperature();
+    learn_temp_start = AP::baro().get_temperature();
     learn_temp_step = 0.25;
     learn_count = 200;
     learn_i = 0;
@@ -170,6 +169,7 @@ void AP_TempCalibration::calculate_calibration(void)
 void AP_TempCalibration::learn_calibration(void)
 {
     // just for first baro now
+    const AP_Baro &baro = AP::baro();
     if (!baro.healthy(0) ||
         hal.util->get_soft_armed() ||
         baro.get_temperature(0) < Tzero) {
@@ -216,6 +216,7 @@ void AP_TempCalibration::learn_calibration(void)
  */
 void AP_TempCalibration::apply_calibration(void)
 {
+    AP_Baro &baro = AP::baro();
     // just for first baro now
     if (!baro.healthy(0)) {
         return;

--- a/libraries/AP_TempCalibration/AP_TempCalibration.h
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.h
@@ -27,7 +27,7 @@ class AP_TempCalibration
 {
 public:
     // constructor
-    AP_TempCalibration(AP_Baro &baro, AP_InertialSensor &ins);
+    AP_TempCalibration(AP_InertialSensor &ins);
 
     // settable parameters
     static const struct AP_Param::GroupInfo var_info[];
@@ -41,7 +41,6 @@ public:
     };
     
 private:
-    AP_Baro &baro;
     AP_InertialSensor &ins;
 
     AP_Int8 enabled;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -121,7 +121,7 @@ public:
     void Log_Write_RCIN(void);
     void Log_Write_RCOUT(void);
     void Log_Write_RSSI(AP_RSSI &rssi);
-    void Log_Write_Baro(AP_Baro &baro, uint64_t time_us=0);
+    void Log_Write_Baro(uint64_t time_us=0);
     void Log_Write_Power(void);
     void Log_Write_AHRS2(AP_AHRS &ahrs);
     void Log_Write_POS(AP_AHRS &ahrs);
@@ -295,7 +295,7 @@ private:
     void Log_Write_EKF3(AP_AHRS_NavEKF &ahrs);
 #endif
 
-    void Log_Write_Baro_instance(AP_Baro &baro, uint64_t time_us, uint8_t baro_instance, enum LogMessages type);
+    void Log_Write_Baro_instance(uint64_t time_us, uint8_t baro_instance, enum LogMessages type);
     void Log_Write_IMU_instance(const AP_InertialSensor &ins,
                                 uint64_t time_us,
                                 uint8_t imu_instance,

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -425,8 +425,9 @@ void DataFlash_Class::Log_Write_RSSI(AP_RSSI &rssi)
     WriteBlock(&pkt, sizeof(pkt));
 }
 
-void DataFlash_Class::Log_Write_Baro_instance(AP_Baro &baro, uint64_t time_us, uint8_t baro_instance, enum LogMessages type)
+void DataFlash_Class::Log_Write_Baro_instance(uint64_t time_us, uint8_t baro_instance, enum LogMessages type)
 {
+    AP_Baro &baro = AP::baro();
     float climbrate = baro.get_climb_rate();
     float drift_offset = baro.get_baro_drift_offset();
     float ground_temp = baro.get_ground_temperature();
@@ -445,17 +446,18 @@ void DataFlash_Class::Log_Write_Baro_instance(AP_Baro &baro, uint64_t time_us, u
 }
 
 // Write a BARO packet
-void DataFlash_Class::Log_Write_Baro(AP_Baro &baro, uint64_t time_us)
+void DataFlash_Class::Log_Write_Baro(uint64_t time_us)
 {
     if (time_us == 0) {
         time_us = AP_HAL::micros64();
     }
-    Log_Write_Baro_instance(baro, time_us, 0, LOG_BARO_MSG);
+    const AP_Baro &baro = AP::baro();
+    Log_Write_Baro_instance(time_us, 0, LOG_BARO_MSG);
     if (baro.num_instances() > 1 && baro.healthy(1)) {
-        Log_Write_Baro_instance(baro, time_us, 1, LOG_BAR2_MSG);
+        Log_Write_Baro_instance(time_us, 1, LOG_BAR2_MSG);
     }
     if (baro.num_instances() > 2 && baro.healthy(2)) {
-        Log_Write_Baro_instance(baro, time_us, 2, LOG_BAR3_MSG);
+        Log_Write_Baro_instance(time_us, 2, LOG_BAR3_MSG);
     }
 }
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -164,8 +164,8 @@ public:
     void send_system_time();
     void send_radio_in(uint8_t receiver_rssi);
     void send_raw_imu(const AP_InertialSensor &ins, const Compass &compass);
-    void send_scaled_pressure(AP_Baro &barometer);
-    void send_sensor_offsets(const AP_InertialSensor &ins, const Compass &compass, AP_Baro &barometer);
+    void send_scaled_pressure();
+    void send_sensor_offsets(const AP_InertialSensor &ins, const Compass &compass);
     void send_ahrs();
     void send_battery2(const AP_BattMonitor &battery);
 #if AP_AHRS_NAVEKF_AVAILABLE

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1064,9 +1064,10 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
         mag.z);        
 }
 
-void GCS_MAVLINK::send_scaled_pressure(AP_Baro &barometer)
+void GCS_MAVLINK::send_scaled_pressure()
 {
     uint32_t now = AP_HAL::millis();
+    const AP_Baro &barometer = AP::baro();
     float pressure = barometer.get_pressure(0);
     mavlink_msg_scaled_pressure_send(
         chan,
@@ -1098,7 +1099,7 @@ void GCS_MAVLINK::send_scaled_pressure(AP_Baro &barometer)
     }
 }
 
-void GCS_MAVLINK::send_sensor_offsets(const AP_InertialSensor &ins, const Compass &compass, AP_Baro &barometer)
+void GCS_MAVLINK::send_sensor_offsets(const AP_InertialSensor &ins, const Compass &compass)
 {
     // run this message at a much lower rate - otherwise it
     // pointlessly wastes quite a lot of bandwidth
@@ -1111,6 +1112,8 @@ void GCS_MAVLINK::send_sensor_offsets(const AP_InertialSensor &ins, const Compas
     const Vector3f &mag_offsets = compass.get_offsets(0);
     const Vector3f &accel_offsets = ins.get_accel_offsets(0);
     const Vector3f &gyro_offsets = ins.get_gyro_offsets(0);
+
+    const AP_Baro &barometer = AP::baro();
 
     mavlink_msg_sensor_offsets_send(chan,
                                     mag_offsets.x,


### PR DESCRIPTION
Some time ago we created a barometer singleton.

This PR makes us use it everywhere except within Baro itself.  Notionally we could do without the `_frontend` AP_Baro_Backend member, but it looks odd doing that.
