### PR TITLE
AP_Mission: Specify start WP

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -29,6 +29,13 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 
+    // @Param: STARTWP
+    // @DisplayName: Mission Start WP
+    // @Description: Specify the start WP of the mission.
+    // @Values: 0: Default Start
+    // @User: Standard
+    AP_GROUPINFO("STARTWP",  3, AP_Mission, _startwp, 0),
+
     AP_GROUPEND
 };
 
@@ -162,8 +169,16 @@ void AP_Mission::reset()
     _flags.nav_cmd_loaded  = false;
     _flags.do_cmd_loaded   = false;
     _flags.do_cmd_all_done = false;
+    switch (_startwp) {
+    case 0:
+    case 1:
     _nav_cmd.index         = AP_MISSION_CMD_INDEX_NONE;
     _do_cmd.index          = AP_MISSION_CMD_INDEX_NONE;
+        break;
+    default:
+        _nav_cmd.index     = _startwp - 1;
+        _do_cmd.index      = _startwp - 1;
+    }
     _prev_nav_cmd_index    = AP_MISSION_CMD_INDEX_NONE;
     _prev_nav_cmd_wp_index = AP_MISSION_CMD_INDEX_NONE;
     _prev_nav_cmd_id       = AP_MISSION_CMD_ID_NONE;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -530,6 +530,7 @@ private:
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
     AP_Int16                _options;    // bitmask options for missions, currently for mission clearing on reboot but can be expanded as required
+    AP_Int16                _startwp;  // Start Mission WP
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started


### PR DESCRIPTION
I will be able to specify the start WP of multiple missions "take off landing".
I want to change the start WP from multiple missions according to the flight environment.
I want to reduce the operation of writing a mission every time.
I want to reduce mission write errors and mission selection mistakes.
For each discontinuity of each mission, the next mission is not executed by setting WP after landing.
Alternatively, specify DISARM as the mission.
![ddd](https://user-images.githubusercontent.com/646194/44176051-2d419480-a123-11e8-8445-d4528376986a.png)
