### PR TITLE
AP_Baro: fixed program uexpected stop in AP_Baro::calibrate.

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -163,8 +163,10 @@ AP_Baro::AP_Baro()
 // the altitude() or climb_rate() interfaces can be used
 void AP_Baro::calibrate(bool save)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
-
+    if(&gcs()!=nullptr){
+        gcs().send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
+    }
+    
     // reset the altitude offset when we calibrate. The altitude
     // offset is supposed to be for within a flight
     _alt_offset.set_and_save(0);
@@ -231,7 +233,9 @@ void AP_Baro::calibrate(bool save)
     // panic if all sensors are not calibrated
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (sensors[i].calibrated) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+            if(&gcs()!=nullptr){
+                gcs().send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+            }
             return;
         }
     }


### PR DESCRIPTION
fixed program uexpected stop when using GCS to send msg in AP_Baro::calibrate, while GCS object haven't been initialised first. It happens in BARO_ generic example sketch. fmuv2 build has been test.