### PR TITLE
Rover: deceleration improvements

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -148,6 +148,9 @@ void Mode::set_desired_location(const struct Location& destination, float next_l
         if (is_zero(turn_angle_cd)) {
             // if not turning can continue at full speed
             _desired_speed_final = _desired_speed;
+        } else if (rover.use_pivot_steering(turn_angle_cd)) {
+            // pivoting so we will stop
+            _desired_speed_final = 0.0f;
         } else {
             // calculate maximum speed that keeps overshoot within bounds
             const float radius_m = fabsf(g.waypoint_overshoot / (cosf(radians(turn_angle_cd * 0.01f)) - 1.0f));

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -26,10 +26,10 @@ void ModeAcro::update()
     const float target_turn_rate = (desired_steering / 4500.0f) * radians(g2.acro_turn_rate);
 
     // run steering turn rate controller and throttle controller
-    const float steering_out = attitude_control.get_steering_out_rate(
-                                                                    target_turn_rate,
-                                                                    g2.motors.limit.steer_left,
-                                                                    g2.motors.limit.steer_right);
+    const float steering_out = attitude_control.get_steering_out_rate(target_turn_rate,
+                                                                      g2.motors.limit.steer_left,
+                                                                      g2.motors.limit.steer_right,
+                                                                      rover.G_Dt);
 
     g2.motors.set_steering(steering_out * 4500.0f);
 }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -67,7 +67,8 @@ void ModeGuided::update()
                 // run steering and throttle controllers
                 float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f),
                                                                             g2.motors.limit.steer_left,
-                                                                            g2.motors.limit.steer_right);
+                                                                            g2.motors.limit.steer_right,
+                                                                            rover.G_Dt);
                 g2.motors.set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true, true);
             } else {

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -28,11 +28,7 @@ void ModeLoiter::update()
 
     // if within waypoint radius slew desired speed towards zero and use existing desired heading
     if (_distance_to_destination <= g.waypoint_radius) {
-        if (is_negative(_desired_speed)) {
-            _desired_speed = MIN(_desired_speed + attitude_control.get_decel_max() * rover.G_Dt, 0.0f);
-        } else {
-            _desired_speed = MAX(_desired_speed - attitude_control.get_decel_max() * rover.G_Dt, 0.0f);
-        }
+        _desired_speed = attitude_control.get_desired_speed_accel_limited(0.0f, rover.G_Dt);
         _yaw_error_cd = 0.0f;
     } else {
         // P controller with hard-coded gain to convert distance to desired speed

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -26,7 +26,8 @@ void ModeSteering::update()
         // run steering turn rate controller and throttle controller
         const float steering_out = attitude_control.get_steering_out_rate(target_turn_rate,
                                                                           g2.motors.limit.steer_left,
-                                                                          g2.motors.limit.steer_right);
+                                                                          g2.motors.limit.steer_right,
+                                                                          rover.G_Dt);
         g2.motors.set_steering(steering_out * 4500.0f);
     } else {
         // In steering mode we control lateral acceleration directly.

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -405,6 +405,9 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
     // if we were stopped in the last 300ms, assume we are still stopped
     bool _stopped = (_stop_last_ms != 0) && (now - _stop_last_ms) < 300;
 
+    // get deceleration limited speed
+    float desired_speed_limited = get_desired_speed_accel_limited(0.0f);
+
     // get speed forward
     float speed;
     if (!get_forward_speed(speed)) {
@@ -412,7 +415,7 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
         _stopped = true;
     } else {
         // if desired speed is zero and vehicle drops below _stop_speed consider it stopped
-        if (is_zero(_desired_speed) && fabsf(speed) <= fabsf(_stop_speed)) {
+        if (is_zero(desired_speed_limited) && fabsf(speed) <= fabsf(_stop_speed)) {
             _stopped = true;
         }
     }
@@ -429,7 +432,7 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
         // clear stopped system time
         _stop_last_ms = 0;
         // run speed controller to bring vehicle to stop
-        return get_throttle_out_speed(0.0f, motor_limit_low, motor_limit_high, cruise_speed, cruise_throttle);
+        return get_throttle_out_speed(desired_speed_limited, motor_limit_low, motor_limit_high, cruise_speed, cruise_throttle);
     }
 }
 

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -24,7 +24,7 @@
 #define AR_ATTCONTROL_TIMEOUT_MS        200
 
 // throttle/speed control maximum acceleration/deceleration (in m/s) (_ACCEL_MAX parameter default)
-#define AR_ATTCONTROL_THR_ACCEL_MAX     5.00f
+#define AR_ATTCONTROL_THR_ACCEL_MAX     2.00f
 
 // minimum speed in m/s
 #define AR_ATTCONTROL_STEER_SPEED_MIN   1.0f

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -44,15 +44,15 @@ public:
     //
 
     // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
-    // positive lateral acceleration is to the right.
-    float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right);
+    // positive lateral acceleration is to the right.  dt should normally be the main loop rate.
+    float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // return a steering servo output from -1 to +1 given a heading in radians
-    float get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right);
+    float get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // return a steering servo output from -1 to +1 given a
     // desired yaw rate in radians/sec. Positive yaw is to the right.
-    float get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right);
+    float get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only
     float get_desired_turn_rate() const;
@@ -76,10 +76,10 @@ public:
     //   desired_speed argument should already have been passed through get_desired_speed_accel_limited function
     //   motor_limit should be true if motors have hit their upper or lower limits
     //   cruise speed should be in m/s, cruise throttle should be a number from -1 to +1
-    float get_throttle_out_speed(float desired_speed, bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle);
+    float get_throttle_out_speed(float desired_speed, bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle, float dt);
 
     // return a throttle output from -1 to +1 to perform a controlled stop.  stopped is set to true once stop has been completed
-    float get_throttle_out_stop(bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle, bool &stopped);
+    float get_throttle_out_stop(bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle, float dt, bool &stopped);
 
     // low level control accessors for reporting and logging
     AC_P& get_steering_angle_p() { return _steer_angle_p; }
@@ -99,7 +99,7 @@ public:
     float get_desired_speed() const;
 
     // get acceleration limited desired speed
-    float get_desired_speed_accel_limited(float desired_speed) const;
+    float get_desired_speed_accel_limited(float desired_speed, float dt) const;
 
     // get minimum stopping distance (in meters) given a speed (in m/s)
     float get_stopping_distance(float speed);


### PR DESCRIPTION
This PR fixes two items from [this issue](https://github.com/ArduPilot/ardupilot/issues/8448):

- deceleration limits are properly applied after reaching a waypoint (previously desired speed would immediately drop to zero)
- skid-steer vehicles properly decelerate to zero in sharp corners

In addition the main vehicle code now passes in "dt" (time since last iteration) to all attitude controller calls.  This is a small improvement that removes jitter that would come from the method in which the dt was calculated within the attitude controller..

Below are graphs from a skid-steering rover (top graph) and regular rover (bottom graph) run though a simple mission (see pic of mission below).  It shows how the desired speed (and vehicle's actual speed) does not drop off suddenly.

![rover-stop-fix-mission](https://user-images.githubusercontent.com/1498098/40419187-7a4820ec-5ebf-11e8-8b31-d55d8c59b434.png)
![before-after-skid](https://user-images.githubusercontent.com/1498098/40419191-7d201482-5ebf-11e8-8003-cba0d8e965a0.png)
![before-after-regular](https://user-images.githubusercontent.com/1498098/40419192-7edc4ebc-5ebf-11e8-80ef-8aa7ed9e75fd.png)


