### PR TITLE
Param: moved parameter saving to IO thread and new semaphore API

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -159,3 +159,24 @@ bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 #else
 #define SITL_printf(fmt, args ...)
 #endif
+
+/*
+  a method to make semaphores less error prone
+ */
+class WithSemaphore {
+public:
+    WithSemaphore(HAL_Semaphore &mtx) :
+    _mtx(mtx)
+    {
+        _mtx.take_blocking();
+    }
+
+    ~WithSemaphore() {
+        _mtx.give();
+    }
+private:
+    HAL_Semaphore &_mtx;
+};
+
+#define WITH_SEMAPHORE(sem) WithSemaphore _getsem(sem)
+

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -159,24 +159,3 @@ bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 #else
 #define SITL_printf(fmt, args ...)
 #endif
-
-/*
-  a method to make semaphores less error prone
- */
-class WithSemaphore {
-public:
-    WithSemaphore(HAL_Semaphore &mtx) :
-    _mtx(mtx)
-    {
-        _mtx.take_blocking();
-    }
-
-    ~WithSemaphore() {
-        _mtx.give();
-    }
-private:
-    HAL_Semaphore &_mtx;
-};
-
-#define WITH_SEMAPHORE(sem) WithSemaphore _getsem(sem)
-

--- a/libraries/AP_Common/Semaphore.h
+++ b/libraries/AP_Common/Semaphore.h
@@ -1,0 +1,37 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  a method to make semaphores less error prone. The WITH_SEMAPHORE()
+  macro will block forever for a semaphore, and will automatically
+  release the semaphore when it goes out of scope
+ */
+class WithSemaphore {
+public:
+    WithSemaphore(HAL_Semaphore &mtx) :
+    _mtx(mtx)
+    {
+        _mtx.take_blocking();
+    }
+
+    ~WithSemaphore() {
+        _mtx.give();
+    }
+private:
+    HAL_Semaphore &_mtx;
+};
+
+#define WITH_SEMAPHORE(sem) WithSemaphore _getsem(sem)
+

--- a/libraries/AP_HAL/board/chibios.h
+++ b/libraries/AP_HAL/board/chibios.h
@@ -38,6 +38,10 @@
 #define HAL_WITH_RAMTRON 0
 #endif
 
+// allow for static semaphores
+#include <AP_HAL_ChibiOS/Semaphores.h>
+#define HAL_Semaphore ChibiOS::Semaphore
+
 /* string names for well known SPI devices */
 #define HAL_BARO_MS5611_NAME "ms5611"
 #ifndef HAL_BARO_MS5611_SPI_INT_NAME

--- a/libraries/AP_HAL/board/empty.h
+++ b/libraries/AP_HAL/board/empty.h
@@ -11,3 +11,5 @@
 
 #define HAL_HAVE_BOARD_VOLTAGE 1
 #define HAL_HAVE_SAFETY_SWITCH 1
+
+#define HAL_Semaphore Empty::Semaphore

--- a/libraries/AP_HAL/board/f4light.h
+++ b/libraries/AP_HAL/board/f4light.h
@@ -83,3 +83,7 @@
  
  
 #define STATS_ENABLED DISABLED // to reduce flash degradation
+
+#include <AP_HAL_F4Light/Semaphores.h>
+#define HAL_Semaphore F4Light::Semaphore
+

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -395,3 +395,6 @@
 #ifndef HAL_LINUX_I2C_EXTERNAL_BUS_MASK
 #define HAL_LINUX_I2C_EXTERNAL_BUS_MASK 0xFFFF
 #endif
+
+#include <AP_HAL_Linux/Semaphores.h>
+#define HAL_Semaphore Linux::Semaphore

--- a/libraries/AP_HAL/board/px4.h
+++ b/libraries/AP_HAL/board/px4.h
@@ -140,3 +140,6 @@
 #ifndef AP_FEATURE_SBUS_OUT
 #define AP_FEATURE_SBUS_OUT 1
 #endif
+
+#include <AP_HAL_PX4/Semaphores.h>
+#define HAL_Semaphore PX4::Semaphore

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -20,3 +20,7 @@
 
 #define HAL_HAVE_BOARD_VOLTAGE 1
 #define HAL_HAVE_SAFETY_SWITCH 0
+
+// allow for static semaphores
+#include <AP_HAL_SITL/Semaphores.h>
+#define HAL_Semaphore HALSITL::Semaphore

--- a/libraries/AP_HAL/board/vrbrain.h
+++ b/libraries/AP_HAL/board/vrbrain.h
@@ -94,3 +94,7 @@
 #ifndef HAL_HAVE_SAFETY_SWITCH
 #define HAL_HAVE_SAFETY_SWITCH 1
 #endif
