### PR TITLE
Move override handling out of the HAL and into RC_Channel

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -776,19 +776,21 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+        uint32_t tnow = AP_HAL::millis();
+
         mavlink_rc_channels_override_t packet;
         mavlink_msg_rc_channels_override_decode(msg, &packet);
 
-        RC_Channels::set_override(0, packet.chan1_raw);
-        RC_Channels::set_override(1, packet.chan2_raw);
-        RC_Channels::set_override(2, packet.chan3_raw);
-        RC_Channels::set_override(3, packet.chan4_raw);
-        RC_Channels::set_override(4, packet.chan5_raw);
-        RC_Channels::set_override(5, packet.chan6_raw);
-        RC_Channels::set_override(6, packet.chan7_raw);
-        RC_Channels::set_override(7, packet.chan8_raw);
+        RC_Channels::set_override(0, packet.chan1_raw, tnow);
+        RC_Channels::set_override(1, packet.chan2_raw, tnow);
+        RC_Channels::set_override(2, packet.chan3_raw, tnow);
+        RC_Channels::set_override(3, packet.chan4_raw, tnow);
+        RC_Channels::set_override(4, packet.chan5_raw, tnow);
+        RC_Channels::set_override(5, packet.chan6_raw, tnow);
+        RC_Channels::set_override(6, packet.chan7_raw, tnow);
+        RC_Channels::set_override(7, packet.chan8_raw, tnow);
 
-        rover.failsafe.rc_override_timer = AP_HAL::millis();
+        rover.failsafe.rc_override_timer = tnow;
         rover.failsafe_trigger(FAILSAFE_EVENT_RC, false);
         break;
     }
@@ -805,13 +807,15 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
         if (packet.target != rover.g.sysid_this_mav) {
             break; // only accept control aimed at us
         }
+
+        uint32_t tnow = AP_HAL::millis();
         
         const int16_t roll = (packet.y == INT16_MAX) ? 0 : rover.channel_steer->get_radio_min() + (rover.channel_steer->get_radio_max() - rover.channel_steer->get_radio_min()) * (packet.y + 1000) / 2000.0f;
         const int16_t throttle = (packet.z == INT16_MAX) ? 0 : rover.channel_throttle->get_radio_min() + (rover.channel_throttle->get_radio_max() - rover.channel_throttle->get_radio_min()) * (packet.z + 1000) / 2000.0f;
-        RC_Channels::set_override(uint8_t(rover.rcmap.roll() - 1), roll);
-        RC_Channels::set_override(uint8_t(rover.rcmap.throttle() - 1), throttle);
+        RC_Channels::set_override(uint8_t(rover.rcmap.roll() - 1), roll, tnow);
+        RC_Channels::set_override(uint8_t(rover.rcmap.throttle() - 1), throttle, tnow);
 
-        rover.failsafe.rc_override_timer = AP_HAL::millis();
+        rover.failsafe.rc_override_timer = tnow;
         rover.failsafe_trigger(FAILSAFE_EVENT_RC, false);
         break;
     }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -403,7 +403,6 @@ void Plane::set_servos_flaps(void)
     // work out any manual flap input
     RC_Channel *flapin = RC_Channels::rc_channel(g.flapin_channel-1);
     if (flapin != nullptr && !failsafe.rc_failsafe && failsafe.throttle_counter == 0) {
-        flapin->input();
         manual_flap_percent = flapin->percent_input();
     }
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -713,21 +713,24 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         if (msg->sysid != sub.g.sysid_my_gcs) {
             break;    // Only accept control from our gcs
         }
+
+        uint32_t tnow = AP_HAL::millis();
+
         mavlink_rc_channels_override_t packet;
         mavlink_msg_rc_channels_override_decode(msg, &packet);
 
