### PR TITLE
Tail Sitter interpolate gains

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -358,6 +358,22 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Range: 1 5
     // @User: Standard
     AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 5),
+    
+    // @Param: TAILSIT_SCLSPD
+    // @DisplayName: Tailsitter airspeed scaling 50-50 point
+    // @Description: airspeed at which tailster is controlled equaly by VTOL and forward flight gains  
+    // @Units: m/s
+    // @Range: 0 50
+    // @User: Standard
+    AP_GROUPINFO("TAILSIT_SCLSPD", 4, QuadPlane, tailsitter.scaling_speed, 10),
+    
+    // @Param: TAILSIT_SCLRNG
+    // @DisplayName: Range of airspeed that tailsitter airspeed scaling takes place
+    // @Description: At air speeds below TAILSIT_SCLSPD - 0.5 * TAILSIT_SCLRNG tailsitter will be contoled by 100% VTOL gains, at air speeds above TAILSIT_SCLSPD + 0.5 * TAILSIT_SCLRNG it will be 100% forward flight gains  
+    // @Units: m/s  
+    // @Range: 0 20
+    // @User: Standard
+    AP_GROUPINFO("TAILSIT_SCLRNG", 5, QuadPlane, tailsitter.scaling_range, 10),
 	
     AP_GROUPEND
 };

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -405,6 +405,8 @@ private:
         AP_Float vectored_hover_gain;
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
+        AP_Float scaling_speed;
+        AP_Float scaling_range;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller


### PR DESCRIPTION
Interpolate Gains between VTOL gains and forward flight gains in Q modes based on airspeed. 

Do this based on two new parameters that define the airspeed range at which the change over occurs. 

This is a significant improvement at high airspeed although is not perfect. This would benefit from a plane yaw rate controller and body frame rather than earth frame yaw control. Hope to add Q_assist support for this code at some-point so the plane modes can also benefit from this gain interpolation. Also a QAcro mode would be fun. 

Significantly adds to the Q modes flight envelope for tail sitters. 

Tested in SITL. 

https://www.youtube.com/watch?v=4sVT3VI5HDw&feature=youtu.be