### PR TITLE
Copter: partialy revert 9eda7f4e31 to use NEU frames in both pos and vel info

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -160,7 +160,7 @@ void NOINLINE Copter::send_location(mavlink_channel_t chan)
         current_loc.alt * 10,           // millimeters above ground
         vel.x * 100,                    // X speed cm/s (+ve North)
         vel.y * 100,                    // Y speed cm/s (+ve East)
-        vel.z * 100,                    // Z speed cm/s (+ve Down)
+       -vel.z * 100,                    // Z speed cm/s (+ve Up)
         ahrs.yaw_sensor);               // compass heading in 1/100 degree
 }
 


### PR DESCRIPTION
Mavlink GLOBAL_POSITION_INT messages in arducopter have been using NEU frames
for both position and velocity information up until February 2018.
At that time 9eda7f4e31 changed velocity to NED to match existing mavlink
documentation.
That documentation was corrected in April 2018 to NEU. So we can revert back
to NEU. This means that all past and future released ArduCopter software uses
NEU.