### PR TITLE
Tools:Support for duplicate parameters within library

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -194,6 +194,7 @@ def process_library(vehicle, library, pathprefix=None):
                     debug("Setting vehicle-specific value (%s)" % str(this_vehicle_value))
                     setattr(p, field[0], this_vehicle_value)
                 debug("Appending (non_vehicle_specific_values_seen=%u other_vehicle_values_seen=%u this_vehicle_values_seen=%u!)" % (non_vehicle_specific_values_seen, other_vehicle_values_seen, this_vehicle_values_seen))
+                p.path=path # Add path. Later deleted - only used for duplicates
                 library.params.append(p)
 
         group_matches = prog_groups.findall(p_text)
@@ -263,6 +264,27 @@ def validate(param):
 for vehicle in vehicles:
     for param in vehicle.params:
         validate(param)
+
+# Find duplicate names in library and fix up path
+for library in libraries:
+    param_names_seen=set()
+    param_names_duplicate=set()
+    #Find duplicates
+    for param in library.params:
+        if param.name in param_names_seen: #is duplicate
+            param_names_duplicate.add(param.name)
+        param_names_seen.add(param.name)
+    #Fix up path for duplicates
+    for param in library.params:
+        if param.name in param_names_duplicate:
+            param.path=param.path.rsplit('/')[-1].rsplit('.')[0]
+        else:
+            #not a duplicate, so delete attribute.
+            delattr(param, "path")
+
+
+    
+                
 
 for library in libraries:
     for param in library.params:

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -282,10 +282,6 @@ for library in libraries:
             #not a duplicate, so delete attribute.
             delattr(param, "path")
 
-
-    
-                
-
 for library in libraries:
     for param in library.params:
         validate(param)

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -16,8 +16,8 @@ from mdemit import MDEmit
 
 parser = OptionParser("param_parse.py [options]")
 parser.add_option("-v", "--verbose", dest='verbose', action='store_true', default=False, help="show debugging output")
-parser.add_option("--vehicle", default='*',  help="Vehicle type to generate for")
-parser.add_option("--no-emit", dest='emit_params', action='store_false', default=True, help="don't emit parameter documention, just validate")
+parser.add_option("--vehicle", default='*', help="Vehicle type to generate for")
+parser.add_option("--no-emit", dest='emit_params', action='store_false', default=True, help="don't emit parameter documentation, just validate")
 (opts, args) = parser.parse_args()
 
 
@@ -58,6 +58,7 @@ def error(str_to_print):
     error_count += 1
     print(str_to_print)
 
