### PR TITLE
AP_Notify: make LED blink at constant rate in Rover

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -83,20 +83,7 @@ void RGBLed::update_colours(void)
         break;
     }
 
-    // slow rate from 50Hz to 10hz
-    counter++;
-    if (counter < 5) {
-        return;
-    }
-
-    // reset counter
-    counter = 0;
-
-    // move forward one step
-    step++;
-    if (step >= 10) {
-        step = 0;
-    }
+    const uint8_t step = (AP_HAL::millis()/100) % 10;
 
     // use dim light when connected through USB
     if (hal.gpio->usb_connected() && brightness > _led_dim) {

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -50,8 +50,6 @@ protected:
     virtual void update_override();
     
     // meta-data common to all hw devices
-    uint8_t counter;
-    uint8_t step;
     uint8_t _red_des, _green_des, _blue_des;     // color requested by timed update
     uint8_t _red_curr, _green_curr, _blue_curr;  // current colours displayed by the led
     uint8_t _led_off;


### PR DESCRIPTION
Fixes the blinking without needing the `uint16_t millis16()` implementation.
