### PR TITLE
Allow parameters to always be saved

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1033,6 +1033,11 @@ bool AP_Param::save(bool force_save)
         return false;
     }
 
+    // always save a parameter that is marked as force save
+    if (ginfo != nullptr && (ginfo->flags & AP_PARAM_FLAG_FORCE_SAVE)) {
+        force_save = true;
+    }
+
     // if the value is the default value then don't save
     if (phdr.type <= AP_PARAM_FLOAT) {
         float v1 = cast_to_float((enum ap_var_type)phdr.type);

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -65,13 +65,16 @@
 // ignore the enable parameter on this group
 #define AP_PARAM_FLAG_IGNORE_ENABLE (1<<5)
 
+// always save this parameter
+#define AP_PARAM_FLAG_FORCE_SAVE    (1<<6)
+
 // keep all flags before the FRAME tags
 
 // vehicle and frame type flags, used to hide parameters when not
 // relevent to a vehicle type. Use AP_Param::set_frame_type_flags() to
 // enable parameters flagged in this way. frame type flags are stored
 // in flags field, shifted by AP_PARAM_FRAME_TYPE_SHIFT.
-#define AP_PARAM_FRAME_TYPE_SHIFT   6
+#define AP_PARAM_FRAME_TYPE_SHIFT   7
 
 // supported frame types for parameters
 #define AP_PARAM_FRAME_COPTER       (1<<0)

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Range: 800 2200
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("MIN",  1, RC_Channel, radio_min, 1100),
+    AP_GROUPINFO_FLAGS("MIN",  1, RC_Channel, radio_min, 1100, AP_PARAM_FLAG_FORCE_SAVE),
 
     // @Param: TRIM
     // @DisplayName: RC trim PWM
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Range: 800 2200
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("MAX",  3, RC_Channel, radio_max, 1900),
+    AP_GROUPINFO_FLAGS("MAX",  3, RC_Channel, radio_max, 1900, AP_PARAM_FLAG_FORCE_SAVE),
 
     // @Param: REVERSED
     // @DisplayName: RC reversed


### PR DESCRIPTION
This resolves an issue with copter arming checks about a channel not being configured, even though an RC calibration was preformed. (As we discard writes that were identical to the previous value). This is the workaround that I presented on the dev call. It allows the parameter flags to indicate if a parameter should always be written to storage regardless of if it's an identical value.

This patch is pleasantly small for the UX problem that it resolves.