### PR TITLE
RangeFinder: added a function to change the I2C address of VL53L0X chips

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -267,6 +267,11 @@ bool AP_RangeFinder_VL53L0X::check_id(void)
     return true;
 }
 
+void AP_RangeFinder_VL53L0X::set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> base_dev, uint8_t addr)
+{
+	base_dev->write_register(0x8a, addr);
+}
+
 // Get reference SPAD (single photon avalanche diode) count and type
 // based on VL53L0X_get_info_from_device(),
 // but only gets reference SPAD count and type

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -267,7 +267,7 @@ bool AP_RangeFinder_VL53L0X::check_id(void)
     return true;
 }
 
-void AP_RangeFinder_VL53L0X::set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> base_dev, uint8_t addr)
+void AP_RangeFinder_VL53L0X::set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> &base_dev, uint8_t addr)
 {
 	base_dev->write_register(I2C_SLAVE_DEVICE_ADDRESS, addr);
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -269,7 +269,7 @@ bool AP_RangeFinder_VL53L0X::check_id(void)
 
 void AP_RangeFinder_VL53L0X::set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> base_dev, uint8_t addr)
 {
-	base_dev->write_register(0x8a, addr);
+	base_dev->write_register(I2C_SLAVE_DEVICE_ADDRESS, addr);
 }
 
 // Get reference SPAD (single photon avalanche diode) count and type

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
@@ -14,6 +14,8 @@ public:
     // update state
     void update(void);
 
+    static void set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, uint8_t addr);
+
 protected:
 
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
@@ -14,7 +14,7 @@ public:
     // update state
     void update(void);
 
-    static void set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, uint8_t addr);
+    static void set_addr(AP_HAL::OwnPtr<AP_HAL::I2CDevice> &dev, uint8_t addr);
 
 protected:
 


### PR DESCRIPTION
This adds a static function to the class AP_RangeFinder_VL53L0X that allows to change the I2C address of the chips before creating a RangeFinder_Backend object.

VL53L0X chips always have the address 0x29 assigned when they are turned on, but this address can be changed. If someone can turn these chips on individually to set the address one by one, it would allow multiple VL53L0X chips to run simultaneously without collisions.