### PR TITLE
AP_OSD: fixes for roll/pitch direction and home direction

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -139,6 +139,7 @@ void AP_OSD::update_osd()
     backend->flush();
 }
 
+//Thanks to minimosd authors for the multiple osd screen idea
 void AP_OSD::update_current_screen()
 {
     if (rc_channel == 0) {

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -261,6 +261,7 @@ void AP_OSD_MAX7456::buffer_add_cmd(uint8_t reg, uint8_t arg)
     }
 }
 
+//Thanks to betaflight for the max stall/reboot detection approach and ntsc/pal autodetection
 void AP_OSD_MAX7456::check_reinit()
 {
     uint8_t check = 0xFF;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -196,6 +196,8 @@ void AP_OSD_Screen::draw_batused(uint8_t x, uint8_t y)
     backend->write(x,y, battery.has_failsafed(), "%c%4.0f", SYM_MAH, battery.consumed_mah());
 }
 
+//Autoscroll message is the same as in minimosd-extra.
+//Thanks to night-ghost for the approach.
 void AP_OSD_Screen::draw_message(uint8_t x, uint8_t y)
 {
     AP_Notify * notify = AP_Notify::instance();
@@ -250,6 +252,7 @@ void AP_OSD_Screen::draw_gspeed(uint8_t x, uint8_t y)
     backend->write(x, y, false, "%3.0f%c", v, SYM_KMH);
 }
 
+//Thanks to betaflight/inav for simple and clean artificial horizon visual design
 void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
 {
     AP_AHRS &ahrs = AP::ahrs();

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -282,7 +282,7 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
     if (ahrs.get_position(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
         float distance = get_distance(home_loc, loc);
-        int32_t angle = get_bearing_cd(loc, home_loc);
+        int32_t angle = wrap_360_cd(get_bearing_cd(loc, home_loc) - ahrs.yaw_sensor);
         int32_t interval = 36000 / SYM_ARROW_COUNT;
         if (distance < 2.0f) {
             //avoid fast rotating arrow at small distances

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -256,8 +256,8 @@ void AP_OSD_Screen::draw_gspeed(uint8_t x, uint8_t y)
 void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
 {
     AP_AHRS &ahrs = AP::ahrs();
-    float roll = -ahrs.roll;
-    float pitch = ahrs.pitch;
+    float roll = ahrs.roll;
+    float pitch = -ahrs.pitch;
 
     roll = constrain_float(roll, -ah_max_roll, ah_max_roll);
     pitch = constrain_float(pitch, -ah_max_pitch, ah_max_pitch);


### PR DESCRIPTION
This pr:
1. fixes roll and pitch direction in horizon. 
2. fixes home direction.

Thanks to @vierfuffzig  and @Kelly-Foster for finding bug and testing the fix.