### PR TITLE
HAL: take account of available bytes in receive_time_constraint_us

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -84,5 +84,5 @@ public:
 
       A return value of zero means the HAL does not support this API
      */
-    virtual uint64_t receive_time_constraint_us(uint16_t nbytes) const { return 0; }
+    virtual uint64_t receive_time_constraint_us(uint16_t nbytes) { return 0; }
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -970,12 +970,12 @@ void UARTDriver::receive_timestamp_update(void)
   
   A return value of zero means the HAL does not support this API
 */
-uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     uint64_t last_receive_us = _receive_timestamp[_receive_timestamp_idx];
     if (_baudrate > 0 && !sdef.is_usb) {
         // assume 10 bits per byte. For USB we assume zero transport delay
-        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * (nbytes + available());
         last_receive_us -= transport_time_us;
     }
     return last_receive_us;

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -94,7 +94,7 @@ public:
 
       A return value of zero means the HAL does not support this API
      */
-    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
     
 private:
     bool tx_bounce_buf_ready;

--- a/libraries/AP_HAL_F4Light/UARTDriver.cpp
+++ b/libraries/AP_HAL_F4Light/UARTDriver.cpp
@@ -149,14 +149,14 @@ void UARTDriver::update_timestamp(){  // called from ISR
 }
 
 // this is mostly a 
-uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) const {
+uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) {
 
     // timestamp is 32 bits so read is atomic, in worst case we get 2nd timestamp
     uint32_t time_from_last_byte = AP_HAL::micros() -  _receive_timestamp[_time_idx];
     uint32_t transport_time_us = 0;
     if (_baudrate > 0) {
         // assume 10 bits per byte
-        transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        transport_time_us = (1000000UL * 10UL / _baudrate) * (nbytes+available());
     }
     return AP_HAL::micros64() - (time_from_last_byte + transport_time_us);
 }

--- a/libraries/AP_HAL_F4Light/UARTDriver.h
+++ b/libraries/AP_HAL_F4Light/UARTDriver.h
@@ -53,7 +53,7 @@ public:
 
     inline void disable(){ _usart_device = NULL; } // pins used for another needs
 
-    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
 
     void update_timestamp(); 
 

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -494,12 +494,12 @@ void UARTDriver::_timer_tick(void)
   
   A return value of zero means the HAL does not support this API
 */
-uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     uint64_t last_receive_us = _receive_timestamp[_receive_timestamp_idx];
     if (_baudrate > 0) {
         // assume 10 bits per byte.
-        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * (nbytes+available());
         last_receive_us -= transport_time_us;
     }
     return last_receive_us;

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -62,7 +62,7 @@ public:
 
       A return value of zero means the HAL does not support this API
      */
-    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
     
 private:
     AP_HAL::OwnPtr<SerialDevice> _device;

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -542,12 +542,12 @@ void PX4UARTDriver::_timer_tick(void)
   
   A return value of zero means the HAL does not support this API
 */
-uint64_t PX4UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+uint64_t PX4UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     uint64_t last_receive_us = _receive_timestamp[_receive_timestamp_idx];
     if (_baudrate > 0 && !_is_usb) {
         // assume 10 bits per byte. For USB we assume zero transport delay
-        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * nbytes;
+        uint32_t transport_time_us = (1000000UL * 10UL / _baudrate) * (nbytes+available());
         last_receive_us -= transport_time_us;
     }
     return last_receive_us;

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -57,7 +57,7 @@ public:
 
       A return value of zero means the HAL does not support this API
      */
-    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
     
 private:
     const char *_devpath;

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -518,12 +518,12 @@ void UARTDriver::_timer_tick(void)
   
   A return value of zero means the HAL does not support this API
 */
-uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes) const
+uint64_t UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     uint64_t last_receive_us = _receive_timestamp;
     if (_uart_baudrate > 0) {
         // assume 10 bits per byte. 
-        uint32_t transport_time_us = (1000000UL * 10UL / _uart_baudrate) * nbytes;
+        uint32_t transport_time_us = (1000000UL * 10UL / _uart_baudrate) * (nbytes+available());
         last_receive_us -= transport_time_us;
     }
     return last_receive_us;

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -80,7 +80,7 @@ public:
 
       A return value of zero means the HAL does not support this API
      */
-    uint64_t receive_time_constraint_us(uint16_t nbytes) const override;
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
     
 private:
     uint8_t _portNumber;


### PR DESCRIPTION
This removes the error due to unprocessed bytes on the uart. That will make the time sync for vision messages more accuracy when the mavlink uart is busy
