### PR TITLE
add -Werror-sign-compare to all builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -130,6 +130,7 @@ class Board:
             '-Werror=uninitialized',
             '-Werror=init-self',
             '-Werror=switch',
+            '-Werror=sign-compare',
             '-Wfatal-errors',
             '-Wno-trigraphs',
         ]

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -296,14 +296,16 @@ def build(bld):
         source=bld.path.ant_glob(bld.env.HWDEF),
         rule="python '${AP_HAL_ROOT}/hwdef/scripts/chibios_hwdef.py' -D '${BUILDROOT}' %s %s" % (bld.env.HWDEF, bld.env.BOOTLOADER_OPTION),
         group='dynamic_sources',
-        target=['hwdef.h', 'apj.prototype', 'ldscript.ld']
+        target=[bld.bldnode.find_or_declare('hwdef.h'),
+                bld.bldnode.find_or_declare('apj.prototype'),
+                bld.bldnode.find_or_declare('ldscript.ld')]
     )
     
     bld(
         # create the file modules/ChibiOS/include_dirs
         rule="touch Makefile && BUILDDIR=${BUILDDIR_REL} CHIBIOS=${CH_ROOT_REL} AP_HAL=${AP_HAL_REL} ${CHIBIOS_BUILD_FLAGS} ${CHIBIOS_BOARD_NAME} ${MAKE} pass -f '${BOARD_MK}'",
         group='dynamic_sources',
-        target='modules/ChibiOS/include_dirs'
+        target=bld.bldnode.find_or_declare('modules/ChibiOS/include_dirs')
     )
 
     common_src = [bld.bldnode.find_or_declare('hwdef.h'),
@@ -318,7 +320,7 @@ def build(bld):
         rule="BUILDDIR='${BUILDDIR_REL}' CHIBIOS='${CH_ROOT_REL}' AP_HAL=${AP_HAL_REL} ${CHIBIOS_BUILD_FLAGS} ${CHIBIOS_BOARD_NAME} '${MAKE}' lib -f '${BOARD_MK}'",
         group='dynamic_sources',
         source=common_src,
-        target='modules/ChibiOS/libch.a'
+        target=bld.bldnode.find_or_declare('modules/ChibiOS/libch.a')
     )
     ch_task.name = "ChibiOS_lib"
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -183,7 +183,7 @@ bool SPIDevice::clock_pulse(uint32_t n)
 uint16_t SPIDevice::derive_freq_flag_bus(uint8_t busid, uint32_t _frequency)
 {
     uint32_t spi_clock_freq = SPI1_CLOCK;
-    if (busid > 0 && busid-1 < ARRAY_SIZE_SIMPLE(bus_clocks)) {
+    if (busid > 0 && uint8_t(busid-1) < ARRAY_SIZE_SIMPLE(bus_clocks)) {
         spi_clock_freq = bus_clocks[busid-1] / 2;
     }
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -22,8 +22,8 @@
 #include "shared_dma.h"
 #include "Semaphores.h"
 
-#define RX_BOUNCE_BUFSIZE 128
-#define TX_BOUNCE_BUFSIZE 64
+#define RX_BOUNCE_BUFSIZE 128U
+#define TX_BOUNCE_BUFSIZE 64U
 
 #define UART_MAX_DRIVERS 7
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/hwdef.dat
@@ -7,8 +7,6 @@
 # MCU class and specific type
 MCU STM32F4xx STM32F405xx
 
-define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_CHIBIOS_KAKUTEF4
-
 # board ID for firmware load
 APJ_BOARD_ID 122
 


### PR DESCRIPTION
This is so we don't get frustrated with semaphore errors as the makefile build uses this flag