### PR TITLE
autotest fixes

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1106,7 +1106,6 @@ class AutoTestCopter(AutoTest):
 
     def autotest(self):
         """Autotest ArduCopter in SITL."""
-        self.frame = '+'
         if not self.hasInit:
             self.init()
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -148,7 +148,6 @@ class AutoTestQuadPlane(AutoTest):
 
     def autotest(self):
         """Autotest QuadPlane in SITL."""
-        self.frame = 'quadplane'
         if not self.hasInit:
             self.init()
 


### PR DESCRIPTION
The autotest framework accepts and initializes the frame.
But copter and quadplane where overwriting that value with an hardcoded one. This removes that.