-        RC_Channels::set_override(0, packet.chan1_raw);
-        RC_Channels::set_override(1, packet.chan2_raw);
-        RC_Channels::set_override(2, packet.chan3_raw);
-        RC_Channels::set_override(3, packet.chan4_raw);
-        RC_Channels::set_override(4, packet.chan5_raw);
-        RC_Channels::set_override(5, packet.chan6_raw);
-        RC_Channels::set_override(6, packet.chan7_raw);
-        RC_Channels::set_override(7, packet.chan8_raw);
+        RC_Channels::set_override(0, packet.chan1_raw, tnow);
+        RC_Channels::set_override(1, packet.chan2_raw, tnow);
+        RC_Channels::set_override(2, packet.chan3_raw, tnow);
+        RC_Channels::set_override(3, packet.chan4_raw, tnow);
+        RC_Channels::set_override(4, packet.chan5_raw, tnow);
+        RC_Channels::set_override(5, packet.chan6_raw, tnow);
+        RC_Channels::set_override(6, packet.chan7_raw, tnow);
+        RC_Channels::set_override(7, packet.chan8_raw, tnow);
 
-        sub.failsafe.last_pilot_input_ms = AP_HAL::millis();
+        sub.failsafe.last_pilot_input_ms = tnow;
         // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes
-        sub.failsafe.last_heartbeat_ms = AP_HAL::millis();
+        sub.failsafe.last_heartbeat_ms = tnow;
         break;
     }
 

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -91,28 +91,30 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
         rollTrim  =  y * rpyScale;
     }
 
-    RC_Channels::set_override(0, constrain_int16(pitchTrim + rpyCenter,1100,1900)); // pitch
-    RC_Channels::set_override(1, constrain_int16(rollTrim  + rpyCenter,1100,1900)); // roll
+    uint32_t tnow = AP_HAL::millis();
 
-    RC_Channels::set_override(2, constrain_int16((z+zTrim)*throttleScale+throttleBase,1100,1900)); // throttle
-    RC_Channels::set_override(3, constrain_int16(r*rpyScale+rpyCenter,1100,1900));                 // yaw
+    RC_Channels::set_override(0, constrain_int16(pitchTrim + rpyCenter,1100,1900), tnow); // pitch
+    RC_Channels::set_override(1, constrain_int16(rollTrim  + rpyCenter,1100,1900), tnow); // roll
+
+    RC_Channels::set_override(2, constrain_int16((z+zTrim)*throttleScale+throttleBase,1100,1900), tnow); // throttle
+    RC_Channels::set_override(3, constrain_int16(r*rpyScale+rpyCenter,1100,1900), tnow);                 // yaw
 
     // maneuver mode:
     if (roll_pitch_flag == 0) {
         // adjust forward and lateral with joystick input instead of roll and pitch
-        RC_Channels::set_override(4, constrain_int16((x+xTrim)*rpyScale+rpyCenter,1100,1900)); // forward for ROV
-        RC_Channels::set_override(5, constrain_int16((y+yTrim)*rpyScale+rpyCenter,1100,1900)); // lateral for ROV
+        RC_Channels::set_override(4, constrain_int16((x+xTrim)*rpyScale+rpyCenter,1100,1900), tnow); // forward for ROV
+        RC_Channels::set_override(5, constrain_int16((y+yTrim)*rpyScale+rpyCenter,1100,1900), tnow); // lateral for ROV
     } else {
         // neutralize forward and lateral input while we are adjusting roll and pitch
-        RC_Channels::set_override(4, constrain_int16(xTrim*rpyScale+rpyCenter,1100,1900)); // forward for ROV
-        RC_Channels::set_override(5, constrain_int16(yTrim*rpyScale+rpyCenter,1100,1900)); // lateral for ROV
+        RC_Channels::set_override(4, constrain_int16(xTrim*rpyScale+rpyCenter,1100,1900), tnow); // forward for ROV
+        RC_Channels::set_override(5, constrain_int16(yTrim*rpyScale+rpyCenter,1100,1900), tnow); // lateral for ROV
     }
 
