### PR TITLE
Build SkyViper-v2450 binaries as part of build_binaries.py

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -81,7 +81,7 @@ class generate_fw(Task.Task):
     run_str='${OBJCOPY} -O binary ${SRC} ${SRC}.bin && \
     python ${UPLOAD_TOOLS}/px_mkfw.py --image ${SRC}.bin \
     --prototype ${BUILDROOT}/apj.prototype > ${TGT} && \
-    ${TOOLS_SCRIPTS}/make_abin.sh ${SRC}.bin ${SRC}.abin'
+    cd ${TOOLS_SCRIPTS} && ./make_abin.sh $OLDPWD/${SRC}.bin $OLDPWD/${SRC}.abin'
     always_run = True
     def keyword(self):
         return "Generating"

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -65,10 +65,16 @@ class upload_fw(Task.Task):
 
 class set_default_parameters(Task.Task):
     color='CYAN'
-    run_str='python ${APJ_TOOL} --set-file ${DEFAULT_PARAMETERS} ${SRC}'
     always_run = True
     def keyword(self):
         return "apj_tool"
+    def run(self):
+        rel_default_parameters = self.env.get_flat('DEFAULT_PARAMETERS')
+        abs_default_parameters = os.path.join(self.env.STANDARD_BUILDDIR,
+                                              rel_default_parameters)
+        run_str = ("python ${APJ_TOOL} --set-file %s ${SRC}" %
+                   (abs_default_parameters,))
+
 
 class generate_fw(Task.Task):
     color='CYAN'
@@ -188,6 +194,7 @@ def configure(cfg):
     env.TOOLS_SCRIPTS = srcpath('Tools/scripts')
     env.APJ_TOOL = srcpath('Tools/scripts/apj_tool.py')
     env.SERIAL_PORT = srcpath('/dev/serial/by-id/*_STLink*')
+    env.STANDARD_BUILDDIR = srcpath("build/some-board")
 
     # relative paths to pass to make, relative to directory that make is run from
     env.CH_ROOT_REL = os.path.relpath(env.CH_ROOT, env.BUILDROOT)

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -162,7 +162,7 @@ is bob we will attempt to checkout bob-AVR'''
     def skip_frame(self, board, frame):
         '''returns true if this board/frame combination should not be built'''
         if frame == "heli":
-            if board in ["bebop", "aerofc-v1"]:
+            if board in ["bebop", "aerofc-v1", "skyviper-v2450"]:
                 self.progress("Skipping heli build for %s" % board)
                 return True
         return False
@@ -469,8 +469,9 @@ is bob we will attempt to checkout bob-AVR'''
 
     def build_arducopter(self, tag):
         '''build Copter binaries'''
