### PR TITLE
DataFlash: Change the judgment of logging failed.

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -165,8 +165,8 @@ bool AP_Arming::airspeed_checks(bool report)
 
 bool AP_Arming::logging_checks(bool report)
 {
-    if ((checks_to_perform & ARMING_CHECK_ALL) ||
-        (checks_to_perform & ARMING_CHECK_LOGGING)) {
+    if ((DataFlash_Class::instance()->getDastaFlashBackendTypes() != 0) &&
+        ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_LOGGING))) {
         if (DataFlash_Class::instance()->logging_failed()) {
             check_failed(ARMING_CHECK_LOGGING, report, "Logging failed");
             return false;

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -383,6 +383,9 @@ bool DataFlash_Class::logging_enabled() const
 }
 bool DataFlash_Class::logging_failed() const
 {
+    if (_params.backend_types == DATAFLASH_BACKEND_NONE) {
+        return false;
+    }
     if (_next_backend < 1) {
         // we should not have been called!
         return true;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -221,6 +221,8 @@ public:
     float quiet_nanf() const { return nanf("0x4152"); } // "AR"
     double quiet_nan() const { return nan("0x4152445550490a"); } // "ARDUPI"
 
+    int8_t getDastaFlashBackendTypes() const { return _params.backend_types; }
+
 protected:
 
     const struct LogStructure *_structures;


### PR DESCRIPTION
I specified 0 for LOG_BACKEND_TYPE because I do not need a log.
I received "Logging failed" message with arm check.
In this case, I think that it is better to do "do not log" by arm check.