### PR TITLE
Copter: Circle Mode Radius Control using the Pitch Input

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -535,6 +535,10 @@ private:
 
     // Circle
     bool pilot_yaw_override = false; // true if pilot is overriding yaw
+
+    // Used for changing the circle radius inflight from pitch inputs
+    float get_target_radius(float current_radius, float radial_velocity, float dt);
+    float get_desired_radial_velocity(float norm_pitch_input);
 };
 
 


### PR DESCRIPTION
This is the first part of the patch for [adding in-flight modification](https://github.com/ArduPilot/ardupilot/issues/5450) of the CIRCLE mode's parameters. I have re-purposed the Pitch stick to change the radius of the circle. The radial velocity is set to a fractional value of the WPNAV's Loiter speed for now.