### PR TITLE
Try to fix alt reset in NavEKF2/3

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -216,6 +216,7 @@ bool NavEKF2_core::resetHeightDatum(void)
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same
     if (validOrigin) {
         ekfGpsRefHgt += (double)oldHgt;
+        EKF_origin.alt += (int32_t)(100.0f * oldHgt);
     }
     // adjust the terrain state
     terrainState += oldHgt;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -214,6 +214,7 @@ bool NavEKF3_core::resetHeightDatum(void)
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same
     if (validOrigin) {
         ekfGpsRefHgt += (double)oldHgt;
+        EKF_origin.alt += (int32_t)(100.0f * oldHgt);
     }
     // adjust the terrain state
     terrainState += oldHgt;


### PR DESCRIPTION
This should be a problem in EKF when resetHeightDatum: ekfGpsRefHgt is reset but EKF_origin.alt is missing. This mightbe cause wrong alt-hold when AUTO-mode (lower or higher than expecting). 