### PR TITLE
AP_Cam: support actions via sbus for Black Magic

### DIFF
--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -46,7 +46,8 @@ public:
     AP_Camera &operator=(const AP_Camera&) = delete;
 
     // get singleton instance
-    static AP_Camera *get_singleton() {
+    static AP_Camera *get_singleton()
+    {
         return _singleton;
     }
 
@@ -60,7 +61,10 @@ public:
     void            control(float session, float zoom_pos, float zoom_step, float focus_lock, float shooting_cmd, float cmd_id);
 
     // set camera trigger distance in a mission
-    void            set_trigger_distance(uint32_t distance_m) { _trigg_dist.set(distance_m); }
+    void            set_trigger_distance(uint32_t distance_m)
+    {
+        _trigg_dist.set(distance_m);
+    }
 
     void take_picture();
 
@@ -73,7 +77,15 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
 
     // set if vehicle is in AUTO mode
-    void set_is_auto_mode(bool enable) { _is_in_auto_mode = enable; }
+    void set_is_auto_mode(bool enable)
+    {
+        _is_in_auto_mode = enable;
+    }
+
+    enum camera_types {
+        CAMERA_TYPE_STD,
+        CAMERA_TYPE_BMMCC
+    };
 
 private:
 
@@ -85,8 +97,10 @@ private:
     AP_Int16        _servo_on_pwm;      // PWM value to move servo to when shutter is activated
     AP_Int16        _servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
     uint8_t         _trigger_counter;   // count of number of cycles shutter has been held open
+    uint8_t         _trigger_counter_cam_function;   // count of number of cycles alternative camera function has been held open
     AP_Relay       *_apm_relay;         // pointer to relay object from the base class Relay.
     AP_Int8         _auto_mode_only;    // if 1: trigger by distance only if in AUTO mode.
+    AP_Int8         _type;              // Set the type of camera in use, will open additional parameters if set
     bool            _is_in_auto_mode;   // true if in AUTO mode
 
     void            servo_pic();        // Servo operated camera
@@ -97,7 +111,7 @@ private:
     static void     capture_callback(void *context, uint32_t chan_index,
                                      hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);
 #endif
-    
+
     AP_Float        _trigg_dist;        // distance between trigger points (meters)
     AP_Int16        _min_interval;      // Minimum time between shots required by camera
     AP_Int16        _max_roll;          // Maximum acceptable roll angle when trigging camera
@@ -132,10 +146,13 @@ private:
     bool check_feedback_pin(void);
 
     // return true if we are using a feedback pin
-    bool using_feedback_pin(void) const { return _feedback_pin > 0; }
+    bool using_feedback_pin(void) const
+    {
+        return _feedback_pin > 0;
+    }
 
 };
 
 namespace AP {
-    AP_Camera *camera();
+AP_Camera *camera();
 };

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -122,6 +122,10 @@ public:
         k_dspoilerRight2        = 87,           ///< differential spoiler 2 (right wing)
         k_winch                 = 88,
         k_mainsail_sheet        = 89,           ///< Main Sail control via sheet
+        k_cam_iso               = 90,
+        k_cam_aperture          = 91,
+        k_cam_focus             = 92,
+        k_cam_shutter_speed     = 93,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 


### PR DESCRIPTION
The PR is to support the addition of the Black Magic Micro Cinema Camera (BMMCC) that is controlled via sbus.  The PR works as a stand alone PR but combined with another change to open solo allows control of most of the camera functions.  In theory it would apply to any camera that uses SBUS and behaves in a similar way to the BMMCC.

It adds a parameter for the type of camera (used in AP_Cam and also a corresponding change to OpenSolo - PR will be created once this PR is approved as I'm sure this will have some changes when it gets reviewed).

Instead of just passing the camera configure message it also checks to see if the camera type is of the BMMCC (other types could be added in the future) and if it is then it will set the servo functions for the various controls.  For controls that require a 'flipping' action such as ISO a new counter has been created.  Where possible it uses the parameters for the camera trigger to conserve the amount of new parameters required.  I have lumped the additional functions into one counter to keep it simple as config changes will typically come in a single message.

This is currently being used on a X8 multicopter with a Gremsy S1 gimbal patched onto 3.6 RC10.  Discussion with BM support indicates that they may continue to have SBUS input on some future cameras and given this is the interface they have used on several I'd expect it to not change. 

Yes these items could be done just through servo commands and using OpenSolo but this allows for normal transmitters to be used to have the same control (was originally tested on a X9D+).  It made sense to put them here as the camera trigger action is handled here.
