### PR TITLE
Tools - updated URL and git submodule command for install-prereqs

### DIFF
--- a/Tools/scripts/install-prereqs-arch.sh
+++ b/Tools/scripts/install-prereqs-arch.sh
@@ -19,7 +19,7 @@ ARCH_AUR_PKGS="genromfs"
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/PX4-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="ardupilot/Tools/autotest"
@@ -82,8 +82,7 @@ fi
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
 (
     cd $SCRIPT_DIR
-    git submodule init
-    git submodule update --recursive
+    git submodule update --init --recursive
 )
 
 echo "Done. Please log out and log in again."

--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -26,7 +26,7 @@ fi
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/PX4-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="Tools/autotest"
@@ -130,7 +130,6 @@ apt-cache search arm-none-eabi
 
 (
  cd $ARDUPILOT_ROOT
- git submodule init
- git submodule update
+ git submodule update --init --recursive
 )
 echo "---------- $0 end ----------"


### PR DESCRIPTION
Fixed two issues:
-URL for the arm-gcc download has changed
-``git submodule`` needs to use ``--recursive`` to get all the relevant files 

Tested in a Ubuntu 18.04 VM

(Noted that the ``install-prereqs-mac.sh`` script does not need these changes)