### PR TITLE
AP_BattMonitor: compiler warning, APInt32 class conversion

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_UAVCAN.cpp
@@ -38,7 +38,7 @@ void AP_BattMonitor_UAVCAN::init()
         switch (_type) {
             case UAVCAN_BATTERY_INFO:
                 if (ap_uavcan->register_BM_bi_listener_to_id(this, _params._serial_number)) {
-                    debug_bm_uavcan(2, "UAVCAN BattMonitor BatteryInfo registered id: %d\n\r", _params._serial_number);
+                    debug_bm_uavcan(2, "UAVCAN BattMonitor BatteryInfo registered id: %d\n\r", (int32_t)_params._serial_number);
                 }
                 break;
         }


### PR DESCRIPTION
simple compiler warning. Casting class APInt32 to int32_t