### PR TITLE
AP_Compass: move common code to backend

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -70,8 +70,6 @@ private:
     void timer();
 
     uint8_t compass_instance;
-    Vector3f accum;
-    uint16_t accum_count;
     bool force_external;
     enum Rotation rotation;
 };

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -314,47 +314,14 @@ void AP_Compass_BMM150::_update()
     /* convert uT to milligauss */
     raw_field *= 10;
 
-    /* rotate raw_field from sensor frame to body frame */
-    rotate_field(raw_field, _compass_instance);
-
-    /* publish raw_field (uncorrected point sample) for calibration use */
-    publish_raw_field(raw_field, _compass_instance);
-
-    /* correct raw_field for known errors */
-    correct_field(raw_field, _compass_instance);
-
     _last_read_ms = AP_HAL::millis();
-    
-    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        return;
-    }
-    _mag_accum += raw_field;
-    _accum_count++;
-    if (_accum_count == 10) {
-        _mag_accum /= 2;
-        _accum_count = 5;
-    }
-    _sem->give();
 
+    accumulate_sample(raw_field, _compass_instance);
     _dev->check_next_register();
 }
 
 void AP_Compass_BMM150::read()
 {
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    if (_accum_count == 0) {
-        _sem->give();
-        return;
-    }
-
-    Vector3f field(_mag_accum);
-    field /= _accum_count;
-    _mag_accum.zero();
-    _accum_count = 0;
-    _sem->give();
-
-    publish_filtered_field(field, _compass_instance);
+    drain_accumulated_samples(_compass_instance);
 }
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.h
+++ b/libraries/AP_Compass/AP_Compass_BMM150.h
@@ -47,9 +47,6 @@ private:
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
 
-    Vector3f _mag_accum;
-    uint32_t _accum_count;
-
     uint8_t _compass_instance;
 
     struct {

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -81,6 +81,10 @@ protected:
     void publish_filtered_field(const Vector3f &mag, uint8_t instance);
     void set_last_update_usec(uint32_t last_update, uint8_t instance);
 
+    void accumulate_sample(Vector3f &field, uint8_t instance,
+                           uint32_t max_samples = 10);
+    void drain_accumulated_samples(uint8_t instance, const Vector3f *scale = NULL);
+
     // register a new compass instance with the frontend
     uint8_t register_compass(void) const;
 
@@ -107,6 +111,10 @@ protected:
 
     // semaphore for access to shared frontend data
     AP_HAL::Semaphore *_sem;
+
+    // accumulated samples, protected by _sem
+    Vector3f    _accum;
+    uint32_t    _accum_count;
 
     // Check that the compass field is valid by using a mean filter on the vector length
     bool field_ok(const Vector3f &field);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -233,47 +233,19 @@ void AP_Compass_HMC5843::_timer()
         return;
     }
 
-    // the _mag_N values are in the range -2048 to 2047, so we can
-    // accumulate up to 15 of them in an int16_t. Let's make it 14
-    // for ease of calculation. We expect to do reads at 10Hz, and
-    // we get new data at most 75Hz, so we don't expect to
-    // accumulate more than 8 before a read
     // get raw_field - sensor frame, uncorrected
     Vector3f raw_field = Vector3f(_mag_x, _mag_y, _mag_z);
     raw_field *= _gain_scale;
-    
+
     // rotate to the desired orientation
     if (is_external(_compass_instance)) {
         raw_field.rotate(ROTATION_YAW_90);
     }
 
