### PR TITLE
Copter: support MAV_CMD_NAV_TAKEOFF_LOCAL

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -927,6 +927,7 @@ private:
     // takeoff.cpp
     bool current_mode_has_user_takeoff(bool must_navigate);
     bool do_user_takeoff(float takeoff_alt_cm, bool must_navigate);
+    bool do_user_takeoff_local(float z_pos_m);
     void takeoff_timer_start(float alt_cm);
     void takeoff_stop();
     void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -824,6 +824,18 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             break;
         }
 
+        case MAV_CMD_NAV_TAKEOFF_LOCAL: {
+            // param1~6 : not supported
+            // param7 : Z Position in MAV_FRAME_LOCAL_NED in meters
+
+            if(copter.do_user_takeoff_local(packet.param7)) {
+                result = MAV_RESULT_ACCEPTED;
+            } else {
+                result = MAV_RESULT_FAILED;
+            }
+            break;
+        }
+
 
         case MAV_CMD_NAV_LOITER_UNLIM:
             if (copter.set_mode(LOITER, MODE_REASON_GCS_COMMAND)) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -767,6 +767,7 @@ public:
     bool limit_check();
 
     bool takeoff_start(float final_alt_above_home);
+    bool takeoff_start_local(float z_pos_m);
 
     GuidedMode mode() const { return guided_mode; }
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -78,6 +78,26 @@ bool Copter::ModeGuided::takeoff_start(float final_alt_above_home)
     return true;
 }
 
+bool Copter::ModeGuided::takeoff_start_local(float z_pos_m)
+{
+    guided_mode = Guided_TakeOff;
+
+    const Vector3f& curr_pos = inertial_nav.get_position();
+    // no need to check return status because terrain data is not used
+    wp_nav->set_wp_destination(Vector3f(curr_pos.x, curr_pos.y, -z_pos_m * 100), false);
+
+    // initialise yaw
+    auto_yaw.set_mode(AUTO_YAW_HOLD);
+
+    // clear i term when we're taking off
+    set_throttle_takeoff();
+
+    // get initial alt for WP_NAVALT_MIN
+    copter.auto_takeoff_set_start_alt();
+
+    return true;
+}
+
 // initialise guided mode's position controller
 void Copter::ModeGuided::pos_control_start()
 {


### PR DESCRIPTION
MAV_CMD_NAV_TAKEOFF is not working in guided mode when using MAVLink vision messages (VISION_POSITION_ESTIMATE and ATT_POS_MOCAP). Although auto takeoff is working in loiter mode, it needs RC controller or RC override to set throttle in 50%.  It is more convenient to takeoff in guided mode for full autonomous flight.