-    RC_Channels::set_override(6, cam_pan);       // camera pan
-    RC_Channels::set_override(7, cam_tilt);      // camera tilt
-    RC_Channels::set_override(8, lights1);       // lights 1
-    RC_Channels::set_override(9, lights2);       // lights 2
-    RC_Channels::set_override(10, video_switch); // video switch
+    RC_Channels::set_override(6, cam_pan, tnow);       // camera pan
+    RC_Channels::set_override(7, cam_tilt, tnow);      // camera tilt
+    RC_Channels::set_override(8, lights1, tnow);       // lights 1
+    RC_Channels::set_override(9, lights2, tnow);       // lights 2
+    RC_Channels::set_override(10, video_switch, tnow); // video switch
 
     // Store old x, y, z values for use in input hold logic
     x_last = x;
@@ -678,13 +680,14 @@ void Sub::default_js_buttons()
 
 void Sub::set_neutral_controls()
 {
+    uint32_t tnow = AP_HAL::millis();
 
     for (uint8_t i = 0; i < 6; i++) {
-        RC_Channels::set_override(i, 1500);
+        RC_Channels::set_override(i, 1500, tnow);
     }
 
     for (uint8_t i = 6; i < 11; i++) {
-        RC_Channels::set_override(i, 0xffff);
+        RC_Channels::set_override(i, 0xffff, tnow);
     }
 
     // Clear pitch/roll trim settings

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -44,11 +44,6 @@ public:
      *  v > 0   -> set v as override.
      */
 
-    /* set_override: set just a specific channel */
-    virtual bool set_override(uint8_t channel, int16_t override) = 0;
-    /* clear_overrides: equivalent to setting all overrides to 0 */
-    virtual void clear_overrides() = 0;
-
     /* execute receiver bind */
     virtual bool rc_bind(int dsmMode) { return false; }
 };

--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -25,6 +25,8 @@
 extern AP_IOMCU iomcu;
 #endif
 
+#include <AP_Math/AP_Math.h>
+
 #define SIG_DETECT_TIMEOUT_US 500000
 using namespace ChibiOS;
 extern const AP_HAL::HAL& hal;
@@ -54,12 +56,7 @@ bool RCInput::new_input()
     }
     bool valid = _rcin_timestamp_last_signal != _last_read;
 
-    if (_override_valid) {
-        // if we have RC overrides active, then always consider it valid
-        valid = true;
-    }
     _last_read = _rcin_timestamp_last_signal;
-    _override_valid = false;
     rcin_mutex.give();
 
 #if HAL_RCINPUT_WITH_AP_RADIO
@@ -84,22 +81,10 @@ uint8_t RCInput::num_channels()
 
 uint16_t RCInput::read(uint8_t channel)
 {
-    if (!_init) {
-        return 0;
-    }
-    if (channel >= RC_INPUT_MAX_CHANNELS) {
+    if (!_init || (channel >= MIN(RC_INPUT_MAX_CHANNELS, _num_channels))) {
         return 0;
     }
     rcin_mutex.take(HAL_SEMAPHORE_BLOCK_FOREVER);
-    if (_override[channel]) {
-        uint16_t v = _override[channel];
-        rcin_mutex.give();
-        return v;
-    }
-    if (channel >=  _num_channels) {
-        rcin_mutex.give();
-        return 0;
-    }
     uint16_t v = _rc_values[channel];
     rcin_mutex.give();
 #if HAL_RCINPUT_WITH_AP_RADIO
@@ -125,34 +110,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     }
     return len;
 }
