### PR TITLE
Copter: Change Need 3D Fix message.

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -520,14 +520,14 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
     if (mode_requires_gps) {
         if (!copter.position_ok()) {
             // There is no need to call prearm_failure_reason again, because prearm_healthy sure be true if we reach here
-            check_failed(display_failure, "Need 3D Fix");
+            check_failed(display_failure, "Need Position Estimate");
             return false;
         }
     } else {
         if (fence_requires_gps) {
             if (!copter.position_ok()) {
                 // clarify to user why they need GPS in non-GPS flight mode
-                check_failed(display_failure, "Fence enabled, need 3D Fix");
+                check_failed(display_failure, "Fence enabled, need position estimate");
                 return false;
             }
         } else {


### PR DESCRIPTION
I see the message "PreArm: Need 3D Fix" though the GPS status on the MP HUD screen is "rtk Fixed".
This message does not see GPS status.
This message is displayed when the home position is not decided.
Therefore, "Need 3D Fix" if the GPS status is not 3D FIX, "Need home position" if the GPS status is 3D FIx.

Before
![ddd](https://user-images.githubusercontent.com/646194/43461039-5f680f88-950d-11e8-8a63-064a1d80d26f.png)

After
![eee](https://user-images.githubusercontent.com/646194/43461069-757c0d10-950d-11e8-9af0-53e05a7fbb4f.png)