### PR TITLE
Make AHRS do set-home notifications

### DIFF
--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -69,13 +69,6 @@ bool Rover::set_home(const Location& loc, bool lock)
     // Save Home to EEPROM
     mission.write_home_to_storage();
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
     // send text of home position to ground stations
     gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
             static_cast<double>(loc.lat * 1.0e-7f),
@@ -98,8 +91,6 @@ void Rover::update_home()
         if (ahrs.get_position(loc)) {
             if (get_distance(loc, ahrs.get_home()) > DISTANCE_HOME_MAX) {
                 ahrs.set_home(loc);
-                ahrs.Log_Write_Home_And_Origin();
-                gcs().send_home();
             }
         }
     }

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -158,9 +158,6 @@ void Tracker::set_home(struct Location temp)
     if (ahrs.get_origin(ekf_origin)) {
         ahrs.set_home(temp);
     }
-
-    gcs().send_home();
-    gcs().send_ekf_origin();
 }
 
 void Tracker::arm_servos()

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -100,13 +100,6 @@ bool Copter::set_home(const Location& loc, bool lock)
         ahrs.lock_home();
     }
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
     // return success
     return true;
 }

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -139,6 +139,4 @@ void Plane::set_home_persistently(const Location &loc)
 void Plane::set_home(const Location &loc)
 {
     ahrs.set_home(loc);
-    ahrs.Log_Write_Home_And_Origin();
-    gcs().send_home();
 }

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -88,13 +88,6 @@ bool Sub::set_home(const Location& loc, bool lock)
         ahrs.lock_home();
     }
 
-    // log ahrs home and ekf origin dataflash
-    ahrs.Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_home();
-    gcs().send_ekf_origin();
-
     // return success
     return true;
 }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -22,6 +22,7 @@
  */
 #include "AP_AHRS.h"
 #include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -1030,6 +1031,13 @@ void AP_AHRS_DCM::set_home(const Location &loc)
     _home = loc;
     _home.options = 0;
     _home_is_set = true;
+
+    // log ahrs home and ekf origin dataflash
+    Log_Write_Home_And_Origin();
+
+    // send new home and ekf origin to GCS
+    gcs().send_home();
+    gcs().send_ekf_origin();
 }
 
 //  a relative ground position to home in meters, Down


### PR DESCRIPTION
This is not NFC.

It does make the vehicles more similar in their behaviour in terms of notifications.

Rover will send ekf origin when home is automatically updated
tracker will only send origin and home if it sets home
Plane will send origin along with home to gcs
tracker will log home and origin
