### PR TITLE
AP_Compass: add support for IST8308

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -54,7 +54,8 @@ compass_types = {
     0x0C : "DEVTYPE_MMC3416",
     0x0D : "DEVTYPE_QMC5883L",
     0x0E : "DEVTYPE_MAG3110",
-    0x0F : "DEVTYPE_SITL"
+    0x0F : "DEVTYPE_SITL",
+    0x10 : "DEVTYPE_IST8308",
 }
 
 imu_types = {

--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -9,6 +9,13 @@ the sensor library, such as libraries/AP_Compass/AP_Compass_Backend.h
 import sys
 import optparse
 
+def num(s):
+    try:
+        return int(s)
+    except ValueError:
+        return int(s, 16)
+
+
 parser = optparse.OptionParser("decode_devid.py")
 parser.add_option("-C", "--compass", action='store_true', help='decode compass IDs')
 parser.add_option("-I", "--imu", action='store_true', help='decode IMU IDs')
@@ -19,7 +26,7 @@ if len(args) == 0:
     print("Please supply a device ID")
     sys.exit(1)
 
-devid=int(args[0])
+devid=num(args[0])
 
 bus_type=devid & 0x07
 bus=(devid>>3) & 0x1F

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -437,7 +437,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Param: TYPEMASK
     // @DisplayName: Compass disable driver type mask
     // @Description: This is a bitmask of driver types to disable. If a driver type is set in this mask then that driver will not try to find a sensor at startup
-    // @Bitmask: 0:HMC5883,1:LSM303D,2:AK8963,3:BMM150,4:LSM9DS1,5:LIS3MDL,6:AK09916,7:IST8310,8:ICM20948,9:MMC3416,11:UAVCAN,12:QMC5883
+    // @Bitmask: 0:HMC5883,1:LSM303D,2:AK8963,3:BMM150,4:LSM9DS1,5:LIS3MDL,6:AK09916,7:IST8310,8:ICM20948,9:MMC3416,11:UAVCAN,12:QMC5883,14:MAG3110,15:IST8308
     // @User: Advanced
     AP_GROUPINFO("TYPEMASK", 33, Compass, _driver_type_mask, 0),
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -11,6 +11,7 @@
 #include "AP_Compass_BMM150.h"
 #include "AP_Compass_HIL.h"
 #include "AP_Compass_HMC5843.h"
+#include "AP_Compass_IST8308.h"
 #include "AP_Compass_IST8310.h"
 #include "AP_Compass_LSM303D.h"
 #include "AP_Compass_LSM9DS1.h"
@@ -680,6 +681,12 @@ void Compass::_probe_external_i2c_compasses(void)
             ADD_BACKEND(DRIVER_IST8310, AP_Compass_IST8310::probe(GET_I2C_DEVICE(i, HAL_COMPASS_IST8310_I2C_ADDR),
                                                                   all_external, default_rotation));
         }
+    }
+
+    // external i2c bus
+    FOREACH_I2C_EXTERNAL(i) {
+        ADD_BACKEND(DRIVER_IST8308, AP_Compass_IST8308::probe(GET_I2C_DEVICE(i, HAL_COMPASS_IST8308_I2C_ADDR),
+                                                              true, ROTATION_NONE));
     }
 #endif // HAL_MINIMIZE_FEATURES
 }

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -378,6 +378,7 @@ private:
         DRIVER_QMC5883  =12,
         DRIVER_SITL     =13,
         DRIVER_MAG3110  =14,
+        DRIVER_IST8308  = 15,
     };
 
     bool _driver_enabled(enum DriverType driver_type);

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -57,6 +57,7 @@ public:
         DEVTYPE_QMC5883L = 0x0D,
         DEVTYPE_MAG3110  = 0x0E,
         DEVTYPE_SITL  = 0x0F,
