### PR TITLE
Use mavlink define for statustext length

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -381,15 +381,12 @@ void AP_AccelCal::_printf(const char* fmt, ...)
     if (!_gcs) {
         return;
     }
-    char msg[50];
+    char msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     va_list ap;
     va_start(ap, fmt);
     hal.util->vsnprintf(msg, sizeof(msg), fmt, ap);
     va_end(ap);
-    if (msg[strlen(msg)-1] == '\n') {
-        // STATUSTEXT messages should not add linefeed
-        msg[strlen(msg)-1] = 0;
-    }
+
     AP_HAL::UARTDriver *uart = _gcs->get_uart();
     /*
      *     to ensure these messages get to the user we need to wait for the

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -58,7 +58,7 @@ void AP_Frsky_Telem::init(const AP_SerialManager &serial_manager,
         if (_frame_string == nullptr) {
             queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
         } else {
-            char firmware_buf[50];
+            char firmware_buf[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
             snprintf(firmware_buf, sizeof(firmware_buf), "%s %s", AP::fwversion().fw_string, _frame_string);
             queue_message(MAV_SEVERITY_INFO, firmware_buf);
         }

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -158,14 +158,14 @@ void AP_GPS_Backend::_detection_message(char *buffer, const uint8_t buflen) cons
 
 void AP_GPS_Backend::broadcast_gps_type() const
 {
-    char buffer[64];
+    char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     _detection_message(buffer, sizeof(buffer));
     gcs().send_text(MAV_SEVERITY_INFO, buffer);
 }
 
 void AP_GPS_Backend::Write_DataFlash_Log_Startup_messages() const
 {
-    char buffer[64];
+    char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     _detection_message(buffer, sizeof(buffer));
     DataFlash_Class::instance()->Log_Write_Message(buffer);
 }


### PR DESCRIPTION
Also strip out dead code - the callers don't terminate with `\n`
