### PR TITLE
build: fixed references to -debug build directory

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -312,8 +312,7 @@ Examples:
 
 It's possible to pass the option `--debug` to the `configure` command. That
 will set compiler flags to store debugging information in the binaries so that
-you can use them with `gdb`, for example. The build directory will be set to
-`build/<board>-debug/`. That option might come handy when using SITL.
+you can use them with `gdb`, for example. That option might come handy when using SITL.
 
 ### Build-system wrappers ###
 

--- a/Tools/CPUInfo/Makefile
+++ b/Tools/CPUInfo/Makefile
@@ -3,7 +3,7 @@
 all:
 	@cd ../../ && modules/waf/waf-light configure --board linux --debug
 	@cd ../../ && modules/waf/waf-light tools
-	@cp ../../build/linux-debug/tools/CPUInfo CPUInfo.elf
+	@cp ../../build/linux/tools/CPUInfo CPUInfo.elf
 	@echo Built CPUInfo.elf
 
 clean:

--- a/Tools/Replay/Makefile
+++ b/Tools/Replay/Makefile
@@ -3,7 +3,7 @@
 all:
 	@cd ../../ && modules/waf/waf-light configure --board linux --debug
 	@cd ../../ && modules/waf/waf-light --target tools/Replay
-	@cp ../../build/linux-debug/tools/Replay Replay.elf
+	@cp ../../build/linux/tools/Replay Replay.elf
 	@echo Built Replay.elf
 
 clean:

--- a/libraries/AP_Beacon/examples/AP_Marvelmind_test/inject_marvelmind_dump.sh
+++ b/libraries/AP_Beacon/examples/AP_Marvelmind_test/inject_marvelmind_dump.sh
@@ -3,7 +3,7 @@
 ./waf configure --board=linux --debug
 ./waf build --target=examples/AP_Marvelmind_test -j6
 repo_root="$(git rev-parse --show-toplevel)/"
-"$repo_root/build/linux-debug/examples/AP_Marvelmind_test" -A tcp:127.0.0.1:5111 &
+"$repo_root/build/linux/examples/AP_Marvelmind_test" -A tcp:127.0.0.1:5111 &
 sleep 1
 cat ${repo_root}/libraries/AP_Beacon/examples/AP_Marvelmind_test/sample.dump| socat - tcp:127.0.0.1:5111
 wait


### PR DESCRIPTION
These were left over from a recent change
