### PR TITLE
AP_HAL_SITL: Protect against nullpointer dereference

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -492,8 +492,9 @@ void SITL_State::set_height_agl(void)
     }
 
 #if AP_TERRAIN_AVAILABLE
-    if (_terrain &&
-            _sitl->terrain_enable) {
+    if (_terrain != nullptr &&
+        _sitl != nullptr &&
+        _sitl->terrain_enable) {
         // get height above terrain from AP_Terrain. This assumes
         // AP_Terrain is working
         float terrain_height_amsl;
@@ -508,8 +509,10 @@ void SITL_State::set_height_agl(void)
     }
 #endif
 
-    // fall back to flat earth model
-    _sitl->height_agl = _sitl->state.altitude - home_alt;
+    if (_sitl != nullptr) {
+        // fall back to flat earth model
+        _sitl->height_agl = _sitl->state.altitude - home_alt;
+    }
 }
 
 #endif


### PR DESCRIPTION
This was found by static analysis. It's a bit of a silly one as if we don't have a `_sitl` pointer a lot is going to be not terribly useful in SITL. However, we have extensive checks elsewhere that handle if `_sitl` is nullptr already which implies there is a use case where it could be nullptr that I can't think of. 