### PR TITLE
SITL: default OSD_TYPE when using --osd

### DIFF
--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -233,6 +233,7 @@ def check_SFML(cfg, env):
     for lib in libs:
         if not cfg.check(compiler='cxx', lib=lib, mandatory=False,
                          global_define=True):
+            cfg.fatal("Missing SFML libraries - please install libsfml-dev")
             return False
     
     # see if we need Graphics.hpp or Graphics.h
@@ -241,6 +242,7 @@ def check_SFML(cfg, env):
                      msg="Checking for Graphics.hpp", mandatory=False):
         if not cfg.check(compiler='cxx', fragment='''#include <SFML/Graphics.h>\nint main() {}''', define_name="HAVE_SFML_GRAPHICS_H",
                          msg="Checking for Graphics.h", mandatory=False):
+            cfg.fatal("Missing SFML headers SFML/Graphics.hpp or SFML/Graphics.h")
             return False
     env.LIB += libs
     return True

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -87,6 +87,9 @@ AP_OSD::AP_OSD()
     AP_Param::setup_object_defaults(this, var_info);
     // default first screen enabled
     screen[0].enabled = 1;
+#ifdef WITH_SITL_OSD
+    osd_type.set_default(2);
+#endif
 }
 
 void AP_OSD::init()


### PR DESCRIPTION
and stops build if libraries not found