### PR TITLE
AP_HAL_ChibiOS: Remove unused priority level

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -30,7 +30,6 @@
 #define APM_UART_PRIORITY        60
 #define APM_STORAGE_PRIORITY     59
 #define APM_IO_PRIORITY          58
-#define APM_SHELL_PRIORITY       57
 #define APM_STARTUP_PRIORITY     10
 
 #ifndef APM_SPI_PRIORITY


### PR DESCRIPTION
The shell priority is unused (was just looking for a priority I could grab for scripting).