### PR TITLE
HAL: Clear UART buffers when opening a port

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -9,6 +9,7 @@
 class AP_HAL::UARTDriver : public AP_HAL::BetterStream {
 public:
     UARTDriver() {}
+    // begin() implicitly clears rx/tx buffers, even if the port was already open (unless the UART is the console UART)
     virtual void begin(uint32_t baud) = 0;
 	/// Extended port open method
 	///

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -148,13 +148,15 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       thrashing of the heap once we are up. The ttyACM0 driver may not
       connect for some time after boot
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (rxS != _readbuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
-
         _readbuf.set_size(rxS);
+    }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _readbuf.clear();
     }
 
     if (b != 0) {
@@ -173,12 +175,15 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     /*
       allocate the write buffer
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (txS != _writebuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
         _writebuf.set_size(txS);
+    }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _writebuf.clear();
     }
 
     if (sdef.is_usb) {

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -103,9 +103,6 @@ private:
     // thread used for all UARTs
     static thread_t *uart_thread_ctx;
 
-    // last time we ran the uart thread
-    static uint32_t last_thread_run_us;
-    
     // table to find UARTDrivers from serial number, used for event handling
     static UARTDriver *uart_drivers[UART_MAX_DRIVERS];
 

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -108,6 +108,10 @@ void UARTDriver::_allocate_buffers(uint16_t rxS, uint16_t txS)
     if (_writebuf.set_size(txS) && _readbuf.set_size(rxS)) {
         _initialised = true;
     }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _readbuf.clear();
+        _writebuf.clear();
+    }
 }
 
 void UARTDriver::_deallocate_buffers()

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -71,13 +71,15 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       thrashing of the heap once we are up. The ttyACM0 driver may not
       connect for some time after boot
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (rxS != _readbuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
-
         _readbuf.set_size(rxS);
+    }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+      _readbuf.clear();
     }
 
     if (b != 0) {
@@ -87,12 +89,15 @@ void PX4UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     /*
       allocate the write buffer
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (txS != _writebuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
         _writebuf.set_size(txS);
+    }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+      _writebuf.clear();
     }
 
 	if (_fd == -1) {

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -105,6 +105,11 @@ void UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         free(s);
     }
 
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _readbuffer.clear();
+        _writebuffer.clear();
+    }
+
     _set_nonblocking(_fd);
 }
 

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
@@ -70,14 +70,17 @@ void VRBRAINUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
       thrashing of the heap once we are up. The ttyACM0 driver may not
       connect for some time after boot
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (rxS != _readbuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
-
         _readbuf.set_size(rxS);
     }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _readbuf.clear();
+    }
+
 
     if (b != 0) {
         _baudrate = b;
@@ -86,12 +89,15 @@ void VRBRAINUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     /*
       allocate the write buffer
      */
+    while (_in_timer) {
+        hal.scheduler->delay(1);
+    }
     if (txS != _writebuf.get_size()) {
         _initialised = false;
-        while (_in_timer) {
-            hal.scheduler->delay(1);
-        }
         _writebuf.set_size(txS);
+    }
+    if (hal.console != this) { // don't clear USB buffers (allows early startup messages to escape)
+        _writebuf.clear();
     }
 
 	if (_fd == -1) {


### PR DESCRIPTION
First commit should be straightforward, reduces flash consumption by 32 bytes.

The second commit is the more interesting one. It's attempting to fix #5670. When GPS drivers are autobauding the UART buffers can contain data from a baud the GPS is moving off from. This can result in false positive detections after you have moved to a baud rate other then the one that was initially desired. By clearing buffers whenever `UARTDriver::begin()` is called this should be avoided. This patch should be replicated on the other HAL's as well, but I wanted to run it by here for opinions before I rote replicated it.