### PR TITLE
modifications for ArduPilot to work with the latest JSBSim

### DIFF
--- a/Tools/autotest/jsb_sim/fgout_template.xml
+++ b/Tools/autotest/jsb_sim/fgout_template.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0"?>
-<output name="localhost" type="FLIGHTGEAR" port="%(FGOUTPORT)s" protocol="udp" rate="1000"/>
+<output name="localhost" type="FLIGHTGEAR" port="%(FGOUTPORT)s" protocol="UDP" rate="1000"/>

--- a/Tools/autotest/jsb_sim/runsim.py
+++ b/Tools/autotest/jsb_sim/runsim.py
@@ -127,7 +127,7 @@ def process_sitl_input(buf):
     if throttle != sitl_state.throttle:
         buf += 'set fcs/throttle-cmd-norm %s\n' % throttle
         sitl_state.throttle = throttle
-    buf += 'step\n'
+    buf += 'iterate 1\n'
     global jsb_console
     jsb_console.send(buf)
 
@@ -275,7 +275,7 @@ jsb_console.send('info\n')
 jsb_console.send('resume\n')
 jsb.expect(["trim computation time", "Trim Results"])
 time.sleep(1.5)
-jsb_console.send('step\n')
+jsb_console.send('iterate 1\n')
 jsb_console.logfile = None
 
 print("Simulator ready to fly")

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -978,8 +978,8 @@ frame_infos = vinfo.options_for_frame(cmd_opts.frame,
                                       cmd_opts.vehicle,
                                       cmd_opts)
 
-if frame_infos["model"] == "jsbsim":
-    check_jsbsim_version()
+# if frame_infos["model"] == "jsbsim":
+#     check_jsbsim_version()
 
 vehicle_dir = os.path.realpath(os.path.join(find_root_dir(), cmd_opts.vehicle))
 if not os.path.exists(vehicle_dir):

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -126,7 +126,7 @@ bool JSBSim::create_templates(void)
         AP_HAL::panic("Unable to create jsbsim fgout script %s", jsbsim_fgout);
     }
     fprintf(f, "<?xml version=\"1.0\"?>\n"
-            "<output name=\"127.0.0.1\" type=\"FLIGHTGEAR\" port=\"%u\" protocol=\"udp\" rate=\"1000\"/>\n",
+            "<output name=\"127.0.0.1\" type=\"FLIGHTGEAR\" port=\"%u\" protocol=\"UDP\" rate=\"1000\"/>\n",
             fdm_port);
     fclose(f);
 

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -109,7 +109,10 @@ bool JSBSim::create_templates(void)
 "    <event name=\"Trim\">\n"
 "      <condition>simulation/sim-time-sec ge 0.01</condition>\n"
 "      <set name=\"simulation/do_simple_trim\" value=\"2\"/>\n"
-"      <notify/>\n"
+"      <notify>\n"
+"         <property>velocities/vc-kts</property>\n"
+"         <property>position/h-agl-ft</property>\n"
+"      </notify>\n"
 "    </event>\n"
 "  </run>\n"
 "\n"
@@ -291,7 +294,7 @@ bool JSBSim::open_control_socket(void)
     char startup[] =
         "info\n"
         "resume\n"
-        "step\n"
+        "iterate 1\n"
         "set atmosphere/turb-type 4\n";
     sock_control.send(startup, strlen(startup));
     return true;
@@ -351,7 +354,7 @@ void JSBSim::send_servos(const struct sitl_input &input)
              "set atmosphere/wind-mag-fps %f\n"
              "set atmosphere/turbulence/milspec/windspeed_at_20ft_AGL-fps %f\n"
              "set atmosphere/turbulence/milspec/severity %f\n"
-             "step\n",
+             "iterate 1\n",
              aileron, elevator, rudder, throttle,
              radians(input.wind.direction),
              wind_speed_fps,
@@ -424,10 +427,10 @@ void JSBSim::recv_fdm(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
-    
+
     rpm1 = fdm.rpm[0];
     rpm2 = fdm.rpm[1];
-    
+
     // assume 1kHz for now
     time_now_us += 1000;
 }


### PR DESCRIPTION
This modifications allows using the latest JSBSim code

the tutorial to setup SITL ( http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html#setting-up-sitl-on-linux ) points to [www.github.com/tridge/jsbsim]() which uses the JSBSim code from 2012

these modifications allow the use of the latest JSBSim code found at [https://github.com/JSBSim-Team/jsbsim]() and involves

- removing the version check "(ArduPilot)"
- replacing "udp" with "UDP", otherwise it defaults to the TCP port

