### PR TITLE
Factor out handling of command-long and command-int messages

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -728,12 +728,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
         return MAV_RESULT_ACCEPTED;
     }
 
-    case MAV_CMD_ACCELCAL_VEHICLE_POS:
-        if (!rover.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_ACCEPTED;
-
     case MAV_CMD_DO_MOTOR_TEST:
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -517,6 +517,95 @@ MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlin
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
 }
 
+MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_int_t &packet)
+{
+    switch (packet.command) {
+
+    case MAV_CMD_DO_CHANGE_SPEED:
+        // param1 : unused
+        // param2 : new speed in m/s
+        if (!rover.control_mode->set_desired_speed(packet.param2)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_DO_SET_HOME: {
+        // assume failure
+        if (is_equal(packet.param1, 1.0f)) {
+            // if param1 is 1, use current location
+            if (rover.set_home_to_current_location(true)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+        // ensure param1 is zero
+        if (!is_zero(packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+        // check frame type is supported
+        if (packet.frame != MAV_FRAME_GLOBAL &&
+            packet.frame != MAV_FRAME_GLOBAL_INT &&
+            packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
+            packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+            return MAV_RESULT_FAILED;
+        }
+        // sanity check location
+        if (!check_latlng(packet.x, packet.y)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location new_home_loc {};
+        new_home_loc.lat = packet.x;
+        new_home_loc.lng = packet.y;
+        new_home_loc.alt = packet.z * 100;
+        // handle relative altitude
+        if (packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT || packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+            if (!rover.ahrs.home_is_set()) {
+                // cannot use relative altitude if home is not set
+                return MAV_RESULT_FAILED;
+            }
+            new_home_loc.alt += rover.ahrs.get_home().alt;
+        }
+        if (!rover.set_home(new_home_loc, true)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+    }
+
+#if MOUNT == ENABLED
+    case MAV_CMD_DO_SET_ROI: {
+        // param1 : /* Region of interest mode (not used)*/
+        // param2 : /* MISSION index/ target ID (not used)*/
+        // param3 : /* ROI index (not used)*/
+        // param4 : /* empty */
+        // x : lat
+        // y : lon
+        // z : alt
+        // sanity check location
+        if (!check_latlng(packet.x, packet.y)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location roi_loc;
+        roi_loc.lat = packet.x;
+        roi_loc.lng = packet.y;
+        roi_loc.alt = (int32_t)(packet.z * 100.0f);
+        if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
+            // switch off the camera tracking if enabled
+            if (rover.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
+                rover.camera_mount.set_mode_to_default();
+            }
+        } else {
+            // send the command to the camera mount
+            rover.camera_mount.set_roi_target(roi_loc);
+        }
+        return MAV_RESULT_ACCEPTED;
+    }
+#endif
+
+    default:
+        return GCS_MAVLINK::handle_command_int_packet(packet);
+    }
+}
+
 MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
     switch (packet.command) {
@@ -666,108 +755,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
 void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
-
-    case MAVLINK_MSG_ID_COMMAND_INT: {
-        // decode packet
-        mavlink_command_int_t packet;
-        mavlink_msg_command_int_decode(msg, &packet);
-        MAV_RESULT result = MAV_RESULT_UNSUPPORTED;
-
-        switch (packet.command) {
-
-        case MAV_CMD_DO_CHANGE_SPEED:
-            // param1 : unused
-            // param2 : new speed in m/s
-            if (rover.control_mode->set_desired_speed(packet.param2)) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-            break;
-
-        case MAV_CMD_DO_SET_HOME: {
-            // assume failure
-            result = MAV_RESULT_FAILED;
-            if (is_equal(packet.param1, 1.0f)) {
-                // if param1 is 1, use current location
-                if (rover.set_home_to_current_location(true)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-                break;
-            }
-            // ensure param1 is zero
-            if (!is_zero(packet.param1)) {
-                break;
-            }
-            // check frame type is supported
-            if (packet.frame != MAV_FRAME_GLOBAL &&
-                packet.frame != MAV_FRAME_GLOBAL_INT &&
-                packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
-                packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
-                break;
-            }
-            // sanity check location
-            if (!check_latlng(packet.x, packet.y)) {
-                break;
-            }
-            Location new_home_loc {};
-            new_home_loc.lat = packet.x;
-            new_home_loc.lng = packet.y;
-            new_home_loc.alt = packet.z * 100;
-            // handle relative altitude
-            if (packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT || packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
-                if (!rover.ahrs.home_is_set()) {
-                    // cannot use relative altitude if home is not set
-                    break;
-                }
-                new_home_loc.alt += rover.ahrs.get_home().alt;
-            }
-            if (rover.set_home(new_home_loc, true)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-        }
-
-#if MOUNT == ENABLED
-        case MAV_CMD_DO_SET_ROI: {
-            // param1 : /* Region of interest mode (not used)*/
-            // param2 : /* MISSION index/ target ID (not used)*/
-            // param3 : /* ROI index (not used)*/
-            // param4 : /* empty */
-            // x : lat
-            // y : lon
-            // z : alt
-            // sanity check location
-            if (!check_latlng(packet.x, packet.y)) {
-                break;
-            }
-            Location roi_loc;
-            roi_loc.lat = packet.x;
-            roi_loc.lng = packet.y;
-            roi_loc.alt = (int32_t)(packet.z * 100.0f);
-            if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
-                // switch off the camera tracking if enabled
-                if (rover.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                    rover.camera_mount.set_mode_to_default();
-                }
-            } else {
-                // send the command to the camera mount
-                rover.camera_mount.set_roi_target(roi_loc);
-            }
-            result = MAV_RESULT_ACCEPTED;
-            break;
-        }
-#endif
-
-        default:
-            result = MAV_RESULT_UNSUPPORTED;
-            break;
-        }
-
-        // send ACK or NAK
-        mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
-        break;
-    }
 
     case MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE:
     {

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -26,6 +26,7 @@ protected:
     bool set_mode(uint8_t mode) override;
 
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     virtual bool in_hil_mode() const override;

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -26,6 +26,7 @@ protected:
     bool set_mode(uint8_t mode) override;
 
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     virtual bool in_hil_mode() const override;
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -402,12 +402,6 @@ MAV_RESULT GCS_MAVLINK_Tracker::handle_command_long_packet(const mavlink_command
         tracker.set_mode(AUTO, MODE_REASON_GCS_COMMAND);
         return MAV_RESULT_ACCEPTED;
 
-    case MAV_CMD_ACCELCAL_VEHICLE_POS:
-        if (!tracker.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_ACCEPTED;
-
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet);
     }

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -370,6 +370,49 @@ MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro()
     return ret;
 }
 
+MAV_RESULT GCS_MAVLINK_Tracker::handle_command_long_packet(const mavlink_command_long_t &packet)
+{
+    // do command
+    send_text(MAV_SEVERITY_INFO,"Command received: ");
+
+    switch(packet.command) {
+
+    case MAV_CMD_COMPONENT_ARM_DISARM:
+        if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
+            if (is_equal(packet.param1,1.0f)) {
+                tracker.arm_servos();
+                return MAV_RESULT_ACCEPTED;
+            } else if (is_zero(packet.param1))  {
+                tracker.disarm_servos();
+                return MAV_RESULT_ACCEPTED;
+            } else {
+                return MAV_RESULT_UNSUPPORTED;
+            }
+        }
+        return MAV_RESULT_UNSUPPORTED;
+
+    case MAV_CMD_DO_SET_SERVO:
+        if (!tracker.servo_test_set_servo(packet.param1, packet.param2)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+        // mavproxy/mavutil sends this when auto command is entered 
+    case MAV_CMD_MISSION_START:
+        tracker.set_mode(AUTO, MODE_REASON_GCS_COMMAND);
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_ACCELCAL_VEHICLE_POS:
+        if (!tracker.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    default:
+        return GCS_MAVLINK::handle_command_long_packet(packet);
+    }
+}
+
 void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
@@ -377,67 +420,6 @@ void GCS_MAVLINK_Tracker::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_HEARTBEAT:
         break;
 
-    case MAVLINK_MSG_ID_COMMAND_LONG:
-    {
-        // decode
-        mavlink_command_long_t packet;
-        mavlink_msg_command_long_decode(msg, &packet);
-        
-        MAV_RESULT result = MAV_RESULT_UNSUPPORTED;
-        
-        // do command
-        send_text(MAV_SEVERITY_INFO,"Command received: ");
-        
-        switch(packet.command) {
-
-            case MAV_CMD_COMPONENT_ARM_DISARM:
-                if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
-                    if (is_equal(packet.param1,1.0f)) {
-                        tracker.arm_servos();
-                        result = MAV_RESULT_ACCEPTED;
-                    } else if (is_zero(packet.param1))  {
-                        tracker.disarm_servos();
-                        result = MAV_RESULT_ACCEPTED;
-                    } else {
-                        result = MAV_RESULT_UNSUPPORTED;
-                    }
-                } else {
-                    result = MAV_RESULT_UNSUPPORTED;
-                }
-            break;
-
-            case MAV_CMD_DO_SET_SERVO:
-                if (tracker.servo_test_set_servo(packet.param1, packet.param2)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-                break;
-
-                // mavproxy/mavutil sends this when auto command is entered 
-            case MAV_CMD_MISSION_START:
-                tracker.set_mode(AUTO, MODE_REASON_GCS_COMMAND);
-                result = MAV_RESULT_ACCEPTED;
-                break;
-
-            case MAV_CMD_ACCELCAL_VEHICLE_POS:
-                result = MAV_RESULT_FAILED;
-
-                if (tracker.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-                break;
-
-            default:
-                result = handle_command_long_message(packet);
-                break;
-        }
-        mavlink_msg_command_ack_send(
-            chan,
-            packet.command,
-            result);
-        
-        break;
-    }
-         
     // When mavproxy 'wp sethome' 
     case MAVLINK_MSG_ID_MISSION_WRITE_PARTIAL_LIST:
     {

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -24,6 +24,7 @@ protected:
     bool set_mode(uint8_t mode) override;
 
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
+    MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     int32_t global_position_int_relative_alt() const {
         return 0; // what if we have been picked up and carried somewhere?

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -995,12 +995,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         return MAV_RESULT_ACCEPTED;
     }
 
-    case MAV_CMD_ACCELCAL_VEHICLE_POS:
-        if (!copter.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_ACCEPTED;
-
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet);
     }

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -35,6 +35,8 @@ protected:
 
     void send_position_target_global_int() override;
 
+    MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
+
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -36,6 +36,7 @@ protected:
     void send_position_target_global_int() override;
 
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
+    MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
 private:
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -758,6 +758,254 @@ bool GCS_MAVLINK_Plane::should_disable_overrides_on_reboot() const
     return (plane.quadplane.enable != 0);
 }
 
+
+MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_long_t &packet)
+{
+    switch(packet.command) {
+
+    case MAV_CMD_DO_CHANGE_SPEED:
+        // if we're in failsafe modes (e.g., RTL, LOITER) or in pilot
+        // controlled modes (e.g., MANUAL, TRAINING)
+        // this command should be ignored since it comes in from GCS
+        // or a companion computer:
+        if (plane.control_mode != GUIDED && plane.control_mode != AUTO && plane.control_mode != AVOID_ADSB) {
+            // failed
+            return MAV_RESULT_FAILED;
+        }
+
+        AP_Mission::Mission_Command cmd;
+        if (AP_Mission::mavlink_cmd_long_to_mission_cmd(packet, cmd) == MAV_MISSION_ACCEPTED) {
+            plane.do_change_speed(cmd);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_NAV_LOITER_UNLIM:
+        plane.set_mode(LOITER, MODE_REASON_GCS_COMMAND);
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_NAV_RETURN_TO_LAUNCH:
+        plane.set_mode(RTL, MODE_REASON_GCS_COMMAND);
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_NAV_TAKEOFF: {
+        // user takeoff only works with quadplane code for now
+        // param7 : altitude [metres]
+        float takeoff_alt = packet.param7;
+        if (plane.quadplane.available() && plane.quadplane.do_user_takeoff(takeoff_alt)) {
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+    }
+
+#if MOUNT == ENABLED
+        // Sets the region of interest (ROI) for the camera
+    case MAV_CMD_DO_SET_ROI:
+        // sanity check location
+        if (!check_latlng(packet.param5, packet.param6)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location roi_loc;
+        roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
+        roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
+        roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
+        if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
+            // switch off the camera tracking if enabled
+            if (plane.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
+                plane.camera_mount.set_mode_to_default();
+            }
+        } else {
+            // send the command to the camera mount
+            plane.camera_mount.set_roi_target(roi_loc);
+        }
+        return MAV_RESULT_ACCEPTED;
+#endif
+
+#if MOUNT == ENABLED
+    case MAV_CMD_DO_MOUNT_CONTROL:
+        plane.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
+        return MAV_RESULT_ACCEPTED;
+#endif
+
+    case MAV_CMD_MISSION_START:
+        plane.set_mode(AUTO, MODE_REASON_GCS_COMMAND);
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_COMPONENT_ARM_DISARM:
+        if (is_equal(packet.param1,1.0f)) {
+            // run pre_arm_checks and arm_checks and display failures
+            const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
+            if (plane.arm_motors(AP_Arming::MAVLINK, do_arming_checks)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        } else if (is_zero(packet.param1))  {
+            if (plane.disarm_motors()) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_UNSUPPORTED;
+
+    case MAV_CMD_DO_LAND_START:
+        // attempt to switch to next DO_LAND_START command in the mission
+        if (plane.mission.jump_to_landing_sequence()) {
+            plane.set_mode(AUTO, MODE_REASON_UNKNOWN);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_GO_AROUND:
+        if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
+            // Initiate an aborted landing. This will trigger a pitch-up and
+            // climb-out to a safe altitude holding heading then one of the
+            // following actions will occur, check for in this order:
+            // - If MAV_CMD_CONTINUE_AND_CHANGE_ALT is next command in mission,
+            //      increment mission index to execute it
+            // - else if DO_LAND_START is available, jump to it
+            // - else decrement the mission index to repeat the landing approach
+
+            if (!is_zero(packet.param1)) {
+                plane.auto_state.takeoff_altitude_rel_cm = packet.param1 * 100;
+            }
+            if (plane.landing.request_go_around()) {
+                plane.auto_state.next_wp_crosstrack = false;
+                return MAV_RESULT_ACCEPTED;
+            }
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_FENCE_ENABLE:
+        if (!plane.geofence_present()) {
+            gcs().send_text(MAV_SEVERITY_NOTICE,"Fence not configured");
+            return MAV_RESULT_FAILED;
+        }
+        switch((uint16_t)packet.param1) {
+        case 0:
+            if (! plane.geofence_set_enabled(false, GCS_TOGGLED)) {
+                return MAV_RESULT_FAILED;
+            }
+            return MAV_RESULT_ACCEPTED;
+        case 1:
+            if (! plane.geofence_set_enabled(true, GCS_TOGGLED)) {
+                return MAV_RESULT_FAILED;
+            }
+            return MAV_RESULT_ACCEPTED;
+        case 2: //disable fence floor only
+            if (! plane.geofence_set_floor_enabled(false)) {
+                return MAV_RESULT_FAILED;
+            }
+            gcs().send_text(MAV_SEVERITY_NOTICE,"Fence floor disabled");
+            return MAV_RESULT_ACCEPTED;
+        default:
+            break;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_SET_HOME: {
+        // param1 : use current (1=use current location, 0=use specified location)
+        // param5 : latitude
+        // param6 : longitude
+        // param7 : altitude (absolute)
+        if (is_equal(packet.param1,1.0f)) {
+            plane.set_home_persistently(AP::gps().location());
+            AP::ahrs().lock_home();
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            // ensure param1 is zero
+            if (!is_zero(packet.param1)) {
+                return MAV_RESULT_FAILED;
+            }
+            if (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7)) {
+                // don't allow the 0,0 position
+                return MAV_RESULT_FAILED;
+            }
+            // sanity check location
+            if (!check_latlng(packet.param5,packet.param6)) {
+                return MAV_RESULT_FAILED;
+            }
+            Location new_home_loc {};
+            new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
+            new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
+            new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
+            plane.set_home(new_home_loc);
+            AP::ahrs().lock_home();
+            return MAV_RESULT_ACCEPTED;
+        }
+        break;
+    }
+
+    case MAV_CMD_DO_AUTOTUNE_ENABLE:
+        // param1 : enable/disable
+        plane.autotune_enable(!is_zero(packet.param1));
+        return MAV_RESULT_ACCEPTED;
+
+#if PARACHUTE == ENABLED
+    case MAV_CMD_DO_PARACHUTE:
+        // configure or release parachute
+        switch ((uint16_t)packet.param1) {
+        case PARACHUTE_DISABLE:
+            plane.parachute.enabled(false);
+            return MAV_RESULT_ACCEPTED;
+        case PARACHUTE_ENABLE:
+            plane.parachute.enabled(true);
+            return MAV_RESULT_ACCEPTED;
+        case PARACHUTE_RELEASE:
+            // treat as a manual release which performs some additional check of altitude
+            if (plane.parachute.released()) {
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute already released");
+                return MAV_RESULT_FAILED;
+            }
+            if (!plane.parachute.enabled()) {
+                gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute not enabled");
+                return MAV_RESULT_FAILED;
+            }
+            if (!plane.parachute_manual_release()) {
+                return MAV_RESULT_FAILED;
+            }
+            return MAV_RESULT_ACCEPTED;
+        default:
+            break;
+        }
+        return MAV_RESULT_FAILED;
+#endif
+
+    case MAV_CMD_DO_MOTOR_TEST:
+        // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
+        // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
+        // param3 : throttle (range depends upon param2)
+        // param4 : timeout (in seconds)
+        // param5 : motor count (number of motors to test in sequence)
+        return plane.quadplane.mavlink_motor_test_start(chan,
+                                                        (uint8_t)packet.param1,
+                                                        (uint8_t)packet.param2,
+                                                        (uint16_t)packet.param3,
+                                                        packet.param4,
+                                                        (uint8_t)packet.param5);
+
+    case MAV_CMD_DO_VTOL_TRANSITION:
+        if (!plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_DO_ENGINE_CONTROL:
+        if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_ACCELCAL_VEHICLE_POS:
+        if (!plane.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    default:
+        return GCS_MAVLINK::handle_command_long_packet(packet);
+    }
+}
+
 void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
 {
     switch (msg->msgid) {
@@ -877,297 +1125,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
             } else {
                 result = MAV_RESULT_FAILED; // failed as we are not in guided
             }
-            break;
-        }
-
-        mavlink_msg_command_ack_send_buf(
-            msg,
-            chan,
-            packet.command,
-            result);
-
-        break;
-    }
-
-    case MAVLINK_MSG_ID_COMMAND_LONG:
-    {
-        // decode
-        mavlink_command_long_t packet;
-        mavlink_msg_command_long_decode(msg, &packet);
-
-        MAV_RESULT result = MAV_RESULT_UNSUPPORTED;
-
-        // do command
-
-        switch(packet.command) {
-
-        case MAV_CMD_DO_CHANGE_SPEED:
-            // if we're in failsafe modes (e.g., RTL, LOITER) or in pilot
-            // controlled modes (e.g., MANUAL, TRAINING)
-            // this command should be ignored since it comes in from GCS
-            // or a companion computer:
-            result = MAV_RESULT_FAILED;
-            if (plane.control_mode != GUIDED && plane.control_mode != AUTO && plane.control_mode != AVOID_ADSB) {
-                // failed
-                break;
-            }
-
-            AP_Mission::Mission_Command cmd;
-            if (AP_Mission::mavlink_cmd_long_to_mission_cmd(packet, cmd)
-                    == MAV_MISSION_ACCEPTED) {
-                plane.do_change_speed(cmd);
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_NAV_LOITER_UNLIM:
-            plane.set_mode(LOITER, MODE_REASON_GCS_COMMAND);
-            result = MAV_RESULT_ACCEPTED;
-            break;
-
-        case MAV_CMD_NAV_RETURN_TO_LAUNCH:
-            plane.set_mode(RTL, MODE_REASON_GCS_COMMAND);
-            result = MAV_RESULT_ACCEPTED;
-            break;
-
-        case MAV_CMD_NAV_TAKEOFF: {
-            // user takeoff only works with quadplane code for now
-            // param7 : altitude [metres]
-            float takeoff_alt = packet.param7;
-            if (plane.quadplane.available() && plane.quadplane.do_user_takeoff(takeoff_alt)) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-            break;
-        }
-            
-#if MOUNT == ENABLED
-        // Sets the region of interest (ROI) for the camera
-        case MAV_CMD_DO_SET_ROI:
-            // sanity check location
-            if (!check_latlng(packet.param5, packet.param6)) {
-                break;
-            }
-            Location roi_loc;
-            roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-            roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-            roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
-            if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
-                // switch off the camera tracking if enabled
-                if (plane.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                    plane.camera_mount.set_mode_to_default();
-                }
-            } else {
-                // send the command to the camera mount
-                plane.camera_mount.set_roi_target(roi_loc);
-            }
-            result = MAV_RESULT_ACCEPTED;
-            break;
-#endif
-
-        case MAV_CMD_DO_MOUNT_CONTROL:
-#if MOUNT == ENABLED
-            plane.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
-            result = MAV_RESULT_ACCEPTED;
-#endif
-            break;
-
-        case MAV_CMD_MISSION_START:
-            plane.set_mode(AUTO, MODE_REASON_GCS_COMMAND);
-            result = MAV_RESULT_ACCEPTED;
-            break;
-
-        case MAV_CMD_COMPONENT_ARM_DISARM:
-            if (is_equal(packet.param1,1.0f)) {
-                // run pre_arm_checks and arm_checks and display failures
-                const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-                if (plane.arm_motors(AP_Arming::MAVLINK, do_arming_checks)) {
-                    result = MAV_RESULT_ACCEPTED;
-                } else {
-                    result = MAV_RESULT_FAILED;
-                }
-            } else if (is_zero(packet.param1))  {
-                if (plane.disarm_motors()) {
-                    result = MAV_RESULT_ACCEPTED;
-                } else {
-                    result = MAV_RESULT_FAILED;
-                }
-            } else {
-                result = MAV_RESULT_UNSUPPORTED;
-            }
-            break;
-
-        case MAV_CMD_DO_LAND_START:
-            result = MAV_RESULT_FAILED;
-            
-            // attempt to switch to next DO_LAND_START command in the mission
-            if (plane.mission.jump_to_landing_sequence()) {
-                plane.set_mode(AUTO, MODE_REASON_UNKNOWN);
-                result = MAV_RESULT_ACCEPTED;
-            } 
-            break;
-
-        case MAV_CMD_DO_GO_AROUND:
-            result = MAV_RESULT_FAILED;
-
-            if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
-                // Initiate an aborted landing. This will trigger a pitch-up and
-                // climb-out to a safe altitude holding heading then one of the
-                // following actions will occur, check for in this order:
-                // - If MAV_CMD_CONTINUE_AND_CHANGE_ALT is next command in mission,
-                //      increment mission index to execute it
-                // - else if DO_LAND_START is available, jump to it
-                // - else decrement the mission index to repeat the landing approach
-
-                if (!is_zero(packet.param1)) {
-                    plane.auto_state.takeoff_altitude_rel_cm = packet.param1 * 100;
-                }
-                if (plane.landing.request_go_around()) {
-                    plane.auto_state.next_wp_crosstrack = false;
-                    result = MAV_RESULT_ACCEPTED;
-                }
-            }
-            break;
-
-        case MAV_CMD_DO_FENCE_ENABLE:
-            result = MAV_RESULT_ACCEPTED;
-            
-            if (!plane.geofence_present()) {
-                gcs().send_text(MAV_SEVERITY_NOTICE,"Fence not configured");
-                result = MAV_RESULT_FAILED;
-            } else {
-                switch((uint16_t)packet.param1) {
-                case 0:
-                    if (! plane.geofence_set_enabled(false, GCS_TOGGLED)) {
-                        result = MAV_RESULT_FAILED;
-                    }
-                    break;
-                case 1:
-                    if (! plane.geofence_set_enabled(true, GCS_TOGGLED)) {
-                        result = MAV_RESULT_FAILED; 
-                    }
-                    break;
-                case 2: //disable fence floor only 
-                    if (! plane.geofence_set_floor_enabled(false)) {
-                        result = MAV_RESULT_FAILED;
-                    } else {
-                        gcs().send_text(MAV_SEVERITY_NOTICE,"Fence floor disabled");
-                    }
-                    break;
-                default:
-                    result = MAV_RESULT_FAILED;
-                    break;
-                }
-            }
-            break;
-
-        case MAV_CMD_DO_SET_HOME: {
-            // param1 : use current (1=use current location, 0=use specified location)
-            // param5 : latitude
-            // param6 : longitude
-            // param7 : altitude (absolute)
-            result = MAV_RESULT_FAILED; // assume failure
-            if (is_equal(packet.param1,1.0f)) {
-                plane.set_home_persistently(AP::gps().location());
-                AP::ahrs().lock_home();
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                // ensure param1 is zero
-                if (!is_zero(packet.param1)) {
-                    break;
-                }
-                if (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7)) {
-                    // don't allow the 0,0 position
-                    break;
-                }
-                // sanity check location
-                if (!check_latlng(packet.param5,packet.param6)) {
-                    break;
-                }
-                Location new_home_loc {};
-                new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-                new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-                new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                plane.set_home(new_home_loc);
-                AP::ahrs().lock_home();
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-        }
-
-        case MAV_CMD_DO_AUTOTUNE_ENABLE:
-            // param1 : enable/disable
-            plane.autotune_enable(!is_zero(packet.param1));
-            break;
-
-#if PARACHUTE == ENABLED
-        case MAV_CMD_DO_PARACHUTE:
-            // configure or release parachute
-            result = MAV_RESULT_ACCEPTED;
-            switch ((uint16_t)packet.param1) {
-                case PARACHUTE_DISABLE:
-                    plane.parachute.enabled(false);
-                    break;
-                case PARACHUTE_ENABLE:
-                    plane.parachute.enabled(true);
-                    break;
-                case PARACHUTE_RELEASE:
-                    // treat as a manual release which performs some additional check of altitude
-                    if (plane.parachute.released()) {
-                        gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute already released");
-                        result = MAV_RESULT_FAILED;
-                    } else if (!plane.parachute.enabled()) {
-                        gcs().send_text(MAV_SEVERITY_NOTICE, "Parachute not enabled");
-                        result = MAV_RESULT_FAILED;
-                    } else {
-                        if (!plane.parachute_manual_release()) {
-                            result = MAV_RESULT_FAILED;
-                        }
-                    }
-                    break;
-                default:
-                    result = MAV_RESULT_FAILED;
-                    break;
-            }
-            break;
-#endif
-
-        case MAV_CMD_DO_MOTOR_TEST:
-            // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
-            // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
-            // param3 : throttle (range depends upon param2)
-            // param4 : timeout (in seconds)
-            // param5 : motor count (number of motors to test in sequence)
-            result = plane.quadplane.mavlink_motor_test_start(chan, (uint8_t)packet.param1, (uint8_t)packet.param2, (uint16_t)packet.param3, packet.param4, (uint8_t)packet.param5);
-            break;
-            
-        case MAV_CMD_DO_VTOL_TRANSITION:
-            if (!plane.quadplane.handle_do_vtol_transition((enum MAV_VTOL_STATE)packet.param1)) {
-                result = MAV_RESULT_FAILED;
-            } else {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_DO_ENGINE_CONTROL:
-            if (!plane.g2.ice_control.engine_control(packet.param1, packet.param2, packet.param3)) {
-                result = MAV_RESULT_FAILED;
-            } else {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_ACCELCAL_VEHICLE_POS:
-            result = MAV_RESULT_FAILED;
-
-            if (plane.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        default:
-            result = handle_command_long_message(packet);
             break;
         }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1105,12 +1105,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         }
         return MAV_RESULT_ACCEPTED;
 
-    case MAV_CMD_ACCELCAL_VEHICLE_POS:
-        if (!plane.ins.get_acal()->gcs_vehicle_position(packet.param1)) {
-            return MAV_RESULT_FAILED;
-        }
-        return MAV_RESULT_ACCEPTED;
-
     default:
         return GCS_MAVLINK::handle_command_long_packet(packet);
     }

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -31,6 +31,7 @@ protected:
 
     MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     void send_position_target_global_int() override;
 

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -31,6 +31,7 @@ protected:
 
     MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     void send_position_target_global_int() override;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -661,6 +661,77 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
 }
 
+MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_packet(const mavlink_command_int_t &packet)
+{
+    switch (packet.command) {
+
+    case MAV_CMD_DO_SET_HOME: {
+        // assume failure
+        if (is_equal(packet.param1, 1.0f)) {
+            // if param1 is 1, use current location
+            if (sub.set_home_to_current_location(true)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+            return MAV_RESULT_FAILED;
+        }
+        // ensure param1 is zero
+        if (!is_zero(packet.param1)) {
+            return MAV_RESULT_FAILED;
+        }
+        // check frame type is supported
+        if (packet.frame != MAV_FRAME_GLOBAL &&
+            packet.frame != MAV_FRAME_GLOBAL_INT &&
+            packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
+            packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+            return MAV_RESULT_FAILED;
+        }
+        // sanity check location
+        if (!check_latlng(packet.x, packet.y)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location new_home_loc {};
+        new_home_loc.lat = packet.x;
+        new_home_loc.lng = packet.y;
+        new_home_loc.alt = packet.z * 100;
+        // handle relative altitude
+        if (packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT || packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+            if (!AP::ahrs().home_is_set()) {
+                // cannot use relative altitude if home is not set
+                return MAV_RESULT_FAILED;
+            }
+            new_home_loc.alt += sub.ahrs.get_home().alt;
+        }
+        if (sub.set_home(new_home_loc, true)) {
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+    }
+
+    case MAV_CMD_DO_SET_ROI: {
+        // param1 : /* Region of interest mode (not used)*/
+        // param2 : /* MISSION index/ target ID (not used)*/
+        // param3 : /* ROI index (not used)*/
+        // param4 : /* empty */
+        // x : lat
+        // y : lon
+        // z : alt
+        // sanity check location
+        if (!check_latlng(packet.x, packet.y)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location roi_loc;
+        roi_loc.lat = packet.x;
+        roi_loc.lng = packet.y;
+        roi_loc.alt = (int32_t)(packet.z * 100.0f);
+        sub.set_auto_yaw_roi(roi_loc);
+        return MAV_RESULT_ACCEPTED;
+    }
+    default:
+        return GCS_MAVLINK::handle_command_int_packet(packet);
+    }
+}
+
+
 void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
 {
     MAV_RESULT result = MAV_RESULT_FAILED;         // assume failure.  Each messages id is responsible for return ACK or NAK if required
@@ -735,85 +806,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         break;
     }
 
-
-    case MAVLINK_MSG_ID_COMMAND_INT: {
-        // decode packet
-        mavlink_command_int_t packet;
-        mavlink_msg_command_int_decode(msg, &packet);
-        switch (packet.command) {
-
-        case MAV_CMD_DO_SET_HOME: {
-            // assume failure
-            result = MAV_RESULT_FAILED;
-            if (is_equal(packet.param1, 1.0f)) {
-                // if param1 is 1, use current location
-                if (sub.set_home_to_current_location(true)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-                break;
-            }
-            // ensure param1 is zero
-            if (!is_zero(packet.param1)) {
-                break;
-            }
-            // check frame type is supported
-            if (packet.frame != MAV_FRAME_GLOBAL &&
-                packet.frame != MAV_FRAME_GLOBAL_INT &&
-                packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
-                packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
-                break;
-            }
-            // sanity check location
-            if (!check_latlng(packet.x, packet.y)) {
-                break;
-            }
-            Location new_home_loc {};
-            new_home_loc.lat = packet.x;
-            new_home_loc.lng = packet.y;
-            new_home_loc.alt = packet.z * 100;
-            // handle relative altitude
-            if (packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT || packet.frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
-                if (!AP::ahrs().home_is_set()) {
-                    // cannot use relative altitude if home is not set
-                    break;
-                }
-                new_home_loc.alt += sub.ahrs.get_home().alt;
-            }
-            if (sub.set_home(new_home_loc, true)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-        }
-
-        case MAV_CMD_DO_SET_ROI: {
-            // param1 : /* Region of interest mode (not used)*/
-            // param2 : /* MISSION index/ target ID (not used)*/
-            // param3 : /* ROI index (not used)*/
-            // param4 : /* empty */
-            // x : lat
-            // y : lon
-            // z : alt
-            // sanity check location
-            if (!check_latlng(packet.x, packet.y)) {
-                break;
-            }
-            Location roi_loc;
-            roi_loc.lat = packet.x;
-            roi_loc.lng = packet.y;
-            roi_loc.alt = (int32_t)(packet.z * 100.0f);
-            sub.set_auto_yaw_roi(roi_loc);
-            result = MAV_RESULT_ACCEPTED;
-            break;
-        }
-        default:
-            result = MAV_RESULT_UNSUPPORTED;
-            break;
-        }
-
-        // send ACK or NAK
-        mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
-        break;
-    }
 
     // Pre-Flight calibration requests
     case MAVLINK_MSG_ID_COMMAND_LONG: {     // MAV ID: 76

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -732,10 +732,155 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_packet(const mavlink_command_int_
 }
 
 
+MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_long_t &packet)
+{
+    switch (packet.command) {
+    case MAV_CMD_NAV_LOITER_UNLIM:
+        if (!sub.set_mode(POSHOLD, MODE_REASON_GCS_COMMAND)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_NAV_LAND:
+        if (!sub.set_mode(SURFACE, MODE_REASON_GCS_COMMAND)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    case MAV_CMD_CONDITION_YAW:
+        // param1 : target angle [0-360]
+        // param2 : speed during change [deg per second]
+        // param3 : direction (-1:ccw, +1:cw)
+        // param4 : relative offset (1) or absolute angle (0)
+        if ((packet.param1 >= 0.0f)   &&
+            (packet.param1 <= 360.0f) &&
+            (is_zero(packet.param4) || is_equal(packet.param4,1.0f))) {
+            sub.set_auto_yaw_look_at_heading(packet.param1, packet.param2, (int8_t)packet.param3, (uint8_t)packet.param4);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_CHANGE_SPEED:
+        // param1 : unused
+        // param2 : new speed in m/s
+        // param3 : unused
+        // param4 : unused
+        if (packet.param2 > 0.0f) {
+            sub.wp_nav.set_speed_xy(packet.param2 * 100.0f);
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_SET_HOME:
+        // param1 : use current (1=use current location, 0=use specified location)
+        // param5 : latitude
+        // param6 : longitude
+        // param7 : altitude (absolute)
+        if (is_equal(packet.param1,1.0f) || (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7))) {
+            if (sub.set_home_to_current_location(true)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+        } else {
+            // ensure param1 is zero
+            if (!is_zero(packet.param1)) {
+                return MAV_RESULT_FAILED;
+            }
+            // sanity check location
+            if (!check_latlng(packet.param5, packet.param6)) {
+                return MAV_RESULT_FAILED;
+            }
+            Location new_home_loc;
+            new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
+            new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
+            new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
+            if (!sub.far_from_EKF_origin(new_home_loc)) {
+                if (sub.set_home(new_home_loc, true)) {
+                    return MAV_RESULT_ACCEPTED;
+                }
+            }
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_DO_SET_ROI:
+        // param1 : regional of interest mode (not supported)
+        // param2 : mission index/ target id (not supported)
+        // param3 : ROI index (not supported)
+        // param5 : x / lat
+        // param6 : y / lon
+        // param7 : z / alt
+        // sanity check location
+        if (!check_latlng(packet.param5, packet.param6)) {
+            return MAV_RESULT_FAILED;
+        }
+        Location roi_loc;
+        roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
+        roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
+        roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
+        sub.set_auto_yaw_roi(roi_loc);
+        return MAV_RESULT_ACCEPTED;
+
+#if MOUNT == ENABLED
+    case MAV_CMD_DO_MOUNT_CONTROL:
+        sub.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
+        return MAV_RESULT_ACCEPTED;
+#endif
+
+    case MAV_CMD_MISSION_START:
+        if (sub.motors.armed() && sub.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
+            return MAV_RESULT_ACCEPTED;
+        }
+        return MAV_RESULT_FAILED;
+
+    case MAV_CMD_COMPONENT_ARM_DISARM:
+        if (is_equal(packet.param1,1.0f)) {
+            // attempt to arm and return success or failure
+            if (sub.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK)) {
+                return MAV_RESULT_ACCEPTED;
+            }
+        } else if (is_zero(packet.param1))  {
+            // force disarming by setting param2 = 21196 is deprecated
+            // see COMMAND_LONG DO_FLIGHTTERMINATION
+            sub.init_disarm_motors();
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            return MAV_RESULT_UNSUPPORTED;
+        }
+        return MAV_RESULT_FAILED;
+
+#if AC_FENCE == ENABLED
+    case MAV_CMD_DO_FENCE_ENABLE:
+        switch ((uint16_t)packet.param1) {
+        case 0:
+            sub.fence.enable(false);
+            return MAV_RESULT_ACCEPTED;
+        case 1:
+            sub.fence.enable(true);
+            return MAV_RESULT_ACCEPTED;
+        default:
+            break;
+        }
+        return MAV_RESULT_FAILED;
+#endif
+
+    case MAV_CMD_DO_MOTOR_TEST:
+        // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
+        // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
+        // param3 : throttle (range depends upon param2)
+        // param4 : timeout (in seconds)
+        if (!sub.handle_do_motor_test(packet)) {
+            return MAV_RESULT_FAILED;
+        }
+        return MAV_RESULT_ACCEPTED;
+
+    default:
+        return GCS_MAVLINK::handle_command_long_packet(packet);
+    }
+}
+
+
+
 void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
 {
-    MAV_RESULT result = MAV_RESULT_FAILED;         // assume failure.  Each messages id is responsible for return ACK or NAK if required
-
     switch (msg->msgid) {
 
     case MAVLINK_MSG_ID_HEARTBEAT: {    // MAV ID: 0
@@ -803,174 +948,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         sub.failsafe.last_pilot_input_ms = tnow;
         // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes
         sub.failsafe.last_heartbeat_ms = tnow;
-        break;
-    }
-
-
-    // Pre-Flight calibration requests
-    case MAVLINK_MSG_ID_COMMAND_LONG: {     // MAV ID: 76
-        // decode packet
-        mavlink_command_long_t packet;
-        mavlink_msg_command_long_decode(msg, &packet);
-
-        switch (packet.command) {
-        case MAV_CMD_NAV_LOITER_UNLIM:
-            if (sub.set_mode(POSHOLD, MODE_REASON_GCS_COMMAND)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_NAV_LAND:
-            if (sub.set_mode(SURFACE, MODE_REASON_GCS_COMMAND)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_CONDITION_YAW:
-            // param1 : target angle [0-360]
-            // param2 : speed during change [deg per second]
-            // param3 : direction (-1:ccw, +1:cw)
-            // param4 : relative offset (1) or absolute angle (0)
-            if ((packet.param1 >= 0.0f)   &&
-                    (packet.param1 <= 360.0f) &&
-                    (is_zero(packet.param4) || is_equal(packet.param4,1.0f))) {
-                sub.set_auto_yaw_look_at_heading(packet.param1, packet.param2, (int8_t)packet.param3, (uint8_t)packet.param4);
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-            break;
-
-        case MAV_CMD_DO_CHANGE_SPEED:
-            // param1 : unused
-            // param2 : new speed in m/s
-            // param3 : unused
-            // param4 : unused
-            if (packet.param2 > 0.0f) {
-                sub.wp_nav.set_speed_xy(packet.param2 * 100.0f);
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-            break;
-
-        case MAV_CMD_DO_SET_HOME:
-            // param1 : use current (1=use current location, 0=use specified location)
-            // param5 : latitude
-            // param6 : longitude
-            // param7 : altitude (absolute)
-            result = MAV_RESULT_FAILED; // assume failure
-            if (is_equal(packet.param1,1.0f) || (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7))) {
-                if (sub.set_home_to_current_location(true)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-            } else {
-                // ensure param1 is zero
-                if (!is_zero(packet.param1)) {
-                    break;
-                }
-                // sanity check location
-                if (!check_latlng(packet.param5, packet.param6)) {
-                    break;
-                }
-                Location new_home_loc;
-                new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-                new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-                new_home_loc.alt = (int32_t)(packet.param7 * 100.0f);
-                if (!sub.far_from_EKF_origin(new_home_loc)) {
-                    if (sub.set_home(new_home_loc, true)) {
-                        result = MAV_RESULT_ACCEPTED;
-                    }
-                }
-            }
-            break;
-
-        case MAV_CMD_DO_SET_ROI:
-            // param1 : regional of interest mode (not supported)
-            // param2 : mission index/ target id (not supported)
-            // param3 : ROI index (not supported)
-            // param5 : x / lat
-            // param6 : y / lon
-            // param7 : z / alt
-            // sanity check location
-            if (!check_latlng(packet.param5, packet.param6)) {
-                break;
-            }
-            Location roi_loc;
-            roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-            roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-            roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
-            sub.set_auto_yaw_roi(roi_loc);
-            result = MAV_RESULT_ACCEPTED;
-            break;
-
-        case MAV_CMD_DO_MOUNT_CONTROL:
-#if MOUNT == ENABLED
-            sub.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
-            result = MAV_RESULT_ACCEPTED;
-#endif
-            break;
-
-        case MAV_CMD_MISSION_START:
-            if (sub.motors.armed() && sub.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        case MAV_CMD_COMPONENT_ARM_DISARM:
-            if (is_equal(packet.param1,1.0f)) {
-                // attempt to arm and return success or failure
-                if (sub.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK)) {
-                    result = MAV_RESULT_ACCEPTED;
-                }
-            } else if (is_zero(packet.param1))  {
-                // force disarming by setting param2 = 21196 is deprecated
-                // see COMMAND_LONG DO_FLIGHTTERMINATION
-                sub.init_disarm_motors();
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_UNSUPPORTED;
-            }
-            break;
-
-        case MAV_CMD_DO_FENCE_ENABLE:
-#if AC_FENCE == ENABLED
-            result = MAV_RESULT_ACCEPTED;
-            switch ((uint16_t)packet.param1) {
-            case 0:
-                sub.fence.enable(false);
-                break;
-            case 1:
-                sub.fence.enable(true);
-                break;
-            default:
-                result = MAV_RESULT_FAILED;
-                break;
-            }
-#else
-            // if fence code is not included return failure
-            result = MAV_RESULT_FAILED;
-#endif
-            break;
-
-        case MAV_CMD_DO_MOTOR_TEST:
-            // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
-            // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
-            // param3 : throttle (range depends upon param2)
-            // param4 : timeout (in seconds)
-            if (sub.handle_do_motor_test(packet)) {
-                result = MAV_RESULT_ACCEPTED;
-            }
-            break;
-
-        default:
-            result = handle_command_long_message(packet);
-            break;
-        }
-
-        // send ACK or NAK
-        mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
-
         break;
     }
 
@@ -1069,22 +1046,11 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
 
         // send request
         if (!pos_ignore && !vel_ignore && acc_ignore) {
-            if (sub.guided_set_destination_posvel(pos_vector, vel_vector)) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
+            sub.guided_set_destination_posvel(pos_vector, vel_vector);
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.guided_set_velocity(vel_vector);
-            result = MAV_RESULT_ACCEPTED;
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            if (sub.guided_set_destination(pos_vector)) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-        } else {
-            result = MAV_RESULT_FAILED;
+            sub.guided_set_destination(pos_vector);
         }
 
         break;
@@ -1126,7 +1092,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         if (!pos_ignore) {
             // sanity check location
             if (!check_latlng(packet.lat_int, packet.lon_int)) {
-                result = MAV_RESULT_FAILED;
                 break;
             }
             Location loc;
@@ -1155,29 +1120,17 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         }
 
         if (!pos_ignore && !vel_ignore && acc_ignore) {
-            if (sub.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f))) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
+            sub.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
-            result = MAV_RESULT_ACCEPTED;
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            if (sub.guided_set_destination(pos_neu_cm)) {
-                result = MAV_RESULT_ACCEPTED;
-            } else {
-                result = MAV_RESULT_FAILED;
-            }
-        } else {
-            result = MAV_RESULT_FAILED;
+            sub.guided_set_destination(pos_neu_cm);
         }
 
         break;
     }
 
     case MAVLINK_MSG_ID_DISTANCE_SENSOR: {
-        result = MAV_RESULT_ACCEPTED;
         sub.rangefinder.handle_msg(msg);
         break;
     }

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -27,6 +27,7 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
+    MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
     // override sending of scaled_pressure3 to send on-board temperature:
     void send_scaled_pressure3() override;

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -26,6 +26,7 @@ protected:
 
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
+    MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
 
     // override sending of scaled_pressure3 to send on-board temperature:
     void send_scaled_pressure3() override;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -951,6 +951,8 @@ GCS_Dummy _gcs;
 
 // dummy methods to avoid linking with these libraries
 void AP_Camera::send_feedback(mavlink_channel_t) {}
+void AP_Camera::control(float, float, float, float, float, float) {}
+void AP_Camera::configure(float, float, float, float, float, float, float) {}
 bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reason) { return false; }
 
 AP_HAL_MAIN_CALLBACKS(&replay);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -355,6 +355,7 @@ protected:
     virtual MAV_RESULT _handle_command_preflight_calibration_baro();
 
     void handle_command_long(mavlink_message_t* msg);
+    MAV_RESULT handle_command_accelcal_vehicle_pos(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -354,11 +354,12 @@ protected:
     virtual MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet);
     virtual MAV_RESULT _handle_command_preflight_calibration_baro();
 
+    void handle_command_long(mavlink_message_t* msg);
     MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
-    MAV_RESULT handle_command_long_message(mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_send_banner(const mavlink_command_long_t &packet);
-    MAV_RESULT handle_command_do_gripper(mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_do_gripper(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
 
@@ -392,7 +393,7 @@ private:
 
     virtual void        handleMessage(mavlink_message_t * msg) = 0;
 
-    MAV_RESULT handle_servorelay_message(mavlink_command_long_t &packet);
+    MAV_RESULT handle_servorelay_message(const mavlink_command_long_t &packet);
 
     bool calibrate_gyros();
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -284,6 +284,9 @@ protected:
 
     virtual void handle_command_ack(const mavlink_message_t* msg);
     void handle_set_mode(mavlink_message_t* msg);
+    void handle_command_int(mavlink_message_t* msg);
+    virtual MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
+
     void handle_mission_request_list(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_request(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2318,6 +2318,10 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
         handle_common_mission_message(msg);
         break;
 
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        handle_command_int(msg);
+        break;
+
     case MAVLINK_MSG_ID_SERIAL_CONTROL:
         handle_serial_control(msg);
         break;
@@ -2767,6 +2771,23 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
     }
 
     return result;
+}
+
+MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &packet)
+{
+    return MAV_RESULT_UNSUPPORTED;
+}
+
+void GCS_MAVLINK::handle_command_int(mavlink_message_t *msg)
+{
+    // decode packet
+    mavlink_command_int_t packet;
+    mavlink_msg_command_int_decode(msg, &packet);
+
+    const MAV_RESULT result = handle_command_int_packet(packet);
+
+    // send ACK or NAK
+    mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
 }
 
 bool GCS_MAVLINK::try_send_compass_message(const enum ap_message id)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2318,6 +2318,10 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
         handle_common_mission_message(msg);
         break;
 
+    case MAVLINK_MSG_ID_COMMAND_LONG:
+        handle_command_long(msg);
+        break;
+
     case MAVLINK_MSG_ID_COMMAND_INT:
         handle_command_int(msg);
         break;
@@ -2653,7 +2657,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_get_home_position(const mavlink_command_l
     return MAV_RESULT_ACCEPTED;
 }
 
-MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(const mavlink_command_long_t &packet)
 {
     AP_Gripper *gripper = AP::gripper();
     if (gripper == nullptr) {
@@ -2685,7 +2689,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(mavlink_command_long_t &packet
     return result;
 }
 
-MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
     MAV_RESULT result = MAV_RESULT_FAILED;
 
@@ -2771,6 +2775,18 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
     }
 
     return result;
+}
+
+void GCS_MAVLINK::handle_command_long(mavlink_message_t *msg)
+{
+    // decode packet
+    mavlink_command_long_t packet;
+    mavlink_msg_command_long_decode(msg, &packet);
+
+    const MAV_RESULT result = handle_command_long_packet(packet);
+
+    // send ACK or NAK
+    mavlink_msg_command_ack_send_buf(msg, chan, packet.command, result);
 }
 
 MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &packet)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2689,11 +2689,22 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(const mavlink_command_long_t &
     return result;
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_accelcal_vehicle_pos(const mavlink_command_long_t &packet)
+{
+    if (!AP::ins().get_acal()->gcs_vehicle_position(packet.param1)) {
+        return MAV_RESULT_FAILED;
+    }
+    return MAV_RESULT_ACCEPTED;
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
     MAV_RESULT result = MAV_RESULT_FAILED;
 
     switch (packet.command) {
+
+    case MAV_CMD_ACCELCAL_VEHICLE_POS:
+        result = handle_command_accelcal_vehicle_pos(packet);
 
     case MAV_CMD_DO_SET_MODE:
         result = handle_command_do_set_mode(packet);

--- a/libraries/GCS_MAVLink/GCS_ServoRelay.cpp
+++ b/libraries/GCS_MAVLink/GCS_ServoRelay.cpp
@@ -2,7 +2,7 @@
 
 #include "AP_ServoRelayEvents/AP_ServoRelayEvents.h"
 
-MAV_RESULT GCS_MAVLINK::handle_servorelay_message(mavlink_command_long_t &packet)
+MAV_RESULT GCS_MAVLINK::handle_servorelay_message(const mavlink_command_long_t &packet)
 {
     AP_ServoRelayEvents *handler = AP::servorelayevents();
     if (handler == nullptr) {


### PR DESCRIPTION
These messages are handled in the base class, with a virtual method to actually implement the vehicle-specific messages; that callback takes the decoded packet rather than the mavlink message.

This is not quite NFC.  We will return UNSUPPORTED in place of FAILED for messages where something has been compiled out entirely - fence and mount being the common ones.

I've also moved handling of accelcal up to the base class.
