### PR TITLE
Copter: COMPASS_USE=0 skips pre-arm checks and disables position hold modes

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -196,6 +196,13 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     }
 #endif
 
+    //disables flight modes with position hold when compass is disabled
+    if (new_flightmode->requires_GPS() && (!compass.use_for_yaw())) {
+    	gcs().send_text(MAV_SEVERITY_WARNING,"Compass Disabled! Flight mode change failed");
+    	Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE,mode);
+    	return false;
+    }
+
     if (!new_flightmode->init(ignore_checks)) {
         gcs().send_text(MAV_SEVERITY_WARNING,"Flight mode change failed");
         Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE,mode);


### PR DESCRIPTION
Fix for issue #5454 
- Existing code already skips pre-arm compass check if COMPASS_USE=0.
https://github.com/ArduPilot/ardupilot/blob/1baa6eb049ab7090b845ffe0b50c7978c1fb9e73/libraries/AP_Arming/AP_Arming.cpp#L279
- I have also disabled switching to GPS based(needs compass) flight modes when this param is set to zero.