### PR TITLE
AP_RangeFinder: Maxbotixi2c fixes to improve reliability

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -330,7 +330,7 @@ void Rover::update_sensor_status_flags(void)
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }
-    if (rover.g2.proximity.get_status() < AP_Proximity::Proximity_Good) {
+    if (rover.g2.proximity.get_status() == AP_Proximity::Proximity_NoData) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_LASER_POSITION;
     }
     if (rover.DataFlash.logging_failed()) {

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -324,9 +324,7 @@ void Rover::update_sensor_status_flags(void)
 
     if (rangefinder.num_sensors() > 0) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        if (g.rangefinder_trigger_cm > 0) {
-            control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        }
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         AP_RangeFinder_Backend *s = rangefinder.get_backend(0);
         if (s != nullptr && s->has_data()) {
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -79,7 +79,7 @@ bool AP_RangeFinder_MaxsonarI2CXL::_init(void)
     }
 
     // give time for the sensor to process the request
-    hal.scheduler->delay(50);
+    hal.scheduler->delay(100);
 
     uint16_t reading_cm;
     if (!get_reading(reading_cm)) {
@@ -89,7 +89,7 @@ bool AP_RangeFinder_MaxsonarI2CXL::_init(void)
 
     _dev->get_semaphore()->give();
 
-    _dev->register_periodic_callback(50000,
+    _dev->register_periodic_callback(100000,
                                      FUNCTOR_BIND_MEMBER(&AP_RangeFinder_MaxsonarI2CXL::_timer, void));
 
     return true;
@@ -124,7 +124,7 @@ bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 }
 
 /*
-  timer called at 20Hz
+  timer called at 10Hz
 */
 void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -129,13 +129,11 @@ bool AP_RangeFinder_MaxsonarI2CXL::get_reading(uint16_t &reading_cm)
 */
 void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 {
-    uint16_t d;
-    if (get_reading(d)) {
-        if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-            distance = d;
-            new_distance = true;
-            _sem->give();
-        }
+    if (get_reading(state.distance_cm)) {
+        // update range_valid state based on distance measured
+        update_status();
+    } else {
+        set_status(RangeFinder::RangeFinder_NoData);
     }
 }
 
@@ -145,14 +143,5 @@ void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 */
 void AP_RangeFinder_MaxsonarI2CXL::update(void)
 {
-    if (_sem->take_nonblocking()) {
-        if (new_distance) {
-            state.distance_cm = distance;
-            new_distance = false;
-            update_status();
-        } else {
-            set_status(RangeFinder::RangeFinder_NoData);
-        }
-         _sem->give();
-    }
+    // nothing to do - its all done in the timer()
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -72,7 +72,6 @@ bool AP_RangeFinder_MaxsonarI2CXL::_init(void)
     if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
-    
 
     if (!start_reading()) {
         _dev->get_semaphore()->give();
@@ -89,10 +88,10 @@ bool AP_RangeFinder_MaxsonarI2CXL::_init(void)
     }
 
     _dev->get_semaphore()->give();
-    
+
     _dev->register_periodic_callback(50000,
                                      FUNCTOR_BIND_MEMBER(&AP_RangeFinder_MaxsonarI2CXL::_timer, void));
-    
+
     return true;
 }
 
@@ -136,7 +135,6 @@ void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
         set_status(RangeFinder::RangeFinder_NoData);
     }
 }
-
 
 /*
    update the state of the sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
@@ -37,9 +37,6 @@ private:
     bool _init(void);
     void _timer(void);
 
-    uint16_t distance;
-    bool new_distance;
-    
     // start a reading
     bool start_reading(void);
     bool get_reading(uint16_t &reading_cm);


### PR DESCRIPTION
This PR fixes two issues reported by @gmorph:

- distances are copied to the front end from within the _timer (run in the I/O thread).  This is consistent with how the LightwareI2C driver works and apparently removes the need for using a semaphore.
- update rate is reduced to 10hz which is the maximum update rate of the sensor.
- two changes to the reporting of health when range finders are used but not proximity sensors.  these two changes are also in the NMEA sonar driver PR (https://github.com/ArduPilot/ardupilot/pull/8462).

This has been successfully tested by Grant and he's confirmed this behaviour:

- ranges update reliably (they didn't before)
- sonar presence and health is reported reliably
- if sonar is disconnected at startup it is reported as not being present
- if sonar is connected at startup but later disconnected the sonar is temporarily reported as unhealthy but when plugged back in again it becomes healthy and correct range readings resume.