### PR TITLE
Move GCS mount handling up to base class

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -241,7 +241,7 @@ private:
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps solution for altitude rather than gps only.
-    AP_Mount camera_mount{ahrs, current_loc};
+    AP_Mount camera_mount{current_loc};
 #endif
 
     // true if initialisation has completed

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -504,7 +504,7 @@ private:
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps solution for altitude rather than gps only.
-    AP_Mount camera_mount{ahrs, current_loc};
+    AP_Mount camera_mount{current_loc};
 #endif
 
     // AC_Fence library to reduce fly-aways

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -322,24 +322,10 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
 #endif
         break;
 
-    case MSG_MOUNT_STATUS:
-#if MOUNT == ENABLED
-        CHECK_PAYLOAD_SIZE(MOUNT_STATUS);
-        copter.camera_mount.status_msg(chan);
-#endif // MOUNT == ENABLED
-        break;
-
     case MSG_OPTICAL_FLOW:
 #if OPTFLOW == ENABLED
         CHECK_PAYLOAD_SIZE(OPTICAL_FLOW);
         send_opticalflow(copter.optflow);
-#endif
-        break;
-
-    case MSG_GIMBAL_REPORT:
-#if MOUNT == ENABLED
-        CHECK_PAYLOAD_SIZE(GIMBAL_REPORT);
-        copter.camera_mount.send_gimbal_report(chan);
 #endif
         break;
 
@@ -602,6 +588,15 @@ MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavli
 }
 
 
+MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi(const Location &roi_loc)
+{
+    if (!check_latlng(roi_loc)) {
+        return MAV_RESULT_FAILED;
+    }
+    copter.flightmode->auto_yaw.set_roi(roi_loc);
+    return MAV_RESULT_ACCEPTED;
+}
+
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_int_t &packet)
 {
     switch(packet.command) {
@@ -657,30 +652,30 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_i
         return MAV_RESULT_ACCEPTED;
     }
 
-    case MAV_CMD_DO_SET_ROI: {
-        // param1 : /* Region of interest mode (not used)*/
-        // param2 : /* MISSION index/ target ID (not used)*/
-        // param3 : /* ROI index (not used)*/
-        // param4 : /* empty */
-        // x : lat
-        // y : lon
-        // z : alt
-        // sanity check location
-        if (!check_latlng(packet.x, packet.y)) {
-            return MAV_RESULT_FAILED;
-        }
-        Location roi_loc;
-        roi_loc.lat = packet.x;
-        roi_loc.lng = packet.y;
-        roi_loc.alt = (int32_t)(packet.z * 100.0f);
-        copter.flightmode->auto_yaw.set_roi(roi_loc);
-        return MAV_RESULT_ACCEPTED;
-    }
     default:
         return GCS_MAVLINK::handle_command_int_packet(packet);
     }
 }
 
+MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_long_t &packet)
+{
+    // if the mount doesn't do pan control then yaw the entire vehicle instead:
+    switch (packet.command) {
+#if MOUNT == ENABLED
+    case MAV_CMD_DO_MOUNT_CONTROL:
+        if(!copter.camera_mount.has_pan_control()) {
+            copter.flightmode->auto_yaw.set_fixed_yaw(
+                (float)packet.param3 / 100.0f,
+                0.0f,
+                0,0);
+        }
+        break;
+#endif
+    default:
+        break;
+    }
+    return GCS_MAVLINK::handle_command_mount(packet);
+}
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_long_t &packet)
 {
@@ -790,36 +785,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             }
         }
         return MAV_RESULT_FAILED;
-
-    case MAV_CMD_DO_SET_ROI:
-        // param1 : regional of interest mode (not supported)
-        // param2 : mission index/ target id (not supported)
-        // param3 : ROI index (not supported)
-        // param5 : x / lat
-        // param6 : y / lon
-        // param7 : z / alt
-        // sanity check location
-        if (!check_latlng(packet.param5, packet.param6)) {
-            return MAV_RESULT_FAILED;
-        }
-        Location roi_loc;
-        roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-        roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-        roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
-        copter.flightmode->auto_yaw.set_roi(roi_loc);
-        return MAV_RESULT_ACCEPTED;
-
-#if MOUNT == ENABLED
-    case MAV_CMD_DO_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control()) {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                (float)packet.param3 / 100.0f,
-                0.0f,
-                0,0);
-        }
-        copter.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
-        return MAV_RESULT_ACCEPTED;
-#endif
 
 #if MODE_AUTO_ENABLED == ENABLED
     case MAV_CMD_MISSION_START:
@@ -1018,6 +983,25 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
     }
 }
 
+void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t* msg)
+{
+    switch (msg->msgid) {
+#if MOUNT == ENABLED
+    case MAVLINK_MSG_ID_MOUNT_CONTROL:
+        if(!copter.camera_mount.has_pan_control()) {
+            // if the mount doesn't do pan control then yaw the entire vehicle instead:
+            copter.flightmode->auto_yaw.set_fixed_yaw(
+                mavlink_msg_mount_control_get_input_c(msg)/100.0f,
+                0.0f,
+                0,
+                0);
+
+            break;
+        }
+#endif
+    }
+    GCS_MAVLINK::handle_mount_message(msg);
+}
 
 void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
 {
@@ -1028,22 +1012,6 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         // We keep track of the last time we received a heartbeat from our GCS for failsafe purposes
         if(msg->sysid != copter.g.sysid_my_gcs) break;
         copter.failsafe.last_heartbeat_ms = AP_HAL::millis();
-        break;
-    }
-
-    case MAVLINK_MSG_ID_PARAM_VALUE:
-    {
-#if MOUNT == ENABLED
-        copter.camera_mount.handle_param_value(msg);
-#endif
-        break;
-    }
-
-    case MAVLINK_MSG_ID_GIMBAL_REPORT:
-    {
-#if MOUNT == ENABLED
-        handle_gimbal_report(copter.camera_mount, msg);
-#endif
         break;
     }
 
@@ -1413,24 +1381,6 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         copter.fence.handle_msg(*this, msg);
         break;
 #endif // AC_FENCE == ENABLED
