### PR TITLE
HAL: Remove analogPinToDigitalPin

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -294,17 +294,13 @@ void Rover::notify_mode(const Mode *mode)
  */
 uint8_t Rover::check_digital_pin(uint8_t pin)
 {
-    const int8_t dpin = hal.gpio->analogPinToDigitalPin(pin);
-    if (dpin == -1) {
-        return 0;
-    }
     // ensure we are in input mode
-    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT);
+    hal.gpio->pinMode(pin, HAL_GPIO_INPUT);
 
     // enable pullup
-    hal.gpio->write(dpin, 1);
+    hal.gpio->write(pin, 1);
 
-    return hal.gpio->read(dpin);
+    return hal.gpio->read(pin);
 }
 
 /*

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -380,12 +380,8 @@ void AP_Camera::setup_feedback_callback(void)
 failed:
 #endif // CONFIG_HAL_BOARD
 
-    int8_t dpin = hal.gpio->analogPinToDigitalPin(_feedback_pin);
-    if (dpin == -1) {
-        return;
-    }
-    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT); // ensure we are in input mode
-    hal.gpio->write(dpin, 1);                // enable pullup
+    hal.gpio->pinMode(_feedback_pin, HAL_GPIO_INPUT); // ensure we are in input mode
+    hal.gpio->write(_feedback_pin, 1);                // enable pullup
 
     // install a 1kHz timer to check feedback pin
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Camera::feedback_pin_timer, void));

--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -33,7 +33,6 @@ public:
     virtual uint8_t read(uint8_t pin) = 0;
     virtual void    write(uint8_t pin, uint8_t value) = 0;
     virtual void    toggle(uint8_t pin) = 0;
-    virtual int8_t  analogPinToDigitalPin(uint8_t pin) = 0;
 
     /* Alternative interface: */
     virtual AP_HAL::DigitalSource* channel(uint16_t n) = 0;

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -78,11 +78,6 @@ void GPIO::pinMode(uint8_t pin, uint8_t output)
     }
 }
 
-int8_t GPIO::analogPinToDigitalPin(uint8_t pin)
-{
-    return -1;
-}
-
 
 uint8_t GPIO::read(uint8_t pin)
 {

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -31,7 +31,6 @@ public:
     GPIO();
     void    init();
     void    pinMode(uint8_t pin, uint8_t output);
-    int8_t  analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
     void    write(uint8_t pin, uint8_t value);
     void    toggle(uint8_t pin);

--- a/libraries/AP_HAL_Empty/GPIO.cpp
+++ b/libraries/AP_HAL_Empty/GPIO.cpp
@@ -12,12 +12,6 @@ void GPIO::init()
 void GPIO::pinMode(uint8_t pin, uint8_t output)
 {}
 
-int8_t GPIO::analogPinToDigitalPin(uint8_t pin)
-{
-	return -1;
-}
-
-
 uint8_t GPIO::read(uint8_t pin) {
     return 0;
 }

--- a/libraries/AP_HAL_Empty/GPIO.h
+++ b/libraries/AP_HAL_Empty/GPIO.h
@@ -7,7 +7,6 @@ public:
     GPIO();
     void    init();
     void    pinMode(uint8_t pin, uint8_t output);
-    int8_t  analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
     void    write(uint8_t pin, uint8_t value);
     void    toggle(uint8_t pin);

--- a/libraries/AP_HAL_F4Light/GPIO.h
+++ b/libraries/AP_HAL_F4Light/GPIO.h
@@ -156,9 +156,6 @@ public:
         return gpio_read_bit(PIN_MAP[BOARD_USB_SENSE].gpio_device,PIN_MAP[BOARD_USB_SENSE].gpio_bit);
     }
     
-    inline        int8_t  analogPinToDigitalPin(uint8_t pin) override { return pin; }
-    static inline uint8_t analogPinToDigital(uint8_t pin){ return pin; }
-    
 // internal usage static versions
     static void           _pinMode(uint8_t pin, uint8_t output);
     static inline uint8_t _read(uint8_t pin) { const stm32_pin_info &pp = PIN_MAP[pin];   return gpio_read_bit( pp.gpio_device, pp.gpio_bit) ? HIGH : LOW; }

