### PR TITLE
Collapse RC has_new_input() with set_pwm_all()

### DIFF
--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -101,15 +101,13 @@ void Rover::rudder_arm_disarm_check()
 
 void Rover::read_radio()
 {
-    if (!RC_Channels::has_new_input()) {
+    if (!RC_Channels::read_input()) {
         // check if we lost RC link
         control_failsafe(channel_throttle->get_radio_in());
         return;
     }
 
     failsafe.last_valid_rc_ms = AP_HAL::millis();
-    // read the RC value
-    RC_Channels::set_pwm_all();
     // check that RC value are valid
     control_failsafe(channel_throttle->get_radio_in());
 

--- a/AntennaTracker/radio.cpp
+++ b/AntennaTracker/radio.cpp
@@ -4,7 +4,5 @@
 
 void Tracker::read_radio()
 {
-    if (RC_Channels::has_new_input()) {
-        RC_Channels::set_pwm_all();
-    }
+    RC_Channels::read_input();
 }

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -95,9 +95,8 @@ void Copter::read_radio()
 {
     uint32_t tnow_ms = millis();
 
-    if (RC_Channels::has_new_input()) {
+    if (RC_Channels::read_input()) {
         ap.new_radio_frame = true;
-        RC_Channels::set_pwm_all();
 
         set_throttle_and_failsafe(channel_throttle->get_radio_in());
         set_throttle_zero_flag(channel_throttle->get_control_in());

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -171,7 +171,7 @@ void Plane::rudder_arm_disarm_check()
 
 void Plane::read_radio()
 {
-    if (!RC_Channels::has_new_input()) {
+    if (!RC_Channels::read_input()) {
         control_failsafe();
         return;
     }
@@ -183,8 +183,6 @@ void Plane::read_radio()
 
     failsafe.last_valid_rc_ms = millis();
 
-    RC_Channels::set_pwm_all();
-    
     if (control_mode == TRAINING) {
         // in training mode we don't want to use a deadzone, as we
         // want manual pass through when not exceeding attitude limits

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -158,7 +158,7 @@ void Sub::fifty_hz_loop()
     failsafe_sensors_check();
 
     // Update rc input/output
-    RC_Channels::set_pwm_all();
+    RC_Channels::read_input();
     SRV_Channels::output_ch_all();
 }
 

--- a/libraries/AC_PID/examples/AC_PID_test/AC_PID_test.cpp
+++ b/libraries/AC_PID/examples/AC_PID_test/AC_PID_test.cpp
@@ -48,7 +48,7 @@ void loop()
     radio_trim = RC_Channels::get_radio_in(0);
 
     while (true) {
-        RC_Channels::set_pwm_all(); // poll the radio for new values
+        RC_Channels::read_input(); // poll the radio for new values
         radio_in = RC_Channels::get_radio_in(0);
         error = radio_in - radio_trim;
         pid.set_input_filter_all(error);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -152,14 +152,12 @@ public:
 
     static uint8_t get_valid_channel_count(void);                      // returns the number of valid channels in the last read
     static int16_t get_receiver_rssi(void);                            // returns [0, 255] for receiver RSSI (0 is no link) if present, otherwise -1
-    static bool has_new_input(void);                                   // returns true if there has been new input since last checked
+    static bool read_input(void);                                      // returns true if new input has been read in
     static void clear_overrides(void);                                 // clears any active overrides
     static bool receiver_bind(const int dsmMode);                      // puts the reciever in bind mode if present, returns true if success
     static bool set_override(const uint8_t chan, const int16_t value); // set a channels override value
     static bool set_overrides(int16_t *overrides, const uint8_t len);  // set multiple overrides at once
 
-    static void set_pwm_all(void);
-    
 private:
     // this static arrangement is to avoid static pointers in AP_Param tables
     static RC_Channel *channels;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -139,14 +139,20 @@ uint8_t RC_Channels::get_radio_in(uint16_t *chans, const uint8_t num_channels)
 }
 
 /*
-  call read() and set_pwm() on all channels
+  call read() and set_pwm() on all channels if there is new data
  */
-void
-RC_Channels::set_pwm_all(void)
+bool
+RC_Channels::read_input(void)
 {
+    if (!hal.rcin->new_input()) {
+        return false;
+    }
+
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
         channels[i].set_pwm(channels[i].read());
     }
+
+    return true;
 }
 
 uint8_t RC_Channels::get_valid_channel_count(void)
@@ -157,11 +163,6 @@ uint8_t RC_Channels::get_valid_channel_count(void)
 int16_t RC_Channels::get_receiver_rssi(void)
 {
     return hal.rcin->get_rssi();
-}
-
-bool RC_Channels::has_new_input(void)
-{
-    return hal.rcin->new_input();
 }
 
 void RC_Channels::clear_overrides(void)

--- a/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
@@ -51,7 +51,7 @@ void setup()
 
 void loop()
 {
-    RC_Channels::set_pwm_all();
+    RC_Channels::read_input();
     print_pwm();
     
     hal.scheduler->delay(20);


### PR DESCRIPTION
The split interface of checking if there is input, then reading the channels later causes a number of problems when trying to fix the handling of overrides. It's also just painfully inconsistent between vehicles, and allows for differences to sneak in between the vehicles.

Given the lack of callbacks from RC_Channels to the vehicle this *should* be a no impact change, I'm presenting this as it's own PR now, to reduce friction later on an override rework effort I have going on here.