### PR TITLE
AC_PrecLand: Improve logging

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -199,6 +199,12 @@ bool AC_PrecLand::get_target_position_cm(Vector2f& ret)
     return true;
 }
 
+void AC_PrecLand::get_target_position_measurement_cm(Vector3f& ret)
+{
+    ret = _target_pos_rel_meas_NED*100.0f;
+    return;
+}
+
 bool AC_PrecLand::get_target_position_relative_cm(Vector2f& ret)
 {
     if (!target_acquired()) {

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -59,11 +59,23 @@ public:
     // returns time of last update
     uint32_t last_update_ms() const { return _last_update_ms; }
 
+    // returns time of last time target was seen
+    uint32_t last_backend_los_meas_ms() const { return _last_backend_los_meas_ms; }
+
+    // returns estimator type
+    uint8_t estimator_type() const { return _estimator_type; }
+
+    // returns ekf outlier count
+    uint32_t ekf_outlier_count() const { return _outlier_reject_count; }
+
     // give chance to driver to get updates from sensor, should be called at 400hz
     void update(float rangefinder_alt_cm, bool rangefinder_alt_valid);
 
     // returns target position relative to the EKF origin
     bool get_target_position_cm(Vector2f& ret);
+
+    // returns target relative position as 3D vector
+    void get_target_position_measurement_cm(Vector3f& ret);
 
     // returns target position relative to vehicle
     bool get_target_position_relative_cm(Vector2f& ret);


### PR DESCRIPTION
This adds 6 new fields to AC_PrecLand logging:
```
        meas_x          : target_pos_meas.x,
        meas_y          : target_pos_meas.y,
        meas_z          : target_pos_meas.z,
        last_meas       : precland.last_backend_los_meas_ms(),
        ekf_outcount    : precland.ekf_outlier_count(),
        estimator       : precland.estimator_type()
```
Currently it logs position data:
```
        pos_x           : target_pos_rel.x,
        pos_y           : target_pos_rel.y,
        vel_x           : target_vel_rel.x,
        vel_y           : target_vel_rel.y,
```
This is position and velocity data after it has been through the estimator, offset correction and output predictions.   The new meas_x,meas_y,meas_z fields are the measurement position data before it goes through these steps, and are more useful for debugging the raw sensor output (eg. IRLock).

The other three new fields - last_meas, ekf_outcount, estimator, are useful for correlation and information.