### PR TITLE
build: improved build speed with ccache

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -276,7 +276,8 @@ def build(bld):
     )
 
     common_src = [bld.bldnode.find_or_declare('hwdef.h'),
-                  bld.bldnode.find_or_declare('modules/ChibiOS/include_dirs')]
+                  bld.bldnode.find_or_declare('modules/ChibiOS/include_dirs'),
+                  bld.bldnode.find_or_declare('ap_romfs_embedded.h')]
     common_src += bld.path.ant_glob('libraries/AP_HAL_ChibiOS/hwdef/common/*.[ch]')
     common_src += bld.path.ant_glob('libraries/AP_HAL_ChibiOS/hwdef/common/*.mk')
     common_src += bld.path.ant_glob('modules/ChibiOS/os/hal/**/*.[ch]')

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -131,7 +131,7 @@ def configure(cfg):
     _filter_supported_cxx_compilers('g++', 'clang++')
 
     if cfg.env.TOOLCHAIN == 'native':
-        cfg.load('compiler_cxx compiler_c')
+        cfg.load('compiler_cxx compiler_c gccdeps')
         if cfg.env.COMPILER_CC == 'clang' or cfg.env.COMPILER_CXX == 'clang++':
             Logs.warn("Warning! Native clang builds can be unstable, please use gcc/g++. \
 \nRefer ardupilot.org docs for more details.")
@@ -140,7 +140,7 @@ def configure(cfg):
     cfg.find_toolchain_program('ar')
 
     cfg.msg('Using toolchain', cfg.env.TOOLCHAIN)
-    cfg.load('compiler_cxx compiler_c')
+    cfg.load('compiler_cxx compiler_c gccdeps')
 
     if cfg.env.COMPILER_CC == 'clang':
         cfg.env.CFLAGS += cfg.env.CLANG_FLAGS

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -481,11 +481,9 @@ private:
         uint8_t current_baud;
         bool auto_detected_baud;
         struct UBLOX_detect_state ublox_detect_state;
-#if !HAL_MINIMIZE_FEATURES
         struct MTK_detect_state mtk_detect_state;
         struct MTK19_detect_state mtk19_detect_state;
         struct SIRF_detect_state sirf_detect_state;
-#endif // !HAL_MINIMIZE_FEATURES
         struct NMEA_detect_state nmea_detect_state;
         struct SBP_detect_state sbp_detect_state;
         struct SBP2_detect_state sbp2_detect_state;


### PR DESCRIPTION
This improves build speed for the common case of:
  rm -rf build; ./waf configure --board fmuv3; ./waf plane

this PR changes us from the builtin c_preproc depenency checker in waf to the gcc based -MD system (using .d files). That reduces the time for the above build with ccache from 90 seconds to 9 seconds

It is also faster with no ccache. On my machine rover build drops from 3:25 to 2:47
