### PR TITLE
AP_Math: header and const cleanup

### DIFF
--- a/libraries/AP_Math/AP_GeodesicGrid.cpp
+++ b/libraries/AP_Math/AP_GeodesicGrid.cpp
@@ -101,7 +101,7 @@
  *  by the non-zero coefficient.
  */
 
-#include <assert.h>
+#include <cassert>
 
 #include "AP_GeodesicGrid.h"
 

--- a/libraries/AP_Math/AP_GeodesicGrid.h
+++ b/libraries/AP_Math/AP_GeodesicGrid.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include "AP_Math.h"
 
 /**

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -1,7 +1,5 @@
 #include "AP_Math.h"
 
-#include <float.h>
-
 /*
  * is_equal(): Integer implementation, provided for convenience and
  * compatibility with old code. Expands to the same as comparing the values

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -2,7 +2,8 @@
 
 #include <cmath>
 #include <limits>
-#include <stdint.h>
+#include <cstdint>
+#include <cfloat>
 #include <type_traits>
 
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -16,7 +16,6 @@
   collection of CRCs. 
  */
 
-#include <stdint.h>
 #include "crc.h"
 
 static const uint8_t crc8_table[] = {

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -48,11 +48,10 @@ static const uint8_t crc8_table[] = {
  */
 uint8_t crc_crc8(const uint8_t *p, uint8_t len)
 {
-	uint16_t i;
 	uint16_t crc = 0x0;
 
 	while (len--) {
-		i = (crc ^ *p++) & 0xFF;
+		const uint16_t i = (crc ^ *p++) & 0xFF;
 		crc = (crc8_table[i] ^ (crc << 8)) & 0xFF;
 	}
 

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -15,8 +15,11 @@
 /*
   interfaces to ArduPilot collection of CRCs. 
  */
+#pragma once
+
+#include <cstdint>
 
 uint8_t crc_crc8(const uint8_t *p, uint8_t len);
 uint16_t crc_xmodem_update(uint16_t crc, uint8_t data);
-uint16_t crc_xmodem(const uint8_t *b, uint16_t len);
+uint16_t crc_xmodem(const uint8_t *data, uint16_t len);
 uint32_t crc_crc32(uint32_t crc, const uint8_t *buf, uint32_t size);

--- a/libraries/AP_Math/edc.h
+++ b/libraries/AP_Math/edc.h
@@ -17,6 +17,6 @@
 // Contact: Fergus Noble <fergus@swift-nav.com>
 #pragma once
 
-#include <inttypes.h>
+#include <cstdint>
 
 uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);

--- a/libraries/AP_Math/examples/matrix_alg/matrix_alg.cpp
+++ b/libraries/AP_Math/examples/matrix_alg/matrix_alg.cpp
@@ -4,7 +4,8 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <stdio.h>
+#include <cstdio>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 #define MAT_ALG_ACCURACY    1e-4f

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -20,7 +20,8 @@
  *  this module deals with calculations involving struct Location
  */
 #include <AP_HAL/AP_HAL.h>
-#include <stdlib.h>
+#include <cstdlib>
+#include <cmath>
 #include "AP_Math.h"
 #include "location.h"
 

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cstdint>
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>

--- a/libraries/AP_Math/location_double.cpp
+++ b/libraries/AP_Math/location_double.cpp
@@ -22,7 +22,7 @@
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 
 #include <AP_HAL/AP_HAL.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include "AP_Math.h"
 #include "location.h"
 

--- a/libraries/AP_Math/matrix3.cpp
+++ b/libraries/AP_Math/matrix3.cpp
@@ -114,17 +114,9 @@ void Matrix3<T>::from_euler312(float roll, float pitch, float yaw)
 template <typename T>
 void Matrix3<T>::rotate(const Vector3<T> &g)
 {
-    Matrix3<T> temp_matrix;
-    temp_matrix.a.x = a.y * g.z - a.z * g.y;
-    temp_matrix.a.y = a.z * g.x - a.x * g.z;
-    temp_matrix.a.z = a.x * g.y - a.y * g.x;
-    temp_matrix.b.x = b.y * g.z - b.z * g.y;
-    temp_matrix.b.y = b.z * g.x - b.x * g.z;
-    temp_matrix.b.z = b.x * g.y - b.y * g.x;
-    temp_matrix.c.x = c.y * g.z - c.z * g.y;
-    temp_matrix.c.y = c.z * g.x - c.x * g.z;
-    temp_matrix.c.z = c.x * g.y - c.y * g.x;
-
+    const Matrix3<T> temp_matrix(a.y * g.z - a.z * g.y, a.z * g.x - a.x * g.z, a.x * g.y - a.y * g.x,
+                                 b.y * g.z - b.z * g.y, b.z * g.x - b.x * g.z, b.x * g.y - b.y * g.x,
+                                 c.y * g.z - c.z * g.y, c.z * g.x - c.x * g.z, c.x * g.y - c.y * g.x);
     (*this) += temp_matrix;
 }
 

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -37,7 +37,9 @@
 //
 #pragma once
 
+#include <cstdint>
 #include "vector3.h"
+#include "vector2.h"
 
 // 3x3 matrix with elements of type T
 template <typename T>

--- a/libraries/AP_Math/matrixN.h
+++ b/libraries/AP_Math/matrixN.h
@@ -43,6 +43,6 @@ public:
     // Matrix symmetry routine
     void force_symmetry(void);
 
-private:
     T v[N][N];
+private:
 };

--- a/libraries/AP_Math/matrixN.h
+++ b/libraries/AP_Math/matrixN.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "math.h"
-#include <stdint.h>
+#include <cmath>
+#include <cstdint>
 #include "vectorN.h"
 
 template <typename T, uint8_t N>

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -19,9 +19,9 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#include <stdio.h>
+#include <cstdio>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#include <fenv.h>
+#include <cfenv>
 #endif
 
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -21,7 +21,9 @@
 #if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif
-#include <math.h>
+#include <cstdint>
+#include "matrix3.h"
+#include "vector3.h"
 
 class Quaternion {
 public:

--- a/libraries/AP_Math/rotations.h
+++ b/libraries/AP_Math/rotations.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <cstdint>
 // these rotations form a full set - every rotation in the following
 // list when combined with another in the list forms an entry which is
 // also in the list. This is an important property. Please run the

--- a/libraries/AP_Math/spline5.cpp
+++ b/libraries/AP_Math/spline5.cpp
@@ -21,7 +21,7 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
+#include <cstdint>
 #include "spline5.h"
 
 void splinterp5(const float x[5], float out[4][4])

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -24,12 +24,15 @@
 *          18-12-2003
 *          06-06-2004
 *
-* © 2003, This code is provided "as is" and you can use it freely as long as
+* Copyright 2003, This code is provided "as is" and you can use it freely as long as
 * credit is given to Bill Perone in the application it is used in
 ****************************************/
 #pragma once
 
 #include <cmath>
+#include <cstdint>
+#include <cfloat>
+
 #if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -20,7 +20,7 @@
 
 #include "AP_Math.h"
 
-#define HALF_SQRT_2 0.70710678118654757f
+static const float HALF_SQRT_2 = 0.70710678118654757f;
 
 // rotate a vector by a standard rotation, attempting
 // to use the minimum number of floating point operations

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -48,8 +48,10 @@
 #pragma once
 
 #include <cmath>
-#include <float.h>
-#include <string.h>
+#include <cstdint>
+#include <cfloat>
+#include <cstring>
+
 #if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <cmath>
-#include <string.h>
+#include <cstring>
 #include "matrixN.h"
 
 #ifndef MATH_CHECK_INDEXES


### PR DESCRIPTION
This PR intend to include the right header in the right place.
It unifies the header include by using c++ version instead of mixing both C and C++ one's
Solve an access error on a private variable
Const local variable
Correct some scope and assignement

Size is unchanged on fmuv3, on SITL debug f26b60a take a little more space