### PR TITLE
AP_Arming: initialise statustext stack variable

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -121,7 +121,7 @@ void AP_Arming::check_failed(const enum AP_Arming::ArmingChecks check, bool repo
     if (!report) {
         return;
     }
-    char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
     hal.util->snprintf((char*)taggedfmt, sizeof(taggedfmt)-1, "PreArm: %s", fmt);
     MAV_SEVERITY severity = check_severity(check);
     va_list arg_list;


### PR DESCRIPTION
While we debate the merits of https://github.com/ArduPilot/ardupilot/pull/9289 - we should probably put this fix in.
