### PR TITLE
Plane: Quadplane flight modes pitch trim

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -358,7 +358,16 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Range: 1 5
     // @User: Standard
     AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 5),
-	
+
+    // @Param: TRIM_PIT
+    // @DisplayName: Quadplane AHRS trim pitch
+    // @Description: Compensates for the pitch angle trim difference between forward and vertical flight pitch, NOTE! this is relative to forward flight trim not mounting locaiton
+    // @Units: deg
+    // @Range: -180 +180
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("TRIM_PIT", 4, QuadPlane, quadplane_ahrs_trim_pitch, 0),
+
     AP_GROUPEND
 };
 
@@ -548,11 +557,11 @@ bool QuadPlane::setup(void)
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
 
     // create the attitude view used by the VTOL code
-    ahrs_view = ahrs.create_view(rotation);
+    ahrs_view = ahrs.create_view_trim(rotation, (float)quadplane_ahrs_trim_pitch);
     if (ahrs_view == nullptr) {
         goto failed;
     }
-    
+
     attitude_control = new AC_AttitudeControl_Multi(*ahrs_view, aparm, *motors, loop_delta_t);
     if (!attitude_control) {
         hal.console->printf("%s attitude_control\n", strUnableToAllocate);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -359,14 +359,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Standard
     AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 5),
 
-    // @Param: TRIM_PIT
+    // @Param: TRIM_PITCH
     // @DisplayName: Quadplane AHRS trim pitch
-    // @Description: Compensates for the pitch angle trim difference between forward and vertical flight pitch, NOTE! this is relative to forward flight trim not mounting locaiton
+    // @Description: This sets the compensation for the pitch angle trim difference between forward and vertical flight pitch, NOTE! this is relative to forward flight trim not mounting locaiton. For tailsitters this is relative to a baseline of 90 degrees.
     // @Units: deg
-    // @Range: -180 +180
-    // @User: Standard
+    // @Range: -10 +10
+    // @Increment: 0.1
+    // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("TRIM_PIT", 4, QuadPlane, quadplane_ahrs_trim_pitch, 0),
+    AP_GROUPINFO("TRIM_PITCH", 4, QuadPlane, ahrs_trim_pitch, 0),
 
     AP_GROUPEND
 };
@@ -557,7 +558,7 @@ bool QuadPlane::setup(void)
     AP_Param::load_object_from_eeprom(motors, motors_var_info);
 
     // create the attitude view used by the VTOL code
-    ahrs_view = ahrs.create_view_trim(rotation, (float)quadplane_ahrs_trim_pitch);
+    ahrs_view = ahrs.create_view(rotation, ahrs_trim_pitch);
     if (ahrs_view == nullptr) {
         goto failed;
     }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -230,7 +230,10 @@ private:
 
     // transition deceleration, m/s/s
     AP_Float transition_decel;
-    
+
+    // Quadplane trim, degrees
+    AP_Float quadplane_ahrs_trim_pitch;
+
     AP_Int16 rc_speed;
 
     // min and max PWM for throttle

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -232,7 +232,7 @@ private:
     AP_Float transition_decel;
 
     // Quadplane trim, degrees
-    AP_Float quadplane_ahrs_trim_pitch;
+    AP_Float ahrs_trim_pitch;
 
     AP_Int16 rc_speed;
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -359,15 +359,15 @@ void AP_AHRS::update_cd_values(void)
 }
 
 /*
-  create a rotated view of AP_AHRS with pitch trim
+  create a rotated view of AP_AHRS with optional pitch trim
  */
-AP_AHRS_View *AP_AHRS::create_view_trim(enum Rotation rotation, float pitch_trim)
+AP_AHRS_View *AP_AHRS::create_view(enum Rotation rotation, float pitch_trim_deg)
 {
     if (_view != nullptr) {
         // can only have one
         return nullptr;
     }
-    _view = new AP_AHRS_View(*this, rotation, pitch_trim);
+    _view = new AP_AHRS_View(*this, rotation, pitch_trim_deg);
     return _view;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -359,15 +359,15 @@ void AP_AHRS::update_cd_values(void)
 }
 
 /*
-  create a rotated view of AP_AHRS
+  create a rotated view of AP_AHRS with pitch trim
  */
-AP_AHRS_View *AP_AHRS::create_view(enum Rotation rotation)
+AP_AHRS_View *AP_AHRS::create_view_trim(enum Rotation rotation, float pitch_trim)
 {
     if (_view != nullptr) {
         // can only have one
         return nullptr;
     }
-    _view = new AP_AHRS_View(*this, rotation);
+    _view = new AP_AHRS_View(*this, rotation, pitch_trim);
     return _view;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -546,12 +546,7 @@ public:
     }
 
     // create a view
