### PR TITLE
AP_HAL_ChibiOS: fix spi clock calculation

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -156,7 +156,7 @@ uint16_t SPIDevice::derive_freq_flag(uint32_t _frequency)
     uint32_t spi_clock_freq = SPI1_CLOCK;
     uint8_t busid = spi_devices[device_desc.bus].busid;
     if (busid > 0 && busid-1 < ARRAY_SIZE_SIMPLE(bus_clocks)) {
-        spi_clock_freq = bus_clocks[busid-1];
+        spi_clock_freq = bus_clocks[busid-1] / 2;
     }
 
     // find first divisor that brings us below the desired SPI clock


### PR DESCRIPTION
A clock divider value of 0 = fPCLK/2, 1 = fPCLK/4. The maximum SPI clock can be half of the clock of the SPI module.


![bildschirmfoto vom 2018-04-18 00-08-35](https://user-images.githubusercontent.com/10398007/38901545-e375dae4-429c-11e8-9ac0-a170838eba09.png)
