### PR TITLE
Copter: Immediately execute emergency stop motor instruction

### DIFF
--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -125,7 +125,7 @@ void Copter::auto_disarm_check()
     }
 
     // disarm once timer expires
-    if ((tnow_ms-auto_disarm_begin) >= disarm_delay_ms) {
+    if ((tnow_ms-auto_disarm_begin) >= disarm_delay_ms || ap.motor_emergency_stop) {
         init_disarm_motors();
         auto_disarm_begin = tnow_ms;
     }


### PR DESCRIPTION
I think that delay of 5 seconds is unnecessary for "emergency motor stop" of multicopter. Immediately, I think that I want to use it when I want to crash. I do not know the need for this 5 seconds. There is a mode called interlock for normal motor stop.

I specified the emergency stop motor with a return switch. I turned off the return switch for less than 5 seconds. . . I was surprised that the motor spun. . As the propeller played the stones on the ground, the aircraft went rampant. .