### PR TITLE
Remove RC_Channels::set_overrides() interface

### DIFF
--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -53,8 +53,6 @@ void Sub::init_joystick()
 void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t z, int16_t r, uint16_t buttons)
 {
 
-    int16_t channels[11];
-
     float rpyScale = 0.4*gain; // Scale -1000-1000 to -400-400 with gain
     float throttleScale = 0.8*gain*g.throttle_gain; // Scale 0-1000 to 0-800 times gain
     int16_t rpyCenter = 1500;
@@ -93,35 +91,33 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
         rollTrim  =  y * rpyScale;
     }
 
-    channels[0] = constrain_int16(pitchTrim + rpyCenter,1100,1900); // pitch
-    channels[1] = constrain_int16(rollTrim  + rpyCenter,1100,1900); // roll
+    RC_Channels::set_override(0, constrain_int16(pitchTrim + rpyCenter,1100,1900)); // pitch
+    RC_Channels::set_override(1, constrain_int16(rollTrim  + rpyCenter,1100,1900)); // roll
 
-    channels[2] = constrain_int16((z+zTrim)*throttleScale+throttleBase,1100,1900); // throttle
-    channels[3] = constrain_int16(r*rpyScale+rpyCenter,1100,1900);                 // yaw
+    RC_Channels::set_override(2, constrain_int16((z+zTrim)*throttleScale+throttleBase,1100,1900)); // throttle
+    RC_Channels::set_override(3, constrain_int16(r*rpyScale+rpyCenter,1100,1900));                 // yaw
 
     // maneuver mode:
     if (roll_pitch_flag == 0) {
         // adjust forward and lateral with joystick input instead of roll and pitch
-        channels[4] = constrain_int16((x+xTrim)*rpyScale+rpyCenter,1100,1900); // forward for ROV
-        channels[5] = constrain_int16((y+yTrim)*rpyScale+rpyCenter,1100,1900); // lateral for ROV
+        RC_Channels::set_override(4, constrain_int16((x+xTrim)*rpyScale+rpyCenter,1100,1900)); // forward for ROV
+        RC_Channels::set_override(5, constrain_int16((y+yTrim)*rpyScale+rpyCenter,1100,1900)); // lateral for ROV
     } else {
         // neutralize forward and lateral input while we are adjusting roll and pitch
-        channels[4] = constrain_int16(xTrim*rpyScale+rpyCenter,1100,1900); // forward for ROV
-        channels[5] = constrain_int16(yTrim*rpyScale+rpyCenter,1100,1900); // lateral for ROV
+        RC_Channels::set_override(4, constrain_int16(xTrim*rpyScale+rpyCenter,1100,1900)); // forward for ROV
+        RC_Channels::set_override(5, constrain_int16(yTrim*rpyScale+rpyCenter,1100,1900)); // lateral for ROV
     }
 
-    channels[6] = cam_pan;       // camera pan
-    channels[7] = cam_tilt;      // camera tilt
-    channels[8] = lights1;       // lights 1
-    channels[9] = lights2;       // lights 2
-    channels[10] = video_switch; // video switch
+    RC_Channels::set_override(6, cam_pan);       // camera pan
+    RC_Channels::set_override(7, cam_tilt);      // camera tilt
+    RC_Channels::set_override(8, lights1);       // lights 1
+    RC_Channels::set_override(9, lights2);       // lights 2
+    RC_Channels::set_override(10, video_switch); // video switch
 
     // Store old x, y, z values for use in input hold logic
     x_last = x;
     y_last = y;
     z_last = z;
-
-    RC_Channels::set_overrides(channels, 11);
 }
 
 void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
@@ -680,17 +676,14 @@ void Sub::default_js_buttons()
 
 void Sub::set_neutral_controls()
 {
-    int16_t channels[11];
 
     for (uint8_t i = 0; i < 6; i++) {
-        channels[i] = 1500;
+        RC_Channels::set_override(i, 1500);
     }
 
     for (uint8_t i = 6; i < 11; i++) {
-        channels[i] = 0xffff;
+        RC_Channels::set_override(i, 0xffff);
     }
-
-    RC_Channels::set_overrides(channels, 10);
 
     // Clear pitch/roll trim settings
     pitchTrim = 0;

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -44,8 +44,6 @@ public:
      *  v > 0   -> set v as override.
      */
 
-    /* set_overrides: array starts at ch 0, for len channels */
-    virtual bool set_overrides(int16_t *overrides, uint8_t len) = 0;
     /* set_override: set just a specific channel */
     virtual bool set_override(uint8_t channel, int16_t override) = 0;
     /* clear_overrides: equivalent to setting all overrides to 0 */

--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -126,19 +126,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    if (!_init) {
-        return false;
-    }
-
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override)
 {
     if (!_init) {

--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -51,7 +51,6 @@ public:
     }
         
     
-    bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
 

--- a/libraries/AP_HAL_Empty/RCInput.cpp
+++ b/libraries/AP_HAL_Empty/RCInput.cpp
@@ -29,10 +29,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len) {
     return len;
 }
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    return true;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override) {
     return true;
 }

--- a/libraries/AP_HAL_Empty/RCInput.h
+++ b/libraries/AP_HAL_Empty/RCInput.h
@@ -11,7 +11,6 @@ public:
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
-    bool set_overrides(int16_t *overrides, uint8_t len);
     bool set_override(uint8_t channel, int16_t override);
     void clear_overrides();
 };

