### PR TITLE
Plane: make soaring an optional build feature

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -78,7 +78,9 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(Log_Write_Fast,         25,    300),
     SCHED_TASK(update_logging1,        25,    300),
     SCHED_TASK(update_logging2,        25,    300),
+#if SOARING_ENABLED == ENABLED
     SCHED_TASK(update_soaring,         50,    400),
+#endif
     SCHED_TASK(parachute_check,        10,    200),
 #if AP_TERRAIN_AVAILABLE
     SCHED_TASK_CLASS(AP_Terrain, &plane.terrain, update, 10, 200),
@@ -821,6 +823,13 @@ void Plane::update_alt()
             distance_beyond_land_wp = get_distance(current_loc, next_WP_loc);
         }
 
+        bool soaring_active = false;
+#if SOARING_ENABLED == ENABLED
+        if (g2.soaring_controller.is_active() && g2.soaring_controller.get_throttle_suppressed()) {
+            soaring_active = true;
+        }
+#endif
+        
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
                                                  flight_stage,
@@ -828,7 +837,8 @@ void Plane::update_alt()
                                                  get_takeoff_pitch_min_cd(),
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
-                                                 aerodynamic_load_factor);
+                                                 aerodynamic_load_factor,
+                                                 soaring_active);
     }
 }
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -264,9 +264,11 @@ int16_t GCS_MAVLINK_Plane::vfr_hud_throttle() const
 
 float GCS_MAVLINK_Plane::vfr_hud_climbrate() const
 {
+#if SOARING_ENABLED == ENABLED
     if (plane.g2.soaring_controller.is_active()) {
         return plane.g2.soaring_controller.get_vario_reading();
     }
+#endif
     return AP::baro().get_climb_rate();
 }
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1140,9 +1140,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/RC_Channel/RC_Channels.cpp
     AP_SUBGROUPINFO(rc_channels, "RC", 7, ParametersG2, RC_Channels),
     
+#if SOARING_ENABLED == ENABLED
     // @Group: SOAR_
     // @Path: ../libraries/AP_Soaring/AP_Soaring.cpp
     AP_SUBGROUPINFO(soaring_controller, "SOAR_", 8, ParametersG2, SoaringController),
+#endif
   
     // @Param: RUDD_DT_GAIN
     // @DisplayName: rudder differential thrust gain
@@ -1179,8 +1181,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 };
 
 ParametersG2::ParametersG2(void) :
-    ice_control(plane.rpm_sensor, plane.ahrs),
-    soaring_controller(plane.ahrs, plane.TECS_controller, plane.aparm)
+    ice_control(plane.rpm_sensor, plane.ahrs)
+#if SOARING_ENABLED == ENABLED
+    ,soaring_controller(plane.ahrs, plane.TECS_controller, plane.aparm)
+#endif
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -525,9 +525,11 @@ public:
 
     // whether to enforce acceptance of packets only from sysid_my_gcs
     AP_Int8 sysid_enforce;
-    
+
+#if SOARING_ENABLED == ENABLED
     // ArduSoar parameters
     SoaringController soaring_controller;
+#endif
 
     // dual motor tailsitter rudder to differential thrust scaling: 0-100%
     AP_Int8 rudd_dt_gain;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -221,7 +221,7 @@ private:
     AP_AHRS_DCM ahrs;
 #endif
 
-    AP_TECS TECS_controller{ahrs, aparm, landing, g2.soaring_controller};
+    AP_TECS TECS_controller{ahrs, aparm, landing};
     AP_L1_Control L1_controller{ahrs, &TECS_controller};
 
     // Attitude to servo controllers
@@ -1029,7 +1029,9 @@ private:
 #endif
     void accel_cal_update(void);
     void update_soft_armed();
+#if SOARING_ENABLED == ENABLED
     void update_soaring();
