### PR TITLE
Use named float wrapper to fix GCC 8.1 compile error

### DIFF
--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -517,8 +517,7 @@ void Copter::ModeFlowHold::update_height_estimate(void)
                                            (double)ins_height,
                                            (double)last_ins_height,
                                            dt_ms);
-    mavlink_msg_named_value_float_send(MAVLINK_COMM_0, AP_HAL::millis(), "HEST", height_estimate);
-    mavlink_msg_named_value_float_send(MAVLINK_COMM_1, AP_HAL::millis(), "HEST", height_estimate);
+    gcs().send_named_float("HEST", height_estimate);
     delta_velocity_ne.zero();
     last_ins_height = ins_height;
 }

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -364,58 +364,35 @@ void NOINLINE Sub::send_temperature(mavlink_channel_t chan)
         celsius.temperature() * 100);
 }
 
-bool NOINLINE Sub::send_info(mavlink_channel_t chan)
+bool GCS_MAVLINK_Sub::send_info()
 {
     // Just do this all at once, hopefully the hard-wire telemetry requirement means this is ok
     // Name is char[10]
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "CamTilt",
-            1 - (SRV_Channels::get_output_norm(SRV_Channel::k_mount_tilt) / 2.0f + 0.5f));
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("CamTilt",
+                     1 - (SRV_Channels::get_output_norm(SRV_Channel::k_mount_tilt) / 2.0f + 0.5f));
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "CamPan",
-            1 - (SRV_Channels::get_output_norm(SRV_Channel::k_mount_pan) / 2.0f + 0.5f));
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("CamPan",
+                     1 - (SRV_Channels::get_output_norm(SRV_Channel::k_mount_pan) / 2.0f + 0.5f));
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "TetherTrn",
-            quarter_turn_count/4);
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("TetherTrn",
+                     sub.quarter_turn_count/4);
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "Lights1",
-            SRV_Channels::get_output_norm(SRV_Channel::k_rcin9) / 2.0f + 0.5f);
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("Lights1",
+                     SRV_Channels::get_output_norm(SRV_Channel::k_rcin9) / 2.0f + 0.5f);
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "Lights2",
-            SRV_Channels::get_output_norm(SRV_Channel::k_rcin10) / 2.0f + 0.5f);
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("Lights2",
+                     SRV_Channels::get_output_norm(SRV_Channel::k_rcin10) / 2.0f + 0.5f);
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "PilotGain",
-            gain);
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("PilotGain", sub.gain);
 
-    CHECK_PAYLOAD_SIZE2(NAMED_VALUE_FLOAT);
-    mavlink_msg_named_value_float_send(
-            chan,
-            AP_HAL::millis(),
-            "InputHold",
-            input_hold_engaged);
+    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
+    send_named_float("InputHold", sub.input_hold_engaged);
 
     return true;
 }
@@ -503,7 +480,7 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
     switch (id) {
 
     case MSG_NAMED_FLOAT:
-        sub.send_info(chan);
+        send_info();
         break;
 
     case MSG_EXTENDED_STATUS1:

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -35,6 +35,8 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     bool try_send_message(enum ap_message id) override;
 
+    bool send_info(void);
+
     MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -487,7 +487,6 @@ private:
     void rpm_update();
 #endif
     void send_temperature(mavlink_channel_t chan);
-    bool send_info(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void gcs_data_stream_send(void);
     void gcs_check_input(void);

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -401,7 +401,7 @@ void AP_Airspeed::read(void)
 #if 1
     // debugging until we get MAVLink support for 2nd airspeed sensor
     if (enabled(1)) {
-        mavlink_msg_named_value_float_send(MAVLINK_COMM_0, AP_HAL::millis(), "AS2", get_airspeed(1));
+        gcs().send_named_float("AS2", get_airspeed(1));
     }
 #endif
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -29,6 +29,11 @@ void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
         }                                            \
     } while (0)
 
+void GCS::send_named_float(const char *name, float value) const
+{
+    FOR_EACH_ACTIVE_CHANNEL(send_named_float(name, value));
+}
+
 void GCS::send_home(const Location &home) const
 {
     FOR_EACH_ACTIVE_CHANNEL(send_home(home));

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -184,6 +184,7 @@ public:
     void send_autopilot_version() const;
     void send_local_position() const;
     void send_vibration() const;
+    void send_named_float(const char *name, float value) const;
     void send_home(const Location &home) const;
     void send_ekf_origin(const Location &ekf_origin) const;
     void send_servo_output_raw(bool hil);
@@ -537,6 +538,7 @@ public:
     virtual uint8_t num_gcs() const = 0;
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
+    void send_named_float(const char *name, float value) const;
     void send_home(const Location &home) const;
     void send_ekf_origin(const Location &ekf_origin) const;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -585,11 +585,12 @@ void GCS_MAVLINK::handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) 
 
 void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...)
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] {};
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
     va_list arg_list;
     va_start(arg_list, fmt);
     hal.util->vsnprintf((char *)text, sizeof(text), fmt, arg_list);
     va_end(arg_list);
+    text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = 0;
     gcs().send_statustext(severity, (1<<chan), text);
 }
 
@@ -1523,6 +1524,13 @@ void GCS_MAVLINK::send_vibration() const
         ins.get_accel_clip_count(0),
         ins.get_accel_clip_count(1),
         ins.get_accel_clip_count(2));
+}
+
+void GCS_MAVLINK::send_named_float(const char *name, float value) const
+{
+    char float_name[MAVLINK_MSG_NAMED_VALUE_FLOAT_FIELD_NAME_LEN+1] {};
+    strncpy(float_name, name, MAVLINK_MSG_NAMED_VALUE_FLOAT_FIELD_NAME_LEN);
+    mavlink_msg_named_value_float_send(chan, AP_HAL::millis(), float_name, value);
 }
 
 void GCS_MAVLINK::send_home(const Location &home) const


### PR DESCRIPTION
Fixes #8353 with a silly 10 byte name. Required to let GCC 8.1 work.