### PR TITLE
AP_RCProtocol: add support for non-inverted s-bus

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -19,11 +19,13 @@
 #include "AP_RCProtocol_PPMSum.h"
 #include "AP_RCProtocol_DSM.h"
 #include "AP_RCProtocol_SBUS.h"
+#include "AP_RCProtocol_SBUS_NI.h"
 
 void AP_RCProtocol::init()
 {
     backend[AP_RCProtocol::PPM] = new AP_RCProtocol_PPMSum(*this);
     backend[AP_RCProtocol::SBUS] = new AP_RCProtocol_SBUS(*this);
+    backend[AP_RCProtocol::SBUS_NI] = new AP_RCProtocol_SBUS_NI(*this);
     backend[AP_RCProtocol::DSM] = new AP_RCProtocol_DSM(*this);
 }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -27,6 +27,7 @@ public:
     enum rcprotocol_t{
         PPM = 0,
         SBUS,
+        SBUS_NI,
         DSM,
         NONE    //last enum always is None
     };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS_NI.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS_NI.h
@@ -1,0 +1,31 @@
+/*
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+#pragma once
+
+#include "AP_RCProtocol.h"
+#include "AP_RCProtocol_SBUS.h"
+
+class AP_RCProtocol_SBUS_NI : public AP_RCProtocol_SBUS {
+public:
+    AP_RCProtocol_SBUS_NI(AP_RCProtocol &_frontend) : AP_RCProtocol_SBUS(_frontend), saved_width(0) {}
+    void process_pulse(uint32_t width_s0, uint32_t width_s1) override {
+        AP_RCProtocol_SBUS::process_pulse(saved_width, width_s0);
+        saved_width = width_s1;
+    }
+private:
+    uint32_t saved_width;
+};


### PR DESCRIPTION
This is quite simple change to support both kinds of s-bus. This allows to use s-bus pin on matekf405-wing. Also some rx (such as openlrsng) have non-inverted s-bus output.
S-bus has checksum, so no danger to lock on it.
