### PR TITLE
Replace global static send_param_value_all with gcs(). method

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1043,7 +1043,7 @@ bool AP_Param::save(bool force_save)
             v2 = get_default_value(this, &info->def_value);
         }
         if (is_equal(v1,v2) && !force_save) {
-            GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type, v2);
+            gcs().send_parameter_value(name, (enum ap_var_type)info->type, v2);
             return true;
         }
         if (!force_save &&
@@ -1051,7 +1051,7 @@ bool AP_Param::save(bool force_save)
              (fabsf(v1-v2) < 0.0001f*fabsf(v1)))) {
             // for other than 32 bit integers, we accept values within
             // 0.01 percent of the current value as being the same
-            GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type, v2);
+            gcs().send_parameter_value(name, (enum ap_var_type)info->type, v2);
             return true;
         }
     }
@@ -2060,7 +2060,7 @@ void AP_Param::send_parameter(const char *name, enum ap_var_type var_type, uint8
     }
     if (var_type != AP_PARAM_VECTOR3F) {
         // nice and simple for scalar types
-        GCS_MAVLINK::send_parameter_value_all(name, var_type, cast_to_float(var_type));
+        gcs().send_parameter_value(name, var_type, cast_to_float(var_type));
         return;
     }
 
@@ -2075,11 +2075,11 @@ void AP_Param::send_parameter(const char *name, enum ap_var_type var_type, uint8
     char &name_axis = name2[strlen(name)-1];
     
     name_axis = 'X';
-    GCS_MAVLINK::send_parameter_value_all(name2, AP_PARAM_FLOAT, v.x);
+    gcs().send_parameter_value(name2, AP_PARAM_FLOAT, v.x);
     name_axis = 'Y';
-    GCS_MAVLINK::send_parameter_value_all(name2, AP_PARAM_FLOAT, v.y);
+    gcs().send_parameter_value(name2, AP_PARAM_FLOAT, v.y);
     name_axis = 'Z';
-    GCS_MAVLINK::send_parameter_value_all(name2, AP_PARAM_FLOAT, v.z);
+    gcs().send_parameter_value(name2, AP_PARAM_FLOAT, v.z);
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -188,9 +188,6 @@ public:
     // return a bitmap of streaming channels
     static uint8_t streaming_channel_mask(void) { return chan_is_streaming; }
 
-    // send a PARAM_VALUE message to all active MAVLink connections.
-    static void send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value);
-
     // send queued parameters if needed
     void send_queued_parameters(void);
 
@@ -478,6 +475,11 @@ public:
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_home(const Location &home) const;
     void send_ekf_origin(const Location &ekf_origin) const;
+
+    void send_parameter_value(const char *param_name,
+                              ap_var_type param_type,
+                              float param_value);
+
     // push send_message() messages and queued statustext messages etc:
     void retry_deferred();
     void data_stream_send();

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -323,14 +323,15 @@ bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
 /*
   send a parameter value message to all active MAVLink connections
  */
-void GCS_MAVLINK::send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value)
+void GCS::send_parameter_value(const char *param_name, ap_var_type param_type, float param_value)
 {
+    const uint8_t mavlink_active = GCS_MAVLINK::active_channel_mask();
     for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
         if ((1U<<i) & mavlink_active) {
-            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
-            if (HAVE_PAYLOAD_SPACE(chan, PARAM_VALUE)) {
+            const mavlink_channel_t _chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
+            if (HAVE_PAYLOAD_SPACE(_chan, PARAM_VALUE)) {
                 mavlink_msg_param_value_send(
-                    chan,
+                    _chan,
                     param_name,
                     param_value,
                     mav_var_type(param_type),


### PR DESCRIPTION
We can avoid recreating the structure each time by using this `_struct` function.

This should be more efficient when you have multiple mavlink links to feed, and will serve as an example where we broadcast other messages (more frequently!)  In particular, it may be possible to modify `GCS::send_message()` to pack only one copy of the structure, directly sending to each channel that has space and deferring for those that don't.

Also makes send-parameter-value-all non-static.
