### PR TITLE
DataFlash: Log the frame a mission command is planned in

### DIFF
--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1448,7 +1448,8 @@ bool DataFlash_Backend::Log_Write_MavCmd(uint16_t cmd_total, const mavlink_missi
         param4          : (float)mav_cmd.param4,
         latitude        : (float)mav_cmd.x,
         longitude       : (float)mav_cmd.y,
-        altitude        : (float)mav_cmd.z
+        altitude        : (float)mav_cmd.z,
+        frame           : (uint8_t)mav_cmd.frame
     };
     return WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -609,6 +609,7 @@ struct PACKED log_Cmd {
     float latitude;
     float longitude;
     float altitude;
+    uint8_t frame;
 };
 
 struct PACKED log_Radio {
@@ -1203,7 +1204,7 @@ Format characters in the format string for binary log messages
     { LOG_POWR_MSG, sizeof(log_POWR), \
       "POWR","QffH","TimeUS,Vcc,VServo,Flags", "svv-", "FBB-" },  \
     { LOG_CMD_MSG, sizeof(log_Cmd), \
-      "CMD", "QHHHfffffff","TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt", "s-------DUm", "F-------GG0" }, \
+      "CMD", "QHHHfffffffB","TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt,Frame", "s-------DUm-", "F-------GG0-" }, \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------" }, \
     { LOG_CAMERA_MSG, sizeof(log_Camera), \


### PR DESCRIPTION
For some reason we weren't logging the frames a mission were planned in. This is actually both quite important for log analysis, as well as important to allow a mission to be extracted from a log with minimal errors.