### PR TITLE
Copter/Rover: add ability to disarm rudder arming

### DIFF
--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -48,7 +48,7 @@ void Rover::init_rc_out()
 void Rover::rudder_arm_disarm_check()
 {
     // check if arming/disarm using rudder is allowed
-    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
+    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
     if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
         return;
     }

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -47,6 +47,12 @@ void Rover::init_rc_out()
 */
 void Rover::rudder_arm_disarm_check()
 {
+    // check if arming/disarm using rudder is allowed
+    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
+    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
+        return;
+    }
+
     // In Rover we need to check that its set to the throttle trim and within the DZ
     // if throttle is not within trim dz, then pilot cannot rudder arm/disarm
     if (!channel_throttle->in_trim_dz()) {
@@ -79,7 +85,7 @@ void Rover::rudder_arm_disarm_check()
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if (!g2.motors.active()) {
+    } else if ((arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM) && !g2.motors.active()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
         if (channel_steer->get_control_in() < -4000) {
             const uint32_t now = millis();

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -25,20 +25,20 @@ void Copter::arm_motors_check()
         return;
     }
 #endif
-    
+
     // ensure throttle is down
     if (channel_throttle->get_control_in() > 0) {
         arming_counter = 0;
         return;
     }
 
-    int16_t tmp = channel_yaw->get_control_in();
+    int16_t yaw_in = channel_yaw->get_control_in();
 
     // full right
-    if (tmp > 4000) {
+    if (yaw_in > 4000) {
 
         // increase the arming counter to a maximum of 1 beyond the auto trim counter
-        if( arming_counter <= AUTO_TRIM_DELAY ) {
+        if (arming_counter <= AUTO_TRIM_DELAY) {
             arming_counter++;
         }
 
@@ -58,14 +58,14 @@ void Copter::arm_motors_check()
         }
 
     // full left and rudder disarming is enabled
-    } else if ((tmp < -4000) && (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM)) {
+    } else if ((yaw_in < -4000) && (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM)) {
         if (!flightmode->has_manual_throttle() && !ap.land_complete) {
             arming_counter = 0;
             return;
         }
 
         // increase the counter to a maximum of 1 beyond the disarm delay
-        if( arming_counter <= DISARM_DELAY ) {
+        if (arming_counter <= DISARM_DELAY) {
             arming_counter++;
         }
 
@@ -75,7 +75,7 @@ void Copter::arm_motors_check()
         }
 
     // Yaw is centered so reset arming counter
-    }else{
+    } else {
         arming_counter = 0;
     }
 }

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -14,7 +14,7 @@ void Copter::arm_motors_check()
     static int16_t arming_counter;
 
     // check if arming/disarm using rudder is allowed
-    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
+    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
     if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
         return;
     }

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -13,6 +13,12 @@ void Copter::arm_motors_check()
 {
     static int16_t arming_counter;
 
+    // check if arming/disarm using rudder is allowed
+    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
+    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
+        return;
+    }
+
 #if TOY_MODE_ENABLED == ENABLED
     if (g2.toy_mode.enabled()) {
         // not armed with sticks in toy mode
@@ -51,8 +57,8 @@ void Copter::arm_motors_check()
             auto_disarm_begin = millis();
         }
 
-    // full left
-    }else if (tmp < -4000) {
+    // full left and rudder disarming is enabled
+    } else if ((tmp < -4000) && (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM)) {
         if (!flightmode->has_manual_throttle() && !ap.land_complete) {
             arming_counter = 0;
             return;

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -8,12 +8,7 @@ const AP_Param::GroupInfo AP_Arming_Plane::var_info[] = {
     // variables from parent vehicle
     AP_NESTEDGROUPINFO(AP_Arming, 0),
 
-    // @Param: RUDDER
-    // @DisplayName: Rudder Arming
-    // @Description: Control arm/disarm by rudder input. When enabled arming is done with right rudder, disarming with left rudder. Rudder arming only works in manual throttle modes with throttle at zero +- deadzone (RCx_DZ)
-    // @Values: 0:Disabled,1:ArmingOnly,2:ArmOrDisarm
-    // @User: Advanced
-    AP_GROUPINFO("RUDDER",       3,     AP_Arming_Plane,  rudder_arming_value,     ARMING_RUDDER_ARMONLY),
+    // index 3 was RUDDER and should not be used
 
     AP_GROUPEND
 };

--- a/ArduPlane/AP_Arming.h
+++ b/ArduPlane/AP_Arming.h
@@ -14,19 +14,11 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     }
 
-    enum ArmingRudder {
-        ARMING_RUDDER_DISABLED  = 0,
-        ARMING_RUDDER_ARMONLY   = 1,
-        ARMING_RUDDER_ARMDISARM = 2
-    };
-
     /* Do not allow copies */
     AP_Arming_Plane(const AP_Arming_Plane &other) = delete;
     AP_Arming_Plane &operator=(const AP_Arming_Plane&) = delete;
 
     bool pre_arm_checks(bool report);
-
-    ArmingRudder rudder_arming() const { return (ArmingRudder)rudder_arming_value.get(); }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -34,6 +26,4 @@ public:
 protected:
     bool ins_checks(bool report);
 
-    // parameters
-    AP_Int8                 rudder_arming_value;
 };

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1241,7 +1241,7 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_quadplane,         14,      AP_PARAM_FLOAT, "Q_VXY_P" },
     { Parameters::k_param_quadplane,         15,      AP_PARAM_FLOAT, "Q_VZ_P" },
     { Parameters::k_param_quadplane,         16,      AP_PARAM_FLOAT, "Q_AZ_P" },
