### PR TITLE
Rover: remove jump forward when transitioning from forward to reverse

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -116,7 +116,7 @@ protected:
 
     // calculates the amount of throttle that should be output based
     // on things like proximity to corners and current speed
-    virtual void calc_throttle(float target_speed, bool nudge_allowed = true);
+    virtual void calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled);
 
     // performs a controlled stop. returns true once vehicle has stopped
     bool stop_vehicle();
@@ -194,7 +194,7 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
-    void calc_throttle(float target_speed, bool nudge_allowed = true);
+    void calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled);
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -35,10 +35,7 @@ void ModeAcro::update()
         // convert pilot throttle input to desired speed
         float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
 
-        // apply object avoidance to desired speed using half vehicle's maximum acceleration/deceleration
-        rover.g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_accel_max(), ahrs.yaw, target_speed, rover.G_Dt);
-
-        calc_throttle(target_speed, false);
+        calc_throttle(target_speed, false, true);
     }
 }
 

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -56,7 +56,7 @@ void ModeAuto::update()
             if (!_reached_destination || (rover.is_boat() && !near_wp)) {
                 // continue driving towards destination
                 calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination, _reversed);
-                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true);
+                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, false);
             } else {
                 // we have reached the destination so stop
                 stop_vehicle();
@@ -69,7 +69,7 @@ void ModeAuto::update()
             if (!_reached_heading) {
                 // run steering and throttle controllers
                 calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
-                calc_throttle(_desired_speed, true);
+                calc_throttle(_desired_speed, true, false);
                 // check if we have reached within 5 degrees of target
                 _reached_heading = (fabsf(_desired_yaw_cd - ahrs.yaw_sensor) < 500);
             } else {
@@ -197,12 +197,12 @@ bool ModeAuto::check_trigger(void)
     return false;
 }
 
-void ModeAuto::calc_throttle(float target_speed, bool nudge_allowed)
+void ModeAuto::calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled)
 {
     // If not autostarting set the throttle to minimum
     if (!check_trigger()) {
         stop_vehicle();
         return;
     }
-    Mode::calc_throttle(target_speed, nudge_allowed);
+    Mode::calc_throttle(target_speed, nudge_allowed, avoidance_enabled);
 }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -31,7 +31,7 @@ void ModeGuided::update()
             if (!_reached_destination || (rover.is_boat() && !near_wp)) {
                 // drive towards destination
                 calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination);
-                calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
+                calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true, true);
             } else {
                 stop_vehicle();
             }
@@ -48,7 +48,7 @@ void ModeGuided::update()
             if (have_attitude_target) {
                 // run steering and throttle controllers
                 calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
-                calc_throttle(_desired_speed, true);
+                calc_throttle(_desired_speed, true, true);
             } else {
                 stop_vehicle();
                 g2.motors.set_steering(0.0f);
@@ -67,7 +67,7 @@ void ModeGuided::update()
                 // run steering and throttle controllers
                 float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
                 g2.motors.set_steering(steering_out * 4500.0f);
-                calc_throttle(_desired_speed, true);
+                calc_throttle(_desired_speed, true, true);
             } else {
                 stop_vehicle();
                 g2.motors.set_steering(0.0f);

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -35,7 +35,7 @@ void ModeRTL::update()
     if (!_reached_destination || (rover.is_boat() && !near_wp)) {
         // continue driving towards destination
         calc_steering_to_waypoint(_reached_destination ? rover.current_loc :_origin, _destination);
-        calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
+        calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true, false);
     } else {
         // we've reached destination so stop
         stop_vehicle();

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -68,7 +68,7 @@ void ModeSmartRTL::update()
             }
             // continue driving towards destination
             calc_steering_to_waypoint(_origin, _destination);
-            calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
+            calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true, false);
             break;
 
         case SmartRTL_StopAtHome:
