### PR TITLE
STorM32 native serial mount

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -7,6 +7,7 @@
 #include "AP_Mount_Alexmos.h"
 #include "AP_Mount_SToRM32.h"
 #include "AP_Mount_SToRM32_serial.h"
+#include "AP_Mount_STorM32_native.h"
 
 const AP_Param::GroupInfo AP_Mount::var_info[] = {
     // @Param: _DEFLT_MODE
@@ -461,6 +462,11 @@ void AP_Mount::init(const AP_SerialManager& serial_manager)
         // check for SToRM32 mounts using serial protocol
         } else if (mount_type == Mount_Type_SToRM32_serial) {
             _backends[instance] = new AP_Mount_SToRM32_serial(*this, state[instance], instance);
+            _num_instances++;
+
+        // check for STorM32 mounts using native serial protocol
+        } else if (mount_type == Mount_Type_STorM32_native) {
+            _backends[instance] = new AP_Mount_STorM32_native(*this, state[instance], instance);
             _num_instances++;
         }
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -38,6 +38,7 @@ class AP_Mount_SoloGimbal;
 class AP_Mount_Alexmos;
 class AP_Mount_SToRM32;
 class AP_Mount_SToRM32_serial;
+class AP_Mount_STorM32_native;
 
 /*
   This is a workaround to allow the MAVLink backend access to the
@@ -53,6 +54,7 @@ class AP_Mount
     friend class AP_Mount_Alexmos;
     friend class AP_Mount_SToRM32;
     friend class AP_Mount_SToRM32_serial;
+    friend class AP_Mount_STorM32_native;
 
 public:
     AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc);
@@ -69,7 +71,8 @@ public:
         Mount_Type_SoloGimbal = 2,      /// Solo's gimbal
         Mount_Type_Alexmos = 3,         /// Alexmos mount
         Mount_Type_SToRM32 = 4,         /// SToRM32 mount using MAVLink protocol
-        Mount_Type_SToRM32_serial = 5   /// SToRM32 mount using custom serial protocol
+        Mount_Type_SToRM32_serial = 5,  /// SToRM32 mount using custom serial protocol
+        Mount_Type_STorM32_native = 6,  /// STorM32 mount using native serial protocol
     };
 
     // init - detect and initialise all mounts

--- a/libraries/AP_Mount/AP_Mount_STorM32_native.cpp
+++ b/libraries/AP_Mount/AP_Mount_STorM32_native.cpp
@@ -1,0 +1,497 @@
+#include "AP_Mount_STorM32_native.h"
+
+extern const AP_HAL::HAL& hal;
+
+AP_Mount_STorM32_native::AP_Mount_STorM32_native(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance) :
+    AP_Mount_Backend(frontend, state, instance),
+    _initialised(false),
+    _armed(false),
+    _send_armeddisarmed(false)
+{
+    _uart = nullptr;
+    _mount_type = AP_Mount::Mount_Type_None; //the mount type will be determined in init()
+
+    _task_time_last = 0;
+    _task_counter = TASK_SLOT0;
+
+    _bitmask = SEND_STORM32LINK_V2 | SEND_CMD_SETINPUTS | SEND_CMD_DOCAMERA;
+
+    _status.pitch_deg = _status.roll_deg = _status.yaw_deg = 0.0f;
+    _status_updated = false;
+
+    _target_to_send = false;
+    _target_mode_last = MAV_MOUNT_MODE_RETRACT;
+}
+
+//------------------------------------------------------
+// AP_Mount_STorM32_native interface functions
+//------------------------------------------------------
+
+// init - performs any required initialisation for this instance
+void AP_Mount_STorM32_native::init(const AP_SerialManager& serial_manager)
+{
+    //from instance we can determine its type, we keep it here since that's easier/shorter
+    _mount_type = _frontend.get_mount_type(_instance);
+
+    // it should never happen that it's not one of them, but let's enforce it, to not depend on the outside
+    if (_mount_type != AP_Mount::Mount_Type_STorM32_native) {
+        _mount_type = AP_Mount::Mount_Type_None;
+    }
+
+    if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+        _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_STorM32_Native, 0);
+        if (_uart) {
+            _serial_is_initialised = true; //tell the STorM32_lib class
+            //we do not set _initialised = true, since we first need to pass find_gimbal()
+        } else {
+            _serial_is_initialised = false; //tell the STorM32_lib class
+            _mount_type = AP_Mount::Mount_Type_None; //this prevents many things from happening, safety guard
+        }
+    }
+
+    set_mode((enum MAV_MOUNT_MODE)_state._default_mode.get()); //set mode to default value set by user via parameter
+    _target_mode_last = _state._mode;
+}
+
+// update mount position - should be called periodically
+// this function must be defined in any case
+void AP_Mount_STorM32_native::update()
+{
+    if (!_initialised) {
+        find_gimbal_native(); //this searches for a gimbal on serial
+        return;
+    }
+
+    send_text_to_gcs();
+}
+
+// 400 Hz loop
+void AP_Mount_STorM32_native::update_fast()
+{
+    if (!_initialised) {
+        return;
+    }
+
+    //slow down everything to 100 Hz
+    // we can't use update(), since 50 Hz isn't compatible with the desired 20 Hz STorM32Link rate
+    // each message is send at 20 Hz i.e. 50 ms, for 5 task slots => 10 ms per task slot
+    uint64_t current_time_ms = AP_HAL::millis64();
+    if ((current_time_ms - _task_time_last) >= 10) {
+        _task_time_last = current_time_ms;
+
+        const uint16_t LIVEDATA_FLAGS = LIVEDATA_STATUS_V2|LIVEDATA_ATTITUDE_RELATIVE;
+
+        switch (_task_counter) {
+            case TASK_SLOT0:
+                if (_bitmask & SEND_STORM32LINK_V2) {
+                    send_storm32link_v2(_frontend._ahrs); //2.3ms
+                }
+
+                break;
+            case TASK_SLOT1:
+                // trigger live data
+                if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+                    receive_reset_wflush(); //we are brutal and kill all incoming bytes
+                    send_cmd_getdatafields(LIVEDATA_FLAGS); //0.6ms
+                }
+
+                // send do_camera here
+                // not currently supported
+
+                break;
+            case TASK_SLOT2:
+                set_target_angles_bymountmode();
+                send_target_angles(); //1.7 ms or 1.0ms
+
+                break;
+            case TASK_SLOT3:
+                if (_bitmask & SEND_CMD_SETINPUTS) {
+                    send_cmd_setinputs(); //2.4ms
+                }
+
+                break;
+            case TASK_SLOT4:
+                // receive live data
+                if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+                    do_receive(); //we had now 4/5*50ms = 40ms time, this should be more than enough
+                    if (message_received() && (_serial_in.cmd == 0x06) && (_serial_in.getdatafields.flags == LIVEDATA_FLAGS)) {
+                        // attitude angles are in STorM32 convention
+                        // convert from STorM32 to ArduPilot convention, this need correction p:-1,r:+1,y:-1
+                        set_status_angles_deg(
+                            -_serial_in.getdatafields.livedata_attitude.pitch_deg,
+                             _serial_in.getdatafields.livedata_attitude.roll_deg,
+                            -_serial_in.getdatafields.livedata_attitude.yaw_deg );
+                        // we also can check if the gimbal is in normal mode
+                        bool _armed_new = is_normal_state(_serial_in.getdatafields.livedata_status.state);
+                        if (_armed_new != _armed) { _send_armeddisarmed = true; }
+                        _armed = _armed_new;
+                    }
+                }
+
+                break;
+        }
+
+        _task_counter++;
+        if (_task_counter >= TASK_SLOTNUMBER) { _task_counter = 0; }
+    }
+}
+
+// set_mode - sets mount's mode
+void AP_Mount_STorM32_native::set_mode(enum MAV_MOUNT_MODE mode)
+{
+    if (!_initialised) {
+        return;
+    }
+
+    // record the mode change
+    _state._mode = mode;
+}
+
+// status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_STorM32_native::status_msg(mavlink_channel_t chan)
+{
+    //it does not matter if not _initalised, so no check here
+    // will then send out zeros
+
+    float pitch_deg, roll_deg, yaw_deg;
+
+    get_status_angles_deg(&pitch_deg, &roll_deg, &yaw_deg);
+
+    // MAVLink MOUNT_STATUS: int32_t pitch(deg*100), int32_t roll(deg*100), int32_t yaw(deg*100)
+    mavlink_msg_mount_status_send(chan, 0, 0, pitch_deg*100.0f, roll_deg*100.0f, yaw_deg*100.0f);
+}
+
+//------------------------------------------------------
+// AP_Mount_STorM32_native private function
+//------------------------------------------------------
+
+void AP_Mount_STorM32_native::set_target_angles_bymountmode(void)
+{
+    uint16_t pitch_pwm, roll_pwm, yaw_pwm;
+
+    bool get_pwm_target_from_radio = (_bitmask & GET_PWM_TARGET_FROM_RADIO) ? true : false;
+
+    // flag to trigger sending target angles to gimbal
+    bool send_ef_target = false;
+    bool send_pwm_target = false;
+
+    // update based on mount mode
+    enum MAV_MOUNT_MODE mount_mode = get_mode();
+
+    switch (mount_mode) {
+        // move mount to a "retracted" position.
+        case MAV_MOUNT_MODE_RETRACT:
+            {
+                const Vector3f &target = _state._retract_angles.get();
+                _angle_ef_target_rad.x = ToRad(target.x);
+                _angle_ef_target_rad.y = ToRad(target.y);
+                _angle_ef_target_rad.z = ToRad(target.z);
+                send_ef_target = true;
+            }
+            break;
+
+        // move mount to a neutral position, typically pointing forward
+        case MAV_MOUNT_MODE_NEUTRAL:
+            {
+                const Vector3f &target = _state._neutral_angles.get();
+                _angle_ef_target_rad.x = ToRad(target.x);
+                _angle_ef_target_rad.y = ToRad(target.y);
+                _angle_ef_target_rad.z = ToRad(target.z);
+                send_ef_target = true;
+            }
+            break;
+
+        // point to the angles given by a mavlink message
+        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+            // earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            send_ef_target = true;
+            break;
+
+        // RC radio manual angle control, but with stabilization from the AHRS
+        case MAV_MOUNT_MODE_RC_TARGETING:
+            // update targets using pilot's rc inputs
+            if (get_pwm_target_from_radio) {
+                get_pwm_target_angles_from_radio(&pitch_pwm, &roll_pwm, &yaw_pwm);
+                send_pwm_target = true;
+            } else {
+                update_targets_from_rc();
+                send_ef_target = true;
+            }
+            if (is_failsafe()) {
+                pitch_pwm = roll_pwm = yaw_pwm = 1500;
+                _angle_ef_target_rad.y = _angle_ef_target_rad.x = _angle_ef_target_rad.z = 0.0f;
+            }
+            break;
+
+        // point mount to a GPS point given by the mission planner
+        case MAV_MOUNT_MODE_GPS_POINT:
+            if (AP::gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
+                calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, true, true);
+                send_ef_target = true;
+            }
+            break;
+
+        default:
+            // we do not know this mode so do nothing
+            break;
+    }
+
+    // send target angles
+    if (send_ef_target) {
+        set_target_angles_rad(_angle_ef_target_rad.y, _angle_ef_target_rad.x, _angle_ef_target_rad.z, mount_mode);
+    }
+
+    if (send_pwm_target) {
+        set_target_angles_pwm(pitch_pwm, roll_pwm, yaw_pwm, mount_mode);
+    }
+}
+
+void AP_Mount_STorM32_native::get_pwm_target_angles_from_radio(uint16_t* pitch_pwm, uint16_t* roll_pwm, uint16_t* yaw_pwm)
+{
+    get_valid_pwm_from_channel(_state._tilt_rc_in, pitch_pwm);
+    get_valid_pwm_from_channel(_state._roll_rc_in, roll_pwm);
+    get_valid_pwm_from_channel(_state._pan_rc_in, yaw_pwm);
+}
+
+void AP_Mount_STorM32_native::get_valid_pwm_from_channel(uint8_t rc_in, uint16_t* pwm)
+{
+    #define rc_ch(i) RC_Channels::rc_channel(i-1)
+
+    if (rc_in && (rc_ch(rc_in))) {
+        *pwm = rc_ch(rc_in)->get_radio_in();
+    } else {
+        *pwm = 1500;
+    }
+}
+
+void AP_Mount_STorM32_native::set_target_angles_deg(float pitch_deg, float roll_deg, float yaw_deg, enum MAV_MOUNT_MODE mount_mode)
+{
+    _target.deg.pitch = pitch_deg;
+    _target.deg.roll = roll_deg;
+    _target.deg.yaw = yaw_deg;
+    _target.type = angles_deg;
+    _target.mode = mount_mode;
+    _target_to_send = true;
+}
+
+void AP_Mount_STorM32_native::set_target_angles_rad(float pitch_rad, float roll_rad, float yaw_rad, enum MAV_MOUNT_MODE mount_mode)
+{
+    _target.deg.pitch = ToDeg(pitch_rad);
+    _target.deg.roll = ToDeg(roll_rad);
+    _target.deg.yaw = ToDeg(yaw_rad);
+    _target.type = angles_deg;
+    _target.mode = mount_mode;
+    _target_to_send = true;
+}
+
+void AP_Mount_STorM32_native::set_target_angles_pwm(uint16_t pitch_pwm, uint16_t roll_pwm, uint16_t yaw_pwm, enum MAV_MOUNT_MODE mount_mode)
+{
+    _target.pwm.pitch = pitch_pwm;
+    _target.pwm.roll = roll_pwm;
+    _target.pwm.yaw = yaw_pwm;
+    _target.type = angles_pwm;
+    _target.mode = mount_mode;
+    _target_to_send = true;
+}
+
+void AP_Mount_STorM32_native::send_target_angles(void)
+{
+    if (_target.mode <= MAV_MOUNT_MODE_NEUTRAL) { //RETRACT and NEUTRAL
+        if (_target_mode_last != _target.mode) { // only do it once, i.e., when mode has just changed
+            // trigger a recenter camera, this clears all internal Remote states
+            // the camera does not need to be recentered explicitly, thus return
+            send_cmd_recentercamera();
+            _target_mode_last = _target.mode;
+        }
+        return;
+    }
+
+    // update to current mode, to avoid repeated actions on some mount mode changes
+    _target_mode_last = _target.mode;
+
+    if (_target.type == angles_pwm) {
+        uint16_t pitch_pwm = _target.pwm.pitch;
+        uint16_t roll_pwm = _target.pwm.roll;
+        uint16_t yaw_pwm = _target.pwm.yaw;
+
+        const uint16_t DZ = 10;
+
+        if (pitch_pwm < 10) { pitch_pwm = 1500; }
+        if (pitch_pwm < 1500-DZ) { pitch_pwm += DZ; } else if (pitch_pwm > 1500+DZ) { pitch_pwm -= DZ; } else { pitch_pwm = 1500; }
+
+        if (roll_pwm < 10) { roll_pwm = 1500; }
+        if (roll_pwm < 1500-DZ) { roll_pwm += DZ; } else if (roll_pwm > 1500+DZ) { roll_pwm -= DZ; } else { roll_pwm = 1500; }
+
+        if (yaw_pwm < 10) { yaw_pwm = 1500; }
+        if (yaw_pwm < 1500-DZ) { yaw_pwm += DZ; } else if (yaw_pwm > 1500+DZ) { yaw_pwm -= DZ; } else { yaw_pwm = 1500; }
+
+        send_cmd_setpitchrollyaw(pitch_pwm, roll_pwm, yaw_pwm);
+    } else {
+        float pitch_deg = _target.deg.pitch;
+        float roll_deg = _target.deg.roll;
+        float yaw_deg = _target.deg.yaw;
+
+        //convert from ArduPilot to STorM32 convention, this need correction p:-1,r:+1,y:-1
+        send_cmd_setangles(-pitch_deg, roll_deg, -yaw_deg, 0);
+    }
+}
+
+//------------------------------------------------------
+// status angles handlers, angles are in ArduPilot convention
+//------------------------------------------------------
+
+void AP_Mount_STorM32_native::set_status_angles_deg(float pitch_deg, float roll_deg, float yaw_deg)
+{
+    _status.pitch_deg = pitch_deg;
+    _status.roll_deg = roll_deg;
+    _status.yaw_deg = yaw_deg;
+
+    _status_updated = true;
+}
+
+void AP_Mount_STorM32_native::get_status_angles_deg(float* pitch_deg, float* roll_deg, float* yaw_deg)
+{
+    *pitch_deg = _status.pitch_deg;
+    *roll_deg = _status.roll_deg;
+    *yaw_deg = _status.yaw_deg;
+}
+
+//------------------------------------------------------
+// discovery functions
+//------------------------------------------------------
+
+void AP_Mount_STorM32_native::find_gimbal_native(void)
+{
+    if (_mount_type != AP_Mount::Mount_Type_STorM32_native) {
+        return;
+    }
+
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    uint64_t current_time_ms = AP_HAL::millis64();
+
+#if FIND_GIMBAL_MAX_SEARCH_TIME_MS
+    if (current_time_ms > FIND_GIMBAL_MAX_SEARCH_TIME_MS) {
+        _initialised = false; //should be already false, but it can't hurt to ensure that
+       _serial_is_initialised = false; //switch off BP_STorM32
+       _mount_type = AP_Mount::Mount_Type_None; //switch off finally, also makes find_gimbal() to stop searching
+        return;
+    }
+#endif
+
+    if ((current_time_ms - _task_time_last) > 100) { //try it every 100 ms
+        _task_time_last = current_time_ms;
+
+        switch (_task_counter) {
+            case TASK_SLOT0:
+                // send GETVERSIONSTR
+                receive_reset_wflush(); //we are brutal and kill all incoming bytes
+                send_cmd_getversionstr();
+                break;
+            case TASK_SLOT1:
+                // receive GETVERSIONSTR response
+                do_receive();
+                if (message_received() && (_serial_in.cmd == 0x02)) {
+                    for (uint16_t n=0;n<16;n++) versionstr[n] = _serial_in.getversionstr.versionstr[n];
+                    versionstr[16] = '\0';
+                    for (uint16_t n=0;n<16;n++) boardstr[n] = _serial_in.getversionstr.boardstr[n];
+                    boardstr[16] = '\0';
+                    _task_counter = TASK_SLOT0;
+                    _initialised = true;
+                }
+                break;
+        }
+        _task_counter++;
+        if (_task_counter >= 3) { _task_counter = 0; }
+    }
+}
+
+
+void AP_Mount_STorM32_native::send_text_to_gcs(void)
+{
+    if (!_initialised) {
+        return;
+    }
+
+    if (_send_armeddisarmed) {
+        _send_armeddisarmed = false;
+        gcs().send_text(MAV_SEVERITY_INFO, (_armed) ? "  STorM32: ARMED" : "  STorM32: DISARMED" );
+    }
+}
+
+//------------------------------------------------------
+// interfaces to STorM32_lib
+//------------------------------------------------------
+
+size_t AP_Mount_STorM32_native::_serial_txspace(void)
+{
+    if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+        return (size_t)_uart->txspace();
+    }
+    return 0;
+}
+
+
+size_t AP_Mount_STorM32_native::_serial_write(const uint8_t *buffer, size_t size, uint8_t priority)
+{
+    if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+
+        if (_uart != nullptr) {
+            return _uart->write(buffer, size);
+        }
+
+        return 0;
+    }
+    return 0;
+}
+
+
+uint32_t AP_Mount_STorM32_native::_serial_available(void)
+{
+    if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+        return _uart->available();
+    }
+    return 0;
+}
+
+
+int16_t AP_Mount_STorM32_native::_serial_read(void)
+{
+    if (_mount_type == AP_Mount::Mount_Type_STorM32_native) {
+        return _uart->read();
+    }
+    return 0;
+}
+
+
+uint16_t AP_Mount_STorM32_native::_rcin_read(uint8_t ch)
+{
+    return hal.rcin->read(ch);
+}
+
+
+//------------------------------------------------------
+// helper
+//------------------------------------------------------
+
+bool AP_Mount_STorM32_native::is_failsafe(void)
+{
+    #define rc_ch(i) RC_Channels::rc_channel(i-1)
+
+    uint8_t roll_rc_in = _state._roll_rc_in;
+    uint8_t tilt_rc_in = _state._tilt_rc_in;
+    uint8_t pan_rc_in = _state._pan_rc_in;
+
+    if (roll_rc_in && (rc_ch(roll_rc_in)) && (rc_ch(roll_rc_in)->get_radio_in() < 700)) { return true; }
+    if (tilt_rc_in && (rc_ch(tilt_rc_in)) && (rc_ch(tilt_rc_in)->get_radio_in() < 700)) { return true; }
+    if (pan_rc_in && (rc_ch(pan_rc_in)) && (rc_ch(pan_rc_in)->get_radio_in() < 700)) { return true; }
+
+    return false;
+}
+
+
+
+
+

--- a/libraries/AP_Mount/AP_Mount_STorM32_native.cpp
+++ b/libraries/AP_Mount/AP_Mount_STorM32_native.cpp
@@ -12,7 +12,14 @@ extern const AP_HAL::HAL& hal;
 AP_Mount_STorM32_native::AP_Mount_STorM32_native(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance) :
     AP_Mount_Backend(frontend, state, instance)
 {
-    _mount_type = AP_Mount::Mount_Type_None; //the mount type will be determined in init()
+    //these need to be initialized to the following values
+// but doesn't need to be done explicitly, since they are zero
+//    _initialised = false;
+//    _armed = false;
+//    _task_time_last = 0;
+//    _task_counter = TASK_SLOT0;
+//    _send_armeddisarmed = false;
+//    _mount_type = AP_Mount::Mount_Type_None; //the mount type will be determined in init()
 
     _bitmask = SEND_STORM32LINK_V2 | SEND_CMD_SETINPUTS | SEND_CMD_DOCAMERA;
 }
@@ -401,14 +408,6 @@ void AP_Mount_STorM32_native::find_gimbal_native(void)
                 // receive GETVERSIONSTR response
                 do_receive();
                 if (message_received() && (_serial_in.cmd == 0x02)) {
-                    for (uint16_t n=0;n<16;n++) {
-                        versionstr[n] = _serial_in.getversionstr.versionstr[n];
-                    }
-                    versionstr[16] = '\0';
-                    for (uint16_t n=0;n<16;n++) {
-                        boardstr[n] = _serial_in.getversionstr.boardstr[n];
-                    }
-                    boardstr[16] = '\0';
                     _task_counter = TASK_SLOT0;
                     _initialised = true;
                     return; //done, get out of here

--- a/libraries/AP_Mount/AP_Mount_STorM32_native.h
+++ b/libraries/AP_Mount/AP_Mount_STorM32_native.h
@@ -16,12 +16,12 @@ public:
     // Constructor
     AP_Mount_STorM32_native(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
-    /* Do not allow copies */
+    // do not allow copies
     AP_Mount_STorM32_native(const AP_Mount_STorM32_native &other) = delete;
     AP_Mount_STorM32_native &operator=(const AP_Mount_STorM32_native&) = delete;
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);    //COMMENT ??????
+    virtual void init(const AP_SerialManager& serial_manager);
 
     // update mount position - should be called periodically
     virtual void update();
