### PR TITLE
Copter: Add judgment data to the message.

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -44,7 +44,8 @@ void Copter::crash_check()
 #endif
 
     // vehicle not crashed if 1hz filtered acceleration is more than 3m/s (1G on Z-axis has been subtracted)
-    if (land_accel_ef_filter.get().length() >= CRASH_CHECK_ACCEL_MAX) {
+    const float filtered_acc = land_accel_ef_filter.get().length();
+    if (filtered_acc >= CRASH_CHECK_ACCEL_MAX) {
         crash_counter = 0;
         return;
     }
@@ -65,7 +66,7 @@ void Copter::crash_check()
         // keep logging even if disarmed:
         AP::logger().set_force_log_disarmed(true);
         // send message to gcs
-        gcs().send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming");
+        gcs().send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming: AngErr=%.0f>%.0f, Accel=%.1f<%.1f", angle_error, CRASH_CHECK_ANGLE_DEVIATION_DEG, filtered_acc, CRASH_CHECK_ACCEL_MAX);
         // disarm motors
         copter.arming.disarm(AP_Arming::Method::CRASH);
     }


### PR DESCRIPTION
I want to know the reason for the crash as soon as possible. For that purpose add judgment data to the message.
I crashed while flying in guided mode at SITL.
I confirmed why it crashed with sauce.
To analyze using the BIN file, I do not know until I recover the aircraft.

In this message, I was able to know immediately that the crash was caused by the angle exceeding 30 degrees.
Messge:
Crash: Disarming:AC=0.127062, AN=45.61665

Frame: QUAD
ArduCopter V3.6-dev (95faf9e6)

![aaa](https://user-images.githubusercontent.com/646194/41798120-6d3cf4cc-76a7-11e8-9a23-6cae60929fe3.png)
