### PR TITLE
AP_Soaring: Add POMDP controller

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -80,6 +80,24 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(update_logging2,        25,    300),
 #if SOARING_ENABLED == ENABLED
     SCHED_TASK(update_soaring,         50,    400),
+    /* Break up the soaring POMDP calculation into
+    several small time slices to avoid starving
+    other vital processes. */
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
+    SCHED_TASK(soaring_policy_computation,          50,    1000),
 #endif
     SCHED_TASK(parachute_check,        10,    200),
 #if AP_TERRAIN_AVAILABLE

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -564,6 +564,11 @@ void Plane::calc_nav_roll()
             millis() - plane.guided_state.last_forced_rpy_ms.x < 3000) {
         commanded_roll = plane.guided_state.forced_rpy_cd.x;
     }
+    else if (control_mode == LOITER &&
+         g2.soaring_controller.is_active() &&
+         g2.soaring_controller.is_controlling_roll()) {
+        commanded_roll = g2.soaring_controller.get_roll_cmd();
+    }
 
     nav_roll_cd = constrain_int32(commanded_roll, -roll_limit_cd, roll_limit_cd);
     update_load_factor();

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -564,12 +564,13 @@ void Plane::calc_nav_roll()
             millis() - plane.guided_state.last_forced_rpy_ms.x < 3000) {
         commanded_roll = plane.guided_state.forced_rpy_cd.x;
     }
+#if SOARING_ENABLED == ENABLED
     else if (control_mode == LOITER &&
          g2.soaring_controller.is_active() &&
          g2.soaring_controller.is_controlling_roll()) {
         commanded_roll = g2.soaring_controller.get_roll_cmd();
     }
-
+#endif
     nav_roll_cd = constrain_int32(commanded_roll, -roll_limit_cd, roll_limit_cd);
     update_load_factor();
 }

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1183,7 +1183,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 ParametersG2::ParametersG2(void) :
     ice_control(plane.rpm_sensor, plane.ahrs)
 #if SOARING_ENABLED == ENABLED
-    ,soaring_controller(plane.ahrs, plane.TECS_controller, plane.aparm)
+    ,soaring_controller(plane.ahrs, plane.TECS_controller, plane.aparm, plane.rollController, plane.g.scaling_speed)
 #endif
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1031,8 +1031,10 @@ private:
     void update_soft_armed();
 #if SOARING_ENABLED == ENABLED
     void update_soaring();
+    void soaring_policy_computation();
 #endif
-
+    
+    
     // support for AP_Avoidance custom flight mode, AVOID_ADSB
     bool avoid_adsb_init(bool ignore_checks);
     void avoid_adsb_run();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1033,8 +1033,7 @@ private:
     void update_soaring();
     void soaring_policy_computation();
 #endif
-    
-    
+
     // support for AP_Avoidance custom flight mode, AVOID_ADSB
     bool avoid_adsb_init(bool ignore_checks);
     void avoid_adsb_run();