-
-#if MOUNT == ENABLED
-    //deprecated. Use MAV_CMD_DO_MOUNT_CONFIGURE
-    case MAVLINK_MSG_ID_MOUNT_CONFIGURE:        // MAV ID: 204
-        copter.camera_mount.configure_msg(msg);
-        break;
-    //deprecated. Use MAV_CMD_DO_MOUNT_CONTROL
-    case MAVLINK_MSG_ID_MOUNT_CONTROL:
-        if(!copter.camera_mount.has_pan_control()) {
-            copter.flightmode->auto_yaw.set_fixed_yaw(
-                mavlink_msg_mount_control_get_input_c(msg)/100.0f,
-                0.0f,
-                0,
-                0);
-        }
-        copter.camera_mount.control_msg(msg);
-        break;
-#endif // MOUNT == ENABLED
 
     case MAVLINK_MSG_ID_TERRAIN_DATA:
     case MAVLINK_MSG_ID_TERRAIN_CHECK:

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -33,8 +33,13 @@ protected:
 
     void send_position_target_global_int() override;
 
+    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+
+    MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
+
+    void handle_mount_message(const mavlink_message_t* msg) override;
 
 private:
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -745,7 +745,7 @@ private:
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
-    AP_Mount camera_mount{ahrs, current_loc};
+    AP_Mount camera_mount{current_loc};
 #endif
 
     // Arming/Disarming mangement class

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -441,24 +441,10 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
 #endif
         break;
 
-    case MSG_MOUNT_STATUS:
-#if MOUNT == ENABLED
-        CHECK_PAYLOAD_SIZE(MOUNT_STATUS);
-        sub.camera_mount.status_msg(chan);
-#endif // MOUNT == ENABLED
-        break;
-
     case MSG_OPTICAL_FLOW:
 #if OPTFLOW == ENABLED
         CHECK_PAYLOAD_SIZE(OPTICAL_FLOW);
         send_opticalflow(sub.optflow);
-#endif
-        break;
-
-    case MSG_GIMBAL_REPORT:
-#if MOUNT == ENABLED
-        CHECK_PAYLOAD_SIZE(GIMBAL_REPORT);
-        sub.camera_mount.send_gimbal_report(chan);
 #endif
         break;
 
@@ -661,6 +647,15 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet);
 }
 
+MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)
+{
+    if (!check_latlng(roi_loc)) {
+        return MAV_RESULT_FAILED;
+    }
+    sub.set_auto_yaw_roi(roi_loc);
+    return MAV_RESULT_ACCEPTED;
+}
+
 MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_packet(const mavlink_command_int_t &packet)
 {
     switch (packet.command) {
@@ -707,25 +702,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_packet(const mavlink_command_int_
         return MAV_RESULT_FAILED;
     }
 
-    case MAV_CMD_DO_SET_ROI: {
-        // param1 : /* Region of interest mode (not used)*/
-        // param2 : /* MISSION index/ target ID (not used)*/
-        // param3 : /* ROI index (not used)*/
-        // param4 : /* empty */
-        // x : lat
-        // y : lon
-        // z : alt
-        // sanity check location
-        if (!check_latlng(packet.x, packet.y)) {
-            return MAV_RESULT_FAILED;
-        }
-        Location roi_loc;
-        roi_loc.lat = packet.x;
-        roi_loc.lng = packet.y;
-        roi_loc.alt = (int32_t)(packet.z * 100.0f);
-        sub.set_auto_yaw_roi(roi_loc);
-        return MAV_RESULT_ACCEPTED;
-    }
     default:
         return GCS_MAVLINK::handle_command_int_packet(packet);
     }
@@ -801,30 +777,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
         }
         return MAV_RESULT_FAILED;
 
-    case MAV_CMD_DO_SET_ROI:
-        // param1 : regional of interest mode (not supported)
-        // param2 : mission index/ target id (not supported)
-        // param3 : ROI index (not supported)
-        // param5 : x / lat
-        // param6 : y / lon
-        // param7 : z / alt
-        // sanity check location
-        if (!check_latlng(packet.param5, packet.param6)) {
-            return MAV_RESULT_FAILED;
-        }
-        Location roi_loc;
-        roi_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
-        roi_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
-        roi_loc.alt = (int32_t)(packet.param7 * 100.0f);
-        sub.set_auto_yaw_roi(roi_loc);
-        return MAV_RESULT_ACCEPTED;
-
-#if MOUNT == ENABLED
-    case MAV_CMD_DO_MOUNT_CONTROL:
-        sub.camera_mount.control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
-        return MAV_RESULT_ACCEPTED;
-#endif
-
     case MAV_CMD_MISSION_START:
         if (sub.motors.armed() && sub.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
             return MAV_RESULT_ACCEPTED;
@@ -889,20 +841,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
             break;
         }
         sub.failsafe.last_heartbeat_ms = AP_HAL::millis();
-        break;
-    }
-
-    case MAVLINK_MSG_ID_PARAM_VALUE: {
-#if MOUNT == ENABLED
-        sub.camera_mount.handle_param_value(msg);
-#endif
-        break;
-    }
-
-    case MAVLINK_MSG_ID_GIMBAL_REPORT: {
-#if MOUNT == ENABLED
-        handle_gimbal_report(sub.camera_mount, msg);
-#endif
         break;
     }
 
@@ -1142,17 +1080,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         sub.fence.handle_msg(*this, msg);
         break;
 #endif // AC_FENCE == ENABLED
-
-#if MOUNT == ENABLED
-        //deprecated. Use MAV_CMD_DO_MOUNT_CONFIGURE
-    case MAVLINK_MSG_ID_MOUNT_CONFIGURE:        // MAV ID: 204
-        sub.camera_mount.configure_msg(msg);
-        break;
-        //deprecated. Use MAV_CMD_DO_MOUNT_CONTROL
-    case MAVLINK_MSG_ID_MOUNT_CONTROL:
-        sub.camera_mount.control_msg(msg);
-        break;
-#endif // MOUNT == ENABLED
 
     case MAVLINK_MSG_ID_TERRAIN_DATA:
     case MAVLINK_MSG_ID_TERRAIN_CHECK:

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -22,6 +22,7 @@ protected:
     bool set_mode(uint8_t mode) override;
     bool should_zero_rc_outputs_on_reboot() const override { return true; }
 
+    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet) override;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -408,7 +408,7 @@ private:
     // Camera/Antenna mount tracking and stabilisation stuff
 #if MOUNT == ENABLED
     // current_loc uses the baro/gps soloution for altitude rather than gps only.
