### PR TITLE
Rover: min speed crash check bypassed for balance bot

### DIFF
--- a/APMrover2/crash_check.cpp
+++ b/APMrover2/crash_check.cpp
@@ -27,22 +27,24 @@ void Rover::crash_check()
   // TODO : Check if min vel can be calculated
   // min_vel = ( CRASH_CHECK_THROTTLE_MIN * g.speed_cruise) / g.throttle_cruise;
 
-  if (!crashed && ((ahrs.groundspeed() >= CRASH_CHECK_VEL_MIN) ||        // Check velocity
-      (fabsf(ahrs.get_gyro().z) >= CRASH_CHECK_VEL_MIN) ||  // Check turn speed
-      (fabsf(g2.motors.get_throttle()) < CRASH_CHECK_THROTTLE_MIN))) {
-    crash_counter = 0;
-    return;
+  if (!is_balancebot()) {
+      if (!crashed && ((ahrs.groundspeed() >= CRASH_CHECK_VEL_MIN) ||        // Check velocity
+          (fabsf(ahrs.get_gyro().z) >= CRASH_CHECK_VEL_MIN) ||  // Check turn speed
+          (fabsf(g2.motors.get_throttle()) < CRASH_CHECK_THROTTLE_MIN))) {
+        crash_counter = 0;
+        return;
+      }
+
+      // we may be crashing
+      crash_counter++;
+
+      // check if crashing for 2 seconds
+      if (crash_counter >= (CRASH_CHECK_TRIGGER_SEC * 10)) {
+        crashed = true;
+      }
   }
 
-  // we may be crashing
-  crash_counter++;
-
-  // check if crashing for 2 seconds
-  if (crash_counter >= (CRASH_CHECK_TRIGGER_SEC * 10)) {
-    crashed = true;
-  }
-
-  if (crashed){
+  if (crashed) {
     // log an error in the dataflash
     Log_Write_Error(ERROR_SUBSYSTEM_CRASH_CHECK, ERROR_CODE_CRASH_CHECK_CRASH);
 


### PR DESCRIPTION
This is a continuation to PR #8701 and issue #7899. In the previous implementation the minimum speed check was applied to balance bots as well. Though its fine on SITL, this gives false positives all the time on the real vehicle. So I felt its best to bypass it. 
I am thinking if the balance bot actually gets its wheels stuck, then it will topple, triggering the angle crash check. So the minimum speed check might actually be redundant.
@rmackay9 What do you think?