### PR TITLE
Bikeshedding: Save some flash space on plane

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -147,7 +147,7 @@ void Plane::ahrs_update()
     ahrs.update();
 
     if (should_log(MASK_LOG_IMU)) {
-        Log_Write_IMU();
+        DataFlash.Log_Write_IMU();
     }
 
     // calculate a scaled roll limit based on current pitch
@@ -244,10 +244,10 @@ void Plane::update_logging1(void)
     }
 
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_IMU))
-        Log_Write_IMU();
+        DataFlash.Log_Write_IMU();
 
     if (should_log(MASK_LOG_ATTITUDE_MED))
-        Log_Write_AOA_SSA();
+        DataFlash.Log_Write_AOA_SSA(ahrs);
 }
 
 /*

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -272,11 +272,6 @@ void Plane::Log_Write_AETR()
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
-void Plane::Log_Write_IMU()
-{
-    DataFlash.Log_Write_IMU();
-}
-
 void Plane::Log_Write_RC(void)
 {
     DataFlash.Log_Write_RCIN();
@@ -285,18 +280,6 @@ void Plane::Log_Write_RC(void)
         DataFlash.Log_Write_RSSI(rssi);
     }
     Log_Write_AETR();
-}
-
-// Write a AIRSPEED packet
-void Plane::Log_Write_Airspeed(void)
-{
-    DataFlash.Log_Write_Airspeed(airspeed);
-}
-
-// Write a AOA and SSA packet
-void Plane::Log_Write_AOA_SSA(void)
-{
-    DataFlash.Log_Write_AOA_SSA(ahrs);
 }
 
 // log ahrs home and EKF origin to dataflash
@@ -375,7 +358,6 @@ void Plane::log_init(void)
 
 #else // LOGGING_ENABLED
 
-void Plane::Log_Write_AOA_SSA(void) {}
 void Plane::Log_Write_Attitude(void) {}
 void Plane::Log_Write_Fast(void) {}
 void Plane::Log_Write_Performance() {}
@@ -390,9 +372,7 @@ void Plane::Log_Write_Optflow() {}
  #endif
 
 void Plane::Log_Arm_Disarm() {}
-void Plane::Log_Write_IMU() {}
 void Plane::Log_Write_RC(void) {}
-void Plane::Log_Write_Airspeed(void) {}
 void Plane::Log_Write_Home_And_Origin() {}
 void Plane::Log_Write_Vehicle_Startup_Messages() {}
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -800,9 +800,7 @@ private:
     void Log_Write_Sonar();
     void Log_Write_Optflow();
     void Log_Arm_Disarm();
-    void Log_Write_IMU();
     void Log_Write_RC(void);
-    void Log_Write_Airspeed(void);
     void Log_Write_Home_And_Origin();
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Write_AOA_SSA();

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -73,7 +73,7 @@ void Plane::read_airspeed(void)
     if (airspeed.enabled()) {
         airspeed.read();
         if (should_log(MASK_LOG_IMU)) {
-            Log_Write_Airspeed();
+            DataFlash.Log_Write_Airspeed(airspeed);
         }
 
         // supply a new temperature to the barometer from the digital

--- a/libraries/AP_GPS/AP_GPS_ERB.cpp
+++ b/libraries/AP_GPS/AP_GPS_ERB.cpp
@@ -34,13 +34,6 @@ extern const AP_HAL::HAL& hal;
 
 AP_GPS_ERB::AP_GPS_ERB(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port),
-    _step(0),
-    _msg_id(0),
-    _payload_length(0),
-    _payload_counter(0),
-    _fix_count(0),
-    _new_position(0),
-    _new_speed(0),
     next_fix(AP_GPS::NO_FIX)
 {
 }

--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -22,7 +22,6 @@
 AP_GPS_MAV::AP_GPS_MAV(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
 {
-    _new_data = false;
 }
 
 // Reading does nothing in this class; we simply return whether or not

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -51,13 +51,7 @@ extern const AP_HAL::HAL& hal;
 #define hexdigit(x) ((x)>9?'A'+((x)-10):'0'+(x))
 
 AP_GPS_NMEA::AP_GPS_NMEA(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
-    AP_GPS_Backend(_gps, _state, _port),
-    _parity(0),
-    _is_checksum_term(false),
-    _sentence_type(0),
-    _term_number(0),
-    _term_offset(0),
-    _gps_data_good(false)
+    AP_GPS_Backend(_gps, _state, _port)
 {
     // this guarantees that _term is always nul terminated
     memset(_term, 0, sizeof(_term));

--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -40,9 +40,7 @@ do {                                            \
 
 AP_GPS_NOVA::AP_GPS_NOVA(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                        AP_HAL::UARTDriver *_port) :
-    AP_GPS_Backend(_gps, _state, _port),
-    _new_position(0),
-    _new_speed(0)
+    AP_GPS_Backend(_gps, _state, _port)
 {
     nova_msg.nova_state = nova_msg_parser::PREAMBLE1;
 

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -46,13 +46,7 @@ do {                                            \
 
 AP_GPS_SBP::AP_GPS_SBP(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                        AP_HAL::UARTDriver *_port) :
-    AP_GPS_Backend(_gps, _state, _port),
-
-    last_injected_data_ms(0),
-    last_iar_num_hypotheses(0),
-    last_full_update_tow(0),
-    last_full_update_cpu_ms(0),
-    crc_error_counter(0)
+    AP_GPS_Backend(_gps, _state, _port)
 {
 
     Debug("SBP Driver Initialized");

--- a/libraries/AP_GPS/AP_GPS_SIRF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SIRF.cpp
@@ -33,12 +33,7 @@ const uint8_t AP_GPS_SIRF::_initialisation_blob[] = {
 };
 
 AP_GPS_SIRF::AP_GPS_SIRF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
-    AP_GPS_Backend(_gps, _state, _port),
-    _step(0),
-    _gather(false),
-    _payload_length(0),
-    _payload_counter(0),
-    _msg_id(0)
+    AP_GPS_Backend(_gps, _state, _port)
 {
     gps.send_blob_start(state.instance, (const char *)_initialisation_blob, sizeof(_initialisation_blob));
 }

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -31,7 +31,6 @@ extern const AP_HAL::HAL& hal;
 AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port)
 {
-    _new_data = false;
     _sem_gnss = hal.util->new_semaphore();
 }
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -45,28 +45,12 @@ extern const AP_HAL::HAL& hal;
 
 AP_GPS_UBLOX::AP_GPS_UBLOX(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port),
-    _step(0),
-    _msg_id(0),
-    _payload_length(0),
-    _payload_counter(0),
-    _class(0),
-    _cfg_saved(false),
-    _last_cfg_sent_time(0),
-    _num_cfg_save_tries(0),
-    _last_config_time(0),
-    _delay_time(0),
     _next_message(STEP_PVT),
     _ublox_port(255),
-    _have_version(false),
     _unconfigured_messages(CONFIG_ALL),
     _hardware_generation(UBLOX_UNKNOWN_HARDWARE_GENERATION),
-    _new_position(0),
-    _new_speed(0),
-    _disable_counter(0),
     next_fix(AP_GPS::NO_FIX),
-    _cfg_needs_save(false),
-    noReceivedHdop(true),
-    havePvtMsg(false)
+    noReceivedHdop(true)
 {
     // stop any config strings that are pending
     gps.send_blob_start(state.instance, nullptr, 0);


### PR DESCRIPTION
I may have gotten slightly distracted when trying to chase reducing the build size to get PX4-V2 to fit when built with make (it does fit under waf, which leads to interesting questions about flag differences). Anyways removing some unneeded initializers and indirection saves 192 bytes on plane with make builds.