### PR TITLE
Use singletons in arming process

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -67,7 +67,7 @@ bool AP_Arming_Rover::fence_checks(bool report)
 {
     // check fence is initialised
     const char *fail_msg = nullptr;
-    if (!_fence.pre_arm_check(fail_msg)) {
+    if (!rover.g2.fence.pre_arm_check(fail_msg)) {
         if (report && fail_msg != nullptr) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Fence : %s", fail_msg);
         }

--- a/APMrover2/AP_Arming.h
+++ b/APMrover2/AP_Arming.h
@@ -9,12 +9,8 @@
 class AP_Arming_Rover : public AP_Arming
 {
 public:
-    AP_Arming_Rover(const AP_AHRS &ahrs_ref, Compass &compass,
-                    const AP_BattMonitor &battery, const AC_Fence &fence)
-        : AP_Arming(ahrs_ref, compass, battery),
-          _fence(fence)
-    {
-    }
+
+    AP_Arming_Rover() : AP_Arming() { }
 
     /* Do not allow copies */
     AP_Arming_Rover(const AP_Arming_Rover &other) = delete;
@@ -29,5 +25,5 @@ protected:
     bool proximity_check(bool report);
 
 private:
-    const AC_Fence& _fence;
+
 };

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -179,7 +179,7 @@ private:
 #endif
 
     // Arming/Disarming management class
-    AP_Arming_Rover arming{ahrs, compass, battery, g2.fence};
+    AP_Arming_Rover arming;
 
     AP_L1_Control L1_controller{ahrs, nullptr};
 

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -7,11 +7,8 @@ class AP_Arming_Copter : public AP_Arming
 public:
     friend class Copter;
     friend class ToyMode;
-    AP_Arming_Copter(const AP_AHRS_NavEKF &ahrs_ref, Compass &compass,
-                     const AP_BattMonitor &battery, const AP_InertialNav_NavEKF &inav)
-        : AP_Arming(ahrs_ref, compass, battery)
-        , _inav(inav)
-        , _ahrs_navekf(ahrs_ref)
+
+    AP_Arming_Copter() : AP_Arming()
     {
         // default REQUIRE parameter to 1 (Copter does not have an
         // actual ARMING_REQUIRE parameter)
@@ -51,9 +48,6 @@ protected:
     void set_pre_arm_check(bool b);
 
 private:
-
-    const AP_InertialNav_NavEKF &_inav;
-    const AP_AHRS_NavEKF &_ahrs_navekf;
 
     void parameter_checks_pid_warning_message(bool display_failure, const char *error_msg);
 };

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -281,7 +281,7 @@ private:
 #endif
 
     // Arming/Disarming mangement class
-    AP_Arming_Copter arming{ahrs, compass, battery, inertial_nav};
+    AP_Arming_Copter arming;
 
     // Optical flow sensor
 #if OPTFLOW == ENABLED

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -94,8 +94,8 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
     // additional plane specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!ahrs.healthy()) {
-            const char *reason = ahrs.prearm_failure_reason();
+        if (!AP::ahrs().healthy()) {
+            const char *reason = AP::ahrs().prearm_failure_reason();
             if (reason == nullptr) {
                 reason = "AHRS not healthy";
             }

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -8,9 +8,8 @@
 class AP_Arming_Plane : public AP_Arming
 {
 public:
-    AP_Arming_Plane(const AP_AHRS &ahrs_ref, Compass &compass,
-                    const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, compass, battery)
+    AP_Arming_Plane()
+        : AP_Arming()
     {
         AP_Param::setup_object_defaults(this, var_info);
     }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -747,7 +747,7 @@ private:
 #endif
 
     // Arming/Disarming mangement class
-    AP_Arming_Plane arming{ahrs, compass, battery};
+    AP_Arming_Plane arming;
 
     AP_Param param_loader {var_info};
 

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -28,11 +28,11 @@ bool AP_Arming_Sub::ins_checks(bool display_failure)
         return false;
     }
 
-    // additional plane specific checks
+    // additional sub-specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!ahrs.healthy()) {
-            const char *reason = ahrs.prearm_failure_reason();
+        if (!AP::ahrs().healthy()) {
+            const char *reason = AP::ahrs().prearm_failure_reason();
             if (reason == nullptr) {
                 reason = "AHRS not healthy";
             }

--- a/ArduSub/AP_Arming_Sub.h
+++ b/ArduSub/AP_Arming_Sub.h
@@ -4,11 +4,8 @@
 
 class AP_Arming_Sub : public AP_Arming {
 public:
-    AP_Arming_Sub(const AP_AHRS &ahrs_ref, Compass &compass,
-                  const AP_BattMonitor &battery)
-        : AP_Arming(ahrs_ref, compass, battery)
-    {
-    }
+
+    AP_Arming_Sub() : AP_Arming() { }
 
     /* Do not allow copies */
     AP_Arming_Sub(const AP_Arming_Sub &other) = delete;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -333,7 +333,7 @@ private:
                            FUNCTOR_BIND_MEMBER(&Sub::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
 
-    AP_Arming_Sub arming{ahrs, compass, battery};
+    AP_Arming_Sub arming;
 
     // Altitude
     // The cm/s we are moving up or down based on filtered data - Positive = UP

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -9,6 +9,13 @@
 
 class AP_Arming {
 public:
+
+    AP_Arming();
+
+    /* Do not allow copies */
+    AP_Arming(const AP_Arming &other) = delete;
+    AP_Arming &operator=(const AP_Arming&) = delete;
+
     enum ArmingChecks {
         ARMING_CHECK_NONE       = 0x0000,
         ARMING_CHECK_ALL        = 0x0001,
@@ -62,19 +69,12 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
-    AP_Arming(const AP_AHRS &ahrs_ref, Compass &compass,
-              const AP_BattMonitor &battery);
 
     // Parameters
     AP_Int8                 require;
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Float                _min_voltage[AP_BATT_MONITOR_MAX_INSTANCES];
-
-    // references
-    const AP_AHRS           &ahrs;
-    Compass                 &_compass;
-    const AP_BattMonitor    &_battery;
 
     // internal members
     bool                    armed:1;

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -140,7 +140,7 @@ public:
 
     void cancel_calibration_all();
 
-    bool compass_cal_requires_reboot() { return _cal_complete_requires_reboot; }
+    bool compass_cal_requires_reboot() const { return _cal_complete_requires_reboot; }
     bool is_calibrating() const;
 
     /*


### PR DESCRIPTION
Some things we don't have singletons for - but are in the vehicle-specific subdirectories - in which case we reach across into the vehicle to get a-hold of the object.
