### PR TITLE
Tools: autotest: avoid exception when using Python3 on MacOSX

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -468,6 +468,7 @@ def run_in_terminal_window(autotest, name, cmd):
     if under_macos() and os.environ.get('DISPLAY'):
         # on MacOS record the window IDs so we can close them later
         out = subprocess.Popen(runme, stdout=subprocess.PIPE).communicate()[0]
+        out = out.decode('utf-8')
         import re
         p = re.compile('tab 1 of window id (.*)')
                         


### PR DESCRIPTION
File "./Tools/autotest/sim_vehicle.py", line 999, in <module>
location)
File "./Tools/autotest/sim_vehicle.py", line 573, in start_vehicle
run_in_terminal_window(autotest, cmd_name, cmd)
File "./Tools/autotest/sim_vehicle.py", line 476, in
run_in_terminal_window
tabs = p.findall(out)
TypeError: cannot use a string pattern on a bytes-like object
SIM_VEHICLE: Killing tasks