### PR TITLE
AP_BattMonitor: added voltage_smoothed

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -201,6 +201,7 @@ AP_BattMonitor::read()
         if (drivers[i] != nullptr && _params[i].type() != AP_BattMonitor_Params::BattMonitor_TYPE_NONE) {
             drivers[i]->read();
             drivers[i]->update_resistance_estimate();
+            drivers[i]->update_voltage_smoothed();
         }
     }
 
@@ -245,6 +246,16 @@ float AP_BattMonitor::voltage(uint8_t instance) const
 {
     if (instance < _num_instances) {
         return state[instance].voltage;
+    } else {
+        return 0.0f;
+    }
+}
+
+/// voltage_smoothed - returns battery voltage in volts with long term low-pass filter
+float AP_BattMonitor::voltage_smoothed(uint8_t instance) const
+{
+    if (instance < _num_instances) {
+        return state[instance].voltage_smoothed;
     } else {
         return 0.0f;
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -65,6 +65,7 @@ public:
     struct BattMonitor_State {
         cells       cell_voltages;             // battery cell voltages in millivolts, 10 cells matches the MAVLink spec
         float       voltage;                   // voltage in volts
+        float       voltage_smoothed;          // voltage in volts with big low-pass filter applied
         float       current_amps;              // current in amperes
         float       consumed_mah;              // total current draw in milliamp hours since start-up
         float       consumed_wh;               // total energy consumed in Wh since start-up
@@ -103,6 +104,10 @@ public:
     /// voltage - returns battery voltage in millivolts
     float voltage(uint8_t instance) const;
     float voltage() const { return voltage(AP_BATT_PRIMARY_INSTANCE); }
+
+    /// voltage_smoothed - returns battery voltage in millivolts with LPF applied
+    float voltage_smoothed(uint8_t instance) const;
+    float voltage_smoothed() const { return voltage_smoothed(AP_BATT_PRIMARY_INSTANCE); }
 
     /// get voltage with sag removed (based on battery current draw and resistance)
     /// this will always be greater than or equal to the raw voltage

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -41,6 +41,24 @@ uint8_t AP_BattMonitor_Backend::capacity_remaining_pct() const
     }
 }
 
+// update battery voltage LPF'd smoothed estimate
+void AP_BattMonitor_Backend::update_voltage_smoothed()
+{
+    const float lpf_fast = 0.90f;
+    const float lpf_slow = 0.98f;
+
+    if (is_zero(_state.voltage_smoothed)) {
+        // initialize
+        _state.voltage_smoothed = _state.voltage;
+    } else if (fabsf(_state.voltage_smoothed - _state.voltage) > 0.5f) {
+        // diff is big, go fast
+        _state.voltage_smoothed = (_state.voltage_smoothed * lpf_fast) + (_state.voltage * (1-lpf_fast));
+    } else {
+        // diff is small, go slow
+        _state.voltage_smoothed = (_state.voltage_smoothed * lpf_slow) + (_state.voltage * (1-lpf_slow));
+    }
+}
+
 // update battery resistance estimate
 // faster rates of change of the current and voltage readings cause faster updates to the resistance estimate
 // the battery resistance is calculated by comparing the latest current and voltage readings to a low-pass filtered current and voltage

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -49,6 +49,9 @@ public:
     // update battery resistance estimate and voltage_resting_estimate
     void update_resistance_estimate();
 
+    // update battery volage_smoothed
+    void update_voltage_smoothed();
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)


### PR DESCRIPTION
Add a low-pass filtered version of battery.voltage().

This will help https://github.com/ArduPilot/ardupilot/pull/9506