### PR TITLE
Heli: revision to #8442, convert servo outputs to use SRV_Channels library

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -395,13 +395,13 @@ bool AP_MotorsHeli::parameter_check(bool display_msg) const
 }
 
 // reset_swash_servo
-void AP_MotorsHeli::reset_swash_servo(SRV_Channel *servo)
+void AP_MotorsHeli::reset_swash_servo(SRV_Channel::Aux_servo_function_t function)
 {
-    servo->set_range(1000);
+    // outputs are defined on a -500 to 500 range for swash servos
+    SRV_Channels::set_range(function, 1000);
 
     // swash servos always use full endpoints as restricting them would lead to scaling errors
-    servo->set_output_min(1000);
-    servo->set_output_max(2000);
+    SRV_Channels::set_output_min_max(function, 1000, 2000);
 }
 
 // update the throttle input filter
@@ -426,22 +426,16 @@ void AP_MotorsHeli::reset_flight_controls()
     calculate_scalars();
 }
 
-// convert input in -1 to +1 range to pwm output for swashplate servo.  Special handling of trim is required 
-// to keep travel between the swashplate servos consistent.  Swashplate servo travel range is fixed to 1000 pwm
-// and therefore the input is multiplied by 500 to get PWM output.
-int16_t AP_MotorsHeli::calc_pwm_output_1to1_swash_servo(float input, const SRV_Channel *servo)
+// convert input in -1 to +1 range to pwm output for swashplate servo.
+// The value 0 corresponds to the trim value of the servo. Swashplate
+// servo travel range is fixed to 1000 pwm and therefore the input is
+// multiplied by 500 to get PWM output.
+void AP_MotorsHeli::rc_write_swash(uint8_t chan, float swash_in)
 {
-    int16_t ret;
-
-    input = constrain_float(input, -1.0f, 1.0f);
-
-    if (servo->get_reversed()) {
-        input = -input;
-    }
-
-    ret = (int16_t (input * 500.0f) + servo->get_trim());
-
-    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
+    uint16_t pwm = (uint16_t)(1500 + 500 * swash_in);
+    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
+    SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
+
 
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -99,7 +99,7 @@ public:
     uint8_t get_rsc_mode() const { return _rsc_mode; }
 
     // get_rsc_setpoint - gets contents of _rsc_setpoint parameter (0~1)
-    float get_rsc_setpoint() const { return _rsc_setpoint / 1000.0f; }
+    float get_rsc_setpoint() const { return _rsc_setpoint * 0.001f; }
 
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     virtual void set_desired_rotor_speed(float desired_speed) = 0;
@@ -166,7 +166,7 @@ protected:
     virtual void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) = 0;
 
     // reset_swash_servo - free up swash servo for maximum movement
-    void reset_swash_servo(SRV_Channel *servo);
+    void reset_swash_servo(SRV_Channel::Aux_servo_function_t function);
 
     // init_outputs - initialise Servo/PWM ranges and endpoints
     virtual bool init_outputs() = 0;
@@ -184,10 +184,9 @@ protected:
     // to be overloaded by child classes, different vehicle types would have different movement patterns
     virtual void servo_test() = 0;
 
-    // convert input in -1 to +1 range to pwm output for swashplate servos. .  Special handling of trim is required 
-    // to keep travel between the swashplate servos consistent.
-    int16_t calc_pwm_output_1to1_swash_servo(float input, const SRV_Channel *servo);
-
+    // write to a swash servo. output value is pwm
+    void rc_write_swash(uint8_t chan, float swash_in);
+    
     // flags bitmask
     struct heliflags_type {
         uint8_t landing_collective      : 1;    // true if collective is setup for landing which has much higher minimum

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -169,13 +169,10 @@ void AP_MotorsHeli_Dual::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    uint32_t mask =
-        1U << AP_MOTORS_MOT_1 |
-        1U << AP_MOTORS_MOT_2 |
-        1U << AP_MOTORS_MOT_3 |
-        1U << AP_MOTORS_MOT_4 |
-        1U << AP_MOTORS_MOT_5 |
-        1U << AP_MOTORS_MOT_6;
+    uint16_t mask = 0;
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        mask |= 1U << (AP_MOTORS_MOT_1+i);
+    }
 
     rc_set_freq(mask, _speed_hz);
 }
