### PR TITLE
Use CLOEXEC in more places

### DIFF
--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -111,6 +111,14 @@ void SocketAPM::set_blocking(bool blocking)
 }
 
 /*
+  set cloexec state
+ */
+void SocketAPM::set_cloexec()
+{
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+}
+
+/*
   send some data
  */
 ssize_t SocketAPM::send(const void *buf, size_t size)

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -39,6 +39,7 @@ public:
     bool bind(const char *address, uint16_t port);
     void reuseaddress();
     void set_blocking(bool blocking);
+    void set_cloexec();
     void set_broadcast(void);
 
     ssize_t send(const void *pkt, size_t size);

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -118,11 +118,12 @@ void SITL_State::_setup_fdm(void)
 {
     if (!_sitl_rc_in.bind("0.0.0.0", _rcin_port)) {
         fprintf(stderr, "SITL: socket bind failed on RC in port : %d - %s\n", _rcin_port, strerror(errno));
-        fprintf(stderr, "Abording launch...\n");
+        fprintf(stderr, "Aborting launch...\n");
         exit(1);
     }
     _sitl_rc_in.reuseaddress();
     _sitl_rc_in.set_blocking(false);
+    _sitl_rc_in.set_cloexec();
 }
 #endif
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -267,6 +267,7 @@ void UARTDriver::_tcp_start_connection(uint16_t port, bool wait_for_connection)
         }
         setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
         setsockopt(_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+        fcntl(_fd, F_SETFD, FD_CLOEXEC);
         _connected = true;
     }
 }


### PR DESCRIPTION
When combined with a pymavlink patch (https://github.com/ArduPilot/pymavlink/pull/188), this allows the reboot command in SITL (and autotest, hopefully!) to work entirely.

@macusers are encouraged to test :-)
