### PR TITLE
Plane: Cruise target speed handling

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1180,7 +1180,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual, Stabilize, Acro)
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual, Stabilize, Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -199,5 +199,6 @@ enum {
 };
 
 enum FlightOptions {
-    DIRECT_RUDDER_ONLY = (1 << 0),
+    DIRECT_RUDDER_ONLY   = (1 << 0),
+    CRUISE_TRIM_THROTTLE = (1 << 1),
 };

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -107,9 +107,8 @@ void Plane::calc_airspeed_errors()
     // may be using synthetic airspeed
     ahrs.airspeed_estimate(&airspeed_measured);
 
-    // FBW_B airspeed target
-    if (control_mode == FLY_BY_WIRE_B || 
-        control_mode == CRUISE) {
+    // FBW_B/cruise airspeed target
+    if (!failsafe.rc_failsafe && (control_mode == FLY_BY_WIRE_B || control_mode == CRUISE)) {
         target_airspeed_cm = ((int32_t)(aparm.airspeed_max -
                                         aparm.airspeed_min) *
                               channel_throttle->get_control_in()) +

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -5,9 +5,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 
-#define RC_CHANNEL_TYPE_ANGLE       0
-#define RC_CHANNEL_TYPE_RANGE       1
-
 #define NUM_RC_CHANNELS 16
 
 /// @class	RC_Channel
@@ -31,8 +28,14 @@ public:
         RC_IGNORE_OVERRIDES = (1 << 1), // MAVLink overrides
     };
 
+    enum ChannelType {
+        RC_CHANNEL_TYPE_ANGLE = 0,
+        RC_CHANNEL_TYPE_RANGE = 1,
+    };
+
     // setup the control preferences
     void        set_range(uint16_t high);
+    uint16_t    get_range() const { return high_in; }
     void        set_angle(uint16_t angle);
     bool        get_reverse(void) const;
     void        set_default_dead_zone(int16_t dzone);
@@ -97,6 +100,8 @@ public:
 
     // set and save trim if changed
     void       set_and_save_radio_trim(int16_t val) { radio_trim.set_and_save_ifchanged(val);}
+
+    ChannelType get_type(void) const { return type_in; }
 
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
 
@@ -205,7 +210,7 @@ private:
     AP_Int8     reversed;
     AP_Int16    dead_zone;
 
-    uint8_t     type_in;
+    ChannelType type_in;
     int16_t     high_in;
 
     // the input channel this corresponds to


### PR DESCRIPTION
This presents a couple of small changes to planes handling of target airspeed selection in cruise (or fly by wire b).

First, it no longer slows down to the minimum airspeed on RC loss when in cruise is a poor pattern, because it keeps the vehicle closest to stalling out, and moves it outside of the envelope it was primarily tuned against.

The second option that this adds is it allows a user to specify that centered throttle stick should indicate trim airspeed, rather then being in the middle of the minimum/maximum airspeed. This allows for easier handling of center sprung throttle aircraft that have an asymmetric range above/below trim airspeed.

Finally it adds an accessor in RC_Channel that allows you to request what the maximum range on a channel was configured to. This was added as plane uses a range of 100 right now on throttle, and this assumption is hard coded. I'd like to slowly work on removing this assumption, as this introduces problematic quantization of the input signal and is known to cause the target airspeed (and pitch) to experience oscillation. So this simply keeps me from having to revisit the assumption in once spot in the future.