### PR TITLE
CI: Run param parse last, on all CI instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,6 @@ before_install:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then export CI_CRON_JOB=1 ; fi
 
 script:
-  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2
-  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle AntennaTracker
-  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduCopter
-  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduPlane
-  - python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduSub
   - Tools/scripts/build_ci.sh
 
 before_cache:

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -128,5 +128,11 @@ for t in $CI_BUILD_TARGET; do
     fi
 done
 
+python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle APMrover2
+python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle AntennaTracker
+python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduCopter
+python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduPlane
+python Tools/autotest/param_metadata/param_parse.py --no-emit --vehicle ArduSub
+
 echo build OK
 exit 0


### PR DESCRIPTION
This makes param parse failures much more obvious in the CI logs, as
well as ensuring that both Semaphore and Travis will fail on bad
parameter data (which should reduce user confusion when one service
passes and the other fails).