### PR TITLE
AP_Math: Speed up location calculations slightly

### DIFF
--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -26,7 +26,7 @@
 
 float longitude_scale(const struct Location &loc)
 {
-    float scale = cosf(loc.lat * 1.0e-7f * DEG_TO_RAD);
+    float scale = cosf(loc.lat * (1.0e-7f * DEG_TO_RAD));
     return constrain_float(scale, 0.01f, 1.0f);
 }
 


### PR DESCRIPTION
The compiler isn't allowed to do the constant multiplication for us, because as it can result in marginally different values. However we can prove that changing the order here does not cause us problems with any input data we have. Maximum change before the cosf is 1.490116e-08, after cosf is -5.960464e-08 which is a level of change I'm comfortable with on this function. (I didn't scratch out if it is more or less accurate on a technical level).

The quick test program used to demonstrate this:
```
#include <stdint.h>
#include <stdio.h>
#include <math.h>

#define DEG_TO_RAD      ((float)(M_PI / 180.0f))

int main(int argc, char **argv) {
    const int32_t max_lat = 90*1000*1000;
    double max_error = 0;
    int max_error_index = -max_lat; 
    for (int i = -max_lat; i <= max_lat; i++) {
        const float current  = i * 1e-7f * DEG_TO_RAD;
        const float proposed = i * (1e-7f * DEG_TO_RAD);
        const float f_delta  = current-proposed;
        const double current_d  = i * 1e-7f * DEG_TO_RAD;
        const double proposed_d = i * (1e-7f * DEG_TO_RAD);
        const double d_delta    = current_d - proposed_d;

        if (fabs(d_delta) > fabs(max_error)) {                                                                                                           
            max_error = d_delta;
            max_error_index = i;
            printf("Input: %d Old: %0.8f Proposed: %0.8f Delta: %e Double Delta: %e\n",
                   i, current, proposed, f_delta, d_delta);
        }
    }   
    printf("Max Error: %e at %d\n", max_error, max_error_index);
    return 0;
}

```

If you swap the condition for printing from `>` to `>=` you will see a lot more printing as there are a number of places that have this level of change.