### PR TITLE
Fix bad rebase for NMEA rangefinders + misc cleanup

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -273,10 +273,10 @@ void AP_AutoTune::log_param_change(float v, const char *suffix)
     }
     char key[AP_MAX_NAME_SIZE+1];
     if (type == AUTOTUNE_ROLL) {
-        strncpy(key, "RLL2SRV_", 8);
+        strncpy(key, "RLL2SRV_", 9);
         strncpy(&key[8], suffix, AP_MAX_NAME_SIZE-8);
     } else {
-        strncpy(key, "PTCH2SRV_", 9);
+        strncpy(key, "PTCH2SRV_", 10);
         strncpy(&key[9], suffix, AP_MAX_NAME_SIZE-9);
     }
     key[AP_MAX_NAME_SIZE] = 0;

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -83,7 +83,10 @@ public:
 
     // return true if airspeed is enabled
     bool enabled(uint8_t i) const {
-        return param[i].type.get() != TYPE_NONE;
+        if (i < AIRSPEED_MAX_SENSORS) {
+            return param[i].type.get() != TYPE_NONE;
+        }
+        return false;
     }
     bool enabled(void) const { return enabled(primary); }
 
@@ -92,8 +95,7 @@ public:
         state[primary].airspeed = airspeed;
     }
 
-    // return the differential pressure in Pascal for the last
-    // airspeed reading. Used by the calibration code
+    // return the differential pressure in Pascal for the last airspeed reading
     float get_differential_pressure(uint8_t i) const {
         return state[i].last_pressure;
     }
@@ -215,6 +217,8 @@ private:
     uint8_t primary;
     
     void read(uint8_t i);
+    // return the differential pressure in Pascal for the last airspeed reading for the requested instance
+    // returns 0 if the sensor is not enabled
     float get_pressure(uint8_t i);
     void update_calibration(uint8_t i, float raw_pressure);
     void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -739,8 +739,8 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case RangeFinder_TYPE_NMEA:
         if (AP_RangeFinder_NMEA::detect(serial_manager, serial_instance)) {
             drivers[instance] = new AP_RangeFinder_NMEA(state[instance], serial_manager, serial_instance++);
-            break;
         }
+        break;
     case RangeFinder_TYPE_WASP:
         if (AP_RangeFinder_Wasp::detect(serial_manager, serial_instance)) {
             drivers[instance] = new AP_RangeFinder_Wasp(state[instance], serial_manager, serial_instance++);


### PR DESCRIPTION
This started as a misc compiler warning (and internal docs) set of clean up commits, but it turns out I rebased on the NMEA stuff from randy badly by accident and got the break statement in the wrong place, potentially causing some NMEA rangefinder users issues.