### PR TITLE
add ToneAlarm test/example for ChibiOS builds

### DIFF
--- a/libraries/AP_HAL_ChibiOS/ToneAlarm.cpp
+++ b/libraries/AP_HAL_ChibiOS/ToneAlarm.cpp
@@ -72,7 +72,7 @@ void ToneAlarm::stop()
 
 bool ToneAlarm::play()
 {
-    uint16_t cur_time = AP_HAL::millis();
+    uint32_t cur_time = AP_HAL::millis();
     if(tune_num != prev_tune_num) {
         stop();
         tune_changed = true;

--- a/libraries/AP_HAL_Linux/ToneAlarm.cpp
+++ b/libraries/AP_HAL_Linux/ToneAlarm.cpp
@@ -81,7 +81,7 @@ void ToneAlarm::stop()
 
 bool ToneAlarm::play()
 {
-    uint16_t cur_time = AP_HAL::millis();
+    uint32_t cur_time = AP_HAL::millis();
     if(tune_num != prev_tune_num){
         tune_changed = true;
         return true;


### PR DESCRIPTION
Plays each defined tune at 4 second intervals.

also fix a type error in ToneAlarm::play() which did not cause any apparent problems 
(thanks @peterbarker)

tested with fmuv3 build on mRo X2.1