### PR TITLE
waf: fixes for python 3.7

### DIFF
--- a/Tools/ardupilotwaf/cmake.py
+++ b/Tools/ardupilotwaf/cmake.py
@@ -200,10 +200,6 @@ class cmake_build_task(Task.Task):
     def keyword(self):
         return 'CMake Build'
 
-# allow tasks to depend on possible headers or other resources if the user
-# declares outputs for the cmake build
-cmake_build_task = Task.update_outputs(cmake_build_task)
-
 cmake_build_task.original_post_run = cmake_build_task.post_run
 def _cmake_build_task_post_run(self):
     self.output_patterns = Utils.to_list(self.output_patterns)

--- a/waf
+++ b/waf
@@ -8,8 +8,10 @@ import sys
 d = p.dirname(p.realpath(__file__))
 waf_light = p.join(d, 'modules', 'waf', 'waf-light')
 
+python = sys.executable
+
 try:
-    subprocess.check_call(['python', waf_light] + sys.argv[1:])
+    subprocess.check_call([python, waf_light] + sys.argv[1:])
 except subprocess.CalledProcessError as e:
     if e.returncode != 2 or p.isfile(waf_light):
         sys.exit(1)

--- a/wscript
+++ b/wscript
@@ -155,11 +155,12 @@ configuration in order to save typing.
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []
-        if hasattr(m, '__file__'):
+        if hasattr(m, '__file__') and m.__file__ is not None:
             paths.append(m.__file__)
         elif hasattr(m, '__path__'):
             for p in m.__path__:
-                paths.append(p)
+                if p is not None:
+                    paths.append(p)
 
         for p in paths:
             if p in cfg.files or not os.path.isfile(p):


### PR DESCRIPTION
This updates the waf module to 2.0.9, which fixes some issues with python 3.7
it also keeps the same python version throughout the build, so you can force a python version with:

 pythonX.Y waf ....
 
ping @WickedShell 