### PR TITLE
Remove send_home/send_ekf_origin arguments

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -75,8 +75,8 @@ bool Rover::set_home(const Location& loc, bool lock)
     ahrs.Log_Write_Home_And_Origin();
 
     // send new home and ekf origin to GCS
-    gcs().send_home(loc);
-    gcs().send_ekf_origin(loc);
+    gcs().send_home();
+    gcs().send_ekf_origin();
 
     // send text of home position to ground stations
     gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
@@ -123,7 +123,7 @@ void Rover::update_home()
             if (get_distance(loc, ahrs.get_home()) > DISTANCE_HOME_MAX) {
                 ahrs.set_home(loc);
                 ahrs.Log_Write_Home_And_Origin();
-                gcs().send_home(gps.location());
+                gcs().send_home();
             }
         }
     }

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -106,6 +106,15 @@ void Tracker::one_second_loop()
         }
         one_second_counter = 0;
     }
+
+    if (!ahrs.home_is_set()) {
+        // set home to current location
+        Location temp_loc;
+        if (ahrs.get_location(temp_loc)) {
+            set_home(temp_loc);
+        }
+        return;
+    }
 }
 
 void Tracker::ten_hz_logging_loop()

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -496,11 +496,8 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
             break;
 
             case MAV_CMD_GET_HOME_POSITION:
-                send_home(tracker.ahrs.get_home());
-                Location ekf_origin;
-                if (tracker.ahrs.get_origin(ekf_origin)) {
-                    send_ekf_origin(ekf_origin);
-                }
+                send_home();
+                send_ekf_origin();
                 result = MAV_RESULT_ACCEPTED;
                 break;
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -495,12 +495,6 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
                 }
             break;
 
-            case MAV_CMD_GET_HOME_POSITION:
-                send_home();
-                send_ekf_origin();
-                result = MAV_RESULT_ACCEPTED;
-                break;
-
             case MAV_CMD_DO_SET_SERVO:
                 if (tracker.servo_test_set_servo(packet.param1, packet.param2)) {
                     result = MAV_RESULT_ACCEPTED;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -158,11 +158,15 @@ void Tracker::set_home(struct Location temp)
 {
     set_home_eeprom(temp);
     current_loc = temp;
-    gcs().send_home(temp);
+
+    // check EKF origin has been set
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
-        gcs().send_ekf_origin(ekf_origin);
+        ahrs.set_home(temp);
     }
+
+    gcs().send_home();
+    gcs().send_ekf_origin();
 }
 
 void Tracker::arm_servos()

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -163,6 +163,7 @@ void Tracker::set_home(struct Location temp)
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
         ahrs.set_home(temp);
+        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
     }
 
     gcs().send_home();

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -103,8 +103,8 @@ bool Copter::set_home(const Location& loc, bool lock)
     ahrs.Log_Write_Home_And_Origin();
 
     // send new home and ekf origin to GCS
-    gcs().send_home(loc);
-    gcs().send_ekf_origin(ekf_origin);
+    gcs().send_home();
+    gcs().send_ekf_origin();
 
     // return success
     return true;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -877,7 +877,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 plane.ahrs.set_home(new_home_loc);
                 AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
                 AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home(new_home_loc);
+                gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
                 gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                         (double)(new_home_loc.lat*1.0e-7f),
@@ -1163,7 +1163,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 plane.ahrs.set_home(new_home_loc);
                 AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
                 AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home(new_home_loc);
+                gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
                 gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                         (double)(new_home_loc.lat*1.0e-7f),
@@ -1581,7 +1581,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         plane.ahrs.set_home(new_home_loc);
         plane.ahrs.set_home_status(HOME_SET_NOT_LOCKED);
         plane.ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home(new_home_loc);
+        gcs().send_home();
         gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                 (double)(new_home_loc.lat*1.0e-7f),
                                 (double)(new_home_loc.lng*1.0e-7f),

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -112,7 +112,7 @@ void Plane::init_home()
     ahrs.set_home(gps.location());
     ahrs.set_home_status(HOME_SET_NOT_LOCKED);
     ahrs.Log_Write_Home_And_Origin();
-    gcs().send_home(gps.location());
+    gcs().send_home();
 
     // Save Home to EEPROM
     mission.write_home_to_storage();
@@ -143,7 +143,7 @@ void Plane::update_home()
         if(ahrs.get_position(loc)) {
             ahrs.set_home(loc);
             ahrs.Log_Write_Home_And_Origin();
-            gcs().send_home(loc);
+            gcs().send_home();
         }
     }
     barometer.update_calibration();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -939,12 +939,8 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
         ahrs.set_home(cmd.content.location);
         ahrs.set_home_status(HOME_SET_NOT_LOCKED);
         ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home(cmd.content.location);
-        // send ekf origin if set
-        Location ekf_origin;
-        if (ahrs.get_origin(ekf_origin)) {
-            gcs().send_ekf_origin(ekf_origin);
-        }
+        gcs().send_home();
+        gcs().send_ekf_origin();
     }
 }
 

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -98,8 +98,8 @@ bool Sub::set_home(const Location& loc, bool lock)
     ahrs.Log_Write_Home_And_Origin();
 
     // send new home and ekf origin to GCS
