### PR TITLE
AP_HAL_ChibiOS: Make getcwd() take size_t as per the standard

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
@@ -1594,7 +1594,7 @@ int fchmod(int fd, mode_t mode)
 /// @return 0 on sucess.
 /// @return -1 on error with errno set.
 
-char *getcwd(char *pathname, int len)
+char *getcwd(char *pathname, size_t len)
 {
     int res;
     errno = 0;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
@@ -361,7 +361,7 @@ int dirname ( char *str );
  int fchmod ( int fd , mode_t mode );
 #endif
 
-char *getcwd ( char *pathname , int len );
+char *getcwd ( char *pathname , size_t len );
 int mkdir ( const char *pathname , mode_t mode );
 int rename ( const char *oldpath , const char *newpath );
 int rmdir ( const char *pathname );


### PR DESCRIPTION
`getcwd()` is expected to take a size_t rather then int.

EDIT: Further comment: `f_getcwd()` the actual function that uses the length, expects a unsigned int for the argument, not a signed int.