### PR TITLE
Copter: correct compilation for missing define

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -74,7 +74,6 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
     case MISSION_RESET:
     case ATTCON_FEEDFWD:
     case ATTCON_ACCEL_LIM:
-    case LOST_COPTER_SOUND:
     case MOTOR_ESTOP:
     case MOTOR_INTERLOCK:
     case AVOID_ADSB:


### PR DESCRIPTION
Bad interaction between two PRs that were merged.