@@ -77,7 +77,7 @@ void ModeSmartRTL::update()
             if (rover.is_boat()) {
                 // boats attempt to hold position at home
                 calc_steering_to_waypoint(rover.current_loc, _destination);
-                calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true);
+                calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true, false);
             } else {
                 // rovers stop
                 stop_vehicle();

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -54,5 +54,5 @@ void ModeSteering::update()
     calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
 
     // run speed to throttle controller
-    calc_throttle(target_speed, false);
+    calc_throttle(target_speed, false, true);
 }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -432,8 +432,8 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
         // could not get speed so assume stopped
         _stopped = true;
     } else {
-        // if vehicle drops below _stop_speed consider it stopped
-        if (fabsf(speed) <= fabsf(_stop_speed)) {
+        // if desired speed is zero and vehicle drops below _stop_speed consider it stopped
+        if (is_zero(_desired_speed) && fabsf(speed) <= fabsf(_stop_speed)) {
             _stopped = true;
         }
     }
@@ -489,14 +489,14 @@ float AR_AttitudeControl::get_desired_speed() const
 // get acceleration limited desired speed
 float AR_AttitudeControl::get_desired_speed_accel_limited(float desired_speed) const
 {
-    // return zero if no recent calls to speed controller
+    // return input value if no recent calls to speed controller
     const uint32_t now = AP_HAL::millis();
     if ((_speed_last_ms == 0) || ((now - _speed_last_ms) > AR_ATTCONTROL_TIMEOUT_MS) || !is_positive(_throttle_accel_max)) {
         return desired_speed;
     }
 
     // calculate dt
-    float dt = (now - _speed_last_ms) / 1000.0f;
+    const float dt = (now - _speed_last_ms) / 1000.0f;
 
     // acceleration limit desired speed
     const float speed_change_max = _throttle_accel_max * dt;

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -73,6 +73,7 @@ public:
     void set_throttle_limits(float throttle_accel_max, float throttle_decel_max);
 
     // return a throttle output from -1 to +1 given a desired speed in m/s (use negative speeds to travel backwards)
+    //   desired_speed argument should already have been passed through get_desired_speed_accel_limited function
     //   motor_limit should be true if motors have hit their upper or lower limits
     //   cruise speed should be in m/s, cruise throttle should be a number from -1 to +1
     float get_throttle_out_speed(float desired_speed, bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle);
@@ -93,6 +94,9 @@ public:
 
     // get latest desired speed recorded during call to get_throttle_out_speed.  For reporting purposes only
     float get_desired_speed() const;
+
+    // get acceleration limited desired speed
+    float get_desired_speed_accel_limited(float desired_speed) const;
 
     // get minimum stopping distance (in meters) given a speed (in m/s)
     float get_stopping_distance(float speed);


### PR DESCRIPTION
This PR fixes a bug in which the Rover would jump forward for a moment when this was done:

- driver drove vehicle forward towards a barrier in ACRO mode
- avoidance feature caused vehicle to stop before hitting the barrier
- pilot attempted to backup vehicle by pulling throttle down but the Rover would jump forward for a moment before backing up

The cause of the problem was:

- when the driver quickly changes from demanding forward movement to backwards movement, because of acceleration limiting done in the AR_AttitudeControl::speed-to-throttle-output method, the desired-speed used might still be positive.
- the avoidance feature was running off the driver's input (not the acceleration limited input) meaning it would be checking what was behind the vehicle instead of continuing to check what was in front of it

The fix is to apply the acceleration limiting to the pilot's desired speed before performing avoidance.

*beforee (with Jump)*
![master-with-jump](https://user-images.githubusercontent.com/1498098/39081393-90b3f4bc-457b-11e8-80ab-b9a574040b84.png)

*after (No Jump)*
![new-without-jump](https://user-images.githubusercontent.com/1498098/39081398-9a132cda-457b-11e8-905c-f5cab274bd66.png)

This PR also:

- enables simple object avoidance for Guided and Steering mode
- removes a small jerk when stopping or transitioning from forward to reverse
