### PR TITLE
GCS_MAVlink: vision-position-estimate support ignores message timestamp

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -431,8 +431,7 @@ private:
     void handle_vision_position_estimate(mavlink_message_t *msg);
     void handle_global_vision_position_estimate(mavlink_message_t *msg);
     void handle_att_pos_mocap(mavlink_message_t *msg);
-    void _handle_common_vision_position_estimate_data(const uint64_t usec,
-                                                      const float x,
+    void _handle_common_vision_position_estimate_data(const float x,
                                                       const float y,
                                                       const float z,
                                                       const float roll,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1873,7 +1873,7 @@ void GCS_MAVLINK::handle_vision_position_estimate(mavlink_message_t *msg)
     mavlink_vision_position_estimate_t m;
     mavlink_msg_vision_position_estimate_decode(msg, &m);
 
-    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+    _handle_common_vision_position_estimate_data(m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
 }
 
 void GCS_MAVLINK::handle_global_vision_position_estimate(mavlink_message_t *msg)
@@ -1881,7 +1881,7 @@ void GCS_MAVLINK::handle_global_vision_position_estimate(mavlink_message_t *msg)
     mavlink_global_vision_position_estimate_t m;
     mavlink_msg_global_vision_position_estimate_decode(msg, &m);
 
-    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+    _handle_common_vision_position_estimate_data(m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
 }
 
 void GCS_MAVLINK::handle_vicon_position_estimate(mavlink_message_t *msg)
@@ -1889,14 +1889,13 @@ void GCS_MAVLINK::handle_vicon_position_estimate(mavlink_message_t *msg)
     mavlink_vicon_position_estimate_t m;
     mavlink_msg_vicon_position_estimate_decode(msg, &m);
 
-    _handle_common_vision_position_estimate_data(m.usec, m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
+    _handle_common_vision_position_estimate_data(m.x, m.y, m.z, m.roll, m.pitch, m.yaw);
 }
 
 // there are several messages which all have identical fields in them.
 // This function provides common handling for the data contained in
 // these packets
-void GCS_MAVLINK::_handle_common_vision_position_estimate_data(const uint64_t usec,
-                                                               const float x,
+void GCS_MAVLINK::_handle_common_vision_position_estimate_data(const float x,
                                                                const float y,
                                                                const float z,
                                                                const float roll,
@@ -1915,7 +1914,7 @@ void GCS_MAVLINK::_handle_common_vision_position_estimate_data(const uint64_t us
     attitude.from_euler(roll, pitch, yaw); // from_vector312?
     const float posErr = 0; // parameter required?
     const float angErr = 0; // parameter required?
-    const uint32_t timestamp_ms = usec * 0.001;
+    const uint32_t timestamp_ms = AP_HAL::millis();
     const uint32_t reset_timestamp_ms = 0; // no data available
 
     AP::ahrs().writeExtNavData(sensor_offset,
@@ -1942,7 +1941,7 @@ void GCS_MAVLINK::handle_att_pos_mocap(mavlink_message_t *msg)
     Quaternion attitude = Quaternion(m.q);
     const float posErr = 0; // parameter required?
     const float angErr = 0; // parameter required?
-    const uint32_t timestamp_ms = m.time_usec * 0.001;
+    const uint32_t timestamp_ms = AP_HAL::millis();
     const uint32_t reset_timestamp_ms = 0; // no data available
 
     AP::ahrs().writeExtNavData(sensor_offset,


### PR DESCRIPTION
Copter-3.6 and Rover-3.3 can consume these external position estimate messages:

- [ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP)
- [VISION_POSITION_ESTIMATE](http://mavlink.org/messages/common#VISION_POSITION_ESTIMATE)
- [VICON_POSITION_ESTIMATE](http://mavlink.org/messages/common#VICON_POSITION_ESTIMATE)
- [GLOBAL_VISION_POSITION_ESTIMATE](http://mavlink.org/messages/common#GLOBAL_VISION_POSITION_ESTIMATE)

This PR changes the time passed into the EKF so that we use the flight controller's system time at the time message arrived instead of the time provided in the message from the companion computer.  This is important because the flight controller and companion computers' clocks will not be syncronised in most cases.

It's possible that we should add a parameter to allow choosing which time is used or perhaps add a check that the time is within a couple of seconds of our system time.  I've add this possibility to [this somewhat related issue](https://github.com/ArduPilot/ardupilot/issues/8061).