### PR TITLE
AP_ADSB: Add user-assignable squawk to ADSB-out part2

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -305,6 +305,7 @@ void Plane::one_second_loop()
     ahrs.set_orientation();
 
     adsb.set_stall_speed_cm(aparm.airspeed_min);
+    adsb.set_max_speed(aparm.airspeed_max);
 
     // sync MAVLink system ID
     mavlink_system.sysid = g.sysid_this_mav;

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -100,6 +100,7 @@ known_units = {
              'A/V'     : 'ampere per volt'       ,
              'm/V'     : 'meters per volt'       ,
              'gravities': 'standard acceleration due to gravity' , # g_n would be a more correct unit, but IMHO no one understands what g_n means
+             'octal'   : 'octal'                 ,
              }
 
 required_param_fields = [

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -57,6 +57,12 @@ public:
     void send_adsb_vehicle(mavlink_channel_t chan);
 
     void set_stall_speed_cm(const uint16_t stall_speed_cm) { out_state.cfg.stall_speed_cm = stall_speed_cm; }
+    void set_max_speed(int16_t max_speed) {
+        if (!out_state.cfg.was_set_externally) {
+            // convert m/s to knots
+            out_state.cfg.maxAircraftSpeed_knots = (float)max_speed * 1.94384f;
+        }
+    }
 
     void set_is_auto_mode(const bool is_in_auto_mode) { out_state._is_in_auto_mode = is_in_auto_mode; }
     void set_is_flying(const bool is_flying) { out_state.is_flying = is_flying; }
@@ -102,11 +108,17 @@ private:
     void send_configure(const mavlink_channel_t chan);
     void send_dynamic_out(const mavlink_channel_t chan);
 
+    // special helpers for uAvionix workarounds
+    uint32_t get_encoded_icao(void);
+    uint8_t get_encoded_callsign_null_char(void);
+
     // add or update vehicle_list from inbound mavlink msg
     void handle_vehicle(const mavlink_message_t* msg);
 
     // handle ADS-B transceiver report for ping2020
     void handle_transceiver_report(mavlink_channel_t chan, const mavlink_message_t* msg);
+
+    void handle_out_cfg(const mavlink_message_t* msg);
 
     AP_Int8     _enabled;
 
@@ -143,13 +155,18 @@ private:
             int32_t     ICAO_id;
             AP_Int32    ICAO_id_param;
             int32_t     ICAO_id_param_prev = -1; // assume we never send
-            char        callsign[9]; //Vehicle identifier (8 characters, null terminated, valid characters are A-Z, 0-9, " " only).
+            char        callsign[MAVLINK_MSG_UAVIONIX_ADSB_OUT_CFG_FIELD_CALLSIGN_LEN]; //Vehicle identifier (8 characters, null terminated, valid characters are A-Z, 0-9, " " only).
             AP_Int8     emitterType;
             AP_Int8     lengthWidth;  // Aircraft length and width encoding (table 2-35 of DO-282B)
             AP_Int8     gpsLatOffset;
             AP_Int8     gpsLonOffset;
             uint16_t    stall_speed_cm;
             AP_Int8     rfSelect;
+            AP_Int16    squawk_octal_param;
+            uint16_t    squawk_octal;
+            float       maxAircraftSpeed_knots;
+            AP_Int8     rf_capable;
+            bool        was_set_externally;
         } cfg;
 
     } out_state;

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -237,3 +237,20 @@ Vector3f rand_vec3f(void)
     return v;
 }
 #endif
+
+bool is_valid_octal(uint16_t octal)
+{
+    // treat "octal" as decimal and test if any decimal digit is > 7
+    if (octal > 7777) {
+        return false;
+    } else if (octal % 10 > 7) {
+        return false;
+    } else if ((octal % 100)/10 > 7) {
+        return false;
+    } else if ((octal % 1000)/100 > 7) {
+        return false;
+    } else if ((octal % 10000)/1000 > 7) {
+        return false;
+    }
+    return true;
+}

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -249,3 +249,7 @@ float rand_float(void);
 
 // generate a random Vector3f of size 1
 Vector3f rand_vec3f(void);
+
+// confirm a value is a valid octal value
+bool is_valid_octal(uint16_t octal);
+


### PR DESCRIPTION
This is a replacement of https://github.com/ArduPilot/ardupilot/pull/8283

Add user-assignable squawk to ADSB-out and other goodies.

This was requested, and then written, while standing in the uAvionix booth at AUVSI 2018. Now THAT is customer service! Aaaaaaaand then they wanted more.. which I happily did.

For backwards compatibility with existing uAvionix hardware in the field, they decided to override the last null char in the callsign with some encoded bits instead of extending the MAVlink protocol which they viewed as a potentially viewed as a loooooong process to upstream. So, the last callsign byte has a few flags in it. Up until now, unknowingly to us, you had to remove the HW from ArduPilot and connect your computer and use their software app to the HW to configure it to utilizw these extra features. Now this can be done by the autopilot using params.

I've also added a MAVLink configure passthrough so that if you did use their app, you can talk MAVLink to the main ArduPilot on one serial port and the mavlink router will forward it to the HW on the other serial port instead of having to remove it from the system.

A px4-v3 binary was sent to uAvionix who confirmed functionality on their hardware.