### PR TITLE
AP_WheelEncoder: remove un-needed initialisations

### DIFF
--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -139,14 +139,9 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     AP_GROUPEND
 };
 
-AP_WheelEncoder::AP_WheelEncoder(void) :
-    num_instances(0)
+AP_WheelEncoder::AP_WheelEncoder(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
-
-    // init state and drivers
-    memset(state, 0, sizeof(state));
-    memset(drivers, 0, sizeof(drivers));
 }
 
 // initialise the AP_WheelEncoder class.


### PR DESCRIPTION
Should only be created statically