### PR TITLE
Plane: fixed relaxing of attitude controller on transition

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -186,6 +186,7 @@ private:
     void init_stabilize(void);
     void control_stabilize(void);
 
+    void check_attitude_relax(void);
     void init_hover(void);
     void control_hover(void);
     void run_rate_controller(void);
@@ -304,6 +305,9 @@ private:
 
     // pitch when we enter loiter mode
     int32_t loiter_initial_pitch_cd;
+
+    // when did we last run the attitude controller?
+    uint32_t last_att_control_ms;
 
     // true if we have reached the airspeed threshold for transition
     enum {


### PR DESCRIPTION
this fixes an issue found by Leonard where the attitude controller
could have residual control left over from a previous transition when
engaging the VTOL attitude controller