### PR TITLE
AP_HAL_ChibiOS: add f767-min board support

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/f767-min/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f767-min/hwdef.dat
@@ -1,0 +1,43 @@
+# hw definition file for processing by chibios_hwdef.py
+# for minimal F767 based board (tested with NUCLEO-F767ZI)
+
+# MCU class and specific type
+MCU STM32F7xx STM32F767xx
+
+# crystal frequency
+OSCILLATOR_HZ 8000000
+
+define STM32_LSECLK 32768U
+define STM32_LSEDRV (3U << 3U)
+define STM32_PLLSRC STM32_PLLSRC_HSE
+define STM32_PLLM_VALUE 8
+define STM32_PLLN_VALUE 432
+define STM32_PLLP_VALUE 2
+define STM32_PLLQ_VALUE 9
+
+# board ID for firmware load
+APJ_BOARD_ID 78
+
+FLASH_SIZE_KB 2048
+
+# we don't use a bootloader
+FLASH_RESERVE_START_KB 0
+
+# board voltage
+STM32_VDD 330U
+
+# order of UARTs (and USB)
+UART_ORDER OTG1
+
+PA11 OTG_FS_DM OTG1
+PA12 OTG_FS_DP OTG1
+
+PA13 JTMS-SWDIO SWD
+PA14 JTCK-SWCLK SWD
+
+define HAL_USE_EMPTY_STORAGE 1
+define HAL_STORAGE_SIZE 16384
+
+define HAL_COMPASS_DEFAULT HAL_COMPASS_NONE
+define HAL_INS_DEFAULT HAL_INS_NONE
+define HAL_BARO_DEFAULT HAL_BARO_NONE


### PR DESCRIPTION
Add f767-min board support. Tested with NUCLEO-F767ZI.