### PR TITLE
Split locked / set states for home.  Tidy/Fix Plane's home-setting

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -46,14 +46,12 @@ bool Rover::set_home(const Location& loc, bool lock)
         return false;
     }
 
+    const bool home_was_set = ahrs.home_is_set();
+
     // set ahrs home
     ahrs.set_home(loc);
 
-    // init compass declination
-    if (!ahrs.home_is_set()) {
-        // record home is set
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
-
+    if (!home_was_set) {
         // log new home position which mission library will pull from ahrs
         if (should_log(MASK_LOG_CMD)) {
             AP_Mission::Mission_Command temp_cmd;
@@ -65,7 +63,7 @@ bool Rover::set_home(const Location& loc, bool lock)
 
     // lock home position
     if (lock) {
-        ahrs.set_home_status(HOME_SET_AND_LOCKED);
+        ahrs.lock_home();
     }
 
     // Save Home to EEPROM
@@ -117,7 +115,7 @@ void Rover::set_system_time_from_GPS()
 */
 void Rover::update_home()
 {
-    if (ahrs.home_status() == HOME_SET_NOT_LOCKED) {
+    if (!ahrs.home_is_locked()) {
         Location loc;
         if (ahrs.get_position(loc)) {
             if (get_distance(loc, ahrs.get_home()) > DISTANCE_HOME_MAX) {

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -163,7 +163,6 @@ void Tracker::set_home(struct Location temp)
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
         ahrs.set_home(temp);
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
     }
 
     gcs().send_home();

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -72,15 +72,16 @@ bool Copter::set_home(const Location& loc, bool lock)
         return false;
     }
 
+    const bool home_was_set = ahrs.home_is_set();
+
     // set ahrs home (used for RTL)
     ahrs.set_home(loc);
 
     // init inav and compass declination
-    if (!ahrs.home_is_set()) {
+    if (!home_was_set) {
         // update navigation scalers.  used to offset the shrinking longitude as we go towards the poles
         scaleLongDown = longitude_scale(loc);
         // record home is set
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
         Log_Write_Event(DATA_SET_HOME);
 
 #if MODE_AUTO_ENABLED == ENABLED
@@ -96,7 +97,7 @@ bool Copter::set_home(const Location& loc, bool lock)
 
     // lock home position
     if (lock) {
-        ahrs.set_home_status(HOME_SET_AND_LOCKED);
+        ahrs.lock_home();
     }
 
     // log ahrs home and ekf origin dataflash

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -180,7 +180,7 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
 
         // we have reset height, so arming height is zero
         arming_altitude_m = 0;        
-    } else if (ahrs.home_status() == HOME_SET_NOT_LOCKED) {
+    } else if (!ahrs.home_is_locked()) {
         // Reset home position if it has already been set before (but not locked)
         set_home_to_current_location(false);
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -436,7 +436,11 @@ void Plane::update_GPS_10Hz(void)
                 ground_start_count = 5;
 
             } else {
-                init_home();
+                gcs().send_text(MAV_SEVERITY_INFO, "Init HOME");
+
+                set_home_persistently(gps.location());
+
+                next_WP_loc = prev_WP_loc = home;
 
                 // set system clock for log timestamps
                 uint64_t gps_timestamp = gps.time_epoch_usec();

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -436,8 +436,6 @@ void Plane::update_GPS_10Hz(void)
                 ground_start_count = 5;
 
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Init HOME");
-
                 set_home_persistently(gps.location());
 
                 next_WP_loc = prev_WP_loc = home;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -777,6 +777,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1, 1.0f)) {
                 plane.set_home_persistently(AP::gps().location());
+                result = MAV_RESULT_ACCEPTED;
             } else {
                 // ensure param1 is zero
                 if (!is_zero(packet.param1)) {
@@ -1071,6 +1072,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1,1.0f)) {
                 plane.set_home_persistently(AP::gps().location());
+                result = MAV_RESULT_ACCEPTED;
             } else {
                 // ensure param1 is zero
                 if (!is_zero(packet.param1)) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -810,7 +810,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                     new_home_loc.alt += plane.ahrs.get_home().alt;
                 }
                 plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
                 AP::ahrs().Log_Write_Home_And_Origin();
                 gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
@@ -1096,7 +1095,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
                 plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().set_home_status(HOME_SET_NOT_LOCKED);
                 AP::ahrs().Log_Write_Home_And_Origin();
                 gcs().send_home();
                 result = MAV_RESULT_ACCEPTED;
@@ -1514,7 +1512,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.lng = packet.longitude;
         new_home_loc.alt = packet.altitude / 10;
         plane.ahrs.set_home(new_home_loc);
-        plane.ahrs.set_home_status(HOME_SET_NOT_LOCKED);
         plane.ahrs.Log_Write_Home_And_Origin();
         gcs().send_home();
         gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -776,7 +776,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_DO_SET_HOME: {
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1, 1.0f)) {
-                plane.init_home();
+                plane.set_home_persistently(AP::gps().location());
             } else {
                 // ensure param1 is zero
                 if (!is_zero(packet.param1)) {
@@ -809,9 +809,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                     }
                     new_home_loc.alt += plane.ahrs.get_home().alt;
                 }
-                plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home();
+                plane.set_home(new_home_loc);
                 result = MAV_RESULT_ACCEPTED;
                 gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                         (double)(new_home_loc.lat*1.0e-7f),
@@ -1076,7 +1074,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             // param7 : altitude (absolute)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1,1.0f)) {
-                plane.init_home();
+                plane.set_home_persistently(AP::gps().location());
             } else {
                 // ensure param1 is zero
                 if (!is_zero(packet.param1)) {
@@ -1094,9 +1092,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                plane.ahrs.set_home(new_home_loc);
-                AP::ahrs().Log_Write_Home_And_Origin();
-                gcs().send_home();
+                plane.set_home(new_home_loc);
                 result = MAV_RESULT_ACCEPTED;
                 gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                         (double)(new_home_loc.lat*1.0e-7f),
@@ -1511,9 +1507,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.lat = packet.latitude;
         new_home_loc.lng = packet.longitude;
         new_home_loc.alt = packet.altitude / 10;
-        plane.ahrs.set_home(new_home_loc);
-        plane.ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home();
+        plane.set_home(new_home_loc);
         gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
                                 (double)(new_home_loc.lat*1.0e-7f),
                                 (double)(new_home_loc.lng*1.0e-7f),

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -811,10 +811,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 }
                 plane.set_home(new_home_loc);
                 result = MAV_RESULT_ACCEPTED;
-                gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                        (double)(new_home_loc.lat*1.0e-7f),
-                                        (double)(new_home_loc.lng*1.0e-7f),
-                                        (uint32_t)(new_home_loc.alt*0.01f));
             }
             break;
         }
@@ -1094,10 +1090,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
                 plane.set_home(new_home_loc);
                 result = MAV_RESULT_ACCEPTED;
-                gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                        (double)(new_home_loc.lat*1.0e-7f),
-                                        (double)(new_home_loc.lng*1.0e-7f),
-                                        (uint32_t)(new_home_loc.alt*0.01f));
             }
             break;
         }
