### PR TITLE
Enable Werror by default, fix GCC 8.1

### DIFF
--- a/Tools/Replay/DataFlashFileReader.cpp
+++ b/Tools/Replay/DataFlashFileReader.cpp
@@ -81,7 +81,10 @@ bool DataFlashFileReader::update(char type[5])
             return false;
         }
         memcpy(&formats[f.type], &f, sizeof(formats[f.type]));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         strncpy(type, "FMT", 3);
+#pragma GCC diagnostic pop
         type[3] = 0;
 
         message_count++;

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -373,9 +373,12 @@ void LogReader::end_format_msgs(void)
                 pkt.msgid = LOG_FORMAT_MSG;
                 pkt.type = s->msg_type;
                 pkt.length = s->msg_len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
                 strncpy(pkt.name, s->name, sizeof(pkt.name));
                 strncpy(pkt.format, s->format, sizeof(pkt.format));
                 strncpy(pkt.labels, s->labels, sizeof(pkt.labels));
+#pragma GCC diagnostic pop
                 dataflash.WriteCriticalBlock(&pkt, sizeof(pkt));
             }
         }

--- a/Tools/Replay/MsgHandler.h
+++ b/Tools/Replay/MsgHandler.h
@@ -115,6 +115,7 @@ inline void MsgHandler::field_value_for_type_at_offset(uint8_t *msg,
 {
     /* we register the types - add_field_type - so can we do without
      * this switch statement somehow? */
+
     switch (type) {
     case 'B':
         ret = (R)(((uint8_t*)&msg[offset])[0]);

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -923,7 +923,10 @@ void Replay::load_param_file(const char *pfilename)
             continue;
         }
         struct user_parameter *u = new user_parameter;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         strncpy(u->name, pname, sizeof(u->name));
+#pragma GCC diagnostic pop
         u->value = value;
         u->next = user_parameters;
         user_parameters = u;

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -132,7 +132,14 @@ class Board:
             '-Werror=switch',
             '-Wfatal-errors',
             '-Wno-trigraphs',
+            '-Wno-unknown-warning',
+            '-Wno-class-memaccess',
         ]
+
+        if not cfg.options.disable_werror:
+            env.CXXFLAGS += [
+                    '-Werror'
+            ]
 
         if 'clang++' in cfg.env.COMPILER_CXX:
             env.CXXFLAGS += [

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -639,7 +639,10 @@ uint8_t AP_ADSB::get_encoded_callsign_null_char()
 
     // using the above logic, we must always assign the squawk. once we get configured
     // externally then get_encoded_callsign_null_char() stops getting called
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal));
+#pragma GCC diagnostic pop
     memset(&out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
     encoded_null |= 0x40;
 

--- a/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
+++ b/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
@@ -184,6 +184,7 @@ static void spi_init()
 }
 #endif
 
+#ifdef HAL_INS_MPU60x0_NAME
 /*
   send a 16 bit command to the baro
  */
@@ -217,7 +218,6 @@ static bool read_calibration_data(void)
     return true;
 }
 
