### PR TITLE
AC_Circle: use stopping point to get closest point on circle

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -176,12 +176,13 @@ void AC_Circle::get_closest_point_on_circle(Vector3f &result)
     }
 
     // get current position
-    const Vector3f &curr_pos = _inav.get_position();
+    Vector3f stopping_point;
+    _pos_control.get_stopping_point_xy(stopping_point);
 
     // calc vector from current location to circle center
     Vector2f vec;   // vector from circle center to current location
-    vec.x = (curr_pos.x - _center.x);
-    vec.y = (curr_pos.y - _center.y);
+    vec.x = (stopping_point.x - _center.x);
+    vec.y = (stopping_point.y - _center.y);
     float dist = norm(vec.x, vec.y);
 
     // if current location is exactly at the center of the circle return edge directly behind vehicle


### PR DESCRIPTION
tested in simulation. if use stopping point to calculate closest, airliner could be tracked  well.

**use stopping  point to calculate closest point on circle**
![a752bdbdd2e92d6e64e2c10412dd6a8](https://user-images.githubusercontent.com/16251761/42986460-34dade78-8c28-11e8-999e-448463047251.png)

**use current point to calculate closest point on circle**
![2655aaedc5a515d37fdb809d0be0e4e](https://user-images.githubusercontent.com/16251761/42986464-38622df8-8c28-11e8-9469-688ad26ef85e.png)

