### PR TITLE
SITL: fixed tailsitter behaviour in RealFlight SITL

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -202,3 +202,8 @@ bool AP_Compass_Backend::field_ok(const Vector3f &field)
     return ret;
 }
 
+
+enum Rotation AP_Compass_Backend::get_board_orientation(void) const
+{
+    return _compass._board_orientation;
+}

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -106,6 +106,9 @@ protected:
     // set rotation of an instance
     void set_rotation(uint8_t instance, enum Rotation rotation);
 
+    // get board orientation (for SITL)
+    enum Rotation get_board_orientation(void) const;
+    
     // access to frontend
     Compass &_compass;
 

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -114,7 +114,9 @@ void AP_Compass_SITL::_timer()
         if (i == 0) {
             // rotate the first compass, allowing for testing of external compass rotation
             f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
+            f.rotate(get_board_orientation());
         }
+        
         rotate_field(f, _compass_instance[i]);
         publish_raw_field(f, _compass_instance[i]);
         correct_field(f, _compass_instance[i]);

--- a/libraries/SITL/SIM_Gimbal.cpp
+++ b/libraries/SITL/SIM_Gimbal.cpp
@@ -57,10 +57,8 @@ void Gimbal::update(void)
     Matrix3f vehicle_dcm;
     fdm.quaternion.rotation_matrix(vehicle_dcm);
 
-    Vector3f vehicle_gyro = Vector3f(radians(fdm.rollRate),
-                                     radians(fdm.pitchRate),
-                                     radians(fdm.yawRate));
-    Vector3f vehicle_accel_body = Vector3f(fdm.xAccel, fdm.yAccel, fdm.zAccel);
+    const Vector3f &vehicle_gyro = AP::ins().get_gyro();
+    const Vector3f &vehicle_accel_body = AP::ins().get_accel();
 
     // take a copy of the demanded rates to bypass the limiter function for testing
     Vector3f demRateRaw = demanded_angular_rate;


### PR DESCRIPTION
this caused QLAND to never come down in the Cat tailsitter
