### PR TITLE
Copter: Tradheli - fixes collective jump on rotor shutdown in althold and loiter

### DIFF
--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -66,6 +66,9 @@ void Copter::ModeAltHold::run()
         // force descent rate and call position controller
         pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
         heli_flags.init_targets_on_arming=true;
+        if (ap.land_complete_maybe) {
+            pos_control->relax_alt_hold_controllers(0.0f);
+        }
 #else
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
 #endif

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -122,6 +122,9 @@ void Copter::ModeLoiter::run()
 #if FRAME_CONFIG == HELI_FRAME
         // force descent rate and call position controller
         pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
+        if (ap.land_complete_maybe) {
+            pos_control->relax_alt_hold_controllers(0.0f);
+        }
 #else
         loiter_nav->init_target();
         attitude_control->reset_rate_controller_I_terms();


### PR DESCRIPTION
This PR fixes the collective jump experienced by users with setting motor interlock disabled immediately upon landing in althold or loiter flight modes.  This issue is described in #8561.

This PR is an intermediate fix.  All flight mode logic for heli will be reviewed when spool logic is implemented to further align heli with multi where able.  As I stated in the issue post, I will look at why a descent is forced in the motors stopped state and why that differs from the landed state.

This fix was tested in the SITL with realflight and works as expected.  @ChristopherOlson it is up to you if you want to check this in a real heli.  I'm fairly confident you will get the same results as I did. 