### PR TITLE
Rover: Loiter mode mostly for boats

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -106,9 +106,6 @@ void AP_MotorsUGV::init()
 
     // set safety output
     setup_safety_output();
-
-    // sanity check parameters
-    _vector_throttle_base = constrain_float(_vector_throttle_base, 0.0f, 100.0f);
 }
 
 // setup output in case of main CPU failure
@@ -162,9 +159,6 @@ void AP_MotorsUGV::set_steering(float steering)
 // set throttle as a value from -100 to 100
 void AP_MotorsUGV::set_throttle(float throttle)
 {
-    // sanity check throttle min and max
-    _throttle_min = constrain_int16(_throttle_min, 0, 20);
-    _throttle_max = constrain_int16(_throttle_max, 30, 100);
 
     // check throttle is between -_throttle_max ~ +_throttle_max but outside -throttle_min ~ +throttle_min
     _throttle = constrain_float(throttle, -_throttle_max, _throttle_max);
@@ -188,6 +182,9 @@ void AP_MotorsUGV::output(bool armed, float dt)
     if (!hal.util->get_soft_armed()) {
         armed = false;
     }
+
+    // sanity check parameters
+    sanity_check_parameters();
 
     // clear and set limits based on input (limit flags may be set again by output_regular or output_skid_steering methods)
     set_limits_from_input(armed, _steering, _throttle);
@@ -331,6 +328,14 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
         return false;
     }
     return true;
