### PR TITLE
Github: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: If you are sure you have found a bug, then choose this to open a bug report
+
+---
+
+**IF YOU DON'T REMOVE THESE FOUR LINES, THEN YOUR REPORT WILL BE CLOSED AUTOMATICALLY**
+Questions and user problems should be directed at the forum (http://discuss.ardupilot.org)
+_**Please be very sure you have found a bug when opening this issue**_
+If there was a previous discussion in the forum, link to it
+
+### Bug report
+
+**Issue details**
+
+_Please describe the problem_
+
+**Version**
+_What version was the issue encountered with_
+
+**Platform**
+[  ] All
+[  ] AntennaTracker
+[  ] Copter
+[  ] Plane
+[  ] Rover
+[  ] Submarine
+
+**Airframe type**
+_What type of airframe (flying wing, glider, hex, Y6, octa etc)_
+
+**Hardware type**
+_What autopilot hardware was used? (Pixhawk, Cube, Pixracer, Navio2, etc)_
+
+**Logs**
+_Please provide a link to any relevant logs that show the issue_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: If you have an idea for a new feature, choose this option
+
+---
+
+**IF YOU DON'T REMOVE THESE FOUR LINES, THEN YOUR REQUEST WILL BE CLOSED AUTOMATICALLY**
+Questions and user problems should be directed at the forum (http://discuss.ardupilot.org)
+_**Please do a careful search before opening this, there are already a lot of feature requests**_
+If there was a previous discussion in the forum, link to it
+
+### Feature request
+
+**Is your feature request related to a problem? Please describe.**
+_A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]_
+
+**Describe the solution you'd like**
+_A clear and concise description of what you want to happen._
+
+**Describe alternatives you've considered**
+_A clear and concise description of any alternative solutions or features you've considered._
+
+**Platform**
+[  ] All
+[  ] AntennaTracker
+[  ] Copter
+[  ] Plane
+[  ] Rover
+[  ] Submarine
+
+**Additional context**
+_Add any other context or screenshots about the feature request here._


### PR DESCRIPTION
GitHub has new options for opening an issue, namely Bug reports and Feature requests. This should allow us to more clearly distinguish between the two.

I've also added text to discourage people from opening them as we have a huge number of issues and many of them should be in the forum and not here.

P.S.: The branch, the commit and the PR were automatically created by GitHub so if anything doesn't follow our rules, blame them 🙂 