### PR TITLE
Disable some modules to test septentrio AsteRX M2 (fw 4.4.0) boot issues

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -6,43 +6,44 @@
 // uncomment the lines below to disable features (flash sizes listed are for APM2 boards and will underestimate savings on Pixhawk and other boards)
 //#define LOGGING_ENABLED       DISABLED            // disable dataflash logging to save 11K of flash space
 //#define MOUNT                 DISABLED            // disable the camera gimbal to save 8K of flash space
-//#define AUTOTUNE_ENABLED      DISABLED            // disable the auto tune functionality to save 7k of flash
-//#define AC_FENCE              DISABLED            // disable fence to save 2k of flash
-//#define CAMERA                DISABLED            // disable camera trigger to save 1k of flash
-//#define RANGEFINDER_ENABLED   DISABLED            // disable rangefinder to save 1k of flash
-//#define PROXIMITY_ENABLED     DISABLED            // disable proximity sensors
-//#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
-//#define AC_AVOID_ENABLED      DISABLED            // disable stop-at-fence library
-//#define AC_TERRAIN            DISABLED            // disable terrain library
-//#define PARACHUTE             DISABLED            // disable parachute release to save 1k of flash
-//#define NAV_GUIDED            DISABLED            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands
-//#define OPTFLOW               DISABLED            // disable optical flow sensor to save 5K of flash space
-//#define VISUAL_ODOMETRY_ENABLED DISABLED          // disable visual odometry to save 2K of flash space
-//#define FRSKY_TELEM_ENABLED   DISABLED            // disable FRSky telemetry
-//#define ADSB_ENABLED          DISABLED            // disable ADSB support
-//#define PRECISION_LANDING     DISABLED            // disable precision landing using companion computer or IRLock sensor
-//#define BEACON_ENABLED        DISABLED            // disable beacon support
-//#define SPRAYER_ENABLED       DISABLED            // disable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
-//#define WINCH_ENABLED         DISABLED            // disable winch support
-//#define GRIPPER_ENABLED       DISABLED            // disable gripper support
-//#define RPM_ENABLED           DISABLED            // disable rotations per minute sensor support
+#define AUTOTUNE_ENABLED      DISABLED            // disable the auto tune functionality to save 7k of flash
+#define AC_FENCE              DISABLED            // disable fence to save 2k of flash
+#define CAMERA                DISABLED            // disable camera trigger to save 1k of flash
+#define RANGEFINDER_ENABLED   DISABLED            // disable rangefinder to save 1k of flash
+#define PROXIMITY_ENABLED     DISABLED            // disable proximity sensors
+#define AC_RALLY              DISABLED            // disable rally points library (must also disable terrain which relies on rally)
+#define AC_AVOID_ENABLED      DISABLED            // disable stop-at-fence library
+#define AC_TERRAIN            DISABLED            // disable terrain library
+#define PARACHUTE             DISABLED            // disable parachute release to save 1k of flash
+#define NAV_GUIDED            DISABLED            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands
+#define OPTFLOW               DISABLED            // disable optical flow sensor to save 5K of flash space
+#define VISUAL_ODOMETRY_ENABLED DISABLED          // disable visual odometry to save 2K of flash space
+#define FRSKY_TELEM_ENABLED   DISABLED            // disable FRSky telemetry
+#define ADSB_ENABLED          DISABLED            // disable ADSB support
+#define PRECISION_LANDING     DISABLED            // disable precision landing using companion computer or IRLock sensor
+#define BEACON_ENABLED        DISABLED            // disable localization beacon support
+#define SPRAYER_ENABLED       DISABLED            // disable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
+#define WINCH_ENABLED         DISABLED            // disable winch support
+#define GRIPPER_ENABLED       DISABLED            // disable gripper support
+#define RPM_ENABLED           DISABLED            // disable rotations per minute sensor support
 //#define MAGNETOMETER          DISABLED            // disable magnetometer support
 //#define STATS_ENABLED         DISABLED            // disable statistics support
-//#define MODE_ACRO_ENABLED     DISABLED            // disable acrobatic mode support
+#define MODE_ACRO_ENABLED     DISABLED            // disable acrobatic mode support
 //#define MODE_AUTO_ENABLED     DISABLED            // disable auto mode support
-//#define MODE_BRAKE_ENABLED    DISABLED            // disable brake mode support
+#define MODE_BRAKE_ENABLED    DISABLED            // disable brake mode support
 //#define MODE_CIRCLE_ENABLED   DISABLED            // disable circle mode support
