### PR TITLE
Sub: send AP_ADC

### DIFF
--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -262,11 +262,15 @@ NOINLINE void Sub::send_extended_status1(mavlink_channel_t chan)
     static const uint8_t max_channels = 6;
     static const uint8_t pins[max_channels] = { 15, 14, 13, 12, 11, 10 };
 
-    float adcs[max_channels];
+    uint16_t adcs[max_channels];
 
     for (uint8_t i = 0; i < max_channels; i++) {
         AP_HAL::AnalogSource* adc = hal.analogin->channel(pins[i]);
-        adcs[i] = adc->read_average();
+        if (adc != nullptr) {
+            adcs[i] = adc->read_average();
+        } else {
+            adcs[i] = 0;
+        }
     }
 
     mavlink_msg_ap_adc_send(

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1,4 +1,5 @@
 #include "Sub.h"
+#include "AP_HAL/AnalogIn.h"
 
 #include "GCS_Mavlink.h"
 
@@ -255,6 +256,28 @@ NOINLINE void Sub::send_extended_status1(mavlink_channel_t chan)
         0, // comm drops %,
         0, // comm drops in pkts,
         0, 0, 0, 0);
+
+    // FMUV2 support only
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+    static const uint8_t max_channels = 6;
+    static const uint8_t pins[max_channels] = { 15, 14, 13, 12, 11, 10 };
+
+    float adcs[max_channels];
+
+    for (uint8_t i = 0; i < max_channels; i++) {
+        AP_HAL::AnalogSource* adc = hal.analogin->channel(pins[i]);
+        adcs[i] = adc->read_average();
+    }
+
+    mavlink_msg_ap_adc_send(
+            chan,
+            adcs[0],
+            adcs[1],
+            adcs[2],
+            adcs[3],
+            adcs[4],
+            adcs[5]);
+#endif
 
 }
 

--- a/libraries/AP_HAL_PX4/AnalogIn.cpp
+++ b/libraries/AP_HAL_PX4/AnalogIn.cpp
@@ -380,16 +380,15 @@ void PX4AnalogIn::_timer_tick(void)
 
 AP_HAL::AnalogSource* PX4AnalogIn::channel(int16_t pin) 
 {
-    uint8_t j;
-    for (j=0; j<PX4_ANALOG_MAX_CHANNELS; j++) {
+    for (uint8_t j=0; j<PX4_ANALOG_MAX_CHANNELS; j++) {
         if (_channels[j] == nullptr) {
             _channels[j] = new PX4AnalogSource(pin, 0.0f);
-            break;
+            return _channels[j]; // no existing match, create a new source
         } else if (_channels[j]->get_pin() == pin){
-            break;
+            return _channels[j]; // we have found an existing match
         }
     }
-    return _channels[j];
+    return nullptr; // Out of sources, no existing match
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/AnalogIn.cpp
+++ b/libraries/AP_HAL_PX4/AnalogIn.cpp
@@ -380,14 +380,16 @@ void PX4AnalogIn::_timer_tick(void)
 
 AP_HAL::AnalogSource* PX4AnalogIn::channel(int16_t pin) 
 {
-    for (uint8_t j=0; j<PX4_ANALOG_MAX_CHANNELS; j++) {
+    uint8_t j;
+    for (j=0; j<PX4_ANALOG_MAX_CHANNELS; j++) {
         if (_channels[j] == nullptr) {
             _channels[j] = new PX4AnalogSource(pin, 0.0f);
-            return _channels[j];
+            break;
+        } else if (_channels[j]->get_pin() == pin){
+            break;
         }
     }
-    hal.console->printf("Out of analog channels\n");
-    return nullptr;
+    return _channels[j];
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/AnalogIn.h
+++ b/libraries/AP_HAL_PX4/AnalogIn.h
@@ -21,16 +21,16 @@ class PX4::PX4AnalogSource : public AP_HAL::AnalogSource {
 public:
     friend class PX4::PX4AnalogIn;
     PX4AnalogSource(int16_t pin, float initial_value);
-    float read_average();
-    float read_latest();
-    void set_pin(uint8_t p);
-    float voltage_average();
-    float voltage_latest();
-    float voltage_average_ratiometric();
+    float read_average() override;
+    float read_latest() override;
+    void set_pin(uint8_t p) override;
+    float voltage_average() override;
+    float voltage_latest() override;
+    float voltage_average_ratiometric() override;
 
     // implement stop pins
-    void set_stop_pin(uint8_t p);
-    void set_settle_time(uint16_t settle_time_ms) { _settle_time_ms = settle_time_ms; }
+    void set_stop_pin(uint8_t p) override;
+    void set_settle_time(uint16_t settle_time_ms) override { _settle_time_ms = settle_time_ms; }
 
 private:
     // what pin it is attached to

--- a/libraries/AP_HAL_PX4/AnalogIn.h
+++ b/libraries/AP_HAL_PX4/AnalogIn.h
@@ -24,6 +24,7 @@ public:
     float read_average() override;
     float read_latest() override;
     void set_pin(uint8_t p) override;
+    uint8_t get_pin() { return _pin; }
     float voltage_average() override;
     float voltage_latest() override;
     float voltage_average_ratiometric() override;


### PR DESCRIPTION
This required some tweaks to the channel() api on PX4.

In master there is currently no way for global access to adc values in HAL api as far as I could find.

This will work for #877 on Sub.