@@ -41,11 +41,11 @@ private:
     bool is_failsafe(void);
 
     // interface to STorM32_lib
-    virtual size_t _serial_txspace(void);
-    virtual size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority);
-    virtual uint32_t _serial_available(void);
-    virtual int16_t _serial_read(void);
-    uint16_t _rcin_read(uint8_t ch);
+    size_t _serial_txspace(void) override;
+    size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority) override;
+    uint32_t _serial_available(void) override;
+    int16_t _serial_read(void) override;
+    uint16_t _rcin_read(uint8_t ch) override;
 
     // internal variables
     AP_HAL::UARTDriver *_uart;
@@ -63,12 +63,6 @@ private:
     };
     uint64_t _task_time_last;
     uint16_t _task_counter;
-
-    // we want to keep that info, the fields are 16 in size, so add one to convert it to string
-    //  _initialised = true indicates that these fields were set
-    char versionstr[16+1];  //COMMENT ??????
-    char namestr[16+1];
-    char boardstr[16+1];
 
     // discovery functions
     void find_gimbal_native(void);

--- a/libraries/AP_Mount/AP_Mount_STorM32_native.h
+++ b/libraries/AP_Mount/AP_Mount_STorM32_native.h
@@ -1,0 +1,138 @@
+/*
+  STorM32 mount backend class
+ */
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <AP_GPS/AP_GPS.h>
+#include <GCS_MAVLink/GCS.h>
+#include <RC_Channel/RC_Channel.h>
+#include "AP_Mount.h"
+#include "AP_Mount_Backend.h"
+#include "STorM32_lib.h"
+
+#define FIND_GIMBAL_MAX_SEARCH_TIME_MS  90000 //AP's startup has become quite slow, so give it plenty of time, set to 0 to disable
+
+class AP_Mount_STorM32_native : public AP_Mount_Backend, public STorM32_lib
+{
+
+public:
+    // Constructor
+    AP_Mount_STorM32_native(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
+
+    // init - performs any required initialisation for this instance
+    virtual void init(const AP_SerialManager& serial_manager);
+
+    // update mount position - should be called periodically
+    virtual void update();
+    virtual void update_fast();
+
+    // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
+    virtual bool has_pan_control() const { return false; }
+
+    // set_mode - sets mount's mode
+    virtual void set_mode(enum MAV_MOUNT_MODE mode);
+
+    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+    virtual void status_msg(mavlink_channel_t chan);
+
+    // every mount should have this !!!
+    virtual bool is_armed(){ return _armed; }
+
+private:
+    // helper to handle corrupted rcin data
+    bool is_failsafe(void);
+
+    // interface to STorM32_lib
+    virtual size_t _serial_txspace(void);
+    virtual size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority);
+    virtual uint32_t _serial_available(void);
+    virtual int16_t _serial_read(void);
+    uint16_t _rcin_read(uint8_t ch);
+
+    // internal variables
+    AP_HAL::UARTDriver *_uart;
+    AP_Mount::MountType _mount_type;
+    bool _initialised;              // true once the driver has been initialised
+    bool _armed;                    // true once the gimbal has reached normal operation state
+
+    enum TASKENUM {
+        TASK_SLOT0 = 0,
+        TASK_SLOT1,
+        TASK_SLOT2,
+        TASK_SLOT3,
+        TASK_SLOT4,
+        TASK_SLOTNUMBER,
+    };
+    uint64_t _task_time_last;
+    uint16_t _task_counter;
+
+    // we want to keep that info, the fields are 16 in size, so add one to convert it to string
+    //  _initialised = true indicates that these fields were set
+    char versionstr[16+1];
+    char namestr[16+1];
+    char boardstr[16+1];
+
+    // discovery functions
+    void find_gimbal_native(void);
+
+    // send info to gcs functions
+    bool _send_armeddisarmed;       // true when a armed/disarmed message should be send out
+    void send_text_to_gcs(void);
+
+    // bit mask, allows to enable/disable particular functions/features
+    enum BITMASKENUM {
+        SEND_STORM32LINK_V2 = 0x01,
+        SEND_CMD_SETINPUTS = 0x02,
+        GET_PWM_TARGET_FROM_RADIO = 0x04,
+        SEND_CMD_DOCAMERA = 0x08,
+    };
+    uint16_t _bitmask; //this mask is to control some functions
+
+    // storm32.Status in
+    struct {
+        float pitch_deg;
+        float roll_deg;
+        float yaw_deg;
+    } _status;
+    bool _status_updated;
+
+    void set_status_angles_deg(float pitch_deg, float roll_deg, float yaw_deg);
+    void get_status_angles_deg(float* pitch_deg, float* roll_deg, float* yaw_deg);
+
+    // target out
+    enum ANGLESTYPEENUM {
+        angles_deg = 0, //the STorM32 convention is angles in deg, not rad!
+        angles_pwm
+    };
+
+    struct {
+        enum MAV_MOUNT_MODE mode;
+        enum ANGLESTYPEENUM type;
+        union {
+            struct {
+                float pitch;
+                float roll;
+                float yaw;
+            } deg;
+            struct {
+                uint16_t pitch;
+                uint16_t roll;
+                uint16_t yaw;
+            } pwm;
+        };
+    } _target;
+    bool _target_to_send;
+    enum MAV_MOUNT_MODE _target_mode_last;
+
+    void set_target_angles_bymountmode(void);
+    void get_pwm_target_angles_from_radio(uint16_t* pitch_pwm, uint16_t* roll_pwm, uint16_t* yaw_pwm);
+    void get_valid_pwm_from_channel(uint8_t rc_in, uint16_t* pwm);
+    void set_target_angles_deg(float pitch_deg, float roll_deg, float yaw_deg, enum MAV_MOUNT_MODE mount_mode);
+    void set_target_angles_rad(float pitch_rad, float roll_rad, float yaw_rad, enum MAV_MOUNT_MODE mount_mode);
+    void set_target_angles_pwm(uint16_t pitch_pwm, uint16_t roll_pwm, uint16_t yaw_pwm, enum MAV_MOUNT_MODE mount_mode);
+    void send_target_angles(void);
+};

