### PR TITLE
GCS_MAVLink: reserve uart buffer for small responses

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -213,18 +213,6 @@ void GCS_MAVLINK::handle_param_request_read(mavlink_message_t *msg)
     mavlink_param_request_read_t packet;
     mavlink_msg_param_request_read_decode(msg, &packet);
 
-    /*
-      we reserve some space for sending parameters if the client ever
-      fails to get a parameter due to lack of space
-     */
-    uint32_t saved_reserve_param_space_start_ms = reserve_param_space_start_ms;
-    reserve_param_space_start_ms = 0;
-    if (!HAVE_PAYLOAD_SPACE(chan, PARAM_VALUE)) {
-        reserve_param_space_start_ms = AP_HAL::millis();
-        return;
-    }
-    reserve_param_space_start_ms = saved_reserve_param_space_start_ms;
-
     struct pending_param_request req;
     req.chan = chan;
     req.param_index = packet.param_index;

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -238,18 +238,9 @@ bool GCS_MAVLINK::signing_enabled(void) const
 uint8_t GCS_MAVLINK::packet_overhead_chan(mavlink_channel_t chan)
 {
     /*
-      reserve 100 bytes for parameters when a GCS fails to fetch a
-      parameter due to lack of buffer space. The reservation lasts 2
-      seconds
+      reserve 100 bytes for small responses what do not check avaliable buffer size
      */
-    uint8_t reserved_space = 0;
-    if (reserve_param_space_start_ms != 0 &&
-        AP_HAL::millis() - reserve_param_space_start_ms < 2000) {
-        reserved_space = 100;
-    } else {
-        reserve_param_space_start_ms = 0;
-    }
-    
+    uint8_t reserved_space = 100;
     const mavlink_status_t *status = mavlink_get_channel_status(chan);
     if (status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
         return MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_SIGNATURE_BLOCK_LEN + reserved_space;


### PR DESCRIPTION
This PR mainly for discussion.

1. Reserve small amount of uart buffer for responses that do not check
available buffer size. Example of such response https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp#L389
If we do not reserve space, message could be partially written and get corrupted in hal layer. 

2. Do not silently drop param request. This fix qgc param download with
slow link.