### PR TITLE
Tools: install-prereqs-ubuntu: add xterm to SITL install list

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -10,7 +10,7 @@ PX4_PKGS="python-argparse openocd flex bison libncurses5-dev \
           zip genromfs python-empy cmake cmake-data"
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf"
 # python-wxgtk packages are added to SITL_PKGS below
-SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing realpath"
+SITL_PKGS="libtool libxml2-dev libxslt1-dev python-dev python-pip python-setuptools python-matplotlib python-serial python-scipy python-opencv python-numpy python-pyparsing realpath xterm"
 ASSUME_YES=false
 QUIET=false
 


### PR DESCRIPTION
This doesn't cost much and it will prevent that on default ubuntu, the SITL output is hide in background. Having xterm ensure that SITL is launch in its on term 