### PR TITLE
Modified socket creation in order to make it work on macOS

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -222,9 +222,14 @@ void UARTDriver::_tcp_start_connection(uint16_t port, bool wait_for_connection)
         }
         sockaddr.sin_family = AF_INET;
 
-        _listen_fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        _listen_fd = socket(AF_INET, SOCK_STREAM, 0);
         if (_listen_fd == -1) {
             fprintf(stderr, "socket failed - %s\n", strerror(errno));
+            exit(1);
+        }
+        ret = fcntl(_listen_fd, F_SETFD, FD_CLOEXEC);
+        if (ret == -1) {
+            fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
             exit(1);
         }
 
@@ -300,9 +305,14 @@ void UARTDriver::_tcp_start_client(const char *address, uint16_t port)
     sockaddr.sin_family = AF_INET;
     sockaddr.sin_addr.s_addr = inet_addr(address);
 
-    _fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    _fd = socket(AF_INET, SOCK_STREAM, 0);
     if (_fd == -1) {
         fprintf(stderr, "socket failed - %s\n", strerror(errno));
+        exit(1);
+    }
+    ret = fcntl(_fd, F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
         exit(1);
     }
 


### PR DESCRIPTION
SITL no longer compiles under macOS after commit f986f1366ff55859bb96764a09fc3e28d83ec776 adds the SOCK_CLOEXEC option to the socket type. This is not standard unix and doesn't work on the Mac.

In order to make it work I've removed the SOCK_CLOEXEC option and added FD_CLOEXEC parameter with fcntl after creating the socket.

This should make it compatible with any modern unix. I've tested it and it compiles under mac.