### PR TITLE
SITL wind options

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -359,23 +359,43 @@ void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
     uint32_t now = AP_HAL::micros();
     last_update_usec = now;
 
-    // pass wind into simulators, using a wind gradient below 60m
     float altitude = _barometer?_barometer->get_altitude():0;
     float wind_speed = 0;
     float wind_direction = 0;
     float wind_dir_z = 0;
-    if (_sitl) {
+
+    // give 5 seconds to calibrate airspeed sensor at 0 wind speed
+    if (wind_start_delay_micros == 0) {
+        wind_start_delay_micros = now;
+    } else if (_sitl && (now - wind_start_delay_micros) > 5000000 ) {
         // The EKF does not like step inputs so this LPF keeps it happy.
         wind_speed =     _sitl->wind_speed_active     = (0.95f*_sitl->wind_speed_active)     + (0.05f*_sitl->wind_speed);
         wind_direction = _sitl->wind_direction_active = (0.95f*_sitl->wind_direction_active) + (0.05f*_sitl->wind_direction);
         wind_dir_z =     _sitl->wind_dir_z_active     = (0.95f*_sitl->wind_dir_z_active)     + (0.05f*_sitl->wind_dir_z);
-    }
+        
+        // pass wind into simulators using different wind types via param SIM_WIND_T*.
+        switch (_sitl->wind_type) {
+        case SITL::SITL::WIND_TYPE_SQRT:
+            if (altitude < _sitl->wind_type_alt) {
+                wind_speed *= sqrtf(MAX(altitude / _sitl->wind_type_alt, 0));
+            }
+            break;
 
+        case SITL::SITL::WIND_TYPE_COEF:
+            wind_speed += (altitude - _sitl->wind_type_alt) * _sitl->wind_type_coef;
+            break;
+
+        case SITL::SITL::WIND_TYPE_NO_LIMIT:
+        default:
+            break;
+        }
+
+        // never allow negative wind velocity
+        wind_speed = MAX(wind_speed, 0);
+    }
+    
     if (altitude < 0) {
         altitude = 0;
-    }
-    if (altitude < 60) {
-        wind_speed *= sqrtf(MAX(altitude / 60, 0));
     }
 
     input.wind.speed = wind_speed;

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -202,6 +202,7 @@ private:
     VectorN<readings_wind,wind_buffer_length> buffer_wind_2;
     uint32_t time_delta_wind;
     uint32_t delayed_time_wind;
+    uint32_t wind_start_delay_micros;
 
     // internal SITL model
     SITL::Aircraft *sitl_model;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -113,6 +113,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD2_FAILP",12, SITL,  arspd2_fail_pressure, 0),
     AP_GROUPINFO("ARSPD2_PITOT",13, SITL,  arspd2_fail_pitot_pressure, 0),
     AP_GROUPINFO("VICON_HSTLEN",14, SITL,  vicon_observation_history_length, 0),
+    AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
+    AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
+    AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -130,6 +130,12 @@ public:
     AP_Int8  odom_enable; // enable visual odomotry data
     
     // wind control
+    enum WindType {
+        WIND_TYPE_SQRT = 0,
+        WIND_TYPE_NO_LIMIT = 1,
+        WIND_TYPE_COEF = 2,
+    };
+    
     float wind_speed_active;
     float wind_direction_active;
     float wind_dir_z_active;
@@ -138,6 +144,9 @@ public:
     AP_Float wind_turbulance;
     AP_Float gps_drift_alt;
     AP_Float wind_dir_z;
+    AP_Int8  wind_type; // enum WindLimitType
+    AP_Float wind_type_alt;
+    AP_Float wind_type_coef;
 
     AP_Int16  baro_delay; // barometer data delay in ms
     AP_Int16  mag_delay; // magnetometer data delay in ms


### PR DESCRIPTION
Adresses 2 issues:
- the wind in SITL was always going to 0 at altitudes below 60m. Now this can be setup differently if needed.
- If the simulation starts with predefined wind, then calibration of airspeed sensor gets wrong.