@@ -376,7 +373,12 @@ void AP_MotorsHeli_Dual::calculate_roll_pitch_collective_factors()
 uint16_t AP_MotorsHeli_Dual::get_motor_mask()
 {
     // dual heli uses channels 1,2,3,4,5,6 and 8
-    return (1U << 0 | 1U << 1 | 1U << 2 | 1U << 3 | 1U << 4 | 1U << 5 | 1U << 6 | 1U << AP_MOTORS_HELI_DUAL_RSC);
+    uint16_t mask = 0;
+    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
+        mask |= 1U << (AP_MOTORS_MOT_1+i);
+    }
+    mask |= 1U << AP_MOTORS_HELI_DUAL_RSC;
+    return mask;
 }
 
 // update_motor_controls - sends commands to motor controllers

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -136,13 +136,6 @@ protected:
     AP_Float        _dcp_yaw_effect;                // feed-forward compensation to automatically add yaw input when differential collective pitch is applied.
     AP_Float        _yaw_scaler;                    // scaling factor applied to the yaw mixing
 
-    SRV_Channel    *_swash_servo_1;
-    SRV_Channel    *_swash_servo_2;
-    SRV_Channel    *_swash_servo_3;
-    SRV_Channel    *_swash_servo_4;
-    SRV_Channel    *_swash_servo_5;
-    SRV_Channel    *_swash_servo_6;
-
     // internal variables
     float           _collective2_mid_pct = 0.0f;      // collective mid parameter value for rear swashplate converted to 0 ~ 1 range
     float           _rollFactor[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -28,6 +28,8 @@ const AP_Param::GroupInfo AP_MotorsHeli_Quad::var_info[] = {
     AP_GROUPEND
 };
 
+#define QUAD_SERVO_MAX_ANGLE 4500
+
 // set update rate to motors - a value in hertz
 void AP_MotorsHeli_Quad::set_update_rate( uint16_t speed_hz )
 {
@@ -51,10 +53,8 @@ bool AP_MotorsHeli_Quad::init_outputs()
     }
 
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        _servo[i] = SRV_Channels::get_channel_for(SRV_Channels::get_motor_function(i), CH_1+i);
-        if (!_servo[i]) {
-            return false;
-        }
+        add_motor_num(CH_1+i);
+        SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), QUAD_SERVO_MAX_ANGLE);
     }
 
     // set rotor servo range
@@ -270,7 +270,7 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
 
     // move the servos
     for (uint8_t i=0; i<AP_MOTORS_HELI_QUAD_NUM_MOTORS; i++) {
-        rc_write(AP_MOTORS_MOT_1+i, calc_pwm_output_1to1(out[i], _servo[i]));
+        rc_write_angle(AP_MOTORS_MOT_1+i, out[i] * QUAD_SERVO_MAX_ANGLE);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -86,9 +86,6 @@ protected:
     //  objects we depend upon
     AP_MotorsHeli_RSC           _rotor;             // main rotor controller
 
-    // parameters
-    SRV_Channel    *_servo[AP_MOTORS_HELI_QUAD_NUM_MOTORS];
-
     // rate factors
     float _rollFactor[AP_MOTORS_HELI_QUAD_NUM_MOTORS];
     float _pitchFactor[AP_MOTORS_HELI_QUAD_NUM_MOTORS];

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -25,6 +25,10 @@ void AP_MotorsHeli_RSC::init_servo()
 {
     // setup RSC on specified channel by default
     SRV_Channels::set_aux_channel_default(_aux_fn, _default_channel);
+
+    // set servo range 
+    SRV_Channels::set_range(SRV_Channels::get_motor_function(_aux_fn), 1000);
+
 }
 
 // set_power_output_range

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -347,8 +347,19 @@ void AP_MotorsHeli_Single::calculate_roll_pitch_collective_factors()
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint16_t AP_MotorsHeli_Single::get_motor_mask()
 {
-    // heli uses channels 1,2,3,4,7 and 8
-    return rc_map_mask(1U << 0 | 1U << 1 | 1U << 2 | 1U << 3 | 1U << AP_MOTORS_HELI_SINGLE_EXTGYRO | 1U << AP_MOTORS_HELI_SINGLE_RSC);
+    // heli uses channels 1,2,3,4 and 8
+    // setup fast channels
+    uint32_t mask = 1U << 0 | 1U << 1 | 1U << 2 | 1U << 3 | 1U << AP_MOTORS_HELI_SINGLE_RSC;
+
+    if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
+        mask |= 1U << AP_MOTORS_HELI_SINGLE_EXTGYRO;
+    }
+
+    if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPITCH) {
+        mask |= 1U << AP_MOTORS_HELI_SINGLE_TAILRSC;
+    }
+
+    return rc_map_mask(mask);
 }
 
 // update_motor_controls - sends commands to motor controllers

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -8,9 +8,10 @@
 #include "AP_MotorsHeli.h"
 #include "AP_MotorsHeli_RSC.h"
 
