### PR TITLE
AP_HAL_ChibiOS: add STM32F7 I2C support

### DIFF
--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -36,6 +36,7 @@ class I2CBus : public DeviceBus {
 public:
     I2CConfig i2ccfg;
     uint8_t busnum;
+    uint32_t busclock;
     bool i2c_started;
     bool i2c_active;
     


### PR DESCRIPTION
Add STM32F7 I2C support to AP_HAL_ChibiOS.
* Tested with NUCLEO-F767ZI (STM32F767ZI) board and HMC5983.