### PR TITLE
Rover: allow steering to Motors beyond -1 to +1 range

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -449,7 +449,7 @@ void AP_MotorsUGV::output_regular(bool armed, float ground_speed, float steering
                         limit.steer_right = true;
                     }
                 }
-                // reverse steering output if backing up
+                // reverse steering direction when backing up
                 if (is_negative(ground_speed)) {
                     steering *= -1.0f;
                 }

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -88,6 +88,14 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("VEC_THR_BASE", 10, AP_MotorsUGV, _vector_throttle_base, 0.0f),
 
+    // @Param: SPD_SCA_BASE
+    // @DisplayName: Motor speed scaling base speed
+    // @Description: Speed above which steering is scaled down when using regular steering/throttle vehicles.  zero to disable speed scaling
+    // @Units: m/s
+    // @Range: 0 10
+    // @User: Advanced
+    AP_GROUPINFO("SPD_SCA_BASE", 11, AP_MotorsUGV, _speed_scale_base, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -431,9 +439,9 @@ void AP_MotorsUGV::output_regular(bool armed, float ground_speed, float steering
                     steering *= constrain_float(_vector_throttle_base / fabsf(throttle), 0.0f, 1.0f);
                 }
             } else {
-                // scale steering down as speed increase above 1m/s
-                if (fabsf(ground_speed) > 1.0f) {
-                    steering *= (1.0f / fabsf(ground_speed));
+                // scale steering down as speed increase above MOT_SPD_SCA_BASE (1 m/s default)
+                if (is_positive(_speed_scale_base) && (fabsf(ground_speed) > _speed_scale_base)) {
+                    steering *= (_speed_scale_base / fabsf(ground_speed));
                 } else {
                     // regular steering rover at low speed so set limits to stop I-term build-up in controllers
                     if (!have_skid_steering()) {

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -131,6 +131,7 @@ protected:
     AP_Int8 _throttle_max; // throttle maximum percentage
     AP_Float _thrust_curve_expo; // thrust curve exponent from -1 to +1 with 0 being linear
     AP_Float _vector_throttle_base;  // throttle level above which steering is scaled down when using vector thrust.  zero to disable vectored thrust
+    AP_Float _speed_scale_base;  // speed above which steering is scaled down when using regular steering/throttle vehicles.  zero to disable speed scaling
 
     // internal variables
     float   _steering;  // requested steering as a value from -4500 to +4500

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -285,7 +285,7 @@ float AR_AttitudeControl::get_steering_out_rate(float desired_rate, bool motor_l
     const float d = _steer_rate_pid.get_d();
 
     // constrain and return final output
-    return constrain_float(ff + p + i + d, -1.0f, 1.0f);
+    return (ff + p + i + d);
 }
 
 // get latest desired turn rate in rad/sec (recorded during calls to get_steering_out_rate)

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -43,15 +43,18 @@ public:
     // steering controller
     //
 
-    // return a steering servo output from -1.0 to +1.0 given a desired lateral acceleration rate in m/s/s.
+    // return a steering servo output given a desired lateral acceleration rate in m/s/s.
     // positive lateral acceleration is to the right.  dt should normally be the main loop rate.
+    // return value is normally in range -1.0 to +1.0 but can be higher or lower
     float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right, float dt);
 
-    // return a steering servo output from -1 to +1 given a heading in radians
+    // return a steering servo output given a heading in radians
+    // return value is normally in range -1.0 to +1.0 but can be higher or lower
     float get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right, float dt);
 
-    // return a steering servo output from -1 to +1 given a
-    // desired yaw rate in radians/sec. Positive yaw is to the right.
+    // return a steering servo output given a desired yaw rate in radians/sec.
+    // positive yaw is to the right
+    // return value is normally in range -1.0 to +1.0 but can be higher or lower
     float get_steering_out_rate(float desired_rate, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // get latest desired turn rate in rad/sec recorded during calls to get_steering_out_rate.  For reporting purposes only


### PR DESCRIPTION
This PR attempts to resolve and issue with loss of steering control for vehicles traveling at high speeds.  This issue was caused by [this earlier PR](https://github.com/ArduPilot/ardupilot/pull/8312) which moved the speed-scaling from the attitude controller to the motors library.  The potential issue was recognised and sadly now it's been confirmed during beta testing.  Comments from the PR are copied below:

> the potential downside of the change is that at very high speeds the steering control may become so limited that it cannot counteract a physical misalignment in the steering linkage. For example at 20m/s (70km/h) only 5% of the total steering range is available. **A potential solution to this though is to allow steering inputs > 1.**
> 

This PR resolved the problem by allowing the high-level steering request sent to the motors to be outside the -1 to +1 range.

Below are images before and after showing the simulated vehicle is better able to achieve the desired turn rate.  In this test an Ackermann style rover (i.e. separate throttle and steering controls) was driven slowly (2m/s) but with full left steering.  In master, because the speed scaling, the steering output was scaled back too far to achieve the desired turn rate.  With this PR the vehicle comes much closer.

![master-turnrate](https://user-images.githubusercontent.com/1498098/41139637-d9aad618-6b23-11e8-8060-58aa65a00b7f.png)
![new-turnrate](https://user-images.githubusercontent.com/1498098/41139638-db769d74-6b23-11e8-9d96-7be20f00a8f0.png)

Somewhat separately this PR also adds a new parameter MOT_SPD_SCA_BASE (i.e. "Motor Speed Scaling Base") which is equivalent to the similar "Vector Thrust Scaling Base" parameter.  It allows the user to specify the lowest speed that the scaling is applied.  I don't expect many people to change this but it could be useful especially for very slow vehicles because it will give them better steering control below 1m/s.  Very fast vehicles that spend very little time below 1m/s.

This issue is discussed [here in the Rover-3.4.0-rc1 beta testing thread](https://discuss.ardupilot.org/t/rover-3-4-0-rc1-released-for-beta-testing).