### PR TITLE
RC_Channel: treat zero trim as average of min and max

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -456,9 +456,13 @@ bool AP_Arming::hardware_safety_check(bool report)
 bool AP_Arming::rc_calibration_checks(bool report)
 {
     bool check_passed = true;
+    const uint8_t num_channels = RC_Channels::get_valid_channel_count();
     for (uint8_t i = 0; i < NUM_RC_CHANNELS; i++) {
         const RC_Channel *ch = RC_Channels::rc_channel(i);
         if (ch == nullptr) {
+            continue;
+        }
+        if (i >= num_channels && !(ch->has_override())) {
             continue;
         }
         const uint16_t trim = ch->get_radio_trim();

--- a/libraries/AP_HAL_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_SITL/RCInput.cpp
@@ -2,6 +2,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include "RCInput.h"
+#include <SITL/SITL.h>
 
 using namespace HALSITL;
 
@@ -22,7 +23,7 @@ bool RCInput::new_input()
 
 uint16_t RCInput::read(uint8_t ch)
 {
-    if (ch >= SITL_RC_INPUT_CHANNELS) {
+    if (ch >= num_channels()) {
         return 0;
     }
     return _sitlState->pwm_input[ch];
@@ -30,13 +31,22 @@ uint16_t RCInput::read(uint8_t ch)
 
 uint8_t RCInput::read(uint16_t* periods, uint8_t len)
 {
-    if (len > SITL_RC_INPUT_CHANNELS) {
-        len = SITL_RC_INPUT_CHANNELS;
+    if (len > num_channels()) {
+        len = num_channels();
     }
     for (uint8_t i=0; i < len; i++) {
         periods[i] = read(i);
     }
     return len;
+}
+
+uint8_t RCInput::num_channels()
+{
+    SITL::SITL *_sitl = AP::sitl();
+    if (_sitl) {
+        return MIN(_sitl->rc_chancount.get(), SITL_RC_INPUT_CHANNELS);
+    }
+    return SITL_RC_INPUT_CHANNELS;
 }
 
 #endif

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -12,9 +12,7 @@ public:
     explicit RCInput(SITL_State *sitlState): _sitlState(sitlState) {}
     void init() override;
     bool new_input() override;
-    uint8_t num_channels() override {
-        return SITL_RC_INPUT_CHANNELS;
-    }
+    uint8_t num_channels() override;
     uint16_t read(uint8_t ch) override;
     uint8_t read(uint16_t* periods, uint8_t len) override;
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -121,6 +121,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("MAG_DIA",     18, SITL,  mag_diag, 0),
     AP_GROUPINFO("MAG_ODI",     19, SITL,  mag_offdiag, 0),
     AP_GROUPINFO("MAG_ORIENT",  20, SITL,  mag_orient, 0),
+    AP_GROUPINFO("RC_CHANCOUNT",21, SITL,  rc_chancount, 16),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -134,6 +134,7 @@ public:
     AP_Float batt_voltage; // battery voltage base
     AP_Float accel_fail;  // accelerometer failure value
     AP_Int8  rc_fail;     // fail RC input
+    AP_Int8  rc_chancount; // channel count
     AP_Int8  baro_disable; // disable simulated barometer
     AP_Int8  float_exception; // enable floating point exception checks
     AP_Int8  flow_enable; // enable simulated optflow


### PR DESCRIPTION
this prevents a problem with arming after RC calibration by
MissionPlanner