### PR TITLE
Plane: fixed a bug in Q_ASSIST_ modes for tiltrotors

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1277,8 +1277,10 @@ void QuadPlane::update_transition(void)
         }
     }
     
-    // if rotors are fully forward then we are not transitioning
-    if (tiltrotor_fully_fwd()) {
+    // if rotors are fully forward then we are not transitioning,
+    // unless we are waiting for airspeed to increase (in which case
+    // the tilt will decrease rapidly)
+    if (tiltrotor_fully_fwd() && transition_state != TRANSITION_AIRSPEED_WAIT) {
         transition_state = TRANSITION_DONE;
     }
     


### PR DESCRIPTION
when a tilt-rotor drops below Q_ASSIST_SPEED we need to keep it in the
airspeed wait state until it has regained airspeed, otherwise we will
end up with too low throttle