### PR TITLE
Plane: Remove unused/legacy state structure

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -309,17 +309,6 @@ private:
     // This is used to enable the PX4IO override for testing
     bool px4io_override_enabled;
 
-    struct {
-        // These are trim values used for elevon control
-        // For elevons radio_in[CH_ROLL] and radio_in[CH_PITCH] are
-        // equivalent aileron and elevator, not left and right elevon
-        uint16_t trim1;
-        uint16_t trim2;
-        // These are used in the calculation of elevon1_trim and elevon2_trim
-        uint16_t ch1_temp;
-        uint16_t ch2_temp;
-    } elevon { 1500, 1500, 1500, 1500 };
-
     // Failsafe
     struct {
         // Used to track if the value on channel 3 (throtttle) has fallen below the failsafe threshold

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -183,25 +183,15 @@ void Plane::read_radio()
 
     failsafe.last_valid_rc_ms = millis();
 
-    elevon.ch1_temp = channel_roll->read();
-    elevon.ch2_temp = channel_pitch->read();
-    uint16_t pwm_roll, pwm_pitch;
-
-    pwm_roll = elevon.ch1_temp;
-    pwm_pitch = elevon.ch2_temp;
-
     RC_Channels::set_pwm_all();
     
     if (control_mode == TRAINING) {
         // in training mode we don't want to use a deadzone, as we
         // want manual pass through when not exceeding attitude limits
-        channel_roll->set_pwm_no_deadzone(pwm_roll);
-        channel_pitch->set_pwm_no_deadzone(pwm_pitch);
-        channel_throttle->set_pwm_no_deadzone(channel_throttle->read());
-        channel_rudder->set_pwm_no_deadzone(channel_rudder->read());
-    } else {
-        channel_roll->set_pwm(pwm_roll);
-        channel_pitch->set_pwm(pwm_pitch);
+        channel_roll->recompute_pwm_no_deadzone();
+        channel_pitch->recompute_pwm_no_deadzone();
+        channel_throttle->recompute_pwm_no_deadzone();
+        channel_rudder->recompute_pwm_no_deadzone();
     }
 
     control_failsafe();

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -122,14 +122,12 @@ RC_Channel::set_pwm(int16_t pwm)
     }
 }
 
-// read input from APM_RC - create a control_in value, but use a 
-// zero value for the dead zone. When done this way the control_in
-// value can be used as servo_out to give the same output as input
+// recompute control values with no deadzone
+// When done this way the control_in value can be used as servo_out
+// to give the same output as input
 void
-RC_Channel::set_pwm_no_deadzone(int16_t pwm)
+RC_Channel::recompute_pwm_no_deadzone()
 {
-    radio_in = pwm;
-
     if (type_in == RC_CHANNEL_TYPE_RANGE) {
         control_in = pwm_to_range_dz(0);
     } else {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -43,7 +43,7 @@ public:
 
     // read input from hal.rcin - create a control_in value
     void        set_pwm(int16_t pwm);
-    void        set_pwm_no_deadzone(int16_t pwm);
+    void        recompute_pwm_no_deadzone();
 
     // calculate an angle given dead_zone and trim. This is used by the quadplane code
     // for hover throttle


### PR DESCRIPTION
This is some old legacy code that needed the struct. We only used members in one local function. Removal saves ~32~ bytes of build size, and makes radio.cpp a lot less confusing. (I couldn't figure out why we were stashing stuff in a struct named elevon)

EDIT: Later changes saved 96 bytes as well as being more runtime efficient.