--- a/libraries/AP_Mount/AP_Mount_STorM32_native.h
+++ b/libraries/AP_Mount/AP_Mount_STorM32_native.h
@@ -3,13 +3,6 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Common/AP_Common.h>
-#include <AP_AHRS/AP_AHRS.h>
-#include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_GPS/AP_GPS.h>
-#include <GCS_MAVLink/GCS.h>
-#include <RC_Channel/RC_Channel.h>
 #include "AP_Mount.h"
 #include "AP_Mount_Backend.h"
 #include "STorM32_lib.h"
@@ -23,8 +16,12 @@ public:
     // Constructor
     AP_Mount_STorM32_native(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
+    /* Do not allow copies */
+    AP_Mount_STorM32_native(const AP_Mount_STorM32_native &other) = delete;
+    AP_Mount_STorM32_native &operator=(const AP_Mount_STorM32_native&) = delete;
+
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);
+    virtual void init(const AP_SerialManager& serial_manager);    //COMMENT ??????
 
     // update mount position - should be called periodically
     virtual void update();
@@ -38,9 +35,6 @@ public:
 
     // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     virtual void status_msg(mavlink_channel_t chan);
-
-    // every mount should have this !!!
-    virtual bool is_armed(){ return _armed; }
 
 private:
     // helper to handle corrupted rcin data
