### PR TITLE
AP_ADSB: Fix error snprintf output truncated with waf on linux

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -639,7 +639,7 @@ uint8_t AP_ADSB::get_encoded_callsign_null_char()
 
     // using the above logic, we must always assign the squawk. once we get configured
     // externally then get_encoded_callsign_null_char() stops getting called
-    snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal));
+    snprintf(out_state.cfg.callsign, 5, "%04d", unsigned(out_state.cfg.squawk_octal) & 0x1FFF);
     memset(&out_state.cfg.callsign[4], 0, 5); // clear remaining 5 chars
     encoded_null |= 0x40;
 


### PR DESCRIPTION
A fix for this issue https://github.com/ArduPilot/ardupilot/issues/8947. Possibly related to this PR https://github.com/ArduPilot/ardupilot/pull/8497. 

Tested on linux with `./waf copter` and `Tools/scripts/build_all.sh`. 

If this turns out to break other compilers than probably should not be merged :) 