### PR TITLE
HAL_SITL: use posix_memalign instead of memalign

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -263,8 +263,7 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
     if (!a->f) {
         goto failed;
     }
-    a->stack = memalign(4096, alloc_stack);
-    if (!a->stack) {
+    if (posix_memalign(&(a->stack), 4096, alloc_stack)) {
         goto failed;
     }
     memset(a->stack, stackfill, alloc_stack);


### PR DESCRIPTION
Solve compilation on OSX notice by @lvale : see #9233 
I am not sure about the syntax, but it should be ok