### PR TITLE
Global: Delete the new line character from the Panic message.

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -36,7 +36,7 @@ AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation) :
         rot_view.from_euler(0, radians(270), 0);
         break;
     default:
-        AP_HAL::panic("Unsupported AHRS view %u\n", (unsigned)rotation);
+        AP_HAL::panic("Unsupported AHRS view %u", (unsigned)rotation);
     }
 
     // setup initial state

--- a/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig_CAN.cpp
@@ -139,7 +139,7 @@ void AP_BoardConfig_CAN::setup_canbus(void)
                 _var_info_can_protocol[i]._uavcan = new AP_UAVCAN;
 
                 if (_var_info_can_protocol[i]._uavcan == nullptr) {
-                    AP_HAL::panic("Failed to allocate uavcan %d\n\r", i + 1);
+                    AP_HAL::panic("Failed to allocate uavcan %d", i + 1);
                     continue;
                 }
                 

--- a/libraries/AP_HAL_F4Light/AnalogIn.cpp
+++ b/libraries/AP_HAL_F4Light/AnalogIn.cpp
@@ -85,7 +85,7 @@ AnalogSource* AnalogIn::_create_channel(uint8_t chnum) {
 
 void AnalogIn::_register_channel(AnalogSource* ch) {
     if (_num_channels >= F4Light_INPUT_MAX_CHANNELS) {
-        AP_HAL::panic("Error: AP_HAL_F4Light::AnalogIn out of channels\r\n");
+        AP_HAL::panic("Error: AP_HAL_F4Light::AnalogIn out of channels");
     }
     _channels[_num_channels] = ch;
 

--- a/libraries/AP_HAL_F4Light/Storage.cpp
+++ b/libraries/AP_HAL_F4Light/Storage.cpp
@@ -87,19 +87,19 @@ void Storage::late_init(bool defer) {
 void Storage::error_parse(uint16_t status){
     switch(status) {
     case EEPROM_NO_VALID_PAGE: // despite repeated attempts, EEPROM does not work, but should
-        AP_HAL::panic("EEPROM Error: no valid page\r\n");
+        AP_HAL::panic("EEPROM Error: no valid page");
         break;
 
     case EEPROM_OUT_SIZE:
-        AP_HAL::panic("EEPROM Error: full\r\n");
+        AP_HAL::panic("EEPROM Error: full");
         break;
         
     case EEPROM_BAD_FLASH: // 
-        AP_HAL::panic("EEPROM Error: page not empty after erase\r\n");
+        AP_HAL::panic("EEPROM Error: page not empty after erase");
         break;
 
     case EEPROM_WRITE_FAILED:
-        AP_HAL::panic("EEPROM Error: write failed\r\n");
+        AP_HAL::panic("EEPROM Error: write failed");
         break;
 
     case EEPROM_BAD_ADDRESS: // just not found

--- a/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_Navio2.cpp
@@ -20,7 +20,7 @@ void AnalogSource_Navio2::set_channel(uint8_t pin)
     }
 
     if (asprintf(&channel_path, "%s/ch%d", ADC_BASE_PATH, pin) == -1) {
-        AP_HAL::panic("asprintf failed\n");
+        AP_HAL::panic("asprintf failed");
     }
 
     if (_fd >= 0) {

--- a/libraries/AP_HAL_Linux/CameraSensor_Mt9v117.cpp
+++ b/libraries/AP_HAL_Linux/CameraSensor_Mt9v117.cpp
@@ -126,7 +126,7 @@ CameraSensor_Mt9v117::CameraSensor_Mt9v117(const char *device_path,
         _configure_sensor_qvga();
         break;
     default:
-        AP_HAL::panic("mt9v117: unsupported resolution\n");
+        AP_HAL::panic("mt9v117: unsupported resolution");
         break;
     }
 
@@ -409,7 +409,7 @@ void CameraSensor_Mt9v117::_init_sensor()
 
     id = _read_reg16(CHIP_ID);
     if (id != MT9V117_CHIP_ID) {
-        AP_HAL::panic("Mt9v117: bad chip id 0x%04x\n", id);
+        AP_HAL::panic("Mt9v117: bad chip id 0x%04x", id);
     }
     _soft_reset();
     _apply_patch();

--- a/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
+++ b/libraries/AP_HAL_Linux/OpticalFlow_Onboard.cpp
@@ -88,7 +88,7 @@ void OpticalFlow_Onboard::init()
     if (!_camerasensor->set_format(HAL_OPTFLOW_ONBOARD_SENSOR_WIDTH,
                                    HAL_OPTFLOW_ONBOARD_SENSOR_HEIGHT,
                                    V4L2_MBUS_FMT_UYVY8_2X8)) {
-        AP_HAL::panic("OpticalFlow_Onboard: couldn't set subdev fmt\n");
+        AP_HAL::panic("OpticalFlow_Onboard: couldn't set subdev fmt");
     }
     _format = V4L2_PIX_FMT_NV12;
 #endif
@@ -100,7 +100,7 @@ void OpticalFlow_Onboard::init()
 
     if (_format != V4L2_PIX_FMT_NV12 && _format != V4L2_PIX_FMT_GREY &&
         _format != V4L2_PIX_FMT_YUYV) {
-        AP_HAL::panic("OpticalFlow_Onboard: format not supported\n");
+        AP_HAL::panic("OpticalFlow_Onboard: format not supported");
     }
 
     if (_width == HAL_OPTFLOW_ONBOARD_OUTPUT_WIDTH &&
@@ -267,7 +267,7 @@ void OpticalFlow_Onboard::_run_optflow()
 
         convert_buffer = (uint8_t *)calloc(1, convert_buffer_size);
         if (!convert_buffer) {
-            AP_HAL::panic("OpticalFlow_Onboard: couldn't allocate conversion buffer\n");
+            AP_HAL::panic("OpticalFlow_Onboard: couldn't allocate conversion buffer");
         }
     }
 
@@ -281,7 +281,7 @@ void OpticalFlow_Onboard::_run_optflow()
                 free(convert_buffer);
             }
 
-            AP_HAL::panic("OpticalFlow_Onboard: couldn't allocate crop buffer\n");
+            AP_HAL::panic("OpticalFlow_Onboard: couldn't allocate crop buffer");
         }
     }
 
@@ -317,7 +317,7 @@ void OpticalFlow_Onboard::_run_optflow()
                free(output_buffer);
             }
 
-            AP_HAL::panic("OpticalFlow_Onboard: couldn't get frame\n");
+            AP_HAL::panic("OpticalFlow_Onboard: couldn't get frame");
         }
 
         if (_format == V4L2_PIX_FMT_YUYV) {

--- a/libraries/AP_HAL_Linux/RCInput_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Navio2.cpp
@@ -23,7 +23,7 @@ void RCInput_Navio2::init()
     for (size_t i = 0; i < ARRAY_SIZE(channels); i++) {
         channels[i] = open_channel(i);
         if (channels[i] < 0) {
-            AP_HAL::panic("[RCInput_Navio2]: failed to open channels\n");
+            AP_HAL::panic("[RCInput_Navio2]: failed to open channels");
         }
     }
 }