-    AP_Mount camera_mount{ahrs, current_loc};
+    AP_Mount camera_mount{current_loc};
 #endif
 
     // AC_Fence library to reduce fly-aways

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9,9 +9,10 @@ import time
 
 import pexpect
 from pymavlink import mavutil
+from pymavlink import mavextra
+from pymavlink import quaternion
 
 from pysim import util
-
 from common import AutoTest
 from common import NotAchievedException, AutoTestTimeoutException, PreconditionFailedException
 
@@ -1702,6 +1703,40 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    def fly_guided_move_relative(self, lat, lon, alt):
+        startpos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
+                                       blocking=True)
+
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time() - tstart > 200:
+                raise NotAchievedException("Did not move far enough")
+            # send a position-control command
+            self.mav.mav.set_position_target_global_int_send(
+                0, # timestamp
+                1, # target system_id
+                1, # target component id
+                mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+                0b1111111111111000, # mask specifying use-only-lat-lon-alt
+                lat, # lat
+                lon, # lon
+                alt, # alt
+                0, # vx
+                0, # vy
+                0, # vz
+                0, # afx
+                0, # afy
+                0, # afz
+                0, # yaw
+                0, # yawrate
+            )
+            pos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
+                                      blocking=True)
+            delta = self.get_distance_int(startpos, pos)
+            self.progress("delta=%f (want >10)" % delta)
+            if delta > 10:
+                break
+
     def fly_guided_change_submode(self):
         """"Ensure we can move around in guided after a takeoff command."""
 
@@ -1720,43 +1755,12 @@ class AutoTestCopter(AutoTest):
 
             self.user_takeoff(alt_min=10)
 
-            startpos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
-                                           blocking=True)
-
             """yaw through absolute angles using MAV_CMD_CONDITION_YAW"""
             self.guided_achieve_heading(45)
             self.guided_achieve_heading(135)
 
             """move the vehicle using set_position_target_global_int"""
-            tstart = self.get_sim_time()
-            while True:
-                if self.get_sim_time() - tstart > 200:
-                    raise NotAchievedException("Did not move far enough")
-                # send a position-control command
-                self.mav.mav.set_position_target_global_int_send(
-                    0, # timestamp
-                    1, # target system_id
-                    1, # target component id
-                    mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
-                    0b1111111111111000, # mask specifying use-only-lat-lon-alt
-                    5, # lat
-                    5, # lon
-                    10, # alt
-                    0, # vx
-                    0, # vy
-                    0, # vz
-                    0, # afx
-                    0, # afy
-                    0, # afz
-                    0, # yaw
-                    0, # yawrate
-                )
-                pos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
-                                          blocking=True)
-                delta = self.get_distance_int(startpos, pos)
-                self.progress("delta=%f (want >10)" % delta)
-                if delta > 10:
-                    break
+            self.fly_guided_move_relative(5, 5, 10)
 
             self.progress("Landing")
             self.mavproxy.send('switch 2\n')  # land mode
@@ -1793,6 +1797,325 @@ class AutoTestCopter(AutoTest):
             ex = e
         self.context_pop()
         self.mav.motors_disarmed_wait()
