### PR TITLE
Add Sensor-Rate logging to BatchSampler

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -534,6 +534,7 @@ uint8_t AP_InertialSensor::register_gyro(uint16_t raw_sample_rate_hz,
 
     _gyro_raw_sample_rates[_gyro_count] = raw_sample_rate_hz;
     _gyro_over_sampling[_gyro_count] = 1;
+    _gyro_raw_sampling_multiplier[_gyro_count] = INT16_MAX/radians(2000);
 
     bool saved = _gyro_id[_gyro_count].load();
 
@@ -567,6 +568,7 @@ uint8_t AP_InertialSensor::register_accel(uint16_t raw_sample_rate_hz,
 
     _accel_raw_sample_rates[_accel_count] = raw_sample_rate_hz;
     _accel_over_sampling[_accel_count] = 1;
+    _accel_raw_sampling_multiplier[_accel_count] = INT16_MAX/(16*GRAVITY_MSS);
 
     bool saved = _accel_id[_accel_count].load();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -300,6 +300,7 @@ public:
         // Parameters
         AP_Int16 _required_count;
         AP_Int8 _sensor_mask;
+        AP_Int8 _batch_raw;
         // end Parameters
 
     private:
@@ -336,7 +337,7 @@ public:
         // you are running a on an FMU with three IMUs then you
         // will loop back around to the first sensor after about
         // twenty seconds.
-        const uint8_t push_interval_ms = 100;
+        const uint8_t push_interval_ms = 20;
         const uint16_t samples_per_msg = 32;
 
         const AP_InertialSensor &_imu;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -54,7 +54,7 @@ void AP_InertialSensor_Backend::_set_gyro_oversampling(uint8_t instance, uint8_t
   sensor may vary slightly from the system clock. This slowly adjusts
   the rate to the observed rate
 */
-void AP_InertialSensor_Backend::_update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz)
+void AP_InertialSensor_Backend::_update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz) const
 {
     uint32_t now = AP_HAL::micros();
     if (start_us == 0) {
@@ -226,7 +226,9 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
         };
         dataflash->WriteBlock(&pkt, sizeof(pkt));
     } else {
-        //_imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
+        if (!_imu.batchsampler.doing_sensor_rate_logging()) {
+            _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
+        }
     }
 }
 
@@ -319,13 +321,20 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     log_accel_raw(instance, sample_us, accel);
 }
 
-void AP_InertialSensor_Backend::_notify_new_accel_fast_sample(uint8_t instance, const Vector3f &accel)
+void AP_InertialSensor_Backend::_notify_new_accel_sensor_rate_sample(uint8_t instance, const Vector3f &accel)
 {
+    if (!_imu.batchsampler.doing_sensor_rate_logging()) {
+        return;
+    }
+
     _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, AP_HAL::micros64(), accel);
 }
 
-void AP_InertialSensor_Backend::_notify_new_gyro_fast_sample(uint8_t instance, const Vector3f &gyro)
+void AP_InertialSensor_Backend::_notify_new_gyro_sensor_rate_sample(uint8_t instance, const Vector3f &gyro)
 {
+    if (!_imu.batchsampler.doing_sensor_rate_logging()) {
+        return;
+    }
     _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, AP_HAL::micros64(), gyro);
 }
 
@@ -348,7 +357,9 @@ void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t s
         };
         dataflash->WriteBlock(&pkt, sizeof(pkt));
     } else {
-        //_imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);
+        if (!_imu.batchsampler.doing_sensor_rate_logging()) {
+            _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);
+        }
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -226,7 +226,7 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
         };
         dataflash->WriteBlock(&pkt, sizeof(pkt));
     } else {
-        _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
+        //_imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, sample_us, gyro);
     }
 }
 
@@ -319,6 +319,16 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     log_accel_raw(instance, sample_us, accel);
 }
 
