### PR TITLE
Added a trigger delay parameter to delay the CAMERA_FEEDBACK messages (for geotagging purposes) 

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -100,10 +100,10 @@ const AP_Param::GroupInfo AP_Camera::var_info[] = {
     AP_GROUPINFO("AUTO_ONLY",  10, AP_Camera, _auto_mode_only, 0),
 
     // @Param: TRIGG_DELAY
-    // @DisplayName: Trigger Delay for the geotag
-    // @Description: Delays the CAMERA_FEEDBACK message
-    // @user: Standard
-    // @units: cs
+    // @DisplayName: Trigger Delay for the geotag packet
+    // @Description: Delays the camera feedback message
+    // @User: Standard
+    // @Units: cs
     // @Range: 0 127
     AP_GROUPINFO("TRIGG_DELAY", 11, AP_Camera, _trigger_delay, 0),
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -72,7 +72,11 @@ public:
     // set if vehicle is in AUTO mode
     void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
 
+    // count of number of cycles after which CAMERA_FEEDBACK should be sent
+    static volatile int16_t _delay_counter;
+
 private:
+    AP_Int8         _trigger_delay;     // Delay the CAMERA_FEEDBACK packet
     AP_Int8         _trigger_type;      // 0:Servo,1:Relay
     AP_Int8         _trigger_duration;  // duration in 10ths of a second that the camera shutter is held open
     AP_Int8         _relay_on;          // relay value to trigger camera


### PR DESCRIPTION
I added a new parameter in the AP_Camera class called "Trigg_Delay" which delays the geotagging packet. Also, added support to feedback_pol such that it also sends a geotagging packet when Feedback_Pol=0. 

I also need your suggestions/advice on how to back-port these changes to Copter-3.5.5 (Stable) as I did not realize master has diverged a lot from Copter-3.5.5.