### PR TITLE
HAL_ChibiOS: cleanup some F405 targets

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405-Wing/hwdef.dat
@@ -158,10 +158,16 @@ define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"
 define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 define HAL_DATAFLASH_FILE_BUFSIZE 8
 define HAL_DATAFLASH_MAV_BUFSIZE 2
+
+# define default battery setup
 define HAL_BATT_VOLT_PIN 10
 define HAL_BATT_CURR_PIN 11
 define HAL_BATT_VOLT_SCALE 11
 define HAL_BATT_CURR_SCALE 31.7
+
+#analog rssi pin (also could be used as analog airspeed input)
+# PC5 - ADC12_CH15
+define BOARD_RSSI_ANA_PIN 15
 
 # no built-in compass, but probe the i2c bus for all possible
 # external compass types

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekF405/hwdef.dat
@@ -73,10 +73,16 @@ PC4 BATT_CURRENT_SENS ADC1 SCALE(1)
 PB1 RSSI_ADC_PIN ADC1 SCALE(1)
 
 # define default battery setup
-define HAL_BATT_VOLT_PIN 13
-define HAL_BATT_CURR_PIN 12
+# PC5 - ADC12_CH15
+define HAL_BATT_VOLT_PIN 15
+# PC4 - ADC12_CH14
+define HAL_BATT_CURR_PIN 14
 define HAL_BATT_VOLT_SCALE 10.1
 define HAL_BATT_CURR_SCALE 17.0
+
+#analog rssi pin (also could be used as analog airspeed input)
+# PB1 - ADC12_CH9
+define BOARD_RSSI_ANA_PIN 9
 
 # USART1
 PA9 USART1_TX USART1

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef-bl.dat
@@ -21,7 +21,6 @@ FLASH_RESERVE_START_KB 0
 
 # LEDs
 PB5 LED_BOOTLOADER OUTPUT LOW
-PB4 LED_ACTIVITY OUTPUT LOW
 define HAL_LED_ON 0
 
 # the location where the bootloader will put the firmware

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
@@ -122,6 +122,11 @@ define HAL_BATT_CURR_PIN 11
 define HAL_BATT_VOLT_SCALE 11
 define HAL_BATT_CURR_SCALE 18.2
 
+#analog rssi pin (also could be used as analog airspeed input)
+# PA0 - ADC123_CH0
+define BOARD_RSSI_ANA_PIN 0
+
+
 define HAL_GPIO_A_LED_PIN 57
 
 define OSD_ENABLED ENABLED


### PR DESCRIPTION
- do not use PB4 as led pin on omnibus, it is buzzer pin
- fix MatekF405 voltage and current sensors pins (reported on rcdesign forum)
- define BOARD_RSSI_ANA_PIN on omnibus and matek boards. This setting is not trivial to guess