--- a/ArduPlane/soaring.cpp
+++ b/ArduPlane/soaring.cpp
@@ -23,7 +23,7 @@ void Plane::update_soaring() {
     case FLY_BY_WIRE_B:
     case CRUISE:
         if (!g2.soaring_controller.suppress_throttle()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Soaring: forcing RTL");
+            gcs().send_text(MAV_SEVERITY_INFO, "Out of allowable altitude range, exiting soaring.");
             set_mode(RTL, MODE_REASON_SOARING_FBW_B_WITH_MOTOR_RUNNING);
         }
         break;
@@ -61,6 +61,8 @@ void Plane::update_soaring() {
 
         if (g2.soaring_controller.check_cruise_criteria()) {
             // Exit as soon as thermal state estimate deteriorates
+            g2.soaring_controller.stop_computation();
+
             switch (previous_mode) {
             case FLY_BY_WIRE_B:
                 gcs().send_text(MAV_SEVERITY_INFO, "Soaring: Thermal ended, entering RTL");
@@ -94,6 +96,11 @@ void Plane::update_soaring() {
         // nothing to do
         break;
     }
+}
+
+void Plane::soaring_policy_computation()
+{
+    g2.soaring_controller.soaring_policy_computation();
 }
 
 #endif // SOARING_ENABLED

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -44,6 +44,10 @@ public:
     AP_Float &kI(void) { return gains.I; }
     AP_Float &kD(void) { return gains.D; }
     AP_Float &kFF(void) { return gains.FF; }
+    AP_Float &tau(void) { return gains.tau; }
+    AP_Int16 &rmax(void) { return gains.rmax; }
+    AP_Int16 &imax(void) { return gains.imax; }
+    AP_AutoTune::ATGains &get_gains(void) { return gains; }
 
 private:
     const AP_Vehicle::FixedWing &aparm;

--- a/libraries/AP_Math/matrixN.cpp
+++ b/libraries/AP_Math/matrixN.cpp
@@ -58,3 +58,8 @@ template void MatrixN<float,4>::mult(const VectorN<float,4> &A, const VectorN<fl
 template MatrixN<float,4> &MatrixN<float,4>::operator -=(const MatrixN<float,4> &B);
 template MatrixN<float,4> &MatrixN<float,4>::operator +=(const MatrixN<float,4> &B);
 template void MatrixN<float,4>::force_symmetry(void);
+
+template void MatrixN<float, 3>::mult(const VectorN<float, 3> &A, const VectorN<float, 3> &B);
+template MatrixN<float, 3> &MatrixN<float, 3>::operator -=(const MatrixN<float, 3> &B);
+template MatrixN<float, 3> &MatrixN<float, 3>::operator +=(const MatrixN<float, 3> &B);
+template void MatrixN<float, 3>::force_symmetry(void);

--- a/libraries/AP_Math/matrixN.h
+++ b/libraries/AP_Math/matrixN.h
@@ -40,8 +40,18 @@ public:
     // add B to the matrix
     MatrixN<T,N> &operator +=(const MatrixN<T,N> &B);
     
+    T (&getarray())[N][N]{ return v;  }
+    
     // Matrix symmetry routine
     void force_symmetry(void);
+    
+    inline const T & operator()(uint8_t i, uint8_t j) const {
+        return v[i][j];
+    }
+
+    inline T & operator()(uint8_t i, uint8_t j) {
+        return v[i][j];
+    }
 
 private:
     T v[N][N];

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -231,8 +231,9 @@ void SoaringController::init_ekf()
     const MatrixN<float,4> p{init_p};
     
     Vector2f ground_vector = _ahrs.groundspeed_vector();
-    float head_sin = ground_vector.y / ground_vector.length();
-    float head_cos = ground_vector.x / ground_vector.length();
+    float L = ground_vector.length();
+    float head_sin = ground_vector.y / L;
+    float head_cos = ground_vector.x / L;
 
     // New state vector filter will be reset. Thermal location is placed in front of a/c
     const float init_xr[4] = {INITIAL_THERMAL_STRENGTH,

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -11,11 +11,14 @@
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_GPS/AP_GPS.h>
+#include <APM_Control/APM_Control.h>
 #include <DataFlash/DataFlash.h>
 #include <AP_Math/AP_Math.h>
 #include "ExtendedKalmanFilter.h"
 #include "Variometer.h"
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
+#include "POMDP_Soar.h"
 
 #define EXPECTED_THERMALLING_SINK 0.7
 #define INITIAL_THERMAL_STRENGTH 2.0
@@ -23,9 +26,13 @@
 #define INITIAL_STRENGTH_COVARIANCE 0.0049
 #define INITIAL_RADIUS_COVARIANCE 2500.0
 #define INITIAL_POSITION_COVARIANCE 300.0
+#define SOARING_RND_UPDATE_RATE 20 // 260 microseconds of Box Miller 4D rnd samples
 
 
 class SoaringController {
+
+    friend class POMDSoarAlgorithm;
+
     ExtendedKalmanFilter _ekf{};
     AP_AHRS &_ahrs;
     AP_SpdHgtControl &_spdHgt;
@@ -35,20 +42,22 @@ class SoaringController {
     struct Location _prev_update_location;
 
     // store time thermal was entered for hysteresis
-    unsigned long _thermal_start_time_us;
+    uint64_t _thermal_start_time_us;
 
     // store time cruise was entered for hysteresis
-    unsigned long _cruise_start_time_us;
+    uint64_t _cruise_start_time_us;
 
     // store time of last update
-    unsigned long _prev_update_time;
+    uint64_t _prev_update_time;
 
     float _loiter_rad;
     bool _throttle_suppressed;
-
+    float correct_netto_rate(float climb_rate, float phi, float aspd) const;
     float McCready(float alt);
     void get_wind_corrected_drift(const Location *current_loc, const Vector3f *wind, float *wind_drift_x, float *wind_drift_y, float *dx, float *dy);
-    void get_altitude_wrt_home(float *alt);
+    void get_altitude_wrt_home(float *alt) const;
+
+    POMDSoarAlgorithm _pomdsoar;
 
 protected:
     AP_Int8 soar_active;
@@ -66,34 +75,37 @@ protected:
     AP_Float alt_max;
     AP_Float alt_min;
     AP_Float alt_cutoff;
+    AP_Int8 exit_mode;
 
 public:
-    SoaringController(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, const AP_Vehicle::FixedWing &parms);
-
+    SoaringController(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, const AP_Vehicle::FixedWing &parms, AP_RollController &rollController, AP_Float &scaling_speed);
     // this supports the TECS_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
     void get_target(Location & wp);
     bool suppress_throttle();
     bool check_thermal_criteria();
     bool check_cruise_criteria();
-    bool check_init_thermal_criteria();
+    bool is_in_thermal_locking_period();
+    void init_ekf();
     void init_thermalling();
     void init_cruising();
     void update_thermalling();
     void update_cruising();
     bool is_active() const;
-    bool get_throttle_suppressed() const
-    {
-        return _throttle_suppressed;
-    }
-    void set_throttle_suppressed(bool suppressed)
-    {
-        _throttle_suppressed = suppressed;
-    }
-    float get_vario_reading() const
-    {
-        return _vario.displayed_reading;
-    }
-
+    bool get_throttle_suppressed() const { return _throttle_suppressed; }
+    void set_throttle_suppressed(bool suppressed) { _throttle_suppressed = suppressed;  }
+    float get_vario_reading() const { return _vario.displayed_reading; }
     void update_vario();
+    void soaring_policy_computation();
+    void stop_computation();
+    float get_roll_cmd();
+    void get_relative_position_wrt_home(Vector2f &vec) const;
+    float get_aspd() const;
+    void get_position(Location& loc);
+    float get_rate() const;
+    float get_roll() const;
+    float get_eas2tas() const;
+    void get_heading_estimate(float *hdx, float *hdy) const;
+    void get_velocity_estimate(float dt, float *v0) const;
+    bool is_controlling_roll();
 };

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -42,13 +42,13 @@ class SoaringController {
     struct Location _prev_update_location;
 
     // store time thermal was entered for hysteresis
-    uint64_t _thermal_start_time_us;
+    uint32_t _thermal_start_time_ms;
 
     // store time cruise was entered for hysteresis
-    uint64_t _cruise_start_time_us;
+    uint32_t _cruise_start_time_ms;
 
     // store time of last update
-    uint64_t _prev_update_time;
+    uint32_t _prev_update_time_us;
 
     float _loiter_rad;
     bool _throttle_suppressed;

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -105,7 +105,6 @@ public:
     float get_rate() const;
     float get_roll() const;
     float get_eas2tas() const;
-    void get_heading_estimate(float *hdx, float *hdy) const;
-    void get_velocity_estimate(float dt, float *v0) const;
+    float get_yaw() const;
     bool is_controlling_roll();
 };

--- a/libraries/AP_Soaring/ExtendedKalmanFilter.cpp
+++ b/libraries/AP_Soaring/ExtendedKalmanFilter.cpp
@@ -2,7 +2,7 @@
 #include "AP_Math/matrixN.h"
 
 
-float ExtendedKalmanFilter::measurementpredandjacobian(VectorN<float,N> &A)
+float ExtendedKalmanFilter::measurementpredandjacobian(VectorN<float,EKF_N> &A)
 {
     // This function computes the Jacobian using equations from
     // analytical derivation of Gaussian updraft distribution
@@ -20,7 +20,7 @@ float ExtendedKalmanFilter::measurementpredandjacobian(VectorN<float,N> &A)
 }
 
 
-void ExtendedKalmanFilter::reset(const VectorN<float,N> &x, const MatrixN<float,N> &p, const MatrixN<float,N> q, float r)
+void ExtendedKalmanFilter::reset(const VectorN<float,EKF_N> &x, const MatrixN<float,EKF_N> &p, const MatrixN<float,EKF_N> q, float r)
 {
     P = p;
     X = x;
@@ -31,10 +31,10 @@ void ExtendedKalmanFilter::reset(const VectorN<float,N> &x, const MatrixN<float,
 
 void ExtendedKalmanFilter::update(float z, float Vx, float Vy)
 {
-    MatrixN<float,N> tempM;
-    VectorN<float,N> H;
-    VectorN<float,N> P12;
-    VectorN<float,N> K;
+    MatrixN<float,EKF_N> tempM;
+    VectorN<float,EKF_N> H;
+    VectorN<float,EKF_N> P12;
+    VectorN<float,EKF_N> K;
     
     // LINE 28
     // Estimate new state from old.

--- a/libraries/AP_Soaring/ExtendedKalmanFilter.h
+++ b/libraries/AP_Soaring/ExtendedKalmanFilter.h
@@ -9,19 +9,19 @@ Extended Kalman Filter class by Sam Tabor, 2013.
 
 #include <AP_Math/matrixN.h>
 
-#define N 4
+#define EKF_N 4
 
 class ExtendedKalmanFilter {
 public:
     ExtendedKalmanFilter(void) {}
     
-    VectorN<float,N> X;
-    MatrixN<float,N> P;
-    MatrixN<float,N> Q;
+    VectorN<float,EKF_N> X;
+    MatrixN<float,EKF_N> P;
+    MatrixN<float,EKF_N> Q;
     float R;
-    void reset(const VectorN<float,N> &x, const MatrixN<float,N> &p, const MatrixN<float,N> q, float r);
+    void reset(const VectorN<float,EKF_N> &x, const MatrixN<float,EKF_N> &p, const MatrixN<float,EKF_N> q, float r);
     void update(float z, float Vx, float Vy);
 
 private:
-    float measurementpredandjacobian(VectorN<float,N> &A);
+    float measurementpredandjacobian(VectorN<float,EKF_N> &A);
 };

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -239,9 +239,10 @@ void POMDSoarAlgorithm::init_actions(POMDP_Mode mode)
 
 void POMDSoarAlgorithm::init_thermalling()
 {
-    float ground_course = radians(_sc->_ahrs.get_gps().ground_course());
-    float head_sin = sinf(ground_course);
-    float head_cos = cosf(ground_course);
+    Vector2f ground_vector = _sc->_ahrs.groundspeed_vector();
+    float head_sin = ground_vector.y / ground_vector.length();
+    float head_cos = ground_vector.x / ground_vector.length();
+
     float xprod = _sc->_ekf.X[3] * head_cos - _sc->_ekf.X[2] * head_sin;
     _sign = xprod <= 0 ? -1.0 : 1.0;
     _pomdp_roll_cmd = pomdp_roll1 * _sign;
@@ -477,7 +478,7 @@ void POMDSoarAlgorithm::update_thermalling(const Location &current_loc)
         float trP = _sc->_ekf.P(0, 0) / n[0] + _sc->_ekf.P(1, 1) / n[1] + _sc->_ekf.P(2, 2) / n[2] + _sc->_ekf.P(3, 3) / n[3];
 
         // Update the correct mode (exploit vs explore) based on EKF covariance trace
-        _pomdp_mode = trP < pomdp_pth && pomdp_pth > 0.0f ? POMPD_MODE_EXPLOIT : POMPD_MODE_EXPLORE;
+        _pomdp_mode = trP < pomdp_pth && pomdp_pth > 0.0f ? POMDP_MODE_EXPLOIT : POMDP_MODE_EXPLORE;
         
         // Initialise actions accordingly.
         init_actions(_pomdp_mode);

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -1,0 +1,633 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#include <GCS_MAVLink/GCS.h>
+#include "AP_Soaring.h"
+#include "POMDP_Soar.h"
+
+// ArduSoar parameters
+const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
+    // @Param: ENABLE
+    // @DisplayName: Is the POMDSoar algorithm on?
+    // @Description: If 1, the soaring controller uses the POMDSoar algorithm. If 0, the soaring controller uses the ArduSoar algorithm.
+    // @Units: boolean
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 1, POMDSoarAlgorithm, pomdp_on, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: N
+    // @DisplayName: Number of samples per action trajectory used by POMDSoar
+    // @Description: Number of samples per action trajectory used by POMDSoar.
+    // @Units: samples
+    // @Range: 0 100
+    // @User: Advanced
+    AP_GROUPINFO("N", 2, POMDSoarAlgorithm, pomdp_n, 10),
+
+    // @Param: K
+    // @DisplayName: Number of POMDP sample points per 1 second of an action's trajectory used by POMDSoar.
+    // @Description: Number of POMDP sample points per 1 second of an action's trajectory used by POMDSoar.
+    // @Units: samples
+    // @Range: 0 100
+    // @User: Advanced
+    AP_GROUPINFO("K", 3, POMDSoarAlgorithm, pomdp_k, 5),
+
+    // @Param: HORI
+    // @DisplayName: POMDP planning horizon used by POMDSoar.
+    // @Description: POMDP planning horizon used by POMDSoar.
+    // @Units: seconds
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("HORI", 4, POMDSoarAlgorithm, pomdp_hori, 4.0),
+
+    // @Param: STEP_T
+    // @DisplayName:POMDP planning step solve time
+    // @Description: The amount of computation time the POMDP solver has for computing the next action
+    // @Units: seconds
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("STEP", 5, POMDSoarAlgorithm, pomdp_step_t, 1),
+
+    // @Param: LOOP
+    // @DisplayName: Number of POMDP solver's inner loop executions per planning step
+    // @Description: Number of POMDP solver's inner loop executions per planning step (see also the STEP_T parameter)
+    // @Units:
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("LOOP", 6, POMDSoarAlgorithm, pomdp_loop_load, 1),
+
+    // @Param: ROLL1
+    // @DisplayName: POMDP's maximum commanded roll angle.
+    // @Description: Maximum commanded roll angle in the POMDP used by POMDSoar.
+    // @Units: degrees
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("ROLL1", 7, POMDSoarAlgorithm, pomdp_roll1, 15),
+
+    // @Param: ROLL2
+    // @DisplayName: POMDP's minimum commanded roll angle.
+    // @Description: Minimum commanded roll angle in the POMDP used by POMDSoar.
+    // @Units: degrees
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("ROLL2", 8, POMDSoarAlgorithm, pomdp_roll2, 45),
+
+    // @Param: RRATE
+    // @DisplayName: The sailplane UAV's roll rate increment used by POMDSoar
+    // @Description: The sailplane UAV's roll rate increment used by POMDSoar.
+    // @Units: degrees/second
+    // @Range: 0 1000
+    // @User: Advanced
+    AP_GROUPINFO("RRATE", 9, POMDSoarAlgorithm, pomdp_roll_rate, 75),
+
+    // @Param: N_ACT
+    // @DisplayName: POMDP number of actions
+    // @Description: Number of actions in the POMDP used by POMDSoar. The roll angle input commands corresponding to actions are endpoints of (N_ACT-1) equal intervals between ROLL2 and ROLL1 (inclusive).
+    // @Units: seconds
+    // @Range: 1 254
+    // @User: Advanced
+    AP_GROUPINFO("N_ACT", 10, POMDSoarAlgorithm, pomdp_n_actions, 2),
+
+    // @Param: I_MOMENT
+    // @DisplayName: I-moment coefficient
+    // @Description: Airframe-specific I-moment coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("I_MOM", 11, POMDSoarAlgorithm, I_moment, 0.00257482),
+
+    // @Param: K_AILERON
+    // @DisplayName: Aileron K coefficient
+    // @Description: Airframe-specific aileron K coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
+    // @Units: seconds
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("K_AIL", 12, POMDSoarAlgorithm, k_aileron, 1.44833047),
+
+    // @Param: K_ROLLDAMP
+    // @DisplayName: Roll dampening K coefficient
+    // @Description: Airframe-specific roll-dampening K coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("RLLDMP", 13, POMDSoarAlgorithm, k_roll_damping, 0.41073589),
+
+    // @Param: ROLL_CLP
+    // @DisplayName: CLP coefficient
+    // @Description: Airframe-specific CLP coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("RLLCLP", 14, POMDSoarAlgorithm, c_lp, -1.12808702679),
+
+    // @Param: POLY_A
+    // @DisplayName: Sink polynomial coefficient a
+    // @Description: a*x^2 + b*x + c sink polynomial for netto vario correction
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("POLY_A", 15, POMDSoarAlgorithm, poly_a, -0.03099261),
+
+    // @Param: POLY_B
+    // @DisplayName: Sink polynomial coefficient b
+    // @Description: a*x^2 + b*x + c sink polynomial for netto vario correction
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("POLY_B", 16, POMDSoarAlgorithm, poly_b, 0.44731854),
+
+    // @Param: POLY_C
+    // @DisplayName: Sink polynomial coefficient c
+    // @Description: a*x^2 + b*x + c sink polynomial for netto vario correction
+    // @Units:
+    // @Range: -10000 10000
+    // @User: Advanced
+    AP_GROUPINFO("POLY_C", 17, POMDSoarAlgorithm, poly_c, -2.30292972),
+
+    // @Param: TH
+    // @DisplayName: POMDSoar's threshold on tr(P) for switching between explore and max-lift modes.
+    // @Description: POMDSoar's threshold on the P matrix trace for switching between explore and max-lift modes.
+    // @Units:
+    // @Range: 0 10000
+    // @User: Advanced
+    AP_GROUPINFO("PTH", 18, POMDSoarAlgorithm, pomdp_pth, 50),
+
+    // @Param: NORM
+    // @DisplayName: Normalize the P matrix trace when solving the POMDP
+    // @Description: Normalize the trace of the P matrix used for switching between explore and max-lift modes in POMDSoar. 0 = no normalizing, 1 = normalize tr(P)
+    // @Units:
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("NORM", 19, POMDSoarAlgorithm, pomdp_norm_pth, 0),
+
+    // @Param: EXT
+    // @DisplayName: Enable action duration extension in POMDSoar's max-lift mode compared to the explore mode
+    // @Description: 0 = off, > 1 = multiplicative factor by which to extend action duration in max-lift compared to the explore mode.
+    // @Units:
+    // @Range: 0 10000
+    // @User: Advanced
+    AP_GROUPINFO("EXT", 20, POMDSoarAlgorithm, pomdp_extend, 0),
+
+    // @Param: PLN
+    // @DisplayName: Enable deterministic trajectory planning mode for the POMDP
+    // @Description: Enable deterministic trajectory planning mode for the POMDP. 0 = off, 1 on.
+    // @Units:
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("PLN", 21, POMDSoarAlgorithm, pomdp_plan_mode, 0),
+
+    AP_GROUPEND
+};
+
+POMDSoarAlgorithm::POMDSoarAlgorithm(const SoaringController *sc, AP_RollController &rollController, AP_Float &scaling_speed) :
+    _sc(sc),
+    _gains(rollController.get_gains()),
+    _scaling_speed(scaling_speed)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    _prev_pomdp_update_time = AP_HAL::micros64();
+}
+
+
+void POMDSoarAlgorithm::init_actions(POMDP_Mode mode)
+{
+    _n_actions = MIN(pomdp_n_actions, MAX_ACTIONS);
+    float max_roll = fmax(pomdp_roll1 * _sign, pomdp_roll2 * _sign);
+    float min_roll = fmin(pomdp_roll1 * _sign, pomdp_roll2 * _sign);
+
+    switch (mode) {
+        case POMDP_MODE_EXPLOIT:
+        {
+            float new_max_roll = _pomdp_roll_cmd + pomdp_roll_rate;
+            float new_min_roll = _pomdp_roll_cmd - pomdp_roll_rate;
+
+            if (new_max_roll > max_roll)
+            {
+                new_max_roll = max_roll;
+                new_min_roll = max_roll - 2 * pomdp_roll_rate;
+            }
+
+            if (new_min_roll < min_roll)
+            {
+                new_min_roll = min_roll;
+                new_max_roll = min_roll + 2 * pomdp_roll_rate;
+            }
+
+            float roll = new_max_roll;
+            float roll_rate = (new_max_roll - new_min_roll) / (_n_actions - 1);
+            for (int i = 0; i < _n_actions; i++) {
+                _roll_cmds[i] = roll;
+                //gcs().send_text(MAV_SEVERITY_INFO, "Action[%d] %f", i, (double)_roll_cmds[i]);
+                roll -= roll_rate;
+            }
+        }
+        case POMDP_MODE_EXPLORE:
+        {
+            float roll = max_roll;
+            float roll_rate = (max_roll - min_roll) / (_n_actions - 1);
+            for (int i = 0; i < _n_actions; i++)
+            {
+                _roll_cmds[i] = roll;
+                //gcs().send_text(MAV_SEVERITY_INFO, "Action[%d] %f", i, (double)_roll_cmds[i]);
+                roll -= roll_rate;
+            }
+        }
+    }
+
+    _prev_n_actions = _n_actions;
+}
+
+
+void POMDSoarAlgorithm::init_thermalling()
+{
+    float ground_course = radians(_sc->_ahrs.get_gps().ground_course());
+    float head_sin = sinf(ground_course);
+    float head_cos = cosf(ground_course);
+    float xprod = _sc->_ekf.X[3] * head_cos - _sc->_ekf.X[2] * head_sin;
+    _sign = xprod <= 0 ? -1.0 : 1.0;
+    _pomdp_roll_cmd = pomdp_roll1 * _sign;
+    init_actions(POMDP_MODE_EXPLORE);
+    float aspd = _sc->get_aspd();
+    float eas2tas = _sc->get_eas2tas();
+    // This assumes that SoaringController called get_position(_prev_update_location) right before this call to init_thermalling
+    _pomdp_wp = _sc->_prev_update_location;
+    _sc->get_relative_position_wrt_home(_pomdp_vecNE);
+    //printf("_pomdp_wp = %f %f\n", ((double)_pomdp_wp.lat) * 1e-7, ((double)_pomdp_wp.lng) * 1e-7);
+    float hdx, hdy;
+    _sc->get_heading_estimate(&hdx, &hdy);
+    float wind_corrected_heading = atan2f(hdy, hdx);
+
+    // Prepare everything necessary for generating action trajectories (by modelling trajectories resulting from various commanded roll angles)
+    _solver.set_pid_gains(_gains.P, _gains.I, _gains.D, _gains.FF, _gains.tau, _gains.imax, _gains.rmax, _scaling_speed);
+    _solver.set_polar(float(poly_a), float(poly_b), float(poly_c));
+    _n_action_samples = pomdp_hori * pomdp_k;
+
+    _solver.generate_action_paths(aspd, eas2tas, wind_corrected_heading, degrees(_sc->get_roll()),
+        degrees(_sc->get_rate()), _pomdp_roll_cmd, pomdp_k, _n_actions, _roll_cmds,
+        pomdp_step_t, pomdp_hori, float(I_moment), float(k_aileron), float(k_roll_damping), float(c_lp), 0);
+    _m = 0;
+    _solver.init_step(pomdp_loop_load, pomdp_n, _sc->_ekf.X, _sc->_ekf.P, _sc->_ekf.Q, _sc->_ekf.R, _weights, false);
+    // This assumes that SoaringController updated _thermal_start_time_us right before this call to init_thermalling
+    _prev_pomdp_update_time = _sc->_thermal_start_time_us;
+    _prev_pomdp_wp = _sc->_prev_update_location;
+    _pomdp_active = true;
+    _pomdp_mode = POMDP_MODE_EXPLORE;
+    _prev_pomdp_action = _sign > 0 ? _n_actions - 1 : 0;
+}
+
+
+float POMDSoarAlgorithm::assess_thermalability(uint8_t exit_mode)
+{
+    float thermalability = -1e6;
+    float aspd = _sc->get_aspd();
+
+    if (exit_mode == 1)
+    {
+        float expected_thermalling_sink = _sc->correct_netto_rate(0.0f, radians(_pomdp_roll_cmd), aspd);
+        float dist_sqr = _sc->_ekf.X[2] * _sc->_ekf.X[2] + _sc->_ekf.X[3] * _sc->_ekf.X[3];
+        thermalability = (_sc->_ekf.X[0] * expf(-dist_sqr / powf(_sc->_ekf.X[1], 2))) - expected_thermalling_sink;
+    }
+    else if (exit_mode == 2)
+    {
+        int n_samps = 20;
+        float theta_step = fmax(pomdp_roll1, pomdp_roll2) / (float)n_samps;
+        float theta = 0;
+
+        for (int i = 0; i < n_samps; i++)
+        {
+            float expected_thermalling_sink = _sc->correct_netto_rate(0.0f, radians(theta), aspd);
+            float r = (aspd * aspd) / (GRAVITY_MSS * tanf(radians(theta)));
+            thermalability = MAX(thermalability, (_sc->_ekf.X[0] * expf(-(r*r) / powf(_sc->_ekf.X[1], 2))) - expected_thermalling_sink);
+            theta += theta_step;
+        }
+    }
+
+    return thermalability;
+}
+
+
+bool POMDSoarAlgorithm::are_computations_in_progress()
+{
+    return _pomdp_active;
+}
+
+
+void POMDSoarAlgorithm::update_solver()
+{
+    if (_solver.running())
+    {
+        uint64_t start_time = AP_HAL::micros64();
+        _solver.update();
+        _pomp_loop_time = AP_HAL::micros64() - start_time;
+        //gcs().send_text(MAV_SEVERITY_INFO, "slice time: %lluus  samps: %d", _pomp_loop_time, samps);
+        _pomp_loop_min_time = (_pomp_loop_min_time > _pomp_loop_time) ? _pomp_loop_time : _pomp_loop_min_time;
+        _pomp_loop_max_time = (_pomp_loop_max_time < _pomp_loop_time) ? _pomp_loop_time : _pomp_loop_max_time;
+        _pomp_loop_av_time = _pomp_loop_av_time * 0.9 + _pomp_loop_time * 0.1;
+    }
+}
+
+
+void POMDSoarAlgorithm::update_solver_test()
+{
+    _solver.update_test();
+}
+
+
+void POMDSoarAlgorithm::stop_computations()
+{
+    _pomdp_active = false;
+}
+
+
+bool POMDSoarAlgorithm::is_set_to_continue_past_thermal_locking_period()
+{
+    return (pomdp_pth > 0);
+}
+
+
+int POMDSoarAlgorithm::get_curr_mode()
+{
+    return _pomdp_mode;
+}
+
+
+uint64_t POMDSoarAlgorithm::get_latest_pomdp_solve_time()
+{
+    return _pomdp_solve_time;
+}
+
+
+float POMDSoarAlgorithm::get_action()
+{
+    return _pomdp_roll_cmd * 100;
+}
+
+
+void POMDSoarAlgorithm::send_test_out_msg(mavlink_channel_t chan)
+{
+    /*
+    0: pomdp_wp.lat (y0)
+    4: pomdp_wp.lng (x0)
+    8:  v0
+    10: psi0
+    12: x1,y1,psi1,x2,y2,psi2,x3,y3,psi3,x4,y4,psi4
+    36: x1,y1,psi1,x2,y2,psi2,x3,y3,psi3,x4,y4,psi4
+    60: a1
+    61: a2
+    62-63: 2 bytes spare
+    */
+    // uint8_t *_debug_out_bytes = (uint8_t *)&_debug_out[0];
+    // uint8_t *a1 = &_debug_out_bytes[60];
+    // uint8_t *a2 = &_debug_out_bytes[61];
+
+    // if (_pomdp_active && _m < _solver.actions_generated())
+    // {
+    //     _debug_out_mode = 0;
+    //     int32_t *pos_ptr = (int32_t *)(&_debug_out[0]);
+    //     pos_ptr[0] = _pomdp_wp.lat;
+    //     pos_ptr[1] = _pomdp_wp.lng;
+
+    //     int16_t *v0 = (int16_t *)&_debug_out_bytes[8];
+    //     *v0 = (int16_t)(_solver.get_action_v0() * 256);
+
+    //     int16_t *psi0 = (int16_t *)&_debug_out_bytes[10];
+    //     *psi0 = (int16_t)(_solver.get_action_path_psi(0, 0) * 256);
+
+    //     int16_t *action1 = (int16_t *)&_debug_out_bytes[12];
+    //     int16_t *action2 = (int16_t *)&_debug_out_bytes[36];
+
+    //     int k_step = _n_action_samples / 4;
+    //     *a1 = _m;
+    //     int k = k_step;
+
+    //     for (int i = 0; i < 12; i += 3)
+    //     {
+    //         action1[i] = (int16_t)(_solver.get_action_path_x(_m, k) * 256);
+    //         action1[i + 1] = (int16_t)(_solver.get_action_path_y(_m, k) * 256);
+    //         action1[i + 2] = (int16_t)(_solver.get_action_path_psi(_m, k) * 256);
+    //         k += k_step;
+    //     }
+
+    //     _m++;
+
+    //     if (_m < _n_actions && _m < _solver.actions_generated())
+    //     {
+    //         *a2 = _m;
+    //         k = k_step;
+
+    //         for (int i = 0; i < 12; i += 3) {
+    //             action2[i] = (int16_t)(_solver.get_action_path_x(_m, k) * 256);
+    //             action2[i + 1] = (int16_t)(_solver.get_action_path_y(_m, k) * 256);
+    //             action2[i + 2] = (int16_t)(_solver.get_action_path_psi(_m, k) * 256);
+    //             k += k_step;
+    //         }
+    //     }
+    //     else
+    //     {
+    //         *a2 = 255;
+    //     }
+
+    //     _m++;
+
+    //     if (_m >= _n_actions)
+    //     {
+    //         _m = 0;
+    //     }
+    // }
+    // else
+    // {
+    //     _debug_out_mode = 0;
+    //     *a1 = 255; // action = 255 to signal no more action data
+    //     *a2 = 255; // action = 255 to signal no more action data
+    // }
+
+    // mavlink_msg_soar_test_out_send(
+    //     chan,
+    //     _debug_out_mode,
+    //     _debug_out); //<field name = "debug" type = "float[16]">Debug results< / field>
+}
+
+
+void POMDSoarAlgorithm::update_thermalling(const Location &current_loc)
+{
+    if (!_solver.running())
+    {
+        _pomdp_solve_time = AP_HAL::micros64() - _prev_pomdp_update_time;
+
+        float eas2tas = _sc->get_eas2tas();
+        float aspd = _sc->get_aspd();
+        uint8_t action = (uint8_t)_solver.get_best_action();
+        _pomdp_roll_cmd = _roll_cmds[action];
+
+        _sc->get_relative_position_wrt_home(_pomdp_vecNE);
+        float hdx, hdy;
+        _sc->get_heading_estimate(&hdx, &hdy);
+        float wind_corrected_heading = atan2f(hdy, hdx);
+        //gcs().send_text(MAV_SEVERITY_INFO, "head %f %f %f", hdx, hdy, wind_corrected_heading);
+        float n[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+        // Normalise the trace of covariance matrix, if required.
+        if (pomdp_norm_pth)
+        {
+            n[0] = fabsf(_sc->_ekf.X[0]) > 0.0f ? fabsf(_sc->_ekf.X[0]) : 1.0f;
+            n[1] = fabsf(_sc->_ekf.X[1]) > 0.0f ? fabsf(_sc->_ekf.X[1]) : 1.0f;
+            n[2] = n[1];
+            n[3] = n[1];
+        }
+
+        float trP = _sc->_ekf.P(0, 0) / n[0] + _sc->_ekf.P(1, 1) / n[1] + _sc->_ekf.P(2, 2) / n[2] + _sc->_ekf.P(3, 3) / n[3];
+
+        // Update the correct mode (exploit vs explore) based on EKF covariance trace
+        _pomdp_mode = trP < pomdp_pth && pomdp_pth > 0.0f ? POMPD_MODE_EXPLOIT : POMPD_MODE_EXPLORE;
+        
+        // Initialise actions accordingly.
+        init_actions(_pomdp_mode);
+
+        // Determine appropriate number of action samples. Planning horizon in seconds times times samples/second.
+        _n_action_samples = pomdp_hori * pomdp_k;
+
+        if (_pomdp_mode==POMDP_MODE_EXPLOIT)
+        {
+            // Extend horizon in exploitation mode.
+            _n_action_samples = MIN(MAX_ACTION_SAMPLES, int(pomdp_hori * pomdp_k * pomdp_extend));
+        }
+
+        //  Determine appropriate number of samples.
+        //  pompd_n = "Number of samples per action trajectory" - how is this different from n_action_samples?
+        int n_samples = pomdp_n;
+        float step_w = 1.0f;
+
+        if (_pomdp_mode==POMDP_MODE_EXPLOIT && pomdp_plan_mode)
+        {
+            // "Enable deterministic trajectory planning mode for the POMDP"
+            n_samples = 1;
+            step_w = 1.0f / pomdp_n;
+        }
+
+        _solver.generate_action_paths(aspd, eas2tas, wind_corrected_heading, degrees(_sc->get_roll()), degrees(_sc->get_rate()), _pomdp_roll_cmd, pomdp_k, _n_actions, _roll_cmds,
+            pomdp_step_t * step_w, pomdp_hori, float(I_moment), float(k_aileron), float(k_roll_damping), float(c_lp), pomdp_extend);
+        _m = 0;
+        _solver.init_step(pomdp_loop_load, n_samples, _sc->_ekf.X, _sc->_ekf.P, _sc->_ekf.Q, _sc->_ekf.R, _weights, _pomdp_mode==POMDP_MODE_EXPLOIT);
+
+        _prev_pomdp_update_time = AP_HAL::micros64();
+        _prev_pomdp_action = action;
+
+        DataFlash_Class::instance()->Log_Write("POMP", "TimeUS,n,k,action,x,y,sign,lat,lng,rlat,rlng,roll,mode,Q", "QQHHBfffLLLLfB",
+            AP_HAL::micros64(),
+            pomdp_n,
+            pomdp_k,
+            action,
+            (double)_pomdp_vecNE.y,
+            (double)_pomdp_vecNE.x,
+            (double)_sign,
+            current_loc.lat,
+            current_loc.lng,
+            _pomdp_wp.lat,
+            _pomdp_wp.lng,
+            (double)_pomdp_roll_cmd,
+            (uint8_t)_pomdp_mode,
+            (double)_solver.get_action_Q(action));
+        DataFlash_Class::instance()->Log_Write("POMT", "TimeUS,loop_min,loop_max,loop_time,solve_time,load,n,k", "QQQQQQHHH",
+            AP_HAL::micros64(),
+            _pomp_loop_min_time,
+            _pomp_loop_max_time,
+            _pomp_loop_time,
+            _pomdp_solve_time,
+            pomdp_loop_load,
+            pomdp_n,
+            pomdp_k
+        );
+        DataFlash_Class::instance()->Log_Write("PDBG", "TimeUS,lat,lng,v0,psi,x1,y1,x2,y2,x3,y3,x4,y4,x5,y5,x6,y6", "QLLffffffffffffff",
+            AP_HAL::micros64(),
+            _pomdp_wp.lat,
+            _pomdp_wp.lng,
+            (double)_solver.get_action_v0(),
+            (double)_solver.get_action_path_psi(action, 0),
+            (double)_solver.get_action_path_x(action, 1),
+            (double)_solver.get_action_path_y(action, 1),
+            (double)_solver.get_action_path_x(action, 2),
+            (double)_solver.get_action_path_y(action, 2),
+            (double)_solver.get_action_path_x(action, 3),
+            (double)_solver.get_action_path_y(action, 3),
+            (double)_solver.get_action_path_x(action, 4),
+            (double)_solver.get_action_path_y(action, 4),
+            (double)_solver.get_action_path_x(action, 5),
+            (double)_solver.get_action_path_y(action, 5),
+            (double)_solver.get_action_path_x(action, 6),
+            (double)_solver.get_action_path_y(action, 6)
+        );
+
+        _pomdp_wp = current_loc;
+        _prev_pomdp_wp = current_loc;
+        _pomp_loop_min_time = (unsigned long)1e12;
+        _pomp_loop_max_time = 0;
+    }
+}
+
+bool POMDSoarAlgorithm::ok_to_stop()
+{
+    return (!_solver.running() && is_set_to_continue_past_thermal_locking_period());
+}
+
+
+void POMDSoarAlgorithm::run_tests()
+{
+    int8_t test_id = 1;
+    uint64_t start_time = AP_HAL::micros64();
+    uint64_t total_time   = 0;
+    uint64_t total_time_2 = 0;
+
+    switch (test_id) {
+    case 1:
+        _solver.run_exp_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring exp test: %llu us", total_time);
+        break;
+    case 2:
+        _solver.run_fast_exp_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring fast exp test: %llu us", total_time);
+        break;
+    case 3:
+        _solver.fill_random_array();
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring fill rnd array: %llu us", total_time);
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring fill rnd array: %llu us", total_time);
+        break;
+    case 4:
+        _solver.run_rnd_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring rnd test: %llu us", total_time);
+        break;
+    case 5:
+        _solver.run_ekf_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring EKF test: %llu us", total_time);
+        break;
+    case 6:
+        _solver.run_loop_test(1000, false);
+        total_time = AP_HAL::micros64() - start_time;
+        start_time = AP_HAL::micros64();
+        _solver.run_loop_test(1000, true);
+        total_time_2 = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring loop test: %llu us ML: %llu us", total_time, total_time_2);
+        break;
+    case 7:
+        _solver.run_multivariate_normal_sample_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring multivariate_normal test: %llu us", total_time);
+        break;
+    case 8:
+        // test #8 is run by the SoaringController class itself
+        break;
+    case 9:
+        _solver.run_trig_box_muller_test(1000);
+        total_time = AP_HAL::micros64() - start_time;
+        start_time = AP_HAL::micros64();
+        _solver.run_polar_box_muller_test(1000);
+        total_time_2 = AP_HAL::micros64() - start_time;
+        gcs().send_text(MAV_SEVERITY_INFO, "Soaring box-muller trig: %llu us polar: %llu us", total_time, total_time_2);
+        break;
+    }
+
+    _prev_run_timing_test = test_id;
+}

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("HORI", 4, POMDSoarAlgorithm, pomdp_hori, 4.0),
 
-    // @Param: STEP_T
+    // @Param: STEP
     // @DisplayName:POMDP planning step solve time
     // @Description: The amount of computation time the POMDP solver has for computing the next action
     // @Units: seconds
@@ -55,29 +55,29 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("LOOP", 6, POMDSoarAlgorithm, pomdp_loop_load, 1),
 
-    // @Param: ROLL1
+    // @Param: RLLMAX
     // @DisplayName: POMDP's maximum commanded roll angle.
     // @Description: Maximum commanded roll angle in the POMDP used by POMDSoar.
     // @Units: degrees
     // @Range: 0 1000
     // @User: Advanced
-    AP_GROUPINFO("ROLL1", 7, POMDSoarAlgorithm, pomdp_roll1, 15),
+    AP_GROUPINFO("RLLMAX", 7, POMDSoarAlgorithm, pomdp_roll1, 15),
 
-    // @Param: ROLL2
+    // @Param: RLLMIN
     // @DisplayName: POMDP's minimum commanded roll angle.
     // @Description: Minimum commanded roll angle in the POMDP used by POMDSoar.
     // @Units: degrees
     // @Range: 0 1000
     // @User: Advanced
-    AP_GROUPINFO("ROLL2", 8, POMDSoarAlgorithm, pomdp_roll2, 45),
+    AP_GROUPINFO("RLLMIN", 8, POMDSoarAlgorithm, pomdp_roll2, 45),
 
-    // @Param: RRATE
+    // @Param: RLLRT
     // @DisplayName: The sailplane UAV's roll rate increment used by POMDSoar
     // @Description: The sailplane UAV's roll rate increment used by POMDSoar.
     // @Units: degrees/second
     // @Range: 0 1000
     // @User: Advanced
-    AP_GROUPINFO("RRATE", 9, POMDSoarAlgorithm, pomdp_roll_rate, 75),
+    AP_GROUPINFO("RLLRT", 9, POMDSoarAlgorithm, pomdp_roll_rate, 75),
 
     // @Param: N_ACT
     // @DisplayName: POMDP number of actions
@@ -87,7 +87,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("N_ACT", 10, POMDSoarAlgorithm, pomdp_n_actions, 2),
 
-    // @Param: I_MOMENT
+    // @Param: I_MOM
     // @DisplayName: I-moment coefficient
     // @Description: Airframe-specific I-moment coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
     // @Units:
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("I_MOM", 11, POMDSoarAlgorithm, I_moment, 0.00257482),
 
-    // @Param: K_AILERON
+    // @Param: K_AIL
     // @DisplayName: Aileron K coefficient
     // @Description: Airframe-specific aileron K coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
     // @Units: seconds
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("K_AIL", 12, POMDSoarAlgorithm, k_aileron, 1.44833047),
 
-    // @Param: K_ROLLDAMP
+    // @Param: RLLDMP
     // @DisplayName: Roll dampening K coefficient
     // @Description: Airframe-specific roll-dampening K coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
     // @Units:
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RLLDMP", 13, POMDSoarAlgorithm, k_roll_damping, 0.41073589),
 
-    // @Param: ROLL_CLP
+    // @Param: RLLCLP
     // @DisplayName: CLP coefficient
     // @Description: Airframe-specific CLP coefficient used by POMDSoar to model the trajectory corresponding to a given commanded roll angle.
     // @Units:
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("POLY_C", 17, POMDSoarAlgorithm, poly_c, -2.30292972),
 
-    // @Param: TH
+    // @Param: PTH
     // @DisplayName: POMDSoar's threshold on tr(P) for switching between explore and max-lift modes.
     // @Description: POMDSoar's threshold on the P matrix trace for switching between explore and max-lift modes.
     // @Units:
@@ -167,13 +167,13 @@ const AP_Param::GroupInfo POMDSoarAlgorithm::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("EXT", 20, POMDSoarAlgorithm, pomdp_extend, 0),
 
-    // @Param: PLN
+    // @Param: PLAN
     // @DisplayName: Enable deterministic trajectory planning mode for the POMDP
     // @Description: Enable deterministic trajectory planning mode for the POMDP. 0 = off, 1 on.
     // @Units:
     // @Range: 0 1
     // @User: Advanced
-    AP_GROUPINFO("PLN", 21, POMDSoarAlgorithm, pomdp_plan_mode, 0),
+    AP_GROUPINFO("PLAN", 21, POMDSoarAlgorithm, pomdp_plan_mode, 0),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -219,6 +219,7 @@ void POMDSoarAlgorithm::init_actions(POMDP_Mode mode)
                 //gcs().send_text(MAV_SEVERITY_INFO, "Action[%d] %f", i, (double)_roll_cmds[i]);
                 roll -= roll_rate;
             }
+            break;
         }
         case POMDP_MODE_EXPLORE:
         {
@@ -230,6 +231,7 @@ void POMDSoarAlgorithm::init_actions(POMDP_Mode mode)
                 //gcs().send_text(MAV_SEVERITY_INFO, "Action[%d] %f", i, (double)_roll_cmds[i]);
                 roll -= roll_rate;
             }
+            break;
         }
     }
 

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -261,8 +261,7 @@ void POMDSoarAlgorithm::init_thermalling()
 
     _solver.init_step(pomdp_loop_load, pomdp_n, _sc->_ekf.X, _sc->_ekf.P, _sc->_ekf.Q, _sc->_ekf.R, _weights, false);
     
-    // This assumes that SoaringController updated _thermal_start_time_us right before this call to init_thermalling
-    _prev_pomdp_update_time = _sc->_thermal_start_time_us;
+    _prev_pomdp_update_time = AP_HAL::micros64();
     _prev_pomdp_wp          = _sc->_prev_update_location;
     _pomdp_active      = true;
     _pomdp_mode        = POMDP_MODE_EXPLORE;

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -463,9 +463,8 @@ void POMDSoarAlgorithm::update_thermalling(const Location &current_loc)
         _pomdp_roll_cmd = _roll_cmds[action];
 
         _sc->get_relative_position_wrt_home(_pomdp_vecNE);
-        float hdx, hdy;
-        _sc->get_heading_estimate(&hdx, &hdy);
-        float wind_corrected_heading = atan2f(hdy, hdx);
+        
+        float heading = _sc->get_yaw();
         //gcs().send_text(MAV_SEVERITY_INFO, "head %f %f %f", hdx, hdy, wind_corrected_heading);
         float n[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
 
@@ -507,7 +506,7 @@ void POMDSoarAlgorithm::update_thermalling(const Location &current_loc)
             step_w = 1.0f / pomdp_n;
         }
 
-        _solver.generate_action_paths(aspd, eas2tas, wind_corrected_heading, degrees(_sc->get_roll()), degrees(_sc->get_rate()), _pomdp_roll_cmd, pomdp_k, _n_actions, _roll_cmds,
+        _solver.generate_action_paths(aspd, eas2tas, heading, degrees(_sc->get_roll()), degrees(_sc->get_rate()), _pomdp_roll_cmd, pomdp_k, _n_actions, _roll_cmds,
             pomdp_step_t * step_w, pomdp_hori, float(I_moment), float(k_aileron), float(k_roll_damping), float(c_lp), pomdp_extend);
         _m = 0;
         _solver.init_step(pomdp_loop_load, n_samples, _sc->_ekf.X, _sc->_ekf.P, _sc->_ekf.Q, _sc->_ekf.R, _weights, _pomdp_mode==POMDP_MODE_EXPLOIT);

--- a/libraries/AP_Soaring/POMDP_Soar.cpp
+++ b/libraries/AP_Soaring/POMDP_Soar.cpp
@@ -242,8 +242,9 @@ void POMDSoarAlgorithm::init_actions(POMDP_Mode mode)
 void POMDSoarAlgorithm::init_thermalling()
 {
     Vector2f ground_vector = _sc->_ahrs.groundspeed_vector();
-    float head_sin = ground_vector.y / ground_vector.length();
-    float head_cos = ground_vector.x / ground_vector.length();
+    float L = ground_vector.length();
+    float head_sin = ground_vector.y / L;
+    float head_cos = ground_vector.x / L;
 
     float xprod = _sc->_ekf.X[3] * head_cos - _sc->_ekf.X[2] * head_sin;
     _sign = xprod <= 0 ? -1.0 : 1.0;

--- a/libraries/AP_Soaring/POMDP_Soar.h
+++ b/libraries/AP_Soaring/POMDP_Soar.h
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#pragma once
+
+#include <APM_Control/APM_Control.h>
+#include "POMDP_Solver.h"
+class SoaringController;
+
+enum POMDP_Mode
+{
+    POMDP_MODE_EXPLORE = 0,
+    POMDP_MODE_EXPLOIT = 1
+};
+
+//
+// POMDSoarAlgorithm, the POMDP/Bayesian RL-based logic used by SoaringController to decide on the course of action
+//
+class POMDSoarAlgorithm
+{
+    friend class SoaringController;
+
+private:
+    float _roll_cmds[MAX_ACTIONS];
+    int _n_actions = 2;
+    int _prev_n_actions = 2;
+    bool _pomdp_active = false;
+    Location _pomdp_wp;
+    Location _prev_pomdp_wp;
+    float _sign = 1;
+    float _pomdp_radius;
+    uint64_t _prev_pomdp_update_time = 0;
+    int _prev_pomdp_action = 0;
+    uint64_t _pomdp_solve_time;
+    uint64_t _pomp_loop_time;
+    uint64_t _pomp_loop_min_time;
+    uint64_t _pomp_loop_max_time;
+    uint64_t _pomp_loop_av_time = 0;
+    float _pomdp_roll_cmd = 0;
+    Vector2f _pomdp_vecNE;
+    int _m = 0;
+    int _j = 0;
+    int _n_action_samples;
+    bool _new_actions_to_send = false;
+    POMDP_Mode _pomdp_mode = POMDP_MODE_EXPLORE;
+    float _weights[4] = { 1, 1, 1, 1 };
+    uint8_t _prev_run_timing_test;
+
+    float _debug_out[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    uint8_t _debug_out_mode;
+
+    const AP_AutoTune::ATGains &_gains;
+    AP_Float &_scaling_speed;
+    PomdpSolver _solver;
+    const SoaringController *_sc;
+
+    AP_Int8 pomdp_on;
+    AP_Float poly_a;
+    AP_Float poly_b;
+    AP_Float poly_c;
+    AP_Int16 pomdp_n;
+    AP_Int16 pomdp_k;
+    AP_Float pomdp_hori;
+    AP_Float pomdp_roll1;
+    AP_Float pomdp_roll2;
+    AP_Float pomdp_step_t;
+    AP_Float pomdp_loop_load;
+    AP_Int8 pomdp_n_actions;
+    AP_Float pomdp_roll_rate;
+    AP_Float I_moment;
+    AP_Float k_aileron;
+    AP_Float k_roll_damping;
+    AP_Float c_lp;
+    AP_Int8 pomdp_norm_pth;
+    AP_Int8 pomdp_extend;
+    AP_Int8 pomdp_plan_mode;
+    AP_Float pomdp_pth;
+
+    void init_actions(POMDP_Mode mode);
+
+public:
+    POMDSoarAlgorithm(const SoaringController *sc, AP_RollController &rollController, AP_Float &scaling_speed);
+    static const struct AP_Param::GroupInfo var_info[];
+    void init_thermalling();
+    float assess_thermalability(uint8_t exit_mode);
+    bool are_computations_in_progress();
+    void stop_computations();
+    void update_solver();
+    void update_solver_test();
+    bool is_set_to_continue_past_thermal_locking_period();
+    int get_curr_mode();
+    uint64_t get_latest_pomdp_solve_time();
+    float get_action();
+    void send_test_out_msg(mavlink_channel_t chan);
+    void update_thermalling(const Location &current_loc);
+    void run_tests();
+    bool ok_to_stop();
+};

--- a/libraries/AP_Soaring/POMDP_Soar.h
+++ b/libraries/AP_Soaring/POMDP_Soar.h
@@ -27,7 +27,6 @@ private:
     bool _pomdp_active = false;
     Location _pomdp_wp;
     Location _prev_pomdp_wp;
-    float _sign = 1;
     float _pomdp_radius;
     uint64_t _prev_pomdp_update_time = 0;
     int _prev_pomdp_action = 0;
@@ -38,7 +37,6 @@ private:
     uint64_t _pomp_loop_av_time = 0;
     float _pomdp_roll_cmd = 0;
     Vector2f _pomdp_vecNE;
-    int _m = 0;
     int _j = 0;
     int _n_action_samples;
     bool _new_actions_to_send = false;
@@ -91,7 +89,6 @@ public:
     int get_curr_mode();
     uint64_t get_latest_pomdp_solve_time();
     float get_action();
-    void send_test_out_msg(mavlink_channel_t chan);
     void update_thermalling(const Location &current_loc);
     void run_tests();
     bool ok_to_stop();

--- a/libraries/AP_Soaring/POMDP_Soar.h
+++ b/libraries/AP_Soaring/POMDP_Soar.h
@@ -69,7 +69,6 @@ private:
     AP_Float k_aileron;
     AP_Float k_roll_damping;
     AP_Float c_lp;
-    AP_Int8 pomdp_norm_pth;
     AP_Int8 pomdp_extend;
     AP_Int8 pomdp_plan_mode;
     AP_Float pomdp_pth;

--- a/libraries/AP_Soaring/POMDP_Solver.cpp
+++ b/libraries/AP_Soaring/POMDP_Solver.cpp
@@ -1,0 +1,659 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#include "POMDP_Solver.h"
+#include <GCS_MAVLink/GCS.h>
+
+#define EKF_FAST_MATH
+
+#ifdef EKF_FAST_MATH
+static union
+{
+    float d;
+    int i;
+} _eco;
+#define EXP_A 12102203 /* int(1<<23/math.log(2)) */
+#define EXP_C 0 /* see text for choice of c values */
+
+// Adapted from Schraudolph, "A Fast, Compact Approximation if the Exponential Function",
+// Tech Report UDSIA-07-98
+#define fastexp(y) (_eco.i = EXP_A*(y)+(1065353216 - EXP_C), _eco.d)
+/*
+in the above fastexp macro:
+values of x around -88 to -89 can result in NaN,
+values below about -89 are not valid:
+x                                    hex value                                 hex value
+-88.0    exp(x) = 6.0546014852e-39   41edc4      fastexp(x) = 5.0357061614e-40     57bc0
+-88.5    exp(x) = 3.6723016101e-39   27fce2      fastexp(x) = NaN               ffa92680
+-89.0    exp(x) = 2.2273639090e-39   1840fc      fastexp(x) = -2.7225029733e+38 ff4cd180
+so we check that x is than 88 to avoid this.
+(Note we also assume here that x is always negative, which is the case when used in a gaussian)
+*/
+
+#define EXP(x) ( (x) > -88.0f ? fastexp(x) : 0.0 )
+#else
+#define EXP(x) expf(x)
+#endif
+
+#define fastarctan(x) ( M_PI_4*(x) - (x)*(fabs(x) - 1)*(0.2447 + 0.0663*fabs(x)) )
+
+PomdpSolver::PomdpSolver()
+{
+    fill_random_array();
+    _i_ptr = 0;
+    _s_ptr = 0;
+}
+
+
+// This as mostly a cut and paste of the _get_rate_out() from AP_RollController.cpp
+// so that we can model the aileron PID controller
+float PomdpSolver::_get_rate_out(float dt, float aspeed, float eas2tas, float achieved_rate, float desired_rate)
+{
+    // Calculate equivalent gains so that values for K_P and K_I can be taken across from the old PID law
+    // No conversion is required for K_D
+    float ki_rate = gains.I * gains.tau;
+    float kp_ff = MAX((gains.P - gains.I * gains.tau) * gains.tau - gains.D, 0) / eas2tas;
+    float k_ff = gains.FF / eas2tas;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+    // Limit the demanded roll rate
+    if (gains.rmax && desired_rate < -gains.rmax) {
+        desired_rate = -gains.rmax;
+    }
+    else if (gains.rmax && desired_rate > gains.rmax) {
+        desired_rate = gains.rmax;
+    }
+#pragma GCC diagnostic pop
+    float scaler = 2.0;
+
+    if (aspeed > 0.0001f)
+    {
+        scaler = _scaling_speed / aspeed;
+    }
+    scaler = constrain_float(scaler, 0.5f, 2.0f);
+    float rate_error = (desired_rate - achieved_rate) * scaler;
+
+    // Multiply roll rate error by _ki_rate, apply scaler and integrate
+    // Scaler is applied before integrator so that integrator state relates directly to aileron deflection
+    // This means aileron trim offset doesn't change as the value of scaler changes with airspeed
+    if (ki_rate > 0) 
+    {
+        // only integrate if airspeed above min value.
+        if (aspeed > float(_aparm.airspeed_min))
+        {
+            float integrator_delta = rate_error * ki_rate * dt * scaler;
+            // prevent the integrator from increasing if surface defln demand is above the upper limit
+            if (_last_out < -45)
+            {
+                integrator_delta = MAX(integrator_delta, 0);
+            }
+            else if (_last_out > 45)
+            {
+                // prevent the integrator from decreasing if surface defln demand  is below the lower limit
+                integrator_delta = MIN(integrator_delta, 0);
+            }
+            _pid_I += integrator_delta;
+        }
+    }
+    else
+    {
+        _pid_I = 0;
+    }
+
+    // Scale the integration limit
+    float intLimScaled = gains.imax * 0.01f;
+
+    // Constrain the integrator state
+    _pid_I = constrain_float(_pid_I, -intLimScaled, intLimScaled);
+
+    // Calculate the demanded control surface deflection
+    // Note the scaler is applied again. We want a 1/speed scaler applied to the feed-forward
+    // path, but want a 1/speed^2 scaler applied to the rate error path. 
+    // This is because acceleration scales with speed^2, but rate scales with speed.
+    _pid_D = rate_error * gains.D * scaler;
+    _pid_P = desired_rate * kp_ff * scaler;
+    _pid_FF = desired_rate * k_ff * scaler;
+    _pid_desired = desired_rate;
+
+    _last_out = _pid_FF + _pid_P + _pid_D + _pid_I;
+
+    //  constrain
+    return constrain_float(_last_out, -45, 45);
+}
+
+
+void PomdpSolver::set_pid_gains(float P, float I, float D, float FF, float tau, float imax, float rmax, float scaling_speed)
+{
+    gains.P = P;
+    gains.I = I;
+    gains.D = D;
+    gains.FF = FF;
+    gains.tau = tau;
+    gains.imax = imax;
+    gains.rmax = rmax;
+    _scaling_speed = scaling_speed;
+}
+
+
+void PomdpSolver::set_polar(float poly_a, float poly_b, float poly_c)
+{
+    _poly_a = poly_a;
+    _poly_b = poly_b;
+    _poly_c = poly_c;
+}
+
+
+void PomdpSolver::generate_action_paths(float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, int nactions, float* action,
+    float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int extend)
+{
+    _v0 = v0;
+    int k = int(t_hori * pomdp_k);
+    _t_hori = t_hori;
+    _t_step = t_step;
+
+    if (extend > 1)
+    {
+        k = int(extend * t_hori * pomdp_k);
+
+        if (k > MAX_ACTION_SAMPLES)
+        {
+            k = MAX_ACTION_SAMPLES;
+            _t_hori = k / (float)pomdp_k;
+        }
+        else
+        {
+            _t_hori = extend * t_hori;
+        }
+        _t_step = extend * t_step;
+    }
+
+    _actions = action;
+    _eas2tas = eas2tas;
+    _psi0 = psi0;
+    _roll0 = roll0;
+    _roll_rate0 = roll_rate0;
+    _I_moment = I_moment;
+    _k_aileron = k_aileron;
+    _k_roll_damping = k_roll_damping;
+    _c_lp = c_lp;
+    _extend = extend;
+    //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "gact k:%d", k);
+    _k = k;
+    _nactions = nactions;
+    _prev_action = current_action;
+}
+
+void PomdpSolver::generate_action(int m, float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int k, int nactions, float* action,
+    float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int j0, int j1)
+{
+    const int rate_x = 10;
+    const float g = -9.80665;
+    float dt = t_hori / (k * rate_x);
+    //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "gact %f %f %f %f %f %f", v0, psi0, roll0, roll_rate0, action[0], action[1]);
+    float px = 0.0f;
+    float py = 0.0f;
+    float psi = psi0;
+    float theta_cmd = current_action;
+    float theta = roll0;
+    float theta_rate = roll_rate0;
+    float t = dt;
+
+    if (j0 == 0)
+    {
+        _pid_I = 0;
+        //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "])", m + 1);
+        _action_path_x[m][0] = px;
+        _action_path_y[m][0] = py;
+        _action_path_psi[m][0] = psi;
+        _action_path_theta[m][0] = theta;
+    }
+    else {
+        px = _action_path_x[m][j0];
+        py = _action_path_y[m][j0];
+        psi = _action_path_psi[m][j0];
+        theta = _action_path_theta[m][j0];
+        theta_rate = _theta_rate;
+        t = _t;
+    }
+
+    for (int j = j0; j < k && j < j1; j++)
+    {	
+        for (int i = 0; i < rate_x; i++)
+        {
+            if (t > t_step)
+            {
+                theta_cmd = action[m];
+            }
+            else
+            {
+                theta_cmd = current_action;
+            }
+
+            float C_lp = -c_lp * (theta_rate) / (2 * v0);
+            float desired_rate = (theta_cmd - theta) / gains.tau;
+            float aileron_out = _get_rate_out(dt, v0, eas2tas, theta_rate, desired_rate) / 45.0f;
+            float theta_acc = (aileron_out * k_aileron - k_roll_damping * C_lp) / I_moment;
+            theta_rate += theta_acc * dt;
+            theta += theta_rate * dt;
+            psi -= dt * (g * tanf((theta * M_PI) / 180.0f) / v0);
+            px += dt * v0 * sinf(psi);
+            py += dt * v0 * cosf(psi);
+            t += dt;
+        }
+
+        _action_path_x[m][j + 1] = px;
+        _action_path_y[m][j + 1] = py;
+        _action_path_psi[m][j + 1] = psi;
+        _action_path_theta[m][j + 1] = theta;
+        //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "%3u j:%2d m:%2d %f %f %f %f", _slice_count, j+1, m, px, py, theta_cmd, t);
+        //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "[%f, %f],", px,py);
+    }
+        
+    //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "a%d = np.array([", m + 1);
+    _theta_rate = theta_rate;
+    _t = t;
+    _log_j = 0; //start logging new actions
+    _new_actions = true;
+}
+
+
+void PomdpSolver::log_actions(uint64_t thermal_id)
+{
+    if (_new_actions && _log_j < _k + 1)
+    {
+        for (int m = 0; m < _nactions; m++) 
+        {
+            DataFlash_Class::instance()->Log_Write("POMA", "TimeUS,id,m,j,x,y,roll",
+                "QQBBfff",
+                AP_HAL::micros64(),
+                thermal_id,
+                m, _log_j,
+                (double)_action_path_x[m][_log_j],
+                (double)_action_path_y[m][_log_j],
+                (double)_action_path_theta[m][_log_j]
+            );
+        }
+        _log_j++;
+    }
+    else
+    {
+        _new_actions = false;
+    }
+}
+
+
+void PomdpSolver::init_step(int max_loops, int n,
+    const VectorN<float, 4> &x0, const MatrixN<float, 4> &p0, const MatrixN<float, 4> &q0, float r0,
+    float weights[4], bool max_lift)
+{
+    _n = n;
+    _inv_n = 1.0f / (float)n;
+
+    for (int i = 0; i < 4; i++)
+    {
+        _x0[i] = x0[i];
+        _weights[i] = weights[i];	
+    }
+
+    _p0 = p0;
+    _q0 = q0;
+    _r0 = r0;
+    cholesky44(_p0.getarray(),_chol_p0);
+    _max_lift = max_lift;
+    _dt = _t_hori / ((float)_k);
+    _k_t_step = int(_t_step / _dt);
+    _therm_x = _x0[3];
+    _therm_y = _x0[2];
+    _best_action = 0;
+    _i = 0;
+    _j = 0;
+    _m = 0;
+    _Q[0] = 0;
+    _running = true;
+    _loop = 0;
+    _max_loops = max_loops;
+    _generate_actions = true;
+    _start_action_loop = true;
+    _start_sample_loop = true;
+    _slice_count = 0;
+}
+
+
+float PomdpSolver::sink_polar(float aspd, float poly_a, float poly_b, float poly_c, float roll)
+{
+    float netto_rate;
+    float phi = (roll * M_PI) / 180.0f;
+    float cosphi;
+    cosphi = (1 - phi * phi / 2); // first two terms of mclaurin series for cos(phi)
+    netto_rate = (poly_a * aspd* aspd + poly_b * aspd + poly_c) / cosphi;
+    return netto_rate;
+}
+
+
+void PomdpSolver::inner_loop()
+{
+    float px1 = _action_path_x[_m][_j];
+    float py1 = _action_path_y[_m][_j];
+    float rx = px1 - _x;
+    float ry = py1 - _y;
+    float z = _w * EXP(-(rx * rx + ry * ry) / (_r * _r));
+
+    if (_max_lift)
+    {
+        _total_lift += z + sink_polar(_v0, _poly_a, _poly_b, _poly_c, _action_path_theta[_m][_j]);
+    }
+
+    _ekf.update(z, py1 - _py0, px1 - _px0);
+    _px0 = px1;
+    _py0 = py1;
+}
+
+
+void PomdpSolver::sample_loop()
+{
+    float s[4];
+    if (_n > 1)
+    {
+        multivariate_normal(s, _mean, _chol_p0);
+        samp_count++;
+        //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Sample: %f %f %f %f", s[0], s[1], s[2], s[3]);
+        _w = _x0[0] + s[0];
+        _r = _x0[1] + s[1];
+        _x = _therm_x + s[3]; // Note: state vector index 3 = East = x 
+        _y = _therm_y + s[2]; // Note: state vector index 2 = North = y
+    }
+    else {
+        _w = _x0[0];
+        _r = _x0[1];
+        _x = _therm_x;
+        _y = _therm_y;
+    }
+
+    _total_lift = 0;
+    _px0 = 0;
+    _py0 = 0;
+
+    _ekf.reset(_x0, _p0, _q0, _r0);
+}
+
+
+void PomdpSolver::action_loop()
+{
+    if (_max_lift)
+    {
+        _Q[_m] = 0;
+    }
+    else
+    {
+        _Q[_m] = 0;
+    }
+
+    if (_n <= 1) {
+        _s[0][0] = _x0[0];
+        _s[0][1] = _x0[1];
+        _s[0][2] = 0;
+        _s[0][3] = 0;
+    }
+}
+
+
+int PomdpSolver::update()
+{
+    samp_count = 0;
+    _slice_count++;
+    _solve_time = AP_HAL::micros64();
+    if (_generate_actions)
+    {
+        if (_m >= _nactions)
+        {
+            _generate_actions = false;
+            _m = 0;
+            return 0;
+        }
+
+        int j1 = MIN(_j + ACTION_GENERATION_STEPS_PER_LOOP, _k);
+        generate_action(_m, _v0, _eas2tas, _psi0, _roll0, _roll_rate0, _prev_action, _k, _nactions, _actions,
+            _t_step, _t_hori, _I_moment, _k_aileron, _k_roll_damping, _c_lp, _j, j1);
+        //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "%lluus %3u loop:%6lluus j:%2d m:%2d", _solve_time, _slice_count, AP_HAL::micros64() - _solve_time, _j, _m);
+        _j += ACTION_GENERATION_STEPS_PER_LOOP;
+        if (_j >= _k)
+        {
+            _j = 0;
+            _m++;
+
+            if (_m >= _nactions)
+            {
+                _generate_actions = false;
+                _m = 0;
+            }
+        }
+        
+        return 0;
+    }
+
+    if (_start_action_loop)
+    {
+        // action loop init
+        action_loop();
+        _start_action_loop = false;
+    }
+
+    if (_start_sample_loop)
+    {
+        // sample loop init
+        sample_loop();
+        _start_sample_loop = false;
+    }
+    
+    _loop = 0;
+    while (_loop < _max_loops)
+    {
+        // inner loop body
+        inner_loop();
+        // GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "%02u loop:%02d i:%02d j:%02d m:%02d ip%03u sp:%03u", _slice_count, _loop, _i, _j, _m, _i_ptr, _s_ptr);
+        _loop++;
+        _j++;
+        
+        if (_j >= _k)
+        {
+            if (_max_lift)
+            {
+                // maximizing lift = minimizing the negative of the lift
+                _Q[_m] += - _total_lift; // *_inv_n;
+            }
+            else
+            {
+                _Q[_m] += (_weights[0] * _ekf.P(0,0)
+                           + _weights[1] * _ekf.P(1,1)
+                           + _weights[2] * _ekf.P(2,2)
+                           + _weights[3] * _ekf.P(3,3)) * 1.0 / _n;
+            }
+            
+            _j = 0;
+            _i++;
+            
+            if (_i >= _n)
+            {
+                
+                if (_max_lift && _Q[_m] < _Q[_best_action])
+                {
+                    _best_action = _m;
+                }
+                else if (_Q[_m] < _Q[_best_action])
+                {
+                    _best_action = _m;
+                }
+                
+                _i = 0;
+                _m++;
+                
+                if (_m >= _nactions)
+                {
+                    _running = false;
+                    //GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Solver finished: %d %lluus", _slice_count, AP_HAL::micros64() - _solve_time);
+                    _solve_time = AP_HAL::micros64();
+                    return samp_count;
+                }
+                
+                action_loop();
+            }
+            
+            sample_loop();
+        }
+    }
+
+    return samp_count;
+}
+
+
+void PomdpSolver::run_exp_test(unsigned n)
+{
+    for(unsigned i=0; i < n; i++)
+    {
+        _dummy[0] = expf(_s[i % MAX_GAUSS_SAMPLES][0]);
+        _dummy[1] = expf(_s[i % MAX_GAUSS_SAMPLES][1]);
+        _dummy[2] = expf(_s[i % MAX_GAUSS_SAMPLES][2]);
+        _dummy[3] = expf(_s[i % MAX_GAUSS_SAMPLES][3]);
+    }
+}
+
+
+void PomdpSolver::run_fast_exp_test(unsigned n)
+{
+    for(unsigned i=0; i < n; i++)
+    {
+        _dummy[0] = EXP(_s[i % MAX_GAUSS_SAMPLES][0]);
+        _dummy[1] = EXP(_s[i % MAX_GAUSS_SAMPLES][1]);
+        _dummy[2] = EXP(_s[i % MAX_GAUSS_SAMPLES][2]);
+        _dummy[3] = EXP(_s[i % MAX_GAUSS_SAMPLES][3]);
+    }
+}
+
+
+void PomdpSolver::fill_random_array()
+{
+    float cov[4][4];
+    float mean[4] = { 0, 0, 0, 0 };
+    cov[0][0] = 1;
+    cov[1][1] = 1;
+    cov[2][2] = 1;
+    cov[3][3] = 1;
+    multivariate_normal_fill(_s, mean, cov, MAX_GAUSS_SAMPLES);
+}
+
+
+void PomdpSolver::run_rnd_test(unsigned n)
+{
+    for (unsigned i = 0; i < n; i++)
+    {
+        xorshift128();
+    }
+}
+
+
+void PomdpSolver::run_multivariate_normal_sample_test(unsigned n)
+{
+    float L[4][4];
+    float mean[4] = { 0, 0, 0, 0 };
+    L[0][0] = 1;
+    L[1][1] = 1;
+    L[2][2] = 1;
+    L[3][3] = 1;
+    float s[4];
+
+    for (unsigned i = 0; i < n; i++) {
+        multivariate_normal(s,mean,L);
+    }
+}
+
+
+void PomdpSolver::run_trig_box_muller_test(unsigned n)
+{
+    float y1, y2;
+    for (unsigned i = 0; i < n; i++) {
+        trig_box_muller(&y1,&y2);
+    }
+}
+
+
+void PomdpSolver::run_polar_box_muller_test(unsigned n)
+{
+    float y1, y2;
+
+    for (unsigned i = 0; i < n; i++)
+    {
+        polar_box_muller(&y1,&y2);
+    }
+}
+
+
+void PomdpSolver::run_ekf_test(unsigned n)
+{
+    VectorN<float, 4> X = (const float[]) {2.5,100,0,0};
+    MatrixN<float, 4> P = (const float[]) { 1,100,1000,1000 };
+    MatrixN<float, 4> Q = (const float[]) { 0.0025,1,2,2};
+    float R = 0.024;
+    _ekf.reset(X,P,Q,R);
+
+    for (unsigned i = 0; i < n; i++)
+    {
+        _ekf.update(0.1, 1.0, 2.0);
+    }
+}
+
+
+void PomdpSolver::run_loop_test(unsigned n, bool max_lift)
+{
+    VectorN<float, 4> X = (const float[]) { 2.5, 100, 0, 0 };
+    MatrixN<float, 4> P = (const float[]) { 1, 100, 1000, 1000 };
+    MatrixN<float, 4> Q = (const float[]) { 0.0025, 1, 2, 2 };
+    float R = 0.024;
+    _ekf.reset(X, P, Q, R);
+    _w = X[0];
+    _r = X[1];
+    _y = X[2];
+    _x = X[3];
+    _max_lift = max_lift;
+    _m = 0;
+    _j = 0;
+    _action_path_x[_m][_j] = 1.0;
+    _action_path_y[_m][_j] = 2.0;
+
+    for (unsigned i = 0; i < n; i++)
+    {
+        inner_loop();
+        _px0 = 0;
+        _py0 = 0;
+    }
+}
+
+
+void PomdpSolver::update_random_buffer(unsigned n, MatrixN<float, 4> &cov, bool reset)
+{
+    unsigned div = MIN(MAX_GAUSS_SAMPLES - _s_ptr, n);
+    unsigned rem = n - div;
+    float mean[4] = { 0, 0, 0, 0 };
+    MatrixN<float, 4> &p = cov;
+
+    if (_running) {
+        p = _p0;
+    }
+
+    multivariate_normal_fill(_s, mean, p.getarray(), div, _s_ptr);
+    
+    if (rem > 0) {
+        multivariate_normal_fill(_s, mean, p.getarray(), rem, 0);
+    }
+    
+    if (reset) {
+        _i_ptr = _s_ptr;
+    }
+
+    _s_ptr = (_s_ptr + n) % MAX_GAUSS_SAMPLES;
+}
+
+void PomdpSolver::update_test() {
+    update_test_counter++;
+}
+
+

--- a/libraries/AP_Soaring/POMDP_Solver.h
+++ b/libraries/AP_Soaring/POMDP_Solver.h
@@ -115,8 +115,8 @@ public:
     void set_polar(float poly_a, float poly_b, float poly_c);
     void generate_action_paths(float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, int nactions, float* action,
         float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int extend);
-    void generate_action(int m, float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, int nactions, float* action,
-        float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int j0, int j1);
+    void generate_action(int i_action, float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, float* action,
+        float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int step_start, int step_end);
     void log_actions(uint64_t thermal_id);
     float sink_polar(float aspd, float poly_a, float poly_b, float poly_c, float roll);
     void init_step(int max_loops, int n,const VectorN<float, 4> &x0, 

--- a/libraries/AP_Soaring/POMDP_Solver.h
+++ b/libraries/AP_Soaring/POMDP_Solver.h
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#pragma once
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include "ExtendedKalmanFilter.h"
+#include "random.h"
+#include <AP_Math/matrixN.h>
+
+
+#define MAX_ACTIONS 10
+#define MAX_ACTION_SAMPLES 100
+#define ACTION_GENERATION_STEPS_PER_LOOP 7
+class PomdpSolver
+{
+    struct {
+        float airspeed_min;
+    } _aparm;
+
+    struct {
+        float P;
+        float I;
+        float D;
+        float FF;
+        float tau;
+        float imax;
+        float rmax;
+    } gains;
+
+    float _scaling_speed;
+    ExtendedKalmanFilter _ekf;
+    float _Q[MAX_ACTIONS]; // quality of action
+    float _s[MAX_GAUSS_SAMPLES][4]; // Gaussian samples
+    unsigned _s_ptr = 0;
+    unsigned _i_ptr = 0;
+    float _action_path_x[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
+    float _action_path_y[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
+    float _action_path_psi[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
+    float _action_path_theta[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
+    int _prev_action;
+    int _n;
+    int _k;
+    int _nactions;
+    float _inv_n;
+    float _action[MAX_ACTIONS];
+    float _t_step;
+    float _t_hori;
+    VectorN<float, 4> _x0;
+    MatrixN<float, 4> _p0;
+    MatrixN<float, 4> _q0;
+    float _r0;
+    float _chol_p0[4][4];
+    float _weights[4];
+    float _mean[4] = { 0, 0, 0, 0 };
+    bool _max_lift;
+    float _dt;
+    int _k_t_step;
+    float _therm_x;
+    float _therm_y;
+    int _best_action;
+    float _v0;
+    float _poly_a;
+    float _poly_b;
+    float _poly_c;
+    float _total_lift;
+    float _px0;
+    float _py0;
+    float _px1;
+    float _py1;
+    int _i;
+    int _j;
+    int _m;
+    float _w ;
+    float _r ;
+    float _x ;
+    float _y ;
+    bool _running = false;
+    int _loop;
+    int _max_loops;
+    bool _start_sample_loop;
+    bool _start_action_loop;
+    float _pid_P;
+    float _pid_I;
+    float _pid_D;
+    float _pid_FF;
+    float _pid_desired;
+    float _last_out;
+    int _log_j;
+    bool _new_actions = false;
+    void inner_loop();
+    void sample_loop();
+    void action_loop();
+    float _get_rate_out(float dt, float aspeed, float eas2tas, float achieved_rate, float desired_rate);
+    float _dummy[4];
+    int _slice_count = 0;
+    uint64_t _solve_time = 0;
+    float _eas2tas;
+    float _psi0;
+    float _roll0;
+    float _roll_rate0;
+    float _I_moment;
+    float _k_aileron;
+    float _k_roll_damping;
+    float _c_lp;
+    int _extend;
+    float* _actions;
+    bool _generate_actions = false;
+    float _theta_rate;
+    float _t;
+    
+
+public:
+    PomdpSolver(); 
+    void set_pid_gains(float P, float I, float D, float FF, float tau, float imax, float rmax, float scaling_speed);
+    void set_polar(float poly_a, float poly_b, float poly_c);
+    void generate_action_paths(float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, int nactions, float* action,
+        float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int extend);
+    void generate_action(int m, float v0, float eas2tas, float psi0, float roll0, float roll_rate0, float current_action, int pomdp_k, int nactions, float* action,
+        float t_step, float t_hori, float I_moment, float k_aileron, float k_roll_damping, float c_lp, int j0, int j1);
+    void log_actions(uint64_t thermal_id);
+    float sink_polar(float aspd, float poly_a, float poly_b, float poly_c, float roll);
+    void init_step(int max_loops, int n,const VectorN<float, 4> &x0, 
+                   const MatrixN<float, 4> &p0, const MatrixN<float, 4> &q0, float r0,
+                   float weights[4], bool max_lift);
+    int update();
+    int get_best_action() { return _best_action;  }
+    float get_action_path_x(int a, int k) { return _action_path_x[a][k]; }
+    float get_action_path_y(int a, int k) { return _action_path_y[a][k]; }
+    float get_action_path_theta(int a, int k) { return _action_path_theta[a][k]; }
+    float get_action_path_psi(int a, int k) { return _action_path_psi[a][k]; }
+    float get_action_v0() { return _v0; }
+    float get_action_Q(int i) { return _Q[i]; }
+
+    bool running() { return _running;  }
+    void run_exp_test(unsigned n);
+    void run_fast_exp_test(unsigned n);
+    void fill_random_array();
+    void run_rnd_test(unsigned n);
+    void run_multivariate_normal_sample_test(unsigned n);
+    void run_trig_box_muller_test(unsigned n);
+    void run_polar_box_muller_test(unsigned n);
+    void run_ekf_test(unsigned n);
+    void run_loop_test(unsigned n, bool max_lift);
+    void update_random_buffer(unsigned n, MatrixN<float, 4> &cov, bool reset);
+    void update_test();
+    unsigned update_test_counter = 0;
+    int actions_generated() { return _generate_actions ? _m : _nactions; }
+    float samp_count;
+};

--- a/libraries/AP_Soaring/POMDP_Solver.h
+++ b/libraries/AP_Soaring/POMDP_Solver.h
@@ -40,10 +40,9 @@ class PomdpSolver
     float _action_path_psi[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
     float _action_path_theta[MAX_ACTIONS][MAX_ACTION_SAMPLES + 1];
     int _prev_action;
-    int _n;
-    int _k;
-    int _nactions;
-    float _inv_n;
+    int _n_sample; // number of samples per action trajectory
+    int _n_step; // number of action steps (_i_step)
+    int _n_actions; // numer of actions (_i_action)
     float _action[MAX_ACTIONS];
     float _t_step;
     float _t_hori;
@@ -54,7 +53,7 @@ class PomdpSolver
     float _chol_p0[4][4];
     float _weights[4];
     float _mean[4] = { 0, 0, 0, 0 };
-    bool _max_lift;
+    bool _mode_exploit;
     float _dt;
     int _k_t_step;
     float _therm_x;
@@ -69,15 +68,14 @@ class PomdpSolver
     float _py0;
     float _px1;
     float _py1;
-    int _i;
-    int _j;
-    int _m;
+    int _i_sample; // Index of the current sample
+    int _i_step;   // Index of the current action step
+    int _i_action; // Index of the current action
     float _w ;
     float _r ;
     float _x ;
     float _y ;
     bool _running = false;
-    int _loop;
     int _max_loops;
     bool _start_sample_loop;
     bool _start_action_loop;
@@ -124,7 +122,7 @@ public:
     void init_step(int max_loops, int n,const VectorN<float, 4> &x0, 
                    const MatrixN<float, 4> &p0, const MatrixN<float, 4> &q0, float r0,
                    float weights[4], bool max_lift);
-    int update();
+    void update();
     int get_best_action() { return _best_action;  }
     float get_action_path_x(int a, int k) { return _action_path_x[a][k]; }
     float get_action_path_y(int a, int k) { return _action_path_y[a][k]; }
@@ -146,6 +144,5 @@ public:
     void update_random_buffer(unsigned n, MatrixN<float, 4> &cov, bool reset);
     void update_test();
     unsigned update_test_counter = 0;
-    int actions_generated() { return _generate_actions ? _m : _nactions; }
-    float samp_count;
+    int actions_generated() { return _generate_actions ? _i_action : _n_actions; }
 };

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -55,7 +55,7 @@ float Variometer::correct_netto_rate(float climb_rate,
                                      float aspd,
                                      const float polar_K,
                                      const float polar_CD0,
-                                     const float polar_B)
+                                     const float polar_B) const
 {
     // Remove aircraft sink rate
     float CL0;  // CL0 = 2*W/(rho*S*V^2)

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -38,7 +38,7 @@ public:
     bool new_data;
 
     void update(const float polar_K, const float polar_CD0, const float polar_B);
-    float correct_netto_rate(float climb_rate, float phi, float aspd, const float polar_K, const float polar_CD0, const float polar_B);
+    float correct_netto_rate(float climb_rate, float phi, float aspd, const float polar_K, const float polar_CD0, const float polar_B) const;
 
 };
 

--- a/libraries/AP_Soaring/random.cpp
+++ b/libraries/AP_Soaring/random.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#include <stdint.h>
+#include "random.h"
+#include <cmath>
+
+
+// xorshift128
+//
+// See "Xorshift RNGs" by George Marsaglia, The Florida State University
+//
+// Code based on snippet from Wikipedia
+// https://en.wikipedia.org/wiki/Xorshift
+//
+
+// non zero seed
+uint32_t s[] = { 12793,912503,84501,73115 };
+
+uint32_t xorshift128(void)
+{
+    uint32_t t = s[0];
+    t ^= t << 11;
+    t ^= t >> 8;
+    s[0] = s[1]; s[1] = s[2]; s[2] = s[3];
+    s[3] ^= s[3] >> 19;
+    s[3] ^= t;
+    return s[3];
+}
+
+/* Polar form of Box-Muller transform
+*  (run time increases if sample point lands outside 
+*  unit cicle, but avoids using trig functions)
+*/
+void polar_box_muller(float* y1, float* y2)
+{
+    float x1, x2, w;
+    uint32_t t;
+    int i = 0;
+    
+    do
+    {
+        t = s[0];
+        t ^= s[0] << 11;
+        t ^= t >> 8;
+        s[0] = s[1]; s[1] = s[2]; s[2] = s[3];
+        s[3] ^= s[3] >> 19;
+        s[3] ^= t;
+        x1 = 2.0 * ((s[3] >> 8) * XSADD_FLOAT_MUL) - 1.0;
+        t = s[0];
+        t ^= s[0] << 11;
+        t ^= t >> 8;
+        s[0] = s[1]; s[1] = s[2]; s[2] = s[3];
+        s[3] ^= s[3] >> 19;
+        s[3] ^= t;
+        x2 = 2.0 * ((s[3] >> 8) * XSADD_FLOAT_MUL) - 1.0;
+        w = x1 * x1 + x2 * x2;
+        i++;
+    }
+    while ( w >= 1.0 );
+    
+    w = sqrtf( (-2.0 * logf( w ) ) / w );
+    *y1 = x1 * w;
+    *y2 = x2 * w;
+}
+
+/* Standard form of Box-Muller transform
+ * (constant run time)
+ */
+void trig_box_muller(float* y1, float* y2)
+{
+	float x1, x2;
+	uint32_t t;
+
+	t = s[0];
+	t ^= s[0] << 11;
+	t ^= t >> 8;
+	s[0] = s[1]; s[1] = s[2]; s[2] = s[3];
+	s[3] ^= s[3] >> 19;
+	s[3] ^= t;
+	x1 = ((s[3] >> 8) * XSADD_FLOAT_MUL);
+	t = s[0];
+	t ^= s[0] << 11;
+	t ^= t >> 8;
+	s[0] = s[1]; s[1] = s[2]; s[2] = s[3];
+	s[3] ^= s[3] >> 19;
+	s[3] ^= t;
+	x2 = ((s[3] >> 8) * XSADD_FLOAT_MUL);
+	float r = sqrtf(-2.0 * logf(x1));
+	float theta = 2.0 * M_PI * x2;
+	*y1 = r*sinf(theta);
+	*y2 = r*cosf(theta);
+}
+
+
+// cholesky decomposition of 4x4 matix A into L
+// A must be positive definite (not tested for)
+// L will be set to the lower triangular cholesky decomposition of A
+void cholesky44(float (&A)[4][4], float (&L)[4][4])
+{
+    L[0][0] =  sqrtf(A[0][0]);
+    L[1][0] =  1.0 / L[0][0] * (A[1][0]);
+    L[1][1] =  sqrtf(A[1][1] - L[1][0] * L[1][0]);
+    L[2][0] =  1.0 / L[0][0] * (A[2][0] );
+    L[2][1] =  1.0 / L[1][1] * (A[2][1] - L[2][0] * L[1][0]);
+    L[2][2] =  sqrtf(A[2][2] - (L[2][0] * L[2][0] + L[2][1] * L[2][1]));
+    L[3][0] =  1.0 / L[0][0] * (A[3][0]);
+    L[3][1] =  1.0 / L[1][1] * (A[3][1] - L[3][0] * L[1][0]);
+    L[3][2] =  1.0 / L[2][2] * (A[3][2] - (L[3][0] * L[2][0] + L[3][1] * L[2][1]));
+    L[3][3] =  sqrtf(A[3][3] - (L[3][0] * L[3][0] + L[3][1] * L[3][1] + L[3][2] * L[3][2]));
+}
+
+void multivariate_normal_fill(float (&samp)[MAX_GAUSS_SAMPLES][4], float (&mean)[4], float (&cov)[4][4], const int size, const int offset) {
+
+    float m[4];
+    float L[4][4];
+    cholesky44(cov, L);
+
+    for (int j = offset; j < offset + size; j++)
+    {
+        gaussian(&m[0],&m[2]);
+        gaussian(&m[1],&m[3]);
+        samp[j][0] = mean[0] + L[0][0] * m[0];
+        samp[j][1] = mean[1] + L[1][0] * m[0] + L[1][1] * m[1];
+        samp[j][2] = mean[2] + L[2][0] * m[0] + L[2][1] * m[1] + L[2][2] * m[2];
+        samp[j][3] = mean[3] + L[3][0] * m[0] + L[3][1] * m[1] + L[3][2] * m[2] + L[3][3] * m[3];
+    }
+}
+
+void multivariate_normal(float (&samp)[4], float (&mean)[4], float (&L)[4][4])
+{    
+    float m[4];   
+    gaussian(&m[0],&m[2]);
+    gaussian(&m[1],&m[3]);
+    samp[0] = mean[0] + L[0][0] * m[0];
+    samp[1] = mean[1] + L[1][0] * m[0] + L[1][1] * m[1];
+    samp[2] = mean[2] + L[2][0] * m[0] + L[2][1] * m[1] + L[2][2] * m[2];
+    samp[3] = mean[3] + L[3][0] * m[0] + L[3][1] * m[1] + L[3][2] * m[2] + L[3][3] * m[3];
+}

--- a/libraries/AP_Soaring/random.h
+++ b/libraries/AP_Soaring/random.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the GPLv3 license
+
+#pragma once
+#include <stdint.h>
+
+#define XSADD_FLOAT_MUL (1.0f / 16777216.0f)
+#define MAX_GAUSS_SAMPLES 1000
+#ifdef BOX_MULLER
+#define gaussian(y1,y2) trig_box_muller(y1,y2)
+#else
+#define gaussian(y1,y2) polar_box_muller(y1,y2)
+#endif
+void polar_box_muller(float* y1, float* y2);
+void trig_box_muller(float* y1, float* y2);
+uint32_t xorshift128(void);
+void cholesky44(float (&A)[4][4], float (&L)[4][4]);
+void multivariate_normal_fill(float (&samp)[MAX_GAUSS_SAMPLES][4], float (&mean)[4], float (&cov)[4][4], const int size, const int offset = 0);
+void multivariate_normal(float (&samp)[4], float (&mean)[4], float (&cov)[4][4]);
+
+extern uint32_t s0[];


### PR DESCRIPTION
This PR adds a new flight path controller based on Partially Observable Markov Decision Process techniques. It uses the existing EKF and high-level switching logic, but is able to generate more optimised flightpaths by directly setting the desired roll angle. It operated in one of two modes:
POMDP_MODE_EXPLORE: Initial mode. Optimises flight path to reduce the trace of EKF covariance matrix (explores thermal)
POMDP_MODE_EXPLOIT: This mode is entered when the knowledge of the thermal location and state is good enough. The flight path is now optimised for altitude gain.

This is a rebase of https://github.com/Microsoft/Frigatebird with most of the changes not directly related to the POMDP solver removed for simplicity. More information is here https://arxiv.org/pdf/1805.09875.pdf . Many thanks to the Microsoft team for keeping the code open.

It compiles and runs OK in SITL but requires some code improvements and more rigorous simulated and flight tests before merge.