### PR TITLE
AP_InertialSensor: remove the _enable_mask reset again

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -870,8 +870,6 @@ AP_InertialSensor::detect_backends(void)
     #error Unrecognised HAL_INS_TYPE setting
 #endif
 
-    _enable_mask.set(found_mask);
-
     if (_backend_count == 0) {
         AP_BoardConfig::sensor_config_error("INS: unable to initialise driver");
     }


### PR DESCRIPTION
@tridge  Could you please review this pr, This is get in by the pr https://github.com/ArduPilot/ardupilot/pull/7563  you post. TKS
As I found that sometimes the variable `_enable_mask` will change and the driver will not startup correcttly.