-// rsc and aux function output channels
+// rsc and extgyro function output channels. 
 #define AP_MOTORS_HELI_SINGLE_RSC                              CH_8
-#define AP_MOTORS_HELI_SINGLE_AUX                              CH_7
+#define AP_MOTORS_HELI_SINGLE_EXTGYRO                          CH_7
+#define AP_MOTORS_HELI_SINGLE_TAILRSC                          CH_7
 
 // servo position defaults
 #define AP_MOTORS_HELI_SINGLE_SERVO1_POS                       -60
@@ -52,7 +53,7 @@ public:
                          uint16_t       speed_hz = AP_MOTORS_HELI_SPEED_DEFAULT) :
         AP_MotorsHeli(loop_rate, speed_hz),
         _main_rotor(SRV_Channel::k_heli_rsc, AP_MOTORS_HELI_SINGLE_RSC),
-        _tail_rotor(SRV_Channel::k_heli_tail_rsc, AP_MOTORS_HELI_SINGLE_AUX)
+        _tail_rotor(SRV_Channel::k_heli_tail_rsc, AP_MOTORS_HELI_SINGLE_TAILRSC)
     {
         AP_Param::setup_object_defaults(this, var_info);
     };
@@ -121,9 +122,6 @@ protected:
     // move_yaw - moves the yaw servo
     void move_yaw(float yaw_out);
 
-    // write_aux - converts servo_out parameter value (0 to 1 range) to pwm and outputs to aux channel (ch7)
-    void write_aux(float servo_out);
-
     // servo_test - move servos through full range of movement
     void servo_test() override;
 
@@ -152,12 +150,6 @@ protected:
     AP_Float        _collective_yaw_effect;     // Feed-forward compensation to automatically add rudder input when collective pitch is increased. Can be positive or negative depending on mechanics.
     AP_Int8         _flybar_mode;               // Flybar present or not.  Affects attitude controller used during ACRO flight mode
     AP_Int16        _direct_drive_tailspeed;    // Direct Drive VarPitch Tail ESC speed (0 ~ 1000)
-
-    SRV_Channel    *_swash_servo_1;
-    SRV_Channel    *_swash_servo_2;
-    SRV_Channel    *_swash_servo_3;
-    SRV_Channel    *_yaw_servo;
-    SRV_Channel    *_servo_aux;
 
     bool            _acro_tail = false;
     float           _rollFactor[AP_MOTORS_HELI_SINGLE_NUM_SWASHPLATE_SERVOS];

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -161,42 +161,6 @@ uint32_t AP_Motors::rc_map_mask(uint32_t mask) const
     return mask2;
 }
 
