### PR TITLE
add comment for #7936 (altitude type)

### DIFF
--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1455,7 +1455,7 @@ bool DataFlash_Backend::Log_Write_MavCmd(uint16_t cmd_total, const mavlink_missi
         latitude        : (float)mav_cmd.x,
         longitude       : (float)mav_cmd.y,
         altitude        : (float)mav_cmd.z,
-        frame           : (uint8_t)mav_cmd.frame
+        frame           : (uint8_t)mav_cmd.frame//0 -> absolute altitude; 3 -> relative altitude; 10 -> terrain
     };
     return WriteBlock(&pkt, sizeof(pkt));
 }


### PR DESCRIPTION
based on documentation from mavlink/message_definitions/v1.0/common.xml
meaning for different values:
0 -> absolute altitude
3 -> relative altitude
10 -> terrain altitude