### PR TITLE
AP_RangeFinder: Added update rate parameter.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -62,8 +62,8 @@ AP_RangeFinder_Backend *AP_RangeFinder_LightWareI2C::detect(RangeFinder::RangeFi
 
 void AP_RangeFinder_LightWareI2C::init()
 {
-    // call timer() at 20Hz
-    _dev->register_periodic_callback(50000,
+    // call timer() at 20Hz(50000)
+    _dev->register_periodic_callback(state.update_rate>0?1000000/state.update_rate:50000,
                                      FUNCTOR_BIND_MEMBER(&AP_RangeFinder_LightWareI2C::timer, void));
 }
 

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -171,6 +171,13 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Path: AP_RangeFinder_Wasp.cpp
     AP_SUBGROUPVARPTR(drivers[0], "_",  57, RangeFinder, backend_var_info[0]),
 
+    // @Param: _UPRATE
+    // @DisplayName: Update rate
+    // @Description: Measurement cycle for updating distance.
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("_UPRATE",  61, RangeFinder, state[0].update_rate, 0),
+
 #if RANGEFINDER_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
@@ -293,6 +300,14 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Group: 2_
     // @Path: AP_RangeFinder_Wasp.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 58, RangeFinder, backend_var_info[1]),
+
+    // @Param: 2_UPRATE
+    // @DisplayName: Update rate
+    // @Description: Measurement cycle for updating distance.
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("2_UPRATE",  62, RangeFinder, state[1].update_rate, 0),
+
 #endif
 
 #if RANGEFINDER_MAX_INSTANCES > 2
@@ -418,6 +433,14 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Group: 3_
     // @Path: AP_RangeFinder_Wasp.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 59, RangeFinder, backend_var_info[2]),
+
+    // @Param: 3_UPRATE
+    // @DisplayName: Update rate
+    // @Description: Measurement cycle for updating distance.
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("3_UPRATE",  63, RangeFinder, state[2].update_rate, 0),
+
 #endif
 
 #if RANGEFINDER_MAX_INSTANCES > 3
@@ -543,6 +566,14 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     // @Group: 4_
     // @Path: AP_RangeFinder_Wasp.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 60, RangeFinder, backend_var_info[3]),
+
+    // @Param: 4_UPRATE
+    // @DisplayName: Update rate
+    // @Description: Measurement cycle for updating distance.
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("4_UPRATE",  64, RangeFinder, state[3].update_rate, 0),
+
 #endif
 
     AP_GROUPEND

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -103,6 +103,7 @@ public:
         AP_Int8  address;
         AP_Vector3f pos_offset; // position offset in body frame
         AP_Int8  orientation;
+        AP_Int16 update_rate;
         const struct AP_Param::GroupInfo *var_info;
     };
 


### PR DESCRIPTION
I am using LightWare LW20C with I2C. A health error occurs. Looking at the device driver, the callback cycle is 20 Hz. Since this device does not have a buffer, it becomes no data unless data can be received when accessed. Therefore, the minimum period of this device is 48 Hz, and eight periods can be selected.
I think that it would be better to be able to set the call back time with the config parameter in order to tune.

Default LM value: 8

![111](https://user-images.githubusercontent.com/646194/45614749-70d24a00-baa5-11e8-85f3-6684ead4f7d0.png)

![111](https://user-images.githubusercontent.com/646194/45614869-da525880-baa5-11e8-8e4f-dc193832ac8a.png)

