### PR TITLE
Tools: fix motor rpm display in flightgear

### DIFF
--- a/Tools/autotest/aircraft/arducopter/arducopter-set.xml
+++ b/Tools/autotest/aircraft/arducopter/arducopter-set.xml
@@ -54,6 +54,20 @@ Arducotper UAV Model
       <!-- controllable -->
     </flight>
   </controls>
+  <engines>
+     <engine n="0">
+        <rpm>0</rpm>
+     </engine>
+     <engine n="1">
+        <rpm>0</rpm>
+     </engine>
+     <engine n="2">
+        <rpm>0</rpm>
+     </engine>
+     <engine n="3">
+        <rpm>0</rpm>
+     </engine>
+  </engines>
   <consumables>
     <fuel>
       <tank n="0">


### PR DESCRIPTION
http://ardupilot.org/dev/_images/flightgear_copter_windows.jpg

When use flightgear to visualize SITL. motor_right, motor_left, motor_front and motor_back OSD are all nil. It remains nil even copter is armed and take off. FlightGear shows "Nasal runtime error: nul used in numeric context". It could be solved by assign initial values