### PR TITLE
Correct some broken syntax on autotest

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -622,6 +622,7 @@ class AutoTestRover(AutoTest):
 
     def autotest(self):
         """Autotest APMrover2 in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
         self.progress("Started simulator")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -376,7 +376,7 @@ class AutoTestCopter(AutoTest):
         tstart = self.get_sim_time()
         while self.get_sim_time() < tstart + timeout:
             m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
-            alt = m.alt / 1000.0 # mm -> m
+            alt = m.relative_alt / 1000.0 # mm -> m
             pos = self.mav.location()
             home_distance = self.get_distance(HOME, pos)
             self.progress("Alt: %u  HomeDist: %.0f" % (alt, home_distance))

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -148,6 +148,8 @@ class AutoTestCopter(AutoTest):
         self.mavproxy.send('switch 6\n')  # stabilize mode
         self.wait_mode('STABILIZE')
         if arm:
+            self.progress("Waiting reading for arm")
+            self.wait_ready_to_arm()
             self.set_rc(3, 1000)
             self.arm_vehicle()
         self.set_rc(3, takeoff_throttle)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -318,6 +318,7 @@ class AutoTestCopter(AutoTest):
         if time_left < 20:
             time_left = 20
         self.wait_altitude(-10, 10, time_left, relative=True)
+        self.set_rc(3, 1500)
         self.save_wp()
 
     # enter RTL mode and wait for the vehicle to disarm
@@ -356,7 +357,8 @@ class AutoTestCopter(AutoTest):
         self.set_rc(4, 1500)
 
         # raise throttle slightly to avoid hitting the ground
-        self.set_rc(3, 1600)
+        self.set_rc(3, 1800)
+        self.wait_altitude(20, 25, relative=True)
 
         # switch to stabilize mode
         self.mavproxy.send('switch 6\n')
@@ -1155,6 +1157,7 @@ class AutoTestCopter(AutoTest):
         # wait here until ready
         self.mavproxy.send('switch 5\n')  # loiter mode
         self.wait_mode('LOITER')
+        self.set_rc(3, 1500)
 
     def fly_vision_position(self):
         '''disable GPS navigation, enable Vicon input'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1697,6 +1697,7 @@ class AutoTestCopter(AutoTest):
 
     def autotest(self):
         """Autotest ArduCopter in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -427,6 +427,7 @@ class AutoTestCopter(AutoTest):
         self.set_parameter('BATT_FS_LOW_ACT', 0)
 
         self.progress("Successfully entered LAND after battery failsafe")
+        self.reboot_sitl()
 
     # fly_stability_patch - fly south, then hold loiter within 5m
     # position and altitude and reduce 1 motor to 60% efficiency

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1143,7 +1143,7 @@ class AutoTestCopter(AutoTest):
 
         return True
 
-    def fly_mission(self,):
+    def fly_mission(self):
         """Fly a mission from a file."""
         global num_wp
         self.progress("test: Fly a mission from 1 to %u" % num_wp)
@@ -1763,20 +1763,17 @@ class AutoTestCopter(AutoTest):
                 self.progress("save_mission_to_file failed")
 
             # fly the stored mission
-            self.run_test("Fly CH7 saved mission",
-                          lambda: self.fly_mission)
+            self.run_test("Fly CH7 saved mission", self.fly_mission)
 
             # Throttle Failsafe
-            self.run_test("Test Failsafe",
-                          lambda: self.fly_throttle_failsafe)
+            self.run_test("Test Failsafe", self.fly_throttle_failsafe)
 
             # Takeoff
             self.run_test("Takeoff to test battery failsafe",
                           lambda: self.takeoff(10))
 
             # Battery failsafe
-            self.run_test("Fly Battery Failsafe",
-                          lambda: self.fly_battery_failsafe)
+            self.run_test("Fly Battery Failsafe", self.fly_battery_failsafe)
 
             # Takeoff
             self.run_test("Takeoff to test stability patch",
@@ -1787,7 +1784,7 @@ class AutoTestCopter(AutoTest):
                           lambda: self.fly_stability_patch(30))
 
             # RTL
-            self.run_test("RTL after stab patch", lambda: self.fly_RTL)
+            self.run_test("RTL after stab patch", self.fly_RTL)
 
             # Takeoff
             self.run_test("Takeoff to test horizontal fence",
@@ -1798,8 +1795,7 @@ class AutoTestCopter(AutoTest):
                           lambda: self.fly_fence_test(180))
 
             # Fence test
