### PR TITLE
Rover: BalanceBot control improvements

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -54,7 +54,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Beacon,           &rover.g2.beacon,        update,         50,  200),
     SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         50,  200),
     SCHED_TASK(update_visual_odom,     50,    200),
-    SCHED_TASK(update_wheel_encoder,   20,    200),
+    SCHED_TASK(update_wheel_encoder,   50,    200),
     SCHED_TASK(update_compass,         10,    200),
     SCHED_TASK(update_mission,         50,    200),
     SCHED_TASK(update_logging1,        10,    200),

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -119,13 +119,14 @@ protected:
     void output_regular(bool armed, float ground_speed, float steering, float throttle);
 
     // output to skid steering channels
-    void output_skid_steering(bool armed, float steering, float throttle);
+    void output_skid_steering(bool armed, float steering, float throttle, float dt);
 
     // output for vectored and custom motors configuration
     void output_custom_config(bool armed, float steering, float throttle, float lateral);
 
     // output throttle (-100 ~ +100) to a throttle channel.  Sets relays if required
-    void output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle);
+    // dt is the main loop time interval and is required when rate control is required
+    void output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt = 0.0f);
 
     // slew limit throttle for one iteration
     void slew_limit_throttle(float dt);
@@ -135,6 +136,9 @@ protected:
 
     // scale a throttle using the _thrust_curve_expo parameter.  throttle should be in the range -100 to +100
     float get_scaled_throttle(float throttle) const;
+
+    // use rate controller to achieve desired throttle
+    float get_rate_controlled_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt);
 
     // external references
     AP_ServoRelayEvents &_relayEvents;

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -227,6 +227,36 @@ void Rover::send_pid_tuning(mavlink_channel_t chan)
             return;
         }
     }
+
+    // left wheel rate control pid
+    if (g.gcs_pid_mask & 8) {
+        pid_info = &g2.wheel_rate_control.get_pid(0).get_pid_info();
+        mavlink_msg_pid_tuning_send(chan, 7,
+                                    pid_info->desired,
+                                    pid_info->actual,
+                                    pid_info->FF,
+                                    pid_info->P,
+                                    pid_info->I,
+                                    pid_info->D);
+        if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
+            return;
+        }
+    }
+
+    // right wheel rate control pid
+    if (g.gcs_pid_mask & 16) {
+        pid_info = &g2.wheel_rate_control.get_pid(1).get_pid_info();
+        mavlink_msg_pid_tuning_send(chan, 8,
+                                    pid_info->desired,
+                                    pid_info->actual,
+                                    pid_info->FF,
+                                    pid_info->P,
+                                    pid_info->I,
+                                    pid_info->D);
+        if (!HAVE_PAYLOAD_SPACE(chan, PID_TUNING)) {
+            return;
+        }
+    }
 }
 
 void Rover::send_fence_status(mavlink_channel_t chan)

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -217,9 +217,9 @@ void Rover::send_pid_tuning(mavlink_channel_t chan)
     if (g.gcs_pid_mask & 4) {
         pid_info = &g2.attitude_control.get_pitch_to_throttle_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_PITCH,
-                                    pid_info->desired,
-                                    ahrs.pitch,
-                                    0,
+                                    degrees(pid_info->desired),
+                                    degrees(ahrs.pitch),
+                                    pid_info->FF,
                                     pid_info->P,
                                     pid_info->I,
                                     pid_info->D);

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -64,8 +64,8 @@ const AP_Param::Info Rover::var_info[] = {
     // @DisplayName: GCS PID tuning mask
     // @Description: bitmask of PIDs to send MAVLink PID_TUNING messages for
     // @User: Advanced
-    // @Values: 0:None,1:Steering,2:Throttle,4:Pitch
-    // @Bitmask: 0:Steering,1:Throttle,2:Pitch
+    // @Values: 0:None,1:Steering,2:Throttle,4:Pitch,8:Left Wheel,16:Right Wheel
+    // @Bitmask: 0:Steering,1:Throttle,2:Pitch,3:Left Wheel,4:Right Wheel
     GSCALAR(gcs_pid_mask,           "GCS_PID_MASK",     0),
 
     // @Param: MAG_ENABLE

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -575,6 +575,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_Sprayer/AC_Sprayer.cpp
     AP_SUBGROUPINFO(sprayer, "SPRAY_", 26, ParametersG2, AC_Sprayer),
 
+    // @Group: WRC
+    // @Path: ../libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+    AP_SUBGROUPINFO(wheel_rate_control, "WRC", 27, ParametersG2, AP_WheelRateControl),
+
     AP_GROUPEND
 };
 
