### PR TITLE
Fix warning

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2239,7 +2239,6 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
     case MAVLINK_MSG_ID_DIGICAM_CONFIGURE:
         FALLTHROUGH;
     case MAVLINK_MSG_ID_DIGICAM_CONTROL:
-        FALLTHROUGH;
         handle_common_camera_message(msg);
         break;
 
@@ -2647,7 +2646,6 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
     case MAV_CMD_DO_SET_RELAY:
         FALLTHROUGH;
     case MAV_CMD_DO_REPEAT_RELAY:
-        FALLTHROUGH;
         result = handle_servorelay_message(packet);
         break;
 

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -73,7 +73,7 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
 
     if (time_offset_us == 0) {
         time_offset_us = (unsigned(random()) % 7000) * 1000000ULL;
-        printf("time_offset_us %ull\n", time_offset_us);
+        printf("time_offset_us %" PRIu64 "\n", time_offset_us);
     }
     
     if (time_send_us && now_us >= time_send_us) {


### PR DESCRIPTION
fix warning cause by useless FALLTHROUGH macro.
Fix printf warning about uint64_t by using PRIu64 type (from inttypes.h that we already include)