### PR TITLE
Copter: further explain even if RTL_ALT set to zero, copter still climb to 2m…

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -108,7 +108,7 @@ const AP_Param::Info Copter::var_info[] = {
 #if MODE_RTL_ENABLED == ENABLED
     // @Param: RTL_ALT
     // @DisplayName: RTL Altitude
-    // @Description: The minimum relative altitude the model will move to before Returning to Launch.  Set to zero to return at current altitude.
+    // @Description: The minimum relative altitude the model will move to before Returning to Launch.  Set to zero to return at current altitude. Copter still climb to 2m above ground if its current altitude lower than 2m (defined as RTL_ALT_MIN in config.h)
     // @Units: cm
     // @Range: 0 8000
     // @Increment: 1


### PR DESCRIPTION
… above ground

In current description of RTL_ALT, it states "Set to zero to return at current altitude". But if current altitude of a copter is below 2m above ground, it will climb up to 2m (defined as RTL_ALT_MIN in config.h) rather than "current altitude"). It works well outdoor, but when a copter fly indoor, it may hit ceiling.  And user will feel confused about why copter climb up with  RTL_ALT = 0.