### PR TITLE
AP_HAL_Linux: fix spelling of generated in panics

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -32,7 +32,7 @@ using namespace Linux;
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutputAioPRU.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutputAioPRU.cpp:SIGBUS error generated\n");
 }
 void RCOutput_AioPRU::init()
 {

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -23,7 +23,7 @@ static const uint8_t chan_pru_map[]= {10,8,11,9,7,6,5,4,3,2,1,0};               
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutput.cpp:SIGBUS error generated\n");
 }
 void RCOutput_PRU::init()
 {

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -31,7 +31,7 @@ using namespace Linux;
 
 static void catch_sigbus(int sig)
 {
-    AP_HAL::panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    AP_HAL::panic("RCOutput.cpp:SIGBUS error generated\n");
 }
 void RCOutput_ZYNQ::init()
 {


### PR DESCRIPTION
Self explanatory. Found these while trying to make AP work on BB Blue.