### PR TITLE
AP_OSD: imperial units and warning levels

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -98,6 +98,27 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_H_OFFSET", 11, AP_OSD, h_offset, 32),
 
+    // @Param: _W_RSSI
+    // @DisplayName: RSSI warn level (in %)
+    // @Description: Set level at which RSSI item will flash
+    // @Range: 0 99
+    // @User: Standard
+    AP_GROUPINFO("_W_RSSI", 11, AP_OSD, warn_rssi, 30),
+
+    // @Param: _W_NSAT
+    // @DisplayName: NSAT warn leve
+    // @Description: Set level at which NSAT item will flash
+    // @Range: 1 30
+    // @User: Standard
+    AP_GROUPINFO("_W_NSAT", 12, AP_OSD, warn_nsat, 9),
+
+    // @Param: _W_BATVOLT
+    // @DisplayName: BAT_VOLT warn level
+    // @Description: Set level at which BAT_VOLT item will flash
+    // @Range: 0 100
+    // @User: Standard
+    AP_GROUPINFO("_W_BATVOLT", 13, AP_OSD, warn_batvolt, 10.0f),
+
     AP_GROUPEND
 };
 
@@ -163,7 +184,7 @@ void AP_OSD::update_osd()
     backend->clear();
 
     update_current_screen();
-    
+
     screen[current_screen].set_osd(this);
     screen[current_screen].set_backend(backend);
     screen[current_screen].draw();

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: OSD Options
     // @Description: This sets options that change the display
-    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll, 3:ImperialUnits
+    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 8, AP_OSD, options, OPTION_DECIMAL_PACK),
 
@@ -89,6 +89,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Description: Sets vertical offset of the osd inside image
     // @Range: 0 31
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("_V_OFFSET", 10, AP_OSD, v_offset, 16),
 
     // @Param: _H_OFFSET
@@ -96,6 +97,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Description: Sets horizontal offset of the osd inside image
     // @Range: 0 63
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("_H_OFFSET", 11, AP_OSD, h_offset, 32),
 
     // @Param: _W_RSSI
@@ -103,21 +105,21 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Description: Set level at which RSSI item will flash
     // @Range: 0 99
     // @User: Standard
-    AP_GROUPINFO("_W_RSSI", 11, AP_OSD, warn_rssi, 30),
+    AP_GROUPINFO("_W_RSSI", 12, AP_OSD, warn_rssi, 30),
 
     // @Param: _W_NSAT
-    // @DisplayName: NSAT warn leve
+    // @DisplayName: NSAT warn level
     // @Description: Set level at which NSAT item will flash
     // @Range: 1 30
     // @User: Standard
-    AP_GROUPINFO("_W_NSAT", 12, AP_OSD, warn_nsat, 9),
+    AP_GROUPINFO("_W_NSAT", 13, AP_OSD, warn_nsat, 9),
 
     // @Param: _W_BATVOLT
     // @DisplayName: BAT_VOLT warn level
     // @Description: Set level at which BAT_VOLT item will flash
     // @Range: 0 100
     // @User: Standard
-    AP_GROUPINFO("_W_BATVOLT", 13, AP_OSD, warn_batvolt, 10.0f),
+    AP_GROUPINFO("_W_BATVOLT", 14, AP_OSD, warn_batvolt, 10.0f),
 
     AP_GROUPEND
 };
@@ -185,7 +187,6 @@ void AP_OSD::update_osd()
 
     update_current_screen();
 
-    screen[current_screen].set_osd(this);
     screen[current_screen].set_backend(backend);
     screen[current_screen].draw();
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -121,6 +121,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_W_BATVOLT", 14, AP_OSD, warn_batvolt, 10.0f),
 
+    // @Param: _UNITS
+    // @DisplayName: Display Units
+    // @Description: Sets the units to use in displaying items
+    // @Values: 0:Metric,1:Imperial
+    // @User: Standard
+    AP_GROUPINFO("_UNITS", 15, AP_OSD, units, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: OSD Options
     // @Description: This sets options that change the display
-    // @Bitmask: 0:UseDecimalPack
+    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 8, AP_OSD, options, OPTION_DECIMAL_PACK),
 
