### PR TITLE
Rover: log echologger depth

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -166,7 +166,8 @@ struct PACKED log_Arm_Disarm {
     uint16_t arm_checks;
 };
 
-void Rover::Log_Arm_Disarm() {
+void Rover::Log_Write_Arm_Disarm()
+{
     struct log_Arm_Disarm pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
         time_us                 : AP_HAL::micros64(),
@@ -322,7 +323,7 @@ void Rover::Log_Write_Rangefinder() {}
 void Rover::Log_Write_Attitude() {}
 void Rover::Log_Write_RC(void) {}
 void Rover::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
-void Rover::Log_Arm_Disarm() {}
+void Rover::Log_Write_Arm_Disarm() {}
 void Rover::Log_Write_Error(uint8_t sub_system, uint8_t error_code) {}
 void Rover::Log_Write_Steering() {}
 void Rover::Log_Write_WheelEncoder() {}

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -40,6 +40,28 @@ void Rover::Log_Write_Attitude()
     DataFlash.Log_Write_PID(LOG_PIDA_MSG, g2.attitude_control.get_throttle_speed_pid().get_pid_info());
 }
 
+// Write a range finder depth message
+void Rover::Log_Write_Depth()
+{
+    // only log depth on boats with working downward facing range finders
+    if (!rover.is_boat() || !rangefinder.has_data_orient(ROTATION_PITCH_270)) {
+        return;
+    }
+
+    // get position
+    Location loc;
+    if (!rover.ahrs.get_position(loc)) {
+        return;
+    }
+
+    DataFlash.Log_Write("DPTH", "TimeUS,Lat,Lng,Depth",
+                        "sDUm", "FGG0", "QLLf",
+                        AP_HAL::micros64(),
+                        loc.lat,
+                        loc.lng,
+                        (double)(rangefinder.distance_cm_orient(ROTATION_PITCH_270) * 0.01f));
+}
+
 struct PACKED log_Error {
   LOG_PACKET_HEADER;
   uint64_t time_us;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -478,6 +478,7 @@ private:
     // Log.cpp
     void Log_Write_Arm_Disarm();
     void Log_Write_Attitude();
+    void Log_Write_Depth();
     void Log_Write_Error(uint8_t sub_system, uint8_t error_code);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_Nav_Tuning();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -476,7 +476,6 @@ private:
     void gcs_retry_deferred(void);
 
     // Log.cpp
-    void Log_Write_Performance();
     void Log_Write_Steering();
     void Log_Write_Startup(uint8_t type);
     void Log_Write_Throttle();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -482,7 +482,7 @@ private:
     void Log_Write_Nav_Tuning();
     void Log_Write_Attitude();
     void Log_Write_Rangefinder();
-    void Log_Arm_Disarm();
+    void Log_Write_Arm_Disarm();
     void Log_Write_RC(void);
     void Log_Write_Error(uint8_t sub_system, uint8_t error_code);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -476,21 +476,21 @@ private:
     void gcs_retry_deferred(void);
 
     // Log.cpp
-    void Log_Write_Steering();
-    void Log_Write_Startup(uint8_t type);
-    void Log_Write_Throttle();
-    void Log_Write_Nav_Tuning();
-    void Log_Write_Attitude();
-    void Log_Write_Rangefinder();
     void Log_Write_Arm_Disarm();
-    void Log_Write_RC(void);
+    void Log_Write_Attitude();
     void Log_Write_Error(uint8_t sub_system, uint8_t error_code);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
-    void Log_Write_WheelEncoder();
+    void Log_Write_Nav_Tuning();
     void Log_Write_Proximity();
+    void Log_Write_Startup(uint8_t type);
+    void Log_Write_Steering();
+    void Log_Write_Throttle();
+    void Log_Write_Rangefinder();
+    void Log_Write_RC(void);
+    void Log_Write_WheelEncoder();
+    void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void log_init(void);
-    void Log_Write_Vehicle_Startup_Messages();
 
     // Parameters.cpp
     void load_parameters(void);

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -226,6 +226,7 @@ void Rover::read_rangefinders(void)
     }
 
     Log_Write_Rangefinder();
+    Log_Write_Depth();
 
     // no object detected - reset after the turn time
     if (obstacle.detected_count >= g.rangefinder_debounce &&

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -337,7 +337,7 @@ bool Rover::should_log(uint32_t mask)
  */
 void Rover::change_arm_state(void)
 {
-    Log_Arm_Disarm();
+    Log_Write_Arm_Disarm();
     update_soft_armed();
 }
 


### PR DESCRIPTION
This PR logs a DPTH message which hold the vehicle location and current depth (Issue: https://github.com/ArduPilot/ardupilot/issues/8489).

It is a very special case message meant to simplify producing underwater maps using an echosounder like the [ECT400](http://ardupilot.org/rover/docs/common-echologger-ect400.html).

It only logs when the vehicle is a boat, the sonar is downward facing and the vehicle's position is known.

This PR also includes three other non-functional changes:

- alphabetise the Log_Write_xxx function in Log.cpp
- removes an unimplemented function declaration
- renames one log writing function to make it more similar to others.

Here is a screen shot of a bench test that the logging works as expected:
![log-depth](https://user-images.githubusercontent.com/1498098/41232235-a99a260a-6dc0-11e8-96aa-dec157eacfb1.png)
