### PR TITLE
Plane: improved throttle control for internal combustion engine

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -664,6 +664,11 @@ void Plane::set_servos(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, override_pct);
     }
 
+    // implement throttle limiting based on RPM
+    int16_t thr_demand = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+    g2.ice_control.throttle_adjustment(thr_demand, aparm.throttle_min);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, thr_demand);
+
     // run output mixer and send values to the hal for output
     servos_output();
 }

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -47,7 +47,10 @@ public:
 
     // handle DO_ENGINE_CONTROL messages via MAVLink or mission
     bool engine_control(float start_control, float cold_start, float height_delay);
-    
+
+    // limit throttle based on RPM
+    void throttle_limit(int16_t &throttle);
+
 private:
     const AP_RPM &rpm;
     const AP_AHRS &ahrs;
@@ -77,7 +80,11 @@ private:
     
     // RPM above which engine is considered to be running
     AP_Int32 rpm_threshold;
-    
+
+    // thresholds for throttle advance
+    AP_Int32 rpm_threshold_high;
+    AP_Int8 thr_threshold_high;
+
     // time when we started the starter
     uint32_t starter_start_time_ms;
 

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -49,7 +49,7 @@ public:
     bool engine_control(float start_control, float cold_start, float height_delay);
 
     // limit throttle based on RPM
-    void throttle_limit(int16_t &throttle);
+    void throttle_adjustment(int16_t &throttle, int16_t thr_min);
 
 private:
     const AP_RPM &rpm;
@@ -84,6 +84,8 @@ private:
     // thresholds for throttle advance
     AP_Int32 rpm_threshold_high;
     AP_Int8 thr_threshold_high;
+    AP_Int32 idle_rpm;
+    AP_Int8 idle_adjust;
 
     // time when we started the starter
     uint32_t starter_start_time_ms;
@@ -102,5 +104,9 @@ private:
 
     // we are waiting for valid height data
     bool height_pending:1;
+
+    // time we last did idle adjustment
+    uint32_t last_idle_adjust_ms;
+    float idle_adjustment;
 };
 


### PR DESCRIPTION
This adds two new features:
 - a throttle threshold based on RPM, to cope with engines where you need slower throttle rise while waiting for the engine to "catch"
 - RPM based idle adjustment, allowing you to set a target RPM for idle