--- a/libraries/AP_HAL_Linux/GPIO_BBB.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.cpp
@@ -77,12 +77,6 @@ void GPIO_BBB::pinMode(uint8_t pin, uint8_t output)
     }
 }
 
-int8_t GPIO_BBB::analogPinToDigitalPin(uint8_t pin)
-{
-    return -1;
-}
-
-
 uint8_t GPIO_BBB::read(uint8_t pin) {
 
     uint8_t bank = pin/32;

--- a/libraries/AP_HAL_Linux/GPIO_BBB.h
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.h
@@ -122,7 +122,6 @@ public:
     GPIO_BBB();
     void    init();
     void    pinMode(uint8_t pin, uint8_t output);
-    int8_t  analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
     void    write(uint8_t pin, uint8_t value);
     void    toggle(uint8_t pin);

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -30,6 +30,7 @@
 #define GPIO_SET_HIGH       *(_gpio+7)  // sets   bits which are 1
 #define GPIO_SET_LOW        *(_gpio+10) // clears bits which are 1
 #define GPIO_GET(g)         (*(_gpio+13)&(1<<g)) // 0 if LOW, (1<<g) if HIGH
+#define GPIO_RPI_MAX_NUMBER_PINS 32
 
 using namespace Linux;
 
@@ -93,6 +94,9 @@ void GPIO_RPI::pinMode(uint8_t pin, uint8_t output, uint8_t alt)
 
 uint8_t GPIO_RPI::read(uint8_t pin)
 {
+    if (pin >= GPIO_RPI_MAX_NUMBER_PINS) {
+        return 0;
+    }
     uint32_t value = GPIO_GET(pin);
     return value ? 1: 0;
 }

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -91,11 +91,6 @@ void GPIO_RPI::pinMode(uint8_t pin, uint8_t output, uint8_t alt)
     }
 }
 
-int8_t GPIO_RPI::analogPinToDigitalPin(uint8_t pin)
-{
-    return -1;
-}
-
 uint8_t GPIO_RPI::read(uint8_t pin)
 {
     uint32_t value = GPIO_GET(pin);

--- a/libraries/AP_HAL_Linux/GPIO_RPI.h
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.h
@@ -49,7 +49,6 @@ public:
     void    init();
     void    pinMode(uint8_t pin, uint8_t output);
     void    pinMode(uint8_t pin, uint8_t output, uint8_t alt);
-    int8_t  analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
     void    write(uint8_t pin, uint8_t value);
     void    toggle(uint8_t pin);

--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
@@ -171,11 +171,6 @@ void GPIO_Sysfs::toggle(uint8_t vpin)
     write(vpin, !read(vpin));
 }
 
-int8_t GPIO_Sysfs::analogPinToDigitalPin(uint8_t vpin)
-{
-    return -1;
-}
-
 AP_HAL::DigitalSource* GPIO_Sysfs::channel(uint16_t vpin)
 {
     assert_vpin(vpin, n_pins, nullptr);

--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.h
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.h
@@ -50,11 +50,6 @@ public:
     AP_HAL::DigitalSource *channel(uint16_t vpin) override;
 
     /*
-     * Currently this function always returns -1.
-     */
-    int8_t analogPinToDigitalPin(uint8_t vpin) override;
-
-    /*
      * Currently this function always returns false.
      */
     bool attach_interrupt(uint8_t interrupt_num, AP_HAL::Proc p, uint8_t mode) override;

--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -91,17 +91,6 @@ void PX4GPIO::pinMode(uint8_t pin, uint8_t output)
     }
 }
 
