### PR TITLE
examples/RCInput:add boardconfig initialization to prevent failure of…

### DIFF
--- a/libraries/AP_HAL/examples/RCInput/RCInput.cpp
+++ b/libraries/AP_HAL/examples/RCInput/RCInput.cpp
@@ -3,11 +3,13 @@
  */
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 void setup();
 void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+AP_BoardConfig BoardConfig;
 
 #define MAX_CHANNELS 16
 
@@ -17,12 +19,14 @@ static uint16_t last_value[MAX_CHANNELS];
 void setup(void)
 {
     hal.console->printf("Starting RCInput test\n");
+    BoardConfig.init();
 }
 
 void loop(void)
 {
     bool changed = false;
     uint8_t nchannels = hal.rcin->num_channels();  // Get the numbers channels detected by RC_INPUT.
+    hal.console->printf("channelnum=%d.\n", nchannels);
     if (nchannels > MAX_CHANNELS) {
         nchannels = MAX_CHANNELS;
     }

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
@@ -5,11 +5,13 @@
 */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 void setup();
 void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+AP_BoardConfig BoardConfig;
 
 #define MAX_CHANNELS 14
 
@@ -19,7 +21,7 @@ static uint16_t last_value[MAX_CHANNELS];
 void setup(void)
 {
     hal.console->printf("Starting RCInputToRCOutput test\n");
-
+    BoardConfig.init();
     for (uint8_t i = 0; i < MAX_CHANNELS; i++) {
         hal.rcout->enable_ch(i);
     }

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
@@ -1,11 +1,19 @@
 /*
-    RC input pass trough to RC output
-    Max RC channels 14
-    Max update rate 10 Hz
+* RC input pass trough to RC output
+* Max RC channels 14
+* Max update rate 10 Hz
+* Attention: If your board has safety switch,
+* don't forget to push it to enable the PWM output.
 */
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+
+/* change "PWM_COUNT" value accoding to the board type.
+* If you are using Pixhawk,  set to 6 will enable all of the
+* FMU output as PWM channels
+*/
+#define FMU_PWM_COUNT 6
 
 void setup();
 void loop();
@@ -21,6 +29,7 @@ static uint16_t last_value[MAX_CHANNELS];
 void setup(void)
 {
     hal.console->printf("Starting RCInputToRCOutput test\n");
+     AP_Param::set_object_value(&BoardConfig, BoardConfig.var_info, "PWM_COUNT", FMU_PWM_COUNT);
     BoardConfig.init();
     for (uint8_t i = 0; i < MAX_CHANNELS; i++) {
         hal.rcout->enable_ch(i);

--- a/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
@@ -1,9 +1,17 @@
 /*
-  simple test of RC output interface
- */
+* simple test of RC output interface
+* Attention: If your board has safety switch,
+* don't forget to push it to enable the PWM output.
+*/
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+
+/* change "PWM_COUNT" value accoding to the board type.
+* If you are using Pixhawk,  set to 6 will enable all of the
+* FMU output as PWM channels
+*/
+#define FMU_PWM_COUNT 6
 
 void setup();
 void loop();
@@ -14,6 +22,7 @@ AP_BoardConfig BoardConfig;
 void setup (void)
 {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
+    AP_Param::set_object_value(&BoardConfig, BoardConfig.var_info, "PWM_COUNT", FMU_PWM_COUNT);
     BoardConfig.init();
     for (uint8_t i = 0; i< 14; i++) {
         hal.rcout->enable_ch(i);

--- a/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
@@ -3,15 +3,18 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 void setup();
 void loop();
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+AP_BoardConfig BoardConfig;
 
 void setup (void)
 {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
+    BoardConfig.init();
     for (uint8_t i = 0; i< 14; i++) {
         hal.rcout->enable_ch(i);
     }
@@ -30,7 +33,7 @@ void loop (void)
             hal.console->printf("reversing\n");
         } else if (delta < 0 && pwm <= 1000) {
             delta = 1;
-            hal.console->printf("reversing\n");
+            hal.console->printf("normalizing\n");
         }
     }
     hal.scheduler->delay(5);

--- a/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
@@ -1,5 +1,7 @@
 /*
-  Simple test of RC output interface with Menu
+* Simple test of RC output interface with Menu
+* Attention: If your board has safety switch,
+* don't forget to push it to enable the PWM output.
 */
 
 #include <AP_Common/AP_Common.h>
@@ -7,6 +9,11 @@
 #include <AP_Menu/AP_Menu.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
+/* change "PWM_COUNT" value accoding to the board type.
+* If you are using Pixhawk,  set to 6 will enable all of the
+* FMU output as PWM channels
+*/
+#define FMU_PWM_COUNT 6
 
 void setup();
 void loop();
@@ -80,6 +87,7 @@ MENU(menu, "Menu: ", rcoutput_menu_commands);
 
 void setup(void) {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
+     AP_Param::set_object_value(&BoardConfig, BoardConfig.var_info, "PWM_COUNT", FMU_PWM_COUNT);
     BoardConfig.init();
     for (uint8_t i = 0; i < 14; i++) {
         hal.rcout->enable_ch(i);

--- a/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
@@ -5,6 +5,8 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Menu/AP_Menu.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
 
 void setup();
 void loop();
@@ -29,6 +31,7 @@ public:
 };
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+AP_BoardConfig BoardConfig;
 
 Menu_Commands commands;
 
@@ -77,7 +80,7 @@ MENU(menu, "Menu: ", rcoutput_menu_commands);
 
 void setup(void) {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
-
+    BoardConfig.init();
     for (uint8_t i = 0; i < 14; i++) {
         hal.rcout->enable_ch(i);
     }


### PR DESCRIPTION
examples/RCInput : add boardconfig initialization to prevent failure of reading and writing channels. Has been tested in Pixhawk and Pixhawk4