### PR TITLE
Rover: improved handling of reverse

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -169,7 +169,7 @@ void AP_MotorsUGV::set_throttle(float throttle)
         return;
     }
 
-    // check throttle is between -_throttle_max ~ +_throttle_max but outside -throttle_min ~ +throttle_min
+    // check throttle is between -_throttle_max and  +_throttle_max
     _throttle = constrain_float(throttle, -_throttle_max, _throttle_max);
 }
 

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -35,8 +35,10 @@ public:
     void setup_servo_output();
 
     // get or set steering as a value from -4500 to +4500
+    //   apply_scaling should be set to false for manual modes where
+    //   no scaling by speed or angle should e performed
     float get_steering() const { return _steering; }
-    void set_steering(float steering);
+    void set_steering(float steering, bool apply_scaling = true);
 
     // get or set throttle as a value from -100 to 100
     float get_throttle() const { return _throttle; }
@@ -52,7 +54,9 @@ public:
     bool have_vectored_thrust() const { return is_positive(_vector_throttle_base); }
 
     // output to motors and steering servos
-    void output(bool armed, float dt);
+    // ground_speed should be the vehicle's speed over the surface in m/s
+    // dt should be expected time between calls to this function
+    void output(bool armed, float ground_speed, float dt);
 
     // test steering or throttle output as a percentage of the total (range -100 to +100)
     // used in response to DO_MOTOR_TEST mavlink command
@@ -84,7 +88,7 @@ protected:
     void setup_pwm_type();
 
     // output to regular steering and throttle channels
-    void output_regular(bool armed, float steering, float throttle);
+    void output_regular(bool armed, float ground_speed, float steering, float throttle);
 
     // output for omni style frames
     void output_omni(bool armed, float steering, float throttle);
@@ -121,4 +125,5 @@ protected:
     float   _steering;  // requested steering as a value from -4500 to +4500
     float   _throttle;  // requested throttle as a value from -100 to 100
     float   _throttle_prev; // throttle input from previous iteration
+    bool    _scale_steering = true; // true if we should scale steering by speed or angle
 };

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -44,6 +44,11 @@ public:
     float get_throttle() const { return _throttle; }
     void set_throttle(float throttle);
 
+    // get slew limited throttle
+    // used by manual mode to avoid bad steering behaviour during transitions from forward to reverse
+    // same as private slew_limit_throttle method (see below) but does not update throttle state
+    float get_slew_limited_throttle(float throttle, float dt) const;
+
     // true if vehicle is capable of skid steering
     bool have_skid_steering() const;
 

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -39,6 +39,12 @@ void Rover::set_servos(void)
     if (motor_test) {
         motor_test_output();
     } else {
-        g2.motors.output(arming.is_armed() && hal.util->get_soft_armed(), G_Dt);
+        // get ground speed
+        float speed;
+        if (!g2.attitude_control.get_forward_speed(speed)) {
+            speed = 0.0f;
+        }
+
+        g2.motors.output(arming.is_armed(), speed, G_Dt);
     }
 }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -329,7 +329,7 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
 
     if (rover.use_pivot_steering(_yaw_error_cd)) {
         // for pivot turns use heading controller
-        calc_steering_to_heading(desired_heading, reversed);
+        calc_steering_to_heading(desired_heading);
     } else {
         // call lateral acceleration to steering controller
         calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
@@ -351,11 +351,8 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
 
     // send final steering command to motor library
     const float steering_out = attitude_control.get_steering_out_lat_accel(lat_accel,
-                                                                           g2.motors.have_skid_steering(),
-                                                                           g2.motors.have_vectored_thrust(),
                                                                            g2.motors.limit.steer_left,
-                                                                           g2.motors.limit.steer_right,
-                                                                           reversed);
+                                                                           g2.motors.limit.steer_right);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
 
@@ -364,11 +361,8 @@ void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
 {
     // calculate yaw error (in radians) and pass to steering angle controller
     const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f),
-                                                                         g2.motors.have_skid_steering(),
-                                                                         g2.motors.have_vectored_thrust(),
                                                                          g2.motors.limit.steer_left,
