### PR TITLE
AP_Math: Add a warning to rotations to indicate that it is expected to match the MAVLink definitions

### DIFF
--- a/libraries/AP_Math/rotations.h
+++ b/libraries/AP_Math/rotations.h
@@ -66,6 +66,12 @@ enum Rotation : uint8_t {
     ROTATION_ROLL_90_PITCH_68_YAW_293 = 38,
     ROTATION_PITCH_315           = 39,
     ROTATION_ROLL_90_PITCH_315   = 40,
+    ///////////////////////////////////////////////////////////////////////
+    // Do not add more rotations without checking that there is not a conflict
+    // with the MAVLink spec. MAV_SENSOR_ORIENTATION is expected to match our
+    // list of rotations here. If a new rotation is added it needs to be added
+    // to the MAVLink messages as well.
+    ///////////////////////////////////////////////////////////////////////
     ROTATION_MAX,
     ROTATION_CUSTOM              = 100,
 };


### PR DESCRIPTION
Upstream MAVLink accepted a breaking change on the enum to bring the MAVLink spec inline with our rotations, as that is far more useful for us and GCS's. We should ensure we don't create another breakage in this area.