### PR TITLE
Rover: guided mode more forgiving of set-position-targets type_mask

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -962,7 +962,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             }
 
             // set guided mode targets
-            if (!pos_ignore && vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {
+            if (!pos_ignore) {
                 // consume position target
                 rover.mode_guided.set_desired_location(target_loc);
             } else if (pos_ignore && !vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {
@@ -1064,7 +1064,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
             }
 
             // set guided mode targets
-            if (!pos_ignore && vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {
+            if (!pos_ignore) {
                 // consume position target
                 rover.mode_guided.set_desired_location(target_loc);
             } else if (pos_ignore && !vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {


### PR DESCRIPTION
This change to rover means we will accept position targets received in SET_POSITION_TARGET_LOCAL_NED and SET_POSITION_TARGET_GLOBAL_INT messages more easily.

At least one user has hit problems getting Rover to obey these commands because one of the type-mask field bits was set incorrectly ([discussion is here](https://discuss.ardupilot.org/t/driving-rover-with-waypoints-without-gps)).  In this particular case the bit for heading or yaw-rate was set which Rover interpreted as meaning the user wanted to specify a heading or yaw-rate.  In rovers, the combination of a position request and a heading or yaw-rate is not a valid request and currently we reject this.  With this change we will instead process the position-target request, ignoring the requested heading.