### PR TITLE
AC_Circle: Select the center of the circle.

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -23,6 +23,13 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RATE",    1, AC_Circle, _rate,    AC_CIRCLE_RATE_DEFAULT),
 
+    // @Param: RADUSED
+    // @DisplayName: Circle Radius used
+    // @Description: Use the radius at the center of the circle.
+    // @Values: 0:Not used,1:Used
+    // @User: Standard
+    AP_GROUPINFO("RADUSED",    2, AC_Circle, _radius_used, AC_CIRCLE_RADIUS_USED),
+
     AP_GROUPEND
 };
 
@@ -86,8 +93,13 @@ void AC_Circle::init()
     const Vector3f& stopping_point = _pos_control.get_pos_target();
 
     // set circle center to circle_radius ahead of stopping point
-    _center.x = stopping_point.x + _radius * _ahrs.cos_yaw();
-    _center.y = stopping_point.y + _radius * _ahrs.sin_yaw();
+    if (_radius_used) {
+        _center.x = stopping_point.x + _radius * _ahrs.cos_yaw();
+        _center.y = stopping_point.y + _radius * _ahrs.sin_yaw();
+    } else {
+        _center.x = stopping_point.x;
+        _center.y = stopping_point.y;
+    }
     _center.z = stopping_point.z;
 
     // calculate velocities

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -23,12 +23,12 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RATE",    1, AC_Circle, _rate,    AC_CIRCLE_RATE_DEFAULT),
 
-    // @Param: RADUSED
-    // @DisplayName: Circle Radius used
-    // @Description: Use the radius at the center of the circle.
-    // @Values: 0:Not used,1:Used
+    // @Param: BASEPOINT
+    // @DisplayName: Base Point
+    // @Description: The base point is the center of the circle or the starting point of the arc.
+    // @Values: 0:Center,1:Arc
     // @User: Standard
-    AP_GROUPINFO("RADUSED",    2, AC_Circle, _radius_used, AC_CIRCLE_RADIUS_USED),
+    AP_GROUPINFO("BASEPOINT",    2, AC_Circle, _base_point, AC_CIRCLE_ARC),
 
     AP_GROUPEND
 };
@@ -93,7 +93,7 @@ void AC_Circle::init()
     const Vector3f& stopping_point = _pos_control.get_pos_target();
 
     // set circle center to circle_radius ahead of stopping point
-    if (_radius_used) {
+    if (_base_point == AC_CIRCLE_ARC) {
         _center.x = stopping_point.x + _radius * _ahrs.cos_yaw();
         _center.y = stopping_point.y + _radius * _ahrs.sin_yaw();
     } else {

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -10,6 +10,7 @@
 #define AC_CIRCLE_RADIUS_DEFAULT    1000.0f     // radius of the circle in cm that the vehicle will fly
 #define AC_CIRCLE_RATE_DEFAULT      20.0f       // turn rate in deg/sec.  Positive to turn clockwise, negative for counter clockwise
 #define AC_CIRCLE_ANGULAR_ACCEL_MIN 2.0f        // angular acceleration should never be less than 2deg/sec
+#define AC_CIRCLE_RADIUS_USED       1           // use the radius value.
 
 class AC_Circle
 {
@@ -92,6 +93,7 @@ private:
     // parameters
     AP_Float    _radius;        // maximum horizontal speed in cm/s during missions
     AP_Float    _rate;          // rotation speed in deg/sec
+    AP_Int8     _radius_used;   // circle radius used
 
     // internal variables
     Vector3f    _center;        // center of circle in cm from home

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -10,7 +10,7 @@
 #define AC_CIRCLE_RADIUS_DEFAULT    1000.0f     // radius of the circle in cm that the vehicle will fly
 #define AC_CIRCLE_RATE_DEFAULT      20.0f       // turn rate in deg/sec.  Positive to turn clockwise, negative for counter clockwise
 #define AC_CIRCLE_ANGULAR_ACCEL_MIN 2.0f        // angular acceleration should never be less than 2deg/sec
-#define AC_CIRCLE_RADIUS_USED       1           // use the radius value.
+#define AC_CIRCLE_ARC               1           // the starting point of the arc.
 
 class AC_Circle
 {
@@ -93,7 +93,7 @@ private:
     // parameters
     AP_Float    _radius;        // maximum horizontal speed in cm/s during missions
     AP_Float    _rate;          // rotation speed in deg/sec
-    AP_Int8     _radius_used;   // circle radius used
+    AP_Int8     _base_point;    // Base point is center or arc value.
 
     // internal variables
     Vector3f    _center;        // center of circle in cm from home


### PR DESCRIPTION
I thought that I want a mode that I want to circulate around the base point.
The default is to add the radius from the base point to the center of the circle.
Also, if the radius is 0, the aircraft will rotate 360 degrees at the base point.

circulate around the base point
![aaa](https://user-images.githubusercontent.com/646194/40265682-d4d4f4d6-5b77-11e8-8d37-6290c10087bc.png)

default:
![bbb](https://user-images.githubusercontent.com/646194/40265691-f46535cc-5b77-11e8-8d4f-f861772eb0da.png)