-        boards = self.common_boards()[:]
-        boards.extend(["aerofc-v1", "bebop"])
+        boards = []
+        boards.extend(["skyviper-v2450", "aerofc-v1", "bebop"])
+        boards.extend(self.common_boards()[:])
         self.build_vehicle(tag,
                            "ArduCopter",
                            boards,

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -371,15 +371,19 @@ is bob we will attempt to checkout bob-AVR'''
                                          board,
                                          "bin",
                                          "".join([binaryname, framesuffix]))
-                px4_path = "".join([bare_path, ".px4"])
-                if os.path.exists(px4_path):
-                    path = px4_path
-                else:
-                    path = bare_path
-                try:
-                    self.copyit(path, ddir, tag, vehicle)
-                except Exception as e:
-                    self.progress("Failed to copy %s to %s: %s" % (path, ddir, str(e)))
+                files_to_copy = []
+                if os.path.exists(bare_path):
+                    files_to_copy.append(bare_path)
+                for extension in [".px4", ".apj", ".abin"]:
+                    filepath = "".join([bare_path, extension])
+                    if os.path.exists(filepath):
+                        files_to_copy.append(filepath)
+
+                for path in files_to_copy:
+                    try:
+                        self.copyit(path, ddir, tag, vehicle)
+                    except Exception as e:
+                        self.progress("Failed to copy %s to %s: %s" % (path, ddir, str(e)))
                 # why is touching this important? -pb20170816
                 self.touch_filepath(os.path.join(self.binaries,
                                                  vehicle_binaries_subdir, tag))

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -300,6 +300,11 @@ is bob we will attempt to checkout bob-AVR'''
             with open(filepath, "a"):
                 pass
 
+    def board_is_chibios(self, board):
+        if board == 'skyviper-v2450':
+            return True;
+        return False
+
     def build_vehicle(self, tag, vehicle, boards, vehicle_binaries_subdir,
                       binaryname, px4_binaryname, frames=[None]):
         '''build vehicle binaries'''
@@ -346,6 +351,18 @@ is bob we will attempt to checkout bob-AVR'''
                     continue
                 self.progress("Configuring for %s in %s" %
                               (board, self.buildroot))
+                orig_path = os.environ["PATH"]
+                if self.board_is_chibios(board):
+                    # need to run a more modern compiler for ChibiOS:
+                    environ_varname = "CHIBIOS_GCC_DIRPATH"
+                    gcc_dirpath = os.getenv(environ_varname, None)
+                    if gcc_dirpath is None:
+                        self.progress("Skipping ChibiOS build %s (no %s)" %
+                                      (board, environ_varname))
+                        continue
+                    self.progress("Using ChibiOS GCC (%s)" % gcc_dirpath)
+                    os.environ['PATH'] = ":".join([os.path.join(gcc_dirpath,"bin"),
+                                                   orig_path])
                 try:
                     waf_opts = ["configure",
                                 "--board", board,
@@ -355,6 +372,7 @@ is bob we will attempt to checkout bob-AVR'''
                     self.run_waf(waf_opts)
                 except subprocess.CalledProcessError as e:
                     self.progress("waf configure failed")
+                    os.environ["PATH"] = orig_path
                     continue
                 try:
                     target = os.path.join("bin",
@@ -365,7 +383,9 @@ is bob we will attempt to checkout bob-AVR'''
                            (vehicle, board, framesuffix, tag))
                     self.progress(msg)
                     self.error_strings.append(msg)
+                    os.environ["PATH"] = orig_path
                     continue
+                os.environ["PATH"] = orig_path
 
                 bare_path = os.path.join(self.buildroot,
                                          board,

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -4,6 +4,7 @@ setup board.h for chibios
 '''
 
 import argparse, sys, fnmatch, os, dma_resolver, shlex, pickle
+import shutil
 
 parser = argparse.ArgumentParser("chibios_pins.py")
 parser.add_argument(
@@ -369,8 +370,14 @@ MEMORY
     ram0  : org = 0x20000000, len = %uk
 }
 
-INCLUDE ../../libraries/AP_HAL_ChibiOS/hwdef/common/common.ld
+INCLUDE common.ld
 ''' % (flash_base, flash_length, ram_size))
+
+def copy_common_linkerscript(outdir, hwdef):
+    dirpath = os.path.dirname(hwdef)
+    shutil.copy(os.path.join(dirpath, "../common/common.ld"),
+                os.path.join(outdir, "common.ld"))
+
 
 
 def write_USB_config(f):
@@ -1025,6 +1032,10 @@ write_hwdef_header(os.path.join(outdir, "hwdef.h"))
 
 # write out ldscript.ld
 write_ldscript(os.path.join(outdir, "ldscript.ld"))
+
+# copy the shared linker script into the build directory; it must
+# exist in the same directory as the ldscript.ld file we generate.
+copy_common_linkerscript(outdir, args.hwdef)
 
 # write out env.py
 pickle.dump(env_vars, open(os.path.join(outdir, "env.py"), "wb"))


### PR DESCRIPTION
The majority of this PR is to get `waf` to build ChibiOS boards when `--out` is specified.

My understanding is that we really, really want to use a more modern gcc when compiling ChibiOS, so there is allowance for specifying a gcc just for ChibiOS builds in the environment.  I expect to set that environment variable in `APM/build_autotest.sh` on the autotest server.  The compiler is in place in `/home/autotest/gcc/gcc-arm-none-eabi-6-2017-q2-update/`
