### PR TITLE
Move sending of simstate message up

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -152,14 +152,6 @@ void Rover::send_vfr_hud(mavlink_channel_t chan)
         0);
 }
 
-// report simulator state
-void Rover::send_simstate(mavlink_channel_t chan)
-{
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.simstate_send(chan);
-#endif
-}
-
 void Rover::send_rangefinder(mavlink_channel_t chan)
 {
     float distance_cm;
@@ -295,11 +287,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_VFR_HUD:
         CHECK_PAYLOAD_SIZE(VFR_HUD);
         rover.send_vfr_hud(chan);
-        break;
-
-    case MSG_SIMSTATE:
-        CHECK_PAYLOAD_SIZE(SIMSTATE);
-        rover.send_simstate(chan);
         break;
 
     case MSG_RANGEFINDER:

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -467,7 +467,6 @@ private:
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
-    void send_simstate(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void send_wheel_encoder(mavlink_channel_t chan);

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -115,14 +115,6 @@ void Tracker::send_nav_controller_output(mavlink_channel_t chan)
 }
 
 
-// report simulator state
-void Tracker::send_simstate(mavlink_channel_t chan)
-{
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.simstate_send(chan);
-#endif
-}
-
 bool GCS_MAVLINK_Tracker::handle_guided_request(AP_Mission::Mission_Command&)
 {
     // do nothing
@@ -142,11 +134,6 @@ bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         tracker.send_nav_controller_output(chan);
-        break;
-
-    case MSG_SIMSTATE:
-        CHECK_PAYLOAD_SIZE(SIMSTATE);
-        tracker.send_simstate(chan);
         break;
 
     case MSG_EXTENDED_STATUS1:

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -201,7 +201,6 @@ private:
     void ten_hz_logging_loop();
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_simstate(mavlink_channel_t chan);
     void gcs_data_stream_send(void);
     void gcs_update(void);
     void gcs_retry_deferred(void);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -761,7 +761,6 @@ private:
     void send_fence_status(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_simstate(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
     void send_rpm(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -171,14 +171,6 @@ void NOINLINE Copter::send_nav_controller_output(mavlink_channel_t chan)
         0);
 }
 
-// report simulator state
-void NOINLINE Copter::send_simstate(mavlink_channel_t chan)
-{
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.simstate_send(chan);
-#endif
-}
-
 void NOINLINE Copter::send_vfr_hud(mavlink_channel_t chan)
 {
     mavlink_msg_vfr_hud_send(
@@ -340,15 +332,6 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(FENCE_STATUS);
         copter.send_fence_status(chan);
 #endif
-        break;
-
-    case MSG_SIMSTATE:
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        CHECK_PAYLOAD_SIZE(SIMSTATE);
-        copter.send_simstate(chan);
-#endif
-        CHECK_PAYLOAD_SIZE(AHRS2);
-        send_ahrs2();
         break;
 
     case MSG_MOUNT_STATUS:

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -263,12 +263,12 @@ static mavlink_hil_state_t last_hil_state;
 #endif
 
 // report simulator state
-void Plane::send_simstate(mavlink_channel_t chan)
+void GCS_MAVLINK_Plane::send_simstate() const
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.simstate_send(chan);
+    GCS_MAVLINK::send_simstate();
 #elif HIL_SUPPORT
-    if (g.hil_mode == 1) {
+    if (plane.g.hil_mode == 1) {
         mavlink_msg_simstate_send(chan,
                                   last_hil_state.roll,
                                   last_hil_state.pitch,
@@ -428,13 +428,6 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(FENCE_STATUS);
         plane.send_fence_status(chan);
 #endif
-        break;
-
-    case MSG_SIMSTATE:
-        CHECK_PAYLOAD_SIZE(SIMSTATE);
-        plane.send_simstate(chan);
-        CHECK_PAYLOAD_SIZE2(AHRS2);
-        send_ahrs2();
         break;
 
     case MSG_TERRAIN:

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -37,6 +37,7 @@ protected:
     virtual bool in_hil_mode() const override;
 
     void send_attitude() const override;
+    void send_simstate() const override;
 
 private:
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -774,7 +774,6 @@ private:
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
-    void send_simstate(mavlink_channel_t chan);
     void send_wind(mavlink_channel_t chan);
     void send_pid_info(const mavlink_channel_t chan, const DataFlash_Class::PID_Info *pid_info, const uint8_t axis, const float achieved);
     void send_pid_tuning(mavlink_channel_t chan);

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -251,14 +251,6 @@ void NOINLINE Sub::send_nav_controller_output(mavlink_channel_t chan)
         0);
 }
 
-// report simulator state
-void NOINLINE Sub::send_simstate(mavlink_channel_t chan)
-{
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.simstate_send(chan);
-#endif
-}
-
 void NOINLINE Sub::send_vfr_hud(mavlink_channel_t chan)
 {
     mavlink_msg_vfr_hud_send(
@@ -459,15 +451,6 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(FENCE_STATUS);
         sub.fence_send_mavlink_status(chan);
 #endif
-        break;
-
-    case MSG_SIMSTATE:
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        CHECK_PAYLOAD_SIZE(SIMSTATE);
-        sub.send_simstate(chan);
-#endif
-        CHECK_PAYLOAD_SIZE(AHRS2);
-        send_ahrs2();
         break;
 
     case MSG_MOUNT_STATUS:

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -476,7 +476,6 @@ private:
     void send_heartbeat(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_simstate(mavlink_channel_t chan);
     void send_vfr_hud(mavlink_channel_t chan);
 #if RPM_ENABLED == ENABLED
     void send_rpm(mavlink_channel_t chan);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -177,6 +177,7 @@ public:
     virtual void send_scaled_pressure3(); // allow sub to override this
     void send_scaled_pressure();
     void send_sensor_offsets();
+    virtual void send_simstate() const;
     void send_ahrs();
     void send_battery2();
 #if AP_AHRS_NAVEKF_AVAILABLE

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -28,6 +28,8 @@ extern const AP_HAL::HAL& hal;
 
 namespace SITL {
 
+SITL *SITL::_s_instance = nullptr;
+
 // table of user settable parameters
 const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("BARO_RND",   0, SITL,  baro_noise,  0.2f),
@@ -220,3 +222,13 @@ Vector3f SITL::convert_earth_frame(const Matrix3f &dcm, const Vector3f &gyro)
 }
 
 } // namespace SITL
+
+
+namespace AP {
+
+SITL::SITL *sitl()
+{
+    return SITL::SITL::get_instance();
+}
+
+};

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -41,7 +41,18 @@ public:
         mag_ofs.set(Vector3f(5, 13, -18));
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
+        if (_s_instance != nullptr) {
+            AP_HAL::panic("Too many SITL instances");
+        }
+        _s_instance = this;
     }
+
+    /* Do not allow copies */
+    SITL(const SITL &other) = delete;
+    SITL &operator=(const SITL&) = delete;
+
+    static SITL *_s_instance;
+    static SITL *get_instance() { return _s_instance; }
 
     enum GPSType {
         GPS_TYPE_NONE  = 0,
@@ -193,3 +204,8 @@ public:
 };
 
 } // namespace SITL
+
+
+namespace AP {
+    SITL::SITL *sitl();
+};


### PR DESCRIPTION
Reduces code duplication.

Note this isn't NFC for some vehicles; some vehicles were sending secondary attitude solutions in SIM, some weren't.  After this they all will.
