### PR TITLE
Added UART timestamp API for mavlink vision and GPS timing

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -70,4 +70,19 @@ public:
      * can implement it if their HAL layer requires.
      */
     virtual void _timer_tick(void) { }
+
+    /*
+      return timestamp estimate in microseconds for when the start of
+      a nbytes packet arrived on the uart. This should be treated as a
+      time constraint, not an exact time. It is guaranteed that the
+      packet did not start being received after this time, but it
+      could have been in a system buffer before the returned time.
+
+      This takes account of the baudrate of the link. For transports
+      that have no baudrate (such as USB) the time estimate may be
+      less accurate.
+
+      A return value of zero means the HAL does not support this API
+     */
+    virtual uint64_t receive_time_constraint_us(uint16_t nbytes) const { return 0; }
 };

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -87,6 +87,8 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 
     _device->set_speed(b);
 
+    _baudrate = b;
+
     _allocate_buffers(rxS, txS);
 }
 
@@ -471,6 +473,10 @@ void UARTDriver::_timer_tick(void)
         }
         _readbuf.commit((unsigned)ret);
 
+        // update receive timestamp
+        _receive_timestamp[_receive_timestamp_idx^1] = AP_HAL::micros64();
+        _receive_timestamp_idx ^= 1;
+        
         /* stop reading as we read less than we asked for */
         if ((unsigned)ret < vec[i].len) {
             break;
@@ -478,4 +484,28 @@ void UARTDriver::_timer_tick(void)
     }
 
     _in_timer = false;
+}
+
+/*
+  return timestamp estimate in microseconds for when the start of
+  a nbytes packet arrived on the uart. This should be treated as a
+  time constraint, not an exact time. It is guaranteed that the
+  packet did not start being received after this time, but it
+  could have been in a system buffer before the returned time.
+  
+  This takes account of the baudrate of the link. For transports
+  that have no baudrate (such as USB) the time estimate may be
+  less accurate.
+  
+  A return value of zero means the HAL does not support this API
+*/
+uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+{
+    uint64_t last_receive_us = _receive_timestamp[_receive_timestamp_idx];
+    if (_baudrate > 0) {
+        // assume 10 bits per byte.
+        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        last_receive_us -= transport_time_us;
+    }
+    return last_receive_us;
 }

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -50,6 +50,7 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     uint16_t min_tx_buffer = 1024;
     uint16_t min_rx_buffer = 512;
     if (strcmp(_devpath, "/dev/ttyACM0") == 0) {
+        _is_usb = true;
         min_tx_buffer = 4096;
         min_rx_buffer = 1024;
     }
