### PR TITLE
AP_Baro: MS5611 set bus speed

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -85,6 +85,9 @@ bool AP_Baro_MS56XX::_init()
         AP_HAL::panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
     }
 
+    // set bus speed to high
+    _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
+
     // high retries for init
     _dev->set_retries(10);
     


### PR DESCRIPTION
Bus speed is not set in this driver. Result MS5611 bus speed depends on default I2C / SPI bus speed.

ChibiOS set SPI bus speed to LOW as default at the moment (https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/SPIDevice.cpp#L99), the result is LOW speed operation of the MS5611 the whole time.