### PR TITLE
RC_Channel: Fix accidental quantization of override_timeout to 1 second resolution

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -336,9 +336,12 @@ void RC_Channel::clear_override()
 
 bool RC_Channel::has_override() const
 {
-    int32_t override_timeout = (int32_t)(*RC_Channels::override_timeout);
-    return (override_value > 0) && ((override_timeout < 0) ||
-                                    ((AP_HAL::millis() - last_override_time) < (uint32_t)(override_timeout * 1000)));
+    if (override_value <= 0) {
+        return false;
+    }
+
+    const float override_timeout_ms = RC_Channels::override_timeout->get() * 1e3f;
+    return is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms);
 }
 
 //


### PR DESCRIPTION
This provides the optimization that @peterbarker proposed in #9105 as well as fixes the accidental quantizing of override timeouts to 1 second resolution that was found when reviewing on the dev call.