@@ -72,7 +66,7 @@ private:
 
     // we want to keep that info, the fields are 16 in size, so add one to convert it to string
     //  _initialised = true indicates that these fields were set
-    char versionstr[16+1];
+    char versionstr[16+1];  //COMMENT ??????
     char namestr[16+1];
     char boardstr[16+1];
 
@@ -98,15 +92,14 @@ private:
         float roll_deg;
         float yaw_deg;
     } _status;
-    bool _status_updated;
 
     void set_status_angles_deg(float pitch_deg, float roll_deg, float yaw_deg);
     void get_status_angles_deg(float* pitch_deg, float* roll_deg, float* yaw_deg);
 
     // target out
     enum ANGLESTYPEENUM {
-        angles_deg = 0, //the STorM32 convention is angles in deg, not rad!
-        angles_pwm
+        ANGLES_DEG = 0, //the STorM32 convention is angles in deg, not rad!
+        ANGLES_PWM
     };
 
     struct {
@@ -125,13 +118,11 @@ private:
             } pwm;
         };
     } _target;
-    bool _target_to_send;
     enum MAV_MOUNT_MODE _target_mode_last;
 
     void set_target_angles_bymountmode(void);
     void get_pwm_target_angles_from_radio(uint16_t* pitch_pwm, uint16_t* roll_pwm, uint16_t* yaw_pwm);
     void get_valid_pwm_from_channel(uint8_t rc_in, uint16_t* pwm);
-    void set_target_angles_deg(float pitch_deg, float roll_deg, float yaw_deg, enum MAV_MOUNT_MODE mount_mode);
     void set_target_angles_rad(float pitch_rad, float roll_rad, float yaw_rad, enum MAV_MOUNT_MODE mount_mode);
     void set_target_angles_pwm(uint16_t pitch_pwm, uint16_t roll_pwm, uint16_t yaw_pwm, enum MAV_MOUNT_MODE mount_mode);
     void send_target_angles(void);

