### PR TITLE
Remove min max configured pre-arm checks

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -19,10 +19,6 @@ bool AP_Arming_Rover::pre_arm_rc_checks(const bool display_failure)
         const RC_Channel *channel = channels[i];
         const char *channel_name = channel_names[i];
         // check if radio has been calibrated
-        if (!channel->min_max_configured()) {
-            check_failed(ARMING_CHECK_RC, display_failure, "RC %s not configured", channel_name);
-            return false;
-        }
         if (channel->get_radio_min() > 1300) {
             check_failed(ARMING_CHECK_RC, display_failure, "%s radio min too high", channel_name);
             return false;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -687,10 +687,6 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
         const RC_Channel *channel = channels[i];
         const char *channel_name = channel_names[i];
         // check if radio has been calibrated
-        if (check_min_max && !channel->min_max_configured()) {
-            check_failed(ARMING_CHECK_RC, display_failure, "RC %s not configured", channel_name);
-            ret = false;
-        }
         if (channel->get_radio_min() > 1300) {
             check_failed(ARMING_CHECK_RC, display_failure, "%s radio min too high", channel_name);
             ret = false;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -29,8 +29,6 @@ extern const AP_HAL::HAL& hal;
 
 #include <GCS_MAVLink/GCS.h>
 
-uint32_t RC_Channel::configured_mask;
-
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN
     // @DisplayName: RC min PWM
@@ -338,20 +336,6 @@ bool RC_Channel::has_override() const
     int32_t override_timeout = (int32_t)(*RC_Channels::override_timeout);
     return (override_value > 0) && ((override_timeout < 0) ||
                                     ((AP_HAL::millis() - last_override_time) < (uint32_t)(override_timeout * 1000)));
-}
-
-bool RC_Channel::min_max_configured() const
-{
-    if (configured_mask & (1U << ch_in)) {
-        return true;
-    }
-    if (radio_min.configured() && radio_max.configured()) {
-        // once a channel is known to be configured it has to stay
-        // configured due to the nature of AP_Param
-        configured_mask |= (1U<<ch_in);
-        return true;
-    }
-    return false;
 }
 
 //

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -97,9 +97,7 @@ public:
 
     // set and save trim if changed
     void       set_and_save_radio_trim(int16_t val) { radio_trim.set_and_save_ifchanged(val);}
-    
-    bool min_max_configured() const;
-    
+
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
 
     // auxillary switch support:
@@ -214,9 +212,6 @@ private:
     // overrides
     uint16_t override_value;
     uint32_t last_override_time;
-
-    // bits set when channel has been identified as configured
-    static uint32_t configured_mask;
 
     int16_t pwm_to_angle();
     int16_t pwm_to_angle_dz(uint16_t dead_zone);


### PR DESCRIPTION
These are really, really expensive to run while your RC isn't
configured.

We now have a split between inputs (RC) and servos (SRV), so these
aren't as critical as they were.  We also have range checks to ensure
they're roughly good enough to fly with.
