### PR TITLE
AP_Motors:TradHeli - fix metadata for H_COL_CTRL_DIR

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -154,8 +154,8 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
 
     // @Param: COL_CTRL_DIR
     // @DisplayName: Collective Control Direction
-    // @Description: Collective Control Direction - 0 for Normal. 1 for Reversed
-    // @Values: 0: Normal, 1: Reversed
+    // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
+    // @Values: 0:Normal,1:Reversed
     // @User: Standard
     AP_GROUPINFO("COL_CTRL_DIR", 19, AP_MotorsHeli_Dual, _collective_direction, AP_MOTORS_HELI_DUAL_COLLECTIVE_DIRECTION_NORMAL),
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -120,8 +120,8 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
 
     // @Param: COL_CTRL_DIR
     // @DisplayName: Collective Control Direction
-    // @Description: Collective Control Direction - 0 for Normal. 1 for Reversed
-    // @Values: 0: Normal, 1: Reversed
+    // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
+    // @Values: 0:Normal,1:Reversed
     // @User: Standard
     AP_GROUPINFO("COL_CTRL_DIR", 19, AP_MotorsHeli_Single, _collective_direction, AP_MOTORS_HELI_SINGLE_COLLECTIVE_DIRECTION_NORMAL),
 


### PR DESCRIPTION
Remove whitespace from metadata.