### PR TITLE
AP_HAL_ChibiOS: Don't redefine errno

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
@@ -114,10 +114,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ///  Note: fdevopen assigns stdin,stdout,stderr
 
-///@brief POSIX errno.
-int errno;
-
-
 ///@brief POSIX fileno to POSIX FILE stream table
 ///
 /// - Note: the index of __iob[] is reffered to "fileno".
@@ -126,50 +122,6 @@ int errno;
 /// - __iob[1] = stdout.
 /// - __iob[2] = stderr.
 FILE *__iob[MAX_FILES];
-
-/// @brief POSIX error messages for each errno value.
-///
-/// - man page errno (3)
-const char *sys_errlist[] =
-{
-    "OK",
-    "Operation not permitted",
-    "No such file or directory",
-    "No such process",
-    "Interrupted system call",
-    "I/O error",
-    "No such device or address",
-    "Argument list too long",
-    "Exec format error",
-    "Bad file number",
-    "No child processes",
-    "Try again",
-    "Out of memory",
-    "Permission denied",
-    "Bad address",
-    "Block device required",
-    "Device or resource busy",
-    "File exists",
-    "Cross-device link",
-    "No such device",
-    "Not a directory",
-    "Is a directory",
-    "Invalid argument",
-    "File table overflow",
-    "Too many open files",
-    "Not a typewriter",
-    "Text file busy",
-    "File too large",
-    "No space left on device",
-    "Illegal seek",
-    "Read-only file system",
-    "Too many links",
-    "Broken pipe",
-    "Math argument out of domain of func",
-    "Math result not representable",
-    "Bad Message",
-    NULL
-};
 
 // =============================================
 /// - POSIX character I/O functions
@@ -1815,45 +1767,62 @@ int ferror(FILE *stream)
     return(0);
 }
 
-/// @brief POSIX perror() -  convert POSIX errno to text with user message.
-///
-/// - man page errno (3).
-///
-/// @param[in] s: User message displayed before the error message
-///
-/// @see sys_errlist[].
-/// @return  void.
-
-void perror(const char *s)
-{
-    const char *ptr = NULL;
-
-
-    if(errno >=0 && errno < EBADMSG)
-        ptr = sys_errlist[errno];
-    else
-        ptr = sys_errlist[EBADMSG];
-
-    if(s && *s)
-        printf("%s: %s\n", s, ptr);
-    else
-        printf("%s\n", ptr);
-}
 
 /// @brief POSIX strerror() -  convert POSIX errno to text with user message.
 ///
 /// - man page strerror (3).
 ///
-/// @param[in] errnum: index for sys_errlist[]
+/// @param[in] errnum: error provided from <errno.h>
 ///
-/// @see sys_errlist[].
 /// @return  char *
 
 char *strerror(int errnum)
 {
-    return( (char *)sys_errlist[errnum] );
-}
+#define SWITCH_ERROR(errno) case errno: return #errno; break
+    switch (errnum) {
+        SWITCH_ERROR(EPERM);
+        SWITCH_ERROR(ENOENT);
+        SWITCH_ERROR(ESRCH);
+        SWITCH_ERROR(EINTR);
+        SWITCH_ERROR(EIO);
+        SWITCH_ERROR(ENXIO);
+        SWITCH_ERROR(E2BIG);
+        SWITCH_ERROR(ENOEXEC);
+        SWITCH_ERROR(EBADF);
+        SWITCH_ERROR(ECHILD);
+        SWITCH_ERROR(EAGAIN);
+        SWITCH_ERROR(ENOMEM);
+        SWITCH_ERROR(EACCES);
+        SWITCH_ERROR(EFAULT);
+#ifdef ENOTBLK
+        SWITCH_ERROR(ENOTBLK);
+#endif // ENOTBLK
+        SWITCH_ERROR(EBUSY);
+        SWITCH_ERROR(EEXIST);
+        SWITCH_ERROR(EXDEV);
+        SWITCH_ERROR(ENODEV);
+        SWITCH_ERROR(ENOTDIR);
+        SWITCH_ERROR(EISDIR);
+        SWITCH_ERROR(EINVAL);
+        SWITCH_ERROR(ENFILE);
+        SWITCH_ERROR(EMFILE);
+        SWITCH_ERROR(ENOTTY);
+        SWITCH_ERROR(ETXTBSY);
+        SWITCH_ERROR(EFBIG);
+        SWITCH_ERROR(ENOSPC);
+        SWITCH_ERROR(ESPIPE);
+        SWITCH_ERROR(EROFS);
+        SWITCH_ERROR(EMLINK);
+        SWITCH_ERROR(EPIPE);
+        SWITCH_ERROR(EDOM);
+        SWITCH_ERROR(ERANGE);
+        SWITCH_ERROR(EBADMSG);
+    }
 
