### PR TITLE
ArduCopter: simplify home distance and bearing calculation

### DIFF
--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -14,9 +14,7 @@ void Copter::run_nav_updates(void)
 uint32_t Copter::home_distance()
 {
     if (position_ok()) {
-        const Vector3f home = pv_location_to_vector(ahrs.get_home());
-        const Vector3f curr = inertial_nav.get_position();
-        _home_distance = get_horizontal_distance_cm(curr, home);
+        _home_distance = get_distance_cm(current_loc, ahrs.get_home());
     }
     return _home_distance;
 }
@@ -25,9 +23,7 @@ uint32_t Copter::home_distance()
 int32_t Copter::home_bearing()
 {
     if (position_ok()) {
-        const Vector3f home = pv_location_to_vector(ahrs.get_home());
-        const Vector3f curr = inertial_nav.get_position();
-        _home_bearing = get_bearing_cd(curr,home);
+        _home_bearing = get_bearing_cd(current_loc, ahrs.get_home());
     }
     return _home_bearing;
 }


### PR DESCRIPTION
No change for home_distance(), the calculations are even
But not for get_bearing_cd() ... surely due to the numerous conversion done in both case ...

This isn't much blocking as get_bearing_cd is only used once for simpe mode .

The main advantage from this change is that it get ride of pv_location_to_vector and inertial_nav call, those two make little sens since we already get equivalent functions in ahrs or location.

Another improvement that can be done, is to move those two functions into ahrs .

It was test on SITL.