### PR TITLE
UAVCAN: remove extra whitespace

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -30,17 +30,14 @@ void AP_BattMonitor_UAVCAN::init()
     }
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] == nullptr) {
+        AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
+        if (ap_uavcan == nullptr) {
             continue;
         }
-        AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
-        if (uavcan == nullptr) {
-            continue;
-        }
-
+        
         switch (_type) {
             case UAVCAN_BATTERY_INFO:
-                if (uavcan->register_BM_bi_listener_to_id(this, _params._serial_number)) {
+                if (ap_uavcan->register_BM_bi_listener_to_id(this, _params._serial_number)) {
                     debug_bm_uavcan(2, "UAVCAN BattMonitor BatteryInfo registered id: %d\n\r", _params._serial_number);
                 }
                 break;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -25,20 +25,25 @@ AP_BattMonitor_UAVCAN::AP_BattMonitor_UAVCAN(AP_BattMonitor &mon, AP_BattMonitor
 
 void AP_BattMonitor_UAVCAN::init()
 {
-    if (AP_BoardConfig_CAN::get_can_num_ifaces() != 0) {
-        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
-                if (uavcan != nullptr) {
-                    switch (_type) {
-                        case UAVCAN_BATTERY_INFO:
-                            if (uavcan->register_BM_bi_listener_to_id(this, _params._serial_number)) {
-                                debug_bm_uavcan(2, "UAVCAN BattMonitor BatteryInfo registered id: %d\n\r", _params._serial_number);
-                            }
-                            break;
-                    }
+    if (AP_BoardConfig_CAN::get_can_num_ifaces() == 0) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
+        }
+        AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+        if (uavcan == nullptr) {
+            continue;
+        }
+
+        switch (_type) {
+            case UAVCAN_BATTERY_INFO:
+                if (uavcan->register_BM_bi_listener_to_id(this, _params._serial_number)) {
+                    debug_bm_uavcan(2, "UAVCAN BattMonitor BatteryInfo registered id: %d\n\r", _params._serial_number);
                 }
-            }
+                break;
         }
     }
 }

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -127,29 +127,29 @@ void AP_BoardConfig_CAN::setup_canbus(void)
 
     if (initret) {
         for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                hal.can_mgr[i]->initialized(true);
-                printf("can_mgr %d initialized well\n\r", i + 1);
+            if (hal.can_mgr[i] == nullptr) {
+                continue;
+            }
+            hal.can_mgr[i]->initialized(true);
+            printf("can_mgr %d initialized well\n\r", i + 1);
 
-                if (_var_info_can_protocol[i]._protocol == UAVCAN_PROTOCOL_ENABLE) {
-                    _var_info_can_protocol[i]._uavcan = new AP_UAVCAN;
+            if (_var_info_can_protocol[i]._protocol == UAVCAN_PROTOCOL_ENABLE) {
+                _var_info_can_protocol[i]._uavcan = new AP_UAVCAN;
 
-                    if (_var_info_can_protocol[i]._uavcan != nullptr)
-                    {
-                        AP_Param::load_object_from_eeprom(_var_info_can_protocol[i]._uavcan, AP_UAVCAN::var_info);
+                if (_var_info_can_protocol[i]._uavcan == nullptr) {
+                    AP_HAL::panic("Failed to allocate uavcan %d\n\r", i + 1);
+                    continue;
+                }
+                
+                AP_Param::load_object_from_eeprom(_var_info_can_protocol[i]._uavcan, AP_UAVCAN::var_info);
 
-                        hal.can_mgr[i]->set_UAVCAN(_var_info_can_protocol[i]._uavcan);
-                        _var_info_can_protocol[i]._uavcan->set_parent_can_mgr(hal.can_mgr[i]);
+                hal.can_mgr[i]->set_UAVCAN(_var_info_can_protocol[i]._uavcan);
+                _var_info_can_protocol[i]._uavcan->set_parent_can_mgr(hal.can_mgr[i]);
 
-                        if (_var_info_can_protocol[i]._uavcan->try_init() == true) {
-                            any_uavcan_present = true;
-                        } else {
-                            printf("Failed to initialize uavcan interface %d\n\r", i + 1);
-                        }
-
-                    } else {
-                        AP_HAL::panic("Failed to allocate uavcan %d\n\r", i + 1);
-                    }
+                if (_var_info_can_protocol[i]._uavcan->try_init() == true) {
+                    any_uavcan_present = true;
+                } else {
+                    printf("Failed to initialize uavcan interface %d\n\r", i + 1);
                 }
             }
         }

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -100,11 +100,13 @@ void AP_BoardConfig_CAN::setup_canbus(void)
     // Create all drivers that we need
     bool initret = true;
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++) {
+        // Check the driver number assigned to this physical interface
         uint8_t drv_num = _var_info_can[i]._driver_number;
 
         if (drv_num != 0 && drv_num <= MAX_NUMBER_OF_CAN_DRIVERS) {
             if (hal.can_mgr[drv_num - 1] == nullptr) {
-                
+                // CAN Manager is the driver
+                // So if this driver was not created before for other physical interface - do it
                 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
                     const_cast <AP_HAL::HAL&> (hal).can_mgr[drv_num - 1] = new PX4::PX4CANManager;
                 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
@@ -112,9 +114,9 @@ void AP_BoardConfig_CAN::setup_canbus(void)
                 #elif CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
                     const_cast <AP_HAL::HAL&> (hal).can_mgr[drv_num - 1] = new ChibiOS::CANManager;
                 #endif
-                
             }
 
+            // For this now existing driver (manager), start the physical interface
             if (hal.can_mgr[drv_num - 1] != nullptr) {
                 initret &= hal.can_mgr[drv_num - 1]->begin(_var_info_can[i]._can_bitrate, i);
             } else {

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -72,7 +72,7 @@ AP_Compass_Backend *AP_Compass_UAVCAN::probe(Compass &compass)
         if (ap_uavcan == nullptr) {
             continue;
         }
-        uint8_t freemag = uavcan->find_smallest_free_mag_node();
+        uint8_t freemag = ap_uavcan->find_smallest_free_mag_node();
         if (freemag == UINT8_MAX) {
             continue;
         }
@@ -93,7 +93,7 @@ bool AP_Compass_UAVCAN::register_uavcan_compass(uint8_t mgr, uint8_t node)
 {
     AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
-        return;
+        return false;
     }
     _manager = mgr;
 

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -39,7 +39,7 @@ extern const AP_HAL::HAL& hal;
 AP_Compass_UAVCAN::AP_Compass_UAVCAN(Compass &compass):
     AP_Compass_Backend(compass)
 {
-    _mag_baro = hal.util->new_semaphore();
+    _sem_mag = hal.util->new_semaphore();
 }
 
 AP_Compass_UAVCAN::~AP_Compass_UAVCAN()
@@ -47,15 +47,15 @@ AP_Compass_UAVCAN::~AP_Compass_UAVCAN()
     if (!_initialized) {
         return;
     }
-    if (hal.can_mgr[_manager] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
+    
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(_manager);
     if (ap_uavcan == nullptr) {
         return;
     }
-
+    
     ap_uavcan->remove_mag_listener(this);
+    delete _sem_mag;
+    
     debug_mag_uavcan(2, "AP_Compass_UAVCAN destructed\n\r");
 }
 
@@ -68,11 +68,8 @@ AP_Compass_Backend *AP_Compass_UAVCAN::probe(Compass &compass)
     AP_Compass_UAVCAN *sensor;
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] == nullptr) {
-            continue;
-        }
-        AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
-        if (uavcan == nullptr) {
+        AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
+        if (ap_uavcan == nullptr) {
             continue;
         }
         uint8_t freemag = uavcan->find_smallest_free_mag_node();
@@ -94,46 +91,45 @@ AP_Compass_Backend *AP_Compass_UAVCAN::probe(Compass &compass)
 
 bool AP_Compass_UAVCAN::register_uavcan_compass(uint8_t mgr, uint8_t node)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            _manager = mgr;
-
-            if (ap_uavcan->register_mag_listener_to_node(this, node)) {
-                _instance = register_compass();
-
-                struct DeviceStructure {
-                    uint8_t bus_type : 3;
-                    uint8_t bus: 5;
-                    uint8_t address;
-                    uint8_t devtype;
-                };
-                union DeviceId {
-                    struct DeviceStructure devid_s;
-                    uint32_t devid;
-                };
-                union DeviceId d;
-
-                d.devid_s.bus_type = 3;
-                d.devid_s.bus = mgr;
-                d.devid_s.address = node;
-                d.devid_s.devtype = 1;
-
-                set_dev_id(_instance, d.devid);
-                set_external(_instance, true);
-
-                _sum.zero();
-                _count = 0;
-
-                accumulate();
-
-                debug_mag_uavcan(2, "AP_Compass_UAVCAN loaded\n\r");
-
-                return true;
-            }
-        }
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
+    if (ap_uavcan == nullptr) {
+        return;
     }
+    _manager = mgr;
 
+    if (ap_uavcan->register_mag_listener_to_node(this, node)) {
+        _instance = register_compass();
+
+        struct DeviceStructure {
+            uint8_t bus_type : 3;
+            uint8_t bus: 5;
+            uint8_t address;
+            uint8_t devtype;
+        };
+        union DeviceId {
+            struct DeviceStructure devid_s;
+            uint32_t devid;
+        };
+        union DeviceId d;
+
+        d.devid_s.bus_type = 3;
+        d.devid_s.bus = mgr;
+        d.devid_s.address = node;
+        d.devid_s.devtype = 1;
+
+        set_dev_id(_instance, d.devid);
+        set_external(_instance, true);
+
+        _sum.zero();
+        _count = 0;
+
+        accumulate();
+
+        debug_mag_uavcan(2, "AP_Compass_UAVCAN loaded\n\r");
+
+        return true;
+    }
+    
     return false;
 }
 
@@ -144,14 +140,14 @@ void AP_Compass_UAVCAN::read(void)
         return;
     }
 
-    if (_mag_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (_sem_mag->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _sum /= _count;
 
         publish_filtered_field(_sum, _instance);
 
         _sum.zero();
         _count = 0;
-        _mag_baro->give();
+        _sem_mag->give();
     }
 }
 
@@ -168,11 +164,11 @@ void AP_Compass_UAVCAN::handle_mag_msg(Vector3f &mag)
     // correct raw_field for known errors
     correct_field(raw_field, _instance);
 
-    if (_mag_baro->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (_sem_mag->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         // accumulate into averaging filter
         _sum += raw_field;
         _count++;
-        _mag_baro->give();
+        _sem_mag->give();
     }
 }
 

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.h
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.h
@@ -28,5 +28,5 @@ private:
     bool _initialized;
     uint8_t _manager;
 
-    AP_HAL::Semaphore *_mag_baro;
+    AP_HAL::Semaphore *_sem_mag;
 };

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -437,14 +437,14 @@ void AP_GPS::detect_instance(uint8_t instance)
                 continue;
             }
             
-            uint8_t gps_node = uavcan->find_gps_without_listener();
+            uint8_t gps_node = ap_uavcan->find_gps_without_listener();
             if (gps_node == UINT8_MAX) {
                 continue;
             }
 
             new_gps = new AP_GPS_UAVCAN(*this, state[instance], nullptr);
             ((AP_GPS_UAVCAN*) new_gps)->set_uavcan_manager(i);
