### PR TITLE
AP_HAL_Chibios: Fix race condition when reading analog sources

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -71,20 +71,27 @@ AnalogSource::AnalogSource(int16_t pin, float initial_value) :
     _sum_value(0),
     _sum_ratiometric(0)
 {
+    _semaphore = hal.util->new_semaphore();
 }
 
 
 float AnalogSource::read_average() 
 {
-    if (_sum_count == 0) {
+    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        if (_sum_count == 0) {
+            _semaphore->give();
+            return _value;
+        }
+        _value = _sum_value / _sum_count;
+        _value_ratiometric = _sum_ratiometric / _sum_count;
+        _sum_value = 0;
+        _sum_ratiometric = 0;
+        _sum_count = 0;
+        _semaphore->give();
+        return _value;
+    } else {
         return _value;
     }
-    _value = _sum_value / _sum_count;
-    _value_ratiometric = _sum_ratiometric / _sum_count;
-    _sum_value = 0;
-    _sum_ratiometric = 0;
-    _sum_count = 0;
-    return _value;
 }
 
 float AnalogSource::read_latest() 
@@ -135,16 +142,20 @@ float AnalogSource::voltage_latest()
 
 void AnalogSource::set_pin(uint8_t pin)
 {
-    if (_pin == pin) {
-        return;
+    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        if (_pin == pin) {
+            _semaphore->give();
+            return;
+        }
+        _pin = pin;
+        _sum_value = 0;
+        _sum_ratiometric = 0;
+        _sum_count = 0;
+        _latest_value = 0;
+        _value = 0;
+        _value_ratiometric = 0;
+        _semaphore->give();
     }
-    _pin = pin;
-    _sum_value = 0;
-    _sum_ratiometric = 0;
-    _sum_count = 0;
-    _latest_value = 0;
-    _value = 0;
-    _value_ratiometric = 0;
 }
 
 /*
@@ -152,20 +163,23 @@ void AnalogSource::set_pin(uint8_t pin)
  */
 void AnalogSource::_add_value(float v, float vcc5V)
 {
-    _latest_value = v;
-    _sum_value += v;
-    if (vcc5V < 3.0f) {
-        _sum_ratiometric += v;
-    } else {
-        // this compensates for changes in the 5V rail relative to the
-        // 3.3V reference used by the ADC.
-        _sum_ratiometric += v * 5.0f / vcc5V;
-    }
-    _sum_count++;
-    if (_sum_count == 254) {
-        _sum_value /= 2;
-        _sum_ratiometric /= 2;
-        _sum_count /= 2;
+    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        _latest_value = v;
+        _sum_value += v;
+        if (vcc5V < 3.0f) {
+            _sum_ratiometric += v;
+        } else {
+            // this compensates for changes in the 5V rail relative to the
+            // 3.3V reference used by the ADC.
+            _sum_ratiometric += v * 5.0f / vcc5V;
+        }
+        _sum_count++;
+        if (_sum_count == 254) {
+            _sum_value /= 2;
+            _sum_ratiometric /= 2;
+            _sum_count /= 2;
+        }
+        _semaphore->give();
     }
 }
 

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -50,6 +50,7 @@ private:
     float _sum_ratiometric;
     void _add_value(float v, float vcc5V);
     float _pin_scaler();
+    AP_HAL::Semaphore *_semaphore;
 };
 
 class ChibiOS::AnalogIn : public AP_HAL::AnalogIn {


### PR DESCRIPTION
This is the minimal version of fixing the race condition when reading analog inputs. The usage of timer suspending is what the PX4 HAL does, it feels a bit dirty compared to a semaphore, but I couldn't come up with a code path that would call read_average() from a higher priority then the timer thread. (If we have any tasks that are running on timers that might call this then we should be using semaphores instead I think).