### PR TITLE
Copter: Circle Mode Angular Velocity Control using the Roll Input

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -536,6 +536,10 @@ private:
 
     // Circle
     bool pilot_yaw_override = false; // true if pilot is overriding yaw
+
+    // Used for changing the angular velocity from the input on the roll stick
+    float get_desired_angular_acceleration(float norm_pitch_input);
+    float get_target_angular_velocity(float current_angular_velocity, float angular_acceleration, float G_Dt);
 };
 
 

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -40,6 +40,9 @@ public:
     /// set_circle_rate - set circle rate in degrees per second
     void set_rate(float deg_per_sec);
 
+    /// get angular velocity in degrees per second
+    float get_rate() { return _rate.get(); }
+
     /// get_angle_total - return total angle in radians that vehicle has circled
     float get_angle_total() const { return _angle_total; }
 


### PR DESCRIPTION
I have repurposed the roll input to change the angular velocity (aka rate) of the circle mode inflight. It is a part of a number of patches to [improve](https://github.com/ArduPilot/ardupilot/issues/386#issuecomment-375664735) ArduCopter's circle mode.

This patch is very similar to my other one for using the pitch stick to modify the radius of the circle: [https://github.com/ArduPilot/ardupilot/pull/7930](https://github.com/ArduPilot/ardupilot/pull/7930)

My concern with this is that I'm not sure what to take as the maximum angular acceleration for the roll stick. For now, I have used a fractional value of `AC_CIRCLE_ANGULAR_ACCEL_MIN`. Yet this approach seems arbitrary. Is there some other constant I can use for this?