### PR TITLE
SPI threads on Linux

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -171,8 +171,8 @@ public:
     int fd = -1;
     uint16_t bus;
     uint16_t subdev;
-    uint8_t ref;
     int16_t last_mode = -1;
+    uint8_t ref;
 };
 
 SPIBus::~SPIBus()
@@ -222,7 +222,7 @@ SPIDevice::SPIDevice(SPIBus &bus, SPIDesc &device_desc)
     set_device_bus(_bus.bus);
     set_device_address(_desc.subdev);
     _speed = _desc.highspeed;
-    
+
     if (_desc.cs_pin != SPI_CS_KERNEL) {
         _cs = hal.gpio->channel(_desc.cs_pin);
         if (!_cs) {
@@ -466,7 +466,8 @@ SPIDeviceManager::get_device(const char *name)
     return dev;
 }
 
-uint8_t SPIDeviceManager::get_count() {
+uint8_t SPIDeviceManager::get_count()
+{
    return _n_device_desc;
 }
 
@@ -483,7 +484,9 @@ SPIDeviceManager::_create_device(SPIBus &b, SPIDesc &desc) const
     if (!dev) {
         return nullptr;
     }
+
     b.ref++;
+
     return dev;
 }
 

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -37,6 +37,8 @@
 #include "Thread.h"
 #include "Util.h"
 
+#define DEBUG 0
+
 namespace Linux {
 
 static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
@@ -295,8 +297,8 @@ bool SPIDevice::transfer(const uint8_t *send, uint32_t send_len,
         return false;
     }
 
-    int r;
-    if (_bus.last_mode == _desc.mode) {
+#if DEBUG
+    if (_desc.mode == _bus.last_mode) {
         /*
           the mode in the kernel is not tied to the file descriptor,
           so there is a chance some other process has changed it since
@@ -316,6 +318,9 @@ bool SPIDevice::transfer(const uint8_t *send, uint32_t send_len,
             _bus.last_mode = -1;
         }
     }
+#endif
+
+    int r;
     if (_desc.mode != _bus.last_mode) {
         r = ioctl(fd, SPI_IOC_WR_MODE, &_desc.mode);
         if (r < 0) {


### PR DESCRIPTION
@staroselskii I did this in order to get threads for the spi bus on edge down from 3 to 1 (since it is using a single bus with 3 chip select).

I did some bench tests and it apparently is working. Could you do some tests on your end as well?

Side note:  on master branch it seems the version you are shipping of QGC is not happy with the parameters. It complains about missing BATT params and missing WIFI_TX. For WIFI_TX it complains even with arducopter from the 1.5 image. I wanted to switch it to client mode in order to get `perf` installed to get more insight on what's going on with the threads... on RPI we already have one kernel thread per chip select, so I wanted to trace their interaction.