### PR TITLE
GCS_MAVLink: avoid pushing partial RC_CHANNEL message into uart

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1014,10 +1014,10 @@ void GCS_MAVLINK::send_radio_in()
             values[6],
             values[7],
             receiver_rssi);
-        if (!HAVE_PAYLOAD_SPACE(chan, RC_CHANNELS)) {
-            // can't fit RC_CHANNELS
-            return;
-        }
+    }
+    if (!HAVE_PAYLOAD_SPACE(chan, RC_CHANNELS)) {
+        // can't fit RC_CHANNELS
+        return;
     }
     mavlink_msg_rc_channels_send(
         chan,


### PR DESCRIPTION
In the case we do not send RC_CHANNELS_RAW, we will not check to see if
RC_CHANNELS will fit.  RC_CHANNELS is larger than RC_CHANNELS_RAW, so the
check in the caller is insufficient.