### PR TITLE
Backup parameter storage

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Storage.h
+++ b/libraries/AP_HAL_ChibiOS/Storage.h
@@ -47,6 +47,7 @@ private:
     volatile bool _initialised;
     void _storage_create(void);
     void _storage_open(void);
+    void _save_backup(void);
     void _mark_dirty(uint16_t loc, uint16_t length);
     uint8_t _buffer[CH_STORAGE_SIZE] __attribute__((aligned(4)));
     Bitmask _dirty_mask{CH_STORAGE_NUM_LINES};

--- a/libraries/AP_HAL_PX4/Storage.cpp
+++ b/libraries/AP_HAL_PX4/Storage.cpp
@@ -24,7 +24,7 @@ using namespace PX4;
 // name the storage file after the sketch so you can use the same sd
 // card for ArduCopter and ArduPlane
 #define STORAGE_DIR "/fs/microsd/APM"
-//#define SAVE_STORAGE_FILE STORAGE_DIR "/" SKETCHNAME ".sav"
+#define SAVE_STORAGE_FILE STORAGE_DIR "/" SKETCHNAME ".bak"
 #define MTD_PARAMS_FILE "/fs/mtd"
 
 extern const AP_HAL::HAL& hal;
@@ -53,11 +53,10 @@ void PX4Storage::_storage_open(void)
 #endif
 
 #ifdef SAVE_STORAGE_FILE
-    fd = open(SAVE_STORAGE_FILE, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    int fd = open(SAVE_STORAGE_FILE, O_WRONLY|O_CREAT|O_TRUNC, 0644);
     if (fd != -1) {
         write(fd, _buffer, sizeof(_buffer));
         close(fd);
-        ::printf("Saved storage file %s\n", SAVE_STORAGE_FILE);
     }
 #endif
     _initialised = true;


### PR DESCRIPTION
This automatically backs up storage on startup, which is very useful for diagnosing faults. If a board fails to boot because of bad parameters you can take the backup file and test it on SITL
