### PR TITLE
Add ability to navigate using MAVLink vision messages

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -314,7 +314,7 @@ private:
             uint8_t land_complete_maybe     : 1; // 14      // true if we may have landed (less strict version of land_complete)
             uint8_t throttle_zero           : 1; // 15      // true if the throttle stick is at zero, debounced, determines if pilot intends shut-down when not using motor interlock
             uint8_t system_time_set         : 1; // 16      // true if the system time has been set from the GPS
-            uint8_t gps_glitching           : 1; // 17      // true if the gps is glitching
+            uint8_t gps_glitching           : 1; // 17      // true if GPS glitching is affecting navigation accuracy
             uint8_t using_interlock         : 1; // 20      // aux switch motor interlock function is in use
             uint8_t motor_emergency_stop    : 1; // 21      // motor estop switch, shuts off motors when enabled
             uint8_t land_repo_active        : 1; // 22      // true if the pilot is overriding the landing position

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -585,6 +585,9 @@ public:
     // false when no limiting is required
     virtual bool get_hgt_ctrl_limit(float &limit) const { return false; };
 
+    // Write position and quaternion data from an external navigation system
+    virtual void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms) { }
+
 protected:
     AHRS_VehicleClass _vehicle_class;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1164,6 +1164,13 @@ void  AP_AHRS_NavEKF::writeBodyFrameOdom(float quality, const Vector3f &delPos, 
     EKF3.writeBodyFrameOdom(quality, delPos, delAng, delTime, timeStamp_ms, posOffset);
 }
 
+// Write position and quaternion data from an external navigation system
+void AP_AHRS_NavEKF::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms)
+{
+    EKF2.writeExtNavData(sensOffset, pos, quat, posErr, angErr, timeStamp_ms, resetTime_ms);
+}
+
+
 // inhibit GPS usage
 uint8_t AP_AHRS_NavEKF::setInhibitGPS(void)
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -163,6 +163,9 @@ public:
     // write body odometry measurements to the EKF
     void writeBodyFrameOdom(float quality, const Vector3f &delPos, const Vector3f &delAng, float delTime, uint32_t timeStamp_ms, const Vector3f &posOffset);
 
+    // Write position and quaternion data from an external navigation system
+    void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms) override;
+
     // inhibit GPS usage
     uint8_t setInhibitGPS(void);
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -191,6 +191,12 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
     }
 }
 
+#define streq(a, b) (!strcmp(a, b))
+int SITL_State::sim_fd(const char *name, const char *arg)
+{
+    AP_HAL::panic("unknown simulated device: %s", name);
+}
+
 #ifndef HIL_MODE
 /*
   check for a SITL RC input packet

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -52,6 +52,10 @@ public:
         return _base_port;
     }
 
+    // create a file desciptor attached to a virtual device; type of
+    // device is given by name parameter
+    int sim_fd(const char *name, const char *arg);
+
     bool use_rtscts(void) const {
         return _use_rtscts;
     }

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -22,6 +22,7 @@
 #include <SITL/SITL.h>
 #include <SITL/SIM_Gimbal.h>
 #include <SITL/SIM_ADSB.h>
+#include <SITL/SIM_Vicon.h>
 #include <AP_HAL/utility/Socket.h>
 
 class HAL_SITL;
@@ -209,6 +210,9 @@ private:
 
     // simulated ADSb
     SITL::ADSB *adsb;
+
+    // simulated vicon system:
+    SITL::Vicon *vicon;
 
     // output socket for flightgear viewing
     SocketAPM fg_socket{true};

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -67,6 +67,7 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
              tcp:0:wait       // tcp listen on use base_port + 0
              tcpclient:192.168.2.15:5762
              uart:/dev/ttyUSB0:57600
+             sim:ParticleSensor_SDS021:
          */
         char *saveptr = nullptr;
         char *s = strdup(path);
@@ -89,6 +90,12 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             _uart_path = strdup(args1);
             _uart_baudrate = baudrate;
             _uart_start_connection();
+        } else if (strcmp(devtype, "sim") == 0) {
+            ::printf("SIM connection %s:%s\n", args1, args2);
+            if (!_connected) {
+                _connected = true;
+                _fd = _sitlState->sim_fd(args1, args2);
+            }
         } else {
             AP_HAL::panic("Invalid device path: %s", path);
         }

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -40,6 +40,12 @@ public:
     {
     }
 
+    // setting constructor
+    Quaternion(const float _q[4]) :
+        q1(_q[0]), q2(_q[1]), q3(_q[2]), q4(_q[3])
+    {
+    }
+
     // function call operator
     void operator()(const float _q1, const float _q2, const float _q3, const float _q4)
     {

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -32,7 +32,7 @@ union nav_filter_status {
         uint16_t takeoff            : 1; // 11 - true if filter is compensating for baro errors during takeoff
         uint16_t touchdown          : 1; // 12 - true if filter is compensating for baro errors during touchdown
         uint16_t using_gps          : 1; // 13 - true if we are using GPS position
-        uint16_t gps_glitching      : 1; // 14 - true if the the GPS is glitching
+        uint16_t gps_glitching      : 1; // 14 - true if GPS glitching is affecting navigation accuracy
     } flags;
     uint16_t value;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1471,8 +1471,8 @@ void NavEKF2::getTimingStatistics(int8_t instance, struct ekf_timing &timing)
 /*
  * Write position and quaternion data from an external navigation system
  *
- * pos        : position in the RH navigation frame. Frame is assumed to be NED if frameIsNED is true. (m)
- * quat       : quaternion desribing the the rotation from navigation frame to body frame
+ * pos        : XYZ position (m) in a RH navigation frame with the Z axis pointing down and XY axes horizontal. Frame must be aligned with NED if the magnetomer is being used for yaw.
+ * quat       : quaternion describing the the rotation from navigation frame to body frame
  * posErr     : 1-sigma spherical position error (m)
  * angErr     : 1-sigma spherical angle error (rad)
  * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1468,4 +1468,24 @@ void NavEKF2::getTimingStatistics(int8_t instance, struct ekf_timing &timing)
     }
 }
 
+/*
+ * Write position and quaternion data from an external navigation system
+ *
+ * pos        : position in the RH navigation frame. Frame is assumed to be NED if frameIsNED is true. (m)
+ * quat       : quaternion desribing the the rotation from navigation frame to body frame
+ * posErr     : 1-sigma spherical position error (m)
+ * angErr     : 1-sigma spherical angle error (rad)
+ * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+ * resetTime_ms : system time of the last position reset request (mSec)
+ *
+*/
+void NavEKF2::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms)
+{
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].writeExtNavData(sensOffset, pos, quat, posErr, angErr, timeStamp_ms, resetTime_ms);
+        }
+    }
+}
+
 #endif //HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -323,6 +323,19 @@ public:
     // get timing statistics structure
     void getTimingStatistics(int8_t instance, struct ekf_timing &timing);
 
