### PR TITLE
Remove pointless gpio attach_interrupt overrides

### DIFF
--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -49,7 +49,9 @@ public:
     FUNCTOR_TYPEDEF(irq_handler_fn_t, void, uint8_t, bool, uint32_t);
     virtual bool    attach_interrupt(uint8_t pin,
                                      irq_handler_fn_t fn,
-                                     INTERRUPT_TRIGGER_TYPE mode) = 0;
+                                     INTERRUPT_TRIGGER_TYPE mode) {
+        return false;
+    }
 
     virtual bool    attach_interrupt(uint8_t pin,
                                      AP_HAL::Proc proc,

--- a/libraries/AP_HAL_Empty/GPIO.cpp
+++ b/libraries/AP_HAL_Empty/GPIO.cpp
@@ -27,13 +27,6 @@ AP_HAL::DigitalSource* GPIO::channel(uint16_t n) {
     return new DigitalSource(0);
 }
 
-/* Interrupt interface: */
-bool GPIO::attach_interrupt(uint8_t interrupt_num,
-                            irq_handler_fn_t fn,
-                            INTERRUPT_TRIGGER_TYPE mode) {
-    return true;
-}
-
 bool GPIO::usb_connected(void)
 {
     return false;

--- a/libraries/AP_HAL_Empty/GPIO.h
+++ b/libraries/AP_HAL_Empty/GPIO.h
@@ -14,11 +14,6 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n);
 
-    /* Interrupt interface: */
-    bool    attach_interrupt(uint8_t interrupt_num,
-                             irq_handler_fn_t fn,
-                             INTERRUPT_TRIGGER_TYPE mode) override;
-
     /* return true if USB cable is connected */
     bool    usb_connected(void);
 };

--- a/libraries/AP_HAL_Linux/GPIO_BBB.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.cpp
@@ -112,14 +112,6 @@ AP_HAL::DigitalSource* GPIO_BBB::channel(uint16_t n) {
     return new DigitalSource(n);
 }
 
-/* Interrupt interface: */
-bool GPIO_BBB::attach_interrupt(uint8_t interrupt_num,
-                                irq_handler_fn_t fn,
-                                INTERRUPT_TRIGGER_TYPE mode)
-{
-    return true;
-}
-
 bool GPIO_BBB::usb_connected(void)
 {
     return false;

--- a/libraries/AP_HAL_Linux/GPIO_BBB.h
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.h
@@ -129,11 +129,6 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n);
 
-    /* Interrupt interface: */
-    bool    attach_interrupt(uint8_t interrupt_num,
-                             irq_handler_fn_t fn,
-                             INTERRUPT_TRIGGER_TYPE mode) override;
-
     /* return true if USB cable is connected */
     bool    usb_connected(void);
 };

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -121,14 +121,6 @@ AP_HAL::DigitalSource* GPIO_RPI::channel(uint16_t n)
     return new DigitalSource(n);
 }
 
-/* Interrupt interface: */
-bool GPIO_RPI::attach_interrupt(uint8_t interrupt_num,
-                                irq_handler_fn_t fn,
-                                INTERRUPT_TRIGGER_TYPE mode)
-{
-    return true;
-}
-
 bool GPIO_RPI::usb_connected(void)
 {
     return false;

--- a/libraries/AP_HAL_Linux/GPIO_RPI.h
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.h
@@ -56,11 +56,6 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n);
 
-    /* Interrupt interface: */
-    bool    attach_interrupt(uint8_t interrupt_num,
-                             irq_handler_fn_t fn,
-                             INTERRUPT_TRIGGER_TYPE mode);
-
     /* return true if USB cable is connected */
     bool    usb_connected(void);
 

--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.cpp
@@ -188,13 +188,6 @@ AP_HAL::DigitalSource* GPIO_Sysfs::channel(uint16_t vpin)
     return new DigitalSource_Sysfs(pin, value_fd);
 }
 
