### PR TITLE
Plane and Rover: Simplify radio trimming

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -510,8 +510,11 @@ void GCS_MAVLINK_Rover::handle_change_alt_request(AP_Mission::Mission_Command &c
 MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
 {
     if (is_equal(packet.param4, 1.0f)) {
-        rover.trim_radio();
-        return MAV_RESULT_ACCEPTED;
+        if (rover.trim_radio()) {
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            return MAV_RESULT_FAILED;
+        }
     }
 
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -502,8 +502,7 @@ private:
     void rudder_arm_disarm_check();
     void read_radio();
     void control_failsafe(uint16_t pwm);
-    void trim_control_surfaces();
-    void trim_radio();
+    bool trim_radio();
 
     // sensors.cpp
     void init_compass(void);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -134,22 +134,20 @@ void Rover::control_failsafe(uint16_t pwm)
     }
 }
 
-void Rover::trim_control_surfaces()
+bool Rover::trim_radio()
 {
-    read_radio();
+    if (failsafe.bits & FAILSAFE_EVENT_RC) {
+        // can't trim without valid input
+        return false;
+    }
+
     // Store control surface trim values
     // ---------------------------------
     if ((channel_steer->get_radio_in() > 1400) && (channel_steer->get_radio_in() < 1600)) {
-        channel_steer->set_radio_trim(channel_steer->get_radio_in());
-        // save to eeprom
-        channel_steer->save_eeprom();
+        channel_steer->set_and_save_radio_trim(channel_steer->get_radio_in());
+    } else {
+        return false;
     }
-}
 
-void Rover::trim_radio()
-{
-    for (uint8_t y = 0; y < 30; y++) {
-        read_radio();
-    }
-    trim_control_surfaces();
+    return true;
 }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -732,11 +732,11 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_preflight_calibration(const mavlink
 MAV_RESULT GCS_MAVLINK_Plane::_handle_command_preflight_calibration(const mavlink_command_long_t &packet)
 {
     if (is_equal(packet.param4,1.0f)) {
-        /*
-          radio trim
-        */
-        plane.trim_radio();
-        return MAV_RESULT_ACCEPTED;
+        if (plane.trim_radio()) {
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            return MAV_RESULT_FAILED;
+        }
     }
 
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -904,8 +904,7 @@ private:
     void rudder_arm_disarm_check();
     void read_radio();
     void control_failsafe();
-    void trim_control_surfaces();
-    void trim_radio();
+    bool trim_radio();
     bool rc_failsafe_active(void);
     void init_rangefinder(void);
     void read_rangefinder(void);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -282,9 +282,13 @@ void Plane::control_failsafe()
     }
 }
 
-void Plane::trim_control_surfaces()
+bool Plane::trim_radio()
 {
-    read_radio();
+    if (failsafe.rc_failsafe) {
+        // can't trim if we don't have valid input
+        return false;
+    }
+
     int16_t trim_roll_range = (channel_roll->get_radio_max() - channel_roll->get_radio_min())/5;
     int16_t trim_pitch_range = (channel_pitch->get_radio_max() - channel_pitch->get_radio_min())/5;
     if (channel_roll->get_radio_in() < channel_roll->get_radio_min()+trim_roll_range ||
@@ -295,7 +299,7 @@ void Plane::trim_control_surfaces()
         // there is less than 20 percent range left then assume the
         // sticks are not properly centered. This also prevents
         // problems with starting APM with the TX off
-        return;
+        return false;
     }
 
     // trim main surfaces
@@ -330,15 +334,8 @@ void Plane::trim_control_surfaces()
     channel_roll->set_and_save_trim();
     channel_pitch->set_and_save_trim();
     channel_rudder->set_and_save_trim();
-}
 
-void Plane::trim_radio()
-{
-    for (uint8_t y = 0; y < 30; y++) {
-        read_radio();
-    }
-
-    trim_control_surfaces();
+    return true;
 }
 
 /*

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -271,8 +271,9 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         return;
     }
 
-    if(g.auto_trim > 0 && control_mode == MANUAL)
-        trim_control_surfaces();
+    if(g.auto_trim > 0 && control_mode == MANUAL) {
+        trim_radio();
+    }
 
     // perform any cleanup required for prev flight mode
     exit_mode(control_mode);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -157,26 +157,6 @@ int16_t RC_Channel::get_control_mid() const
     }
 }
 
-// ------------------------------------------
-
-void RC_Channel::load_eeprom(void)
-{
-    radio_min.load();
-    radio_trim.load();
-    radio_max.load();
-    reversed.load();
-    dead_zone.load();
-}
-
-void RC_Channel::save_eeprom(void)
-{
-    radio_min.save();
-    radio_trim.save();
-    radio_max.save();
-    reversed.save();
-    dead_zone.save();
-}
-
 /*
   return an "angle in centidegrees" (normally -4500 to 4500) from
   the current radio_in value using the specified dead_zone

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -26,11 +26,6 @@ public:
         RC_CHANNEL_LIMIT_MAX
     };
 
-    // startup
-    void        load_eeprom(void);
-    void        save_eeprom(void);
-    void        save_trim(void);
-
     // setup the control preferences
     void        set_range(uint16_t high);
     void        set_angle(uint16_t angle);


### PR DESCRIPTION
This simplifies the radio trimming interface on both plane and rover. The `trim_radio(void)` and `trim_control_surfaces(void)` are easily collapsed and overlapped, calling `read_radio(void)` 31 times is of minimal to no value (you might read a single new reading in, but it's very unlikely and should have been managed by the continuous RC polling already) (there is an argument for calling it once, but anything more is excessive).

The MAVLink command that triggers trimming can now fail appropriately if trimming doesn't actually do anything.