### PR TITLE
EKF: use onGround flag to set rangefinder on-ground range

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -93,7 +93,7 @@ void NavEKF2_core::readRangeFinder(void)
                 // indicate we have updated the measurement
                 rngValidMeaTime_ms = imuSampleTime_ms;
 
-            } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+            } else if (onGround && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
                 rangeDataNew.rng = rngOnGnd;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -89,7 +89,7 @@ void NavEKF3_core::readRangeFinder(void)
                 // indicate we have updated the measurement
                 rngValidMeaTime_ms = imuSampleTime_ms;
 
-            } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+            } else if (onGround && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
                 rangeDataNew.rng = rngOnGnd;


### PR DESCRIPTION
Fixes Issue #7824.

I found the same problem recently wherein the EKF didn't properly switch the altitude source to Baro even when I left my radar altimeter unplugged. The readRangeFinder() function currently pushes a new rangefinder measurement of 'rngOnGnd' when there's no recent rangefinder measurement _and_  'takeOffDetected' is false. However, 'takeOffDetected' is only set when optical flow is enabled, so even if the rangefinder reports NoData this readRangeFinder() function will continue to effectively report that there's a valid rangefinder measurement of 'rngOnGnd'. In other words, if something happened to the rangefinder mid-flight, the EKF never actually switches to Baro Alt which causes a flyaway condition in the altitude controller.

This PR changes the above behavior such that the readRangeFinder() function will only assume on-ground range when 'onGround' is True - 'onGround' being independent of optical flow and updated whenever the EKF is updated via NavEKF2_core::UpdateFilter(). Testing showed proper switching to Baro Alt and good altitude control even when the rangefinder was not plugged into the flight controller.

Note, I'm not exactly certain how this will affect behavior when optical flow is in use, so it might make more sense to still utilize 'takeOffDetected' but only when optical flow is enabled. 