### PR TITLE
Rover: fix forward-back acceleration limiting

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -455,18 +455,22 @@ float AR_AttitudeControl::get_desired_speed() const
 // get acceleration limited desired speed
 float AR_AttitudeControl::get_desired_speed_accel_limited(float desired_speed) const
 {
-    // return input value if no recent calls to speed controller
-    const uint32_t now = AP_HAL::millis();
-    if ((_speed_last_ms == 0) || ((now - _speed_last_ms) > AR_ATTCONTROL_TIMEOUT_MS) || !is_positive(_throttle_accel_max)) {
-        return desired_speed;
-    }
-
     // calculate dt
-    const float dt = (now - _speed_last_ms) / 1000.0f;
+    const uint32_t now = AP_HAL::millis();
+    float dt = (now - _speed_last_ms) / 1000.0f;
+
+    // use previous desired speed as basis for accel limiting
+    float speed_prev = _desired_speed;
+
+    // if no recent calls to speed controller limit based on current speed
+    if (is_negative(dt) || (dt > AR_ATTCONTROL_TIMEOUT_MS / 1000.0f)) {
+        dt = 0.0f;
+        get_forward_speed(speed_prev);
+    }
 
     // acceleration limit desired speed
     const float speed_change_max = _throttle_accel_max * dt;
-    return constrain_float(desired_speed, _desired_speed - speed_change_max, _desired_speed + speed_change_max);
+    return constrain_float(desired_speed, speed_prev - speed_change_max, speed_prev + speed_change_max);
 }
 
 // get minimum stopping distance (in meters) given a speed (in m/s)


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/ArduPilot/ardupilot/issues/8426) found in [this discussion](https://discuss.ardupilot.org/t/skid-steer-mower-overshooting-pivot-turns/28910).

The issue was that when first engaging the speed controller, we were not acceleration limiting the desired-speed, instead we simply let the desired-speed jump up to whatever the caller requested.  With this change, in these situations we limited the desired-speed using the vehicle's current speed as a base.

To test this change was correct, a SITL rover was loaded with a very simple mission (just one waypoint) and then soon after arming, the vehicle was switched from MANUAL mode to AUTO.  Below is a graph of the desired speed vs actual speed and we can see in the "BEFORE" image that the desired speed immediately spikes up to the WP_SPEED (set to 5m/s) while in the "AFTER" image it rises more slowly.

![before-after](https://user-images.githubusercontent.com/1498098/40216653-008bc710-5aa3-11e8-927c-67cebb83c0cd.png)

