### PR TITLE
Rover: accept do-change-speed within COMMAND_LONG and COMMAND_INT messages

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -510,6 +510,16 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 
         switch (packet.command) {
 
+        case MAV_CMD_DO_CHANGE_SPEED:
+            // param1 : unused
+            // param2 : new speed in m/s
+            if (rover.control_mode->set_desired_speed(packet.param2)) {
+                result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
+            }
+            break;
+
         case MAV_CMD_DO_SET_HOME: {
             // assume failure
             result = MAV_RESULT_FAILED;
@@ -686,6 +696,16 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                 default:
                     result = MAV_RESULT_FAILED;
                     break;
+            }
+            break;
+
+        case MAV_CMD_DO_CHANGE_SPEED:
+            // param1 : unused
+            // param2 : new speed in m/s
+            if (rover.control_mode->set_desired_speed(packet.param2)) {
+                result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
             }
             break;
 

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -375,8 +375,7 @@ bool Rover::verify_within_distance()
 void Rover::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     // set speed for active mode
-    if ((cmd.content.speed.target_ms >= 0.0f) && (cmd.content.speed.target_ms <= rover.control_mode->get_speed_default())) {
-        control_mode->set_desired_speed(cmd.content.speed.target_ms);
+    if (control_mode->set_desired_speed(cmd.content.speed.target_ms)) {
         gcs().send_text(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
     }
 }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -216,6 +216,16 @@ void Mode::set_desired_speed_to_default(bool rtl)
     _desired_speed = get_speed_default(rtl);
 }
 
+// set desired speed in m/s
+bool Mode::set_desired_speed(float speed)
+{
+    if (!is_negative(speed)) {
+        _desired_speed = speed;
+        return true;
+    }
+    return false;
+}
+
 void Mode::calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled)
 {
     // add in speed nudging

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -104,8 +104,8 @@ public:
     // rtl argument should be true if called from RTL or SmartRTL modes (handled here to avoid duplication)
     float get_speed_default(bool rtl = false) const;
 
-    // set desired speed
-    void set_desired_speed(float speed) { _desired_speed = speed; }
+    // set desired speed in m/s
+    bool set_desired_speed(float speed);
 
     // restore desired speed to default from parameter values (CRUISE_SPEED or WP_SPEED)
     // rtl argument should be true if called from RTL or SmartRTL modes (handled here to avoid duplication)


### PR DESCRIPTION
This PR adds support for the DO_CHANGE_SPEED command within Auto, Guided and RTL.

It also consolidates the range checking of the speed in one place (within the Mode::set_desired_speed() method) and removes the speed limit on DO_CHANGE_SPEED commands within missions.  This is a sensible change because the WP_SPEED and CRUISE_SPEED parameters are not meant to specify the maximum speed of the vehicle.

Of course I've tested this in the simulator with a little triangular mission and the vehicle does appropriately change speed.

This PR resolves this issue: https://github.com/ArduPilot/ardupilot/issues/8608