### PR TITLE
AC_PrecLand: Add LANDING_TARGET.target_num support

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -199,6 +199,7 @@ void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
     // update estimator of target position
     if (_backend != nullptr && _enabled) {
         _backend->update();
+        _target_num = _backend->target_num();
         run_estimator(rangefinder_alt_cm*0.01f, rangefinder_alt_valid);
     }
 }

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -87,6 +87,9 @@ public:
     // returns true when the landing target has been detected
     bool target_acquired();
 
+    // returns target ID
+    uint8_t target_num() const { return _target_num; }
+
     // process a LANDING_TARGET mavlink message
     void handle_msg(mavlink_message_t* msg);
 
@@ -127,6 +130,7 @@ private:
     AP_Float                    _accel_noise;       // accelometer process noise
     AP_Vector3f                 _cam_offset;        // Position of the camera relative to the CG
 
+    uint8_t                     _target_num;        // target ID
     uint32_t                    _last_update_ms;    // system time in millisecond when update was last called
     bool                        _target_acquired;   // true if target has been seen recently
     uint32_t                    _last_backend_los_meas_ms;  // system time target was last seen

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -35,6 +35,9 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     virtual float distance_to_target() { return 0.0f; };
 
+    // returns target ID
+    virtual uint8_t target_num() { return 0; };
+
     // parses a mavlink message from the companion computer
     virtual void handle_msg(mavlink_message_t* msg) {};
 

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -44,6 +44,12 @@ float AC_PrecLand_Companion::distance_to_target()
     return _distance_to_target;
 }
 
+// return target ID
+uint8_t AC_PrecLand_Companion::target_num()
+{
+    return _target_num;    
+}
+
 void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 {
     // parse mavlink message
@@ -52,6 +58,7 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 
     _timestamp_us = packet.time_usec;
     _distance_to_target = packet.distance;
+    _target_num = packet.target_num;
 
     // compute unit vector towards target
     _los_meas_body = Vector3f(-tanf(packet.angle_y), tanf(packet.angle_x), 1.0f);
@@ -59,4 +66,5 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
 
     _los_meas_time_ms = AP_HAL::millis();
     _have_los_meas = true;
+
 }

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -34,6 +34,9 @@ public:
     // returns distance to target in meters (0 means distance is not known)
     float distance_to_target() override;
 
+    // returns target ID
+    uint8_t target_num() override;
+
     // parses a mavlink message from the companion computer
     void handle_msg(mavlink_message_t* msg) override;
 
@@ -44,4 +47,6 @@ private:
     Vector3f            _los_meas_body;         // unit vector in body frame pointing towards target
     bool                _have_los_meas;         // true if there is a valid measurement from the camera
     uint32_t            _los_meas_time_ms;      // system time in milliseconds when los was measured
+
+    uint8_t             _target_num;            // target ID
 };


### PR DESCRIPTION
Add preliminary support for LANDING_TARGET.target_num field.  This is intended to represent the ID of the detected/sent target.
This PR doesn't do anything yet, other than add target_num to AC_PrecLand, AC_PrecLand_Backend, and to return 0 (Light Beacon) for IRLock backend, and take the value from Mavlink LANDING_TARGET.target_num field for Companion backend.

Along with #9132, future support could restrict landing unless on a recognised ID, and if marker maps (fiducial matrix) were supported then 'encrypted landing targets' (for want of a better term) could be used.  In the shorter term, this will be very useful for debugging, and once merged then #9125 and #9130 can be expanded to support target_num.