+        if ex is not None:
+            raise ex
+
+    def test_mount_pitch(self, despitch, despitch_tolerance, timeout=5):
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time() - tstart > timeout:
+                raise NotAchievedException()
+
+            m = self.mav.recv_match(type='MOUNT_STATUS',
+                                    blocking=True,
+                                    timeout=5)
+#            self.progress("pitch=%f roll=%f yaw=%f" %
+#                          (m.pointing_a, m.pointing_b, m.pointing_c))
+            mount_pitch = m.pointing_a/100.0 # centidegrees to degrees
+            if abs(despitch - mount_pitch) > despitch_tolerance:
+                self.progress("Mount pitch incorrect: %f != %f" %
+                              (mount_pitch, despitch))
+                continue
+            self.progress("Mount pitch correct: %f degrees == %f" %
+                          (mount_pitch, despitch))
+            return
+
+    def do_pitch(self, pitch):
+        '''pitch aircraft in guided/angle mode'''
+        self.mav.mav.set_attitude_target_send(
+            0, # time_boot_ms
+            1, # target sysid
+            1, # target compid
+            0, # bitmask of things to ignore
+            mavextra.euler_to_quat([0, math.radians(pitch), 0]), # att
+            0, # roll rate (rad/s)
+            1, # pitch rate
+            0, # yaw rate
+            0.5) # thrust, 0 to 1, translated to a climb/descent rate
+
+    def test_mount(self):
+        ex = None
+        self.context_push()
+        try:
+            '''start by disabling GCS failsafe, otherwise we immediately disarm
+            due to (apparently) not receiving traffic from the GCS for
+            too long.  This is probably a function of --speedup'''
+            self.set_parameter("FS_GCS_ENABLE", 0)
+
+            self.progress("Setting up servo mount")
+            roll_servo = 5
+            pitch_servo = 6
+            yaw_servo = 7
+            self.set_parameter("MNT_TYPE", 1)
+            self.set_parameter("SERVO%u_FUNCTION" % roll_servo, 8) # roll
+            self.set_parameter("SERVO%u_FUNCTION" % pitch_servo, 7) # pitch
+            self.set_parameter("SERVO%u_FUNCTION" % yaw_servo, 6) # yaw
+            self.reboot_sitl() # to handle MNT_TYPE changing
+
+            # make sure we're getting mount status and gimbal reports
+            self.mav.recv_match(type='MOUNT_STATUS',
+                                blocking=True,
+                                timeout=5)
+            self.mav.recv_match(type='GIMBAL_REPORT',
+                                blocking=True,
+                                timeout=5)
+
+            # test pitch isn't stabilising:
+            m = self.mav.recv_match(type='MOUNT_STATUS',
+                                    blocking=True,
+                                    timeout=5)
+            if m.pointing_a != 0 or m.pointing_b != 0 or m.pointing_c != 0:
+                self.progress("Stabilising when not requested")
+                raise NotAchievedException()
+
+            self.mavproxy.send('mode guided\n')
+            self.wait_mode('GUIDED')
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+
+            self.user_takeoff()
+
+            despitch = 10
+            despitch_tolerance = 3
+
+            self.progress("Pitching vehicle")
+            self.do_pitch(despitch) # will time out!
+
+            self.wait_pitch(despitch, despitch_tolerance)
+
+            # check we haven't modified:
+            m = self.mav.recv_match(type='MOUNT_STATUS',
+                                    blocking=True,
+                                    timeout=5)
+            if m.pointing_a != 0 or m.pointing_b != 0 or m.pointing_c != 0:
+                self.progress("Stabilising when not requested")
+                raise NotAchievedException()
+
+            self.progress("Enable pitch stabilization using MOUNT_CONFIGURE")
+            self.do_pitch(despitch)
+            self.mav.mav.mount_configure_send(
+                1, # target system
+                1, # target component
+                mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING,
+                0, # stab-roll
+                1, # stab-pitch
+                0)
+
+            self.test_mount_pitch(-despitch, 1)
+
+            self.progress("Disable pitch using MAV_CMD_DO_MOUNT_CONFIGURE")
+            self.do_pitch(despitch)
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOUNT_CONFIGURE,
+                         mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         )
+            self.test_mount_pitch(0, 0)
+
+            self.progress("Point somewhere using MOUNT_CONTROL (ANGLE)")
+            self.do_pitch(despitch)
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOUNT_CONFIGURE,
+                         mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         )
+            self.mav.mav.mount_control_send(
+                1, # target system
+                1, # target component
+                20 *100, # pitch
+                20 *100, # roll (centidegrees)
+                0,  # yaw
+                0   # save position
+            )
+            self.test_mount_pitch(20, 1)
+
+            self.progress("Point somewhere using MOUNT_CONTROL (GPS)")
+            self.do_pitch(despitch)
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOUNT_CONFIGURE,
+                         mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         )
+            start = self.mav.location()
+            self.progress("start=%s" % str(start))
+            (t_lat, t_lon) = mavextra.gps_offset(start.lat, start.lng, 10, 20)
+            t_alt = 0
+
+            self.progress("loc %f %f %f" % (start.lat, start.lng, start.alt))
+            self.progress("targetting %f %f %f" % (t_lat, t_lon, t_alt))
+            self.do_pitch(despitch)
+            self.mav.mav.mount_control_send(
+                1, # target system
+                1, # target component
+                t_lat * 1e7, # lat
+                t_lon * 1e7, # lon
+                t_alt * 100, # alt
+                0  # save position
+            )
+            self.test_mount_pitch(-52, 5)
+
+            # now test RC targetting
+            self.progress("Testing mount RC targetting")
+
+            # this is a one-off; ArduCopter *will* time out this directive!
+            self.progress("Levelling aircraft")
+            self.mav.mav.set_attitude_target_send(
+                0, # time_boot_ms
+                1, # target sysid
+                1, # target compid
+                0, # bitmask of things to ignore
+                mavextra.euler_to_quat([0, 0, 0]), # att
+                1, # roll rate (rad/s)
+                1, # pitch rate
+                1, # yaw rate
+                0.5) # thrust, 0 to 1, translated to a climb/descent rate
+
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_MOUNT_CONFIGURE,
+                         mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         )
+            try:
+                self.context_push()
+                self.set_parameter('MNT_RC_IN_ROLL', 11)
+                self.set_parameter('MNT_RC_IN_TILT', 12)
+                self.set_parameter('MNT_RC_IN_PAN', 13)
+                self.progress("Testing RC angular control")
+                self.set_rc(11, 1500)
+                self.set_rc(12, 1500)
+                self.set_rc(13, 1500)
+                self.test_mount_pitch(0, 1)
+                self.set_rc(12, 1400)
+                self.test_mount_pitch(-11.25, 0.01)
+                self.set_rc(12, 1800)
+                self.test_mount_pitch(33.75, 0.01)
+                self.set_rc(11, 1500)
+                self.set_rc(12, 1500)
+                self.set_rc(13, 1500)
+
+                self.progress("Testing RC rate control")
+                self.set_parameter('MNT_JSTICK_SPD', 10)
+                self.test_mount_pitch(0, 1)
+                self.set_rc(12, 1300)
+                self.test_mount_pitch(-5, 1)
+                self.test_mount_pitch(-10, 1)
+                self.test_mount_pitch(-15, 1)
+                self.test_mount_pitch(-20, 1)
+                self.set_rc(12, 1700)
+                self.test_mount_pitch(-15, 1)
+                self.test_mount_pitch(-10, 1)
+                self.test_mount_pitch(-5, 1)
+                self.test_mount_pitch(0, 1)
+                self.test_mount_pitch(5, 1)
+
+                self.progress("Reverting to angle mode")
+                self.set_parameter('MNT_JSTICK_SPD', 0)
+                self.set_rc(12, 1500)
+                self.test_mount_pitch(0, 0.1)
+
+                self.context_pop()
+
+            except Exception:
+                self.context_pop()
+                raise
+
+            self.progress("Testing mount ROI behaviour")
+            self.test_mount_pitch(0, 0.1)
+            start = self.mav.location()
+            self.progress("start=%s" % str(start))
+            (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
+                                                     start.lng,
+                                                     10,
+                                                     20)
+            roi_alt = 0
+            self.progress("Using MAV_CMD_DO_SET_ROI_LOCATION")
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
+                         0,
+                         0,
+                         0,
+                         0,
+                         roi_lat,
+                         roi_lon,
+                         roi_alt,
+                         )
+            self.test_mount_pitch(-52, 5)
+
+            start = self.mav.location()
+            (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
+                                                     start.lng,
+                                                     -100,
+                                                     -200)
+            roi_alt = 0
+            self.progress("Using MAV_CMD_DO_SET_ROI")
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI,
+                         0,
+                         0,
+                         0,
+                         0,
+                         roi_lat,
+                         roi_lon,
+                         roi_alt,
+                         )
+            self.test_mount_pitch(-7.5, 1)
+
+            self.progress("checking ArduCopter yaw-aircraft-for-roi")
+            try:
+                self.context_push()
+
+                m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+                self.progress("current heading %u" % m.heading)
+                self.set_parameter("SERVO%u_FUNCTION" % yaw_servo, 0) # yaw
+                self.progress("Waiting for check_servo_map to do its job")
+                self.wait_seconds(5)
+                start = self.mav.location()
+                self.progress("Moving to guided/position controller")
+                self.fly_guided_move_relative(0, 0, 0)
+                self.guided_achieve_heading(0)
+                (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
+                                                         start.lng,
+                                                         -100,
+                                                         -200)
+                roi_alt = 0
+                self.progress("Using MAV_CMD_DO_SET_ROI")
+                self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI,
+                             0,
+                             0,
+                             0,
+                             0,
+                             roi_lat,
+                             roi_lon,
+                             roi_alt,
+                             )
+
+                self.wait_heading(110, timeout=600)
+
+                self.context_pop()
+            except Exception:
+                self.context_pop()
+                raise
+
+        except Exception as e:
+            ex = e
+        self.context_pop()
+
+        self.reboot_sitl() # to handle MNT_TYPE changing
+
         if ex is not None:
             raise ex
 
