### PR TITLE
Factor GCS heartbeat send methods

### DIFF
--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -36,4 +36,9 @@ private:
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override;
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     bool try_send_message(enum ap_message id) override;
+
+    MAV_TYPE frame_type() const override;
+    MAV_MODE base_mode() const override;
+    uint32_t custom_mode() const override;
+    MAV_STATE system_status() const override;
 };

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -469,7 +469,6 @@ private:
     void fence_send_mavlink_status(mavlink_channel_t chan);
 
     // GCS_Mavlink.cpp
-    void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -35,4 +35,8 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     bool try_send_message(enum ap_message id) override;
 
+    MAV_TYPE frame_type() const override;
+    MAV_MODE base_mode() const override;
+    uint32_t custom_mode() const override;
+    MAV_STATE system_status() const override;
 };

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -202,7 +202,6 @@ private:
 
     void one_second_loop();
     void ten_hz_logging_loop();
-    void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -387,6 +387,10 @@ private:
         uint8_t adsb                : 1; // true if an adsb related failsafe has occurred
     } failsafe;
 
+    bool any_failsafe_triggered() const {
+        return failsafe.radio || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain || failsafe.adsb;
+    }
+
     // sensor health for logging
     struct {
         uint8_t baro        : 1;    // true if baro is healthy
@@ -772,7 +776,6 @@ private:
     // GCS_Mavlink.cpp
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);
-    void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
@@ -949,7 +952,7 @@ private:
     void check_usb_mux(void);
     bool should_log(uint32_t mask);
     void set_default_frame_class();
-    uint8_t get_frame_mav_type();
+    MAV_TYPE get_frame_mav_type();
     const char* get_frame_string();
     void allocate_motors(void);
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -22,17 +22,14 @@ void Copter::gcs_send_deferred(void)
  *  pattern below when adding any new messages
  */
 
-NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
+MAV_TYPE GCS_MAVLINK_Copter::frame_type() const
 {
-    uint8_t base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-    uint8_t system_status = ap.land_complete ? MAV_STATE_STANDBY : MAV_STATE_ACTIVE;
-    uint32_t custom_mode = control_mode;
+    return copter.get_frame_mav_type();
+}
 