--- a/libraries/AP_Mount/STorM32_lib.cpp
+++ b/libraries/AP_Mount/STorM32_lib.cpp
@@ -1,0 +1,404 @@
+#include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
+#include <AP_Notify/AP_Notify.h>
+#include <AP_Mount/STorM32_lib.h>
+
+//******************************************************
+// STorM32_lib class functions
+//******************************************************
+
+/// Constructor
+STorM32_lib::STorM32_lib() :
+    _serial_is_initialised(false),
+    _storm32link_seq(0)
+{
+    _serial_in.state = SERIALSTATE_IDLE;
+}
+
+// determines from the STorM32 state if the gimbal is in a normal operation mode
+bool STorM32_lib::is_normal_state(uint16_t state)
+{
+    if ((state == STORM32STATE_NORMAL) || (state == STORM32STATE_STARTUP_FASTLEVEL)) { return true; }
+    return false;
+}
+
+//------------------------------------------------------
+// send stuff
+//------------------------------------------------------
+
+// 33 bytes = 2865us @ 115200bps
+void STorM32_lib::send_storm32link_v2(const AP_AHRS_TYPE &ahrs)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tSTorM32LinkV2) +2) {
+        return;
+    }
+
+    enum STORM32LINKFCSTATUSAPENUM {
+        STORM32LINK_FCSTATUS_AP_AHRSHEALTHY       = 0x01, //=> Q ok, ca. 15 secs
+        STORM32LINK_FCSTATUS_AP_AHRSINITIALIZED   = 0x02, //=> vz ok, ca. 32 secs
+        STORM32LINK_FCSTATUS_AP_GPS3DFIX          = 0x04, //ca 60-XXs
+        STORM32LINK_FCSTATUS_AP_NAVHORIZVEL       = 0x08, //comes very late, after GPS fix and few secs after position_ok()
+        STORM32LINK_FCSTATUS_AP_ARMED             = 0x40, //tells when copter is about to take-off
+        STORM32LINK_FCSTATUS_ISARDUPILOT          = 0x80, //permanently set, to indicate that it's ArduPilot, so STorM32 knows about and can act accordingly
+    };
+
+    uint8_t status = STORM32LINK_FCSTATUS_ISARDUPILOT;
+
+    nav_filter_status nav_status;
+    ahrs.get_filter_status(nav_status);
+
+    AP_Notify *notify = AP_Notify::instance();
+
+    if (ahrs.healthy()) { status |= STORM32LINK_FCSTATUS_AP_AHRSHEALTHY; }
+    if (ahrs.initialised()) { status |= STORM32LINK_FCSTATUS_AP_AHRSINITIALIZED; }
+    if (nav_status.flags.horiz_vel) { status |= STORM32LINK_FCSTATUS_AP_NAVHORIZVEL; }
+    if (AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) { status |= STORM32LINK_FCSTATUS_AP_GPS3DFIX; }
+    if (notify && (notify->flags.armed)) { status |= STORM32LINK_FCSTATUS_AP_ARMED; }
+
+    int16_t yawrate = 0;
+
+    Quaternion quat;
+    quat.from_rotation_matrix(ahrs.get_rotation_body_to_ned());
+
+    Vector3f vel;
+    //ahrs.get_velocity_NED(vel) returns a bool, what does it exactly mean ???
+    // whatever it means it's probably a good idea to consider it
+    if (!ahrs.get_velocity_NED(vel)) { vel.x = vel.y = vel.z = 0.0f; }
+
+    tSTorM32LinkV2 t;
+    t.stx = 0xF9;
+    t.len = 0x21;
+    t.cmd = 0xDA;
+    t.seq = _storm32link_seq; _storm32link_seq++;
+    t.status = status;
+    t.spare = 0;
+    t.yawratecmd = yawrate;
+    t.q0 = quat.q1;
+    t.q1 = quat.q2;
+    t.q2 = quat.q3;
+    t.q3 = quat.q4;
+    t.vx = vel.x;
+    t.vy = vel.y;
+    t.vz = vel.z;
+    t.crc = crc_calculate(&(t.len), sizeof(tSTorM32LinkV2)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tSTorM32LinkV2), PRIORITY_HIGHEST );
+}
+
+// 19 bytes = 1650us @ 115200bps
+void STorM32_lib::send_cmd_setangles(float pitch_deg, float roll_deg, float yaw_deg, uint16_t flags)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdSetAngles) +2) {
+        return;
+    }
+
+    tCmdSetAngles t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x0E;
+    t.cmd = 0x11;
+    t.pitch = pitch_deg;
+    t.roll = roll_deg;
+    t.yaw = yaw_deg;
+    t.flags = flags;
+    t.type = 0;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdSetAngles)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdSetAngles) );
+}
+
+// 11 bytes = 955us @ 115200bps
+void STorM32_lib::send_cmd_setpitchrollyaw(uint16_t pitch, uint16_t roll, uint16_t yaw)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdSetPitchRollYaw) +2) {
+        return;
+    }
+
+    tCmdSetPitchRollYaw t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x06;
+    t.cmd = 0x12;
+    t.pitch = pitch;
+    t.roll = roll;
+    t.yaw = yaw;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdSetPitchRollYaw)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdSetPitchRollYaw) );
+}
+
+
+// 11 bytes = 955us @ 115200bps
+void STorM32_lib::send_cmd_recentercamera(void)
+{
+    send_cmd_setpitchrollyaw(0, 0, 0);
+}
+
+// 11 bytes = 955us @ 115200bps
+void STorM32_lib::send_cmd_docamera(uint16_t camera_cmd)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdDoCamera) +2) {
+        return;
+    }
+
+    tCmdDoCamera t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x06;
+    t.cmd = 0x0F;
+    t.dummy1 = 0;
+    t.camera_cmd = camera_cmd;
+    t.dummy2 = 0;
+    t.dummy3 = 0;
+    t.dummy4 = 0;
+    t.dummy5 = 0;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdDoCamera)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdDoCamera) );
+}
+
+// 28 bytes = 2431us @ 115200bps
+void STorM32_lib::send_cmd_setinputs(void)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdSetInputs) +2) {
+        return;
+    }
+
+    uint8_t status = 0;
+
+    tCmdSetInputs t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x17;
+    t.cmd = 0x16;
+    t.channel0 = _rcin_read(0);
+    t.channel1 = _rcin_read(1);
+    t.channel2 = _rcin_read(2);
+    t.channel3 = _rcin_read(3);
+    t.channel4 = _rcin_read(4);
+    t.channel5 = _rcin_read(5);
+    t.channel6 = _rcin_read(6);
+    t.channel7 = _rcin_read(7);
+    t.channel8 = _rcin_read(8);
+    t.channel9 = _rcin_read(9);
+    t.channel10 = _rcin_read(10);
+    t.channel11 = _rcin_read(11);
+    t.channel12 = _rcin_read(12);
+    t.channel13 = _rcin_read(13);
+    t.channel14 = _rcin_read(14);
+    t.channel15 = _rcin_read(15);
+    t.status = status;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdSetInputs)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdSetInputs) );
+}
+
+// 19 bytes = 1650us @ 115200bps
+void STorM32_lib::send_cmd_sethomelocation(const AP_AHRS_TYPE &ahrs)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdSetHomeTargetLocation) +2) {
+        return;
+    }
+
+    uint16_t status = 0; //= LOCATION_INVALID
+    struct Location location = {};
+
+    if (ahrs.get_position(location)) {
+        status = 0x0001; //= LOCATION_VALID
+    }
+
+    tCmdSetHomeTargetLocation t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x0E;
+    t.cmd = 0x17;
+    t.latitude = location.lat;
+    t.longitude = location.lng;
+    t.altitude = location.alt;
+    t.status = status;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdSetHomeTargetLocation)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdSetHomeTargetLocation) );
+}
+
+// 19 bytes = 1650us @ 115200bps
+void STorM32_lib::send_cmd_settargetlocation(void)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdSetHomeTargetLocation) +2) {
+        return;
+    }
+
+    uint16_t status = 0; //= LOCATION_INVALID
+    struct Location location = {};
+
+    tCmdSetHomeTargetLocation t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x0E;
+    t.cmd = 0x18;
+    t.latitude = location.lat;
+    t.longitude = location.lng;
+    t.altitude = location.alt;
+    t.status = status;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdSetHomeTargetLocation)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdSetHomeTargetLocation) );
+}
+
+// 7 bytes = 608us @ 115200bps
+void STorM32_lib::send_cmd_getdatafields(uint16_t flags)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdGetDataFields) +2) {
+        return;
+    }
+
+    tCmdGetDataFields t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x02;
+    t.cmd = 0x06;
+    t.flags = flags;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdGetDataFields)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdGetDataFields) );
+}
+
+// 5 bytes = 434us @ 115200bps
+void STorM32_lib::send_cmd_getversionstr(void)
+{
+    if (!_serial_is_initialised) {
+        return;
+    }
+
+    if (_serial_txspace() < sizeof(tCmdGetVersionStr) +2) {
+        return;
+    }
+
+    tCmdGetVersionStr t;
+    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.len = 0x00;
+    t.cmd = 0x02;
+    t.crc = crc_calculate(&(t.len), sizeof(tCmdGetVersionStr)-3);
+
+    _serial_write( (uint8_t*)(&t), sizeof(tCmdGetVersionStr) );
+}
+
+//------------------------------------------------------
+// receive stuff, only relevant for a real serial, not CAN
+//------------------------------------------------------
+
+void STorM32_lib::receive_reset(void)
+{
+    _serial_in.state = SERIALSTATE_IDLE;
+}
+
+void STorM32_lib::receive_reset_wflush(void)
+{
+    while (_serial_available() > 0) {
+        _serial_read();
+    }
+    _serial_in.state = SERIALSTATE_IDLE;
+}
+
+//reads in one char and processes it
+// there is no explicit timeout handling or error handling
+// call a flush_rx() and receive_reset() to take care of both of that
+void STorM32_lib::do_receive_singlechar(void)
+{
+    uint8_t c;
+
+    if (_serial_available() <= 0) { return; } //this should never happen, but play it safe
+
+    switch (_serial_in.state) {
+        case SERIALSTATE_IDLE:
+            c = _serial_read();
+
+            if (c == 0xFB) { //the outcoming RCcmd start sign was received
+                _serial_in.stx = c;
+                _serial_in.state = SERIALSTATE_RECEIVE_PAYLOAD_LEN;
+            }
+            break;
+
+        case SERIALSTATE_RECEIVE_PAYLOAD_LEN:
+            c = _serial_read();
+
+            _serial_in.len = c;
+            _serial_in.state = SERIALSTATE_RECEIVE_CMD;
+            break;
+
+        case SERIALSTATE_RECEIVE_CMD:
+            c = _serial_read();
+
+            _serial_in.cmd = c;
+            _serial_in.payload_cnt = 0;
+            _serial_in.state = SERIALSTATE_RECEIVE_PAYLOAD;
+            break;
+
+        case SERIALSTATE_RECEIVE_PAYLOAD:
+            c = _serial_read();
+
+            if (_serial_in.payload_cnt >= SERIAL_RECEIVE_BUFFER_SIZE) {
+                _serial_in.state = SERIALSTATE_IDLE; //error, get out of here
+                return;
+            }
+
+            _serial_in.buf[_serial_in.payload_cnt++] = c;
+
+            if (_serial_in.payload_cnt >= _serial_in.len + 2) { //do expect always a crc
+              uint16_t crc = 0; //XX ignore crc for the moment
+              if (crc == 0) {
+                  _serial_in.state = SERIALSTATE_MESSAGE_RECEIVED;
+              }
+            }
+            break;
+
+        case SERIALSTATE_MESSAGE_RECEIVED:
+        case SERIALSTATE_MESSAGE_RECEIVEDANDDIGESTED:
+            c = _serial_read();
+            break;
+    }
+}
+
+//reads in as many chars as there are there
+void STorM32_lib::do_receive(void)
+{
+    while (_serial_available() > 0) {
+        do_receive_singlechar();
+    }
+
+    // serial state is reset by a flush_rx() and receive_reset(), so, don't worry further
+}
+
+bool STorM32_lib::message_received(void)
+{
+    if (_serial_in.state == SERIALSTATE_MESSAGE_RECEIVED) {
+        _serial_in.state = SERIALSTATE_MESSAGE_RECEIVEDANDDIGESTED;
+        return true;
+    }
+    return false;
+}
+

