### PR TITLE
Copter: use vector to set takeoff destination in guided mode

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -55,16 +55,8 @@ bool Copter::ModeGuided::do_user_takeoff_start(float final_alt_above_home)
 {
     guided_mode = Guided_TakeOff;
 
-    // initialise wpnav destination
-    Location_Class target_loc = copter.current_loc;
-    target_loc.set_alt_cm(final_alt_above_home, Location_Class::ALT_FRAME_ABOVE_HOME);
-
-    if (!wp_nav->set_wp_destination(target_loc)) {
-        // failure to set destination can only be because of missing terrain data
-        copter.Log_Write_Error(ERROR_SUBSYSTEM_NAVIGATION, ERROR_CODE_FAILED_TO_SET_DESTINATION);
-        // failure is propagated to GCS with NAK
-        return false;
-    }
+    const Vector3f& curr_pos = inertial_nav.get_position();
+    wp_nav->set_wp_destination(Vector3f(curr_pos.x, curr_pos.y, curr_pos.z + final_alt_above_home), false);
 
     // initialise yaw
     auto_yaw.set_mode(AUTO_YAW_HOLD);


### PR DESCRIPTION
replace  #8683 

Currently, takeoff in guided mode is not working when using external navigation (VISION_POSITION_ESTIMATE or ATT_POS_MOCAP). By using vector to set takeoff destination,  takeoff in guided mode works with both GPS and external navigation.

Tested OK outdoor (GPS, with or without rangefinder) and indoor (ATT_POS_MOCAP, Optitrack motion capture system)