@@ -1508,10 +1500,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
         new_home_loc.lng = packet.longitude;
         new_home_loc.alt = packet.altitude / 10;
         plane.set_home(new_home_loc);
-        gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %um",
-                                (double)(new_home_loc.lat*1.0e-7f),
-                                (double)(new_home_loc.lng*1.0e-7f),
-                                (uint32_t)(new_home_loc.alt*0.01f));
         break;
     }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -777,6 +777,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1, 1.0f)) {
                 plane.set_home_persistently(AP::gps().location());
+                AP::ahrs().lock_home();
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 // ensure param1 is zero
@@ -811,6 +812,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                     new_home_loc.alt += plane.ahrs.get_home().alt;
                 }
                 plane.set_home(new_home_loc);
+                AP::ahrs().lock_home();
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1072,6 +1074,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             result = MAV_RESULT_FAILED; // assume failure
             if (is_equal(packet.param1,1.0f)) {
                 plane.set_home_persistently(AP::gps().location());
+                AP::ahrs().lock_home();
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 // ensure param1 is zero
@@ -1091,6 +1094,7 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
                 new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
                 new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
                 plane.set_home(new_home_loc);
+                AP::ahrs().lock_home();
                 result = MAV_RESULT_ACCEPTED;
             }
             break;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -828,8 +828,11 @@ private:
     void rangefinder_height_update(void);
     void set_next_WP(const struct Location &loc);
     void set_guided_WP(void);
-    void init_home();
     void update_home();
+    // set home location and store it persistently:
+    void set_home_persistently(const Location &loc);
+    // set home location:
+    void set_home(const Location &loc);
     void do_RTL(int32_t alt);
     bool verify_takeoff();
     bool verify_loiter_unlim();

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -110,7 +110,6 @@ void Plane::init_home()
     gcs().send_text(MAV_SEVERITY_INFO, "Init HOME");
 
     ahrs.set_home(gps.location());
-    ahrs.set_home_status(HOME_SET_NOT_LOCKED);
     ahrs.Log_Write_Home_And_Origin();
     gcs().send_home();
 
@@ -138,7 +137,7 @@ void Plane::update_home()
         // significantly
         return;
     }
