### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    - compiler: "gcc"
+    - if: type != cron
+      compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v2 revo-bootloader"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v4 revo-mini"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,13 @@ language: cpp
 sudo: false
 
 addons:
-  coverity_scan:
-    project:
-      name: "diydrones/ardupilot"
-      description: "Build submitted via Travis CI"
-    notification_email: andrew-scan@tridgell.net
-    build_command_prepend: "make clean"
-    build_command:   "make"
-    branch_pattern: coverity_scan
-    
   apt:
     sources:
-      - sourceline: 'ppa:george-edison55/cmake-3.x'
       - ubuntu-toolchain-r-test
-#      - george-edison55-cmake-3.x
 #      - llvm-toolchain-precise-3.7
     packages:
       - build-essential
       - gawk
-      - ccache
       - genromfs
       - libc6-i386
       - libxml2-dev
@@ -30,13 +18,13 @@ addons:
       - zlib1g-dev
       - gcc-4.9
       - g++-4.9
-      - cmake
-      - cmake-data
+      - cmake3
+      - cmake3-data
 #      - clang-3.7
 #      - llvm-3.7
 
 cache:
-  ccache: true
+  ccache: false
   directories:
     - $HOME/opt
 
@@ -46,9 +34,6 @@ before_install:
 
 script:
   - Tools/scripts/build_ci.sh
-
-before_cache:
-  - ccache -z
 
 notifications:
   webhooks:
@@ -75,7 +60,9 @@ matrix:
       env: CI_BUILD_TARGET="px4-v2 revo-bootloader"
     - compiler: "gcc"
       env: CI_BUILD_TARGET="px4-v4 revo-mini"
-    - compiler: "gcc"
+    - if: type != cron
+      compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-copter"
-    - compiler: "gcc"
+    - if: type != cron
+      compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-quadplane sitltest-plane sitltest-rover"

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -25,14 +25,6 @@ if [ -z "$CI_BUILD_TARGET" ]; then
     CI_BUILD_TARGET="sitl linux px4-v2"
 fi
 
-if [[ "$CI_BUILD_TARGET" == *"px4"* ]]; then
-    export CCACHE_MAXSIZE="250M"
-elif [[ "$CI_BUILD_TARGET" == "sitltest" ]]; then
-    export CCACHE_MAXSIZE="20M"
-else
-    export CCACHE_MAXSIZE="150M"
-fi
-
 declare -A waf_supported_boards
 
 waf=modules/waf/waf-light
@@ -122,7 +114,7 @@ for t in $CI_BUILD_TARGET; do
             fi
 
             start_time=$(get_time)
-            CCACHE_DISABLE="true" make $t -j$(nproc)
+            make $t -j$(nproc)
             diff_time=$(($(get_time)-$start_time))
             echo -e "\033[32m'make' finished successfully (${diff_time}s)\033[0m"
             popd

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -12,7 +12,7 @@ ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
 RPI_ROOT="master"
 RPI_TARBALL="$RPI_ROOT.tar.gz"
 
-CCACHE_ROOT="ccache-3.3.4"
+CCACHE_ROOT="ccache-3.4.2"
 CCACHE_TARBALL="$CCACHE_ROOT.tar.bz2"
 
 mkdir -p $HOME/opt
@@ -20,14 +20,14 @@ pushd $HOME
 
 # PX4 toolchain
 dir=$ARM_ROOT
-if [ ! -d "$HOME/opt/$dir" ]; then
+if [ ! -d "$HOME/opt/$dir" -o ! -x "$HOME/opt/$dir/bin/arm-none-eabi-g++" ]; then
   wget http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL
   tar -xf $ARM_TARBALL -C opt
 fi
 
 # RPi/BBB toolchain
 dir="tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64"
-if [ ! -d "$HOME/opt/$dir" ]; then
+if [ ! -d "$HOME/opt/$dir" -o ! -x "$HOME/opt/$dir/bin/arm-linux-gnueabihf-g++" ]; then
   wget http://firmware.ardupilot.org/Tools/Travis/NavIO/$RPI_TARBALL
   tar -xf $RPI_TARBALL -C opt $dir
 fi
@@ -35,8 +35,8 @@ fi
 # ccache
 dir=$CCACHE_ROOT
 if [ ! -d "$HOME/opt/$dir" ]; then
-  # if version 3 isn't there, try to remove older v2 folders from CI cache
-  rm -rf "$HOME/opt"/ccache-3.2*
+  # if version 3.4 isn't there, try to remove older v3.3 folders from CI cache
+  rm -rf "$HOME/opt"/ccache-3.3*
 
   wget https://www.samba.org/ftp/ccache/$CCACHE_TARBALL
   tar -xf $CCACHE_TARBALL

--- a/Tools/scripts/install-apt-ci.sh
+++ b/Tools/scripts/install-apt-ci.sh
@@ -6,7 +6,6 @@ set -ex
 PKGS=" \
     build-essential \
     gawk \
-    ccache \
     genromfs \
     libc6-i386 \
     libxml2-dev \
@@ -16,19 +15,13 @@ PKGS=" \
     zlib1g-dev \
     gcc-4.9 \
     g++-4.9 \
-    cmake \
-    cmake-data \
+    cmake3 \
+    cmake3-data \
     "
 
 read -r UBUNTU_CODENAME <<<$(lsb_release -c -s)
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-
-if [ "$UBUNTU_CODENAME" = "precise" ]; then
-    sudo add-apt-repository ppa:george-edison55/precise-backports -y
-elif [ "$UBUNTU_CODENAME" = "trusty" ]; then
-    sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
-fi
 
 #wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 #sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y


### PR DESCRIPTION
Travis:
 - Remove coverity settings since that's in its own branch (and Travis conf file)
 - Disable caching ccache DB between builds
 - Don't run jobs on cron that won't do Make builds
- Don't run PX4-v2 Make build (this is last commit and I'm not sure if it is wanted or not)

All CI:
 - Remove old CMake PPA (trusty-updates has a more recent version)
 - Remove ccache from APT install since we build it from source
 - Update ccache to version 3.4.2
 - Add extra checks for compiler presence
 - Since no ccache DB is saved between builds we don't limit its size anymore