### PR TITLE
ChibiOS: fixed pixracer i2c mask

### DIFF
--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -331,7 +331,7 @@ I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
 */
 uint32_t I2CDeviceManager::get_bus_mask(void) const
 {
-    return (1U << ARRAY_SIZE_SIMPLE(I2CD)) - 1;
+    return ((1U << ARRAY_SIZE_SIMPLE(I2CD)) - 1) << HAL_I2C_BUS_BASE;
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
@@ -30,6 +30,7 @@ I2C_ORDER I2C1
 
 # to match px4 we make the first bus number 1
 define HAL_I2C_BUS_BASE 1
+define HAL_I2C_INTERNAL_MASK 0
 
 # order of UARTs (and USB)
 UART_ORDER OTG1 UART4 USART2 USART3 UART8 USART1 UART7


### PR DESCRIPTION
external compasses were not being detected on pixracer as the external i2c bus mask was 0
