### PR TITLE
waf: don't make --debug create a new build varient

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -203,10 +203,7 @@ def binary_path(step, debug=False):
         # cope with builds that don't have a specific binary
         return None
 
-    if debug:
-        binary_basedir = "sitl-debug"
-    else:
-        binary_basedir = "sitl"
+    binary_basedir = "sitl"
 
     binary = util.reltopdir(os.path.join('build', binary_basedir, 'bin', binary_name))
     if not os.path.exists(binary):

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -998,10 +998,7 @@ else:
         do_build_parameters(cmd_opts.vehicle)
 
     if cmd_opts.build_system == "waf":
-        if cmd_opts.debug:
-            binary_basedir = "build/sitl-debug"
-        else:
-            binary_basedir = "build/sitl"
+        binary_basedir = "build/sitl"
         vehicle_binary = os.path.join(find_root_dir(),
                                       binary_basedir,
                                       frame_infos["waf_target"])

--- a/wscript
+++ b/wscript
@@ -144,8 +144,6 @@ def configure(cfg):
     cfg.env.AUTOCONFIG = cfg.options.autoconfig
 
     cfg.env.VARIANT = cfg.env.BOARD
-    if cfg.env.DEBUG:
-        cfg.env.VARIANT += '-debug'
 
     _set_build_context_variant(cfg.env.VARIANT)
     cfg.setenv(cfg.env.VARIANT)


### PR DESCRIPTION
This really didn't help with anything, and is very annoying when switching between debug and non-debug builds
