### PR TITLE
Tools/scripts: make_intel_hex.py force python2

### DIFF
--- a/Tools/scripts/make_intel_hex.py
+++ b/Tools/scripts/make_intel_hex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, os, shutil, struct
 import intelhex


### PR DESCRIPTION
Single character PR to force python2.
Resolves failure to build hex file on systems where python3 is the default.  Should have no effect where python2 is already the default python.