### PR TITLE
Move notifications concerning setting of home position into AHRS

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -71,19 +71,6 @@ bool Rover::set_home(const Location& loc, bool lock)
     // Save Home to EEPROM
     mission.write_home_to_storage();
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
-    // send text of home position to ground stations
-    gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
-            static_cast<double>(loc.lat * 1.0e-7f),
-            static_cast<double>(loc.lng * 1.0e-7f),
-            static_cast<double>(loc.alt * 0.01f));
-
     // return success
     return true;
 }
@@ -122,8 +109,6 @@ void Rover::update_home()
         if (ahrs.get_position(loc)) {
             if (get_distance(loc, ahrs.get_home()) > DISTANCE_HOME_MAX) {
                 ahrs.set_home(loc);
-                ahrs.Log_Write_Home_And_Origin();
-                gcs().send_home();
             }
         }
     }

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -161,13 +161,11 @@ void Tracker::set_home(struct Location temp)
 
     // check EKF origin has been set
     Location ekf_origin;
-    if (ahrs.get_origin(ekf_origin)) {
-        ahrs.set_home(temp);
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
+    if (!ahrs.get_origin(ekf_origin)) {
+        return;
     }
-
-    gcs().send_home();
-    gcs().send_ekf_origin();
+    ahrs.set_home(temp);
+    ahrs.set_home_status(HOME_SET_NOT_LOCKED);
 }
 
 void Tracker::arm_servos()

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -72,15 +72,20 @@ bool Copter::set_home(const Location& loc, bool lock)
         return false;
     }
 
+    const bool home_was_set = ahrs.home_is_set();
+
     // set ahrs home (used for RTL)
-    ahrs.set_home(loc);
+    if (lock) {
+        ahrs.set_home(loc, HOME_SET_AND_LOCKED);
+    } else {
+        ahrs.set_home(loc, HOME_SET_NOT_LOCKED);
+    }
 
     // init inav and compass declination
-    if (!ahrs.home_is_set()) {
+    if (!home_was_set) {
         // update navigation scalers.  used to offset the shrinking longitude as we go towards the poles
         scaleLongDown = longitude_scale(loc);
-        // record home is set
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
+
         Log_Write_Event(DATA_SET_HOME);
 
 #if MODE_AUTO_ENABLED == ENABLED
@@ -92,11 +97,6 @@ bool Copter::set_home(const Location& loc, bool lock)
             }
         }
 #endif
-    }
-
-    // lock home position
-    if (lock) {
-        ahrs.set_home_status(HOME_SET_AND_LOCKED);
     }
 
     // return success

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -99,13 +99,6 @@ bool Copter::set_home(const Location& loc, bool lock)
         ahrs.set_home_status(HOME_SET_AND_LOCKED);
     }
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
     // return success
     return true;
 }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -826,13 +826,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 }
                 plane.ahrs.set_home(new_home_loc);
                 AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
-                AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
-                gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                        (double)(new_home_loc.lat*1.0e-7f),
-                                        (double)(new_home_loc.lng*1.0e-7f),
-                                        (uint32_t)(new_home_loc.alt*0.01f));
             }
             break;
         }
@@ -1112,13 +1106,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
                 plane.ahrs.set_home(new_home_loc);
                 AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
-                AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
-                gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                        (double)(new_home_loc.lat*1.0e-7f),
-                                        (double)(new_home_loc.lng*1.0e-7f),
-                                        (uint32_t)(new_home_loc.alt*0.01f));
             }
             break;
         }
@@ -1530,12 +1518,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.alt = packet.altitude / 10;
         plane.ahrs.set_home(new_home_loc);
         plane.ahrs.set_home_status(HOME_SET_NOT_LOCKED);
-        plane.ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home();
-        gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                (double)(new_home_loc.lat*1.0e-7f),
-                                (double)(new_home_loc.lng*1.0e-7f),
-                                (uint32_t)(new_home_loc.alt*0.01f));
         break;
     }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1103,7 +1103,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                plane.ahrs.set_home(new_home_loc, HOME_SET_NOT_LOCKED);