+}
+
+// sanity check parameters
+void AP_MotorsUGV::sanity_check_parameters()
+{
+    _throttle_min = constrain_int16(_throttle_min, 0, 20);
+    _throttle_max = constrain_int16(_throttle_max, 30, 100);
+    _vector_throttle_base = constrain_float(_vector_throttle_base, 0.0f, 100.0f);
 }
 
 // setup pwm output type

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -159,6 +159,10 @@ void AP_MotorsUGV::set_steering(float steering)
 // set throttle as a value from -100 to 100
 void AP_MotorsUGV::set_throttle(float throttle)
 {
+    // only allow setting throttle if armed
+    if (!hal.util->get_soft_armed()) {
+        return;
+    }
 
     // check throttle is between -_throttle_max ~ +_throttle_max but outside -throttle_min ~ +throttle_min
     _throttle = constrain_float(throttle, -_throttle_max, _throttle_max);
@@ -181,6 +185,7 @@ void AP_MotorsUGV::output(bool armed, float dt)
     // soft-armed overrides passed in armed status
     if (!hal.util->get_soft_armed()) {
         armed = false;
+        _throttle = 0.0f;
     }
 
     // sanity check parameters

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -74,6 +74,9 @@ public:
 
 protected:
 
+    // sanity check parameters
+    void sanity_check_parameters();
+
     // setup pwm output type
     void setup_pwm_type();
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -241,7 +241,7 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: MODE1
     // @DisplayName: Mode1
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     // @Description: Driving mode for switch position 1 (910 to 1230 and above 2049)
     GSCALAR(mode1,           "MODE1",         MANUAL),
@@ -249,35 +249,35 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: MODE2
     // @DisplayName: Mode2
     // @Description: Driving mode for switch position 2 (1231 to 1360)
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     GSCALAR(mode2,           "MODE2",         MANUAL),
 
     // @Param: MODE3
     // @DisplayName: Mode3
     // @Description: Driving mode for switch position 3 (1361 to 1490)
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     GSCALAR(mode3,           "MODE3",         MANUAL),
 
     // @Param: MODE4
     // @DisplayName: Mode4
     // @Description: Driving mode for switch position 4 (1491 to 1620)
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     GSCALAR(mode4,           "MODE4",         MANUAL),
 
     // @Param: MODE5
     // @DisplayName: Mode5
     // @Description: Driving mode for switch position 5 (1621 to 1749)
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     GSCALAR(mode5,           "MODE5",         MANUAL),
 
     // @Param: MODE6
     // @DisplayName: Mode6
     // @Description: Driving mode for switch position 6 (1750 to 2049)
-    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,10:Auto,11:RTL,12:SmartRTL,15:Guided
+    // @Values: 0:Manual,1:Acro,3:Steering,4:Hold,5:Loiter,10:Auto,11:RTL,12:SmartRTL,15:Guided
     // @User: Standard
     GSCALAR(mode6,           "MODE6",         MANUAL),
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -113,6 +113,7 @@ public:
     friend class ModeAuto;
     friend class ModeGuided;
     friend class ModeHold;
+    friend class ModeLoiter;
     friend class ModeSteering;
     friend class ModeManual;
     friend class ModeRTL;
@@ -372,6 +373,7 @@ private:
     ModeAcro mode_acro;
     ModeGuided mode_guided;
     ModeAuto mode_auto;
+    ModeLoiter mode_loiter;
     ModeSteering mode_steering;
     ModeRTL mode_rtl;
     ModeSmartRTL mode_smartrtl;

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -18,6 +18,9 @@ Mode *Rover::mode_from_mode_num(const enum mode num)
     case HOLD:
         ret = &mode_hold;
         break;
+    case LOITER:
+        ret = &mode_loiter;
+        break;
     case AUTO:
         ret = &mode_auto;
         break;

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -40,6 +40,7 @@ enum mode {
     ACRO         = 1,
     STEERING     = 3,
     HOLD         = 4,
+    LOITER       = 5,
     AUTO         = 10,
     RTL          = 11,
     SMART_RTL    = 12,

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -303,6 +303,23 @@ public:
     bool requires_velocity() const override { return false; }
 };
 
+class ModeLoiter : public Mode
+{
+public:
+
+    uint32_t mode_number() const override { return LOITER; }
+    const char *name4() const override { return "LOIT"; }
+
+    // methods that affect movement of the vehicle in this mode
+    void update() override;
+
+    // return distance (in meters) to destination
+    float get_distance_to_destination() const override { return _distance_to_destination; }
+
+protected:
+
+    bool _enter() override;
+};
 
 class ModeManual : public Mode
 {

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -1,0 +1,65 @@
+#include "mode.h"
+#include "Rover.h"
+
+bool ModeLoiter::_enter()
+{
+    // set _destination to reasonable stopping point
+    calc_stopping_location(_destination);
+
+    // initialise desired speed to current speed
+    if (!attitude_control.get_forward_speed(_desired_speed)) {
+        _desired_speed = 0.0f;
+    }
+
+    // initialise heading to current heading
+    _desired_yaw_cd = ahrs.yaw_sensor;
+    _yaw_error_cd = 0.0f;
+
+    // set reversed based on speed
+    rover.set_reverse(is_negative(_desired_speed));
+
+    return true;
+}
+
+void ModeLoiter::update()
+{
+    // get distance (in meters) to destination
+    _distance_to_destination = get_distance(rover.current_loc, _destination);
+
+    // if within waypoint radius slew desired speed towards zero and use existing desired heading
+    if (_distance_to_destination <= g.waypoint_radius) {
+        if (is_negative(_desired_speed)) {
+            _desired_speed = MIN(_desired_speed + attitude_control.get_accel_max() * rover.G_Dt, 0.0f);
+        } else {
+            _desired_speed = MAX(_desired_speed - attitude_control.get_accel_max() * rover.G_Dt, 0.0f);
+        }
+        _yaw_error_cd = 0.0f;
+    } else {
+        // P controller with hard-coded gain to convert distance to desired speed
+        // To-Do: make gain configurable or calculate from attitude controller's maximum accelearation
+        _desired_speed = MIN((_distance_to_destination - g.waypoint_radius) * 0.5f, g.speed_cruise);
+
+        // calculate bearing to destination
+        _desired_yaw_cd = get_bearing_cd(rover.current_loc, _destination);
+        _yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
+        // if destination is behind vehicle, reverse towards it
+        if (fabsf(_yaw_error_cd) > 9000) {
+            _desired_yaw_cd = wrap_180_cd(_desired_yaw_cd + 18000);
+            _yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
+            _desired_speed = -_desired_speed;
+        }
+
+        // reduce desired speed if yaw_error is large
+        // note: copied from calc_reduced_speed_for_turn_or_distance
+        float yaw_error_ratio = 1.0f - constrain_float(fabsf(_yaw_error_cd / 9000.0f), 0.0f, 1.0f) * ((100.0f - g.speed_turn_gain) * 0.01f);
+        _desired_speed *= yaw_error_ratio;
+    }
+
+    // run steering and throttle controllers
+    calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
+    calc_throttle(_desired_speed, false, true);
+
+    // mark us as in_reverse when using a negative throttle
+    // To-Do: only in reverse if vehicle is actually travelling backwards?
+    rover.set_reverse(_desired_speed < 0);
+}

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -47,9 +47,6 @@ void ModeSteering::update()
     // mark us as in_reverse when using a negative throttle
     rover.set_reverse(reversed);
 
-    // apply object avoidance to desired speed using half vehicle's maximum acceleration/deceleration
-    rover.g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_accel_max(), ahrs.yaw, target_speed, rover.G_Dt);
-
     // run lateral acceleration to steering controller
     calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -213,7 +213,10 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool skid_
     const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
 
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
-    const float desired_rate = _steer_angle_p.get_p(yaw_error);
+    float desired_rate = _steer_angle_p.get_p(yaw_error);
+    if (reversed) {
+        desired_rate = -desired_rate;
+    }
 
     return get_steering_out_rate(desired_rate, skid_steering, vect_thrust, motor_limit_left, motor_limit_right, reversed);
 }


