### PR TITLE
RFC - AP_UAVCAN: add redundancy feature to mute outputs

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -6,6 +6,7 @@
 #define AP_UAVCAN_H_
 
 #include <uavcan/uavcan.hpp>
+#include <vector>
 
 #include <AP_HAL/CAN.h>
 #include <AP_HAL/Semaphores.h>
@@ -47,6 +48,8 @@
 #define AP_UAVCAN_MAX_LED_DEVICES 4
 #define AP_UAVCAN_LED_DELAY_MILLISECONDS 50
 
+#define AP_UAVCAN_MAX_NODESTATUS_LIST_SIZE 10
+
 class AP_UAVCAN {
 public:
     AP_UAVCAN();
@@ -77,6 +80,22 @@ public:
 
     // Updates all listeners of specified node
     void update_gps_state(uint8_t node);
+
+    struct nodeStatus_info {
+        uavcan::protocol::NodeStatus nodeStatus;
+        uint8_t id;
+        uint32_t timestamp_ms;
+     };
+     std::vector<nodeStatus_info> _nodeStatus_info;
+
+     struct redundancy_info {
+         uint32_t task_last_ms;
+         uint8_t highest_active_nodeId;
+         uint8_t highest_active_nodeId_index;
+         AP_Int8 enabled;
+         bool allow_outputs;
+     };
+     redundancy_info _redundancy;
 
     struct Baro_Info {
         float pressure;
@@ -250,6 +269,8 @@ private:
         {
         }
     };
+
+    void redundancy_task();
 
     uavcan::HeapBasedPoolAllocator<UAVCAN_NODE_POOL_BLOCK_SIZE, AP_UAVCAN::RaiiSynchronizer> _node_allocator;
 


### PR DESCRIPTION
Request For Comment - Redundancy. This is an initial attempt to make redundancy possible with UAVCAN. 

When enabled, if it detects any other device on the bus with a higher NodeID then it mutes all outputs. The idea is to keep this unit in constant RTL state so that if another primary autopilot with a higher Node ID dies then this one will instantly takeover the servo/ESC control and fly you home.

This is a bit primitive, and could be expanded on much more. Such as,:
- checking that the higher NodeID is actually an autopilot
- once a failsafe state happens and this unit takes over, it might be good to stay in that state forever (sticky failsafe state) but that runs the risk of two units talking to the Servos/ESCs on the same bus... so it gets complicated.


Several other events need to happen to make this possible, such as setting the home point and arming, but that is outside the scope of this PR.