### PR TITLE
HAL: added thread_create() API

### DIFF
--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -83,6 +83,31 @@ public:
     virtual void call_delay_cb();
     uint16_t _min_delay_cb_ms;
 
+    /*
+      priority_base is used to select what the priority for a new
+      thread is relative to
+     */
+    enum priority_base {
+        PRIORITY_BOOST,
+        PRIORITY_MAIN,
+        PRIORITY_SPI,
+        PRIORITY_I2C,
+        PRIORITY_CAN,
+        PRIORITY_TIMER,
+        PRIORITY_RCIN,
+        PRIORITY_IO,
+        PRIORITY_UART,
+        PRIORITY_STORAGE
+    };
+    
+    /*
+      create a new thread
+     */
+    virtual bool thread_create(AP_HAL::MemberProc proc, const char *name,
+                               uint32_t stack_size, priority_base base, int8_t priority) {
+        return false;
+    }
+
 private:
 
     AP_HAL::Proc _delay_cb;

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -176,16 +176,14 @@ bool Scheduler::check_called_boost(void)
 
 void Scheduler::delay(uint16_t ms)
 {
-    if (!in_main_thread()) {
-        //chprintf("ERROR: delay() from timer process\n");
-        return;
-    }
     uint64_t start = AP_HAL::micros64();
 
     while ((AP_HAL::micros64() - start)/1000 < ms) {
         delay_microseconds(1000);
         if (_min_delay_cb_ms <= ms) {
-            call_delay_cb();
+            if (in_main_thread()) {
+                call_delay_cb();
+            }
         }
     }
 }

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -92,6 +92,11 @@ public:
       restore interrupt state from disable_interrupts_save()
      */
     void restore_interrupts(void *) override;
+
+    /*
+      create a new thread
+     */
+    bool thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
     
 private:
     bool _initialized;
@@ -132,5 +137,6 @@ private:
 #endif
     void _run_timers();
     void _run_io(void);
+    static void thread_create_trampoline(void *ctx);    
 };
 #endif

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -148,17 +148,12 @@ void Scheduler::delay(uint16_t ms)
         return;
     }
 
-    if (!in_main_thread()) {
-        fprintf(stderr, "Scheduler::delay() called outside main thread\n");
-        return;
-    }
-
     uint64_t start = AP_HAL::millis64();
 
     while ((AP_HAL::millis64() - start) < ms) {
         // this yields the CPU to other apps
         microsleep(1000);
-        if (_min_delay_cb_ms <= ms) {
+        if (in_main_thread() && _min_delay_cb_ms <= ms) {
             call_delay_cb();
         }
     }

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #include "RCInput.h"
@@ -26,6 +27,7 @@ using namespace Linux;
 
 extern const AP_HAL::HAL& hal;
 
+#define APM_LINUX_MAX_PRIORITY          20
 #define APM_LINUX_TIMER_PRIORITY        15
 #define APM_LINUX_UART_PRIORITY         14
 #define APM_LINUX_RCIN_PRIORITY         13
@@ -355,4 +357,68 @@ void Scheduler::teardown()
     _rcin_thread.join();
     _uart_thread.join();
     _tonealarm_thread.join();
+}
+
+/*
+  trampoline for thread create
+*/
+void *Scheduler::thread_create_trampoline(void *ctx)
+{
+    AP_HAL::MemberProc *t = (AP_HAL::MemberProc *)ctx;
+    (*t)();
+    free(t);
+    return nullptr;
+}
+
+/*
+  create a new thread
+*/
+bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_t stack_size, priority_base base, int8_t priority)
+{
+    // take a copy of the MemberProc, it is freed after thread exits
+    AP_HAL::MemberProc *tproc = (AP_HAL::MemberProc *)malloc(sizeof(proc));
+    if (!tproc) {
+        return false;
+    }
+    *tproc = proc;
+
+    uint8_t thread_priority = APM_LINUX_IO_PRIORITY;
+    static const struct {
+        priority_base base;
+        uint8_t p;
+    } priority_map[] = {
+        { PRIORITY_BOOST, APM_LINUX_MAIN_PRIORITY},
+        { PRIORITY_MAIN, APM_LINUX_MAIN_PRIORITY},
+        { PRIORITY_SPI, AP_LINUX_SENSORS_SCHED_PRIO},
+        { PRIORITY_I2C, AP_LINUX_SENSORS_SCHED_PRIO},
+        { PRIORITY_CAN, APM_LINUX_TIMER_PRIORITY},
+        { PRIORITY_TIMER, APM_LINUX_TIMER_PRIORITY},
+        { PRIORITY_RCIN, APM_LINUX_RCIN_PRIORITY},
+        { PRIORITY_IO, APM_LINUX_IO_PRIORITY},
+        { PRIORITY_UART, APM_LINUX_UART_PRIORITY},
+        { PRIORITY_STORAGE, APM_LINUX_IO_PRIORITY},
+    };
+    for (uint8_t i=0; i<ARRAY_SIZE(priority_map); i++) {
+        if (priority_map[i].base == base) {
+            thread_priority = constrain_int16(priority_map[i].p + priority, 1, APM_LINUX_MAX_PRIORITY);
+            break;
+        }
+    }
+    pthread_t thread;
+    pthread_attr_t thread_attr;
+    struct sched_param param;
+
+    pthread_attr_init(&thread_attr);
+    pthread_attr_setstacksize(&thread_attr, stack_size);
+
+    param.sched_priority = thread_priority;
+    (void)pthread_attr_setschedparam(&thread_attr, &param);
+    pthread_attr_setschedpolicy(&thread_attr, SCHED_FIFO);
+
+    if (pthread_create(&thread, &thread_attr, thread_create_trampoline, tproc) != 0) {
+        free(tproc);
+        return false;
+    }
+    pthread_setname_np(thread, name);
+    return true;
 }

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -47,6 +47,11 @@ public:
 
     void teardown();
 