-    gcs().send_home(loc);
-    gcs().send_ekf_origin(loc);
+    gcs().send_home();
+    gcs().send_ekf_origin();
 
     // return success
     return true;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -34,14 +34,14 @@ void GCS::send_named_float(const char *name, float value) const
     FOR_EACH_ACTIVE_CHANNEL(send_named_float(name, value));
 }
 
-void GCS::send_home(const Location &home) const
+void GCS::send_home() const
 {
-    FOR_EACH_ACTIVE_CHANNEL(send_home(home));
+    FOR_EACH_ACTIVE_CHANNEL(send_home());
 }
 
-void GCS::send_ekf_origin(const Location &ekf_origin) const
+void GCS::send_ekf_origin() const
 {
-    FOR_EACH_ACTIVE_CHANNEL(send_ekf_origin(ekf_origin));
+    FOR_EACH_ACTIVE_CHANNEL(send_ekf_origin());
 }
 
 /*

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -184,8 +184,8 @@ public:
     void send_local_position() const;
     void send_vibration() const;
     void send_named_float(const char *name, float value) const;
-    void send_home(const Location &home) const;
-    void send_ekf_origin(const Location &ekf_origin) const;
+    void send_home() const;
+    void send_ekf_origin() const;
     void send_servo_output_raw(bool hil);
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint32_t position);
@@ -555,8 +555,8 @@ public:
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_named_float(const char *name, float value) const;
-    void send_home(const Location &home) const;
-    void send_ekf_origin(const Location &ekf_origin) const;
+    void send_home() const;
+    void send_ekf_origin() const;
 
     void send_parameter_value(const char *param_name,
                               ap_var_type param_type,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1548,32 +1548,44 @@ void GCS_MAVLINK::send_named_float(const char *name, float value) const
     mavlink_msg_named_value_float_send(chan, AP_HAL::millis(), float_name, value);
 }
 
-void GCS_MAVLINK::send_home(const Location &home) const
+void GCS_MAVLINK::send_home() const
 {
-    if (HAVE_PAYLOAD_SPACE(chan, HOME_POSITION)) {
-        const float q[4] = {1.0f, 0.0f, 0.0f, 0.0f};
-        mavlink_msg_home_position_send(
-            chan,
-            home.lat,
-            home.lng,
-            home.alt * 10,
-            0.0f, 0.0f, 0.0f,
-            q,
-            0.0f, 0.0f, 0.0f,
-            AP_HAL::micros64());
+    if (!HAVE_PAYLOAD_SPACE(chan, HOME_POSITION)) {
+        return;
     }
+    if (!AP::ahrs().home_is_set()) {
+        return;
+    }
+
+    Location home = AP::ahrs().get_home();
+
+    const float q[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+    mavlink_msg_home_position_send(
+        chan,
+        home.lat,
+        home.lng,
+        home.alt * 10,
+        0.0f, 0.0f, 0.0f,
+        q,
+        0.0f, 0.0f, 0.0f,
+        AP_HAL::micros64());
 }
 
-void GCS_MAVLINK::send_ekf_origin(const Location &ekf_origin) const
+void GCS_MAVLINK::send_ekf_origin() const
 {
-    if (HAVE_PAYLOAD_SPACE(chan, GPS_GLOBAL_ORIGIN)) {
-        mavlink_msg_gps_global_origin_send(
-            chan,
-            ekf_origin.lat,
-            ekf_origin.lng,
-            ekf_origin.alt * 10,
-            AP_HAL::micros64());
+    if (!HAVE_PAYLOAD_SPACE(chan, GPS_GLOBAL_ORIGIN)) {
+        return;
     }
+    Location ekf_origin;
+    if (!AP::ahrs().get_origin(ekf_origin)) {
+        return;
+    }
+    mavlink_msg_gps_global_origin_send(
+        chan,
+        ekf_origin.lat,
+        ekf_origin.lng,
+        ekf_origin.alt * 10,
+        AP_HAL::micros64());
 }
 
 /*
@@ -1902,7 +1914,7 @@ void GCS_MAVLINK::set_ekf_origin(const Location& loc)
     ahrs.Log_Write_Home_And_Origin();
 
     // send ekf origin to GCS
-    send_ekf_origin(loc);
+    send_ekf_origin();
 }
 
 void GCS_MAVLINK::handle_set_gps_global_origin(const mavlink_message_t *msg)
@@ -2464,12 +2476,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_get_home_position(const mavlink_command_l
     if (!AP::ahrs().home_is_set()) {
         return MAV_RESULT_FAILED;
     }
-    send_home(AP::ahrs().get_home());
+    send_home();
+    send_ekf_origin();
 
-    Location ekf_origin;
-    if (AP::ahrs().get_origin(ekf_origin)) {
-        send_ekf_origin(ekf_origin);
-    }
     return MAV_RESULT_ACCEPTED;
 }
 


### PR DESCRIPTION
Corrects a minor problem in Rover where we send home as ekf origin