### PR TITLE
Tools: Fix a race condition on the regression tests on Windows

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -366,9 +366,9 @@ class AutoTest(ABC):
         for i in range(1, 10):
             self.mavproxy.send("param set %s %s\n" % (name, str(value)))
             self.mavproxy.send("param fetch %s\n" % name)
-            self.mavproxy.expect("%s = (.*)" % (name,))
+            self.mavproxy.expect("%s = (.*)\r\n" % (name,))
             returned_value = self.mavproxy.match.group(1)
-            if float(returned_value) == float(value):
+            if float(returned_value.split('\r\n')[0]) == float(value):
                 # yes, exactly equal.
                 break
             self.progress("Param fetch returned incorrect value (%s) vs (%s)"


### PR DESCRIPTION
This fixes this error:

AUTOTEST: FAILED : [('Fly Vision Position', ValueError('invalid literal for float(): 0.000000\r\nAPM: GPS Glitch cleared\r\n',))]
FAILED STEP: fly.ArduCopter at Wed Jul 4 14:04:40 2018
FAILED 1 tests: ['fly.ArduCopter']