### PR TITLE
AP_HAL: fix RCOutput, RCOutput2 and RCInputToRCOutput examples to pre…

### DIFF
--- a/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
@@ -2,9 +2,19 @@
     RC input pass trough to RC output
     Max RC channels 14
     Max update rate 10 Hz
+    Attention: If your board has safety switch,
+    don't forget to push it to enable the PWM output.
 */
 
 #include <AP_HAL/AP_HAL.h>
+
+// we need a boardconfig created so that the io processor's enable
+// parameter is available
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_IOMCU/AP_IOMCU.h>
+AP_BoardConfig BoardConfig;
+#endif
 
 void setup();
 void loop();
@@ -20,6 +30,9 @@ void setup(void)
 {
     hal.console->printf("Starting RCInputToRCOutput test\n");
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    BoardConfig.init();
+#endif
     for (uint8_t i = 0; i < MAX_CHANNELS; i++) {
         hal.rcout->enable_ch(i);
     }

--- a/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput/RCOutput.cpp
@@ -1,8 +1,18 @@
 /*
   simple test of RC output interface
+  Attention: If your board has safety switch,
+  don't forget to push it to enable the PWM output.
  */
 
 #include <AP_HAL/AP_HAL.h>
+
+// we need a boardconfig created so that the io processor's enable
+// parameter is available
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_IOMCU/AP_IOMCU.h>
+AP_BoardConfig BoardConfig;
+#endif
 
 void setup();
 void loop();
@@ -12,6 +22,9 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 void setup (void)
 {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    BoardConfig.init();
+#endif
     for (uint8_t i = 0; i< 14; i++) {
         hal.rcout->enable_ch(i);
     }
@@ -27,10 +40,10 @@ void loop (void)
         pwm += delta;
         if (delta > 0 && pwm >= 2000) {
             delta = -1;
-            hal.console->printf("reversing\n");
+            hal.console->printf("decreasing\n");
         } else if (delta < 0 && pwm <= 1000) {
             delta = 1;
-            hal.console->printf("reversing\n");
+            hal.console->printf("increasing\n");
         }
     }
     hal.scheduler->delay(5);

--- a/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCOutput2/RCOutput.cpp
@@ -1,10 +1,20 @@
 /*
   Simple test of RC output interface with Menu
+  Attention: If your board has safety switch,
+  don't forget to push it to enable the PWM output.
 */
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Menu/AP_Menu.h>
+
+// we need a boardconfig created so that the io processor's enable
+// parameter is available
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_IOMCU/AP_IOMCU.h>
+AP_BoardConfig BoardConfig;
+#endif
 
 void setup();
 void loop();
@@ -78,6 +88,9 @@ MENU(menu, "Menu: ", rcoutput_menu_commands);
 void setup(void) {
     hal.console->printf("Starting AP_HAL::RCOutput test\n");
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    BoardConfig.init();
+#endif
     for (uint8_t i = 0; i < 14; i++) {
         hal.rcout->enable_ch(i);
     }


### PR DESCRIPTION
AP_HAL: fix RCOutput, RCOutput2 and RCInputToRCOutput examples to prevent the failure of reading and writing channels.