### PR TITLE
AP_Math: Fix the accuracy of the radians function.

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -132,7 +132,7 @@ inline int32_t constrain_int32(const int32_t amt, const int32_t low, const int32
 }
 
 // degrees -> radians
-static inline float radians(float deg)
+static inline double radians(double deg)
 {
     return deg * DEG_TO_RAD;
 }


### PR DESCRIPTION
Using the floating type causes jittery motion in a renderer from external FDM input (such as FlightGear). To reproduce this bug: The jittery motion appears at locations far from (latitude: 0, longitude: 0).
For example, if the movement is around the 39.993117,-0.068812 the latitude motion will have jitter.

See https://github.com/ArduPilot/ardupilot/blob/ad81760bfd41d7f8f9605fea1bdc868d676b21f0/libraries/AP_HAL_SITL/SITL_State.cpp#L239