### PR TITLE
remove more parameters when ACRO is disabled

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -212,7 +212,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         }
 
         // acro balance parameter check
-#if MODE_ACRO_ENABLED == ENABLED
+#if MODE_ACRO_ENABLED == ENABLED || MODE_SPORT_ENABLED == ENABLED
         if ((copter.g.acro_balance_roll > copter.attitude_control->get_angle_roll_p().kP()) || (copter.g.acro_balance_pitch > copter.attitude_control->get_angle_pitch_p().kP())) {
             if (display_failure) {
                 gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: ACRO_BAL_ROLL/PITCH");

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -526,9 +526,10 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(acro_yaw_p,                 "ACRO_YAW_P",           ACRO_YAW_P),
 
+#if MODE_ACRO_ENABLED == ENABLED || MODE_SPORT_ENABLED == ENABLED
     // @Param: ACRO_BAL_ROLL
     // @DisplayName: Acro Balance Roll
-    // @Description: rate at which roll angle returns to level in acro mode.  A higher value causes the vehicle to return to level faster.
+    // @Description: rate at which roll angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster.
     // @Range: 0 3
     // @Increment: 0.1
     // @User: Advanced
@@ -536,12 +537,14 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: ACRO_BAL_PITCH
     // @DisplayName: Acro Balance Pitch
-    // @Description: rate at which pitch angle returns to level in acro mode.  A higher value causes the vehicle to return to level faster.
+    // @Description: rate at which pitch angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster.
     // @Range: 0 3
     // @Increment: 0.1
     // @User: Advanced
     GSCALAR(acro_balance_pitch,     "ACRO_BAL_PITCH",   ACRO_BALANCE_PITCH),
+#endif
 
+#if MODE_ACRO_ENABLED == ENABLED
     // @Param: ACRO_TRAINER
     // @DisplayName: Acro Trainer
     // @Description: Type of trainer used in acro mode
@@ -556,6 +559,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Range: -0.5 1.0
     // @User: Advanced
     GSCALAR(acro_rp_expo,  "ACRO_RP_EXPO",    ACRO_RP_EXPO_DEFAULT),
+#endif
 
     // variables not in the g class which contain EEPROM saved variables
 

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -489,11 +489,13 @@ void ToyMode::update()
         send_named_int("VIDEOTOG", 1);
         break;
 
-#if MODE_THROW_ENABLED == ENABLED
     case ACTION_MODE_ACRO:
+#if MODE_ACRO_ENABLED == ENABLED
         new_mode = ACRO;
-        break;
+#else
+        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: ACRO is disabled");
 #endif
+        break;
 
     case ACTION_MODE_ALTHOLD:
         new_mode = ALT_HOLD;
@@ -539,11 +541,13 @@ void ToyMode::update()
         new_mode = BRAKE;
         break;
 
-#if MODE_THROW_ENABLED == ENABLED
     case ACTION_MODE_THROW:
+#if MODE_THROW_ENABLED == ENABLED
         new_mode = THROW;
-        break;
+#else
+        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: THROW is disabled");
 #endif
+        break;
 
     case ACTION_MODE_FLIP:
         new_mode = FLIP;


### PR DESCRIPTION
It also fixes a copy-paste error, and improves comments

I checked that the removed parameters are only used in either ACRO or SPORT