### PR TITLE
AP_Motors: separate roll and pitch limits

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -108,7 +108,8 @@ void QuadPlane::tailsitter_output(void)
         float tilt_right = extra_elevator + (elevator - aileron) * tailsitter.vectored_hover_gain;
         if (fabsf(tilt_left) >= 4500 || fabsf(tilt_right) >= 4500) {
             // prevent integrator windup
-            motors->limit.roll_pitch = 1;
+            motors->limit.roll = 1;
+            motors->limit.pitch = 1;
             motors->limit.yaw = 1;
         }
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -830,7 +830,7 @@ float AC_AttitudeControl::rate_target_to_motor_roll(float rate_actual_rads, floa
     float integrator = get_rate_roll_pid().get_integrator();
 
     // Ensure that integrator can only be reduced if the output is saturated
-    if (!_motors.limit.roll_pitch || ((is_positive(integrator) && is_negative(rate_error_rads)) || (is_negative(integrator) && is_positive(rate_error_rads)))) {
+    if (!_motors.limit.roll || ((is_positive(integrator) && is_negative(rate_error_rads)) || (is_negative(integrator) && is_positive(rate_error_rads)))) {
         integrator = get_rate_roll_pid().get_i();
     }
 
@@ -853,7 +853,7 @@ float AC_AttitudeControl::rate_target_to_motor_pitch(float rate_actual_rads, flo
     float integrator = get_rate_pitch_pid().get_integrator();
 
     // Ensure that integrator can only be reduced if the output is saturated
-    if (!_motors.limit.roll_pitch || ((is_positive(integrator) && is_negative(rate_error_rads)) || (is_negative(integrator) && is_positive(rate_error_rads)))) {
+    if (!_motors.limit.pitch || ((is_positive(integrator) && is_negative(rate_error_rads)) || (is_negative(integrator) && is_positive(rate_error_rads)))) {
         integrator = get_rate_pitch_pid().get_i();
     }
 

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -205,7 +205,8 @@ void AP_Motors6DOF::output_min()
     int8_t i;
 
     // set limits flags
-    limit.roll_pitch = true;
+    limit.roll = true;
+    limit.pitch = true;
     limit.yaw = true;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
@@ -302,7 +303,8 @@ void AP_Motors6DOF::output_armed_stabilizing()
         float linear_out[AP_MOTORS_MAX_NUM_MOTORS]; // 3 linear DOF mix for each motor
 
         // initialize limits flags
-        limit.roll_pitch = false;
+        limit.roll = false;
+        limit.pitch = false;
         limit.yaw = false;
         limit.throttle_lower = false;
         limit.throttle_upper = false;
@@ -408,7 +410,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored()
     float linear_out[AP_MOTORS_MAX_NUM_MOTORS]; // 3 linear DOF mix for each motor
 
     // initialize limits flags
-    limit.roll_pitch = false;
+    limit.roll = false;
+    limit.pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
@@ -494,7 +497,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
     float yfl_max;
 
     // initialize limits flags
-    limit.roll_pitch = false;
+    limit.roll = false;
+    limit.pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -160,7 +160,8 @@ void AP_MotorsCoax::output_armed_stabilizing()
     } else {
         rp_scale = constrain_float((1.0f - MIN(fabsf(yaw_thrust), 0.5f*(float)_yaw_headroom/1000.0f)) / rp_thrust_max, 0.0f, 1.0f);
         if (rp_scale < 1.0f) {
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
         }
     }
 
@@ -195,7 +196,8 @@ void AP_MotorsCoax::output_armed_stabilizing()
     float thrust_out_actuator = constrain_float(MAX(_throttle_hover*0.5f,thrust_out), 0.5f, 1.0f);
 
     if (is_zero(thrust_out)) {
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
     }
     // force of a lifting surface is approximately equal to the angle of attack times the airflow velocity squared
     // static thrust is proportional to the airflow velocity squared
@@ -204,11 +206,11 @@ void AP_MotorsCoax::output_armed_stabilizing()
     _actuator_out[0] = roll_thrust/thrust_out_actuator;
     _actuator_out[1] = pitch_thrust/thrust_out_actuator;
     if (fabsf(_actuator_out[0]) > 1.0f) {
-        limit.roll_pitch = true;
+        limit.roll = true;
         _actuator_out[0] = constrain_float(_actuator_out[0], -1.0f, 1.0f);
     }
     if (fabsf(_actuator_out[1]) > 1.0f) {
-        limit.roll_pitch = true;
+        limit.pitch = true;
         _actuator_out[1] = constrain_float(_actuator_out[1], -1.0f, 1.0f);
     }
     _actuator_out[2] = -_actuator_out[0];

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -246,7 +246,8 @@ void AP_MotorsHeli::output_min()
     update_motor_control(ROTOR_CONTROL_STOP);
 
     // override limits flags
-    limit.roll_pitch = true;
+    limit.roll = true;
+    limit.pitch = true;
     limit.yaw = true;
     limit.throttle_lower = true;
     limit.throttle_upper = false;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -410,7 +410,8 @@ void AP_MotorsHeli_Dual::update_motor_control(RotorControlState state)
 void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
     // initialize limits flag
-    limit.roll_pitch = false;
+    limit.roll = false;
+    limit.pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
@@ -418,22 +419,22 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     if (_dual_mode == AP_MOTORS_HELI_DUAL_MODE_TRANSVERSE) {
         if (pitch_out < -_cyclic_max/4500.0f) {
             pitch_out = -_cyclic_max/4500.0f;
-            limit.roll_pitch = true;
+            limit.pitch = true;
         }
 
         if (pitch_out > _cyclic_max/4500.0f) {
             pitch_out = _cyclic_max/4500.0f;
-            limit.roll_pitch = true;
+            limit.pitch = true;
         }
     } else {
         if (roll_out < -_cyclic_max/4500.0f) {
             roll_out = -_cyclic_max/4500.0f;
-            limit.roll_pitch = true;
+            limit.roll = true;
         }
 
         if (roll_out > _cyclic_max/4500.0f) {
             roll_out = _cyclic_max/4500.0f;
-            limit.roll_pitch = true;
+            limit.roll = true;
         }
     }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -195,7 +195,8 @@ void AP_MotorsHeli_Quad::update_motor_control(RotorControlState state)
 void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
     // initialize limits flag
-    limit.roll_pitch = false;
+    limit.roll = false;
+    limit.pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -394,7 +394,8 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     float yaw_offset = 0.0f;
 
     // initialize limits flag
-    limit.roll_pitch = false;
+    limit.roll = false;
+    limit.pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
     limit.throttle_upper = false;
@@ -413,7 +414,8 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
         float ratio = (float)(_cyclic_max/4500.0f) / total_out;
         roll_out *= ratio;
         pitch_out *= ratio;
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
     }
 
     // constrain collective input

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -225,7 +225,8 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // check for roll and pitch saturation
     if (rp_high-rp_low > 1.0f || throttle_avg_max < -rp_low) {
         // Full range is being used by roll and pitch.
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
     }
 
     // calculate the highest allowed average thrust that will provide maximum control range
@@ -282,7 +283,8 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     thr_adj = throttle_thrust - throttle_thrust_best_rpy;
     if (rpy_scale < 1.0f) {
         // Full range is being used by roll, pitch, and yaw.
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
         limit.yaw = true;
         if (thr_adj > 0.0f) {
             limit.throttle_upper = true;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -426,8 +426,12 @@ void AP_MotorsMulticopter::update_throttle_hover(float dt)
 void AP_MotorsMulticopter::output_logic()
 {
     if (_flags.armed) {
-        _disarm_safety_timer = 100;
-    } else if (_disarm_safety_timer != 0) {
+        if (_disarm_disable_pwm && _disarm_safety_timer < 100) {
+            _disarm_safety_timer++;
+        } else {
+            _disarm_safety_timer = 100;
+        }
+    } else if (_disarm_safety_timer > 0) {
         _disarm_safety_timer--;
     }
 
@@ -454,7 +458,7 @@ void AP_MotorsMulticopter::output_logic()
             limit.throttle_upper = true;
 
             // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DESIRED_SHUT_DOWN) {
+            if (_spool_desired != DESIRED_SHUT_DOWN && _disarm_safety_timer >= 100) {
                 _spool_mode = SPIN_WHEN_ARMED;
                 break;
             }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -452,7 +452,8 @@ void AP_MotorsMulticopter::output_logic()
             // Servos set to their trim values or in a test condition.
 
             // set limits flags
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
             limit.yaw = true;
             limit.throttle_lower = true;
             limit.throttle_upper = true;
@@ -477,7 +478,8 @@ void AP_MotorsMulticopter::output_logic()
             // Servos should be moving to correct the current attitude.
 
             // set limits flags
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
             limit.yaw = true;
             limit.throttle_lower = true;
             limit.throttle_upper = true;
@@ -517,7 +519,8 @@ void AP_MotorsMulticopter::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // initialize limits flags
-            limit.roll_pitch = false;
+            limit.roll = false;
+            limit.pitch = false;
             limit.yaw = false;
             limit.throttle_lower = false;
             limit.throttle_upper = false;
@@ -550,7 +553,8 @@ void AP_MotorsMulticopter::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // initialize limits flags
-            limit.roll_pitch = false;
+            limit.roll = false;
+            limit.pitch = false;
             limit.yaw = false;
             limit.throttle_lower = false;
             limit.throttle_upper = false;
@@ -577,7 +581,8 @@ void AP_MotorsMulticopter::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // initialize limits flags
-            limit.roll_pitch = false;
+            limit.roll = false;
+            limit.pitch = false;
             limit.yaw = false;
             limit.throttle_lower = false;
             limit.throttle_upper = false;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -188,7 +188,7 @@ protected:
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
     float               _throttle_thrust_max;   // the maximum allowed throttle thrust 0.0 to 1.0 in the range throttle_min to throttle_max
-    uint16_t            _disarm_safety_timer;
+    uint16_t            _disarm_safety_timer;   // Number of writes to the esc when transitioning between zero pwm to minimum
 
     // vehicle supplied callback for thrust compensation. Used for tiltrotors and tiltwings
     thrust_compensation_fn_t _thrust_compensation_callback;

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -165,7 +165,8 @@ void AP_MotorsSingle::output_armed_stabilizing()
     } else {
         rp_scale = constrain_float((1.0f - MIN(fabsf(yaw_thrust), (float)_yaw_headroom/1000.0f)) / rp_thrust_max, 0.0f, 1.0f);
         if (rp_scale < 1.0f) {
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
         }
     }
 
@@ -200,7 +201,8 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _thrust_out = throttle_avg_max + thr_adj;
 
     if (is_zero(_thrust_out)) {
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
         limit.yaw = true;
     }
 
@@ -216,7 +218,8 @@ void AP_MotorsSingle::output_armed_stabilizing()
     if (actuator_max > thrust_out_actuator && !is_zero(actuator_max)) {
         // roll, pitch and yaw request can not be achieved at full servo defection
         // reduce roll, pitch and yaw to reduce the requested defection to maximum
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
         limit.yaw = true;
         rp_scale = thrust_out_actuator/actuator_max;
     } else {

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -57,7 +57,8 @@ void AP_MotorsTailsitter::output_to_motors()
         case SHUT_DOWN:
             throttle = 0;
             // set limits flags
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
             limit.yaw = true;
             limit.throttle_lower = true;
             limit.throttle_upper = true;
@@ -66,7 +67,8 @@ void AP_MotorsTailsitter::output_to_motors()
             // sends output to motors when armed but not flying
             throttle = constrain_float(_spin_up_ratio, 0.0f, 1.0f) * _spin_min;
             // set limits flags
-            limit.roll_pitch = true;
+            limit.roll = true;
+            limit.pitch = true;
             limit.yaw = true;
             limit.throttle_lower = true;
             limit.throttle_upper = true;
@@ -78,7 +80,8 @@ void AP_MotorsTailsitter::output_to_motors()
             throttle_left  = constrain_float(throttle + _rudder*0.5, _spin_min, 1);
             throttle_right = constrain_float(throttle - _rudder*0.5, _spin_min, 1);
             // initialize limits flags
-            limit.roll_pitch = false;
+            limit.roll = false;
+            limit.pitch = false;
             limit.yaw = false;
             limit.throttle_lower = false;
             limit.throttle_upper = false;

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -215,7 +215,8 @@ void AP_MotorsTri::output_armed_stabilizing()
     thr_adj = throttle_thrust - throttle_thrust_best_rpy;
     if(rpy_scale < 1.0f){
         // Full range is being used by roll, pitch, and yaw.
-        limit.roll_pitch = true;
+        limit.roll = true;
+        limit.pitch = true;
         if (thr_adj > 0.0f){
             limit.throttle_upper = true;
         }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -44,7 +44,8 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     _throttle_filter.reset(0.0f);
 
     // init limit flags
-    limit.roll_pitch = true;
+    limit.roll = true;
+    limit.pitch = true;
     limit.yaw = true;
     limit.throttle_lower = true;
     limit.throttle_upper = true;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -117,7 +117,8 @@ public:
 
     // structure for holding motor limit flags
     struct AP_Motors_limit {
-        uint8_t roll_pitch      : 1; // we have reached roll or pitch limit
+        uint8_t roll            : 1; // we have reached roll  limit
+        uint8_t pitch           : 1; // we have reached pitch limit
         uint8_t yaw             : 1; // we have reached yaw limit
         uint8_t throttle_lower  : 1; // we have reached throttle's lower limit
         uint8_t throttle_upper  : 1; // we have reached throttle's upper limit

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -168,11 +168,11 @@ void stability_test()
                     avg_out = ((hal.rcout->read(0) + hal.rcout->read(1) + hal.rcout->read(2) + hal.rcout->read(3))/4);
                     // display input and output
 #if NUM_OUTPUTS <= 4
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",                // quad
+                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",                // quad
 #elif NUM_OUTPUTS <= 6
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",          // hexa
+                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",          // hexa
 #else
-                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",    // octa
+                    hal.console->printf("%d,%d,%d,%3.1f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",    // octa
 #endif
                             (int)roll_in,
                             (int)pitch_in,
@@ -191,7 +191,8 @@ void stability_test()
                             (int)hal.rcout->read(7),
 #endif
                             (int)avg_out,
-                            (int)motors.limit.roll_pitch,
+                            (int)motors.limit.roll,
+                            (int)motors.limit.pitch,
                             (int)motors.limit.yaw,
                             (int)motors.limit.throttle_lower,
                             (int)motors.limit.throttle_upper);


### PR DESCRIPTION
This pull request makes two changes:
1. it ensures there is a delay between enabling the pwm output and increasing the throttle above minimum throttle when _disarm_disable_pwm is being used.
2. it adds maximum limits for roll, pitch and yaw motor mixer inputs. This is very useful when some axis should not use the full actuator range.