### PR TITLE
AP_Baro: Delete judgment that the same value lasted 2 seconds

### DIFF
--- a/libraries/AP_Baro/AP_Baro_Backend.cpp
+++ b/libraries/AP_Baro/AP_Baro_Backend.cpp
@@ -19,11 +19,10 @@ void AP_Baro_Backend::update_healthy_flag(uint8_t instance)
     }
 
     // consider a sensor as healthy if it has had an update in the
-    // last 0.5 seconds and values are non-zero and have changed within the last 2 seconds
+    // last 0.5 seconds and values are non-zero.
     const uint32_t now = AP_HAL::millis();
     _frontend.sensors[instance].healthy =
         (now - _frontend.sensors[instance].last_update_ms < BARO_TIMEOUT_MS) &&
-        (now - _frontend.sensors[instance].last_change_ms < BARO_DATA_CHANGE_TIMEOUT_MS) &&
         !is_zero(_frontend.sensors[instance].pressure);
 
     _sem.give();


### PR DESCRIPTION
I saw a healthy message with a disarm in the test of the atmospheric pressure sensor. I have not found a soft reset on the device with barometric pressure sensor MPL3115A2 if it is equivalent for 2 seconds. I think that it is better to process the judgment to detect the inherent device fault with that device class.