### PR TITLE
AP_Arming: move copter-specific code into Copter subclass 

### DIFF
--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -13,6 +13,9 @@ public:
         , _inav(inav)
         , _ahrs_navekf(ahrs_ref)
     {
+        // default REQUIRE parameter to 1 (Copter does not have an
+        // actual ARMING_REQUIRE parameter)
+        require.set_default(YES_MIN_PWM);
     }
 
     /* Do not allow copies */

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -95,7 +95,7 @@ uint16_t AP_Arming::compass_magfield_expected() const
 
 bool AP_Arming::is_armed()
 {
-    return require == NONE || armed;
+    return (ArmingRequired)require.get() == NO || armed;
 }
 
 uint16_t AP_Arming::get_enabled_checks()

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -83,13 +83,9 @@ AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, Compass &compass,
     ahrs(ahrs_ref),
     _compass(compass),
     _battery(battery),
-    armed(false),
     arming_method(NONE)
 {
     AP_Param::setup_object_defaults(this, var_info);
-
-    memset(last_accel_pass_ms, 0, sizeof(last_accel_pass_ms));
-    memset(last_gyro_pass_ms, 0, sizeof(last_gyro_pass_ms));
 }
 
 uint16_t AP_Arming::compass_magfield_expected() const

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -88,11 +88,6 @@ AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, Compass &compass,
 {
     AP_Param::setup_object_defaults(this, var_info);
 
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-    // default REQUIRE parameter to 1 (needed for Copter which is missing the parameter declaration above)
-    require.set_default(YES_MIN_PWM);
-#endif
-
     memset(last_accel_pass_ms, 0, sizeof(last_accel_pass_ms));
     memset(last_gyro_pass_ms, 0, sizeof(last_gyro_pass_ms));
 }


### PR DESCRIPTION
Also sneak in a few cleanups.