+#endif
 
     // support for AP_Avoidance custom flight mode, AVOID_ADSB
     bool avoid_adsb_init(bool ignore_checks);

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -378,3 +378,10 @@
  #define OSD_ENABLED DISABLED
 #endif
 
+#ifndef SOARING_ENABLED
+#if HAL_MINIMIZE_FEATURES
+ #define SOARING_ENABLED DISABLED
+#else
+ #define SOARING_ENABLED ENABLED
+#endif
+#endif

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -386,6 +386,7 @@ void Plane::set_servos_controlled(void)
             constrain_int16(quadplane.forward_throttle_pct(), min_throttle, max_throttle));
     }
 
+#if SOARING_ENABLED == ENABLED
     // suppress throttle when soaring is active
     if ((control_mode == FLY_BY_WIRE_B || control_mode == CRUISE ||
         control_mode == AUTO || control_mode == LOITER) &&
@@ -393,6 +394,7 @@ void Plane::set_servos_controlled(void)
         g2.soaring_controller.get_throttle_suppressed()) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
     }
+#endif
 }
 
 /*

--- a/ArduPlane/soaring.cpp
+++ b/ArduPlane/soaring.cpp
@@ -1,5 +1,7 @@
 #include "Plane.h"
 
+#if SOARING_ENABLED == ENABLED
+
 /*
 *  ArduSoar support function
 *
@@ -94,3 +96,4 @@ void Plane::update_soaring() {
     }
 }
 
+#endif // SOARING_ENABLED

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -381,9 +381,11 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         auto_navigation_mode = false;
         cruise_state.locked_heading = false;
         cruise_state.lock_timer_ms = 0;
-        
+
+#if SOARING_ENABLED == ENABLED
         // for ArduSoar soaring_controller
         g2.soaring_controller.init_cruising();
+#endif
         
         set_target_altitude_current();
         break;
@@ -392,9 +394,11 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         throttle_allows_nudging = false;
         auto_throttle_mode = true;
         auto_navigation_mode = false;
-        
+
+#if SOARING_ENABLED == ENABLED
         // for ArduSoar soaring_controller
         g2.soaring_controller.init_cruising();
+#endif
 
         set_target_altitude_current();
         break;
@@ -419,8 +423,10 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         next_WP_loc = prev_WP_loc = current_loc;
         // start or resume the mission, based on MIS_AUTORESET
         mission.start_or_resume();
-		
+
+#if SOARING_ENABLED == ENABLED
         g2.soaring_controller.init_cruising();
+#endif
         break;
 
     case RTL:
@@ -436,12 +442,14 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
         auto_throttle_mode = true;
         auto_navigation_mode = true;
         do_loiter_at_location();
-		
+
+#if SOARING_ENABLED == ENABLED		
         if (g2.soaring_controller.is_active() &&
             g2.soaring_controller.suppress_throttle()) {
 			g2.soaring_controller.init_thermalling();
 			g2.soaring_controller.get_target(next_WP_loc); // ahead on flight path
 		}
+#endif
 		
         break;
 

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -32,7 +32,8 @@ public:
 										int32_t ptchMinCO_cd,
 										int16_t throttle_nudge,
                                         float hgt_afe,
-										float load_factor) = 0;
+										float load_factor,
+                                        bool soaring_active) = 0;
 
 	// demanded throttle in percentage
 	// should return 0 to 100

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -761,11 +761,6 @@ void AP_TECS::_detect_bad_descent(void)
     {
         _flags.badDescent = false;
     }
-
-    // when soaring is active we never trigger a bad descent
-    if (_soaring_controller.is_active() && _soaring_controller.get_throttle_suppressed()) {
-        _flags.badDescent = false;        
-    }
 }
 
 void AP_TECS::_update_pitch(void)
@@ -946,7 +941,8 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     int32_t ptchMinCO_cd,
                                     int16_t throttle_nudge,
                                     float hgt_afe,
-                                    float load_factor)
+                                    float load_factor,
+                                    bool soaring_active)
 {
     // Calculate time in seconds since last update
     uint64_t now = AP_HAL::micros64();
@@ -1071,6 +1067,11 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
     // Detect bad descent due to demanded airspeed being too high
     _detect_bad_descent();
+
+    // when soaring is active we never trigger a bad descent
+    if (soaring_active) {
+        _flags.badDescent = false;        
+    }
 
     // Calculate pitch demand
     _update_pitch();

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -25,15 +25,13 @@
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
 #include <DataFlash/DataFlash.h>
 #include <AP_Landing/AP_Landing.h>
-#include <AP_Soaring/AP_Soaring.h>
 
 class AP_TECS : public AP_SpdHgtControl {
 public:
-    AP_TECS(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, const AP_Landing &landing, const SoaringController &soaring_controller)
+    AP_TECS(AP_AHRS &ahrs, const AP_Vehicle::FixedWing &parms, const AP_Landing &landing)
         : _ahrs(ahrs)
         , aparm(parms)
         , _landing(landing)
-        , _soaring_controller(soaring_controller)
     {
         AP_Param::setup_object_defaults(this, var_info);
     }
@@ -45,7 +43,7 @@ public:
     // Update of the estimated height and height rate internal state
     // Update of the inertial speed rate internal state
     // Should be called at 50Hz or greater
-    void update_50hz(void);
+    void update_50hz(void) override;
 
     // Update the control loop calculations
     void update_pitch_throttle(int32_t hgt_dem_cm,
@@ -55,47 +53,48 @@ public:
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
                                float hgt_afe,
-                               float load_factor);
+                               float load_factor,
+                               bool soaring_active) override;
 
     // demanded throttle in percentage
     // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
-    int32_t get_throttle_demand(void) {
+    int32_t get_throttle_demand(void) override {
         return int32_t(_throttle_dem * 100.0f);
     }
 
     // demanded pitch angle in centi-degrees
     // should return between -9000 to +9000
-    int32_t get_pitch_demand(void) {
+    int32_t get_pitch_demand(void) override {
         return int32_t(_pitch_dem * 5729.5781f);
     }
 
     // Rate of change of velocity along X body axis in m/s^2
-    float get_VXdot(void) {
+    float get_VXdot(void) override {
         return _vel_dot;
     }
 
     // return current target airspeed
-    float get_target_airspeed(void) const {
+    float get_target_airspeed(void) const override {
         return _TAS_dem / _ahrs.get_EAS2TAS();
     }
 
     // return maximum climb rate
-    float get_max_climbrate(void) const {
+    float get_max_climbrate(void) const override {
         return _maxClimbRate;
     }
 
     // added to let SoaringContoller reset pitch integrator to zero
-    void reset_pitch_I(void) {
+    void reset_pitch_I(void) override {
         _integSEB_state = 0.0f;
     }
     
     // return landing sink rate
-    float get_land_sinkrate(void) const {
+    float get_land_sinkrate(void) const override {
         return _land_sink;
     }
 
     // return landing airspeed
-    float get_land_airspeed(void) const {
+    float get_land_airspeed(void) const override {
         return _landAirspeed;
     }
 
@@ -105,7 +104,7 @@ public:
     }
 
     // set path_proportion
-    void set_path_proportion(float path_proportion) {
+    void set_path_proportion(float path_proportion) override {
         _path_proportion = constrain_float(path_proportion, 0.0f, 1.0f);
     }
 
@@ -140,9 +139,6 @@ private:
     // reference to const AP_Landing to access it's params
     const AP_Landing &_landing;
     
-    // reference to const SoaringController to access its state
-    const SoaringController &_soaring_controller;
-
     // TECS tuning parameters
     AP_Float _hgtCompFiltOmega;
     AP_Float _spdCompFiltOmega;


### PR DESCRIPTION
This saves 5k of flash on px4-v2, and allows us to consder pr #9042, which takes a lot of flash space
