### PR TITLE
AC_PrecLand: Add LANDING_TARGET_TYPE and LANDING_TARGET.type support

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -426,6 +426,7 @@ struct PACKED log_Precland {
     uint32_t last_meas;
     uint32_t ekf_outcount;
     uint8_t estimator;
+    uint8_t target_type;
 };
 
 // Write a precision landing entry
@@ -458,7 +459,8 @@ void Copter::Log_Write_Precland()
         meas_z          : target_pos_meas.z,
         last_meas       : precland.last_backend_los_meas_ms(),
         ekf_outcount    : precland.ekf_outlier_count(),
-        estimator       : precland.estimator_type()
+        estimator       : precland.estimator_type(),
+        target_type     : precland.target_type()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
  #endif     // PRECISION_LANDING == ENABLED
@@ -535,7 +537,7 @@ const struct LogStructure Copter::log_structure[] = {
 #endif
 #if PRECISION_LANDING == ENABLED
     { LOG_PRECLAND_MSG, sizeof(log_Precland),
-      "PL",    "QBBfffffffIIB",    "TimeUS,Heal,TAcq,pX,pY,vX,vY,mX,mY,mZ,LastMeasUS,EKFOutl,Est", "s--ddmmddms--","F--00BB00BC--" },
+      "PL",    "QBBfffffffIIBB",    "TimeUS,Heal,TAcq,pX,pY,vX,vY,mX,mY,mZ,Lst,Ol,Est,Ty", "s--ddmmddms---","F--00BB00BC---" },
 #endif
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
       "GUID",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -199,8 +199,14 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
     // update estimator of target position
     if (_backend != nullptr && _enabled) {
         _backend->update();
+        _target_type = _backend->target_type();
         run_estimator(rangefinder_alt_cm*0.01f, rangefinder_alt_valid);
     }
+}
+
+LANDING_TARGET_TYPE AC_PrecLand::target_type()
+{
+    return _backend->target_type();
 }
 
 bool AC_PrecLand::target_acquired()

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -87,6 +87,9 @@ public:
     // returns true when the landing target has been detected
     bool target_acquired();
 
+    // returns target type
+    LANDING_TARGET_TYPE target_type();
+
     // process a LANDING_TARGET mavlink message
     void handle_msg(mavlink_message_t* msg);
 
@@ -127,6 +130,7 @@ private:
     AP_Float                    _accel_noise;       // accelometer process noise
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
 
+    LANDING_TARGET_TYPE         _target_type;       // target type (LANDING_TARGET_TYPE enum)
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -35,6 +35,10 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     virtual float distance_to_target() { return 0.0f; };
 
+    // returns target type
+    // Note 0 = LANDING_TARGET_TYPE_LIGHT_BEACON, but there is no 'null' default to set
+    virtual LANDING_TARGET_TYPE target_type() = 0;
+
     // parses a mavlink message from the companion computer
     virtual void handle_msg(mavlink_message_t* msg) {};
 

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -44,6 +44,12 @@ float AC_PrecLand_Companion::distance_to_target()
     return _distance_to_target;
 }
 
+// return target type
+LANDING_TARGET_TYPE AC_PrecLand_Companion::target_type()
+{
+    return _target_type;
+}
+
 void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 {
     // parse mavlink message
@@ -59,4 +65,6 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 
     _los_meas_time_ms = AP_HAL::millis();
     _have_los_meas = true;
+    
+    _target_type = (LANDING_TARGET_TYPE)packet.type;
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -34,6 +34,9 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     float distance_to_target() override;
 
+    // returns target type
+    LANDING_TARGET_TYPE target_type() override;
+
     // parses a mavlink message from the companion computer
     void handle_msg(mavlink_message_t* msg) override;
 
@@ -44,4 +47,6 @@ private:
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    
+    LANDING_TARGET_TYPE _target_type;           // LANDING_TARGET_TYPE enum
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.cpp
@@ -52,3 +52,9 @@ uint32_t AC_PrecLand_IRLock::los_meas_time_ms() {
 bool AC_PrecLand_IRLock::have_los_meas() {
     return _have_los_meas;
 }
+
+// return target type - Will always be 0 (light beacon) for IRLock
+LANDING_TARGET_TYPE AC_PrecLand_IRLock::target_type()
+{
+    return LANDING_TARGET_TYPE_LIGHT_BEACON;
+}

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -36,6 +36,9 @@ public:
 
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
+    
+    // return target type
+    LANDING_TARGET_TYPE target_type() override;
 
 private:
     AP_IRLock_I2C irlock;
@@ -43,4 +46,5 @@ private:
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    LANDING_TARGET_TYPE _target_type;           // LANDING_TARGET_TYPE enum
 };

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.cpp
@@ -54,4 +54,11 @@ bool AC_PrecLand_SITL::get_los_body(Vector3f& ret) {
     return true;
 }
 
+// return target type - SITL doesn't have a particular target type as it always returns home,
+//  so we call it a 'radio beacon' for want of a better type
+LANDING_TARGET_TYPE AC_PrecLand_SITL::target_type()
+{
+    return LANDING_TARGET_TYPE_RADIO_BEACON;
+}
+
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL.h
@@ -32,10 +32,14 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
 
+    // return target type
+    LANDING_TARGET_TYPE target_type() override;
+
 private:
 
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    LANDING_TARGET_TYPE _target_type;           // LANDING_TARGET_TYPE enum
 };
 
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.cpp
@@ -55,4 +55,10 @@ bool AC_PrecLand_SITL_Gazebo::have_los_meas() {
     return _have_los_meas;
 }
 
+// return target type - Will always be 0 (light beacon) for IRLock
+LANDING_TARGET_TYPE AC_PrecLand_SITL_Gazebo::target_type()
+{
+    return LANDING_TARGET_TYPE_LIGHT_BEACON;
+}
+
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_SITL_Gazebo.h
@@ -34,12 +34,16 @@ public:
     // return true if there is a valid los measurement available
     bool have_los_meas() override;
 
+    // return target type
+    LANDING_TARGET_TYPE target_type() override;
+
 private:
     AP_IRLock_SITL irlock;
 
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+    LANDING_TARGET_TYPE _target_type;           // LANDING_TARGET_TYPE enum
 };
 
 #endif


### PR DESCRIPTION
Add preliminary support for LANDING_TARGET.type field.  This type field represents the target type, defined in LANDING_TARGET_TYPE:
```
Field Name | Description
-- | --
0 | LANDING_TARGET_TYPE_LIGHT_BEACON | Landing target signaled by light beacon (ex: IR-LOCK)
1 | LANDING_TARGET_TYPE_RADIO_BEACON | Landing target signaled by radio beacon (ex: ILS, NDB)
2 | LANDING_TARGET_TYPE_VISION_FIDUCIAL | Landing target represented by a fiducial marker (ex: ARTag)
3 | LANDING_TARGET_TYPE_VISION_OTHER | Landing target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)
```
This PR doesn't do anything yet, other than add target_type to AC_PrecLand, AC_PrecLand_Backend, and to return 0 (Light Beacon) for IRLock and SITL_Gazebo backends, 1 (Radio Beacon) for SITL backend, and take the value from Mavlink LANDING_TARGET.type field for Companion backend.

It also adds a TgtType log field to precland PL log entries.