### PR TITLE
AP_HAL_SITL: update parameter with using command line speedup option

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -232,6 +232,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             break;
         case 's':
             speedup = strtof(gopt.optarg, nullptr);
+            char speedup_string[18];
+            snprintf(speedup_string, sizeof(speedup_string), "SIM_SPEEDUP=%s", gopt.optarg);
+            _set_param_default(speedup_string);
             break;
         case 'r':
             _framerate = (unsigned)atoi(gopt.optarg);


### PR DESCRIPTION
currently using --speedup with sim_vehicle.py doens't update the parameter, so we have no wait to get the right speedup parameter ...