### PR TITLE
AP_Camera: populate camera singleton

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -38,6 +38,7 @@ public:
     {
         AP_Param::setup_object_defaults(this, var_info);
         _apm_relay = obj_relay;
+        _singleton = this;
     }
 
     /* Do not allow copies */


### PR DESCRIPTION
This is helpful.  If you're going to make a singleton object, best populate it at some stage.