-    if (ahrs.home_status() == HOME_SET_NOT_LOCKED) {
+    if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         Location loc;
         if(ahrs.get_position(loc)) {
             ahrs.set_home(loc);

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -103,24 +103,6 @@ void Plane::set_guided_WP(void)
     loiter_angle_reset();
 }
 
-// run this at setup on the ground
-// -------------------------------
-void Plane::init_home()
-{
-    gcs().send_text(MAV_SEVERITY_INFO, "Init HOME");
-
-    ahrs.set_home(gps.location());
-    ahrs.Log_Write_Home_And_Origin();
-    gcs().send_home();
-
-    // Save Home to EEPROM
-    mission.write_home_to_storage();
-
-    // Save prev loc
-    // -------------
-    next_WP_loc = prev_WP_loc = home;
-}
-
 /*
   update home location from GPS
   this is called as long as we have 3D lock and the arming switch is
@@ -140,10 +122,23 @@ void Plane::update_home()
     if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         Location loc;
         if(ahrs.get_position(loc)) {
-            ahrs.set_home(loc);
-            ahrs.Log_Write_Home_And_Origin();
-            gcs().send_home();
+            plane.set_home(loc);
         }
     }
     barometer.update_calibration();
+}
+
+void Plane::set_home_persistently(const Location &loc)
+{
+    set_home(loc);
+
+    // Save Home to EEPROM
+    mission.write_home_to_storage();
+}
+
+void Plane::set_home(const Location &loc)
+{
+    ahrs.set_home(loc);
+    ahrs.Log_Write_Home_And_Origin();
+    gcs().send_home();
 }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -934,11 +934,9 @@ void Plane::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
-        init_home();
+        set_home_persistently(gps.location());
     } else {
-        ahrs.set_home(cmd.content.location);
-        ahrs.Log_Write_Home_And_Origin();
-        gcs().send_home();
+        plane.set_home(cmd.content.location);
         gcs().send_ekf_origin();
     }
 }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -937,7 +937,6 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
         init_home();
     } else {
         ahrs.set_home(cmd.content.location);
-        ahrs.set_home_status(HOME_SET_NOT_LOCKED);
         ahrs.Log_Write_Home_And_Origin();
         gcs().send_home();
         gcs().send_ekf_origin();

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -50,7 +50,7 @@ bool Sub::init_arm_motors(bool arming_from_gcs)
         // Always use absolute altitude for ROV
         // ahrs.resetHeightDatum();
         // Log_Write_Event(DATA_EKF_ALT_RESET);
-    } else if (ahrs.home_status() == HOME_SET_NOT_LOCKED) {
+    } else if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         // Reset home position if it has already been set before (but not locked)
         set_home_to_current_location(false);
     }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -436,14 +436,18 @@ public:
         return _home;
     }
 
-    enum HomeState home_status(void) const {
-        return _home_status;
+    // functions to handle locking of home.  Some vehicles use this to
+    // allow GCS to lock in a home location.
+    void lock_home() {
+        _home_locked = true;
     }
-    void set_home_status(enum HomeState new_status) {
-        _home_status = new_status;
+    bool home_is_locked() const {
+        return _home_locked;
     }
+
+    // returns true if home is set
     bool home_is_set(void) const {
-        return _home_status != HOME_UNSET;
+        return _home_is_set;
     }
 
     // set the home location in 10e7 degrees. This should be called
@@ -649,6 +653,8 @@ protected:
 
     // reference position for NED positions
     struct Location _home;
+    bool _home_is_set :1;
+    bool _home_locked :1;
 
     // helper trig variables
     float _cos_roll, _cos_pitch, _cos_yaw;
@@ -666,9 +672,6 @@ protected:
 
 private:
     static AP_AHRS *_singleton;
-
-    // Flag for if we have g_gps lock and have set the home location in AHRS
-    enum HomeState _home_status = HOME_UNSET;
 
 };
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1012,6 +1012,7 @@ void AP_AHRS_DCM::set_home(const Location &loc)
 {
     _home = loc;
     _home.options = 0;
+    _home_is_set = true;
 }
 
 //  a relative ground position to home in meters, Down

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -587,11 +587,6 @@ Vector2f AP_AHRS_NavEKF::groundspeed_vector(void)
     }
 }
 
-void AP_AHRS_NavEKF::set_home(const Location &loc)
-{
-    AP_AHRS_DCM::set_home(loc);
-}
-
 // set the EKF's origin location in 10e7 degrees.  This should only
 // be called when the EKF has no absolute position reference (i.e. GPS)
 // from which to decide the origin on its own

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -125,9 +125,6 @@ public:
     // blended accelerometer values in the earth frame in m/s/s
     const Vector3f &get_accel_ef_blended() const override;
 
-    // set home location
-    void set_home(const Location &loc) override;
-
     // set the EKF's origin location in 10e7 degrees.  This should only
     // be called when the EKF has no absolute position reference (i.e. GPS)
     // from which to decide the origin on its own

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -144,15 +144,6 @@ struct PACKED Location {
     int32_t lng;                                        ///< param 4 - Longitude * 10**7
 };
 
-/*
-  home states. Used to record if user has overridden home position.
-*/
-enum HomeState {
-    HOME_UNSET,                 // home is unset, no GPS positions yet received
-    HOME_SET_NOT_LOCKED,        // home is set to EKF origin or armed location (can be moved)
-    HOME_SET_AND_LOCKED         // home has been set by user, cannot be moved except by user initiated do-set-home command
-};
-
 //@}
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes a problem in Plane where setting your home location (e.g. via a mavlink message) may reset your current waypoint.

`init_home` is removed in Plane on the basis that resetting your waypoint in the way that it does is not something you ever want to do apart from during the boot sequence (or, in the future, when home is first set).

The original bug can be reproduced in SITL by starting to fly the standard CMAC pattern then `long DO_SET_HOME 1`; you should see the vehicle skip from its current waypoint to the next.

