### PR TITLE
AP_AHRS: AP_AHRS_DCM: do not use home altitude if it is not set

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -664,7 +664,7 @@ if __name__ == "__main__":
                       action='store_true',
                       help='enable experimental tests')
     parser.add_option("--timeout",
-                      default=3000,
+                      default=3600,
                       type='int',
                       help='maximum runtime in seconds')
     parser.add_option("--frame",

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1709,6 +1709,15 @@ class AutoTest(ABC):
         if orig_home is None:
             raise AutoTestTimeoutException()
         self.progress("Original home: %s" % str(orig_home))
+        # original home should be close to SITL home...
+        start_loc = self.sitl_start_location()
+        self.progress("SITL start loc: %s" % str(start_loc))
+        if abs(orig_home.latitude * 1.0e-7 - start_loc.lat) > 0.0000001:
+            raise ValueError("homes differ in lat")
+        if abs(orig_home.longitude * 1.0e-7 - start_loc.lng) > 0.0000001:
+            raise ValueError("homes differ in lon")
+        if abs(orig_home.altitude * 1.0e-3 - start_loc.alt) > 2: # metres
+            raise ValueError("homes differ in alt")
         new_x = orig_home.latitude + 1000
         new_y = orig_home.longitude + 2000
         new_z = orig_home.altitude + 300000 # 300 metres

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -13,7 +13,7 @@ import operator
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
-HOME = mavutil.location(-27.274439, 151.290064, 343, 8.7)
+SITL_START_LOCATION = mavutil.location(-27.274439, 151.290064, 343, 8.7)
 MISSION = 'ArduPlane-Missions/Dalby-OBC2016.txt'
 FENCE = 'ArduPlane-Missions/Dalby-OBC2016-fence.txt'
 WIND = "0,180,0.2"  # speed,direction,variance
@@ -39,17 +39,24 @@ class AutoTestQuadPlane(AutoTest):
         self.gdbserver = gdbserver
         self.breakpoints = breakpoints
 
-        self.home = "%f,%f,%u,%u" % (HOME.lat,
-                                     HOME.lng,
-                                     HOME.alt,
-                                     HOME.heading)
-        self.homeloc = None
         self.speedup = speedup
 
         self.log_name = "QuadPlane"
         self.logfile = None
 
         self.sitl = None
+
+    # def initial_mode(self):
+    #     return "FBWA"
+
+    def initial_mode_switch_mode(self):
+        return "FBWA"
+
+    def default_mode(self):
+        return "FBWA"
+
+    def sitl_start_location(self):
+        return SITL_START_LOCATION
 
     def init(self):
         if self.frame is None:
@@ -64,7 +71,7 @@ class AutoTestQuadPlane(AutoTest):
         self.sitl = util.start_SITL(self.binary,
                                     wipe=True,
                                     model=self.frame,
-                                    home=self.home,
+                                    home=self.sitl_home(),
                                     speedup=self.speedup,
                                     defaults_file=defaults_filepath,
                                     valgrind=self.valgrind,

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -376,7 +376,10 @@ AP_AHRS_DCM::_yaw_gain(void) const
 // return true if we have and should use GPS
 bool AP_AHRS_DCM::have_gps(void) const
 {
-    if (AP::gps().status() <= AP_GPS::NO_FIX || !_gps_use) {
+    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+        return false;
+    }
+    if (!_gps_use) {
         return false;
     }
     return true;
@@ -631,7 +634,6 @@ AP_AHRS_DCM::drift_correction(float deltat)
     const AP_GPS &_gps = AP::gps();
 
     if (!have_gps() ||
-            _gps.status() < AP_GPS::GPS_OK_FIX_3D ||
             _gps.num_sats() < _gps_minsats) {
         // no GPS, or not a good lock. From experience we need at
         // least 6 satellites to get a really reliable velocity number

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -194,4 +194,9 @@ private:
 
     // time when DCM was last reset
     uint32_t _last_startup_ms;
+
+    // we may set _home.alt from the GPS to avoid a circular
+    // dependency when attempting to use DCM's position to set home
+    // location.
+    bool _home_alt_set_from_gps;
 };


### PR DESCRIPTION
_home.alt may be unset here.

In particular, Rover calls ahrs.get_position() when it is trying to set
home.  That means we are trying to set home using a function which
relies on home location being set....

Without this patch Rover gets an absolute home position of 0 metres.

One alternative is to do what Plane does - set it from GPS in the Rover code.  We would probably need the same patch in Tracker, however.
