### PR TITLE
Heli: convert servo outputs to use SRV_Channels library

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -166,7 +166,7 @@ protected:
     virtual void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) = 0;
 
     // reset_swash_servo - free up swash servo for maximum movement
-    void reset_swash_servo(SRV_Channel *servo);
+    void reset_swash_servo(SRV_Channel::Aux_servo_function_t function);
 
     // init_outputs - initialise Servo/PWM ranges and endpoints
     virtual bool init_outputs() = 0;
@@ -184,10 +184,9 @@ protected:
     // to be overloaded by child classes, different vehicle types would have different movement patterns
     virtual void servo_test() = 0;
 
-    // convert input in -1 to +1 range to pwm output for swashplate servos. .  Special handling of trim is required 
-    // to keep travel between the swashplate servos consistent.
-    int16_t calc_pwm_output_1to1_swash_servo(float input, const SRV_Channel *servo);
-
+    // write to a swash servo. output value is from -1 to 1
+    void rc_write_swash(uint8_t chan, float value);
+    
     // flags bitmask
     struct heliflags_type {
         uint8_t landing_collective      : 1;    // true if collective is setup for landing which has much higher minimum

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -184,25 +184,16 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
 bool AP_MotorsHeli_Dual::init_outputs()
 {
     if (!_flags.initialised_ok) {
-        _swash_servo_1 = SRV_Channels::get_channel_for(SRV_Channel::k_motor1, CH_1);
-        _swash_servo_2 = SRV_Channels::get_channel_for(SRV_Channel::k_motor2, CH_2);
-        _swash_servo_3 = SRV_Channels::get_channel_for(SRV_Channel::k_motor3, CH_3);
-        _swash_servo_4 = SRV_Channels::get_channel_for(SRV_Channel::k_motor4, CH_4);
-        _swash_servo_5 = SRV_Channels::get_channel_for(SRV_Channel::k_motor5, CH_5);
-        _swash_servo_6 = SRV_Channels::get_channel_for(SRV_Channel::k_motor6, CH_6);
-        if (!_swash_servo_1 || !_swash_servo_2 || !_swash_servo_3 ||
-            !_swash_servo_4 || !_swash_servo_5 || !_swash_servo_6) {
-            return false;
+        // make sure 6 output channels are mapped
+        for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+            add_motor_num(CH_1+i);
         }
     }
 
     // reset swash servo range and endpoints
-    reset_swash_servo (_swash_servo_1);
-    reset_swash_servo (_swash_servo_2);
-    reset_swash_servo (_swash_servo_3);
-    reset_swash_servo (_swash_servo_4);
-    reset_swash_servo (_swash_servo_5);
-    reset_swash_servo (_swash_servo_6);
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        reset_swash_servo(SRV_Channels::get_motor_function(i));
+    }
 
     // set rotor servo range
     _rotor.init_servo();
@@ -513,28 +504,21 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     _rotor.set_collective(fabsf(collective_out));
 
     // swashplate servos
-    float servo1_out = (_rollFactor[CH_1] * roll_out + _pitchFactor[CH_1] * pitch_out + _yawFactor[CH_1] * yaw_out)*0.45f + _collectiveFactor[CH_1] * collective_out_scaled;
-    float servo2_out = (_rollFactor[CH_2] * roll_out + _pitchFactor[CH_2] * pitch_out + _yawFactor[CH_2] * yaw_out)*0.45f + _collectiveFactor[CH_2] * collective_out_scaled;
-    float servo3_out = (_rollFactor[CH_3] * roll_out + _pitchFactor[CH_3] * pitch_out + _yawFactor[CH_3] * yaw_out)*0.45f + _collectiveFactor[CH_3] * collective_out_scaled;
-    float servo4_out = (_rollFactor[CH_4] * roll_out + _pitchFactor[CH_4] * pitch_out + _yawFactor[CH_4] * yaw_out)*0.45f + _collectiveFactor[CH_4] * collective2_out_scaled;
-    float servo5_out = (_rollFactor[CH_5] * roll_out + _pitchFactor[CH_5] * pitch_out + _yawFactor[CH_5] * yaw_out)*0.45f + _collectiveFactor[CH_5] * collective2_out_scaled;
-    float servo6_out = (_rollFactor[CH_6] * roll_out + _pitchFactor[CH_6] * pitch_out + _yawFactor[CH_6] * yaw_out)*0.45f + _collectiveFactor[CH_6] * collective2_out_scaled;
+    float servo_out[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];
+    
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        servo_out[i] = (_rollFactor[i] * roll_out + _pitchFactor[i] * pitch_out + _yawFactor[i] * yaw_out)*0.45f + _collectiveFactor[i] * collective_out_scaled;
+    }
 
     // rescale from -1..1, so we can use the pwm calc that includes trim
