### PR TITLE
TradHeli Swashplate Servo Trim Fix in Copter 3.6

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -425,3 +425,27 @@ void AP_MotorsHeli::reset_flight_controls()
     init_outputs();
     calculate_scalars();
 }
+
+// convert input in -1 to +1 range to pwm output for swashplate servo.  Special handling of trim is required 
+// to keep travel between the swashplate servos consistent.
+int16_t AP_MotorsHeli::calc_pwm_output_1to1_swash_servo(float input, const SRV_Channel *servo)
+{
+    int16_t ret;
+
+    input = constrain_float(input, -1.0f, 1.0f);
+
+    if (servo->get_reversed()) {
+        input = -input;
+    }
+
+// With values of trim other than 1500 between swashplate servos
+    if (input >= 0.0f) {
+        ret = (int16_t (input * 500.0f) + servo->get_trim());
+    } else {
+        ret = (int16_t (input * 500.0f) + servo->get_trim());
+    }
+
+    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
+}
+
+

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -184,6 +184,10 @@ protected:
     // to be overloaded by child classes, different vehicle types would have different movement patterns
     virtual void servo_test() = 0;
 
+    // convert input in -1 to +1 range to pwm output for swashplate servos. .  Special handling of trim is required 
+    // to keep travel between the swashplate servos consistent.
+    int16_t calc_pwm_output_1to1_swash_servo(float input, const SRV_Channel *servo);
+
     // flags bitmask
     struct heliflags_type {
         uint8_t landing_collective      : 1;    // true if collective is setup for landing which has much higher minimum

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -529,12 +529,12 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     servo6_out = 2*servo6_out - 1;
 
     // actually move the servos
-    rc_write(AP_MOTORS_MOT_1, calc_pwm_output_1to1(servo1_out, _swash_servo_1));
-    rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(servo2_out, _swash_servo_2));
-    rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(servo3_out, _swash_servo_3));
-    rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1(servo4_out, _swash_servo_4));
-    rc_write(AP_MOTORS_MOT_5, calc_pwm_output_1to1(servo5_out, _swash_servo_5));
-    rc_write(AP_MOTORS_MOT_6, calc_pwm_output_1to1(servo6_out, _swash_servo_6));
+    rc_write(AP_MOTORS_MOT_1, calc_pwm_output_1to1_swash_servo(servo1_out, _swash_servo_1));
+    rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1_swash_servo(servo2_out, _swash_servo_2));
+    rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1_swash_servo(servo3_out, _swash_servo_3));
+    rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1_swash_servo(servo4_out, _swash_servo_4));
+    rc_write(AP_MOTORS_MOT_5, calc_pwm_output_1to1_swash_servo(servo5_out, _swash_servo_5));
+    rc_write(AP_MOTORS_MOT_6, calc_pwm_output_1to1_swash_servo(servo6_out, _swash_servo_6));
 }
 
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -457,9 +457,9 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     servo3_out = 2*servo3_out - 1;
 
     // actually move the servos
-    rc_write(AP_MOTORS_MOT_1, calc_pwm_output_1to1(servo1_out, _swash_servo_1));
-    rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1(servo2_out, _swash_servo_2));
-    rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1(servo3_out, _swash_servo_3));
+    rc_write(AP_MOTORS_MOT_1, calc_pwm_output_1to1_swash_servo(servo1_out, _swash_servo_1));
+    rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1_swash_servo(servo2_out, _swash_servo_2));
+    rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1_swash_servo(servo3_out, _swash_servo_3));
 
     // update the yaw rate using the tail rotor/servo
     move_yaw(yaw_out + yaw_offset);


### PR DESCRIPTION
This PR is being submitted to fix a bug found with the swashplate servo movement relative to trim.  If the servo is not in the center of the servo range, the movement is based on a fraction of the remaining throw of the servo.  The swashplate relies on the coordinated movement of the three servos.  Thus if each servo had a different trim position, a collective input request will cause the swashplate to be tilted due to the requested fraction of movement would result in different PWM output because each servo has a different remaining throw from trim.  This issue is further discussed [here](https://discuss.ardupilot.org/t/improper-handling-of-swashplate-servo-trim-causing-unequal-cyclic-output-from-one-side-to-the-other/27886)

This PR fixes this issue for single and dual heli frames.  I don't know enough about quad heli frames to know whether this is an issue.  

This fix was tested in the SITL for proper functionality for both single and dual heli frames.  Chris and I have flight tested it on our heli's with no issues.