### PR TITLE
Tools:Basic support for duplicate parameters within vehicle type

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -30,6 +30,7 @@ known_param_fields = [
              'Bitmask',
              'Volatile',
              'ReadOnly',
+             'FrameType',
                       ]
 
 # Follow SI units conventions from:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -207,7 +207,7 @@ Complete Parameter List
                 continue
                 
             # Check if frame_type defined
-            frame_type = '' if not hasattr(param, 'FrameType') else param.FrameType.strip()
+            frame_type = param.FrameType.strip() if hasattr(param, 'FrameType') else ''
             
             d = param.__dict__
             if self.annotate_with_vehicle:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -205,12 +205,17 @@ Complete Parameter List
         for param in g.params:
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
+                
+            # Check if frame_type defined
+            frame_type = '' if not hasattr(param, 'FrameType') else param.FrameType.strip()
+            
             d = param.__dict__
             if self.annotate_with_vehicle:
                 name = param.name
             else:
                 name = param.name.split(':')[-1]
-            tag = '%s: %s' % (self.escape(name), self.escape(param.DisplayName),)
+            tag_frametype =' (%s)' % frame_type if frame_type else ''
+            tag = '%s%s: %s' % (self.escape(name), self.escape(tag_frametype), self.escape(param.DisplayName),)
             tag = tag.strip()
             reference = param.name
             # remove e.g. "ArduPlane:" from start of parameter name:
@@ -218,7 +223,8 @@ Complete Parameter List
                 reference = g.name + "_" + reference.split(":")[-1]
             else:
                 reference = reference.split(":")[-1]
