### PR TITLE
Rover: fix limiting of turn rate using PIVOT_TURN_RATE

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -446,14 +446,15 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
 }
 
 // calculate steering output to drive towards desired heading
-void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max, bool reversed)
+// rate_max is a maximum turn rate in deg/s.  set to zero to use default turn rate limits
+void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max_degs)
 {
     // calculate yaw error so it can be used for reporting and slowing the vehicle
     _yaw_error_cd = wrap_180_cd(desired_heading_cd - ahrs.yaw_sensor);
 
     // call heading controller
     const float steering_out = attitude_control.get_steering_out_heading(radians(desired_heading_cd*0.01f),
-                                                                         rate_max,
+                                                                         radians(rate_max_degs),
                                                                          g2.motors.limit.steer_left,
                                                                          g2.motors.limit.steer_right,
                                                                          rover.G_Dt);

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -141,7 +141,8 @@ protected:
     void calc_steering_from_lateral_acceleration(float lat_accel, bool reversed = false);
 
     // calculate steering output to drive towards desired heading
-    void calc_steering_to_heading(float desired_heading_cd, float rate_max, bool reversed = false);
+    // rate_max is a maximum turn rate in deg/s.  set to zero to use default turn rate limits
+    void calc_steering_to_heading(float desired_heading_cd, float rate_max_degs = 0.0f);
 
     // calculates the amount of throttle that should be output based
     // on things like proximity to corners and current speed

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -65,7 +65,7 @@ void ModeAuto::update()
         {
             if (!_reached_heading) {
                 // run steering and throttle controllers
-                calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
+                calc_steering_to_heading(_desired_yaw_cd);
                 calc_throttle(_desired_speed, true, false);
                 // check if we have reached within 5 degrees of target
                 _reached_heading = (fabsf(_desired_yaw_cd - ahrs.yaw_sensor) < 500);

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -68,6 +68,6 @@ void ModeFollow::update()
     _desired_yaw_cd = wrap_180_cd(atan2f(desired_velocity_ne.y, desired_velocity_ne.x) * DEGX100);
 
     // run steering and throttle controllers
-    calc_steering_to_heading(_desired_yaw_cd, desired_speed < 0);
+    calc_steering_to_heading(_desired_yaw_cd);
     calc_throttle(calc_reduced_speed_for_turn_or_distance(desired_speed), false, true);
 }

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -45,7 +45,7 @@ void ModeGuided::update()
             }
             if (have_attitude_target) {
                 // run steering and throttle controllers
-                calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
+                calc_steering_to_heading(_desired_yaw_cd);
                 calc_throttle(calc_reduced_speed_for_turn_or_distance(_desired_speed), true, true);
             } else {
                 stop_vehicle();

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -49,6 +49,6 @@ void ModeLoiter::update()
     }
 
     // run steering and throttle controllers
-    calc_steering_to_heading(_desired_yaw_cd, _desired_speed < 0);
+    calc_steering_to_heading(_desired_yaw_cd);
     calc_throttle(_desired_speed, false, true);
 }

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -264,7 +264,9 @@ float AR_AttitudeControl::get_steering_out_lat_accel(float desired_accel, bool m
 }
 
 // return a steering servo output from -1 to +1 given a heading in radians
-float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right, float dt)
+// set rate_max_rads to a non-zero number to apply a limit on the desired turn rate
+// return value is normally in range -1.0 to +1.0 but can be higher or lower
+float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate_max_rads, bool motor_limit_left, bool motor_limit_right, float dt)
 {
     // calculate heading error (in radians)
     const float yaw_error = wrap_PI(heading_rad - _ahrs.yaw);
@@ -272,8 +274,8 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
     float desired_rate = _steer_angle_p.get_p(yaw_error);
     // limit desired_rate if a custom pivot turn rate is selected, otherwise use ATC_STR_RAT_MAX
-    if (is_positive(rate_max)) {
-        desired_rate = constrain_float(desired_rate, -rate_max, rate_max);
+    if (is_positive(rate_max_rads)) {
+        desired_rate = constrain_float(desired_rate, -rate_max_rads, rate_max_rads);
     }
 
     return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right, dt);

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -55,8 +55,9 @@ public:
     float get_steering_out_lat_accel(float desired_accel, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // return a steering servo output given a heading in radians
+    // set rate_max_rads to a non-zero number to apply a limit on the desired turn rate
     // return value is normally in range -1.0 to +1.0 but can be higher or lower
-    float get_steering_out_heading(float heading_rad, float rate_max, bool motor_limit_left, bool motor_limit_right, float dt);
+    float get_steering_out_heading(float heading_rad, float rate_max_rads, bool motor_limit_left, bool motor_limit_right, float dt);
 
     // return a steering servo output given a desired yaw rate in radians/sec.
     // positive yaw is to the right


### PR DESCRIPTION
This PR fixes a bug in the use of the PIVOT_TURN_RATE parameter caused by a mix-up in deg/s vs rad/s between the vehicle code (which uses deg/s) and the AR_AttitudeControl library (which uses rad/s).

To hopefully protect against this a little bit, the argument names have been modified to include the units.

Below are some pictures showing how **before** the PIVOT_TURN_RATE (set to 10deg/sec) was not being applied but **after** it is.
![pivot-turn-rate-fix-graph](https://user-images.githubusercontent.com/1498098/45284701-22a8ce00-b51c-11e8-9dab-bf951fe59e7d.png)

This was tested in SITL using a simple triangular shaped mission.
![pivot-turn-rate-fix](https://user-images.githubusercontent.com/1498098/45284718-2a687280-b51c-11e8-96fc-0a7b8e1af20b.png)