@@ -64,7 +64,7 @@ int RCInput_Navio2::open_channel(int channel)
 {
     char *channel_path;
     if (asprintf(&channel_path, "%s/ch%d", RCIN_SYSFS_PATH, channel) == -1) {
-        AP_HAL::panic("[RCInput_Navio2]: not enough memory\n");
+        AP_HAL::panic("[RCInput_Navio2]: not enough memory");
     }
 
     int fd = ::open(channel_path, O_RDONLY|O_CLOEXEC);

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -32,7 +32,7 @@ using namespace Linux;
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutputAioPRU.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutputAioPRU.cpp:SIGBUS error gernerated");
 }
 void RCOutput_AioPRU::init()
 {

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -23,7 +23,7 @@ static const uint8_t chan_pru_map[]= {10,8,11,9,7,6,5,4,3,2,1,0};               
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated");
 }
 void RCOutput_PRU::init()
 {

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -31,7 +31,7 @@ using namespace Linux;
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated");
 }
 void RCOutput_ZYNQ::init()
 {

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
@@ -57,7 +57,7 @@ void SPIUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         _buffer = new uint8_t[rxS];
         if (_buffer == nullptr) {
             hal.console->printf("Not enough memory\n");
-            AP_HAL::panic("Not enough memory\n");
+            AP_HAL::panic("Not enough memory");
         }
     }
 