@@ -599,6 +603,7 @@ ParametersG2::ParametersG2(void)
 #endif
     beacon(rover.serial_manager),
     motors(rover.ServoRelayEvents),
+    wheel_rate_control(wheel_encoder),
     attitude_control(rover.ahrs),
     smart_rtl(),
     fence(rover.ahrs),

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -312,6 +312,7 @@ public:
 
     // wheel encoders
     AP_WheelEncoder wheel_encoder;
+    AP_WheelRateControl wheel_rate_control;
 
     // steering and throttle controller
     AR_AttitudeControl attitude_control;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -65,6 +65,7 @@
 #include <AP_Vehicle/AP_Vehicle.h>                  // needed for AHRS build
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_WheelEncoder/AP_WheelEncoder.h>
+#include <AP_WheelEncoder/AP_WheelRateControl.h>
 #include <APM_Control/AR_AttitudeControl.h>
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <DataFlash/DataFlash.h>
@@ -565,6 +566,7 @@ public:
 
     // frame type
     uint8_t get_frame_type() { return g2.frame_type.get(); }
+    AP_WheelRateControl& get_wheel_rate_control() { return g2.wheel_rate_control; }
 };
 
 extern const AP_HAL::HAL& hal;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -388,6 +388,10 @@ private:
     void update_GPS(void);
     void update_current_mode(void);
 
+    // balance_bot.cpp
+    void balancebot_pitch_control(float &throttle);
+    bool is_balancebot() const;
+
     // capabilities.cpp
     void init_capabilities(void);
 
@@ -552,11 +556,6 @@ private:
 public:
     void mavlink_delay_cb();
     void failsafe_check();
-
-    // BalanceBot.cpp
-    void balancebot_pitch_control(float &, bool);
-    bool is_balancebot() const;
-
     void update_soft_armed();
     // Motor test
     void motor_test_output();

--- a/APMrover2/balance_bot.cpp
+++ b/APMrover2/balance_bot.cpp
@@ -2,16 +2,13 @@
 #include "Rover.h"
 
 // Function to set a desired pitch angle according to throttle
-void Rover::balancebot_pitch_control(float &throttle, bool armed)
+void Rover::balancebot_pitch_control(float &throttle)
 {
     // calculate desired pitch angle
     const float demanded_pitch = radians(-throttle * 0.01f * g2.bal_pitch_max);
 
     // calculate required throttle using PID controller
-    const float balance_throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, G_Dt) * 100.0f;
-
-    // constrain throttle between -100 and 100
-    throttle = constrain_float(balance_throttle, -100.0f, 100.0f);
+    throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, G_Dt) * 100.0f;
 }
 
 // returns true if vehicle is a balance bot

--- a/APMrover2/balance_bot.cpp
+++ b/APMrover2/balance_bot.cpp
@@ -8,7 +8,7 @@ void Rover::balancebot_pitch_control(float &throttle, bool armed)
     const float demanded_pitch = radians(-throttle * 0.01f * g2.bal_pitch_max);
 
     // calculate required throttle using PID controller
-    const float balance_throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, armed, G_Dt) * 100.0f;
+    const float balance_throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, G_Dt) * 100.0f;
 
     // constrain throttle between -100 and 100
     throttle = constrain_float(balance_throttle, -100.0f, 100.0f);

--- a/APMrover2/balance_bot.cpp
+++ b/APMrover2/balance_bot.cpp
@@ -7,8 +7,15 @@ void Rover::balancebot_pitch_control(float &throttle)
     // calculate desired pitch angle
     const float demanded_pitch = radians(-throttle * 0.01f * g2.bal_pitch_max);
 
+    // calculate speed from wheel encoders
+    float veh_speed_pct = 0.0f;
+    if (g2.wheel_encoder.enabled(0) && g2.wheel_encoder.enabled(1) && is_positive(g2.wheel_rate_control.get_rate_max_rads())) {
+        veh_speed_pct = (g2.wheel_encoder.get_rate(0) + g2.wheel_encoder.get_rate(1)) / (2.0f * g2.wheel_rate_control.get_rate_max_rads()) * 100.0f;
+        veh_speed_pct = constrain_float(veh_speed_pct, -100.0f, 100.0f);
+    }
+
     // calculate required throttle using PID controller
-    throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, G_Dt) * 100.0f;
+    throttle = g2.attitude_control.get_throttle_out_from_pitch(demanded_pitch, veh_speed_pct, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, G_Dt) * 100.0f;
 }
 
 // returns true if vehicle is a balance bot

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -267,7 +267,7 @@ void Mode::calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_
 
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
-        rover.balancebot_pitch_control(throttle_out, rover.arming.is_armed());
+        rover.balancebot_pitch_control(throttle_out);
     }
 
     // send to motor
