### PR TITLE
ChibiOS: fixed rate settings for IOMCU

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -526,16 +526,16 @@ bool QuadPlane::setup(void)
 
     switch (motor_class) {
     case AP_Motors::MOTOR_FRAME_TRI:
-        motors = new AP_MotorsTri(plane.scheduler.get_loop_rate_hz());
+        motors = new AP_MotorsTri(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsTri::var_info;
         break;
     case AP_Motors::MOTOR_FRAME_TAILSITTER:
-        motors = new AP_MotorsTailsitter(plane.scheduler.get_loop_rate_hz());
+        motors = new AP_MotorsTailsitter(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsTailsitter::var_info;
         rotation = ROTATION_PITCH_90;
         break;
     default:
-        motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz());
+        motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsMatrix::var_info;
         break;
     }
@@ -1170,7 +1170,7 @@ bool QuadPlane::assistance_needed(float aspeed)
         return false;
     }
     
-    uint32_t max_angle_cd = 100U*assist_angle;
+    int32_t max_angle_cd = 100U*assist_angle;
     if ((labs(ahrs.roll_sensor - plane.nav_roll_cd) < max_angle_cd &&
          labs(ahrs.pitch_sensor - plane.nav_pitch_cd) < max_angle_cd)) {
         // not beyond angle error

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -80,7 +80,7 @@ void RCOutput::init()
     chMtxObjectInit(&trigger_mutex);
 
     // setup default output rate of 50Hz
-    set_freq(0xFFFF, 50);
+    set_freq(0xFFFF ^ ((1U<<chan_offset)-1), 50);
 
 #ifdef HAL_GPIO_PIN_SAFETY_IN
     safety_state = AP_HAL::Util::SAFETY_DISARMED;
@@ -169,10 +169,15 @@ void RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
 #if HAL_WITH_IO_MCU
     if (AP_BoardConfig::io_enabled()) {
         // change frequency on IOMCU
+        uint16_t io_chmask = chmask & 0xFF;
         if (freq_hz > 50) {
-            io_fast_channel_mask = chmask;
+            io_fast_channel_mask |= io_chmask;
+        } else {
+            io_fast_channel_mask &= ~io_chmask;
         }
-        iomcu.set_freq(chmask, freq_hz);
+        if (io_chmask) {
+            iomcu.set_freq(io_fast_channel_mask, freq_hz);
+        }
     }
 #endif
 
@@ -205,9 +210,6 @@ void RCOutput::set_freq(uint32_t chmask, uint16_t freq_hz)
         if (group_freq > 50) {
             fast_channel_mask |= group.ch_mask;
         }
-    }
-    if (chmask != update_mask) {
-        hal.console->printf("RCOutput: Failed to set PWM frequency req %x set %x\n", (unsigned)chmask, (unsigned)update_mask);
     }
 }
 

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -550,8 +550,15 @@ void AP_IOMCU::push(void)
 // set output frequency
 void AP_IOMCU::set_freq(uint16_t chmask, uint16_t freq)
 {
+    const uint8_t masks[] = { 0x03,0x0C,0xF0 };
+    // ensure mask is legal for the timer layout
+    for (uint8_t i=0; i<ARRAY_SIZE_SIMPLE(masks); i++) {
+        if (chmask & masks[i]) {
+            chmask |= masks[i];
+        }
+    }
     rate.freq = freq;
-    rate.chmask = chmask;
+    rate.chmask |= chmask;
     trigger_event(IOEVENT_SET_RATES);
 }
 


### PR DESCRIPTION
The IO fw only accepts bitmasks that match the timer output, so ensure we set complete masks in AP_IOMCU

ping @lthall 