### PR TITLE
Fix uart index

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -550,8 +550,8 @@ def write_UART_config(f):
     # write out driver declarations for HAL_ChibOS_Class.cpp
     devnames = "ABCDEFGH"
     sdev = 0
+    idx = 0
     for dev in uart_list:
-        idx = uart_list.index(dev)
         if dev == 'EMPTY':
             f.write('#define HAL_UART%s_DRIVER Empty::UARTDriver uart%sDriver\n' %
                 (devnames[idx], devnames[idx]))
@@ -560,6 +560,7 @@ def write_UART_config(f):
                 '#define HAL_UART%s_DRIVER ChibiOS::UARTDriver uart%sDriver(%u)\n'
                 % (devnames[idx], devnames[idx], sdev))
             sdev += 1
+        idx += 1
     for idx in range(len(uart_list), 6):
         f.write('#define HAL_UART%s_DRIVER Empty::UARTDriver uart%sDriver\n' %
                 (devnames[idx], devnames[idx]))


### PR DESCRIPTION
calling uart_list.index() will find the first element with that name,
which is not really what we want when we have multiple EMPTY uarts.