-
-bool RCInput::set_override(uint8_t channel, int16_t override)
-{
-    if (!_init) {
-        return false;
-    }
-
-    if (override < 0) {
-        return false; /* -1: no change. */
-    }
-    if (channel >= RC_INPUT_MAX_CHANNELS) {
-        return false;
-    }
-    _override[channel] = override;
-    if (override != 0) {
-        _override_valid = true;
-        return true;
-    }
-    return false;
-}
-
-void RCInput::clear_overrides()
-{
-    for (uint8_t i = 0; i < RC_INPUT_MAX_CHANNELS; i++) {
-        set_override(i, 0);
-    }
-}
-
 
 void RCInput::_timer_tick(void)
 {

--- a/libraries/AP_HAL_ChibiOS/RCInput.h
+++ b/libraries/AP_HAL_ChibiOS/RCInput.h
@@ -50,20 +50,13 @@ public:
         return _rssi;
     }
         
-    
-    bool set_override(uint8_t channel, int16_t override) override;
-    void clear_overrides() override;
-
     void _timer_tick(void);
     bool rc_bind(int dsmMode) override;
 
 private:
-    /* override state */
-    uint16_t _override[RC_INPUT_MAX_CHANNELS];
     uint16_t _rc_values[RC_INPUT_MAX_CHANNELS] = {0};
 
     uint64_t _last_read;
-    bool _override_valid;
     uint8_t _num_channels;
     Semaphore rcin_mutex;
     int16_t _rssi = -1;

--- a/libraries/AP_HAL_Empty/RCInput.cpp
+++ b/libraries/AP_HAL_Empty/RCInput.cpp
@@ -29,10 +29,3 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len) {
     return len;
 }
 
-bool RCInput::set_override(uint8_t channel, int16_t override) {
-    return true;
-}
-
-void RCInput::clear_overrides()
-{}
-

--- a/libraries/AP_HAL_Empty/RCInput.h
+++ b/libraries/AP_HAL_Empty/RCInput.h
@@ -10,7 +10,4 @@ public:
     uint8_t num_channels();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
-
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
 };

--- a/libraries/AP_HAL_F4Light/RCInput.cpp
+++ b/libraries/AP_HAL_F4Light/RCInput.cpp
@@ -58,9 +58,6 @@ uint8_t   RCInput::_valid_channels IN_CCM; //  = 0;
 uint64_t  RCInput::_last_read IN_CCM; // = 0;
 
 
-uint16_t RCInput::_override[F4Light_RC_INPUT_NUM_CHANNELS] IN_CCM;
-bool RCInput::_override_valid;
-
 bool RCInput::is_PPM IN_CCM;
 
 uint8_t RCInput::_last_read_from IN_CCM;
@@ -88,8 +85,6 @@ RCInput::RCInput()
 void RCInput::init() {
     caddr_t ptr;
 
-    memset((void *)&_override[0],   0, sizeof(_override));
-
 /* OPLINK AIR port pinout
 1       2       3       4       5       6       7
                PD2     PA15                
@@ -103,8 +98,6 @@ for RFM        int     cs
     is_PPM=true;
     _last_read_from=0;
     max_num_pulses=0;
-
-    clear_overrides();
 
     pwmInit(is_PPM); // PPM sum mode
 
@@ -150,8 +143,6 @@ void RCInput::late_init(uint8_t b) {
 // we can have 4 individual sources of data - internal DSM from UART5, SBUS from UART1 and 2 PPM parsers
 bool RCInput::new_input()
 {
-    if(_override_valid) return true;
-
     uint8_t inp=hal_param_helper->_rc_input;
     if(inp &&  inp < num_parsers+1){
         inp-=1;
@@ -258,10 +249,6 @@ uint16_t RCInput::read(uint8_t ch)
         }
     }
 
-    /* Check for override */
-    uint16_t over = _override[ch];
-    if(over) return over;
-
     if( ch == 4) {
         last_4 = data;
     }
@@ -312,27 +299,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     }
 
     return _valid_channels;