--- a/libraries/AP_HAL_F4Light/RCInput.cpp
+++ b/libraries/AP_HAL_F4Light/RCInput.cpp
@@ -311,15 +311,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
 }
 
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    bool res = false;
-    for (int i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override)
 {
     if (override < 0) return false; /* -1: no change. */

--- a/libraries/AP_HAL_F4Light/RCInput.h
+++ b/libraries/AP_HAL_F4Light/RCInput.h
@@ -43,7 +43,6 @@ public:
     bool     new_input() override;
     uint8_t  num_channels() override;
 
-    bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
     

--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -68,18 +68,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    bool res = false;
-    if(len > LINUX_RC_INPUT_NUM_CHANNELS){
-        len = LINUX_RC_INPUT_NUM_CHANNELS;
-    }
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override)
 {
     if (override < 0) return false; /* -1: no change. */

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -26,7 +26,6 @@ public:
         return _rssi;
     }
     
-    bool set_overrides(int16_t *overrides, uint8_t len);
     bool set_override(uint8_t channel, int16_t override);
     void clear_overrides();
 

--- a/libraries/AP_HAL_Linux/RCOutput_qflight.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_qflight.cpp
@@ -19,6 +19,8 @@
  */
 #include <AP_HAL/AP_HAL.h>
 
+#include <RC_Channel/RC_Channel.h>
+
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
 
 #include "RCOutput_qflight.h"
@@ -166,7 +168,13 @@ void RCOutput_QFLIGHT::check_rc_in(void)
                 }
             }
             if (have_data) {
-                hal.rcin->set_overrides((int16_t*)rcu.rcin.rcin, 8);
+                // FIXME: This is an incredibly dirty hack as this probhibits the usage of
+                // overrides if an RC reciever is connected, as the next RC input will
+                // stomp over the GCS set overrides. This results in incredibly confusing,
+                // undocumented behaviour, that cannot be reported to the user.
+                for (uint8_t i = 0; i < 8; i++) {
+                    RC_Channels::set_override(i, rcu.rcin.rcin[i]);
+                }
             }
         }
         nrcin_bytes = 0;

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -101,15 +101,6 @@ uint8_t PX4RCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool PX4RCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool PX4RCInput::set_override(uint8_t channel, int16_t override) {
     if (override < 0) {
         return false; /* -1: no change. */

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -24,7 +24,6 @@ public:
     }
         
     
-    bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
 

--- a/libraries/AP_HAL_QURT/RCInput.cpp
+++ b/libraries/AP_HAL_QURT/RCInput.cpp
@@ -101,18 +101,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     return (i+1);
 }
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len) 
-{
-    bool res = false;
-    if(len > QURT_RC_INPUT_NUM_CHANNELS){
-        len = QURT_RC_INPUT_NUM_CHANNELS;
-    }
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override) 
 {
     if (override < 0) return false; /* -1: no change. */

--- a/libraries/AP_HAL_QURT/RCInput.h
+++ b/libraries/AP_HAL_QURT/RCInput.h
@@ -22,7 +22,6 @@ public:
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
-    bool set_overrides(int16_t *overrides, uint8_t len);
     bool set_override(uint8_t channel, int16_t override);
     void clear_overrides();
 

--- a/libraries/AP_HAL_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_SITL/RCInput.cpp
@@ -43,18 +43,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool RCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    bool res = false;
-    if (len > SITL_RC_INPUT_CHANNELS) {
-        len = SITL_RC_INPUT_CHANNELS;
-    }
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool RCInput::set_override(uint8_t channel, int16_t override)
 {
     if (override < 0) {

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -18,7 +18,6 @@ public:
     uint16_t read(uint8_t ch) override;
     uint8_t read(uint16_t* periods, uint8_t len) override;
 
-    bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
 

--- a/libraries/AP_HAL_VRBRAIN/RCInput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.cpp
@@ -86,15 +86,6 @@ uint8_t VRBRAINRCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool VRBRAINRCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
 bool VRBRAINRCInput::set_override(uint8_t channel, int16_t override) {
     if (override < 0) {
         return false; /* -1: no change. */

--- a/libraries/AP_HAL_VRBRAIN/RCInput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.h
@@ -23,7 +23,6 @@ public:
     }
         
     
-    bool set_overrides(int16_t *overrides, uint8_t len) override;
     bool set_override(uint8_t channel, int16_t override) override;
     void clear_overrides() override;
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -156,7 +156,6 @@ public:
     static void clear_overrides(void);                                 // clears any active overrides
     static bool receiver_bind(const int dsmMode);                      // puts the reciever in bind mode if present, returns true if success
     static bool set_override(const uint8_t chan, const int16_t value); // set a channels override value
-    static bool set_overrides(int16_t *overrides, const uint8_t len);  // set multiple overrides at once
 
 private:
     // this static arrangement is to avoid static pointers in AP_Param tables

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -178,11 +178,6 @@ bool RC_Channels::set_override(const uint8_t chan, const int16_t value)
     return false;
 }
 
-bool RC_Channels::set_overrides(int16_t *overrides, const uint8_t len)
-{
-    return hal.rcin->set_overrides(overrides, len);
-}
-
 bool RC_Channels::receiver_bind(const int dsmMode)
 {
     return hal.rcin->rc_bind(dsmMode);


### PR DESCRIPTION
This was handled differently between the various HAL's, and is simply a for loop anyways. Given that the only user is sub, and that it actually has to go out of it's way to build the array of channels removing it is straightforward (and reduces flash usage).