-                                                                         g2.motors.limit.steer_right,
-                                                                         reversed);
+                                                                         g2.motors.limit.steer_right);
     g2.motors.set_steering(steering_out * 4500.0f);
 }
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -356,10 +356,10 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
     float desired_lat_accel = rover.nav_controller->lateral_acceleration();
     float desired_heading = rover.nav_controller->target_bearing_cd();
     if (reversed) {
-        _yaw_error_cd = wrap_180_cd(desired_heading - ahrs.yaw_sensor + 18000);
-    } else {
-        _yaw_error_cd = wrap_180_cd(desired_heading - ahrs.yaw_sensor);
+        desired_heading = wrap_360_cd(desired_heading + 18000);
+        desired_lat_accel *= -1.0f;
     }
+    _yaw_error_cd = wrap_180_cd(desired_heading - ahrs.yaw_sensor);
 
     if (rover.use_pivot_steering(_yaw_error_cd)) {
         // for pivot turns use heading controller
@@ -376,6 +376,7 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
 void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reversed)
 {
     // add obstacle avoidance response to lateral acceleration target
+    // ToDo: replace this type of object avoidance with path planning
     if (!reversed) {
         lat_accel += (rover.obstacle.turn_angle / 45.0f) * g.turn_max_g;
     }

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -101,10 +101,13 @@ protected:
     // subclasses override this to perform any required cleanup when exiting the mode
     virtual void _exit() { return; }
 
-    // decode pilot steering held in channel_steer, channel_throttle and return in steer_out and throttle_out arguments
+    // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments
     // steering_out is in the range -4500 ~ +4500 with positive numbers meaning rotate clockwise
     // throttle_out is in the range -100 ~ +100
     void get_pilot_desired_steering_and_throttle(float &steering_out, float &throttle_out);
+
+    // decode pilot input steering and return steering_out and speed_out (in m/s)
+    void get_pilot_desired_steering_and_speed(float &steering_out, float &speed_out);
 
     // calculate steering output to drive along line from origin to destination waypoint
     void calc_steering_to_waypoint(const struct Location &origin, const struct Location &destination, bool reversed = false);
@@ -139,6 +142,13 @@ protected:
 
     // calculate vehicle stopping location using current location, velocity and maximum acceleration
     void calc_stopping_location(Location& stopping_loc);
+
+protected:
+
+    // decode pilot steering and throttle inputs and return in steer_out and throttle_out arguments
+    // steering_out is in the range -4500 ~ +4500 with positive numbers meaning rotate clockwise
+    // throttle_out is in the range -100 ~ +100
+    void get_pilot_input(float &steering_out, float &throttle_out);
 
     // references to avoid code churn:
     class AP_AHRS &ahrs;

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -102,7 +102,8 @@ protected:
     virtual void _exit() { return; }
 
     // decode pilot steering held in channel_steer, channel_throttle and return in steer_out and throttle_out arguments
-    // steering_out is in the range -4500 ~ +4500, throttle_out is in the range -100 ~ +100
+    // steering_out is in the range -4500 ~ +4500 with positive numbers meaning rotate clockwise
+    // throttle_out is in the range -100 ~ +100
     void get_pilot_desired_steering_and_throttle(float &steering_out, float &throttle_out);
 
     // calculate steering output to drive along line from origin to destination waypoint

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -3,14 +3,24 @@
 
 void ModeAcro::update()
 {
-
-    // convert pilot stick input into desired steering and throttle
-    float desired_steering, desired_throttle;
-    get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
-
-    // set reverse flag backing up
-    const bool reversed = is_negative(desired_throttle);
-    rover.set_reverse(reversed);
+    // get speed forward
+    float speed, desired_steering;
+    if (!attitude_control.get_forward_speed(speed)) {
+        float desired_throttle;
+        // convert pilot stick input into desired steering and throttle
+        get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
+        // no valid speed, just use the provided throttle
+        g2.motors.set_throttle(desired_throttle);
+        // set reverse flag if negative throttle
+        rover.set_reverse(is_negative(desired_throttle));
+    } else {
+        float desired_speed;
+        // convert pilot stick input into desired steering and speed
+        get_pilot_desired_steering_and_speed(desired_steering, desired_speed);
+        calc_throttle(desired_speed, false, true);
+        // set reverse flag if negative desired speed
+        rover.set_reverse(is_negative(desired_speed));
+    }
 
     // convert pilot steering input to desired turn rate in radians/sec
     const float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
@@ -22,19 +32,6 @@ void ModeAcro::update()
                                                                     g2.motors.limit.steer_right);
 
     g2.motors.set_steering(steering_out * 4500.0f);
-
-    // get speed forward
-    float speed;
-    if (!attitude_control.get_forward_speed(speed)) {
-        // no valid speed, just use the provided throttle
-        g2.motors.set_throttle(desired_throttle);
-    } else {
-
-        // convert pilot throttle input to desired speed
-        float target_speed = desired_throttle * 0.01f * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
-
-        calc_throttle(target_speed, false, true);
-    }
 }
 
 bool ModeAcro::requires_velocity() const

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -18,11 +18,8 @@ void ModeAcro::update()
     // run steering turn rate controller and throttle controller
     const float steering_out = attitude_control.get_steering_out_rate(
                                                                     target_turn_rate,
-                                                                    g2.motors.have_skid_steering(),
-                                                                    g2.motors.have_vectored_thrust(),
                                                                     g2.motors.limit.steer_left,
-                                                                    g2.motors.limit.steer_right,
-                                                                    reversed);
+                                                                    g2.motors.limit.steer_right);
 
     g2.motors.set_steering(steering_out * 4500.0f);
 

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -66,11 +66,8 @@ void ModeGuided::update()
             if (have_attitude_target) {
                 // run steering and throttle controllers
                 float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f),