-//#define MODE_DRIFT_ENABLED    DISABLED            // disable drift mode support
-//#define MODE_FOLLOW_ENABLED   DISABLED            // disable follow mode support
+#define MODE_DRIFT_ENABLED    DISABLED            // disable drift mode support
+#define MODE_FOLLOW_ENABLED   DISABLED            // disable follow mode support
 //#define MODE_GUIDED_ENABLED   DISABLED            // disable guided mode support
 //#define MODE_GUIDED_NOGPS_ENABLED   DISABLED      // disable guided/nogps mode support
 //#define MODE_LOITER_ENABLED   DISABLED            // disable loiter mode support
 //#define MODE_POSHOLD_ENABLED  DISABLED            // disable poshold mode support
-//#define MODE_RTL_ENABLED DISABLED                 // disable rtl mode support
-//#define MODE_SMARTRTL_ENABLED DISABLED            // disable smartrtl mode support
-//#define MODE_SPORT_ENABLED DISABLED               // disable sport mode support
-//#define MODE_THROW_ENABLED    DISABLED            // disable throw mode support
-//#define DEVO_TELEM_ENABLED DISABLED               // disable DEVO telemetry, if you don't use Walkera RX-707 (or newer) receivers
+//#define MODE_RTL_ENABLED      DISABLED            // disable rtl mode support
+#define MODE_SMARTRTL_ENABLED DISABLED            // disable smartrtl mode support
+#define MODE_SPORT_ENABLED    DISABLED            // disable sport mode support
+#define MODE_THROW_ENABLED    DISABLED            // disable throw mode support
+#define DEVO_TELEM_ENABLED    DISABLED            // disable DEVO telemetry, if you don't use Walkera RX-707 (or newer) receivers
+#define OSD_ENABLED           DISABLED            // disable on-screen-display support
 
 
 // features below are disabled by default on all boards

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1561,11 +1561,11 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("FLTMODE_CH", fltmode_ch)
             self.set_rc(fltmode_ch, 1000) # PWM for mode1
             testmodes = [("FLTMODE1", 4, "GUIDED", 1165),
-                         ("FLTMODE2", 13, "SPORT", 1295),
+#                         ("FLTMODE2", 13, "SPORT", 1295),
                          ("FLTMODE3", 6, "RTL", 1425),
                          ("FLTMODE4", 7, "CIRCLE", 1555),
-                         ("FLTMODE5", 1, "ACRO", 1685),
-                         ("FLTMODE6", 17, "BRAKE", 1815),
+#                         ("FLTMODE5", 1, "ACRO", 1685),
+#                         ("FLTMODE6", 17, "BRAKE", 1815),
                          ]
             for mode in testmodes:
                 (parm, parm_value, name, pwm) = mode
@@ -1586,10 +1586,10 @@ class AutoTestCopter(AutoTest):
                 self.set_rc(fltmode_ch, pwm)
                 self.wait_mode(name)
 
-            self.mavproxy.send('switch 6\n')
-            self.wait_mode("BRAKE")
-            self.mavproxy.send('switch 5\n')
-            self.wait_mode("ACRO")
+#            self.mavproxy.send('switch 6\n')
+#            self.wait_mode("BRAKE")
+#            self.mavproxy.send('switch 5\n')
+#            self.wait_mode("ACRO")
 
         except Exception as e:
             self.progress("Exception caught")
@@ -1751,7 +1751,7 @@ class AutoTestCopter(AutoTest):
                           lambda: self.takeoff(10))
 
             # AutoTune mode
-            self.run_test("Fly AUTOTUNE mode", self.fly_autotune)
+            #self.run_test("Fly AUTOTUNE mode", self.fly_autotune)
 
             # Fly a square in Stabilize mode
             self.run_test("Fly a square and save WPs with CH7",
@@ -1789,6 +1789,7 @@ class AutoTestCopter(AutoTest):
             # RTL
             self.run_test("RTL after stab patch", self.fly_RTL)
 
+            '''
             # Takeoff
             self.run_test("Takeoff to test horizontal fence",
                           lambda: self.takeoff(10))
@@ -1803,6 +1804,7 @@ class AutoTestCopter(AutoTest):
 
             # Fence test
             self.run_test("Test Max Alt Fence", self.fly_alt_max_fence_test)
+            '''
 
             # Takeoff
             self.run_test("Takeoff to test GPS glitch loiter",
@@ -1903,7 +1905,7 @@ class AutoTestCopter(AutoTest):
             self.mav.motors_disarmed_wait()
 
             # Gripper test
-            self.run_test("Test gripper", self.test_gripper)
+            #self.run_test("Test gripper", self.test_gripper)
 
             '''vision position'''  # expects vehicle to be disarmed
             self.run_test("Fly Vision Position", self.fly_vision_position)


### PR DESCRIPTION
I disabled dome modules that I do not need, this probably makes Ardupilot boot a bit faster.

Can this be the reason that Septentrio AsteRX M2 (fw 4.4.0) does not get detected?

This PR is meat for people that want/need to diagnose this, this is *NOT* meant to be merged to master.