### PR TITLE
AP_HAL_Linux: change SPI Bus for PocketPilot final design

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -101,8 +101,8 @@ SPIDesc SPIDeviceManager::_device[] = {
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_POCKET
 SPIDesc SPIDeviceManager::_device[] = {
-    SPIDesc("mpu9250",    1, 1, SPI_MODE_3, 8, SPI_CS_KERNEL,  1*MHZ, 11*MHZ),
-    SPIDesc("bmp280",     1, 0, SPI_MODE_0, 8, SPI_CS_KERNEL,  10*MHZ,10*MHZ),
+    SPIDesc("mpu9250",    2, 1, SPI_MODE_3, 8, SPI_CS_KERNEL,  1*MHZ, 11*MHZ),
+    SPIDesc("bmp280",     2, 0, SPI_MODE_0, 8, SPI_CS_KERNEL,  10*MHZ,10*MHZ),
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_OCPOC_ZYNQ
 SPIDesc SPIDeviceManager::_device[] = {


### PR DESCRIPTION
 PocketPilot should be released with Linux RT Kernel 4.14. Unfortunately this Kernel has still some issues (~40% idle CPU load). That is the reason PocketPilot will now use Linux RT Kernel 4.9, tested with BBBmini and BeagleBone Blue without any issues. But from 4.9 to 4.14 the /dev/spidev names (numbers) changed, that is the reason for this PR.