+                plane.ahrs.set_home(new_home_loc, HOME_SET_AND_LOCKED);
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1514,7 +1514,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.lat = packet.latitude;
         new_home_loc.lng = packet.longitude;
         new_home_loc.alt = packet.altitude / 10;
-        plane.ahrs.set_home(new_home_loc, HOME_SET_NOT_LOCKED);
+        plane.ahrs.set_home(new_home_loc, HOME_SET_AND_LOCKED);
         break;
     }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -824,8 +824,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                     }
                     new_home_loc.alt += plane.ahrs.get_home().alt;
                 }
-                plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
+                plane.ahrs.set_home(new_home_loc, HOME_SET_NOT_LOCKED);
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1104,8 +1103,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
+                plane.ahrs.set_home(new_home_loc, HOME_SET_NOT_LOCKED);
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1516,8 +1514,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.lat = packet.latitude;
         new_home_loc.lng = packet.longitude;
         new_home_loc.alt = packet.altitude / 10;
-        plane.ahrs.set_home(new_home_loc);
-        plane.ahrs.set_home_status(HOME_SET_NOT_LOCKED);
+        plane.ahrs.set_home(new_home_loc, HOME_SET_NOT_LOCKED);
         break;
     }
 

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -111,8 +111,6 @@ void Plane::init_home()
 
     ahrs.set_home(gps.location());
     ahrs.set_home_status(HOME_SET_NOT_LOCKED);
-    ahrs.Log_Write_Home_And_Origin();
-    gcs().send_home();
 
     // Save Home to EEPROM
     mission.write_home_to_storage();
@@ -142,8 +140,6 @@ void Plane::update_home()
         Location loc;
         if(ahrs.get_position(loc)) {
             ahrs.set_home(loc);
-            ahrs.Log_Write_Home_And_Origin();
-            gcs().send_home();
         }
     }
     barometer.update_calibration();

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -109,8 +109,7 @@ void Plane::init_home()
 {
     gcs().send_text(MAV_SEVERITY_INFO, "Init HOME");
 
-    ahrs.set_home(gps.location());
-    ahrs.set_home_status(HOME_SET_NOT_LOCKED);
+    ahrs.set_home(gps.location(), HOME_SET_NOT_LOCKED);
 
     // Save Home to EEPROM
     mission.write_home_to_storage();
@@ -139,7 +138,7 @@ void Plane::update_home()
     if (ahrs.home_status() == HOME_SET_NOT_LOCKED) {
         Location loc;
         if(ahrs.get_position(loc)) {
-            ahrs.set_home(loc);
+            ahrs.set_home(loc, HOME_SET_NOT_LOCKED);
         }
     }
     barometer.update_calibration();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -936,7 +936,7 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
     if (cmd.p1 == 1 && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
         init_home();
     } else {
-        ahrs.set_home(cmd.content.location, HOME_SET_NOT_LOCKED);
+        ahrs.set_home(cmd.content.location, HOME_SET_AND_LOCKED);
     }
 }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -938,9 +938,6 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
     } else {
         ahrs.set_home(cmd.content.location);
         ahrs.set_home_status(HOME_SET_NOT_LOCKED);
-        ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home();
-        gcs().send_ekf_origin();
     }
 }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -936,8 +936,7 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
     if (cmd.p1 == 1 && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
         init_home();
     } else {
-        ahrs.set_home(cmd.content.location);
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
+        ahrs.set_home(cmd.content.location, HOME_SET_NOT_LOCKED);
     }
 }
 

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -94,13 +94,6 @@ bool Sub::set_home(const Location& loc, bool lock)
         ahrs.set_home_status(HOME_SET_AND_LOCKED);
     }
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
     // return success
     return true;
 }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -439,9 +439,6 @@ public:
     enum HomeState home_status(void) const {
         return _home_status;
     }
-    void set_home_status(enum HomeState new_status) {
-        _home_status = new_status;
-    }
     bool home_is_set(void) const {
         return _home_status != HOME_UNSET;
     }
@@ -449,7 +446,8 @@ public:
     // set the home location in 10e7 degrees. This should be called
     // when the vehicle is at this position. It is assumed that the
     // current barometer and GPS altitudes correspond to this altitude
