### PR TITLE
Copter: ekf failsafe disabled for acro and stabilize

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -716,7 +716,6 @@ private:
 
     // ekf_check.cpp
     void ekf_check();
-    bool ekf_check_position_problem();
     bool ekf_over_threshold();
     void failsafe_ekf_event();
     void failsafe_ekf_off_event(void);

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -136,14 +136,14 @@ void Copter::failsafe_ekf_event()
     failsafe.ekf = true;
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_EKFINAV, ERROR_CODE_FAILSAFE_OCCURRED);
 
-    // does this mode require position?
-    if (!copter.flightmode->requires_GPS() && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE)) {
+    // sometimes LAND *does* require GPS so ensure we are in non-GPS land
+    if (control_mode == LAND && landing_with_GPS()) {
+        mode_land.do_not_use_GPS();
         return;
     }
 
-    // sometimes LAND *does* require GPS:
-    if (control_mode == LAND && landing_with_GPS()) {
-        mode_land.do_not_use_GPS();
+    // does this mode require position?
+    if (!copter.flightmode->requires_GPS() && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE)) {
         return;
     }
 


### PR DESCRIPTION
This PR:

- disables the EKF failsafe while in manual modes (Stabilize and Acro)
- restructures the ekf failsafe check to combine the ekf_over_threshold and ekf_check_position_problem methods

I've tested this in SITL by doing the following:

- set SIM_COMPASS_OFS_X, Y to 300 so the compass gives a very incorrect heading
- disabled backup compasses to stop the EKF from switching to them (i.e. COMPASS_USE2=0, COMPASS_USE3=0)
- took off in Loiter, EKF failsafe triggered a LAND within 30seconds
- took off in Stabilize to about 30m, pitch forward.  With master the vehicle switched into Land, with this PR applied the vehicle did not switch into land.

Logs are available here for [master](https://www.dropbox.com/s/4pj4nvmydang3k0/master.bin?dl=0) and [this new change](https://www.dropbox.com/s/57ugqzlfqfexxhf/new.bin?dl=0).