### PR TITLE
HAL_ChibiOS: maintain rcout state beyond BRD_PWM_COUNT

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -88,20 +88,22 @@
 #endif
 #endif
 
+#ifndef BOARD_PWM_COUNT_DEFAULT
+#define BOARD_PWM_COUNT_DEFAULT 8
+#endif
+
 extern const AP_HAL::HAL& hal;
 AP_BoardConfig *AP_BoardConfig::instance;
 
 // table of user settable parameters
 const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
-#if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM)
     // @Param: PWM_COUNT
     // @DisplayName: Auxiliary pin config
     // @Description: Control assigning of FMU pins to PWM output, timer capture and GPIO. All unassigned pins can be used for GPIO
     // @Values: 0:No PWMs,2:Two PWMs,4:Four PWMs,6:Six PWMs,7:Three PWMs and One Capture
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO("PWM_COUNT",    0, AP_BoardConfig, state.pwm_count, BOARD_PWM_COUNT_DEFAULT),
-#endif
+    AP_GROUPINFO("PWM_COUNT",    0, AP_BoardConfig, pwm_count, BOARD_PWM_COUNT_DEFAULT),
 
 #if AP_FEATURE_RTSCTS
     // @Param: SER1_RTSCTS

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -122,12 +122,7 @@ public:
 
     // get number of PWM outputs enabled on FMU
     static uint8_t get_pwm_count(void) {
-#if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM)
-        return instance?instance->state.pwm_count.get():4;
-#else
-        // default to 16, which means all PWM channels available
-        return 16;
-#endif
+        return instance?instance->pwm_count.get():4;
     }
 
 #if AP_FEATURE_SAFETY_BUTTON
@@ -157,10 +152,10 @@ private:
     static AP_BoardConfig *instance;
     
     AP_Int16 vehicleSerialNumber;
-
+    AP_Int8 pwm_count;
+    
 #if AP_FEATURE_BOARD_DETECT || defined(AP_FEATURE_BRD_PWM_COUNT_PARAM) || AP_FEATURE_SAFETY_BUTTON
     struct {
-        AP_Int8 pwm_count;
         AP_Int8 safety_enable;
         AP_Int16 safety_option;
         AP_Int32 ignore_safety_channels;

--- a/libraries/AP_BoardConfig/px4_drivers.cpp
+++ b/libraries/AP_BoardConfig/px4_drivers.cpp
@@ -62,7 +62,7 @@ void AP_BoardConfig::px4_setup_pwm()
         { 8, PWM_SERVO_MODE_12PWM, 0 },
 #endif
     };
-    uint8_t mode_parm = (uint8_t)state.pwm_count.get();
+    uint8_t mode_parm = (uint8_t)pwm_count.get();
     uint8_t i;
     for (i=0; i<ARRAY_SIZE(mode_table); i++) {
         if (mode_table[i].mode_parm == mode_parm) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -214,17 +214,21 @@ private:
     // offset of first local channel
     uint8_t chan_offset;
 
-    // total number of channels
-    uint8_t total_channels;
+    // total number of channels on FMU
+    uint8_t num_fmu_channels;
+
+    // number of active fmu channels
+    uint8_t active_fmu_channels;
+    
+    static const uint8_t max_channels = 16;
     
     // last sent values are for all channels
-    uint16_t last_sent[16];
+    uint16_t last_sent[max_channels];
     
     // these values are for the local channels. Non-local channels are handled by IOMCU
     uint32_t en_mask;
-    uint16_t period[16];
-    uint16_t safe_pwm[16]; // pwm to use when safety is on
-    uint8_t num_channels;
+    uint16_t period[max_channels];
+    uint16_t safe_pwm[max_channels]; // pwm to use when safety is on
     bool corked;
     // mask of channels that are running in high speed
     uint16_t fast_channel_mask;


### PR DESCRIPTION
allow channels beyond BRD_PWM_COUNT to be sent over SBUS or DShot
distribution