### PR TITLE
AP_HAL_SITL: move include for pthread.h

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -5,7 +5,6 @@
 #include "UARTDriver.h"
 #include <sys/time.h>
 #include <fenv.h>
-#include <pthread.h>
 
 using namespace HALSITL;
 

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -4,6 +4,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_HAL_SITL_Namespace.h"
 #include <sys/time.h>
+#include <pthread.h>
 
 #define SITL_SCHEDULER_MAX_TIMER_PROCS 4
 


### PR DESCRIPTION
We need pthread_t for a member