### PR TITLE
AP_Terrain: compiler warning printing %u with signed value

### DIFF
--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -173,9 +173,9 @@ void AP_Terrain::open_file(void)
     }
     snprintf(p, 13, "/%c%02u%c%03u.DAT",
              block.lat_degrees<0?'S':'N',
-             MIN(abs((int32_t)block.lat_degrees), 99),
+             (unsigned)MIN(abs((int32_t)block.lat_degrees), 99),
              block.lon_degrees<0?'W':'E',
-             MIN(abs((int32_t)block.lon_degrees), 999));
+             (unsigned)MIN(abs((int32_t)block.lon_degrees), 999));
 
     // create directory if need be
     if (!directory_created) {


### PR DESCRIPTION
simple compiler warning for when printing %u with signed value that is a result of abs()