-int8_t PX4GPIO::analogPinToDigitalPin(uint8_t pin)
-{
-    switch (pin) {
-    case PX4_GPIO_FMU_SERVO_PIN(0) ... PX4_GPIO_FMU_SERVO_PIN(5):
-        // the only pins that can be mapped are the FMU servo rail pins */
-        return pin;
-    }
-    return -1;
-}
-
-
 uint8_t PX4GPIO::read(uint8_t pin) {
     switch (pin) {
 

--- a/libraries/AP_HAL_PX4/GPIO.h
+++ b/libraries/AP_HAL_PX4/GPIO.h
@@ -37,7 +37,6 @@ public:
     PX4GPIO();
     void    init() override;
     void    pinMode(uint8_t pin, uint8_t output) override;
-    int8_t  analogPinToDigitalPin(uint8_t pin) override;
     uint8_t read(uint8_t pin) override;
     void    write(uint8_t pin, uint8_t value) override;
     void    toggle(uint8_t pin) override;

--- a/libraries/AP_HAL_SITL/GPIO.cpp
+++ b/libraries/AP_HAL_SITL/GPIO.cpp
@@ -11,11 +11,6 @@ void GPIO::init()
 void GPIO::pinMode(uint8_t pin, uint8_t output)
 {}
 
-int8_t GPIO::analogPinToDigitalPin(uint8_t pin)
-{
-    return pin;
-}
-
 uint8_t GPIO::read(uint8_t pin)
 {
     if (!_sitlState->_sitl) {

--- a/libraries/AP_HAL_SITL/GPIO.h
+++ b/libraries/AP_HAL_SITL/GPIO.h
@@ -7,7 +7,6 @@ public:
     explicit GPIO(SITL_State *sitlState): _sitlState(sitlState) {}
     void init();
     void pinMode(uint8_t pin, uint8_t output);
-    int8_t analogPinToDigitalPin(uint8_t pin);
     uint8_t read(uint8_t pin);
     void write(uint8_t pin, uint8_t value);
     void toggle(uint8_t pin);

--- a/libraries/AP_HAL_VRBRAIN/GPIO.cpp
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.cpp
@@ -84,12 +84,6 @@ void VRBRAINGPIO::pinMode(uint8_t pin, uint8_t output)
     }
 }
 
-int8_t VRBRAINGPIO::analogPinToDigitalPin(uint8_t pin)
-{
-    return -1;
-}
-
-
 uint8_t VRBRAINGPIO::read(uint8_t pin) {
     switch (pin) {
 

--- a/libraries/AP_HAL_VRBRAIN/GPIO.h
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.h
@@ -23,7 +23,6 @@ public:
 	VRBRAINGPIO();
     void    init() override;
     void    pinMode(uint8_t pin, uint8_t output) override;
-    int8_t  analogPinToDigitalPin(uint8_t pin) override;
     uint8_t read(uint8_t pin) override;
     void    write(uint8_t pin, uint8_t value) override;
     void    toggle(uint8_t pin) override;


### PR DESCRIPTION
`analogPinToDigitalPin(uint8_t)` was an old function used with the old AVR stuff. On all the interesting boards at the moment it generally returns a `-1` or does a direct pass through of the pin. This was only implemented in F4Light and PX4 builds. This was needed for a rover feature (something about auto trigger pins), and camera feedback setup.

The main note about this is that camera and rover can now ask you to check an arbitrary pin that the user has specified. I came across a UB in GPIO_RPI with reading where the pin number was used as the shift width. The last commit fixes the read to always be (silently) safe, however this behaviour seems to be much more spread through the GPIO code (particularly in GPIO_RPI). @lucasdemarchi I can push up checks on `GPIO_RPI::write()` that pin is less then 32 bits as well, but soome of the other macros use div/mod 10 so I'm a bit unsure what the GPIO range should be constrained to (and the fact that large pins just overflow is surprising). I'm only worried about the UB because users can specify some of the pins as parameters. (The write is particularly bad, as the relay pins documentation include values for the UI that would be out of range). This is an exsisting bug though, so if you aren't happy with this solution/want to look at it separately @lucasdemarchi I can drop that commit for now.