### PR TITLE
HAL_ChibiOS: Check the health of the required directory.

### DIFF
--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -61,7 +61,12 @@ void sdcard_init()
         }
         //Create APM Directory
         if (mkdir("/APM", 0777) != 0) {
-            printf("Err: Not create an APM Directory!\n");
+            // Is there an APM directory?
+            if (chdir("/APM") != 0) {
+                printf("Err: Not create an APM Directory!\n");
+            } else {
+                chdir("/");
+            }
         }
     }
 #elif HAL_USE_MMC_SPI
@@ -94,7 +99,12 @@ void sdcard_init()
         }
         //Create APM Directory
         if (mkdir("/APM", 0777) != 0) {
-            printf("Err: Not create an APM Directory!\n");
+            // Is there an APM directory?
+            if (chdir("/APM") != 0) {
+                printf("Err: Not create an APM Directory!\n");
+            } else {
+                chdir("/");
+            }
         }
     }
 #endif

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -60,7 +60,9 @@ void sdcard_init()
             printf("Successfully mounted SDCard..\n");
         }
         //Create APM Directory
-        mkdir("/APM", 0777);
+        if (mkdir("/APM", 0777) != 0) {
+            printf("Err: Not create an APM Directory!\n");
+        }
     }
 #elif HAL_USE_MMC_SPI
     device = AP_HAL::get_HAL().spi->get_device("sdcard");
@@ -91,7 +93,9 @@ void sdcard_init()
             printf("Successfully mounted SDCard..\n");
         }
         //Create APM Directory
-        mkdir("/APM", 0777);
+        if (mkdir("/APM", 0777) != 0) {
+            printf("Err: Not create an APM Directory!\n");
+        }
     }
 #endif
 #endif


### PR DESCRIPTION
I think the APM directory is essential for SD card. First create this directory on the SD card. If this directory can not be created, I do not expect logs to be output. I think that it is better to judge the error to detect the initial error.