### PR TITLE
AP_HAL_Linux: fix log after tonealarm thread removal

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -119,8 +119,7 @@ void Scheduler::_debug_stack()
                 "\ttimer = %zu\n"
                 "\tio    = %zu\n"
                 "\trcin  = %zu\n"
-                "\tuart  = %zu\n"
-                "\ttone  = %zu\n",
+                "\tuart  = %zu\n",
                 _timer_thread.get_stack_usage(),
                 _io_thread.get_stack_usage(),
                 _rcin_thread.get_stack_usage(),


### PR DESCRIPTION
../../libraries/AP_HAL_Linux/Scheduler.cpp: In member function ‘void Linux::Scheduler::_debug_stack()’:
../../libraries/AP_HAL_Linux/Scheduler.cpp:127:47: warning: format ‘%zu’ expects a matching ‘size_t’ argument [-Wformat=]
                 _uart_thread.get_stack_usage());
                                               ^

@jschall @tridge 