### PR TITLE
AP_Compass: don't publish frozen data

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -21,6 +21,8 @@
 
 #include "AP_Compass.h"
 
+#define FREEZE_THRESHOLD 30
+
 class Compass;  // forward declaration
 class AP_Compass_Backend
 {
@@ -112,11 +114,20 @@ protected:
     bool field_ok(const Vector3f &field);
     
     uint32_t get_error_count() const { return _error_count; }
+    
+    virtual uint8_t get_freeze_threshold() const { return FREEZE_THRESHOLD; }
+    
 private:
     void apply_corrections(Vector3f &mag, uint8_t i);
+    
+    // check the field value is same all the time
+    bool is_frozen(const Vector3f &field);
     
     // mean field length for range filter
     float _mean_field_length;
     // number of dropped samples. Not used for now, but can be usable to choose more reliable sensor
     uint32_t _error_count;
+    
+    Vector3f _frozen_check_field;
+    uint8_t _field_freeze_count;
 };

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -17,6 +17,10 @@ public:
 
     void read(void);
 
+protected:
+    // disable data freeze checking
+    uint8_t get_freeze_threshold() const { return 0; }
+    
 private:
     uint8_t _compass_instance[SITL_NUM_COMPASSES];
     SITL::SITL *_sitl;


### PR DESCRIPTION
This is a try to avoid a situation described in 
https://discuss.ardupilot.org/t/compass-stop-working-but-remains-healthy/33205
when compass hangs up for some reason. It still can be read but does not provide any changes. So it stays healthy all the time:
![image](https://user-images.githubusercontent.com/9112882/46834136-45e0ca80-cdb3-11e8-86a9-e21b92e65a58.png)
(plz never mind the peaks, they're likely caused by a long wires)

This fix does monitor the values published and if they are equal for a number in a row ( > threshold), then publishing will stop till the values be different again. Stop of publish will lead to a bad compass health, that is the goal.