### PR TITLE
DataFlash: Clarify the Bad logging message.

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -165,10 +165,15 @@ bool AP_Arming::airspeed_checks(bool report)
 
 bool AP_Arming::logging_checks(bool report)
 {
+    const char *fail_detail[9] = {"none", "not backend",
+                                  "MAVLINK not sending to client",
+                                  "File not initialized", "File open error", "File io thread not alive",
+                                  "SD not write FD", "SD open error", "SD io thread not alive"};
+
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_LOGGING)) {
-        if (DataFlash_Class::instance()->logging_failed()) {
-            check_failed(ARMING_CHECK_LOGGING, report, "Logging failed");
+        if (int8_t check = DataFlash_Class::instance()->logging_failed()) {
+            check_failed(ARMING_CHECK_LOGGING, report, "Logging failed. %s", fail_detail[check]);
             return false;
         }
         if (!DataFlash_Class::instance()->CardInserted()) {

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -381,18 +381,21 @@ bool DataFlash_Class::logging_enabled() const
     }
     return false;
 }
-bool DataFlash_Class::logging_failed() const
+int8_t DataFlash_Class::logging_failed() const
 {
+    if (_params.backend_types == DATAFLASH_BACKEND_NONE) {
+        return 0;
+    }
     if (_next_backend < 1) {
         // we should not have been called!
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::NOT_BACKEND);
     }
     for (uint8_t i=0; i<_next_backend; i++) {
-        if (backends[i]->logging_failed()) {
-            return true;
+        if (int8_t check = backends[i]->logging_failed()) {
+            return check;
         }
     }
-    return false;
+    return 0;
 }
 
 void DataFlash_Class::Log_Write_MessageF(const char *fmt, ...)

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -41,6 +41,19 @@ enum DataFlash_Backend_Type {
     DATAFLASH_BACKEND_BOTH = 3,
 };
 
+enum struct DataFlash_Fail {
+    NONE = 0,
+    NOT_BACKEND = 1,
+    MAVLINK_SENDING_TO_CLIENT = 2,
+    FILE_NOT_INITIALIZED = 3,
+    FILE_OPEN_ERROR = 4,
+    FILE_IO_THREAD_NOT_ALIVE = 5,
+    SD_NOT_WRITE_FD = 6,
+    SD_OPEN_ERROR = 7,
+    SD_IO_THREAD_NOT_ALIVE = 8,
+    UNDEFINED = 9,
+};
+
 // fwd declarations to avoid include errors
 class AC_AttitudeControl;
 class AC_PosControl;
@@ -210,7 +223,7 @@ public:
     // typically DataFlash_File.
     bool logging_present() const;
     bool logging_enabled() const;
-    bool logging_failed() const;
+    int8_t logging_failed() const;
 
     void set_vehicle_armed(bool armed_state);
     bool vehicle_is_armed() const { return _armed; }

--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -117,7 +117,7 @@ public:
 
     // these methods are used when reporting system status over mavlink
     virtual bool logging_enabled() const = 0;
-    virtual bool logging_failed() const = 0;
+    virtual int8_t logging_failed() const = 0;
 
     virtual void vehicle_was_disarmed() { };
 

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -1094,21 +1094,21 @@ bool DataFlash_File::io_thread_alive() const
     return (AP_HAL::millis() - _io_timer_heartbeat) < 1000;
 }
 
-bool DataFlash_File::logging_failed() const
+int8_t DataFlash_File::logging_failed() const
 {
     if (!_initialised) {
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::FILE_NOT_INITIALIZED);
     }
     if (_open_error) {
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::FILE_OPEN_ERROR);
     }
     if (!io_thread_alive()) {
         // No heartbeat in a second.  IO thread is dead?! Very Not
         // Good.
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::FILE_IO_THREAD_NOT_ALIVE);
     }
 
-    return false;
+    return 0;
 }
 
 

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -50,7 +50,7 @@ public:
 
     // this method is used when reporting system status over mavlink
     bool logging_enabled() const override;
