### PR TITLE
Copter: RTL if not in AUTO mode & FS_THR_ENABLED_CONTINUE_MISSION enabled

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -23,6 +23,8 @@ void Copter::failsafe_radio_on_event()
         } else {
             if (g.failsafe_throttle == FS_THR_ENABLED_ALWAYS_RTL) {
                 set_mode_RTL_or_land_with_pause(MODE_REASON_RADIO_FAILSAFE);
+            } else if (g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION) {
+                set_mode_RTL_or_land_with_pause(MODE_REASON_RADIO_FAILSAFE);
             } else if (g.failsafe_throttle == FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_RTL) {
                 set_mode_SmartRTL_or_RTL(MODE_REASON_RADIO_FAILSAFE);
             } else if (g.failsafe_throttle == FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_LAND) {


### PR DESCRIPTION
If radio fail safe was set to "Enabled Continue with Mission in AUTO" it didn't follow operation defined in documentation. If it was not in AUTO mode, then it set failsafe to a "LAND" mode.
http://ardupilot.org/copter/docs/radio-failsafe.html