### PR TITLE
Improve DataFlash log download speeds

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -506,10 +506,6 @@ GCS_MAVLINK_Rover::data_stream_send(void)
 {
     gcs().set_out_of_time(false);
 
-    if (!rover.in_mavlink_delay) {
-        rover.DataFlash.handle_log_send(*this);
-    }
-
     send_queued_parameters();
 
     if (gcs().out_of_time()) {

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -324,10 +324,6 @@ GCS_MAVLINK_Tracker::data_stream_send(void)
         return;
     }
 
-    if (!tracker.in_mavlink_delay) {
-        tracker.DataFlash.handle_log_send(*this);
-    }
-
     if (stream_trigger(STREAM_RAW_SENSORS)) {
         send_message(MSG_RAW_IMU1);
         send_message(MSG_RAW_IMU2);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -560,10 +560,6 @@ GCS_MAVLINK_Copter::data_stream_send(void)
         return;
     }
 
-    if (!copter.in_mavlink_delay && !copter.motors->armed()) {
-        copter.DataFlash.handle_log_send(*this);
-    }
-
     gcs().set_out_of_time(false);
 
     send_queued_parameters();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -686,10 +686,6 @@ GCS_MAVLINK_Plane::data_stream_send(void)
 {
     gcs().set_out_of_time(false);
 
-    if (!plane.in_mavlink_delay) {
-        plane.DataFlash.handle_log_send(*this);
-    }
-
     send_queued_parameters();
 
     if (gcs().out_of_time()) return;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -727,10 +727,6 @@ GCS_MAVLINK_Sub::data_stream_send(void)
         return;
     }
 
-    if (!sub.in_mavlink_delay && !sub.motors.armed()) {
-        sub.DataFlash.handle_log_send(*this);
-    }
-
     gcs().set_out_of_time(false);
 
     send_queued_parameters();

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -583,7 +583,8 @@ void DataFlash_Class::handle_mavlink_msg(GCS_MAVLINK &link, mavlink_message_t* m
 }
 
 void DataFlash_Class::periodic_tasks() {
-     FOR_EACH_BACKEND(periodic_tasks());
+    handle_log_send();
+    FOR_EACH_BACKEND(periodic_tasks());
 }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -222,7 +222,7 @@ public:
     void set_vehicle_armed(bool armed_state);
     bool vehicle_is_armed() const { return _armed; }
 
-    void handle_log_send(class GCS_MAVLINK &);
+    void handle_log_send();
     bool in_log_download() const { return _in_log_download; }
 
     float quiet_nanf() const { return nanf("0x4152"); } // "AR"
@@ -370,7 +370,7 @@ private:
     // start page of log data
     uint16_t _log_data_page;
 
-    int8_t _log_sending_chan = -1;
+    GCS_MAVLINK *_log_sending_link;
 
     bool should_handle_log_message();
     void handle_log_message(class GCS_MAVLINK &, mavlink_message_t *msg);
@@ -379,8 +379,8 @@ private:
     void handle_log_request_data(class GCS_MAVLINK &, mavlink_message_t *msg);
     void handle_log_request_erase(class GCS_MAVLINK &, mavlink_message_t *msg);
     void handle_log_request_end(class GCS_MAVLINK &, mavlink_message_t *msg);
-    void handle_log_send_listing(class GCS_MAVLINK &);
-    bool handle_log_send_data(class GCS_MAVLINK &);
+    void handle_log_send_listing();
+    bool handle_log_send_data();
 
     void get_log_info(uint16_t log_num, uint32_t &size, uint32_t &time_utc);
 


### PR DESCRIPTION
These patches move downloading log files from a USB-connected PixRacer to my laptop from ~225kB/s to ~320kB/s

They also seem to improve loop performance times; instead of getting 500 slow-loops while downloading a log file I get ~90 slow loops.  The worst-case loop time is also not as bad.
