### PR TITLE
HAL_ChibiOS: allow printf() to work on systems without debug console

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.c
@@ -107,13 +107,16 @@ int vprintf(const char *fmt, va_list arg)
 #endif
 }
 
+// hook to allow for printf() on systems without HAL_STDOUT_SERIAL
+int (*vprintf_console_hook)(const char *fmt, va_list arg) = vprintf;
+
 int printf(const char *fmt, ...)
 {
    va_list arg;
    int done;
  
    va_start (arg, fmt);
-   done =  vprintf(fmt, arg);
+   done =  vprintf_console_hook(fmt, arg);
    va_end (arg);
  
    return done;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -13,6 +13,9 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#pragma once
+
 #include "posix.h"
 #include <stdarg.h>
 #include <stdint.h>
@@ -37,6 +40,9 @@ int vsscanf (const char *buf, const char *s, va_list ap);
 void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
 void free(void *ptr);
+
+extern int (*vprintf_console_hook)(const char *fmt, va_list arg);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
map to hal.console once initialised