### PR TITLE
AP_Compass: remove pointless initialisations

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -451,16 +451,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
 // Note that the Vector/Matrix constructors already implicitly zero
 // their values.
 //
-Compass::Compass(void) :
-    _compass_cal_autoreboot(false),
-    _cal_complete_requires_reboot(false),
-    _cal_has_run(false),
-    _backend_count(0),
-    _compass_count(0),
-    _board_orientation(ROTATION_NONE),
-    _custom_rotation(nullptr),
-    _null_init_done(false),
-    _hil_mode(false)
+Compass::Compass(void)
 {
     if (_singleton != nullptr) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -470,15 +461,6 @@ Compass::Compass(void) :
     }
     _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
-    for (uint8_t i=0; i<COMPASS_MAX_BACKEND; i++) {
-        _backends[i] = nullptr;
-        _state[i].last_update_usec = 0;
-    }
-
-    // default device ids to zero.  init() method will overwrite with the actual device ids
-    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        _state[i].dev_id = 0;
-    }
 }
 
 // Default init method

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -395,7 +395,7 @@ private:
     AP_Int8 _learn;
 
     // board orientation from AHRS
-    enum Rotation _board_orientation;
+    enum Rotation _board_orientation = ROTATION_NONE;
     Matrix3f* _custom_rotation;
 
     // primary instance


### PR DESCRIPTION
If you are allocating one of these on the stack you're doing something
wrong.

Split from https://github.com/ArduPilot/ardupilot/pull/8033
