### PR TITLE
AP_BoardConfig: rover safety switch default to allow disarming

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -641,6 +641,14 @@ void Rover::load_parameters(void)
     const uint16_t old_aux_chan_mask = 0x3FFA;
     SRV_Channels::upgrade_parameters(old_rc_keys, old_aux_chan_mask, &rcmap);
     hal.console->printf("load_all took %uus\n", unsigned(micros() - before));
+
     // set a more reasonable default NAVL1_PERIOD for rovers
     L1_controller.set_default_period(NAVL1_PERIOD);
+
+    // configure safety switch to allow stopping the motors while armed
+#if AP_FEATURE_SAFETY_BUTTON
+    AP_Param::set_default_by_name("BRD_SAFETYOPTION", AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF|
+                                                      AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON|
+                                                      AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_ARMED);
+#endif
 }


### PR DESCRIPTION
This change reverts the default safety switch behaviour for Rover to allow using the safety switch to disable the output to the motors. 

As background, in Rover-3.3, Copter-3.6 and Plane-3.9 the safety switch behaviour has changed to disallow users from disarming the vehicle using the safety switch.  This was done because of a couple of incidents involving wet planes apparently having the switch go to the disarmed state in flight.

The risk for rovers of a disarm-in-flight are far lower and we've had one complaint since the Rover-3.3 release that they would like the behaviour as it was.  I agree the old behaviour is fine, perhaps better for users to be able to disarm their rover using the switch.