### PR TITLE
AP_Arming: Restrict GPS/AHRS difference to a 2D solution

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -384,7 +384,7 @@ bool AP_Arming::gps_checks(bool report)
         Location gps_loc = gps.location();
         Location ahrs_loc;
         if (ahrs.get_position(ahrs_loc)) {
-            float distance = location_3d_diff_NED(gps_loc, ahrs_loc).length();
+            const float distance = location_diff(gps_loc, ahrs_loc).length();
             if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
                 if (report) {
                     gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS and AHRS differ by %4.1fm", (double)distance);


### PR DESCRIPTION
The check is attempting to constrain that the GPS and AHRS position are similar, if you are using GPS as your altitude source then the check behaves quite reasonably. However if you are using baro (the default) and have not turned on origin drifting (also the default behavior) if your GPS vertical position has shifted since the EKF origin was set (which happens easily on plane at least) the reported altitude won't track this. If you start the vehicle with a poor initial fix (that is later improved by gaining more correction data/moving to a better signal environment) it's quite easy to trigger the check. We should only be checking the 2D positions are tracking.

We could check the 3D position if we checked that the EKF was drifting the position to follow GPS on height, or if GPS was the primary height reference. I left that out as scope creep for this PR. Resolves #7644 and helps me stop going crazy.