-
+            if frame_type:
+                reference = reference + '__' + frame_type
             ret += """
 
 .. _{reference}:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -214,7 +214,7 @@ Complete Parameter List
                 name = param.name
             else:
                 name = param.name.split(':')[-1]
-            tag_frametype =' (%s)' % frame_type if frame_type else ''
+            tag_frametype = ' (%s)' % frame_type if frame_type else ''
             tag = '%s%s: %s' % (self.escape(name), self.escape(tag_frametype), self.escape(param.DisplayName),)
             tag = tag.strip()
             reference = param.name

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -12,6 +12,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Units: cdeg
     // @Range: 0 1000
     // @User: Advanced
+    // @FrameType: Heli
     AP_GROUPINFO("HOVR_ROL_TRM",    1, AC_AttitudeControl_Heli, _hover_roll_trim, AC_ATTITUDE_HELI_HOVER_ROLL_TRIM_DEFAULT),
 
     // @Param: RAT_RLL_P
@@ -20,6 +21,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.08 0.35
     // @Increment: 0.005
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_RLL_I
     // @DisplayName: Roll axis rate controller I gain
@@ -27,6 +29,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.01 0.6
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_RLL_IMAX
     // @DisplayName: Roll axis rate controller I gain maximum
@@ -34,6 +37,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_RLL_D
     // @DisplayName: Roll axis rate controller D gain
@@ -41,6 +45,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.001 0.03
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_RLL_FF
     // @DisplayName: Roll axis rate controller feed forward
@@ -48,6 +53,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 0.5
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_RLL_FILT
     // @DisplayName: Roll axis rate controller input frequency in Hz
@@ -55,6 +61,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Units: Hz
     // @Range: 1 20
     // @Increment: 1
+    // @FrameType: Heli
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 2, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: RAT_PIT_P
@@ -63,6 +70,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.08 0.35
     // @Increment: 0.005
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_PIT_I
     // @DisplayName: Pitch axis rate controller I gain
@@ -70,6 +78,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.01 0.6
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_PIT_IMAX
     // @DisplayName: Pitch axis rate controller I gain maximum
@@ -77,6 +86,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_PIT_D
     // @DisplayName: Pitch axis rate controller D gain
@@ -84,6 +94,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.001 0.03
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_PIT_FF
     // @DisplayName: Pitch axis rate controller feed forward
@@ -91,6 +102,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 0.5
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_PIT_FILT
     // @DisplayName: Pitch axis rate controller input frequency in Hz
@@ -98,6 +110,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Units: Hz
     // @Range: 1 20
     // @Increment: 1
+    // @FrameType: Heli
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 3, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: RAT_YAW_P
@@ -106,6 +119,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.180 0.60
     // @Increment: 0.005
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_YAW_I
     // @DisplayName: Yaw axis rate controller I gain
@@ -113,6 +127,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.01 0.06
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_YAW_IMAX
     // @DisplayName: Yaw axis rate controller I gain maximum
@@ -120,6 +135,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_YAW_D
     // @DisplayName: Yaw axis rate controller D gain
@@ -127,6 +143,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0.000 0.02
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_YAW_FF
     // @DisplayName: Yaw axis rate controller feed forward
@@ -134,6 +151,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Range: 0 0.5
     // @Increment: 0.001
     // @User: Standard
+    // @FrameType: Heli
 
     // @Param: RAT_YAW_FILT
     // @DisplayName: Yaw axis rate controller input frequency in Hz
@@ -141,6 +159,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Units: Hz
     // @Range: 1 20
     // @Increment: 1
+    // @FrameType: Heli
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 4, AC_AttitudeControl_Heli, AC_HELI_PID),
 
     // @Param: PIRO_COMP
@@ -148,6 +167,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Description: Pirouette compensation enabled
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
+    // @FrameType: Heli
     AP_GROUPINFO("PIRO_COMP",    5, AC_AttitudeControl_Heli, _piro_comp_enabled, 0),
     
     AP_GROUPEND

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -30,6 +30,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV1_POS", 1, AP_MotorsHeli_Dual, _servo1_pos, AP_MOTORS_HELI_DUAL_SERVO1_POS),
 
     // @Param: SV2_POS
@@ -39,6 +40,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV2_POS", 2, AP_MotorsHeli_Dual, _servo2_pos,  AP_MOTORS_HELI_DUAL_SERVO2_POS),
 
     // @Param: SV3_POS
@@ -48,6 +50,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV3_POS", 3, AP_MotorsHeli_Dual, _servo3_pos,  AP_MOTORS_HELI_DUAL_SERVO3_POS),
 
     // @Param: SV4_POS
@@ -57,6 +60,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV4_POS", 4, AP_MotorsHeli_Dual, _servo4_pos, AP_MOTORS_HELI_DUAL_SERVO4_POS),
 
     // @Param: SV5_POS
@@ -66,6 +70,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV5_POS", 5, AP_MotorsHeli_Dual, _servo5_pos, AP_MOTORS_HELI_DUAL_SERVO5_POS),
 
     // @Param: SV6_POS
@@ -75,6 +80,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("SV6_POS", 6, AP_MotorsHeli_Dual, _servo6_pos, AP_MOTORS_HELI_DUAL_SERVO6_POS),
 
     // @Param: PHANG1
@@ -84,6 +90,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Advanced
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("PHANG1", 7, AP_MotorsHeli_Dual, _swash1_phase_angle, 0),
 
     // @Param: PHANG2
@@ -93,6 +100,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: deg
     // @User: Advanced
     // @Increment: 1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("PHANG2", 8, AP_MotorsHeli_Dual, _swash2_phase_angle, 0),
 
     // @Param: DUAL_MODE
@@ -100,6 +108,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Description: Sets the dual mode of the heli, either as tandem or as transverse.
     // @Values: 0:Longitudinal, 1:Transverse
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("DUAL_MODE", 9, AP_MotorsHeli_Dual, _dual_mode, AP_MOTORS_HELI_DUAL_MODE_TANDEM),
 
     // @Param: DCP_SCALER
@@ -107,6 +116,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Description: Scaling factor applied to the differential-collective-pitch
     // @Range: 0 1
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("DCP_SCALER", 10, AP_MotorsHeli_Dual, _dcp_scaler, AP_MOTORS_HELI_DUAL_DCP_SCALER),
 
     // @Param: DCP_YAW
@@ -114,6 +124,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Description: Feed-forward compensation to automatically add yaw input when differential collective pitch is applied.
     // @Range: -10 10
     // @Increment: 0.1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("DCP_YAW", 11, AP_MotorsHeli_Dual, _dcp_yaw_effect, 0),
 
     // @Param: YAW_SCALER
@@ -121,6 +132,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Description: Scaler for mixing yaw into roll or pitch.
     // @Range: -10 10
     // @Increment: 0.1
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("YAW_SCALER", 12, AP_MotorsHeli_Dual, _yaw_scaler, 1.0f),
 
     // Indices 13-15 were used by RSC_PWM_MIN, RSC_PWM_MAX and RSC_PWM_REV and should not be used
@@ -132,6 +144,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("COL2_MIN", 16, AP_MotorsHeli_Dual, _collective2_min, AP_MOTORS_HELI_DUAL_COLLECTIVE2_MIN),
 
     // @Param: COL2_MAX
@@ -141,6 +154,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("COL2_MAX", 17, AP_MotorsHeli_Dual, _collective2_max, AP_MOTORS_HELI_DUAL_COLLECTIVE2_MAX),
 
     // @Param: COL2_MID
@@ -150,6 +164,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("COL2_MID", 18, AP_MotorsHeli_Dual, _collective2_mid, AP_MOTORS_HELI_DUAL_COLLECTIVE2_MID),
 
     // @Param: COL_CTRL_DIR
@@ -157,6 +172,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
     // @Values: 0:Normal,1:Reversed
     // @User: Standard
+    // @FrameType: Heli_Dual
     AP_GROUPINFO("COL_CTRL_DIR", 19, AP_MotorsHeli_Dual, _collective_direction, AP_MOTORS_HELI_DUAL_COLLECTIVE_DIRECTION_NORMAL),
 
     AP_GROUPEND

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -31,6 +31,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Single
     AP_GROUPINFO("SV1_POS", 1, AP_MotorsHeli_Single, _servo1_pos, AP_MOTORS_HELI_SINGLE_SERVO1_POS),
 
     // @Param: SV2_POS
@@ -40,6 +41,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Single
     AP_GROUPINFO("SV2_POS", 2, AP_MotorsHeli_Single, _servo2_pos, AP_MOTORS_HELI_SINGLE_SERVO2_POS),
 
     // @Param: SV3_POS
@@ -49,6 +51,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: deg
     // @User: Standard
     // @Increment: 1
+    // @FrameType: Heli_Single
     AP_GROUPINFO("SV3_POS", 3, AP_MotorsHeli_Single, _servo3_pos, AP_MOTORS_HELI_SINGLE_SERVO3_POS),
 
     // @Param: TAIL_TYPE
@@ -56,6 +59,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Description: Tail type selection.  Simpler yaw controller used if external gyro is selected
     // @Values: 0:Servo only,1:Servo with ExtGyro,2:DirectDrive VarPitch,3:DirectDrive FixedPitch
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("TAIL_TYPE", 4, AP_MotorsHeli_Single, _tail_type, AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO),
 
     // @Param: SWASH_TYPE
@@ -63,6 +67,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Description: Swash Type Setting
     // @Values: 0:H3 CCPM Adjustable, 1:H1 Straight Swash, 2:H3_140 CCPM
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("SWASH_TYPE", 5, AP_MotorsHeli_Single, _swash_type, AP_MOTORS_HELI_SINGLE_SWASH_H3),
 
     // @Param: GYR_GAIN
@@ -72,6 +77,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("GYR_GAIN", 6, AP_MotorsHeli_Single, _ext_gyro_gain_std, AP_MOTORS_HELI_SINGLE_EXT_GYRO_GAIN),
 
     // @Param: PHANG
@@ -81,6 +87,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: deg
     // @User: Advanced
     // @Increment: 1
+    // @FrameType: Heli_Single
     AP_GROUPINFO("PHANG", 7, AP_MotorsHeli_Single, _phase_angle, 0),
 
     // @Param: COLYAW
@@ -89,6 +96,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Range: -10 10
     // @Increment: 0.1
     // @User: Advanced
+    // @FrameType: Heli_Single
     AP_GROUPINFO("COLYAW", 8,  AP_MotorsHeli_Single, _collective_yaw_effect, 0),
 
     // @Param: FLYBAR_MODE
@@ -96,6 +104,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Description: Flybar present or not.  Affects attitude controller used during ACRO flight mode
     // @Values: 0:NoFlybar,1:Flybar
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("FLYBAR_MODE", 9, AP_MotorsHeli_Single, _flybar_mode, AP_MOTORS_HELI_NOFLYBAR),
 
     // @Param: TAIL_SPEED
@@ -105,6 +114,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("TAIL_SPEED", 10, AP_MotorsHeli_Single, _direct_drive_tailspeed, AP_MOTORS_HELI_SINGLE_DDVP_SPEED_DEFAULT),
 
     // @Param: GYR_GAIN_ACRO
@@ -114,6 +124,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Units: PWM
     // @Increment: 1
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("GYR_GAIN_ACRO", 11, AP_MotorsHeli_Single,  _ext_gyro_gain_acro, 0),
 
     // Indices 16-18 were used by RSC_PWM_MIN, RSC_PWM_MAX and RSC_PWM_REV and should not be used
@@ -123,6 +134,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Description: Direction collective moves for positive pitch. 0 for Normal, 1 for Reversed
     // @Values: 0:Normal,1:Reversed
     // @User: Standard
+    // @FrameType: Heli_Single
     AP_GROUPINFO("COL_CTRL_DIR", 19, AP_MotorsHeli_Single, _collective_direction, AP_MOTORS_HELI_SINGLE_COLLECTIVE_DIRECTION_NORMAL),
 
     // parameters up to and including 29 are reserved for tradheli


### PR DESCRIPTION
There are a bunch of duplicate parameters, as reported [in this discussion](https://discuss.ardupilot.org/t/why-duplicated-parameter-exists/20870/8). Mostly these are because Heli proposes different values than multicopter for many parameters, and redefines them. 
The main toolchain understands the difference in frametype, but our docs only understand the main vehicle - so we end up with duplicates.

There are numerous ways we might fix this. This is the easiest, designed to simply remove the duplicate links and make it possible to recognise that some parameters with the same name are different.

All it does is add a new value @FrameType that you can add to parameters. If this exists the frametype will be used in the reference (link anchor) as well as the tag name. Also the heading will include the frametype so you can see the difference. The FrameType has been added to all parameters in the conflicting Heli .cpp files.
