### PR TITLE
clarify "AHRS not healthy" prearm failure message

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -119,7 +119,7 @@ bool AP_Arming_Plane::ins_checks(bool report)
                 if (reason) {
                     gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: %s", reason);
                 } else {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: AHRS not healthy");
+                    gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: AHRS not enabled");
                 }
             }
             return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1332,7 +1332,7 @@ uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel) const
 const char *NavEKF2::prearm_failure_reason(void) const
 {
     if (!core) {
-        return nullptr;
+        return "EKF2 not enabled";
     }
     return core[primary].prearm_failure_reason();
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -594,10 +594,10 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
 // report the reason for why the backend is refusing to initialise
 const char *NavEKF2_core::prearm_failure_reason(void) const
 {
-    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
-        // we are not failing
-        return nullptr;
-    }
+//    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
+//        // we are not failing
+//        return nullptr;
+//    }
     return prearm_fail_string;
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -220,7 +220,7 @@ bool NavEKF2_core::calcGpsGoodToAlign(void)
 
     // assume failed first time through and notify user checks have started
     if (lastGpsVelFail_ms == 0) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF starting GPS checks");
+        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF waiting for GPS checks");
         lastGpsVelFail_ms = imuSampleTime_ms;
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1151,7 +1151,7 @@ private:
     } mag_state;
 
     // string representing last reason for prearm failure
-    char prearm_fail_string[40];
+    char prearm_fail_string[40]{"not enabled"};
 
     // performance counters
     AP_HAL::Util::perf_counter_t  _perf_UpdateFilter;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -788,7 +788,7 @@ void NavEKF3::UpdateFilter(void)
 bool NavEKF3::healthy(void) const
 {
     if (!core) {
-        return false;
+        return "EKF3 not enabled";
     }
     return core[primary].healthy();
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -605,10 +605,10 @@ void NavEKF3_core::send_status_report(mavlink_channel_t chan)
 // report the reason for why the backend is refusing to initialise
 const char *NavEKF3_core::prearm_failure_reason(void) const
 {
-    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
-        // we are not failing
-        return nullptr;
-    }
+//    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
+//        // we are not failing
+//        return nullptr;
+//    }
     return prearm_fail_string;
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -219,7 +219,7 @@ bool NavEKF3_core::calcGpsGoodToAlign(void)
 
     // assume failed first time through and notify user checks have started
     if (lastGpsVelFail_ms == 0) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF starting GPS checks");
+        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "EKF waiting for GPS checks");
         lastGpsVelFail_ms = imuSampleTime_ms;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1219,7 +1219,7 @@ private:
     } mag_state;
 
     // string representing last reason for prearm failure
-    char prearm_fail_string[40];
+    char prearm_fail_string[40]{"not enabled"};
 
     // performance counters
     AP_HAL::Util::perf_counter_t  _perf_UpdateFilter;


### PR DESCRIPTION
@tridge These changes report "EKFn not enabled" instead of "not healthy" when the core pointer is null.
This occurred when EK3_ENABLE was 0 with AHRS_EKF_TYPE=3

I've just commented out the code which was suppressing that error report; perhaps it would be better instead to enforce the appropriate EKn_ENABLE to match AHRS_EKF_TYPE ?
