### PR TITLE
Rover: use MOT_THR_MIN as deadzone

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -472,7 +472,7 @@ void AP_MotorsUGV::slew_limit_throttle(float dt)
 {
     if (_slew_rate > 0) {
         // slew throttle
-        const float throttle_change_max = MAX(1.0f, _slew_rate * dt * 0.01f * (_throttle_max - _throttle_min));
+        const float throttle_change_max = MAX(1.0f, (float)_slew_rate * dt);
         if (_throttle > _throttle_prev + throttle_change_max) {
             _throttle = _throttle_prev + throttle_change_max;
             limit.throttle_upper = true;


### PR DESCRIPTION
This PR improves the usefulness of the MOT_THR_MIN parameter by allowing it to be used to set a deadzone for the motor outputs.

Master currently uses this as the minimum value it will output to the motors.  So for example if the MOT_THR_MIN value is 20 (meaning 20%) a requested throttle between 0% to 20% will all result in an output of 20%.  This is not good especially for the speed controllers that are not aware of this deadzone. 

The new behaviour hides this deadzone from upper levels.  So a throttle request of 0% results in a throttle output of 0 (i.e. SERVOx_TRIM) and any non-zero throttle request results in an output which is linearly interpolated between the MOT_THR_MIN value and 100%.

![mot-thr-min-as-dz](https://user-images.githubusercontent.com/1498098/38160500-2ebd0b5e-34fa-11e8-8023-406b3e5a7174.png)

Some additional changes/comments:

- the throttle slewing (AP_motorsUGV::slew_limit_throttle() using the MOT_THR_SLEW parameter) is limiting the change in throttle *input* into the AR_MotorsUGV library.  In master the slew is being scaled by the MOT_THR_MIN/MAX values which are the throttle *output* ranges.  I think this is inconsistent so I've removed this scaling.
- the MOT_THR_MIN applies to all motors meaning we cannot have different deadzones for each motor.  The only way to have different deadzones would be to add a SERVOx_DZ parameter which would add a ton of parameters for only a little bit of additional value.
- the potentially controversial part of this change may be the behaviour when the throttle input to the motor controller is zero.  From the MOT_THR_MIN parameter description, it seems this parameters original purpose was to stop internal combustion engines from stalling.  I personally have not seen enough ICE engine users to know if this was actually useful.  I suspect it was not actually helpful or could be accomplished equally well by setting SERVOx_TRIM values.