### PR TITLE
AP_HAL_ChibiOS: fix safety switch option handling

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1442,11 +1442,11 @@ void RCOutput::safety_update(void)
         safety_pressed = false;
     }
     if (safety_state==AP_HAL::Util::SAFETY_DISARMED &&
-        !(safety_options & AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON)) {
+        !(safety_options & AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF)) {
         safety_pressed = false;        
     }
     if (safety_state==AP_HAL::Util::SAFETY_ARMED &&
-        !(safety_options & AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF)) {
+        !(safety_options & AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON)) {
         safety_pressed = false;        
     }
     if (safety_pressed) {


### PR DESCRIPTION
This resolves an [issue raised by Sergey in this Copter-3.6.0 beta testing discussion](https://discuss.ardupilot.org/t/copter-3-6-0-rc11-available-for-beta-testing/33558/18).

This fix was made after discussing with @tridge and I've also tested on a pixracer these options:

BRD_SAFETYOPTION = 1 : was able to arm the safety switch but never disarm
BRD_SAFETYOPTION = 3 : was able to arm and disarm the safety switch but only while the vehicle was disarmed
BRD_SAFETYOPTION = 7 : was always able to arm and disarm the safety switch