### PR TITLE
ChibiOS: change scheduler boost approach

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -80,6 +80,10 @@ void AP_AHRS_NavEKF::reset_gyro_drift(void)
 
 void AP_AHRS_NavEKF::update(bool skip_ins_update)
 {
+    // drop back to normal priority if we were boosted by the INS
+    // calling delay_microseconds_boost()
+    hal.scheduler->boost_end();
+    
     // EKF1 is no longer supported - handle case where it is selected
     if (_ekf_type == 1) {
         _ekf_type.set(2);

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -29,6 +29,11 @@ public:
      */
     virtual void     delay_microseconds_boost(uint16_t us) { delay_microseconds(us); }
 
+    /*
+      end the priority boost from delay_microseconds_boost()
+     */
+    virtual void     boost_end(void) {}
+    
     virtual void     register_delay_callback(AP_HAL::Proc,
                                              uint16_t min_time_ms) = 0;
 

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -38,10 +38,6 @@
 #define APM_MAIN_PRIORITY_BOOST 182
 #endif
 
-#ifndef APM_MAIN_PRIORITY_BOOST_USEC
-#define APM_MAIN_PRIORITY_BOOST_USEC 200
-#endif
-
 #ifndef APM_SPI_PRIORITY
 // SPI priority needs to be above main priority to ensure fast sampling of IMUs can keep up
 // with the data rate
@@ -70,16 +66,17 @@ public:
 
 
     void     init();
-    void     delay(uint16_t ms);
-    void     delay_microseconds(uint16_t us);
-    void     delay_microseconds_boost(uint16_t us);
-    void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
-    void     register_timer_process(AP_HAL::MemberProc);
-    void     register_io_process(AP_HAL::MemberProc);
-    void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
-    void     suspend_timer_procs();
-    void     resume_timer_procs();
-    void     reboot(bool hold_in_bootloader);
+    void     delay(uint16_t ms) override;
+    void     delay_microseconds(uint16_t us) override;
+    void     delay_microseconds_boost(uint16_t us) override;
+    void     boost_end(void) override;
+    void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms) override;
+    void     register_timer_process(AP_HAL::MemberProc) override;
+    void     register_io_process(AP_HAL::MemberProc) override;
+    void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
+    void     suspend_timer_procs() override;
+    void     resume_timer_procs() override;
+    void     reboot(bool hold_in_bootloader) override;
 
     bool     in_main_thread() const override;
     void     system_initialized();
@@ -106,6 +103,7 @@ private:
     uint16_t _min_delay_cb_ms;
     AP_HAL::Proc _failsafe;
     bool _called_boost;
+    bool _priority_boosted;
     
     volatile bool _timer_suspended;
 
@@ -119,7 +117,6 @@ private:
 
     volatile bool _timer_event_missed;
 
-    virtual_timer_t _boost_timer;
     thread_t* _timer_thread_ctx;
     thread_t* _rcin_thread_ctx;
     thread_t* _io_thread_ctx;


### PR DESCRIPTION
This changes the scheduler boost approach to not use a timer and instead drop the boosted priority when AHRS::update runs. This means that it drops the priority when it starts the expensive maths of the EKF, but keeps it for the PID updates and motor of copter. This should provide more consistent timing of PID outputs, and avoids some nasty issues with ChibiOS scheduling