@@ -2015,6 +2338,9 @@ class AutoTestCopter(AutoTest):
 
             '''vision position'''  # expects vehicle to be disarmed
             self.run_test("Fly Vision Position", self.fly_vision_position)
+
+            '''tests for camera/antenna mount'''
+            self.run_test("Test Mount", self.test_mount)
 
             # Download logs
             self.run_test("log download",

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -397,6 +397,14 @@ AP_Mount::AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc)
     _ahrs(ahrs),
     _current_loc(current_loc)
 {
+    if (_singleton != nullptr) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        AP_HAL::panic("Mount must be singleton");
+#endif
+        return;
+    }
+    _singleton = this;
+
 	AP_Param::setup_object_defaults(this, var_info);
 }
 
@@ -635,3 +643,16 @@ void AP_Mount::send_gimbal_report(mavlink_channel_t chan)
         }
     }    
 }
+
+
+// singleton instance
+AP_Mount *AP_Mount::_singleton;
+
+namespace AP {
+
+AP_Mount *mount()
+{
+    return AP_Mount::get_singleton();
+}
+
+};

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -393,8 +393,7 @@ const AP_Param::GroupInfo AP_Mount::var_info[] = {
     AP_GROUPEND
 };
 
-AP_Mount::AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc) :
-    _ahrs(ahrs),
+AP_Mount::AP_Mount(const struct Location &current_loc) :
     _current_loc(current_loc)
 {
     if (_singleton != nullptr) {
@@ -560,47 +559,79 @@ void AP_Mount::set_angle_targets(uint8_t instance, float roll, float tilt, float
     _backends[instance]->set_angle_targets(roll, tilt, pan);
 }
 
-/// Change the configuration of the mount
-/// triggered by a MavLink packet.
-void AP_Mount::configure_msg(uint8_t instance, mavlink_message_t* msg)
+MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_long_t &packet)
 {
-    if (instance >= AP_MOUNT_MAX_INSTANCES || _backends[instance] == nullptr) {
-        return;
+    if (_primary >= AP_MOUNT_MAX_INSTANCES || _backends[_primary] == nullptr) {
+        return MAV_RESULT_FAILED;
+    }
+    _backends[_primary]->set_mode((MAV_MOUNT_MODE)packet.param1);
+    state[0]._stab_roll = packet.param2;
+    state[0]._stab_tilt = packet.param3;
+    state[0]._stab_pan = packet.param4;
+
+    return MAV_RESULT_ACCEPTED;
+}
+
+
+MAV_RESULT AP_Mount::handle_command_do_mount_control(const mavlink_command_long_t &packet)
+{
+    if (_primary >= AP_MOUNT_MAX_INSTANCES || _backends[_primary] == nullptr) {
+        return MAV_RESULT_FAILED;
     }
 
     // send message to backend
-    _backends[instance]->configure_msg(msg);
+    _backends[_primary]->control(packet.param1, packet.param2, packet.param3, (MAV_MOUNT_MODE) packet.param7);
+
+    return MAV_RESULT_ACCEPTED;
+}
+
+MAV_RESULT AP_Mount::handle_command_long(const mavlink_command_long_t &packet)
+{
+    switch (packet.command) {
+    case MAV_CMD_DO_MOUNT_CONFIGURE:
+        return handle_command_do_mount_configure(packet);
+    case MAV_CMD_DO_MOUNT_CONTROL:
+        return handle_command_do_mount_control(packet);
+    default:
+        return MAV_RESULT_UNSUPPORTED;
+    }
+}
+
+/// Change the configuration of the mount
+void AP_Mount::handle_mount_configure(const mavlink_message_t *msg)
+{
+    if (_primary >= AP_MOUNT_MAX_INSTANCES || _backends[_primary] == nullptr) {
+        return;
+    }
+
+    mavlink_mount_configure_t packet;
+    mavlink_msg_mount_configure_decode(msg, &packet);
+
+    // send message to backend
+    _backends[_primary]->handle_mount_configure(packet);
 }
 
 /// Control the mount (depends on the previously set mount configuration)
-/// triggered by a MavLink packet.
-void AP_Mount::control_msg(uint8_t instance, mavlink_message_t *msg)
+void AP_Mount::handle_mount_control(const mavlink_message_t *msg)
 {
-    if (instance >= AP_MOUNT_MAX_INSTANCES || _backends[instance] == nullptr) {
+    if (_primary >= AP_MOUNT_MAX_INSTANCES || _backends[_primary] == nullptr) {
         return;
     }
 
-    // send message to backend
-    _backends[instance]->control_msg(msg);
-}
-
-void AP_Mount::control(uint8_t instance, int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, enum MAV_MOUNT_MODE mount_mode)
-{
-    if (instance >= AP_MOUNT_MAX_INSTANCES || _backends[instance] == nullptr) {
-        return;
-    }
+    mavlink_mount_control_t packet;
+    mavlink_msg_mount_control_decode(msg, &packet);
 
     // send message to backend
-    _backends[instance]->control(pitch_or_lat, roll_or_lon, yaw_or_alt, mount_mode);
+    _backends[_primary]->handle_mount_control(packet);
 }
 
 /// Return mount status information
-void AP_Mount::status_msg(mavlink_channel_t chan)
+void AP_Mount::send_mount_status(mavlink_channel_t chan)
 {
-    // call status_msg for  each instance
+    // call send_mount_status for  each instance
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         if (_backends[instance] != nullptr) {
-            _backends[instance]->status_msg(chan);
+            _backends[instance]->send_mount_status(chan);
         }
     }
 }
@@ -615,7 +646,7 @@ void AP_Mount::set_roi_target(uint8_t instance, const struct Location &target_lo
 }
 
 // pass a GIMBAL_REPORT message to the backend
-void AP_Mount::handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg)
+void AP_Mount::handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t *msg)
 {
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         if (_backends[instance] != nullptr) {
@@ -624,8 +655,28 @@ void AP_Mount::handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *m
     }
 }
 
