### PR TITLE
RangeFinder: add NMEA driver

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -330,7 +330,7 @@ void Rover::update_sensor_status_flags(void)
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
-    if (rover.g2.proximity.get_status() < AP_Proximity::Proximity_Good) {
+    if (rover.g2.proximity.get_status() == AP_Proximity::Proximity_NoData) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
     if (rover.DataFlash.logging_failed()) {

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -324,9 +324,7 @@ void Rover::update_sensor_status_flags(void)
 
     if (rangefinder.num_sensors() > 0) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        if (g.rangefinder_trigger_cm > 0) {
-            control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        }
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         AP_RangeFinder_Backend *s = rangefinder.get_backend(0);
         if (s != nullptr && s->has_data()) {
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -368,7 +368,7 @@ void Copter::update_sensor_status_flags(void)
     }
 
 #if PROXIMITY_ENABLED == ENABLED
-    if (copter.g2.proximity.get_status() < AP_Proximity::Proximity_Good) {
+    if (copter.g2.proximity.get_status() == AP_Proximity::Proximity_NoData) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
@@ -1,0 +1,186 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_RangeFinder_LightWareSerial.h"
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <ctype.h>
+#include "AP_RangeFinder_NMEA.h"
+
+extern const AP_HAL::HAL& hal;
+
+// constructor initialises the rangefinder
+// Note this is called after detect() returns true, so we
+// already know that we should setup the rangefinder
+AP_RangeFinder_NMEA::AP_RangeFinder_NMEA(RangeFinder::RangeFinder_State &_state,
+                                         AP_SerialManager &serial_manager,
+                                         uint8_t serial_instance) :
+    AP_RangeFinder_Backend(_state),
+    _distance_m(-1.0f)
+{
+    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance);
+    if (uart != nullptr) {
+        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance));
+    }
+}
+
+// detect if a NMEA rangefinder by looking to see if the user has configured it
+bool AP_RangeFinder_NMEA::detect(AP_SerialManager &serial_manager, uint8_t serial_instance)
+{
+    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Rangefinder, serial_instance) != nullptr;
+}
+
+// update the state of the sensor
+void AP_RangeFinder_NMEA::update(void)
+{
+    uint32_t now = AP_HAL::millis();
+    if (get_reading(state.distance_cm)) {
+        // update range_valid state based on distance measured
+        _last_reading_ms = now;
+        update_status();
+    } else if ((now - _last_reading_ms) > 3000) {
+        set_status(RangeFinder::RangeFinder_NoData);
+    }
+}
+
+// return last value measured by sensor
+bool AP_RangeFinder_NMEA::get_reading(uint16_t &reading_cm)
+{
+    if (uart == nullptr) {
+        return false;
+    }
+
+    // read any available lines from the lidar
+    float sum = 0.0f;
+    uint16_t count = 0;
+    int16_t nbytes = uart->available();
+    while (nbytes-- > 0) {
+        char c = uart->read();
+        if (decode(c)) {
+            sum += _distance_m;
+            count++;
+        }
+    }
+
+    // return false on failure
+    if (count == 0) {
+        return false;
+    }
+
+    // return average of all measurements
+    reading_cm = 100.0f * sum / count;
+    return true;
+}
+
+// add a single character to the buffer and attempt to decode
+// returns true if a complete sentence was successfully decoded
+bool AP_RangeFinder_NMEA::decode(char c)
+{
+    switch (c) {
+    case ',':
+        // end of a term, add to checksum
+        _checksum ^= c;
+        FALLTHROUGH;
+    case '\r':
+    case '\n':
+    case '*':
+    {
+        // null terminate and decode latest term
+        _term[_term_offset] = 0;
+        bool valid_sentence = decode_latest_term();
+
+        // move onto next term
+        _term_number++;
+        _term_offset = 0;
+        _term_is_checksum = (c == '*');
+        return valid_sentence;
+    }
+
+    case '$': // sentence begin
+        _sentence_type = SONAR_UNKNOWN;
+        _term_number = 0;
+        _term_offset = 0;
+        _checksum = 0;
+        _term_is_checksum = false;
+        _distance_m = -1.0f;
+        return false;
+    }
+
+    // ordinary characters are added to term
+    if (_term_offset < sizeof(_term) - 1)
+        _term[_term_offset++] = c;
+    if (!_term_is_checksum)
+        _checksum ^= c;
+
+    return false;
+}
+
+// decode the most recently consumed term
+// returns true if new sentence has just passed checksum test and is validated
+bool AP_RangeFinder_NMEA::decode_latest_term()
+{
+    // handle the last term in a message
+    if (_term_is_checksum) {
+        uint8_t checksum = 16 * char_to_hex(_term[0]) + char_to_hex(_term[1]);
+        return ((checksum == _checksum) &&
+                !is_negative(_distance_m) &&
+                (_sentence_type == SONAR_DBT || _sentence_type == SONAR_DPT));
+    }
+
+    // the first term determines the sentence type
+    if (_term_number == 0) {
+        // the first two letters of the NMEA term are the talker ID.
+        // we accept any two characters here.
+        if (_term[0] < 'A' || _term[0] > 'Z' ||
+            _term[1] < 'A' || _term[1] > 'Z') {
+            _sentence_type = SONAR_UNKNOWN;
+            return false;
+        }
+        const char *term_type = &_term[2];
+        if (strcmp(term_type, "DBT") == 0) {
+            _sentence_type = SONAR_DBT;
+        } else if (strcmp(term_type, "DPT") == 0) {
+            _sentence_type = SONAR_DPT;
+        } else {
+            _sentence_type = SONAR_UNKNOWN;
+        }
+        return false;
+    }
+
+    if (_sentence_type == SONAR_DBT) {
+        // parse DBT messages
+        if (_term_number == 3) {
+            _distance_m = atof(_term);
+        }
+    } else if (_sentence_type == SONAR_DPT) {
+        // parse DPT messages
+        if (_term_number == 1) {
+            _distance_m = atof(_term);
+        }
+    }
+
+    return false;
+}
+
+// return the numeric value of an ascii hex character
+int16_t AP_RangeFinder_NMEA::char_to_hex(char a)
+{
+    if (a >= 'A' && a <= 'F')
+        return a - 'A' + 10;
+    else if (a >= 'a' && a <= 'f')
+        return a - 'a' + 10;
+    else
+        return a - '0';
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.h
@@ -1,0 +1,77 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "RangeFinder.h"
+#include "RangeFinder_Backend.h"
+
+class AP_RangeFinder_NMEA : public AP_RangeFinder_Backend
+{
+
+public:
+    // constructor
+    AP_RangeFinder_NMEA(RangeFinder::RangeFinder_State &_state,
+                        AP_SerialManager &serial_manager,
+                        uint8_t serial_instance);
+
+    // static detection function
+    static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
+
+    // update state
+    void update(void) override;
+
+protected:
+
+    virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_ULTRASOUND;
+    }
+
+private:
+
+    /// enum for handled messages
+    enum sentence_types : uint8_t {
+        SONAR_UNKNOWN = 0,
+        SONAR_DBT,
+        SONAR_DPT
+    };
+
+    // get a reading
+    bool get_reading(uint16_t &reading_cm);
+
+    // add a single character to the buffer and attempt to decode
+    // returns true if a complete sentence was successfully decoded
+    // distance should be pulled directly from _distance_m member
+    bool decode(char c);
+
+    // decode the just-completed term
+    // returns true if new sentence has just passed checksum test and is validated
+    bool decode_latest_term();
+
+    // return the numeric value of an ascii hex character
+    static int16_t char_to_hex(char a);
+
+    AP_HAL::UARTDriver *uart = nullptr;     // pointer to serial uart
+    uint32_t _last_reading_ms;              // system time of last successful reading
+
+    // message decoding related members
+    char _term[15];                         // buffer for the current term within the current sentence
+    uint8_t _term_offset;                   // offset within the _term buffer where the next character should be placed
+    uint8_t _term_number;                   // term index within the current sentence
+    float _distance_m;                      // distance in meters parsed from a term, -1 if no distance
+    uint8_t _checksum;                      // checksum accumulator
+    bool _term_is_checksum;                 // current term is the checksum
+    sentence_types _sentence_type;          // the sentence type currently being processed
+};

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -32,6 +32,7 @@
 #include "AP_RangeFinder_uLanding.h"
 #include "AP_RangeFinder_TeraRangerI2C.h"
 #include "AP_RangeFinder_VL53L0X.h"
