### PR TITLE
AP_Mount: Change mount stabilize limit and typos

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -152,7 +152,7 @@ void AP_Mount_Servo::stabilize()
         // lead filter
         const Vector3f &gyro = _frontend._ahrs.get_gyro();
 
-        if (_state._stab_roll && !is_zero(_state._roll_stb_lead) && fabsf(_frontend._ahrs.pitch) < M_PI/3.0f) {
+        if (_state._stab_roll && !is_zero(_state._roll_stb_lead) && fabsf(_frontend._ahrs.pitch) < radians(80)) {
             // Compute rate of change of euler roll angle
             float roll_rate = gyro.x + (_frontend._ahrs.sin_pitch() / _frontend._ahrs.cos_pitch()) * (gyro.y * _frontend._ahrs.sin_roll() + gyro.z * _frontend._ahrs.cos_roll());
             _angle_bf_output_deg.x -= degrees(roll_rate) * _state._roll_stb_lead;
@@ -169,11 +169,11 @@ void AP_Mount_Servo::stabilize()
 // closest_limit - returns closest angle to 'angle' taking into account limits.  all angles are in degrees * 10
 int16_t AP_Mount_Servo::closest_limit(int16_t angle, int16_t angle_min, int16_t angle_max)
 {
-    // Make sure the angle lies in the interval [-180 .. 180[ degrees
+    // Make sure the angle lies in the interval [-180 .. 180] degrees
     while (angle < -1800) angle += 3600;
     while (angle >= 1800) angle -= 3600;
 
-    // Make sure the angle limits lie in the interval [-180 .. 180[ degrees
+    // Make sure the angle limits lie in the interval [-180 .. 180] degrees
     while (angle_min < -1800) angle_min += 3600;
     while (angle_min >= 1800) angle_min -= 3600;
     while (angle_max < -1800) angle_max += 3600;


### PR DESCRIPTION
After discussion with Tridge we found that the hard limit of the maximum mount stabilization angle was pi/3 radians or 60 degrees. We decided to increase the maximum stabilization angle from 60 degrees to 80 degrees for higher bank angles.

This is my first commit and pull request from my desktop. Please review thoroughly.