### PR TITLE
 AP_RCProtocol: improve s-bus parsing

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
@@ -34,7 +34,7 @@ extern const AP_HAL::HAL& hal;
 
 void AP_RCProtocol_DSM::process_pulse(uint32_t width_s0, uint32_t width_s1)
 {
-    // convert to bit widths, allowing for up to 1usec error, assuming 115200 bps
+    // convert to bit widths, allowing for up to about 4usec error, assuming 115200 bps
     uint16_t bits_s0 = ((width_s0+4)*(uint32_t)115200) / 1000000;
     uint16_t bits_s1 = ((width_s1+4)*(uint32_t)115200) / 1000000;
     uint8_t bit_ofs, byte_ofs;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SBUS.cpp
@@ -204,9 +204,9 @@ bool AP_RCProtocol_SBUS::sbus_decode(const uint8_t frame[25], uint16_t *values, 
  */
 void AP_RCProtocol_SBUS::process_pulse(uint32_t width_s0, uint32_t width_s1)
 {
-    // convert to bit widths, allowing for up to 1usec error, assuming 100000 bps
-    uint16_t bits_s0 = (width_s0+1) / 10;
-    uint16_t bits_s1 = (width_s1+1) / 10;
+    // convert to bit widths, allowing for up to 4usec error, assuming 100000 bps
+    uint16_t bits_s0 = (width_s0+4) / 10;
+    uint16_t bits_s1 = (width_s1+4) / 10;
     uint16_t nlow;
 
     uint8_t byte_ofs = sbus_state.bit_ofs/12;


### PR DESCRIPTION
This relax s-bus timing requirement to allow not so perfect signals.
Fixes s-bus on s-bus pin in matekf405-wing.

MatekF405-wing uses simple inverter based on mosfet and resistor. It has issue, what rising signal is distorted, cause it pulled throuth 10k range resistor. 
Thanks to all on gitter channel helped track issue and check fix.

![](https://quadmeup.com/wp-content/uploads/2016/12/simplest-hardware-inverter.png)
