### PR TITLE
AP_Avoidance: track src with correct label - use MAVLink label

### DIFF
--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -580,7 +580,7 @@ void AP_Avoidance::handle_msg(const mavlink_message_t &msg)
                             packet.vy/100.0f,
                             packet.vz/100.0f);
     add_obstacle(AP_HAL::millis(),
-                 MAV_COLLISION_SRC_ADSB,
+                 MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT,
                  msg.sysid,
                  loc,
                  vel);


### PR DESCRIPTION
AP_Avoidance takes data from two mavlink sources: GLOBAL_POSITION_INT and ADSB_VEHICLE. However, in the avoidance library both will being labeled as coming from ADSB. 

This should pretty much have no effect but should be implemented correctly just in case. Since [the only place that checks it](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Avoidance/AP_Avoidance.cpp#L205) also checks the src ID which is an apples vs oranges check (mavlink sys ID vs 24bit ICAO) those will never match unless you're intentionally broadcasting/using an invalid ICAO.

However, this may effect users who are using the ADSB_VEHICLE packet for avoidance without using ADSB hardware, just using it as a packet to utilize the avoidance library and may indeed be using illegal ICAO numbers because they didn't know it auto-magically works with GLOBAL_POSITION_INT.