### PR TITLE
Tools: fix copter propeller animation in FlightGear multiplayer

### DIFF
--- a/Tools/autotest/aircraft/arducopter/Models/arducopter.xml
+++ b/Tools/autotest/aircraft/arducopter/Models/arducopter.xml
@@ -17,7 +17,7 @@
   <animation>
     <type>spin</type>
     <object-name>propeller0</object-name>
-    <property>/engines/engine[0]/rpm</property>
+    <property>engines/engine[0]/rpm</property>
     <factor>100</factor>
     <axis>
       <x1-m>0.000</x1-m>
@@ -36,7 +36,7 @@
   <animation>
     <type>spin</type>
     <object-name>propeller1</object-name>
-    <property>/engines/engine[1]/rpm</property>
+    <property>engines/engine[1]/rpm</property>
     <factor>100</factor>
     <axis>
       <x1-m>0.000</x1-m>
@@ -55,7 +55,7 @@
   <animation>
     <type>spin</type>
     <object-name>propeller2</object-name>
-    <property>/engines/engine[2]/rpm</property>
+    <property>engines/engine[2]/rpm</property>
     <factor>100</factor>
     <axis>
       <x1-m>0.288</x1-m>
@@ -74,7 +74,7 @@
   <animation>
     <type>spin</type>
     <object-name>propeller3</object-name>
-    <property>/engines/engine[3]/rpm</property>
+    <property>engines/engine[3]/rpm</property>
     <factor>100</factor>
     <axis>
       <x1-m>-0.288</x1-m>


### PR DESCRIPTION
When FlightGear multiplayer is used to visualize SITL swarms, copter propeller spin animation is incorrect.
For example:
PC 1 : flightgear + SITL (copter 1)
PC 2 : flightgear + SITL (copter 2)
both flightgear is connected to multiplayer sever
When copter 1 armed. in its flightgear display, both copters propellers are spinning.  Meanwhile, in copter 2 flightgear display. neither copter propeller is spinning. If you take copter 1 off, in  copter 2  flightgear display you can see copter 1 taken off without its propellers spinning (like UFO).

in http://wiki.flightgear.org/Howto:Animate_models
it states "Note the omission of the leading slash '/' when reffering to the property. This assures that when the model is used for AI or multiplayer traffic the animations will follow that of the AI controller instead of that of the user."