+#undef SWITCH_ERROR
+
+    return NULL;
+}
 
 /// @brief POSIX strerror_r() -  convert POSIX errno to text with user message.
 ///
@@ -1868,10 +1837,9 @@ char *strerror(int errnum)
 
 char *__wrap_strerror_r(int errnum, char *buf, size_t buflen)
 {
-        strncpy(buf, sys_errlist[errnum], buflen);
+        strncpy(buf, strerror(errnum), buflen);
         return(buf);
 }
-
 
 // =============================================
 // =============================================

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
@@ -27,14 +27,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef USE_POSIX
 #define POSIX
 #pragma GCC diagnostic ignored "-Wshadow"
-///@brief make sure we use our EDOM and ERANGE values
-#undef EDOM
-#undef ERANGE
 #include <stdint.h>
 #include <stddef.h>
 #include <ff.h>
 #include <stdarg.h>
 #include <time.h>
+#include <errno.h>
 
 #define MAXLN 128
 #define ISSPACE " \t\n\r\f\v"
@@ -44,58 +42,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef __cplusplus
 extern "C" {
 #endif
-// =============================================
-///@brief Standard POSIX typedefs.
-///
-/// - Using these makes code portable accross many acrchitectures
-//typedef uint32_t blkcnt_t;  /*< blkcnt_t for this architecture */
-//typedef uint32_t blksize_t; /*< blksize_t for this architecture */
-typedef int32_t      off_t;
-typedef off_t        fpos_t;
-extern int errno;
-// =============================================
-
-// @brief posix errno values
-enum POSIX_errno
-{
-    EOK,        /*< 	0   NO ERROR */
-    EPERM,     /*< 	1   Operation not permitted */
-    ENOENT,    /*< 	2   No such file or directory */
-    ESRCH,     /*< 	3   No such process */
-    EINTR,     /*< 	4   Interrupted system call */
-    EIO,       /*< 	5   I/O error */
-    ENXIO,     /*< 	6   No such device or address */
-    E2BIG,     /*< 	7   Argument list too long */
-    ENOEXEC,   /*< 	8   Exec format error */
-    EBADF,     /*< 	9   Bad file number */
-    ECHILD,    /*< 	10  No child processes */
-    EAGAIN,    /*< 	11  Try again */
-    ENOMEM,    /*< 	12  Out of memory */
-    EACCES,    /*< 	13  Permission denied */
-    EFAULT,    /*< 	14  Bad address */
-    ENOTBLK,   /*< 	15  Block device required */
-    EBUSY,     /*< 	16  Device or resource busy */
-    EEXIST,    /*< 	17  File exists */
-    EXDEV,     /*< 	18  Cross-device link */
-    ENODEV,    /*< 	19  No such device */
-    ENOTDIR,   /*< 	20  Not a directory */
-    EISDIR,    /*< 	21  Is a directory */
-    EINVAL,    /*< 	22  Invalid argument */
-    ENFILE,    /*< 	23  File table overflow */
-    EMFILE,    /*< 	24  Too many open files */
-    ENOTTY,    /*< 	25  Not a typewriter */
-    ETXTBSY,   /*< 	26  Text file busy */
-    EFBIG,     /*< 	27  File too large */
-    ENOSPC,    /*< 	28  No space left on device */
-    ESPIPE,    /*< 	29  Illegal seek */
-    EROFS,     /*< 	30  Read-only file system */
-    EMLINK,    /*< 	31  Too many links */
-    EPIPE,     /*< 	32  Broken pipe */
-    EDOM,      /*< 	33  Math argument out of domain of func */
-    ERANGE,    /*< 	34  Math result not representable */
-    EBADMSG    /*< 	35  Bad Message */
-};
-// =============================================
 
 ///@brief POSIX stat structure
 ///@see stat()
@@ -372,7 +318,6 @@ DIR *opendir ( const char *pathdir );
 struct dirent *readdir ( DIR *dirp );
 void clrerror ( FILE *stream );
 int ferror ( FILE *stream );
-void perror ( const char *s );
 char *strerror ( int errnum );
 char *__wrap_strerror_r ( int errnum , char *buf , size_t buflen );
 FILE *fdevopen ( int (*put )(char ,FILE *), int (*get )(FILE *));


### PR DESCRIPTION
I can't find the background to why we provide our own implementation of the error codes. It is provided in the GCC headers and as far I can tell the values match. The motivation for the change is that this causes problems with any external code that includes the actual errno.h (IE scripting). Compiling and running on a Cube works just fine with this change set.