@@ -283,7 +283,7 @@ bool Mode::stop_vehicle()
 
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
-        rover.balancebot_pitch_control(throttle_out, rover.arming.is_armed());
+        rover.balancebot_pitch_control(throttle_out);
     }
 
     // send to motor

--- a/APMrover2/mode_hold.cpp
+++ b/APMrover2/mode_hold.cpp
@@ -7,7 +7,7 @@ void ModeHold::update()
 
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
-        rover.balancebot_pitch_control(throttle, rover.arming.is_armed());
+        rover.balancebot_pitch_control(throttle);
     }
 
     // hold position - stop motors and center steering

--- a/APMrover2/mode_manual.cpp
+++ b/APMrover2/mode_manual.cpp
@@ -15,7 +15,7 @@ void ModeManual::update()
 
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
-        rover.balancebot_pitch_control(desired_throttle, rover.arming.is_armed());
+        rover.balancebot_pitch_control(desired_throttle);
     }
 
     // copy RC scaled inputs to outputs

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -76,8 +76,9 @@ public:
     float       get_integrator() const { return _integrator; }
     void        set_integrator(float i) { _integrator = i; }
 
-    // set the designed rate (for logging purposes)
+    // set the desired and actual rates (for logging purposes)
     void        set_desired_rate(float desired) { _pid_info.desired = desired; }
