### PR TITLE
autotest: disable the Drive Brake test in rover

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -497,7 +497,8 @@ class AutoTestRover(AutoTest):
             self.run_test("Drive Mission %s" % "rover1.txt",
                           self.drive_mission_rover1)
 
-            self.run_test("Drive Brake", self.drive_brake)
+            # disabled due to frequent failures in travis. This test needs re-writing
+            #self.run_test("Drive Brake", self.drive_brake)
 
             self.run_test("Disarm Vehicle", self.disarm_vehicle)
 


### PR DESCRIPTION
this test fails far too often