-    // rotate raw_field from sensor frame to body frame
-    rotate_field(raw_field, _compass_instance);
-    
-    // publish raw_field (uncorrected point sample) for calibration use
-    publish_raw_field(raw_field, _compass_instance);
-    
-    // correct raw_field for known errors
-    correct_field(raw_field, _compass_instance);
-    
-    if (!field_ok(raw_field)) {
-        return;
-    }
-
-    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        return; 
-    }
-    _mag_x_accum += raw_field.x;
-    _mag_y_accum += raw_field.y;
-    _mag_z_accum += raw_field.z;
-    _accum_count++;
-    if (_accum_count == 14) {
-        _mag_x_accum /= 2;
-        _mag_y_accum /= 2;
-        _mag_z_accum /= 2;
-        _accum_count = 7;
-    }
-    _sem->give();
+    // We expect to do reads at 10Hz, and  we get new data at most 75Hz, so we
+    // don't expect to accumulate more than 8 before a read; let's make it
+    // 14 to give more room for the initialization phase
+    accumulate_sample(raw_field, _compass_instance, 14);
 }
 
 /*
@@ -291,26 +263,7 @@ void AP_Compass_HMC5843::read()
         return;
     }
 
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    
-    if (_accum_count == 0) {
-        _sem->give();
-        return;
-    }
-
-    Vector3f field(_mag_x_accum * _scaling[0],
-                   _mag_y_accum * _scaling[1],
-                   _mag_z_accum * _scaling[2]);
-    field /= _accum_count;
-
-    _accum_count = 0;
-    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
-
-    _sem->give();
-    
-    publish_filtered_field(field, _compass_instance);
+    drain_accumulated_samples(_compass_instance, &_scaling);
 }
 
 bool AP_Compass_HMC5843::_setup_sampling_mode()

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -47,16 +47,12 @@ private:
 
     AP_HMC5843_BusDriver *_bus;
 
-    float _scaling[3];
+    Vector3f _scaling;
     float _gain_scale;
 
     int16_t _mag_x;
     int16_t _mag_y;
     int16_t _mag_z;
-    int16_t _mag_x_accum;
-    int16_t _mag_y_accum;
-    int16_t _mag_z_accum;
-    uint8_t _accum_count;
 
     uint8_t _compass_instance;
 

--- a/libraries/AP_Compass/AP_Compass_IST8310.h
+++ b/libraries/AP_Compass/AP_Compass_IST8310.h
@@ -53,9 +53,6 @@ private:
     AP_HAL::Util::perf_counter_t _perf_xfer_err;
     AP_HAL::Util::perf_counter_t _perf_bad_data;
 
-    Vector3f _accum = Vector3f();
-    uint32_t _accum_count = 0;
-
     enum Rotation _rotation;
     uint8_t _instance;
     bool _ignore_next_sample;

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -157,20 +157,7 @@ void AP_Compass_LIS3MDL::timer()
 
     field(data.magx * range_scale, data.magy * range_scale, data.magz * range_scale);
 
-    /* rotate raw_field from sensor frame to body frame */
-    rotate_field(field, compass_instance);
-
-    /* publish raw_field (uncorrected point sample) for calibration use */
-    publish_raw_field(field, compass_instance);
-
-    /* correct raw_field for known errors */
-    correct_field(field, compass_instance);
-
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        accum += field;
-        accum_count++;
-        _sem->give();
-    }
+    accumulate_sample(field, compass_instance);
 
 check_registers:
     dev->check_next_register();
@@ -178,34 +165,5 @@ check_registers:
 
 void AP_Compass_LIS3MDL::read()
 {
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    if (accum_count == 0) {
-        _sem->give();
-        return;
-    }
-
-#if 0
-    // debugging code for sample rate
-    static uint32_t lastt;
-    static uint32_t total;
-    total += accum_count;
-    uint32_t now = AP_HAL::micros();
-    float dt = (now - lastt) * 1.0e-6;
-    if (dt > 1) {
-        printf("%u samples\n", total);
-        lastt = now;
-        total = 0;
-    }
-#endif
-    
-    accum /= accum_count;
-
-    publish_filtered_field(accum, compass_instance);
-
-    accum.zero();
-    accum_count = 0;
-    
-    _sem->give();
+    drain_accumulated_samples(compass_instance);
 }

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.h
@@ -55,8 +55,6 @@ private:
     void timer();
 
     uint8_t compass_instance;
-    Vector3f accum;
-    uint16_t accum_count;
     bool force_external;
     enum Rotation rotation;
 };

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -341,28 +341,7 @@ void AP_Compass_LSM303D::_update()
 
     Vector3f raw_field = Vector3f(_mag_x, _mag_y, _mag_z) * _mag_range_scale;
 
-    // rotate raw_field from sensor frame to body frame
-    rotate_field(raw_field, _compass_instance);
-
-    // publish raw_field (uncorrected point sample) for calibration use
-    publish_raw_field(raw_field, _compass_instance);
-
-    // correct raw_field for known errors
-    correct_field(raw_field, _compass_instance);
-
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mag_x_accum += raw_field.x;
-        _mag_y_accum += raw_field.y;
-        _mag_z_accum += raw_field.z;
-        _accum_count++;
-        if (_accum_count == 10) {
-            _mag_x_accum /= 2;
-            _mag_y_accum /= 2;
-            _mag_z_accum /= 2;
-            _accum_count = 5;
-        }
-        _sem->give();
-    }
+    accumulate_sample(raw_field, _compass_instance, 10);
 }
 
 // Read Sensor data
@@ -372,25 +351,7 @@ void AP_Compass_LSM303D::read()
         return;
     }
 
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    
-    if (_accum_count == 0) {
-        /* We're not ready to publish*/
-        _sem->give();
-        return;
-    }
-
-    Vector3f field(_mag_x_accum, _mag_y_accum, _mag_z_accum);
-    field /= _accum_count;
-
-    _accum_count = 0;
-    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
-
-    _sem->give();    
-
-    publish_filtered_field(field, _compass_instance);
+    drain_accumulated_samples(_compass_instance);
 }
 
 void AP_Compass_LSM303D::_disable_i2c()

--- a/libraries/AP_Compass/AP_Compass_LSM303D.h
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.h
@@ -42,13 +42,9 @@ private:
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
 
     float _mag_range_scale;
-    float _mag_x_accum;
-    float _mag_y_accum;
-    float _mag_z_accum;
     int16_t _mag_x;
     int16_t _mag_y;
     int16_t _mag_z;
-    uint8_t _accum_count;
 
     uint8_t _compass_instance;
     bool _initialised;

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -155,49 +155,12 @@ void AP_Compass_LSM9DS1::_update(void)
 
     raw_field *= _scaling;
 