-            if (uavcan->register_gps_listener_to_node(new_gps, gps_node)) {
+            if (ap_uavcan->register_gps_listener_to_node(new_gps, gps_node)) {
                 if (AP_BoardConfig_CAN::get_can_debug() >= 2) {
                     printf("AP_GPS_UAVCAN registered\n\r");
                 }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -428,28 +428,31 @@ void AP_GPS::detect_instance(uint8_t instance)
     // user has to explicitly set the UAVCAN type, do not use AUTO
     case GPS_TYPE_UAVCAN:
         dstate->auto_detected_baud = false; // specified, not detected
-        if (AP_BoardConfig_CAN::get_can_num_ifaces() >= 1) {
-            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-                if (hal.can_mgr[i] != nullptr) {
-                    AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+        if (AP_BoardConfig_CAN::get_can_num_ifaces() == 0) {
+            return;
+        }
+        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+            if (hal.can_mgr[i] == nullptr) {
+                continue;
+            }
+            AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
+            if (uavcan == nullptr) {
+                continue;
+            }
+            uint8_t gps_node = uavcan->find_gps_without_listener();
+            if (gps_node == UINT8_MAX) {
+                continue;
+            }
 
-                    if (uavcan != nullptr) {
-                        uint8_t gps_node = uavcan->find_gps_without_listener();
-
-                        if (gps_node != UINT8_MAX) {
-                            new_gps = new AP_GPS_UAVCAN(*this, state[instance], nullptr);
-                            ((AP_GPS_UAVCAN*) new_gps)->set_uavcan_manager(i);
-                            if (uavcan->register_gps_listener_to_node(new_gps, gps_node)) {
-                                if (AP_BoardConfig_CAN::get_can_debug() >= 2) {
-                                    printf("AP_GPS_UAVCAN registered\n\r");
-                                }
-                                goto found_gps;
-                            } else {
-                                delete new_gps;
-                            }
-                        }
-                    }
+            new_gps = new AP_GPS_UAVCAN(*this, state[instance], nullptr);
+            ((AP_GPS_UAVCAN*) new_gps)->set_uavcan_manager(i);
+            if (uavcan->register_gps_listener_to_node(new_gps, gps_node)) {
+                if (AP_BoardConfig_CAN::get_can_debug() >= 2) {
+                    printf("AP_GPS_UAVCAN registered\n\r");
                 }
+                goto found_gps;
+            } else {
+                delete new_gps;
             }
         }
         return;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -432,13 +432,11 @@ void AP_GPS::detect_instance(uint8_t instance)
             return;
         }
         for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] == nullptr) {
+            AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
+            if (ap_uavcan == nullptr) {
                 continue;
             }
-            AP_UAVCAN *uavcan = hal.can_mgr[i]->get_UAVCAN();
-            if (uavcan == nullptr) {
-                continue;
-            }
+            
             uint8_t gps_node = uavcan->find_gps_without_listener();
             if (gps_node == UINT8_MAX) {
                 continue;

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -37,15 +37,14 @@ AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UA
 // For each instance we need to deregister from AP_UAVCAN class
 AP_GPS_UAVCAN::~AP_GPS_UAVCAN()
 {
-    if (hal.can_mgr[_manager] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(_manager);
     if (ap_uavcan == nullptr) {
         return;
     }
-
+    
     ap_uavcan->remove_gps_listener(this);
+    delete _sem_gnss;
+    
     debug_gps_uavcan(2, "AP_GPS_UAVCAN destructed\n\r");
 }
 

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -37,14 +37,16 @@ AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UA
 // For each instance we need to deregister from AP_UAVCAN class
 AP_GPS_UAVCAN::~AP_GPS_UAVCAN()
 {
-    if (hal.can_mgr[_manager] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            ap_uavcan->remove_gps_listener(this);
-
-            debug_gps_uavcan(2, "AP_GPS_UAVCAN destructed\n\r");
-        }
+    if (hal.can_mgr[_manager] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[_manager]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+
+    ap_uavcan->remove_gps_listener(this);
+    debug_gps_uavcan(2, "AP_GPS_UAVCAN destructed\n\r");
 }
 
 void AP_GPS_UAVCAN::set_uavcan_manager(uint8_t mgr)

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -308,7 +308,7 @@ void Scheduler::_uavcan_thread(void *arg)
     while (true) {
         sched->delay_microseconds(100);
         for (int i = 0; i < MAX_NUMBER_OF_CAN_INTERFACES; i++) {
-            if(hal.can_mgr[i] != nullptr) {
+            if (AP_UAVCAN::get_uavcan(i) != nullptr) {
                 CANManager::from(hal.can_mgr[i])->_timer_tick();
             }
         }

--- a/libraries/AP_HAL_PX4/CAN.cpp
+++ b/libraries/AP_HAL_PX4/CAN.cpp
@@ -110,32 +110,36 @@ void BusEvent::signalFromInterrupt()
 
 static void handleTxInterrupt(uint8_t iface_index)
 {
-    if (iface_index < CAN_STM32_NUM_IFACES) {
-        uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
+    if (iface_index >= CAN_STM32_NUM_IFACES) {
+        return;
+    }
+    uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
 
-        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                PX4CAN* iface = ((PX4CANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
-                if (iface != nullptr) {
-                    iface->handleTxInterrupt(utc_usec);
-                }
-            }
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
+        }
+        PX4CAN* iface = ((PX4CANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
+        if (iface != nullptr) {
+            iface->handleTxInterrupt(utc_usec);
         }
     }
 }
 
 static void handleRxInterrupt(uint8_t iface_index, uint8_t fifo_index)
 {
-    if (iface_index < CAN_STM32_NUM_IFACES) {
-        uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
+    if (iface_index >= CAN_STM32_NUM_IFACES) {
+        return;
+    }
+    uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
 
-        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                PX4CAN* iface = ((PX4CANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
-                if (iface != nullptr) {
-                    iface->handleRxInterrupt(fifo_index, utc_usec);
-                }
-            }
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
+        }
+        PX4CAN* iface = ((PX4CANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
+        if (iface != nullptr) {
+            iface->handleRxInterrupt(fifo_index, utc_usec);
         }
     }
 }
@@ -238,10 +242,8 @@ int PX4CAN::computeTimings(const uint32_t target_bitrate, Timings& out_timings)
             bs1(arg_bs1), bs2(uint8_t(bs1_bs2_sum - bs1)), sample_point_permill(
                 uint16_t(1000 * (1 + bs1) / (1 + bs1 + bs2)))
         {
-            if (bs1_bs2_sum <= arg_bs1) {
-                if (AP_BoardConfig_CAN::get_can_debug() >= 1) {
-                    AP_HAL::panic("PX4CAN::computeTimings bs1_bs2_sum <= arg_bs1");
-                }
+            if (bs1_bs2_sum <= arg_bs1 && (AP_BoardConfig_CAN::get_can_debug() >= 1)) {
+                AP_HAL::panic("PX4CAN::computeTimings bs1_bs2_sum <= arg_bs1");
             }
         }
 
@@ -385,69 +387,69 @@ int16_t PX4CAN::receive(uavcan::CanFrame& out_frame, uavcan::MonotonicTime& out_
 
 int16_t PX4CAN::configureFilters(const uavcan::CanFilterConfig* filter_configs, uint16_t num_configs)
 {
-    if (num_configs <= NumFilters) {
-        CriticalSectionLocker lock;
-
-        can_->FMR |= bxcan::FMR_FINIT;
-
-        // Slave (CAN2) gets half of the filters
-        can_->FMR = (can_->FMR & ~0x00003F00) | static_cast<uint32_t>(NumFilters) << 8;
-
-        can_->FFA1R = 0x0AAAAAAA; // FIFO's are interleaved between filters
-        can_->FM1R = 0; // Identifier Mask mode
-        can_->FS1R = 0x7ffffff; // Single 32-bit for all
-
-        const uint8_t filter_start_index = (self_index_ == 0) ? 0 : NumFilters;
-
-        if (num_configs == 0) {
-            can_->FilterRegister[filter_start_index].FR1 = 0;
-            can_->FilterRegister[filter_start_index].FR2 = 0;
-            can_->FA1R = 1 << filter_start_index;
-        } else {
-            for (uint8_t i = 0; i < NumFilters; i++) {
-                if (i < num_configs) {
-                    uint32_t id   = 0;
-                    uint32_t mask = 0;
-
-                    const uavcan::CanFilterConfig* const cfg = filter_configs + i;
-
-                    if ((cfg->id & uavcan::CanFrame::FlagEFF) || !(cfg->mask & uavcan::CanFrame::FlagEFF)) {
-                        id   = (cfg->id   & uavcan::CanFrame::MaskExtID) << 3;
-                        mask = (cfg->mask & uavcan::CanFrame::MaskExtID) << 3;
-                        id |= bxcan::RIR_IDE;
-                    } else {
-                        id   = (cfg->id   & uavcan::CanFrame::MaskStdID) << 21;
-                        mask = (cfg->mask & uavcan::CanFrame::MaskStdID) << 21;
-                    }
-
-                    if (cfg->id & uavcan::CanFrame::FlagRTR) {
-                        id |= bxcan::RIR_RTR;
-                    }
-
-                    if (cfg->mask & uavcan::CanFrame::FlagEFF) {
-                        mask |= bxcan::RIR_IDE;
-                    }
-
-                    if (cfg->mask & uavcan::CanFrame::FlagRTR) {
-                        mask |= bxcan::RIR_RTR;
-                    }
-
-                    can_->FilterRegister[filter_start_index + i].FR1 = id;
-                    can_->FilterRegister[filter_start_index + i].FR2 = mask;
-
-                    can_->FA1R |= (1 << (filter_start_index + i));
-                } else {
-                    can_->FA1R &= ~(1 << (filter_start_index + i));
-                }
-            }
-        }
-
-        can_->FMR &= ~bxcan::FMR_FINIT;
-
-        return 0;
+    if (num_configs > NumFilters) {
+        return -ErrFilterNumConfigs;
     }
 
-    return -ErrFilterNumConfigs;
+    CriticalSectionLocker lock;
+
+    can_->FMR |= bxcan::FMR_FINIT;
+
+    // Slave (CAN2) gets half of the filters
+    can_->FMR = (can_->FMR & ~0x00003F00) | static_cast<uint32_t>(NumFilters) << 8;
+
+    can_->FFA1R = 0x0AAAAAAA; // FIFO's are interleaved between filters
+    can_->FM1R = 0; // Identifier Mask mode
+    can_->FS1R = 0x7ffffff; // Single 32-bit for all
+
+    const uint8_t filter_start_index = (self_index_ == 0) ? 0 : NumFilters;
+
+    if (num_configs == 0) {
+        can_->FilterRegister[filter_start_index].FR1 = 0;
+        can_->FilterRegister[filter_start_index].FR2 = 0;
+        can_->FA1R = 1 << filter_start_index;
+    } else {
+        for (uint8_t i = 0; i < NumFilters; i++) {
+            if (i < num_configs) {
+                uint32_t id   = 0;
+                uint32_t mask = 0;
+
+                const uavcan::CanFilterConfig* const cfg = filter_configs + i;
+
+                if ((cfg->id & uavcan::CanFrame::FlagEFF) || !(cfg->mask & uavcan::CanFrame::FlagEFF)) {
+                    id   = (cfg->id   & uavcan::CanFrame::MaskExtID) << 3;
+                    mask = (cfg->mask & uavcan::CanFrame::MaskExtID) << 3;
+                    id |= bxcan::RIR_IDE;
+                } else {
+                    id   = (cfg->id   & uavcan::CanFrame::MaskStdID) << 21;
+                    mask = (cfg->mask & uavcan::CanFrame::MaskStdID) << 21;
+                }
+
+                if (cfg->id & uavcan::CanFrame::FlagRTR) {
+                    id |= bxcan::RIR_RTR;
+                }
+
+                if (cfg->mask & uavcan::CanFrame::FlagEFF) {
+                    mask |= bxcan::RIR_IDE;
+                }
+
+                if (cfg->mask & uavcan::CanFrame::FlagRTR) {
+                    mask |= bxcan::RIR_RTR;
+                }
+
+                can_->FilterRegister[filter_start_index + i].FR1 = id;
+                can_->FilterRegister[filter_start_index + i].FR2 = mask;
+
+                can_->FA1R |= (1 << (filter_start_index + i));
+            } else {
+                can_->FA1R &= ~(1 << (filter_start_index + i));
+            }
+        }
+    }
+
+    can_->FMR &= ~bxcan::FMR_FINIT;
+
+    return 0;
 }
 
 bool PX4CAN::waitMsrINakBitStateChange(bool target_state)
@@ -601,7 +603,7 @@ void PX4CAN::handleTxInterrupt(const uint64_t utc_usec)
         handleTxMailboxInterrupt(2, txok, utc_usec);
     }
 
-    if(update_event_ != nullptr) {
+    if (update_event_ != nullptr) {
         update_event_->signalFromInterrupt();
     }
 
@@ -610,83 +612,85 @@ void PX4CAN::handleTxInterrupt(const uint64_t utc_usec)
 
 void PX4CAN::handleRxInterrupt(uint8_t fifo_index, uint64_t utc_usec)
 {
-    if (fifo_index < 2) {
-
-        volatile uint32_t* const rfr_reg = (fifo_index == 0) ? &can_->RF0R : &can_->RF1R;
-        if ((*rfr_reg & bxcan::RFR_FMP_MASK) == 0) {
-            return;
-        }
-
-        /*
-         * Register overflow as a hardware error
-         */
-        if ((*rfr_reg & bxcan::RFR_FOVR) != 0) {
-            error_cnt_++;
-        }
-
-        /*
-         * Read the frame contents
-         */
-        uavcan::CanFrame frame;
-        const bxcan::RxMailboxType& rf = can_->RxMailbox[fifo_index];
-
-        if ((rf.RIR & bxcan::RIR_IDE) == 0) {
-            frame.id = uavcan::CanFrame::MaskStdID & (rf.RIR >> 21);
-        } else {
-            frame.id = uavcan::CanFrame::MaskExtID & (rf.RIR >> 3);
-            frame.id |= uavcan::CanFrame::FlagEFF;
-        }
-
-        if ((rf.RIR & bxcan::RIR_RTR) != 0) {
-            frame.id |= uavcan::CanFrame::FlagRTR;
-        }
-
-        frame.dlc = rf.RDTR & 15;
-
-        frame.data[0] = uint8_t(0xFF & (rf.RDLR >> 0));
-        frame.data[1] = uint8_t(0xFF & (rf.RDLR >> 8));
-        frame.data[2] = uint8_t(0xFF & (rf.RDLR >> 16));
-        frame.data[3] = uint8_t(0xFF & (rf.RDLR >> 24));
-        frame.data[4] = uint8_t(0xFF & (rf.RDHR >> 0));
-        frame.data[5] = uint8_t(0xFF & (rf.RDHR >> 8));
-        frame.data[6] = uint8_t(0xFF & (rf.RDHR >> 16));
-        frame.data[7] = uint8_t(0xFF & (rf.RDHR >> 24));
-
-        *rfr_reg = bxcan::RFR_RFOM | bxcan::RFR_FOVR | bxcan::RFR_FULL; // Release FIFO entry we just read
-
-        /*
-         * Store with timeout into the FIFO buffer and signal update event
-         */
-        CanRxItem frm;
-        frm.frame = frame;
-        frm.flags = 0;
-        frm.utc_usec = utc_usec;
-        rx_queue_.push(frm);
-
-        had_activity_ = true;
-        if(update_event_ != nullptr) {
-            update_event_->signalFromInterrupt();
-        }
-
-        pollErrorFlagsFromISR();
+    if (fifo_index >= 2) {
+        return;
     }
+
+    volatile uint32_t* const rfr_reg = (fifo_index == 0) ? &can_->RF0R : &can_->RF1R;
+    if ((*rfr_reg & bxcan::RFR_FMP_MASK) == 0) {
+        return;
+    }
+
+    /*
+     * Register overflow as a hardware error
+     */
+    if ((*rfr_reg & bxcan::RFR_FOVR) != 0) {
+        error_cnt_++;
+    }
+
+    /*
+     * Read the frame contents
+     */
+    uavcan::CanFrame frame;
+    const bxcan::RxMailboxType& rf = can_->RxMailbox[fifo_index];
+
+    if ((rf.RIR & bxcan::RIR_IDE) == 0) {
+        frame.id = uavcan::CanFrame::MaskStdID & (rf.RIR >> 21);
+    } else {
+        frame.id = uavcan::CanFrame::MaskExtID & (rf.RIR >> 3);
+        frame.id |= uavcan::CanFrame::FlagEFF;
+    }
+
+    if ((rf.RIR & bxcan::RIR_RTR) != 0) {
+        frame.id |= uavcan::CanFrame::FlagRTR;
+    }
+
+    frame.dlc = rf.RDTR & 15;
+
+    frame.data[0] = uint8_t(0xFF & (rf.RDLR >> 0));
+    frame.data[1] = uint8_t(0xFF & (rf.RDLR >> 8));
+    frame.data[2] = uint8_t(0xFF & (rf.RDLR >> 16));
+    frame.data[3] = uint8_t(0xFF & (rf.RDLR >> 24));
+    frame.data[4] = uint8_t(0xFF & (rf.RDHR >> 0));
+    frame.data[5] = uint8_t(0xFF & (rf.RDHR >> 8));
+    frame.data[6] = uint8_t(0xFF & (rf.RDHR >> 16));
+    frame.data[7] = uint8_t(0xFF & (rf.RDHR >> 24));
+
+    *rfr_reg = bxcan::RFR_RFOM | bxcan::RFR_FOVR | bxcan::RFR_FULL; // Release FIFO entry we just read
+
+    /*
+     * Store with timeout into the FIFO buffer and signal update event
+     */
+    CanRxItem frm;
+    frm.frame = frame;
+    frm.flags = 0;
+    frm.utc_usec = utc_usec;
+    rx_queue_.push(frm);
+
+    had_activity_ = true;
+    if (update_event_ != nullptr) {
+        update_event_->signalFromInterrupt();
+    }
+
+    pollErrorFlagsFromISR();
 }
 
 void PX4CAN::pollErrorFlagsFromISR()
 {
     const uint8_t lec = uint8_t((can_->ESR & bxcan::ESR_LEC_MASK) >> bxcan::ESR_LEC_SHIFT);
-    if (lec != 0) {
-        can_->ESR = 0;
-        error_cnt_++;
+    if (lec == 0) {
+        return;
+    }
+    can_->ESR = 0;
+    error_cnt_++;
 
-        // Serving abort requests
-        for (int i = 0; i < NumTxMailboxes; i++) { // Dear compiler, may I suggest you to unroll this loop please.
-            TxItem& txi = pending_tx_[i];
-            if (txi.pending && txi.abort_on_error) {
-                can_->TSR = TSR_ABRQx[i];
-                txi.pending = false;
-                served_aborts_cnt_++;
-            }
+    // Serving abort requests
+    for (int i = 0; i < NumTxMailboxes; i++) { // Dear compiler, may I suggest you to unroll this loop please.
+        TxItem& txi = pending_tx_[i];
+        if (txi.pending && txi.abort_on_error) {
+            can_->TSR = TSR_ABRQx[i];
+            txi.pending = false;
+            served_aborts_cnt_++;
         }
     }
 }
@@ -799,16 +803,17 @@ int32_t PX4CAN::available()
 
 int32_t PX4CAN::tx_pending()
 {
-    int32_t ret = -1;
+    if (!initialized_) {
+        return -1;
+    }
 
-    if (initialized_) {
-        ret = 0;
-        CriticalSectionLocker lock;
+    int32_t ret = 0;
 
-        for (int mbx = 0; mbx < NumTxMailboxes; mbx++) {
-            if (pending_tx_[mbx].pending) {
-                ret++;
-            }
+    CriticalSectionLocker lock;
+
+    for (int mbx = 0; mbx < NumTxMailboxes; mbx++) {
+        if (pending_tx_[mbx].pending) {
+            ret++;
         }
     }
 
@@ -835,15 +840,17 @@ uavcan::CanSelectMasks PX4CANManager::makeSelectMasks(const uavcan::CanFrame* (&
     uavcan::CanSelectMasks msk;
 
     for (uint8_t i = 0; i < _ifaces_num; i++) {
-        if (ifaces[i] != nullptr) {
-            if (!ifaces[i]->isRxBufferEmpty()) {
-                msk.read |= 1 << i;
-            }
+        if (ifaces[i] == nullptr) {
+            continue;
+        }
 
-            if (pending_tx[i] != nullptr) {
-                if (ifaces[i]->canAcceptNewTxFrame(*pending_tx[i])) {
-                    msk.write |= 1 << i;
-                }
+        if (!ifaces[i]->isRxBufferEmpty()) {
+            msk.read |= 1 << i;
+        }
+
+        if (pending_tx[i] != nullptr) {
+            if (ifaces[i]->canAcceptNewTxFrame(*pending_tx[i])) {
+                msk.write |= 1 << i;
             }
         }
     }
@@ -871,12 +878,13 @@ int16_t PX4CANManager::select(uavcan::CanSelectMasks& inout_masks,
     const uavcan::MonotonicTime time = clock::getMonotonic();
 
     for (uint8_t i = 0; i < _ifaces_num; i++) {
-        if (ifaces[i] != nullptr) {
-            ifaces[i]->discardTimedOutTxMailboxes(time);
-            {
-                CriticalSectionLocker cs_locker;
-                ifaces[i]->pollErrorFlagsFromISR();
-            }
+        if (ifaces[i] == nullptr) {
+            continue;
+        }
+        ifaces[i]->discardTimedOutTxMailboxes(time);
+        {
+            CriticalSectionLocker cs_locker;
+            ifaces[i]->pollErrorFlagsFromISR();
         }
     }
 
@@ -951,62 +959,62 @@ void PX4CANManager::initOnce(uint8_t can_number)
 
 int PX4CANManager::init(const uint32_t bitrate, const PX4CAN::OperatingMode mode, uint8_t can_number)
 {
-    int res = -ErrNotImplemented;
+    if (can_number >= CAN_STM32_NUM_IFACES) {
+        return -ErrNotImplemented;
+    }
     static bool initialized_once[CAN_STM32_NUM_IFACES];
 
-    if (can_number < CAN_STM32_NUM_IFACES) {
-        res = 0;
+    int res = 0;
+
+    if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
+        printf("PX4CANManager::init Bitrate %lu mode %d bus %d\n\r", static_cast<unsigned long>(bitrate),
+               static_cast<int>(mode), static_cast<int>(can_number));
+    }
+
+    // If this outside physical interface was never inited - do this and add it to in/out conversion tables
+    if (!initialized_once[can_number]) {
+        initialized_once[can_number] = true;
+        _ifaces_num++;
+        _ifaces_out_to_in[can_number] = _ifaces_num - 1;
 
         if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-            printf("PX4CANManager::init Bitrate %lu mode %d bus %d\n\r", static_cast<unsigned long>(bitrate),
-                   static_cast<int>(mode), static_cast<int>(can_number));
+            printf("PX4CANManager::init First initialization bus %d\n\r", static_cast<int>(can_number));
         }
 
-        // If this outside physical interface was never inited - do this and add it to in/out conversion tables
-        if (!initialized_once[can_number]) {
-            initialized_once[can_number] = true;
-            _ifaces_num++;
-            _ifaces_out_to_in[can_number] = _ifaces_num - 1;
+        initOnce(can_number);
+    }
 
-            if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-                printf("PX4CANManager::init First initialization bus %d\n\r", static_cast<int>(can_number));
-            }
-
-            initOnce(can_number);
+    /*
+     * CAN1
+     */
+    if (can_number == 0) {
+        if (AP_BoardConfig_CAN::get_can_debug(0) >= 2) {
+            printf("PX4CANManager::init Initing iface 0...\n\r");
         }
-
-        /*
-         * CAN1
-         */
-        if (can_number == 0) {
-            if (AP_BoardConfig_CAN::get_can_debug(0) >= 2) {
-                printf("PX4CANManager::init Initing iface 0...\n\r");
-            }
-            ifaces[_ifaces_out_to_in[can_number]] = &if0_;               // This link must be initialized first,
-        }
+        ifaces[_ifaces_out_to_in[can_number]] = &if0_;               // This link must be initialized first,
+    }
 
 #if CAN_STM32_NUM_IFACES > 1
-        /*
-         * CAN2
-         */
-        if (can_number == 1) {
-            if (AP_BoardConfig_CAN::get_can_debug(1) >= 2) {
-                printf("PX4CANManager::init Initing iface 1...\n\r");
-            }
-            ifaces[_ifaces_out_to_in[can_number]] = &if1_;                          // Same thing here.
+    /*
+     * CAN2
+     */
+    if (can_number == 1) {
+        if (AP_BoardConfig_CAN::get_can_debug(1) >= 2) {
+            printf("PX4CANManager::init Initing iface 1...\n\r");
         }
+        ifaces[_ifaces_out_to_in[can_number]] = &if1_;                          // Same thing here.
+    }
 #endif
 
-        ifaces[_ifaces_out_to_in[can_number]]->set_update_event(&update_event_);
-        res = ifaces[_ifaces_out_to_in[can_number]]->init(bitrate, mode);
-        if (res < 0) {
-            ifaces[_ifaces_out_to_in[can_number]] = nullptr;
-            return res;
-        }
+    ifaces[_ifaces_out_to_in[can_number]]->set_update_event(&update_event_);
+    res = ifaces[_ifaces_out_to_in[can_number]]->init(bitrate, mode);
+    if (res < 0) {
+        ifaces[_ifaces_out_to_in[can_number]] = nullptr;
+        return res;
+    }
 
-        if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-            printf("PX4CANManager::init CAN drv init OK, res = %d\n\r", res);
-        }
+    if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
+        printf("PX4CANManager::init CAN drv init OK, res = %d\n\r", res);
     }
 
     return res;

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -518,7 +518,7 @@ void PX4RCOutput::_send_outputs(void)
                 }
             }
         }
-
+        
         perf_end(_perf_rcout);
         _last_output = now;
     }

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -518,7 +518,6 @@ void PX4RCOutput::_send_outputs(void)
                 }
             }
         }
-        
         perf_end(_perf_rcout);
         _last_output = now;
     }

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -105,15 +105,17 @@ void PX4Scheduler::create_uavcan_thread()
     pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] != nullptr) {
-            if (hal.can_mgr[i]->get_UAVCAN() != nullptr) {
-                _uavcan_thread_arg *arg = new _uavcan_thread_arg;
-                arg->sched = this;
-                arg->uavcan_number = i;
-
-                pthread_create(&_uavcan_thread_ctx, &thread_attr, &PX4Scheduler::_uavcan_thread, arg);
-            }
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
         }
+        if (hal.can_mgr[i]->get_UAVCAN() == nullptr) {
+            continue;
+        }
+        _uavcan_thread_arg *arg = new _uavcan_thread_arg;
+        arg->sched = this;
+        arg->uavcan_number = i;
+
+        pthread_create(&_uavcan_thread_ctx, &thread_attr, &PX4Scheduler::_uavcan_thread, arg);
     }
 #endif
 }

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -105,10 +105,7 @@ void PX4Scheduler::create_uavcan_thread()
     pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] == nullptr) {
-            continue;
-        }
-        if (hal.can_mgr[i]->get_UAVCAN() == nullptr) {
+        if (AP_UAVCAN::get_uavcan(i) == nullptr) {
             continue;
         }
         _uavcan_thread_arg *arg = new _uavcan_thread_arg;

--- a/libraries/AP_HAL_VRBRAIN/CAN.cpp
+++ b/libraries/AP_HAL_VRBRAIN/CAN.cpp
@@ -110,32 +110,36 @@ void BusEvent::signalFromInterrupt()
 
 static void handleTxInterrupt(uint8_t iface_index)
 {
-    if (iface_index < CAN_STM32_NUM_IFACES) {
-        uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
+    if (iface_index >= CAN_STM32_NUM_IFACES) {
+        return;
+    }
+    uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
 
-        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                VRBRAINCAN* iface = ((VRBRAINCANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
-                if (iface != nullptr) {
-                    iface->handleTxInterrupt(utc_usec);
-                }
-            }
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
+        }
+        VRBRAINCAN* iface = ((VRBRAINCANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
+        if (iface != nullptr) {
+            iface->handleTxInterrupt(utc_usec);
         }
     }
 }
 
 static void handleRxInterrupt(uint8_t iface_index, uint8_t fifo_index)
 {
-    if (iface_index < CAN_STM32_NUM_IFACES) {
-        uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
+    if (iface_index >= CAN_STM32_NUM_IFACES) {
+        return;
+    }
+    uint64_t utc_usec = clock::getUtcUSecFromCanInterrupt();
 
-        for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-            if (hal.can_mgr[i] != nullptr) {
-                VRBRAINCAN* iface = ((VRBRAINCANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
-                if (iface != nullptr) {
-                    iface->handleRxInterrupt(fifo_index, utc_usec);
-                }
-            }
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
+        }
+        VRBRAINCAN* iface = ((VRBRAINCANManager*) hal.can_mgr[i])->getIface_out_to_in(iface_index);
+        if (iface != nullptr) {
+            iface->handleRxInterrupt(fifo_index, utc_usec);
         }
     }
 }
@@ -385,69 +389,69 @@ int16_t VRBRAINCAN::receive(uavcan::CanFrame& out_frame, uavcan::MonotonicTime& 
 
 int16_t VRBRAINCAN::configureFilters(const uavcan::CanFilterConfig* filter_configs, uint16_t num_configs)
 {
-    if (num_configs <= NumFilters) {
-        CriticalSectionLocker lock;
-
-        can_->FMR |= bxcan::FMR_FINIT;
-
-        // Slave (CAN2) gets half of the filters
-        can_->FMR = (can_->FMR & ~0x00003F00) | static_cast<uint32_t>(NumFilters) << 8;
-
-        can_->FFA1R = 0x0AAAAAAA; // FIFO's are interleaved between filters
-        can_->FM1R = 0; // Identifier Mask mode
-        can_->FS1R = 0x7ffffff; // Single 32-bit for all
-
-        const uint8_t filter_start_index = (self_index_ == 0) ? 0 : NumFilters;
-
-        if (num_configs == 0) {
-            can_->FilterRegister[filter_start_index].FR1 = 0;
-            can_->FilterRegister[filter_start_index].FR2 = 0;
-            can_->FA1R = 1 << filter_start_index;
-        } else {
-            for (uint8_t i = 0; i < NumFilters; i++) {
-                if (i < num_configs) {
-                    uint32_t id   = 0;
-                    uint32_t mask = 0;
-
-                    const uavcan::CanFilterConfig* const cfg = filter_configs + i;
-
-                    if ((cfg->id & uavcan::CanFrame::FlagEFF) || !(cfg->mask & uavcan::CanFrame::FlagEFF)) {
-                        id   = (cfg->id   & uavcan::CanFrame::MaskExtID) << 3;
-                        mask = (cfg->mask & uavcan::CanFrame::MaskExtID) << 3;
-                        id |= bxcan::RIR_IDE;
-                    } else {
-                        id   = (cfg->id   & uavcan::CanFrame::MaskStdID) << 21;
-                        mask = (cfg->mask & uavcan::CanFrame::MaskStdID) << 21;
-                    }
-
-                    if (cfg->id & uavcan::CanFrame::FlagRTR) {
-                        id |= bxcan::RIR_RTR;
-                    }
-
-                    if (cfg->mask & uavcan::CanFrame::FlagEFF) {
-                        mask |= bxcan::RIR_IDE;
-                    }
-
-                    if (cfg->mask & uavcan::CanFrame::FlagRTR) {
-                        mask |= bxcan::RIR_RTR;
-                    }
-
-                    can_->FilterRegister[filter_start_index + i].FR1 = id;
-                    can_->FilterRegister[filter_start_index + i].FR2 = mask;
-
-                    can_->FA1R |= (1 << (filter_start_index + i));
-                } else {
-                    can_->FA1R &= ~(1 << (filter_start_index + i));
-                }
-            }
-        }
-
-        can_->FMR &= ~bxcan::FMR_FINIT;
-
-        return 0;
+    if (num_configs > NumFilters) {
+        return -ErrFilterNumConfigs;
     }
 
-    return -ErrFilterNumConfigs;
+    CriticalSectionLocker lock;
+
+    can_->FMR |= bxcan::FMR_FINIT;
+
+    // Slave (CAN2) gets half of the filters
+    can_->FMR = (can_->FMR & ~0x00003F00) | static_cast<uint32_t>(NumFilters) << 8;
+
+    can_->FFA1R = 0x0AAAAAAA; // FIFO's are interleaved between filters
+    can_->FM1R = 0; // Identifier Mask mode
+    can_->FS1R = 0x7ffffff; // Single 32-bit for all
+
+    const uint8_t filter_start_index = (self_index_ == 0) ? 0 : NumFilters;
+
+    if (num_configs == 0) {
+        can_->FilterRegister[filter_start_index].FR1 = 0;
+        can_->FilterRegister[filter_start_index].FR2 = 0;
+        can_->FA1R = 1 << filter_start_index;
+    } else {
+        for (uint8_t i = 0; i < NumFilters; i++) {
+            if (i < num_configs) {
+                uint32_t id   = 0;
+                uint32_t mask = 0;
+
+                const uavcan::CanFilterConfig* const cfg = filter_configs + i;
+
+                if ((cfg->id & uavcan::CanFrame::FlagEFF) || !(cfg->mask & uavcan::CanFrame::FlagEFF)) {
+                    id   = (cfg->id   & uavcan::CanFrame::MaskExtID) << 3;
+                    mask = (cfg->mask & uavcan::CanFrame::MaskExtID) << 3;
+                    id |= bxcan::RIR_IDE;
+                } else {
+                    id   = (cfg->id   & uavcan::CanFrame::MaskStdID) << 21;
+                    mask = (cfg->mask & uavcan::CanFrame::MaskStdID) << 21;
+                }
+
+                if (cfg->id & uavcan::CanFrame::FlagRTR) {
+                    id |= bxcan::RIR_RTR;
+                }
+
+                if (cfg->mask & uavcan::CanFrame::FlagEFF) {
+                    mask |= bxcan::RIR_IDE;
+                }
+
+                if (cfg->mask & uavcan::CanFrame::FlagRTR) {
+                    mask |= bxcan::RIR_RTR;
+                }
+
+                can_->FilterRegister[filter_start_index + i].FR1 = id;
+                can_->FilterRegister[filter_start_index + i].FR2 = mask;
+
+                can_->FA1R |= (1 << (filter_start_index + i));
+            } else {
+                can_->FA1R &= ~(1 << (filter_start_index + i));
+            }
+        }
+    }
+
+    can_->FMR &= ~bxcan::FMR_FINIT;
+
+    return 0;
 }
 
 bool VRBRAINCAN::waitMsrINakBitStateChange(bool target_state)
@@ -564,22 +568,23 @@ int VRBRAINCAN::init(const uint32_t bitrate, const OperatingMode mode)
 
 void VRBRAINCAN::handleTxMailboxInterrupt(uint8_t mailbox_index, bool txok, const uint64_t utc_usec)
 {
-    if (mailbox_index < NumTxMailboxes) {
-
-        had_activity_ = had_activity_ || txok;
-
-        TxItem& txi = pending_tx_[mailbox_index];
-
-        if (txi.loopback && txok && txi.pending) {
-            CanRxItem frm;
-            frm.frame = txi.frame;
-            frm.flags = uavcan::CanIOFlagLoopback;
-            frm.utc_usec = utc_usec;
-            rx_queue_.push(frm);
-        }
-
-        txi.pending = false;
+    if (mailbox_index >= NumTxMailboxes) {
+        return;
     }
+
+    had_activity_ = had_activity_ || txok;
+
+    TxItem& txi = pending_tx_[mailbox_index];
+
+    if (txi.loopback && txok && txi.pending) {
+        CanRxItem frm;
+        frm.frame = txi.frame;
+        frm.flags = uavcan::CanIOFlagLoopback;
+        frm.utc_usec = utc_usec;
+        rx_queue_.push(frm);
+    }
+
+    txi.pending = false;
 }
 
 void VRBRAINCAN::handleTxInterrupt(const uint64_t utc_usec)
@@ -610,83 +615,85 @@ void VRBRAINCAN::handleTxInterrupt(const uint64_t utc_usec)
 
 void VRBRAINCAN::handleRxInterrupt(uint8_t fifo_index, uint64_t utc_usec)
 {
-    if (fifo_index < 2) {
-
-        volatile uint32_t* const rfr_reg = (fifo_index == 0) ? &can_->RF0R : &can_->RF1R;
-        if ((*rfr_reg & bxcan::RFR_FMP_MASK) == 0) {
-            return;
-        }
-
-        /*
-         * Register overflow as a hardware error
-         */
-        if ((*rfr_reg & bxcan::RFR_FOVR) != 0) {
-            error_cnt_++;
-        }
-
-        /*
-         * Read the frame contents
-         */
-        uavcan::CanFrame frame;
-        const bxcan::RxMailboxType& rf = can_->RxMailbox[fifo_index];
-
-        if ((rf.RIR & bxcan::RIR_IDE) == 0) {
-            frame.id = uavcan::CanFrame::MaskStdID & (rf.RIR >> 21);
-        } else {
-            frame.id = uavcan::CanFrame::MaskExtID & (rf.RIR >> 3);
-            frame.id |= uavcan::CanFrame::FlagEFF;
-        }
-
-        if ((rf.RIR & bxcan::RIR_RTR) != 0) {
-            frame.id |= uavcan::CanFrame::FlagRTR;
-        }
-
-        frame.dlc = rf.RDTR & 15;
-
-        frame.data[0] = uint8_t(0xFF & (rf.RDLR >> 0));
-        frame.data[1] = uint8_t(0xFF & (rf.RDLR >> 8));
-        frame.data[2] = uint8_t(0xFF & (rf.RDLR >> 16));
-        frame.data[3] = uint8_t(0xFF & (rf.RDLR >> 24));
-        frame.data[4] = uint8_t(0xFF & (rf.RDHR >> 0));
-        frame.data[5] = uint8_t(0xFF & (rf.RDHR >> 8));
-        frame.data[6] = uint8_t(0xFF & (rf.RDHR >> 16));
-        frame.data[7] = uint8_t(0xFF & (rf.RDHR >> 24));
-
-        *rfr_reg = bxcan::RFR_RFOM | bxcan::RFR_FOVR | bxcan::RFR_FULL; // Release FIFO entry we just read
-
-        /*
-         * Store with timeout into the FIFO buffer and signal update event
-         */
-        CanRxItem frm;
-        frm.frame = frame;
-        frm.flags = 0;
-        frm.utc_usec = utc_usec;
-        rx_queue_.push(frm);
-
-        had_activity_ = true;
-        if(update_event_ != nullptr) {
-            update_event_->signalFromInterrupt();
-        }
-
-        pollErrorFlagsFromISR();
+    if (fifo_index >= 2) {
+        return;
     }
+
+    volatile uint32_t* const rfr_reg = (fifo_index == 0) ? &can_->RF0R : &can_->RF1R;
+    if ((*rfr_reg & bxcan::RFR_FMP_MASK) == 0) {
+        return;
+    }
+
+    /*
+     * Register overflow as a hardware error
+     */
+    if ((*rfr_reg & bxcan::RFR_FOVR) != 0) {
+        error_cnt_++;
+    }
+
+    /*
+     * Read the frame contents
+     */
+    uavcan::CanFrame frame;
+    const bxcan::RxMailboxType& rf = can_->RxMailbox[fifo_index];
+
+    if ((rf.RIR & bxcan::RIR_IDE) == 0) {
+        frame.id = uavcan::CanFrame::MaskStdID & (rf.RIR >> 21);
+    } else {
+        frame.id = uavcan::CanFrame::MaskExtID & (rf.RIR >> 3);
+        frame.id |= uavcan::CanFrame::FlagEFF;
+    }
+
+    if ((rf.RIR & bxcan::RIR_RTR) != 0) {
+        frame.id |= uavcan::CanFrame::FlagRTR;
+    }
+
+    frame.dlc = rf.RDTR & 15;
+
+    frame.data[0] = uint8_t(0xFF & (rf.RDLR >> 0));
+    frame.data[1] = uint8_t(0xFF & (rf.RDLR >> 8));
+    frame.data[2] = uint8_t(0xFF & (rf.RDLR >> 16));
+    frame.data[3] = uint8_t(0xFF & (rf.RDLR >> 24));
+    frame.data[4] = uint8_t(0xFF & (rf.RDHR >> 0));
+    frame.data[5] = uint8_t(0xFF & (rf.RDHR >> 8));
+    frame.data[6] = uint8_t(0xFF & (rf.RDHR >> 16));
+    frame.data[7] = uint8_t(0xFF & (rf.RDHR >> 24));
+
+    *rfr_reg = bxcan::RFR_RFOM | bxcan::RFR_FOVR | bxcan::RFR_FULL; // Release FIFO entry we just read
+
+    /*
+     * Store with timeout into the FIFO buffer and signal update event
+     */
+    CanRxItem frm;
+    frm.frame = frame;
+    frm.flags = 0;
+    frm.utc_usec = utc_usec;
+    rx_queue_.push(frm);
+
+    had_activity_ = true;
+    if(update_event_ != nullptr) {
+        update_event_->signalFromInterrupt();
+    }
+
+    pollErrorFlagsFromISR();
 }
 
 void VRBRAINCAN::pollErrorFlagsFromISR()
 {
     const uint8_t lec = uint8_t((can_->ESR & bxcan::ESR_LEC_MASK) >> bxcan::ESR_LEC_SHIFT);
-    if (lec != 0) {
-        can_->ESR = 0;
-        error_cnt_++;
+    if (lec == 0) {
+        return;
+    }
+    can_->ESR = 0;
+    error_cnt_++;
 
-        // Serving abort requests
-        for (int i = 0; i < NumTxMailboxes; i++) { // Dear compiler, may I suggest you to unroll this loop please.
-            TxItem& txi = pending_tx_[i];
-            if (txi.pending && txi.abort_on_error) {
-                can_->TSR = TSR_ABRQx[i];
-                txi.pending = false;
-                served_aborts_cnt_++;
-            }
+    // Serving abort requests
+    for (int i = 0; i < NumTxMailboxes; i++) { // Dear compiler, may I suggest you to unroll this loop please.
+        TxItem& txi = pending_tx_[i];
+        if (txi.pending && txi.abort_on_error) {
+            can_->TSR = TSR_ABRQx[i];
+            txi.pending = false;
+            served_aborts_cnt_++;
         }
     }
 }
@@ -799,10 +806,12 @@ int32_t VRBRAINCAN::available()
 
 int32_t VRBRAINCAN::tx_pending()
 {
-    int32_t ret = -1;
+    if (!initialized_) {
+        return -1;
+    }
 
-    if (initialized_) {
-        ret = 0;
+    int32_t ret = 0;
+    {
         CriticalSectionLocker lock;
 
         for (int mbx = 0; mbx < NumTxMailboxes; mbx++) {
@@ -811,7 +820,6 @@ int32_t VRBRAINCAN::tx_pending()
             }
         }
     }
-
     return ret;
 }
 
@@ -835,16 +843,19 @@ uavcan::CanSelectMasks VRBRAINCANManager::makeSelectMasks(const uavcan::CanFrame
     uavcan::CanSelectMasks msk;
 
     for (uint8_t i = 0; i < _ifaces_num; i++) {
-        if (ifaces[i] != nullptr) {
-            if (!ifaces[i]->isRxBufferEmpty()) {
-                msk.read |= 1 << i;
-            }
+        if (ifaces[i] == nullptr) {
+            continue;
+        }
+        if (!ifaces[i]->isRxBufferEmpty()) {
+            msk.read |= 1 << i;
+        }
 
-            if (pending_tx[i] != nullptr) {
-                if (ifaces[i]->canAcceptNewTxFrame(*pending_tx[i])) {
-                    msk.write |= 1 << i;
-                }
-            }
+        if (pending_tx[i] == nullptr) {
+            continue;
+        }
+
+        if (ifaces[i]->canAcceptNewTxFrame(*pending_tx[i])) {
+            msk.write |= 1 << i;
         }
     }
 
@@ -871,12 +882,13 @@ int16_t VRBRAINCANManager::select(uavcan::CanSelectMasks& inout_masks,
     const uavcan::MonotonicTime time = clock::getMonotonic();
 
     for (uint8_t i = 0; i < _ifaces_num; i++) {
-        if (ifaces[i] != nullptr) {
-            ifaces[i]->discardTimedOutTxMailboxes(time);
-            {
-                CriticalSectionLocker cs_locker;
-                ifaces[i]->pollErrorFlagsFromISR();
-            }
+        if (ifaces[i] == nullptr) {
+            continue;
+        }
+        ifaces[i]->discardTimedOutTxMailboxes(time);
+        {
+            CriticalSectionLocker cs_locker;
+            ifaces[i]->pollErrorFlagsFromISR();
         }
     }
 
@@ -951,62 +963,63 @@ void VRBRAINCANManager::initOnce(uint8_t can_number)
 
 int VRBRAINCANManager::init(const uint32_t bitrate, const VRBRAINCAN::OperatingMode mode, uint8_t can_number)
 {
-    int res = -ErrNotImplemented;
     static bool initialized_once[CAN_STM32_NUM_IFACES];
 
-    if (can_number < CAN_STM32_NUM_IFACES) {
-        res = 0;
+    if (can_number >= CAN_STM32_NUM_IFACES) {
+        return -ErrNotImplemented;
+    }
+
+    int res = 0;
+
+    if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
+        printf("VRBRAINCANManager::init Bitrate %lu mode %d bus %d\n\r", static_cast<unsigned long>(bitrate),
+               static_cast<int>(mode), static_cast<int>(can_number));
+    }
+
+    // If this outside physical interface was never inited - do this and add it to in/out conversion tables
+    if (!initialized_once[can_number]) {
+        initialized_once[can_number] = true;
+        _ifaces_num++;
+        _ifaces_out_to_in[can_number] = _ifaces_num - 1;
 
         if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-            printf("VRBRAINCANManager::init Bitrate %lu mode %d bus %d\n\r", static_cast<unsigned long>(bitrate),
-                   static_cast<int>(mode), static_cast<int>(can_number));
+            printf("VRBRAINCANManager::init First initialization bus %d\n\r", static_cast<int>(can_number));
         }
 
-        // If this outside physical interface was never inited - do this and add it to in/out conversion tables
-        if (!initialized_once[can_number]) {
-            initialized_once[can_number] = true;
-            _ifaces_num++;
-            _ifaces_out_to_in[can_number] = _ifaces_num - 1;
+        initOnce(can_number);
+    }
 
-            if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-                printf("VRBRAINCANManager::init First initialization bus %d\n\r", static_cast<int>(can_number));
-            }
-
-            initOnce(can_number);
+    /*
+     * CAN1
+     */
+    if (can_number == 0) {
+        if (AP_BoardConfig_CAN::get_can_debug(0) >= 2) {
+            printf("VRBRAINCANManager::init Initing iface 0...\n\r");
         }
-
-        /*
-         * CAN1
-         */
-        if (can_number == 0) {
-            if (AP_BoardConfig_CAN::get_can_debug(0) >= 2) {
-                printf("VRBRAINCANManager::init Initing iface 0...\n\r");
-            }
-            ifaces[_ifaces_out_to_in[can_number]] = &if0_;               // This link must be initialized first,
-        }
+        ifaces[_ifaces_out_to_in[can_number]] = &if0_;               // This link must be initialized first,
+    }
 
 #if CAN_STM32_NUM_IFACES > 1
-        /*
-         * CAN2
-         */
-        if (can_number == 1) {
-            if (AP_BoardConfig_CAN::get_can_debug(1) >= 2) {
-                printf("VRBRAINCANManager::init Initing iface 1...\n\r");
-            }
-            ifaces[_ifaces_out_to_in[can_number]] = &if1_;                          // Same thing here.
+    /*
+     * CAN2
+     */
+    if (can_number == 1) {
+        if (AP_BoardConfig_CAN::get_can_debug(1) >= 2) {
+            printf("VRBRAINCANManager::init Initing iface 1...\n\r");
         }
+        ifaces[_ifaces_out_to_in[can_number]] = &if1_;                          // Same thing here.
+    }
 #endif
 
-        ifaces[_ifaces_out_to_in[can_number]]->set_update_event(&update_event_);
-        res = ifaces[_ifaces_out_to_in[can_number]]->init(bitrate, mode);
-        if (res < 0) {
-            ifaces[_ifaces_out_to_in[can_number]] = nullptr;
-            return res;
-        }
+    ifaces[_ifaces_out_to_in[can_number]]->set_update_event(&update_event_);
+    res = ifaces[_ifaces_out_to_in[can_number]]->init(bitrate, mode);
+    if (res < 0) {
+        ifaces[_ifaces_out_to_in[can_number]] = nullptr;
+        return res;
+    }
 
-        if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
-            printf("VRBRAINCANManager::init CAN drv init OK, res = %d\n\r", res);
-        }
+    if (AP_BoardConfig_CAN::get_can_debug(can_number) >= 2) {
+        printf("VRBRAINCANManager::init CAN drv init OK, res = %d\n\r", res);
     }
 
     return res;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -105,10 +105,7 @@ void VRBRAINScheduler::create_uavcan_thread()
     pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] == nullptr) {
-            continue;
-        }
-        if (hal.can_mgr[i]->get_UAVCAN() == nullptr) {
+        if (AP_UAVCAN::get_uavcan(i) == nullptr) {
             continue;
         }
 

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -105,15 +105,18 @@ void VRBRAINScheduler::create_uavcan_thread()
     pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
 
     for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-        if (hal.can_mgr[i] != nullptr) {
-            if (hal.can_mgr[i]->get_UAVCAN() != nullptr) {
-                _uavcan_thread_arg *arg = new _uavcan_thread_arg;
-                arg->sched = this;
-                arg->uavcan_number = i;
-
-                pthread_create(&_uavcan_thread_ctx, &thread_attr, &VRBRAINScheduler::_uavcan_thread, arg);
-            }
+        if (hal.can_mgr[i] == nullptr) {
+            continue;
         }
+        if (hal.can_mgr[i]->get_UAVCAN() == nullptr) {
+            continue;
+        }
+
+        _uavcan_thread_arg *arg = new _uavcan_thread_arg;
+        arg->sched = this;
+        arg->uavcan_number = i;
+
+        pthread_create(&_uavcan_thread_ctx, &thread_attr, &VRBRAINScheduler::_uavcan_thread, arg);
     }
 #endif
 }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -88,104 +88,107 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
 
 static void gnss_fix_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
+    }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
+    if (state == nullptr) {
+        return;
+    }
 
-            if (state != nullptr) {
-                bool process = false;
+    bool process = false;
 
-                if (msg.status == uavcan::equipment::gnss::Fix::STATUS_NO_FIX) {
-                    state->status = AP_GPS::GPS_Status::NO_FIX;
-                } else {
-                    if (msg.status == uavcan::equipment::gnss::Fix::STATUS_TIME_ONLY) {
-                        state->status = AP_GPS::GPS_Status::NO_FIX;
-                    } else if (msg.status == uavcan::equipment::gnss::Fix::STATUS_2D_FIX) {
-                        state->status = AP_GPS::GPS_Status::GPS_OK_FIX_2D;
-                        process = true;
-                    } else if (msg.status == uavcan::equipment::gnss::Fix::STATUS_3D_FIX) {
-                        state->status = AP_GPS::GPS_Status::GPS_OK_FIX_3D;
-                        process = true;
-                    }
+    if (msg.status == uavcan::equipment::gnss::Fix::STATUS_NO_FIX) {
+        state->status = AP_GPS::GPS_Status::NO_FIX;
+    } else {
+        if (msg.status == uavcan::equipment::gnss::Fix::STATUS_TIME_ONLY) {
+            state->status = AP_GPS::GPS_Status::NO_FIX;
+        } else if (msg.status == uavcan::equipment::gnss::Fix::STATUS_2D_FIX) {
+            state->status = AP_GPS::GPS_Status::GPS_OK_FIX_2D;
+            process = true;
+        } else if (msg.status == uavcan::equipment::gnss::Fix::STATUS_3D_FIX) {
+            state->status = AP_GPS::GPS_Status::GPS_OK_FIX_3D;
+            process = true;
+        }
 
-                    if (msg.gnss_time_standard == uavcan::equipment::gnss::Fix::GNSS_TIME_STANDARD_UTC) {
-                        uint64_t epoch_ms = uavcan::UtcTime(msg.gnss_timestamp).toUSec();
-                        epoch_ms /= 1000;
-                        uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
-                        state->time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
-                        state->time_week_ms = (uint32_t)(gps_ms - (state->time_week) * AP_MSEC_PER_WEEK);
-                    }
-                }
-
-                if (process) {
-                    Location loc = { };
-                    loc.lat = msg.latitude_deg_1e8 / 10;
-                    loc.lng = msg.longitude_deg_1e8 / 10;
-                    loc.alt = msg.height_msl_mm / 10;
-                    state->location = loc;
-                    state->location.options = 0;
-
-                    if (!uavcan::isNaN(msg.ned_velocity[0])) {
-                        Vector3f vel(msg.ned_velocity[0], msg.ned_velocity[1], msg.ned_velocity[2]);
-                        state->velocity = vel;
-                        state->ground_speed = norm(vel.x, vel.y);
-                        state->ground_course = wrap_360(degrees(atan2f(vel.y, vel.x)));
-                        state->have_vertical_velocity = true;
-                    } else {
-                        state->have_vertical_velocity = false;
-                    }
-
-                    float pos_cov[9];
-                    msg.position_covariance.unpackSquareMatrix(pos_cov);
-                    if (!uavcan::isNaN(pos_cov[8])) {
-                        if (pos_cov[8] > 0) {
-                            state->vertical_accuracy = sqrtf(pos_cov[8]);
-                            state->have_vertical_accuracy = true;
-                        } else {
-                            state->have_vertical_accuracy = false;
-                        }
-                    } else {
-                        state->have_vertical_accuracy = false;
-                    }
-
-                    const float horizontal_pos_variance = MAX(pos_cov[0], pos_cov[4]);
-                    if (!uavcan::isNaN(horizontal_pos_variance)) {
-                        if (horizontal_pos_variance > 0) {
-                            state->horizontal_accuracy = sqrtf(horizontal_pos_variance);
-                            state->have_horizontal_accuracy = true;
-                        } else {
-                            state->have_horizontal_accuracy = false;
-                        }
-                    } else {
-                        state->have_horizontal_accuracy = false;
-                    }
-
-                    float vel_cov[9];
-                    msg.velocity_covariance.unpackSquareMatrix(vel_cov);
-                    if (!uavcan::isNaN(vel_cov[0])) {
-                        state->speed_accuracy = sqrtf((vel_cov[0] + vel_cov[4] + vel_cov[8]) / 3.0);
-                        state->have_speed_accuracy = true;
-                    } else {
-                        state->have_speed_accuracy = false;
-                    }
-
-                    state->num_sats = msg.sats_used;
-                } else {
-                    state->have_vertical_velocity = false;
-                    state->have_vertical_accuracy = false;
-                    state->have_horizontal_accuracy = false;
-                    state->have_speed_accuracy = false;
-                    state->num_sats = 0;
-                }
-
-                state->last_gps_time_ms = AP_HAL::millis();
-
-                // after all is filled, update all listeners with new data
-                ap_uavcan->update_gps_state(msg.getSrcNodeID().get());
-            }
+        if (msg.gnss_time_standard == uavcan::equipment::gnss::Fix::GNSS_TIME_STANDARD_UTC) {
+            uint64_t epoch_ms = uavcan::UtcTime(msg.gnss_timestamp).toUSec();
+            epoch_ms /= 1000;
+            uint64_t gps_ms = epoch_ms - UNIX_OFFSET_MSEC;
+            state->time_week = (uint16_t)(gps_ms / AP_MSEC_PER_WEEK);
+            state->time_week_ms = (uint32_t)(gps_ms - (state->time_week) * AP_MSEC_PER_WEEK);
         }
     }
+
+    if (process) {
+        Location loc = { };
+        loc.lat = msg.latitude_deg_1e8 / 10;
+        loc.lng = msg.longitude_deg_1e8 / 10;
+        loc.alt = msg.height_msl_mm / 10;
+        state->location = loc;
+        state->location.options = 0;
+
+        if (!uavcan::isNaN(msg.ned_velocity[0])) {
+            Vector3f vel(msg.ned_velocity[0], msg.ned_velocity[1], msg.ned_velocity[2]);
+            state->velocity = vel;
+            state->ground_speed = norm(vel.x, vel.y);
+            state->ground_course = wrap_360(degrees(atan2f(vel.y, vel.x)));
+            state->have_vertical_velocity = true;
+        } else {
+            state->have_vertical_velocity = false;
+        }
+
+        float pos_cov[9];
+        msg.position_covariance.unpackSquareMatrix(pos_cov);
+        if (!uavcan::isNaN(pos_cov[8])) {
+            if (pos_cov[8] > 0) {
+                state->vertical_accuracy = sqrtf(pos_cov[8]);
+                state->have_vertical_accuracy = true;
+            } else {
+                state->have_vertical_accuracy = false;
+            }
+        } else {
+            state->have_vertical_accuracy = false;
+        }
+
+        const float horizontal_pos_variance = MAX(pos_cov[0], pos_cov[4]);
+        if (!uavcan::isNaN(horizontal_pos_variance)) {
+            if (horizontal_pos_variance > 0) {
+                state->horizontal_accuracy = sqrtf(horizontal_pos_variance);
+                state->have_horizontal_accuracy = true;
+            } else {
+                state->have_horizontal_accuracy = false;
+            }
+        } else {
+            state->have_horizontal_accuracy = false;
+        }
+
+        float vel_cov[9];
+        msg.velocity_covariance.unpackSquareMatrix(vel_cov);
+        if (!uavcan::isNaN(vel_cov[0])) {
+            state->speed_accuracy = sqrtf((vel_cov[0] + vel_cov[4] + vel_cov[8]) / 3.0);
+            state->have_speed_accuracy = true;
+        } else {
+            state->have_speed_accuracy = false;
+        }
+
+        state->num_sats = msg.sats_used;
+    } else {
+        state->have_vertical_velocity = false;
+        state->have_vertical_accuracy = false;
+        state->have_horizontal_accuracy = false;
+        state->have_speed_accuracy = false;
+        state->num_sats = 0;
+    }
+
+    state->last_gps_time_ms = AP_HAL::millis();
+
+    // after all is filled, update all listeners with new data
+    ap_uavcan->update_gps_state(msg.getSrcNodeID().get());
 }
 
 static void gnss_fix_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg)
@@ -197,21 +200,24 @@ static void (*gnss_fix_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
 
 static void gnss_aux_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
+    }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
+    if (state == nullptr) {
+        return;
+    }
 
-            if (state != nullptr) {
-                if (!uavcan::isNaN(msg.hdop)) {
-                    state->hdop = msg.hdop * 100.0;
-                }
+    if (!uavcan::isNaN(msg.hdop)) {
+        state->hdop = msg.hdop * 100.0;
+    }
 
-                if (!uavcan::isNaN(msg.vdop)) {
-                    state->vdop = msg.vdop * 100.0;
-                }
-            }
-        }
+    if (!uavcan::isNaN(msg.vdop)) {
+        state->vdop = msg.vdop * 100.0;
     }
 }
 
@@ -224,20 +230,24 @@ static void (*gnss_aux_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
 
 static void magnetic_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), 0);
-            if (state != nullptr) {
-                state->mag_vector[0] = msg.magnetic_field_ga[0];
-                state->mag_vector[1] = msg.magnetic_field_ga[1];
-                state->mag_vector[2] = msg.magnetic_field_ga[2];
-
-                // after all is filled, update all listeners with new data
-                ap_uavcan->update_mag_state(msg.getSrcNodeID().get(), 0);
-            }
-        }
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), 0);
+    if (state == nullptr) {
+        return;
+    }
+
+    state->mag_vector[0] = msg.magnetic_field_ga[0];
+    state->mag_vector[1] = msg.magnetic_field_ga[1];
+    state->mag_vector[2] = msg.magnetic_field_ga[2];
+
+    // after all is filled, update all listeners with new data
+    ap_uavcan->update_mag_state(msg.getSrcNodeID().get(), 0);
 }
 
 static void magnetic_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg)
@@ -249,20 +259,24 @@ static void (*magnetic_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
         
 static void magnetic_cb_2(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength2>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), msg.sensor_id);
-            if (state != nullptr) {
-                state->mag_vector[0] = msg.magnetic_field_ga[0];
-                state->mag_vector[1] = msg.magnetic_field_ga[1];
-                state->mag_vector[2] = msg.magnetic_field_ga[2];
-
-                // after all is filled, update all listeners with new data
-                ap_uavcan->update_mag_state(msg.getSrcNodeID().get(), msg.sensor_id);
-            }
-        }
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), msg.sensor_id);
+    if (state == nullptr) {
+        return;
+    }
+
+    state->mag_vector[0] = msg.magnetic_field_ga[0];
+    state->mag_vector[1] = msg.magnetic_field_ga[1];
+    state->mag_vector[2] = msg.magnetic_field_ga[2];
+
+    // after all is filled, update all listeners with new data
+    ap_uavcan->update_mag_state(msg.getSrcNodeID().get(), msg.sensor_id);
 }
 
 static void magnetic_cb_2_0(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength2>& msg)
@@ -274,20 +288,23 @@ static void (*magnetic_cb_2_arr[2])(const uavcan::ReceivedDataStructure<uavcan::
 
 static void air_data_sp_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
-
-            if (state != nullptr) {
-                state->pressure = msg.static_pressure;
-                state->pressure_variance = msg.static_pressure_variance;
-
-                // after all is filled, update all listeners with new data
-                ap_uavcan->update_baro_state(msg.getSrcNodeID().get());
-            }
-        }
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
+    if (state == nullptr) {
+        return;
+    }
+
+    state->pressure = msg.static_pressure;
+    state->pressure_variance = msg.static_pressure_variance;
+
+    // after all is filled, update all listeners with new data
+    ap_uavcan->update_baro_state(msg.getSrcNodeID().get());
 }
 
 static void air_data_sp_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg)
@@ -300,17 +317,20 @@ static void (*air_data_sp_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan:
 // Temperature is not main parameter so do not update listeners when it is received
 static void air_data_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
-
-            if (state != nullptr) {
-                state->temperature = msg.static_temperature;
-                state->temperature_variance = msg.static_temperature_variance;
-            }
-        }
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
+    if (state == nullptr) {
+        return;
+    }
+
+    state->temperature = msg.static_temperature;
+    state->temperature_variance = msg.static_temperature_variance;
 }
 
 static void air_data_st_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg)
@@ -322,24 +342,27 @@ static void (*air_data_st_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan:
 
 static void battery_info_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::power::BatteryInfo>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] != nullptr) {
-        AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
-        if (ap_uavcan != nullptr) {
-            AP_UAVCAN::BatteryInfo_Info *state = ap_uavcan->find_bi_id((uint16_t) msg.battery_id);
-
-            if (state != nullptr) {
-                state->temperature = msg.temperature;
-                state->voltage = msg.voltage;
-                state->current = msg.current;
-                state->full_charge_capacity_wh = msg.full_charge_capacity_wh;
-                state->remaining_capacity_wh = msg.remaining_capacity_wh;
-                state->status_flags = msg.status_flags;
-
-                // after all is filled, update all listeners with new data
-                ap_uavcan->update_bi_state((uint16_t) msg.battery_id);
-            }
-        }
+    if (hal.can_mgr[mgr] == nullptr) {
+        return;
     }
+    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    AP_UAVCAN::BatteryInfo_Info *state = ap_uavcan->find_bi_id((uint16_t) msg.battery_id);
+    if (state == nullptr) {
+        return;
+    }
+
+    state->temperature = msg.temperature;
+    state->voltage = msg.voltage;
+    state->current = msg.current;
+    state->full_charge_capacity_wh = msg.full_charge_capacity_wh;
+    state->remaining_capacity_wh = msg.remaining_capacity_wh;
+    state->status_flags = msg.status_flags;
+
+    // after all is filled, update all listeners with new data
+    ap_uavcan->update_bi_state((uint16_t) msg.battery_id);
 }
 
 static void battery_info_st_cb0(const uavcan::ReceivedDataStructure<uavcan::equipment::power::BatteryInfo>& msg)
@@ -412,142 +435,147 @@ AP_UAVCAN::~AP_UAVCAN()
 
 bool AP_UAVCAN::try_init(void)
 {
-    if (_parent_can_mgr != nullptr) {
-        if (_parent_can_mgr->is_initialized() && !_initialized) {
+    if (_parent_can_mgr == nullptr) {
+        return false;
+    }
 
-            _uavcan_i = UINT8_MAX;
-            for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
-                if (_parent_can_mgr == hal.can_mgr[i]) {
-                    _uavcan_i = i;
-                    break;
-                }
-            }
-
-            if(_uavcan_i == UINT8_MAX) {
-                return false;
-            }
-
-            auto *node = get_node();
-
-            if (node != nullptr) {
-                if (!node->isStarted()) {
-                    uavcan::NodeID self_node_id(_uavcan_node);
-                    node->setNodeID(self_node_id);
-
-                    char ndname[20];
-                    snprintf(ndname, sizeof(ndname), "org.ardupilot:%u", _uavcan_i);
-
-                    uavcan::NodeStatusProvider::NodeName name(ndname);
-                    node->setName(name);
-
-                    uavcan::protocol::SoftwareVersion sw_version; // Standard type uavcan.protocol.SoftwareVersion
-                    sw_version.major = AP_UAVCAN_SW_VERS_MAJOR;
-                    sw_version.minor = AP_UAVCAN_SW_VERS_MINOR;
-                    node->setSoftwareVersion(sw_version);
-
-                    uavcan::protocol::HardwareVersion hw_version; // Standard type uavcan.protocol.HardwareVersion
-
-                    hw_version.major = AP_UAVCAN_HW_VERS_MAJOR;
-                    hw_version.minor = AP_UAVCAN_HW_VERS_MINOR;
-                    node->setHardwareVersion(hw_version);
-
-                    const int node_start_res = node->start();
-                    if (node_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN: node start problem\n\r");
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::gnss::Fix> *gnss_fix;
-                    gnss_fix = new uavcan::Subscriber<uavcan::equipment::gnss::Fix>(*node);
-
-                    const int gnss_fix_start_res = gnss_fix->start(gnss_fix_cb_arr[_uavcan_i]);
-                    if (gnss_fix_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN GNSS subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary> *gnss_aux;
-                    gnss_aux = new uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary>(*node);
-                    const int gnss_aux_start_res = gnss_aux->start(gnss_aux_cb_arr[_uavcan_i]);
-                    if (gnss_aux_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN GNSS Aux subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength> *magnetic;
-                    magnetic = new uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength>(*node);
-                    const int magnetic_start_res = magnetic->start(magnetic_cb_arr[_uavcan_i]);
-                    if (magnetic_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN Compass subscriber start problem\n\r");
-                        return false;
-                    }
-                    
-                    uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength2> *magnetic2;
-                    magnetic2 = new uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength2>(*node);
-                    const int magnetic_start_res_2 = magnetic2->start(magnetic_cb_2_arr[_uavcan_i]);
-                    if (magnetic_start_res_2 < 0) {
-                        debug_uavcan(1, "UAVCAN Compass for multiple mags subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure> *air_data_sp;
-                    air_data_sp = new uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure>(*node);
-                    const int air_data_sp_start_res = air_data_sp->start(air_data_sp_cb_arr[_uavcan_i]);
-                    if (air_data_sp_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN Baro subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature> *air_data_st;
-                    air_data_st = new uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature>(*node);
-                    const int air_data_st_start_res = air_data_st->start(air_data_st_cb_arr[_uavcan_i]);
-                    if (air_data_st_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN Temperature subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    uavcan::Subscriber<uavcan::equipment::power::BatteryInfo> *battery_info_st;
-                    battery_info_st = new uavcan::Subscriber<uavcan::equipment::power::BatteryInfo>(*node);
-                    const int battery_info_start_res = battery_info_st->start(battery_info_st_cb_arr[_uavcan_i]);
-                    if (battery_info_start_res < 0) {
-                        debug_uavcan(1, "UAVCAN BatteryInfo subscriber start problem\n\r");
-                        return false;
-                    }
-
-                    act_out_array[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*node);
-                    act_out_array[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(CAN_PERIODIC_TX_TIMEOUT_MS));
-                    act_out_array[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
-
-                    esc_raw[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::esc::RawCommand>(*node);
-                    esc_raw[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(CAN_PERIODIC_TX_TIMEOUT_MS));
-                    esc_raw[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
-
-                    rgb_led[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::indication::LightsCommand>(*node);
-                    rgb_led[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(CAN_PERIODIC_TX_TIMEOUT_MS));
-                    rgb_led[_uavcan_i]->setPriority(uavcan::TransferPriority::OneHigherThanLowest);
-
-                    _led_conf.devices_count = 0;
-
-                    /*
-                     * Informing other nodes that we're ready to work.
-                     * Default mode is INITIALIZING.
-                     */
-                    node->setModeOperational();
-
-                    _initialized = true;
-
-                    debug_uavcan(1, "UAVCAN: init done\n\r");
-
-                    return true;
-                }
-            }
-        }
-
-        if (_initialized) {
-            return true;
+    if (_initialized) {
+        return true;
+    }
+    
+    if (!_parent_can_mgr->is_initialized()) {
+        return false;
+    }
+    
+    _uavcan_i = UINT8_MAX;
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        if (_parent_can_mgr == hal.can_mgr[i]) {
+            _uavcan_i = i;
+            break;
         }
     }
 
-    return false;
+    if(_uavcan_i == UINT8_MAX) {
+        return false;
+    }
+
+    auto *node = get_node();
+
+    if (node == nullptr) {
+        return false;
+    }
+    
+    if (node->isStarted()) {
+        return false;
+    }
+    
+    uavcan::NodeID self_node_id(_uavcan_node);
+    node->setNodeID(self_node_id);
+
+    char ndname[20];
+    snprintf(ndname, sizeof(ndname), "org.ardupilot:%u", _uavcan_i);
+
+    uavcan::NodeStatusProvider::NodeName name(ndname);
+    node->setName(name);
+
+    uavcan::protocol::SoftwareVersion sw_version; // Standard type uavcan.protocol.SoftwareVersion
+    sw_version.major = AP_UAVCAN_SW_VERS_MAJOR;
+    sw_version.minor = AP_UAVCAN_SW_VERS_MINOR;
+    node->setSoftwareVersion(sw_version);
+
+    uavcan::protocol::HardwareVersion hw_version; // Standard type uavcan.protocol.HardwareVersion
+
+    hw_version.major = AP_UAVCAN_HW_VERS_MAJOR;
+    hw_version.minor = AP_UAVCAN_HW_VERS_MINOR;
+    node->setHardwareVersion(hw_version);
+
+    const int node_start_res = node->start();
+    if (node_start_res < 0) {
+        debug_uavcan(1, "UAVCAN: node start problem\n\r");
+    }
+
+    uavcan::Subscriber<uavcan::equipment::gnss::Fix> *gnss_fix;
+    gnss_fix = new uavcan::Subscriber<uavcan::equipment::gnss::Fix>(*node);
+
+    const int gnss_fix_start_res = gnss_fix->start(gnss_fix_cb_arr[_uavcan_i]);
+    if (gnss_fix_start_res < 0) {
+        debug_uavcan(1, "UAVCAN GNSS subscriber start problem\n\r");
+        return false;
+    }
+
+    uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary> *gnss_aux;
+    gnss_aux = new uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary>(*node);
+    const int gnss_aux_start_res = gnss_aux->start(gnss_aux_cb_arr[_uavcan_i]);
+    if (gnss_aux_start_res < 0) {
+        debug_uavcan(1, "UAVCAN GNSS Aux subscriber start problem\n\r");
+        return false;
+    }
+
+    uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength> *magnetic;
+    magnetic = new uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength>(*node);
+    const int magnetic_start_res = magnetic->start(magnetic_cb_arr[_uavcan_i]);
+    if (magnetic_start_res < 0) {
+        debug_uavcan(1, "UAVCAN Compass subscriber start problem\n\r");
+        return false;
+    }
+
+    uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength2> *magnetic2;
+    magnetic2 = new uavcan::Subscriber<uavcan::equipment::ahrs::MagneticFieldStrength2>(*node);
+    const int magnetic_start_res_2 = magnetic2->start(magnetic_cb_2_arr[_uavcan_i]);
+    if (magnetic_start_res_2 < 0) {
+        debug_uavcan(1, "UAVCAN Compass for multiple mags subscriber start problem\n\r");
+        return false;
+    }
+
+    uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure> *air_data_sp;
+    air_data_sp = new uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure>(*node);
+    const int air_data_sp_start_res = air_data_sp->start(air_data_sp_cb_arr[_uavcan_i]);
+    if (air_data_sp_start_res < 0) {
+        debug_uavcan(1, "UAVCAN Baro subscriber start problem\n\r");
+        return false;
+    }
+    
+    uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature> *air_data_st;
+    air_data_st = new uavcan::Subscriber<uavcan::equipment::air_data::StaticTemperature>(*node);
+    const int air_data_st_start_res = air_data_st->start(air_data_st_cb_arr[_uavcan_i]);
+    if (air_data_st_start_res < 0) {
+        debug_uavcan(1, "UAVCAN Temperature subscriber start problem\n\r");
+        return false;
+    }
+    
+    uavcan::Subscriber<uavcan::equipment::power::BatteryInfo> *battery_info_st;
+    battery_info_st = new uavcan::Subscriber<uavcan::equipment::power::BatteryInfo>(*node);
+    const int battery_info_start_res = battery_info_st->start(battery_info_st_cb_arr[_uavcan_i]);
+    if (battery_info_start_res < 0) {
+        debug_uavcan(1, "UAVCAN BatteryInfo subscriber start problem\n\r");
+        return false;
+    }
+
+    act_out_array[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>(*node);
+    act_out_array[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+    act_out_array[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+
+    esc_raw[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::esc::RawCommand>(*node);
+    esc_raw[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+    esc_raw[_uavcan_i]->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+
+    rgb_led[_uavcan_i] = new uavcan::Publisher<uavcan::equipment::indication::LightsCommand>(*node);
+    rgb_led[_uavcan_i]->setTxTimeout(uavcan::MonotonicDuration::fromMSec(20));
+    rgb_led[_uavcan_i]->setPriority(uavcan::TransferPriority::OneHigherThanLowest);
+
+    _led_conf.devices_count = 0;
+
+    /*
+     * Informing other nodes that we're ready to work.
+     * Default mode is INITIALIZING.
+     */
+    node->setModeOperational();
+
+    _initialized = true;
+
+    debug_uavcan(1, "UAVCAN: init done\n\r");
+
+    return true;
 }
 
 void AP_UAVCAN::SRV_sem_take()
@@ -847,27 +875,27 @@ uint8_t AP_UAVCAN::register_gps_listener(AP_GPS_Backend* new_listener, uint8_t p
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        if (preferred_channel != 0) {
-            if (preferred_channel <= AP_UAVCAN_MAX_GPS_NODES) {
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
+
+    if (preferred_channel != 0 && preferred_channel <= AP_UAVCAN_MAX_GPS_NODES) {
+        _gps_listeners[sel_place] = new_listener;
+        _gps_listener_to_node[sel_place] = preferred_channel - 1;
+        _gps_node_taken[_gps_listener_to_node[sel_place]]++;
+        ret = preferred_channel;
+
+        debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, preferred_channel);
+    } else {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
+            if (_gps_node_taken[i] == 0) {
                 _gps_listeners[sel_place] = new_listener;
-                _gps_listener_to_node[sel_place] = preferred_channel - 1;
-                _gps_node_taken[_gps_listener_to_node[sel_place]]++;
-                ret = preferred_channel;
+                _gps_listener_to_node[sel_place] = i;
+                _gps_node_taken[i]++;
+                ret = i + 1;
 
-                debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, preferred_channel);
-            }
-        } else {
-            for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
-                if (_gps_node_taken[i] == 0) {
-                    _gps_listeners[sel_place] = new_listener;
-                    _gps_listener_to_node[sel_place] = i;
-                    _gps_node_taken[i]++;
-                    ret = i + 1;
-
-                    debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, i);
-                    break;
-                }
+                debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, i);
+                break;
             }
         }
     }
@@ -886,17 +914,18 @@ uint8_t AP_UAVCAN::register_gps_listener_to_node(AP_GPS_Backend* new_listener, u
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
-            if (_gps_nodes[i] == node) {
-                _gps_listeners[sel_place] = new_listener;
-                _gps_listener_to_node[sel_place] = i;
-                _gps_node_taken[i]++;
-                ret = i + 1;
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
+        if (_gps_nodes[i] == node) {
+            _gps_listeners[sel_place] = new_listener;
+            _gps_listener_to_node[sel_place] = i;
+            _gps_node_taken[i]++;
+            ret = i + 1;
 
-                debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, i);
-                break;
-            }
+            debug_uavcan(2, "reg_GPS place:%d, chan: %d\n\r", sel_place, i);
+            break;
         }
     }
 
@@ -944,11 +973,12 @@ void AP_UAVCAN::update_gps_state(uint8_t node)
 {
     // Go through all listeners of specified node and call their's update methods
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_GPS_NODES; i++) {
-        if (_gps_nodes[i] == node) {
-            for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
-                if (_gps_listener_to_node[j] == i) {
-                    _gps_listeners[j]->handle_gnss_msg(_gps_node_state[i]);
-                }
+        if (_gps_nodes[i] != node) {
+            continue;
+        }
+        for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
+            if (_gps_listener_to_node[j] == i) {
+                _gps_listeners[j]->handle_gnss_msg(_gps_node_state[i]);
             }
         }
     }
@@ -965,27 +995,26 @@ uint8_t AP_UAVCAN::register_baro_listener(AP_Baro_Backend* new_listener, uint8_t
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        if (preferred_channel != 0) {
-            if (preferred_channel < AP_UAVCAN_MAX_BARO_NODES) {
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
+    if (preferred_channel != 0 && preferred_channel < AP_UAVCAN_MAX_BARO_NODES) {
+        _baro_listeners[sel_place] = new_listener;
+        _baro_listener_to_node[sel_place] = preferred_channel - 1;
+        _baro_node_taken[_baro_listener_to_node[sel_place]]++;
+        ret = preferred_channel;
+
+        debug_uavcan(2, "reg_Baro place:%d, chan: %d\n\r", sel_place, preferred_channel);
+    } else {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
+            if (_baro_node_taken[i] == 0) {
                 _baro_listeners[sel_place] = new_listener;
-                _baro_listener_to_node[sel_place] = preferred_channel - 1;
-                _baro_node_taken[_baro_listener_to_node[sel_place]]++;
-                ret = preferred_channel;
+                _baro_listener_to_node[sel_place] = i;
+                _baro_node_taken[i]++;
+                ret = i + 1;
 
-                debug_uavcan(2, "reg_Baro place:%d, chan: %d\n\r", sel_place, preferred_channel);
-            }
-        } else {
-            for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
-                if (_baro_node_taken[i] == 0) {
-                    _baro_listeners[sel_place] = new_listener;
-                    _baro_listener_to_node[sel_place] = i;
-                    _baro_node_taken[i]++;
-                    ret = i + 1;
-
-                    debug_uavcan(2, "reg_BARO place:%d, chan: %d\n\r", sel_place, i);
-                    break;
-                }
+                debug_uavcan(2, "reg_BARO place:%d, chan: %d\n\r", sel_place, i);
+                break;
             }
         }
     }
@@ -1006,15 +1035,16 @@ uint8_t AP_UAVCAN::register_baro_listener_to_node(AP_Baro_Backend* new_listener,
 
     if (sel_place != UINT8_MAX) {
         for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
-            if (_baro_nodes[i] == node) {
-                _baro_listeners[sel_place] = new_listener;
-                _baro_listener_to_node[sel_place] = i;
-                _baro_node_taken[i]++;
-                ret = i + 1;
-
-                debug_uavcan(2, "reg_BARO place:%d, chan: %d\n\r", sel_place, i);
-                break;
+            if (_baro_nodes[i] != node) {
+                continue;
             }
+            _baro_listeners[sel_place] = new_listener;
+            _baro_listener_to_node[sel_place] = i;
+            _baro_node_taken[i]++;
+            ret = i + 1;
+
+            debug_uavcan(2, "reg_BARO place:%d, chan: %d\n\r", sel_place, i);
+            break;
         }
     }
 
@@ -1025,15 +1055,16 @@ void AP_UAVCAN::remove_baro_listener(AP_Baro_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
-        if (_baro_listeners[i] == rem_listener) {
-            _baro_listeners[i] = nullptr;
-
-            // Also decrement usage counter and reset listening node
-            if (_baro_node_taken[_baro_listener_to_node[i]] > 0) {
-                _baro_node_taken[_baro_listener_to_node[i]]--;
-            }
-            _baro_listener_to_node[i] = UINT8_MAX;
+        if (_baro_listeners[i] != rem_listener) {
+            continue;
         }
+        _baro_listeners[i] = nullptr;
+
+        // Also decrement usage counter and reset listening node
+        if (_baro_node_taken[_baro_listener_to_node[i]] > 0) {
+            _baro_node_taken[_baro_listener_to_node[i]]--;
+        }
+        _baro_listener_to_node[i] = UINT8_MAX;
     }
 }
 
@@ -1063,11 +1094,12 @@ void AP_UAVCAN::update_baro_state(uint8_t node)
 {
     // Go through all listeners of specified node and call their's update methods
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_BARO_NODES; i++) {
-        if (_baro_nodes[i] == node) {
-            for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
-                if (_baro_listener_to_node[j] == i) {
-                    _baro_listeners[j]->handle_baro_msg(_baro_node_state[i].pressure, _baro_node_state[i].temperature);
-                }
+        if (_baro_nodes[i] != node) {
+            continue;
+        }
+        for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
+            if (_baro_listener_to_node[j] == i) {
+                _baro_listeners[j]->handle_baro_msg(_baro_node_state[i].pressure, _baro_node_state[i].temperature);
             }
         }
     }
@@ -1099,27 +1131,26 @@ uint8_t AP_UAVCAN::register_mag_listener(AP_Compass_Backend* new_listener, uint8
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        if (preferred_channel != 0) {
-            if (preferred_channel < AP_UAVCAN_MAX_MAG_NODES) {
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
+    if (preferred_channel != 0 && preferred_channel < AP_UAVCAN_MAX_MAG_NODES) {
+        _mag_listeners[sel_place] = new_listener;
+        _mag_listener_to_node[sel_place] = preferred_channel - 1;
+        _mag_node_taken[_mag_listener_to_node[sel_place]]++;
+        ret = preferred_channel;
+
+        debug_uavcan(2, "reg_Compass place:%d, chan: %d\n\r", sel_place, preferred_channel);
+    } else {
+        for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
+            if (_mag_node_taken[i] == 0) {
                 _mag_listeners[sel_place] = new_listener;
-                _mag_listener_to_node[sel_place] = preferred_channel - 1;
-                _mag_node_taken[_mag_listener_to_node[sel_place]]++;
-                ret = preferred_channel;
+                _mag_listener_to_node[sel_place] = i;
+                _mag_node_taken[i]++;
+                ret = i + 1;
 
-                debug_uavcan(2, "reg_Compass place:%d, chan: %d\n\r", sel_place, preferred_channel);
-            }
-        } else {
-            for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-                if (_mag_node_taken[i] == 0) {
-                    _mag_listeners[sel_place] = new_listener;
-                    _mag_listener_to_node[sel_place] = i;
-                    _mag_node_taken[i]++;
-                    ret = i + 1;
-
-                    debug_uavcan(2, "reg_MAG place:%d, chan: %d\n\r", sel_place, i);
-                    break;
-                }
+                debug_uavcan(2, "reg_MAG place:%d, chan: %d\n\r", sel_place, i);
+                break;
             }
         }
     }
@@ -1138,19 +1169,21 @@ uint8_t AP_UAVCAN::register_mag_listener_to_node(AP_Compass_Backend* new_listene
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-            if (_mag_nodes[i] == node) {
-                _mag_listeners[sel_place] = new_listener;
-                _mag_listener_to_node[sel_place] = i;
-                _mag_listener_sensor_ids[sel_place] = 0;
-                _mag_node_taken[i]++;
-                ret = i + 1;
-
-                debug_uavcan(2, "reg_MAG place:%d, chan: %d\n\r", sel_place, i);
-                break;
-            }
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
+        if (_mag_nodes[i] != node) {
+            continue;
         }
+        _mag_listeners[sel_place] = new_listener;
+        _mag_listener_to_node[sel_place] = i;
+        _mag_listener_sensor_ids[sel_place] = 0;
+        _mag_node_taken[i]++;
+        ret = i + 1;
+
+        debug_uavcan(2, "reg_MAG place:%d, chan: %d\n\r", sel_place, i);
+        break;
     }
 
     return ret;
@@ -1160,15 +1193,16 @@ void AP_UAVCAN::remove_mag_listener(AP_Compass_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
-        if (_mag_listeners[i] == rem_listener) {
-            _mag_listeners[i] = nullptr;
-
-            // Also decrement usage counter and reset listening node
-            if (_mag_node_taken[_mag_listener_to_node[i]] > 0) {
-                _mag_node_taken[_mag_listener_to_node[i]]--;
-            }
-            _mag_listener_to_node[i] = UINT8_MAX;
+        if (_mag_listeners[i] != rem_listener) {
+            continue;
         }
+        _mag_listeners[i] = nullptr;
+
+        // Also decrement usage counter and reset listening node
+        if (_mag_node_taken[_mag_listener_to_node[i]] > 0) {
+            _mag_node_taken[_mag_listener_to_node[i]]--;
+        }
+        _mag_listener_to_node[i] = UINT8_MAX;
     }
 }
 
@@ -1176,23 +1210,25 @@ AP_UAVCAN::Mag_Info *AP_UAVCAN::find_mag_node(uint8_t node, uint8_t sensor_id)
 {
     // Check if such node is already defined
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-        if (_mag_nodes[i] == node) {
-            if (_mag_node_max_sensorid_count[i] < sensor_id) {
-                _mag_node_max_sensorid_count[i] = sensor_id;
-                debug_uavcan(2, "AP_UAVCAN: Compass: found sensor id %d on node %d\n\r", (int)(sensor_id), (int)(node));
-            }
-            return &_mag_node_state[i];
+        if (_mag_nodes[i] != node) {
+            continue;
         }
+        if (_mag_node_max_sensorid_count[i] < sensor_id) {
+            _mag_node_max_sensorid_count[i] = sensor_id;
+            debug_uavcan(2, "AP_UAVCAN: Compass: found sensor id %d on node %d\n\r", (int)(sensor_id), (int)(node));
+        }
+        return &_mag_node_state[i];
     }
 
     // If not - try to find free space for it
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-        if (_mag_nodes[i] == UINT8_MAX) {
-            _mag_nodes[i] = node;
-            _mag_node_max_sensorid_count[i] = (sensor_id ? sensor_id : 1);
-            debug_uavcan(2, "AP_UAVCAN: Compass: register sensor id %d on node %d\n\r", (int)(sensor_id), (int)(node));  
-            return &_mag_node_state[i];
+        if (_mag_nodes[i] != UINT8_MAX) {
+            continue;
         }
+        _mag_nodes[i] = node;
+        _mag_node_max_sensorid_count[i] = (sensor_id ? sensor_id : 1);
+        debug_uavcan(2, "AP_UAVCAN: Compass: register sensor id %d on node %d\n\r", (int)(sensor_id), (int)(node));
+        return &_mag_node_state[i];
     }
 
     // If no space is left - return nullptr
@@ -1222,33 +1258,35 @@ void AP_UAVCAN::update_mag_state(uint8_t node, uint8_t sensor_id)
 {
     // Go through all listeners of specified node and call their's update methods
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_MAG_NODES; i++) {
-        if (_mag_nodes[i] == node) {
-            for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
-                if (_mag_listener_to_node[j] == i) {
-                    
-                    /*If the current listener has default sensor_id,
-                      while our sensor_id is not default, we have
-                      to assign our sensor_id to this listener*/ 
-                    if ((_mag_listener_sensor_ids[j] == 0) && (sensor_id != 0)) {
-                        bool already_taken = false;
-                        for (uint8_t k = 0; k < AP_UAVCAN_MAX_LISTENERS; k++) {
-                            if (_mag_listener_sensor_ids[k] == sensor_id) {
-                                already_taken = true;
-                            }
-                        }
-                        if (!already_taken) {
-                            debug_uavcan(2, "AP_UAVCAN: Compass: sensor_id updated to %d for listener %d\n", sensor_id, j);
-                            _mag_listener_sensor_ids[j] = sensor_id;
-                        }
-                    }
-                    
-                    /*If the current listener has the sensor_id that we have,
-                      or our sensor_id is default, ask the listener to handle the measurements
-                      (the default one is used for the nodes that have only one compass*/
-                    if ((sensor_id == 0) || (_mag_listener_sensor_ids[j] == sensor_id)) {
-                        _mag_listeners[j]->handle_mag_msg(_mag_node_state[i].mag_vector);
+        if (_mag_nodes[i] != node) {
+            continue;
+        }
+        for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
+            if (_mag_listener_to_node[j] != i) {
+                continue;
+            }
+
+            /*If the current listener has default sensor_id,
+              while our sensor_id is not default, we have
+              to assign our sensor_id to this listener*/
+            if ((_mag_listener_sensor_ids[j] == 0) && (sensor_id != 0)) {
+                bool already_taken = false;
+                for (uint8_t k = 0; k < AP_UAVCAN_MAX_LISTENERS; k++) {
+                    if (_mag_listener_sensor_ids[k] == sensor_id) {
+                        already_taken = true;
                     }
                 }
+                if (!already_taken) {
+                    debug_uavcan(2, "AP_UAVCAN: Compass: sensor_id updated to %d for listener %d\n", sensor_id, j);
+                    _mag_listener_sensor_ids[j] = sensor_id;
+                }
+            }
+
+            /*If the current listener has the sensor_id that we have,
+              or our sensor_id is default, ask the listener to handle the measurements
+              (the default one is used for the nodes that have only one compass*/
+            if ((sensor_id == 0) || (_mag_listener_sensor_ids[j] == sensor_id)) {
+                _mag_listeners[j]->handle_mag_msg(_mag_node_state[i].mag_vector);
             }
         }
     }
@@ -1265,18 +1303,21 @@ uint8_t AP_UAVCAN::register_BM_bi_listener_to_id(AP_BattMonitor_Backend* new_lis
         }
     }
 
-    if (sel_place != UINT8_MAX) {
-        for (uint8_t i = 0; i < AP_UAVCAN_MAX_BI_NUMBER; i++) {
-            if (_bi_id[i] == id) {
-                _bi_BM_listeners[sel_place] = new_listener;
-                _bi_BM_listener_to_id[sel_place] = i;
-                _bi_id_taken[i]++;
-                ret = i + 1;
+    if (sel_place == UINT8_MAX) {
+        return 0;
+    }
 
-                debug_uavcan(2, "reg_BI place:%d, chan: %d\n\r", sel_place, i);
-                break;
-            }
+    for (uint8_t i = 0; i < AP_UAVCAN_MAX_BI_NUMBER; i++) {
+        if (_bi_id[i] != id) {
+            continue;
         }
+        _bi_BM_listeners[sel_place] = new_listener;
+        _bi_BM_listener_to_id[sel_place] = i;
+        _bi_id_taken[i]++;
+        ret = i + 1;
+
+        debug_uavcan(2, "reg_BI place:%d, chan: %d\n\r", sel_place, i);
+        break;
     }
 
     return ret;
@@ -1286,15 +1327,17 @@ void AP_UAVCAN::remove_BM_bi_listener(AP_BattMonitor_Backend* rem_listener)
 {
     // Check for all listeners and compare pointers
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_LISTENERS; i++) {
-       if (_bi_BM_listeners[i] == rem_listener) {
-           _bi_BM_listeners[i] = nullptr;
-
-           // Also decrement usage counter and reset listening node
-           if (_bi_id_taken[_bi_BM_listener_to_id[i]] > 0) {
-               _bi_id_taken[_bi_BM_listener_to_id[i]]--;
-           }
-           _bi_BM_listener_to_id[i] = UINT8_MAX;
+       if (_bi_BM_listeners[i] != rem_listener) {
+           continue;
        }
+
+       _bi_BM_listeners[i] = nullptr;
+
+       // Also decrement usage counter and reset listening node
+       if (_bi_id_taken[_bi_BM_listener_to_id[i]] > 0) {
+           _bi_id_taken[_bi_BM_listener_to_id[i]]--;
+       }
+       _bi_BM_listener_to_id[i] = UINT8_MAX;
     }
 }
 
@@ -1336,12 +1379,14 @@ void AP_UAVCAN::update_bi_state(uint8_t id)
 {
     // Go through all listeners of specified node and call their's update methods
     for (uint8_t i = 0; i < AP_UAVCAN_MAX_BI_NUMBER; i++) {
-        if (_bi_id[i] == id) {
-            for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
-                if (_bi_BM_listener_to_id[j] == i) {
-                    _bi_BM_listeners[j]->handle_bi_msg(_bi_id_state[i].voltage, _bi_id_state[i].current, _bi_id_state[i].temperature);
-                }
+        if (_bi_id[i] != id) {
+            continue;
+        }
+        for (uint8_t j = 0; j < AP_UAVCAN_MAX_LISTENERS; j++) {
+            if (_bi_BM_listener_to_id[j] != i) {
+                continue;
             }
+            _bi_BM_listeners[j]->handle_bi_msg(_bi_id_state[i].voltage, _bi_id_state[i].current, _bi_id_state[i].temperature);
         }
     }
 }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -88,13 +88,11 @@ const AP_Param::GroupInfo AP_UAVCAN::var_info[] = {
 
 static void gnss_fix_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
     if (state == nullptr) {
         return;
@@ -200,13 +198,11 @@ static void (*gnss_fix_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
 
 static void gnss_aux_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_GPS::GPS_State *state = ap_uavcan->find_gps_node(msg.getSrcNodeID().get());
     if (state == nullptr) {
         return;
@@ -230,13 +226,11 @@ static void (*gnss_aux_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
 
 static void magnetic_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), 0);
     if (state == nullptr) {
         return;
@@ -259,13 +253,11 @@ static void (*magnetic_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan::eq
         
 static void magnetic_cb_2(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength2>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_UAVCAN::Mag_Info *state = ap_uavcan->find_mag_node(msg.getSrcNodeID().get(), msg.sensor_id);
     if (state == nullptr) {
         return;
@@ -288,13 +280,11 @@ static void (*magnetic_cb_2_arr[2])(const uavcan::ReceivedDataStructure<uavcan::
 
 static void air_data_sp_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
     if (state == nullptr) {
         return;
@@ -317,13 +307,11 @@ static void (*air_data_sp_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan:
 // Temperature is not main parameter so do not update listeners when it is received
 static void air_data_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticTemperature>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_UAVCAN::Baro_Info *state = ap_uavcan->find_baro_node(msg.getSrcNodeID().get());
     if (state == nullptr) {
         return;
@@ -342,13 +330,11 @@ static void (*air_data_st_cb_arr[2])(const uavcan::ReceivedDataStructure<uavcan:
 
 static void battery_info_st_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::power::BatteryInfo>& msg, uint8_t mgr)
 {
-    if (hal.can_mgr[mgr] == nullptr) {
-        return;
-    }
-    AP_UAVCAN *ap_uavcan = hal.can_mgr[mgr]->get_UAVCAN();
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
     if (ap_uavcan == nullptr) {
         return;
     }
+    
     AP_UAVCAN::BatteryInfo_Info *state = ap_uavcan->find_bi_id((uint16_t) msg.battery_id);
     if (state == nullptr) {
         return;


### PR DESCRIPTION
This cleans up a lot of whitespace in the UAVCan and other CAN areas where there's excessive indents from excessive use of { } brackets. I've simplified it by having functions fail and return early instead of indenting the whoooooole function. same with some loops where a loop content only runs on an if, so instead if it fails it continues and the rest runs without the indent.