### PR TITLE
Compass/All vehicles: remove compass.accumulate

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -74,7 +74,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #endif
     SCHED_TASK(gcs_failsafe_check,     10,    200),
     SCHED_TASK(fence_check,            10,    200),
-    SCHED_TASK(compass_accumulate,     50,    200),
     SCHED_TASK_CLASS(ModeSmartRTL,        &rover.mode_smartrtl,    save_position,   3,  200),
     SCHED_TASK_CLASS(AP_Notify,           &rover.notify,           update,         50,  300),
     SCHED_TASK(one_second_loop,         1,   1500),
@@ -290,6 +289,9 @@ void Rover::one_second_loop(void)
         gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
         update_home();
     }
+
+    // init compass location for declination
+    init_compass_location();
 
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -496,7 +496,7 @@ private:
 
     // sensors.cpp
     void init_compass(void);
-    void compass_accumulate(void);
+    void init_compass_location(void);
     void init_beacon();
     void init_visual_odom();
     void update_visual_odom();

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -18,17 +18,10 @@ void Rover::init_compass()
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
-  also update initial location used for declination
+  initialise compass's location used for declination
  */
-void Rover::compass_accumulate(void)
+void Rover::init_compass_location(void)
 {
-    if (!g.compass_enabled) {
-        return;
-    }
-
-    compass.accumulate();
-
     // update initial location used for declination
     if (!compass_init_location) {
         Location loc;

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -41,7 +41,6 @@ const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Baro,          &tracker.barometer,  update,         10,   1500),
     SCHED_TASK(gcs_update,             50,   1700),
     SCHED_TASK(gcs_data_stream_send,   50,   3000),
-    SCHED_TASK(compass_accumulate,     50,   1500),
     SCHED_TASK_CLASS(AP_Baro,           &tracker.barometer, accumulate,     50,  900),
     SCHED_TASK(ten_hz_logging_loop,    10,    300),
 #if LOGGING_ENABLED == ENABLED

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -213,7 +213,6 @@ private:
     void read_radio();
     void update_ahrs();
     void update_compass(void);
-    void compass_accumulate(void);
     void accel_cal_update(void);
     void update_GPS(void);
     void init_servos();

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -23,16 +23,6 @@ void Tracker::update_compass(void)
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
- */
-void Tracker::compass_accumulate(void)
-{
-    if (g.compass_enabled) {
-        compass.accumulate();
-    }    
-}
-
-/*
  calibrate compass
 */
 void Tracker::compass_cal_update() {

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -117,7 +117,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #endif
     SCHED_TASK(three_hz_loop,          3,     75),
     SCHED_TASK_CLASS(AP_ServoRelayEvents,  &copter.ServoRelayEvents,      update_events, 50,     75),
-    SCHED_TASK(compass_accumulate,   100,    100),
     SCHED_TASK_CLASS(AP_Baro,              &copter.barometer,           accumulate,      50,  90),
 #if PRECISION_LANDING == ENABLED
     SCHED_TASK(update_precland,      400,     50),
@@ -456,6 +455,9 @@ void Copter::one_hz_loop()
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
     update_sensor_status_flags();
+
+    // init compass location for declination
+    init_compass_location();
 }
 
 // called at 50hz

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -862,7 +862,7 @@ private:
     bool rangefinder_alt_ok();
     void rpm_update();
     void init_compass();
-    void compass_accumulate(void);
+    void init_compass_location();
     void init_optflow();
     void update_optical_flow(void);
     void compass_cal_update(void);

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -137,8 +137,6 @@ MAV_RESULT Copter::mavlink_compassmot(mavlink_channel_t chan)
     while (command_ack_start == command_ack_counter && compass.healthy() && motors->armed()) {
         // 50hz loop
         if (millis() - last_run_time < 20) {
-            // grab some compass values
-            compass.accumulate();
             hal.scheduler->delay(5);
             continue;
         }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -102,17 +102,10 @@ void Copter::init_compass()
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
-  also update initial location used for declination
+  initialise compass's location used for declination
  */
-void Copter::compass_accumulate(void)
+void Copter::init_compass_location()
 {
-    if (!g.compass_enabled) {
-        return;
-    }
-
-    compass.accumulate();
-
     // update initial location used for declination
     if (!ap.compass_init_location) {
         Location loc;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -53,7 +53,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(gcs_data_stream_send,   50,    500),
     SCHED_TASK(update_events,          50,    150),
     SCHED_TASK_CLASS(AP_BattMonitor, &plane.battery, read, 10, 300),
-    SCHED_TASK(compass_accumulate,     50,    200),
     SCHED_TASK_CLASS(AP_Baro, &plane.barometer, accumulate, 50, 150),
     SCHED_TASK(update_notify,          50,    300),
     SCHED_TASK(read_rangefinder,       50,    100),
@@ -190,16 +189,6 @@ void Plane::update_compass(void)
             DataFlash.Log_Write_Compass();
         }
     }
-}
-
-/*
-  if the compass is enabled then try to accumulate a reading
- */
-void Plane::compass_accumulate(void)
-{
-    if (g.compass_enabled) {
-        compass.accumulate();
-    }    
 }
 
 /*

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -942,7 +942,6 @@ private:
     void update_compass(void);
     void update_alt(void);
     void afs_fs_check(void);
-    void compass_accumulate(void);
     void compass_cal_update();
     void update_optical_flow(void);
     void one_second_loop(void);

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -35,7 +35,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(update_altitude,       10,    100),
     SCHED_TASK(three_hz_loop,          3,     75),
     SCHED_TASK(update_turn_counter,   10,     50),
-    SCHED_TASK(compass_accumulate,   100,    100),
     SCHED_TASK_CLASS(AP_Baro,             &sub.barometer,    accumulate,          50,  90),
     SCHED_TASK_CLASS(AP_Notify,           &sub.notify,       update,              50,  90),
     SCHED_TASK(one_hz_loop,            1,    100),
@@ -289,6 +288,9 @@ void Sub::one_hz_loop()
 
     // log terrain data
     terrain_logging();
+
+    // init compass location for declination
+    init_compass_location();
 }
 
 // called at 50hz

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -456,7 +456,7 @@ private:
     static const AP_Param::Info var_info[];
     static const struct LogStructure log_structure[];
 
-    void compass_accumulate(void);
+    void init_compass_location();
     void compass_cal_update(void);
     void fast_loop();
     void fifty_hz_loop();

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -93,17 +93,10 @@ void Sub::init_compass()
 }
 
 /*
-  if the compass is enabled then try to accumulate a reading
-  also update initial location used for declination
+  initialise compass's location used for declination
  */
-void Sub::compass_accumulate()
+void Sub::init_compass_location()
 {
-    if (!g.compass_enabled) {
-        return;
-    }
-
-    compass.accumulate();
-
     // update initial location used for declination
     if (!ap.compass_init_location) {
         Location loc;

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1017,15 +1017,6 @@ void Compass::_detect_backends(void)
     }
 }
 
-void
-Compass::accumulate(void)
-{
-    for (uint8_t i=0; i< _backend_count; i++) {
-        // call accumulate on each of the backend
-        _backends[i]->accumulate();
-    }
-}
-
 bool
 Compass::read(void)
 {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -74,10 +74,6 @@ public:
     ///
     bool read();
 
-    /// use spare CPU cycles to accumulate values from the compass if
-    /// possible (this method should also be implemented in the backends)
-    void accumulate();
-
     /// Calculate the tilt-compensated heading_ variables.
     ///
     /// @param dcm_matrix			The current orientation rotation matrix

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -34,10 +34,6 @@ public:
     // read sensor data
     virtual void read(void) = 0;
 
-    // accumulate a reading from the magnetometer. Optional in
-    // backends
-    virtual void accumulate(void) {};
-
     // callback for UAVCAN messages
     virtual void handle_mag_msg(Vector3f &mag) {};
 

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -123,8 +123,6 @@ bool AP_Compass_UAVCAN::register_uavcan_compass(uint8_t mgr, uint8_t node)
         _sum.zero();
         _count = 0;
 
-        accumulate();
-
         debug_mag_uavcan(2, "AP_Compass_UAVCAN loaded\n\r");
 
         return true;

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -41,8 +41,6 @@ static void loop()
     static float max[COMPASS_MAX_INSTANCES][3];
     static float offset[COMPASS_MAX_INSTANCES][3];
 
-    compass.accumulate();
-
     if ((AP_HAL::micros() - timer) > 100000L) {
         timer = AP_HAL::micros();
         compass.read();


### PR DESCRIPTION
compass.accumulate is a noop on all backends so after discussion with @tridge, I've created this PR to remove it from the compass library and all vehicles.

For Rover, Sub and Copter, the accumulate is removed and only the compass.init_location() call remains which tells the compass it's location so it can lookup it's declination.  I've reduced it's update rate to 1hz, we could increase this to 10hz if people think it's important.

Plane and Tracker's compass_accumulate functions could be removed completely because their compass.init_location is called as part of the udpate_GPS function.