-    // rotate raw_field from sensor frame to body frame
-    rotate_field(raw_field, _compass_instance);
-
-    // publish raw_field (uncorrected point sample) for calibration use
-    publish_raw_field(raw_field, _compass_instance);
-
-    // correct raw_field for known errors
-    correct_field(raw_field, _compass_instance);
-
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mag_x_accum += raw_field.x;
-        _mag_y_accum += raw_field.y;
-        _mag_z_accum += raw_field.z;
-        _accum_count++;
-        if (_accum_count == 10) {
-            _mag_x_accum /= 2;
-            _mag_y_accum /= 2;
-            _mag_z_accum /= 2;
-            _accum_count = 5;
-        }
-        _sem->give();
-    }
+    accumulate_sample(raw_field, _compass_instance);
 }
 
 void AP_Compass_LSM9DS1::read()
 {
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    if (_accum_count == 0) {
-        /* We're not ready to publish*/
-        _sem->give();
-        return;
-    }
-
-    Vector3f field(_mag_x_accum, _mag_y_accum, _mag_z_accum);
-    field /= _accum_count;
-    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
-    _accum_count = 0;
-
-    _sem->give();
-
-    publish_filtered_field(field, _compass_instance);
+    drain_accumulated_samples(_compass_instance);
 }
 
 bool AP_Compass_LSM9DS1::_check_id(void)

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -38,9 +38,5 @@ private:
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
     uint8_t _compass_instance;
     float _scaling;
-    float _mag_x_accum;
-    float _mag_y_accum;
-    float _mag_z_accum;
-    uint32_t _accum_count;
     enum Rotation _rotation;
 };

--- a/libraries/AP_Compass/AP_Compass_MAG3110.cpp
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.cpp
@@ -207,32 +207,7 @@ void AP_Compass_MAG3110::_update()
 
     Vector3f raw_field = Vector3f((float)_mag_x, (float)_mag_y, (float)_mag_z) * MAG_SCALE;
 
-    // rotate raw_field from sensor frame to body frame
-    rotate_field(raw_field, _compass_instance);
-    
-    // publish raw_field (uncorrected point sample) for calibration use
-    publish_raw_field(raw_field, _compass_instance);
-    
-    // correct raw_field for known errors
-    correct_field(raw_field, _compass_instance);
-
-    if (!field_ok(raw_field)) {
-        return;
-    }
-    
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mag_x_accum += raw_field.x;
-        _mag_y_accum += raw_field.y;
-        _mag_z_accum += raw_field.z;
-        _accum_count++;
-        if (_accum_count == 10) {
-            _mag_x_accum /= 2;
-            _mag_y_accum /= 2;
-            _mag_z_accum /= 2;
-            _accum_count /= 2;
-        }
-        _sem->give();
-    }
+    accumulate_sample(raw_field, _compass_instance);
 }
 
 
@@ -243,23 +218,5 @@ void AP_Compass_MAG3110::read()
         return;
     }
 
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-    
-    if (_accum_count == 0) {
-        /* We're not ready to publish*/
-        _sem->give();
-        return;
-    }
-
-    Vector3f field = Vector3f(_mag_x_accum, _mag_y_accum, _mag_z_accum);
-    field /= _accum_count;
-
-    _accum_count = 0;
-    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
-
-    _sem->give();    
-
-    publish_filtered_field(field, _compass_instance);
+    drain_accumulated_samples(_compass_instance);
 }

--- a/libraries/AP_Compass/AP_Compass_MAG3110.h
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.h
@@ -41,11 +41,6 @@ private:
     int32_t _mag_y;
     int32_t _mag_z;
 
-    float _mag_x_accum;
-    float _mag_y_accum;
-    float _mag_z_accum;
-    uint8_t _accum_count;
-
     uint8_t _compass_instance;
     bool _initialised;
 };

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -61,8 +61,6 @@ private:
     void accumulate_field(Vector3f &field);
 
     uint8_t compass_instance;
-    Vector3f accum;
-    uint16_t accum_count;
     bool force_external;
     Vector3f offset;
     uint16_t measure_count;

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -62,9 +62,6 @@ private:
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
 
-    Vector3f _accum = Vector3f();
-    uint32_t _accum_count = 0;
-
     enum Rotation _rotation;
     uint8_t _instance;
     bool _force_external:1;

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -117,6 +117,12 @@ public:
     // uniform scaling
     Vector3<T> &operator /=(const T num);
 
+    // non-uniform scaling
+    Vector3<T> &operator *=(const Vector3<T> &v) {
+        x *= v.x; y *= v.y; z *= v.z;
+        return *this;
+    }
+
     // allow a vector3 to be used as an array, 0 indexed
     T & operator[](uint8_t i) {
         T *_v = &x;


### PR DESCRIPTION
This was triggered after writing #9411 and seeing the duplicate code we have in the drivers.

The change in behavior here is that now all the drivers call the `field_ok()` function instead of only 3, but this needs to be verified if it's safe for all of them.