### PR TITLE
SITL: setup dev IDs for INS and compass

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -29,7 +29,8 @@ devtype=(devid>>16)
 bustypes = {
     1: "I2C",
     2: "SPI",
-    3: "UAVCAN"
+    3: "UAVCAN",
+    4: "SITL"
 }
 
 compass_types = {
@@ -44,7 +45,9 @@ compass_types = {
     0x0A : "DEVTYPE_IST8310",
     0x0B : "DEVTYPE_ICM20948",
     0x0C : "DEVTYPE_MMC3416",
-    0x0D : "DEVTYPE_QMC5883L"
+    0x0D : "DEVTYPE_QMC5883L",
+    0x0E : "DEVTYPE_MAG3110",
+    0x0F : "DEVTYPE_SITL"
 }
 
 imu_types = {
@@ -62,6 +65,8 @@ imu_types = {
     0x26 : "DEVTYPE_GYR_LSM9DS1",
     0x27 : "DEVTYPE_INS_ICM20789",
     0x28 : "DEVTYPE_INS_ICM20689",
+    0x29 : "DEVTYPE_INS_BMI055",
+    0x2A : "DEVTYPE_SITL",
 }
 
 decoded_devname = ""

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -133,6 +133,14 @@ void AP_Compass_Backend::set_dev_id(uint8_t instance, uint32_t dev_id)
 }
 
 /*
+  save dev_id, used by SITL
+*/
+void AP_Compass_Backend::save_dev_id(uint8_t instance)
+{
+    _compass._state[instance].dev_id.save();
+}
+
+/*
   set external for an instance
 */
 void AP_Compass_Backend::set_external(uint8_t instance, bool external)

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -61,8 +61,9 @@ public:
         DEVTYPE_IST8310 = 0x0A,
         DEVTYPE_ICM20948 = 0x0B,
         DEVTYPE_MMC3416 = 0x0C,
-	DEVTYPE_QMC5883L = 0x0D,
-	DEVTYPE_MAG3110  = 0x0E,
+        DEVTYPE_QMC5883L = 0x0D,
+        DEVTYPE_MAG3110  = 0x0E,
+        DEVTYPE_SITL  = 0x0F,
     };
 
 

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -94,6 +94,9 @@ protected:
     // set dev_id for an instance
     void set_dev_id(uint8_t instance, uint32_t dev_id);
 
+    // save dev_id, used by SITL
+    void save_dev_id(uint8_t instance);
+
     // set external state for an instance
     void set_external(uint8_t instance, bool external);
 

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -13,6 +13,9 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
     if (_sitl != nullptr) {
         _compass._setup_earth_field();
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
+            // default offsets to correct value
+            compass.set_offsets(i, _sitl->mag_ofs);
+            
             _compass_instance[i] = register_compass();
             set_dev_id(_compass_instance[i], AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL));
 

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -15,6 +15,9 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
             _compass_instance[i] = register_compass();
             set_dev_id(_compass_instance[i], AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL));
+
+            // save so the compass always comes up configured in SITL
+            save_dev_id(_compass_instance[i]);
         }
         hal.scheduler->register_timer_process(FUNCTOR_BIND(this, &AP_Compass_SITL::_timer, void));
     }

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -14,6 +14,7 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
         _compass._setup_earth_field();
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
             _compass_instance[i] = register_compass();
+            set_dev_id(_compass_instance[i], AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL));
         }
         hal.scheduler->register_timer_process(FUNCTOR_BIND(this, &AP_Compass_SITL::_timer, void));
     }

--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -30,7 +30,8 @@ public:
         BUS_TYPE_UNKNOWN = 0,
         BUS_TYPE_I2C     = 1,
         BUS_TYPE_SPI     = 2,
-        BUS_TYPE_UAVCAN  = 3
+        BUS_TYPE_UAVCAN  = 3,
+        BUS_TYPE_SITL    = 4
     };
 
     enum Speed {
@@ -230,7 +231,7 @@ public:
      * the standard HAL Device types, such as UAVCAN devices
      */
     static uint32_t make_bus_id(enum BusType bus_type, uint8_t bus, uint8_t address, uint8_t devtype) {
-        union DeviceId d;
+        union DeviceId d {};
         d.devid_s.bus_type = bus_type;
         d.devid_s.bus = bus;
         d.devid_s.address = address;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -105,6 +105,7 @@ public:
         DEVTYPE_INS_ICM20789 = 0x27,
         DEVTYPE_INS_ICM20689 = 0x28,
         DEVTYPE_INS_BMI055   = 0x29,
+        DEVTYPE_SITL         = 0x2A,
     };
 
 protected:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -37,8 +37,11 @@ bool AP_InertialSensor_SITL::init_sensor(void)
 
     // grab the used instances
     for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
-        gyro_instance[i] = _imu.register_gyro(gyro_sample_hz[i], i);
-        accel_instance[i] = _imu.register_accel(accel_sample_hz[i], i);
+
+        gyro_instance[i] = _imu.register_gyro(gyro_sample_hz[i],
+                                              AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 1, DEVTYPE_SITL));
+        accel_instance[i] = _imu.register_accel(accel_sample_hz[i],
+                                              AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 2, DEVTYPE_SITL));
     }
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -40,9 +40,19 @@ using namespace SITL;
 static const struct {
     const char *name;
     float value;
+    bool save;
 } sim_defaults[] = {
     { "AHRS_EKF_TYPE", 10 },
     { "INS_GYR_CAL", 0 },
+    { "RC1_MIN", 1000, true },
+    { "RC1_MAX", 2000, true },
+    { "RC2_MIN", 1000, true },
+    { "RC2_MAX", 2000, true },
+    { "RC3_MIN", 1000, true },
+    { "RC3_MAX", 2000, true },
+    { "RC4_MIN", 1000, true },
+    { "RC4_MAX", 2000, true },
+    { "RC2_REVERSED", 1 }, // interlink has reversed rc2
     { "SERVO1_MIN", 1000 },
     { "SERVO1_MAX", 2000 },
     { "SERVO2_MIN", 1000 },
@@ -85,6 +95,13 @@ FlightAxis::FlightAxis(const char *home_str, const char *frame_str) :
     }
     for (uint8_t i=0; i<ARRAY_SIZE(sim_defaults); i++) {
         AP_Param::set_default_by_name(sim_defaults[i].name, sim_defaults[i].value);
+        if (sim_defaults[i].save) {
+            enum ap_var_type ptype;
+            AP_Param *p = AP_Param::find(sim_defaults[i].name, &ptype);
+            if (!p->configured()) {
+                p->save();
+            }
+        }
     }
 
     /* Create the thread that will be waiting for data from FlightAxis */


### PR DESCRIPTION
This makes it possible to run SITL with FlightAxis with only one param set needed (the FRAME_CLASS)
