### PR TITLE
AP_RangeFinder: Delete unnecessary judgment

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.cpp
@@ -107,7 +107,7 @@ void AP_RangeFinder_analog::update(void)
         } else {
             dist_m = scaling / (v - offset);
         }
-        if (isinf(dist_m) || dist_m > _max_distance_cm * 0.01f) {
+        if (dist_m > _max_distance_cm * 0.01f) {
             dist_m = _max_distance_cm * 0.01f;
         }
         break;


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/8042
I think that isinf's judgment is unnecessary in this PR.