-                                                                            g2.motors.have_skid_steering(),
-                                                                            g2.motors.have_vectored_thrust(),
                                                                             g2.motors.limit.steer_left,
-                                                                            g2.motors.limit.steer_right,
-                                                                            _desired_speed < 0);
+                                                                            g2.motors.limit.steer_right);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true, true);
             } else {

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -8,7 +8,7 @@ void ModeManual::update()
 
     // copy RC scaled inputs to outputs
     g2.motors.set_throttle(desired_throttle);
-    g2.motors.set_steering(desired_steering);
+    g2.motors.set_steering(desired_steering, false);
 
     // mark us as in_reverse when using a negative throttle to stop AHRS getting off
     rover.set_reverse(is_negative(g2.motors.get_throttle()));

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -15,37 +15,40 @@ void ModeSteering::update()
     float desired_steering, desired_speed;
     get_pilot_desired_steering_and_speed(desired_steering, desired_speed);
 
+    bool reversed = is_negative(desired_speed);
+
     // determine if pilot is requesting pivot turn
-    bool is_pivot_turning = g2.motors.have_skid_steering() && is_zero(desired_speed) && (!is_zero(desired_steering));
+    if (g2.motors.have_skid_steering() && is_zero(desired_speed)) {
+        // pivot turning using turn rate controller
+        // convert pilot steering input to desired turn rate in radians/sec
+        const float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
 
-    // In steering mode we control lateral acceleration directly.
-    // For pivot steering vehicles we use the TURN_MAX_G parameter
-    // For regular steering vehicles we use the maximum lateral acceleration at full steering lock for this speed: V^2/R where R is the radius of turn.
-    float max_g_force;
-    if (is_pivot_turning) {
-        max_g_force = g.turn_max_g * GRAVITY_MSS;
+        // run steering turn rate controller and throttle controller
+        const float steering_out = attitude_control.get_steering_out_rate(target_turn_rate,
+                                                                          g2.motors.limit.steer_left,
+                                                                          g2.motors.limit.steer_right);
+        g2.motors.set_steering(steering_out * 4500.0f);
     } else {
-        max_g_force = speed * speed / MAX(g2.turn_radius, 0.1f);
-    }
+        // In steering mode we control lateral acceleration directly.
+        // For regular steering vehicles we use the maximum lateral acceleration
+        //  at full steering lock for this speed: V^2/R where R is the radius of turn.
+        float max_g_force = speed * speed / MAX(g2.turn_radius, 0.1f);
+        max_g_force = constrain_float(max_g_force, 0.1f, g.turn_max_g * GRAVITY_MSS);
 
-    // constrain to user set TURN_MAX_G
-    max_g_force = constrain_float(max_g_force, 0.1f, g.turn_max_g * GRAVITY_MSS);
+        // convert pilot steering input to desired lateral acceleration
+        float desired_lat_accel = max_g_force * (desired_steering / 4500.0f);
 
-    // convert pilot steering input to desired lateral acceleration
-    float desired_lat_accel = max_g_force * (desired_steering / 4500.0f);
+        // reverse target lateral acceleration if backing up
+        if (reversed) {
+            desired_lat_accel = -desired_lat_accel;
+        }
 
-    // reverse target lateral acceleration if backing up
-    bool reversed = false;
-    if (is_negative(desired_speed)) {
-        reversed = true;
-        desired_lat_accel = -desired_lat_accel;
+        // run lateral acceleration to steering controller
+        calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
     }
 
     // mark us as in_reverse when using a negative throttle
     rover.set_reverse(reversed);
-
-    // run lateral acceleration to steering controller
-    calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
 
     // run speed to throttle controller
     calc_throttle(desired_speed, false, true);

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -187,12 +187,13 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool m
         return 0.0f;
     }
 
-    // only use positive speed. Use reverse flag instead of negative speeds.
-    speed = fabsf(speed);
-
     // enforce minimum speed to stop oscillations when first starting to move
-    if (speed < AR_ATTCONTROL_STEER_SPEED_MIN) {
-        speed = AR_ATTCONTROL_STEER_SPEED_MIN;
+    if (fabsf(speed) < AR_ATTCONTROL_STEER_SPEED_MIN) {
+        if (is_negative(speed)) {
+            speed = -AR_ATTCONTROL_STEER_SPEED_MIN;
+        } else {
+            speed = AR_ATTCONTROL_STEER_SPEED_MIN;
+        }
     }
 
     // Calculate the desired steering rate given desired_accel and speed

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -45,14 +45,14 @@ public:
 
     // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
     // positive lateral acceleration is to the right.
-    float get_steering_out_lat_accel(float desired_accel, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right);
 
     // return a steering servo output from -1 to +1 given a heading in radians
-    float get_steering_out_heading(float heading_rad, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_heading(float heading_rad, bool motor_limit_left, bool motor_limit_right);
 
     // return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.
-    float get_steering_out_rate(float desired_rate, bool skid_steering, bool vect_thrust, bool motor_limit_left, bool motor_limit_right, bool reversed);
+    float get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right);
 
     // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only
     float get_desired_turn_rate() const;


### PR DESCRIPTION
This PR improves Rover's handling of reversing including fixing this issue (https://github.com/ArduPilot/ardupilot/issues/8311):

- AP_MotorsUGV always interprets a positive steering input as a request to turn the vehicle clockwise regardless of the throttle input.  Essentially this change involves making Ackermann steering vehicles like skid-steering vehicles instead of the other way around.  This simplifies higher level steering controllers because it reduces the number of places we need to check if the vehicle is moving forwards or backwards.
- In manual/semi-manual modes (manual, acro, steering) when interpreting the driver's steering input (which can depend upon the throttle input) we use a throttle-slew or acceleration-limited throttle.  This resolves an issue in which the vehicle might temporarily turn in the wrong direction as the vehicle transitioned between forward and reverse.
- speed scaling of steering for Ackermann steer vehicles is done in the motors library instead of the attitude controller.  This has the following benefits:
   - architecturally puts the scaling very close to the similar scaling for vectored-thrust vehicles
   - allows support for vehicles with both skid-steering and Ackermann style steering (like a ski-doo).
   - essentially scales down the I-term contribution to steering as speed increases.  previously when done in the attitude controller, the scaling was done on the error term.  This led to I-term built up at low speeds taking longer to "bleed off" at high speeds.
- the potential downside of the above change is that at very high speeds the steering control may become so limited that it cannot counteract a physical misalignment in the steering linkage.  For example at 20m/s (70km/h) only 5% of the total steering range is available.  A potential solution to this though is to allow steering inputs > 1.
- a relatively minor change included in this PR is that we perform no steering scaling in manual mode.  this change only affects the relatively new vector-thrust feature that has not yet been released.