### PR TITLE
AP_OSD: add external baro temperature display

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -101,6 +101,7 @@ private:
     AP_OSD_Setting roll_angle{false, 0, 0};
     AP_OSD_Setting pitch_angle{false, 0, 0};
     AP_OSD_Setting temp{false, 0, 0};
+    AP_OSD_Setting btemp{false, 0, 0};
     AP_OSD_Setting hdop{false, 0, 0};
     AP_OSD_Setting waypoint{false, 0, 0};
     AP_OSD_Setting xtrack_error{false, 0, 0};
@@ -158,6 +159,7 @@ private:
     void draw_roll_angle(uint8_t x, uint8_t y);
     void draw_pitch_angle(uint8_t x, uint8_t y);
     void draw_temp(uint8_t x, uint8_t y);
+    void draw_btemp(uint8_t x, uint8_t y);
     void draw_hdop(uint8_t x, uint8_t y);
     void draw_waypoint(uint8_t x, uint8_t y);
     void draw_xtrack_error(uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -189,6 +189,10 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Group: EFF
     // @Path: AP_OSD_Setting.cpp
     AP_SUBGROUPINFO(eff, "EFF", 36, AP_OSD_Screen, AP_OSD_Setting),
+    
+    // @Group: BTEMP
+    // @Path: AP_OSD_Setting.cpp
+    AP_SUBGROUPINFO(btemp, "BTEMP", 37, AP_OSD_Screen, AP_OSD_Setting),
 
     AP_GROUPEND
 };
@@ -908,6 +912,13 @@ void AP_OSD_Screen::draw_climbeff(uint8_t x, uint8_t y)
     } 
 }
 
+void AP_OSD_Screen::draw_btemp(uint8_t x, uint8_t y)
+{
+    AP_Baro &barometer = AP::baro();
+    float btmp = barometer.get_temperature(1);
+    backend->write(x, y, false, "%3d%c", (int)u_scale(TEMPERATURE, btmp), u_icon(TEMPERATURE));
+}
+
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 void AP_OSD_Screen::draw(void)
@@ -941,6 +952,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(roll_angle);
     DRAW_SETTING(pitch_angle);
     DRAW_SETTING(temp);
+    DRAW_SETTING(btemp);
     DRAW_SETTING(hdop);
     DRAW_SETTING(flightime);
 


### PR DESCRIPTION
adds secondary baro instance's temperature display, making use of the new GND_ options to easily add external baros