### PR TITLE
Copter/Plane/Sub: add more missing clear-pilot-desired-acceleration for loiter init

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -829,6 +829,7 @@ void Copter::ModeAuto::land_run()
     if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
         zero_throttle_and_relax_ac();
         // set target to current position
+        loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
         return;
     }
@@ -924,6 +925,7 @@ void Copter::ModeAuto::payload_place_run()
     if (!payload_place_run_should_run()) {
         zero_throttle_and_relax_ac();
         // set target to current position
+        loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
         return;
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -851,6 +851,7 @@ void QuadPlane::control_hover(void)
 void QuadPlane::init_loiter(void)
 {
     // initialise loiter
+    loiter_nav->clear_pilot_desired_acceleration();
     loiter_nav->init_target();
 
     // initialize vertical speed and acceleration
@@ -961,6 +962,7 @@ void QuadPlane::control_loiter()
         motors->set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
         attitude_control->set_throttle_out_unstabilized(0, true, 0);
         pos_control->relax_alt_hold_controllers(0);
+        loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
         return;
     }
@@ -973,6 +975,7 @@ void QuadPlane::control_loiter()
 
     const uint32_t now = AP_HAL::millis();
     if (now - last_loiter_ms > 500) {
+        loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
     }
     last_loiter_ms = now;
@@ -1855,6 +1858,7 @@ void QuadPlane::vtol_position_controller(void)
         if (plane.auto_state.wp_proportion >= 1 ||
             plane.auto_state.wp_distance < 5) {
             poscontrol.state = QPOS_POSITION2;
+            loiter_nav->clear_pilot_desired_acceleration();
             loiter_nav->init_target();
             gcs().send_text(MAV_SEVERITY_INFO,"VTOL position2 started v=%.1f d=%.1f",
                                     (double)ahrs.groundspeed(), (double)plane.auto_state.wp_distance);
@@ -2131,6 +2135,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     throttle_wait = false;
 
     // set target to current position
+    loiter_nav->clear_pilot_desired_acceleration();
     loiter_nav->init_target();
 
     // initialize vertical speed and acceleration

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -646,6 +646,7 @@ bool Sub::auto_terrain_recover_start()
     mission.stop();
 
     // Reset xy target
+    loiter_nav.clear_pilot_desired_acceleration();
     loiter_nav.init_target();
 
     // Reset z axis controller

--- a/ArduSub/control_poshold.cpp
+++ b/ArduSub/control_poshold.cpp
@@ -24,6 +24,7 @@ bool Sub::poshold_init()
 
     // set target to current position
     // only init here as we can switch to PosHold in flight with a velocity <> 0 that will be used as _last_vel in PosControl and never updated again as we inhibit Reset_I
+    loiter_nav.clear_pilot_desired_acceleration();
     loiter_nav.init_target();
 
     last_pilot_heading = ahrs.yaw_sensor;
@@ -40,6 +41,7 @@ void Sub::poshold_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_SPIN_WHEN_ARMED);
+        loiter_nav.clear_pilot_desired_acceleration();
         loiter_nav.init_target();
         attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
@@ -64,6 +66,7 @@ void Sub::poshold_run()
     if (fabsf(pilot_lateral) > 0.1 || fabsf(pilot_forward) > 0.1) {
         lateral_out = pilot_lateral;
         forward_out = pilot_forward;
+        loiter_nav.clear_pilot_desired_acceleration();
         loiter_nav.init_target(); // initialize target to current position after repositioning
     } else {
         translate_wpnav_rp(lateral_out, forward_out);


### PR DESCRIPTION
This is a follow up to this earlier PR from @lthall: https://github.com/ArduPilot/ardupilot/pull/9445

This PR adds more initialisation of desired accelerations when loiter is initialised.

The general rule appears to be that if loiter.init_target() is called with no 3D vector provided we need to clear the pilot desired accelerations.