### PR TITLE
AP_Scheduler: remove unused log_dropped variable

### DIFF
--- a/libraries/AP_Scheduler/PerfInfo.cpp
+++ b/libraries/AP_Scheduler/PerfInfo.cpp
@@ -18,7 +18,6 @@ void AP::PerfInfo::reset()
     max_time = 0;
     min_time = 0;
     long_running = 0;
-    log_dropped = DataFlash_Class::instance()->num_dropped();
     sigma_time = 0;
     sigmasquared_time = 0;
 }
@@ -92,12 +91,6 @@ uint32_t AP::PerfInfo::get_min_time() const
 uint16_t AP::PerfInfo::get_num_long_running() const
 {
     return long_running;
-}
-
-// get_num_dropped - get number of dropped log messages
-uint32_t AP::PerfInfo::get_num_dropped() const
-{
-    return log_dropped;
 }
 
 // get_avg_time - return average loop time (in microseconds)

--- a/libraries/AP_Scheduler/PerfInfo.h
+++ b/libraries/AP_Scheduler/PerfInfo.h
@@ -19,7 +19,6 @@ public:
     uint32_t get_max_time() const;
     uint32_t get_min_time() const;
     uint16_t get_num_long_running() const;
-    uint32_t get_num_dropped() const;
     uint32_t get_avg_time() const;
     uint32_t get_stddev_time() const;
     float    get_filtered_time() const;
@@ -36,7 +35,6 @@ private:
     uint64_t sigma_time;
     uint64_t sigmasquared_time;
     uint16_t long_running;
-    uint32_t log_dropped;
     uint32_t last_check_us;
     float filtered_loop_time;
     bool ignore_loop;


### PR DESCRIPTION
Seems this variable is unused.

Removes the need for this PR: https://github.com/ArduPilot/ardupilot/pull/7784/files
