### PR TITLE
move send_attitude() up to GCS_MAVLINK

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -75,20 +75,6 @@ MAV_STATE GCS_MAVLINK_Rover::system_status() const
     return MAV_STATE_ACTIVE;
 }
 
-void Rover::send_attitude(mavlink_channel_t chan)
-{
-    const Vector3f omega = ahrs.get_gyro();
-    mavlink_msg_attitude_send(
-        chan,
-        millis(),
-        ahrs.roll,
-        ahrs.pitch,
-        ahrs.yaw,
-        omega.x,
-        omega.y,
-        omega.z);
-}
-
 void Rover::send_extended_status1(mavlink_channel_t chan)
 {
     int16_t battery_current = -1;
@@ -310,11 +296,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
             CHECK_PAYLOAD_SIZE(POWER_STATUS);
             send_power_status();
         }
-        break;
-
-    case MSG_ATTITUDE:
-        CHECK_PAYLOAD_SIZE(ATTITUDE);
-        rover.send_attitude(chan);
         break;
 
     case MSG_LOCATION:

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -464,7 +464,6 @@ private:
     void fence_send_mavlink_status(mavlink_channel_t chan);
 
     // GCS_Mavlink.cpp
-    void send_attitude(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -74,21 +74,6 @@ MAV_STATE GCS_MAVLINK_Tracker::system_status() const
     return MAV_STATE_ACTIVE;
 }
 
