### PR TITLE
Enables relays 1-4 on Beaglebone Blue GP0 connector

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -9,27 +9,45 @@
 #include "AP_Relay.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#define RELAY1_PIN_DEFAULT 13
-#define RELAY2_PIN_DEFAULT -1
-#elif CONFIG_HAL_BOARD == HAL_BOARD_PX4
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
-#define RELAY1_PIN_DEFAULT 111
-#define RELAY2_PIN_DEFAULT -1
-#elif defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
-#define RELAY1_PIN_DEFAULT -1
-#define RELAY2_PIN_DEFAULT -1
-#else
-#define RELAY1_PIN_DEFAULT 54
-#define RELAY2_PIN_DEFAULT 55
+  #define RELAY1_PIN_DEFAULT 13
+
+ #elif CONFIG_HAL_BOARD == HAL_BOARD_PX4
+  #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
+    #define RELAY1_PIN_DEFAULT 111
+
+ #elif !defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
+   #define RELAY1_PIN_DEFAULT 54
+   #define RELAY2_PIN_DEFAULT 55
+ #endif
+
+ #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
+   #define RELAY1_PIN_DEFAULT 33
+
+ #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+  #ifdef HAL_BOARD_SUBTYPE_LINUX_BLUE
+    #define RELAY1_PIN_DEFAULT 57
+    #define RELAY2_PIN_DEFAULT 49
+    #define RELAY3_PIN_DEFAULT 116
+    #define RELAY4_PIN_DEFAULT 113
+  #endif
 #endif
-#elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-#define RELAY1_PIN_DEFAULT 33
-#define RELAY2_PIN_DEFAULT -1
-#else
-// no relay for this board
-#define RELAY1_PIN_DEFAULT -1
-#define RELAY2_PIN_DEFAULT -1
+
+#ifndef RELAY1_PIN_DEFAULT
+  #define RELAY1_PIN_DEFAULT -1
 #endif
+
+#ifndef RELAY2_PIN_DEFAULT
+  #define RELAY2_PIN_DEFAULT -1
+#endif
+
+#ifndef RELAY3_PIN_DEFAULT
+  #define RELAY3_PIN_DEFAULT -1
+#endif
+
+#ifndef RELAY4_PIN_DEFAULT
+  #define RELAY4_PIN_DEFAULT -1
+#endif
+
 
 const AP_Param::GroupInfo AP_Relay::var_info[] = {
     // @Param: PIN
@@ -51,18 +69,18 @@ const AP_Param::GroupInfo AP_Relay::var_info[] = {
     // @Description: Digital pin number for 3rd relay control.
     // @User: Standard
     // @Values: -1:Disabled,13:APM2 A9 pin,47:APM1 relay,50:Pixhawk AUXOUT1,51:Pixhawk AUXOUT2,52:Pixhawk AUXOUT3,53:Pixhawk AUXOUT4,54:Pixhawk AUXOUT5,55:Pixhawk AUXOUT6,111:PX4 FMU Relay1,112:PX4 FMU Relay2,113:PX4IO Relay1,114:PX4IO Relay2,115:PX4IO ACC1,116:PX4IO ACC2
-    AP_GROUPINFO("PIN3",  2, AP_Relay, _pin[2], -1),
+    AP_GROUPINFO("PIN3",  2, AP_Relay, _pin[2], RELAY3_PIN_DEFAULT),
 
     // @Param: PIN4
     // @DisplayName: Fourth Relay Pin
     // @Description: Digital pin number for 4th relay control.
     // @User: Standard
     // @Values: -1:Disabled,13:APM2 A9 pin,47:APM1 relay,50:Pixhawk AUXOUT1,51:Pixhawk AUXOUT2,52:Pixhawk AUXOUT3,53:Pixhawk AUXOUT4,54:Pixhawk AUXOUT5,55:Pixhawk AUXOUT6,111:PX4 FMU Relay1,112:PX4 FMU Relay2,113:PX4IO Relay1,114:PX4IO Relay2,115:PX4IO ACC1,116:PX4IO ACC2
-    AP_GROUPINFO("PIN4",  3, AP_Relay, _pin[3], -1),
+    AP_GROUPINFO("PIN4",  3, AP_Relay, _pin[3], RELAY4_PIN_DEFAULT),
 
     // @Param: DEFAULT
     // @DisplayName: Default relay state
-    // @Description: The state of the relay on boot. 
+    // @Description: The state of the relay on boot.
     // @User: Standard
     // @Values: 0:Off,1:On,2:NoChange
     AP_GROUPINFO("DEFAULT",  4, AP_Relay, _default, 0),


### PR DESCRIPTION
This pull request enables relay functionality on Beaglebone Blue.  It maps ardupilot relays 1-4 to the Beaglebone Blue GP0 connector pins GP0_3-6.