### PR TITLE
 Copter: support changing vertical speed in DO_CHANGE_SPEED

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -755,7 +755,13 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         // param3 : unused
         // param4 : unused
         if (packet.param2 > 0.0f) {
-            copter.wp_nav->set_speed_xy(packet.param2 * 100.0f);
+            if (packet.param1 > 2.9f) { // 3 = speed down
+                copter.wp_nav->set_speed_z(packet.param2 * 100.0f, copter.wp_nav->get_speed_up());
+		    } else if (packet.param1 > 1.9f) { // 2 = speed up
+                copter.wp_nav->set_speed_z(copter.wp_nav->get_speed_down(), packet.param2 * 100.0f);
+            } else {
+                copter.wp_nav->set_speed_xy(packet.param2 * 100.0f);
+            }
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_FAILED;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1316,7 +1316,13 @@ void Copter::ModeAuto::do_yaw(const AP_Mission::Mission_Command& cmd)
 void Copter::ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.content.speed.target_ms > 0) {
-        copter.wp_nav->set_speed_xy(cmd.content.speed.target_ms * 100.0f);
+        if (cmd.content.speed.speed_type == 2)  {
+            copter.wp_nav->set_speed_z(copter.wp_nav->get_speed_down(), cmd.content.speed.target_ms * 100.0f);
+        } else if (cmd.content.speed.speed_type == 3)  {
+            copter.wp_nav->set_speed_z(cmd.content.speed.target_ms * 100.0f, copter.wp_nav->get_speed_up());
+        } else {
+            copter.wp_nav->set_speed_xy(cmd.content.speed.target_ms * 100.0f);
+        }
     }
 }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -171,6 +171,16 @@ void AC_WPNav::set_speed_xy(float speed_cms)
     }
 }
 
+/// set_speed_z - allows main code to pass target vertical velocity for wp navigation
+void AC_WPNav::set_speed_z(float speed_down_cms, float speed_up_cms)
+{
+    _wp_speed_down_cms = speed_down_cms;
+    _wp_speed_up_cms = speed_up_cms;
+    _pos_control.set_max_speed_z(_wp_speed_down_cms, _wp_speed_up_cms);
+    // flag that wp leash must be recalculated
+    _flags.recalc_wp_leash = true;
+}
+
 /// set_wp_destination waypoint using location class
 ///     returns false if conversion from location to vector from ekf origin cannot be calculated
 bool AC_WPNav::set_wp_destination(const Location_Class& destination)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -78,6 +78,9 @@ public:
     /// set_speed_xy - allows main code to pass target horizontal velocity for wp navigation
     void set_speed_xy(float speed_cms);
 
+    /// set_speed_z - allows main code to pass target vertical velocity for wp navigation
+    void set_speed_z(float speed_down_cms, float speed_up_cms);
+
     /// get_speed_xy - allows main code to retrieve target horizontal velocity for wp navigation
     float get_speed_xy() const { return _wp_speed_cms; }
 


### PR DESCRIPTION
for  #5618 

It allows users to change vertical speed in auto mission using DO_CHANGE_SPEED. set param1 to 2 for changing climb speed. set param1 to 3 for changing descent speed.

Tested on both SITL and my quadcopter (pixhawk 2 on dji f450 frame)

According to [doc](http://ardupilot.org/copter/docs/common-mavlink-mission-command-messages-mav_cmd.html#mav-cmd-do-change-speed). param1 means speed type (0=Airspeed, 1=Ground Speed)