-    virtual void set_home(const Location &loc) = 0;
+    virtual void set_home(const Location &loc,
+                          enum HomeState new_status) = 0;
 
     // set the EKF's origin location in 10e7 degrees.  This should only
     // be called when the EKF has no absolute position reference (i.e. GPS)
@@ -649,6 +647,8 @@ protected:
 
     // reference position for NED positions
     struct Location _home;
+    // Flag for if we have g_gps lock and have set the home location in AHRS
+    enum HomeState _home_status = HOME_UNSET;
 
     // helper trig variables
     float _cos_roll, _cos_pitch, _cos_yaw;
@@ -666,9 +666,6 @@ protected:
 
 private:
     static AP_AHRS *_singleton;
-
-    // Flag for if we have g_gps lock and have set the home location in AHRS
-    enum HomeState _home_status = HOME_UNSET;
 
 };
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -23,6 +23,8 @@
 #include "AP_AHRS.h"
 #include <AP_HAL/AP_HAL.h>
 
+#include <GCS_MAVLink/GCS.h>
+
 extern const AP_HAL::HAL& hal;
 
 // this is the speed in m/s above which we first get a yaw lock with
@@ -1012,6 +1014,20 @@ void AP_AHRS_DCM::set_home(const Location &loc)
 {
     _home = loc;
     _home.options = 0;
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send new home and ekf origin to GCS
+    gcs().send_home();
+    gcs().send_ekf_origin();
+
+    // send text of home position to ground stations
+    gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
+                    static_cast<double>(loc.lat * 1.0e-7f),
+                    static_cast<double>(loc.lng * 1.0e-7f),
+                    static_cast<double>(loc.alt * 0.01f));
+
 }
 
 //  a relative ground position to home in meters, Down

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1010,7 +1010,7 @@ bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret) const
     return ret;
 }
 
-void AP_AHRS_DCM::set_home(const Location &loc)
+void AP_AHRS_DCM::set_home(const Location &loc, enum HomeState new_status)
 {
     _home = loc;
     _home.options = 0;
@@ -1023,11 +1023,14 @@ void AP_AHRS_DCM::set_home(const Location &loc)
     gcs().send_ekf_origin();
 
     // send text of home position to ground stations
-    gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
-                    static_cast<double>(loc.lat * 1.0e-7f),
-                    static_cast<double>(loc.lng * 1.0e-7f),
-                    static_cast<double>(loc.alt * 0.01f));
+    if (new_status != _home_status || new_status != HOME_SET_NOT_LOCKED) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
+                        static_cast<double>(loc.lat * 1.0e-7f),
+                        static_cast<double>(loc.lng * 1.0e-7f),
+                        static_cast<double>(loc.alt * 0.01f));
+    }
 
+    _home_status = new_status;
 }
 
 //  a relative ground position to home in meters, Down

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -93,7 +93,8 @@ public:
 
     bool            use_compass() override;
 
-    void set_home(const Location &loc) override;
+    void set_home(const Location &loc,
+                  enum HomeState new_status) override;
     void estimate_wind(void);
 
     // is the AHRS subsystem healthy?

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -587,11 +587,6 @@ Vector2f AP_AHRS_NavEKF::groundspeed_vector(void)
     }
 }
 
-void AP_AHRS_NavEKF::set_home(const Location &loc)
-{
-    AP_AHRS_DCM::set_home(loc);
-}
-
 // set the EKF's origin location in 10e7 degrees.  This should only
 // be called when the EKF has no absolute position reference (i.e. GPS)
 // from which to decide the origin on its own

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -125,9 +125,6 @@ public:
     // blended accelerometer values in the earth frame in m/s/s
     const Vector3f &get_accel_ef_blended() const override;
 
-    // set home location
-    void set_home(const Location &loc) override;
-
     // set the EKF's origin location in 10e7 degrees.  This should only
     // be called when the EKF has no absolute position reference (i.e. GPS)
     // from which to decide the origin on its own


### PR DESCRIPTION
This does involve some behavioural changes across the vehicle types:
 - all vehicles will send the statustext indicating a new home is set
 - Plane will send origin messages as well as home messages when home is set
- Rover sends AHRS location, not GPS location when home is updated (useful for vision positioning?)