-            self.run_test("Test Max Alt Fence",
-                          lambda: self.fly_alt_max_fence_test)
+            self.run_test("Test Max Alt Fence", self.fly_alt_max_fence_test)
 
             # Takeoff
             self.run_test("Takeoff to test GPS glitch loiter",

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1784,7 +1784,7 @@ class AutoTestCopter(AutoTest):
 
             # Takeoff
             self.run_test("Takeoff to test stability patch",
-                          lambda: self.takeoff(10))
+                          lambda: self.takeoff(10, arm=True))
 
             # Stability patch
             self.run_test("Fly stability patch",
@@ -1795,7 +1795,7 @@ class AutoTestCopter(AutoTest):
 
             # Takeoff
             self.run_test("Takeoff to test horizontal fence",
-                          lambda: self.takeoff(10))
+                          lambda: self.takeoff(10, arm=True))
 
             # Fence test
             self.run_test("Test horizontal fence",
@@ -1826,7 +1826,7 @@ class AutoTestCopter(AutoTest):
                           self.fly_gps_glitch_auto_test)
 
             # Takeoff
-            self.run_test("Takeoff to test loiter", lambda: self.takeoff(10))
+            self.run_test("Takeoff to test loiter", lambda: self.takeoff(10, arm=True))
 
             # Loiter for 10 seconds
             self.run_test("Test Loiter for 10 seconds", self.loiter)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -427,6 +427,7 @@ class AutoTestCopter(AutoTest):
 
         # disable battery failsafe
         self.set_parameter('BATT_FS_LOW_ACT', 0)
+        self.set_parameter('SIM_BATT_VOLTAGE', 13)
 
         self.progress("Successfully entered LAND after battery failsafe")
         self.reboot_sitl()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -531,6 +531,7 @@ class AutoTestPlane(AutoTest):
 
     def autotest(self):
         """Autotest ArduPlane in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
 

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -132,6 +132,7 @@ class AutoTestSub(AutoTest):
 
     def autotest(self):
         """Autotest ArduSub in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
 

--- a/Tools/autotest/balancebot.py
+++ b/Tools/autotest/balancebot.py
@@ -49,6 +49,7 @@ class AutoTestBalanceBot(AutoTestRover):
 
     def autotest(self):
         """Autotest APMrover2 in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
         self.progress("Started simulator")

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -970,9 +970,7 @@ class AutoTest(ABC):
         self.mav.idle_hooks.append(self.idle_hook)
 
     def run_test(self, desc, function, interact=False):
-        self.progress("#")
-        self.progress("########## %s ##########" % (desc))
-        self.progress("#")
+        self.start_test(desc)
 
         try:
             function()
@@ -984,6 +982,26 @@ class AutoTest(ABC):
                 self.mavproxy.interact()
             return
         self.progress('PASSED: "%s"' % desc)
+
+    def check_test_syntax(self, test_file):
+        """Check mistake on autotest function syntax."""
+        import re
+        self.start_test("Check for syntax mistake in autotest lambda")
+        if not os.path.isfile(test_file):
+            self.progress("File %s does not exist" % test_file)
+        test_file = test_file.rstrip('c')
+        try:
+            with open(test_file) as f:
+                # check for lambda: test_function without paranthesis
+                faulty_strings = re.findall(r"lambda\s*:\s*\w+.\w+\s*\)", f.read())
+                if faulty_strings:
+                    self.progress("Syntax error in autotest lamda at : ")
+                    print(faulty_strings)
+                    raise ErrorException()
+        except ErrorException:
+            self.progress('FAILED: "%s"' % "Check for syntax mistake in autotest lambda")
+            exit(1)
+        self.progress('PASSED: "%s"' % "Check for syntax mistake in autotest lambda")
 
     @abc.abstractmethod
     def init(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -131,6 +131,7 @@ class AutoTestQuadPlane(AutoTest):
 
     def autotest(self):
         """Autotest QuadPlane in SITL."""
+        self.check_test_syntax(test_file=os.path.realpath(__file__))
         if not self.hasInit:
             self.init()
 


### PR DESCRIPTION
Correct broken syntax with lambda that result in skipping the test.
Add a synstax test to catch those kind of error