-    AP_AHRS_View *create_view(enum Rotation rotation) {
-        return create_view_trim(rotation, 0.0f);
-    }
-
-    // create a view with pitch trim
-    AP_AHRS_View *create_view_trim(enum Rotation rotation, float pitch_trim);
+    AP_AHRS_View *create_view(enum Rotation rotation, float pitch_trim_deg=0);
 
     // return calculated AOA
     float getAOA(void);

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -546,8 +546,13 @@ public:
     }
 
     // create a view
-    AP_AHRS_View *create_view(enum Rotation rotation);
-    
+    AP_AHRS_View *create_view(enum Rotation rotation) {
+        return create_view_trim(rotation, 0.0f);
+    }
+
+    // create a view with pitch trim
+    AP_AHRS_View *create_view_trim(enum Rotation rotation, float pitch_trim);
+
     // return calculated AOA
     float getAOA(void);
 

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -21,23 +21,27 @@
 #include "AP_AHRS_View.h"
 #include <stdio.h>
 
-AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation) :
+AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_trim) :
     rotation(_rotation),
     ahrs(_ahrs)
 {
     switch (rotation) {
     case ROTATION_NONE:
-        rot_view.identity();
         break;
     case ROTATION_PITCH_90:
-        rot_view.from_euler(0, radians(90), 0);
+        y_angle = 90;
         break;
     case ROTATION_PITCH_270:
-        rot_view.from_euler(0, radians(270), 0);
+        y_angle =  270;
         break;
     default:
         AP_HAL::panic("Unsupported AHRS view %u\n", (unsigned)rotation);
     }
+
+    // Add pitch trim
+    y_angle = wrap_360(y_angle + pitch_trim);
+
+    rot_view.from_euler(radians(x_angle), radians(y_angle), radians(z_angle));
 
     // setup initial state
     update();
@@ -49,7 +53,7 @@ void AP_AHRS_View::update(bool skip_ins_update)
     rot_body_to_ned = ahrs.get_rotation_body_to_ned();
     gyro = ahrs.get_gyro();
 
-    if (rotation != ROTATION_NONE) {
+    if (!is_zero(x_angle) || !is_zero(y_angle) || !is_zero(z_angle)) {
         Matrix3f &r = rot_body_to_ned;
         r.transpose();
         r = rot_view * r;

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -21,12 +21,13 @@
 #include "AP_AHRS_View.h"
 #include <stdio.h>
 
-AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_trim) :
+AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_trim_deg) :
     rotation(_rotation),
     ahrs(_ahrs)
 {
     switch (rotation) {
     case ROTATION_NONE:
+        y_angle = 0;
         break;
     case ROTATION_PITCH_90:
         y_angle = 90;
@@ -39,9 +40,9 @@ AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_
     }
 
     // Add pitch trim
-    y_angle = wrap_360(y_angle + pitch_trim);
+    y_angle = wrap_360(y_angle + pitch_trim_deg);
 
-    rot_view.from_euler(radians(x_angle), radians(y_angle), radians(z_angle));
+    rot_view.from_euler(0, radians(y_angle), 0);
 
     // setup initial state
     update();
@@ -53,7 +54,7 @@ void AP_AHRS_View::update(bool skip_ins_update)
     rot_body_to_ned = ahrs.get_rotation_body_to_ned();
     gyro = ahrs.get_gyro();
 
-    if (!is_zero(x_angle) || !is_zero(y_angle) || !is_zero(z_angle)) {
+    if (!is_zero(y_angle)) {
         Matrix3f &r = rot_body_to_ned;
         r.transpose();
         r = rot_view * r;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -26,7 +26,7 @@ class AP_AHRS_View
 {
 public:
     // Constructor
-    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim);
+    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim_deg=0);
 
     // update state
     void update(bool skip_ins_update=false);
@@ -189,7 +189,5 @@ private:
         float sin_yaw;
     } trig;
 
-    float x_angle;
     float y_angle;
-    float z_angle;
 };

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -26,7 +26,7 @@ class AP_AHRS_View
 {
 public:
     // Constructor
-    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation);
+    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim);
 
     // update state
     void update(bool skip_ins_update=false);
@@ -188,4 +188,8 @@ private:
         float sin_pitch;
         float sin_yaw;
     } trig;
+
+    float x_angle;
+    float y_angle;
+    float z_angle;
 };


### PR DESCRIPTION
Add independent trim functionality when in Quadplane flight modes

Introduced Q_AHRS_TRIM_X, Q_ AHRS_TRIM_Y and Q_AHRS_TRIM_Z these allow quadplane view to be rotated with respect to forward flight view. Quadplanes can then be trimed for forward flight in the usual way, and also trimed sperarly for vertical flight. 

Trim is in radians to match overall trim, trim is relative to forward flight trim, requires reboot to take effect.

I'm abit of a C++ noob so not sure if this is the most efficient method of doing this, does work tested on PH1
