### PR TITLE
AP_BattMonitor: Monitor the Maxell battery with Pixhawk2.

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -76,10 +76,17 @@ AP_BattMonitor::init()
                 _num_instances++;
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_MAXELL:
-                drivers[instance] = new AP_BattMonitor_SMBus_Maxell(*this, state[instance], _params[instance],
-                                                                    hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR,
-                                                                                            100000, true, 20));
-                _num_instances++;
+                drivers[instance] = AP_BattMonitor_SMBus_Maxell::detect(*this, state[instance], _params[instance],
+                                                                        hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_EXTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR,
+                                                                                                100000, true, 20));
+                if (drivers[instance] == nullptr) {
+                    drivers[instance] = AP_BattMonitor_SMBus_Maxell::detect(*this, state[instance], _params[instance],
+                                                                            hal.i2c_mgr->get_device(AP_BATTMONITOR_SMBUS_BUS_INTERNAL, AP_BATTMONITOR_SMBUS_I2C_ADDR,
+                                                                                                    100000, true, 20));
+                }
+                if (drivers[instance] != nullptr) {
+                    _num_instances++;
+                }
                 break;
             case AP_BattMonitor_Params::BattMonitor_TYPE_BEBOP:
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -31,8 +31,8 @@ uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
 */
 
 /**
- * detect if a Maxbotix rangefinder is connected. We'll detect by
- * trying to take a reading on I2C. If we get a result the sensor is
+ * detect if a Maxell battery is connected. We'll detect by
+ * trying to take a reading on I2C. If we get a result the battery is
  * there.
  *
  * @param [in] mon
@@ -52,8 +52,7 @@ AP_BattMonitor_Backend *AP_BattMonitor_SMBus_Maxell::detect(AP_BattMonitor &mon,
     }
 
     if (sensor->_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        uint8_t manufactureName[2];
-        memset(manufactureName, 0, sizeof(manufactureName));
+        uint8_t manufactureName[2] {};
         if (!sensor->_dev->read_registers(BATTMONITOR_SMBUS_MANUFACTURE_NAME, manufactureName, 2)) {
             sensor->_dev->get_semaphore()->give();
             delete sensor;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
@@ -10,6 +10,12 @@ class AP_BattMonitor_SMBus_Maxell : public AP_BattMonitor_SMBus
 {
 public:
 
+    // static detection function
+    static AP_BattMonitor_Backend *detect(AP_BattMonitor &mon,
+                                          AP_BattMonitor::BattMonitor_State &mon_state,
+                                          AP_BattMonitor_Params &params,
+                                          AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+
     // Constructor
     AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,


### PR DESCRIPTION
I want to get Maxell's battery information with Pixhawk 2.
I 2 C of Pixhawk 2 is an internal bus.
So, if you are board type Pixhawk 2, select internal bus.