### PR TITLE
Compass: implement automatic compass orientation

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -297,7 +297,7 @@ def build(bld):
     bld(
         # build hwdef.h and apj.prototype from hwdef.dat. This is needed after a waf clean
         source=bld.path.ant_glob(bld.env.HWDEF),
-        rule="python '${AP_HAL_ROOT}/hwdef/scripts/chibios_hwdef.py' -D '${BUILDROOT}' %s %s" % (bld.env.HWDEF, bld.env.BOOTLOADER_OPTION),
+        rule="python '${AP_HAL_ROOT}/hwdef/scripts/chibios_hwdef.py' -D '${BUILDROOT}' '%s' %s" % (bld.env.HWDEF, bld.env.BOOTLOADER_OPTION),
         group='dynamic_sources',
         target=[bld.bldnode.find_or_declare('hwdef.h'),
                 bld.bldnode.find_or_declare('apj.prototype'),

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -263,6 +263,9 @@ public:
     const Matrix3f& get_rotation_autopilot_body_to_vehicle_body(void) const { return _rotation_autopilot_body_to_vehicle_body; }
     const Matrix3f& get_rotation_vehicle_body_to_autopilot_body(void) const { return _rotation_vehicle_body_to_autopilot_body; }
 
+    // get rotation matrix specifically from DCM backend (used for compass calibrator)
+    virtual const Matrix3f &get_DCM_rotation_body_to_ned(void) const = 0;
+    
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
     virtual bool get_position(struct Location &loc) const = 0;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -436,6 +436,11 @@ AP_AHRS_DCM::drift_correction_yaw(void)
 
     const AP_GPS &_gps = AP::gps();
 
+    if (_compass && _compass->is_calibrating()) {
+        // don't do any yaw correction while calibrating
+        return;
+    }
+    
     if (AP_AHRS_DCM::use_compass()) {
         /*
           we are using compass for yaw

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -53,6 +53,9 @@ public:
         return _body_dcm_matrix;
     }
 
+    // get rotation matrix specifically from DCM backend (used for compass calibrator)
+    const Matrix3f &get_DCM_rotation_body_to_ned(void) const override { return _body_dcm_matrix; }
+    
     // return the current drift correction integrator value
     const Vector3f &get_gyro_drift() const override {
         return _omega_I;

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -445,10 +445,10 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     AP_GROUPINFO("FLTR_RNG", 34, Compass, _filter_range, HAL_COMPASS_FILTER_DEFAULT),
 
     // @Param: ROT_AUTO
-    // @DisplayName: Automatically set orientation
-    // @Description: When enabled this will automatically set the orientation of external compasses on successful completion of compass calibration
-    // @Values: 0:Disabled,1:Enabled
-    AP_GROUPINFO("ROT_AUTO", 35, Compass, _rotate_auto, 1),
+    // @DisplayName: Automatically check orientation
+    // @Description: When enabled this will automatically check the orientation of compasses on successful completion of compass calibration. If set to 2 then external compasses will have their orientation automatically corrected.
+    // @Values: 0:Disabled,1:CheckOnly,2:CheckAndFix
+    AP_GROUPINFO("ROT_AUTO", 35, Compass, _rotate_auto, 2),
     
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -443,6 +443,12 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     AP_GROUPINFO("FLTR_RNG", 34, Compass, _filter_range, HAL_COMPASS_FILTER_DEFAULT),
+
+    // @Param: ROT_AUTO
+    // @DisplayName: Automatically set orientation
+    // @Description: When enabled this will automatically set the orientation of external compasses on successful completion of compass calibration
+    // @Values: 0:Disabled,1:Enabled
+    AP_GROUPINFO("ROT_AUTO", 35, Compass, _rotate_auto, 1),
     
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -444,11 +444,11 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Increment: 1
     AP_GROUPINFO("FLTR_RNG", 34, Compass, _filter_range, HAL_COMPASS_FILTER_DEFAULT),
 
-    // @Param: ROT_AUTO
+    // @Param: AUTO_ROT
     // @DisplayName: Automatically check orientation
     // @Description: When enabled this will automatically check the orientation of compasses on successful completion of compass calibration. If set to 2 then external compasses will have their orientation automatically corrected.
     // @Values: 0:Disabled,1:CheckOnly,2:CheckAndFix
-    AP_GROUPINFO("ROT_AUTO", 35, Compass, _rotate_auto, 2),
+    AP_GROUPINFO("AUTO_ROT", 35, Compass, _rotate_auto, 2),
     
     AP_GROUPEND
 };

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -417,6 +417,9 @@ private:
     // 0 = disabled, 1 = enabled for throttle, 2 = enabled for current
     AP_Int8     _motor_comp_type;
 
+    // automatic compass orientation on calibration
+    AP_Int8     _rotate_auto;
+    
     // throttle expressed as a percentage from 0 ~ 1.0, used for motor compensation
     float       _thr;
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -62,7 +62,10 @@ Compass::_start_calibration(uint8_t i, bool retry, float delay)
         _calibrator[i].set_tolerance(_calibration_threshold*2);
     }
     if (_rotate_auto) {
-        _calibrator[i].set_orientation(_state[i].external?(enum Rotation)_state[i].orientation.get():ROTATION_NONE, _state[i].external, _rotate_auto>=2);
+        enum Rotation r = _state[i].external?(enum Rotation)_state[i].orientation.get():ROTATION_NONE;
+        if (r != ROTATION_CUSTOM) {
+            _calibrator[i].set_orientation(r, _state[i].external, _rotate_auto>=2);
+        }
     }
     _cal_saved[i] = false;
     _calibrator[i].start(retry, delay, get_offsets_max(), i);

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -62,7 +62,7 @@ Compass::_start_calibration(uint8_t i, bool retry, float delay)
         _calibrator[i].set_tolerance(_calibration_threshold*2);
     }
     if (_rotate_auto) {
-        _calibrator[i].set_orientation(_state[i].external?(enum Rotation)_state[i].orientation.get():ROTATION_NONE, _state[i].external);
+        _calibrator[i].set_orientation(_state[i].external?(enum Rotation)_state[i].orientation.get():ROTATION_NONE, _state[i].external, _rotate_auto>=2);
     }
     _cal_saved[i] = false;
     _calibrator[i].start(retry, delay, get_offsets_max(), i);
@@ -150,7 +150,7 @@ Compass::_accept_calibration(uint8_t i)
         set_and_save_diagonals(i,diag);
         set_and_save_offdiagonals(i,offdiag);
 
-        if (_state[i].external && _rotate_auto) {
+        if (_state[i].external && _rotate_auto >= 2) {
             _state[i].orientation.set_and_save_ifchanged(cal.get_orientation());
         }
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -61,6 +61,9 @@ Compass::_start_calibration(uint8_t i, bool retry, float delay)
         // lot noisier
         _calibrator[i].set_tolerance(_calibration_threshold*2);
     }
+    if (_state[i].external && _rotate_auto) {
+        _calibrator[i].set_orientation((enum Rotation)_state[i].orientation.get(), _state[i].external);
+    }
     _cal_saved[i] = false;
     _calibrator[i].start(retry, delay, get_offsets_max());
 
@@ -146,6 +149,10 @@ Compass::_accept_calibration(uint8_t i)
         set_and_save_offsets(i, ofs);
         set_and_save_diagonals(i,diag);
         set_and_save_offdiagonals(i,offdiag);
+
+        if (_state[i].external && _rotate_auto) {
+            _state[i].orientation.set_and_save_ifchanged(cal.get_orientation());
+        }
 
         if (!is_calibrating()) {
             AP_Notify::events.compass_cal_saved = 1;

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -22,7 +22,25 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
             // save so the compass always comes up configured in SITL
             save_dev_id(_compass_instance[i]);
         }
+        
+        // make first compass external
+        set_external(_compass_instance[0], true);
+        
         hal.scheduler->register_timer_process(FUNCTOR_BIND(this, &AP_Compass_SITL::_timer, void));
+
+        // create correction matrix for diagnonals and off-diagonals
+        Vector3f diag = _sitl->mag_diag.get();
+        if (diag.is_zero()) {
+            diag(1,1,1);
+        }
+        const Vector3f &diagonals = diag;
+        const Vector3f &offdiagonals = _sitl->mag_offdiag;
+        _eliptical_corr = Matrix3f(diagonals.x,    offdiagonals.x, offdiagonals.y,
+                                   offdiagonals.x, diagonals.y,    offdiagonals.z,
+                                   offdiagonals.y, offdiagonals.z, diagonals.z);
+        if (!_eliptical_corr.invert()) {
+            _eliptical_corr.identity();
+        }
     }
 }
 
@@ -73,22 +91,31 @@ void AP_Compass_SITL::_timer()
         new_mag_data = buffer[best_index].data;
     }
 
+    new_mag_data = _eliptical_corr * new_mag_data;
     new_mag_data -= _sitl->mag_ofs.get();
 
     for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
-        rotate_field(new_mag_data, _compass_instance[i]);
-        publish_raw_field(new_mag_data, _compass_instance[i]);
-        correct_field(new_mag_data, _compass_instance[i]);
+        Vector3f f = new_mag_data;
+        if (i == 0) {
+            // rotate the first compass, allowing for testing of external compass rotation
+            f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
+        }
+        rotate_field(f, _compass_instance[i]);
+        publish_raw_field(f, _compass_instance[i]);
+        correct_field(f, _compass_instance[i]);
+
+        _mag_accum[i] += f;
     }
 
     if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return;
     }
 
-    _mag_accum += new_mag_data;
     _accum_count++;
     if (_accum_count == 10) {
-        _mag_accum /= 2;
+        for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
+            _mag_accum[i] /= 2;
+        }
         _accum_count = 5;
         _has_sample = true;
     }
@@ -103,14 +130,13 @@ void AP_Compass_SITL::read()
             return;
         }
 
-        Vector3f field(_mag_accum);
-        field /= _accum_count;
-        _mag_accum.zero();
-        _accum_count = 0;
-
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
+            Vector3f field(_mag_accum[i]);
+            field /= _accum_count;
+            _mag_accum[i].zero();
             publish_filtered_field(field, _compass_instance[i]);
         }
+        _accum_count = 0;
 
         _has_sample = false;
         _sem->give();

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -35,8 +35,9 @@ private:
     bool _has_sample;
     uint32_t _last_sample_time;
 
-    Vector3f _mag_accum;
+    Vector3f _mag_accum[SITL_NUM_COMPASSES];
     uint32_t _accum_count;
+    Matrix3f _eliptical_corr;
 
 
 };

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -37,8 +37,11 @@ private:
 
     Vector3f _mag_accum[SITL_NUM_COMPASSES];
     uint32_t _accum_count;
+
+    void _setup_eliptical_correcion();
+    
     Matrix3f _eliptical_corr;
-
-
+    Vector3f _last_dia;
+    Vector3f _last_odi;
 };
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -833,14 +833,14 @@ bool CompassCalibrator::calculate_orientation(void)
         pass = _orientation_confidence > variance_threshold;
     }
     if (!pass) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Mag(%u) bad orientation: %u %.1f\n", _compass_idx, besti, _orientation_confidence);
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Mag(%u) bad orientation: %u %.1f", _compass_idx, besti, _orientation_confidence);
     } else if (besti == _orientation) {
         // no orientation change
-        gcs().send_text(MAV_SEVERITY_INFO, "Mag(%u) good orientation: %u %.1f\n", _compass_idx, besti, _orientation_confidence);
+        gcs().send_text(MAV_SEVERITY_INFO, "Mag(%u) good orientation: %u %.1f", _compass_idx, besti, _orientation_confidence);
     } else if (!_is_external || !_fix_orientation) {
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Mag(%u) internal bad orientation: %u %.1f\n", _compass_idx, besti, _orientation_confidence);
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Mag(%u) internal bad orientation: %u %.1f", _compass_idx, besti, _orientation_confidence);
     } else {
-        gcs().send_text(MAV_SEVERITY_INFO, "Mag(%u) new orientation: %u was %u %.1f\n", _compass_idx, besti, _orientation, _orientation_confidence);
+        gcs().send_text(MAV_SEVERITY_INFO, "Mag(%u) new orientation: %u was %u %.1f", _compass_idx, besti, _orientation, _orientation_confidence);
     }
 
     if (!pass) {

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -15,7 +15,8 @@ enum compass_cal_status_t {
     COMPASS_CAL_RUNNING_STEP_ONE=2,
     COMPASS_CAL_RUNNING_STEP_TWO=3,
     COMPASS_CAL_SUCCESS=4,
-    COMPASS_CAL_FAILED=5
+    COMPASS_CAL_FAILED=5,
+    COMPASS_CAL_BAD_ORIENTATION=6,
 };
 
 class CompassCalibrator {
@@ -24,7 +25,7 @@ public:
 
     CompassCalibrator();
 
-    void start(bool retry, float delay, uint16_t offset_max);
+    void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
     void clear();
 
     void update(bool &failure);
@@ -37,6 +38,7 @@ public:
     void set_orientation(enum Rotation orientation, bool is_external) {
         _auto_orientation = true;
         _orientation = orientation;
+        _orig_orientation = orientation;
         _is_external = is_external;
     }
     
@@ -44,11 +46,13 @@ public:
 
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
     enum Rotation get_orientation(void) { return _orientation; }
+    enum Rotation get_original_orientation(void) { return _orig_orientation; }
 
     float get_completion_percent() const;
     completion_mask_t& get_completion_mask();
     enum compass_cal_status_t get_status() const { return _status; }
     float get_fitness() const { return sqrtf(_fitness); }
+    float get_orientation_confidence() const { return _orientation_confidence; }
     uint8_t get_attempt() const { return _attempt; }
 
 private:
@@ -91,8 +95,10 @@ private:
     };
 
     enum Rotation _orientation;
+    enum Rotation _orig_orientation;
     bool _is_external;
     bool _auto_orientation;
+    uint8_t _compass_idx;
 
     enum compass_cal_status_t _status;
 
@@ -119,6 +125,7 @@ private:
     float _ellipsoid_lambda;
     uint16_t _samples_collected;
     uint16_t _samples_thinned;
+    float _orientation_confidence;
 
     bool set_status(compass_cal_status_t status);
 

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -161,5 +161,5 @@ private:
     void update_completion_mask();
 
     Vector3f calculate_earth_field(CompassSample &sample, enum Rotation r);
-    void calculate_orientation();
+    bool calculate_orientation();
 };

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -35,11 +35,12 @@ public:
 
     bool running() const;
 
-    void set_orientation(enum Rotation orientation, bool is_external) {
-        _auto_orientation = true;
+    void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation) {
+        _check_orientation = true;
         _orientation = orientation;
         _orig_orientation = orientation;
         _is_external = is_external;
+        _fix_orientation = fix_orientation;
     }
     
     void set_tolerance(float tolerance) { _tolerance = tolerance; }
@@ -97,7 +98,8 @@ private:
     enum Rotation _orientation;
     enum Rotation _orig_orientation;
     bool _is_external;
-    bool _auto_orientation;
+    bool _check_orientation;
+    bool _fix_orientation;
     uint8_t _compass_idx;
 
     enum compass_cal_status_t _status;

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -232,7 +232,10 @@ public:
     // create a rotation matrix from Euler angles
     void        from_euler(float roll, float pitch, float yaw);
 
-    // create eulers from a rotation matrix
+    // create eulers from a rotation matrix.
+    // roll is from -Pi to Pi
+    // pitch is from -Pi/2 to Pi/2
+    // yaw is from -Pi to Pi
     void        to_euler(float *roll, float *pitch, float *yaw) const;
 
     // create matrix from rotation enum

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -118,6 +118,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("WIND_T"      ,15, SITL,  wind_type, SITL::WIND_TYPE_SQRT),
     AP_GROUPINFO("WIND_T_ALT"  ,16, SITL,  wind_type_alt, 60),
     AP_GROUPINFO("WIND_T_COEF", 17, SITL,  wind_type_coef, 0.01f),
+    AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
+    AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
+    AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -108,6 +108,9 @@ public:
     AP_Float mag_error;   // in degrees
     AP_Vector3f mag_mot;  // in mag units per amp
     AP_Vector3f mag_ofs;  // in mag units
+    AP_Vector3f mag_diag;  // diagonal corrections
+    AP_Vector3f mag_offdiag;  // off-diagonal corrections
+    AP_Int8 mag_orient;   // external compass orientation
     AP_Float servo_speed; // servo speed in seconds
 
     AP_Float sonar_glitch;// probablility between 0-1 that any given sonar sample will read as max distance


### PR DESCRIPTION
This implements automatic compass orientation for external compasses as part of compass calibration. If the confidence in the orientation is above a threshold then the orientation is fixed in the parameters, and the offsets adjusted for the new orientation.
It is enabled with a parameter COMPASS_ROT_AUTO, and defaults to enabled. 
Some notes:

- if the compass orientation is changed then it will wipe the elliptical correction parameters. We could correct these, but I haven't worked out the maths for it (it is quite complex)
- The reporting is via mavlink statustext
- it is only enabled if the compass is marked external (eg. with COMPASS_EXTERNAL parameter)
- on a F405 based board this adds 1.3k to text size in the build

Testing would be appreciated!