### PR TITLE
RangeFinder: fixed a crash when VL53L0X was enabled in the software but not connected.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -228,6 +228,9 @@ AP_RangeFinder_VL53L0X::AP_RangeFinder_VL53L0X(RangeFinder::RangeFinder_State &_
 */
 AP_RangeFinder_Backend *AP_RangeFinder_VL53L0X::detect(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
 {
+	if(!dev){
+		return nullptr;
+	}
     AP_RangeFinder_VL53L0X *sensor
         = new AP_RangeFinder_VL53L0X(_state, std::move(dev));
 


### PR DESCRIPTION
When VL53L0X was selected as the range finder (RNGFND_TYPE 16), but the hardware was not connected, ArduPilot crashed with a segfault. This patch prevents the crash, allowing ArduPilot to continue normal operation after simply not detecting the chip.

Note: I observed the same behavior with RNGFND_TYPE 14, but I did not attempt to fix that. This likely affects many if not all I2C range finders.