### PR TITLE
Copter: Enable PrecLand target acquisition notification to the user

### DIFF
--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -25,5 +25,18 @@ void Copter::update_precland()
     }
 
     copter.precland.update(height_above_ground_cm, rangefinder_alt_ok());
+    
+    static bool precland_flag = false;
+    if (copter.precland.target_acquired() && !precland_flag )
+    {
+      gcs().send_text(MAV_SEVERITY_INFO, "PrecLand : Target Acquired");
+    }
+    else if (!copter.precland.target_acquired() && precland_flag)
+    {
+      gcs().send_text(MAV_SEVERITY_INFO, "PrecLand : Target Lost");
+    }
+
+    precland_flag = copter.precland.target_acquired();
+
 }
 #endif


### PR DESCRIPTION
This PR utilize AC_PrecLand library to enable notification through GCS when & whether Copter acquired or lost landing target such sensor as IRLock