### PR TITLE
Copter: Added an optional pre-arm check for a GPS fix in all modes

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -47,6 +47,8 @@
 //#define CAL_ALWAYS_REBOOT                         // flight controller will reboot after compass or accelerometer calibration completes
 //#define DISALLOW_GCS_MODE_CHANGE_DURING_RC_FAILSAFE   // disable mode changes from GCS during Radio failsafes.  Avoids a race condition for vehicle like Solo in which the RC and telemetry travel along the same link
 //#define ADVANCED_FAILSAFE     ENABLED             // enabled advanced failsafe which allows running a portion of the mission in failsafe events
+//#define ARM_GPS_ALL_MODES ENABLED // checks for GPS fix during arming even on modes which don't require GPS
+
 
 // other settings
 //#define THROTTLE_IN_DEADBAND   100                // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -390,8 +390,13 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     fence_requires_gps = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
     #endif
 
+    bool check_gps_all_modes = false;
+    #if ARM_GPS_ALL_MODES == ENABLED
+    check_gps_all_modes = true;
+    #endif
+
     // return true if GPS is not required
-    if (!mode_requires_gps && !fence_requires_gps) {
+    if (!mode_requires_gps && !fence_requires_gps && !check_gps_all_modes) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }
@@ -406,6 +411,8 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
                 if (!mode_requires_gps && fence_requires_gps) {
                     // clarify to user why they need GPS in non-GPS flight mode
                     gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Fence enabled, need 3D Fix");
+                } else if (!mode_requires_gps && check_gps_all_modes) {
+                    gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Checking for GPS on non-GPS modes enabled, need 3D Fix");
                 } else {
                     gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Need 3D Fix");
                 }

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -703,6 +703,10 @@
 # define ADVANCED_FAILSAFE DISABLED
 #endif
 
+#ifndef ARM_GPS_ALL_MODES
+# define ARM_GPS_ALL_MODES DISABLED
+#endif
+
 #ifndef CH_MODE_DEFAULT
  # define CH_MODE_DEFAULT   5
 #endif


### PR DESCRIPTION
This is with reference to [https://github.com/ArduPilot/ardupilot/issues/3220](https://github.com/ArduPilot/ardupilot/issues/3220).

This adds a new user settable option to `APM_Config.h` to check for a good GPS fix on all flight modes during arming. Prior to this, there was no requirement for non-GPS flight modes to check for a GPS fix during arming. Setting `ARM_GPS_ALL_MODES` to `ENABLED` will cause arming the UAV to fail if a GPS fix is not found for non-GPS modes.