### PR TITLE
MAVLink-over-CAN virtual serial port

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -41,6 +41,11 @@ void Rover::init_ardupilot()
 
     mavlink_system.sysid = g.sysid_this_mav;
 
+    BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
+
     // initialise serial ports
     serial_manager.init();
 
@@ -50,11 +55,6 @@ void Rover::init_ardupilot()
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
-
-    BoardConfig.init();
-#if HAL_WITH_UAVCAN
-    BoardConfig_CAN.init();
-#endif
 
     // initialise notify system
     notify.init();

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -24,6 +24,11 @@ void Tracker::init_tracker()
 
     mavlink_system.sysid = g.sysid_this_mav;
 
+    BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
+
     // initialise serial ports
     serial_manager.init();
 
@@ -34,11 +39,6 @@ void Tracker::init_tracker()
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
     
-    BoardConfig.init();
-#if HAL_WITH_UAVCAN
-    BoardConfig_CAN.init();
-#endif
-
     // initialise notify
     notify.init();
     AP_Notify::flags.pre_arm_check = true;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -53,6 +53,11 @@ void Copter::init_ardupilot()
     // identify ourselves correctly with the ground station
     mavlink_system.sysid = g.sysid_this_mav;
     
+    BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
+
     // initialise serial ports
     serial_manager.init();
 
@@ -64,11 +69,6 @@ void Copter::init_ardupilot()
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
     
-    BoardConfig.init();
-#if HAL_WITH_UAVCAN
-    BoardConfig_CAN.init();
-#endif
-
     // init cargo gripper
 #if GRIPPER_ENABLED == ENABLED
     g2.gripper.init();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -69,20 +69,22 @@ void Plane::init_ardupilot()
 
     mavlink_system.sysid = g.sysid_this_mav;
 
+    // setup any board specific drivers
+    BoardConfig.init();
+#if HAL_WITH_UAVCAN
+    BoardConfig_CAN.init();
+#endif
+
     // initialise serial ports
     serial_manager.init();
+
+    // setup first port early to allow BoardConfig to report errors
     gcs().chan(0).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, 0);
 
 
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
-
-    // setup any board specific drivers
-    BoardConfig.init();
-#if HAL_WITH_UAVCAN
-    BoardConfig_CAN.init();
-#endif
 
     // initialise rc channels including setting mode
     rc().init();

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -23,6 +23,10 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_SerialManager.h"
 
+#if HAL_WITH_UAVCAN
+#include <AP_UAVCAN/AP_UAVCAN.h>
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 #ifdef HAL_SERIAL5_PROTOCOL
@@ -189,7 +193,18 @@ void AP_SerialManager::init()
     if (state[0].uart == nullptr) {
         init_console();
     }
