### PR TITLE
AP_Follow: Initialize offsets based on offset type (attempt 2)

### DIFF
--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -87,6 +87,9 @@ private:
     // get offsets in meters in NED frame
     bool get_offsets_ned(Vector3f &offsets) const;
 
+    // rotate 3D vector clockwise by specified angle (in degrees)
+    Vector3f rotate_vector(const Vector3f &vec, float angle_deg) const;
+
     // parameters
     AP_Int8     _enabled;           // 1 if this subsystem is enabled
     AP_Int16    _sysid;             // target's mavlink system id (0 to use first sysid seen)


### PR DESCRIPTION
This PR is built upon [PR 8971](https://github.com/ArduPilot/ardupilot/pull/8971) but fixes a couple of things.

This PR resolves [issue 8915](https://github.com/ArduPilot/ardupilot/issues/8915) which highlighted that the FOLL_OFS values (which holds where the vehicle should drive/fly to relative to the lead vehicle) were not being initialised properly when the FOLL_OFS_TYPE was "relative" meaning relative to the lead vehicle's heading.

This PR also fixes the AP_FOLLOW_OFFSET_TYPE_RELATIVE definition.

This has been tested in SITL.  The way I tested it was to:

- override the AP_Follow::get_target_location_and_velocity() method to always return AHRS home.
- overrode AP_Follow:_target_head to be 90 degrees (to simulate the vehicle pointing east)
- drove a rover about 30m north of home
- set OFS_TYPE = 0/NED and switched to follow mode and checked that FOLL_OFS_XYZ were set correctly for OFS_TYPE = 0/NED.  I.e. X=30, Y=0.
- switched back to manual, reset OFS_OFS_XYZ to 0,0,0, param fetch
- set OFS_TYPE = 1 (relative) and switched to follow mode again and checked that FOLL_OFS_XYZ was set correctly, i.e. X=0, Y=-30
- also during these tests, I could see the following behaviour seemed correct, After switching to follow the vehicle did not try to drive anywhere because it was already sitting at the right place because the offsets had been initialised to be the current location