### PR TITLE
Tradheli - disables inverted flight option for single and dual heli frames

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -221,6 +221,13 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         if (!copter.motors->parameter_check(display_failure)) {
             return false;
         }
+        // Inverted flight feature disabled for Heli Single and Dual frames
+        if (copter.g2.frame_class.get() != AP_Motors::MOTOR_FRAME_HELI_QUAD && (copter.g.ch7_option == 43 || copter.g.ch8_option == 43 || copter.g.ch9_option == 43 || copter.g.ch10_option == 43 || copter.g.ch11_option == 43 || copter.g.ch12_option == 43)) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Inverted flight option not supported");
+            }
+            return false;
+        }
         #endif // HELI_FRAME
 
         // check for missing terrain data

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -635,17 +635,20 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
 
         case AUXSW_INVERTED:
 #if FRAME_CONFIG == HELI_FRAME
-            switch (ch_flag) {
-            case AUX_SWITCH_HIGH:
-                motors->set_inverted_flight(true);
-                attitude_control->set_inverted_flight(true);
-                heli_flags.inverted_flight = true;
-                break;
-            case AUX_SWITCH_LOW:
-                motors->set_inverted_flight(false);
-                attitude_control->set_inverted_flight(false);
-                heli_flags.inverted_flight = false;
-                break;
+            // inverted flight option is disabled for heli single and dual frames
+            if (g2.frame_class.get() == AP_Motors::MOTOR_FRAME_HELI_QUAD) {
+                switch (ch_flag) {
+                case AUX_SWITCH_HIGH:
+                    motors->set_inverted_flight(true);
+                    attitude_control->set_inverted_flight(true);
+                    heli_flags.inverted_flight = true;
+                    break;
+                case AUX_SWITCH_LOW:
+                    motors->set_inverted_flight(false);
+                    attitude_control->set_inverted_flight(false);
+                    heli_flags.inverted_flight = false;
+                    break;
+                }
             }
 #endif
             break;


### PR DESCRIPTION
The inverted flight feature is being disabled for the single and dual heli frames because it will not be intuitive to heli users.  Any heli user coming from a RC heli acrobatic background flies inverted with negative collective by pushing down on the collective stick to climb inverted.  This feature is designed to invert the collective so the user has to push up on collective stick to get more negative collective in order to hover or climb inverted.  @ChristopherOlson has flown this on an actual heli and determined that it was not suitable in its current design.  The other issue he noted was that the inverted feature does not lead the maneuver with with an upward acceleration so as to minimize altitude loss.  Additionally the feature was disabled for the dual heli frame because most users developing this frame would most likely not consider inverted flight as an option.  This feature was left available to quad heli users since this frame is more like a multirotor and the user base would most likely have a multirotor background.  They have no expectation for how the collective would be mechanized for this maneuver.