### PR TITLE
Copter: fixed board name in release notes

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -3,7 +3,7 @@ ArduPilot Copter Release Notes:
 Copter 3.6.0-rc3 02-Jul-2018
 Changes from 3.6.0-rc2
 1) ChibiOS:
-    a) airbotf4, matekF305, matekF405-wing, omnibusf4pro, mini-pix, omnibusf7v2, revo-mini, sparky2 binaries built on firmware.ardupilot.org
+    a) airbotf4, matekF405, matekF405-wing, omnibusf4pro, mini-pix, omnibusf7v2, revo-mini, sparky2 binaries built on firmware.ardupilot.org
     b) STM32F7 support including Pixhack5 (aka fmuv4)
     c) fixed dataflash logfile dates
     d) bootloader included in firmware for easier uploading


### PR DESCRIPTION
Really tiny change