### PR TITLE
Rover: add ATC_DECEL_MAX parameter for deceleration limits

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -332,8 +332,8 @@ float Mode::calc_reduced_speed_for_turn_or_distance(float desired_speed)
     float speed_scaled = desired_speed * MIN(lateral_accel_speed_scaling, pivot_speed_scaling);
 
     // limit speed based on distance to waypoint and max acceleration/deceleration
-    if (is_positive(distance_to_waypoint) && is_positive(attitude_control.get_accel_max())) {
-        const float speed_max = safe_sqrt(2.0f * distance_to_waypoint * attitude_control.get_accel_max() + sq(_desired_speed_final));
+    if (is_positive(distance_to_waypoint) && is_positive(attitude_control.get_decel_max())) {
+        const float speed_max = safe_sqrt(2.0f * distance_to_waypoint * attitude_control.get_decel_max() + sq(_desired_speed_final));
         speed_scaled = constrain_float(speed_scaled, -speed_max, speed_max);
     }
 

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -92,6 +92,9 @@ public:
     // get throttle/speed controller maximum acceleration (also used for deceleration)
     float get_accel_max() const { return MAX(_throttle_accel_max, 0.0f); }
 
+    // get throttle/speed controller maximum deceleration
+    float get_decel_max();
+
     // get latest desired speed recorded during call to get_throttle_out_speed.  For reporting purposes only
     float get_desired_speed() const;
 
@@ -114,6 +117,7 @@ private:
     AC_PID   _steer_rate_pid;       // steering rate controller
     AC_PID   _throttle_speed_pid;   // throttle speed controller
     AP_Float _throttle_accel_max;   // speed/throttle control acceleration (and deceleration) maximum in m/s/s.  0 to disable limits
+    AP_Float _throttle_decel_max;    // speed/throttle control deceleration maximum in m/s/s. 0 to disable limits
     AP_Int8  _brake_enable;         // speed control brake enable/disable. if set to 1 a reversed output to the motors to slow the vehicle.
     AP_Float _stop_speed;           // speed control stop speed.  Motor outputs to zero once vehicle speed falls below this value
     AP_Float _steer_accel_max;      // steering angle acceleration max in deg/s/s


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/ArduPilot/ardupilot/issues/8422) found in [this discussion](https://discuss.ardupilot.org/t/skid-steer-mower-overshooting-pivot-turns/28910).