-}
-
-
-bool RCInput::set_override(uint8_t channel, int16_t override)
-{
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < F4Light_RC_INPUT_NUM_CHANNELS) {
-        _override[channel] = override;
-        if (override != 0) {
-    	    _override_valid = true;
-            return true;
-        }
-    }
-    return false;
-}
-
-void RCInput::clear_overrides()
-{
-    for (int i = 0; i < F4Light_RC_INPUT_NUM_CHANNELS; i++) {
-	set_override(i, 0);
-    }
 }
 
 bool RCInput::rc_bind(int dsmMode){

--- a/libraries/AP_HAL_F4Light/RCInput.h
+++ b/libraries/AP_HAL_F4Light/RCInput.h
@@ -43,9 +43,6 @@ public:
     bool     new_input() override;
     uint8_t  num_channels() override;
 
-    bool set_override(uint8_t channel, int16_t override) override;
-    void clear_overrides() override;
-    
     bool rc_bind(int dsmMode) override;
 
     static uint16_t max_num_pulses; // for statistics
@@ -66,10 +63,6 @@ private:
     
     static uint16_t last_4;
     
-    /* override state */
-    static uint16_t _override[F4Light_RC_INPUT_NUM_CHANNELS];
-    static bool _override_valid;
-
     static bool rc_failsafe_enabled;    
 
     static bool fs_flag, aibao_fs_flag;

--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -50,9 +50,6 @@ uint8_t RCInput::num_channels()
 
 uint16_t RCInput::read(uint8_t ch)
 {
-    if (_override[ch]) {
-        return _override[ch];
-    }
     if (ch >= _num_channels) {
         return 0;
     }
@@ -67,27 +64,6 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     }
     return len;
 }
-
-bool RCInput::set_override(uint8_t channel, int16_t override)
-{
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < LINUX_RC_INPUT_NUM_CHANNELS) {
-        _override[channel] = override;
-        if (override != 0) {
-            rc_input_count++;
-            return true;
-        }
-    }
-    return false;
-}
-
-void RCInput::clear_overrides()
-{
-    for (uint8_t i = 0; i < LINUX_RC_INPUT_NUM_CHANNELS; i++) {
-       _override[i] = 0;
-    }
-}
-
 
 /*
   process a PPM-sum pulse of the given width

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -26,9 +26,6 @@ public:
         return _rssi;
     }
     
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
-
     // default empty _timer_tick, this is overridden by board
     // specific implementations
     virtual void _timer_tick() {}
@@ -61,9 +58,6 @@ protected:
     void _process_ppmsum_pulse(uint16_t width);
     void _process_sbus_pulse(uint16_t width_s0, uint16_t width_s1);
     void _process_dsm_pulse(uint16_t width_s0, uint16_t width_s1);
-
-    /* override state */
-    uint16_t _override[LINUX_RC_INPUT_NUM_CHANNELS];
 
     // state of ppm decoder
     struct {

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -21,7 +21,6 @@ void PX4RCInput::init()
     if (_rc_sub == -1) {
         AP_HAL::panic("Unable to subscribe to input_rc");
     }
-    clear_overrides();
     pthread_mutex_init(&rcin_mutex, nullptr);
 
 #if HAL_RCINPUT_WITH_AP_RADIO
@@ -40,12 +39,7 @@ bool PX4RCInput::new_input()
         // don't consider input valid if we are in RC failsafe.
         valid = false;
     }
-    if (_override_valid) {
-        // if we have RC overrides active, then always consider it valid
-        valid = true;
-    }
     _last_read = _rcin.timestamp_last_signal;
