### PR TITLE
Plane: Log target airspeed

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -119,6 +119,7 @@ struct PACKED log_Nav_Tuning {
     int32_t target_lat;
     int32_t target_lng;
     int32_t target_alt;
+    int32_t target_airspeed;
 };
 
 // Write a navigation tuning packet
@@ -137,6 +138,7 @@ void Plane::Log_Write_Nav_Tuning()
         target_lat          : next_WP_loc.lat,
         target_lng          : next_WP_loc.lng,
         target_alt          : next_WP_loc.alt,
+        target_airspeed     : target_airspeed_cm,
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -298,7 +300,7 @@ const struct LogStructure Plane::log_structure[] = {
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qcccchhhf",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThrOut,RdrOut,ThrDem,Aspd", "sdddd---n", "FBBBB---0" },
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
-      "NTUN", "QfcccfffLLi",  "TimeUS,WpDist,TBrg,NavBrg,AltErr,XT,XTi,ArspdErr,TLat,TLng,TAlt", "smddmmmnDUm", "F0BBB0B0GGB" },
+      "NTUN", "QfcccfffLLii",  "TimeUS,Dist,TBrg,NavBrg,AltErr,XT,XTi,AspdE,TLat,TLng,TAlt,TAspd", "smddmmmnDUmn", "F0BBB0B0GGBB" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
       "SONR", "QffBf",   "TimeUS,Dist,Volt,Cnt,Corr", "smv--", "FB0--" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -198,8 +198,8 @@ void DataFlash_Class::Log_Write_RFND(const RangeFinder &rangefinder)
 // Write an RCIN packet
 void DataFlash_Class::Log_Write_RCIN(void)
 {
-    uint16_t values[16] = {};
-    rc().get_radio_in(values, 14);
+    uint16_t values[14] = {};
+    rc().get_radio_in(values, ARRAY_SIZE(values));
     struct log_RCIN pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RCIN_MSG),
         time_us       : AP_HAL::micros64(),

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1022,7 +1022,7 @@ void GCS_MAVLINK::send_radio_in()
     mavlink_status_t *status = mavlink_get_channel_status(chan);
 
     uint16_t values[18] = {};
-    rc().get_radio_in(values, 18);
+    rc().get_radio_in(values, ARRAY_SIZE(values));
 
     if (status && (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
         // for mavlink1 send RC_CHANNELS_RAW, for compatibility with OSD implementations


### PR DESCRIPTION
I've suffered a lot recently with the fact that the plane log doesn't include the target airspeed. It naively seems like you should be able to recover this information from airspeed + airspeed error, however this is an unstable value due to TECS having input onto the airspeed error. It makes it hard to tell if minimum ground speed (or some other controller) is pushing the target airspeed around.

The RC stuff is just fixing up some oddities around `get_radio_in()`.