### PR TITLE
AP_HAL_ChibiOS: Make redefined pins an error, fix FMUv3

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -366,11 +366,6 @@ PE3 VDD_3V3_SENSORS_EN OUTPUT HIGH
 PE7 UART7_RX UART7
 PE8 UART7_TX UART7
 
-# this is the pin to check if we are overcurrent on the "hi power"
-# and "low power" peripheral rails
-PE10 VDD_5V_HIPOWER_OC INPUT
-PE15 VDD_5V_PERIPH_OC INPUT
-
 # define a LED, mapping it to GPIO(0)
 PE12 FMU_LED_AMBER OUTPUT GPIO(0)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1020,7 +1020,7 @@ def process_line(line):
     alllines.append(line)
 
     if a[0].startswith('P') and a[0][1] in ports and a[0] in config:
-        print("WARNING: Pin %s redefined" % a[0])
+        error("Pin %s redefined" % a[0])
     
     config[a[0]] = a[1:]
     if a[0] == 'MCU':


### PR DESCRIPTION
We were building with the later definitions of PE10/PE15 anyways. (They add the pullup attribute)