@@ -163,7 +163,8 @@ void AP_OSD::update_osd()
     backend->clear();
 
     update_current_screen();
-
+    
+    screen[current_screen].set_osd(this);
     screen[current_screen].set_backend(backend);
     screen[current_screen].draw();
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -84,6 +84,20 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("_FONT", 9, AP_OSD, font_num, 0),
     
+    // @Param: _V_OFFSET
+    // @DisplayName: OSD vertical offset
+    // @Description: Sets vertical offset of the osd inside image
+    // @Range: 0 31
+    // @User: Standard
+    AP_GROUPINFO("_V_OFFSET", 10, AP_OSD, v_offset, 16),
+
+    // @Param: _H_OFFSET
+    // @DisplayName: OSD horizontal offset
+    // @Description: Sets horizontal offset of the osd inside image
+    // @Range: 0 63
+    // @User: Standard
+    AP_GROUPINFO("_H_OFFSET", 11, AP_OSD, h_offset, 32),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: OSD Options
     // @Description: This sets options that change the display
-    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll
+    // @Bitmask: 0:UseDecimalPack, 1:InvertedWindPointer, 2:InvertedAHRoll, 3:ImperialUnits
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 8, AP_OSD, options, OPTION_DECIMAL_PACK),
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -51,15 +51,7 @@ public:
 
     void draw(void);
 
-    void set_backend(AP_OSD_Backend *_backend)
-    {
-        backend = _backend;
-    };
-
-    void set_osd(AP_OSD *_osd)
-    {
-        osd = _osd;
-    };
+    void set_backend(AP_OSD_Backend *_backend);
 
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
@@ -109,6 +101,11 @@ private:
     AP_OSD_Setting gps_latitude{true, 9, 13};
     AP_OSD_Setting gps_longitude{true, 9, 14};
 
+    bool check_option(uint32_t option);
+
+    char u_icon(uint16_t unit_type);
+    float u_scale(uint16_t unit_type, float value);
+
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
     void draw_rssi(uint8_t x, uint8_t y);
@@ -127,7 +124,9 @@ private:
     void draw_aspeed(uint8_t x, uint8_t y);
     void draw_vspeed(uint8_t x, uint8_t y);
 
+    //helper functions
     void draw_speed_vector(uint8_t x, uint8_t y, Vector2f v, int32_t yaw);
+    void draw_distance(uint8_t x, uint8_t y, float distance);
 
 #ifdef HAVE_AP_BLHELI_SUPPORT
     void draw_blh_temp(uint8_t x, uint8_t y);
@@ -137,6 +136,17 @@ private:
 
     void draw_gps_latitude(uint8_t x, uint8_t y);
     void draw_gps_longitude(uint8_t x, uint8_t y);
+
+    enum {
+        ALTITUDE=0,
+        SPEED=1,
+        VSPEED=2,
+        DISTANCE=3,
+        DISTANCE_LONG=4,
+        TEMPERATURE=5,
+        UNIT_LAST=6,
+    };
+
 };
 
 class AP_OSD {
@@ -181,10 +191,17 @@ public:
         OPTION_DECIMAL_PACK = 1U<<0,
         OPTION_INVERTED_WIND = 1U<<1,
         OPTION_INVERTED_AH_ROLL = 1U<<2,
-        OPTION_IMPERIAL_UNITS = 1U<<3,
     };
 
     AP_Int32 options;
+
+    enum {
+        UNITS_METRIC=0,
+        UNITS_IMPERIAL=1,
+        UNITS_LAST=2,
+    };
+
+    AP_Int8 units;
 
     AP_OSD_Screen screen[AP_OSD_NUM_SCREENS];
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -75,32 +75,32 @@ private:
     //typical fpv camera has 80deg vertical field of view, 16 row of chars
     static constexpr float ah_pitch_rad_to_char = 16.0f/(DEG_TO_RAD * 80);
 
