### PR TITLE
AP_InertialSensor: Remove unused (and conflicting in some builds) incluse

### DIFF
--- a/libraries/AP_InertialSensor/AuxiliaryBus.cpp
+++ b/libraries/AP_InertialSensor/AuxiliaryBus.cpp
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <errno.h>
 #include <stdlib.h>
 
 #include "AuxiliaryBus.h"


### PR DESCRIPTION
Do to other oddities with the errno handling, this actually results in errno's for ChibiOS that don't agree with the ones we locally provide. Since we don't actually use it here the easy fix is to just remove the pointless include, while we chase getting some more alignment on errno's elsewhere/later.