+#include "AP_RangeFinder_NMEA.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;
@@ -41,7 +42,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA
     // @User: Standard
     AP_GROUPINFO("_TYPE",    0, RangeFinder, state[0].type, 0),
 
@@ -168,7 +169,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA
     // @User: Advanced
     AP_GROUPINFO("2_TYPE",    12, RangeFinder, state[1].type, 0),
 
@@ -289,7 +290,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 3_TYPE
     // @DisplayName: Third Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA
     // @User: Advanced
     AP_GROUPINFO("3_TYPE",    25, RangeFinder, state[2].type, 0),
 
@@ -410,7 +411,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Param: 4_TYPE
     // @DisplayName: Fourth Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA
     // @User: Advanced
     AP_GROUPINFO("4_TYPE",    37, RangeFinder, state[3].type, 0),
 
@@ -714,6 +715,11 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         // note that analog will always come back as present if the pin is valid
         if (AP_RangeFinder_analog::detect(state[instance])) {
             drivers[instance] = new AP_RangeFinder_analog(state[instance]);
+        }
+        break;
+    case RangeFinder_TYPE_NMEA:
+        if (AP_RangeFinder_NMEA::detect(serial_manager, serial_instance)) {
+            drivers[instance] = new AP_RangeFinder_NMEA(state[instance], serial_manager, serial_instance++);
         }
         break;
     default:

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -57,7 +57,8 @@ public:
         RangeFinder_TYPE_MBSER  = 13,
         RangeFinder_TYPE_TRI2C  = 14,
         RangeFinder_TYPE_PLI2CV3= 15,
-        RangeFinder_TYPE_VL53L0X = 16
+        RangeFinder_TYPE_VL53L0X = 16,
+        RangeFinder_TYPE_NMEA = 17
     };
 
     enum RangeFinder_Function {


### PR DESCRIPTION
This PR adds support for a underwater sonar including the [echologger.com's ECT400](http://echologger.com/products/9) and [Garmin DT800](https://buy.garmin.com/en-US/US/p/13583).

This code has been successfully tested on the ECT400 and a wiring diagram is shown below.

The code is largely derived from the NMEA GPS driver but it has been simplified a bit because the protocol is much simpler for sonar.  There are only two messages (DBT, DPT) that provide the data we want.  I considered trying to create a combined GPS/Rangefinder NMEA driver but I came to the conclusion that it wasn't worth the effort and additional complexity.

This PR also includes some system-status fixes I bumped into while testing the sensor.  It seems that previously if a lidar was enabled but proximity was not, that the lidar would be reported as unhealthy to the ground station.  This is fixed for copter and rover.

![echologger-pixhawk-ver3](https://user-images.githubusercontent.com/1498098/40397276-bbe5d9e8-5e6c-11e8-8941-6e23457158a0.png)

