### PR TITLE
Plane: added TKOFF_ACCEL_CNT for multi-shake to start

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1173,7 +1173,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual Stabilize Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual, Stabilize, Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -128,7 +128,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: TKOFF_THR_MINACC
     // @DisplayName: Takeoff throttle min acceleration
-    // @Description: Minimum forward acceleration in m/s/s before arming the ground speed check in auto-takeoff. This is meant to be used for hand launches. Setting this value to 0 disables the acceleration test which means the ground speed check will always be armed which could allow GPS velocity jumps to start the engine. For hand launches and bungee launches this should be set to around 15.
+    // @Description: Minimum forward acceleration in m/s/s before arming the ground speed check in auto-takeoff. This is meant to be used for hand launches. Setting this value to 0 disables the acceleration test which means the ground speed check will always be armed which could allow GPS velocity jumps to start the engine. For hand launches and bungee launches this should be set to around 15. Also see TKOFF_ACCEL_CNT paramter for control of full "shake to arm".
     // @Units: m/s/s
     // @Range: 0 30
     // @Increment: 0.1
@@ -1181,6 +1181,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
     AP_SUBGROUPINFO(scripting, "SCR_", 14, ParametersG2, AP_Scripting),
 #endif
+
+    // @Param: TKOFF_ACCEL_CNT
+    // @DisplayName: Takeoff throttle acceleration count
+    // @Description: This is the number of acceleration events to require for arming with TKOFF_THR_MINACC. The default is 1, which means a single forward acceleration above TKOFF_THR_MINACC will arm. By setting this higher than 1 you can require more forward/backward movements to arm.
+    // @Range: 1 10
+    // @User: User
+    AP_GROUPINFO("TKOFF_ACCEL_CNT", 15, ParametersG2, takeoff_throttle_accel_count, 1),
 
     AP_GROUPEND
 };

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -549,6 +549,8 @@ public:
 #ifdef ENABLE_SCRIPTING
     AP_Scripting scripting;
 #endif // ENABLE_SCRIPTING
+
+    AP_Int8 takeoff_throttle_accel_count;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -430,6 +430,8 @@ private:
         uint32_t last_check_ms;
         uint32_t last_report_ms;
         bool launchTimerStarted;
+        uint8_t accel_event_counter;
+        uint32_t accel_event_ms;
     } takeoff_state;
     
     // ground steering controller state

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -201,4 +201,5 @@ enum {
 enum FlightOptions {
     DIRECT_RUDDER_ONLY   = (1 << 0),
     CRUISE_TRIM_THROTTLE = (1 << 1),
+    DISABLE_TOFF_ATTITUDE_CHK = (1 << 2),
 };

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -75,10 +75,10 @@ bool Plane::auto_takeoff_check(void)
         goto no_launch;
     }
 
-    if (!quadplane.is_tailsitter()) {
+    if (!quadplane.is_tailsitter() &&
+        !(g2.flight_options & FlightOptions::DISABLE_TOFF_ATTITUDE_CHK)) {
         // Check aircraft attitude for bad launch
-        if (ahrs.pitch_sensor <= -3000 ||
-            ahrs.pitch_sensor >= 4500 ||
+        if (ahrs.pitch_sensor <= -3000 || ahrs.pitch_sensor >= 4500 ||
             (!fly_inverted() && labs(ahrs.roll_sensor) > 3000)) {
             gcs().send_text(MAV_SEVERITY_WARNING, "Bad launch AUTO");
             takeoff_state.accel_event_counter = 0;

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -31,11 +31,28 @@ bool Plane::auto_takeoff_check(void)
         return false;
     }
 
-    // Check for launch acceleration if set. NOTE: relies on TECS 50Hz processing
-    if (!takeoff_state.launchTimerStarted &&
-        !is_zero(g.takeoff_throttle_min_accel) &&
-        SpdHgt_Controller->get_VXdot() < g.takeoff_throttle_min_accel) {
-        goto no_launch;
+    if (!takeoff_state.launchTimerStarted && !is_zero(g.takeoff_throttle_min_accel)) {
+        // we are requiring an X acceleration event to launch
+        float xaccel = SpdHgt_Controller->get_VXdot();
+        if (g2.takeoff_throttle_accel_count <= 1) {
+            if (xaccel < g.takeoff_throttle_min_accel) {
+                goto no_launch;
+            }
+        } else {
+            // we need multiple accel events
+            if (now - takeoff_state.accel_event_ms > 500) {
+                takeoff_state.accel_event_counter = 0;
+            }
+            bool odd_event = ((takeoff_state.accel_event_counter & 1) != 0);
+            bool got_event = (odd_event?xaccel < -g.takeoff_throttle_min_accel : xaccel > g.takeoff_throttle_min_accel);
+            if (got_event) {
+                takeoff_state.accel_event_counter++;
+                takeoff_state.accel_event_ms = now;
+            }
+            if (takeoff_state.accel_event_counter < g2.takeoff_throttle_accel_count) {
+                goto no_launch;
+            }
+        }
     }
 
     // we've reached the acceleration threshold, so start the timer
@@ -64,6 +81,7 @@ bool Plane::auto_takeoff_check(void)
             ahrs.pitch_sensor >= 4500 ||
             (!fly_inverted() && labs(ahrs.roll_sensor) > 3000)) {
             gcs().send_text(MAV_SEVERITY_WARNING, "Bad launch AUTO");
+            takeoff_state.accel_event_counter = 0;
             goto no_launch;
         }
     }


### PR DESCRIPTION
this allows you to setup shake to start with a lower accel threshold,
but with multiple fwd/back movements needed.

This implements https://github.com/ArduPilot/ardupilot/issues/2221

I've marked this WIP as it really needs a bit more work. What this implements now is "multi shake to start". You set TKOFF_ACCEL_CNT to the number of fwd/back movements needed to trigger takeoff. So if you set it to 2 then it needs one fwd and one back movement of more than TKOFF_THR_MINACC. If you set it to 6 then it needs 3 fwd and 3 backward movements.

Other features that we should consider:

 - should we allow this for arming in modes other than AUTO with NAV_TAKEOFF?
 - it doesn't implement shake-to-disarm yet. I think we'd need to do that as part of verify_takeoff(). Should it do it with a shake for disarm, or just lack of GPS movement for a number of seconds after triggering launch?

