### PR TITLE
ChibiOS: log system ID 

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -343,7 +343,8 @@ class chibios(Board):
             '-mno-thumb-interwork',
             '-mthumb',
             '-mfpu=fpv4-sp-d16',
-            '-mfloat-abi=hard'
+            '-mfloat-abi=hard',
+            '-DCHIBIOS_BOARD_NAME="%s"' % self.name,
         ]
 
         if sys.platform == 'cygwin':

--- a/libraries/AP_HAL/board/chibios.h
+++ b/libraries/AP_HAL/board/chibios.h
@@ -64,6 +64,10 @@
 #define HAL_COMPASS_HMC5843_NAME "hmc5843"
 #define HAL_COMPASS_LIS3MDL_NAME "lis3mdl"
 
+// allow for short names overridden in hwdef.dat
+#ifndef CHIBIOS_SHORT_BOARD_NAME
+#define CHIBIOS_SHORT_BOARD_NAME CHIBIOS_BOARD_NAME
+#endif
 
 #ifndef CONFIG_HAL_BOARD_SUBTYPE
 // allow for generic boards

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -240,3 +240,24 @@ bool Util::flash_bootloader()
     return false;
 }
 
+/*
+  display system identifer - board type and serial number
+ */
+bool Util::get_system_id(char buf[40])
+{
+    uint8_t serialid[12];
+    char board_name[14];
+    
+    memcpy(serialid, (const void *)UDID_START, 12);
+    strncpy(board_name, CHIBIOS_SHORT_BOARD_NAME, 13);
+    board_name[13] = 0;
+    
+    // this format is chosen to match the human_readable_serial()
+    // function in auth.c
+    snprintf(buf, 40, "%s %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X",
+             board_name,
+             (unsigned)serialid[0], (unsigned)serialid[1], (unsigned)serialid[2], (unsigned)serialid[3], 
+             (unsigned)serialid[4], (unsigned)serialid[5], (unsigned)serialid[6], (unsigned)serialid[7], 
+             (unsigned)serialid[8], (unsigned)serialid[9], (unsigned)serialid[10],(unsigned)serialid[11]); 
+    return true;
+}

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -44,6 +44,9 @@ public:
     void set_imu_temp(float current);
     void set_imu_target_temp(int8_t *target);
 
+    // get system ID as a string
+    bool get_system_id(char buf[40]) override;
+    
 #ifdef HAL_PWM_ALARM
     bool toneAlarm_init();
     void toneAlarm_set_tune(uint8_t tone);


### PR DESCRIPTION
This adds serial number and board type to mavlink and DF logs