+
 truename_map = {
     "APMrover2": "Rover",
     "ArduSub": "Sub",
@@ -65,6 +66,8 @@ truename_map = {
     "ArduPlane": "Plane",
     "AntennaTracker": "Tracker",
 }
+
+
 for vehicle_path in vehicle_paths:
     name = os.path.basename(os.path.dirname(vehicle_path))
     path = os.path.normpath(os.path.dirname(vehicle_path))
@@ -124,6 +127,7 @@ alllibs = libraries[:]
 
 vehicle = vehicles[0]
 
+
 def process_library(vehicle, library, pathprefix=None):
     '''process one library'''
     paths = library.Path.split(',')
@@ -131,7 +135,7 @@ def process_library(vehicle, library, pathprefix=None):
         path = path.strip()
         debug("\n Processing file '%s'" % path)
         if pathprefix is not None:
-            libraryfname = os.path.join(pathprefix, path)            
+            libraryfname = os.path.join(pathprefix, path)
         elif path.find('/') == -1:
             if len(vehicles) != 1:
                 print("Unable to handle multiple vehicles with .pde library")
@@ -170,11 +174,11 @@ def process_library(vehicle, library, pathprefix=None):
             other_vehicle_values_seen = False
             for field in fields:
                 only_for_vehicles = field[1].split(",")
-                only_for_vehicles = [ x.rstrip().lstrip() for x in only_for_vehicles ]
+                only_for_vehicles = [x.rstrip().lstrip() for x in only_for_vehicles]
                 delta = set(only_for_vehicles) - set(truename_map.values())
                 if len(delta):
                     error("Unknown vehicles (%s)" % delta)
-                debug("field[0]=%s vehicle=%s truename=%s field[1]=%s only_for_vehicles=%s\n" % (field[0], vehicle.name,vehicle.truename,field[1], str(only_for_vehicles)))
+                debug("field[0]=%s vehicle=%s truename=%s field[1]=%s only_for_vehicles=%s\n" % (field[0], vehicle.name,vehicle.truename, field[1], str(only_for_vehicles)))
                 value = re.sub('@PREFIX@', library.name, field[2])
                 if field[0] == "Values":
                     if vehicle.truename in only_for_vehicles:
@@ -188,13 +192,12 @@ def process_library(vehicle, library, pathprefix=None):
                     setattr(p, field[0], value)
                 else:
                     error("tagged param<: unknown parameter metadata field '%s'" % field[0])
-            if ((non_vehicle_specific_values_seen or not other_vehicle_values_seen)
-                or this_vehicle_values_seen):
+            if ((non_vehicle_specific_values_seen or not other_vehicle_values_seen) or this_vehicle_values_seen):
                 if this_vehicle_values_seen:
                     debug("Setting vehicle-specific value (%s)" % str(this_vehicle_value))
                     setattr(p, field[0], this_vehicle_value)
                 debug("Appending (non_vehicle_specific_values_seen=%u other_vehicle_values_seen=%u this_vehicle_values_seen=%u!)" % (non_vehicle_specific_values_seen, other_vehicle_values_seen, this_vehicle_values_seen))
-                p.path=path # Add path. Later deleted - only used for duplicates
+                p.path = path # Add path. Later deleted - only used for duplicates
                 library.params.append(p)
 
         group_matches = prog_groups.findall(p_text)
@@ -216,6 +219,7 @@ def process_library(vehicle, library, pathprefix=None):
                 process_library(vehicle, l, os.path.dirname(libraryfname))
                 alllibs.append(l)
 
+
 for library in libraries:
     debug("===\n\n\nProcessing library %s" % library.name)
 
@@ -227,16 +231,18 @@ for library in libraries:
     debug("Processed %u documented parameters" % len(library.params))
 
 # sort libraries by name
-alllibs = sorted(alllibs, key=lambda x : x.name)
+alllibs = sorted(alllibs, key=lambda x: x.name)
 
 libraries = alllibs
-    
+
+
 def is_number(numberString):
     try:
         float(numberString)
         return True
     except ValueError:
         return False
+
 
 def validate(param):
     """
@@ -261,14 +267,15 @@ def validate(param):
         if (param.__dict__["Units"] != "") and (param.__dict__["Units"] not in known_units):
             error("unknown units field '%s'" % param.__dict__["Units"])
 
+
 for vehicle in vehicles:
     for param in vehicle.params:
         validate(param)
 
 # Find duplicate names in library and fix up path
 for library in libraries:
-    param_names_seen=set()
-    param_names_duplicate=set()
+    param_names_seen = set()
+    param_names_duplicate = set()
     #Find duplicates
     for param in library.params:
         if param.name in param_names_seen: #is duplicate
@@ -277,7 +284,7 @@ for library in libraries:
     #Fix up path for duplicates
     for param in library.params:
         if param.name in param_names_duplicate:
-            param.path=param.path.rsplit('/')[-1].rsplit('.')[0]
+            param.path = param.path.rsplit('/')[-1].rsplit('.')[0]
         else:
             #not a duplicate, so delete attribute.
             delattr(param, "path")
@@ -285,6 +292,7 @@ for library in libraries:
 for library in libraries:
     for param in library.params:
         validate(param)
+
 
 def do_emit(emit):
     emit.set_annotate_with_vehicle(len(vehicles) > 1)
@@ -298,6 +306,7 @@ def do_emit(emit):
             emit.emit(library, f)
 
     emit.close()
+
 
 if opts.emit_params:
     do_emit(XmlEmit())

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -9,9 +9,11 @@ import cgi
 # Emit docs in a RST format
 class RSTEmit(Emit):
     def blurb(self):
-        return """This is a complete list of the parameters which can be set (e.g. via the MAVLink protocol) to control vehicle behaviour. They are stored in persistent storage on the vehicle.
+        return """This is a complete list of the parameters which can be set (e.g. via the MAVLink protocol) to control vehicle behaviour.
+They are stored in persistent storage on the vehicle.
 
-This list is automatically generated from the latest ardupilot source code, and so may contain parameters which are not yet in the stable released versions of the code.
+This list is automatically generated from the latest ArduPilot source code,
+and so may contain parameters which are not yet in the stable released versions of the code.
 """
 
     def toolname(self):
@@ -53,7 +55,6 @@ Complete Parameter List
         pass
 
     def tablify_row(self, rowheading, row, widths, height):
-        ret = ""
         joiner = "|"
 
         row_lines = [x.split("\n") for x in row]
@@ -206,15 +207,15 @@ Complete Parameter List
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
             d = param.__dict__
-            
+
             # Get param path if defined (i.e. is duplicate parameter)
             param_path = getattr(param, 'path', '')
-            
+
             if self.annotate_with_vehicle:
                 name = param.name
             else:
                 name = param.name.split(':')[-1]
-                
+
             tag_param_path = ' (%s)' % param_path if param_path else ''
             tag = '%s%s: %s' % (self.escape(name), self.escape(tag_param_path), self.escape(param.DisplayName),)
 
@@ -253,7 +254,8 @@ Complete Parameter List
                     elif field == 'Units':
                         abreviated_units = param.__dict__[field]
                         if abreviated_units != '':
-                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            # use the known_units dictionary to convert the abbreviated unit into a full textual one
+                            units = known_units[abreviated_units]
                             row.append(cgi.escape(units))
                     else:
                         row.append(cgi.escape(param.__dict__[field]))

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -206,11 +206,18 @@ Complete Parameter List
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
             d = param.__dict__
+            
+            # Check if param path defined (i.e. is duplicate parameter)
+            param_path = param.path if hasattr(param, 'path') else ''
+            
             if self.annotate_with_vehicle:
                 name = param.name
             else:
                 name = param.name.split(':')[-1]
-            tag = '%s: %s' % (self.escape(name), self.escape(param.DisplayName),)
+                
+            tag_param_path = ' (%s)' % param_path if param_path else ''
+            tag = '%s%s: %s' % (self.escape(name), self.escape(tag_param_path), self.escape(param.DisplayName),)
+
             tag = tag.strip()
             reference = param.name
             # remove e.g. "ArduPlane:" from start of parameter name:
@@ -218,6 +225,8 @@ Complete Parameter List
                 reference = g.name + "_" + reference.split(":")[-1]
             else:
                 reference = reference.split(":")[-1]
+            if param_path:
+                reference = reference + '__' + param_path
 
             ret += """
 

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -207,8 +207,8 @@ Complete Parameter List
                 continue
             d = param.__dict__
             
-            # Check if param path defined (i.e. is duplicate parameter)
-            param_path = param.path if hasattr(param, 'path') else ''
+            # Get param path if defined (i.e. is duplicate parameter)
+            param_path = getattr(param, 'path', '')
             
             if self.annotate_with_vehicle:
                 name = param.name
@@ -226,7 +226,7 @@ Complete Parameter List
             else:
                 reference = reference.split(":")[-1]
             if param_path:
-                reference = reference + '__' + param_path
+                reference += '__' + param_path
 
             ret += """
 


### PR DESCRIPTION
This creates unique heading and references for generated parameter docs. It checks for duplicates by name, and adds the file name for duplicates (only) in the parameter heading and reference. 

This supersedes #9005. Unlike that PR this does not need any changes to ardupilot source, or addition of new fields. It does dynamically add the *path* to duplicates, but since this is not in the parameter "definition" the information does not appear in any other output.