### PR TITLE
Tools: reduce mavproxy memory usage on autotest

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -326,6 +326,8 @@ def start_MAVProxy_SITL(atype, aircraft=None, setup=False, master='tcp:127.0.0.1
         aircraft = 'test.%s' % atype
     cmd += ' --aircraft=%s' % aircraft
     cmd += ' ' + ' '.join(options)
+    cmd += ' --default-modules log,wp,param,arm,mode,rc,cmdlong,output'
+    cmd += ' --non-interactive'
     ret = pexpect.spawn(cmd, logfile=logfile, encoding=ENCODING, timeout=60)
     ret.delaybeforesend = 0
     pexpect_autoclose(ret)


### PR DESCRIPTION
Pass from > 70Mio used to 24 Mio 
not sure about the non-interactive as there it may be needed in run_test function 