-    servo1_out = 2*servo1_out - 1;
-    servo2_out = 2*servo2_out - 1;
-    servo3_out = 2*servo3_out - 1;
-    servo4_out = 2*servo4_out - 1;
-    servo5_out = 2*servo5_out - 1;
-    servo6_out = 2*servo6_out - 1;
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        servo_out[i] = 2*servo_out[i] - 1;
+    }
 
     // actually move the servos
-    rc_write(AP_MOTORS_MOT_1, calc_pwm_output_1to1_swash_servo(servo1_out, _swash_servo_1));
-    rc_write(AP_MOTORS_MOT_2, calc_pwm_output_1to1_swash_servo(servo2_out, _swash_servo_2));
-    rc_write(AP_MOTORS_MOT_3, calc_pwm_output_1to1_swash_servo(servo3_out, _swash_servo_3));
-    rc_write(AP_MOTORS_MOT_4, calc_pwm_output_1to1_swash_servo(servo4_out, _swash_servo_4));
-    rc_write(AP_MOTORS_MOT_5, calc_pwm_output_1to1_swash_servo(servo5_out, _swash_servo_5));
-    rc_write(AP_MOTORS_MOT_6, calc_pwm_output_1to1_swash_servo(servo6_out, _swash_servo_6));
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        rc_write_swash(i, servo_out[i]);
+    }
 }
 
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -136,13 +136,6 @@ protected:
     AP_Float        _dcp_yaw_effect;                // feed-forward compensation to automatically add yaw input when differential collective pitch is applied.
     AP_Float        _yaw_scaler;                    // scaling factor applied to the yaw mixing
 
-    SRV_Channel    *_swash_servo_1;
-    SRV_Channel    *_swash_servo_2;
-    SRV_Channel    *_swash_servo_3;
-    SRV_Channel    *_swash_servo_4;
-    SRV_Channel    *_swash_servo_5;
-    SRV_Channel    *_swash_servo_6;
-
     // internal variables
     float           _collective2_mid_pct = 0.0f;      // collective mid parameter value for rear swashplate converted to 0 ~ 1 range
     float           _rollFactor[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -28,6 +28,8 @@ const AP_Param::GroupInfo AP_MotorsHeli_Quad::var_info[] = {
     AP_GROUPEND
 };
 
+#define QUAD_SERVO_MAX_ANGLE 4500
+
 // set update rate to motors - a value in hertz
 void AP_MotorsHeli_Quad::set_update_rate( uint16_t speed_hz )
 {
@@ -51,10 +53,8 @@ bool AP_MotorsHeli_Quad::init_outputs()
     }
 
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        _servo[i] = SRV_Channels::get_channel_for(SRV_Channels::get_motor_function(i), CH_1+i);
-        if (!_servo[i]) {
-            return false;
-        }
+        add_motor_num(CH_1+i);
+        SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), QUAD_SERVO_MAX_ANGLE);
     }
 
     // set rotor servo range
@@ -270,7 +270,7 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
 
     // move the servos
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        rc_write(AP_MOTORS_MOT_1+i, calc_pwm_output_1to1(out[i], _servo[i]));
+        rc_write_angle(AP_MOTORS_MOT_1+i, out[i] * QUAD_SERVO_MAX_ANGLE);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -86,9 +86,6 @@ protected:
     //  objects we depend upon
     AP_MotorsHeli_RSC           _rotor;             // main rotor controller
 
