### PR TITLE
Run battery checks in AP_BattMonitor

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -414,13 +414,6 @@ bool AP_Arming::battery_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BATTERY)) {
 
-        if (AP_Notify::flags.failsafe_battery) {
-            if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Battery failsafe on");
-            }
-            return false;
-        }
-
         for (uint8_t i = 0; i < _battery.num_instances(); i++) {
             if ((_min_voltage[i] > 0.0f) && (_battery.voltage(i) < _min_voltage[i])) {
                 if (report) {
@@ -432,6 +425,8 @@ bool AP_Arming::battery_checks(bool report)
                 return false;
             }
         }
+
+        return AP::battery().extended_arming_checks(report);
      }
     return true;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -164,6 +164,9 @@ public:
     float get_resistance() const { return get_resistance(AP_BATT_PRIMARY_INSTANCE); }
     float get_resistance(uint8_t instance) const { return state[instance].resistance; }
 
+    // battery arming checks
+    bool extended_arming_checks(bool report) const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -9,8 +9,9 @@ extern const AP_HAL::HAL& hal;
 /// Constructor
 AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
                                              AP_BattMonitor::BattMonitor_State &mon_state,
-                                             AP_BattMonitor_Params &params) :
-    AP_BattMonitor_Backend(mon, mon_state, params)
+                                             AP_BattMonitor_Params &params,
+                                             uint8_t instance) :
+    AP_BattMonitor_Backend(mon, mon_state, params, instance)
 {
     _volt_pin_analog_source = hal.analogin->channel(_params._volt_pin);
     _curr_pin_analog_source = hal.analogin->channel(_params._curr_pin);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -116,7 +116,7 @@ class AP_BattMonitor_Analog : public AP_BattMonitor_Backend
 public:
 
     /// Constructor
-    AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
+    AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params, uint8_t instance);
 
     /// Read the battery voltage and current.  Should be called at 10hz
     void read();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -22,7 +22,7 @@ class AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
+    AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params, uint8_t instance);
 
     // we declare a virtual destructor so that BattMonitor driver can
     // override with a custom destructor if need be
@@ -53,10 +53,13 @@ public:
     virtual void handle_bi_msg(float voltage, float current,
             float temperature) {}
 
+    bool extended_arming_checks(bool report) const;
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)
     AP_BattMonitor_Params               &_params;   // reference to this instances parameters (held in the front-end)
+    uint8_t                              _instance; // what instance this battery monitor is
 
 private:
     // resistance estimate

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
@@ -22,8 +22,8 @@ class AP_BattMonitor_Bebop :public AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_Bebop(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params):
-        AP_BattMonitor_Backend(mon, mon_state, params),
+    AP_BattMonitor_Bebop(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params, uint8_t instance):
+        AP_BattMonitor_Backend(mon, mon_state, params, instance),
         _prev_vbat_raw(0.0f),
         _prev_vbat(0.0f),
         _battery_voltage_max(0.0f)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -5,8 +5,9 @@
 AP_BattMonitor_SMBus::AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                                            AP_BattMonitor::BattMonitor_State &mon_state,
                                            AP_BattMonitor_Params &params,
+                                           uint8_t instance,
                                            AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-        : AP_BattMonitor_Backend(mon, mon_state, params),
+        : AP_BattMonitor_Backend(mon, mon_state, params, instance),
         _dev(std::move(dev))
 {
     _params._serial_number = AP_BATT_SERIAL_NUMBER_DEFAULT;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -32,6 +32,7 @@ public:
     AP_BattMonitor_SMBus(AP_BattMonitor &mon,
                     AP_BattMonitor::BattMonitor_State &mon_state,
                     AP_BattMonitor_Params &params,
+                    uint8_t instance,
                     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // virtual destructor to reduce compiler warnings

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.cpp
@@ -34,8 +34,9 @@ uint8_t maxell_cell_ids[] = { 0x3f,  // cell 1
 AP_BattMonitor_SMBus_Maxell::AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
                                                    AP_BattMonitor_Params &params,
+                                                   uint8_t instance,
                                                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev))
+    : AP_BattMonitor_SMBus(mon, mon_state, params, instance, std::move(dev))
 {}
 
 void AP_BattMonitor_SMBus_Maxell::timer()

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Maxell.h
@@ -14,6 +14,7 @@ public:
     AP_BattMonitor_SMBus_Maxell(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_BattMonitor_Params &params,
+                             uint8_t instance,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
 private:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -29,8 +29,9 @@
 AP_BattMonitor_SMBus_Solo::AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                                                    AP_BattMonitor::BattMonitor_State &mon_state,
                                                    AP_BattMonitor_Params &params,
+                                                   uint8_t instance,
                                                    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
-    : AP_BattMonitor_SMBus(mon, mon_state, params, std::move(dev))
+    : AP_BattMonitor_SMBus(mon, mon_state, params, instance, std::move(dev))
 {
     _pec_supported = true;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.h
@@ -14,6 +14,7 @@ public:
     AP_BattMonitor_SMBus_Solo(AP_BattMonitor &mon,
                              AP_BattMonitor::BattMonitor_State &mon_state,
                              AP_BattMonitor_Params &params,
+                             uint8_t instance,
                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
 private:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -15,8 +15,12 @@ extern const AP_HAL::HAL& hal;
 #define debug_bm_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { printf(fmt, ##args); }} while (0)
 
 /// Constructor
-AP_BattMonitor_UAVCAN::AP_BattMonitor_UAVCAN(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, BattMonitor_UAVCAN_Type type, AP_BattMonitor_Params &params) :
-    AP_BattMonitor_Backend(mon, mon_state, params),
+AP_BattMonitor_UAVCAN::AP_BattMonitor_UAVCAN(AP_BattMonitor &mon,
+                                             AP_BattMonitor::BattMonitor_State &mon_state,
+                                             BattMonitor_UAVCAN_Type type,
+                                             AP_BattMonitor_Params &params,
+                                             uint8_t instance) :
+    AP_BattMonitor_Backend(mon, mon_state, params, instance),
     _type(type)
 {
     // starts with not healthy

--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.h
@@ -15,7 +15,11 @@ public:
     };
 
     /// Constructor
-    AP_BattMonitor_UAVCAN(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, BattMonitor_UAVCAN_Type type, AP_BattMonitor_Params &params);
+    AP_BattMonitor_UAVCAN(AP_BattMonitor &mon,
+                          AP_BattMonitor::BattMonitor_State &mon_state,
+                          BattMonitor_UAVCAN_Type type,
+                          AP_BattMonitor_Params &params,
+                          uint8_t instance);
 
     /// Read the battery voltage and current.  Should be called at 10hz
     void read() override;


### PR DESCRIPTION
The battery monitor should be responsible for running battery checks directly, as it allows backends that have more information about the battery to run more specific/appropriate checks. It also prevents having to expose a lot of internal/private battery information through the public interface.

This is needed to prevent arming if the vehicle would immediately enter a failsafe condition, (which was removed on copter, and not present on any other vehicle).

This is tagged WIP as the rest of the battery checks should move to the BattMonitor side as well and the params should live inside `AP_BattMonitor_Params` rather then in AP_Arming. (This is particularly true because at the moment this breaks the easy scaling of the number of battery instances). This is primarily waiting on me to do the param conversion code for the existing ARMING_MIN_VOLT params. The PR was sent in now though so it was being tracked for Copter 3.6.0 as it fixes a regression.