+    /*
+      create a new thread
+     */
+    bool thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
+    
 private:
     class SchedulerThread : public PeriodicThread {
     public:
@@ -97,6 +102,8 @@ private:
     pthread_t _main_ctx;
 
     Semaphore _io_semaphore;
+
+    static void *thread_create_trampoline(void *ctx);    
 };
 
 }

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -172,17 +172,13 @@ void PX4Scheduler::delay_microseconds_boost(uint16_t usec)
 
 void PX4Scheduler::delay(uint16_t ms)
 {
-    if (!in_main_thread()) {
-        ::printf("ERROR: delay() from timer process\n");
-        return;
-    }
     perf_begin(_perf_delay);
     uint64_t start = AP_HAL::micros64();
 
     while ((AP_HAL::micros64() - start)/1000 < ms &&
            !_px4_thread_should_exit) {
         delay_microseconds_semaphore(1000);
-        if (_min_delay_cb_ms <= ms) {
+        if (in_main_thread() && _min_delay_cb_ms <= ms) {
             call_delay_cb();
         }
     }

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -10,6 +10,7 @@
 
 #define PX4_SCHEDULER_MAX_TIMER_PROCS 8
 
+#define APM_MAX_PRIORITY        243
 #define APM_MAIN_PRIORITY_BOOST 241
 #define APM_MAIN_PRIORITY       180
 #define APM_TIMER_PRIORITY      181
@@ -72,6 +73,11 @@ public:
       restore interrupt state from disable_interrupts_save()
      */
     void restore_interrupts(void *) override;
+
+    /*
+      create a new thread
+     */
+    bool thread_create(AP_HAL::MemberProc, const char *name, uint32_t stack_size, priority_base base, int8_t priority) override;
     
 private:
     bool _initialized;
@@ -115,5 +121,6 @@ private:
     perf_counter_t  _perf_io_timers;
     perf_counter_t  _perf_storage_timer;
     perf_counter_t  _perf_delay;
+    static void *thread_create_trampoline(void *ctx);    
 };
 #endif

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -185,7 +185,11 @@ void SITL_State::_fdm_input_step(void)
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
     while (AP_HAL::micros64() < wait_time_usec) {
-        _fdm_input_step();
+        if (hal.scheduler->in_main_thread()) {
+            _fdm_input_step();
+        } else {
+            usleep(1000);
+        }
     }
 }
 

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -31,6 +31,15 @@ Scheduler::Scheduler(SITL_State *sitlState) :
 
 void Scheduler::init()
 {
+    _main_ctx = pthread_self();
+}
+
+bool Scheduler::in_main_thread() const
+{
+    if (!_in_timer_proc && !_in_io_proc && pthread_self() == _main_ctx) {
+        return true;
+    }
+    return false;
 }
 
 void Scheduler::delay_microseconds(uint16_t usec)
@@ -51,7 +60,9 @@ void Scheduler::delay(uint16_t ms)
         delay_microseconds(1000);
         ms--;
         if (_min_delay_cb_ms <= ms) {
-            call_delay_cb();
+            if (in_main_thread()) {
+                call_delay_cb();
+            }
         }
     }
 }

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -26,7 +26,7 @@ public:
 
     void register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    bool in_main_thread() const override { return !_in_timer_proc && !_in_io_proc; };
+    bool in_main_thread() const override;
     void system_initialized();
 
     void reboot(bool hold_in_bootloader);
@@ -78,5 +78,6 @@ private:
     bool _initialized;
     uint64_t _stopped_clock_usec;
     uint64_t _last_io_run;
+    pthread_t _main_ctx;
 };
 #endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -49,6 +49,12 @@ public:
 
     static void _run_io_procs();
     static bool _should_reboot;
+
+    /*
+      create a new thread
+     */
+    bool thread_create(AP_HAL::MemberProc, const char *name,
+                       uint32_t stack_size, priority_base base, int8_t priority) override;
     
 private:
     SITL_State *_sitlState;