-    // parameters
-    SRV_Channel    *_servo[AP_MOTORS_HELI_QUAD_NUM_MOTORS];
-
     // rate factors
     float _rollFactor[AP_MOTORS_HELI_QUAD_NUM_MOTORS];
     float _pitchFactor[AP_MOTORS_HELI_QUAD_NUM_MOTORS];

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -153,12 +153,7 @@ protected:
     AP_Int8         _flybar_mode;               // Flybar present or not.  Affects attitude controller used during ACRO flight mode
     AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed (0 ~ 1000)
 
-    SRV_Channel    *_swash_servo_1;
-    SRV_Channel    *_swash_servo_2;
-    SRV_Channel    *_swash_servo_3;
-    SRV_Channel    *_yaw_servo;
-    SRV_Channel    *_servo_aux;
-
+    bool            _have_servo_aux;            // true if we are using an aux servo
     bool            _acro_tail = false;
     float           _rollFactor[AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS];
     float           _pitchFactor[AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS];

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -161,42 +161,6 @@ uint32_t AP_Motors::rc_map_mask(uint32_t mask) const
     return mask2;
 }
 
-// convert input in -1 to +1 range to pwm output
-int16_t AP_Motors::calc_pwm_output_1to1(float input, const SRV_Channel *servo)
-{
-    int16_t ret;
-
-    input = constrain_float(input, -1.0f, 1.0f);
-
-    if (servo->get_reversed()) {
-        input = -input;
-    }
-
-    if (input >= 0.0f) {
-        ret = ((input * (servo->get_output_max() - servo->get_trim())) + servo->get_trim());
-    } else {
-        ret = ((input * (servo->get_trim() - servo->get_output_min())) + servo->get_trim());
-    }
-
-    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
-}
-
-// convert input in 0 to +1 range to pwm output
-int16_t AP_Motors::calc_pwm_output_0to1(float input, const SRV_Channel *servo)
-{
-    int16_t ret;
-
-    input = constrain_float(input, 0.0f, 1.0f);
-
-    if (servo->get_reversed()) {
-        input = 1.0f-input;
-    }
-
-    ret = input * (servo->get_output_max() - servo->get_output_min()) + servo->get_output_min();
-
-    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
-}
-
 /*
   add a motor, setting up default output function as needed
  */

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -178,12 +178,6 @@ protected:
     // save parameters as part of disarming
     virtual void save_params_on_disarm() {}
 
-    // convert input in -1 to +1 range to pwm output
-    int16_t calc_pwm_output_1to1(float input, const SRV_Channel *servo);
-
-    // convert input in 0 to +1 range to pwm output
-    int16_t calc_pwm_output_0to1(float input, const SRV_Channel *servo);
-
     // flag bitmask
     struct AP_Motors_flags {
         uint8_t armed              : 1;    // 0 if disarmed, 1 if armed

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -301,6 +301,9 @@ public:
     // adjust trim of a channel by a small increment
     void adjust_trim(SRV_Channel::Aux_servo_function_t function, float v);
 
+    // set MIN/MAX parameters for a function
+    static void set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm);
+    
     // save trims
     void save_trim(void);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -654,6 +654,17 @@ void SRV_Channels::set_range(SRV_Channel::Aux_servo_function_t function, uint16_
     }
 }
 
+// set MIN parameter for a function
+void SRV_Channels::set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm)
+{
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        if (channels[i].function == function) {
+            channels[i].set_output_min(min_pwm);
+            channels[i].set_output_max(max_pwm);
+        }
+    }
+}
+
 // constrain to output min/max for function
 void SRV_Channels::constrain_pwm(SRV_Channel::Aux_servo_function_t function)
 {


### PR DESCRIPTION
This brings heli in line with all our other vehicles to use the SRV_Channels library for output scaling. It simplifies the code, plus allows for users to setup multiple outputs for a particular function if they want to (eg. have two tail servo output channels if needed)
It should produce exactly the same servo output as the existing code.
