### PR TITLE
HAL_ChibiOS: improved reliability of DShot passthru

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1093,10 +1093,12 @@ bool RCOutput::serial_write_bytes(const uint8_t *bytes, uint16_t len)
             return false;
         }
     }
-    serial_group->dma_handle->unlock();
+
     // add a small delay for last word of output to have completely
     // finished
-    hal.scheduler->delay_microseconds(10);
+    hal.scheduler->delay_microseconds(25);
+    
+    serial_group->dma_handle->unlock();
     return true;
 }
 


### PR DESCRIPTION
thanks to @WickedShell for debugging this on his Wraith32 ESCs. We were
truncating the last bit on some BLHeli transfers