### PR TITLE
create correct USB ID's for the Cube orange

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/cube-black/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/cube-black/hwdef.dat
@@ -1,0 +1,12 @@
+# hw definition file for processing by chibios_hwdef.py
+# for The CUBE Black and the Cube Purple hardware
+# this is based on fmuv3, but with vendor specific USB IDs
+
+include ../fmuv3/hwdef.dat
+
+# USB setup
+USB_VENDOR 0x2DAE # ONLY FOR USE BY HEX! NOBODY ELSE
+USB_PRODUCT 0x1001
+USB_STRING_MANUFACTURER "Hex / ProfiCNC"
+USB_STRING_PRODUCT "CUBE Black"
+USB_STRING_SERIAL  "%SERIAL%"


### PR DESCRIPTION
Also corrected some naming to use the correct "The CUBE" naming convention 
It is The CUBE Black
The Cube Orange etc.
Also deleted the duplicate APJ_BOARD_ID