+void AP_Mount::handle_message(mavlink_channel_t chan, const mavlink_message_t *msg)
+{
+    switch (msg->msgid) {
+    case MAVLINK_MSG_ID_GIMBAL_REPORT:
+        handle_gimbal_report(chan, msg);
+        break;
+    case MAVLINK_MSG_ID_MOUNT_CONFIGURE:
+        handle_mount_configure(msg);
+        break;
+    case MAVLINK_MSG_ID_MOUNT_CONTROL:
+        handle_mount_control(msg);
+        break;
+    default:
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        AP_HAL::panic("Unhandled mount case");
+#endif
+        break;
+    }
+}
+
 // handle PARAM_VALUE
-void AP_Mount::handle_param_value(mavlink_message_t *msg)
+void AP_Mount::handle_param_value(const mavlink_message_t *msg)
 {
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         if (_backends[instance] != nullptr) {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -61,6 +61,10 @@ public:
     AP_Mount(const AP_Mount &other) = delete;
     AP_Mount &operator=(const AP_Mount&) = delete;
 
+    // get singleton instance
+    static AP_Mount *get_singleton() {
+        return _singleton;
+    }
 
     // Enums
     enum MountType {
@@ -139,6 +143,9 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
+
+    static AP_Mount *_singleton;
+
     // private members
     const AP_AHRS_TYPE     &_ahrs;
     const struct Location   &_current_loc;  // reference to the vehicle's current location
@@ -182,4 +189,8 @@ protected:
         MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
         struct Location _roi_target;        // roi target location
     } state[AP_MOUNT_MAX_INSTANCES];
+};
+
+namespace AP {
+    AP_Mount *mount();
 };

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -55,7 +55,7 @@ class AP_Mount
     friend class AP_Mount_SToRM32_serial;
 
 public:
-    AP_Mount(const AP_AHRS_TYPE &ahrs, const struct Location &current_loc);
+    AP_Mount(const struct Location &current_loc);
 
     /* Do not allow copies */
     AP_Mount(const AP_Mount &other) = delete;
@@ -115,29 +115,16 @@ public:
     void set_roi_target(const struct Location &target_loc) { set_roi_target(_primary,target_loc); }
     void set_roi_target(uint8_t instance, const struct Location &target_loc);
 
-    // control - control the mount
-    void control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, enum MAV_MOUNT_MODE mount_mode) { control(_primary, pitch_or_lat, roll_or_lon, yaw_or_alt, mount_mode); }
-    void control(uint8_t instance, int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, enum MAV_MOUNT_MODE mount_mode);
-
-    // configure_msg - process MOUNT_CONFIGURE messages received from GCS
-    void configure_msg(mavlink_message_t* msg) { configure_msg(_primary, msg); }
-    void configure_msg(uint8_t instance, mavlink_message_t* msg);
-
-    // control_msg - process MOUNT_CONTROL messages received from GCS
-    void control_msg(mavlink_message_t* msg) { control_msg(_primary, msg); }
-    void control_msg(uint8_t instance, mavlink_message_t* msg);
-
-    // handle a PARAM_VALUE message
-    void handle_param_value(mavlink_message_t *msg);
-
-    // handle a GIMBAL_REPORT message
-    void handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg);
+    // mavlink message handling:
+    MAV_RESULT handle_command_long(const mavlink_command_long_t &packet);
+    void handle_param_value(const mavlink_message_t *msg);
+    void handle_message(mavlink_channel_t chan, const mavlink_message_t *msg);
 
     // send a GIMBAL_REPORT message to GCS
     void send_gimbal_report(mavlink_channel_t chan);
 
-    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    void status_msg(mavlink_channel_t chan);
+    // send a MOUNT_STATUS message to GCS:
+    void send_mount_status(mavlink_channel_t chan);
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
@@ -147,7 +134,6 @@ protected:
     static AP_Mount *_singleton;
 
     // private members
-    const AP_AHRS_TYPE     &_ahrs;
     const struct Location   &_current_loc;  // reference to the vehicle's current location
 
     // frontend parameters
@@ -189,6 +175,16 @@ protected:
         MAV_MOUNT_MODE  _mode;              // current mode (see MAV_MOUNT_MODE enum)
         struct Location _roi_target;        // roi target location
     } state[AP_MOUNT_MAX_INSTANCES];
+
+private:
+
+    void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t *msg);
+    void handle_mount_configure(const mavlink_message_t *msg);
+    void handle_mount_control(const mavlink_message_t *msg);
+
+    MAV_RESULT handle_command_do_mount_configure(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_do_mount_control(const mavlink_command_long_t &packet);
+
 };
 
 namespace AP {

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -73,8 +73,8 @@ void AP_Mount_Alexmos::set_mode(enum MAV_MOUNT_MODE mode)
     _state._mode = mode;
 }
 
-// status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-void AP_Mount_Alexmos::status_msg(mavlink_channel_t chan)
+// send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_Alexmos::send_mount_status(mavlink_channel_t chan)
 {
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -82,8 +82,8 @@ public:
     // set_mode - sets mount's mode
     virtual void set_mode(enum MAV_MOUNT_MODE mode) ;
 
-    // status_msg - called to allow mounts to send their status to GCS via MAVLink
-    virtual void status_msg(mavlink_channel_t chan) ;
+    // send_mount_status - called to allow mounts to send their status to GCS via MAVLink
+    virtual void send_mount_status(mavlink_channel_t chan) override;
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -24,21 +24,18 @@ void AP_Mount_Backend::set_roi_target(const struct Location &target_loc)
     _frontend.set_mode(_instance, MAV_MOUNT_MODE_GPS_POINT);
 }
 
-// configure_msg - process MOUNT_CONFIGURE messages received from GCS.  deprecated.
-void AP_Mount_Backend::configure_msg(mavlink_message_t* msg)
+// process MOUNT_CONFIGURE messages received from GCS.  deprecated.
+void AP_Mount_Backend::handle_mount_configure(const mavlink_mount_configure_t &packet)
 {
-    __mavlink_mount_configure_t packet;
-    mavlink_msg_mount_configure_decode(msg, &packet);
-
     set_mode((MAV_MOUNT_MODE)packet.mount_mode);
+    _state._stab_roll = packet.stab_roll;
+    _state._stab_tilt = packet.stab_pitch;
+    _state._stab_pan = packet.stab_yaw;
 }
 
