### PR TITLE
Implement BRD_PARAM_HIDE parameter

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo ToyMode::var_info[] = {
     // @Description: tmode (or "toy" mode) gives a simplified user interface designed for mass market drones. Version1 is for the SkyViper V2450GPS. Version2 is for the F412 based boards
     // @Values: 0:Disabled,1:EnableVersion1,2:EnableVersion2
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("_ENABLE", 1, ToyMode, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, ToyMode, enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: _MODE1
     // @DisplayName: Tmode first mode

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -6,6 +6,7 @@
  */
 
 #define GSCALAR(v, name, def) { plane.g.v.vtype, name, Parameters::k_param_ ## v, &plane.g.v, {def_value : def} }
+#define GSCALAR_FLAGS(v, name, def, flags) { plane.g.v.vtype, name, Parameters::k_param_ ## v, &plane.g.v, {def_value : def}, flags }
 #define ASCALAR(v, name, def) { plane.aparm.v.vtype, name, Parameters::k_param_ ## v, (const void *)&plane.aparm.v, {def_value : def} }
 #define GGROUP(v, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, &plane.g.v, {group_info : class::var_info} }
 #define GOBJECT(v, name, class) { AP_PARAM_GROUP, name, Parameters::k_param_ ## v, (const void *)&plane.v, {group_info : class::var_info} }
@@ -696,7 +697,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Description: Number of APM board resets
     // @ReadOnly: True
     // @User: Advanced
-    GSCALAR(num_resets,             "SYS_NUM_RESETS", 0),
+    GSCALAR_FLAGS(num_resets,             "SYS_NUM_RESETS", 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -7,7 +7,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Description: This enables QuadPlane functionality, assuming multicopter motors start on output 5. If this is set to 2 then when starting AUTO mode it will initially be in VTOL AUTO mode.
     // @Values: 0:Disable,1:Enable,2:Enable VTOL AUTO
     // @User: Standard
-    AP_GROUPINFO_FLAGS("ENABLE", 1, QuadPlane, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, QuadPlane, enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Group: M_
     // @Path: ../libraries/AP_Motors/AP_MotorsMulticopter.cpp

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -558,6 +558,10 @@ def start_vehicle(binary, autotest, opts, stuff, loc):
     cmd.append("-S")
     cmd.append("-I" + str(opts.instance))
     cmd.extend(["--home", loc])
+
+    if opts.unhide_groups:
+        cmd.append("--unhide-groups")
+    
     if opts.wipe_eeprom:
         cmd.append("-w")
     cmd.extend(["--model", stuff["model"]])
@@ -888,6 +892,9 @@ group_sim.add_option("", "--no-extra-ports",
                      dest='no_extra_ports',
                      default=False,
                      help="Disable setup of UDP 14550 and 14551 output")
+group_sim.add_option("", "--unhide-groups",
+                     action='store_true',
+                     help="unhide all param groups")
 parser.add_option_group(group_sim)
 
 

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -14,7 +14,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Description: Precision Land enabled/disabled and behaviour
     // @Values: 0:Disabled, 1:Enabled Always Land, 2:Enabled Strict
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLED", 0, AC_PrecLand, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLED", 0, AC_PrecLand, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: TYPE
     // @DisplayName: Precision Land Type

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -11,7 +11,7 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
     // @Description: Allows you to enable (1) or disable (0) the sprayer
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AC_Sprayer, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AC_Sprayer, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: PUMP_RATE
     // @DisplayName: Pump speed

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Description: Enable ADS-B
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FLAGS("ENABLE",     0, AP_ADSB, _enabled,    0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE",     0, AP_ADSB, _enabled,    0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // index 1 is reserved - was BEHAVIOR
 

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_AdvancedFailsafe::var_info[] = {
     // @DisplayName: Enable Advanced Failsafe
     // @Description: This enables the advanced failsafe system. If this is set to zero (disable) then all the other AFS options have no effect
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE",       11, AP_AdvancedFailsafe, _enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE",       11, AP_AdvancedFailsafe, _enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: MAN_PIN
     // @DisplayName: Manual Pin

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -57,7 +57,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Description: Type of airspeed sensor
     // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X
     // @User: Standard
-    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_Airspeed, param[0].type, ARSPD_DEFAULT_TYPE, AP_PARAM_FLAG_ENABLE_MINOR),
 
     // @Param: _USE
     // @DisplayName: Airspeed use
@@ -130,7 +130,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Description: Type of 2nd airspeed sensor
     // @Values: 0:None,1:I2C-MS4525D0,2:Analog,3:I2C-MS5525,4:I2C-MS5525 (0x76),5:I2C-MS5525 (0x77),6:I2C-SDP3X
     // @User: Standard
-    AP_GROUPINFO_FLAGS("2_TYPE", 11, AP_Airspeed, param[1].type, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("2_TYPE", 11, AP_Airspeed, param[1].type, 0, AP_PARAM_FLAG_ENABLE_MINOR),
 
     // @Param: 2_USE
     // @DisplayName: Enable use of 2nd airspeed sensor

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     // @Description: Airspeed calibration offset
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("_OFFSET", 2, AP_Airspeed, param[0].offset, 0),
+    AP_GROUPINFO_FLAGS("_OFFSET", 2, AP_Airspeed, param[0].offset, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: _RATIO
     // @DisplayName: Airspeed ratio

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AP_Avoidance::var_info[] = {
     // @Description: Enable Avoidance using ADSB
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_Avoidance, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_Avoidance, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: F_ACTION
     // @DisplayName: Collision Avoidance Behavior

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @ReadOnly: True
     // @Volatile: True
     // @User: Advanced
-    AP_GROUPINFO("ABS_PRESS", 2, AP_Baro, sensors[0].ground_pressure, 0),
+    AP_GROUPINFO_FLAGS("ABS_PRESS", 2, AP_Baro, sensors[0].ground_pressure, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: TEMP
     // @DisplayName: ground temperature
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @Increment: 1
     // @Volatile: True
     // @User: Advanced
-    AP_GROUPINFO("TEMP", 3, AP_Baro, _user_ground_temperature, 0),
+    AP_GROUPINFO_FLAGS("TEMP", 3, AP_Baro, _user_ground_temperature, 0, AP_PARAM_FLAG_VOLATILE),
 
     // index 4 reserved for old AP_Int8 version in legacy FRAM
     //AP_GROUPINFO("ALT_OFFSET", 4, AP_Baro, _alt_offset, 0),

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @DisplayName: Battery serial number
     // @Description: Battery serial number, automatically filled in for SMBus batteries, otherwise will be -1. With UAVCAN it is the battery_id.
     // @User: Advanced
-    AP_GROUPINFO("SERIAL_NUM", 9, AP_BattMonitor_Params, _serial_number, AP_BATT_SERIAL_NUMBER_DEFAULT),
+    AP_GROUPINFO_FLAGS("SERIAL_NUM", 9, AP_BattMonitor_Params, _serial_number, AP_BATT_SERIAL_NUMBER_DEFAULT, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: LOW_TIMER
     // @DisplayName: Low voltage timeout

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Values: 0:Disabled,3:Analog Voltage Only,4:Analog Voltage and Current,5:Solo,6:Bebop,7:SMBus-Maxell,8:UAVCAN-BatteryInfo
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO_FLAGS("MONITOR", 1, AP_BattMonitor_Params, _type, BattMonitor_TYPE_NONE, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("MONITOR", 1, AP_BattMonitor_Params, _type, BattMonitor_TYPE_NONE, AP_PARAM_FLAG_ENABLE_MINOR),
 
     // @Param: VOLT_PIN
     // @DisplayName: Battery Voltage sensing pin

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -219,6 +219,13 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Path: ../AP_RTC/AP_RTC.cpp
     AP_SUBGROUPINFO(rtc, "RTC", 14, AP_BoardConfig, AP_RTC),
 
+    // @Param: PARAM_HIDE
+    // @DisplayName: Hiding of parameters
+    // @Description: This controls the hiding of unused parameter subsystems. You can choose to not hide any subsystems, or only hide major subsystems or hide both major and minor subsystems
+    // @Bitmask: 0:HideNone,1:HideMajor,2:HideMinor
+    // @User: Standard
+    AP_GROUPINFO("PARAM_HIDE",  15, AP_BoardConfig, _param_hide, 1),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -151,6 +151,14 @@ public:
 #endif
     }
 
+    // get the parameter hide option
+    AP_Param::param_hide get_param_hide(void) {
+        return (AP_Param::param_hide)_param_hide.get();
+    }
+
+    void set_hide_param_default(AP_Param::param_hide v) {
+        _param_hide.set_default((int8_t)v);
+    }
     
 private:
     static AP_BoardConfig *instance;
@@ -173,6 +181,8 @@ private:
     } state;
 #endif
 
+    AP_Int8 _param_hide;
+    
 #if AP_FEATURE_BOARD_DETECT
     static enum px4_board_type px4_configured_board;
 

--- a/libraries/AP_BoardConfig/canbus.cpp
+++ b/libraries/AP_BoardConfig/canbus.cpp
@@ -29,7 +29,7 @@ const AP_Param::GroupInfo AP_BoardConfig_CAN::CAN_if_var_info::var_info[] = {
     // @Values: 0:Disabled,1:First driver,2:Second driver
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO_FLAGS("DRIVER", 1, AP_BoardConfig_CAN::CAN_if_var_info, _driver_number, HAL_CAN_DRIVER_DEFAULT, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("DRIVER", 1, AP_BoardConfig_CAN::CAN_if_var_info, _driver_number, HAL_CAN_DRIVER_DEFAULT, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: BITRATE
     // @DisplayName: Bitrate of CAN interface

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_Button::var_info[] = {
     // @Description: This enables the button checking module. When this is disabled the parameters for setting button inputs are not visible
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Button, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Button, enable, 0, AP_PARAM_FLAG_ENABLE_MINOR),
 
     // @Param: PIN1
     // @DisplayName: First button Pin

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -76,7 +76,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Units: rad
     // @Increment: 0.01
     // @User: Standard
-    AP_GROUPINFO("DEC",    2, Compass, _declination, 0),
+    AP_GROUPINFO_FLAGS("DEC",    2, Compass, _declination, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: LEARN
     // @DisplayName: Learn compass offsets automatically

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -13,7 +13,7 @@ const AP_Param::GroupInfo Compass_PerMotor::var_info[] = {
     // @Description: This enables per-motor compass corrections
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("_EN",  1, Compass_PerMotor, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_EN",  1, Compass_PerMotor, enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: _EXP
     // @DisplayName: per-motor exponential correction

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Description: Enabled/disable following a target
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_Follow, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_Follow, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // 2 is reserved for TYPE parameter
 

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -17,7 +17,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
     // @Description: Gripper enable/disable
     // @User: Standard
     // @Values: 0:Disabled, 1:Enabled
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Gripper, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Gripper, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: TYPE
     // @DisplayName: Gripper Type

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <AP_HAL/utility/getopt_cpp.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 #include <SITL/SIM_Multicopter.h>
 #include <SITL/SIM_Helicopter.h>
@@ -227,9 +228,13 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             AP_Param::erase_all();
             unlink("dataflash.bin");
             break;
-        case 'u':
-            AP_Param::set_hide_disabled_groups(false);
+        case 'u': {
+            AP_BoardConfig *boardconfig = AP_BoardConfig::get_instance();
+            if (boardconfig) {
+                boardconfig->set_hide_param_default(AP_Param::PARAM_HIDE_NONE);
+            }
             break;
+        }
         case 's':
             speedup = strtof(gopt.optarg, nullptr);
             break;

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -47,7 +47,7 @@ void SITL_State::_usage(void)
     printf("Options:\n"
            "\t--help|-h                display this help information\n"
            "\t--wipe|-w                wipe eeprom and dataflash\n"
-           "\t--unhide-groups|-u       parameter enumeration ignores AP_PARAM_FLAG_ENABLE\n"
+           "\t--unhide-groups|-u       parameter enumeration ignores AP_PARAM_FLAG_ENABLE*\n"
            "\t--speedup|-s SPEEDUP     set simulation speedup\n"
            "\t--rate|-r RATE           set SITL framerate\n"
            "\t--console|-C             use console instead of TCP ports\n"

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @Description: This enables internal combusion engine control
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_ICEngine, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_ICEngine, enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: START_CHAN
     // @DisplayName: Input channel for engine start

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -93,7 +93,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Description: Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations
     // @Units: rad/s
     // @User: Advanced
-    AP_GROUPINFO("GYROFFS",     3, AP_InertialSensor, _gyro_offset[0],  0),
+    AP_GROUPINFO_FLAGS("GYROFFS",     3, AP_InertialSensor, _gyro_offset[0],  0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: GYR2OFFS_X
     // @DisplayName: Gyro2 offsets of X axis
@@ -112,7 +112,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Description: Gyro2 sensor offsets of Z axis. This is setup on each boot during gyro calibrations
     // @Units: rad/s
     // @User: Advanced
-    AP_GROUPINFO("GYR2OFFS",    7, AP_InertialSensor, _gyro_offset[1],   0),
+    AP_GROUPINFO_FLAGS("GYR2OFFS",    7, AP_InertialSensor, _gyro_offset[1],   0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: GYR3OFFS_X
     // @DisplayName: Gyro3 offsets of X axis
@@ -131,7 +131,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Description: Gyro3 sensor offsets of Z axis. This is setup on each boot during gyro calibrations
     // @Units: rad/s
     // @User: Advanced
-    AP_GROUPINFO("GYR3OFFS",   10, AP_InertialSensor, _gyro_offset[2],   0),
+    AP_GROUPINFO_FLAGS("GYR3OFFS",   10, AP_InertialSensor, _gyro_offset[2],   0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: ACCSCAL_X
     // @DisplayName: Accelerometer scaling of X axis

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -13,7 +13,7 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @Range: 0 32766
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("TOTAL",  0, AP_Mission, _cmd_total, 0),
+    AP_GROUPINFO_FLAGS("TOTAL",  0, AP_Mission, _cmd_total, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: RESTART
     // @DisplayName: Mission Restart when entering Auto mode

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF2, _enable, 1, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF2, _enable, 1, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // GPS measurement parameters
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -121,7 +121,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF3, _enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF3, _enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // GPS measurement parameters
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Values: 0:None,1:MAX7456
     // @User: Standard
     // @RebootRequired: True
-    AP_GROUPINFO_FLAGS("_TYPE", 1, AP_OSD, osd_type, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_TYPE", 1, AP_OSD, osd_type, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: _CHAN
     // @DisplayName: Screen switch transmitter channel

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Description: Enable this screen
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_OSD_Screen, enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, AP_OSD_Screen, enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: CHAN_MIN
     // @DisplayName: Transmitter switch screen minimum pwm

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -15,7 +15,7 @@ const AP_Param::GroupInfo AP_Parachute::var_info[] = {
     // @Description: Parachute release enabled or disabled
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
-    AP_GROUPINFO_FLAGS("ENABLED", 0, AP_Parachute, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLED", 0, AP_Parachute, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: TYPE
     // @DisplayName: Parachute release mechanism type (relay or servo)

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -593,6 +593,9 @@ private:
      */
     static bool count_embedded_param_defaults(uint16_t &count);
     static void load_embedded_param_defaults(bool last_pass);
+
+    // check for AP_PARAM_FLAG_ENABLE_*
+    static bool check_disabled(uint16_t flags);
     
     // send a parameter to all GCS instances
     void send_parameter(const char *name, enum ap_var_type param_header_type, uint8_t idx) const;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -407,7 +407,13 @@ public:
     // count of parameters in tree
     static uint16_t count_parameters(void);
 
-    static void set_hide_disabled_groups(bool value) { _hide_disabled_groups = value; }
+    enum param_hide {
+        PARAM_HIDE_NONE=0,
+        PARAM_HIDE_MAJOR=1,
+        PARAM_HIDE_MINOR=2,
+    };
+    
+    static void set_hide_disabled_groups(param_hide value) { _hide_disabled_groups = value; }
 
     // set frame type flags. Used to unhide frame specific parameters
     static void set_frame_type_flags(uint16_t flags_to_set) {
@@ -433,7 +439,7 @@ public:
                              enum ap_var_type ptype, 
                              AP_HAL::BetterStream *port);
 #endif // AP_PARAM_KEY_DUMP
-    
+
 private:
     /// EEPROM header
     ///
@@ -607,7 +613,7 @@ private:
     static const uint8_t        k_EEPROM_magic1      = 0x41; ///< "AP"
     static const uint8_t        k_EEPROM_revision    = 6; ///< current format revision
 
-    static bool _hide_disabled_groups;
+    static param_hide _hide_disabled_groups;
 };
 
 /// Template class for scalar variables.

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -69,13 +69,16 @@
 // ignore the enable parameter on this group
 #define AP_PARAM_FLAG_IGNORE_ENABLE (1<<6)
 
+// mark a parameter as volatile (not included in _HASH_CHECK)
+#define AP_PARAM_FLAG_VOLATILE      (1<<7)
+
 // keep all flags before the FRAME tags
 
 // vehicle and frame type flags, used to hide parameters when not
 // relevent to a vehicle type. Use AP_Param::set_frame_type_flags() to
 // enable parameters flagged in this way. frame type flags are stored
 // in flags field, shifted by AP_PARAM_FRAME_TYPE_SHIFT.
-#define AP_PARAM_FRAME_TYPE_SHIFT   7
+#define AP_PARAM_FRAME_TYPE_SHIFT   8
 
 // supported frame types for parameters
 #define AP_PARAM_FRAME_COPTER       (1<<0)
@@ -199,6 +202,7 @@ public:
         uint32_t key : 9;
         uint32_t idx : 5; // offset into array types
         uint32_t group_element : 18;
+        uint16_t flags; // AP_PARAM_FLAG_*
     } ParamToken;
 
     
@@ -599,6 +603,9 @@ private:
     
     // send a parameter to all GCS instances
     void send_parameter(const char *name, enum ap_var_type param_header_type, uint8_t idx) const;
+
+    // update magic param_hash variable
+    static void update_param_hash(void);
     
     static StorageAccess        _storage;
     static uint16_t             _num_vars;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -52,18 +52,22 @@
 #define AP_PARAM_FLAG_POINTER       (1<<1)
 
 // an enable variable allows a whole subtree of variables to be made
-// invisible
-#define AP_PARAM_FLAG_ENABLE        (1<<2)
+// invisible. This is for a major subsystem
+#define AP_PARAM_FLAG_ENABLE_MAJOR  (1<<2)
+
+// an enable variable allows a whole subtree of variables to be made
+// invisible. This is for a minor subsystem
+#define AP_PARAM_FLAG_ENABLE_MINOR  (1<<3)
 
 // don't shift index 0 to index 63. Use this when you know there will be
 // no conflict with the parent
-#define AP_PARAM_NO_SHIFT           (1<<3)
+#define AP_PARAM_NO_SHIFT           (1<<4)
 
 // the var_info is a pointer, allowing for dynamic definition of the var_info tree
-#define AP_PARAM_FLAG_INFO_POINTER  (1<<4)
+#define AP_PARAM_FLAG_INFO_POINTER  (1<<5)
 
 // ignore the enable parameter on this group
-#define AP_PARAM_FLAG_IGNORE_ENABLE (1<<5)
+#define AP_PARAM_FLAG_IGNORE_ENABLE (1<<6)
 
 // keep all flags before the FRAME tags
 
@@ -71,7 +75,7 @@
 // relevent to a vehicle type. Use AP_Param::set_frame_type_flags() to
 // enable parameters flagged in this way. frame type flags are stored
 // in flags field, shifted by AP_PARAM_FRAME_TYPE_SHIFT.
-#define AP_PARAM_FRAME_TYPE_SHIFT   6
+#define AP_PARAM_FRAME_TYPE_SHIFT   7
 
 // supported frame types for parameters
 #define AP_PARAM_FRAME_COPTER       (1<<0)

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
     // @Description: Radio Receiver RSSI type. If your radio receiver supports RSSI of some kind, set it here, then set its associated RSSI_XXXXX parameters, if any.
     // @Values: 0:Disabled,1:AnalogPin,2:RCChannelPwmValue,3:ReceiverProtocol
     // @User: Standard
-    AP_GROUPINFO_FLAGS("TYPE", 0, AP_RSSI, rssi_type,  BOARD_RSSI_DEFAULT, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("TYPE", 0, AP_RSSI, rssi_type,  BOARD_RSSI_DEFAULT, AP_PARAM_FLAG_ENABLE_MINOR),
 
     // @Param: ANA_PIN
     // @DisplayName: Receiver RSSI analog sensing pin

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_Rally::var_info[] = {
     // @DisplayName: Rally Total
     // @Description: Number of rally points currently loaded
     // @User: Advanced
-    AP_GROUPINFO("TOTAL", 0, AP_Rally, _rally_point_total_count, 0),
+    AP_GROUPINFO_FLAGS("TOTAL", 0, AP_Rally, _rally_point_total_count, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: LIMIT_KM
     // @DisplayName: Rally Limit

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -11,7 +11,7 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Description: Toggles the soaring mode on and off
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, SoaringController, soar_active, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, SoaringController, soar_active, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: VSPEED
     // @DisplayName: Vertical v-speed

--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -13,7 +13,7 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Description: Number of times board has been booted
     // @ReadOnly: True
     // @User: Standard
-    AP_GROUPINFO("_BOOTCNT",    0, AP_Stats, params.bootcount, 0),
+    AP_GROUPINFO_FLAGS("_BOOTCNT",    0, AP_Stats, params.bootcount, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: _FLTTIME
     // @DisplayName: Total FlightTime
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Units: s
     // @ReadOnly: True
     // @User: Standard
-    AP_GROUPINFO("_FLTTIME",    1, AP_Stats, params.flttime, 0),
+    AP_GROUPINFO_FLAGS("_FLTTIME",    1, AP_Stats, params.flttime, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: _RUNTIME
     // @DisplayName: Total RunTime
@@ -29,7 +29,7 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @Units: s
     // @ReadOnly: True
     // @User: Standard
-    AP_GROUPINFO("_RUNTIME",    2, AP_Stats, params.runtime, 0),
+    AP_GROUPINFO_FLAGS("_RUNTIME",    2, AP_Stats, params.runtime, 0, AP_PARAM_FLAG_VOLATILE),
 
     // @Param: _RESET
     // @DisplayName: Reset time

--- a/libraries/AP_TempCalibration/AP_TempCalibration.cpp
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.cpp
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_TempCalibration::var_info[] = {
     // @Description: Enable temperature calibration. Set to 0 to disable. Set to 1 to use learned values. Set to 2 to learn new values and use the values
     // @Values: 0:Disabled,1:Enabled,2:EnableAndLearn
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("_ENABLED", 1, AP_TempCalibration, enabled, TC_DISABLED, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLED", 1, AP_TempCalibration, enabled, TC_DISABLED, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: TEMP_MIN
     // @DisplayName: Min learned temperature

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Description: enable terrain data. This enables the vehicle storing a database of terrain data on the SD card. The terrain data is requested from the ground station as needed, and stored for later use on the SD card. To be useful the ground station must support TERRAIN_REQUEST messages and have access to a terrain database, such as the SRTM database.
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Terrain, enable, 1, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, AP_Terrain, enable, 1, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: SPACING
     // @DisplayName: Terrain grid spacing

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     // @Description: What type of WheelEncoder is connected
     // @Values: 0:None,1:Quadrature
     // @User: Standard
-    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_WheelEncoder, _type[0], 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_TYPE", 0, AP_WheelEncoder, _type[0], 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: _CPR
     // @DisplayName: WheelEncoder counts per revolution

--- a/libraries/AP_Winch/AP_Winch.cpp
+++ b/libraries/AP_Winch/AP_Winch.cpp
@@ -9,7 +9,7 @@ const AP_Param::GroupInfo AP_Winch::var_info[] = {
     // @Description: Winch enable/disable
     // @User: Standard
     // @Values: 0:Disabled, 1:Enabled
-    AP_GROUPINFO_FLAGS("_ENABLE", 0, AP_Winch, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLE", 0, AP_Winch, _enabled, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: TYPE
     // @DisplayName: Winch Type

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo NotchFilterVector3fParam::var_info[] = {
     // @Description: Enable notch filter
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, NotchFilterVector3fParam, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, NotchFilterVector3fParam, enable, 0, AP_PARAM_FLAG_ENABLE_MAJOR),
 
     // @Param: FREQ
     // @DisplayName: Frequency


### PR DESCRIPTION
This implements two levels of parameter hiding, MAJOR and MINOR. There is a parameter BRD_PARAM_HIDE which controls what params are hidden, from 0 meaning none, to 2 meaning hide unset minor parameters. The default is to only hide major subsystems.
This was to address a request from @DonLakeFlyer to make UIs easier.
Note that the choice of which ones are major/minor are fairly arbitrary, and are currently chosen to suit places where param hiding is likely to cause UI issues for GCS implementations.

ping @lvale 

UPDATE: this now implements _HASH_CHECK magic parameter as well. There may be some more parameters that should be marked as VOLATILE, plus we need a way to send the volatiles automatically