### PR TITLE
AP_Proximity: Add support for OBSTACLE_DISTANCE mavlink message (Attempt 2)

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1227,6 +1227,9 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
         rover.rangefinder.handle_msg(msg);
         rover.g2.proximity.handle_msg(msg);
         break;
+    case MAVLINK_MSG_ID_OBSTACLE_DISTANCE:
+        rover.g2.proximity.handle_msg(msg);
+        break;
 
     default:
         handle_common_message(msg);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1335,6 +1335,14 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         break;
     }
 
+    case MAVLINK_MSG_ID_OBSTACLE_DISTANCE:
+    {
+#if PROXIMITY_ENABLED == ENABLED
+        copter.g2.proximity.handle_msg(msg);
+#endif
+        break;
+    }
+
 #if HIL_MODE != HIL_MODE_DISABLED
     case MAVLINK_MSG_ID_HIL_STATE:          // MAV ID: 90
     {

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -57,24 +57,90 @@ bool AP_Proximity_MAV::get_upward_distance(float &distance) const
 // handle mavlink DISTANCE_SENSOR messages
 void AP_Proximity_MAV::handle_msg(mavlink_message_t *msg)
 {
-    mavlink_distance_sensor_t packet;
-    mavlink_msg_distance_sensor_decode(msg, &packet);
+    if (msg->msgid == MAVLINK_MSG_ID_DISTANCE_SENSOR) {
+        mavlink_distance_sensor_t packet;
+        mavlink_msg_distance_sensor_decode(msg, &packet);
 
-    // store distance to appropriate sector based on orientation field
-    if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
-        uint8_t sector = packet.orientation;
-        _angle[sector] = sector * 45;
-        _distance[sector] = packet.current_distance / 100.0f;
-        _distance_min = packet.min_distance / 100.0f;
-        _distance_max = packet.max_distance / 100.0f;
-        _distance_valid[sector] = (_distance[sector] >= _distance_min) && (_distance[sector] <= _distance_max);
-        _last_update_ms = AP_HAL::millis();
-        update_boundary_for_sector(sector);
+        // store distance to appropriate sector based on orientation field
+        if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
+            uint8_t sector = packet.orientation;
+            _angle[sector] = sector * 45;
+            _distance[sector] = packet.current_distance / 100.0f;
+            _distance_min = packet.min_distance / 100.0f;
+            _distance_max = packet.max_distance / 100.0f;
+            _distance_valid[sector] = (_distance[sector] >= _distance_min) && (_distance[sector] <= _distance_max);
+            _last_update_ms = AP_HAL::millis();
+            update_boundary_for_sector(sector);
+        }
+
+        // store upward distance
+        if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
+            _distance_upward = packet.current_distance / 100.0f;
+            _last_upward_update_ms = AP_HAL::millis();
+        }
+        return;
     }
 
-    // store upward distance
-    if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
-        _distance_upward = packet.current_distance / 100.0f;
-        _last_upward_update_ms = AP_HAL::millis();
+    if (msg->msgid == MAVLINK_MSG_ID_OBSTACLE_DISTANCE) {
+        mavlink_obstacle_distance_t packet;
+        mavlink_msg_obstacle_distance_decode(msg, &packet);
+
+        // check increment (message's sector width)
+        uint8_t increment = packet.increment;
+        if (packet.increment == 0) {
+            return;
+        }
+
+        const float MAX_DISTANCE = 9999.0f;
+        const uint8_t total_distances = MIN(360.0f / increment, 72);
+
+        // set distance min and max
+        _distance_min = packet.min_distance / 100.0f;
+        _distance_max = packet.max_distance / 100.0f;
+        _last_update_ms = AP_HAL::millis();
+
+        // get user configured yaw correction from front end
+        const float yaw_correction = constrain_float(frontend.get_yaw_correction(state.instance), -360.0f, +360.0f);
+        float dir_correction;
+        if (frontend.get_orientation(state.instance) == 0) {
+            dir_correction = 1.0f;
+        } else {
+            dir_correction = -1.0f;
+        }
+
+        // initialise updated array and proximity sector angles (to closest object) and distances
+        bool sector_updated[_num_sectors];
+        float sector_width_half[_num_sectors];
+        for (uint8_t i = 0; i < _num_sectors; i++) {
+            sector_updated[i] = false;
+            sector_width_half[i] = _sector_width_deg[i] * 0.5f;
+            _angle[i] = _sector_middle_deg[i];
+            _distance[i] = MAX_DISTANCE;
+        }
+
+        // iterate over message's sectors
+        for (uint8_t j = 0; j < total_distances; j++) {
+            const float packet_distance_m = packet.distances[j] * 0.01f;
+            const float mid_angle = wrap_360(j * increment * dir_correction + yaw_correction);
+
+            // iterate over proximity sectors
+            for (uint8_t i = 0; i < _num_sectors; i++) {
+                float angle_diff = fabsf(wrap_180(_sector_middle_deg[i] - mid_angle));
+                // update distance array sector with shortest distance from message
+                if ((angle_diff <= sector_width_half[i]) && (packet_distance_m < _distance[i])) {
+                    _distance[i] = packet_distance_m;
+                    _angle[i] = mid_angle;
+                    sector_updated[i] = true;
+                }
+            }
+        }
+
+        // update proximity sectors validity and boundary point
+        for (uint8_t i = 0; i < _num_sectors; i++) {
+            _distance_valid[i] = (_distance[i] >= _distance_min) && (_distance[i] <= _distance_max);
+            if (sector_updated[i]) {
+                update_boundary_for_sector(i);
+            }
+        }
     }
 }


### PR DESCRIPTION
This replaces this earlier PR (https://github.com/ArduPilot/ardupilot/pull/9418) from @eskaflon to add support for the OBSTACLE_DISTANCE message to the AP_Proximity library.

It builds upon the earlier PR which adds support for receiving [OBSTACLE_DISTANCE](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) messages over mavlink.  This PR makes the fixes requested by @WickedShell and @OXINARF (thanks for your reviews):

- does not parse the message if the increment field is zero (this field specifies how many degrees wide each element of the distances array is).
- simplifies the "mid_angle" calculation which calculates the angle of the middle of the distance array element being consumed
- the "updated" internal variable is removed and the overall efficiency is improved by splitting up the nested loops into multiple loops (one for initialisation, one for consumption of the distance array, one for cleanup).

This has been tested on a real vehicle receiving these messages from ROS/mavros.

