### PR TITLE
Remove intermediate mavlink functions

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <stdint.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>  // for MAV_SEVERITY
+
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Math/AP_Math.h>
+
 #include "defines.h"
 
 #define MODE_NEXT_HEADING_UNKNOWN   99999.0f    // used to indicate to set_desired_location method that next leg's heading is unknown

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -895,7 +895,7 @@ GCS_MAVLINK::update(uint32_t max_time_us)
     uint16_t nbytes = comm_get_available(chan);
     for (uint16_t i=0; i<nbytes; i++)
     {
-        uint8_t c = comm_receive_ch(chan);
+        const uint8_t c = (uint8_t)_port->read();
         const uint32_t protocol_timeout = 4000;
         
         if (alternative.handler &&

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -82,20 +82,6 @@ uint8_t mav_var_type(enum ap_var_type t)
 }
 
 
-/// Read a byte from the nominated MAVLink channel
-///
-/// @param chan		Channel to receive on
-/// @returns		Byte read
-///
-uint8_t comm_receive_ch(mavlink_channel_t chan)
-{
-    if (!valid_channel(chan)) {
-        return 0;
-    }
-
-    return (uint8_t)mavlink_comm_port[chan]->read();
-}
-
 /// Check for available transmit space on the nominated MAVLink channel
 ///
 /// @param chan		Channel to check
@@ -147,16 +133,4 @@ void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len)
         return;
     }
     mavlink_comm_port[chan]->write(buf, len);
-}
-
-extern const AP_HAL::HAL& hal;
-
-/*
-  return true if the MAVLink parser is idle, so there is no partly parsed
-  MAVLink message being processed
- */
-bool comm_is_idle(mavlink_channel_t chan)
-{
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-	return status == nullptr || status->parse_state <= MAVLINK_PARSE_STATE_IDLE;
 }

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -2,9 +2,7 @@
 /// @brief	One size fits all header for MAVLink integration.
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Math/AP_Math.h>
 
 // we have separate helpers disabled to make it possible
 // to select MAVLink 1.0 in the arduino GUI build
@@ -53,27 +51,7 @@ static inline bool valid_channel(mavlink_channel_t chan)
 #pragma clang diagnostic pop
 }
 
-/// Send a byte to the nominated MAVLink channel
-///
-/// @param chan		Channel to send to
-/// @param ch		Byte to send
-///
-static inline void comm_send_ch(mavlink_channel_t chan, uint8_t chr)
-{
-    if (!valid_channel(chan)) {
-        return;
-    }
-    mavlink_comm_port[chan]->write(chr);
-}
-
 void comm_send_buffer(mavlink_channel_t chan, const uint8_t *buf, uint8_t len);
-
-/// Read a byte from the nominated MAVLink channel
-///
-/// @param chan		Channel to receive on
-/// @returns		Byte read
-///
-uint8_t comm_receive_ch(mavlink_channel_t chan);
 
 /// Check for available data on the nominated MAVLink channel
 ///
@@ -87,12 +65,6 @@ uint16_t comm_get_available(mavlink_channel_t chan);
 /// @param chan		Channel to check
 /// @returns		Number of bytes available
 uint16_t comm_get_txspace(mavlink_channel_t chan);
-
-/*
-  return true if the MAVLink parser is idle, so there is no partly parsed
-  MAVLink message being processed
- */
-bool comm_is_idle(mavlink_channel_t chan);
 
 #define MAVLINK_USE_CONVENIENCE_FUNCTIONS
 #include "include/mavlink/v2.0/ardupilotmega/mavlink.h"

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
 class DataFlash_Class;


### PR DESCRIPTION
Pulling characters from the uart is something we do a lot of.  We should not unnecessarily make it slower.
