### PR TITLE
AP_Arming: Check operation guarantee temperature.

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -31,6 +31,7 @@ public:
         ARMING_CHECK_LOGGING    = 0x0400,
         ARMING_CHECK_SWITCH     = 0x0800,
         ARMING_CHECK_GPS_CONFIG = 0x1000,
+        ARMING_CHECK_OPTEMP     = 0x2000,
     };
 
     enum ArmingMethod {
@@ -76,6 +77,8 @@ protected:
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Float                _min_voltage[AP_BATT_MONITOR_MAX_INSTANCES];
+    AP_Float                _operating_temp_min;
+    AP_Float                _operating_temp_max;
 
     // internal members
     bool                    armed:1;
@@ -107,6 +110,8 @@ protected:
 
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const RC_Channel *channels[4], const bool check_min_max = true) const;
+
+    bool optemp_checks(bool report);  // Check operation guarantee temperature
 
     // returns true if a particular check is enabled
     bool check_enabled(const enum AP_Arming::ArmingChecks check) const;


### PR DESCRIPTION
PX4 V1.8.0 compatible FC "Pixhawk 4" "Pixhack v 5" (fmu v5) has operation guarantee temperature defined.
I know that it is better to use electronic devices within guaranteed operation temperature.
So check the FC temperature with Arming check.
If the minimum and maximum temperature judgment values are 0.0 degrees (default value), they will not be checked.
Pixhawk 4
http://www.holybro.com/manual/Pixhawk4-DataSheet.pdf

Pixhack v 5
https://docs.px4.io/en/flight_controller/pixhack_v5.html