+    void        set_actual_rate(float actual) { _pid_info.actual = actual; }
 
     const       DataFlash_Class::PID_Info& get_pid_info(void) const { return _pid_info; }
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -489,8 +489,7 @@ float AR_AttitudeControl::get_throttle_out_stop(bool motor_limit_low, bool motor
 // desired_pitch is in radians
 float AR_AttitudeControl::get_throttle_out_from_pitch(float desired_pitch, bool armed, float dt)
 {
-
-    //reset I term and return if disarmed
+    // reset I term and return if disarmed
     if (!armed){
         _pitch_to_throttle_pid.reset_I();
         return 0.0f;
@@ -499,24 +498,25 @@ float AR_AttitudeControl::get_throttle_out_from_pitch(float desired_pitch, bool 
     // sanity check dt
     dt = constrain_float(dt, 0.0f, 1.0f);
 
-    const uint32_t now = AP_HAL::millis();
-
     // if not called recently, reset input filter
+    const uint32_t now = AP_HAL::millis();
     if ((_balance_last_ms == 0) || ((now - _balance_last_ms) > (AR_ATTCONTROL_TIMEOUT_MS))) {
         _pitch_to_throttle_pid.reset_filter();
-    } else {
-        _pitch_to_throttle_pid.set_dt(dt);
+        _pitch_to_throttle_pid.reset_I();
     }
     _balance_last_ms = now;
 
     // calculate pitch error
     const float pitch_error = desired_pitch - _ahrs.pitch;
 
-    // pitch error is given as input to PID contoller
-    _pitch_to_throttle_pid.set_input_filter_all(pitch_error);
+    // set PID's dt
+    _pitch_to_throttle_pid.set_dt(dt);
 
     // record desired speed for logging purposes only
     _pitch_to_throttle_pid.set_desired_rate(desired_pitch);
+
+    // pitch error is given as input to PID contoller
+    _pitch_to_throttle_pid.set_input_filter_all(pitch_error);
 
     // return output of PID controller
     return constrain_float(_pitch_to_throttle_pid.get_pid(), -1.0f, +1.0f);

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -25,6 +25,7 @@
 #define AR_ATTCONTROL_PITCH_THR_D       0.03f
 #define AR_ATTCONTROL_PITCH_THR_IMAX    1.0f
 #define AR_ATTCONTROL_PITCH_THR_FILT    10.0f
+#define AR_ATTCONTROL_BAL_SPEED_FF      1.0f
 #define AR_ATTCONTROL_DT                0.02f
 #define AR_ATTCONTROL_TIMEOUT_MS        200
 
@@ -89,10 +90,10 @@ public:
     // return a throttle output from -1 to +1 to perform a controlled stop.  stopped is set to true once stop has been completed
     float get_throttle_out_stop(bool motor_limit_low, bool motor_limit_high, float cruise_speed, float cruise_throttle, float dt, bool &stopped);
 
-    // for balancebot
-    // return a throttle output from -1 to +1 given a desired pitch angle
-    // desired_pitch is in radians
-    float get_throttle_out_from_pitch(float desired_pitch, bool motor_limit_low, bool motor_limit_high, float dt);
+    // balancebot pitch to throttle controller
+    // returns a throttle output from -100 to +100 given a desired pitch angle and vehicle's current speed (from wheel encoders)
+    // desired_pitch is in radians, veh_speed_pct is supplied as a percentage (-100 to +100) of vehicle's top speed
+    float get_throttle_out_from_pitch(float desired_pitch, float veh_speed_pct, bool motor_limit_low, bool motor_limit_high, float dt);
 
     // get latest desired pitch in radians for reporting purposes
     float get_desired_pitch() const;
@@ -137,6 +138,7 @@ private:
     AC_PID   _steer_rate_pid;       // steering rate controller
     AC_PID   _throttle_speed_pid;   // throttle speed controller
     AC_PID   _pitch_to_throttle_pid;// balancebot pitch controller
+    AP_Float _pitch_to_throttle_speed_ff;   // balancebot feed forward from speed
 
     AP_Float _throttle_accel_max;   // speed/throttle control acceleration (and deceleration) maximum in m/s/s.  0 to disable limits
     AP_Float _throttle_decel_max;    // speed/throttle control deceleration maximum in m/s/s. 0 to use ATC_ACCEL_MAX for deceleration

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -92,7 +92,7 @@ public:
     // for balancebot
     // return a throttle output from -1 to +1 given a desired pitch angle
     // desired_pitch is in radians
-    float get_throttle_out_from_pitch(float desired_pitch, bool armed, float dt);
+    float get_throttle_out_from_pitch(float desired_pitch, bool motor_limit_low, bool motor_limit_high, float dt);
 
     // get latest desired pitch in radians for reporting purposes
     float get_desired_pitch() const;

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -35,8 +35,9 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     AP_GROUPINFO("_CPR",     1, AP_WheelEncoder, _counts_per_revolution[0], WHEELENCODER_CPR_DEFAULT),
 
     // @Param: _RADIUS
-    // @DisplayName: Wheel radius in meters
-    // @Description: Wheel radius in meters
+    // @DisplayName: Wheel radius
+    // @Description: Wheel radius
+    // @Units: m
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("_RADIUS",  2, AP_WheelEncoder, _wheel_radius[0], WHEELENCODER_RADIUS_DEFAULT),
@@ -46,21 +47,21 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     // @Description: X position of the center of the wheel in body frame. Positive X is forward of the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
 
     // @Param: _POS_Y
     // @DisplayName: Wheel's Y position offset
     // @Description: Y position of the center of the wheel in body frame. Positive Y is to the right of the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
 
     // @Param: _POS_Z
     // @DisplayName: Wheel's Z position offset
     // @Description: Z position of the center of the wheel in body frame. Positive Z is down from the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
     AP_GROUPINFO("_POS",     3, AP_WheelEncoder, _pos_offset[0], 0.0f),
 
     // @Param: _PINA
@@ -93,8 +94,9 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     AP_GROUPINFO("2_CPR",     7, AP_WheelEncoder, _counts_per_revolution[1], WHEELENCODER_CPR_DEFAULT),
 
     // @Param: 2_RADIUS
-    // @DisplayName: Wheel2's radius in meters
-    // @Description: Wheel2's radius in meters
+    // @DisplayName: Wheel2's radius
+    // @Description: Wheel2's radius
+    // @Units: m
     // @Increment: 0.001
     // @User: Standard
     AP_GROUPINFO("2_RADIUS", 8, AP_WheelEncoder, _wheel_radius[1], WHEELENCODER_RADIUS_DEFAULT),
@@ -104,21 +106,21 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     // @Description: X position of the center of the second wheel in body frame. Positive X is forward of the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
 
     // @Param: 2_POS_Y
     // @DisplayName: Wheel2's Y position offset
     // @Description: Y position of the center of the second wheel in body frame. Positive Y is to the right of the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
 
     // @Param: 2_POS_Z
     // @DisplayName: Wheel2's Z position offset
     // @Description: Z position of the center of the second wheel in body frame. Positive Z is down from the origin.
     // @Units: m
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
     AP_GROUPINFO("2_POS",    9, AP_WheelEncoder, _pos_offset[1], 0.0f),
 
     // @Param: 2_PINA

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -253,6 +253,23 @@ float AP_WheelEncoder::get_distance(uint8_t instance) const
     return get_delta_angle(instance) * _wheel_radius[instance];
 }
 
+// get the instantaneous rate in radians/second
+float AP_WheelEncoder::get_rate(uint8_t instance) const
+{
+    // for invalid instances return zero
+    if (instance >= WHEELENCODER_MAX_INSTANCES) {
+        return 0.0f;
+    }
+
+    // protect against divide by zero
+    if ((state[instance].dt_ms == 0) || _counts_per_revolution[instance] == 0) {
+        return 0;
+    }
+
+    // calculate delta_angle (in radians) per second
+    return M_2PI * (state[instance].dist_count_change / _counts_per_revolution[instance]) / (state[instance].dt_ms / 1000.0f);
+}
+
 // get the total number of sensor reading from the encoder
 uint32_t AP_WheelEncoder::get_total_count(uint8_t instance) const
 {

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -48,10 +48,12 @@ public:
     struct WheelEncoder_State {
         uint8_t                instance;        // the instance number of this WheelEncoder
         int32_t                distance_count;  // cumulative number of forward + backwards events received from wheel encoder
-        float                  distance;        // total distance measured
+        float                  distance;        // total distance measured in meters
         uint32_t               total_count;     // total number of successful readings from sensor (used for sensor quality calcs)
         uint32_t               error_count;     // total number of errors reading from sensor (used for sensor quality calcs)
         uint32_t               last_reading_ms; // time of last reading
+        int32_t                dist_count_change; // distance count change during the last update (used to calculating rate)
+        uint32_t               dt_ms;             // time change (in milliseconds) for the previous period (used to calculating rate)
     };
 
     // detect and initialise any available rpm sensors
@@ -83,6 +85,9 @@ public:
 
     // get the total distance traveled in meters
     float get_distance(uint8_t instance) const;
+
+    // get the instantaneous rate in radians/second
+    float get_rate(uint8_t instance) const;
 
     // get the total number of sensor reading from the encoder
     uint32_t get_total_count(uint8_t instance) const;

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -1,0 +1,188 @@
+#include <AP_WheelEncoder/AP_WheelRateControl.h>
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
+    // @Param: _ENABLE
+    // @DisplayName: Wheel rate control enable/disable
+    // @Description: Enable or disable wheel rate control
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, AP_WheelRateControl, _enabled, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: _RATE_MAX
+    // @DisplayName: Wheel max rotation rate
+    // @Description: Wheel max rotation rate
+    // @Units: rad/s
+    // @Range: 0 200
+    // @User: Standard
+    AP_GROUPINFO("_RATE_MAX", 2, AP_WheelRateControl, _rate_max, AP_WHEEL_RATE_MAX_DEFAULT),
+
+    // @Param: _RATE_FF
+    // @DisplayName: Wheel rate control feed forward gain
+    // @Description: Wheel rate control feed forward gain.  Desired rate (in radians/sec) is multiplied by this constant and output to output (in the range -1 to +1)
+    // @Range: 0.100 2.000
+    // @User: Standard
+
+    // @Param: _RATE_P
+    // @DisplayName: Wheel rate control P gain
+    // @Description: Wheel rate control P gain.  Converts rate error (in radians/sec) to output (in the range -1 to +1)
+    // @Range: 0.100 2.000
+    // @User: Standard
+
+    // @Param: _RATE_I
+    // @DisplayName: Wheel rate control I gain
+    // @Description: Wheel rate control I gain.  Corrects long term error between the desired rate (in rad/s) and actual
+    // @Range: 0.000 2.000
+    // @User: Standard
+
+    // @Param: _RATE_IMAX
+    // @DisplayName: Wheel rate control I gain maximum
+    // @Description: Wheel rate control I gain maximum.  Constrains the output (range -1 to +1) that the I term will generate
+    // @Range: 0.000 1.000
+    // @User: Standard
+
+    // @Param: _RATE_D
+    // @DisplayName: Wheel rate control D gain
+    // @Description: Wheel rate control D gain.  Compensates for short-term change in desired rate vs actual
+    // @Range: 0.000 0.400
+    // @User: Standard
+
+    // @Param: _RATE_FILT
+    // @DisplayName: Wheel rate control filter frequency
+    // @Description: Wheel rate control input filter.  Lower values reduce noise but add delay.
+    // @Range: 1.000 100.000
+    // @Units: Hz
+    // @User: Standard
+    AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
+
+    // @Param: 2_RATE_FF
+    // @DisplayName: Wheel rate control feed forward gain
+    // @Description: Wheel rate control feed forward gain.  Desired rate (in radians/sec) is multiplied by this constant and output to output (in the range -1 to +1)
+    // @Range: 0.100 2.000
+    // @User: Standard
+
+    // @Param: 2_RATE_P
+    // @DisplayName: Wheel rate control P gain
+    // @Description: Wheel rate control P gain.  Converts rate error (in radians/sec) to output (in the range -1 to +1)
+    // @Range: 0.100 2.000
+    // @User: Standard
+
+    // @Param: 2_RATE_I
+    // @DisplayName: Wheel rate control I gain
+    // @Description: Wheel rate control I gain.  Corrects long term error between the desired rate (in rad/s) and actual
+    // @Range: 0.000 2.000
+    // @User: Standard
+
+    // @Param: 2_RATE_IMAX
+    // @DisplayName: Wheel rate control I gain maximum
+    // @Description: Wheel rate control I gain maximum.  Constrains the output (range -1 to +1) that the I term will generate
+    // @Range: 0.000 1.000
+    // @User: Standard
+
+    // @Param: 2_RATE_D
+    // @DisplayName: Wheel rate control D gain
+    // @Description: Wheel rate control D gain.  Compensates for short-term change in desired rate vs actual
+    // @Range: 0.000 0.400
+    // @User: Standard
+
+    // @Param: 2_RATE_FILT
+    // @DisplayName: Wheel rate control filter frequency
+    // @Description: Wheel rate control input filter.  Lower values reduce noise but add delay.
+    // @Range: 1.000 100.000
+    // @Units: Hz
+    // @User: Standard
+    AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),
+
+    AP_GROUPEND
+};
+
+AP_WheelRateControl::AP_WheelRateControl(const AP_WheelEncoder &wheel_encoder_ref) :
+        _wheel_encoder(wheel_encoder_ref)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+// returns true if a wheel encoder and rate control PID are available for this instance
+bool AP_WheelRateControl::enabled(uint8_t instance)
+{
+    // sanity check instance
+    if ((instance > 1) || (_enabled == 0)) {
+        return false;
+    }
+    // wheel encoder enabled
+    return _wheel_encoder.enabled(instance);
+}
+
+// get throttle output in the range -100 to +100 given a desired rate expressed as a percentage of the rate_max (-100 to +100)
+// instance can be 0 or 1
+float AP_WheelRateControl::get_rate_controlled_throttle(uint8_t instance, float desired_rate_pct, float dt)
+{
+    if (!enabled(instance)) {
+        return 0;
+    }
+
+    // determine which PID instance to use
+    AC_PID& rate_pid = (instance == 0) ? _rate_pid0 : _rate_pid1;
+
+    // set PID's dt
+    rate_pid.set_dt(dt);
+
+    // check for timeout
+    uint32_t now = AP_HAL::millis();
+    if (now - _last_update_ms > AP_WHEEL_RATE_CONTROL_TIMEOUT_MS) {
+        rate_pid.reset_filter();
+        rate_pid.reset_I();
+        _limit[instance].lower = false;
+        _limit[instance].upper = false;
+    }
+    _last_update_ms = now;
+
+    // convert desired rate as a percentage to radians/sec
+    float desired_rate = desired_rate_pct / 100.0f * get_rate_max_rads();
+
+    // get actual rate from wheeel encoder
+    float actual_rate = _wheel_encoder.get_rate(instance);
+
+    // calculate rate error and pass to pid controller
+    float rate_error = desired_rate - actual_rate;
+    rate_pid.set_input_filter_all(rate_error);
+
+    // store desired and actual for logging purposes
+    rate_pid.set_desired_rate(desired_rate);
+    rate_pid.set_actual_rate(actual_rate);
+
+    // get ff
+    float ff = rate_pid.get_ff(desired_rate);
+
+    // get p
+    float p = rate_pid.get_p();
+
+    // get i unless we hit limit on last iteration
+    float i = rate_pid.get_integrator();
+    if (((is_negative(rate_error) && !_limit[instance].lower) || (is_positive(rate_error) && !_limit[instance].upper))) {
+        i = rate_pid.get_i();
+    }
+
+    // get d
+    float d = rate_pid.get_d();
+
+    // constrain and set limit flags
+    float output = ff + p + i + d;
+
+    // set limits for next iteration
+    _limit[instance].upper = output >= 100.0f;
+    _limit[instance].lower = output <= -100.0f;
+
+    return output;
+}
+
+// get pid objects for reporting
+AC_PID& AP_WheelRateControl::get_pid(uint8_t instance)
+{
+    if (instance == 0) {
+        return _rate_pid0;
+    } else {
+        return _rate_pid0;
+    }
+}

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.h
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.h
@@ -1,0 +1,73 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Param/AP_Param.h>
+#include <AC_PID/AC_PID.h>
+#include <AP_WheelEncoder/AP_WheelEncoder.h>
+
+// wheel rate control defaults
+#define AP_WHEEL_RATE_MAX_DEFAULT   12.0f  // maximum wheel rotation rate in rad/sec (about 115rpm, 687deg/sec)
+#define AP_WHEEL_RATE_CONTROL_FF    8.00f
+#define AP_WHEEL_RATE_CONTROL_P     2.00f
+#define AP_WHEEL_RATE_CONTROL_I     2.00f
+#define AP_WHEEL_RATE_CONTROL_IMAX  1.00f
+#define AP_WHEEL_RATE_CONTROL_D     0.01f
+#define AP_WHEEL_RATE_CONTROL_FILT  0.00f
+#define AP_WHEEL_RATE_CONTROL_DT    0.02f
+#define AP_WHEEL_RATE_CONTROL_TIMEOUT_MS 200
+
+class AP_WheelRateControl {
+
+public:
+
+    AP_WheelRateControl(const AP_WheelEncoder &wheel_encoder_ref);
+
+    // returns true if a wheel encoder and rate control PID are available for this instance
+    bool enabled(uint8_t instance);
+
+    // get throttle output in the range -100 to +100 given a desired rate expressed as a percentage of the rate_max (-100 to +100)
+    // instance can be 0 or 1
+    float get_rate_controlled_throttle(uint8_t instance, float desired_rate_pct, float dt);
+
+    // get rate maximum in radians/sec
+    float get_rate_max_rads() const { return MAX(_rate_max, 0.0f); }
+
+    // get pid objects for reporting
+    AC_PID& get_pid(uint8_t instance);
+
+    static const struct AP_Param::GroupInfo        var_info[];
+
+private:
+
+    // parameters
+    AP_Int8         _enabled;   // top level enable/disable control
+    AP_Float        _rate_max;  // wheel maximum rotation rate in rad/s
+    AC_PID          _rate_pid0 = AC_PID(AP_WHEEL_RATE_CONTROL_P, AP_WHEEL_RATE_CONTROL_I, AP_WHEEL_RATE_CONTROL_D, AP_WHEEL_RATE_CONTROL_IMAX, AP_WHEEL_RATE_CONTROL_FILT, AP_WHEEL_RATE_CONTROL_DT, AP_WHEEL_RATE_CONTROL_FF);
+    AC_PID          _rate_pid1 = AC_PID(AP_WHEEL_RATE_CONTROL_P, AP_WHEEL_RATE_CONTROL_I, AP_WHEEL_RATE_CONTROL_D, AP_WHEEL_RATE_CONTROL_IMAX, AP_WHEEL_RATE_CONTROL_FILT, AP_WHEEL_RATE_CONTROL_DT, AP_WHEEL_RATE_CONTROL_FF);
+
+    // limit flags
+    struct AP_MotorsUGV_limit {
+        bool    lower;  // reached this instance's lower limit on last iteration
+        bool    upper;  // reached this instance's upper limit on last iteration
+    } _limit[2];
+
+    // internal variables
+    const AP_WheelEncoder&  _wheel_encoder;     // pointer to accompanying wheel encoder
+    uint32_t                _last_update_ms;    // system time of last call to get_rate_controlled_throttle
+};

--- a/libraries/AP_WheelEncoder/WheelEncoder_Backend.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Backend.cpp
@@ -43,3 +43,17 @@ int8_t AP_WheelEncoder_Backend::get_pin_b() const
     }
     return _frontend._pinb[_state.instance].get();
 }
