### PR TITLE
Camera cleanups

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -32,9 +32,7 @@ class AP_Camera {
 
 public:
     AP_Camera(AP_Relay *obj_relay, uint32_t _log_camera_bit, const struct Location &_loc, const AP_AHRS &_ahrs)
-        : _trigger_counter(0) // count of number of cycles shutter has been held open
-        , _image_index(0)
-        , log_camera_bit(_log_camera_bit)
+        : log_camera_bit(_log_camera_bit)
         , current_loc(_loc)
         , ahrs(_ahrs)
     {
@@ -122,8 +120,8 @@ private:
     // should be called at 50hz from main program
     void trigger_pic_cleanup();
 
-    // check if trigger pin has fired
-    bool check_trigger_pin(void);
+    // check if feedback pin has fired
+    bool check_feedback_pin(void);
 
     // return true if we are using a feedback pin
     bool using_feedback_pin(void) const { return _feedback_pin > 0; }


### PR DESCRIPTION
This is a set of random collection stuff I stumbled across while chasing something completely unrelated. Taken in no particular order:
1. Adds the reboot required tag to `CAM_FEEDBACK_PIN`, (reboots are always required to detect shifts if it involved the edge feedback pin).
1. Extracts the configuration of pin modes/pull ups from `feedback_pin_timer` and does it before the timer is installed. This is run at 1 kHz, so it's worth keeping this reasonably short, and with the reboot required if you shift pins under some circumstances I didn't feel that this was a large behavior shift.
1. Set `_camera_triggered` to false on boot. ~I believe this fixes the double feedback event when taking the first photo.~
1. Removed some unneeded initialization to reduce binary size
1. Renamed `AP_Camera::check_trigger_pin(void)` to `AP_Camera::check_feedback_pin(void)` to better reflect what it's trying to do. (This is still a very confusing section of code, this is just where I drew the line for limiting refactoring).

I need to test this (probably tomorrow) before we look at merging, but I'm most hopeful about 3, as the double feedback event is really frustrating.