### PR TITLE
DataFlash: avoid stat of current log file

### DIFF
--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -65,6 +65,9 @@ protected:
 
 private:
     int _write_fd;
+    char *_write_filename;
+    uint32_t _last_write_ms;
+    
     int _read_fd;
     uint16_t _read_fd_log_num;
     uint32_t _read_offset;


### PR DESCRIPTION
this avoids getting invalid data base for stat() for the current log
file.

It also only gives up writing to a log file if writes fail for 2
seconds. This avoids a temporary write failure causing the log to be
closed (that can happen on ChibiOS with directory listing while writing)