### PR TITLE
Copter: reduced twitch when entering new loiter

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2081,7 +2081,7 @@ void QuadPlane::init_qrtl(void)
     poscontrol.state = QPOS_POSITION1;
     poscontrol.speed_scale = 0;
     pos_control->set_desired_accel_xy(0.0f, 0.0f);
-    pos_control->init_xy_controller(true);
+    pos_control->init_xy_controller();
 }
 
 /*
@@ -2134,7 +2134,7 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
     poscontrol.state = QPOS_POSITION1;
     poscontrol.speed_scale = 0;
     pos_control->set_desired_accel_xy(0.0f, 0.0f);
-    pos_control->init_xy_controller(true);
+    pos_control->init_xy_controller();
 
     throttle_wait = false;
     landing_detect.lower_limit_start_ms = 0;

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -163,7 +163,7 @@ public:
     ///     sets target roll angle, pitch angle and I terms based on vehicle current lean angles
     ///     should be called once whenever significant changes to the position target are made
     ///     this does not update the xy target
-    void init_xy_controller(bool reset_I = true);
+    void init_xy_controller();
 
     /// set_accel_xy - set horizontal acceleration in cm/s/s
     ///     leash length will be recalculated the next time update_xy_controller() is called

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -59,8 +59,8 @@ AC_PID_2D::AC_PID_2D(float initial_p, float initial_i, float initial_d, float in
     filt_hz(initial_filt_hz);
     filt_d_hz(initial_filt_d_hz);
 
-    // reset input filter to first value received
-    _flags._reset_filter = true;
+    // reset input filter to first value received and derivitive to zero
+    reset_filter();
 }
 
 // set_dt - set time step in seconds
@@ -129,13 +129,6 @@ void AC_PID_2D::set_input_filter_d(const Vector2f& input_delta)
         return;
     }
 
-    // reset input filter
-    if (_flags._reset_filter) {
-        _flags._reset_filter = false;
-        _derivative.x = 0.0f;
-        _derivative.y = 0.0f;
-    }
-
     // update filter and calculate derivative
     if (is_positive(_dt)) {
         const Vector2f derivative = input_delta / _dt;
@@ -190,6 +183,14 @@ Vector2f AC_PID_2D::get_pid()
 
 void AC_PID_2D::reset_I()
 {
+    _integrator.zero();
+}
+
+void AC_PID_2D::reset_filter()
+{
+    _flags._reset_filter = true;
+    _derivative.x = 0.0f;
+    _derivative.y = 0.0f;
     _integrator.zero();
 }
 


### PR DESCRIPTION
This resolves an issue raised by a beta tester ([discussion is here](https://discuss.ardupilot.org/t/copter-3-6-0-rc2-available-for-beta-testing/29740/40)) which involves the vehicle twitching badly when it is switched into Loiter while the vehicle is moving.

This has been tested in SITL by flying the vehicle forward and then switching into Loiter mode.  The graph below shows the before and after result of the pitch angle.  The twitch has been greatly reduced.
![before-vs-after](https://user-images.githubusercontent.com/1498098/44455444-07dbeb80-a639-11e8-8488-00c33fbd25b8.png)
