### PR TITLE
AP_RangeFinder: Make the first driver _TYPE an enable parameter

### DIFF
--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -46,7 +46,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Description: What type of rangefinder device that is connected
     // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLiteV2-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:uLanding,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:BenewakeTFmini
     // @User: Standard
-    AP_GROUPINFO("_TYPE",    0, RangeFinder, state[0].type, 0),
+    AP_GROUPINFO_FLAGS("_TYPE",    0, RangeFinder, state[0].type, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: _PIN
     // @DisplayName: Rangefinder pin


### PR DESCRIPTION
Fixes #4599

This is a bit of a debate, without this change we can't hide the parameters, hiding the parameters for those who aren't using rangefinders removes 38 parameters, however it requires that the first rangefinder instance be the first one the user configures/enables, which is a bit of a behavior change. I'm fine with it either way, but if we don't want to go down this path then we should close the linked issue out as something that won't be resolved.