### PR TITLE
AP_GPS: Remove software check from SBF driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -41,8 +41,7 @@ do {                                            \
 
 #define SBF_EXCESS_COMMAND_BYTES 5 // 2 start bytes + validity byte + space byte + endline byte
 
-#define RX_ERROR_MASK (SOFTWARE      | \
-                       CONGESTION    | \
+#define RX_ERROR_MASK (CONGESTION    | \
                        MISSEDEVENT   | \
                        CPUOVERLOAD   | \
                        INVALIDCONFIG | \


### PR DESCRIPTION
Software bit can be set to easily and is a false positive to check for arming reasons.