### PR TITLE
PX4 ROMFS: Start even if uSD is not installed

### DIFF
--- a/mk/PX4/ROMFS/init.d/rcS
+++ b/mk/PX4/ROMFS/init.d/rcS
@@ -75,24 +75,14 @@ else
     fi
 fi
 
-if [ $HAVE_MICROSD == 0 ]
-then
-    if usb_connected
-    then
-        echo "Opening USB nsh"
-    else
-        echo "booting with no microSD"
-        set HAVE_MICROSD 1
-    fi
-fi
-
 # if this is an APM build then there will be a rc.APM script
 # from an EXTERNAL_SCRIPTS build option
-if [ -f /etc/init.d/rc.APM -a $HAVE_MICROSD == 1 -a ! -f /fs/microsd/APM/nostart ]
+if [ -f /etc/init.d/rc.APM -a ! -f /fs/microsd/APM/nostart ]
 then
     echo Running rc.APM
     # if APM startup is successful then nsh will exit
     sh /etc/init.d/rc.APM
 else
+    echo "Opening USB nsh"
     nshterm /dev/ttyACM0 &
 fi


### PR DESCRIPTION
I've lost hours and hours to this over the years, @tridge is fine with ditching it now since ChibiOS doesn't give us the same behaviour. Tested with USB with no SD, SD, SD no start, and via battery with no SD, SD, SD no start and it all behaves correctly.