### PR TITLE
RC_Channel: small optimisation in has_override

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -336,9 +336,12 @@ void RC_Channel::clear_override()
 
 bool RC_Channel::has_override() const
 {
+    if (override_value <= 0) {
+        return false;
+    }
     int32_t override_timeout = (int32_t)(*RC_Channels::override_timeout);
-    return (override_value > 0) && ((override_timeout < 0) ||
-                                    ((AP_HAL::millis() - last_override_time) < (uint32_t)(override_timeout * 1000)));
+    return ((override_timeout < 0) ||
+            ((AP_HAL::millis() - last_override_time) < (uint32_t)(override_timeout * 1000)));
 }
 
 //

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -339,9 +339,9 @@ bool RC_Channel::has_override() const
     if (override_value <= 0) {
         return false;
     }
-    int32_t override_timeout = (int32_t)(*RC_Channels::override_timeout);
+    const float override_timeout = RC_Channels::override_timeout->get();
     return ((override_timeout < 0) ||
-            ((AP_HAL::millis() - last_override_time) < (uint32_t)(override_timeout * 1000)));
+            ((AP_HAL::millis() - last_override_time) < (override_timeout * 1000)));
 }
 
 //


### PR DESCRIPTION
override_value being zero is the most common case.  Avoid playing with
the parameter if we can.