### PR TITLE
AC_PrecLand: Send Mavlink LANDING_TARGET message

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -362,6 +362,15 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 #endif
         break;
 
+    case MSG_LANDING_TARGET:
+#if PRECISION_LANDING == ENABLED
+        CHECK_PAYLOAD_SIZE(LANDING_TARGET);
+        if (copter.precland.enabled()) {
+            copter.precland.send_landing_target(chan);
+        }
+#endif
+        break;
+
     default:
         return GCS_MAVLINK::try_send_message(id);
     }
@@ -516,6 +525,7 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_VIBRATION,
     MSG_RPM,
     MSG_ESC_TELEMETRY,
+    MSG_LANDING_TARGET,
 };
 static const ap_message STREAM_ADSB_msgs[] = {
     MSG_ADSB_VEHICLE

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -256,6 +256,39 @@ void AC_PrecLand::handle_msg(mavlink_message_t* msg)
     }
 }
 
+// send_landing_target - Send LANDING_TARGET mavlink message, called from ArduCopter/GCS_Mavlink.cpp as part of EXTRA3 stream
+void AC_PrecLand::send_landing_target(mavlink_channel_t chan)
+{
+    // If we have the sensor timestamp then set that as time_usec, otherwise return measurement timestamp
+    uint64_t time_usec;
+    if (_last_backend_los_timestamp) {
+        time_usec = _last_backend_los_timestamp;
+    } else {
+        time_usec = _last_backend_los_meas_ms * 1000;
+    }
+
+    // Pack and send the LANDING_TARGET message
+    // Note: TODO are for message fields that do not yet have data members in AC_PrecLand class or are not supported yet
+    // Note: 0 values here are sent in absence of sensible defaults.  They are not correct, but there is no obvious alternative
+    mavlink_msg_landing_target_send(
+        chan,
+        time_usec, // sensor/measurement timestamp in microseconds, either from epoch or since boot
+        0, // TODO: Target ID
+        MAV_FRAME_BODY_NED, // frame
+        _angle_x, // angle_x,
+        _angle_y, // angle_y,
+        _dist, // distance to target, measured from rangefinder or sensor message
+        0, // TODO: size_x,
+        0, // TODO: size_y,
+        _target_pos_rel_out_NE.x, // x,
+        _target_pos_rel_out_NE.y, // y,
+        0, // TODO: z,
+        0, // TODO: q,
+        0, // TODO: type,
+        target_acquired()
+    );
+}
+
 //
 // Private methods
 //
@@ -359,6 +392,10 @@ bool AC_PrecLand::retrieve_los_meas(Vector3f& target_vec_unit_body)
         _last_backend_los_meas_ms = _backend->los_meas_time_ms();
         _backend->get_los_body(target_vec_unit_body);
 
+        // Calculate angular offsets for send_landing_target()
+        _angle_x = -atanf(target_vec_unit_body.x);
+        _angle_y = atanf(target_vec_unit_body.y);
+
         // Apply sensor yaw alignment rotation
         float sin_yaw_align = sinf(radians(_yaw_align*0.01f));
         float cos_yaw_align = cosf(radians(_yaw_align*0.01f));
@@ -385,13 +422,13 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
         bool target_vec_valid = target_vec_unit_ned.z > 0.0f;
         bool alt_valid = (rangefinder_alt_valid && rangefinder_alt_m > 0.0f) || (_backend->distance_to_target() > 0.0f);
         if (target_vec_valid && alt_valid) {
-            float dist, alt;
+            float alt;
             if (_backend->distance_to_target() > 0.0f) {
-                dist = _backend->distance_to_target();
-                alt = dist * target_vec_unit_ned.z;
+                _dist = _backend->distance_to_target();
+                alt = _dist * target_vec_unit_ned.z;
             } else {
                 alt = MAX(rangefinder_alt_m, 0.0f);
-                dist = alt / target_vec_unit_ned.z;
+                _dist = alt / target_vec_unit_ned.z;
             }
 
             // Compute camera position relative to IMU
@@ -399,7 +436,7 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
             Vector3f cam_pos_ned = inertial_data_delayed->Tbn * (_cam_offset.get() - accel_body_offset);
 
             // Compute target position relative to IMU
-            _target_pos_rel_meas_NED = Vector3f(target_vec_unit_ned.x*dist, target_vec_unit_ned.y*dist, alt) + cam_pos_ned;
+            _target_pos_rel_meas_NED = Vector3f(target_vec_unit_ned.x*_dist, target_vec_unit_ned.y*_dist, alt) + cam_pos_ned;
             return true;
         }
     }

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -90,6 +90,9 @@ public:
     // process a LANDING_TARGET mavlink message
     void handle_msg(mavlink_message_t* msg);
 
+    // send a LANDING_TARGET mavlink message
+    void send_landing_target(mavlink_channel_t chan);
+
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -120,6 +123,7 @@ private:
     AP_Int8                     _type;              // precision landing sensor type
     AP_Int8                     _bus;               // which sensor bus
     AP_Int8                     _estimator_type;    // precision landing estimator type
+    AP_Float                    _dist;              // Distance to target measured from rangefinder or sensor
     AP_Float                    _lag;               // sensor lag in seconds
     AP_Float                    _yaw_align;         // Yaw angle from body x-axis to sensor x-axis.
     AP_Float                    _land_ofs_cm_x;     // Desired landing position of the camera forward of the target in vehicle body frame
@@ -130,10 +134,12 @@ private:
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen
+    uint64_t                    _last_backend_los_timestamp; // sensor time target was last seen
 
     PosVelEKF                   _ekf_x, _ekf_y;     // Kalman Filter for x and y axis
     uint32_t                    _outlier_reject_count;  // mini-EKF's outlier counter (3 consecutive outliers lead to EKF accepting updates)
-    
+
+    float                       _angle_x, _angle_y;     // target's angular offset
     Vector3f                    _target_pos_rel_meas_NED; // target's relative position as 3D vector
 
     Vector2f                    _target_pos_rel_est_NE; // target's position relative to the IMU, not compensated for lag

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -83,6 +83,7 @@ enum ap_message : uint8_t {
     MSG_LANDING,
     MSG_ESC_TELEMETRY,
     MSG_NAMED_FLOAT,
+    MSG_LANDING_TARGET,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };
 


### PR DESCRIPTION
Add LANDING_TARGET mavlink message to EXTRA3 stream to send AC_PrecLand status to GCS/connected mavlink processors.  Not all fields of the expanded LANDING_TARGET message are completed yet as they are either not supported/consumed/processed by ArduPilot, or not available as class data members.  Subsequent PRs will correct/improve this.

This is also a structured alternative to #8985 