-void Tracker::send_attitude(mavlink_channel_t chan)
-{
-    Vector3f omega = ahrs.get_gyro();
-    mavlink_msg_attitude_send(
-        chan,
-        AP_HAL::millis(),
-        ahrs.roll,
-        ahrs.pitch,
-        ahrs.yaw,
-        omega.x,
-        omega.y,
-        omega.z);
-}
-
-
 void Tracker::send_extended_status1(mavlink_channel_t chan)
 {
     int16_t battery_current = -1;
@@ -175,11 +160,6 @@ void GCS_MAVLINK_Tracker::handle_change_alt_request(AP_Mission::Mission_Command&
 bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
 {
     switch (id) {
-
-    case MSG_ATTITUDE:
-        CHECK_PAYLOAD_SIZE(ATTITUDE);
-        tracker.send_attitude(chan);
-        break;
 
     case MSG_LOCATION:
         CHECK_PAYLOAD_SIZE(GLOBAL_POSITION_INT);

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -199,7 +199,6 @@ private:
 
     void one_second_loop();
     void ten_hz_logging_loop();
-    void send_attitude(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -760,7 +760,6 @@ private:
     // GCS_Mavlink.cpp
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);
-    void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -98,20 +98,6 @@ MAV_STATE GCS_MAVLINK_Copter::system_status() const
 }
 
 
-NOINLINE void Copter::send_attitude(mavlink_channel_t chan)
-{
-    const Vector3f &gyro = ins.get_gyro();
-    mavlink_msg_attitude_send(
-        chan,
-        millis(),
-        ahrs.roll,
-        ahrs.pitch,
-        ahrs.yaw,
-        gyro.x,
-        gyro.y,
-        gyro.z);
-}
-
 #if AC_FENCE == ENABLED
 NOINLINE void Copter::send_fence_status(mavlink_channel_t chan)
 {
@@ -317,11 +303,6 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
             CHECK_PAYLOAD_SIZE(POWER_STATUS);
             send_power_status();
         }
-        break;
-
-    case MSG_ATTITUDE:
-        CHECK_PAYLOAD_SIZE(ATTITUDE);
-        copter.send_attitude(chan);
         break;
 
     case MSG_LOCATION:

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -109,16 +109,18 @@ MAV_STATE GCS_MAVLINK_Plane::system_status() const
 }
 
 
-void Plane::send_attitude(mavlink_channel_t chan)
+void GCS_MAVLINK_Plane::send_attitude() const
 {
+    const AP_AHRS &ahrs = AP::ahrs();
+
     float r = ahrs.roll;
-    float p = ahrs.pitch - radians(g.pitch_trim_cd*0.01f);
+    float p = ahrs.pitch - radians(plane.g.pitch_trim_cd*0.01f);
     float y = ahrs.yaw;
     
-    if (quadplane.tailsitter_active()) {
-        r = quadplane.ahrs_view->roll;
-        p = quadplane.ahrs_view->pitch;
-        y = quadplane.ahrs_view->yaw;
+    if (plane.quadplane.tailsitter_active()) {
+        r = plane.quadplane.ahrs_view->roll;
+        p = plane.quadplane.ahrs_view->pitch;
+        y = plane.quadplane.ahrs_view->yaw;
     }
     
     const Vector3f &omega = ahrs.get_gyro();
@@ -421,11 +423,6 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         plane.send_extended_status1(chan);
         CHECK_PAYLOAD_SIZE2(POWER_STATUS);
         send_power_status();
-        break;
-
-    case MSG_ATTITUDE:
-        CHECK_PAYLOAD_SIZE(ATTITUDE);
-        plane.send_attitude(chan);
         break;
 
     case MSG_LOCATION:

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -35,6 +35,8 @@ protected:
 
     virtual bool in_hil_mode() const override;
 
+    void send_attitude() const override;
+
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -768,7 +768,6 @@ private:
     
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
-    void send_attitude(mavlink_channel_t chan);
     void send_fence_status(mavlink_channel_t chan);
     void update_sensor_status_flags(void);
     void send_extended_status1(mavlink_channel_t chan);

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -89,20 +89,6 @@ MAV_STATE GCS_MAVLINK_Sub::system_status() const
     return MAV_STATE_STANDBY;
 }
 
-NOINLINE void Sub::send_attitude(mavlink_channel_t chan)
-{
-    const Vector3f &gyro = ins.get_gyro();
-    mavlink_msg_attitude_send(
-        chan,
-        millis(),
-        ahrs.roll,
-        ahrs.pitch,
-        ahrs.yaw,
-        gyro.x,
-        gyro.y,
-        gyro.z);
-}
-
 #if AC_FENCE == ENABLED
 NOINLINE void Sub::send_limits_status(mavlink_channel_t chan)
 {
@@ -515,11 +501,6 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
             CHECK_PAYLOAD_SIZE(POWER_STATUS);
             send_power_status();
         }
-        break;
-
-    case MSG_ATTITUDE:
-        CHECK_PAYLOAD_SIZE(ATTITUDE);
-        sub.send_attitude(chan);
         break;
 
     case MSG_LOCATION:

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -474,7 +474,6 @@ private:
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);
     void send_heartbeat(mavlink_channel_t chan);
-    void send_attitude(mavlink_channel_t chan);
     void send_limits_status(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_location(mavlink_channel_t chan);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -180,6 +180,7 @@ public:
 #if AP_AHRS_NAVEKF_AVAILABLE
     void send_opticalflow(const OpticalFlow &optflow);
 #endif
+    virtual void send_attitude() const;
     void send_autopilot_version() const;
     void send_local_position() const;
     void send_vibration() const;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2612,6 +2612,21 @@ bool GCS_MAVLINK::try_send_camera_message(const enum ap_message id)
     return ret;
 }
 
+void GCS_MAVLINK::send_attitude() const
+{
+    const AP_AHRS &ahrs = AP::ahrs();
+    const Vector3f omega = ahrs.get_gyro();
+    mavlink_msg_attitude_send(
+        chan,
+        AP_HAL::millis(),
+        ahrs.roll,
+        ahrs.pitch,
+        ahrs.yaw,
+        omega.x,
+        omega.y,
+        omega.z);
+}
+
 bool GCS_MAVLINK::try_send_message(const enum ap_message id)
 {
     if (telemetry_delayed()) {
@@ -2621,6 +2636,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     bool ret = true;
 
     switch(id) {
+
+    case MSG_ATTITUDE:
+        CHECK_PAYLOAD_SIZE(ATTITUDE);
+        send_attitude();
+        break;
 
     case MSG_NEXT_PARAM:
         CHECK_PAYLOAD_SIZE(PARAM_VALUE);


### PR DESCRIPTION
Removes code duplication.

This is not an NFC.

Rover, Tracker and Plane all used the AHRS to source gryo data.

Copter and Sub did not - this changes things so they do source data for `ATTITUDE` from the same place they are sourcing data for the roll, pitch and yaw.  This makes the vehicles consistent.
