### PR TITLE
AP_Arming: Check all channels pass (<= min trim max)

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -455,7 +455,28 @@ bool AP_Arming::hardware_safety_check(bool report)
 
 bool AP_Arming::rc_calibration_checks(bool report)
 {
-    return true;
+    bool check_passed = true;
+    for (uint8_t i = 0; i < NUM_RC_CHANNELS; i++) {
+        const RC_Channel *ch = RC_Channels::rc_channel(i);
+        if (ch == nullptr) {
+            continue;
+        }
+        const uint16_t trim = ch->get_radio_trim();
+        if (ch->get_radio_min() > trim) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: RC%d minimum is greater than trim", i + 1);
+            }
+            check_passed = false;
+        }
+        if (ch->get_radio_max() < trim) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: RC%d maximum is less than trim", i + 1);
+            }
+            check_passed = false;
+        }
+    }
+
+    return check_passed;
 }
 
 bool AP_Arming::manual_transmitter_checks(bool report)

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -15,6 +15,7 @@
 
 #include "AP_Arming.h"
 #include <AP_Notify/AP_Notify.h>
+#include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
 
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
@@ -499,6 +500,33 @@ bool AP_Arming::manual_transmitter_checks(bool report)
     return true;
 }
 
+bool AP_Arming::servo_checks(bool report) const
+{
+    bool check_passed = true;
+    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
+        const SRV_Channel *ch = SRV_Channels::srv_channel(i);
+        if (ch == nullptr || ch->get_function() == SRV_Channel::k_none) {
+            continue;
+        }
+
+        const uint16_t trim = ch->get_trim();
+        if (ch->get_output_min() > trim) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: SERVO%d minimum is greater than trim", i + 1);
+            }
+            check_passed = false;
+        }
+        if (ch->get_output_max() < trim) {
+            if (report) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: SERVO%d maximum is less than trim", i + 1);
+            }
+            check_passed = false;
+        }
+    }
+
+    return check_passed;
+}
+
 bool AP_Arming::board_voltage_checks(bool report)
 {
 #if HAL_HAVE_BOARD_VOLTAGE
@@ -533,6 +561,7 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  battery_checks(report)
         &  logging_checks(report)
         &  manual_transmitter_checks(report)
+        &  servo_checks(report)
         &  board_voltage_checks(report);
 }
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -104,6 +104,7 @@ protected:
 
     bool manual_transmitter_checks(bool report);
 
+    bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4], const bool check_min_max = true) const;
 
 };


### PR DESCRIPTION
This sanity checks all servo and RC channels that the condition min <= trim <= max passes. Really funky things happen when this isn't true. (Note that min == trim == max is accepted as it's common to get this on unused channels during a RC cal with some GCS's).