### PR TITLE
Copter: autotune fix from Leonard

### DIFF
--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -1200,9 +1200,9 @@ void Copter::ModeAutoTune::twitching_test_rate(float rate, float rate_target_max
         meas_rate_min = rate;
     }
 
-    // calculate early stopping time based on the time it takes to get to 90%
+    // calculate early stopping time based on the time it takes to get to 75%
     if (meas_rate_max < rate_target_max * 0.75f) {
-        // the measurement not reached the 90% threshold yet
+        // the measurement not reached the 75% threshold yet
         step_stop_time = step_start_time + (millis() - step_start_time) * 3.0f;
         step_stop_time = MIN(step_stop_time, step_start_time + AUTOTUNE_TESTING_STEP_TIMEOUT_MS);
     }
@@ -1253,7 +1253,7 @@ void Copter::ModeAutoTune::twitching_test_angle(float angle, float rate, float a
         meas_rate_min = rate;
     }
 
-    // calculate early stopping time based on the time it takes to get to 90%
+    // calculate early stopping time based on the time it takes to get to 75%
     if (meas_angle_max < angle_target_max * 0.75f) {
         // the measurement not reached the 75% threshold yet
         step_stop_time = step_start_time + (millis() - step_start_time) * 3.0f;

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -1255,7 +1255,7 @@ void Copter::ModeAutoTune::twitching_test_angle(float angle, float rate, float a
 
     // calculate early stopping time based on the time it takes to get to 90%
     if (meas_angle_max < angle_target_max * 0.75f) {
-        // the measurement not reached the 90% threshold yet
+        // the measurement not reached the 75% threshold yet
         step_stop_time = step_start_time + (millis() - step_start_time) * 3.0f;
         step_stop_time = MIN(step_stop_time, step_start_time + AUTOTUNE_TESTING_STEP_TIMEOUT_MS);
     }
@@ -1449,7 +1449,7 @@ void Copter::ModeAutoTune::updating_rate_p_up_d_down(float &tune_d, float tune_d
 // P is decreased to ensure we are not overshooting the target
 void Copter::ModeAutoTune::updating_angle_p_down(float &tune_p, float tune_p_min, float tune_p_step_ratio, float angle_target, float meas_angle_max, float meas_rate_min, float meas_rate_max)
 {
-    if ((meas_angle_max < angle_target*(1+0.5f*g.autotune_aggressiveness)) && (meas_rate_min > -meas_rate_max*g.autotune_aggressiveness)) {
+    if (meas_angle_max < angle_target*(1+0.5f*g.autotune_aggressiveness)) {
         if (ignore_next == false) {
             // if maximum measurement was lower than target so increment the success counter
             counter++;
@@ -1478,7 +1478,8 @@ void Copter::ModeAutoTune::updating_angle_p_down(float &tune_p, float tune_p_min
 // P is increased until we achieve our target within a reasonable time
 void Copter::ModeAutoTune::updating_angle_p_up(float &tune_p, float tune_p_max, float tune_p_step_ratio, float angle_target, float meas_angle_max, float meas_rate_min, float meas_rate_max)
 {
-    if ((meas_angle_max > angle_target*(1+0.5f*g.autotune_aggressiveness)) || (meas_rate_min < -meas_rate_max*g.autotune_aggressiveness)) {
+    if ((meas_angle_max > angle_target*(1+0.5f*g.autotune_aggressiveness)) ||
+            ((meas_angle_max > angle_target) && (meas_rate_min < -meas_rate_max*g.autotune_aggressiveness))) {
         // ignore the next result unless it is the same as this one
         ignore_next = 1;
         // if maximum measurement was greater than target so increment the success counter

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -848,9 +848,9 @@ void Copter::ModeAutoTune::autotune_attitude_control()
                     mode = SUCCESS;
                     update_gcs(AUTOTUNE_MESSAGE_SUCCESS);
                     Log_Write_Event(DATA_AUTOTUNE_SUCCESS);
-                    AP_Notify::events.autotune_complete = 1;
+                    AP_Notify::events.autotune_complete = true;
                 } else {
-                    AP_Notify::events.autotune_next_axis = 1;
+                    AP_Notify::events.autotune_next_axis = true;
                 }
                 break;
             }
@@ -1481,7 +1481,7 @@ void Copter::ModeAutoTune::updating_angle_p_up(float &tune_p, float tune_p_max, 
     if ((meas_angle_max > angle_target*(1+0.5f*g.autotune_aggressiveness)) ||
             ((meas_angle_max > angle_target) && (meas_rate_min < -meas_rate_max*g.autotune_aggressiveness))) {
         // ignore the next result unless it is the same as this one
-        ignore_next = 1;
+        ignore_next = true;
         // if maximum measurement was greater than target so increment the success counter
         counter++;
     }else{


### PR DESCRIPTION
This is a replacement for this PR: https://github.com/ArduPilot/ardupilot/pull/8141

This change fixes an issue uncovered by @WickedShell during a copter tune.  @lthall can provide details of the issue but it involves the Angle P gain dropping too low.

It also includes an unrelated change to replace "1" with "true" which was brought up during the review of the previous PR.