### PR TITLE
Rover/boat: loiter parameter to allow user to specify always face bow to target point

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -556,6 +556,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_Follow/AP_Follow.cpp
     AP_SUBGROUPINFO(follow, "FOLL", 23, ParametersG2, AP_Follow),
 
+    // @Param: LOIT_TYPE
+    // @DisplayName: Loiter type
+    // @Descriction: Loiter behaviour when around next to a taget point
+    // @Values: 0:Reverse to target point,1:Always face bow to target point
+    // @User: Standard
+    AP_GROUPINFO("LOIT_TYPE", 24, ParametersG2, loit_type, 0),
+
+
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -132,6 +132,7 @@ public:
         k_param_throttle_reduction,     // unused
         k_param_pilot_steer_type,
         k_param_skid_steer_out_old, // unused
+        k_param_loit_type,
 
         // failsafe control
         k_param_fs_action = 180,
@@ -238,6 +239,7 @@ public:
     //
     AP_Int8     throttle_cruise;
     AP_Int8     pilot_steer_type;
+    AP_Int8     loit_type;
 
     // failsafe control
     AP_Int8     fs_action;

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -132,7 +132,6 @@ public:
         k_param_throttle_reduction,     // unused
         k_param_pilot_steer_type,
         k_param_skid_steer_out_old, // unused
-        k_param_loit_type,
 
         // failsafe control
         k_param_fs_action = 180,
@@ -353,6 +352,10 @@ public:
 
     // follow mode library
     AP_Follow follow;
+
+    // loiter type
+    AP_Int8 loit_type;
+
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -36,7 +36,7 @@ void ModeLoiter::update()
         _desired_yaw_cd = get_bearing_cd(rover.current_loc, _destination);
         _yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
         // if destination is behind vehicle, reverse towards it
-        if (fabsf(_yaw_error_cd) > 9000) {
+        if (fabsf(_yaw_error_cd) > 9000 && g2.loit_type == 0) {
             _desired_yaw_cd = wrap_180_cd(_desired_yaw_cd + 18000);
             _yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
             _desired_speed = -_desired_speed;


### PR DESCRIPTION
This PR addresses issue #8711 , a parameter could now be set to have the bow to always be facing the target. 