### PR TITLE
AP_ADSB: fix snprintf warning

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -639,7 +639,7 @@ uint8_t AP_ADSB::get_encoded_callsign_null_char()
 
     // using the above logic, we must always assign the squawk. once we get configured
     // externally then get_encoded_callsign_null_char() stops getting called
-    snprintf(out_state.cfg.callsign, 4, "%04d", unsigned(out_state.cfg.squawk_octal));
+    snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal));
     memset(&out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
     encoded_null |= 0x40;
 


### PR DESCRIPTION
not sur about the fix 
warning is : 
````
../../libraries/AP_ADSB/AP_ADSB.cpp: In member function ‘uint8_t AP_ADSB::get_encoded_callsign_null_char()’:
../../libraries/AP_ADSB/AP_ADSB.cpp:594:9: warning: ‘snprintf’ output truncated before the last format character [-Wformat-truncation=]
 uint8_t AP_ADSB::get_encoded_callsign_null_char()
         ^~~~~~~
../../libraries/AP_ADSB/AP_ADSB.cpp:642:13: note: ‘snprintf’ output between 5 and 6 bytes into a destination of size 4
     snprintf(out_state.cfg.callsign, 4, "%04d", unsigned(out_state.cfg.squawk_octal));

````
I think it complain because will only give a size of 4 and it need to put the \0 at the end of the snprintf ? 
