### PR TITLE
waf: fixes and changes

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -2,8 +2,9 @@
 # encoding: utf-8
 
 from __future__ import print_function
-from waflib import Build, Logs, Options, Utils
+from waflib import Build, ConfigSet, Configure, Context, Errors, Logs, Options, Utils
 from waflib.Configure import conf
+from waflib.Scripting import run_command
 from waflib.TaskGen import before_method, feature
 import os.path, os
 from collections import OrderedDict
@@ -91,6 +92,86 @@ IGNORED_AP_LIBRARIES = [
     'doc',
     'AP_Scripting', # this gets explicitly included when it is needed and should otherwise never be globbed in
 ]
+
+
+def ap_autoconfigure(execute_method):
+    """
+    Decorator that enables context commands to run *configure* as needed.
+    """
+    def execute(self):
+        """
+        Wraps :py:func:`waflib.Context.Context.execute` on the context class
+        """
+        if not Configure.autoconfig:
+            return execute_method(self)
+
+        # Disable autoconfig so waf's version doesn't run (and don't end up on loop of bad configure)
+        Configure.autoconfig = False
+
+        if self.variant == '':
+            raise Errors.WafError('The project is badly configured: run "waf configure" again!')
+
+        env = ConfigSet.ConfigSet()
+        do_config = False
+
+        try:
+            p = os.path.join(Context.out_dir, Build.CACHE_DIR, self.variant + Build.CACHE_SUFFIX)
+            env.load(p)
+        except EnvironmentError:
+            raise Errors.WafError('The project is not configured for board {0}: run "waf configure --board {0} [...]" first!'.format(self.variant))
+
+        lock_env = ConfigSet.ConfigSet()
+
+        try:
+            lock_env.load(os.path.join(Context.top_dir, Options.lockfile))
+        except EnvironmentError:
+            Logs.warn('Configuring the project')
+            do_config = True
+        else:
+            if lock_env.run_dir != Context.run_dir:
+                do_config = True
+            else:
+                h = 0
+
+                for f in env.CONFIGURE_FILES:
+                    try:
+                        h = Utils.h_list((h, Utils.readf(f, 'rb')))
+                    except EnvironmentError:
+                        do_config = True
+                        break
+                else:
+                    do_config = h != env.CONFIGURE_HASH
+
+        if do_config:
+            cmd = lock_env.config_cmd or 'configure'
+            tmp = Options.options.__dict__
+
+            if env.OPTIONS and sorted(env.OPTIONS.keys()) == sorted(tmp.keys()):
+                Options.options.__dict__ = env.OPTIONS
+            else:
+                raise Errors.WafError('The project configure options have changed: run "waf configure" again!')
+
+            try:
+                run_command(cmd)
+            finally:
+                Options.options.__dict__ = tmp
+
+            run_command(self.cmd)
+        else:
+            return execute_method(self)
+
+    return execute
+
+def ap_configure_post_recurse():
+    post_recurse_orig = Configure.ConfigurationContext.post_recurse
+
+    def post_recurse(self, node):
+        post_recurse_orig(self, node)
+
+        self.all_envs[self.variant].CONFIGURE_FILES = self.files
+        self.all_envs[self.variant].CONFIGURE_HASH = self.hash
+
+    return post_recurse
 
 @conf
 def ap_get_all_libraries(bld):

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -203,7 +203,7 @@ class Board:
             env.CXXFLAGS += [
                 '-Wno-error=cast-align',
             ]