-// control_msg - process MOUNT_CONTROL messages received from GCS. deprecated.
-void AP_Mount_Backend::control_msg(mavlink_message_t *msg)
+// process MOUNT_CONTROL messages received from GCS. deprecated.
+void AP_Mount_Backend::handle_mount_control(const mavlink_mount_control_t &packet)
 {
-    __mavlink_mount_control_t packet;
-    mavlink_msg_mount_control_decode(msg, &packet);
-
     control((int32_t)packet.input_a, (int32_t)packet.input_b, (int32_t)packet.input_c, _state._mode);
 }
 
@@ -159,7 +156,7 @@ void AP_Mount_Backend::calc_angle_to_location(const struct Location &target, Vec
         // calc absolute heading and then onvert to vehicle relative yaw
         angles_to_target_rad.z = atan2f(GPS_vector_x, GPS_vector_y);
         if (relative_pan) {
-            angles_to_target_rad.z = wrap_PI(angles_to_target_rad.z - _frontend._ahrs.yaw);
+            angles_to_target_rad.z = wrap_PI(angles_to_target_rad.z - AP::ahrs().yaw);
         }
     }
 }

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -59,23 +59,23 @@ public:
     // control - control the mount
     virtual void control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_t yaw_or_alt, MAV_MOUNT_MODE mount_mode);
     
-    // configure_msg - process MOUNT_CONFIGURE messages received from GCS
-    virtual void configure_msg(mavlink_message_t* msg);
+    // process MOUNT_CONFIGURE messages received from GCS:
+    void handle_mount_configure(const mavlink_mount_configure_t &msg);
 
-    // control_msg - process MOUNT_CONTROL messages received from GCS
-    virtual void control_msg(mavlink_message_t* msg);
+    // process MOUNT_CONTROL messages received from GCS:
+    void handle_mount_control(const mavlink_mount_control_t &packet);
 
-    // status_msg - called to allow mounts to send their status to GCS via MAVLink
-    virtual void status_msg(mavlink_channel_t chan) {}
+    // send_mount_status - called to allow mounts to send their status to GCS via MAVLink
+    virtual void send_mount_status(mavlink_channel_t chan) = 0;
 
     // handle a GIMBAL_REPORT message
-    virtual void handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg) {}
+    virtual void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t *msg) {}
 
     // handle a PARAM_VALUE message
-    virtual void handle_param_value(mavlink_message_t *msg) {}
+    virtual void handle_param_value(const mavlink_message_t *msg) {}
 
     // send a GIMBAL_REPORT message to the GCS
-    virtual void send_gimbal_report(mavlink_channel_t chan) {}
+    virtual void send_gimbal_report(const mavlink_channel_t chan) {}
 
 protected:
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -93,8 +93,8 @@ void AP_Mount_SToRM32::set_mode(enum MAV_MOUNT_MODE mode)
     _state._mode = mode;
 }
 
-// status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-void AP_Mount_SToRM32::status_msg(mavlink_channel_t chan)
+// send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_SToRM32::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.  To-Do: retrieve actual gimbal attitude and send these instead
     mavlink_msg_mount_status_send(chan, 0, 0, ToDeg(_angle_ef_target_rad.y)*100, ToDeg(_angle_ef_target_rad.x)*100, ToDeg(_angle_ef_target_rad.z)*100);

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -36,8 +36,8 @@ public:
     // set_mode - sets mount's mode
     virtual void set_mode(enum MAV_MOUNT_MODE mode);
 
-    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    virtual void status_msg(mavlink_channel_t chan);
+    // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+    virtual void send_mount_status(mavlink_channel_t chan) override;
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -123,8 +123,8 @@ void AP_Mount_SToRM32_serial::set_mode(enum MAV_MOUNT_MODE mode)
     _state._mode = mode;
 }
 
-// status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-void AP_Mount_SToRM32_serial::status_msg(mavlink_channel_t chan)
+// send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_SToRM32_serial::send_mount_status(mavlink_channel_t chan)
 {
     // return target angles as gimbal's actual attitude.
     mavlink_msg_mount_status_send(chan, 0, 0, _current_angle.y, _current_angle.x, _current_angle.z);

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -34,8 +34,8 @@ public:
     // set_mode - sets mount's mode
     virtual void set_mode(enum MAV_MOUNT_MODE mode);
 
-    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    virtual void status_msg(mavlink_channel_t chan);
+    // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+    virtual void send_mount_status(mavlink_channel_t chan);
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -36,8 +36,8 @@ public:
     // set_mode - sets mount's mode
     virtual void set_mode(enum MAV_MOUNT_MODE mode);
 
-    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    virtual void status_msg(mavlink_channel_t chan);
+    // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+    virtual void send_mount_status(mavlink_channel_t chan) override;
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -12,7 +12,7 @@ extern const AP_HAL::HAL& hal;
 
 AP_Mount_SoloGimbal::AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance) :
     AP_Mount_Backend(frontend, state, instance),
-    _gimbal(frontend._ahrs)
+    _gimbal()
 {}
 
 // init - performs any required initialisation for this instance
@@ -99,8 +99,8 @@ void AP_Mount_SoloGimbal::set_mode(enum MAV_MOUNT_MODE mode)
     _state._mode = mode;
 }
 
-// status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-void AP_Mount_SoloGimbal::status_msg(mavlink_channel_t chan)
+// send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+void AP_Mount_SoloGimbal::send_mount_status(mavlink_channel_t chan)
 {
     if (_gimbal.aligned()) {
         mavlink_msg_mount_status_send(chan, 0, 0, degrees(_angle_ef_target_rad.y)*100, degrees(_angle_ef_target_rad.x)*100, degrees(_angle_ef_target_rad.z)*100);
@@ -113,7 +113,7 @@ void AP_Mount_SoloGimbal::status_msg(mavlink_channel_t chan)
 /*
   handle a GIMBAL_REPORT message
  */
-void AP_Mount_SoloGimbal::handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg)
+void AP_Mount_SoloGimbal::handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t *msg)
 {
     _gimbal.update_target(_angle_ef_target_rad);
     _gimbal.receive_feedback(chan,msg);
@@ -133,7 +133,7 @@ void AP_Mount_SoloGimbal::handle_gimbal_report(mavlink_channel_t chan, mavlink_m
     }
 }
 