--- a/libraries/AP_Mount/STorM32_lib.cpp
+++ b/libraries/AP_Mount/STorM32_lib.cpp
@@ -1,3 +1,8 @@
+//******************************************************
+// (c) olliw, www.olliw.eu
+// GPL3
+//******************************************************
+
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Mount/STorM32_lib.h>
@@ -7,9 +12,7 @@
 //******************************************************
 
 /// Constructor
-STorM32_lib::STorM32_lib() :
-    _serial_is_initialised(false),
-    _storm32link_seq(0)
+STorM32_lib::STorM32_lib()
 {
     _serial_in.state = SERIALSTATE_IDLE;
 }
@@ -17,7 +20,9 @@ STorM32_lib::STorM32_lib() :
 // determines from the STorM32 state if the gimbal is in a normal operation mode
 bool STorM32_lib::is_normal_state(uint16_t state)
 {
-    if ((state == STORM32STATE_NORMAL) || (state == STORM32STATE_STARTUP_FASTLEVEL)) { return true; }
+    if ((state == STORM32STATE_NORMAL) || (state == STORM32STATE_STARTUP_FASTLEVEL)) {
+        return true;
+    }
     return false;
 }
 
@@ -52,11 +57,21 @@ void STorM32_lib::send_storm32link_v2(const AP_AHRS_TYPE &ahrs)
 
     AP_Notify *notify = AP_Notify::instance();
 
-    if (ahrs.healthy()) { status |= STORM32LINK_FCSTATUS_AP_AHRSHEALTHY; }
-    if (ahrs.initialised()) { status |= STORM32LINK_FCSTATUS_AP_AHRSINITIALIZED; }
-    if (nav_status.flags.horiz_vel) { status |= STORM32LINK_FCSTATUS_AP_NAVHORIZVEL; }
-    if (AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) { status |= STORM32LINK_FCSTATUS_AP_GPS3DFIX; }
-    if (notify && (notify->flags.armed)) { status |= STORM32LINK_FCSTATUS_AP_ARMED; }
+    if (ahrs.healthy()) {
+        status |= STORM32LINK_FCSTATUS_AP_AHRSHEALTHY;
+    }
+    if (ahrs.initialised()) {
+        status |= STORM32LINK_FCSTATUS_AP_AHRSINITIALIZED;
+    }
+    if (nav_status.flags.horiz_vel) {
+        status |= STORM32LINK_FCSTATUS_AP_NAVHORIZVEL;
+    }
+    if (AP::gps().status() >= AP_GPS::GPS_OK_FIX_3D) {
+        status |= STORM32LINK_FCSTATUS_AP_GPS3DFIX;
+    }
+    if (notify && (notify->flags.armed)) {
+        status |= STORM32LINK_FCSTATUS_AP_ARMED;
+    }
 
     int16_t yawrate = 0;
 
@@ -64,9 +79,10 @@ void STorM32_lib::send_storm32link_v2(const AP_AHRS_TYPE &ahrs)
     quat.from_rotation_matrix(ahrs.get_rotation_body_to_ned());
 
     Vector3f vel;
-    //ahrs.get_velocity_NED(vel) returns a bool, what does it exactly mean ???
-    // whatever it means it's probably a good idea to consider it
-    if (!ahrs.get_velocity_NED(vel)) { vel.x = vel.y = vel.z = 0.0f; }
+    //ahrs.get_velocity_NED(vel) returns a bool, os it's a good idea to consider it
+    if (!ahrs.get_velocity_NED(vel)) {
+        vel.x = vel.y = vel.z = 0.0f;
+    }
 
     tSTorM32LinkV2 t;
     t.stx = 0xF9;
@@ -100,7 +116,7 @@ void STorM32_lib::send_cmd_setangles(float pitch_deg, float roll_deg, float yaw_
     }
 
     tCmdSetAngles t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x0E;
     t.cmd = 0x11;
     t.pitch = pitch_deg;
@@ -125,7 +141,7 @@ void STorM32_lib::send_cmd_setpitchrollyaw(uint16_t pitch, uint16_t roll, uint16
     }
 
     tCmdSetPitchRollYaw t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x06;
     t.cmd = 0x12;
     t.pitch = pitch;
@@ -155,7 +171,7 @@ void STorM32_lib::send_cmd_docamera(uint16_t camera_cmd)
     }
 
     tCmdDoCamera t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x06;
     t.cmd = 0x0F;
     t.dummy1 = 0;
@@ -183,7 +199,7 @@ void STorM32_lib::send_cmd_setinputs(void)
     uint8_t status = 0;
 
     tCmdSetInputs t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x17;
     t.cmd = 0x16;
     t.channel0 = _rcin_read(0);
@@ -254,7 +270,7 @@ void STorM32_lib::send_cmd_settargetlocation(void)
     struct Location location = {};
 
     tCmdSetHomeTargetLocation t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x0E;
     t.cmd = 0x18;
     t.latitude = location.lat;
