### PR TITLE
AP_GPS: Do not inject RTCM data into a non-initialized GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -290,17 +290,6 @@ AP_GPS_NOVA::process_message(void)
     return false;
 }
 
-void
-AP_GPS_NOVA::inject_data(const uint8_t *data, uint16_t len)
-{
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("NOVA: Not enough TXSPACE");
-    }
-}
-
 #define CRC32_POLYNOMIAL 0xEDB88320L
 uint32_t AP_GPS_NOVA::CRC32Value(uint32_t icrc)
 {

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -32,8 +32,6 @@ public:
     // Methods
     bool read() override;
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
     const char *name() const override { return "NOVA"; }
 
 private:
@@ -59,7 +57,6 @@ private:
     static const char* const _initialisation_blob[6];
    
     uint32_t crc_error_counter = 0;
-    uint32_t last_injected_data_ms = 0;
 
     struct PACKED nova_header
     {

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -76,19 +76,6 @@ AP_GPS_SBP::read(void)
 
 }
 
-void
-AP_GPS_SBP::inject_data(const uint8_t *data, uint16_t len)
-{
-
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("PIKSI: Not enough TXSPACE");
-    }
-
-}
-
 //This attempts to reads all SBP messages from the incoming port.
 //Returns true if a new message was read, false if we failed to read a message.
 void

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -36,8 +36,6 @@ public:
     // Methods
     bool read() override;
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
     static bool _detect(struct SBP_detect_state &state, uint8_t data);
 
     const char *name() const override { return "SBP"; }
@@ -158,7 +156,6 @@ private:
     // Internal Received Messages State
     // ************************************************************************
     uint32_t last_heatbeat_received_ms;
-    uint32_t last_injected_data_ms;
 
     struct sbp_gps_time_t last_gps_time;
     struct sbp_dops_t     last_dops;

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -80,17 +80,6 @@ AP_GPS_SBP2::read(void)
     return _attempt_state_update();
 }
 
-void
-AP_GPS_SBP2::inject_data(const uint8_t *data, uint16_t len)
-{
-    if (port->txspace() > len) {
-        last_injected_data_ms = AP_HAL::millis();
-        port->write(data, len);
-    } else {
-        Debug("PIKSI: Not enough TXSPACE");
-    }
-}
-
 //This attempts to reads all SBP messages from the incoming port.
 //Returns true if a new message was read, false if we failed to read a message.
 void

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -34,8 +34,6 @@ public:
     // Methods
     bool read() override;
 
-    void inject_data(const uint8_t *data, uint16_t len) override;
-
     static bool _detect(struct SBP2_detect_state &state, uint8_t data);
 
     const char *name() const override { return "SBP2"; }
@@ -172,7 +170,6 @@ private:
     // Internal Received Messages State
     // ************************************************************************
     uint32_t last_heartbeat_received_ms;
-    uint32_t last_injected_data_ms;
 
     struct sbp_heartbeat_t last_heartbeat;
     struct sbp_gps_time_t  last_gps_time;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -135,6 +135,8 @@ public:
     // get the velocity lag, returns true if the driver is confident in the returned value
     bool get_lag(float &lag_sec) const override;
 
+    void inject_data(const uint8_t *data, uint16_t len) override;
+
     const char *name() const override { return "u-blox"; }
 
     // support for retrieving RTCMv3 data from a moving baseline base

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -129,6 +129,7 @@ AP_GPS_Backend::inject_data(const uint8_t *data, uint16_t len)
         // configuration portion seeing this message and thinking it was NACK'd)
         if (is_configured()) {
             if (port->txspace() > len) {
+                last_injected_data_ms = AP_HAL::millis();
                 port->write(data, len);
             } else {
                 Debug("GPS %d: Not enough TXSPACE", state.instance + 1);

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -79,6 +79,8 @@ public:
         return _last_itow;
     }
 
+    uint32_t last_injected_data_ms = 0;
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
Septentrio configuration step fails if RTCM corrections are injected while configuring/initializing.
So wait until configuration is completed, before injecting RTCM data.