+void AP_InertialSensor_Backend::_notify_new_accel_fast_sample(uint8_t instance, const Vector3f &accel)
+{
+    _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, AP_HAL::micros64(), accel);
+}
+
+void AP_InertialSensor_Backend::_notify_new_gyro_fast_sample(uint8_t instance, const Vector3f &gyro)
+{
+    _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_GYRO, AP_HAL::micros64(), gyro);
+}
+
 void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel)
 {
     DataFlash_Class *dataflash = DataFlash_Class::instance();
@@ -338,7 +348,7 @@ void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t s
         };
         dataflash->WriteBlock(&pkt, sizeof(pkt));
     } else {
-        _imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);
+        //_imu.batchsampler.sample(instance, AP_InertialSensor::IMU_SENSOR_TYPE_ACCEL, sample_us, accel);
     }
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -225,6 +225,9 @@ protected:
         return (_imu._fast_sampling_mask & (1U<<instance)) != 0;
     }
 
+    void _notify_new_accel_fast_sample(uint8_t instance, const Vector3f &accel);
+    void _notify_new_gyro_fast_sample(uint8_t instance, const Vector3f &gyro);
+
     /*
       notify of a FIFO reset so we don't use bad data to update observed sensor rate
     */

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -104,7 +104,7 @@ public:
         DEVTYPE_GYR_LSM9DS1  = 0x26,
         DEVTYPE_INS_ICM20789 = 0x27
     };
-        
+
 protected:
     // access to frontend
     AP_InertialSensor &_imu;
@@ -142,9 +142,35 @@ protected:
 
     // set the amount of oversamping a gyro is doing
     void _set_gyro_oversampling(uint8_t instance, uint8_t n);
-    
+
+    // indicate the backend is doing sensor-rate sampling for this accel
+    void _set_accel_sensor_rate_sampling_enabled(uint8_t instance, bool value) {
+        const uint8_t bit = (1<<instance);
+        if (value) {
+            _imu._accel_sensor_rate_sampling_enabled |= bit;
+        } else {
+            _imu._accel_sensor_rate_sampling_enabled &= ~bit;
+        }
+    }
+
+    void _set_gyro_sensor_rate_sampling_enabled(uint8_t instance, bool value) {
+        const uint8_t bit = (1<<instance);
+        if (value) {
+            _imu._gyro_sensor_rate_sampling_enabled |= bit;
+        } else {
+            _imu._gyro_sensor_rate_sampling_enabled &= ~bit;
+        }
+    }
+
+    void _set_raw_sample_accel_multiplier(uint8_t instance, uint16_t mul) {
+        _imu._accel_raw_sampling_multiplier[instance] = mul;
+    }
+    void _set_raw_sampl_gyro_multiplier(uint8_t instance, uint16_t mul) {
+        _imu._gyro_raw_sampling_multiplier[instance] = mul;
+    }
+
     // update the sensor rate for FIFO sensors
-    void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz);
+    void _update_sensor_rate(uint16_t &count, uint32_t &start_us, float &rate_hz) const;
     
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
@@ -225,8 +251,10 @@ protected:
         return (_imu._fast_sampling_mask & (1U<<instance)) != 0;
     }
 
-    void _notify_new_accel_fast_sample(uint8_t instance, const Vector3f &accel);
-    void _notify_new_gyro_fast_sample(uint8_t instance, const Vector3f &gyro);
+    // called by subclass when data is received from the sensor, thus
+    // at the 'sensor rate'
+    void _notify_new_accel_sensor_rate_sample(uint8_t instance, const Vector3f &accel);
+    void _notify_new_gyro_sensor_rate_sample(uint8_t instance, const Vector3f &gyro);
 
     /*
       notify of a FIFO reset so we don't use bad data to update observed sensor rate

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -254,7 +254,11 @@ void AP_InertialSensor_Invensense::start()
     // update backend sample rate
     _set_accel_raw_sample_rate(_accel_instance, _backend_rate_hz);
     _set_gyro_raw_sample_rate(_gyro_instance, _backend_rate_hz);
-      
+
+    // indicate what multiplier is appropriate for the sensors'
+    // readings to fit them into an int16_t:
+    _set_raw_sample_accel_multiplier(_accel_instance, multiplier_accel);
+
     if (_fast_sampling) {
         hal.console->printf("MPU[%u]: enabled fast sampling rate %uHz/%uHz\n",
                             _accel_instance, _backend_rate_hz*_fifo_downsample_rate, _backend_rate_hz);
@@ -433,7 +437,7 @@ bool AP_InertialSensor_Invensense::_accumulate(uint8_t *samples, uint8_t n_sampl
   gives very good aliasing rejection at frequencies well above what
   can be handled with 1kHz sample rates.
  */
-bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples)
+bool AP_InertialSensor_Invensense::_accumulate_sensor_rate_sampling(uint8_t *samples, uint8_t n_samples)
 {
     int32_t tsum = 0;
     const int32_t clip_limit = AP_INERTIAL_SENSOR_ACCEL_CLIP_THRESH_MSS / _accel_scale;
@@ -465,7 +469,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
             }
             _accum.accel += _accum.accel_filter.apply(a);
             Vector3f a2 = a * _accel_scale;
-            _notify_new_accel_fast_sample(_accel_instance, a2);
+            _notify_new_accel_sensor_rate_sample(_accel_instance, a2);
         }
 
         Vector3f g(int16_val(data, 5),
@@ -473,7 +477,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
                    -int16_val(data, 6));
 
         Vector3f g2 = g * GYRO_SCALE;
-        _notify_new_gyro_fast_sample(_gyro_instance, g2);
+        _notify_new_gyro_sensor_rate_sample(_gyro_instance, g2);
 
         _accum.gyro += _accum.gyro_filter.apply(g);
         _accum.count++;
@@ -573,7 +577,7 @@ void AP_InertialSensor_Invensense::_read_fifo()
         }
 
         if (_fast_sampling) {
-            if (!_accumulate_fast_sampling(rx, n)) {
+            if (!_accumulate_sensor_rate_sampling(rx, n)) {
                 debug("IMU[%u] stop at %u of %u", _accel_instance, n_samples, bytes_read/MPU_SAMPLE_SIZE);
                 break;
             }
@@ -668,6 +672,9 @@ void AP_InertialSensor_Invensense::_set_filter_register(void)
             // for logging purposes set the oversamping rate
             _set_accel_oversampling(_accel_instance, _fifo_downsample_rate/2);
             _set_gyro_oversampling(_gyro_instance, _fifo_downsample_rate);
+
+            _set_accel_sensor_rate_sampling_enabled(_accel_instance, true);
+            _set_gyro_sensor_rate_sampling_enabled(_gyro_instance, true);
 
             /* set divider for internal sample rate to 0x1F when fast
              sampling enabled. This reduces the impact of the slave

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -464,11 +464,16 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
                 clipped = true;
             }
             _accum.accel += _accum.accel_filter.apply(a);
+            Vector3f a2 = a * _accel_scale;
+            _notify_new_accel_fast_sample(_accel_instance, a2);
         }
 
         Vector3f g(int16_val(data, 5),
                    int16_val(data, 4),
                    -int16_val(data, 6));
+
+        Vector3f g2 = g * GYRO_SCALE;
+        _notify_new_gyro_fast_sample(_gyro_instance, g2);
 
         _accum.gyro += _accum.gyro_filter.apply(g);
         _accum.count++;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -64,7 +64,12 @@ public:
         Invensense_ICM20602,
         Invensense_ICM20789,
     };
-    
+
+    // acclerometers on Invensense sensors will return values up to
+    // 24G, but they are not guaranteed to be remotely linear past
+    // 16G
+    const uint16_t multiplier_accel = INT16_MAX/(26*GRAVITY_MSS);
+
 private:
     AP_InertialSensor_Invensense(AP_InertialSensor &imu,
                               AP_HAL::OwnPtr<AP_HAL::Device> dev,
@@ -95,7 +100,7 @@ private:
     void _register_write(uint8_t reg, uint8_t val, bool checked=false);
 
     bool _accumulate(uint8_t *samples, uint8_t n_samples);
-    bool _accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples);
+    bool _accumulate_sensor_rate_sampling(uint8_t *samples, uint8_t n_samples);
 
     bool _check_raw_temp(int16_t t2);
 
@@ -137,8 +142,8 @@ private:
     uint8_t *_fifo_buffer;
 
     /*
-      accumulators for fast sampling
-      See description in _accumulate_fast_sampling()
+      accumulators for sensor_rate sampling
+      See description in _accumulate_sensor_rate_sampling()
     */
     struct {
         Vector3f accel;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Revo.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Revo.cpp
@@ -430,14 +430,14 @@ bool AP_InertialSensor_Revo::_accumulate(uint8_t *samples, uint8_t n_samples)
 }
 
 /*
-  when doing fast sampling the sensor gives us 8k samples/second. Every 2nd accel sample is a duplicate.
+  when doing sensor-rate sampling the sensor gives us 8k samples/second. Every 2nd accel sample is a duplicate.
 
   To filter this we first apply a 1p low pass filter at 188Hz, then we
   average over 8 samples to bring the data rate down to 1kHz. This
   gives very good aliasing rejection at frequencies well above what
   can be handled with 1kHz sample rates.
  */
-bool AP_InertialSensor_Revo::_accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples)
+bool AP_InertialSensor_Revo::_accumulate_sensor_rate_sampling(uint8_t *samples, uint8_t n_samples)
 {
     int32_t tsum = 0;
     const int32_t clip_limit = AP_INERTIAL_SENSOR_ACCEL_CLIP_THRESH_MSS / _accel_scale;
@@ -557,7 +557,7 @@ void AP_InertialSensor_Revo::_read_fifo()
 
 
         if (_fast_sampling) {
-            if (!_accumulate_fast_sampling(rx, 1)) {
+            if (!_accumulate_sensor_rate_sampling(rx, 1)) {
 //                debug("stop at %u of %u", n_samples, bytes_read/MPU_SAMPLE_SIZE);
                 // break;  don't break before all items in queue will be readed
                 continue;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Revo.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Revo.h
@@ -109,7 +109,7 @@ private:
     void _register_write(uint8_t reg, uint8_t val, bool checked=false);
 
     bool _accumulate(uint8_t *samples, uint8_t n_samples);
-    bool _accumulate_fast_sampling(uint8_t *samples, uint8_t n_samples);
+    bool _accumulate_sensor_rate_sampling(uint8_t *samples, uint8_t n_samples);
 
     bool _check_raw_temp(int16_t t2);
 
@@ -149,7 +149,7 @@ private:
 
     /*
       accumulators for fast sampling
-      See description in _accumulate_fast_sampling()
+      See description in _accumulate_sensor_rate_sampling()
     */
     struct {
         Vector3f accel;

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -18,6 +18,13 @@ const AP_Param::GroupInfo AP_InertialSensor::BatchSampler::var_info[] = {
     // @Bitmask: 0:IMU1,1:IMU2,2:IMU3
     AP_GROUPINFO("BAT_MASK",  2, AP_InertialSensor::BatchSampler, _sensor_mask,   DEFAULT_IMU_LOG_BAT_MASK),
 
+    // @Param: BAT_RAW
+    // @DisplayName: Enable raw batch logging
+    // @Description: This allows 4kHz IMU logging on supported sensors
+    // @User: Advanced
+    // @Values: 0:Disabled,1:Enabled
+    AP_GROUPINFO("BAT_RAW",  3, AP_InertialSensor::BatchSampler, _batch_raw, 0),
+    
     AP_GROUPEND
 };
 
@@ -135,10 +142,10 @@ void AP_InertialSensor::BatchSampler::push_data_to_log()
         float sample_rate = 0; // avoid warning about uninitialised values
         switch(type) {
         case IMU_SENSOR_TYPE_GYRO:
-            sample_rate = _imu._gyro_raw_sample_rates[instance];
+            sample_rate = _imu._gyro_raw_sample_rates[instance] * 8;
             break;
         case IMU_SENSOR_TYPE_ACCEL:
-            sample_rate = _imu._accel_raw_sample_rates[instance];
+            sample_rate = _imu._accel_raw_sample_rates[instance] * 4;
             break;
         }
         if (!dataflash->Log_Write_ISBH(isb_seqnum,


### PR DESCRIPTION
Typically our sensors down-sample the data coming from the sensor before feeding it into the frontend for further processing.  This feeding is usually done at 1kHz, and that was the sample rate used by the existing BatchSampling implementation.

This PR adds the facility for a backend to provide data to the BatchSampler at its sensor-rate.  Currently this is only implemented on the InvenSense IMUs, but this allows them to log data at their full sensor rate - 8kHz gyros and 4kHz accelerometers.

Having this data will allow builders to resolve vibration issues more readily, in addition to making cool-looking graphs.

This is a pair of commits; tridge's initial hackery and my cleanups and generalisations.