+    /*
+     * Write position and quaternion data from an external navigation system
+     *
+     * pos        : position in the RH navigation frame. Frame is assumed to be NED if frameIsNED is true. (m)
+     * quat       : quaternion desribing the the rotation from navigation frame to body frame
+     * posErr     : 1-sigma spherical position error (m)
+     * angErr     : 1-sigma spherical angle error (rad)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+     * resetTime_ms : system time of the last position reset request (mSec)
+     *
+    */
+    void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms);
+
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -520,7 +520,7 @@ void  NavEKF2_core::updateFilterStatus(void)
     filterStatus.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
     filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     filterStatus.flags.using_gps = ((imuSampleTime_ms - lastPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
-    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && !extNavUsedForPos; // The GPS is glitching
+    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && !extNavUsedForPos; // GPS glitching is affecting navigation accuracy
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -169,7 +169,7 @@ void NavEKF2_core::setAidingMode()
         // GPS aiding is the preferred option unless excluded by the user
         bool canUseGPS = ((frontend->_fusionModeGPS) != 3 && readyToUseGPS() && filterIsStable && !gpsInhibit);
         bool canUseRangeBeacon = readyToUseRangeBeacon() && filterIsStable;
-        bool canUseExtNav = readyToUseExtNav() && tiltAlignComplete;
+        bool canUseExtNav = readyToUseExtNav();
         if(canUseGPS || canUseRangeBeacon || canUseExtNav) {
             PV_AidingMode = AID_ABSOLUTE;
         } else if (optFlowDataPresent() && filterIsStable) {
@@ -321,7 +321,7 @@ void NavEKF2_core::setAidingMode()
                 // handle yaw reset as special case
                 extNavYawResetRequest = true;
                 controlMagYawReset();
-                // handle height reset as sepcial case
+                // handle height reset as special case
                 hgtMea = -extNavDataDelayed.pos.z;
                 posDownObsNoise = sq(constrain_float(extNavDataDelayed.posErr, 0.1f, 10.0f));
                 ResetHeight();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -169,7 +169,8 @@ void NavEKF2_core::setAidingMode()
         // GPS aiding is the preferred option unless excluded by the user
         bool canUseGPS = ((frontend->_fusionModeGPS) != 3 && readyToUseGPS() && filterIsStable && !gpsInhibit);
         bool canUseRangeBeacon = readyToUseRangeBeacon() && filterIsStable;
-        if(canUseGPS || canUseRangeBeacon) {
+        bool canUseExtNav = readyToUseExtNav() && tiltAlignComplete;
+        if(canUseGPS || canUseRangeBeacon || canUseExtNav) {
             PV_AidingMode = AID_ABSOLUTE;
         } else if (optFlowDataPresent() && filterIsStable) {
             PV_AidingMode = AID_RELATIVE;
@@ -206,17 +207,17 @@ void NavEKF2_core::setAidingMode()
         bool rngBcnUsed = (imuSampleTime_ms - lastRngBcnPassTime_ms <= minTestTime_ms);
 
         // Check if GPS is being used
-        bool gpsPosUsed = (imuSampleTime_ms - lastPosPassTime_ms <= minTestTime_ms);
+        bool posUsed = (imuSampleTime_ms - lastPosPassTime_ms <= minTestTime_ms);
         bool gpsVelUsed = (imuSampleTime_ms - lastVelPassTime_ms <= minTestTime_ms);
 
         // Check if attitude drift has been constrained by a measurement source
-        bool attAiding = gpsPosUsed || gpsVelUsed || optFlowUsed || airSpdUsed || rngBcnUsed;
+        bool attAiding = posUsed || gpsVelUsed || optFlowUsed || airSpdUsed || rngBcnUsed;
 
         // check if velocity drift has been constrained by a measurement source
         bool velAiding = gpsVelUsed || airSpdUsed || optFlowUsed;
 
         // check if position drift has been constrained by a measurement source
-        bool posAiding = gpsPosUsed || rngBcnUsed;
+        bool posAiding = posUsed || rngBcnUsed;
 
         // Check if the loss of attitude aiding has become critical
         bool attAidLossCritical = false;
@@ -300,6 +301,7 @@ void NavEKF2_core::setAidingMode()
         case AID_ABSOLUTE: {
             bool canUseGPS = ((frontend->_fusionModeGPS) != 3 && readyToUseGPS() && !gpsInhibit);
             bool canUseRangeBeacon = readyToUseRangeBeacon();
+            bool canUseExtNav = readyToUseExtNav();
             // We have commenced aiding and GPS usage is allowed
             if (canUseGPS) {
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using GPS",(unsigned)imu_index);
@@ -311,6 +313,18 @@ void NavEKF2_core::setAidingMode()
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using range beacons",(unsigned)imu_index);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NE = %3.1f,%3.1f (m)",(unsigned)imu_index,(double)receiverPos.x,(double)receiverPos.y);
                 gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial beacon pos D offset = %3.1f (m)",(unsigned)imu_index,(double)bcnPosOffset);
+            }
+            // We have commenced aiding and external nav usage is allowed
+            if (canUseExtNav) {
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using external nav data",(unsigned)imu_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
+                // handle yaw reset as special case
+                extNavYawResetRequest = true;
+                controlMagYawReset();
+                // handle height reset as sepcial case
+                hgtMea = -extNavDataDelayed.pos.z;
+                posDownObsNoise = sq(constrain_float(extNavDataDelayed.posErr, 0.1f, 10.0f));
+                ResetHeight();
             }
             // reset the last fusion accepted times to prevent unwanted activation of timeout logic
             lastPosPassTime_ms = imuSampleTime_ms;
@@ -385,6 +399,12 @@ bool NavEKF2_core::readyToUseRangeBeacon(void) const
     return tiltAlignComplete && yawAlignComplete && rngBcnGoodToAlign && rngBcnDataToFuse;
 }
 
+// return true if the filter to be ready to use external nav data
+bool NavEKF2_core::readyToUseExtNav(void) const
+{
+    return tiltAlignComplete && extNavDataToFuse;
+}
+
 // return true if we should use the compass
 bool NavEKF2_core::use_compass(void) const
 {
@@ -405,7 +425,7 @@ bool NavEKF2_core::assume_zero_sideslip(void) const
 // set the LLH location of the filters NED origin
 bool NavEKF2_core::setOriginLLH(const Location &loc)
 {
-    if (PV_AidingMode == AID_ABSOLUTE) {
+    if (PV_AidingMode == AID_ABSOLUTE && !extNavUsedForPos) {
         return false;
     }
     EKF_origin = loc;
@@ -500,7 +520,7 @@ void  NavEKF2_core::updateFilterStatus(void)
     filterStatus.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
     filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     filterStatus.flags.using_gps = ((imuSampleTime_ms - lastPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
-    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE); // The GPS is glitching
+    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && !extNavUsedForPos; // The GPS is glitching
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -87,23 +87,23 @@ void NavEKF2_core::controlMagYawReset()
             finalResetRequest; // the final reset when we have acheived enough height to be in stable magnetic field environment
 
     // Perform a reset of magnetic field states and reset yaw to corrected magnetic heading
-    if (magYawResetRequest || magStateResetRequest) {
-
-        // get the euler angles from the current state estimate
-        Vector3f eulerAngles;
-        stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
-
-        // Use the Euler angles and magnetometer measurement to update the magnetic field states
-        // and get an updated quaternion
-        Quaternion newQuat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+    if (magYawResetRequest || magStateResetRequest || extNavYawResetRequest) {
 
         // if a yaw reset has been requested, apply the updated quaternion to the current state
-        if (magYawResetRequest) {
+        if (extNavYawResetRequest) {
+            // get the euler angles from the current state estimate
+            Vector3f eulerAnglesOld;
+            stateStruct.quat.to_euler(eulerAnglesOld.x, eulerAnglesOld.y, eulerAnglesOld.z);
+
             // previous value used to calculate a reset delta
             Quaternion prevQuat = stateStruct.quat;
 
-            // update the quaternion states using the new yaw angle
-            stateStruct.quat = newQuat;
+            // Get the Euler angles from the external vision data
+            Vector3f eulerAnglesNew;
+            extNavDataDelayed.quat.to_euler(eulerAnglesNew.x, eulerAnglesNew.y, eulerAnglesNew.z);
+
+            // the new quaternion uses the old roll/pitch and new yaw angle
+            stateStruct.quat.from_euler(eulerAnglesOld.x, eulerAnglesOld.y, eulerAnglesNew.z);
 
             // calculate the change in the quaternion state and apply it to the ouput history buffer
             prevQuat = stateStruct.quat/prevQuat;
@@ -111,27 +111,61 @@ void NavEKF2_core::controlMagYawReset()
 
             // send initial alignment status to console
             if (!yawAlignComplete) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial yaw alignment complete",(unsigned)imu_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u ext nav yaw alignment complete",(unsigned)imu_index);
             }
 
-            // send in-flight yaw alignment status to console
-            if (finalResetRequest) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u in-flight yaw alignment complete",(unsigned)imu_index);
-            } else if (interimResetRequest) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 IMU%u ground mag anomaly, yaw re-aligned",(unsigned)imu_index);
-            }
-
-            // update the yaw reset completed status
-            recordYawReset();
+            // record the reset as complete and also record the in-flight reset as complete to stop further resets when hight is gained
+            // in-flight reset is unnecessary because we do not need to consider groudn based magnetic anomaly effects
+            yawAlignComplete = true;
+            finalInflightYawInit = true;
 
             // clear the yaw reset request flag
-            magYawResetRequest = false;
+            extNavYawResetRequest = false;
 
-            // clear the complete flags if an interim reset has been performed to allow subsequent
-            // and final reset to occur
-            if (interimResetRequest) {
-                finalInflightYawInit = false;
-                finalInflightMagInit = false;
+        } else if (magYawResetRequest || magStateResetRequest) {
+            // get the euler angles from the current state estimate
+            Vector3f eulerAngles;
+            stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
+
+            // Use the Euler angles and magnetometer measurement to update the magnetic field states
+            // and get an updated quaternion
+            Quaternion newQuat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+
+            if (magYawResetRequest) {
+                // previous value used to calculate a reset delta
+                Quaternion prevQuat = stateStruct.quat;
+
+                // update the quaternion states using the new yaw angle
+                stateStruct.quat = newQuat;
+
+                // calculate the change in the quaternion state and apply it to the ouput history buffer
+                prevQuat = stateStruct.quat/prevQuat;
+                StoreQuatRotate(prevQuat);
+
+                // send initial alignment status to console
+                if (!yawAlignComplete) {
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial yaw alignment complete",(unsigned)imu_index);
+                }
+
+                // send in-flight yaw alignment status to console
+                if (finalResetRequest) {
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u in-flight yaw alignment complete",(unsigned)imu_index);
+                } else if (interimResetRequest) {
+                    gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 IMU%u ground mag anomaly, yaw re-aligned",(unsigned)imu_index);
+                }
+
+                // update the yaw reset completed status
+                recordYawReset();
+
+                // clear the yaw reset request flag
+                magYawResetRequest = false;
+
+                // clear the complete flags if an interim reset has been performed to allow subsequent
+                // and final reset to occur
+                if (interimResetRequest) {
+                    finalInflightYawInit = false;
+                    finalInflightMagInit = false;
+                }
             }
         }
     }
@@ -256,11 +290,10 @@ void NavEKF2_core::SelectMagFusion()
     // If we have no magnetometer and are on the ground, fuse in a synthetic heading measurement to prevent the
     // filter covariances from becoming badly conditioned
     if (!use_compass()) {
-        if (onGround && (imuSampleTime_ms - lastSynthYawTime_ms > 1000)) {
+        if (onGround && (imuSampleTime_ms - lastYawTime_ms > 1000)) {
             fuseEulerYaw();
             magTestRatio.zero();
             yawTestRatio = 0.0f;
-            lastSynthYawTime_ms = imuSampleTime_ms;
         }
     }
 
@@ -739,6 +772,7 @@ void NavEKF2_core::fuseEulerYaw()
     // calculate observation jacobian, predicted yaw and zero yaw body to earth rotation matrix
     // determine if a 321 or 312 Euler sequence is best
     float predicted_yaw;
+    float measured_yaw;
     float H_YAW[3];
     Matrix3f Tbn_zeroYaw;
     if (fabsf(prevTnb[0][2]) < fabsf(prevTnb[1][2])) {
@@ -771,14 +805,23 @@ void NavEKF2_core::fuseEulerYaw()
         H_YAW[1] = t14*(t15*(q0*q1*2.0f-q2*q3*2.0f)+t9*t10*(q0*q2*2.0f+q1*q3*2.0f));
         H_YAW[2] = t14*(t15*(t2-t3+t4-t5)+t9*t10*(t7-t8));
 
-        // Get the 321 euler angles
+        // calculate predicted and measured yaw angle
         Vector3f euler321;
         stateStruct.quat.to_euler(euler321.x, euler321.y, euler321.z);
         predicted_yaw = euler321.z;
-
-        // set the yaw to zero and calculate the zero yaw rotation from body to earth frame
-        Tbn_zeroYaw.from_euler(euler321.x, euler321.y, 0.0f);
-
+        if (use_compass() && yawAlignComplete && magStateInitComplete) {
+            // Use measured mag components rotated into earth frame to measure yaw
+            Tbn_zeroYaw.from_euler(euler321.x, euler321.y, 0.0f);
+            Vector3f magMeasNED = Tbn_zeroYaw*magDataDelayed.mag;
+            measured_yaw = wrap_PI(-atan2f(magMeasNED.y, magMeasNED.x) + _ahrs->get_compass()->get_declination());
+        } else if (extNavUsedForYaw) {
+            // Get the yaw angle  from the external vision data
+            extNavDataDelayed.quat.to_euler(euler321.x, euler321.y, euler321.z);
+            measured_yaw =  euler321.z;
+        } else {
+            // no data so use predicted to prevent unconstrained variance growth
+            measured_yaw = predicted_yaw;
+        }
     } else {
         // calculate observaton jacobian when we are observing a rotation in a 312 sequence
         float t2 = q0*q0;
@@ -809,25 +852,22 @@ void NavEKF2_core::fuseEulerYaw()
         H_YAW[1] = 0.0f;
         H_YAW[2] = t14*(t15*(t2+t3-t4-t5)+t8*t9*(t7+t10));
 
-        // Get the 321 euler angles
+        // calculate predicted and measured yaw angle
         Vector3f euler312 = stateStruct.quat.to_vector312();
         predicted_yaw = euler312.z;
-
-        // set the yaw to zero and calculate the zero yaw rotation from body to earth frame
-        Tbn_zeroYaw.from_euler312(euler312.x, euler312.y, 0.0f);
-    }
-
-    // rotate measured mag components into earth frame
-    Vector3f magMeasNED = Tbn_zeroYaw*magDataDelayed.mag;
-
-    // Use the difference between the horizontal projection and declination to give the measured yaw
-    // If we can't use compass data, set the  meaurement to the predicted
-    // to prevent uncontrolled variance growth whilst on ground without magnetometer
-    float measured_yaw;
-    if (use_compass() && yawAlignComplete && magStateInitComplete) {
-        measured_yaw = wrap_PI(-atan2f(magMeasNED.y, magMeasNED.x) + _ahrs->get_compass()->get_declination());
-    } else {
-        measured_yaw = predicted_yaw;
+        if (use_compass() && yawAlignComplete && magStateInitComplete) {
+            // Use measured mag components rotated into earth frame to measure yaw
+            Tbn_zeroYaw.from_euler312(euler312.x, euler312.y, 0.0f);
+            Vector3f magMeasNED = Tbn_zeroYaw*magDataDelayed.mag;
+            measured_yaw = wrap_PI(-atan2f(magMeasNED.y, magMeasNED.x) + _ahrs->get_compass()->get_declination());
+        } else if (extNavUsedForYaw) {
+            // Get the yaw angle  from the external vision data
+            euler312 = extNavDataDelayed.quat.to_vector312();
+            measured_yaw =  euler312.z;
+        } else {
+            // no data so use predicted to prevent unconstrained variance growth
+            measured_yaw = predicted_yaw;
+        }
     }
 
     // Calculate the innovation
@@ -938,8 +978,10 @@ void NavEKF2_core::fuseEulerYaw()
         // is used to correct the estimated quaternion on the current time step
         stateStruct.quat.rotate(stateStruct.angErr);
 
-        // record fusion numerical health status
+        // record fusion event
         faultStatus.bad_yaw = false;
+        lastYawTime_ms = imuSampleTime_ms;
+
 
     } else {
         // record fusion numerical health status

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -803,4 +803,32 @@ void NavEKF2_core::getTimingStatistics(struct ekf_timing &_timing)
     memset(&timing, 0, sizeof(timing));
 }
 
+void NavEKF2_core::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms)
+{
+    // limit update rate to maximum allowed by sensor buffers and fusion process
+    // don't try to write to buffer until the filter has been initialised
+    if ((timeStamp_ms - extNavMeasTime_ms) < 70) {
+        return;
+    } else {
+        extNavMeasTime_ms = timeStamp_ms;
+    }
+
+    if (resetTime_ms > extNavLastPosResetTime_ms) {
+        extNavDataNew.posReset = true;
+        extNavLastPosResetTime_ms = resetTime_ms;
+    } else {
+        extNavDataNew.posReset = false;
+    }
+
+    extNavDataNew.pos = pos;
+    extNavDataNew.quat = quat;
+    extNavDataNew.posErr = posErr;
+    extNavDataNew.angErr = angErr;
+    extNavDataNew.body_offset = &sensOffset;
+    extNavDataNew.time_ms = timeStamp_ms;
+
+    storedExtNav.push(extNavDataNew);
+
+}
+
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -101,8 +101,8 @@ bool NavEKF2_core::getRangeBeaconDebug(uint8_t &ID, float &rng, float &innov, fl
 // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
 bool NavEKF2_core::getHeightControlLimit(float &height) const
 {
-    // only ask for limiting if we are doing optical flow navigation
-    if (frontend->_fusionModeGPS == 3) {
+    // only ask for limiting if we are doing optical flow only navigation
+    if (frontend->_fusionModeGPS == 3 && (PV_AidingMode == AID_RELATIVE) && flowDataValid) {
         // If are doing optical flow nav, ensure the height above ground is within range finder limits after accounting for vehicle tilt and control errors
         height = MAX(float(frontend->_rng.max_distance_cm_orient(ROTATION_PITCH_270)) * 0.007f - 1.0f, 1.0f);
         // If we are are not using the range finder as the height reference, then compensate for the difference between terrain and EKF origin

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -91,6 +91,9 @@ bool NavEKF2_core::setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedRangeBeacon.init(imu_buffer_length)) {
         return false;
     }
+    if(!storedExtNav.init(OBS_BUFFER_LENGTH)) {
+        return false;
+    }
     if(!storedIMU.init(imu_buffer_length)) {
         return false;
     }
@@ -125,7 +128,7 @@ void NavEKF2_core::InitialiseVariables()
     lastPosPassTime_ms = 0;
     lastHgtPassTime_ms = 0;
     lastTasPassTime_ms = 0;
-    lastSynthYawTime_ms = imuSampleTime_ms;
+    lastYawTime_ms = imuSampleTime_ms;
     lastTimeGpsReceived_ms = 0;
     secondLastGpsTime_ms = 0;
     lastDecayTime_ms = imuSampleTime_ms;
@@ -277,6 +280,7 @@ void NavEKF2_core::InitialiseVariables()
     ekfGpsRefHgt = 0.0;
     velOffsetNED.zero();
     posOffsetNED.zero();
+    memset(&velPosObs, 0, sizeof(velPosObs));
 
     // range beacon fusion variables
     memset(&rngBcnDataNew, 0, sizeof(rngBcnDataNew));
@@ -317,6 +321,16 @@ void NavEKF2_core::InitialiseVariables()
     memset(&rngBcnFusionReport, 0, sizeof(rngBcnFusionReport));
     last_gps_idx = 0;
 
+    // external nav data fusion
+    memset(&extNavDataNew, 0, sizeof(extNavDataNew));
+    memset(&extNavDataDelayed, 0, sizeof(extNavDataDelayed));
+    extNavDataToFuse = false;
+    extNavMeasTime_ms = 0;
+    extNavLastPosResetTime_ms = 0;
+    extNavUsedForYaw = false;
+    extNavUsedForPos = false;
+    extNavYawResetRequest = false;
+
     // zero data buffers
     storedIMU.reset();
     storedGPS.reset();
@@ -326,6 +340,7 @@ void NavEKF2_core::InitialiseVariables()
     storedRange.reset();
     storedOutput.reset();
     storedRangeBeacon.reset();
+    storedExtNav.reset();
 }
 
 // Initialise the states from accelerometer and magnetometer data (if present)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -46,6 +46,7 @@
 #define HGT_SOURCE_RNG  1
 #define HGT_SOURCE_GPS  2
 #define HGT_SOURCE_BCN  3
+#define HGT_SOURCE_EV   4
 
 // target EKF update time step
 #define EKF_TARGET_DT 0.01f
@@ -306,6 +307,20 @@ public:
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);
     
+    /*
+     * Write position and quaternion data from an external navigation system
+     *
+     * sensOffset : position of the external navigatoin sensor in body frame (m)
+     * pos        : position in the RH navigation frame. Frame is assumed to be NED if frameIsNED is true. (m)
+     * quat       : quaternion desribing the the rotation from navigation frame to body frame
+     * posErr     : 1-sigma spherical position error (m)
+     * angErr     : 1-sigma spherical angle error (rad)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+     * resetTime_ms : system time of the last position reset request (mSec)
+     *
+    */
+    void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms);
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
@@ -439,6 +454,18 @@ private:
         uint32_t    time_ms;        // 4
         Vector3f    bodyRadXYZ;     //8..10
         const Vector3f *body_offset;// 5..7
+    };
+
+    struct ext_nav_elements {
+        bool            frameIsNED; // true if the data is in a NED navigation frame
+        bool            unitsAreSI; // true if the data length units are scaled in metres
+        Vector3f        pos;        // XYZ position measured in a RH navigation frame (m)
+        Quaternion      quat;       // quaternion describing the rotation from navigation to body frame
+        float           posErr;     // spherical poition measurement error 1-std (m)
+        float           angErr;     // spherical angular measurement error 1-std (rad)
+        const Vector3f *body_offset;// pointer to XYZ position of the sensor in body frame (m)
+        uint32_t        time_ms;    // measurement timestamp (msec)
+        bool            posReset;   // true when the position measurement has been reset
     };
 
     // update the navigation filter status
@@ -611,6 +638,9 @@ private:
     // return true if the filter to be ready to use the beacon range measurements
     bool readyToUseRangeBeacon(void) const;
 
+    // return true if the filter to be ready to use external nav data
+    bool readyToUseExtNav(void) const;
+
     // Check for filter divergence
     void checkDivergence(void);
 
@@ -762,6 +792,7 @@ private:
     uint32_t airborneDetectTime_ms; // last time flight movement was detected
     Vector6 innovVelPos;            // innovation output for a group of measurements
     Vector6 varInnovVelPos;         // innovation variance output for a group of measurements
+    Vector6 velPosObs;              // observations for combined velocity and positon group of measurements (3x1 m , 3x1 m/s)
     bool fuseVelData;               // this boolean causes the velNED measurements to be fused
     bool fusePosData;               // this boolean causes the posNE measurements to be fused
     bool fuseHgtData;               // this boolean causes the hgtMea measurements to be fused
@@ -789,7 +820,7 @@ private:
     uint32_t secondLastGpsTime_ms;  // time of second last GPS fix used to determine how long since last update
     uint32_t lastHealthyMagTime_ms; // time the magnetometer was last declared healthy
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
-    uint32_t lastSynthYawTime_ms;   // time stamp when synthetic yaw measurement was last fused to maintain covariance health (msec)
+    uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)
     Matrix24 nextP;                 // Predicted covariance matrix before addition of process noise to diagonals
     Vector24 processNoise;          // process noise added to diagonals of predicted covariance matrix
@@ -1051,6 +1082,17 @@ private:
     float posDownAtLastMagReset;    // vertical position last time the mag states were reset (m)
     float yawInnovAtLastMagReset;   // magnetic yaw innovation last time the yaw and mag field states were reset (rad)
     Quaternion quatAtLastMagReset;  // quaternion states last time the mag states were reset
+
+    // external navigation fusion
+    obs_ring_buffer_t<ext_nav_elements> storedExtNav; // external navigation data buffer
+    ext_nav_elements extNavDataNew;     // External nav data at the current time horizon
+    ext_nav_elements extNavDataDelayed; // External nav at the fusion time horizon
+    uint32_t extNavMeasTime_ms;         // time external measurements were accepted for input to the data buffer (msec)
+    uint32_t extNavLastPosResetTime_ms; // last time the external nav systen performed a position reset (msec)
+    bool extNavDataToFuse;              // true when there is new external nav data to fuse
+    bool extNavUsedForYaw;              // true when the external nav data is also being used as a yaw observation
+    bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
+    bool extNavYawResetRequest;         // true when a reset of vehicle yaw using the external nav data is requested
 
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -561,7 +561,7 @@ void  NavEKF3_core::updateFilterStatus(void)
     filterStatus.flags.takeoff = expectGndEffectTakeoff; // The EKF has been told to expect takeoff and is in a ground effect mitigation mode
     filterStatus.flags.touchdown = expectGndEffectTouchdown; // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     filterStatus.flags.using_gps = ((imuSampleTime_ms - lastPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
-    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE); // The GPS is glitching
+    filterStatus.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE); // GPS glitching is affecting navigation accuracy
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -79,7 +79,7 @@ public:
         uint32_t leak_detected      : 1;    // 1 if leak detected
         float    battery_voltage       ;    // battery voltage
         uint32_t gps_fusion         : 1;    // 0 = GPS fix rejected by EKF, not usable for flight. 1 = GPS in use by EKF, usable for flight
-        uint32_t gps_glitching      : 1;    // 1 if gps is glitching
+        uint32_t gps_glitching      : 1;    // 1 if GPS glitching is affecting navigation accuracy
         uint32_t have_pos_abs       : 1;    // 0 = no absolute position available, 1 = absolute position available
 
         // additional flags

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1387,7 +1387,7 @@ void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs)
     static uint32_t lastEkfStateVarLogTime_ms = 0;
     if (AP_HAL::millis() - lastEkfStateVarLogTime_ms > 490) {
         lastEkfStateVarLogTime_ms = AP_HAL::millis();
-        float stateVar[24];
+        float stateVar[25];
         ahrs.get_NavEKF3().getStateVariances(-1, stateVar);
         struct log_ekfStateVar pktv1 = {
             LOG_PACKET_HEADER_INIT(LOG_XKV1_MSG),
@@ -1420,7 +1420,7 @@ void DataFlash_Class::Log_Write_EKF3(AP_AHRS_NavEKF &ahrs)
             v08 : stateVar[20],
             v09 : stateVar[21],
             v10 : stateVar[22],
-            v11 : stateVar[23]
+            v11 : (stateVar[23]+stateVar[24])
         };
         WriteBlock(&pktv2, sizeof(pktv2));
     }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -579,6 +579,19 @@ struct PACKED log_ekfBodyOdomDebug {
     float velInnovVarZ;
 };
 
+struct PACKED log_ekfExtNavScaleDebug {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float scaleLog;
+    float scaleLogSigma;
+    float innovX;
+    float innovY;
+    float innovZ;
+    float innovVarX;
+    float innovVarY;
+    float innovVarZ;
+};
+
 struct PACKED log_ekfStateVar {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1298,6 +1311,8 @@ Format characters in the format string for binary log messages
     { LOG_XKQ2_MSG, sizeof(log_Quaternion), "XKQ2", QUAT_FMT, QUAT_LABELS, QUAT_UNITS, QUAT_MULTS }, \
     { LOG_XKFD_MSG, sizeof(log_ekfBodyOdomDebug), \
       "XKFD","Qffffff","TimeUS,IX,IY,IZ,IVX,IVY,IVZ", "s------", "F------" }, \
+    { LOG_XKFR_MSG, sizeof(log_ekfExtNavScaleDebug), \
+      "XKFR","Qffffffff","TimeUS,LS,LSS,IX,IY,IZ,IVX,IVY,IVZ", "s--------", "F--------" }, \
     { LOG_XKV1_MSG, sizeof(log_ekfStateVar), \
       "XKV1","Qffffffffffff","TimeUS,V00,V01,V02,V03,V04,V05,V06,V07,V08,V09,V10,V11", "s------------", "F------------" }, \
     { LOG_XKV2_MSG, sizeof(log_ekfStateVar), \
@@ -1443,6 +1458,7 @@ enum LogMessages {
     LOG_XKQ1_MSG,
     LOG_XKQ2_MSG,
     LOG_XKFD_MSG,
+    LOG_XKFR_MSG,
     LOG_XKV1_MSG,
     LOG_XKV2_MSG,
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -433,6 +433,17 @@ private:
     virtual void handle_change_alt_request(AP_Mission::Mission_Command &cmd) = 0;
     void handle_common_mission_message(mavlink_message_t *msg);
 
+    void handle_vicon_position_estimate(mavlink_message_t *msg);
+    void handle_vision_position_estimate(mavlink_message_t *msg);
+    void handle_global_vision_position_estimate(mavlink_message_t *msg);
+    void handle_att_pos_mocap(mavlink_message_t *msg);
+    void _handle_common_vision_position_estimate_data(const uint64_t usec,
+                                                      const float x,
+                                                      const float y,
+                                                      const float z,
+                                                      const float roll,
+                                                      const float pitch,
+                                                      const float yaw);
     void push_deferred_messages();
 
     void lock_channel(mavlink_channel_t chan, bool lock);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1873,6 +1873,92 @@ void GCS_MAVLINK::handle_vision_position_delta(mavlink_message_t *msg)
     visual_odom->handle_msg(msg);
 }
 
+void GCS_MAVLINK::handle_vision_position_estimate(mavlink_message_t *msg)
+{
+    mavlink_vision_position_estimate_t m;
+    mavlink_msg_vision_position_estimate_decode(msg, &m);
+
+    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+}
+
+void GCS_MAVLINK::handle_global_vision_position_estimate(mavlink_message_t *msg)
+{
+    mavlink_global_vision_position_estimate_t m;
+    mavlink_msg_global_vision_position_estimate_decode(msg, &m);
+
+    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+}
+
+void GCS_MAVLINK::handle_vicon_position_estimate(mavlink_message_t *msg)
+{
+    mavlink_vicon_position_estimate_t m;
+    mavlink_msg_vicon_position_estimate_decode(msg, &m);
+
+    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+}
+
+// there are several messages which all have identical fields in them.
+// This function provides common handling for the data contained in
+// these packets
+void GCS_MAVLINK::_handle_common_vision_position_estimate_data(const uint64_t usec,
+                                                               const float x,
+                                                               const float y,
+                                                               const float z,
+                                                               const float roll,
+                                                               const float pitch,
+                                                               const float yaw)
+{
+    // sensor assumed to be at 0,0,0 body-frame; need parameters for this?
+    // or a new message 
+    const Vector3f sensor_offset = {};
+    const Vector3f pos = {
+        x,
+        y,
+        z
+    };
+    Quaternion attitude;
+    attitude.from_euler(roll, pitch, yaw); // from_vector312?
+    const float posErr = 0; // parameter required?
+    const float angErr = 0; // parameter required?
+    const uint32_t timestamp_ms = usec * 0.001;
+    const uint32_t reset_timestamp_ms = 0; // no data available
+
+    AP::ahrs().writeExtNavData(sensor_offset,
+                               pos,
+                               attitude,
+                               posErr,
+                               angErr,
+                               timestamp_ms,
+                               reset_timestamp_ms);
+}
+
+void GCS_MAVLINK::handle_att_pos_mocap(mavlink_message_t *msg)
+{
+    mavlink_att_pos_mocap_t m;
+    mavlink_msg_att_pos_mocap_decode(msg, &m);
+
+    // sensor assumed to be at 0,0,0 body-frame; need parameters for this?
+    const Vector3f sensor_offset = {};
+    const Vector3f pos = {
+        m.x,
+        m.y,
+        m.z
+    };
+    Quaternion attitude = Quaternion(m.q);
+    const float posErr = 0; // parameter required?
+    const float angErr = 0; // parameter required?
+    const uint32_t timestamp_ms = m.time_usec * 0.001;
+    const uint32_t reset_timestamp_ms = 0; // no data available
+
+    AP::ahrs().writeExtNavData(sensor_offset,
+                               pos,
+                               attitude,
+                               posErr,
+                               angErr,
+                               timestamp_ms,
+                               reset_timestamp_ms);
+}
+
 /*
   handle messages which don't require vehicle specific data
  */
@@ -1994,6 +2080,22 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
 
     case MAVLINK_MSG_ID_VISION_POSITION_DELTA:
         handle_vision_position_delta(msg);
+        break;
+
+    case MAVLINK_MSG_ID_VISION_POSITION_ESTIMATE:
+        handle_vision_position_estimate(msg);
+        break;
+
+    case MAVLINK_MSG_ID_GLOBAL_VISION_POSITION_ESTIMATE:
+        handle_vision_position_estimate(msg);
+        break;
+
+    case MAVLINK_MSG_ID_VICON_POSITION_ESTIMATE:
+        handle_vicon_position_estimate(msg);
+        break;
+
+    case MAVLINK_MSG_ID_ATT_POS_MOCAP:
+        handle_att_pos_mocap(msg);
         break;
     }
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -115,6 +115,12 @@ public:
 
     const Location &get_location() const { return location; }
 
+    const Vector3f &get_position() const { return position; }
+
+    void get_attitude(Quaternion &attitude) const {
+        attitude.from_rotation_matrix(dcm);
+    }
+
 protected:
     SITL *sitl;
     Location home;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -113,6 +113,8 @@ public:
 
     virtual float gross_mass() const { return mass; }
 
+    const Location &get_location() const { return location; }
+
 protected:
     SITL *sitl;
     Location home;

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -1,0 +1,128 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple vicon simulator class
+
+  XKFR
+
+*/
+
+#include "SIM_Vicon.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+using namespace SITL;
+
+Vicon::Vicon()
+{
+    int tmp[2];
+    pipe(tmp);
+    fd_my_end    = tmp[1];
+    fd_their_end = tmp[0];
+
+    // make sure we don't screw the simulation up by blocking:
+    fcntl(fd_my_end, F_SETFL, fcntl(fd_my_end, F_GETFL, 0) | O_NONBLOCK);
+    fcntl(fd_their_end, F_SETFL, fcntl(fd_their_end, F_GETFL, 0) | O_NONBLOCK);
+}
+
+void Vicon::maybe_send_heartbeat()
+{
+    const uint32_t now = AP_HAL::millis();
+
+    if (now - last_heartbeat_ms < 100) {
+        // we only provide a heartbeat every so often
+        return;
+    }
+    last_heartbeat_ms = now;
+
+    mavlink_message_t msg;
+    mavlink_msg_heartbeat_pack(system_id,
+                               component_id,
+                               &msg,
+                               MAV_TYPE_GCS,
+                               MAV_AUTOPILOT_INVALID,
+                               0,
+                               0,
+                               0);
+}
+
+void Vicon::update_vicon_position_estimate(const Location &loc,
+                                           const Vector3f &position,
+                                           const Quaternion &attitude)
+{
+    const uint32_t now = AP_HAL::millis();
+
+    if (now - vicon.last_observation_ms < vicon.observation_interval_ms) {
+        return;
+    }
+
+    obs_elements new_obs = {
+        now,
+        position,
+        attitude
+    };
+    vicon.last_observation_ms = now;
+
+    obs_elements observation;
+    if (vicon.observation_history_length == 0) {
+        // no delay
+        observation = new_obs;
+    } else {
+        vicon.observation_history.push(new_obs);
+
+        if (vicon.observation_history.space() != 0) {
+            ::fprintf(stderr, "Insufficient delay\n");
+            return;
+        }
+        if (!vicon.observation_history.pop(observation)) {
+            abort();
+        }
+    }
+
+    float roll;
+    float pitch;
+    float yaw;
+    observation.attitude.to_euler(roll, pitch, yaw);
+
+    mavlink_message_t msg;
+    mavlink_msg_vicon_position_estimate_pack_chan(system_id,
+                                                  component_id,
+                                                  mavlink_ch,
+                                                  &msg,
+                                                  observation.time_ms*1000,
+                                                  observation.position.x,
+                                                  observation.position.y,
+                                                  observation.position.z,
+                                                  roll,
+                                                  pitch,
+                                                  yaw);
+
+    // ::fprintf(stderr, "Vicon: writing pos=(%03.03f %03.03f %03.03f) att=(%01.03f %01.03f %01.03f)\n", observation.position.x, observation.position.y, observation.position.z, roll, pitch, yaw);
+    if (::write(fd_my_end, (void*)&msg, sizeof(msg)) != sizeof(msg)) {
+        ::fprintf(stderr, "Vicon: write failure\n");
+        // abort();
+    }
+}
+
+/*
+  update vicon sensor state
+ */
+void Vicon::update(const Location &loc, const Vector3f &position, const Quaternion &attitude)
+{
+    maybe_send_heartbeat();
+    update_vicon_position_estimate(loc, position, attitude);
+}
+

--- a/libraries/SITL/SIM_Vicon.h
+++ b/libraries/SITL/SIM_Vicon.h
@@ -1,0 +1,74 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  simple particle sensor simulation
+*/
+
+#pragma once
+
+#include "SIM_Aircraft.h"
+
+#include <AP_HAL/utility/RingBuffer.h>
+
+namespace SITL {
+
+class Vicon {
+public:
+
+    Vicon();
+
+    // update state
+    void update(const Location &loc, const Vector3f &position, const Quaternion &attitude);
+
+    // return fd on which data from the device can be read, and data
+    // to the device can be written
+    int fd() { return fd_their_end; }
+
+private:
+
+    // TODO: make these parameters:
+    const uint8_t system_id = 17;
+    const uint8_t component_id = 18;
+
+    // we share channels with the ArduPilot binary!
+    const uint8_t mavlink_ch = 17;
+
+    int fd_their_end;
+    int fd_my_end;
+
+    struct obs_elements {
+        uint32_t    time_ms;        // measurement timestamp (msec)
+        Vector3f    position;
+        Quaternion  attitude;
+    };
+
+    struct {
+        const uint16_t observation_interval_ms = 20;
+        // delay results by some multiplier of the observation_interval:
+        const uint8_t observation_history_length = 0;
+        ObjectArray<obs_elements> observation_history{observation_history_length};
+        uint32_t last_observation_ms;
+    } vicon;
+
+    void update_vicon_position_estimate(const Location &loc,
+                                        const Vector3f &position,
+                                        const Quaternion &attitude);
+
+    void maybe_send_heartbeat();
+    uint32_t last_heartbeat_ms;
+
+};
+
+}

--- a/libraries/SITL/SIM_Vicon.h
+++ b/libraries/SITL/SIM_Vicon.h
@@ -20,6 +20,8 @@
 
 #include "SIM_Aircraft.h"
 
+#include <SITL/SITL.h>
+
 #include <AP_HAL/utility/RingBuffer.h>
 
 namespace SITL {
@@ -37,6 +39,8 @@ public:
     int fd() { return fd_their_end; }
 
 private:
+
+    SITL *_sitl;
 
     // TODO: make these parameters:
     const uint8_t system_id = 17;
@@ -57,8 +61,7 @@ private:
     struct {
         const uint16_t observation_interval_ms = 20;
         // delay results by some multiplier of the observation_interval:
-        const uint8_t observation_history_length = 0;
-        ObjectArray<obs_elements> observation_history{observation_history_length};
+        ObjectArray<obs_elements> *observation_history;
         uint32_t last_observation_ms;
     } vicon;
 
@@ -69,6 +72,7 @@ private:
     void maybe_send_heartbeat();
     uint32_t last_heartbeat_ms;
 
+    bool init_sitl_pointer();
 };
 
 }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -112,6 +112,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("ARSPD2_FAIL", 11, SITL,  arspd2_fail, 0),
     AP_GROUPINFO("ARSPD2_FAILP",12, SITL,  arspd2_fail_pressure, 0),
     AP_GROUPINFO("ARSPD2_PITOT",13, SITL,  arspd2_fail_pitot_pressure, 0),
+    AP_GROUPINFO("VICON_HSTLEN",14, SITL,  vicon_observation_history_length, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -90,6 +90,7 @@ public:
     AP_Float gps_noise; // amplitude of the gps altitude error
     AP_Int16 gps_lock_time; // delay in seconds before GPS gets lock
     AP_Int16 gps_alt_offset; // gps alt error
+    AP_Int8  vicon_observation_history_length; // frame delay for vicon messages
 
     AP_Float mag_noise;   // in mag units (earth field is 818)
     AP_Float mag_error;   // in degrees


### PR DESCRIPTION
We accept messages of various sorts, and feed the data into EKF2, which can fuse this data and allow us to navigate.

Preliminary instructions on testing this are here:
https://github.com/peterbarker/ardupilot_wiki/blob/vicon/dev/source/docs/using-sitl-for-ardupilot-testing.rst#testing-visual-positioning

Notes:
 - arming in loiter is not possible unless GPS checks are disabled

Edit: the earlier issue, in which the vehicle could not climb in Loiter mode while using external position estimates, has been resolved.
