### PR TITLE
AP_Baro: added register checking on BMP280

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP280.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP280.cpp
@@ -105,10 +105,12 @@ bool AP_Baro_BMP280::_init()
         mask = 0x7F;
     }
 
+    _dev->setup_checked_registers(2, 20);
+    
     _dev->write_register((BMP280_REG_CTRL_MEAS & mask), (BMP280_OVERSAMPLING_T << 5) |
-                         (BMP280_OVERSAMPLING_P << 2) | BMP280_MODE);
+                         (BMP280_OVERSAMPLING_P << 2) | BMP280_MODE, true);
 
-    _dev->write_register((BMP280_REG_CONFIG & mask), BMP280_FILTER_COEFFICIENT << 2);
+    _dev->write_register((BMP280_REG_CONFIG & mask), BMP280_FILTER_COEFFICIENT << 2, true);
 
     _instance = _frontend.register_sensor();
 
@@ -131,6 +133,8 @@ void AP_Baro_BMP280::_timer(void)
 
     _update_temperature((buf[3] << 12) | (buf[4] << 4) | (buf[5] >> 4));
     _update_pressure((buf[0] << 12) | (buf[1] << 4) | (buf[2] >> 4));
+
+    _dev->check_next_register();
 }
 
 // transfer data to the frontend


### PR DESCRIPTION
this follows a log which seems to show an in-flight register
corruption on a MatekF405