### PR TITLE
README.md: updated link of contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## How To Get Involved ##
 
-- The ArduPilot project is open source and we encourage participation and code contributions: [guidelines for contributors to the ardupilot codebase](http://dev.ardupilot.org/wiki/guidelines-for-contributors-to-the-apm-codebase)
+- The ArduPilot project is open source and we encourage participation and code contributions: [guidelines for contributors to the ardupilot codebase](http://ardupilot.org/dev/docs/contributing.html)
 
 - We have an active group of Beta Testers especially for ArduCopter to help us find bugs: [release procedures](http://dev.ardupilot.org/wiki/release-procedures)
 


### PR DESCRIPTION
This is a PR to update the dead link for **_Guidelines for contributors to the ArduPilot codebase_** in the README.md documentation file.