+
+#include <AP_HAL_VRBRAIN/Semaphores.h>
+#define HAL_Semaphore VRBRAIN::Semaphore
+

--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -17,12 +17,13 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/OwnPtr.h>
 #include <stdio.h>
+
+#if HAL_USE_I2C == TRUE || HAL_USE_SPI == TRUE
+
 #include "Scheduler.h"
 #include "Semaphores.h"
 #include "Util.h"
 #include "hwdef/common/stm32_util.h"
-
-#if HAL_USE_I2C == TRUE || HAL_USE_SPI == TRUE
 
 using namespace ChibiOS;
 

--- a/libraries/AP_HAL_ChibiOS/Device.h
+++ b/libraries/AP_HAL_ChibiOS/Device.h
@@ -17,6 +17,10 @@
 #include <inttypes.h>
 #include <AP_HAL/HAL.h>
 #include "Semaphores.h"
+#include "AP_HAL_ChibiOS.h"
+
+#if HAL_USE_I2C == TRUE || HAL_USE_SPI == TRUE
+
 #include "Scheduler.h"
 #include "shared_dma.h"
 #include "hwdef/common/bouncebuffer.h"
@@ -57,3 +61,6 @@ private:
 };
 
 }
+
+#endif // I2C or SPI
+

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -17,13 +17,14 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include "Util.h"
+
+#if HAL_USE_I2C == TRUE
+
 #include "Scheduler.h"
 #include "hwdef/common/stm32_util.h"
 
 #include "ch.h"
 #include "hal.h"
