### PR TITLE
AP_Compass_HMC5843：fix bug with uninitialized variables

### DIFF
--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -100,6 +100,7 @@ AP_Compass_HMC5843::AP_Compass_HMC5843(AP_HMC5843_BusDriver *bus,
     , _rotation(rotation)
     , _force_external(force_external)
 {
+    memset(_scaling, 0, sizeof(_scaling));
 }
 
 AP_Compass_HMC5843::~AP_Compass_HMC5843()


### PR DESCRIPTION
fix the bug that the _scaling wasn't initialized when compass calibrate called by init();