-void AP_Mount_SoloGimbal::handle_param_value(mavlink_message_t *msg)
+void AP_Mount_SoloGimbal::handle_param_value(const mavlink_message_t *msg)
 {
     _gimbal.handle_param_value(msg);
 }
@@ -141,7 +141,7 @@ void AP_Mount_SoloGimbal::handle_param_value(mavlink_message_t *msg)
 /*
   handle a GIMBAL_REPORT message
  */
-void AP_Mount_SoloGimbal::handle_gimbal_torque_report(mavlink_channel_t chan, mavlink_message_t *msg)
+void AP_Mount_SoloGimbal::handle_gimbal_torque_report(mavlink_channel_t chan, const mavlink_message_t *msg)
 {
     _gimbal.disable_torque_report();
 }

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -36,16 +36,16 @@ public:
     // set_mode - sets mount's mode
     virtual void set_mode(enum MAV_MOUNT_MODE mode);
 
-    // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    virtual void status_msg(mavlink_channel_t chan);
+    // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
+    virtual void send_mount_status(mavlink_channel_t chan) override;
 
     // handle a GIMBAL_REPORT message
-    virtual void handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg);
-    virtual void handle_gimbal_torque_report(mavlink_channel_t chan, mavlink_message_t *msg);
-    virtual void handle_param_value(mavlink_message_t *msg);
+    void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t *msg) override;
+    void handle_gimbal_torque_report(mavlink_channel_t chan, const mavlink_message_t *msg);
+    void handle_param_value(const mavlink_message_t *msg) override;
 
     // send a GIMBAL_REPORT message to the GCS
-    virtual void send_gimbal_report(mavlink_channel_t chan);
+    void send_gimbal_report(mavlink_channel_t chan) override;
 
     virtual void update_fast();
 

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -38,7 +38,7 @@ gimbal_mode_t SoloGimbal::get_mode()
     }
 }
 
-void SoloGimbal::receive_feedback(mavlink_channel_t chan, mavlink_message_t *msg)
+void SoloGimbal::receive_feedback(mavlink_channel_t chan, const mavlink_message_t *msg)
 {
     mavlink_gimbal_report_t report_msg;
     mavlink_msg_gimbal_report_decode(msg, &report_msg);

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -38,9 +38,9 @@ class SoloGimbal : AP_AccelCal_Client
 {
 public:
     //Constructor
-    SoloGimbal(const AP_AHRS_NavEKF &ahrs) :
-        _ekf(ahrs),
-        _ahrs(ahrs),
+    SoloGimbal() :
+        _ekf(AP::ahrs_navekf()),
+        _ahrs(AP::ahrs_navekf()),
         _state(GIMBAL_STATE_NOT_PRESENT),
         _vehicle_yaw_rate_ef_filt(0.0f),
         _vehicle_to_gimbal_quat(),
@@ -58,7 +58,7 @@ public:
     }
 
     void    update_target(Vector3f newTarget);
-    void    receive_feedback(mavlink_channel_t chan, mavlink_message_t *msg);
+    void    receive_feedback(mavlink_channel_t chan, const mavlink_message_t *msg);
 
     void update_fast();
 
@@ -74,7 +74,7 @@ public:
     void disable_torque_report() { _gimbalParams.set_param(GMB_PARAM_GMB_SND_TORQUE, 0); }
     void fetch_params() { _gimbalParams.fetch_params(); }
 
-    void handle_param_value(mavlink_message_t *msg) {
+    void handle_param_value(const mavlink_message_t *msg) {
         _gimbalParams.handle_param_value(msg);
     }
 

--- a/libraries/AP_Mount/SoloGimbal_Parameters.cpp
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.cpp
@@ -172,7 +172,7 @@ void SoloGimbal_Parameters::update()
     }
 }
 
-void SoloGimbal_Parameters::handle_param_value(mavlink_message_t *msg)
+void SoloGimbal_Parameters::handle_param_value(const mavlink_message_t *msg)
 {
     mavlink_param_value_t packet;
     mavlink_msg_param_value_decode(msg, &packet);

--- a/libraries/AP_Mount/SoloGimbal_Parameters.h
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.h
@@ -54,7 +54,7 @@ public:
     void set_param(gmb_param_t param, float value);
 
     void update();
-    void handle_param_value(mavlink_message_t *msg);
+    void handle_param_value(const mavlink_message_t *msg);
 
     Vector3f get_accel_bias();
     Vector3f get_accel_gain();

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -190,7 +190,9 @@ public:
     void send_local_position() const;
     void send_vfr_hud();
     void send_vibration() const;
+    void send_mount_status() const;
     void send_named_float(const char *name, float value) const;
+    void send_gimbal_report() const;
     void send_home() const;
     void send_ekf_origin() const;
     virtual void send_position_target_global_int() { };
@@ -302,7 +304,8 @@ protected:
     void handle_common_rally_message(mavlink_message_t *msg);
     void handle_rally_fetch_point(mavlink_message_t *msg);
     void handle_rally_point(mavlink_message_t *msg);
-    void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;
+    virtual void handle_mount_message(const mavlink_message_t *msg);
+    void handle_param_value(mavlink_message_t *msg);
     void handle_radio_status(mavlink_message_t *msg, DataFlash_Class &dataflash, bool log_radio);
     void handle_serial_control(const mavlink_message_t *msg);
     void handle_vision_position_delta(mavlink_message_t *msg);
@@ -354,10 +357,14 @@ protected:
 
     void handle_command_long(mavlink_message_t* msg);
     MAV_RESULT handle_command_accelcal_vehicle_pos(const mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_command_mount(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_send_banner(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_do_set_roi(const mavlink_command_int_t &packet);
+    MAV_RESULT handle_command_do_set_roi(const mavlink_command_long_t &packet);
+    virtual MAV_RESULT handle_command_do_set_roi(const Location &roi_loc);
     MAV_RESULT handle_command_do_gripper(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);


### PR DESCRIPTION
Rover can now send gimbal_report messages
Plane will now respond to set-roi sent via command-int
Plane will respond to cmd-mount-configure
All vehicles will pass param-value and other currently-Solo-mount-specific-messages through to mount library

