### PR TITLE
Log Mavlink stats to dataflash

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -110,7 +110,8 @@ const struct UnitStructure log_Units[] = {
     { 'P', "Pa" },            // Pascal
     { 'w', "Ohm" },           // Ohm
     { 'Y', "us" },            // pulse width modulation in microseconds
-    { 'z', "Hz" }             // Hertz
+    { 'z', "Hz" },            // Hertz
+    { '#', "instance" }       // (e.g.)Sensor instance number
 };
 
 // this multiplier information applies to the raw value present in the

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -325,6 +325,15 @@ struct PACKED log_RCOUT {
     uint16_t chan14;
 };
 
+struct PACKED log_MAV {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t chan;
+    uint16_t packet_tx_count;
+    uint16_t packet_rx_success_count;
+    uint16_t packet_rx_drop_count;
+};
+
 struct PACKED log_RSSI {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1461,6 +1470,8 @@ Format characters in the format string for binary log messages
       "RATE", "Qffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut", "skk-kk-kk-oo-", "F?????????BB-" }, \
     { LOG_RALLY_MSG, sizeof(log_Rally), \
       "RALY", "QBBLLh", "TimeUS,Tot,Seq,Lat,Lng,Alt", "s--DUm", "F--GGB" },  \
+    { LOG_MAV_MSG, sizeof(log_MAV),   \
+      "MAV", "QBHHH",   "TimeUS,chan,txp,rxp,rxdp", "s#---", "F-000" },   \
     { LOG_VISUALODOM_MSG, sizeof(log_VisualOdom), \
       "VISO", "Qffffffff", "TimeUS,dt,AngDX,AngDY,AngDZ,PosDX,PosDY,PosDZ,conf", "ssrrrmmm-", "FF000000-" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
@@ -1637,6 +1648,7 @@ enum LogMessages : uint8_t {
     LOG_OPTFLOW_MSG,
     LOG_EVENT_MSG,
     LOG_WHEELENCODER_MSG,
+    LOG_MAV_MSG,
     _LOG_LAST_MSG_
 };
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -446,6 +446,8 @@ protected:
 
 private:
 
+    void log_mavlink_stats();
+
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);
 
     virtual void        handleMessage(mavlink_message_t * msg) = 0;
@@ -687,6 +689,9 @@ private:
 
     void zero_rc_outputs();
 
+    uint8_t last_tx_seq;
+    uint16_t send_packet_count;
+
 #if GCS_DEBUG_SEND_MESSAGE_TIMINGS
     struct {
         uint32_t longest_time_us;
@@ -701,6 +706,7 @@ private:
     uint16_t max_slowdown_ms;
 #endif
 
+    uint32_t last_mavlink_stats_logged;
 };
 
 /// @class GCS


### PR DESCRIPTION
```
pbarker@bluebottle:~/rc/ardupilot/logs(gcs-stats)$ mavlogdump.py 00000002.BIN | grep MAV
2018-04-03 18:50:55.60: FMT {Type : 228, Length : 17, Name : MAV0, Format : QBBHH, Columns : TimeUS,rxseq,txseq,inp,dpp}
2018-04-03 18:50:55.60: FMT {Type : 229, Length : 17, Name : MAV1, Format : QBBHH, Columns : TimeUS,rxseq,txseq,inp,dpp}
2018-04-03 18:50:55.60: FMT {Type : 230, Length : 17, Name : MAV2, Format : QBBHH, Columns : TimeUS,rxseq,txseq,inp,dpp}
2018-04-03 18:50:55.60: FMT {Type : 231, Length : 17, Name : MAV3, Format : QBBHH, Columns : TimeUS,rxseq,txseq,inp,dpp}
2018-04-03 18:50:55.60: FMT {Type : 232, Length : 17, Name : MAV4, Format : QBBHH, Columns : TimeUS,rxseq,txseq,inp,dpp}
2018-04-03 18:50:59.76: PARM {TimeUS : 4179161, Name : SYSID_THISMAV, Value : 1.0}
2018-04-03 18:51:05.58: MAV0 {TimeUS : 10001831, rxseq : 11, txseq : 2, inp : 12, dpp : 0}
2018-04-03 18:51:05.58: MAV1 {TimeUS : 10001831, rxseq : 0, txseq : 0, inp : 0, dpp : 0}
2018-04-03 18:51:05.58: MAV2 {TimeUS : 10001831, rxseq : 0, txseq : 0, inp : 0, dpp : 0}
2018-04-03 18:51:15.58: MAV0 {TimeUS : 20004495, rxseq : 93, txseq : 21, inp : 1118, dpp : 0}
2018-04-03 18:51:15.58: MAV1 {TimeUS : 20004495, rxseq : 0, txseq : 0, inp : 0, dpp : 0}
2018-04-03 18:51:15.58: MAV2 {TimeUS : 20004495, rxseq : 0, txseq : 0, inp : 0, dpp : 0}
```

This being SITL we should only be logging one channel here.  I've raised an issue for that problem.
