### PR TITLE
Copter: booster output respects safety switch

### DIFF
--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -103,14 +103,19 @@ void AP_MotorsCoax::output_to_motors()
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint16_t AP_MotorsCoax::get_motor_mask()
 {
-    uint32_t mask =
+    uint32_t motor_mask =
         1U << AP_MOTORS_MOT_1 |
         1U << AP_MOTORS_MOT_2 |
         1U << AP_MOTORS_MOT_3 |
         1U << AP_MOTORS_MOT_4 |
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
-    return rc_map_mask(mask);
+    uint16_t mask = rc_map_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
 }
 
 // sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -47,7 +47,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t    get_motor_mask();
+    uint16_t            get_motor_mask() override;
 
 protected:
     // output - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -122,13 +122,18 @@ void AP_MotorsMatrix::output_to_motors()
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint16_t AP_MotorsMatrix::get_motor_mask()
 {
-    uint16_t mask = 0;
+    uint16_t motor_mask = 0;
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
-            mask |= 1U << i;
+            motor_mask |= 1U << i;
         }
     }
-    return rc_map_mask(mask);
+    uint16_t mask = rc_map_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
 }
 
 // output_armed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -46,7 +46,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    uint16_t            get_motor_mask();
+    uint16_t            get_motor_mask() override;
 
 protected:
     // output - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -610,6 +610,13 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask)
     }
 }
 
+// get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
+//  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+uint16_t AP_MotorsMulticopter::get_motor_mask()
+{
+    return SRV_Channels::get_output_channel_mask(SRV_Channel::k_boost_throttle);
+}
+
 // save parameters as part of disarming
 void AP_MotorsMulticopter::save_params_on_disarm()
 {

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -86,6 +86,10 @@ public:
     // flight. Thrust is in the range 0 to 1
     virtual void        output_motor_mask(float thrust, uint8_t mask);
 
+    // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
+    //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+    virtual uint16_t    get_motor_mask() override;
+
     // get minimum or maximum pwm value that can be output to motors
     int16_t             get_pwm_output_min() const;
     int16_t             get_pwm_output_max() const;

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -106,14 +106,20 @@ void AP_MotorsSingle::output_to_motors()
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint16_t AP_MotorsSingle::get_motor_mask()
 {
-    uint32_t mask =
+    uint32_t motor_mask =
         1U << AP_MOTORS_MOT_1 |
         1U << AP_MOTORS_MOT_2 |
         1U << AP_MOTORS_MOT_3 |
         1U << AP_MOTORS_MOT_4 |
         1U << AP_MOTORS_MOT_5 |
         1U << AP_MOTORS_MOT_6;
-    return rc_map_mask(mask);
+
+    uint16_t mask = rc_map_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
 }
 
 // sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -47,7 +47,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t    get_motor_mask();
+    uint16_t            get_motor_mask() override;
 
 protected:
     // output - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -27,7 +27,7 @@ public:
     void output_to_motors();
 
     // return 0 motor mask
-    uint16_t get_motor_mask() { return 0; }
+    uint16_t get_motor_mask() override { return 0; }
 
 protected:
     // calculate motor outputs

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -109,10 +109,16 @@ void AP_MotorsTri::output_to_motors()
 uint16_t AP_MotorsTri::get_motor_mask()
 {
     // tri copter uses channels 1,2,4 and 7
-    return rc_map_mask((1U << AP_MOTORS_MOT_1) |
-                       (1U << AP_MOTORS_MOT_2) |
-                       (1U << AP_MOTORS_MOT_4) |
-                       (1U << AP_MOTORS_CH_TRI_YAW));
+    uint16_t motor_mask = (1U << AP_MOTORS_MOT_1) |
+                          (1U << AP_MOTORS_MOT_2) |
+                          (1U << AP_MOTORS_MOT_4) |
+                          (1U << AP_MOTORS_CH_TRI_YAW);
+    uint16_t mask = rc_map_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
 }
 
 // output_armed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -42,7 +42,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t    get_motor_mask();
+    uint16_t            get_motor_mask() override;
 
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward


### PR DESCRIPTION
Copter-3.6 (and higher) support a "booster" motor for multicopters ([blog](https://discuss.ardupilot.org/t/petrol-boosted-tricopter/17823)).  These are configured by setting SERVOx_FUNCTION to 81 (boost_throttle) and then setting MOT_BOOST_SCALE to a postive number from 0 to 1.

This PR enables the output to the booster to reflect the safety switch instead of enabling it along with other "auxiliary" outputs (used for gimbals, etc).

This has been tested on an mRobotics Pixhawk1 under NuttX:

- connected a servo tester to read the output from MAIN OUT 5 of the pixhawk
- set MOT_BOOST_SCALE = 0.5, SERVO5_FUNCTION = 81
- rebooted pixhawk
- with safety switch unpressed (disengaged?), no PWM pulses were sent
- with safety switch pressed, PWM values were output (same value as held in SERVO5_MIN)

This item was reported in [this Copter-3.6 beta testing thread](https://discuss.ardupilot.org/t/copter-3-6-0-rc7-released-for-beta-testing/31513/10).

P.S. I'm not totally overjoyed with the complexity of implementing the get_motor_mask() in the AP_MotorsMulticopter class and then calling it from all the children.  I considered two other alternatives before implementing it this way:

- modify each child class's get_motor_mask() function to include the boost channel (overall less code actually).
- add a get_motor_mask_multicopter (or similar) and force the children to override this method instead of get_motor_mask (this would remove the need for the children to call the parent).