### PR TITLE
Rover: add support for lateral control input in manual mode

### DIFF
--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -44,6 +44,9 @@ public:
     float get_throttle() const { return _throttle; }
     void set_throttle(float throttle);
 
+    // set lateral input as a value from -100 to +100
+    void set_lateral(float lateral);
+
     // get slew limited throttle
     // used by manual mode to avoid bad steering behaviour during transitions from forward to reverse
     // same as private slew_limit_throttle method (see below) but does not update throttle state
@@ -52,8 +55,8 @@ public:
     // true if vehicle is capable of skid steering
     bool have_skid_steering() const;
 
-    //true if vehicle is an omni rover
-    bool is_omni_rover() const;
+    //true if vehicle is capable of lateral movement
+    bool has_lateral_control() const;
 
     // true if vehicle has vectored thrust (i.e. boat with motor on steering servo)
     bool have_vectored_thrust() const { return is_positive(_vector_throttle_base); }
@@ -96,7 +99,7 @@ protected:
     void output_regular(bool armed, float ground_speed, float steering, float throttle);
 
     // output for omni style frames
-    void output_omni(bool armed, float steering, float throttle);
+    void output_omni(bool armed, float steering, float throttle, float lateral);
 
     // output to skid steering channels
     void output_skid_steering(bool armed, float steering, float throttle);
@@ -131,4 +134,5 @@ protected:
     float   _throttle;  // requested throttle as a value from -100 to 100
     float   _throttle_prev; // throttle input from previous iteration
     bool    _scale_steering = true; // true if we should scale steering by speed or angle
+    float   _lateral;  // requested lateral input as a value from -4500 to +4500
 };

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -27,6 +27,7 @@ Rover::Rover(void) :
     channel_steer(nullptr),
     channel_throttle(nullptr),
     channel_aux(nullptr),
+    channel_lateral(nullptr),
     DataFlash{fwver.fw_string, g.log_bitmask},
     modes(&g.mode1),
     nav_controller(&L1_controller),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -155,6 +155,7 @@ private:
     RC_Channel *channel_steer;
     RC_Channel *channel_throttle;
     RC_Channel *channel_aux;
+    RC_Channel *channel_lateral;
 
     DataFlash_Class DataFlash;
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -7,6 +7,7 @@ Mode::Mode() :
     g2(rover.g2),
     channel_steer(rover.channel_steer),
     channel_throttle(rover.channel_throttle),
+    channel_lateral(rover.channel_lateral),
     mission(rover.mission),
     attitude_control(rover.g2.attitude_control)
 { }
@@ -122,6 +123,19 @@ void Mode::get_pilot_desired_steering_and_speed(float &steering_out, float &spee
         steering_out *= -1;
     }
     speed_out = speed_out_limited;
+}
+
+// decode pilot lateral movement input and return in lateral_out argument
+void Mode::get_pilot_desired_lateral(float &lateral_out)
+{
+    // no RC input means no lateral input
+    if (rover.failsafe.bits & FAILSAFE_EVENT_THROTTLE) {
+        lateral_out = 0;
+        return;
+    }
+
+    // get pilot lateral input
+    lateral_out = rover.channel_lateral->get_control_in();
 }
 
 // set desired location

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -112,6 +112,9 @@ protected:
     // decode pilot input steering and return steering_out and speed_out (in m/s)
     void get_pilot_desired_steering_and_speed(float &steering_out, float &speed_out);
 
+    // decode pilot lateral movement input and return in lateral_out argument
+    void get_pilot_desired_lateral(float &lateral_out);
+
     // calculate steering output to drive along line from origin to destination waypoint
     void calc_steering_to_waypoint(const struct Location &origin, const struct Location &destination, bool reversed = false);
 
@@ -159,6 +162,7 @@ protected:
     class ParametersG2 &g2;
     class RC_Channel *&channel_steer;
     class RC_Channel *&channel_throttle;
+    class RC_Channel *&channel_lateral;
     class AP_Mission &mission;
     class AR_AttitudeControl &attitude_control;
 
@@ -352,6 +356,10 @@ public:
     // manual mode does not require position or velocity estimate
     bool requires_position() const override { return false; }
     bool requires_velocity() const override { return false; }
+
+protected:
+
+    void _exit() override;
 };
 
 

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -1,12 +1,20 @@
 #include "mode.h"
 #include "Rover.h"
 
+void ModeManual::_exit()
+{
+    // clear lateral when exiting manual mode
+    g2.motors.set_lateral(0);
+}
+
 void ModeManual::update()
 {
-    float desired_steering, desired_throttle;
+    float desired_steering, desired_throttle, desired_lateral;
     get_pilot_desired_steering_and_throttle(desired_steering, desired_throttle);
+    get_pilot_desired_lateral(desired_lateral);
 
     // copy RC scaled inputs to outputs
     g2.motors.set_throttle(desired_throttle);
     g2.motors.set_steering(desired_steering, false);
+    g2.motors.set_lateral(desired_lateral);
 }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -9,10 +9,12 @@ void Rover::set_control_channels(void)
     channel_steer    = RC_Channels::rc_channel(rcmap.roll()-1);
     channel_throttle = RC_Channels::rc_channel(rcmap.throttle()-1);
     channel_aux      = RC_Channels::rc_channel(g.aux_channel-1);
+    channel_lateral  = RC_Channels::rc_channel(rcmap.yaw()-1);
 
     // set rc channel ranges
     channel_steer->set_angle(SERVO_MAX);
     channel_throttle->set_angle(100);
+    channel_lateral->set_angle(100);
 
     // Allow to reconfigure ouput when not armed
     if (!arming.is_armed()) {
@@ -32,6 +34,7 @@ void Rover::init_rc_in()
     // set rc dead zones
     channel_steer->set_default_dead_zone(30);
     channel_throttle->set_default_dead_zone(30);
+    channel_lateral->set_default_dead_zone(30);
 }
 
 void Rover::init_rc_out()


### PR DESCRIPTION
This PR adds support for lateral control in Rover, it also has changes in the omni rover code so it can take advantage of lateral movement in manual mode. Support for lateral movement in the other modes is currently in the works.