### PR TITLE
AP_HAL_SITL: Add UDP stream of GPS data.

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -98,6 +98,9 @@ void SITL_State::_sitl_setup(const char *home_str)
         if (_use_fg_view) {
             fg_socket.connect("127.0.0.1", _fg_view_port);
         }
+        if (_use_gps_stream) {
+            gps_socket.connect("127.0.0.1", _gps_stream_port);
+        }
 
         fprintf(stdout, "Using Irlock at port : %d\n", _irlock_port);
         _sitl->irlock_port = _irlock_port;

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -166,6 +166,7 @@ private:
     uint16_t _rcout_port;
     uint16_t _rcin_port;
     uint16_t _fg_view_port;
+    uint16_t _gps_stream_port;
     uint16_t _irlock_port;
     float _current;
 
@@ -173,6 +174,7 @@ private:
 
     bool _use_rtscts;
     bool _use_fg_view;
+    bool _use_gps_stream;
     
     const char *_fdm_address;
 
@@ -219,7 +221,10 @@ private:
 
     // output socket for flightgear viewing
     SocketAPM fg_socket{true};
-    
+
+    // output socket for raw GPS mirroring.
+    SocketAPM gps_socket{true};
+
     // TCP address to connect uartC to
     const char *_client_address;
 

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -137,6 +137,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     const char *model_str = nullptr;
     _client_address = nullptr;
     _use_fg_view = true;
+    _use_gps_stream = true;
     char *autotest_dir = nullptr;
     _fdm_address = "127.0.0.1";
 
@@ -144,10 +145,12 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     const int RCIN_PORT = 5501;
     const int RCOUT_PORT = 5502;
     const int FG_VIEW_PORT = 5503;
+    const int GPS_STREAM_PORT = 5504;
     _base_port = BASE_PORT;
     _rcin_port = RCIN_PORT;
     _rcout_port = RCOUT_PORT;
     _fg_view_port = FG_VIEW_PORT;
+    _gps_stream_port = GPS_STREAM_PORT;
 
     const int SIM_IN_PORT = 9003;
     const int SIM_OUT_PORT = 9002;
@@ -265,6 +268,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             }
             if (_irlock_port == IRLOCK_PORT) {
                 _irlock_port += _instance * 10;
+            }
+            if (_gps_stream_port == GPS_STREAM_PORT) {
+                _gps_stream_port += _instance * 10;
             }
         }
         break;

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -103,25 +103,28 @@ int SITL_State::gps2_pipe(void)
  */
 void SITL_State::_gps_write(const uint8_t *p, uint16_t size, uint8_t instance)
 {
-    while (size--) {
+    uint16_t remaining = size;
+    const uint8_t *cur = p;
+    while (remaining--) {
         if (_sitl->gps_byteloss > 0.0f) {
             float r = ((((unsigned)random()) % 1000000)) / 1.0e4;
             if (r < _sitl->gps_byteloss) {
                 // lose the byte
-                p++;
+                cur++;
                 continue;
             }
         }
         if (instance == 0 && gps_state.gps_fd != 0) {
-            write(gps_state.gps_fd, p, 1);
+            write(gps_state.gps_fd, cur, 1);
         }
         if (instance == 1 && _sitl->gps2_enable) {
             if (gps2_state.gps_fd != 0) {
-                write(gps2_state.gps_fd, p, 1);
+                write(gps2_state.gps_fd, cur, 1);
             }
         }
-        p++;
+        cur++;
     }
+    gps_socket.send(p, size);
 }
 
 /*


### PR DESCRIPTION
Enable a copy of the (uncorrupted) GPS stream to be exported over a UDP
port for debugging purposes.