-    
+
+#if HAL_WITH_UAVCAN
+    for (uint8_t can_mgr = 0; can_mgr < MAX_NUMBER_OF_CAN_DRIVERS; can_mgr++) {
+        AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(can_mgr);
+        const uint8_t state_index = (SERIALMANAGER_NUM_PORTS-1) + can_mgr;
+        if (ap_uavcan != nullptr && state_index < SERIALMANAGER_NUM_PORTS) {
+            state[state_index].uart = ap_uavcan->get_tunnel_uart();
+            state[state_index].protocol = ap_uavcan->get_tunnel_protocol();
+        }
+    }
+#endif
+
     // initialise serial ports
     for (uint8_t i=1; i<SERIALMANAGER_NUM_PORTS; i++) {
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -26,8 +26,11 @@
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-// we have hal.uartA to hal.uartG
-#define SERIALMANAGER_NUM_PORTS 7
+#if HAL_WITH_UAVCAN
+    #define SERIALMANAGER_NUM_PORTS (7 + MAX_NUMBER_OF_CAN_INTERFACES)
+#else
+    #define SERIALMANAGER_NUM_PORTS 7
+#endif
 
  // console default baud rates and buffer sizes
 #ifdef HAL_SERIAL0_BAUD_DEFAULT

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -784,10 +784,11 @@ void AP_UAVCAN::tunnel_send()
 
     const uint16_t max_send = 60; // 60 is sizeof(msg.buffer) at max capacity per dsdl
     uint32_t avail = _tunnel.uart->tx_available();
-    if (avail < max_send) {
-        // wait for a full buffer
+    if (avail < max_send && now - _tunnel_last_send < AP_UAVCAN_TUNNEL_SEND_TIMEOUT_FLUSH_MS) {
+        // wait for a full buffer and we haven't waited too long
         return;
     }
+    _tunnel_last_send = now;
 
     if (avail > max_send) {
         avail = max_send;

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -780,30 +780,38 @@ void AP_UAVCAN::tunnel_send()
         return;
     }
 
-    uint32_t now = AP_HAL::millis();
     uint32_t avail = _tunnel.uart->tx_available();
-    uavcan::tunnel::Broadcast bdcst_msg;
 
-    if (avail < bdcst_msg.buffer.capacity() && now - _tunnel_last_send < AP_UAVCAN_TUNNEL_SEND_TIMEOUT_FLUSH_MS) {
+    if (!avail) {
+        // nothing to do
+        return;
+    }
+
+    uint32_t now = AP_HAL::millis();
+    const uavcan::tunnel::Broadcast const_msg;
+
+    if (avail < const_msg.buffer.capacity() &&
+            now - _tunnel_last_send < AP_UAVCAN_TUNNEL_SEND_TIMEOUT_FLUSH_MS) {
         // wait for a full buffer and we haven't waited too long
         return;
     }
     _tunnel_last_send = now;
 
-    if (avail > bdcst_msg.buffer.capacity()) {
-        avail = bdcst_msg.buffer.capacity();
-    }
+    uint8_t packets_sent = 0;
+    while (avail && packets_sent++ < 3) {
 
-    while (avail--) {
-        int16_t data = _tunnel.uart->fetch_for_outbound();
-        if (data < 0) {
-            // fetch failure: Either not initialized, mutex is locked, or buffer was empty
-            break;
+        uavcan::tunnel::Broadcast bdcst_msg;
+        while (avail-- && bdcst_msg.buffer.size() < bdcst_msg.buffer.capacity()) {
+            int16_t data = _tunnel.uart->fetch_for_outbound();
+            if (data < 0) {
+                // fetch failure: Either not initialized, mutex is locked, or buffer was empty
+                break;
+            }
+            avail--;
+            bdcst_msg.buffer.push_back((uint8_t)data);
         }
-
-        bdcst_msg.buffer.push_back((uint8_t)data);
+        tunnel_broadcast_array[_uavcan_i]->broadcast(bdcst_msg);
     }
-    tunnel_broadcast_array[_uavcan_i]->broadcast(bdcst_msg);
 
 }
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -788,9 +788,8 @@ void AP_UAVCAN::tunnel_send()
     }
 
     uint32_t now = AP_HAL::millis();
-    const uavcan::tunnel::Broadcast const_msg;
 
-    if (avail < const_msg.buffer.capacity() &&
+    if (avail < 60 && // 60 == const_msg.buffer.capacity() but there's no way to get a define of it
             now - _tunnel_last_send < AP_UAVCAN_TUNNEL_SEND_TIMEOUT_FLUSH_MS) {
         // wait for a full buffer and we haven't waited too long
         return;
@@ -801,6 +800,9 @@ void AP_UAVCAN::tunnel_send()
     while (avail && packets_sent++ < 3) {
 
         uavcan::tunnel::Broadcast bdcst_msg;
+        bdcst_msg.channel_id = 0;       // TODO: implement multiple channels
+        //bdcst_msg.protocol = uavcan::tunnel::Protocol::MAVLINK;
+
         while (avail-- && bdcst_msg.buffer.size() < bdcst_msg.buffer.capacity()) {
             int16_t data = _tunnel.uart->fetch_for_outbound();
             if (data < 0) {

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -802,15 +802,7 @@ void AP_UAVCAN::tunnel_send()
         return;
     }
 
-#if 0
-    static uint32_t last_send;
     uint32_t now = AP_HAL::millis();
-    if (now - last_send < 10) {
-        return;
-    }
-    last_send = now;
-#endif
-
     if (avail > max_send) {
         avail = max_send;
     }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -140,22 +140,6 @@ public:
     // tunnel output
     void tunnel_send();
 
-    struct tunnel_stats {
-        uint32_t retries;
-        uint32_t fetch_error_1;
-        uint32_t fetch_error_2;
-        uint32_t fetch_error_3;
-        uint32_t buffer_at_max_cap_send_fail;
-        uint32_t delayed_flushes;
-        uint32_t buffer_at_max_cap;
-        uint32_t push_back_count;
-        uint32_t sem_take_fail;
-        uint32_t flush_failed;
-        uint32_t intake_failed;
-    };
-
-    tunnel_stats _tunnel_stats {0};
-
     // protocol tunneling uart interface
     UAVCAN_UARTDriver* get_tunnel_uart();
     AP_SerialManager::SerialProtocol get_tunnel_protocol() { return (AP_SerialManager::SerialProtocol)_tunnel.protocol.get(); }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -139,7 +139,6 @@ public:
 
     // tunnel output
     void tunnel_send();
-    bool tunnel_flush();
 
     struct tunnel_stats {
         uint32_t retries;
@@ -204,7 +203,6 @@ private:
         UAVCAN_UARTDriver* uart;
         uint32_t last_send_ms;
         bool resend;
-        uavcan::tunnel::Broadcast bdcst_msg;
     } _tunnel;
 
     struct {

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -50,7 +50,6 @@
 #define AP_UAVCAN_MAX_LED_DEVICES 4
 #define AP_UAVCAN_LED_DELAY_MILLISECONDS 50
 
-#define AP_UAVCAN_TUNNEL_SENDS_PER_LOOP_MAX         20
 #define AP_UAVCAN_TUNNEL_SEND_TIMEOUT_FLUSH_MS      10
 
 class AP_UAVCAN {
@@ -218,6 +217,8 @@ private:
     AP_HAL::Semaphore *SRV_sem;
     AP_HAL::Semaphore *_led_out_sem;
     AP_HAL::Semaphore *_tunnel_sem;
+
+    uint32_t _tunnel_last_send;
 
     class SystemClock: public uavcan::ISystemClock, uavcan::Noncopyable {
         SystemClock()

--- a/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
+++ b/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
@@ -1,0 +1,173 @@
+#include "UAVCAN_UARTDriver.h"
+
+
+#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_TX            (512*4)
+#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_RX            (512*4)
+
+extern const AP_HAL::HAL& hal;
+
+UAVCAN_UARTDriver::UAVCAN_UARTDriver()
+{
+    _write_mutex = hal.util->new_semaphore();
+    _read_mutex = hal.util->new_semaphore();
+}
+
+/*
+  open virtual port
+ */
+void UAVCAN_UARTDriver::begin(uint32_t baud)
+{
+    begin(baud, 0, 0);
+}
+
+void UAVCAN_UARTDriver::begin(uint32_t baud, uint16_t rxS, uint16_t txS)
+{
+    (void)baud; // unused in virtual ports
+
+    _initialised = false;
+
+    // enforce minimum sizes
+    if (rxS < AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_RX) {
+        rxS = AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_RX;
+    }
+    if (txS < AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_TX) {
+        txS = AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_TX;
+    }
+
+    if (_writebuf.set_size(txS) && _readbuf.set_size(rxS)) {
+        _initialised = true;
+    }
+}
+
+
+/*
+  shutdown a Virtual UART
+ */
+void UAVCAN_UARTDriver::end()
+{
+    _initialised = false;
+    _readbuf.set_size(0);
+    _writebuf.set_size(0);
+}
+
+
+/*
+  do we have any bytes pending transmission?
+ */
+bool UAVCAN_UARTDriver::tx_pending()
+{
+    // any data in SerialManager -> UAVCAN
+    return (_writebuf.available() > 0);
+}
+
+/*
+  return the number of bytes available to be read
+ */
+uint32_t UAVCAN_UARTDriver::available()
+{
+    if (!_initialised) {
+        return 0;
+    }
+    // any data in UAVCAN -> SerialManager
+    return _readbuf.available();
+}
+
+/*
+  how many bytes are available in the output buffer?
+ */
+uint32_t UAVCAN_UARTDriver::txspace()
+{
+    if (!_initialised) {
+        return 0;
+    }
+    // how much free space available in SerialManager -> UAVCAN
+    return _writebuf.space();
+}
+
+uint32_t UAVCAN_UARTDriver::handle_inbound(const uint8_t *buffer, uint32_t size)
+{
+    if (!_read_mutex->take(2)) {
+        return 0;
+    }
+
+    // load data into UAVCAN -> SerialManager
+    uint32_t len = _readbuf.write(buffer, size);
+    _read_mutex->give();
+    return len;
+}
+
+int16_t UAVCAN_UARTDriver::fetch_for_outbound(void)
+{
+    if (!_initialised) {
+        return -1;
+    }
+    if (!_write_mutex->take(2)) {
+        return -2;
+    }
+
+
+    uint8_t byte;
+    if (!_writebuf.read_byte(&byte)) {
+        _write_mutex->give();
+        return -3;
+    }
+
+    _write_mutex->give();
+    return byte;
+}
+
+
+int16_t UAVCAN_UARTDriver::read()
+{
+    if (!_initialised) {
+        return -1;
+    }
+    if ( !_read_mutex->take(2)) {
+        return -1;
+    }
+
+    uint8_t byte;
+    if (!_readbuf.read_byte(&byte)) {
+        _read_mutex->give();
+        return -1;
+    }
+
+    _read_mutex->give();
+
+    return byte;
+}
+
+/* implementation of write virtual methods */
+size_t UAVCAN_UARTDriver::write(uint8_t c)
+{
+    if (!_initialised) {
+        return 0;
+    }
+    if (!_write_mutex->take(2)) {
+        return 0;
+    }
+
+    uint32_t len = _writebuf.write(&c, 1);
+    _write_mutex->give();
+
+    return len;
+}
+
+/*
+  write size bytes to the write buffer
+ */
+size_t UAVCAN_UARTDriver::write(const uint8_t *buffer, size_t size)
+{
+    if (!_initialised) {
+        return 0;
+    }
+    if (!_write_mutex->take(2)) {
+        return 0;
+    }
+
+    uint32_t len = _writebuf.write(buffer, size);
+    _write_mutex->give();
+
+    return len;
+}
+

--- a/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
+++ b/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
@@ -10,7 +10,6 @@ UAVCAN_UARTDriver::UAVCAN_UARTDriver()
 {
     _write_mutex = hal.util->new_semaphore();
     _read_mutex = hal.util->new_semaphore();
-    hal.console->printf("UAVCAN_UARTDriver: constructor\n");
 }
 
 /*
@@ -23,7 +22,6 @@ void UAVCAN_UARTDriver::begin(uint32_t baud)
 
 void UAVCAN_UARTDriver::begin(uint32_t baud, uint16_t rxS, uint16_t txS)
 {
-    hal.console->printf("UAVCAN_UARTDriver: begin %u\n", baud);
     (void)baud; // unused in virtual ports
 
     _initialised = false;
@@ -47,7 +45,6 @@ void UAVCAN_UARTDriver::begin(uint32_t baud, uint16_t rxS, uint16_t txS)
  */
 void UAVCAN_UARTDriver::end()
 {
-    hal.console->printf("UAVCAN_UARTDriver: end\n");
     _initialised = false;
     _readbuf.set_size(0);
     _writebuf.set_size(0);

--- a/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
+++ b/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
@@ -1,8 +1,8 @@
 #include "UAVCAN_UARTDriver.h"
 
 
-#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_TX            (512*4)
-#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_RX            (512*4)
+#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_TX            (1024)
+#define AP_UAVCAN_UARTDRIVER_BUF_SIZE_MIN_RX            (512)
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
+++ b/libraries/AP_UAVCAN/UAVCAN_UARTDriver.cpp
@@ -10,6 +10,7 @@ UAVCAN_UARTDriver::UAVCAN_UARTDriver()
 {
     _write_mutex = hal.util->new_semaphore();
     _read_mutex = hal.util->new_semaphore();
+    hal.console->printf("UAVCAN_UARTDriver: constructor\n");
 }
 
 /*
@@ -22,6 +23,7 @@ void UAVCAN_UARTDriver::begin(uint32_t baud)
 
 void UAVCAN_UARTDriver::begin(uint32_t baud, uint16_t rxS, uint16_t txS)
 {
+    hal.console->printf("UAVCAN_UARTDriver: begin %u\n", baud);
     (void)baud; // unused in virtual ports
 
     _initialised = false;
@@ -45,6 +47,7 @@ void UAVCAN_UARTDriver::begin(uint32_t baud, uint16_t rxS, uint16_t txS)
  */
 void UAVCAN_UARTDriver::end()
 {
+    hal.console->printf("UAVCAN_UARTDriver: end\n");
     _initialised = false;
     _readbuf.set_size(0);
     _writebuf.set_size(0);

--- a/libraries/AP_UAVCAN/UAVCAN_UARTDriver.h
+++ b/libraries/AP_UAVCAN/UAVCAN_UARTDriver.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/RingBuffer.h>
+#include <AP_HAL/Semaphores.h>
+
+class UAVCAN_UARTDriver : public AP_HAL::UARTDriver {
+public:
+    UAVCAN_UARTDriver();
+
+    /* Empty implementations of UARTDriver virtual methods */
+    void begin(uint32_t b) override;
+    void begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
+    void end() override;
+    bool is_initialized() override { return _initialised; }
+    bool tx_pending() override;
+
+    // unimplemented
+    void flush() override {}
+    void set_blocking_writes(bool blocking) override { (void)blocking; }
+
+    uint32_t available() override;
+    uint32_t txspace() override;
+    int16_t read() override;
+
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
+
+    uint32_t handle_inbound(const uint8_t *buffer, uint32_t size);
+    int16_t fetch_for_outbound(void);
+    uint32_t tx_available() { return _writebuf.available(); }
+
+private:
+    bool _initialised;
+    AP_HAL::Semaphore *_write_mutex;
+    AP_HAL::Semaphore *_read_mutex;
+
+    // ring buffers
+    ByteBuffer _readbuf{0};
+    ByteBuffer _writebuf{0};
+};


### PR DESCRIPTION
This implements the uavcan.tunnel.Broadcast packet that can tunnel arbitrary serial data over UAVCAN. It can support any existing SERIALx_PROTOCOL.

Things in this PR:
- creates a UAVCAN_UARTDriver class that is a bi-directional thread safe ring-buffer.
- moves the BoardConfig.init() to be before SerialManager.init() so that the UAVCAN_UARTDriver can get constructed before it is configured
- subscribes to uavcan.tunnel.Broadcast and fwds to UAVCAN_UARTDriver
- polls UAVCAN_UARTDriver in do_cyclic and fills outbound Can buffers with raw serial bytes
- Tries to be efficient by only transmitting full packets but will timeout if a partial packet lingers for >= 5ms.

This has been tested by connecting a Cube and pixhawks v1 together via CAN and:
- set SYSID_THISMAV to each have unique values (my test used 72, 73)
- set CAN_D1_UC_NODE to each have unique values  (in my test I used same as SYSID_THISMAV)
- set CAN_D1_UC_VSER_P both to = 1 ( MAVLink1)
- On Mission Planner both sysIDs show up and while my USB is only connected to HW set  to 72, I can detect the HW with sysid 73 and fetch params and write missions to the HW with sysid 73.

- mental note, we should reduce the uavcan.tunnel.broadcast.buffer size from 1024 down to 60. I've been testing it at various sizes (20, 60, 500, 950, 1024) and it feels like I get less drops at lower uavcan block size but not really sure. Either way, I think a massive buffer is not helpful in a tunnel

Fun Fact: I can connect a single Zubax UAVCAN GPS to the bus and both Pixhawks seemlessly detect and communicate with :)