-    AP_OSD_Setting altitude{true, 1, 1};
-    AP_OSD_Setting bat_volt{true, 9, 1};
-    AP_OSD_Setting rssi{false, 0, 0};
-    AP_OSD_Setting current{true, 1, 2};
-    AP_OSD_Setting batused{true, 1, 3};
-    AP_OSD_Setting sats{true, 1, 4};
-    AP_OSD_Setting fltmode{true, 12, 14};
-    AP_OSD_Setting message{false, 2, 13};
-    AP_OSD_Setting gspeed{false, 0, 0};
-    AP_OSD_Setting horizon{true, 15, 8};
-    AP_OSD_Setting home{false, 0, 0};
-    AP_OSD_Setting throttle{false, 0, 0};
-    AP_OSD_Setting heading{false, 0, 0};
-    AP_OSD_Setting compass{false, 0, 0};
-    AP_OSD_Setting wind{false, 0, 0};
-    AP_OSD_Setting aspeed{false, 0, 0};
-    AP_OSD_Setting vspeed{false, 0, 0};
+    AP_OSD_Setting altitude{true, 23, 8};
+    AP_OSD_Setting bat_volt{true, 24, 1};
+    AP_OSD_Setting rssi{true, 1, 1};
+    AP_OSD_Setting current{true, 25, 2};
+    AP_OSD_Setting batused{true, 23, 3};
+    AP_OSD_Setting sats{true, 1, 3};
+    AP_OSD_Setting fltmode{true, 2, 8};
+    AP_OSD_Setting message{true, 2, 6};
+    AP_OSD_Setting gspeed{true, 2, 14};
+    AP_OSD_Setting horizon{true, 14, 8};
+    AP_OSD_Setting home{true, 14, 1};
+    AP_OSD_Setting throttle{true, 24, 11};
+    AP_OSD_Setting heading{true, 13, 2};
+    AP_OSD_Setting compass{true, 15, 3};
+    AP_OSD_Setting wind{false, 2, 12};
+    AP_OSD_Setting aspeed{false, 2, 13};
+    AP_OSD_Setting vspeed{true, 24, 9};
     
 #ifdef HAVE_AP_BLHELI_SUPPORT
-    AP_OSD_Setting blh_temp{false, 0, 0};
-    AP_OSD_Setting blh_rpm{false, 0, 0};
-    AP_OSD_Setting blh_amps{false, 0, 0};
+    AP_OSD_Setting blh_temp{false, 24, 13};
+    AP_OSD_Setting blh_rpm{false, 22, 12};
+    AP_OSD_Setting blh_amps{false, 24, 14};
 #endif
     
-    AP_OSD_Setting gps_latitude{false, 0, 0};
-    AP_OSD_Setting gps_longitude{false, 0, 0};
+    AP_OSD_Setting gps_latitude{true, 9, 13};
+    AP_OSD_Setting gps_longitude{true, 9, 14};
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -103,8 +103,18 @@ private:
 
     bool check_option(uint32_t option);
 
-    char u_icon(uint16_t unit_type);
-    float u_scale(uint16_t unit_type, float value);
+    enum unit_type {
+        ALTITUDE=0,
+        SPEED=1,
+        VSPEED=2,
+        DISTANCE=3,
+        DISTANCE_LONG=4,
+        TEMPERATURE=5,
+        UNIT_TYPE_LAST=6,
+    };
+    
+    char u_icon(enum unit_type unit);
+    float u_scale(enum unit_type unit, float value);
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
@@ -136,17 +146,6 @@ private:
 
     void draw_gps_latitude(uint8_t x, uint8_t y);
     void draw_gps_longitude(uint8_t x, uint8_t y);
