### PR TITLE
Tools: Update SV2450 default.parm file for AC-3.6

### DIFF
--- a/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
+++ b/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
@@ -165,8 +165,8 @@ FLTMODE6               2
 
 # failsafes
 FS_THR_ENABLE          1
-BATT_CRT_VOLT        3.43
-BATT_FS_CRT_ACT        2
+BATT_LOW_VOLT        3.43
+BATT_FS_LOW_ACT        2
 FS_GCS_ENABLE          0
 
 # baro

--- a/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
+++ b/Tools/Frame_params/SkyViper-2450GPS/defaults.parm
@@ -165,8 +165,8 @@ FLTMODE6               2
 
 # failsafes
 FS_THR_ENABLE          1
-FS_BATT_ENABLE         2
-FS_BATT_VOLTAGE      3.43
+BATT_CRT_VOLT        3.43
+BATT_FS_CRT_ACT        2
 FS_GCS_ENABLE          0
 
 # baro


### PR DESCRIPTION
Update default parameters for Skyviper 2450 GPS battery failsafes, changed in AC-3.6