### PR TITLE
Rover: send correct mav-type for boats

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -54,7 +54,8 @@ void Rover::send_heartbeat(mavlink_channel_t chan)
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(MAV_TYPE_GROUND_ROVER,
+    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(
+                                            is_boat() ? MAV_TYPE_SURFACE_BOAT : MAV_TYPE_GROUND_ROVER,
                                             base_mode,
                                             control_mode->mode_number(),
                                             system_status);

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -80,7 +80,7 @@ void Rover::init_ardupilot()
 
     // setup frsky telemetry
 #if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.init(serial_manager, fwver.fw_string, MAV_TYPE_GROUND_ROVER);
+    frsky_telemetry.init(serial_manager, fwver.fw_string, (is_boat() ? MAV_TYPE_SURFACE_BOAT : MAV_TYPE_GROUND_ROVER));
 #endif
 
 #if LOGGING_ENABLED == ENABLED


### PR DESCRIPTION
This resolves issue [7646](https://github.com/ArduPilot/ardupilot/issues/7646) and makes the icon on the map appear like a boat instead of a car which is quite satisfying.
![mav-type-boat](https://user-images.githubusercontent.com/1498098/37696247-96535500-2d18-11e8-8e11-3ee8b5117e59.png)

An outstanding issue though is that the parameter definition xml if not being created for boats.  I'm not sure exactly how we fix this but perhaps @OXINARF or @peterbarker knows.

![mav-type-boat-param-def-issue](https://user-images.githubusercontent.com/1498098/37696253-9c2e8b7a-2d18-11e8-9806-184d6591faeb.png)