@@ -278,7 +294,7 @@ void STorM32_lib::send_cmd_getdatafields(uint16_t flags)
     }
 
     tCmdGetDataFields t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x02;
     t.cmd = 0x06;
     t.flags = flags;
@@ -299,7 +315,7 @@ void STorM32_lib::send_cmd_getversionstr(void)
     }
 
     tCmdGetVersionStr t;
-    t.stx = 0xF9; //0xFA; //0xF9 to suppress response
+    t.stx = 0xF9; //0xF9 to suppress response
     t.len = 0x00;
     t.cmd = 0x02;
     t.crc = crc_calculate(&(t.len), sizeof(tCmdGetVersionStr)-3);
@@ -333,10 +349,10 @@ void STorM32_lib::do_receive_singlechar(void)
 
     if (_serial_available() <= 0) { return; } //this should never happen, but play it safe
 
+    c = _serial_read();
+
     switch (_serial_in.state) {
         case SERIALSTATE_IDLE:
-            c = _serial_read();
-
             if (c == 0xFB) { //the outcoming RCcmd start sign was received
                 _serial_in.stx = c;
                 _serial_in.state = SERIALSTATE_RECEIVE_PAYLOAD_LEN;
@@ -344,24 +360,18 @@ void STorM32_lib::do_receive_singlechar(void)
             break;
 
         case SERIALSTATE_RECEIVE_PAYLOAD_LEN:
-            c = _serial_read();
-
             _serial_in.len = c;
             _serial_in.state = SERIALSTATE_RECEIVE_CMD;
             break;
 
         case SERIALSTATE_RECEIVE_CMD:
-            c = _serial_read();
-
             _serial_in.cmd = c;
             _serial_in.payload_cnt = 0;
             _serial_in.state = SERIALSTATE_RECEIVE_PAYLOAD;
             break;
 
         case SERIALSTATE_RECEIVE_PAYLOAD:
-            c = _serial_read();
-
-            if (_serial_in.payload_cnt >= SERIAL_RECEIVE_BUFFER_SIZE) {
+            if (_serial_in.payload_cnt >= STORM32_LIB_RECEIVE_BUFFER_SIZE) {
                 _serial_in.state = SERIALSTATE_IDLE; //error, get out of here
                 return;
             }
@@ -378,7 +388,6 @@ void STorM32_lib::do_receive_singlechar(void)
 
         case SERIALSTATE_MESSAGE_RECEIVED:
         case SERIALSTATE_MESSAGE_RECEIVEDANDDIGESTED:
-            c = _serial_read();
             break;
     }
 }

--- a/libraries/AP_Mount/STorM32_lib.h
+++ b/libraries/AP_Mount/STorM32_lib.h
@@ -1,0 +1,255 @@
+#pragma once
+
+#include <AP_AHRS/AP_AHRS.h>
+
+#define SERIAL_RECEIVE_BUFFER_SIZE      96 //the largest RCcmd response can be 77
+
+class STorM32_lib
+{
+
+public:
+    /// Constructor
+    STorM32_lib();
+
+    // interface to write and read from a serial stream (serial or CAN or else)
+    enum PRIORITYENUM {
+        PRIORITY_DEFAULT = 0,
+        PRIORITY_HIGHER = 1,
+        PRIORITY_HIGHEST = 2
+    };
+    
+    bool _serial_is_initialised;
+    virtual size_t _serial_txspace(void){ return 0; }
+    virtual size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority){ return 0; }
+    size_t _serial_write(const uint8_t *buffer, size_t size){ return _serial_write(buffer, size, PRIORITY_DEFAULT); }
+    virtual uint32_t _serial_available(void){ return 0; }
+    virtual int16_t _serial_read(void){ return 0; }
+
+    // interface to read the raw receiver values
+    virtual uint16_t _rcin_read(uint8_t ch){ return 0; };
+
+    // various helper functions
+    bool is_normal_state(uint16_t state);
+
+    // flags for reading live data from the STorM32, requested with cmd GetDataFields
+    enum LIVEDATAENUM {
+      LIVEDATA_STATUS_V1                      = 0x0001,
+      LIVEDATA_TIMES                          = 0x0002,
+      LIVEDATA_IMU1GYRO                       = 0x0004,
+      LIVEDATA_IMU1ACC                        = 0x0008,
+      LIVEDATA_IMU1R                          = 0x0010,
+      LIVEDATA_IMU1ANGLES                     = 0x0020,
+      LIVEDATA_PIDCNTRL                       = 0x0040,
+      LIVEDATA_INPUTS                         = 0x0080,
+      LIVEDATA_IMU2ANGLES                     = 0x0100,
+      LIVEDATA_MAGANGLES                      = 0x0200,
+      LIVEDATA_STORM32LINK                    = 0x0400,
+      LIVEDATA_IMUACCCONFIDENCE               = 0x0800,
+      LIVEDATA_ATTITUDE_RELATIVE              = 0x1000,
+      LIVEDATA_STATUS_V2                      = 0x2000,
+      LIVEDATA_ENCODERANGLES                  = 0x4000,
+      LIVEDATA_IMUACCABS                      = 0x8000,
+    };
+
+    // functions for sending to the STorM32, using RCcmds
+    void send_storm32link_v2(const AP_AHRS_TYPE &ahrs);
+    void send_cmd_setangles(float pitch_deg, float roll_deg, float yaw_deg, uint16_t flags);
+    void send_cmd_setpitchrollyaw(uint16_t pitch, uint16_t roll, uint16_t yaw);
+    void send_cmd_recentercamera(void);
+    void send_cmd_docamera(uint16_t trigger_value);
+    void send_cmd_setinputs(void);
+    void send_cmd_sethomelocation(const AP_AHRS_TYPE &ahrs);
+    void send_cmd_settargetlocation(void);
+    void send_cmd_getdatafields(uint16_t flags);
+    void send_cmd_getversionstr(void);
+
+    // functions for handling reception of data from the STorM32
+    void receive_reset(void);
+    void receive_reset_wflush(void);
+    void do_receive_singlechar(void);
+    void do_receive(void);
+    bool message_received(void);
+
+protected:
+    // STorM32 states
+    enum STORM32STATEENUM {
+      STORM32STATE_STARTUP_MOTORS = 0,
+      STORM32STATE_STARTUP_SETTLE,
+      STORM32STATE_STARTUP_CALIBRATE,
+      STORM32STATE_STARTUP_LEVEL,
+      STORM32STATE_STARTUP_MOTORDIRDETECT,
+      STORM32STATE_STARTUP_RELEVEL,
+      STORM32STATE_NORMAL,
+      STORM32STATE_STARTUP_FASTLEVEL,
+    };
+
+    // RCcmd data packets, outgoing to STorM32
+    enum STORM32RCCMDENUM {
+        STORM32RCCMD_GET_VERSIONSTR = 0x02,
+        STORM32RCCMD_GET_DATAFIELDS = 0x06,
+        STORM32RCCMD_DO_CAMERA = 0x0F,
+        STORM32RCCMD_SET_ANGLES = 0x11,
+        STORM32RCCMD_SET_PITCHROLLYAW = 0x12,
+        STORM32RCCMD_SET_INPUTS = 0x16,
+        STORM32RCCMD_SET_HOMELOCATION= 0x17,
+        STORM32RCCMD_SET_TARGETLOCATION= 0x18,
+        STORM32RCCMD_STORM32LINKV2 = 0xDA,
+    };
+
+    struct PACKED tSTorM32LinkV2 { //len = 0x21, cmd = 0xDA
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint8_t seq;
+        uint8_t status;
+        uint8_t spare;
+        int16_t yawratecmd;
+        float q0;
+        float q1;
+        float q2;
+        float q3;
+        float vx;
+        float vy;
+        float vz;
+        uint16_t crc;
+    };
+    uint8_t _storm32link_seq;
+
+    struct PACKED tCmdSetAngles { //len = 0x0E, cmd = 0x11
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        float pitch;
+        float roll;
+        float yaw;
+        uint8_t flags;
+        uint8_t type;
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdSetPitchRollYaw { //len = 0x06, cmd = 0x12
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint16_t pitch;
+        uint16_t roll;
+        uint16_t yaw;
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdDoCamera { //len = 0x06, cmd = 0x0F
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint8_t dummy1;
+        uint8_t camera_cmd;
+        uint8_t dummy2;
+        uint8_t dummy3;
+        uint8_t dummy4;
+        uint8_t dummy5;
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdSetInputs { //len = 0x17, cmd = 0x16
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint16_t channel0  : 11;  // 176 bits of data (11 bits per channel * 16 channels) = 22 bytes.
+        uint16_t channel1  : 11;  //
+        uint16_t channel2  : 11;
+        uint16_t channel3  : 11;
+        uint16_t channel4  : 11;
+        uint16_t channel5  : 11;
+        uint16_t channel6  : 11;
+        uint16_t channel7  : 11;
+        uint16_t channel8  : 11;
+        uint16_t channel9  : 11;
+        uint16_t channel10 : 11;
+        uint16_t channel11 : 11;
+        uint16_t channel12 : 11;
+        uint16_t channel13 : 11;
+        uint16_t channel14 : 11;
+        uint16_t channel15 : 11;
+        uint8_t status;           // 0x01: reserved1, 0x02: reserved2, 0x04: signal loss, 0x08: failsafe
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdSetHomeTargetLocation { //len = 0x0E, cmd = 0x17 for home, 0x18 for target
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        int32_t latitude;
+        int32_t longitude;
+        int32_t altitude; //in cm //xxxx.x is above sea level in m
+        uint16_t status;
+        uint16_t crc;
+    };
+
+    // RCcmd data packets, outgoing get-cmds to STorM32, and incoming from STorM32
+    struct PACKED tCmdGetVersionStr { //len = 0x00, cmd = 0x02
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdGetVersionStrAckPayload { //response to CmdGetVersionStr, let's use just the payload
+        char versionstr[16];
+        char namestr[16];
+        char boardstr[16];
+    };
+
+    struct PACKED tCmdGetDataFields { //len = 0x02, cmd = 0x06
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        uint16_t flags;
+        uint16_t crc;
+    };
+
+    struct PACKED tCmdGetDataFieldsAckPayload { //response to CmdGetDataFields, let's keep just the payload
+        uint16_t flags;
+        struct {
+            uint16_t state;
+            uint16_t status;
+            uint16_t status2;
+            uint16_t status3;
+            uint16_t performance;
+            uint16_t errors;
+            uint16_t voltage;
+        } livedata_status; //v2
+        struct {
+            uint32_t time_boot_ms;
+            float pitch_deg;
+            float roll_deg;
+            float yaw_deg;
+        } livedata_attitude;
+    };
+
+    // for handling reception of data from the STorM32, received from a serial-UART
+    enum SERIALSTATEENUM {
+        SERIALSTATE_IDLE = 0, //waits for something to come
+        SERIALSTATE_RECEIVE_PAYLOAD_LEN,
+        SERIALSTATE_RECEIVE_CMD,
+        SERIALSTATE_RECEIVE_PAYLOAD,
+        SERIALSTATE_MESSAGE_RECEIVED,
+        SERIALSTATE_MESSAGE_RECEIVEDANDDIGESTED,
+    };
+
+    typedef struct { //structure to process incoming serial data
+        // auxiliary fields to handle reception
+        uint16_t state;
+        uint16_t payload_cnt;
+        // RCcmd message fields, without crc
+        uint8_t stx;
+        uint8_t len;
+        uint8_t cmd;
+        union {
+            uint8_t buf[SERIAL_RECEIVE_BUFFER_SIZE+8]; //have some overhead
+            tCmdGetDataFieldsAckPayload getdatafields;
+            tCmdGetVersionStrAckPayload getversionstr;
+        };
+    } tSerial;
+    tSerial _serial_in;
+
+}; //end of class STorM32_lib

--- a/libraries/AP_Mount/STorM32_lib.h
+++ b/libraries/AP_Mount/STorM32_lib.h
@@ -1,8 +1,16 @@
+//******************************************************
+// (c) olliw, www.olliw.eu
+// GPL3
+//******************************************************
 #pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 
-#define SERIAL_RECEIVE_BUFFER_SIZE      96 //the largest RCcmd response can be 77
+//******************************************************
+// STorM32_lib
+//******************************************************
+
+#define STORM32_LIB_RECEIVE_BUFFER_SIZE      96 //the largest RCcmd response can be 77
 
 class STorM32_lib
 {
@@ -238,14 +246,14 @@ protected:
 
     typedef struct { //structure to process incoming serial data
         // auxiliary fields to handle reception
-        uint16_t state;
+        enum SERIALSTATEENUM state;
         uint16_t payload_cnt;
         // RCcmd message fields, without crc
         uint8_t stx;
         uint8_t len;
         uint8_t cmd;
         union {
-            uint8_t buf[SERIAL_RECEIVE_BUFFER_SIZE+8]; //have some overhead
+            uint8_t buf[STORM32_LIB_RECEIVE_BUFFER_SIZE+8]; //have some overhead
             tCmdGetDataFieldsAckPayload getdatafields;
             tCmdGetVersionStrAckPayload getversionstr;
         };

--- a/libraries/AP_Mount/STorM32_lib.h
+++ b/libraries/AP_Mount/STorM32_lib.h
@@ -27,11 +27,12 @@ public:
     };
     
     bool _serial_is_initialised;
-    virtual size_t _serial_txspace(void){ return 0; }
-    virtual size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority){ return 0; }
+
+    virtual size_t _serial_txspace(void) = 0;
+    virtual size_t _serial_write(const uint8_t *buffer, size_t size, uint8_t priority) = 0;
     size_t _serial_write(const uint8_t *buffer, size_t size){ return _serial_write(buffer, size, PRIORITY_DEFAULT); }
-    virtual uint32_t _serial_available(void){ return 0; }
-    virtual int16_t _serial_read(void){ return 0; }
+    virtual uint32_t _serial_available(void) = 0;
+    virtual int16_t _serial_read(void) = 0;
 
     // interface to read the raw receiver values
     virtual uint16_t _rcin_read(uint8_t ch){ return 0; };

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -243,12 +243,18 @@ void AP_SerialManager::init()
                     state[i].uart->set_unbuffered_writes(true);
                     state[i].uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
                     break;
-
                 case SerialProtocol_ESCTelemetry:
                     // ESC telemetry protocol from BLHeli32 ESCs. Note that baudrate is hardcoded to 115200
                     state[i].baud = 115200;
                     state[i].uart->begin(map_baudrate(state[i].baud), 30, 30);
                     state[i].uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+                    break;
+                case SerialProtocol_STorM32_Native:
+                    // Note baudrate is hardcoded to 115200
+                    state[i].baud = AP_SERIALMANAGER_SToRM32_BAUD / 1000;   // update baud param in case user looks at it
+                    state[i].uart->begin(map_baudrate(state[i].baud),
+                                         AP_SERIALMANAGER_SToRM32_BUFSIZE_RX,
+                                         AP_SERIALMANAGER_SToRM32_BUFSIZE_TX);
                     break;
             }
         }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -100,6 +100,7 @@ public:
         SerialProtocol_Sbus1 = 15,
         SerialProtocol_ESCTelemetry = 16,
         SerialProtocol_Devo_Telem = 17,
+        SerialProtocol_STorM32_Native = 18,          // STorM32 using native serial protocol
     };
 
     // get singleton instance


### PR DESCRIPTION
The PR is about supporting STorM32 over serial UART.

It is motivated by a statement in a recent dev call, "So long as no harm is done outside we should accept new functionality" (https://discuss.ardupilot.org/t/dev-call-apr-23-2018-2300-utc/28358/2). The PR is as isolated as it could be, and does not affect any outside, IMHO. It very closely follows AP_Mount_SToRM32_serial, and only infects the AP_SerialManager.cpp/.h and AP_Mount.cpp/.h library files in trivial ways.

The PR doesn't provide the best possible STorM32 support, but should represent an improvement over alternatives:
 - proper targeting in all mount modes, Solo smart shots, gimbal paddle etc. working
 - STorM32 functions and scripts
 - STorM32-Link horizon and yaw drift compensation

It has been tested to compile for ArduCopter with px4-v2 (dec = 1085520), px4-v3, px4-v4, has been bench tested for px4-v4 using a pixracer, and flight tested for px4-v3 using a Solo (log and video of a test-flight: www.olliw.eu/drop/ap/pr-storm32nativeonly-logs.zip, www.olliw.eu/drop/ap/pr-storm32nativeonly-video.wmv).