### PR TITLE
ServoRelayEvents: Use a more thorough mask

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -60,8 +60,6 @@ void Rover::init_ardupilot()
     notify.init();
     notify_mode(control_mode);
 
-    ServoRelayEvents.set_channel_mask(0xFFF0);
-
     battery.init();
 
     rssi.init();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -138,9 +138,6 @@ void Copter::init_ardupilot()
     // motors initialised so parameters can be sent
     ap.initialised_params = true;
 
-    // initialise which outputs Servo and Relay events can use
-    ServoRelayEvents.set_channel_mask(~motors->get_motor_mask());
-
     relay.init();
 
     /*

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -95,9 +95,6 @@ void Plane::init_ardupilot()
 
     init_rc_out_main();
     
-    // allow servo set on all channels except first 4
-    ServoRelayEvents.set_channel_mask(0xFFF0);
-
     // keep a record of how many resets have happened. This can be
     // used to detect in-flight resets
     g.num_resets.set_and_save(g.num_resets+1);

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -94,9 +94,6 @@ void Sub::init_ardupilot()
     init_rc_out();              // sets up motors and output to escs
     init_joystick();            // joystick initialization
 
-    // initialise which outputs Servo and Relay events can use
-    ServoRelayEvents.set_channel_mask(~motors.get_motor_mask());
-
     relay.init();
 
     /*

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
@@ -27,9 +27,6 @@ public:
         return _singleton;
     }
 
-    // set allowed servo channel mask
-    void set_channel_mask(uint16_t _mask) { mask = _mask; }
-
     bool do_set_servo(uint8_t channel, uint16_t pwm);
     bool do_set_relay(uint8_t relay_num, uint8_t state);
     bool do_repeat_servo(uint8_t channel, uint16_t servo_value, int16_t repeat, uint16_t delay_time_ms);
@@ -41,7 +38,6 @@ private:
     static AP_ServoRelayEvents *_singleton;
 
     AP_Relay &relay;
-    uint16_t mask;
 
     // event control state
     enum event_type { 


### PR DESCRIPTION
It appears that we were attempting to only allow ServoRelayEvents to occur on channels that were not used for vehicle control, but this was done with hard coding the first 4 channels on rover/plane, and copter looks at the motors mask. Unfortunately quadplanes also have a motor mask, and there is no guarantee that the flight surfaces are the first 4 channels. This attempts to preform a more thorough check to determine if a function should be allowed. `AP_ServoRelayEvents::calculate_channel_mask(void)` could probably be renamed to `AP_ServoRelayEvents::init(void)` if people would prefer that.

This also sneaks in a small change to remove one of the unknown mode change reasons on plane.