### PR TITLE
Copter: remove a few redundant calls in AltHold, FlowHold, Loiter

### DIFF
--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -8,10 +8,6 @@
 // althold_init - initialise althold controller
 bool Copter::ModeAltHold::init(bool ignore_checks)
 {
-    // initialize vertical speeds and leash lengths
-    pos_control->set_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
-    pos_control->set_accel_z(g.pilot_accel_z);
-
     // initialise position and desired velocity
     if (!pos_control->is_active_z()) {
         pos_control->set_alt_target_to_current_alt();

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -18,9 +18,6 @@ bool Copter::ModeAltHold::init(bool ignore_checks)
         pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
     }
 
-    // stop takeoff if running
-    takeoff_stop();
-
     return true;
 }
 

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -103,9 +103,6 @@ bool Copter::ModeFlowHold::init(bool ignore_checks)
     quality_filtered = 0;
     flow_pi_xy.reset_I();
     limited = false;
-    
-    // stop takeoff if running
-    copter.takeoff_stop();
 
     flow_pi_xy.set_dt(1.0/copter.scheduler.get_loop_rate_hz());
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -12,10 +12,6 @@ bool Copter::ModeLoiter::init(bool ignore_checks)
         // set target to current position
         wp_nav->init_loiter_target();
 
-        // initialize vertical speed and acceleration
-        pos_control->set_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
-        pos_control->set_accel_z(g.pilot_accel_z);
-
         // initialise position and desired velocity
         if (!pos_control->is_active_z()) {
             pos_control->set_alt_target_to_current_alt();


### PR DESCRIPTION
These are just changes to remove redundant initialisation calls:

- AltHold and Loiter call "pos_control->set_speed_z" and "pos_control->set_accel_z" in both the init and run methods.  No need to be in both places because nothing else in the mode's init relies on these.
- AltHold and FlowHold include a call to "stop_takeoff" but this is already done inside exit_mode().