### PR TITLE
Add extended sys state for Copter

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -362,6 +362,8 @@ private:
     } takeoff_state_t;
     takeoff_state_t takeoff_state;
 
+    bool is_landing;
+
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -97,6 +97,19 @@ MAV_STATE GCS_MAVLINK_Copter::system_status() const
     return MAV_STATE_ACTIVE;
 }
 
+MAV_LANDED_STATE GCS_MAVLINK_Copter::landed_state() const
+{
+    if (copter.takeoff_state.running) {
+        return MAV_LANDED_STATE_TAKEOFF;
+    }
+    if (copter.is_landing) {
+        return MAV_LANDED_STATE_LANDING;
+    }
+    if (copter.ap.land_complete) {
+        return MAV_LANDED_STATE_ON_GROUND;
+    }
+    return MAV_LANDED_STATE_IN_AIR;
+}
 
 #if AC_FENCE == ENABLED
 NOINLINE void Copter::send_fence_status(mavlink_channel_t chan)
@@ -302,6 +315,8 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
             copter.send_extended_status1(chan);
             CHECK_PAYLOAD_SIZE(POWER_STATUS);
             send_power_status();
+            CHECK_PAYLOAD_SIZE(EXTENDED_SYS_STATE);
+            send_extended_sys_state();
         }
         break;
 

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -49,4 +49,5 @@ private:
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
+    MAV_LANDED_STATE landed_state() const override;
 };

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -103,6 +103,9 @@ void Copter::set_land_complete(bool b)
         Log_Write_Event(DATA_NOT_LANDED);
     }
     ap.land_complete = b;
+    if (b) {
+        is_landing = false;
+    }
 
 #if STATS_ENABLED == ENABLED
     g2.stats.set_flying(!b);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -222,6 +222,7 @@ void Copter::ModeAuto::land_start()
 
     // call location specific land start function
     land_start(stopping_point);
+    copter.is_landing = true;
 }
 
 // auto_land_start - initialises controller to implement a landing

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -744,6 +744,7 @@ void Copter::ModeAuto::takeoff_run()
     }
 #else
     set_land_complete(false);
+    takeoff_state.running = !copter.wp_nav->reached_wp_destination();
 #endif
 
     // set motors to full range

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -386,6 +386,7 @@ void Copter::ModeGuided::takeoff_run()
     }
 #else
     set_land_complete(false);
+    takeoff_state.running = !wp_nav->reached_wp_destination();
 #endif
 
     // set motors to full range

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -31,6 +31,7 @@ bool Copter::ModeLand::init(bool ignore_checks)
     land_start_time = millis();
 
     land_pause = false;
+    copter.is_landing = true;
 
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     ap.land_repo_active = false;

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -321,6 +321,7 @@ void Copter::ModeRTL::land_start()
 {
     _state = RTL_Land;
     _state_complete = false;
+    copter.is_landing = true;
 
     // Set wp navigation target to above home
     loiter_nav->init_target(wp_nav->get_wp_destination());

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -283,6 +283,7 @@ void Copter::init_disarm_motors()
     hal.util->set_soft_armed(false);
 
     ap.in_arming_delay = false;
+    is_landing = false;
 }
 
 // motors_output - send output to motors library which will adjust and send to ESCs and servos

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -50,4 +50,5 @@ private:
     MAV_STATE system_status() const override;
 
     uint8_t radio_in_rssi() const;
+    MAV_LANDED_STATE landed_state() const override { return MAV_LANDED_STATE_UNDEFINED;};
 };

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -43,4 +43,5 @@ private:
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
+    MAV_LANDED_STATE landed_state() const override { return MAV_LANDED_STATE_UNDEFINED;};
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -161,6 +161,7 @@ public:
 
     // common send functions
     void send_heartbeat(void) const;
+    void send_extended_sys_state();
     void send_meminfo(void);
     void send_power_status(void);
     void send_battery_status(const AP_BattMonitor &battery,
@@ -260,6 +261,8 @@ protected:
     virtual MAV_MODE base_mode() const = 0;
     virtual uint32_t custom_mode() const = 0;
     virtual MAV_STATE system_status() const = 0;
+    virtual MAV_LANDED_STATE landed_state() const { return MAV_LANDED_STATE_UNDEFINED; };
+    virtual MAV_VTOL_STATE vtol_state() const { return MAV_VTOL_STATE_UNDEFINED; };
 
     bool            waypoint_receiving; // currently receiving
     // the following two variables are only here because of Tracker

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1608,6 +1608,14 @@ void GCS_MAVLINK::send_heartbeat() const
         system_status());
 }
 
+void GCS_MAVLINK::send_extended_sys_state()
+{
+    mavlink_msg_extended_sys_state_send(
+        chan,
+        vtol_state(),
+        landed_state());
+}
+
 float GCS_MAVLINK::adjust_rate_for_stream_trigger(enum streams stream_num)
 {
     // send at a much lower rate while handling waypoints and


### PR DESCRIPTION
This PR add a new flag to report if we are in landing state, update the takeoff state in auto and guided mode, report land and takeoff state in the extended sys state message. Those are need for better CC control sequences !