-    
+
     { Parameters::k_param_land_slope_recalc_shallow_threshold,0,AP_PARAM_FLOAT, "LAND_SLOPE_RCALC" },
     { Parameters::k_param_land_slope_recalc_steep_threshold_to_abort,0,AP_PARAM_FLOAT, "LAND_ABORT_DEG" },
     { Parameters::k_param_land_pitch_cd,      0,      AP_PARAM_INT16, "LAND_PITCH_CD" },
@@ -1257,8 +1257,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_land_flap_percent,  0,      AP_PARAM_INT8,  "LAND_FLAP_PERCENT" },
 
     // battery failsafes
-    { Parameters::k_param_fs_batt_voltage,   0,      AP_PARAM_FLOAT,  "BATT_FS_LOW_VOLT" },
-    { Parameters::k_param_fs_batt_mah,       0,      AP_PARAM_FLOAT,  "BATT_FS_LOW_MAH" },
+    { Parameters::k_param_fs_batt_voltage,    0,      AP_PARAM_FLOAT, "BATT_FS_LOW_VOLT" },
+    { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT, "BATT_FS_LOW_MAH" },
 
     { Parameters::k_param_arming,             3,      AP_PARAM_INT8,  "ARMING_RUDDER" },
 };

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1260,6 +1260,7 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_fs_batt_voltage,   0,      AP_PARAM_FLOAT,  "BATT_FS_LOW_VOLT" },
     { Parameters::k_param_fs_batt_mah,       0,      AP_PARAM_FLOAT,  "BATT_FS_LOW_MAH" },
 
+    { Parameters::k_param_arming,             3,      AP_PARAM_INT8,  "ARMING_RUDDER" },
 };
 
 void Plane::load_parameters(void)

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -106,9 +106,9 @@ void Plane::init_rc_out_aux()
 */
 void Plane::rudder_arm_disarm_check()
 {
-    AP_Arming_Plane::ArmingRudder arming_rudder = arming.rudder_arming();
+    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
 
-    if (arming_rudder == AP_Arming_Plane::ARMING_RUDDER_DISABLED) {
+    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
         //parameter disallows rudder arming/disabling
         return;
     }
@@ -147,7 +147,7 @@ void Plane::rudder_arm_disarm_check()
 			// not at full right rudder
 			rudder_arm_timer = 0;
 		}
