### PR TITLE
OSD widgets for BLHeli32 ESC and lat/long

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -70,6 +70,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_SW_METHOD", 7, AP_OSD, sw_method, AP_OSD::TOGGLE),
 
+    // @Param: _OPTIONS
+    // @DisplayName: OSD Options
+    // @Description: This sets options that change the display
+    // @Bitmask: 0:UseDecimalPack
+    // @User: Standard
+    AP_GROUPINFO("_OPTIONS", 8, AP_OSD, options, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -18,6 +18,7 @@
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_BLHeli/AP_BLHeli.h>
 
 class AP_OSD_Backend;
 
@@ -91,6 +92,15 @@ private:
     AP_OSD_Setting wind{false, 0, 0};
     AP_OSD_Setting aspeed{false, 0, 0};
     AP_OSD_Setting vspeed{false, 0, 0};
+    
+#ifdef HAVE_AP_BLHELI_SUPPORT
+    AP_OSD_Setting blh_temp{false, 0, 0};
+    AP_OSD_Setting blh_rpm{false, 0, 0};
+    AP_OSD_Setting blh_amps{false, 0, 0};
+#endif
+    
+    AP_OSD_Setting gps_latitude{false, 0, 0};
+    AP_OSD_Setting gps_longitude{false, 0, 0};
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
@@ -111,6 +121,15 @@ private:
     void draw_vspeed(uint8_t x, uint8_t y);
 
     void draw_speed_vector(uint8_t x, uint8_t y, Vector2f v, int32_t yaw);
+
+#ifdef HAVE_AP_BLHELI_SUPPORT
+    void draw_blh_temp(uint8_t x, uint8_t y);
+    void draw_blh_rpm(uint8_t x, uint8_t y);
+    void draw_blh_amps(uint8_t x, uint8_t y);
+#endif
+    
+    void draw_gps_latitude(uint8_t x, uint8_t y);
+    void draw_gps_longitude(uint8_t x, uint8_t y);
 };
 
 class AP_OSD {
@@ -159,3 +178,4 @@ private:
     bool switch_debouncer;
     uint32_t last_switch_ms;
 };
+

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -162,6 +162,12 @@ public:
     AP_Int8 rc_channel;
     AP_Int8 sw_method;
 
+    enum {
+        OPTION_DECIMAL_PACK = 1U<<0,
+    };
+    
+    AP_Int32 options;
+
     AP_OSD_Screen screen[AP_OSD_NUM_SCREENS];
 
 private:

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -504,8 +504,8 @@ void AP_OSD_Screen::draw_gps_latitude(uint8_t x, uint8_t y)
     int32_t dec_portion, frac_portion;
     int32_t abs_lat = labs(loc.lat);
 
-    dec_portion = abs_lat / 10000000UL;
-    frac_portion = abs_lat - dec_portion*10000000UL;
+    dec_portion = loc.lat / 10000000L;
+    frac_portion = abs_lat - labs(dec_portion)*10000000UL;
 
     backend->write(x, y, false, "%c%3ld.%07ld", SYM_GPS_LAT, (long)dec_portion,(long)frac_portion);
 }
@@ -517,8 +517,8 @@ void AP_OSD_Screen::draw_gps_longitude(uint8_t x, uint8_t y)
     int32_t dec_portion, frac_portion;
     int32_t abs_lon = labs(loc.lng);
 
-    dec_portion = abs_lon / 10000000UL;
-    frac_portion = abs_lon - dec_portion*10000000UL;
+    dec_portion = loc.lng / 10000000L;
+    frac_portion = abs_lon - labs(dec_portion)*10000000UL;
 
     backend->write(x, y, false, "%c%3ld.%07ld", SYM_GPS_LONG, (long)dec_portion,(long)frac_portion);
 }

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -210,7 +210,7 @@ void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)
 {
     float alt;
     AP::ahrs().get_relative_position_D_home(alt);
-    backend->write(x, y, false, "%4.0f%c", alt, SYM_ALT_M);
+    backend->write(x, y, false, "%4.0f%c", -alt, SYM_ALT_M);
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)


### PR DESCRIPTION
Added five widgets to the OSD code for displaying BLHeli32 ESC parameters amps, temp, and motor RPM.  Also, first cut at displaying GPS lat and long.   This is all WIP by this git noob, as evidenced by the fact that I created the AP_OSD.h and AP_OSD_Screen.cpp in the top directory of Ardupilot, rather than editing the files in .../libraries/AP_OSD/.  The GPS lat and long definitely need some work, and the BLH code needs some surrounding ifdef for cases where BLHeli32 is not part of the build.