### PR TITLE
Tracker: fix servo outputs

### DIFF
--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -114,7 +114,6 @@ void Tracker::one_second_loop()
         if (ahrs.get_location(temp_loc)) {
             set_home(temp_loc);
         }
-        return;
     }
 }
 

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -93,6 +93,9 @@ void Tracker::one_second_loop()
     // sync MAVLink system ID
     mavlink_system.sysid = g.sysid_this_mav;
 
+    // update assigned functions and enable auxiliary servos
+    SRV_Channels::enable_aux_servos();
+
     // updated armed/disarmed status LEDs
     update_armed_disarmed();
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -2,9 +2,6 @@
 
 #include "Tracker.h"
 
-// default sensors are present and healthy: gyro, accelerometer, barometer, rate_control, attitude_stabilization, yaw_position, altitude control, x/y position control, motor_control
-#define MAVLINK_SENSOR_PRESENT_DEFAULT (MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL | MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE | MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL | MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION | MAV_SYS_STATUS_SENSOR_YAW_POSITION | MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL | MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL | MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS)
-
 /*
  *  !!NOTE!!
  *
@@ -84,11 +81,13 @@ void Tracker::send_extended_status1(mavlink_channel_t chan)
         battery_current = battery.current_amps() * 100;
     }
 
+    update_sensor_status_flags();
+
     mavlink_msg_sys_status_send(
         chan,
-        0,
-        0,
-        0,
+        control_sensors_present,
+        control_sensors_enabled,
+        control_sensors_health,
         static_cast<uint16_t>(scheduler.load_average() * 1000),
         battery.voltage() * 1000,  // mV
         battery_current,        // in 10mA units

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -2,6 +2,9 @@
 
 #include <GCS_MAVLink/GCS.h>
 
+// default sensors are present and healthy: gyro, accelerometer, barometer, rate_control, attitude_stabilization, yaw_position, altitude control, x/y position control, motor_control
+#define MAVLINK_SENSOR_PRESENT_DEFAULT (MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL | MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE | MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL | MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION | MAV_SYS_STATUS_SENSOR_YAW_POSITION | MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS)
+
 class GCS_MAVLINK_Tracker : public GCS_MAVLINK
 {
 

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -194,36 +194,69 @@ private:
     static const AP_Param::Info var_info[];
     static const struct LogStructure log_structure[];
 
+    // AntennaTracker.cpp
     void one_second_loop();
     void ten_hz_logging_loop();
-    void send_extended_status1(mavlink_channel_t chan);
-    void send_nav_controller_output(mavlink_channel_t chan);
-    void gcs_data_stream_send(void);
-    void gcs_update(void);
-    void gcs_retry_deferred(void);
-    void load_parameters(void);
+
+    // capabilities.cpp
+    void init_capabilities(void);
+
+    // control_auto.cpp
     void update_auto(void);
     void calc_angle_error(float pitch, float yaw, bool direction_reversed);
     void convert_ef_to_bf(float pitch, float yaw, float& bf_pitch, float& bf_yaw);
     bool convert_bf_to_ef(float pitch, float yaw, float& ef_pitch, float& ef_yaw);
     bool get_ef_yaw_direction();
+
+    // control_manual.cpp
     void update_manual(void);
+
+    // control_scan.cpp
     void update_scan(void);
+
+    // control_servo_test.cpp
     bool servo_test_set_servo(uint8_t servo_num, uint16_t pwm);
+
+    // GCS_Mavlink.cpp
+    void send_extended_status1(mavlink_channel_t chan);
+    void send_nav_controller_output(mavlink_channel_t chan);
+    void gcs_data_stream_send(void);
+    void gcs_update(void);
+    void gcs_retry_deferred(void);
+
+    // Log.cpp
+    void Log_Write_Attitude();
+    void Log_Write_Vehicle_Baro(float pressure, float altitude);
+    void Log_Write_Vehicle_Pos(int32_t lat,int32_t lng,int32_t alt, const Vector3f& vel);
+    void Log_Write_Vehicle_Startup_Messages();
+    void log_init(void);
+
+    // Parameters.cpp
+    void load_parameters(void);
+
+    // radio.cpp
     void read_radio();
+
+    // sensors.cpp
     void update_ahrs();
     void update_compass(void);
+    void compass_cal_update();
     void accel_cal_update(void);
     void update_GPS(void);
+    void handle_battery_failsafe(const char* type_str, const int8_t action);
+
+    // servos.cpp
     void init_servos();
     void update_pitch_servo(float pitch);
     void update_pitch_position_servo(void);
-    void update_pitch_cr_servo(float pitch);
     void update_pitch_onoff_servo(float pitch);
+    void update_pitch_cr_servo(float pitch);
     void update_yaw_servo(float yaw);
     void update_yaw_position_servo(void);
-    void update_yaw_cr_servo(float yaw);
     void update_yaw_onoff_servo(float yaw);
+    void update_yaw_cr_servo(float yaw);
+
+    // system.cpp
     void init_tracker();
     bool get_home_eeprom(struct Location &loc);
     void set_home_eeprom(struct Location temp);
@@ -232,6 +265,9 @@ private:
     void disarm_servos();
     void prepare_servos();
     void set_mode(enum ControlMode mode, mode_reason_t reason);
+    bool should_log(uint32_t mask);
+
+    // tracking.cpp
     void update_vehicle_pos_estimate();
     void update_tracker_position();
     void update_bearing_and_distance();
@@ -240,15 +276,6 @@ private:
     void tracking_update_pressure(const mavlink_scaled_pressure_t &msg);
     void tracking_manual_control(const mavlink_manual_control_t &msg);
     void update_armed_disarmed();
-    void init_capabilities(void);
-    void compass_cal_update();
-    void Log_Write_Attitude();
-    void Log_Write_Vehicle_Pos(int32_t lat,int32_t lng,int32_t alt, const Vector3f& vel);
-    void Log_Write_Vehicle_Baro(float pressure, float altitude);
-    void Log_Write_Vehicle_Startup_Messages();
-    void log_init(void);
-    bool should_log(uint32_t mask);
-    void handle_battery_failsafe(const char* type_str, const int8_t action);
 
 public:
     void mavlink_delay_cb();

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -140,6 +140,11 @@ private:
     GCS_Tracker _gcs; // avoid using this; use gcs()
     GCS_Tracker &gcs() { return _gcs; }
 
+    // variables for extended status MAVLink messages
+    uint32_t control_sensors_present;
+    uint32_t control_sensors_enabled;
+    uint32_t control_sensors_health;
+
     AP_BoardConfig BoardConfig;
 
 #if HAL_WITH_UAVCAN
@@ -244,6 +249,7 @@ private:
     void accel_cal_update(void);
     void update_GPS(void);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
+    void update_sensor_status_flags();
 
     // servos.cpp
     void init_servos();

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -90,3 +90,68 @@ void Tracker::handle_battery_failsafe(const char* type_str, const int8_t action)
     // that is tracked before the tracker loses power to continue tracking it
 }
 
+// update sensors and subsystems present, enabled and healthy flags for reporting to GCS
+void Tracker::update_sensor_status_flags()
+{
+    // default sensors present
+    control_sensors_present = MAVLINK_SENSOR_PRESENT_DEFAULT;
+
+    // first what sensors/controllers we have
+    if (g.compass_enabled) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;  // compass present
+    }
+    if (gps.status() > AP_GPS::NO_GPS) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_GPS;
+    }
+    if (DataFlash.logging_present()) {  // primary logging only (usually File)
+        control_sensors_present |= MAV_SYS_STATUS_LOGGING;
+    }
+
+    // all present sensors enabled by default except rate control, attitude stabilization, yaw, altitude, position control and motor output which we will set individually
+    control_sensors_enabled = control_sensors_present & (~MAV_SYS_STATUS_LOGGING &
+                                                         ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
+                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY);
+
+    if (DataFlash.logging_enabled()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_LOGGING;
+    }
+
+    // set motors outputs as enabled if safety switch is not disarmed (i.e. either NONE or ARMED)
+    if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS;
+    }
+
+    if (battery.num_instances() > 0) {
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_BATTERY;
+    }
+
+    // default to all healthy except compass and gps which we set individually
+    control_sensors_health = control_sensors_present & (~MAV_SYS_STATUS_SENSOR_3D_MAG & ~MAV_SYS_STATUS_SENSOR_GPS);
+    if (g.compass_enabled && compass.healthy(0) && ahrs.use_compass()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
+    }
+    if (gps.is_healthy()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
+    }
+    if (!ins.get_gyro_health_all() || !ins.gyro_calibrated_ok_all()) {
+        control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_3D_GYRO;
+    }
+    if (!ins.get_accel_health_all()) {
+        control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_3D_ACCEL;
+    }
+    if (ahrs.initialised() && !ahrs.healthy()) {
+        // AHRS subsystem is unhealthy
+        control_sensors_health &= ~MAV_SYS_STATUS_AHRS;
+    }
+    if (DataFlash.logging_failed()) {
+        control_sensors_health &= ~MAV_SYS_STATUS_LOGGING;
+    }
+    if (!battery.healthy() || battery.has_failsafed()) {
+        control_sensors_enabled &= ~MAV_SYS_STATUS_SENSOR_BATTERY;
+    }
+    if (ins.calibrating()) {
+        // while initialising the gyros and accels are not enabled
+        control_sensors_enabled &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
+        control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
+    }
+}

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -21,7 +21,7 @@ void Tracker::init_servos()
 
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
-    
+
     yaw_servo_out_filt.set_cutoff_frequency(SERVO_OUT_FILT_HZ);
     pitch_servo_out_filt.set_cutoff_frequency(SERVO_OUT_FILT_HZ);
 }

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -7,6 +7,9 @@
 // init_servos - initialises the servos
 void Tracker::init_servos()
 {
+    // update assigned functions and enable auxiliary servos
+    SRV_Channels::enable_aux_servos();
+
     SRV_Channels::set_default_function(CH_YAW, SRV_Channel::k_tracker_yaw);
     SRV_Channels::set_default_function(CH_PITCH, SRV_Channel::k_tracker_pitch);
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -33,7 +33,7 @@ void Tracker::init_tracker()
     // Register mavlink_delay_cb, which will run anytime you have
     // more than 5ms remaining in your call to hal.scheduler->delay
     hal.scheduler->register_delay_callback(mavlink_delay_cb_static, 5);
-    
+
     BoardConfig.init();
 #if HAL_WITH_UAVCAN
     BoardConfig_CAN.init();

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,12 +6,12 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V1.0.0"
+#define THISFIRMWARE "AntennaTracker V1.1.0-dev"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 1,0,0,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 1,1,0,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 1
-#define FW_MINOR 0
+#define FW_MINOR 1
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV


### PR DESCRIPTION
This PR resolves a few issues reported with the latest Tracker software:

- servo outputs work (enable_aux_servos was not being called)
- safety switch position was not being sent to GCS resulting in (SAFE) always being written on the MP's HUD (fixed by sending extended status message)

It also includes a few non-functional changes:

- update version to 1.1.0-dev (so we can more easily distinguish it from the official release)
- alphabetise the methods in Tracker.h
- minor format fixes

This has been tested on a Pixhawk1 with MP and also with a servo tester using the SERVO_TEST mode.