### PR TITLE
AP_GPS: Report when SBF errors change

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -368,6 +368,10 @@ AP_GPS_SBF::process_message(void)
     {
         const msg4014 &temp = sbf_msg.data.msg4014u;
         RxState = temp.RxState;
+        if ((RxError & RX_ERROR_MASK) != (temp.RxError & RX_ERROR_MASK)) {
+            gcs().send_text(MAV_SEVERITY_INFO, "GPS %d: SBF error changed (0x%08x/0x%08x)", state.instance + 1,
+                            RxError & RX_ERROR_MASK, temp.RxError & RX_ERROR_MASK);
+        }
         RxError = temp.RxError;
         break;
     }


### PR DESCRIPTION
In rare scenarios when the SBF GPS does encounter a self reportable error, we should at least report the class of error to the GCS/DF log as the first step to allowing us to debug it. Otherwise you get stuck with a GPS unhealthy flag, with no path to debugging why this is happening.

@rmackay9 this should go into Copter 3.6