### PR TITLE
HOVER_LEARN is a copter only parameter

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -136,7 +136,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
 
     // @Param: HOVER_LEARN
     // @DisplayName: Hover Value Learning
-    // @Description: Enable/Disable automatic learning of hover throttle
+    // @Description: Enable/Disable automatic learning of hover throttle.  Copter only.
     // @Values: 0:Disabled, 1:Learn, 2:LearnAndSave
     // @User: Advanced
     AP_GROUPINFO("HOVER_LEARN", 22, AP_MotorsMulticopter, _throttle_hover_learn, HOVER_LEARN_AND_SAVE),


### PR DESCRIPTION
Other vehicles (e.g. quadplane) use this lib, but they don't have support for hover learn, so this makes it explicit in the documentation.