### PR TITLE
AP_UAVCAN: add can driver sanity check helper function

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -1347,4 +1347,12 @@ bool AP_UAVCAN::led_write(uint8_t led_index, uint8_t red, uint8_t green, uint8_t
     return true;
 }
 
+AP_UAVCAN *AP_UAVCAN::get_uavcan(uint8_t iface)
+{
+    if (iface >= MAX_NUMBER_OF_CAN_INTERFACES || !hal.can_mgr[iface]) {
+        return nullptr;
+    }
+    return hal.can_mgr[iface]->get_UAVCAN();
+}
+
 #endif // HAL_WITH_UAVCAN

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -54,6 +54,9 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    // Return uavcan from @iface or nullptr if it's not ready or doesn't exist
+    static AP_UAVCAN *get_uavcan(uint8_t iface);
+
     // this function will register the listening class on a first free channel or on the specified channel
     // if preferred_channel = 0 then free channel will be searched for
     // if preferred_channel > 0 then listener will be added to specific channel


### PR DESCRIPTION
followup to a suggestion by @lucasdemarchi in PR https://github.com/ArduPilot/ardupilot/pull/7863

instead of null checking the CAN driver, twice, EVERYWHERE, lets make it a single static function