### PR TITLE
AP_HAL_ChibiOS: fix CubeYellow build

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -400,6 +400,9 @@ define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
 # available (in bytes)
 define HAL_STORAGE_SIZE 16384
 
+# allow to have have a dedicated safety switch pin
+define HAL_HAVE_SAFETY_SWITCH 1
+
 # this enables the use of a ramtron device for storage, if one is
 # found on SPI. You must have a ramtron entry in the SPI device table
 


### PR DESCRIPTION
Fix build error for Cube Yellow target:
```
../../libraries/AP_IOMCU/AP_IOMCU.cpp: In member function 'void AP_IOMCU::update_safety_options()':
../../libraries/AP_IOMCU/AP_IOMCU.cpp:626:37: error: 'class AP_BoardConfig' has no member named 'get_safety_button_options'
     uint16_t options = boardconfig->get_safety_button_options();
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```