### PR TITLE
Correct handling of minimum ground speed to smooth airspeed demand input to TECS

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -360,6 +360,7 @@ private:
     // The calculated airspeed to use in FBW-B.  Also used in higher modes for insuring min ground speed is met.
     // Also used for flap deployment criteria.  Centimeters per second.
     int32_t target_airspeed_cm;
+    int32_t target_airspeed_cm_base; // used for min ground speed compensation
 
     // The difference between current and desired airspeed.  Used in the pitch controller.  Meters per second.
     float airspeed_error;
@@ -374,7 +375,7 @@ private:
 
     // Ground speed
     // The amount current ground speed is below min ground speed.  Centimeters per second
-    int32_t groundspeed_undershoot;
+    float groundspeed_undershoot = 0;
 
     // Difference between current altitude and desired altitude.  Centimeters
     int32_t altitude_error_cm;

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -128,8 +128,8 @@ void Plane::calc_airspeed_errors()
     // but only when this is faster than the target airspeed commanded
     // above.
     if (auto_throttle_mode &&
-    	aparm.min_gndspeed_cm > 0 &&
-    	control_mode != CIRCLE) {
+        aparm.min_gndspeed_cm > 0 &&
+        control_mode != CIRCLE) {
         int32_t min_gnd_target_airspeed = airspeed_measured*100 + groundspeed_undershoot;
         if (min_gnd_target_airspeed > target_airspeed_cm) {
             target_airspeed_cm = min_gnd_target_airspeed;
@@ -152,19 +152,19 @@ void Plane::calc_airspeed_errors()
 
 void Plane::calc_gndspeed_undershoot()
 {
- 	// Use the component of ground speed in the forward direction
-	// This prevents flyaway if wind takes plane backwards
+    // Use the component of ground speed in the forward direction
+    // This prevents flyaway if wind takes plane backwards
     if (gps.status() >= AP_GPS::GPS_OK_FIX_2D) {
-	    Vector2f gndVel = ahrs.groundspeed_vector();
-		const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
-		Vector2f yawVect = Vector2f(rotMat.a.x,rotMat.b.x);
+        Vector2f gndVel = ahrs.groundspeed_vector();
+        const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+        Vector2f yawVect = Vector2f(rotMat.a.x,rotMat.b.x);
         if (!yawVect.is_zero()) {
             yawVect.normalize();
             float gndSpdFwd = yawVect * gndVel;
             groundspeed_undershoot = (aparm.min_gndspeed_cm > 0) ? (aparm.min_gndspeed_cm - gndSpdFwd*100) : 0;
         }
     } else {
-    	groundspeed_undershoot = 0;
+        groundspeed_undershoot = 0;
     }
 }
 


### PR DESCRIPTION
This PR separates the changes to ArduPlane/navigation.cpp from the PR #8014 (please see detailed description there).

Briefly, this minimum ground speed controller is aiming at minimizing the amount of noise that enters the TECS. The major distinction is that the original version used proportional control which was actually responsible for creating quite strong target speed fluctuations: airspeed and groundspeed are kinematically related and change together, but the previous implementation was calculating gndspeed undershoot to add it to the target airspeed, but as the actual airspeed was approaching the new target then also the gndspeed_undershoot was decreasing which in turn produced smaller target airspeed and so the gndspedd_undershoot went up again and so on.

For that reason that was changed to integration control which gives sufficiently fast response but does not create oscillations. (Please see graphs available on PR #8014 )

Additionally, this PR uses the actual ground speed component along desired track as opposed to the original implementation which used ground speed component along aircraft nose which was considerably smaller and resulted in erroneous airspeed targets.

NOTE: when the MIN_GNSPEED is enabled and used it interferes with the AP_Landing which adds half of the headwind to the airspeed for approach. The problem is that AP_Landing uses AHRS estimate of the wind which is update considerably slower than the reaction of the integrating min_ground speed controller so if there is a wind gradient on descent (which is quite often), the implementation which is suggested here will react correctly whereas the AP_Landing version will lag considerably resulting in too high airspeed on short final.