### PR TITLE
HAL_ChibiOS: Fixed s-bus signal polarity in SoftSigReaderInt.cpp

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.cpp
+++ b/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.cpp
@@ -45,7 +45,7 @@ void SoftSigReaderInt::init(EICUDriver* icu_drv, eicuchannel_t chan)
         icucfg.iccfgp[i]=nullptr;
     }
     icucfg.iccfgp[chan] = &channel_config;
-    channel_config.alvl = EICU_INPUT_ACTIVE_HIGH;
+    channel_config.alvl = EICU_INPUT_ACTIVE_LOW;
     channel_config.capture_cb = _irq_handler;
     eicuStart(_icu_drv, &icucfg);
     //sets input filtering to 4 timer clock


### PR DESCRIPTION
This fixes s-bus polarity in SoftSigReaderInt.cpp.
Thanks to @Kelly-Foster and @anbello for spotting this and to @vierfuffzig for verifying the fix.