@@ -67,6 +73,8 @@ private:
 
     void stop_clock(uint64_t time_usec);
 
+    static void *thread_create_trampoline(void *ctx);
+    
     bool _initialized;
     uint64_t _stopped_clock_usec;
     uint64_t _last_io_run;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -173,17 +173,13 @@ void VRBRAINScheduler::delay_microseconds_boost(uint16_t usec)
 
 void VRBRAINScheduler::delay(uint16_t ms)
 {
-    if (!in_main_thread()) {
-        ::printf("ERROR: delay() from timer process\n");
-        return;
-    }
     perf_begin(_perf_delay);
     uint64_t start = AP_HAL::micros64();
 
     while ((AP_HAL::micros64() - start)/1000 < ms &&
            !_vrbrain_thread_should_exit) {
         delay_microseconds_semaphore(1000);
-        if (_min_delay_cb_ms <= ms) {
+        if (in_main_thread() && _min_delay_cb_ms <= ms) {
             call_delay_cb();
         }
     }

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -133,24 +133,11 @@ void AP_IOMCU::init(void)
     if (!boardconfig || boardconfig->io_enabled() == 1) {
         check_crc();
     }
-        
-    thread_ctx = chThdCreateFromHeap(NULL,
-                                     THD_WORKING_AREA_SIZE(1024),
-                                     "IOMCU",
-                                     183,
-                                     thread_start,
-                                     this);
-    if (thread_ctx == nullptr) {
+
+    if (!hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_IOMCU::thread_main, void), "IOMCU",
+                                      1024, AP_HAL::Scheduler::PRIORITY_BOOST, 1)) {
         AP_HAL::panic("Unable to allocate IOMCU thread");
     }
-}
-
-/*
-  static function to enter thread_main()
- */
-void AP_IOMCU::thread_start(void *ctx)
-{
-    ((AP_IOMCU *)ctx)->thread_main();
 }
 
 /*

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -87,7 +87,6 @@ public:
 private:
     AP_HAL::UARTDriver &uart;
 
-    static void thread_start(void *ctx);
     void thread_main(void);
 
     // read count 16 bit registers

--- a/libraries/AP_Notify/ToneAlarm_Linux.cpp
+++ b/libraries/AP_Notify/ToneAlarm_Linux.cpp
@@ -37,8 +37,8 @@ extern const AP_HAL::HAL& hal;
 bool ToneAlarm_Linux::init()
 {
     // open the tone alarm device
-    bool _initialized = hal.util->toneAlarm_init();
-    if (!_initialized) {
+    bool initialized = hal.util->toneAlarm_init();
+    if (!initialized) {
         hal.console->printf("AP_Notify: Failed to initialise ToneAlarm");
         return false;
     }

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -106,7 +106,6 @@ void AP_OSD::init()
             break;
         }
         hal.console->printf("Started MAX7456 OSD\n");
-        hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&AP_OSD::timer, void));
         break;
     }
 
@@ -117,19 +116,20 @@ void AP_OSD::init()
             break;
         }
         hal.console->printf("Started SITL OSD\n");
-        hal.scheduler->register_io_process(FUNCTOR_BIND_MEMBER(&AP_OSD::timer, void));
         break;
     }
 #endif
     }
+    if (backend != nullptr) {
+        // create thread as higher priority than IO
+        hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_OSD::osd_thread, void), "OSD", 512, AP_HAL::Scheduler::PRIORITY_IO, 1);
+    }
 }
 
-void AP_OSD::timer()
+void AP_OSD::osd_thread()
 {
-    uint32_t now = AP_HAL::millis();
-
-    if (now - last_update_ms >= 100) {
-        last_update_ms = now;
+    while (true) {
+        hal.scheduler->delay(100);
         update_osd();
     }
 }

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -171,7 +171,7 @@ public:
     AP_OSD_Screen screen[AP_OSD_NUM_SCREENS];
 
 private:
-    void timer();
+    void osd_thread();
     void update_osd();
     void update_current_screen();
     void next_screen();

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2025,10 +2025,10 @@ void AP_Param::load_embedded_param_defaults(bool last_pass)
         if (!vp) {
             if (last_pass) {
                 ::printf("Ignored unknown param %s from embedded region (offset=%u)\n",
-                         pname, ptr - param_defaults_data.data);
+                         pname, unsigned(ptr - param_defaults_data.data));
                 hal.console->printf(
                          "Ignored unknown param %s from embedded region (offset=%u)\n",
-                         pname, ptr - param_defaults_data.data);
+                         pname, unsigned(ptr - param_defaults_data.data));
             }
             continue;
         }


### PR DESCRIPTION
This adds a new hal.scheduler->thread_create() API and uses it for the OSD. It is deliberately a simple interface for ease of implementation on all HALs.
