### PR TITLE
Factor vfr hud - and have vehicles override just their custom bits

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -140,16 +140,9 @@ void Rover::send_servo_out(mavlink_channel_t chan)
         rssi.read_receiver_rssi_uint8());
 }
 
-void Rover::send_vfr_hud(mavlink_channel_t chan)
+int16_t GCS_MAVLINK_Rover::vfr_hud_throttle() const
 {
-    mavlink_msg_vfr_hud_send(
-        chan,
-        gps.ground_speed(),
-        ahrs.groundspeed(),
-        (ahrs.yaw_sensor / 100) % 360,
-        g2.motors.get_throttle(),
-        current_loc.alt / 100.0f,
-        0);
+    return rover.g2.motors.get_throttle();
 }
 
 void Rover::send_rangefinder(mavlink_channel_t chan)
@@ -282,11 +275,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_SERVO_OUT:
         CHECK_PAYLOAD_SIZE(RC_CHANNELS_SCALED);
         rover.send_servo_out(chan);
-        break;
-
-    case MSG_VFR_HUD:
-        CHECK_PAYLOAD_SIZE(VFR_HUD);
-        rover.send_vfr_hud(chan);
         break;
 
     case MSG_RANGEFINDER:

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -41,4 +41,7 @@ private:
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
+
+    int16_t vfr_hud_throttle() const override;
+
 };

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -465,7 +465,6 @@ private:
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
-    void send_vfr_hud(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void send_wheel_encoder(mavlink_channel_t chan);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -761,7 +761,6 @@ private:
     void send_fence_status(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_vfr_hud(mavlink_channel_t chan);
     void send_rpm(mavlink_channel_t chan);
     void send_pid_tuning(mavlink_channel_t chan);
     void gcs_data_stream_send(void);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -171,16 +171,9 @@ void NOINLINE Copter::send_nav_controller_output(mavlink_channel_t chan)
         0);
 }
 
