### PR TITLE
Tools: autotest: make Copter tests more reliable

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -327,6 +327,10 @@ class AutoTest(ABC):
         self.progress("Failed to send RC commands to channel %s" % str(chan))
         raise SetRCTimeout()
 
+    def armed(self):
+        '''Return true if vehicle is armed and safetyoff'''
+        return self.mav.motors_armed();
+
     def arm_vehicle(self):
         """Arm vehicle with mavlink arm message."""
         self.mavproxy.send('arm throttle\n')


### PR DESCRIPTION
RTL may disarm the vehicle on completion.  We RTL at several times in
the testing, and the subsequent tests were not rearming.  This means we
had a race condition.

We now explicitly wait to be disarmed by the RTL mode, and rearm the
vehicle.

This is an interim patch until we decide whether to make each "test"
self-contained, and have a precondition of "on ground and disarmed".