### PR TITLE
Updated description of ArduPlane Roll Controller for accuracy

### DIFF
--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -192,7 +192,7 @@ int32_t AP_RollController::get_rate_out(float desired_rate, float scaler)
 }
 
 /*
- Function returns an equivalent elevator deflection in centi-degrees in the range from -4500 to 4500
+ Function returns an equivalent aileron deflection in centi-degrees in the range from -4500 to 4500
  A positive demand is up
  Inputs are: 
  1) demanded bank angle in centi-degrees


### PR DESCRIPTION
AP_RollController's get_servo_out function does not return an elevator deflection, as was previously described in the function comments.

Instead, it returns an aileron deflection. Thus, the function description should be updated to reflect this more accurately