@@ -121,7 +122,7 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
 
     if (_writebuf.get_size() && _readbuf.get_size() && _fd != -1) {
         if (!_initialised) {
-            if (strcmp(_devpath, "/dev/ttyACM0") == 0) {
+            if (_is_usb) {
                 ((PX4GPIO *)hal.gpio)->set_usb_connected();
             }
             ::printf("initialised %s OK %u %u\n", _devpath,
@@ -475,7 +476,7 @@ void PX4UARTDriver::_timer_tick(void)
     if (!_initialised) return;
 
     // don't try IO on a disconnected USB port
-    if (strcmp(_devpath, "/dev/ttyACM0") == 0 && !hal.gpio->usb_connected()) {
+    if (_is_usb && !hal.gpio->usb_connected()) {
         return;
     }
 
@@ -514,6 +515,10 @@ void PX4UARTDriver::_timer_tick(void)
         }
         _readbuf.commit((unsigned)ret);
 
+        // update receive timestamp
+        _receive_timestamp[_receive_timestamp_idx^1] = AP_HAL::micros64();
+        _receive_timestamp_idx ^= 1;
+
         /* stop reading as we read less than we asked for */
         if ((unsigned)ret < vec[i].len) {
             break;
@@ -522,6 +527,30 @@ void PX4UARTDriver::_timer_tick(void)
     perf_end(_perf_uart);
 
     _in_timer = false;
+}
+
+/*
+  return timestamp estimate in microseconds for when the start of
+  a nbytes packet arrived on the uart. This should be treated as a
+  time constraint, not an exact time. It is guaranteed that the
+  packet did not start being received after this time, but it
+  could have been in a system buffer before the returned time.
+  
+  This takes account of the baudrate of the link. For transports
+  that have no baudrate (such as USB) the time estimate may be
+  less accurate.
+  
+  A return value of zero means the HAL does not support this API
+*/
+uint64_t PX4UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+{
+    uint64_t last_receive_us = _receive_timestamp[_receive_timestamp_idx];
+    if (_baudrate > 0 && !_is_usb) {
+        // assume 10 bits per byte. For USB we assume zero transport delay
+        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        last_receive_us -= transport_time_us;
+    }
+    return last_receive_us;
 }
 
 #endif

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -44,6 +44,21 @@ public:
     void set_stop_bits(int n);
     bool set_unbuffered_writes(bool on);
 
+    /*
+      return timestamp estimate in microseconds for when the start of
+      a nbytes packet arrived on the uart. This should be treated as a
+      time constraint, not an exact time. It is guaranteed that the
+      packet did not start being received after this time, but it
+      could have been in a system buffer before the returned time.
+
+      This takes account of the baudrate of the link. For transports
+      that have no baudrate (such as USB) the time estimate may be
+      less accurate.
+
+      A return value of zero means the HAL does not support this API
+     */
+    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    
 private:
     const char *_devpath;
     int _fd;
@@ -73,5 +88,11 @@ private:
     uint32_t _total_written;
     enum flow_control _flow_control;
 
+    // timestamp for receiving data on the UART, avoiding a lock
+    uint64_t _receive_timestamp[2];
+    uint8_t _receive_timestamp_idx;
+    
     Semaphore _semaphore;
+
+    bool _is_usb;
 };

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -66,6 +66,21 @@ public:
     bool set_unbuffered_writes(bool on) override;
 
     void _timer_tick(void);
+
+    /*
+      return timestamp estimate in microseconds for when the start of
+      a nbytes packet arrived on the uart. This should be treated as a
+      time constraint, not an exact time. It is guaranteed that the
+      packet did not start being received after this time, but it
+      could have been in a system buffer before the returned time.
+
+      This takes account of the baudrate of the link. For transports
+      that have no baudrate (such as USB) the time estimate may be
+      less accurate.
+
+      A return value of zero means the HAL does not support this API
+     */
+    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
     
 private:
     uint8_t _portNumber;
@@ -94,7 +109,7 @@ private:
     bool set_speed(int speed);
 
     SITL_State *_sitlState;
-
+    uint64_t _receive_timestamp;
 };
 
 #endif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -24,7 +24,8 @@
 #include <AP_Common/AP_FWVersion.h>
 
 // check if a message will fit in the payload space available
-#define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
+#define PAYLOAD_SIZE(chan, id) (GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
+#define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= PAYLOAD_SIZE(chan, id))
 #define CHECK_PAYLOAD_SIZE(id) if (comm_get_txspace(chan) < packet_overhead()+MAVLINK_MSG_ID_ ## id ## _LEN) return false
 #define CHECK_PAYLOAD_SIZE2(id) if (!HAVE_PAYLOAD_SPACE(chan, id)) return false
 
@@ -473,7 +474,8 @@ private:
                                                      const float z,
                                                      const float roll,
                                                      const float pitch,
-                                                     const float yaw);
+                                                     const float yaw,
+                                                     const uint16_t payload_size);
     void log_vision_position_estimate_data(const uint64_t usec,
                                            const float x,
                                            const float y,
@@ -489,7 +491,7 @@ private:
       correct an offboard timestamp in microseconds to a local time
       since boot in milliseconds
      */
-    uint32_t correct_offboard_timestamp_usec_to_ms(uint64_t offboard_usec);
+    uint32_t correct_offboard_timestamp_usec_to_ms(uint64_t offboard_usec, uint16_t payload_size);
     
     mavlink_signing_t signing;
     static mavlink_signing_streams_t signing_streams;


### PR DESCRIPTION
This adds a API on our UART drivers for getting the timestamp of the last input bytes. This is then used for vision processing to constrain the latest possible time the message arrived, which makes the timestamping of vision messages more accurate.

pair-programmed with @peterbarker 