### PR DESCRIPTION
This PR adds a Loiter mode primarily intended for use with Boats as described in [this blog post on ardupilot.org](https://discuss.ardupilot.org/t/boat-with-loiter-mode-aka-position-hold/28558).

- when  the user switches into Loiter mode, the vehicle’s current position, velocity and maximum deceleration are used to project a reasonable stopping point.
- while the boat is within the WP_RADIUS of the target it simply drifts
- if/when the boat strays more than WP_RADIUS from the target it:
   - rotates to point either directly towards the target or directly away from it (whichever results in less rotation)
   - drives/floats forwards or backwards at 0.5 m/s * the distance to the edge of the circle around the target

![boat-loiter-description](https://user-images.githubusercontent.com/1498098/39557944-fe3ba414-4ec5-11e8-8210-eb0b39ff08b7.png)

This PR also includes two mostly unrelated changes:

- removes a redundant call to AC_Avoidance to reduce velocity in case of a barrier.  This same call is already in mode.cpp's calc_throttle function.
- consolidates the parameter sanity checks into a single place and calls them on each update.  It is a bit unnecessary to call them this often but we have no shortage of CPU and they are very quick checks anyway.

There are two known problems with the loiter behaviour that I will fix in follow up PRs:

- if the vehicle is travelling very quickly (i.e. over the CRUISE_SPEED) when the user switches to Loiter the vehicle will rapidly decelerate to the CRUISE_SPEED, continue at that speed for a while and then finally slow-down at stop at the projected point.  This is because the desired-speed is limited to the  CRUISE_SPEED/WP_SPEED while the stopping point is projected using 1/2 the maximum acceleration.  We should remove this limiting during the initial slow-down but I haven't quite figured out how best to do this.
- skid-steering vehicle heading becomes jumpy when the vehicle is attempted to maintain a speed of zero.  The reason is that this leads to the requested throttle changing back and forth between negative and positive and the skid-steering output function of AR_MotorsUGV ends up reversing the steering direction.  This is an existing issue this is quite serious and I will resolve soon with another PR.