### PR TITLE
ChibiOS: implement set_failsafe_pwm()

### DIFF
--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -26,9 +26,17 @@ void AP_AdvancedFailsafe_Plane::terminate_vehicle(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, SERVO_MAX);
         SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, SERVO_MAX);
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, SERVO_MAX);
-        SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
-        SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
-        SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        if (plane.aparm.throttle_min < 0) {
+            // configured for reverse thrust, use TRIM
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        } else {
+            // use MIN
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+            SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        }
         SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     }
@@ -49,9 +57,17 @@ void AP_AdvancedFailsafe_Plane::setup_IO_failsafe(void)
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_aileron, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_rudder, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_elevator, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
-    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
-    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
-    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+    if (plane.aparm.throttle_min < 0) {
+        // configured for reverse thrust, use TRIM
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
+    } else {
+        // normal throttle, use MIN
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+    }
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
 

--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -27,6 +27,8 @@ void AP_AdvancedFailsafe_Plane::terminate_vehicle(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, SERVO_MAX);
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, SERVO_MAX);
         SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+        SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
         SRV_Channels::set_output_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
         SRV_Channels::set_output_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     }
@@ -47,6 +49,9 @@ void AP_AdvancedFailsafe_Plane::setup_IO_failsafe(void)
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_aileron, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_rudder, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_elevator, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
+    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+    SRV_Channels::set_failsafe_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_manual, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
     SRV_Channels::set_failsafe_limit(SRV_Channel::k_none, SRV_Channel::SRV_CHANNEL_LIMIT_TRIM);
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -491,6 +491,11 @@ void Plane::servos_twin_engine_mix(void)
     float rud_gain = float(plane.g2.rudd_dt_gain) / 100;
     float rudder = rud_gain * SRV_Channels::get_output_scaled(SRV_Channel::k_rudder) / float(SERVO_MAX);
 
+    if (afs.should_crash_vehicle()) {
+        // when in AFS failsafe force rudder input for differential thrust to zero
+        rudder = 0;
+    }
+
     float throttle_left, throttle_right;
 
     if (throttle < 0 && aparm.throttle_min < 0) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1443,4 +1443,16 @@ void RCOutput::safety_update(void)
 #endif
 }
 
+/*
+  set PWM to send to a set of channels if the FMU firmware dies
+*/
+void RCOutput::set_failsafe_pwm(uint32_t chmask, uint16_t period_us)
+{
+#if HAL_WITH_IO_MCU
+    if (AP_BoardConfig::io_enabled()) {
+        iomcu.set_failsafe_pwm(chmask, period_us);
+    }
+#endif
+}
+
 #endif // HAL_USE_PWM

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -131,6 +131,11 @@ public:
       get safety switch state, used by Util.cpp
     */
     AP_HAL::Util::safety_state _safety_switch_state(void);
+
+    /*
+      set PWM to send to a set of channels if the FMU firmware dies
+     */
+    void set_failsafe_pwm(uint32_t chmask, uint16_t period_us) override;
     
 private:
     struct pwm_group {

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -51,6 +51,9 @@ public:
 
     // set mask of channels that ignore safety state
     void set_safety_mask(uint16_t chmask);
+
+    // set PWM of channels when in FMU failsafe
+    void set_failsafe_pwm(uint16_t chmask, uint16_t period_us);
     
     /*
       enable sbus output
@@ -188,6 +191,9 @@ private:
         uint8_t safety_pwm_sent;
         uint16_t safety_pwm[IOMCU_MAX_CHANNELS];
         uint16_t safety_mask;
+        uint16_t failsafe_pwm[IOMCU_MAX_CHANNELS];
+        uint8_t failsafe_pwm_set;
+        uint8_t failsafe_pwm_sent;
     } pwm_out;
 
     // read back pwm values

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -172,9 +172,9 @@ uint16_t SRV_Channel::get_limit_pwm(LimitValue limit) const
     case SRV_CHANNEL_LIMIT_TRIM:
         return servo_trim;
     case SRV_CHANNEL_LIMIT_MIN:
-        return servo_min;
+        return reversed?servo_max:servo_min;
     case SRV_CHANNEL_LIMIT_MAX:
-        return servo_max;
+        return reversed?servo_min:servo_max;
     case SRV_CHANNEL_LIMIT_ZERO_PWM:
     default:
         return 0;


### PR DESCRIPTION
This is needed for proper AFS operation when terminating