-#ifdef HAL_INS_MPU60x0_NAME
 // initialise baro on i2c
 static void i2c_init(void)
 {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -467,7 +467,10 @@ void AP_Frsky_Telem::queue_message(MAV_SEVERITY severity, const char *text)
     mavlink_statustext_t statustext{};
 
     statustext.severity = severity;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(statustext.text, text, sizeof(statustext.text));
+#pragma GCC diagnostic pop
 
     // The force push will ensure comm links do not block other comm links forever if they fail.
     // If we push to a full buffer then we overwrite the oldest entry, effectively removing the

--- a/libraries/AP_HAL_Linux/Storage.cpp
+++ b/libraries/AP_HAL_Linux/Storage.cpp
@@ -116,7 +116,7 @@ int Storage::_storage_create(const char *dpath)
     // take up all needed space
     if (ftruncate(fd, sizeof(_buffer)) == -1) {
         fprintf(stderr, "Failed to set file size to %u kB (%m)\n",
-                sizeof(_buffer) / 1024);
+                (unsigned int)(sizeof(_buffer) / 1024));
         goto fail;
     }
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -34,9 +34,12 @@ void DataFlash_Backend::Log_Fill_Format(const struct LogStructure *s, struct log
     pkt.msgid = LOG_FORMAT_MSG;
     pkt.type = s->msg_type;
     pkt.length = s->msg_len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(pkt.name, s->name, sizeof(pkt.name));
     strncpy(pkt.format, s->format, sizeof(pkt.format));
     strncpy(pkt.labels, s->labels, sizeof(pkt.labels));
+#pragma GCC diagnostic pop
 }
 
 /*
@@ -50,8 +53,11 @@ void DataFlash_Backend::Log_Fill_Format_Units(const struct LogStructure *s, stru
     pkt.msgid = LOG_FORMAT_UNITS_MSG;
     pkt.time_us = AP_HAL::micros64();
     pkt.format_type = s->msg_type;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(pkt.units, s->units, sizeof(pkt.units));
     strncpy(pkt.multipliers, s->multipliers, sizeof(pkt.multipliers));
+#pragma GCC diagnostic pop
 }
 
 /*
@@ -75,7 +81,10 @@ bool DataFlash_Backend::Log_Write_Unit(const struct UnitStructure *s)
         type    : s->ID,
         unit    : { }
     };
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(pkt.unit, s->unit, sizeof(pkt.unit));
+#pragma GCC diagnostic pop
 
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
@@ -116,7 +125,10 @@ bool DataFlash_Backend::Log_Write_Parameter(const char *name, float value)
         name  : {},
         value : value
     };
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(pkt.name, name, sizeof(pkt.name));
+#pragma GCC diagnostic pop
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
@@ -430,7 +442,10 @@ bool DataFlash_Backend::Log_Write_Message(const char *message)
         time_us : AP_HAL::micros64(),
         msg  : {}
     };
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(pkt.msg, message, sizeof(pkt.msg));
+#pragma GCC diagnostic pop
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1254,7 +1254,10 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
     }
 
     statustext.msg.severity = severity;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy(statustext.msg.text, text, sizeof(statustext.msg.text));
+#pragma GCC diagnostic pop
 
     // The force push will ensure comm links do not block other comm links forever if they fail.
     // If we push to a full buffer then we overwrite the oldest entry, effectively removing the

--- a/wscript
+++ b/wscript
@@ -138,6 +138,11 @@ configuration in order to save typing.
         default=False,
         help='Force a static build')
 
+    g.add_option('--disable-werror',
+        action='store_true',
+        default=False,
+        help='Disable builds with -Werror')
+
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []


### PR DESCRIPTION
This fixes up a variety of GCC 8.1 warnings about clearing an object of non-trivial type. Stuff like:
```
../../libraries/AP_OpticalFlow/OpticalFlow.cpp: In constructor ‘OpticalFlow::OpticalFlow(AP_AHRS_NavEKF&)’:
../../libraries/AP_OpticalFlow/OpticalFlow.cpp:78:38: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct OpticalFlow::OpticalFlow_state’; use assignment or value-initialization instead [-Wclass-memaccess]                                                              
     memset(&_state, 0, sizeof(_state));
                                      ^
In file included from ../../libraries/AP_OpticalFlow/OpticalFlow.cpp:2:
../../libraries/AP_OpticalFlow/OpticalFlow.h:66:12: note: ‘struct OpticalFlow::OpticalFlow_state’ declared here
     struct OpticalFlow_state {
            ^~~~~~~~~~~~~~~~~
```

There are two possible fixes for this: `memset((void *)&_state, 0, sizeof(_state));` or `_state = {};` the initializer list usually is optimized by the compiler to a memset (as shown by godbolt on a cariety of settings). This PR presents the initializer approach. Sometimes it's a net loss, depends on structure alignment. Overall this change set saves us 336 bytes on fmuv3. (And fixes a lot of noisy warnings on my SITL setup)