-            
+
             env.DEFINES.update(
                 UAVCAN_CPP_VERSION = 'UAVCAN_CPP03',
                 UAVCAN_NO_ASSERTIONS = 1,
@@ -260,13 +260,8 @@ def add_dynamic_boards():
 
 def get_boards_names():
     add_dynamic_boards()
-    ret = sorted(list(_board_classes.keys()))
-    # some board types should not be selected
-    hidden = ['chibios']
-    for h in hidden:
-        if h in ret:
-            ret.remove(h)
-    return ret        
+
+    return sorted(list(_board_classes.keys()), key=str.lower)
 
 @conf
 def get_board(ctx):
@@ -333,8 +328,9 @@ class sitl(Board):
             env.CXXFLAGS += [
                 '-fno-slp-vectorize' # compiler bug when trying to use SLP
             ]
-            
+
 class chibios(Board):
+    abstract = True
     toolchain = 'arm-none-eabi'
 
     def configure_env(self, cfg, env):
@@ -452,7 +448,7 @@ class chibios(Board):
             env.CXXFLAGS += [ '-DHAL_CHIBIOS_ENABLE_ASSERTS' ]
         else:
             cfg.msg("Enabling ChibiOS asserts", "no")
-            
+
         env.LIB += ['gcc', 'm']
 
         env.GIT_SUBMODULES += [
@@ -707,7 +703,7 @@ class rst_zynq(linux):
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_RST_ZYNQ',
         )
-        
+
 class px4(Board):
     abstract = True
     toolchain = 'arm-none-eabi'
@@ -872,7 +868,7 @@ class px4_v4pro(px4):
         self.px4io_name = 'px4io-v2'
         self.romfs_exclude(['oreoled.bin'])
         self.with_uavcan = True		
-		
+
 class aerofc_v1(px4):
     name = 'aerofc-v1'
     def __init__(self):

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -481,8 +481,6 @@ class linux(Board):
     def configure_env(self, cfg, env):
         super(linux, self).configure_env(cfg, env)
 
-        cfg.find_toolchain_program('pkg-config', var='PKGCONFIG')
-
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_LINUX',
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NONE',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import sys, os
 
 import waflib
+from waflib import Utils
 from waflib.Configure import conf
 
 _board_classes = {}
@@ -319,12 +320,13 @@ class sitl(Board):
                 if fnmatch.fnmatch(f, "font*bin"):
                     env.ROMFS_FILES += [(f,'libraries/AP_OSD/fonts/'+f)]
 
-        if sys.platform == 'cygwin':
+        if cfg.env.DEST_OS == 'cygwin':
             env.LIB += [
                 'winmm',
             ]
-            env.CXXFLAGS += ['-DCYGWIN_BUILD']
 
+        if Utils.unversioned_sys_platform() == 'cygwin':
+            env.CXXFLAGS += ['-DCYGWIN_BUILD']
 
         if 'clang++' in cfg.env.COMPILER_CXX:
             print("Disabling SLP for clang++")
@@ -404,7 +406,7 @@ class chibios(Board):
             '-fno-threadsafe-statics',
         ]
 
-        if sys.platform == 'cygwin':
+        if Utils.unversioned_sys_platform() == 'cygwin':
             env.CXXFLAGS += ['-DCYGWIN_BUILD']
 
         bldnode = cfg.bldnode.make_node(self.name)

