### PR TITLE
AP_NavEKF2: support VISION_SPEED_ESTIMATE

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -553,6 +553,9 @@ public:
     // return current vibration vector for primary IMU
     Vector3f get_vibration(void) const;
     
+    // Write velocity data from an external navigation system
+    virtual void writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms) { }
+
     // allow threads to lock against AHRS update
     HAL_Semaphore &get_semaphore(void) {
         return _rsem;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1405,6 +1405,11 @@ void AP_AHRS_NavEKF::writeExtNavData(const Vector3f &sensOffset, const Vector3f 
 #endif
 }
 
+// Write velocity data from an external navigation system
+void AP_AHRS_NavEKF::writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms)
+{
+    EKF2.writeVisionSpeed(vel, timeStamp_ms);
+}
 
 // inhibit GPS usage
 uint8_t AP_AHRS_NavEKF::setInhibitGPS(void)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -176,6 +176,9 @@ public:
     // Write position and quaternion data from an external navigation system
     void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms) override;
 
+    // Write velocity data from an external navigation system
+    void writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms) override;
+
     // inhibit GPS usage
     uint8_t setInhibitGPS(void);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1646,3 +1646,15 @@ bool NavEKF2::isExtNavUsedForYaw() const
     return false;
 }
 
+/* Write velocity data from an external navigation system
+ * vel : velocity in NED (m)
+ * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+*/
+void NavEKF2::writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms)
+{
+    if (core) {
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].writeVisionSpeed(vel, timeStamp_ms);
+        }
+    }
+}

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -354,6 +354,12 @@ public:
     // check if external navigation is being used for yaw observation
     bool isExtNavUsedForYaw(void) const;
 
+    /* Write velocity data from an external navigation system
+     * vel : velocity in NED (m)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+    */
+    void writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms);
+
 private:
     uint8_t num_cores; // number of allocated cores
     uint8_t primary;   // current primary core

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -496,7 +496,7 @@ void  NavEKF2_core::updateFilterStatus(void)
     bool doingFlowNav = (PV_AidingMode == AID_RELATIVE) && flowDataValid;
     bool doingWindRelNav = !tasTimeout && assume_zero_sideslip();
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
-    bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
+    bool someVertRefData = (!velTimeout && (useGpsVertVel || useVisVertVel)) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
     bool optFlowNavPossible = flowDataValid && delAngBiasLearned;
     bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign && delAngBiasLearned;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -1021,7 +1021,7 @@ void NavEKF2_core::writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms)
     } else {
         visionSpeedMeasTime_ms = timeStamp_ms;
     }
-    useGpsVertVel = true;
+    useVisVertVel = true;
     visionSpeedNew.vel = vel;
     // Correct for the average intersampling delay due to the filter updaterate
     timeStamp_ms -= localFilterTimeStep_ms/2;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -1014,3 +1014,19 @@ void NavEKF2_core::learnInactiveBiases(void)
     }
 }
 
+void NavEKF2_core::writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms)
+{
+    if ((timeStamp_ms - visionSpeedMeasTime_ms) < 70) {
+        return;
+    } else {
+        visionSpeedMeasTime_ms = timeStamp_ms;
+    }
+    useGpsVertVel = true;
+    visionSpeedNew.vel = vel;
+    // Correct for the average intersampling delay due to the filter updaterate
+    timeStamp_ms -= localFilterTimeStep_ms/2;
+    // Prevent time delay exceeding age of oldest IMU data in the buffer
+    timeStamp_ms = MAX(timeStamp_ms,imuDataDelayed.time_ms);
+    visionSpeedNew.time_ms = timeStamp_ms;
+    storedVisionSpeed.push(visionSpeedNew);
+}

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -110,6 +110,9 @@ bool NavEKF2_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
+    if(!storedVisionSpeed.init(OBS_BUFFER_LENGTH)) {
+       return false;
+    }
 
     return true;
 }
