### PR TITLE
EKF changes to enable rover operation without a magnetometer

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -416,10 +416,7 @@ bool NavEKF2_core::use_compass(void) const
  */
 bool NavEKF2_core::assume_zero_sideslip(void) const
 {
-    // we don't assume zero sideslip for ground vehicles as EKF could
-    // be quite sensitive to a rapid spin of the ground vehicle if
-    // traction is lost
-    return _ahrs->get_fly_forward() && _ahrs->get_vehicle_class() != AHRS_VEHICLE_GROUND;
+    return _ahrs->get_fly_forward();
 }
 
 // set the LLH location of the filters NED origin

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -175,7 +175,14 @@ void NavEKF2_core::controlMagYawReset()
 // vector from GPS. It is used to align the yaw angle after launch or takeoff.
 void NavEKF2_core::realignYawGPS()
 {
-    if ((sq(gpsDataDelayed.vel.x) + sq(gpsDataDelayed.vel.y)) > 25.0f) {
+    float spdMinSq;
+    if (_ahrs->get_vehicle_class() == AHRS_VEHICLE_GROUND) {
+        spdMinSq = sq(gpsSpdAccuracy) * GPS_SPD_TO_ERR_RATIO_SQ;
+    } else {
+        spdMinSq = 25.0f;
+    }
+
+    if ((sq(gpsDataDelayed.vel.x) + sq(gpsDataDelayed.vel.y)) > spdMinSq) {
         // get quaternion from existing filter states and calculate roll, pitch and yaw angles
         Vector3f eulerAngles;
         stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -300,7 +300,7 @@ void NavEKF2_core::detectFlight()
         onGround indicates a high certainty we are not flying and inFlight indicates a high certainty we are flying. It is possible for
         both onGround and inFlight to be false if the status is uncertain, but they cannot both be true.
 
-        If we are a plane as indicated by the assume_zero_sideslip() status, then different logic is used
+        If we are a plane or ground vehicle as indicated by the assume_zero_sideslip() status, then different logic is used
 
         TODO - this logic should be moved out of the EKF and into the flight vehicle code.
     */
@@ -312,34 +312,49 @@ void NavEKF2_core::detectFlight()
         bool highAirSpd = false;
         bool largeHgtChange = false;
 
-        // trigger at 8 m/s airspeed
-        if (_ahrs->airspeed_sensor_enabled()) {
-            const AP_Airspeed *airspeed = _ahrs->get_airspeed();
-            if (airspeed->get_airspeed() * airspeed->get_EAS2TAS() > 10.0f) {
-                highAirSpd = true;
+        if (_ahrs->get_vehicle_class() == AHRS_VEHICLE_GROUND) {
+            // trigger when velocity is statistically significant
+            float gndSpdMinSq = sq(gpsSpdAccuracy) * GPS_SPD_TO_ERR_RATIO_SQ;
+            if (gndSpdSq > gndSpdMinSq) {
+                highGndSpd = true;
             }
-        }
 
-        // trigger at 10 m/s GPS velocity, but not if GPS is reporting bad velocity errors
-        if (gndSpdSq > 100.0f && gpsSpdAccuracy < 1.0f) {
-            highGndSpd = true;
-        }
+            // Determine to a high certainty we are moving
+            if (motorsArmed && highGndSpd) {
+                airborneDetectTime_ms = imuSampleTime_ms;
+                onGround = false;
+                inFlight = true;
+            }
+        } else {
+            // trigger at 8 m/s airspeed
+            if (_ahrs->airspeed_sensor_enabled()) {
+                const AP_Airspeed *airspeed = _ahrs->get_airspeed();
+                if (airspeed->get_airspeed() * airspeed->get_EAS2TAS() > 10.0f) {
+                    highAirSpd = true;
+                }
+            }
 
-        // trigger if more than 10m away from initial height
-        if (fabsf(hgtMea) > 10.0f) {
-            largeHgtChange = true;
-        }
+            // trigger at 10 m/s GPS velocity, but not if GPS is reporting bad velocity errors
+            if (gndSpdSq > 100.0f && gpsSpdAccuracy < 1.0f) {
+                highGndSpd = true;
+            }
 
-        // Determine to a high certainty we are flying
-        if (motorsArmed && highGndSpd && (highAirSpd || largeHgtChange)) {
-            onGround = false;
-            inFlight = true;
-        }
+            // trigger if more than 10m away from initial height
+            if (fabsf(hgtMea) > 10.0f) {
+                largeHgtChange = true;
+            }
 
-        // if is possible we are in flight, set the time this condition was last detected
-        if (motorsArmed && (highGndSpd || highAirSpd || largeHgtChange)) {
-            airborneDetectTime_ms = imuSampleTime_ms;
-            onGround = false;
+            // Determine to a high certainty we are flying
+            if (motorsArmed && highGndSpd && (highAirSpd || largeHgtChange)) {
+                onGround = false;
+                inFlight = true;
+            }
+
+            // if is possible we are in flight, set the time this condition was last detected
+            if (motorsArmed && (highGndSpd || highAirSpd || largeHgtChange)) {
+                airborneDetectTime_ms = imuSampleTime_ms;
+                onGround = false;
+            }
         }
 
         // Determine to a high certainty we are not flying

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -54,6 +54,9 @@
 // mag fusion final reset altitude
 #define EKF2_MAG_FINAL_RESET_ALT 2.5f
 
+// Square of GPS speed to accuracy ratio required to pass movement checks
+#define GPS_SPD_TO_ERR_RATIO_SQ 9.0f;
+
 class AP_AHRS;
 
 class NavEKF2_core

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -461,10 +461,7 @@ bool NavEKF3_core::use_compass(void) const
  */
 bool NavEKF3_core::assume_zero_sideslip(void) const
 {
-    // we don't assume zero sideslip for ground vehicles as EKF could
-    // be quite sensitive to a rapid spin of the ground vehicle if
-    // traction is lost
-    return _ahrs->get_fly_forward() && _ahrs->get_vehicle_class() != AHRS_VEHICLE_GROUND;
+    return _ahrs->get_fly_forward();
 }
 
 // set the LLH location of the filters NED origin

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -153,7 +153,14 @@ void NavEKF3_core::realignYawGPS()
     Vector3f eulerAngles;
     stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
 
-    if ((sq(gpsDataDelayed.vel.x) + sq(gpsDataDelayed.vel.y)) > 25.0f) {
+        float spdMinSq;
+        if (_ahrs->get_vehicle_class() == AHRS_VEHICLE_GROUND) {
+            spdMinSq = sq(gpsSpdAccuracy) * GPS_SPD_TO_ERR_RATIO_SQ;
+        } else {
+            spdMinSq = 25.0f;
+        }
+
+        if ((sq(gpsDataDelayed.vel.x) + sq(gpsDataDelayed.vel.y)) > spdMinSq) {
         // calculate course yaw angle
         float velYaw = atan2f(stateStruct.velocity.y,stateStruct.velocity.x);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -64,6 +64,9 @@
 // mag fusion final reset altitude (using NED frame so altitude is negative)
 #define EKF3_MAG_FINAL_RESET_ALT 2.5f
 
+// Square of GPS speed to accuracy ratio required to pass movement checks
+#define GPS_SPD_TO_ERR_RATIO_SQ 9.0f;
+
 class AP_AHRS;
 
 class NavEKF3_core


### PR DESCRIPTION
This is work in progress to address the issuer raised here: https://discuss.ardupilot.org/t/rover-without-magnetic-compass. I am still working through the Rover code to understand how the ahrs fly forward attribute can be better set.

Thee changes should be acgive when _ahrs->get_vehicle_class() == AHRS_VEHICLE_GROUND and _ahrs->get_compass()->use_for_yaw for the selected sensorinstance  returns false.