### PR TITLE
EKF2: Take the GPS lag from the GPS driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1112,6 +1112,9 @@ void AP_GPS::Write_DataFlash_Log_Startup_messages()
  */
 bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 {
+    // always enusre a lag is provided
+    lag_sec = GPS_WORST_LAG_SEC;
+
     // return lag of blended GPS
     if (instance == GPS_BLENDED_INSTANCE) {
         lag_sec = _blended_lag_sec;
@@ -1129,8 +1132,6 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
         if (_type[instance] == GPS_TYPE_NONE) {
             lag_sec = 0.0f;
             return true;
-        } else {
-            lag_sec = GPS_WORST_LAG_SEC;
         }
         return _type[instance] == GPS_TYPE_AUTO;
     } else {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -188,15 +188,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Units: m
     AP_GROUPINFO("GLITCH_RAD", 7, NavEKF2, _gpsGlitchRadiusMax, GLITCH_RADIUS_DEFAULT),
 
-    // @Param: GPS_DELAY
-    // @DisplayName: GPS measurement delay (msec)
-    // @Description: This is the number of msec that the GPS measurements lag behind the inertial measurements.
-    // @Range: 0 250
-    // @Increment: 10
-    // @User: Advanced
-    // @Units: ms
-    // @RebootRequired: True
-    AP_GROUPINFO("GPS_DELAY", 8, NavEKF2, _gpsDelay_ms, 220),
+    // 8 was used for GPS_DELAY
 
     // Height measurement parameters
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -362,7 +362,6 @@ private:
     AP_Float _accNoise;             // accelerometer process noise : m/s^2
     AP_Float _gyroBiasProcessNoise; // gyro bias state process noise : rad/s
     AP_Float _accelBiasProcessNoise;// accel bias state process noise : m/s^2
-    AP_Int16 _gpsDelay_ms;          // effective average delay of GPS measurements relative to inertial measurement (msec)
     AP_Int16 _hgtDelay_ms;          // effective average delay of Height measurements relative to inertial measurements (msec)
     AP_Int8  _fusionModeGPS;        // 0 = use 3D velocity, 1 = use 2D velocity, 2 = use no velocity
     AP_Int16  _gpsVelInnovGate;     // Percentage number of standard deviations applied to GPS velocity innovation consistency check

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -423,9 +423,12 @@ void NavEKF2_core::readGpsData()
             // get current fix time
             lastTimeGpsReceived_ms = gps.last_message_time_ms();
 
+
             // estimate when the GPS fix was valid, allowing for GPS processing and other delays
             // ideally we should be using a timing signal from the GPS receiver to set this time
-            gpsDataNew.time_ms = lastTimeGpsReceived_ms - frontend->_gpsDelay_ms;
+            float gps_delay = 0.0;
+            gps.get_lag(gps_delay); // ignore the return value
+            gpsDataNew.time_ms = lastTimeGpsReceived_ms - (uint32_t)(1e3f * gps_delay);
 
             // Correct for the average intersampling delay due to the filter updaterate
             gpsDataNew.time_ms -= localFilterTimeStep_ms/2;


### PR DESCRIPTION
This complements #8409. It allows GPS drivers to provide the lag for the hardware unit, which is automatically adjusted for ublox and septentrio drivers, which provides the EKF with better timestamped data. Users can still override the data, however it's rare that people try to do this (hence the lack of param conversion code), and was previously unclear if the GPS parameter or EKF parameters took precedence.

EKF3 already has this feature implemented (it actually takes it further and uses it to manipulate buffer sizes when starting, I chose to not backport that feature here.

This has not been flight tested.