### PR TITLE
AP_HAL_ChibiOS: Remove unimplemented force_safety_no_wait()

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -208,7 +208,6 @@ void Scheduler::reboot(bool hold_in_bootloader)
 {
     // disarm motors to ensure they are off during a bootloader upload
     hal.rcout->force_safety_on();
-    hal.rcout->force_safety_no_wait();
 
     //stop logging
     DataFlash_Class::instance()->StopLogging();


### PR DESCRIPTION
HAL ChibiOS doesn't implement the method, so there is nothing to be gained by calling the function.