### PR TITLE
ChibiOS: improve blheli pass-thru reliability

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -93,6 +93,13 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Values: 0:None,1:OneShot,2:OneShot125,3:Brushed,4:DShot150,5:DShot300,6:DShot600,7:DShot1200
     // @User: Advanced
     AP_GROUPINFO("OTYPE",  7, AP_BLHeli, output_type, 0),
+
+    // @Param: PORT
+    // @DisplayName: Control port
+    // @Description: This sets the telemetry port to use for blheli pass-thru
+    // @Values: 0:Console,1:Telem1,2:Telem2,3:Telem3,4:Telem4,5:Telem5
+    // @User: Advanced
+    AP_GROUPINFO("PORT",  8, AP_BLHeli, control_port, 0),
     
     AP_GROUPEND
 };
@@ -105,6 +112,7 @@ AP_BLHeli::AP_BLHeli(void)
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);
     singleton = this;
+    last_control_port = -1;
 }
 
 /*
@@ -488,13 +496,14 @@ uint16_t AP_BLHeli::BL_CRC(const uint8_t *buf, uint16_t len)
 
 bool AP_BLHeli::isMcuConnected(void)
 {
-    return blheli.deviceInfo[0] > 0;
+    return blheli.connected[blheli.chan];
 }
 
 void AP_BLHeli::setDisconnected(void)
 {
-    blheli.deviceInfo[0] = 0;
-    blheli.deviceInfo[1] = 0;
+    blheli.connected[blheli.chan] = false;
+    blheli.deviceInfo[blheli.chan][0] = 0;
+    blheli.deviceInfo[blheli.chan][1] = 0;
 }
 
 /*
@@ -520,8 +529,6 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
           least 1 second before we start sending serial data. 
          */
         hal.scheduler->delay(1100);
-    } else {
-        hal.scheduler->delay(10);
     }
     memcpy(blheli.buf, buf, len);
     uint16_t crc = BL_CRC(buf, len);
@@ -608,7 +615,21 @@ bool AP_BLHeli::BL_ReadA(uint8_t cmd, uint8_t *buf, uint16_t n)
         if (!BL_SendBuf(sCMD, 2)) {
             return false;
         }
-        return BL_ReadBuf(buf, n);
+        bool ret = BL_ReadBuf(buf, n);
+        if (ret && n == sizeof(esc_status) && blheli.address == esc_status_addr) {
+            // display esc_status structure if we see it
+            struct esc_status status;
+            memcpy(&status, buf, n);
+            debug("Prot %u Good %u Bad %u %x %x %x x%x\n",
+                  (unsigned)status.protocol,
+                  (unsigned)status.good_frames,
+                  (unsigned)status.bad_frames,
+                  (unsigned)status.unknown[0],
+                  (unsigned)status.unknown[1],
+                  (unsigned)status.unknown[2],
+                  (unsigned)status.unknown2);
+        }
+        return ret;
     }
     return false;
 }
@@ -618,6 +639,10 @@ bool AP_BLHeli::BL_ReadA(uint8_t cmd, uint8_t *buf, uint16_t n)
  */
 bool AP_BLHeli::BL_ConnectEx(void)
 {
+    if (blheli.connected[blheli.chan] != 0) {
+        debug("Using cached interface 0x%x for %u", blheli.interface_mode[blheli.chan], blheli.chan);
+        return true;
+    }
     debug("BL_ConnectEx %u/%u at %u", blheli.chan, num_motors, motor_map[blheli.chan]);
     setDisconnected();
     const uint8_t BootInit[] = {0,0,0,0,0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
@@ -637,19 +662,19 @@ bool AP_BLHeli::BL_ConnectEx(void)
     }
 
     // extract device information
-    blheli.deviceInfo[2] = BootInfo[3];
-    blheli.deviceInfo[1] = BootInfo[4];
-    blheli.deviceInfo[0] = BootInfo[5];
+    blheli.deviceInfo[blheli.chan][2] = BootInfo[3];
+    blheli.deviceInfo[blheli.chan][1] = BootInfo[4];
+    blheli.deviceInfo[blheli.chan][0] = BootInfo[5];
 
-    blheli.interface_mode = 0;
+    blheli.interface_mode[blheli.chan] = 0;
     
-    uint16_t *devword = (uint16_t *)blheli.deviceInfo;
+    uint16_t *devword = (uint16_t *)blheli.deviceInfo[blheli.chan];
     switch (*devword) {
     case 0x9307:
     case 0x930A:
     case 0x930F:
     case 0x940B:
-        blheli.interface_mode = imATM_BLB;
+        blheli.interface_mode[blheli.chan] = imATM_BLB;
         debug("Interface type imATM_BLB");
         break;
     case 0xF310:
@@ -659,14 +684,14 @@ bool AP_BLHeli::BL_ConnectEx(void)
     case 0xF850:
     case 0xE8B1:
     case 0xE8B2:
-        blheli.interface_mode = imSIL_BLB;
+        blheli.interface_mode[blheli.chan] = imSIL_BLB;
         debug("Interface type imSIL_BLB");
         break;
     case 0x1F06:
     case 0x3306:
     case 0x3406:
     case 0x3506:
-        blheli.interface_mode = imARM_BLB;
+        blheli.interface_mode[blheli.chan] = imARM_BLB;
         debug("Interface type imARM_BLB");
         break;
     default:
@@ -674,7 +699,10 @@ bool AP_BLHeli::BL_ConnectEx(void)
         debug("Unknown interface type 0x%04x", *devword);
         break;
     }
-    blheli.deviceInfo[3] = blheli.interface_mode;
+    blheli.deviceInfo[blheli.chan][3] = blheli.interface_mode[blheli.chan];
+    if (blheli.interface_mode[blheli.chan] != 0) {
+        blheli.connected[blheli.chan] = true;
+    }
     return true;
 }
 
