### PR TITLE
Tools: fix use of unassign variable

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -291,7 +291,7 @@ class AutoTest(ABC):
         for p in expect_list:
             if p == e:
                 continue
-        util.pexpect_drain(p)
+            util.pexpect_drain(p)
 
     def drain_mav(self):
         count = 0


### PR DESCRIPTION
Make autotest crash on first reboot in init() ... This error doesn't trigger on Travis 