-
-#if HAL_USE_I2C == TRUE
 
 static const struct I2CInfo {
     struct I2CDriver *i2c;

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -24,11 +24,13 @@
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
 #include <AP_HAL/utility/OwnPtr.h>
+#include "AP_HAL_ChibiOS.h"
+
+#if HAL_USE_I2C == TRUE
+
 #include "Semaphores.h"
 #include "Device.h"
 #include "shared_dma.h"
-
-#if HAL_USE_I2C == TRUE
 
 namespace ChibiOS {
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -17,11 +17,13 @@
 #include <inttypes.h>
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/SPIDevice.h>
+#include "AP_HAL_ChibiOS.h"
+
+#if HAL_USE_SPI == TRUE
+
 #include "Semaphores.h"
 #include "Scheduler.h"
 #include "Device.h"
-
-#if HAL_USE_SPI == TRUE
 
 namespace ChibiOS {
 

--- a/libraries/AP_HAL_ChibiOS/Semaphores.cpp
+++ b/libraries/AP_HAL_ChibiOS/Semaphores.cpp
@@ -16,6 +16,7 @@
  */
 #include <AP_HAL/AP_HAL.h>
 #include "Semaphores.h"
+#include "AP_HAL_ChibiOS.h"
 
 #if CH_CFG_USE_MUTEXES == TRUE
 
@@ -23,16 +24,28 @@ extern const AP_HAL::HAL& hal;
 
 using namespace ChibiOS;
 
+// constructor
+Semaphore::Semaphore()
+{
+    static_assert(sizeof(_lock) >= sizeof(mutex_t), "invalid mutex size");
+#if CH_CFG_USE_MUTEXES == TRUE
+    mutex_t *mtx = (mutex_t *)_lock;
+    chMtxObjectInit(mtx);
+#endif
+}
+
 bool Semaphore::give()
 {
-    chMtxUnlock(&_lock);
+    mutex_t *mtx = (mutex_t *)_lock;
+    chMtxUnlock(mtx);
     return true;
 }
 
 bool Semaphore::take(uint32_t timeout_ms)
 {
+    mutex_t *mtx = (mutex_t *)_lock;
     if (timeout_ms == HAL_SEMAPHORE_BLOCK_FOREVER) {
-        chMtxLock(&_lock);
+        chMtxLock(mtx);
         return true;
     }
     if (take_nonblocking()) {
@@ -50,7 +63,23 @@ bool Semaphore::take(uint32_t timeout_ms)
 
 bool Semaphore::take_nonblocking()
 {
-    return chMtxTryLock(&_lock);
+    mutex_t *mtx = (mutex_t *)_lock;
+    return chMtxTryLock(mtx);
+}
+
+bool Semaphore::check_owner(void)
+{
+    mutex_t *mtx = (mutex_t *)_lock;
+#if CH_CFG_USE_MUTEXES == TRUE
+    return mtx->owner == chThdGetSelfX();
+#else
+    return true;
+#endif
+}
+
+void Semaphore::assert_owner(void)
+{
+    osalDbgAssert(check_owner(), "owner");
 }
 
 #endif // CH_CFG_USE_MUTEXES

--- a/libraries/AP_HAL_ChibiOS/Semaphores.h
+++ b/libraries/AP_HAL_ChibiOS/Semaphores.h
@@ -16,31 +16,24 @@
  */
 #pragma once
 
+#include <stdint.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#include "AP_HAL_ChibiOS.h"
-
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Semaphores.h>
+#include "AP_HAL_ChibiOS_Namespace.h"
 
 class ChibiOS::Semaphore : public AP_HAL::Semaphore {
 public:
-    Semaphore() {
-#if CH_CFG_USE_MUTEXES == TRUE
-        chMtxObjectInit(&_lock);
-#endif
-    }
-    bool give();
-    bool take(uint32_t timeout_ms);
-    bool take_nonblocking();
-    bool check_owner(void) {
-#if CH_CFG_USE_MUTEXES == TRUE
-        return _lock.owner == chThdGetSelfX();
-#else
-        return true;
-#endif
-    }
-    void assert_owner(void) {
-        osalDbgAssert(check_owner(), "owner");
-    }
+    Semaphore();
+    bool give() override;
+    bool take(uint32_t timeout_ms) override;
+    bool take_nonblocking() override;
+
+    // methods within HAL_ChibiOS only
+    bool check_owner(void);
+    void assert_owner(void);
 private:
-    mutex_t _lock;
+    // to avoid polluting the global namespace with the 'ch' variable,
+    // we declare the lock as a uint64_t, and cast inside the cpp file
+    uint64_t _lock[2];
 };

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -18,7 +18,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_ChibiOS_Namespace.h"
-#include "Semaphores.h"
+#include "AP_HAL_ChibiOS.h"
 
 class ChibiOS::Util : public AP_HAL::Util {
 public:

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/chconf.h
@@ -39,6 +39,14 @@
  */
 /*===========================================================================*/
 
+#if !defined(FALSE)
+#define FALSE                               0
+#endif
+
+#if !defined(TRUE)
+#define TRUE                                1
+#endif
+
 #ifdef HAL_CHIBIOS_ENABLE_ASSERTS
 #define CH_DBG_ENABLE_ASSERTS TRUE
 #define CH_DBG_ENABLE_CHECKS TRUE

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1025,6 +1025,14 @@ def write_hwdef_header(outfilename):
 
 #pragma once
 
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
 ''')
 
     write_mcu_config(f)

--- a/libraries/AP_HAL_Linux/Semaphores.h
+++ b/libraries/AP_HAL_Linux/Semaphores.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <pthread.h>
-
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#include "AP_HAL_Linux.h"
+#include <stdint.h>
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Semaphores.h>
+#include <pthread.h>
 
 namespace Linux {
 

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -5,6 +5,7 @@
 
 #include "AP_HAL_Linux.h"
 #include "SerialDevice.h"
+#include "Semaphores.h"
 
 namespace Linux {
 
@@ -97,6 +98,8 @@ protected:
 
     virtual int _write_fd(const uint8_t *buf, uint16_t n);
     virtual int _read_fd(uint8_t *buf, uint16_t n);
+
+    Linux::Semaphore _write_mutex;    
 };
 
 }

--- a/libraries/AP_HAL_PX4/Semaphores.h
+++ b/libraries/AP_HAL_PX4/Semaphores.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
-#include "AP_HAL_PX4.h"
+#include <stdint.h>
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Semaphores.h>
+#include "AP_HAL_PX4_Namespace.h"
 #include <pthread.h>
 
 class PX4::Semaphore : public AP_HAL::Semaphore {
@@ -17,4 +18,4 @@ public:
 private:
     pthread_mutex_t _lock;
 };
-#endif // CONFIG_HAL_BOARD
+

--- a/libraries/AP_HAL_SITL/Semaphores.h
+++ b/libraries/AP_HAL_SITL/Semaphores.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#include "AP_HAL_SITL.h"
+#include <stdint.h>
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Semaphores.h>
+#include "AP_HAL_SITL_Namespace.h"
 #include <pthread.h>
 
 class HALSITL::Semaphore : public AP_HAL::Semaphore {
@@ -17,5 +18,5 @@ public:
 private:
     pthread_mutex_t _lock;
 };
-#endif  // CONFIG_HAL_BOARD
+
 

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -2,6 +2,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_SITL_Namespace.h"
+#include "AP_HAL_SITL.h"
 #include "Semaphores.h"
 
 class HALSITL::Util : public AP_HAL::Util {

--- a/libraries/AP_HAL_VRBRAIN/Semaphores.h
+++ b/libraries/AP_HAL_VRBRAIN/Semaphores.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-#include "AP_HAL_VRBRAIN.h"
+#include <stdint.h>
+#include <AP_HAL/AP_HAL_Macros.h>
+#include <AP_HAL/Semaphores.h>
+#include "AP_HAL_VRBRAIN_Namespace.h"
 #include <pthread.h>
 
 class VRBRAIN::Semaphore : public AP_HAL::Semaphore {
@@ -17,4 +18,4 @@ public:
 private:
     pthread_mutex_t _lock;
 };
-#endif // CONFIG_HAL_BOARD
+

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -67,5 +67,4 @@ bool GCS::install_alternative_protocol(mavlink_channel_t c, GCS_MAVLINK::protoco
     return true;
 }
 
-
 #undef FOR_EACH_ACTIVE_CHANNEL

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -648,7 +648,7 @@ public:
 
     // get the VFR_HUD throttle
     int16_t get_hud_throttle(void) const { return num_gcs()>0?chan(0).vfr_hud_throttle():0; }
-    
+
 private:
 
     static GCS *_singleton;
@@ -664,6 +664,11 @@ private:
     static const uint8_t _status_capacity = 30;
 #endif
 
+    // a lock for the statustext queue, to make it safe to use send_text()
+    // from multiple threads
+    HAL_Semaphore _statustext_sem;
+
+    // queue of outgoing statustext messages
     ObjectArray<statustext_t> _statustext_queue{_status_capacity};
 
     // true if we are running short on time in our main loop

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1281,7 +1281,7 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
     statustext.msg.severity = severity;
     strncpy(statustext.msg.text, text, sizeof(statustext.msg.text));
 
-    _statustext_sem.take_blocking();
+    WITH_SEMAPHORE(_statustext_sem);
     
     // The force push will ensure comm links do not block other comm links forever if they fail.
     // If we push to a full buffer then we overwrite the oldest entry, effectively removing the
@@ -1295,8 +1295,6 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
     if (notify) {
         notify->send_text(text);
     }
-
-    _statustext_sem.give();
 }
 
 /*
@@ -1363,9 +1361,8 @@ void GCS::retry_deferred()
             chan(i).retry_deferred();
         }
     }
-    _statustext_sem.take_blocking();
+    WITH_SEMAPHORE(_statustext_sem);
     service_statustext();
-    _statustext_sem.give();
 }
 
 void GCS::data_stream_send()

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -22,6 +22,7 @@
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_BLHeli/AP_BLHeli.h>
+#include <AP_Common/Semaphore.h>
 
 #include "GCS.h"
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1852,8 +1852,12 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
     // force safety on
     hal.rcout->force_safety_on();
     hal.rcout->force_safety_no_wait();
-    hal.scheduler->delay(200);
 
+    // flush pending parameter writes
+    AP_Param::flush();
+
+    hal.scheduler->delay(200);
+    
     // when packet.param1 == 3 we reboot to hold in bootloader
     const bool hold_in_bootloader = is_equal(packet.param1, 3.0f);
     hal.scheduler->reboot(hold_in_bootloader);

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -11,6 +11,9 @@
 
 #define MAVLINK_SEND_UART_BYTES(chan, buf, len) comm_send_buffer(chan, buf, len)
 
+#define MAVLINK_START_UART_SEND(chan, size) comm_send_lock(chan)
+#define MAVLINK_END_UART_SEND(chan, size) comm_send_unlock(chan)
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 // allow extra mavlink channels in SITL for:
 //    Vicon
@@ -71,5 +74,9 @@ uint16_t comm_get_txspace(mavlink_channel_t chan);
 
 // return a MAVLink variable type given a AP_Param type
 uint8_t mav_var_type(enum ap_var_type t);
+
+// lock and unlock a channel, for multi-threaded mavlink send
+void comm_send_lock(mavlink_channel_t chan);
+void comm_send_unlock(mavlink_channel_t chan);
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This moves parameter saving to the IO thread, ensuring that we don't spend time on scanning the parameter table in the main thread.
This fixes a significant cause of scheduling overruns in copter
Note that this makes param save() a void function, as it makes no sense to give a success return when doing an async save. There were no users of the return value anyway
As parameter save also does a PARAM_VALUE send on MAVLink, this PR also required that we make parameter send thread safe, which means we had to make UART write thread safe in HAL_Linux. It is already thread safe in HAL_PX4 and HAL_ChibiOS.
