### PR TITLE
Rover: waypoint navigation sets origin to prev waypoint or stopping point

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -57,7 +57,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(update_visual_odom,     50,     50),
     SCHED_TASK(update_wheel_encoder,   20,     50),
     SCHED_TASK(update_compass,         10,   2000),
-    SCHED_TASK(update_mission,         10,   1000),
+    SCHED_TASK(update_mission,         50,    500),
     SCHED_TASK(update_logging1,        10,   1000),
     SCHED_TASK(update_logging2,        10,   1000),
     SCHED_TASK(gcs_retry_deferred,     50,   1000),

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -113,13 +113,13 @@ void Mode::set_desired_location(const struct Location& destination, float next_l
     // set final desired speed
     _desired_speed_final = 0.0f;
     if (!is_equal(next_leg_bearing_cd, MODE_NEXT_HEADING_UNKNOWN)) {
-        // if not turning can continue at full speed
-        if (is_zero(next_leg_bearing_cd)) {
+        const float curr_leg_bearing_cd = get_bearing_cd(_origin, _destination);
+        const float turn_angle_cd = wrap_180_cd(next_leg_bearing_cd - curr_leg_bearing_cd);
+        if (is_zero(turn_angle_cd)) {
+            // if not turning can continue at full speed
             _desired_speed_final = _desired_speed;
         } else {
             // calculate maximum speed that keeps overshoot within bounds
-            const float curr_leg_bearing_cd = get_bearing_cd(_origin, _destination);
-            const float turn_angle_cd = wrap_180_cd(next_leg_bearing_cd - curr_leg_bearing_cd);
             const float radius_m = fabsf(g.waypoint_overshoot / (cosf(radians(turn_angle_cd * 0.01f)) - 1.0f));
             _desired_speed_final = MIN(_desired_speed, safe_sqrt(g.turn_max_g * GRAVITY_MSS * radius_m));
         }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -97,8 +97,13 @@ void Mode::get_pilot_desired_steering_and_throttle(float &steering_out, float &t
 // set desired location
 void Mode::set_desired_location(const struct Location& destination, float next_leg_bearing_cd)
 {
-    // record targets
-    _origin = rover.current_loc;
+    // set origin to last destination if waypoint controller active
+    if ((AP_HAL::millis() - last_steer_to_wp_ms < 100) && _reached_destination) {
+        _origin = _destination;
+    } else {
+        // otherwise use reasonable stopping point
+        calc_stopping_location(_origin);
+    }
     _destination = destination;
 
     // initialise distance
@@ -302,6 +307,9 @@ float Mode::calc_reduced_speed_for_turn_or_distance(float desired_speed)
 // this function updates the _yaw_error_cd value
 void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct Location &destination, bool reversed)
 {
+    // record system time of call
+    last_steer_to_wp_ms = AP_HAL::millis();
+
     // Calculate the required turn of the wheels
     // negative error = left turn
     // positive error = right turn
@@ -350,4 +358,29 @@ void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
     const float yaw_error = wrap_PI(radians((desired_heading_cd - ahrs.yaw_sensor) * 0.01f));
     const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
+}
+
+// calculate vehicle stopping point using current location, velocity and maximum acceleration
+void Mode::calc_stopping_location(Location& stopping_loc)
+{
+    // default stopping location
+    stopping_loc = rover.current_loc;
+
+    // get current velocity vector and speed
+    const Vector2f velocity = ahrs.groundspeed_vector();
+    const float speed = velocity.length();
+
+    // avoid divide by zero
+    if (!is_positive(speed)) {
+        stopping_loc = rover.current_loc;
+        return;
+    }
+
+    // get stopping distance in meters
+    const float stopping_dist = attitude_control.get_stopping_distance(speed);
+
+    // calculate stopping position from current location in meters
+    const Vector2f stopping_offset = velocity.normalized() * stopping_dist;
+
+    location_offset(stopping_loc, stopping_offset.x, stopping_offset.y);
 }

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -136,6 +136,9 @@ protected:
     // relies on these internal members being updated: lateral_acceleration, _yaw_error_cd, _distance_to_destination
     float calc_reduced_speed_for_turn_or_distance(float desired_speed);
 
+    // calculate vehicle stopping location using current location, velocity and maximum acceleration
+    void calc_stopping_location(Location& stopping_loc);
+
     // references to avoid code churn:
     class AP_AHRS &ahrs;
     class Parameters &g;
@@ -156,6 +159,7 @@ protected:
     float _desired_speed;       // desired speed in m/s
     float _desired_speed_final; // desired speed in m/s when we reach the destination
     float _speed_error;         // ground speed error in m/s
+    uint32_t last_steer_to_wp_ms;   // system time of last call to calc_steering_to_waypoint
 };
 
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -461,3 +461,18 @@ float AR_AttitudeControl::get_desired_speed() const
     }
     return _desired_speed;
 }
+
+// get minimum stopping distance (in meters) given a speed (in m/s)
+float AR_AttitudeControl::get_stopping_distance(float speed)
+{
+    // get maximum vehicle deceleration
+    const float accel_max = get_accel_max();
+
+    // avoid divide by zero
+    if ((accel_max <= 0.0f) || is_zero(speed)) {
+        return 0.0f;
+    }
+
+    // assume linear deceleration
+    return 0.5f * sq(speed) / accel_max;
+}

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -92,6 +92,9 @@ public:
     // get latest desired speed recorded during call to get_throttle_out_speed.  For reporting purposes only
     float get_desired_speed() const;
 
+    // get minimum stopping distance (in meters) given a speed (in m/s)
+    float get_stopping_distance(float speed);
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
This resolves issue (https://github.com/ArduPilot/ardupilot/issues/7796).

When Rover begins towards the next waypoint, it must initialise both the origin and destination.  Master currently sets the origin to the vehicle's current location which causes the vehicle to drive slightly off the line between waypoints.  This PR fixes the issue by using the previous destination if we've reached it recently.

The improvement is especially obvious if the WP_RADIUS is set to a large number like 10m as shown below.
![wpnav-origin-fix](https://user-images.githubusercontent.com/1498098/37344552-03f469fc-270e-11e8-9c8e-605ccff0beb2.png)

In cases where we don't have a previous waypoint we use a reasonable stopping point calculated from the vehicle's current location, velocity and maximum deceleration.  Master's behaviour is slightly ugly when the vehicle is moving quickly because it initially turns away from the waypoint to get back onto the line.

The final change is to increase the rate at which we process mission commands.  This reduces the amount of time between when a command is completed and the next one starts.