### PR TITLE
Rover: Allow ACRO mode without GPS

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -176,9 +176,9 @@ public:
     // attributes for mavlink system status reporting
     bool has_manual_input() const override { return true; }
 
-    // acro mode requires a velocity estimate
+    // acro mode requires a velocity estimate for non skid-steer rovers
     bool requires_position() const override { return false; }
-    bool requires_velocity() const override { return true; }
+    bool requires_velocity() const override;
 };
 
 

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -3,34 +3,41 @@
 
 void ModeAcro::update()
 {
-    // get speed forward
-    float speed;
-    if (!attitude_control.get_forward_speed(speed)) {
-        // no valid speed so stop
-        g2.motors.set_throttle(0.0f);
-        g2.motors.set_steering(0.0f);
-        return;
-    }
 
     // convert pilot stick input into desired steering and throttle
     float desired_steering, desired_throttle;
     get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
 
-    // convert pilot throttle input to desired speed
-    float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
+    // set reverse flag backing up
+    const bool reversed = is_negative(desired_throttle);
+    rover.set_reverse(reversed);
 
     // convert pilot steering input to desired turn rate in radians/sec
     const float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
 
-    // set reverse flag backing up
-    const bool reversed = is_negative(target_speed);
-    rover.set_reverse(reversed);
-
-    // apply object avoidance to desired speed using half vehicle's maximum acceleration/deceleration
-    rover.g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_accel_max(), ahrs.yaw, target_speed, rover.G_Dt);
-
     // run steering turn rate controller and throttle controller
-    const float steering_out = attitude_control.get_steering_out_rate(target_turn_rate, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    const float steering_out = attitude_control.get_steering_out_rate(
+                                                                    target_turn_rate,
+                                                                    g2.motors.have_skid_steering(),
+                                                                    g2.motors.limit.steer_left,
+                                                                    g2.motors.limit.steer_right,
+                                                                    reversed);
+
     g2.motors.set_steering(steering_out * 4500.0f);
-    calc_throttle(target_speed, false);
+
+    // get speed forward
+    float speed;
+    if (!attitude_control.get_forward_speed(speed)) {
+        // no valid speed, just use the provided throttle
+        g2.motors.set_throttle(desired_throttle);
+    } else {
+
+        // convert pilot throttle input to desired speed
+        float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
+
+        // apply object avoidance to desired speed using half vehicle's maximum acceleration/deceleration
+        rover.g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_accel_max(), ahrs.yaw, target_speed, rover.G_Dt);
+
+        calc_throttle(target_speed, false);
+    }
 }

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -41,3 +41,8 @@ void ModeAcro::update()
         calc_throttle(target_speed, false);
     }
 }
+
+bool ModeAcro::requires_velocity() const
+{
+    return g2.motors.have_skid_steering()? false: true;
+}


### PR DESCRIPTION
This PR allows using ACRO mode without a speed estimate (e.g. without GPS) on skid steer rovers. The manual input throttle is used when no speed is available. This is helpful to tune the steer rate controller in a indoor environment. 

The behavior for non skid steer rovers should not change.