### PR TITLE
AP_HAL_F4Light: NULL pointer dereference in libraries/AP_HAL_F4Light/hardware/hal/timer.c

### DIFF
--- a/libraries/AP_HAL_F4Light/hardware/hal/timer.c
+++ b/libraries/AP_HAL_F4Light/hardware/hal/timer.c
@@ -443,9 +443,10 @@ void timer_set_mode(const timer_dev *dev, timer_Channel channel, timer_mode mode
     assert_param(channel > 0 && channel <= 4);
 
     /* TODO decide about the basic timers */
-    assert_param(dev->type != TIMER_BASIC);
     if (!dev || dev->type == TIMER_BASIC)
         return;
+        
+    assert_param(dev->type != TIMER_BASIC);
 
     switch (mode) {
     case TIMER_DISABLED:


### PR DESCRIPTION
Issue #8641
To protect NULL pointer dereference, I change the order of two statements.
Please check if the code is correct or not.