### PR TITLE
Rover: turn rate max fix

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -197,7 +197,7 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool m
     }
 
     // Calculate the desired steering rate given desired_accel and speed
-    float desired_rate = desired_accel / speed;
+    const float desired_rate = desired_accel / speed;
 
     return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right);
 }
@@ -209,7 +209,7 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool motor
     const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
 
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
-    float desired_rate = _steer_angle_p.get_p(yaw_error);
+    const float desired_rate = _steer_angle_p.get_p(yaw_error);
 
     return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right);
 }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -240,21 +240,22 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_l
 
     // rate limit desired turn rate
     if (is_positive(_steer_rate_max)) {
-        _desired_turn_rate = constrain_float(_desired_turn_rate, -_steer_rate_max, _steer_rate_max);
+        const float steer_rate_max_rad = radians(_steer_rate_max);
+        _desired_turn_rate = constrain_float(_desired_turn_rate, -steer_rate_max_rad, steer_rate_max_rad);
     }
 
     // Calculate the steering rate error (rad/sec)
     // We do this in earth frame to allow for rover leaning over in hard corners
-    const float rate_error = (desired_rate - _ahrs.get_yaw_rate_earth());
+    const float rate_error = (_desired_turn_rate - _ahrs.get_yaw_rate_earth());
 
     // record desired rate for logging purposes only
-    _steer_rate_pid.set_desired_rate(desired_rate);
+    _steer_rate_pid.set_desired_rate(_desired_turn_rate);
 
     // pass error to PID controller
     _steer_rate_pid.set_input_filter_all(rate_error);
 
     // get feed-forward
-    const float ff = _steer_rate_pid.get_ff(desired_rate);
+    const float ff = _steer_rate_pid.get_ff(_desired_turn_rate);
 
     // get p
     const float p = _steer_rate_pid.get_p();


### PR DESCRIPTION
This fixes a bug in the turn rate limiting discovered as part of [this discussion](https://discuss.ardupilot.org/t/skid-steer-mower-overshooting-pivot-turns).  This is just a straight up bug!

Below are some pics of testing results.  In this test a simple back-and-forth mission was run with a skid-steering vehicle.

![turn-rate-max-fix-mission](https://user-images.githubusercontent.com/1498098/39853822-671c2eec-545f-11e8-8831-91989cb36f66.png)

The ATC_STR_RAT_MAX was set to 45 (deg/sec).  In the BEFORE we can see the turn rate is not limited, in the AFTER it is.

![turn-rate-max-fix](https://user-images.githubusercontent.com/1498098/39853824-6a3b0d78-545f-11e8-8cf4-4b3f6026d144.png)