### PR TITLE
HAL_ChibiOS: reduce memory used by serial buffers

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -129,8 +129,8 @@ void UARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
     if (sdef.serial == nullptr) {
         return;
     }
-    uint16_t min_tx_buffer = 4096;
-    uint16_t min_rx_buffer = 1024;
+    uint16_t min_tx_buffer = 1024;
+    uint16_t min_rx_buffer = 512;
     // on PX4 we have enough memory to have a larger transmit and
     // receive buffer for all ports. This means we don't get delays
     // while waiting to write GPS config packets

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
@@ -320,7 +320,7 @@
  *          buffers.
  */
 #if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
-#define SERIAL_BUFFERS_SIZE         1024
+#define SERIAL_BUFFERS_SIZE         512
 #endif
 
 /*===========================================================================*/


### PR DESCRIPTION
this does not appear to affect log download speed. It saves about 27k
of memory