### PR TITLE
SITL: limit on_ground() check to militer accuracy to prevent bouncing

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -171,7 +171,7 @@ float Aircraft::hagl() const
 */
 bool Aircraft::on_ground() const
 {
-    return hagl() <= 0;
+    return hagl() <= 0.001f;  // prevent bouncing around ground
 }
 
 /*


### PR DESCRIPTION
Prevent infinite bouncing on quadplane when distance to ground is really small (<1 mm) 
Example in https://api.travis-ci.org/v3/job/424304231/log.txt look above AUTOTEST: FAILED: "Mission": AutoTestTimeoutException()
This is due to the calculation of hagl() that return really small value (6e-6f in the example) but that isn't small enough to be zero ...
I consider that mm accuracy to check if our model are on ground on SITL is enought. 