@@ -322,6 +325,11 @@ void NavEKF2_core::InitialiseVariables()
     extNavUsedForPos = false;
     extNavYawResetRequest = false;
 
+    memset(&visionSpeedNew, 0, sizeof(visionSpeedNew));
+    memset(&visionSpeedDelayed, 0, sizeof(visionSpeedDelayed));
+    visionSpeedToFuse = false;
+    visionSpeedMeasTime_ms = 0;
+
     // zero data buffers
     storedIMU.reset();
     storedGPS.reset();
@@ -331,6 +339,7 @@ void NavEKF2_core::InitialiseVariables()
     storedOutput.reset();
     storedRangeBeacon.reset();
     storedExtNav.reset();
+    storedVisionSpeed.reset();
 
     // now init mag variables
     yawAlignComplete = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -329,6 +329,7 @@ void NavEKF2_core::InitialiseVariables()
     memset(&visionSpeedDelayed, 0, sizeof(visionSpeedDelayed));
     visionSpeedToFuse = false;
     visionSpeedMeasTime_ms = 0;
+    useVisVertVel = false;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -328,6 +328,13 @@ public:
     // return true when external nav data is also being used as a yaw observation
     bool isExtNavUsedForYaw(void);
 
+    /*
+     * Write velocity data from an external navigation system
+     * vel : velocity in NED (m)
+     * timeStamp_ms : system time the measurement was taken, not the time it was received (mSec)
+    */
+    void writeVisionSpeed(const Vector3f &vel, uint32_t timeStamp_ms);
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
@@ -480,6 +487,7 @@ private:
         bool            posReset;   // true when the position measurement has been reset
     };
 
+<<<<<<< HEAD
     // bias estimates for the IMUs that are enabled but not being used
     // by this core.
     struct {
@@ -487,6 +495,12 @@ private:
         Vector3f gyro_scale;
         float accel_zbias;
     } inactiveBias[INS_MAX_INSTANCES];
+=======
+    struct vision_speed_elements {
+        Vector3f vel;               // velocity in NED (m)
+        uint32_t time_ms;           // measurement timestamp (msec)
+    };
+>>>>>>> e8b10dd... AP_NavEKF2: support VISION_SPEED_ESTIMATE
 
     // update the navigation filter status
     void  updateFilterStatus(void);
@@ -1122,6 +1136,12 @@ private:
     bool extNavUsedForYaw;              // true when the external nav data is also being used as a yaw observation
     bool extNavUsedForPos;              // true when the external nav data is being used as a position reference.
     bool extNavYawResetRequest;         // true when a reset of vehicle yaw using the external nav data is requested
+
+    obs_ring_buffer_t<vision_speed_elements> storedVisionSpeed; // vision speed buffer
+    vision_speed_elements visionSpeedNew;                       // vision speed at the current time horizon
+    vision_speed_elements visionSpeedDelayed;                   // vision speed at the fusion time horizon
+    uint32_t visionSpeedMeasTime_ms;                            // time vision speed measurements were accepted for input to the data buffer (msec)
+    bool visionSpeedToFuse;                                     // true when there is new vision speed to fuse
 
     // flags indicating severe numerical errors in innovation variance calculation for different fusion operations
     struct {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -487,7 +487,6 @@ private:
         bool            posReset;   // true when the position measurement has been reset
     };
 
-<<<<<<< HEAD
     // bias estimates for the IMUs that are enabled but not being used
     // by this core.
     struct {
@@ -495,12 +494,11 @@ private:
         Vector3f gyro_scale;
         float accel_zbias;
     } inactiveBias[INS_MAX_INSTANCES];
-=======
+
     struct vision_speed_elements {
         Vector3f vel;               // velocity in NED (m)
         uint32_t time_ms;           // measurement timestamp (msec)
     };