-
-    enum {
-        ALTITUDE=0,
-        SPEED=1,
-        VSPEED=2,
-        DISTANCE=3,
-        DISTANCE_LONG=4,
-        TEMPERATURE=5,
-        UNIT_LAST=6,
-    };
-
 };
 
 class AP_OSD {

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -177,6 +177,7 @@ public:
         OPTION_DECIMAL_PACK = 1U<<0,
         OPTION_INVERTED_WIND = 1U<<1,
         OPTION_INVERTED_AH_ROLL = 1U<<2,
+        OPTION_IMPERIAL_UNITS = 1U<<3,
     };
 
     AP_Int32 options;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -173,6 +173,10 @@ public:
     AP_Int8 v_offset;
     AP_Int8 h_offset;
 
+    AP_Int8 warn_rssi;
+    AP_Int8 warn_nsat;
+    AP_Float warn_batvolt;
+
     enum {
         OPTION_DECIMAL_PACK = 1U<<0,
         OPTION_INVERTED_WIND = 1U<<1,

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -92,13 +92,13 @@ private:
     AP_OSD_Setting wind{false, 2, 12};
     AP_OSD_Setting aspeed{false, 2, 13};
     AP_OSD_Setting vspeed{true, 24, 9};
-    
+
 #ifdef HAVE_AP_BLHELI_SUPPORT
-    AP_OSD_Setting blh_temp{false, 24, 13};
+    AP_OSD_Setting blh_temp {false, 24, 13};
     AP_OSD_Setting blh_rpm{false, 22, 12};
     AP_OSD_Setting blh_amps{false, 24, 14};
 #endif
-    
+
     AP_OSD_Setting gps_latitude{true, 9, 13};
     AP_OSD_Setting gps_longitude{true, 9, 14};
 
@@ -127,7 +127,7 @@ private:
     void draw_blh_rpm(uint8_t x, uint8_t y);
     void draw_blh_amps(uint8_t x, uint8_t y);
 #endif
-    
+
     void draw_gps_latitude(uint8_t x, uint8_t y);
     void draw_gps_longitude(uint8_t x, uint8_t y);
 };
@@ -163,10 +163,13 @@ public:
     AP_Int8 sw_method;
     AP_Int8 font_num;
 
+    AP_Int8 v_offset;
+    AP_Int8 h_offset;
+
     enum {
         OPTION_DECIMAL_PACK = 1U<<0,
     };
-    
+
     AP_Int32 options;
 
     AP_OSD_Screen screen[AP_OSD_NUM_SCREENS];

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -39,6 +39,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 };
 