+        DEVTYPE_IST8308 = 0x10,
     };
 
 

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2018  Lucas De Marchi. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "AP_Compass_IST8308.h"
+
+#include <stdio.h>
+#include <utility>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/sparse-endian.h>
+#include <AP_Math/AP_Math.h>
+
+#define WAI_REG 0x0
+#define DEVICE_ID 0x08
+
+#define STAT1_REG 0x10
+#define STAT1_VAL_DRDY 0x1
+#define STAT1_VAL_DOR 0x2
+
+#define DATAX_L_REG 0x11
+#define DATAX_H_REG 0x12
+#define DATAY_L_REG 0x13
+#define DATAY_H_REG 0x14
+#define DATAZ_L_REG 0x15
+#define DATAZ_H_REG 0x16
+
+#define CNTL1_REG 0x30
+
+#define CNTL2_REG 0x31
+#define CNTL2_VAL_STANDBY_MODE      0x0
+#define CNTL2_VAL_SINGLE_MODE       0x1
+#define CNTL2_VAL_CONT_ODR10_MODE   0x2
+#define CNTL2_VAL_CONT_ODR20_MODE   0x4
+#define CNTL2_VAL_CONT_ODR50_MODE   0x6
+#define CNTL2_VAL_CONT_ODR100_MODE  0x8
+#define CNTL2_VAL_CONT_ODR200_MODE  0xA
+#define CNTL2_VAL_CONT_ODR8_MODE    0xB
+#define CNTL2_VAL_CONT_ODR1_MODE    0xC
+#define CNTL2_VAL_CONT_ODR0P5_MODE  0xD
+#define CNTL2_VAL_SINGLE_TEST_MODE  0x10
+
+#define CNTL3_REG 0x32
+#define CNTL3_VAL_SRST 1
+#define CNTL3_VAL_DRDY_POLARITY_HIGH (1 << 2)
+#define CNTL3_VAL_DRDY_EN (1 << 3)
+
+#define CNTL4_REG 0x34
+#define CNTL4_VAL_DYNAMIC_RANGE_500 0
+#define CNTL4_VAL_DYNAMIC_RANGE_200 0x1
+
+#define OSRCNTL_REG 0x41
+#define OSRCNTL_VAL_XZ_1  (0)
+#define OSRCNTL_VAL_XZ_2  (1)
+#define OSRCNTL_VAL_XZ_4  (2)
+#define OSRCNTL_VAL_XZ_8  (3)
+#define OSRCNTL_VAL_XZ_16 (4)
+#define OSRCNTL_VAL_XZ_32 (4)
+#define OSRCNTL_VAL_Y_1  (0 << 3)
+#define OSRCNTL_VAL_Y_2  (1 << 3)
+#define OSRCNTL_VAL_Y_4  (2 << 3)
+#define OSRCNTL_VAL_Y_8  (3 << 3)
+#define OSRCNTL_VAL_Y_16 (4 << 3)
+#define OSRCNTL_VAL_Y_32 (5 << 3)
+
+#define SAMPLING_PERIOD_USEC (10 * AP_USEC_PER_MSEC)
+
+extern const AP_HAL::HAL &hal;
+
+AP_Compass_Backend *AP_Compass_IST8308::probe(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                              bool force_external,
+                                              enum Rotation rotation)
+{
+    if (!dev) {
+        return nullptr;
+    }
+
+    AP_Compass_IST8308 *sensor = new AP_Compass_IST8308(std::move(dev), force_external, rotation);
+    if (!sensor || !sensor->init()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
+AP_Compass_IST8308::AP_Compass_IST8308(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                       bool force_external,
+                                       enum Rotation rotation)
+    : _dev(std::move(dev))
+    , _rotation(rotation)
+    , _force_external(force_external)
+{
+}
+
+bool AP_Compass_IST8308::init()
+{
+    uint8_t reset_count = 0;
+
+    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        return false;
+    }
+
+    // high retries for init
+    _dev->set_retries(10);
+
+    uint8_t whoami;
+    if (!_dev->read_registers(WAI_REG, &whoami, 1) ||
+        whoami != DEVICE_ID) {
+        // not an IST8308
+        goto fail;
+    }
+
+    for (; reset_count < 5; reset_count++) {
+        if (!_dev->write_register(CNTL3_REG, CNTL3_VAL_SRST)) {
+            hal.scheduler->delay(10);
+            continue;
+        }
+
+        hal.scheduler->delay(20);
+
+        uint8_t cntl3 = 0xFF;
+        if (_dev->read_registers(CNTL3_REG, &cntl3, 1) &&
+            (cntl3 & 0x01) == 0) {
+            break;
+        }
+    }
+
+    if (reset_count == 5) {
+        printf("IST8308: failed to reset device\n");
+        goto fail;
+    }
+
+    // DRDY enabled
+    // Dynamic Range=±500 uT, Sensitivity=6.6 LSB/uT
+    // OSR 16 (max 100Hz)
+    // Start continuous mode at 100Hz
+    if (!_dev->write_register(CNTL3_REG, CNTL3_VAL_DRDY_EN) ||
+        !_dev->write_register(CNTL4_REG, CNTL4_VAL_DYNAMIC_RANGE_500) ||
+        !_dev->write_register(OSRCNTL_REG, OSRCNTL_VAL_Y_16 | OSRCNTL_VAL_XZ_16) ||
+        !_dev->write_register(CNTL2_REG, CNTL2_VAL_CONT_ODR100_MODE)) {
+        printf("IST8308: found device but could not set it up\n");
+        goto fail;
+    }
+
+    // lower retries for run
+    _dev->set_retries(3);
+
+    _dev->get_semaphore()->give();
+
+    _instance = register_compass();
+
+    printf("%s found on bus %u id %u address 0x%02x\n", name,
+           _dev->bus_num(), _dev->get_bus_id(), _dev->get_bus_address());
+
+    set_rotation(_instance, _rotation);
+
+    _dev->set_device_type(DEVTYPE_IST8308);
+    set_dev_id(_instance, _dev->get_bus_id());
+
+    if (_force_external) {
+        set_external(_instance, true);
+    }
+
+    _dev->register_periodic_callback(SAMPLING_PERIOD_USEC,
+                                     FUNCTOR_BIND_MEMBER(&AP_Compass_IST8308::timer, void));
+
+    _perf_xfer_err = hal.util->perf_alloc(AP_HAL::Util::PC_COUNT, "IST8308_xfer_err");
+
+    return true;
+
+fail:
+    _dev->get_semaphore()->give();
+    return false;
+}
+
+void AP_Compass_IST8308::timer()
+{
+    struct PACKED {
+        le16_t rx;
+        le16_t ry;
+        le16_t rz;
+    } buffer;
+    uint8_t stat;
+
+    if (!_dev->read_registers(STAT1_REG, &stat, 1) ||
+        !(stat & STAT1_VAL_DRDY)) {
+        hal.util->perf_count(_perf_xfer_err);
+        return;
+    }
+
+    if (stat & STAT1_VAL_DOR) {
+        printf("IST8308: data overrun\n");
+    }
+
+    if (!_dev->read_registers(DATAX_L_REG, (uint8_t *) &buffer,
+                              sizeof(buffer))) {
+        hal.util->perf_count(_perf_xfer_err);
+        return;
+    }
+
+    auto x = static_cast<int16_t>(le16toh(buffer.rx));
+    auto y = static_cast<int16_t>(le16toh(buffer.ry));
+    auto z = static_cast<int16_t>(le16toh(buffer.rz));
+
+    // flip Z to conform to right-hand rule convention
+    z = -z;
+
+    /* Resolution: 0.1515 µT/LSB - already convert to milligauss */
+    Vector3f field = Vector3f{x * 1.515f, y * 1.515f, z * 1.515f};
+
+    accumulate_sample(field, _instance);
+}
+
+void AP_Compass_IST8308::read()
+{
+    drain_accumulated_samples(_instance);
+}

--- a/libraries/AP_Compass/AP_Compass_IST8308.h
+++ b/libraries/AP_Compass/AP_Compass_IST8308.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018  Lucas De Marchi. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/I2CDevice.h>
+#include <AP_Math/AP_Math.h>
+
+#include "AP_Compass.h"
+#include "AP_Compass_Backend.h"
+
+#ifndef HAL_COMPASS_IST8308_I2C_ADDR
+#define HAL_COMPASS_IST8308_I2C_ADDR 0x0C
+#endif
+
+class AP_Compass_IST8308 : public AP_Compass_Backend
+{
+public:
+    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
+                                     bool force_external = false,
+                                     enum Rotation rotation = ROTATION_NONE);
+
+    void read() override;
+
+    static constexpr const char *name = "IST8308";
+
+private:
+    AP_Compass_IST8308(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                       bool force_external,
+                       enum Rotation rotation);
+
+    void timer();
+    bool init();
+
+    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Util::perf_counter_t _perf_xfer_err;
+
+    enum Rotation _rotation;
+    uint8_t _instance;
+    bool _force_external;
+};


### PR DESCRIPTION
This is  bench tested on Linux boards and working fine (changes for the Linux boards are not here). Its register map is different enough from IST8310 to deserve a new implementation. It also has a continuous mode that is used here so we don't need to keep asking it for a new measurement.