### PR TITLE
Set storage directory to /edge/ardupilot for Edge board

### DIFF
--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -365,6 +365,9 @@
 #define HAL_GPIO_LED_ON           LOW
 #define HAL_GPIO_LED_OFF          HIGH
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE
+#define HAL_BOARD_LOG_DIRECTORY "/edge/ardupilot/logs"
+#define HAL_BOARD_TERRAIN_DIRECTORY "/edge/ardupilot/terrain"
+#define HAL_BOARD_STORAGE_DIRECTORY "/edge/ardupilot"
 #define HAL_INS_DEFAULT HAL_INS_EDGE
 #define HAL_INS_MPU60x0_NAME "mpu60x0"
 #define HAL_INS_MPU60x0_NAME_EXT "mpu60x0ext"


### PR DESCRIPTION
In Edge firmware v1.2 logs were moved to separate partition `/edge`.