-    _override_valid = false;
     pthread_mutex_unlock(&rcin_mutex);
     if (_rcin.input_source != last_input_source) {
         gcs().send_text(MAV_SEVERITY_DEBUG, "RCInput: decoding %s", input_source_name(_rcin.input_source));
@@ -64,19 +58,10 @@ uint8_t PX4RCInput::num_channels()
 
 uint16_t PX4RCInput::read(uint8_t ch)
 {
-    if (ch >= RC_INPUT_MAX_CHANNELS) {
+    if (ch >= MIN(RC_INPUT_MAX_CHANNELS, _rcin.channel_count)) {
         return 0;
     }
     pthread_mutex_lock(&rcin_mutex);
-    if (_override[ch]) {
-        uint16_t v = _override[ch];
-        pthread_mutex_unlock(&rcin_mutex);
-        return v;
-    }
-    if (ch >= _rcin.channel_count) {
-        pthread_mutex_unlock(&rcin_mutex);
-        return 0;
-    }
     uint16_t v = _rcin.values[ch];
     pthread_mutex_unlock(&rcin_mutex);
 
@@ -99,28 +84,6 @@ uint8_t PX4RCInput::read(uint16_t* periods, uint8_t len)
         periods[i] = read(i);
     }
     return len;
-}
-
-bool PX4RCInput::set_override(uint8_t channel, int16_t override) {
-    if (override < 0) {
-        return false; /* -1: no change. */
-    }
-    if (channel >= RC_INPUT_MAX_CHANNELS) {
-        return false;
-    }
-    _override[channel] = override;
-    if (override != 0) {
-        _override_valid = true;
-        return true;
-    }
-    return false;
-}
-
-void PX4RCInput::clear_overrides()
-{
-    for (uint8_t i = 0; i < RC_INPUT_MAX_CHANNELS; i++) {
-        set_override(i, 0);
-    }
 }
 
 const char *PX4RCInput::input_source_name(uint8_t id) const

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -8,7 +8,7 @@
 
 
 #ifndef RC_INPUT_MAX_CHANNELS
-#define RC_INPUT_MAX_CHANNELS 18
+#define RC_INPUT_MAX_CHANNELS 18u
 #endif
 
 class PX4::PX4RCInput : public AP_HAL::RCInput {
@@ -23,21 +23,15 @@ public:
         return _rssi;
     }
         
-    
-    bool set_override(uint8_t channel, int16_t override) override;
-    void clear_overrides() override;
-
     void _timer_tick(void);
 
     bool rc_bind(int dsmMode) override;
 
 private:
     /* override state */
-    uint16_t _override[RC_INPUT_MAX_CHANNELS];
     struct rc_input_values _rcin;
     int _rc_sub;
     uint64_t _last_read;
-    bool _override_valid;
     perf_counter_t _perf_rcin;
     pthread_mutex_t rcin_mutex;
     int16_t _rssi = -1;

--- a/libraries/AP_HAL_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_SITL/RCInput.cpp
@@ -9,7 +9,6 @@ extern const AP_HAL::HAL& hal;
 
 void RCInput::init()
 {
-    clear_overrides();
 }
 
 bool RCInput::new_input()
@@ -26,9 +25,6 @@ uint16_t RCInput::read(uint8_t ch)
     if (ch >= SITL_RC_INPUT_CHANNELS) {
         return 0;
     }
-    if (_override[ch]) {
-        return _override[ch];
-    }
     return _sitlState->pwm_input[ch];
 }
 
@@ -43,22 +39,4 @@ uint8_t RCInput::read(uint16_t* periods, uint8_t len)
     return len;
 }
 
-bool RCInput::set_override(uint8_t channel, int16_t override)
-{
-    if (override < 0) {
-        return false;  /* -1: no change. */
-    }
-    if (channel < SITL_RC_INPUT_CHANNELS) {
-        _override[channel] = static_cast<uint16_t>(override);
-        if (override != 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-void RCInput::clear_overrides()
-{
-    memset(_override, 0, sizeof(_override));
-}
 #endif

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -18,14 +18,8 @@ public:
     uint16_t read(uint8_t ch) override;
     uint8_t read(uint16_t* periods, uint8_t len) override;
 
-    bool set_override(uint8_t channel, int16_t override) override;
-    void clear_overrides() override;
-
 private:
     SITL_State *_sitlState;
-
-    /* override state */
-    uint16_t _override[SITL_RC_INPUT_CHANNELS];
 };
 
 #endif

--- a/libraries/AP_HAL_VRBRAIN/RCInput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.h
@@ -22,21 +22,14 @@ public:
         return _rssi;
     }
         
-    
-    bool set_override(uint8_t channel, int16_t override) override;
-    void clear_overrides() override;
-
     void _timer_tick(void);
 
     bool rc_bind(int dsmMode) override;
 
 private:
-    /* override state */
-    uint16_t _override[RC_INPUT_MAX_CHANNELS];
     struct rc_input_values _rcin;
     int _rc_sub;
     uint64_t _last_read;
-    bool _override_valid;
     perf_counter_t _perf_rcin;
     pthread_mutex_t rcin_mutex;
     int16_t _rssi = -1;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -319,12 +319,6 @@ RC_Channel::percent_input()
     return ret;
 }
 
