### PR TITLE
AP_BoardConfig: fixed build for some boards

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -10,9 +10,13 @@
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || defined(HAL_CHIBIOS_ARCH_FMUV3) || defined(HAL_CHIBIOS_ARCH_FMUV4) || defined(HAL_CHIBIOS_ARCH_MINDPXV2)
 #define AP_FEATURE_BOARD_DETECT 1
-#define AP_FEATURE_SAFETY_BUTTON 1
 #else
 #define AP_FEATURE_BOARD_DETECT 0
+#endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || defined(HAL_CHIBIOS_ARCH_FMUV3) || defined(HAL_CHIBIOS_ARCH_FMUV4) || defined(HAL_CHIBIOS_ARCH_MINDPXV2) || defined(HAL_GPIO_PIN_SAFETY_IN)
+#define AP_FEATURE_SAFETY_BUTTON 1
+#else
 #define AP_FEATURE_SAFETY_BUTTON 0
 #endif
 
@@ -154,7 +158,7 @@ private:
     
     AP_Int16 vehicleSerialNumber;
 
-#if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM)
+#if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM) || AP_FEATURE_SAFETY_BUTTON
     struct {
         AP_Int8 pwm_count;
         AP_Int8 safety_enable;
@@ -182,8 +186,6 @@ private:
 #endif
     
 
-    void board_init_safety(void);
-    void board_setup_safety_mask(void);
     void board_setup_drivers(void);
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
@@ -191,6 +193,11 @@ private:
 
 #endif // AP_FEATURE_BOARD_DETECT
 
+#if AP_FEATURE_SAFETY_BUTTON
+    void board_init_safety(void);
+    void board_setup_safety_mask(void);
+#endif
+    
     void board_setup_uart(void);
     void board_setup_sbus(void);
     void board_setup(void);

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -22,16 +22,12 @@
 
 extern const AP_HAL::HAL& hal;
 
-#if AP_FEATURE_BOARD_DETECT
-
-AP_BoardConfig::px4_board_type AP_BoardConfig::px4_configured_board;
-
+#if AP_FEATURE_SAFETY_BUTTON
 /*
   init safety state
  */
 void AP_BoardConfig::board_init_safety()
 {
-#if AP_FEATURE_SAFETY_BUTTON
     if (state.safety_enable.get() == 0) {
         hal.rcout->force_safety_off();
         hal.rcout->force_safety_no_wait();
@@ -41,8 +37,13 @@ void AP_BoardConfig::board_init_safety()
             hal.scheduler->delay(20);
         }
     }
-#endif
 }
+#endif
+
+
+#if AP_FEATURE_BOARD_DETECT
+
+AP_BoardConfig::px4_board_type AP_BoardConfig::px4_configured_board;
 
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V4)
 extern "C" {


### PR DESCRIPTION
for boards that don't have board detection but do have a safety switch
this fixes the build