### PR TITLE
Plane: Add a manual only form of stick mixing

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1177,6 +1177,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(gripper, "GRIP_", 12, ParametersG2, AP_Gripper),
 #endif
 
+    // @Param: FLIGHT_OPTIONS
+    // @DisplayName: Flight mode options
+    // @Description: Flight mode specific options
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual, Stabilize, Acro)
+    // @User: Advanced
+    AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -544,6 +544,8 @@ public:
     // Payload Gripper
     AP_Gripper gripper;
 #endif
+
+    AP_Int32 flight_options;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -590,9 +590,6 @@ private:
     // The instantaneous desired pitch angle.  Hundredths of a degree
     int32_t nav_pitch_cd;
 
-    // we separate out rudder input to allow for RUDDER_ONLY=1
-    int16_t rudder_input;
-
     // the aerodymamic load factor. This is calculated from the demanded
     // roll before the roll is clipped, using 1/sqrt(cos(nav_roll))
     float aerodynamic_load_factor = 1.0f;
@@ -909,9 +906,10 @@ private:
     void init_rc_out_aux();
     void rudder_arm_disarm_check();
     void read_radio();
+    int16_t rudder_input(void);
     void control_failsafe();
     bool trim_radio();
-    bool rc_failsafe_active(void);
+    bool rc_failsafe_active(void) const;
     void read_rangefinder(void);
     void read_airspeed(void);
     void rpm_update(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -197,3 +197,7 @@ enum {
     USE_REVERSE_THRUST_FBWB                     = (1<<9),
     USE_REVERSE_THRUST_GUIDED                   = (1<<10),
 };
+
+enum FlightOptions {
+    DIRECT_RUDDER_ONLY = (1 << 0),
+};

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -231,7 +231,7 @@ void Plane::update_cruise()
 {
     if (!cruise_state.locked_heading &&
         channel_roll->get_control_in() == 0 &&
-        rudder_input == 0 &&
+        rudder_input() == 0 &&
         gps.status() >= AP_GPS::GPS_OK_FIX_2D &&
         gps.ground_speed() >= 3 &&
         cruise_state.lock_timer_ms == 0) {


### PR DESCRIPTION
This adds a more constrained form of stick mixing then `STICKING_MIXING_DISABLED`. Despite the name on stick mixing disabled it actually does a lot of mixing, anything other then an auto navigation mode (and FBWA failsafes) preforms stick mixing. This is particularly noticeable with the rudder where it is passed through in all the modes. On plane this pass through is frustrating when in cruise (or FBW, auto tune) as with large control surfaces you get unexpected, uncoordinated perturbations of the aircraft.

EDIT: Tested in SITL with MANUAL_CONTROL messages, behaves as expected.