### PR TITLE
bug fix: camera relay trigger never de-activated

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -141,7 +141,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Mount,             &copter.camera_mount,        update,          50,  75),
 #endif
 #if CAMERA == ENABLED
-    SCHED_TASK_CLASS(AP_Camera,            &copter.camera,              update,          50,  75),
+    SCHED_TASK_CLASS(AP_Camera,            &copter.camera,              update_trigger,          50,  75),
 #endif
 #if LOGGING_ENABLED == ENABLED
     SCHED_TASK(ten_hz_logging_loop,   10,    350),


### PR DESCRIPTION
camera.update() for automatic shots always called from 
void Copter::update_GPS(void)
 , after gps read
copter specific bug