### PR TITLE
AC_AttitudeControl: Prevent DCM fallback from triggering a flyaway

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1185,7 +1185,7 @@ void AC_PosControl::check_for_ekf_z_reset()
     // check for position shift
     float alt_shift;
     uint32_t reset_ms = _ahrs.getLastPosDownReset(alt_shift);
-    if (reset_ms != _ekf_z_reset_ms) {
+    if (reset_ms != 0 && reset_ms != _ekf_z_reset_ms) {
         shift_alt_target(-alt_shift * 100.0f);
         _ekf_z_reset_ms = reset_ms;
     }


### PR DESCRIPTION
Plane can fallback to DCM, which will cause `_ahrs.getLastPosDownReset(alt_shift);` to return 0 and not fill in alt_shift. If the vehicle started with the EKF the comparison for `reset_ms != _ekf_z_reset_ms` passes and we dereference `alt_shift` even though it's garbage on the stack. Simplest fix is to special case that returning 0 (which is what happens when an AHRS doesn't implement the method) is invalid.

This really indicates however that we should not be using timestamps, as the uint32_t will eventually overflow.

Large thanks to clang's static analysis for finding this.