--- a/libraries/AP_HAL_Linux/VideoIn.cpp
+++ b/libraries/AP_HAL_Linux/VideoIn.cpp
@@ -45,7 +45,7 @@ bool VideoIn::get_frame(Frame &frame)
 {
     if (!_streaming) {
         if (!_set_streaming(true)) {
-            AP_HAL::panic("couldn't start streaming\n");
+            AP_HAL::panic("couldn't start streaming");
             return false;
         }
         _streaming = true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -203,10 +203,10 @@ void AP_InertialSensor_BMI160::_check_err_reg()
 
     r = _dev->read_registers(BMI160_REG_ERR_REG, &v, 1);
     if (!r) {
-        AP_HAL::panic("BMI160: couldn't read ERR_REG\n");
+        AP_HAL::panic("BMI160: couldn't read ERR_REG");
     }
     if (v) {
-        AP_HAL::panic("BMI160: error detected on ERR_REG\n");
+        AP_HAL::panic("BMI160: error detected on ERR_REG");
     }
 #endif
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -423,7 +423,7 @@ bool AP_InertialSensor_LSM9DS0::_init_sensor()
     if (_drdy_pin_num_a >= 0) {
         _drdy_pin_a = hal.gpio->channel(_drdy_pin_num_a);
         if (_drdy_pin_a == nullptr) {
-            AP_HAL::panic("LSM9DS0: null accel data-ready GPIO channel\n");
+            AP_HAL::panic("LSM9DS0: null accel data-ready GPIO channel");
         }
 
         _drdy_pin_a->mode(HAL_GPIO_INPUT);
@@ -432,7 +432,7 @@ bool AP_InertialSensor_LSM9DS0::_init_sensor()
     if (_drdy_pin_num_g >= 0) {
         _drdy_pin_g = hal.gpio->channel(_drdy_pin_num_g);
         if (_drdy_pin_g == nullptr) {
-            AP_HAL::panic("LSM9DS0: null gyro data-ready GPIO channel\n");
+            AP_HAL::panic("LSM9DS0: null gyro data-ready GPIO channel");
         }
 
         _drdy_pin_g->mode(HAL_GPIO_INPUT);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
@@ -231,7 +231,7 @@ bool AP_InertialSensor_LSM9DS1::_init_sensor()
     if (_drdy_pin_num_xg >= 0) {
         _drdy_pin_xg = hal.gpio->channel(_drdy_pin_num_xg);
         if (_drdy_pin_xg == nullptr) {
-            AP_HAL::panic("LSM9DS1: null accel data-ready GPIO channel\n");
+            AP_HAL::panic("LSM9DS1: null accel data-ready GPIO channel");
         }
         _drdy_pin_xg->mode(HAL_GPIO_INPUT);
     }

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -59,7 +59,7 @@ bool AP_Radio_cc2500::init(void)
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     if(_irq_handler_ctx != nullptr) {
-        AP_HAL::panic("AP_Radio_cc2500: double instantiation of irq_handler\n");
+        AP_HAL::panic("AP_Radio_cc2500: double instantiation of irq_handler");
     }
     chVTObjectInit(&timeout_vt);
     _irq_handler_ctx = chThdCreateStatic(_irq_handler_wa,

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -266,7 +266,7 @@ bool AP_Radio_cypress::init(void)
     dev = hal.spi->get_device(CYRF_SPI_DEVICE);
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     if(_irq_handler_ctx != nullptr) {
-        AP_HAL::panic("AP_Radio_cypress: double instantiation of irq_handler\n");
+        AP_HAL::panic("AP_Radio_cypress: double instantiation of irq_handler");
     }
     chVTObjectInit(&timeout_vt);
     _irq_handler_ctx = chThdCreateStatic(_irq_handler_wa,


### PR DESCRIPTION
I think that it is unnecessary to specify a carriage return at the end of the message. 
The Panic method outputs a line feed at the end of the message.