### PR TITLE
Be consistent across our vehicles in terms of VFR_HUD.alt

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -53,6 +53,5 @@ private:
     MAV_STATE system_status() const override;
 
     int16_t vfr_hud_throttle() const override;
-    bool vfr_hud_make_alt_relative() const override { return true; }
 
 };

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -48,6 +48,5 @@ private:
     MAV_STATE system_status() const override;
 
     int16_t vfr_hud_throttle() const override;
-    bool vfr_hud_make_alt_relative() const override { return true; }
 
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -371,7 +371,6 @@ protected:
     virtual int32_t global_position_int_relative_alt() const;
 
     // these methods are called after vfr_hud_velned is updated
-    virtual bool vfr_hud_make_alt_relative() const { return false; }
     virtual float vfr_hud_climbrate() const;
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1753,20 +1753,13 @@ void GCS_MAVLINK::send_vfr_hud()
     ahrs.get_position(global_position_current_loc);
     ahrs.get_velocity_NED(vfr_hud_velned);
 
-    float alt;
-    if (vfr_hud_make_alt_relative()) {
-        ahrs.get_relative_position_D_home(alt);
-        alt = -alt;
-    } else {
-        alt = global_position_current_loc.alt / 100.0f;
-    }
     mavlink_msg_vfr_hud_send(
         chan,
         vfr_hud_airspeed(),
         ahrs.groundspeed(),
         (ahrs.yaw_sensor / 100) % 360,
         vfr_hud_throttle(),
-        alt,
+        global_position_current_loc.alt * 0.01f, // cm -> m
         vfr_hud_climbrate());
 }
 
@@ -2867,7 +2860,7 @@ void GCS_MAVLINK::send_global_position_int()
         global_position_current_loc.lat, // in 1E7 degrees
         global_position_current_loc.lng, // in 1E7 degrees
         global_position_int_alt(),       // millimeters above ground/sea level
-        global_position_int_relative_alt(), // millimeters above ground/sea level
+        global_position_int_relative_alt(), // millimeters above home
         vel.x * 100,                     // X speed cm/s (+ve North)
         vel.y * 100,                     // Y speed cm/s (+ve East)
         vel.z * 100,                     // Z speed cm/s (+ve Down)


### PR DESCRIPTION
Sub and Copter were erroneously (according to spec) sending height-above-home in this field.

This PR makes all of our vehicles consistent, sending height above (below...) MSL.

@night-ghost - there's some confusion about MinimOSD's handling of this field.  At least we'll be consistent after this PR.
