### PR TITLE
DataFlash: remove nuttx casename hack

### DIFF
--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -109,20 +109,6 @@ void DataFlash_File::Init()
         return;
     }
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    // try to cope with an existing lowercase log directory
-    // name. NuttX does not handle case insensitive VFAT well
-    DIR *d = opendir("/fs/microsd/APM");
-    if (d != nullptr) {
-        for (struct dirent *de=readdir(d); de; de=readdir(d)) {
-            if (strcmp(de->d_name, "logs") == 0) {
-                rename("/fs/microsd/APM/logs", "/fs/microsd/APM/OLDLOGS");
-                break;
-            }
-        }
-        closedir(d);
-    }
-#endif
     const char* custom_dir = hal.util->get_custom_log_directory();
     if (custom_dir != nullptr){
         _log_directory = custom_dir;


### PR DESCRIPTION
Nobody should have SD cards with this directory name present any more.

The bug in NuttX has probably been fixed by now.