+
+// copy state to front end helper function
+void AP_WheelEncoder_Backend::copy_state_to_frontend(int32_t distance_count, uint32_t total_count, uint32_t error_count, uint32_t last_reading_ms)
+{
+    // record distance and time change for calculating rate before previous state is overwritten
+    _state.dt_ms = last_reading_ms - _state.last_reading_ms;
+    _state.dist_count_change = distance_count - _state.distance_count;
+
+    // copy distance and error count so it is accessible to front end
+    _state.distance_count = distance_count;
+    _state.total_count = total_count;
+    _state.error_count = error_count;
+    _state.last_reading_ms = last_reading_ms;
+}

--- a/libraries/AP_WheelEncoder/WheelEncoder_Backend.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Backend.h
@@ -37,6 +37,9 @@ protected:
     int8_t get_pin_a() const;
     int8_t get_pin_b() const;
 
+    // copy state to front end helper function
+    void copy_state_to_frontend(int32_t distance_count, uint32_t total_count, uint32_t error_count, uint32_t last_reading_ms);
+
     AP_WheelEncoder &_frontend;
     AP_WheelEncoder::WheelEncoder_State &_state;
 };

--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.cpp
@@ -77,10 +77,10 @@ void AP_WheelEncoder_Quadrature::update(void)
     void *irqstate = hal.scheduler->disable_interrupts_save();
 
     // copy distance and error count so it is accessible to front end