-bool GPIO_Sysfs::attach_interrupt(uint8_t interrupt_num,
-                                  irq_handler_fn_t p,
-                                  INTERRUPT_TRIGGER_TYPE mode)
-{
-    return false;
-}
-
 bool GPIO_Sysfs::usb_connected(void)
 {
     return false;

--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.h
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.h
@@ -52,13 +52,6 @@ public:
     /*
      * Currently this function always returns false.
      */
-    bool attach_interrupt(uint8_t interrupt_num,
-                          irq_handler_fn_t p,
-                          INTERRUPT_TRIGGER_TYPE mode) override;
-
-    /*
-     * Currently this function always returns false.
-     */
     bool usb_connected() override;
 
 protected:

--- a/libraries/AP_HAL_SITL/GPIO.cpp
+++ b/libraries/AP_HAL_SITL/GPIO.cpp
@@ -52,14 +52,6 @@ AP_HAL::DigitalSource* GPIO::channel(uint16_t n) {
 
 }
 
-/* Interrupt interface: */
-bool GPIO::attach_interrupt(uint8_t interrupt_num,
-                            irq_handler_fn_t fn,
-                            INTERRUPT_TRIGGER_TYPE mode)
-{
-    return true;
-}
-
 bool GPIO::usb_connected(void)
 {
     return false;

--- a/libraries/AP_HAL_SITL/GPIO.h
+++ b/libraries/AP_HAL_SITL/GPIO.h
@@ -14,11 +14,6 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n);
 
-    /* Interrupt interface: */
-    bool attach_interrupt(uint8_t interrupt_num,
-                          irq_handler_fn_t fn,
-                          INTERRUPT_TRIGGER_TYPE mode) override;
-
     /* return true if USB cable is connected */
     bool usb_connected(void);
 

--- a/libraries/AP_HAL_VRBRAIN/GPIO.cpp
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.cpp
@@ -172,14 +172,6 @@ AP_HAL::DigitalSource* VRBRAINGPIO::channel(uint16_t n) {
     return new VRBRAINDigitalSource(0);
 }
 
-/* Interrupt interface: */
-bool VRBRAINGPIO::attach_interrupt(uint8_t interrupt_num,
-                                   irq_handler_fn_t fn,
-                                   INTERRUPT_TRIGGER_TYPE mode)
-{
-    return true;
-}
-
 /*
   return true when USB connected
  */

--- a/libraries/AP_HAL_VRBRAIN/GPIO.h
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.h
@@ -30,11 +30,6 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n) override;
 
-    /* Interrupt interface: */
-    bool attach_interrupt(uint8_t interrupt_num,
-                          irq_handler_fn_t fn,
-                          INTERRUPT_TRIGGER_TYPE mode) override;
-
     /* return true if USB cable is connected */
     bool usb_connected(void) override;
 

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -14,14 +14,10 @@
  */
 
 #include <AP_RSSI/AP_RSSI.h>
-#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <GCS_MAVLink/GCS.h>
 #include <RC_Channel/RC_Channel.h>
 
 #include <utility>
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-#include <board_config.h>
-#endif
 
 extern const AP_HAL::HAL& hal;
 
@@ -246,7 +242,6 @@ void AP_RSSI::check_pwm_pin_rssi()
 // read the PWM value from a pin
 float AP_RSSI::read_pwm_pin_rssi()
 {
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     // check if pin has changed and configure interrupt handlers if required:
     check_pwm_pin_rssi();
 
@@ -275,9 +270,6 @@ float AP_RSSI::read_pwm_pin_rssi()
     }
 
     return pwm_state.rssi_value;
-#else
-    return 0.0f;
-#endif
 }
 
 // Scale and constrain a float rssi value to 0.0 to 1.0 range 
@@ -313,7 +305,6 @@ float AP_RSSI::scale_and_constrain_float_rssi(float current_rssi_value, float lo
 // interrupt handler for reading pwm value
 void AP_RSSI::irq_handler(uint8_t pin, bool pin_high, uint32_t timestamp_us)
 {
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN || CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     if (pin_high) {
         pwm_state.pulse_start_us = timestamp_us;
     } else {
@@ -322,7 +313,6 @@ void AP_RSSI::irq_handler(uint8_t pin, bool pin_high, uint32_t timestamp_us)
             pwm_state.pulse_start_us = 0;
         }
     }
-#endif
 }
 
 AP_RSSI *AP_RSSI::_s_instance = nullptr;


### PR DESCRIPTION
This might be contentious.  But having all of these empty definitions - which returned true for some strange reason - was painful when I was playing with the attach-a-functor change.
