### PR TITLE
Tools: Be able to create a terminal in Mac OS

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -28,7 +28,7 @@ if [ -n "$SITL_RITW_TERMINAL" ]; then
   printf "%q " "$@" >>"$FILEPATH"
   chmod +x "$FILEPATH"
   $SITL_RITW_TERMINAL "$FILEPATH" &
-elif [ -n "$DISPLAY" -a -n "$(which osascript)" ]; then
+elif [ -n "$(which osascript)" ]; then
   osascript -e 'tell application "Terminal" to do script "'"$* "'"'
 elif [ -n "$DISPLAY" -a -n "$(which xterm)" ]; then
   if [ $SITL_RITW_MINIMIZE -eq 1 ]; then

--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -52,4 +52,5 @@ else
 # _fdm_input_step sees ArduPilot has no parent and kills ArduPilot!
   ( : ; "$cmd" $* &>"$filename" < /dev/null ) &
 fi
+sleep 1
 exit 0

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -499,6 +499,8 @@ def run_in_terminal_window(autotest, name, cmd):
             progress("Cannot find %s process terminal" % name)
     else:
         p = subprocess.Popen(runme)
+        if under_macos():
+            p.wait()
 
 
 tracker_uarta = None  # blemish


### PR DESCRIPTION
- Display env does not exist in the last version of High Sierra.
- SITL does not wait connection and fail, it was necessary to add a delay and a wait to connect properly. 

> Note: I would like to add a timeout in SITL to allow delays between the TCP connection when starting. Probably someone will be able to guide me. Removing 
74694b5