### PR TITLE
AP_HAL: Util: make vsnprintf and snprintf always null-terminate

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -125,7 +125,7 @@ void AP_Arming::check_failed(const enum AP_Arming::ArmingChecks check, bool repo
         return;
     }
     char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
-    hal.util->snprintf((char*)taggedfmt, sizeof(taggedfmt)-1, "PreArm: %s", fmt);
+    hal.util->snprintf(taggedfmt, sizeof(taggedfmt), "PreArm: %s", fmt);
     MAV_SEVERITY severity = check_severity(check);
     va_list arg_list;
     va_start(arg_list, fmt);

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -209,9 +209,9 @@ void AP_BattMonitor::convert_params(void) {
         info.old_group_element = conversionTable[i].old_element;
         info.type = (ap_var_type)AP_BattMonitor_Params::var_info[destination_index].type;
         if (param_instance) {
-            hal.util->snprintf(param_name, 17, "BATT2_%s", AP_BattMonitor_Params::var_info[destination_index].name);
+            hal.util->snprintf(param_name, sizeof(param_name), "BATT2_%s", AP_BattMonitor_Params::var_info[destination_index].name);
         } else {
-            hal.util->snprintf(param_name, 17, "BATT_%s", AP_BattMonitor_Params::var_info[destination_index].name);
+            hal.util->snprintf(param_name, sizeof(param_name), "BATT_%s", AP_BattMonitor_Params::var_info[destination_index].name);
         }
 
         AP_Param::convert_old_parameter(&info, 1.0f, 0);

--- a/libraries/AP_HAL/Util.cpp
+++ b/libraries/AP_HAL/Util.cpp
@@ -52,9 +52,12 @@ int AP_HAL::Util::snprintf(char* str, size_t size, const char *format, ...)
 
 int AP_HAL::Util::vsnprintf(char* str, size_t size, const char *format, va_list ap)
 {
-    BufferPrinter buf(str, size);
+    if (size == 0) {
+        return 0;
+    }
+    BufferPrinter buf(str, size-1);
     print_vprintf(&buf, format, ap);
-    // null terminate if possible
+    // null terminate
     int ret = buf._offs;
     buf.write(0);
     return ret;

--- a/libraries/AP_HAL/examples/Printf/Printf.cpp
+++ b/libraries/AP_HAL/examples/Printf/Printf.cpp
@@ -47,8 +47,10 @@ static const struct {
     { "%.1f", 10.6f, "10.6" },
 };
 
-static void test_printf(void)
+static void test_printf_floats(void)
 {
+    hal.console->printf("Starting Printf floats test\n");
+
     uint8_t i;
     char buf[30];
     uint8_t failures = 0;
@@ -73,6 +75,40 @@ static void test_printf(void)
         }
     }
     hal.console->printf("%u failures\n", (unsigned)failures);
+}
+
+static void test_printf_null_termination(void)
+{
+    hal.console->printf("Starting Printf null-termination tests\n");
+
+    {
+        char buf[10];
+        int ret = hal.util->snprintf(buf,sizeof(buf), "%s", "ABCDEABCDE");
+        const int want = 9;
+        if (ret != want) {
+            hal.console->printf("snprintf returned %d expected %d\n", ret, want);
+        }
+        if (!strncmp(buf, "ABCDEABCD", sizeof(buf))) {
+            hal.console->printf("Bad snprintf string (%s)\n", buf);
+        }
+    }
+    {
+        char buf[10];
+        int ret = hal.util->snprintf(buf,sizeof(buf), "ABCDEABCDE");
+        const int want = 9;
+        if (ret != want) {
+            hal.console->printf("snprintf returned %d expected %d\n", ret, want);
+        }
+        if (!strncmp(buf, "ABCDEABCD", sizeof(buf))) {
+            hal.console->printf("Bad snprintf string (%s)\n", buf);
+        }
+    }
+}
+
+static void test_printf(void)
+{
+    test_printf_floats();
+    test_printf_null_termination();
 }
 
 void loop(void)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1155,7 +1155,7 @@ private:
     } mag_state;
 
     // string representing last reason for prearm failure
-    char prearm_fail_string[40];
+    char prearm_fail_string[41];
 
     // performance counters
     AP_HAL::Util::perf_counter_t  _perf_UpdateFilter;

--- a/libraries/AP_OSD/AP_OSD_Backend.cpp
+++ b/libraries/AP_OSD/AP_OSD_Backend.cpp
@@ -28,7 +28,7 @@ void AP_OSD_Backend::write(uint8_t x, uint8_t y, bool blink, const char *fmt, ..
     if (blink && (blink_phase < 2)) {
         return;
     }
-    char buff[32];
+    char buff[32+1]; // +1 for snprintf null-termination
     va_list ap;
     va_start(ap, fmt);
     int res = hal.util->vsnprintf(buff, sizeof(buff), fmt, ap);
@@ -43,7 +43,7 @@ void AP_OSD_Backend::write(uint8_t x, uint8_t y, bool blink, const char *fmt, ..
             res--;
         }
     }
-    if (res < int(sizeof(buff))) {
+    if (res < int(sizeof(buff))-1) {
         write(x, y, buff);
     }
     va_end(ap);

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -431,7 +431,7 @@ bool DataFlash_Class::logging_failed() const
 
 void DataFlash_Class::Log_Write_MessageF(const char *fmt, ...)
 {
-    char msg[64] {};
+    char msg[65] {}; // sizeof(log_Message.msg) + null-termination
 
     va_list ap;
     va_start(ap, fmt);

--- a/libraries/DataFlash/DataFlash_Backend.cpp
+++ b/libraries/DataFlash/DataFlash_Backend.cpp
@@ -408,7 +408,7 @@ bool DataFlash_Backend::ShouldLog(bool is_critical)
 
 bool DataFlash_Backend::Log_Write_MessageF(const char *fmt, ...)
 {
-    char msg[64] {};
+    char msg[65] {}; // sizeof(log_Message.msg) + null-termination
 
     va_list ap;
     va_start(ap, fmt);

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -7,8 +7,8 @@ extern const AP_HAL::HAL& hal;
  */
 void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
-    hal.util->vsnprintf((char *)text, sizeof(text)-1, fmt, arg_list);
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
     send_statustext(severity, GCS_MAVLINK::active_channel_mask() | GCS_MAVLINK::streaming_channel_mask(), text);
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -628,8 +628,8 @@ void GCS_MAVLINK::handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) 
 
 void GCS_MAVLINK::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list)
 {
-    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
-    hal.util->vsnprintf((char *)text, sizeof(text)-1, fmt, arg_list);
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    hal.util->vsnprintf(text, sizeof(text), fmt, arg_list);
     gcs().send_statustext(severity, (1<<chan), text);
 }
 void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...)


### PR DESCRIPTION
The C++ standard indicates these functions always return a
null-terminated string.  We should rename these functions if we're not
going to conform to the standards.

From https://en.cppreference.com/w/cpp/io/c/vfprintf :

"Writes the results to a character string buffer. At most buf_size-1
characters are written. The resulting character string will be
terminated with a null character"

We are still not standards-compliant in the case a length of 0 is passed
in, returning 0 where we should return the space that would be required
to store the formatted string.