+class AP_OSD;
 
 /*
   class to hold one screen of settings
@@ -55,6 +56,11 @@ public:
         backend = _backend;
     };
 
+    void set_osd(AP_OSD *_osd)
+    {
+        osd = _osd;
+    };
+
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -64,6 +70,7 @@ public:
 
 private:
     AP_OSD_Backend *backend;
+    AP_OSD *osd;
 
     static const uint16_t message_show_time_ms = 20000;
     static const uint8_t message_visible_width = 26;
@@ -168,6 +175,8 @@ public:
 
     enum {
         OPTION_DECIMAL_PACK = 1U<<0,
+        OPTION_INVERTED_WIND = 1U<<1,
+        OPTION_INVERTED_AH_ROLL = 1U<<2,
     };
 
     AP_Int32 options;

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -49,6 +49,11 @@ public:
         INVERT = (1 << 3),
     };
 
+    AP_OSD * get_osd()
+    {
+        return &_osd;
+    }
+
 protected:
     AP_OSD& _osd;
 

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -361,7 +361,6 @@ void AP_OSD_MAX7456::flush()
 
 void AP_OSD_MAX7456::transfer_frame()
 {
-    uint16_t updated_chars = 0;
     uint8_t last_attribute = 0xFF;
     uint16_t previous_pos = UINT16_MAX - 1;
     if (!initialized) {
@@ -375,7 +374,8 @@ void AP_OSD_MAX7456::transfer_frame()
             if (frame[y][x] == shadow_frame[y][x] && attr[y][x] == shadow_attr[y][x]) {
                 continue;
             }
-            if (updated_chars > max_updated_chars) {
+            //ensure space for 1 char and escape sequence
+            if (buffer_offset >= spi_buffer_size - 32) {
                 break;
             }
             shadow_frame[y][x] = frame[y][x];
@@ -389,7 +389,7 @@ void AP_OSD_MAX7456::transfer_frame()
             if (position_changed) {
                 //it is impossible to write to MAX7456ADD_DMAH/MAX7456ADD_DMAL in autoincrement mode
                 //so, exit autoincrement mode
-                if (updated_chars != 0) {
+                if (buffer_offset != 0) {
                     buffer_add_cmd(MAX7456ADD_DMDI, 0xFF);
                     buffer_add_cmd(MAX7456ADD_DMM, 0);
                 }
@@ -404,7 +404,6 @@ void AP_OSD_MAX7456::transfer_frame()
             }
 
             buffer_add_cmd(MAX7456ADD_DMDI, chr);
-            updated_chars++;
             previous_pos = pos;
         }
     }

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -337,6 +337,12 @@ void AP_OSD_MAX7456::reinit()
     _dev->write_register(MAX7456ADD_VM1, BLINK_DUTY_CYCLE_50_50 | BLINK_TIME_3 | BACKGROUND_BRIGHTNESS_28);
     _dev->write_register(MAX7456ADD_DMM, DMM_CLEAR_DISPLAY);
 
+    //write osd position
+    int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
+    int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
+    _dev->write_register(MAX7456ADD_HOS, hos);
+    _dev->write_register(MAX7456ADD_VOS, vos);
+
     // force redrawing all screen
     memset(shadow_frame, 0xFF, sizeof(shadow_frame));
     memset(shadow_attr, 0xFF, sizeof(shadow_attr));

--- a/libraries/AP_OSD/AP_OSD_MAX7456.h
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.h
@@ -64,8 +64,7 @@ private:
     static const uint8_t video_lines_ntsc = 13;
     static const uint8_t video_lines_pal = 16;
     static const uint8_t video_columns = 30;
-    static const uint16_t max_updated_chars = 64; //up to 480
-    static const uint16_t spi_buffer_size = ((max_updated_chars + 1) * 8);
+    static const uint16_t spi_buffer_size = 512;
 
     uint8_t frame[video_lines_pal][video_columns];
 

--- a/libraries/AP_OSD/AP_OSD_MAX7456.h
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.h
@@ -60,6 +60,8 @@ private:
     uint8_t  video_signal_reg;
     bool initialized;
     uint8_t last_font;
+    int8_t last_v_offset;
+    int8_t last_h_offset;
 
     static const uint8_t video_lines_ntsc = 13;
     static const uint8_t video_lines_pal = 16;

--- a/libraries/AP_OSD/AP_OSD_SITL.cpp
+++ b/libraries/AP_OSD/AP_OSD_SITL.cpp
@@ -84,7 +84,7 @@ void AP_OSD_SITL::load_font(void)
                     p[3] = 255;
                     break;
                 }
-                    
+
             }
         }
         font[i].update(pixels);
@@ -131,13 +131,12 @@ void AP_OSD_SITL::update_thread(void)
     }
 
     uint8_t blink = 0;
-    while (w->isOpen())
-    {
+    while (w->isOpen()) {
         sf::Event event;
-        while (w->pollEvent(event))
-        {
-            if (event.type == sf::Event::Closed)
+        while (w->pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
                 w->close();
+            }
         }
         if (counter == last_counter) {
             usleep(10000);
@@ -170,7 +169,7 @@ void AP_OSD_SITL::update_thread(void)
                 w->draw(s);
             }
         }
-        
+
         blink = (blink+1) % 4;
         w->display();
         usleep(10000);

--- a/libraries/AP_OSD/AP_OSD_SITL.h
+++ b/libraries/AP_OSD/AP_OSD_SITL.h
@@ -59,7 +59,7 @@ private:
 
     // scaling factor to make it easier to read
     static const uint8_t char_scale = 2;
-    
+
     uint8_t buffer[video_lines][video_cols];
     uint8_t attr[video_lines][video_cols];
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -526,7 +526,7 @@ void AP_OSD_Screen::draw_gps_latitude(uint8_t x, uint8_t y)
     dec_portion = loc.lat / 10000000L;
     frac_portion = abs_lat - labs(dec_portion)*10000000UL;
 
-    backend->write(x, y, false, "%c%3ld.%07ld", SYM_GPS_LAT, (long)dec_portion,(long)frac_portion);
+    backend->write(x, y, false, "%c%4ld.%07ld", SYM_GPS_LAT, (long)dec_portion,(long)frac_portion);
 }
 
 void AP_OSD_Screen::draw_gps_longitude(uint8_t x, uint8_t y)
@@ -539,7 +539,7 @@ void AP_OSD_Screen::draw_gps_longitude(uint8_t x, uint8_t y)
     dec_portion = loc.lng / 10000000L;
     frac_portion = abs_lon - labs(dec_portion)*10000000UL;
 
-    backend->write(x, y, false, "%c%3ld.%07ld", SYM_GPS_LONG, (long)dec_portion,(long)frac_portion);
+    backend->write(x, y, false, "%c%4ld.%07ld", SYM_GPS_LONG, (long)dec_portion,(long)frac_portion);
 }
 
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -230,40 +230,73 @@ bool AP_OSD_Screen::check_option(uint32_t option)
     return (osd->options & option) != 0;
 }
 
-char AP_OSD_Screen::u_icon(uint16_t unit)
+/*
+  get the right units icon given a unit
+ */
+char AP_OSD_Screen::u_icon(enum unit_type unit)
 {
-    static const char icons[UNIT_LAST][AP_OSD::UNITS_LAST] = {
-        {(char)SYM_ALT_M, (char)SYM_ALT_FT},  //ALTITUDE
-        {(char)SYM_KMH, (char)SYM_MPH},       //SPEED
-        {(char)SYM_MS, (char)SYM_FS},         //VSPEED
-        {(char)SYM_M, (char)SYM_FT},          //DISTANCE
-        {(char)SYM_KM, (char)SYM_MI},         //DISTANCE_LONG
-        {(char)SYM_DEGREES_C, (char)SYM_DEGREES_F}//TEMPERATURE
+    static const char icons_metric[UNIT_TYPE_LAST] {
+        (char)SYM_ALT_M,    //ALTITUDE
+        (char)SYM_KMH,      //SPEED
+        (char)SYM_MS,       //VSPEED
+        (char)SYM_M,        //DISTANCE
+        (char)SYM_KM,       //DISTANCE_LONG
+        (char)SYM_DEGREES_C //TEMPERATURE
     };
-    return icons[unit][osd->units];
+    static const char icons_imperial[UNIT_TYPE_LAST] {
+        (char)SYM_ALT_FT,   //ALTITUDE
+        (char)SYM_MPH,      //SPEED
+        (char)SYM_FS,       //VSPEED
+        (char)SYM_FT,       //DISTANCE
+        (char)SYM_MI,       //DISTANCE_LONG
+        (char)SYM_DEGREES_F //TEMPERATURE
+    };
+    static const char *icons[AP_OSD::UNITS_LAST] = {
+        icons_metric,
+        icons_imperial
+    };
+    return icons[constrain_int16(osd->units, 0, AP_OSD::UNITS_LAST-1)][unit];
 }
 
-float AP_OSD_Screen::u_scale(uint16_t unit, float value)
+/*
+  scale a value for the user selected units
+ */
+float AP_OSD_Screen::u_scale(enum unit_type unit, float value)
 {
-    static const float scale[UNIT_LAST][AP_OSD::UNITS_LAST] = {
-        {1.0f, 3.28084f},             //ALTITUDE
-        {3.6f, 2.23694f},             //SPEED
-        {1.0f, 3.28084f},             //VSPEED
-        {1.0f, 3.28084f},             //DISTANCE
-        {1.0f/1000.0f, 1.0f/1609.34f},//DISTANCE_LONG
-        {1.0f, 1.8f}                  //TEMPERATURE
+    static const float scale_metric[UNIT_TYPE_LAST] = {
+        1.0,       //ALTITUDE
+        3.6,       //SPEED
+        1.0,       //VSPEED
+        1.0,       //DISTANCE
+        1.0/1000,  //DISTANCE_LONG
+        1.0,       //TEMPERATURE
     };
-
-    static const float offset[UNIT_LAST][AP_OSD::UNITS_LAST] = {
-        {0.0f, 0.0f},          //ALTITUDE
-        {0.0f, 0.0f},          //SPEED
-        {0.0f, 0.0f},          //VSPEED
-        {0.0f, 0.0f},          //DISTANCE
-        {0.0f, 0.0f},          //DISTANCE_LONG
-        {0.0f, 32.0f},         //TEMPERATURE
+    static const float scale_imperial[UNIT_TYPE_LAST] = {
+        3.28084,     //ALTITUDE
+        2.23694,     //SPEED
+        3.28084,     //VSPEED
+        3.28084,     //DISTANCE
+        1.0/1609.34, //DISTANCE_LONG
+        1.8,         //TEMPERATURE
     };
-
-    return value * scale[unit][osd->units] + offset[unit][osd->units];
+    static const float offset_imperial[UNIT_TYPE_LAST] = {
+        0.0,          //ALTITUDE
+        0.0,          //SPEED
+        0.0,          //VSPEED
+        0.0,          //DISTANCE
+        0.0,          //DISTANCE_LONG
+        32.0,         //TEMPERATURE
+    };
+    static const float *scale[AP_OSD::UNITS_LAST] = {
+        scale_metric,
+        scale_imperial
+    };
+    static const float *offsets[AP_OSD::UNITS_LAST] = {
+        nullptr,
+        offset_imperial
+    };
+    uint8_t units = constrain_int16(osd->units, 0, AP_OSD::UNITS_LAST-1);
+    return value * scale[units][unit] + (offsets[units]?offsets[units][unit]:0);
 }
 
 void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -342,6 +342,11 @@ void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
     AP_AHRS &ahrs = AP::ahrs();
     float roll = ahrs.roll;
     float pitch = -ahrs.pitch;
+    
+    //inverted roll AH
+    if(osd->options.get() & AP_OSD::OPTION_INVERTED_AH_ROLL) {
+        roll = -roll;
+    }
 
     roll = constrain_float(roll, -ah_max_roll, ah_max_roll);
     pitch = constrain_float(pitch, -ah_max_pitch, ah_max_pitch);
@@ -434,6 +439,9 @@ void AP_OSD_Screen::draw_wind(uint8_t x, uint8_t y)
 {
     AP_AHRS &ahrs = AP::ahrs();
     Vector3f v = ahrs.wind_estimate();
+    if(osd->options.get() & AP_OSD::OPTION_INVERTED_WIND) {
+        v = -v;
+    }
     backend->write(x, y, false, "%c", SYM_WSPD);
     draw_speed_vector(x + 1, y, Vector2f(v.x, v.y), ahrs.yaw_sensor);
 }


### PR DESCRIPTION
- Added support for imperial units
- Fixed lat/lon field width, so it will display well for 3 digit number with sign
- Add warning levels for vbat, rssi, nsat
- Add setting for inverted roll AHI and inverted wind direction
- Added fine tune settings to adjust osd inside screen (using VOS and HOS MAX7456 registers)
- Reworked default osd items position ( thanks to @Kelly-Foster  for the layout)
- Fixed spi buffer size calculation
