### PR TITLE
AP_InertialSensor: Fix a divide by 0

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -474,7 +474,7 @@ bool AP_InertialSensor_Invensense::_accumulate_fast_sampling(uint8_t *samples, u
         _accum.count++;
 
         if (_accum.count == _fifo_downsample_rate) {
-            float ascale = _accel_scale / (_fifo_downsample_rate/2);
+            float ascale = _accel_scale / (_fifo_downsample_rate * 0.5f);
             _accum.accel *= ascale;
 
             float gscale = GYRO_SCALE / _fifo_downsample_rate;


### PR DESCRIPTION
_fifo_downsample_rate was a integer so it's doing integer math here. When it was set to 1 this always results in a divide by 0.

Spotted by Coverity, CID 261369