@@ -705,7 +733,7 @@ bool AP_BLHeli::BL_PageErase(void)
 void AP_BLHeli::BL_SendCMDRunRestartBootloader(void)
 {
     uint8_t sCMD[] = {RestartBootloader, 0};
-    blheli.deviceInfo[0] = 1;
+    blheli.deviceInfo[blheli.chan][0] = 1;
     BL_SendBuf(sCMD, 2);
 }
 
@@ -831,12 +859,19 @@ void AP_BLHeli::blheli_process_command(void)
             uart->lock_port(0);
             uart_locked = false;
         }
+        memset(blheli.connected, 0, sizeof(blheli.connected));
         break;
     }
     case cmd_DeviceReset: {
         debug("cmd_DeviceReset(%u)", unsigned(blheli.buf[0]));
+        if (blheli.buf[0] >= num_motors) {
+            debug("bad reset channel %u", blheli.buf[0]);
+            blheli.ack = ACK_D_GENERAL_ERROR;
+            blheli_send_reply(&blheli.buf[0], 1);            
+            break;
+        }
         blheli.chan = blheli.buf[0];
-        switch (blheli.interface_mode) {
+        switch (blheli.interface_mode[blheli.chan]) {
         case imSIL_BLB:
         case imATM_BLB:
         case imARM_BLB:
@@ -852,26 +887,25 @@ void AP_BLHeli::blheli_process_command(void)
 
     case cmd_DeviceInitFlash: {
         debug("cmd_DeviceInitFlash(%u)", unsigned(blheli.buf[0]));
-        blheli.chan = blheli.buf[0];
-        for (uint8_t tries=0; tries<5; tries++) {
-            blheli.ack = ACK_OK;
-            setDisconnected();
-            if (BL_ConnectEx()) {
-                break;
-            }
+        if (blheli.buf[0] >= num_motors) {
+            debug("bad channel %u", blheli.buf[0]);
+            break;
         }
-        uint8_t buf[4] = {blheli.deviceInfo[0],
-                          blheli.deviceInfo[1],
-                          blheli.deviceInfo[2],
-                          blheli.deviceInfo[3]};  // device ID
+        blheli.chan = blheli.buf[0];
+        blheli.ack = ACK_OK;
+        BL_ConnectEx();
+        uint8_t buf[4] = {blheli.deviceInfo[blheli.chan][0],
+                          blheli.deviceInfo[blheli.chan][1],
+                          blheli.deviceInfo[blheli.chan][2],
+                          blheli.deviceInfo[blheli.chan][3]};  // device ID
         blheli_send_reply(buf, sizeof(buf));
         break;
     }
 
     case cmd_InterfaceSetMode: {
         debug("cmd_InterfaceSetMode(%u)", unsigned(blheli.buf[0]));
-        blheli.interface_mode = blheli.buf[0];
-        blheli_send_reply(&blheli.interface_mode, 1);
+        blheli.interface_mode[blheli.chan] = blheli.buf[0];
+        blheli_send_reply(&blheli.interface_mode[blheli.chan], 1);
         break;
     }
 
@@ -879,7 +913,7 @@ void AP_BLHeli::blheli_process_command(void)
         uint16_t nbytes = blheli.buf[0]?blheli.buf[0]:256;
         debug("cmd_DeviceRead(%u) n=%u", blheli.chan, nbytes);
         uint8_t buf[nbytes];
-        uint8_t cmd = blheli.interface_mode==imATM_BLB?CMD_READ_FLASH_ATM:CMD_READ_FLASH_SIL;
+        uint8_t cmd = blheli.interface_mode[blheli.chan]==imATM_BLB?CMD_READ_FLASH_ATM:CMD_READ_FLASH_SIL;
         if (!BL_ReadA(cmd, buf, nbytes)) {
             nbytes = 1;
         }
@@ -889,11 +923,11 @@ void AP_BLHeli::blheli_process_command(void)
 
     case cmd_DevicePageErase: {
         uint8_t page = blheli.buf[0];
-        debug("cmd_DevicePageErase(%u) im=%u", page, blheli.interface_mode);
-        switch (blheli.interface_mode) {
+        debug("cmd_DevicePageErase(%u) im=%u", page, blheli.interface_mode[blheli.chan]);
+        switch (blheli.interface_mode[blheli.chan]) {
         case imSIL_BLB:
         case imARM_BLB: {
-            if  (blheli.interface_mode == imARM_BLB) {
+            if  (blheli.interface_mode[blheli.chan] == imARM_BLB) {
                 // Address =Page * 1024
                 blheli.address = page << 10;
             } else {
@@ -916,10 +950,10 @@ void AP_BLHeli::blheli_process_command(void)
 
     case cmd_DeviceWrite: {
         uint16_t nbytes = blheli.param_len;
-        debug("cmd_DeviceWrite n=%u im=%u", nbytes, blheli.interface_mode);
+        debug("cmd_DeviceWrite n=%u im=%u", nbytes, blheli.interface_mode[blheli.chan]);
         uint8_t buf[nbytes];
         memcpy(buf, blheli.buf, nbytes);
-        switch (blheli.interface_mode) {
+        switch (blheli.interface_mode[blheli.chan]) {
         case imSIL_BLB:
         case imATM_BLB:
         case imARM_BLB: {
@@ -938,8 +972,8 @@ void AP_BLHeli::blheli_process_command(void)
 
     case cmd_DeviceVerify: {
         uint16_t nbytes = blheli.param_len;
-        debug("cmd_DeviceWrite n=%u im=%u", nbytes, blheli.interface_mode);
-        switch (blheli.interface_mode) {
+        debug("cmd_DeviceWrite n=%u im=%u", nbytes, blheli.interface_mode[blheli.chan]);
+        switch (blheli.interface_mode[blheli.chan]) {
         case imARM_BLB: {
             uint8_t buf[nbytes];
             memcpy(buf, blheli.buf, nbytes);            
@@ -958,8 +992,8 @@ void AP_BLHeli::blheli_process_command(void)
     case cmd_DeviceReadEEprom: {
         uint16_t nbytes = blheli.buf[0]?blheli.buf[0]:256;
         uint8_t buf[nbytes];
-        debug("cmd_DeviceReadEEprom n=%u im=%u", nbytes, blheli.interface_mode);
-        switch (blheli.interface_mode) {
+        debug("cmd_DeviceReadEEprom n=%u im=%u", nbytes, blheli.interface_mode[blheli.chan]);
+        switch (blheli.interface_mode[blheli.chan]) {
         case imATM_BLB: {
             if (!BL_ReadA(CMD_READ_EEPROM, buf, nbytes)) {
                 blheli.ack = ACK_D_GENERAL_ERROR;
@@ -982,8 +1016,8 @@ void AP_BLHeli::blheli_process_command(void)
         uint16_t nbytes = blheli.param_len;
         uint8_t buf[nbytes];
         memcpy(buf, blheli.buf, nbytes);
-        debug("cmd_DeviceWriteEEprom n=%u im=%u", nbytes, blheli.interface_mode);
-        switch (blheli.interface_mode) {
+        debug("cmd_DeviceWriteEEprom n=%u im=%u", nbytes, blheli.interface_mode[blheli.chan]);
+        switch (blheli.interface_mode[blheli.chan]) {
         case imATM_BLB:
             BL_WriteA(CMD_PROG_EEPROM, buf, nbytes, 1000);
             break;
@@ -1024,6 +1058,7 @@ bool AP_BLHeli::process_input(uint8_t b)
     }
     if (msp.escMode != PROTOCOL_4WAY && msp.state == MSP_IDLE && b == '/') {
         debug("Change to BLHeli mode");
+        memset(blheli.connected, 0, sizeof(blheli.connected));
         msp.escMode = PROTOCOL_4WAY;
     }
     if (msp.escMode == PROTOCOL_4WAY) {
@@ -1080,6 +1115,10 @@ void AP_BLHeli::run_connection_test(uint8_t chan)
 {
     debug_uart = hal.console;
     uint8_t saved_chan = blheli.chan;
+    if (blheli.buf[0] >= num_motors) {
+        debug("bad channel %u", chan);
+        return;
+    }
     blheli.chan = chan;
     debug("Running test on channel %u", blheli.chan);
     run_test.set_and_notify(0);
@@ -1089,10 +1128,21 @@ void AP_BLHeli::run_connection_test(uint8_t chan)
         setDisconnected();
         if (BL_ConnectEx()) {
             uint8_t buf[256];
-            uint8_t cmd = blheli.interface_mode==imATM_BLB?CMD_READ_FLASH_ATM:CMD_READ_FLASH_SIL;
+            uint8_t cmd = blheli.interface_mode[blheli.chan]==imATM_BLB?CMD_READ_FLASH_ATM:CMD_READ_FLASH_SIL;
             passed = true;
-            blheli.address = blheli.interface_mode==imATM_BLB?0:0x7c00;
+            blheli.address = blheli.interface_mode[blheli.chan]==imATM_BLB?0:0x7c00;
             passed &= BL_ReadA(cmd, buf, sizeof(buf));
+            if (blheli.interface_mode[blheli.chan]==imARM_BLB) {
+                if (passed) {
+                    // read status structure
+                    blheli.address = esc_status_addr;
+                    passed &= BL_SendCMDSetAddress();
+                }
+                if (passed) {
+                    struct esc_status status;
+                    passed &= BL_ReadA(CMD_READ_FLASH_SIL, (uint8_t *)&status, sizeof(status));
+                }
+            }
             BL_SendCMDRunRestartBootloader();
             break;
         }
@@ -1139,11 +1189,16 @@ void AP_BLHeli::update(void)
     initialised = true;
 
     run_test.set_and_notify(0);
-    
-    if (gcs().install_alternative_protocol(MAVLINK_COMM_0,
+
+    if (last_control_port > 0 && last_control_port != control_port) {
+        gcs().install_alternative_protocol((mavlink_channel_t)(MAVLINK_COMM_0+last_control_port), nullptr);
+        last_control_port = -1;
+    }
+    if (gcs().install_alternative_protocol((mavlink_channel_t)(MAVLINK_COMM_0+control_port),
                                            FUNCTOR_BIND_MEMBER(&AP_BLHeli::protocol_handler,
                                                                bool, uint8_t, AP_HAL::UARTDriver *))) {
-        debug("BLHeli installed");
+        debug("BLHeli installed on port %u", (unsigned)control_port);
+        last_control_port = control_port;
     }
 
     uint16_t mask = uint16_t(channel_mask.get());

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -515,7 +515,7 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
     if (blheli.chan >= num_motors) {
         return false;
     }
-    if (!hal.rcout->serial_setup_output(motor_map[blheli.chan], 19200)) {
+    if (!hal.rcout->serial_setup_output(motor_map[blheli.chan], 19200, motor_mask)) {
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
@@ -1115,7 +1115,7 @@ void AP_BLHeli::run_connection_test(uint8_t chan)
 {
     debug_uart = hal.console;
     uint8_t saved_chan = blheli.chan;
-    if (blheli.buf[0] >= num_motors) {
+    if (chan >= num_motors) {
         debug("bad channel %u", chan);
         return;
     }
@@ -1256,6 +1256,7 @@ void AP_BLHeli::update(void)
             num_motors++;
         }
     }
+    motor_mask = mask;
     debug("ESC: %u motors mask=0x%04x", num_motors, mask);
 
     if (telem_rate > 0) {

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -237,6 +237,7 @@ private:
 
     // mapping from BLHeli motor numbers to RC output channels
     uint8_t motor_map[max_motors];
+    uint16_t motor_mask;
 
     // when did we last request telemetry?
     uint32_t last_telem_request_us;

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -137,12 +137,12 @@ public:
       databits. This is used for passthrough ESC configuration and
       firmware flashing
 
-      While serial output is active normal output to this channel is
-      suspended. Output to some other channels (such as those in the
-      same channel timer group) may also be stopped, depending on the
-      implementation
+      While serial output is active normal output to all channels in
+      the chanmask is suspended. Output to some other channels (such
+      as those in the same channel timer groups) may also be stopped,
+      depending on the implementation
      */
-    virtual bool serial_setup_output(uint8_t chan, uint32_t baudrate) { return false; }
+    virtual bool serial_setup_output(uint8_t chan, uint32_t baudrate, uint16_t chanmask) { return false; }
 
     /*
       write a set of bytes to an ESC, using settings from

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -158,7 +158,8 @@ private:
         uint32_t rc_frequency;
         bool in_serial_dma;
         uint64_t last_dshot_send_us;
-
+        virtual_timer_t dma_timeout;
+        
         // serial output
         struct {
             // expected time per bit
@@ -277,9 +278,10 @@ private:
     /*
       DShot handling
      */
-    const uint8_t dshot_post = 6;
+    const uint8_t dshot_post = 2;
     const uint16_t dshot_bit_length = 16 + dshot_post;
     const uint16_t dshot_buffer_length = dshot_bit_length*4*sizeof(uint32_t);
+    static const uint16_t dshot_min_gap_us = 100;
     uint32_t dshot_pulse_time_us;
     uint16_t telem_request_mask;
     
@@ -289,6 +291,7 @@ private:
     void fill_DMA_buffer_dshot(uint32_t *buffer, uint8_t stride, uint16_t packet, uint16_t clockmul);
     void dshot_send(pwm_group &group, bool blocking);
     static void dma_irq_callback(void *p, uint32_t flags);
+    static void dma_unlock(void *p);
     bool mode_requires_dma(enum output_mode mode) const;
     bool setup_group_DMA(pwm_group &group, uint32_t bitrate, uint32_t bit_width, bool active_high);
     void send_pulses_DMAR(pwm_group &group, uint32_t buffer_length);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -199,6 +199,10 @@ private:
         
         // thread waiting for byte to be read
         thread_t *waiter;
+
+        // timeout for byte read
+        virtual_timer_t serial_timeout;
+        bool timed_out;
     } irq;
 
     
@@ -206,7 +210,7 @@ private:
     struct pwm_group *serial_group;
     thread_t *serial_thread;
     tprio_t serial_priority;
-
+    
     static pwm_group pwm_group_list[];
     uint16_t _esc_pwm_min;
     uint16_t _esc_pwm_max;
@@ -296,6 +300,7 @@ private:
     bool serial_read_byte(uint8_t &b);
     void fill_DMA_buffer_byte(uint32_t *buffer, uint8_t stride, uint8_t b , uint32_t bitval);
     static void serial_bit_irq(void);
+    static void serial_byte_timeout(void *ctx);
 
 };
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -100,7 +100,7 @@ public:
       same channel timer group) may also be stopped, depending on the
       implementation
      */
-    bool serial_setup_output(uint8_t chan, uint32_t baudrate) override;
+    bool serial_setup_output(uint8_t chan, uint32_t baudrate, uint16_t motor_mask) override;
 
     /*
       write a set of bytes to an ESC, using settings from
@@ -278,8 +278,10 @@ private:
     /*
       DShot handling
      */
+    // the pre-bit is needed with TIM5, or we can get some corrupt frames
+    const uint8_t dshot_pre = 1;
     const uint8_t dshot_post = 2;
-    const uint16_t dshot_bit_length = 16 + dshot_post;
+    const uint16_t dshot_bit_length = 16 + dshot_pre + dshot_post;
     const uint16_t dshot_buffer_length = dshot_bit_length*4*sizeof(uint32_t);
     static const uint16_t dshot_min_gap_us = 100;
     uint32_t dshot_pulse_time_us;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -58,7 +58,7 @@ bool GCS::install_alternative_protocol(mavlink_channel_t c, GCS_MAVLINK::protoco
     if (c >= num_gcs()) {
         return false;
     }
-    if (chan(c).alternative.handler) {
+    if (chan(c).alternative.handler && handler) {
         // already have one installed - we may need to add support for
         // multiple alternative handlers
         return false;


### PR DESCRIPTION
This makes the pass-thru protocol considerably more reliable

It also gets the "bad frame" count reported from BLHeli32 for Dshot to be zero, fixing a number of causes of bad DShot frames