### PR TITLE
Copter: move Log_Write_AutoTune to mode_autotune.cpp #7759

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -26,18 +26,6 @@ struct PACKED log_AutoTuneDetails {
     float    angle_cd;      // lean angle in centi-degrees
     float    rate_cds;      // current rotation rate in centi-degrees / second
 };
-
-// Write an Autotune data packet
-void Copter::ModeAutoTune::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds)
-{
-    struct log_AutoTuneDetails pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNEDETAILS_MSG),
-        time_us     : AP_HAL::micros64(),
-        angle_cd    : angle_cd,
-        rate_cds    : rate_cds
-    };
-    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
-}
 #endif
 
 struct PACKED log_Optflow {

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -20,25 +20,6 @@ struct PACKED log_AutoTune {
     float   new_ddt;        // newly calculated gain
 };
 
-// Write an Autotune data packet
-void Copter::ModeAutoTune::Log_Write_AutoTune(uint8_t _axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt)
-{
-    struct log_AutoTune pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNE_MSG),
-        time_us     : AP_HAL::micros64(),
-        axis        : _axis,
-        tune_step   : tune_step,
-        meas_target : meas_target,
-        meas_min    : meas_min,
-        meas_max    : meas_max,
-        new_gain_rp : new_gain_rp,
-        new_gain_rd : new_gain_rd,
-        new_gain_sp : new_gain_sp,
-        new_ddt     : new_ddt
-    };
-    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
-}
-
 struct PACKED log_AutoTuneDetails {
     LOG_PACKET_HEADER;
     uint64_t time_us;

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -1523,4 +1523,36 @@ void Copter::ModeAutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch
     yaw_cd_out = target_yaw_cd;
 }
 
+struct PACKED log_AutoTune {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t axis;           // roll or pitch
+    uint8_t tune_step;      // tuning PI or D up or down
+    float   meas_target;    // target achieved rotation rate
+    float   meas_min;       // maximum achieved rotation rate
+    float   meas_max;       // maximum achieved rotation rate
+    float   new_gain_rp;    // newly calculated gain
+    float   new_gain_rd;    // newly calculated gain
+    float   new_gain_sp;    // newly calculated gain
+    float   new_ddt;        // newly calculated gain
+};
+
+// Write an Autotune data packet
+void Copter::ModeAutoTune::Log_Write_AutoTune(uint8_t _axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt)
+{
+    struct log_AutoTune pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNE_MSG),
+        time_us     : AP_HAL::micros64(),
+        axis        : _axis,
+        tune_step   : tune_step,
+        meas_target : meas_target,
+        meas_min    : meas_min,
+        meas_max    : meas_max,
+        new_gain_rp : new_gain_rp,
+        new_gain_rd : new_gain_rd,
+        new_gain_sp : new_gain_sp,
+        new_ddt     : new_ddt
+    };
+    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
 #endif  // AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -1523,6 +1523,25 @@ void Copter::ModeAutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch
     yaw_cd_out = target_yaw_cd;
 }
 
+struct PACKED log_AutoTuneDetails {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float    angle_cd;      // lean angle in centi-degrees
+    float    rate_cds;      // current rotation rate in centi-degrees / second
+};
+
+// Write an Autotune data packet
+void Copter::ModeAutoTune::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds)
+{
+    struct log_AutoTuneDetails pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNEDETAILS_MSG),
+        time_us     : AP_HAL::micros64(),
+        angle_cd    : angle_cd,
+        rate_cds    : rate_cds
+    };
+    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
 struct PACKED log_AutoTune {
     LOG_PACKET_HEADER;
     uint64_t time_us;

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -1523,25 +1523,6 @@ void Copter::ModeAutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch
     yaw_cd_out = target_yaw_cd;
 }
 
-struct PACKED log_AutoTuneDetails {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    float    angle_cd;      // lean angle in centi-degrees
-    float    rate_cds;      // current rotation rate in centi-degrees / second
-};
-
-// Write an Autotune data packet
-void Copter::ModeAutoTune::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds)
-{
-    struct log_AutoTuneDetails pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNEDETAILS_MSG),
-        time_us     : AP_HAL::micros64(),
-        angle_cd    : angle_cd,
-        rate_cds    : rate_cds
-    };
-    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
-}
-
 struct PACKED log_AutoTune {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1571,6 +1552,25 @@ void Copter::ModeAutoTune::Log_Write_AutoTune(uint8_t _axis, uint8_t tune_step, 
         new_gain_rd : new_gain_rd,
         new_gain_sp : new_gain_sp,
         new_ddt     : new_ddt
+    };
+    copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
+}
+
+struct PACKED log_AutoTuneDetails {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float    angle_cd;      // lean angle in centi-degrees
+    float    rate_cds;      // current rotation rate in centi-degrees / second
+};
+
+// Write an Autotune data packet
+void Copter::ModeAutoTune::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds)
+{
+    struct log_AutoTuneDetails pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_AUTOTUNEDETAILS_MSG),
+        time_us     : AP_HAL::micros64(),
+        angle_cd    : angle_cd,
+        rate_cds    : rate_cds
     };
     copter.DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }


### PR DESCRIPTION
Pull request for #7759 
Moved the below two functions from Log.cpp to mode_autotune.cpp:-
1) Log_Write_AutoTune
2) Log_Write_AutoTuneDetails

NOTE: I copied the following structures: log_AutoTuneDetails and log_AutoTune to mode_autotune.cpp. I didn't remove those structures in Log.cpp since they were used in Copter::log_structure[]. Any suggestions on this?