### PR TITLE
AP_Frsky_Telem: Increase rate of velandyaw messages

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -142,7 +142,7 @@ void AP_Frsky_Telem::send_SPort_Passthrough(void)
                 _passthrough.home_timer = AP_HAL::millis();
                 return;
             }
-            if ((now - _passthrough.velandyaw_timer) >= 500) {
+            if ((now - _passthrough.velandyaw_timer) >= 100) {
                 send_uint32(DIY_FIRST_ID+5, calc_velandyaw());
                 _passthrough.velandyaw_timer = AP_HAL::millis();
                 return;


### PR DESCRIPTION
This message is used for the variometer signal when the yaapu telemetry script is running but the existing 2Hz rate has too much latency. This PR increases the rate to 10Hz, resulting in a usable variometer signal.