### PR TITLE
plane: tail-sitter interpolate gains with airspeed and enable Q_Assist

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -111,9 +111,9 @@ public:
     // check if we have completed transition to vtol
     bool tailsitter_transition_vtol_complete(void) const;
 
-    // account for surface speed scaling in hover
-    void tailsitter_speed_scaling(void);
-    
+    // calculate speed scaler of control surfaces in VTOL modes
+    float get_tailsitter_speed_scaling(void);
+
     // user initiated takeoff for guided mode
     bool do_user_takeoff(float takeoff_altitude);
 
@@ -434,6 +434,8 @@ private:
         AP_Float throttle_scale_max;
         AP_Float max_roll_angle;
         AP_Int16 motor_mask;
+        AP_Float scaling_speed_min;
+        AP_Float scaling_speed_max;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller


### PR DESCRIPTION
Interpolate Gains between VTOL gains and forward flight gains in Q modes based on airspeed.

Do this based on two new parameters that define the airspeed range at which the change over occurs.

This is a significant improvement at high airspeed although is not perfect. This would benefit from a plane yaw rate controller and body frame rather than earth frame yaw control. Hope to add Q_assist support for this code at some-point so the plane modes can also benefit from this gain interpolation. Also a QAcro mode would be fun.

Significantly adds to the Q modes flight envelope for tail sitters.

Tested in SITL.

https://www.youtube.com/watch?v=4sVT3VI5HDw&feature=youtu.be