### PR TITLE
AP_Notify: Use a bitfield to load LED drivers

### DIFF
--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -58,6 +58,17 @@ public:
         OreoLED_Automobile      = 2,    // Automobile themed lighting (white front, red back)
     };
 
+    enum Notify_LED_Type {
+        Notify_LED_None                     = 0,        // not enabled
+        Notify_LED_Board                    = (1 << 0), // Built in board LED's
+        Notify_LED_ToshibaLED_I2C_Internal  = (1 << 1), // Internal ToshibaLED_I2C
+        Notify_LED_ToshibaLED_I2C_External  = (1 << 2), // External ToshibaLED_I2C
+        Notify_LED_PCA9685LED_I2C_External  = (1 << 3), // External PCA9685_I2C
+        Notify_LED_OreoLED                  = (1 << 4), // Oreo
+        Notify_LED_UAVCAN                   = (1 << 5), // UAVCAN RGB LED
+        Notify_LED_MAX
+    };
+
     /// notify_flags_type - bitmask of notification flags
     struct notify_flags_and_values_type {
         uint32_t initialising       : 1;    // 1 if initialising and copter should not be moved
@@ -159,6 +170,7 @@ private:
     AP_Int8 _display_type;
     AP_Int8 _oreo_theme;
     AP_Int8 _buzzer_pin;
+    AP_Int32 _led_type;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed

--- a/libraries/AP_Notify/PCA9685LED_I2C.cpp
+++ b/libraries/AP_Notify/PCA9685LED_I2C.cpp
@@ -25,7 +25,10 @@
 #define NAVIO_LED_OFF    0xFF    // off
 
 #define PCA9685_ADDRESS 0x40
+#define PCA9685_MODE1 0x00
 #define PCA9685_PWM 0x6
+#define PCA9685_MODE_SLEEP          (1 << 4)
+#define PCA9685_MODE_AUTO_INCREMENT (1 << 5)
 
 extern const AP_HAL::HAL& hal;
 
@@ -41,6 +44,29 @@ bool PCA9685LED_I2C::hw_init()
     if (!_dev) {
         return false;
     }
+
+    _dev->get_semaphore()->take_blocking();
+
+    _dev->set_retries(5);
+
+    // read the current mode1 configuration
+    uint8_t mode1 = 0;
+    if (!_dev->read_registers(PCA9685_MODE1, &mode1, sizeof(mode1))) {
+        _dev->get_semaphore()->give();
+        return false;
+    }
+
+    // bring the device out of sleep, and enable auto register increment
+    uint8_t new_mode1 = (mode1 | PCA9685_MODE_AUTO_INCREMENT) & ~PCA9685_MODE_SLEEP;
+    const uint8_t config[2] = {PCA9685_MODE1, new_mode1};
+    if (!_dev->transfer(config, sizeof(config), nullptr, 0)) {
+        _dev->get_semaphore()->give();
+        return false;
+    }
+
+    _dev->set_retries(1);
+
+    _dev->get_semaphore()->give();
 
     _dev->register_periodic_callback(20000, FUNCTOR_BIND_MEMBER(&PCA9685LED_I2C::_timer, void));
 

--- a/libraries/AP_Notify/PCA9685LED_I2C.cpp
+++ b/libraries/AP_Notify/PCA9685LED_I2C.cpp
@@ -1,5 +1,5 @@
 /*
-  NavioLED I2C driver
+  PCA9685LED I2C driver
 */
 /*
    This program is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "NavioLED_I2C.h"
+#include "PCA9685LED_I2C.h"
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -29,12 +29,12 @@
 
 extern const AP_HAL::HAL& hal;
 
-NavioLED_I2C::NavioLED_I2C() : 
+PCA9685LED_I2C::PCA9685LED_I2C() : 
     RGBLed(NAVIO_LED_OFF, NAVIO_LED_BRIGHT, NAVIO_LED_MEDIUM, NAVIO_LED_DIM)
 {
 }
 
-bool NavioLED_I2C::hw_init()
+bool PCA9685LED_I2C::hw_init()
 {
     _dev = hal.i2c_mgr->get_device(1, PCA9685_ADDRESS);
 
@@ -42,13 +42,13 @@ bool NavioLED_I2C::hw_init()
         return false;
     }
 
-    _dev->register_periodic_callback(20000, FUNCTOR_BIND_MEMBER(&NavioLED_I2C::_timer, void));
+    _dev->register_periodic_callback(20000, FUNCTOR_BIND_MEMBER(&PCA9685LED_I2C::_timer, void));
 
     return true;
 }
 
 // set_rgb - set color as a combination of red, green and blue values
-bool NavioLED_I2C::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
+bool PCA9685LED_I2C::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 {
     rgb.r = red;
     rgb.g = green;
@@ -57,7 +57,7 @@ bool NavioLED_I2C::hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
     return true;
 }
 
-void NavioLED_I2C::_timer(void)
+void PCA9685LED_I2C::_timer(void)
 {
     if (!_need_update) {
         return;

--- a/libraries/AP_Notify/PCA9685LED_I2C.h
+++ b/libraries/AP_Notify/PCA9685LED_I2C.h
@@ -1,5 +1,5 @@
 /*
-   NavioLED I2C driver
+   PCA9685LED I2C driver
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -19,10 +19,10 @@
 #include <AP_HAL/I2CDevice.h>
 #include "RGBLed.h"
 
-class NavioLED_I2C : public RGBLed
+class PCA9685LED_I2C : public RGBLed
 {
 public:
-    NavioLED_I2C(void);
+    PCA9685LED_I2C(void);
 protected:
     bool hw_init(void) override;
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;


### PR DESCRIPTION
This splits up the adding of notify devices, and allows the user to use a parameter to control what LED's are enabled. The default bitmask is set to preserve the current behavior, however by setting extra bits you can include other drivers as desired. (IE a cube can now load a PCA9685 or a EmlidEDGE UAVCAN driver).

It also always attempts to load a display backend. Because `NTF_DISPLAY_TYPE` must be non 0 to keep the driver up (and select what type of display to probe for) this is a fairly safe change.

This has a slight impact on build sizes as all boards that have UAVCAN enabled included the UAVCAN driver, and a couple of builds that didn't have displays before (just a couple of Linux ones where size isn't a real issue anyways).

This needs a fair amount of testing/careful reviewing to make sure I didn't accidentally lose a device we had before, but I think this represents a much more maintainable path in the future. (This also replaces #8768 with a more robust implementation).

This does need some significant real hardware testing, I will update the list below as I (or someone else reports) that they have tested a configuration:
- Cube, PX4-V3, Here GPS, (Default values, turned off external toshiba, turned on only external toshiba)
- Cube, fmuv3, Here GPS, (Default values, turned off external toshiba, turned on only external toshiba and searched for a PCA9685)
- Pixhawk, fmuv3, No external parts (Default values, turned off internal toshiba, turned on only internal toshiba)
- Pixhawk, PX4-v3, External PCA9685 (Default values, turned off internal toshiba, turned on external PCA9685)