### PR TITLE
Tools: some test and update quadplane functions

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -445,6 +445,46 @@ class AutoTest(ABC):
         else:
             self.set_rc(3, 1000)
 
+    def set_output_to_max(self, chan):
+        """Set output to max with RC Radio taking into account REVERSED parameter."""
+        is_reversed = self.get_parameter("RC%u_REVERSED" % chan)
+        out_max = int(self.get_parameter("RC%u_MAX" % chan))
+        out_min = int(self.get_parameter("RC%u_MIN" % chan))
+        if is_reversed == 0:
+            self.set_rc(chan, out_max)
+        else:
+            self.set_rc(chan, out_min)
+
+    def set_output_to_min(self, chan):
+        """Set output to min with RC Radio taking into account REVERSED parameter."""
+        is_reversed = self.get_parameter("RC%u_REVERSED" % chan)
+        out_max = int(self.get_parameter("RC%u_MAX" % chan))
+        out_min = int(self.get_parameter("RC%u_MIN" % chan))
+        if is_reversed == 0:
+            self.set_rc(chan, out_min)
+        else:
+            self.set_rc(chan, out_max)
+
+    def set_output_to_trim(self, chan):
+        """Set output to trim with RC Radio."""
+        out_trim = int(self.get_parameter("RC%u_TRIM" % chan))
+        self.set_rc(chan, out_trim)
+
+    def get_arming_rudder(self):
+        if self.mav.mav_type in [mavutil.mavlink.MAV_TYPE_QUADROTOR,
+                                 mavutil.mavlink.MAV_TYPE_HELICOPTER,
+                                 mavutil.mavlink.MAV_TYPE_HEXAROTOR,
+                                 mavutil.mavlink.MAV_TYPE_OCTOROTOR,
+                                 mavutil.mavlink.MAV_TYPE_COAXIAL,
+                                 mavutil.mavlink.MAV_TYPE_TRICOPTER]:
+            return int(self.get_parameter("RCMAP_YAW"))
+        if self.mav.mav_type == mavutil.mavlink.MAV_TYPE_FIXED_WING:
+            return int(self.get_parameter("RCMAP_YAW"))
+        if self.mav.mav_type == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:
+            return int(self.get_parameter("RCMAP_ROLL"))
+        if self.mav.mav_type == mavutil.mavlink.MAV_TYPE_SUBMARINE:
+            raise ErrorException("Arming with rudder is not supported by Submarine")
+
     def armed(self):
         """Return true if vehicle is armed and safetyoff"""
         return self.mav.motors_armed()
@@ -511,26 +551,26 @@ class AutoTest(ABC):
         """Arm motors with radio."""
         self.progress("Arm motors with radio")
         self.set_throttle_zero()
-        self.mavproxy.send('rc 1 2000\n')
+        self.set_output_to_max(self.get_arming_rudder())
         tstart = self.get_sim_time()
         timeout = 15
         while self.get_sim_time() < tstart + timeout:
             self.mav.wait_heartbeat()
-            if not self.mav.motors_armed():
+            if self.mav.motors_armed():
                 arm_delay = self.get_sim_time() - tstart
                 self.progress("MOTORS ARMED OK WITH RADIO")
-                self.mavproxy.send('rc 1 1500\n')
+                self.set_output_to_trim(self.get_arming_rudder())
                 self.progress("Arm in %ss" % arm_delay)  # TODO check arming time
                 return True
         self.progress("FAILED TO ARM WITH RADIO")
-        self.mavproxy.send('rc 1 1500\n')
+        self.set_output_to_trim(self.get_arming_rudder())
         return False
 
     def disarm_motors_with_rc_input(self):
         """Disarm motors with radio."""
         self.progress("Disarm motors with radio")
         self.set_throttle_zero()
-        self.mavproxy.send('rc 1 1000\n')
+        self.set_output_to_min(self.get_arming_rudder())
         tstart = self.get_sim_time()
         timeout = 15
         while self.get_sim_time() < tstart + timeout:
@@ -538,11 +578,11 @@ class AutoTest(ABC):
             if not self.mav.motors_armed():
                 disarm_delay = self.get_sim_time() - tstart
                 self.progress("MOTORS DISARMED OK WITH RADIO")
-                self.mavproxy.send('rc 1 1500\n')
+                self.set_output_to_trim(self.get_arming_rudder())
                 self.progress("Disarm in %ss" % disarm_delay)  # TODO check disarming time
                 return True
         self.progress("FAILED TO DISARM WITH RADIO")
-        self.mavproxy.send('rc 1 1500\n')
+        self.set_output_to_trim(self.get_arming_rudder())
         return False
 
     def autodisarm_motors(self):
@@ -1197,6 +1237,8 @@ class AutoTest(ABC):
 
     def test_arm_feature(self):
         """Common feature to test."""
+        self.context_push()
+        self.set_parameter("ARMING_RUDDER", 2)
         # TEST ARMING/DISARM
         if not self.arm_vehicle():
             self.progress("Failed to ARM")
@@ -1210,12 +1252,14 @@ class AutoTest(ABC):
         if not self.mavproxy_disarm_vehicle():
             self.progress("Failed to DISARM")
             raise NotAchievedException()
-        if not self.arm_motors_with_rc_input():
-            raise NotAchievedException()
-        if not self.disarm_motors_with_rc_input():
-            raise NotAchievedException()
-        if not self.autodisarm_motors():
-            raise NotAchievedException()
+        if self.mav.mav_type != mavutil.mavlink.MAV_TYPE_SUBMARINE:
+            if not self.arm_motors_with_rc_input():
+                raise NotAchievedException()
+            if not self.disarm_motors_with_rc_input():
+                raise NotAchievedException()
+            if not self.autodisarm_motors():
+                raise NotAchievedException()
+        self.context_pop()
         # TODO : add failure test : arming check, wrong mode; Test arming magic; Same for disarm
 
     def test_gripper(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -120,13 +120,14 @@ class AutoTestQuadPlane(AutoTest):
         self.wait_mode('AUTO')
         self.wait_waypoint(1, 19, max_dist=60, timeout=1200)
 
-        self.mavproxy.expect('DISARMED')
+        self.mav.motors_disarmed_wait()
         # wait for blood sample here
         self.mavproxy.send('wp set 20\n')
+        self.wait_ready_to_arm()
         self.arm_vehicle()
         self.wait_waypoint(20, 34, max_dist=60, timeout=1200)
 
-        self.mavproxy.expect('DISARMED')
+        self.mav.motors_disarmed_wait()
         self.progress("Mission OK")
 
     def autotest(self):
@@ -151,7 +152,7 @@ class AutoTestQuadPlane(AutoTest):
 
             # wait for EKF and GPS checks to pass
             self.progress("Waiting reading for arm")
-            self.wait_seconds(30)
+            self.wait_ready_to_arm()
 
             self.run_test("Arm features", self.test_arm_feature)
             self.arm_vehicle()


### PR DESCRIPTION
The error was catch by @bnsgeyer !  The valid condition in arm_motors_with_rc_input was wrong, so the test was always pass and then disarm_motors_with_rc_input always pass too. 
This PR correct this problem.
It auto select the correct arming stick and put it in the good value.