-	} else if (arming_rudder == AP_Arming_Plane::ARMING_RUDDER_ARMDISARM && !is_flying()) {
+	} else if ((arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM) && !is_flying()) {
 		// when armed and not flying, full left rudder starts disarming counter
 		if (channel_rudder->get_control_in() < -4000) {
 			uint32_t now = millis();

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -106,7 +106,7 @@ void Plane::init_rc_out_aux()
 */
 void Plane::rudder_arm_disarm_check()
 {
-    AP_Arming::ArmingRudder arming_rudder = arming.rudder_arming();
+    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
 
     if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
         //parameter disallows rudder arming/disabling

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -26,6 +26,12 @@
 #define AP_ARMING_ACCEL_ERROR_THRESHOLD 0.75f
 #define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS
 
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+  #define ARMING_RUDDER_DEFAULT         ARMING_RUDDER_ARMONLY
+#else
+  #define ARMING_RUDDER_DEFAULT         ARMING_RUDDER_ARMDISARM
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_Arming::var_info[] = {
@@ -73,6 +79,16 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("VOLT2_MIN",     5,     AP_Arming,  _min_voltage[1],  0),
 
+    // @Param: RUDDER
+    // @DisplayName: Arming with Rudder enable/disable
+    // @Description: Allow arm/disarm by rudder input. When enabled arming can be done with right rudder, disarming with left rudder. Rudder arming only works in manual throttle modes with throttle at zero +- deadzone (RCx_DZ)
+    // @Values: 0:Disabled,1:ArmingOnly,2:ArmOrDisarm
+    // @User: Advanced
+    AP_GROUPINFO_FRAME("RUDDER",  6,     AP_Arming, _rudder_arming, ARMING_RUDDER_DEFAULT, AP_PARAM_FRAME_PLANE |
+                                                                                           AP_PARAM_FRAME_ROVER |
+                                                                                           AP_PARAM_FRAME_COPTER |
+                                                                                           AP_PARAM_FRAME_TRICOPTER |
+                                                                                           AP_PARAM_FRAME_HELI),
     AP_GROUPEND
 };
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -73,7 +73,7 @@ public:
         ARMING_RUDDER_ARMONLY   = 1,
         ARMING_RUDDER_ARMDISARM = 2
     };
-    ArmingRudder rudder_arming() const { return (ArmingRudder)_rudder_arming.get(); }
+    ArmingRudder get_rudder_arming_type() const { return (ArmingRudder)_rudder_arming.get(); }
 
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -56,7 +56,6 @@ public:
     // get bitmask of enabled checks
     uint16_t get_enabled_checks();
 
-
     // pre_arm_checks() is virtual so it can be modified in a vehicle specific subclass
     virtual bool pre_arm_checks(bool report);
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -68,6 +68,14 @@ public:
     // get expected magnetic field strength
     uint16_t compass_magfield_expected() const;
 
+    // rudder arming support
+    enum ArmingRudder {
+        ARMING_RUDDER_DISABLED  = 0,
+        ARMING_RUDDER_ARMONLY   = 1,
+        ARMING_RUDDER_ARMDISARM = 2
+    };
+    ArmingRudder rudder_arming() const { return (ArmingRudder)_rudder_arming.get(); }
+
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
@@ -77,6 +85,7 @@ protected:
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Float                _min_voltage[AP_BATT_MONITOR_MAX_INSTANCES];
+    AP_Int8                 _rudder_arming;
 
     // internal members
     bool                    armed:1;


### PR DESCRIPTION
This PR allows arming and/or disarming via the sticks to be disabled.  This has been requested by both by the TradHeli maintainers (@ChristopherOlson, @bnsgeyer) and also by @IamPete1 who is working on Rover's sailboat support.

In particular this PR makes the following changes:

- moves the ARMING_RUDDER parameter from Plane up to the AP_Arming class so that it can be used by Copter and Rover.
- Parameter conversion for Plane so that the old ARMING_RUDDER parameter value is copied to the new location.  @tridge I'm surprised the way I've done this works so I would like to check with you.
- some minor formatting fixes

This PR does not affect Sub or Tracker.

This has been tested on Plane, Rover and Copter on a Pixhawk1 flight controller.  For the test I set the ARMING_RUDDER parameter to 0, 1 and 2 and tested that I was able to arming from the sticks (or not) as defined by the parameter description.