### PR TITLE
GCS_MAVLink: Expand timesync handling

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -320,7 +320,18 @@ protected:
     void handle_device_op_read(mavlink_message_t *msg);
     void handle_device_op_write(mavlink_message_t *msg);
 
+    void send_timesync();
+    // returns the time a timesync message was most likely received:
+    uint64_t timesync_receive_timestamp_ns() const;
+    // returns a timestamp suitable for packing into the ts1 field of TIMESYNC:
+    uint64_t timesync_timestamp_ns() const;
     void handle_timesync(mavlink_message_t *msg);
+    struct {
+        int64_t sent_ts1;
+        uint32_t last_sent_ms;
+        const uint16_t interval_ms = 10000;
+    }  _timesync_request;
+
     void handle_statustext(mavlink_message_t *msg);
 
     bool telemetry_delayed() const;


### PR DESCRIPTION
This is expanding @fnoop 's timesync to use tridge's new receive-buffer jitter adjustments.

It also adds the sending of timesync messages, 'though they are only logged for the time being.
