### PR TITLE
Plane: update servo.cpp - crow brakes- diff. spoilers

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1194,6 +1194,22 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AP_LandingGear/AP_LandingGear.cpp
     AP_SUBGROUPINFO(landing_gear, "LGR_", 16, ParametersG2, AP_LandingGear),
 #endif
+
+    // @Param: DSPOILER_CROW_W1
+    // @DisplayName: Differential spoiler crow flaps inner weight
+    // @Description: This is amount of deflection applied to the two inner surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 25.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("DSPOILER_CROW_W1", 17, ParametersG2, crow_flap_weight1, 0),
+
+    // @Param: DSPOILER_CROW_W2
+    // @DisplayName: Differential spoiler crow flaps outer weight
+    // @Description: This is amount of deflection applied to the two outer  surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 45.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("DSPOILER_CROW_W2", 18, ParametersG2, crow_flap_weight2, 0),
     
     AP_GROUPEND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -555,6 +555,10 @@ public:
 #if LANDING_GEAR_ENABLED == ENABLED
     AP_LandingGear landing_gear;
 #endif
+
+    // crow flaps weighting
+    AP_Int8 crow_flap_weight1;
+    AP_Int8 crow_flap_weight2;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -205,15 +205,24 @@ void Plane::dspoiler_update(void)
     float dspoiler2_left = elevon_left;
     float dspoiler1_right = elevon_right;
     float dspoiler2_right = elevon_right;
+    RC_Channel *flapin = RC_Channels::rc_channel(g.flapin_channel-1);
+	int8_t flap_percent = flapin->percent_input();;
     if (rudder > 0) {
         // apply rudder to right wing
         dspoiler1_right = constrain_float(elevon_right + rudder, -4500, 4500);
         dspoiler2_right = constrain_float(elevon_right - rudder, -4500, 4500);
     } else {
         // apply rudder to left wing
-        dspoiler1_left = constrain_float(elevon_left + rudder, -4500, 4500);
-        dspoiler2_left = constrain_float(elevon_left - rudder, -4500, 4500);
+        dspoiler1_left = constrain_float(elevon_left - rudder, -4500, 4500);
+        dspoiler2_left = constrain_float(elevon_left + rudder, -4500, 4500);
     }
+	if (flap_percent > 0) {
+		//apply crow brakes to both wings
+	    dspoiler1_left = constrain_float(elevon_left + flap_percent * 25, -4500, 4500);
+        dspoiler2_left = constrain_float(elevon_left - flap_percent * 45, -4500, 4500);
+	    dspoiler1_right = constrain_float(elevon_right + flap_percent * 25, -4500, 4500);
+        dspoiler2_right = constrain_float(elevon_right - flap_percent * 45, -4500, 4500); 
+	}
     SRV_Channels::set_output_scaled(SRV_Channel::k_dspoilerLeft1, dspoiler1_left);
     SRV_Channels::set_output_scaled(SRV_Channel::k_dspoilerLeft2, dspoiler2_left);
     SRV_Channels::set_output_scaled(SRV_Channel::k_dspoilerRight1, dspoiler1_right);


### PR DESCRIPTION
added crow braking via flap channel to differential spoilers and reversed dspoiler outputs because having the inner elevon go up and outer go down causes tip stall. now inner goes down, outer goes up. still could use a percentage adjustment to change how much throw each surface gets when using flap input.