### PR TITLE
Plane: fixed a bug in transition to QSTABILIZE for tailsitters

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -874,6 +874,9 @@ bool QuadPlane::is_flying(void)
     if (motors->get_throttle() > 0.01f && !motors->limit.throttle_lower) {
         return true;
     }
+    if (in_tailsitter_vtol_transition()) {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
this bug was found bug Marco on his tailsitter. It resulted in zero
throttle for 2s in transition from FBWA to QSTABILIZE
ping @robustini 