### PR TITLE
AC_Fence: able to use polygon fence as stay-out zone

### DIFF
--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -9,6 +9,8 @@
 #include <AC_Fence/AC_PolyFence_loader.h>
 #include <AP_Common/Location.h>
 
+#define AC_FENCE_ENABLED_NFZ                        2       // enabled fence for no-fly zone
+
 // bit masks for enabled fence types.  Used for TYPE parameter
 #define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
 #define AC_FENCE_TYPE_CIRCLE                        2       // circular horizontal fence (usually initiates an RTL)


### PR DESCRIPTION
A simple but not complete solution for #391 and #1056. I need no-fly zone/stay-out zone for my current project. So I make a quick solution.

It use geofence code to implement stay-out zone.  By setting FENCE_ENABLE = 2.  It makes polygon fence become stay-out zone. Setup procedure is identical to polygon geofence using mission planner.  It is possible to use circle/altitude geofence along with polygon stay-out zone.

Current limit:
1. Only polygon stay-out zone is supported
2. Only one stay-out zone is support
