### PR TITLE
Tools: autotest: add the path for sim_vehicle.py to .bashrc

### DIFF
--- a/Tools/autotest/win_sitl/jsbsimAPM_install.sh
+++ b/Tools/autotest/win_sitl/jsbsimAPM_install.sh
@@ -11,3 +11,4 @@ cp src/JSBSim.exe /usr/local/bin
 cd ../ardupilot
 git submodule update --init --recursive
 ./modules/waf/waf-light configure --board=sitl
+echo 'export PATH=$PATH:$HOME/ardupilot/Tools/autotest' >> ~/.bashrc

--- a/Tools/autotest/win_sitl/jsbsimAPM_install.sh
+++ b/Tools/autotest/win_sitl/jsbsimAPM_install.sh
@@ -11,4 +11,10 @@ cp src/JSBSim.exe /usr/local/bin
 cd ../ardupilot
 git submodule update --init --recursive
 ./modules/waf/waf-light configure --board=sitl
-echo 'export PATH=$PATH:$HOME/ardupilot/Tools/autotest' >> ~/.bashrc
+
+read -p "Add $HOME/ardupilot/Tools/autotest to your PATH [Y/n]?"
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo 'export PATH=$PATH:$HOME/ardupilot/Tools/autotest' >> ~/.bashrc
+else
+    echo "Skipping adding $HOME/ardupilot/Tools/autotest to PATH."
+fi


### PR DESCRIPTION
This is useful for the one who run sim_vehicle.py directly.