### PR TITLE
AP_Declination: Fix the generation script for python 3

### DIFF
--- a/libraries/AP_Declination/generate/generate.py
+++ b/libraries/AP_Declination/generate/generate.py
@@ -3,7 +3,7 @@
 generate field tables from IGRF12
 '''
 
-import pyigrf12 as igrf
+import igrf12 as igrf
 import numpy as np
 import datetime
 from pathlib import Path
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     for i,lat in enumerate(lats):
         for j,lon in enumerate(lons):
-            mag = igrf.igrf(date=date, glat=lat, glon=lon, alt=0., isv=0, itype=1)
+            mag = igrf.igrf(date, glat=lat, glon=lon, alt_km=0., isv=0, itype=1)
             intensity_table[i][j] = mag.total/1e5
             inclination_table[i][j] = mag.incl
             declination_table[i][j] = mag.decl

--- a/libraries/AP_Declination/generate/generate.py
+++ b/libraries/AP_Declination/generate/generate.py
@@ -6,93 +6,81 @@ generate field tables from IGRF12
 import pyigrf12 as igrf
 import numpy as np
 import datetime
-import os.path
-import sys
-from math import sqrt, pi, atan2, asin
+from pathlib import Path
 
-if not os.path.isfile("AP_Declination.h"):
-    print("Please run this tool from the AP_Declination directory")
-    sys.exit(1)
+if not Path("AP_Declination.h").is_file():
+    raise OSError("Please run this tool from the AP_Declination directory")
 
 
-def field_to_angles(x, y, z):
-    intensity = sqrt(x**2+y**2+z**2)
-    r2d = 180.0 / pi
-    declination = r2d * atan2(y, x)
-    inclination = r2d * asin(z / intensity)
-    return [intensity, inclination, declination]
+def write_table(f,name, table):
+    '''write one table'''
+    f.write("const float AP_Declination::%s[%u][%u] = {\n" %
+                (name, NUM_LAT, NUM_LON))
+    for i in range(NUM_LAT):
+        f.write("    {")
+        for j in range(NUM_LON):
+            f.write("%.5f" % table[i][j])
+            if j != NUM_LON-1:
+                f.write(",")
+        f.write("}")
+        if i != NUM_LAT-1:
+            f.write(",")
+        f.write("\n")
+    f.write("};\n\n")
 
 
-isv = 0
-date = datetime.datetime.now()
-itype = 1
-alt = 0.0
 
-SAMPLING_RES = 10
-SAMPLING_MIN_LAT = -90
-SAMPLING_MAX_LAT = 90
-SAMPLING_MIN_LON = -180
-SAMPLING_MAX_LON = 180
 
-NUM_LAT = 1 + (SAMPLING_MAX_LAT - SAMPLING_MIN_LAT) / SAMPLING_RES
-NUM_LON = 1 + (SAMPLING_MAX_LON - SAMPLING_MIN_LON) / SAMPLING_RES
+if __name__ == '__main__':
 
-intensity_table = np.empty((NUM_LAT, NUM_LON))
-inclination_table = np.empty((NUM_LAT, NUM_LON))
-declination_table = np.empty((NUM_LAT, NUM_LON))
+    date = datetime.datetime.now()
+   # date = datetime.date(2018,2,20)
 
-for i in range(NUM_LAT):
-    for j in range(NUM_LON):
-        lat = SAMPLING_MIN_LAT + i*SAMPLING_RES
-        lon = SAMPLING_MIN_LON + j*SAMPLING_RES
-        x, y, z, f, d = igrf.gridigrf12(date, isv, itype, alt, lat, lon)
-        intensity, I, D = field_to_angles(x, y, z)
-        intensity_table[i][j] = intensity * 0.00001
-        inclination_table[i][j] = I
-        declination_table[i][j] = D
+    SAMPLING_RES = 10
+    SAMPLING_MIN_LAT = -90
+    SAMPLING_MAX_LAT = 90
+    SAMPLING_MIN_LON = -180
+    SAMPLING_MAX_LON = 180
 
-tfile = open("tables.cpp", 'w')
-tfile.write('''// this is an auto-generated file from the IGRF tables. Do not edit
+    lats = np.arange(SAMPLING_MIN_LAT, SAMPLING_MAX_LAT+SAMPLING_RES, SAMPLING_RES)
+    lons = np.arange(SAMPLING_MIN_LON, SAMPLING_MAX_LON+SAMPLING_RES, SAMPLING_RES)
+
+    NUM_LAT = lats.size
+    NUM_LON = lons.size
+
+    intensity_table = np.empty((NUM_LAT, NUM_LON))
+    inclination_table = np.empty((NUM_LAT, NUM_LON))
+    declination_table = np.empty((NUM_LAT, NUM_LON))
+
+    for i,lat in enumerate(lats):
+        for j,lon in enumerate(lons):
+            mag = igrf.igrf(date=date, glat=lat, glon=lon, alt=0., isv=0, itype=1)
+            intensity_table[i][j] = mag.total/1e5
+            inclination_table[i][j] = mag.incl
+            declination_table[i][j] = mag.decl
+
+    with open("tables.cpp", 'w') as f:
+        f.write('''// this is an auto-generated file from the IGRF tables. Do not edit
 // To re-generate run generate/generate.py
 
 #include "AP_Declination.h"
 
 ''')
 
-tfile.write('''
-const float AP_Declination::SAMPLING_RES = %u;
+        f.write('''const float AP_Declination::SAMPLING_RES = %u;
 const float AP_Declination::SAMPLING_MIN_LAT = %u;
 const float AP_Declination::SAMPLING_MAX_LAT = %u;
 const float AP_Declination::SAMPLING_MIN_LON = %u;
 const float AP_Declination::SAMPLING_MAX_LON = %u;
 
 ''' % (SAMPLING_RES,
-       SAMPLING_MIN_LAT,
-       SAMPLING_MAX_LAT,
-       SAMPLING_MIN_LON,
-       SAMPLING_MAX_LON))
+           SAMPLING_MIN_LAT,
+           SAMPLING_MAX_LAT,
+           SAMPLING_MIN_LON,
+           SAMPLING_MAX_LON))
 
 
-def write_table(name, table):
-    '''write one table'''
-    tfile.write("const float AP_Declination::%s[%u][%u] = {\n" %
-                (name, NUM_LAT, NUM_LON))
-    for i in range(NUM_LAT):
-        tfile.write("    {")
-        for j in range(NUM_LON):
-            tfile.write("%.5f" % table[i][j])
-            if j != NUM_LON-1:
-                tfile.write(",")
-        tfile.write("}")
-        if i != NUM_LAT-1:
-            tfile.write(",")
-        tfile.write("\n")
-    tfile.write("};\n\n")
+        write_table(f,'declination_table', declination_table)
+        write_table(f,'inclination_table', inclination_table)
+        write_table(f,'intensity_table', intensity_table)
 
-
-write_table('declination_table', declination_table)
-write_table('inclination_table', inclination_table)
-write_table('intensity_table', intensity_table)
-
-
-tfile.close()


### PR DESCRIPTION
This replaces #8467 fixing up a couple of the kwargs that changed in the python IGRF package, as well as adapting to the package name change. I squashed the commits from @scivision and dropped the updates to tables.cpp. My last commit is the only new commits that were needed and it can be squashed, I've simply left it alone for ease in reviewing.

The summary of why this matters: The tool does not function with python 3 at the moment, and the package is only distributed for python 3. At the moment the only person with a working python2 install appears to be @tridge and this change allows others to actually regenerate the tables correctly.