### PR TITLE
Plane: Only send healthy airspeed reports

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -243,7 +243,7 @@ float GCS_MAVLINK_Plane::vfr_hud_airspeed() const
     // will use an airspeed sensor, that value is constrained by the
     // ground speed.  When reporting we should send the true airspeed
     // value if possible:
-    if (plane.airspeed.enabled()) {
+    if (plane.airspeed.enabled() && plane.airspeed.healthy()) {
         return plane.airspeed.get_airspeed();
     }
 


### PR DESCRIPTION
Was discussed, and to my recollection agreed on as a reasonable improvement on the last dev call, I couldn't get it attached to #8434 at the time. The key point is that we should always be trying to give the GCS the best possible estimate of what the airspeed is, rather then serving potentially stale data.