-    bool logging_failed() const override;
+    int8_t logging_failed() const override;
 
     bool logging_started(void) const override { return _write_fd != -1; }
 

--- a/libraries/DataFlash/DataFlash_File_sd.cpp
+++ b/libraries/DataFlash/DataFlash_File_sd.cpp
@@ -970,7 +970,7 @@ bool DataFlash_File::io_thread_alive() const
     return false;
 }
 
-bool DataFlash_File::logging_failed() const
+int8_t DataFlash_File::logging_failed() const
 {
     bool op=false;
     
@@ -979,17 +979,17 @@ bool DataFlash_File::logging_failed() const
     if (!op &&
         (hal.util->get_soft_armed() ||
          _front.log_while_disarmed())) {
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::SD_NOT_WRITE_FD);
     }
     if (_open_error) {
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::SD_OPEN_ERROR);
     }
     if (!io_thread_alive()) {
         // No heartbeat in a second.  IO thread is dead?! Very Not Good.
-        return true;
+        return static_cast<int8_t>(DataFlash_Fail::SD_IO_THREAD_NOT_ALIVE);
     }
 
-    return false;
+    return 0;
 }
 
 

--- a/libraries/DataFlash/DataFlash_File_sd.h
+++ b/libraries/DataFlash/DataFlash_File_sd.h
@@ -51,7 +51,7 @@ public:
 
     // this method is used when reporting system status over mavlink
     bool logging_enabled() const;
-    bool logging_failed() const;
+    int8_t logging_failed() const;
 
     void vehicle_was_disarmed() override;
 

--- a/libraries/DataFlash/DataFlash_MAVLink.cpp
+++ b/libraries/DataFlash/DataFlash_MAVLink.cpp
@@ -52,9 +52,13 @@ void DataFlash_MAVLink::Init()
     _initialised = true;
 }
 
-bool DataFlash_MAVLink::logging_failed() const
+int8_t DataFlash_MAVLink::logging_failed() const
 {
-    return !_sending_to_client;
+    if (_sending_to_client == false) {
+        return static_cast<int8_t>(DataFlash_Fail::MAVLINK_SENDING_TO_CLIENT);
+    } else {
+        return 0;
+    }
 }
 
 uint32_t DataFlash_MAVLink::bufferspace_available() {

--- a/libraries/DataFlash/DataFlash_MAVLink.h
+++ b/libraries/DataFlash/DataFlash_MAVLink.h
@@ -121,7 +121,7 @@ private:
 
     // this method is used when reporting system status over mavlink
     bool logging_enabled() const override { return true; }
-    bool logging_failed() const override;
+    int8_t logging_failed() const override;
 
     mavlink_channel_t _chan;
     uint8_t _target_system_id;

--- a/libraries/DataFlash/DataFlash_Revo.h
+++ b/libraries/DataFlash/DataFlash_Revo.h
@@ -160,7 +160,7 @@ public:
     uint8_t     ReadStatus();
 
     bool logging_enabled() const { return true; }
-    bool logging_failed() const  { return false; };
+    int8_t logging_failed() const  { return 0; };
     
     void stop_logging(void) { log_write_started = false; }
     


### PR DESCRIPTION
In order to investigate the cause of "Bad logging" of MP, I add "detected error" to "Logging failed" message.
I am very unclear about "Bad logging" of MP, and it takes time to investigate. There is a comment that it is good to format the SD card when searching on Google.
However, it also occurs in Ras PI & Navio 2.
This is strange. . . Ras PI's Linux is standing up. why?
System error, delay of IO, media error are mixed.
I think the fact that "Logging failed" is not improved even after formatting is also due to this complexity.
Therefore, by adding the following information to the message, we clarify the survey points.

===

This "Logging failed" combines multiple errors.
1. There is no BACKEND
2. MAVLINK could not send to client
3. I could not initialize with FILE
4. I could not open it with FILE
5. IO thread is not healthy with FILE
6. Write with SD There is no FD
7. I could not open it with SD
8. IO thread is not healthy in SD