--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -214,7 +214,12 @@ information about the first %d targets will be printed.
 ''' % MAX_TARGETS)
 
 def configure(cfg):
-    cfg.find_toolchain_program('size', mandatory=False)
+    size_name = 'size'
+
+    if cfg.env.TOOLCHAIN != 'native':
+        size_name = cfg.env.TOOLCHAIN + '-' + size_name
+
+    cfg.find_program(size_name, var='SIZE', mandatory=False)
 
     if not cfg.env.BUILD_SUMMARY_HEADER:
         cfg.env.BUILD_SUMMARY_HEADER = [

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -16,6 +16,7 @@ from waflib import Errors, Context, Utils
 from waflib.Configure import conf
 from waflib.Tools import compiler_c, compiler_cxx
 from waflib.Tools import clang, clangxx, gcc, gxx
+from waflib.Tools import c_config
 from waflib import Logs
 
 import os
@@ -112,19 +113,19 @@ def _filter_supported_cxx_compilers(*compilers):
         l = compiler_cxx.cxx_compiler[k]
         compiler_cxx.cxx_compiler[k] = [c for c in compilers if c in l]
 
-@conf
-def find_toolchain_program(cfg, filename, **kw):
-    filename = Utils.to_list(filename)
+def _set_pkgconfig_crosscompilation_wrapper(cfg):
+    original_validatecfg = cfg.validate_cfg
 
-    if not kw.get('var', ''):
-        # just copy from the original implementation
-        kw['var'] = re.sub(r'[-.]', '_', filename[0].upper())
+    @conf
+    def new_validate_cfg(kw):
+        if not 'path' in kw:
+            if not cfg.env.PKGCONFIG:
+                cfg.find_program('%s-pkg-config' % cfg.env.TOOLCHAIN, var='PKGCONFIG')
+            kw['path'] = cfg.env.PKGCONFIG
 
-    if cfg.env.TOOLCHAIN != 'native':
-        for i, name in enumerate(filename):
-            filename[i] = '%s-%s' % (cfg.env.TOOLCHAIN, name)
+        original_validatecfg(kw)
 
-    return cfg.find_program(filename, **kw)
+    cfg.validate_cfg = new_validate_cfg
 
 def configure(cfg):
     _filter_supported_c_compilers('gcc', 'clang')
@@ -138,9 +139,10 @@ def configure(cfg):
 
         return
 
-    cfg.find_toolchain_program('ar')
-
     cfg.msg('Using toolchain', cfg.env.TOOLCHAIN)
+
+    _set_pkgconfig_crosscompilation_wrapper(cfg)
+    cfg.find_program('%s-ar' % cfg.env.TOOLCHAIN, var='AR', quiet=True)
     cfg.load('compiler_cxx compiler_c')
 
     if not cfg.options.disable_gccdeps:

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -131,13 +131,20 @@ def configure(cfg):
     _filter_supported_cxx_compilers('g++', 'clang++')
 
     if cfg.env.TOOLCHAIN == 'native':
-        cfg.load('compiler_cxx compiler_c gccdeps')
+        cfg.load('compiler_cxx compiler_c')
+
+        if not cfg.options.disable_gccdeps:
+            cfg.load('gccdeps')
+
         return
 
     cfg.find_toolchain_program('ar')
 
     cfg.msg('Using toolchain', cfg.env.TOOLCHAIN)
-    cfg.load('compiler_cxx compiler_c gccdeps')
+    cfg.load('compiler_cxx compiler_c')
+
+    if not cfg.options.disable_gccdeps:
+        cfg.load('gccdeps')
 
     if cfg.env.COMPILER_CC == 'clang':
         cfg.env.CFLAGS += cfg.env.CLANG_FLAGS

--- a/waf
+++ b/waf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import subprocess

--- a/wscript
+++ b/wscript
@@ -67,6 +67,11 @@ def options(opt):
         default=False,
         help='Configure as debug variant.')
 
+    g.add_option('--disable-gccdeps',
+        action='store_true',
+        default=False,
+        help='Disable the use of GCC dependencies output method and use waf default method.')
+
     g.add_option('--enable-asserts',
         action='store_true',
         default=False,

--- a/wscript
+++ b/wscript
@@ -437,7 +437,7 @@ def _build_post_funs(bld):
     if bld.env.SUBMODULE_UPDATE:
         bld.git_submodule_post_fun()
 
-def load_pre_build(bld):
+def _load_pre_build(bld):
     '''allow for a pre_build() function in build modules'''
     brd = bld.get_board()
     if getattr(brd, 'pre_build', None):
@@ -457,7 +457,7 @@ def build(bld):
         cxxflags=['-include', 'ap_config.h'],
     )
 
-    load_pre_build(bld)
+    _load_pre_build(bld)
 
     if bld.get_board().with_uavcan:
         bld.env.AP_LIBRARIES_OBJECTS_KW['use'] += ['uavcan']


### PR DESCRIPTION
Multiple things here:

- fix one method name so it doesn't show up as a waf command
- our waf script had a shebang hardcoded path, changed to use the Python provided by the environment
- remove a ChibiOS "hack" that didn't allow selection of ChibiOS base as a board; we already have a method for this, which is to mark a board class as abstract
- added an option to disable the new GCC dependencies; it fails too much for me (and others)
- long-time coming patch to not fail when pkg-config is not present; it's not a required tool so it will only check for it when needed and failure to find it will only lead to an error if its presence is mandatory
- biggest feature: allow to change board to build at build time instead of needing to re-configure the project:
  - waf, as other tools, is made to run configure once and have everything configured, including all variants (that we use for different boards) and then on build time select what you want to have built.
  
    We don't want to force everyone to configure every board, so implementing the choice of board build-time choice was more difficult due to auto-configure support: as configure is going to be run at different times for each board, we need to save the files, hash and options involved in the configure for each of the variants so we check the correct ones when looking for the need to configure again.

I've done several tests, but it would be nice if other people did as well.