-void NOINLINE Copter::send_vfr_hud(mavlink_channel_t chan)
+int16_t GCS_MAVLINK_Copter::vfr_hud_throttle() const
 {
-    mavlink_msg_vfr_hud_send(
-        chan,
-        gps.ground_speed(),
-        ahrs.groundspeed(),
-        (ahrs.yaw_sensor / 100) % 360,
-        (int16_t)(motors->get_throttle() * 100),
-        current_loc.alt / 100.0f,
-        climb_rate / 100.0f);
+    return (int16_t)(copter.motors->get_throttle() * 100);
 }
 
 /*
@@ -306,11 +299,6 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         copter.send_nav_controller_output(chan);
-        break;
-
-    case MSG_VFR_HUD:
-        CHECK_PAYLOAD_SIZE(VFR_HUD);
-        copter.send_vfr_hud(chan);
         break;
 
     case MSG_RPM:

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -51,4 +51,8 @@ private:
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
+
+    int16_t vfr_hud_throttle() const override;
+    bool vfr_hud_make_alt_relative() const override { return true; }
+
 };

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -237,22 +237,37 @@ void Plane::send_servo_out(mavlink_channel_t chan)
         rssi.read_receiver_rssi_uint8());
 }
 
-void Plane::send_vfr_hud(mavlink_channel_t chan)
+float GCS_MAVLINK_Plane::vfr_hud_airspeed() const
 {
-    float aspeed;
-    if (airspeed.enabled()) {
-        aspeed = airspeed.get_airspeed();
-    } else if (!ahrs.airspeed_estimate(&aspeed)) {
-        aspeed = 0;
+    // airspeed sensors are best.  While the AHRS airspeed_estimate
+    // will use an airspeed sensor, that value is constrained by the
+    // ground speed.  When reporting we should send the true airspeed
+    // value if possible:
+    if (plane.airspeed.enabled()) {
+        return plane.airspeed.get_airspeed();
     }
-    mavlink_msg_vfr_hud_send(
-        chan,
-        aspeed,
-        ahrs.groundspeed(),
-        (ahrs.yaw_sensor / 100) % 360,
-        abs(throttle_percentage()),
-        current_loc.alt / 100.0f,
-        (g2.soaring_controller.is_active() ? g2.soaring_controller.get_vario_reading() : barometer.get_climb_rate()));
+
+    // airspeed estimates are OK:
+    float aspeed;
+    if (AP::ahrs().airspeed_estimate(&aspeed)) {
+        return aspeed;
+    }
+
+    // lying is worst:
+    return 0;
+}
+
+int16_t GCS_MAVLINK_Plane::vfr_hud_throttle() const
+{
+    return abs(plane.throttle_percentage());
+}
+
+float GCS_MAVLINK_Plane::vfr_hud_climbrate() const
+{
+    if (plane.g2.soaring_controller.is_active()) {
+        return plane.g2.soaring_controller.get_vario_reading();
+    }
+    return AP::baro().get_climb_rate();
 }
 
 /*
@@ -416,11 +431,6 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
             plane.send_servo_out(chan);
         }
 #endif
-        break;
-
-    case MSG_VFR_HUD:
-        CHECK_PAYLOAD_SIZE(VFR_HUD);
-        plane.send_vfr_hud(chan);
         break;
 
     case MSG_FENCE_STATUS:

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -53,4 +53,9 @@ private:
     MAV_STATE system_status() const override;
 
     uint8_t radio_in_rssi() const;
+
+    float vfr_hud_airspeed() const override;
+    int16_t vfr_hud_throttle() const override;
+    float vfr_hud_climbrate() const override;
+
 };

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -773,7 +773,6 @@ private:
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
-    void send_vfr_hud(mavlink_channel_t chan);
     void send_wind(mavlink_channel_t chan);
     void send_pid_info(const mavlink_channel_t chan, const DataFlash_Class::PID_Info *pid_info, const uint8_t axis, const float achieved);
     void send_pid_tuning(mavlink_channel_t chan);

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -251,16 +251,9 @@ void NOINLINE Sub::send_nav_controller_output(mavlink_channel_t chan)
         0);
 }
 
-void NOINLINE Sub::send_vfr_hud(mavlink_channel_t chan)
+int16_t GCS_MAVLINK_Sub::vfr_hud_throttle() const
 {
-    mavlink_msg_vfr_hud_send(
-        chan,
-        gps.ground_speed(),
-        gps.ground_speed(),
-        (ahrs.yaw_sensor / 100) % 360,
-        (int16_t)(motors.get_throttle() * 100),
-        current_loc.alt / 100.0f,
-        climb_rate / 100.0f);
+    return (int16_t)(sub.motors.get_throttle() * 100);
 }
 
 /*
@@ -425,11 +418,6 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         sub.send_nav_controller_output(chan);
-        break;
-
-    case MSG_VFR_HUD:
-        CHECK_PAYLOAD_SIZE(VFR_HUD);
-        sub.send_vfr_hud(chan);
         break;
 
     case MSG_RPM:

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -46,4 +46,8 @@ private:
     MAV_MODE base_mode() const override;
     uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
+
+    int16_t vfr_hud_throttle() const override;
+    bool vfr_hud_make_alt_relative() const override { return true; }
+
 };

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -476,7 +476,6 @@ private:
     void send_heartbeat(mavlink_channel_t chan);
     void send_extended_status1(mavlink_channel_t chan);
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_vfr_hud(mavlink_channel_t chan);
 #if RPM_ENABLED == ENABLED
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -90,7 +90,7 @@ public:
     {
         _throttle_suppressed = suppressed;
     }
-    float get_vario_reading()
+    float get_vario_reading() const
     {
         return _vario.displayed_reading;
     }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -186,6 +186,7 @@ public:
     virtual void send_attitude() const;
     void send_autopilot_version() const;
     void send_local_position() const;
+    void send_vfr_hud();
     void send_vibration() const;
     void send_named_float(const char *name, float value) const;
     void send_home() const;
@@ -367,6 +368,13 @@ protected:
     // these two methods are called after current_loc is updated:
     virtual int32_t global_position_int_alt() const;
     virtual int32_t global_position_int_relative_alt() const;
+
+    // these methods are called after vfr_hud_velned is updated
+    virtual bool vfr_hud_make_alt_relative() const { return false; }
+    virtual float vfr_hud_climbrate() const;
+    virtual float vfr_hud_airspeed() const;
+    virtual int16_t vfr_hud_throttle() const { return 0; }
+    Vector3f vfr_hud_velned;
 
 private:
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1730,6 +1730,10 @@ void GCS_MAVLINK::send_accelcal_vehicle_position(uint32_t position)
 
 float GCS_MAVLINK::vfr_hud_airspeed() const
 {
+    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    if (airspeed != nullptr && airspeed->healthy()) {
+        return airspeed->get_airspeed();
+    }
     // because most vehicles don't have airspeed sensors, we return a
     // different sort of speed estimate in the relevant field for
     // comparison's sake.


### PR DESCRIPTION
This is an alternative to https://github.com/ArduPilot/ardupilot/pull/8340

Values for various `VFR_HUD` fields come from overridden methods rather than each vehicle over-riding `send_vfr_hud`.

Makes Plane more ugly (IMO), but makes the other vehicles nicer.

Will help to centralise the sending of `AP_Airspeed` data when that comes into Copter.

Opinions on which we should go with?
