### PR TITLE
Rover: Add pivot_turn_rate parameter 

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -555,6 +555,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_Avoidance/AC_Avoid.cpp
     AP_SUBGROUPINFO(avoid, "AVOID_", 19, ParametersG2, AC_Avoid),
 
+    // @Param: PIVOT_TURN_RATE
+    // @DisplayName: Pivot turn rate
+    // @Description: Desired pivot turn rate in deg/s.
+    // @Units: deg/s
+    // @Range: 0 360
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("PIVOT_TURN_RATE", 20, ParametersG2, pivot_turn_rate, 90),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -341,6 +341,9 @@ public:
 
     // avoidance library
     AC_Avoid avoid;
+
+    // pivot turn rate
+    AP_Int16 pivot_turn_rate;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -363,7 +363,7 @@ void Mode::calc_steering_to_waypoint(const struct Location &origin, const struct
 
     if (rover.use_pivot_steering(_yaw_error_cd)) {
         // for pivot turns use heading controller
-        calc_steering_to_heading(desired_heading);
+        calc_steering_to_heading(desired_heading, g2.pivot_turn_rate);
     } else {
         // call lateral acceleration to steering controller
         calc_steering_from_lateral_acceleration(desired_lat_accel, reversed);
@@ -392,10 +392,11 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
 }
 
 // calculate steering output to drive towards desired heading
-void Mode::calc_steering_to_heading(float desired_heading_cd, bool reversed)
+void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max, bool reversed)
 {
     // calculate yaw error (in radians) and pass to steering angle controller
     const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f),
+                                                                         rate_max,
                                                                          g2.motors.limit.steer_left,
                                                                          g2.motors.limit.steer_right);
     g2.motors.set_steering(steering_out * 4500.0f);

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -116,7 +116,7 @@ protected:
     void calc_steering_from_lateral_acceleration(float lat_accel, bool reversed = false);
 
     // calculate steering output to drive towards desired heading
-    void calc_steering_to_heading(float desired_heading_cd, bool reversed = false);
+    void calc_steering_to_heading(float desired_heading_cd, float rate_max, bool reversed = false);
 
     // calculates the amount of throttle that should be output based
     // on things like proximity to corners and current speed

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -203,13 +203,17 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool m
 }
 
 // return a steering servo output from -1 to +1 given a heading in radians
-float AR_AttitudeControl::get_steering_out_heading(float heading_rad, bool motor_limit_left, bool motor_limit_right)
+float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right)
 {
     // calculate heading error (in radians)
     const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
 
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
-    const float desired_rate = _steer_angle_p.get_p(yaw_error);
+    float desired_rate = _steer_angle_p.get_p(yaw_error);
+    // limit desired_rate if a custom pivot turn rate is selected, otherwise use ATC_STR_RAT_MAX
+    if (is_positive(rate_max)) {
+        desired_rate = constrain_float(desired_rate, -rate_max, rate_max);
+    }
 
     return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right);
 }

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -48,7 +48,7 @@ public:
     float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right);
 
     // return a steering servo output from -1 to +1 given a heading in radians
-    float get_steering_out_heading(float heading_rad, bool motor_limit_left, bool motor_limit_right);
+    float get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right);
 
     // return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/ArduPilot/ardupilot/issues/8404) found in [this discussion](https://discuss.ardupilot.org/t/skid-steer-mower-overshooting-pivot-turns/28910/18).