### PR TITLE
Plane: Fix FLIGHT_OPTIONS bitmask doc

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1173,7 +1173,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual, Stabilize, Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual Stabilize Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 


### PR DESCRIPTION
`,` is used to split the bitmask up, accidentally resulted in very confused output, and makes the wiki look like: http://ardupilot.org/plane/docs/parameters.html#flight-options-flight-mode-options

The better fix is to fixup the param_parse script to split around a comma followed by an optional space then a number and then a colon. I took a quick stab at this, but missed getting it to work correctly. I don't have the time to chase it further, so this PR is the minimum step to fix the documentation up, a future enhancement to the script would be good though.