### PR TITLE
Remove some switch default clauses in AP_NavEKF{2,3}

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -257,11 +257,8 @@ void NavEKF2_core::setAidingMode()
             rngBcnTimeout = true;
             gpsNotAvailable = true;
         }
-        }
         break;
-
-    default:
-        break;
+    }
     }
 
     // check to see if we are starting or stopping aiding and set states and modes as required
@@ -331,9 +328,6 @@ void NavEKF2_core::setAidingMode()
             lastVelPassTime_ms = imuSampleTime_ms;
             lastRngBcnPassTime_ms = imuSampleTime_ms;
             }
-            break;
-
-        default:
             break;
         }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -367,9 +367,6 @@ void NavEKF3_core::setAidingMode()
             lastVelPassTime_ms = imuSampleTime_ms;
             lastRngBcnPassTime_ms = imuSampleTime_ms;
             break;
-
-        default:
-            break;
         }
 
         // Always reset the position and velocity when changing mode


### PR DESCRIPTION
These squelch useful compiler warnings.
