### PR TITLE
Rover: improve pivot turns

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -316,21 +316,20 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
     rover.nav_controller->set_reverse(reversed);
     rover.nav_controller->update_waypoint(origin, destination);
     float desired_lat_accel = rover.nav_controller->lateral_acceleration();
+    float desired_heading = rover.nav_controller->target_bearing_cd();
     if (reversed) {
-        _yaw_error_cd = wrap_180_cd(rover.nav_controller->target_bearing_cd() - ahrs.yaw_sensor + 18000);
+        _yaw_error_cd = wrap_180_cd(desired_heading - ahrs.yaw_sensor + 18000);
     } else {
-        _yaw_error_cd = wrap_180_cd(rover.nav_controller->target_bearing_cd() - ahrs.yaw_sensor);
-    }
-    if (rover.use_pivot_steering(_yaw_error_cd)) {
-        if (_yaw_error_cd >= 0.0f) {
-            desired_lat_accel = g.turn_max_g * GRAVITY_MSS;
-        } else {
-            desired_lat_accel = -g.turn_max_g * GRAVITY_MSS;
-        }
+        _yaw_error_cd = wrap_180_cd(desired_heading - ahrs.yaw_sensor);
     }
 
-    // call lateral acceleration to steering controller
-    calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
+    if (rover.use_pivot_steering(_yaw_error_cd)) {
+        // for pivot turns use heading controller
+        calc_steering_to_heading(desired_heading, reversed);
+    } else {
+        // call lateral acceleration to steering controller
+        calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
+    }
 }
 
 /*

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -314,7 +314,7 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
     // negative error = left turn
     // positive error = right turn
     rover.nav_controller->set_reverse(reversed);
-    rover.nav_controller->update_waypoint(origin, destination);
+    rover.nav_controller->update_waypoint(origin, destination, g.waypoint_radius);
     float desired_lat_accel = rover.nav_controller->lateral_acceleration();
     float desired_heading = rover.nav_controller->target_bearing_cd();
     if (reversed) {

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -354,8 +354,7 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
 void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
 {
     // calculate yaw error (in radians) and pass to steering angle controller
-    const float yaw_error = wrap_PI(radians((desired_heading_cd - ahrs.yaw_sensor) * 0.01f));
-    const float steering_out = attitude_control.get_steering_out_angle_error(yaw_error, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
 

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -66,6 +66,7 @@ known_units = {
 # angle
              'deg'     : 'degrees'               ,     # Not SI, but is some situations more user-friendly than radians
              'deg/s'   : 'degrees per second'    ,     # Not SI, but is some situations more user-friendly than radians
+             'deg/s/s' : 'degrees per square second',  # Not SI, but is some situations more user-friendly than radians
              'cdeg'    : 'centidegrees'          ,     # Not SI, but is some situations more user-friendly than radians
              'cdeg/s'  : 'centidegrees per second',    # Not SI, but is some situations more user-friendly than radians
              'cdeg/s/s': 'centidegrees per square second' , # Not SI, but is some situations more user-friendly than radians

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -206,11 +206,14 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool s
     return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
 }
 
-// return a steering servo output from -1 to +1 given a yaw error in radians
-float AR_AttitudeControl::get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
+// return a steering servo output from -1 to +1 given a heading in radians
+float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
+    // calculate heading error (in radians)
+    const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
+
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
-    const float desired_rate = _steer_angle_p.get_p(angle_err);
+    const float desired_rate = _steer_angle_p.get_p(yaw_error);
 
     return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
 }

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -47,8 +47,8 @@ public:
     // positive lateral acceleration is to the right.
     float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
-    // return a steering servo output from -1 to +1 given an angle error in radians
-    float get_steering_out_angle_error(float angle_err, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    // return a steering servo output from -1 to +1 given a heading in radians
+    float get_steering_out_heading(float heading_rad, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
     // return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -13,6 +13,8 @@
 #define AR_ATTCONTROL_STEER_RATE_IMAX   1.00f
 #define AR_ATTCONTROL_STEER_RATE_D      0.00f
 #define AR_ATTCONTROL_STEER_RATE_FILT   50.00f
+#define AR_ATTCONTROL_STEER_RATE_MAX    360.0f
+#define AR_ATTCONTROL_STEER_ACCEL_MAX   360.0f
 #define AR_ATTCONTROL_THR_SPEED_P       0.20f
 #define AR_ATTCONTROL_THR_SPEED_I       0.20f
 #define AR_ATTCONTROL_THR_SPEED_IMAX    1.00f
@@ -110,6 +112,8 @@ private:
     AP_Float _throttle_accel_max;   // speed/throttle control acceleration (and deceleration) maximum in m/s/s.  0 to disable limits
     AP_Int8  _brake_enable;         // speed control brake enable/disable. if set to 1 a reversed output to the motors to slow the vehicle.
     AP_Float _stop_speed;           // speed control stop speed.  Motor outputs to zero once vehicle speed falls below this value
+    AP_Float _steer_accel_max;      // steering angle acceleration max in deg/s/s
+    AP_Float _steer_rate_max;       // steering rate control maximum rate in deg/s
 
     // steering control
     uint32_t _steer_lat_accel_last_ms;  // system time of last call to lateral acceleration controller (i.e. get_steering_out_lat_accel)

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -195,7 +195,7 @@ void AP_L1_Control::_prevent_indecision(float &Nu)
 }
 
 // update L1 control for waypoint navigation
-void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct Location &next_WP)
+void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min)
 {
 
     struct Location _current_loc;
@@ -238,7 +238,7 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
     // Calculate time varying control parameters
     // Calculate the L1 length required for specified period
     // 0.3183099 = 1/1/pipi
-    _L1_dist = 0.3183099f * _L1_damping * _L1_period * groundSpeed;
+    _L1_dist = MAX(0.3183099f * _L1_damping * _L1_period * groundSpeed, dist_min);
 
     // Calculate the NE position of WP B relative to WP A
     Vector2f AB = location_diff(prev_WP, next_WP);

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -50,7 +50,7 @@ public:
     float turn_distance(float wp_radius) const;
     float turn_distance(float wp_radius, float turn_angle) const;
     float loiter_radius (const float loiter_radius) const;
-    void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP);
+    void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min = 0.0f);
     void update_loiter(const struct Location &center_WP, float radius, int8_t loiter_direction);
     void update_heading_hold(int32_t navigation_heading_cd);
     void update_level_flight(void);

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -67,7 +67,7 @@ public:
     // main flight code will call an output function (such as
     // nav_roll_cd()) after this function to ask for the new required
     // navigation attitude/steering.
-    virtual void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP) = 0;
+    virtual void update_waypoint(const struct Location &prev_WP, const struct Location &next_WP, float dist_min = 0.0f) = 0;
 
     // update the internal state of the navigation controller for when
     // the vehicle has been commanded to circle about a point.  This


### PR DESCRIPTION
This PR improves skid-steering rover's pivot turns in a few ways:

1. reduces the chance of I-term build-up in the steering turn rate control by allowing the user to specify turn rate limits and turn-rate acceleration limits to match the physical limits of their vehicle.
2. pivot turns now use the heading controller instead of the lateral acceleration controller to rotate the vehicle around to the desired heading.  This performs better because the vehicle's turn rate slows as it reaches the target heading while before the TURN_MAX_G (i.e. vehicle's maximum acceleration) was simply blasted into the controllers until the vehicle got within 10deg of the target heading.
3. the L1 controller accepts a minimum distance along the track for the L1_dist ([see wiki page here](http://ardupilot.org/dev/docs/rover-L1.html#l1-controller)).  This reduces the sharp turns requested by the L1 controller in cases where the vehicle is nearly stopped as it begins towards the next waypoint.

I have been running these changes on my Rover and Boat for the past few weeks.  I've also tested in SITL on a simple square mission (see image directly below) and the resulting desired-turn-rate is also shown below.
![pivot-turn-mission](https://user-images.githubusercontent.com/1498098/38160369-95373146-34f7-11e8-8803-d9beafcc89e6.png)
![pivot-turn-test](https://user-images.githubusercontent.com/1498098/38160371-98f14fba-34f7-11e8-94ad-f243dd14de40.png)


