### PR TITLE
Copter: support airspeed sensor

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -100,6 +100,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if RANGEFINDER_ENABLED == ENABLED
     SCHED_TASK(read_rangefinder,      20,    100),
 #endif
+    SCHED_TASK(read_airspeed,         10,    100),
 #if PROXIMITY_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Proximity,         &copter.g2.proximity,        update,         100,  50),
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -84,6 +84,7 @@
 #include <AP_Arming/AP_Arming.h>
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <AP_TempCalibration/AP_TempCalibration.h>
+#include <AP_Airspeed/AP_Airspeed.h>
 
 // Configuration
 #include "defines.h"
@@ -400,6 +401,9 @@ private:
         uint8_t terrain             : 1; // true if the missing terrain data failsafe has occurred
         uint8_t adsb                : 1; // true if an adsb related failsafe has occurred
     } failsafe;
+
+    // Airspeed Sensors
+    AP_Airspeed airspeed;
 
     bool any_failsafe_triggered() const {
         return failsafe.radio || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain || failsafe.adsb;
@@ -874,6 +878,7 @@ private:
     void read_barometer(void);
     void init_rangefinder(void);
     void read_rangefinder(void);
+    void read_airspeed(void);
     bool rangefinder_alt_ok();
     void rpm_update();
     void init_compass();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -620,6 +620,10 @@ const AP_Param::Info Copter::var_info[] = {
     // @Path: ../libraries/AP_AHRS/AP_AHRS.cpp
     GOBJECT(ahrs,                   "AHRS_",    AP_AHRS),
 
+    // @Group: ARSPD
+    // @Path: ../libraries/AP_Airspeed/AP_Airspeed.cpp
+    GOBJECT(airspeed,               "ARSPD",   AP_Airspeed),
+
 #if MOUNT == ENABLED
     // @Group: MNT
     // @Path: ../libraries/AP_Mount/AP_Mount.cpp

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -229,7 +229,7 @@ public:
         //
         // 140: Sensor parameters
         //
-        k_param_imu = 140, // deprecated - can be deleted
+        k_param_airspeed = 140,  // AP_Airspeed parameters
         k_param_battery_monitoring = 141,   // deprecated - can be deleted
         k_param_volt_div_ratio, // deprecated - can be deleted
         k_param_curr_amp_per_volt,  // deprecated - can be deleted

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -162,10 +162,16 @@ void Copter::init_ardupilot()
 
     init_compass();
 
+    // initialise airspeed sensor
+    airspeed.init();
+
 #if OPTFLOW == ENABLED
     // make optflow available to AHRS
     ahrs.set_optflow(&optflow);
 #endif
+
+    // give AHRS the airspeed sensor
+    ahrs.set_airspeed(&airspeed); 
 
     // init Location class
 #if AP_TERRAIN_AVAILABLE && AC_TERRAIN
@@ -217,6 +223,12 @@ void Copter::init_ardupilot()
     //-----------------------------
     barometer.set_log_baro_bit(MASK_LOG_IMU);
     barometer.calibrate();
+
+    if (airspeed.enabled()) {
+        // initialize airspeed sensor
+        // --------------------------
+        airspeed.calibrate(true);
+    }
 
     // initialise rangefinder
     init_rangefinder();


### PR DESCRIPTION
for #7654 

Airspeed sensor can provide more data about copter flight status. It is important for remote operation or flight beyond line of sight. I need airspeed reading for my current project. So I do it. Thanks @rmackay9 's advices. Tested on my quadcopter (analog airspeed sensor connected to pixhawk ADC 6.6v)

Hi @bnsgeyer , Would you be able to taking a look? Because you mention that  you have done it before. Thank you very much.
