### PR TITLE
AP_HAL_ChibiOS: reduce default BRD_PWM_COUNT to 4 for fmuv3

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -343,6 +343,12 @@ PE9  TIM1_CH1 TIM1 PWM(4) GPIO(53)
 PD13 TIM4_CH2 TIM4 PWM(5) GPIO(54)
 PD14 TIM4_CH3 TIM4 PWM(6) GPIO(55)
 
+define BOARD_PWM_COUNT_DEFAULT 4
+
+# relays default to use GPIO pins 54 and 55
+define RELAY1_PIN_DEFAULT 54
+define RELAY2_PIN_DEFAULT 55
+
 # this is the invensense data-ready pin. We don't use it in the
 # default driver
 PD15 MPU_DRDY INPUT


### PR DESCRIPTION
This sets the default BRD_PWM_COUNT, RELAY_PIN1 and RELAY_PIN2 defaults on fmuv3 to be the same as on NuttX which allows the relay pins to be used without changing these parameters.

This issue was spotted by Roland Mayer in this [Copter-3.6 testing thread](https://discuss.ardupilot.org/t/roland-mayers-copter-3-6-issues).