### PR TITLE
Rover: improve attitude control for boats with rotating motors

### DIFF
--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -45,6 +45,9 @@ public:
     // true if vehicle is capable of skid steering
     bool have_skid_steering() const;
 
+    // true if vehicle has vectored thrust (i.e. boat with motor on steering servo)
+    bool have_vectored_thrust() const { return is_positive(_vector_throttle_base); }
+
     // output to motors and steering servos
     void output(bool armed, float dt);
 
@@ -103,6 +106,7 @@ protected:
     AP_Int8 _throttle_min; // throttle minimum percentage
     AP_Int8 _throttle_max; // throttle maximum percentage
     AP_Float _thrust_curve_expo; // thrust curve exponent from -1 to +1 with 0 being linear
+    AP_Float _vector_throttle_base;  // throttle level above which steering is scaled down when using vector thrust.  zero to disable vectored thrust
 
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -346,7 +346,12 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
     lat_accel = constrain_float(lat_accel, -g.turn_max_g * GRAVITY_MSS, g.turn_max_g * GRAVITY_MSS);
 
     // send final steering command to motor library
-    const float steering_out = attitude_control.get_steering_out_lat_accel(lat_accel, g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    const float steering_out = attitude_control.get_steering_out_lat_accel(lat_accel,
+                                                                           g2.motors.have_skid_steering(),
+                                                                           g2.motors.have_vectored_thrust(),
+                                                                           g2.motors.limit.steer_left,
+                                                                           g2.motors.limit.steer_right,
+                                                                           reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
 
@@ -354,7 +359,12 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
 void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
 {
     // calculate yaw error (in radians) and pass to steering angle controller
-    const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, reversed);
+    const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f),
+                                                                         g2.motors.have_skid_steering(),
+                                                                         g2.motors.have_vectored_thrust(),
+                                                                         g2.motors.limit.steer_left,
+                                                                         g2.motors.limit.steer_right,
+                                                                         reversed);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
 

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -19,6 +19,7 @@ void ModeAcro::update()
     const float steering_out = attitude_control.get_steering_out_rate(
                                                                     target_turn_rate,
                                                                     g2.motors.have_skid_steering(),
+                                                                    g2.motors.have_vectored_thrust(),
                                                                     g2.motors.limit.steer_left,
                                                                     g2.motors.limit.steer_right,
                                                                     reversed);

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -65,7 +65,12 @@ void ModeGuided::update()
             }
             if (have_attitude_target) {
                 // run steering and throttle controllers
-                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f), g2.motors.have_skid_steering(), g2.motors.limit.steer_left, g2.motors.limit.steer_right, _desired_speed < 0);
+                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f),
+                                                                            g2.motors.have_skid_steering(),
+                                                                            g2.motors.have_vectored_thrust(),
+                                                                            g2.motors.limit.steer_left,
+                                                                            g2.motors.limit.steer_right,
+                                                                            _desired_speed < 0);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true);
             } else {

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -173,7 +173,7 @@ AR_AttitudeControl::AR_AttitudeControl(AP_AHRS &ahrs) :
 
 // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
 // positive lateral acceleration is to the right.
-float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
+float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // record desired accel for reporting purposes
     _steer_lat_accel_last_ms = AP_HAL::millis();
@@ -203,11 +203,11 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool s
         desired_rate *= -1.0f;
     }
 
-    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
+    return get_steering_out_rate(desired_rate, skid_steering, vect_thrust, motor_limit_left, motor_limit_right, reversed);
 }
 
 // return a steering servo output from -1 to +1 given a heading in radians
-float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
+float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // calculate heading error (in radians)
     const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
@@ -215,12 +215,12 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool skid_
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
     const float desired_rate = _steer_angle_p.get_p(yaw_error);
 
-    return get_steering_out_rate(desired_rate, skid_steering, motor_limit_left, motor_limit_right, reversed);
+    return get_steering_out_rate(desired_rate, skid_steering, vect_thrust, motor_limit_left, motor_limit_right, reversed);
 }
 
 // return a steering servo output from -1 to +1 given a
 // desired yaw rate in radians/sec. Positive yaw is to the right.
-float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed)
+float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed)
 {
     // calculate dt
     const uint32_t now = AP_HAL::millis();
@@ -250,8 +250,9 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool skid_st
     float scaler = 1.0f;
     bool low_speed = false;
 
-    // scaler to linearize output because turn rate increases as vehicle speed increases on non-skid steering vehicles
-    if (!skid_steering) {
+    // scaler to linearize output because turn rate increases as vehicle speed increases
+    // on non-skid steering and non-vectored thrust vehicles
+    if (!skid_steering && !vect_thrust) {
 
         // get speed forward
         float speed;

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -45,14 +45,14 @@ public:
 
     // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
     // positive lateral acceleration is to the right.
-    float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
     // return a steering servo output from -1 to +1 given a heading in radians
-    float get_steering_out_heading(float heading_rad, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_heading(float heading_rad, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
     // return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.
-    float get_steering_out_rate(float desired_rate, bool skid_steering, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_rate(float desired_rate, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
 
     // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only
     float get_desired_turn_rate() const;


### PR DESCRIPTION
This PR improves steering control for boats which turn by rotating the motor.  The changes are primarily:

- the AR_MotorsUGV library is changed so the output to the steering servo is scaled back depending upon the throttle output to the motor and a new MOT_VEC_THR_BASE parameter.  With throttle levels below the MOT_VEC_THR_BASE value, the steering output is normal (i.e. the motor can rotate through its full range) but at full throttle the steering output is only 1/MOT_VEC_THR_BASE (see curve below).
- the AttitudeControl libray's steering rate controller does not scale the steering response by speed for these vehicles

Here is a graph of the steering response (horizontal axis) vs throttle (vertical axis).
![vect-thrust-steer-vs-throttle](https://user-images.githubusercontent.com/1498098/39107588-3eca72a0-46fe-11e8-9c12-b0d3f71141da.png)

Here is a high level image of the final thrust curve we want to get.
![steering-angle](https://user-images.githubusercontent.com/1498098/39107621-6bfdddb6-46fe-11e8-8931-e23c863eb2bd.png)

Some known issues with this change:

- jitter in the throttle sent to the motors library will result in jitter going out to the steering servo.  If we see this in user logs we may need to add extra filtering.
- we do not attempt to correct the throttle portion of the steering-throttle vector based upon the steering output which means the motors library will under-perform in terms of speed response.  Solving for both steering and throttle though is a little tricky so I think we can leave that out for now.
- if MOT_VEC_THR_BASE is very low (but not zero) the vehicle could lose steering control at full throttle.  we should probably add some checks so MOT_VEC_THR_BASE can't be less than 10.