### PR TITLE
Tools: sim_vehicle.py fixups

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -204,7 +204,7 @@ def kill_tasks_psutil(victims):
 def kill_tasks_pkill(victims):
     """Shell out to pkill(1) to kill processed by name"""
     for victim in victims:  # pkill takes a single pattern, so iterate
-        cmd = ["pkill", victim]
+        cmd = ["pkill", victim[:15]] # pkill will only match the first 15 characters
         run_cmd_blocking("pkill", cmd, quiet=True)
 
 
@@ -538,7 +538,7 @@ def start_vehicle(binary, autotest, opts, stuff, loc):
     if opts.gdb or opts.gdb_stopped:
         cmd_name += " (gdb)"
         cmd.append("gdb")
-        gdb_commands_file = tempfile.NamedTemporaryFile(delete=False)
+        gdb_commands_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         atexit.register(os.unlink, gdb_commands_file.name)
 
         for breakpoint in opts.breakpoint:


### PR DESCRIPTION
The GDB file changes are needed to run in python3 (also runs in python2 correctly).

While trying to get `sim_vehicle.py` running again on my machine I noticed that some of the patterns we try to kill are exceeding the allowed length (you see this error printed on the console:
```
pkill: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pkill -f' option to match against the complete command line.
```