->>>>>>> e8b10dd... AP_NavEKF2: support VISION_SPEED_ESTIMATE
 
     // update the navigation filter status
     void  updateFilterStatus(void);
@@ -889,6 +887,7 @@ private:
     uint32_t lastGpsAidBadTime_ms;  // time in msec gps aiding was last detected to be bad
     float posDownAtTakeoff;         // flight vehicle vertical position sampled at transition from on-ground to in-air and used as a reference (m)
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
+    bool useVisVertVel;
     float yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
     uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
     Vector3f tiltErrVec;            // Vector of most recent attitude error correction from Vel,Pos fusion

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -732,6 +732,7 @@ private:
     void handle_vision_position_estimate(const mavlink_message_t &msg);
     void handle_global_vision_position_estimate(const mavlink_message_t &msg);
     void handle_att_pos_mocap(const mavlink_message_t &msg);
+    void handle_vision_speed_estimate(const mavlink_message_t &msg);
     void handle_common_vision_position_estimate_data(const uint64_t usec,
                                                      const float x,
                                                      const float y,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2930,10 +2930,16 @@ void GCS_MAVLINK::handle_data_packet(const mavlink_message_t &msg)
 void GCS_MAVLINK::handle_vision_speed_estimate(const mavlink_message_t &msg)
 {
     mavlink_vision_speed_estimate_t m;
-    mavlink_msg_vision_speed_estimate_decode(msg, &m);
+    mavlink_msg_vision_speed_estimate_decode(&msg, &m);
     const Vector3f vel = {m.x, m.y, m.z};
     uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.usec, PAYLOAD_SIZE(chan, VISION_SPEED_ESTIMATE));
     AP::ahrs().writeVisionSpeed(vel, timestamp_ms);
+    AP::logger().Write("VISS", "TimeUS,RemTimeUS,CTimeMS,VX,VY,VZ",
+                       "sssnnn", "FFC000", "QQIfff",
+                       (uint64_t)AP_HAL::micros64(),
+                       (uint64_t)m.usec,
+                       timestamp_ms,
+                       m.x,m.y,m.z);
 }
 
 void GCS_MAVLINK::handle_vision_position_delta(const mavlink_message_t &msg)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2927,6 +2927,15 @@ void GCS_MAVLINK::handle_data_packet(const mavlink_message_t &msg)
 #endif
 }
 
+void GCS_MAVLINK::handle_vision_speed_estimate(const mavlink_message_t &msg)
+{
+    mavlink_vision_speed_estimate_t m;
+    mavlink_msg_vision_speed_estimate_decode(msg, &m);
+    const Vector3f vel = {m.x, m.y, m.z};
+    uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.usec, PAYLOAD_SIZE(chan, VISION_SPEED_ESTIMATE));
+    AP::ahrs().writeVisionSpeed(vel, timestamp_ms);
+}
+
 void GCS_MAVLINK::handle_vision_position_delta(const mavlink_message_t &msg)
 {
     AP_VisualOdom *visual_odom = AP::visualodom();
@@ -3316,6 +3325,10 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_ATT_POS_MOCAP:
         handle_att_pos_mocap(msg);
+        break;
+
+    case MAVLINK_MSG_ID_VISION_SPEED_ESTIMATE:
+        handle_vision_speed_estimate(msg);
         break;
 
     case MAVLINK_MSG_ID_SYSTEM_TIME:


### PR DESCRIPTION
fix #4498

It enables EKF2 fuse speed from VISION_SPEED_ESTIMATE just like speed from GPS
GCS/companion computer can use VISION_SPEED_ESTIMATE to send their velocity estimate.
It makes copters loiter performance a little better when using external navigation data (VISION_POSITION_ESTIMATE or ATT_POS_MOCAP)

below is the observation of motion capture system
![vision_speed](https://user-images.githubusercontent.com/19793511/46394883-17ad1c00-c71d-11e8-8ac3-6c0d28e4bfac.jpg)
