### PR TITLE
Precision landing target lock notification to GCS

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -121,6 +121,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Baro,              &copter.barometer,           accumulate,      50,  90),
 #if PRECISION_LANDING == ENABLED
     SCHED_TASK(update_precland,      400,     50),
+    SCHED_TASK(check_precland_target,  1,    110),   // Check for PrecLanding target lock and send notification to GCS on changes, max duration is based on gcs_send_heartbeat
 #endif
 #if FRAME_CONFIG == HELI_FRAME
     SCHED_TASK(check_dynamic_flight,  50,     75),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -337,6 +337,7 @@ private:
             uint8_t compass_init_location   : 1; // 26      // true when the compass's initial location has been set
             uint8_t rc_override_enable      : 1; // 27      // aux switch rc_override is allowed
             uint8_t armed_with_switch       : 1; // 28      // we armed using a arming switch
+            uint8_t precland_target_aquired : 1; // 29      // true when precland target is aquired,
         };
         uint32_t value;
     } ap_t;
@@ -745,6 +746,7 @@ private:
     void set_mode_SmartRTL_or_RTL(mode_reason_t reason);
     void set_mode_SmartRTL_or_land_with_pause(mode_reason_t reason);
     bool should_disarm_on_failsafe();
+    void check_precland_target();
 
     // failsafe.cpp
     void failsafe_enable();

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -284,3 +284,28 @@ bool Copter::should_disarm_on_failsafe() {
             return ap.land_complete;
     }
 }
+
+
+// Check precision landing target status and send notification to GCS about changes
+// Severity set to MAV_SEVERITY_WARNING to display message in HUD area
+void Copter::check_precland_target() 
+{
+
+    //Do not waste time if precland is disabled
+    if (!precland.enabled()) {
+        return;
+    }
+
+    bool precland_target_aquired = copter.precland.target_acquired();
+
+    if (precland_target_aquired != ap.precland_target_aquired) {
+        ap.precland_target_aquired = precland_target_aquired;
+        if (precland_target_aquired) {
+            gcs().send_text(MAV_SEVERITY_WARNING,"Precland target aquired");
+        } else {
+            gcs().send_text(MAV_SEVERITY_WARNING,"Precland target lost");
+        }
+    }
+
+ 
+}


### PR DESCRIPTION
1hz task to check precland target status and send a MAV_SEVERITY_WARNING notification to GCS about changes.

I put it into a separated task, since did not find a suitable task which logically can share this function. Max duration of the task is derived from the gcs_heatbeat task.

notification severity is Warning to make it visible in the HUD area (Mission planner).