### PR TITLE
AP_HAL_Linux: force Thread stack to have minimum size

### DIFF
--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -359,7 +359,8 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
         }
     }
 
-    thread->set_stack_size(stack_size);
+    // Add 256k to HAL-independent requested stack size
+    thread->set_stack_size(256 * 1024 + stack_size);
 
     /*
      * We should probably store the thread handlers and join() when exiting,

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -17,6 +17,7 @@
 #include "Thread.h"
 
 #include <alloca.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -243,7 +244,7 @@ bool Thread::set_stack_size(size_t stack_size)
         return false;
     }
 
-    _stack_size = stack_size;
+    _stack_size = MAX(stack_size, (size_t) PTHREAD_STACK_MIN);
 
     return true;
 }


### PR DESCRIPTION
With the addition of a HAL thread creation API, which allows asking for a specific stack size, we need to make sure it's the minimum allowed value in Linux.

This was making the UAVCAN thread failing to be created. I tested my CAN changes on an Edge but apparently I did with a build that wasn't rebased after d2446e12196fea92954044f0f7798c79b4deb490. The previous code would just continue if setting the stack size failed, but the new code just fails silently (I wonder if we should put a panic there too?).