-    _state.distance_count = irq_state.distance_count;
-    _state.total_count = irq_state.total_count;
-    _state.error_count = irq_state.error_count;
-    _state.last_reading_ms = irq_state.last_reading_ms;
+    copy_state_to_frontend(irq_state.distance_count,
+                           irq_state.total_count,
+                           irq_state.error_count,
+                           irq_state.last_reading_ms);
 
     // restore interrupts
     hal.scheduler->restore_interrupts(irqstate);

--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
@@ -44,7 +44,7 @@ private:
 
     struct IrqState {
         uint8_t  phase;             // current phase of encoder (from 0 to 3)
-        int32_t  distance_count;    // distance measured by cumulative steps forward or backwards
+        int32_t  distance_count;    // distance measured by cumulative steps forward or backwards since last update
         uint32_t total_count;       // total number of successful readings from sensor (used for sensor quality calcs)
         uint32_t error_count;       // total number of errors reading from sensor (used for sensor quality calcs)
         uint32_t last_reading_ms;   // system time of last update from encoder

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -158,11 +158,11 @@ public:
     // This structure provides information on the internal member data of a PID for logging purposes
     struct PID_Info {
         float desired;
+        float actual;
         float P;
         float I;
         float D;
         float FF;
-        float AFF;
     };
 
     void Log_Write_PID(uint8_t msg_type, const PID_Info &info);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1589,11 +1589,11 @@ void DataFlash_Class::Log_Write_PID(uint8_t msg_type, const PID_Info &info)
         LOG_PACKET_HEADER_INIT(msg_type),
         time_us         : AP_HAL::micros64(),
         desired         : info.desired,
+        actual          : info.actual,
         P               : info.P,
         I               : info.I,
         D               : info.D,
-        FF              : info.FF,
-        AFF             : info.AFF
+        FF              : info.FF
     };
     WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -665,11 +665,11 @@ struct PACKED log_PID {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     float   desired;
+    float   actual;
     float   P;
     float   I;
     float   D;
     float   FF;
-    float   AFF;
 };
 
 struct PACKED log_Current {
@@ -1125,7 +1125,7 @@ struct PACKED log_DSTL {
 #define MAG_UNITS "sGGGGGGGGG-s"
 #define MAG_MULTS "FCCCCCCCCC-F"
 
-#define PID_LABELS "TimeUS,Des,P,I,D,FF,AFF"
+#define PID_LABELS "TimeUS,Des,Act,P,I,D,FF"
 #define PID_FMT    "Qffffff"
 #define PID_UNITS  "s------"
 #define PID_MULTS  "F------"


### PR DESCRIPTION
This PR improves the balance bot control:

- uses the motor library's upper and lower limits to stop I-term build-up in the BB's pitch control.  This is consistent with how we stop I-term build up in other layered controllers.  For example, if the throttle hits 100%, there's no point in the higher-level pitch control building up I-term because it won't help.
- AR_AttitudeControl's pitch controller gets a feedforward based upon the average wheel speed (from the wheel encoders) is added to the output throttle.  This is the biggest change in terms of improving the balancebot's ability to move at higher speeds.
- new WheelRateControl class which uses two PID objects and rate feedback from the wheel encoders to better control the vehicle's wheel speed.  This is optional but when used it should help get rid of non-linear response in the ESC/motors and reduce the effect of the deadzone in the ESCs.
- increase wheel encoder updates from 20hz to 50hz

Tuning a balance bot is made a little easier with these changes:

- DataFlash's PID_Info structure and the AC_PID class allow storing the "actual" replacing the unused "AFF".  This allows the actual rate (or angle or whatever) used at the time of the PID calculation to be recorded.  This makes reporting more accurate and easier.  This should be extended to existing PID objects as well but that can be done as a separate PR.
- add reporting of the Wheel Rate Control PID objects to the GCS in real-time

This code has been used on a real vehicle as [shown in this video](https://www.youtube.com/watch?v=hbPzTOfn3EA&t=21s) but there are a few things we should check before merging:

- does the EKF's position estimation based on wheel encoders work at the new 50hz update rate?  We need to ask @priseborough and/or test on a real vehicle.
- is the WheelRateControl worth the added complexity?  We should disable this control and see if we can still tune up the vehicle to drive as well as it does now.


We may want to eventually add a filter to the wheel-encoder-to-throttle feed-forward but this is not a requirement for merging.