-    // set system as critical if any failsafe have triggered
-    if (failsafe.radio || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain || failsafe.adsb)  {
-        system_status = MAV_STATE_CRITICAL;
-    }
-
+MAV_MODE GCS_MAVLINK_Copter::base_mode() const
+{
+    uint8_t base_mode = MAV_MODE_FLAG_STABILIZE_ENABLED;
     // work out the base_mode. This value is not very useful
     // for APM, but we calculate it as best we can so a generic
     // MAVLink enabled ground station can work out something about
@@ -41,8 +38,7 @@ NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
     // only get useful information from the custom_mode, which maps to
     // the APM flight mode and has a well defined meaning in the
     // ArduPlane documentation
-    base_mode = MAV_MODE_FLAG_STABILIZE_ENABLED;
-    switch (control_mode) {
+    switch (copter.control_mode) {
     case AUTO:
     case RTL:
     case LOITER:
@@ -71,18 +67,36 @@ NOINLINE void Copter::send_heartbeat(mavlink_channel_t chan)
 #endif
 
     // we are armed if we are not initialising
-    if (motors != nullptr && motors->armed()) {
+    if (copter.motors != nullptr && copter.motors->armed()) {
         base_mode |= MAV_MODE_FLAG_SAFETY_ARMED;
     }
 
     // indicate we have set a custom mode
     base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    gcs().chan(chan-MAVLINK_COMM_0).send_heartbeat(get_frame_mav_type(),
-                                            base_mode,
-                                            custom_mode,
-                                            system_status);
+    return (MAV_MODE)base_mode;
 }
+
+uint32_t GCS_MAVLINK_Copter::custom_mode() const
+{
+    return copter.control_mode;
+}
+
+
+MAV_STATE GCS_MAVLINK_Copter::system_status() const
+{
+    // set system as critical if any failsafe have triggered
+    if (copter.any_failsafe_triggered())  {
+        return MAV_STATE_CRITICAL;
+    }
+
+    if (copter.ap.land_complete) {
+        return MAV_STATE_STANDBY;
+    }
+
+    return MAV_STATE_ACTIVE;
+}
+
 
 NOINLINE void Copter::send_attitude(mavlink_channel_t chan)
 {
@@ -294,7 +308,7 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     case MSG_HEARTBEAT:
         CHECK_PAYLOAD_SIZE(HEARTBEAT);
         last_heartbeat_time = AP_HAL::millis();
-        copter.send_heartbeat(chan);
+        send_heartbeat();
         break;
 
     case MSG_EXTENDED_STATUS1:

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -45,4 +45,9 @@ private:
 
     void packetReceived(const mavlink_status_t &status,
                         mavlink_message_t &msg) override;
+
+    MAV_TYPE frame_type() const override;
+    MAV_MODE base_mode() const override;
+    uint32_t custom_mode() const override;
+    MAV_STATE system_status() const override;
 };

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -459,7 +459,7 @@ void Copter::set_default_frame_class()
 }
 
 // return MAV_TYPE corresponding to frame class
-uint8_t Copter::get_frame_mav_type()
+MAV_TYPE Copter::get_frame_mav_type()
 {
     switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {
         case AP_Motors::MOTOR_FRAME_QUAD:

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -41,4 +41,8 @@ private:
     bool try_send_message(enum ap_message id) override;
     void packetReceived(const mavlink_status_t &status, mavlink_message_t &msg) override;
 
+    MAV_TYPE frame_type() const override;
+    MAV_MODE base_mode() const override;
+    uint32_t custom_mode() const override;
+    MAV_STATE system_status() const override;
 };

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -355,6 +355,10 @@ private:
         uint32_t AFS_last_valid_rc_ms;
     } failsafe;
 
+    bool any_failsafe_triggered() {
+        return failsafe.state != FAILSAFE_NONE || battery.has_failsafed() || failsafe.adsb;
+    }
+
     // A counter used to count down valid gps fixes to allow the gps estimate to settle
     // before recording our home position (and executing a ground start if we booted with an air start)
     uint8_t ground_start_count = 5;
@@ -776,7 +780,6 @@ private:
     
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
-    void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);
     void update_sensor_status_flags(void);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2483,12 +2483,12 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
 /*
   return mav_type for heartbeat
  */
-uint8_t QuadPlane::get_mav_type(void) const
+MAV_TYPE QuadPlane::get_mav_type(void) const
 {
     if (mav_type.get() == 0) {
         return MAV_TYPE_FIXED_WING;
     }
-    return uint8_t(mav_type.get());
+    return MAV_TYPE(mav_type.get());
 }
 
 /*

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -268,7 +268,7 @@ private:
 
     // HEARTBEAT mav_type override
     AP_Int8 mav_type;
-    uint8_t get_mav_type(void) const;
+    MAV_TYPE get_mav_type(void) const;
     
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -35,4 +35,8 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     bool try_send_message(enum ap_message id) override;
 
+    MAV_TYPE frame_type() const override;
+    MAV_MODE base_mode() const override;
+    uint32_t custom_mode() const override;
+    MAV_STATE system_status() const override;
 };

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -285,6 +285,10 @@ private:
         uint8_t sensor_health        : 1; // true if at least one sensor has triggered a failsafe (currently only used for depth in depth enabled modes)
     } failsafe;
 
+    bool any_failsafe_triggered() const {
+        return (failsafe.pilot_input || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain);
+    }
+
     // sensor health for logging
     struct {
         uint8_t baro        : 1;    // true if any single baro is healthy

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -152,6 +152,7 @@ public:
     uint16_t mission_item_reached_index = AP_MISSION_CMD_INDEX_NONE;
 
     // common send functions
+    void send_heartbeat(void);
     void send_meminfo(void);
     void send_power_status(void);
     void send_battery_status(const AP_BattMonitor &battery, const uint8_t instance) const;
@@ -177,7 +178,6 @@ public:
     void send_vibration(const AP_InertialSensor &ins) const;
     void send_home(const Location &home) const;
     void send_ekf_origin(const Location &ekf_origin) const;
-    void send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status);
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint32_t position);
@@ -236,6 +236,11 @@ protected:
     virtual bool set_mode(uint8_t mode) = 0;
     virtual const AP_FWVersion &get_fwver() const = 0;
     virtual void set_ekf_origin(const Location& loc) = 0;
+
+    virtual MAV_TYPE frame_type() const = 0;
+    virtual MAV_MODE base_mode() const = 0;
+    virtual uint32_t custom_mode() const = 0;
+    virtual MAV_STATE system_status() const = 0;
 
     bool            waypoint_receiving; // currently receiving
     // the following two variables are only here because of Tracker

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1520,17 +1520,17 @@ void GCS_MAVLINK::send_ekf_origin(const Location &ekf_origin) const
 }
 
 /*
-  wrapper for sending heartbeat
+  Send MAVLink heartbeat
  */
-void GCS_MAVLINK::send_heartbeat(uint8_t type, uint8_t base_mode, uint32_t custom_mode, uint8_t system_status)
+void GCS_MAVLINK::send_heartbeat()
 {
     mavlink_msg_heartbeat_send(
         chan,
-        type,
+        frame_type(),
         MAV_AUTOPILOT_ARDUPILOTMEGA,
-        base_mode,
-        custom_mode,
-        system_status);
+        base_mode(),
+        custom_mode(),
+        system_status());
 }
 
 float GCS_MAVLINK::adjust_rate_for_stream_trigger(enum streams stream_num)

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -34,6 +34,12 @@ protected:
     uint8_t sysid_my_gcs() const override { return 1; }
     bool set_mode(uint8_t mode) override { return false; };
 
+    // dummy information:
+    MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }
+    MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
+    uint32_t custom_mode() const override { return 3; } // magic number
+    MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
+
 };
 
 /*

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -41,6 +41,12 @@ protected:
     const AP_FWVersion &get_fwver() const override { return fwver; }
     void set_ekf_origin(const Location& loc) override { };
 
+    // dummy information:
+    MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }
+    MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
+    uint32_t custom_mode() const override { return 3; } // magic number
+    MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
+
 private:
 
     void handleMessage(mavlink_message_t * msg) { }


### PR DESCRIPTION
This is NOT NFC.

It inverts the `MAV_STATE_ACTIVE` vs `MAV_STATE_STANDBY` for when your motors are armed you're a touch more active than you were before.

The line was:

```
uint8_t system_status = motors.armed() ? MAV_STATE_STANDBY : MAV_STATE_ACTIVE;
```
