### PR TITLE
HAL_ChibiOS: added a timeout to DMA UART TX

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -955,15 +955,15 @@ void RCOutput::send_pulses_DMAR(pwm_group &group, uint32_t buffer_length)
 void RCOutput::dma_irq_callback(void *p, uint32_t flags)
 {
     pwm_group *group = (pwm_group *)p;
+    chSysLockFromISR();
     dmaStreamDisable(group->dma);
     if (group->in_serial_dma && irq.waiter) {
         // tell the waiting process we've done the DMA
-        chSysLockFromISR();
         chEvtSignalI(irq.waiter, serial_event_mask);
-        chSysUnlockFromISR();
     } else {
         group->dma_handle->unlock_from_IRQ();
     }
+    chSysUnlockFromISR();
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -138,6 +138,7 @@ private:
     Semaphore _write_mutex;
     const stm32_dma_stream_t* rxdma;
     const stm32_dma_stream_t* txdma;
+    virtual_timer_t tx_timeout;    
     bool _in_timer;
     bool _blocking_writes;
     bool _initialised;
@@ -162,6 +163,7 @@ private:
     static void rx_irq_cb(void* sd);
     static void rxbuff_full_irq(void* self, uint32_t flags);
     static void tx_complete(void* self, uint32_t flags);
+    static void handle_tx_timeout(void *arg);
 
     void dma_tx_allocate(Shared_DMA *ctx);
     void dma_tx_deallocate(Shared_DMA *ctx);

--- a/libraries/AP_HAL_ChibiOS/shared_dma.cpp
+++ b/libraries/AP_HAL_ChibiOS/shared_dma.cpp
@@ -164,7 +164,6 @@ void Shared_DMA::unlock_from_lockzone(void)
 void Shared_DMA::unlock_from_IRQ(void)
 {
     osalDbgAssert(have_lock, "must have lock");
-    chSysLockFromISR();
     if (stream_id2 != SHARED_DMA_NONE) {
         chBSemSignalI(&locks[stream_id2].semaphore);        
     }
@@ -172,7 +171,6 @@ void Shared_DMA::unlock_from_IRQ(void)
         chBSemSignalI(&locks[stream_id1].semaphore);
     }
     have_lock = false;
-    chSysUnlockFromISR();
 }
 
 /*


### PR DESCRIPTION
this prevents a shared DMA channel being held for a long time if a CTS
pin is held either by not being connected or by a radio

This PR is WIP as it needs two more things:
- [x] the correct tx_len after a DMA is interrupted
- [ ] a way for other drivers to steal the DMA channel from a UART during TX (eg. I2C)