### PR TITLE
Add instance types to logging, use them in the battery logging messages

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -234,7 +234,7 @@ AP_BattMonitor::read()
 
     DataFlash_Class *df = DataFlash_Class::instance();
     if (df->should_log(_log_battery_bit)) {
-        df->Log_Write_Current();
+        df->Log_Write_Battery();
         df->Log_Write_Power();
     }
 

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -131,7 +131,7 @@ public:
     void Log_Write_Airspeed(AP_Airspeed &airspeed);
     void Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Log_Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
-    void Log_Write_Current();
+    void Log_Write_Battery(void);
     void Log_Write_Compass(uint64_t time_us=0);
     void Log_Write_Mode(uint8_t mode, uint8_t reason);
 
@@ -303,10 +303,6 @@ private:
     void Log_Write_Compass_instance(uint64_t time_us,
                                     uint8_t mag_instance,
                                     enum LogMessages type);
-    void Log_Write_Current_instance(uint64_t time_us,
-                                    uint8_t battery_instance,
-                                    enum LogMessages type,
-                                    enum LogMessages celltype);
     void Log_Write_IMUDT_instance(uint64_t time_us,
                                   uint8_t imu_instance,
                                   enum LogMessages type);

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -91,6 +91,7 @@ const struct UnitStructure log_Units[] = {
     { 'G', "Gauss" },         // Gauss is not an SI unit, but 1 tesla = 10000 gauss so a simple replacement is not possible here
     { 'h', "degheading" },    // 0.? to 359.?
     { 'i', "A.s" },           // Ampere second
+    { 'I', "Instance" },      // Message contains instance fields which should be graphed seperately
     { 'J', "W.s" },           // Joule (Watt second)
     // { 'l', "l" },          // litres
     { 'L', "rad/s/s" },       // radians per second per second
@@ -672,9 +673,10 @@ struct PACKED log_PID {
     float   FF;
 };
 
-struct PACKED log_Current {
+struct PACKED log_Battery {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t  instance;
     float    voltage;
     float    voltage_resting;
     float    current_amps;
@@ -684,9 +686,10 @@ struct PACKED log_Current {
     float    resistance;
 };
 
-struct PACKED log_Current_Cells {
+struct PACKED log_Battery_Cells {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t  instance;
     float    voltage;
     uint16_t cell_voltages[10];
 };
@@ -1135,16 +1138,6 @@ struct PACKED log_DSTL {
 #define QUAT_UNITS  "s????"
 #define QUAT_MULTS  "F????"
 
-#define CURR_LABELS "TimeUS,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res"
-#define CURR_FMT    "Qfffffcf"
-#define CURR_UNITS  "svvA?JOw"
-#define CURR_MULTS  "F000?/?0"
-
-#define CURR_CELL_LABELS "TimeUS,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10"
-#define CURR_CELL_FMT    "QfHHHHHHHHHH"
-#define CURR_CELL_UNITS  "svvvvvvvvvvv"
-#define CURR_CELL_MULTS  "F00000000000"
-
 #define ARSP_LABELS "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset,U,Health,Primary"
 #define ARSP_FMT "QffcffBBB"
 #define ARSP_UNITS "snPOPP---"
@@ -1222,42 +1215,10 @@ Format characters in the format string for binary log messages
       "TRIG", "QIHLLeeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,GPSAlt,Roll,Pitch,Yaw", "s--DUmmmddd", "F--GGBBBBBB" }, \
     { LOG_ARSP_MSG, sizeof(log_AIRSPEED), "ARSP",  ARSP_FMT, ARSP_LABELS, ARSP_UNITS, ARSP_MULTS }, \
     { LOG_ASP2_MSG, sizeof(log_AIRSPEED), "ASP2",  ARSP_FMT, ARSP_LABELS, ARSP_UNITS, ARSP_MULTS }, \
-    { LOG_CURRENT_MSG, sizeof(log_Current), \
-      "BAT", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS },  \
-    { LOG_CURRENT2_MSG, sizeof(log_Current), \
-      "BAT2", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT3_MSG, sizeof(log_Current), \
-      "BAT3", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT4_MSG, sizeof(log_Current), \
-      "BAT4", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT5_MSG, sizeof(log_Current), \
-      "BAT5", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT6_MSG, sizeof(log_Current), \
-      "BAT6", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT7_MSG, sizeof(log_Current), \
-      "BAT7", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT8_MSG, sizeof(log_Current), \
-      "BAT8", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT9_MSG, sizeof(log_Current), \
-      "BAT9", CURR_FMT,CURR_LABELS,CURR_UNITS,CURR_MULTS }, \
-    { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
-      "BCL", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS2_MSG, sizeof(log_Current_Cells), \
-      "BCL2", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS3_MSG, sizeof(log_Current_Cells), \
-      "BCL3", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS4_MSG, sizeof(log_Current_Cells), \
-      "BCL4", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS5_MSG, sizeof(log_Current_Cells), \
-      "BCL5", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS6_MSG, sizeof(log_Current_Cells), \
-      "BCL6", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS7_MSG, sizeof(log_Current_Cells), \
-      "BCL7", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS8_MSG, sizeof(log_Current_Cells), \
-      "BCL8", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
-    { LOG_CURRENT_CELLS9_MSG, sizeof(log_Current_Cells), \
-      "BCL9", CURR_CELL_FMT, CURR_CELL_LABELS, CURR_CELL_UNITS, CURR_CELL_MULTS }, \
+    { LOG_BATTERY_MSG, sizeof(log_Battery), \
+      "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "sIvvA?JOw", "F?000?/?0" },  \
+    { LOG_BATTERY_CELLS_MSG, sizeof(log_Battery_Cells), \
+      "BCL", "QBfHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10", "sIvvvvvvvvvvv", "F?00000000000" }, \
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw", "sddddhhdh", "FBBBBBBBB" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
@@ -1520,24 +1481,8 @@ enum LogMessages : uint8_t {
     LOG_BAR2_MSG,
     LOG_ARSP_MSG,
     LOG_ATTITUDE_MSG,
-    LOG_CURRENT_MSG,
-    LOG_CURRENT2_MSG,
-    LOG_CURRENT3_MSG,
-    LOG_CURRENT4_MSG,
-    LOG_CURRENT5_MSG,
-    LOG_CURRENT6_MSG,
-    LOG_CURRENT7_MSG,
-    LOG_CURRENT8_MSG,
-    LOG_CURRENT9_MSG,
-    LOG_CURRENT_CELLS_MSG,
-    LOG_CURRENT_CELLS2_MSG,
-    LOG_CURRENT_CELLS3_MSG,
-    LOG_CURRENT_CELLS4_MSG,
-    LOG_CURRENT_CELLS5_MSG,
-    LOG_CURRENT_CELLS6_MSG,
-    LOG_CURRENT_CELLS7_MSG,
-    LOG_CURRENT_CELLS8_MSG,
-    LOG_CURRENT_CELLS9_MSG,
+    LOG_BATTERY_MSG,
+    LOG_BATTERY_CELLS_MSG,
     LOG_COMPASS_MSG,
     LOG_COMPASS2_MSG,
     LOG_COMPASS3_MSG,


### PR DESCRIPTION
This follows onto #9414 by moving the logging of battery messages to use an instance field. If you only use one battery monitor (far and away the most common setup) this won't have any impact. If you use multiple monitors you will need GCS tooling to catch up to this to graph fields usefully.

For GCS Authors: There is now a unit type of `I` which means that it is an instance message. The field should be used to split what instance on the vehicle it corresponds to. Thus all BAT messages with instance 0 is the first battery monitor, instance 1 is the second monitor. This allows the GCS to then limit graphing to a per battery instance, while not having to update predefined graphs everytime we add more batteries to the logs. (More importantly we were consuming the 8 bit log ID space much to quickly which meant we were going to have problems adding more messages, this should let us claw a lot back).

The UI will need some thoughts, in MAVExplorer this could be done `graph BAT.Volt@0 BAT.Volt@1` to graph the first and second batteries against each other. (GCS's should also feel free to extend this as they desire, for example including the concept of if the index is not specified then graph the first instance only, or potentially for tools which make lists the way APMPlanner2/Mission Planner do they could just make a heading in the UI for BAT0 BAT1 BAT2 automatically as reasonable).

Final other notes: This is a lot more logging then just current, so I took the time to rename those parts, and I also directly inlined the instance logging function. On a function like this which is only used from one caller I find it much more frustrating to have it elsewhere in the code, particularly when all it actually was being done was just called in a `for` loop. This inlining saves 28 bytes, and should run faster since it allows us to skip fetching the singleton for every battery instance.

EDIT: It should also be note a number of MAVLink messages need instance related graphing such as `BATTERY_STATUS` already so this should be considered as well.