### PR TITLE
AC_AttitudeControl: Use reset_rate_controller_I_terms() helper

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -170,9 +170,7 @@ void AC_AttitudeControl::relax_attitude_controllers()
     // to the input angular velocity and reset the angular velocity integrators.
     // This zeros the output of the angular velocity controller.
     _rate_target_ang_vel = _ahrs.get_gyro();
-    get_rate_roll_pid().reset_I();
-    get_rate_pitch_pid().reset_I();
-    get_rate_yaw_pid().reset_I();
+    reset_rate_controller_I_terms();
 }
 
 void AC_AttitudeControl::reset_rate_controller_I_terms()


### PR DESCRIPTION
Small tweak to use the helper for resetting the I terms when relaxing controllers since it is the same code, and to ensure any future rate controllers are caught at the same time.