-// convert input in -1 to +1 range to pwm output
-int16_t AP_Motors::calc_pwm_output_1to1(float input, const SRV_Channel *servo)
-{
-    int16_t ret;
-
-    input = constrain_float(input, -1.0f, 1.0f);
-
-    if (servo->get_reversed()) {
-        input = -input;
-    }
-
-    if (input >= 0.0f) {
-        ret = ((input * (servo->get_output_max() - servo->get_trim())) + servo->get_trim());
-    } else {
-        ret = ((input * (servo->get_trim() - servo->get_output_min())) + servo->get_trim());
-    }
-
-    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
-}
-
-// convert input in 0 to +1 range to pwm output
-int16_t AP_Motors::calc_pwm_output_0to1(float input, const SRV_Channel *servo)
-{
-    int16_t ret;
-
-    input = constrain_float(input, 0.0f, 1.0f);
-
-    if (servo->get_reversed()) {
-        input = 1.0f-input;
-    }
-
-    ret = input * (servo->get_output_max() - servo->get_output_min()) + servo->get_output_min();
-
-    return constrain_int16(ret, servo->get_output_min(), servo->get_output_max());
-}
-
 /*
   add a motor, setting up default output function as needed
  */

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -178,12 +178,6 @@ protected:
     // save parameters as part of disarming
     virtual void save_params_on_disarm() {}
 
-    // convert input in -1 to +1 range to pwm output
-    int16_t calc_pwm_output_1to1(float input, const SRV_Channel *servo);
-
-    // convert input in 0 to +1 range to pwm output
-    int16_t calc_pwm_output_0to1(float input, const SRV_Channel *servo);
-
     // flag bitmask
     struct AP_Motors_flags {
         uint8_t armed              : 1;    // 0 if disarmed, 1 if armed

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -301,6 +301,9 @@ public:
     // adjust trim of a channel by a small increment
     void adjust_trim(SRV_Channel::Aux_servo_function_t function, float v);
 
+    // set MIN/MAX parameters for a function
+    static void set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm);
+    
     // save trims
     void save_trim(void);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -654,6 +654,17 @@ void SRV_Channels::set_range(SRV_Channel::Aux_servo_function_t function, uint16_
     }
 }
 
+// set MIN parameter for a function
+void SRV_Channels::set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm)
+{
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        if (channels[i].function == function) {
+            channels[i].set_output_min(min_pwm);
+            channels[i].set_output_max(max_pwm);
+        }
+    }
+}
+
 // constrain to output min/max for function
 void SRV_Channels::constrain_pwm(SRV_Channel::Aux_servo_function_t function)
 {

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -414,8 +414,8 @@ bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t fun
         if (channels[channel].function == function) {
             return true;
         }
-        hal.console->printf("Channel %u already assigned %u\n",
-                            (unsigned)channel,
+        hal.console->printf("Channel %u already assigned function %u\n",
+                            (unsigned)(channel + 1),
                             (unsigned)channels[channel].function);
         return false;
     }

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -201,6 +201,7 @@ void SRV_Channels::set_output_pwm(SRV_Channel::Aux_servo_function_t function, ui
 /*
   set radio_out for all channels matching the given function type
   trim the output assuming a 1500 center on the given value
+  reverses pwm output based on channel reversed property
  */
 void
 SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Aux_servo_function_t function, int16_t value)
@@ -210,7 +211,12 @@ SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Aux_servo_function_t function,
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function.get() == function) {
-            int16_t value2 = value - 1500 + channels[i].get_trim();
+            int16_t value2;
+            if (channels[i].get_reversed()) {
+                value2 = 1500 - value + channels[i].get_trim();
+            } else {
+                value2 = value - 1500 + channels[i].get_trim();
+            }
             channels[i].set_output_pwm(constrain_int16(value2,channels[i].get_output_min(),channels[i].get_output_max()));
             channels[i].output_ch();
           }


### PR DESCRIPTION
This pull request is replacing #8442.  Here is the original PR description "This brings heli in line with all our other vehicles to use the SRV_Channels library for output scaling. It simplifies the code, plus allows for users to setup multiple outputs for a particular function if they want to (eg. have two tail servo output channels if needed)"
Here are the additional changes:
1) corrected the swash servo output to properly account for servo trim which required adding a SRV_Channel method.
2) changed the external gyro output method to be PWM based rather than scaled based
3) Revised initialization method in single and dual heli to only initialize all output once and only initialize the special tail outputs only if they are set by the user.  This fixes one of the issues identified in issue #7541.
4) changed set_aux_channel_default method to display the correct channel in the channel already assigned message.  This corrects the other issue identified in issue #7541.
5) Cleaned up the get_motor_mask method to properly identify the channels being used

@tridge I apologize that the changes are not grouped well in the commits.  any help would be appreciated.
Thanks,
Bill


