### PR TITLE
Exit takeoff

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -729,6 +729,10 @@ bool Copter::ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 void Copter::ModeAuto::takeoff_run()
 {
     auto_takeoff_run();
+    if (wp_nav->reached_wp_destination()) {
+        const Vector3f target = wp_nav->get_wp_destination();
+        wp_start(target);
+    }
 }
 
 // auto_wp_run - runs the auto waypoint controller

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -366,6 +366,10 @@ void Copter::ModeGuided::run()
 void Copter::ModeGuided::takeoff_run()
 {
     auto_takeoff_run();
+    if (wp_nav->reached_wp_destination()) {
+        const Vector3f target = wp_nav->get_wp_destination();
+        set_destination(target);
+    }
 }
 
 void Copter::Mode::auto_takeoff_run()


### PR DESCRIPTION
Rework from https://github.com/ArduPilot/ardupilot/pull/8254 to use correctly pos control.
This is need otherwise when the takeoff alt is reach, no mavlink command can be use ... So this switch from takeoff to loiter at waypoint for auto and guided. The waypoint is the takeoff waypoint.

This is based on https://github.com/ArduPilot/ardupilot/pull/8740

Tested on SITL for both copter and heli