### PR TITLE
AP_HAL_SITL: remove cast to signed type

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -154,7 +154,7 @@ size_t UARTDriver::write(uint8_t c)
 
 size_t UARTDriver::write(const uint8_t *buffer, size_t size)
 {
-    if (txspace() <= (ssize_t)size) {
+    if (txspace() <= size) {
         size = txspace();
     }
     if (size <= 0) {


### PR DESCRIPTION
... we're currently taking an unsigned type, casting it to a signed type
and then comparing the result of that to an unsigned type.  That's
unhealthy.