### PR TITLE
AC_Avoid: Change of supplementary explanation and change of judgment method.

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -197,7 +197,7 @@ void AC_Avoid::adjust_roll_pitch(float &roll, float &pitch, float veh_angle_max)
 
     float roll_positive = 0.0f;    // maximum positive roll value
     float roll_negative = 0.0f;    // minimum negative roll value
-    float pitch_positive = 0.0f;   // maximum position pitch value
+    float pitch_positive = 0.0f;   // maximum positive pitch value
     float pitch_negative = 0.0f;   // minimum negative pitch value
 
     // get maximum positive and negative roll and pitch percentages from proximity sensor

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -559,14 +559,12 @@ void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_ne
                 // update roll, pitch maximums
                 if (roll_pct > 0.0f) {
                     roll_positive = MAX(roll_positive, roll_pct);
-                }
-                if (roll_pct < 0.0f) {
+                } else if (roll_pct < 0.0f) {
                     roll_negative = MIN(roll_negative, roll_pct);
                 }
                 if (pitch_pct > 0.0f) {
                     pitch_positive = MAX(pitch_positive, pitch_pct);
-                }
-                if (pitch_pct < 0.0f) {
+                } else if (pitch_pct < 0.0f) {
                     pitch_negative = MIN(pitch_negative, pitch_pct);
                 }
             }


### PR DESCRIPTION
I changed the following.
1. "Positive" is "Position".
2. Changed to logical judgment because the value does not change. With this logical judgment, the code has decreased. code size is 0x10.
The result is px4-v3.
make[1]: Leaving directory '/home/murata/work/ardupilot'
   text	   data	    bss	    dec	    hex	filename
1088028	   2888	  58932	1149848	 118b98	/home/murata/work/ardupilot/modules/PX4Firmware/Build/px4fmu-v3_APM.build/firmware.elf
PX4 ArduCopter Firmware is in ArduCopter-v3.px4

Change before:

make[2]: Leaving directory '/home/murata/work/ardupilot/modules/PX4Firmware/Build/px4fmu-v3_APM.build'
%% Copying /home/murata/work/ardupilot/modules/PX4Firmware/Images/px4fmu-v3_APM.px4
make[1]: Leaving directory '/home/murata/work/ardupilot'
   text	   data	    bss	    dec	    hex	filename
1088044	   2888	  58932	1149864	 118ba8	/home/murata/work/ardupilot/modules/PX4Firmware/Build/px4fmu-v3_APM.build/firmware.elf
PX4 ArduCopter Firmware is in ArduCopter-v3.px4