-void
-RC_Channel::input()
-{
-    radio_in = hal.rcin->read(ch_in);
-}
-
 uint16_t
 RC_Channel::read() const
 {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -82,6 +82,10 @@ public:
     int16_t    get_control_in() const { return control_in;}
     void       set_control_in(int16_t val) { control_in = val;}
 
+    void       clear_override();
+    void       set_override(const uint16_t v, const uint32_t timestamp_us=0);
+    bool       has_override() const;
+
     // get control input with zero deadzone
     int16_t     get_control_in_zero_dz(void);
     
@@ -123,6 +127,10 @@ private:
     // the input channel this corresponds to
     uint8_t     ch_in;
 
+    // overrides
+    uint16_t override_value;
+    uint32_t last_override_time;
+
     // bits set when channel has been identified as configured
     static uint32_t configured_mask;
 
@@ -137,6 +145,7 @@ private:
 class RC_Channels {
 public:
     friend class SRV_Channels;
+    friend class RC_Channel;
     // constructor
     RC_Channels(void);
 
@@ -155,10 +164,14 @@ public:
     static bool read_input(void);                                      // returns true if new input has been read in
     static void clear_overrides(void);                                 // clears any active overrides
     static bool receiver_bind(const int dsmMode);                      // puts the reciever in bind mode if present, returns true if success
-    static bool set_override(const uint8_t chan, const int16_t value); // set a channels override value
+    static void set_override(const uint8_t chan, const int16_t value, const uint32_t timestamp_ms = 0); // set a channels override value
+    static bool has_active_overrides(void);                            // returns true if there are overrides applied that are valid
 
 private:
     // this static arrangement is to avoid static pointers in AP_Param tables
     static RC_Channel *channels;
+    static bool has_new_overrides;
+    static AP_Float *override_timeout;
     RC_Channel obj_channels[NUM_RC_CHANNELS];
+    AP_Float _override_timeout;
 };

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -68,9 +68,6 @@ public:
     // read the input value from hal.rcin for this channel
     uint16_t    read() const;
 
-    // read input from hal.rcin and set as pwm input for channel
-    void        input();
-
     static const struct AP_Param::GroupInfo var_info[];
 
     // return true if input is within deadzone of trim


### PR DESCRIPTION
This is the first part of a several part process in fixing issues with override handling across the vehicles.

This is moving all the override handling out the HAL layer (where it doesn't belong) and into RC_Channels. Overrides are not actually a HAL concept at at all, and are entirely a layer of RC_Channels. By moving them up and out all the HAL's can be expected to handle overrides in the same method, as well as eliminating some inconsistencies between how the various HAL's map out the behavior.

The main changes that should be emphasized:
- Overrides can now individually timeout. Failure to update a channel for one second (Note: Is this to tight? (or should it be a parameter)) means we stop honoring the override on that channel. This is done on a per channel basis as not all channels are necessarily updated at the same time (or are still being updated).
- A side effect of the above change: If I'm flying the vehicle with a gamepad and then stop sending override packets, after one second all vehicle control has reverted to the RC Controller. I consider this a significant improvement as before the only way to revert to the RC input was to actually trigger a failsafe event (on plane this meant actually disconnecting the GCS for the duration, stopping sending packets was insufficient and would not break the vehicle out of the last commanded gamepad option).