### PR TITLE
Removed hal.util->new_semaphore() and use WITH_SEMAPHORE()

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -702,9 +702,9 @@ void ToyMode::trim_update(void)
     // get throttle mid from channel trim
     uint16_t throttle_trim = copter.channel_throttle->get_radio_trim();
     if (abs(throttle_trim - 1500) <= trim_auto) {
-        RC_Channel *ch = copter.channel_throttle;
-        uint16_t ch_min = ch->get_radio_min();
-        uint16_t ch_max = ch->get_radio_max();
+        RC_Channel *c = copter.channel_throttle;
+        uint16_t ch_min = c->get_radio_min();
+        uint16_t ch_max = c->get_radio_max();
         // remember the throttle midpoint
         int16_t new_value = 1000UL * (throttle_trim - ch_min) / (ch_max - ch_min);
         if (new_value != throttle_mid) {
@@ -758,8 +758,8 @@ void ToyMode::trim_update(void)
     
     uint8_t need_trim = 0;
     for (uint8_t i=0; i<4; i++) {
-        RC_Channel *ch = RC_Channels::rc_channel(i);
-        if (ch && abs(chan[i] - ch->get_radio_trim()) > noise_limit) {
+        RC_Channel *c = RC_Channels::rc_channel(i);
+        if (c && abs(chan[i] - c->get_radio_trim()) > noise_limit) {
             need_trim |= 1U<<i;
         }
     }
@@ -768,8 +768,8 @@ void ToyMode::trim_update(void)
     }
     for (uint8_t i=0; i<4; i++) {
         if (need_trim & (1U<<i)) {
-            RC_Channel *ch = RC_Channels::rc_channel(i);
-            ch->set_and_save_radio_trim(chan[i]);
+            RC_Channel *c = RC_Channels::rc_channel(i);
+            c->set_and_save_radio_trim(chan[i]);
         }
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -28,12 +28,10 @@ AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend, uint8_t _instan
     frontend(_frontend),
     instance(_instance)
 {
-    sem = hal.util->new_semaphore();
 }
 
 AP_Airspeed_Backend::~AP_Airspeed_Backend(void)
 {
-    delete sem;
 }
  
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -47,7 +47,7 @@ protected:
     }
     
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *sem;
+    HAL_Semaphore sem;
 
     float get_airspeed_ratio(void) const {
         return frontend.get_airspeed_ratio(instance);

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
@@ -82,13 +82,13 @@ void AP_Airspeed_DLVR::timer()
     float press_h2o = 1.25f * 2.0f * DLVR_FSS * ((pres_raw - DLVR_OFFSET) / DLVR_SCALE);
     float temp = temp_raw * (200.0f / 2047.0f) - 50.0f;
 
-    sem->take_blocking();
+    WITH_SEMAPHORE(sem);
+
     pressure_sum += INCH_OF_H2O_TO_PASCAL * press_h2o;
     temperature_sum += temp;
     press_count++;
     temp_count++;
     last_sample_time_ms = AP_HAL::millis();
-    sem->give();
 }
 
 // return the current differential_pressure in Pascal
@@ -97,14 +97,16 @@ bool AP_Airspeed_DLVR::get_differential_pressure(float &_pressure)
     if ((AP_HAL::millis() - last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+
+    {
+        WITH_SEMAPHORE(sem);
         if (press_count > 0) {
             pressure = pressure_sum / press_count;
             press_count = 0;
             pressure_sum = 0;
         }
-        sem->give();
     }
+
     _pressure = pressure;
     return true;
 }
@@ -115,14 +117,15 @@ bool AP_Airspeed_DLVR::get_temperature(float &_temperature)
     if ((AP_HAL::millis() - last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        if (temp_count > 0) {
-            temperature = temperature_sum / temp_count;
-            temp_count = 0;
-            temperature_sum = 0;
-        }
-        sem->give();
+
+    WITH_SEMAPHORE(sem);
+
+    if (temp_count > 0) {
+        temperature = temperature_sum / temp_count;
+        temp_count = 0;
+        temperature_sum = 0;
     }
+
     _temperature = temperature;
     return true;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -180,14 +180,13 @@ void AP_Airspeed_SDP3X::_timer()
     float diff_press_pa = float(P) / float(_scale);
     float temperature = float(temp) / SDP3X_SCALE_TEMPERATURE;
 
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _press_sum += diff_press_pa;
-        _temp_sum += temperature;
-        _press_count++;
-        _temp_count++;
-        _last_sample_time_ms = now;
-        sem->give();
-    }
+    WITH_SEMAPHORE(sem);
+
+    _press_sum += diff_press_pa;
+    _temp_sum += temperature;
+    _press_count++;
+    _temp_count++;
+    _last_sample_time_ms = now;
 }
 
 /*
@@ -279,14 +278,16 @@ bool AP_Airspeed_SDP3X::get_differential_pressure(float &pressure)
     if (now - _last_sample_time_ms > 100) {
         return false;
     }
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+
+    {
+        WITH_SEMAPHORE(sem);
         if (_press_count > 0) {
             _press = _press_sum / _press_count;
             _press_count = 0;
             _press_sum = 0;
         }
-        sem->give();
     }
+
     pressure = _correct_pressure(_press);
     return true;
 }
@@ -297,14 +298,15 @@ bool AP_Airspeed_SDP3X::get_temperature(float &temperature)
     if ((AP_HAL::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        if (_temp_count > 0) {
-            _temp = _temp_sum / _temp_count;
-            _temp_count = 0;
-            _temp_sum = 0;
-        }
-        sem->give();
+
+    WITH_SEMAPHORE(sem);
+
+    if (_temp_count > 0) {
+        _temp = _temp_sum / _temp_count;
+        _temp_count = 0;
+        _temp_sum = 0;
     }
+
     temperature = _temp;
     return true;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -17,7 +17,7 @@ extern const AP_HAL::HAL& hal;
 UC_REGISTRY_BINDER(AirspeedCb, uavcan::equipment::air_data::RawAirData);
 
 AP_Airspeed_UAVCAN::DetectedModules AP_Airspeed_UAVCAN::_detected_modules[] = {0};
-AP_HAL::Semaphore* AP_Airspeed_UAVCAN::_sem_registry = nullptr;
+HAL_Semaphore AP_Airspeed_UAVCAN::_sem_registry;
 
 // constructor
 AP_Airspeed_UAVCAN::AP_Airspeed_UAVCAN(AP_Airspeed &_frontend, uint8_t _instance) :
@@ -43,16 +43,12 @@ void AP_Airspeed_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
 
 bool AP_Airspeed_UAVCAN::take_registry()
 {
-    if (_sem_registry == nullptr) {
-        _sem_registry = hal.util->new_semaphore();
-    }
-
-    return _sem_registry->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+    return _sem_registry.take(HAL_SEMAPHORE_BLOCK_FOREVER);
 }
 
 void AP_Airspeed_UAVCAN::give_registry()
 {
-    _sem_registry->give();
+    _sem_registry.give();
 }
 
 AP_Airspeed_Backend* AP_Airspeed_UAVCAN::probe(AP_Airspeed &_frontend, uint8_t _instance)

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
@@ -44,5 +44,5 @@ private:
         AP_Airspeed_UAVCAN *driver;
     } _detected_modules[AIRSPEED_MAX_SENSORS];
 
-    static AP_HAL::Semaphore *_sem_registry;
+    static HAL_Semaphore _sem_registry;
 };

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -449,19 +449,19 @@ bool AP_Arming::rc_calibration_checks(bool report)
     bool check_passed = true;
     const uint8_t num_channels = RC_Channels::get_valid_channel_count();
     for (uint8_t i = 0; i < NUM_RC_CHANNELS; i++) {
-        const RC_Channel *ch = rc().channel(i);
-        if (ch == nullptr) {
+        const RC_Channel *c = rc().channel(i);
+        if (c == nullptr) {
             continue;
         }
-        if (i >= num_channels && !(ch->has_override())) {
+        if (i >= num_channels && !(c->has_override())) {
             continue;
         }
-        const uint16_t trim = ch->get_radio_trim();
-        if (ch->get_radio_min() > trim) {
+        const uint16_t trim = c->get_radio_trim();
+        if (c->get_radio_min() > trim) {
             check_failed(ARMING_CHECK_RC, report, "RC%d minimum is greater than trim", i + 1);
             check_passed = false;
         }
-        if (ch->get_radio_max() < trim) {
+        if (c->get_radio_max() < trim) {
             check_failed(ARMING_CHECK_RC, report, "RC%d maximum is less than trim", i + 1);
             check_passed = false;
         }
@@ -492,17 +492,17 @@ bool AP_Arming::servo_checks(bool report) const
 {
     bool check_passed = true;
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        const SRV_Channel *ch = SRV_Channels::srv_channel(i);
-        if (ch == nullptr || ch->get_function() == SRV_Channel::k_none) {
+        const SRV_Channel *c = SRV_Channels::srv_channel(i);
+        if (c == nullptr || c->get_function() == SRV_Channel::k_none) {
             continue;
         }
 
-        const uint16_t trim = ch->get_trim();
-        if (ch->get_output_min() > trim) {
+        const uint16_t trim = c->get_trim();
+        if (c->get_output_min() > trim) {
             check_failed(ARMING_CHECK_NONE, report, "SERVO%d minimum is greater than trim", i + 1);
             check_passed = false;
         }
-        if (ch->get_output_max() < trim) {
+        if (c->get_output_max() < trim) {
             check_failed(ARMING_CHECK_NONE, report, "SERVO%d maximum is less than trim", i + 1);
             check_passed = false;
         }

--- a/libraries/AP_Baro/AP_Baro_Backend.cpp
+++ b/libraries/AP_Baro/AP_Baro_Backend.cpp
@@ -14,9 +14,7 @@ void AP_Baro_Backend::update_healthy_flag(uint8_t instance)
     if (instance >= _frontend._num_sensors) {
         return;
     }
-    if (!_sem.take_nonblocking()) {
-        return;
-    }
+    WITH_SEMAPHORE(_sem);
 
     // consider a sensor as healthy if it has had an update in the
     // last 0.5 seconds and values are non-zero and have changed within the last 2 seconds
@@ -25,8 +23,6 @@ void AP_Baro_Backend::update_healthy_flag(uint8_t instance)
         (now - _frontend.sensors[instance].last_update_ms < BARO_TIMEOUT_MS) &&
         (now - _frontend.sensors[instance].last_change_ms < BARO_DATA_CHANGE_TIMEOUT_MS) &&
         !is_zero(_frontend.sensors[instance].pressure);
-
-    _sem.give();
 }
 
 void AP_Baro_Backend::backend_update(uint8_t instance)

--- a/libraries/AP_Baro/AP_Baro_Backend.h
+++ b/libraries/AP_Baro/AP_Baro_Backend.h
@@ -31,7 +31,7 @@ protected:
     void _copy_to_frontend(uint8_t instance, float pressure, float temperature);
 
     // semaphore for access to shared frontend data
-    HAL_Semaphore _sem;    
+    HAL_Semaphore_Recursive _sem;
 
     virtual void update_healthy_flag(uint8_t instance);
 

--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -210,28 +210,24 @@ void AP_Baro_DPS280::timer(void)
         return;
     }
 
-    if (_sem.take_nonblocking()) {
-        pressure_sum += pressure;
-        temperature_sum += temperature;
-        count++;
-        _sem.give();
-    }
+    WITH_SEMAPHORE(_sem);
+
+    pressure_sum += pressure;
+    temperature_sum += temperature;
+    count++;
 }
 
 // transfer data to the frontend
 void AP_Baro_DPS280::update(void)
 {
-    if (count != 0 && _sem.take_nonblocking()) {
-        if (count == 0) {
-            _sem.give();
-            return;
-        }
-
-        _copy_to_frontend(instance, pressure_sum/count, temperature_sum/count);
-        pressure_sum = 0;
-        temperature_sum = 0;
-        count=0;
-
-        _sem.give();
+    if (count == 0) {
+        return;
     }
+
+    WITH_SEMAPHORE(_sem);
+
+    _copy_to_frontend(instance, pressure_sum/count, temperature_sum/count);
+    pressure_sum = 0;
+    temperature_sum = 0;
+    count=0;
 }

--- a/libraries/AP_Baro/AP_Baro_FBM320.cpp
+++ b/libraries/AP_Baro/AP_Baro_FBM320.cpp
@@ -187,12 +187,12 @@ void AP_Baro_FBM320::timer(void)
     } else {
         int32_t pressure, temperature;
         calculate_PT(value_T, value, pressure, temperature);
-        if (pressure_ok(pressure) && _sem.take_nonblocking()) {
+        if (pressure_ok(pressure)) {
+            WITH_SEMAPHORE(_sem);
             pressure_sum += pressure;
             // sum and convert to degrees
             temperature_sum += temperature*0.01;
             count++;
-            _sem.give();
         }
     }
 
@@ -207,17 +207,13 @@ void AP_Baro_FBM320::timer(void)
 // transfer data to the frontend
 void AP_Baro_FBM320::update(void)
 {
-    if (count != 0 && _sem.take_nonblocking()) {
-        if (count == 0) {
-            _sem.give();
-            return;
-        }
-
-        _copy_to_frontend(instance, pressure_sum/count, temperature_sum/count);
-        pressure_sum = 0;
-        temperature_sum = 0;
-        count=0;
-
-        _sem.give();
+    if (count == 0) {
+        return;
     }
+    WITH_SEMAPHORE(_sem);
+
+    _copy_to_frontend(instance, pressure_sum/count, temperature_sum/count);
+    pressure_sum = 0;
+    temperature_sum = 0;
+    count=0;
 }

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -205,16 +205,13 @@ void AP_Baro_LPS2XH::_timer(void)
 // transfer data to the frontend
 void AP_Baro_LPS2XH::update(void)
 {
-    if (_sem.take_nonblocking()) {
-        if (!_has_sample) {
-            _sem.give();
-            return;
-        }
-
-        _copy_to_frontend(_instance, _pressure, _temperature);
-        _has_sample = false;
-        _sem.give();
+    if (!_has_sample) {
+        return;
     }
+
+    WITH_SEMAPHORE(_sem);
+    _copy_to_frontend(_instance, _pressure, _temperature);
+    _has_sample = false;
 }
 
 // calculate temperature
@@ -224,14 +221,13 @@ void AP_Baro_LPS2XH::_update_temperature(void)
     _dev->read_registers(TEMP_OUT_ADDR, pu8, 2);
     int16_t Temp_Reg_s16 = (uint16_t)(pu8[1]<<8) | pu8[0];
     
-    if (_sem.take_nonblocking()) {
-    	if(_lps2xh_type == BARO_LPS25H){
-    		_temperature=((float)(Temp_Reg_s16/480)+42.5);
-    	}
-    	if(_lps2xh_type == BARO_LPS22H){
-    		_temperature=(float)(Temp_Reg_s16/100);
-    	}
-        _sem.give();
+    WITH_SEMAPHORE(_sem);
+
+    if (_lps2xh_type == BARO_LPS25H) {
+        _temperature=((float)(Temp_Reg_s16/480)+42.5);
+    }
+    if (_lps2xh_type == BARO_LPS22H) {
+        _temperature=(float)(Temp_Reg_s16/100);
     }
 }
 
@@ -242,8 +238,7 @@ void AP_Baro_LPS2XH::_update_pressure(void)
     _dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 3);
     int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|(uint32_t)pressure[0];
     int32_t Pressure_mb = Pressure_Reg_s32 * (100.0 / 4096); // scale for pa
-    if (_sem.take_nonblocking()) {
-        _pressure=Pressure_mb;
-        _sem.give();
-    }
+
+    WITH_SEMAPHORE(_sem);
+    _pressure = Pressure_mb;
 }

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -121,16 +121,13 @@ void AP_Baro_SITL::_timer()
 // Read the sensor
 void AP_Baro_SITL::update(void)
 {
-    if (_sem.take_nonblocking()) {
-        if (!_has_sample) {
-            _sem.give();
-            return;
-        }
-
-        _copy_to_frontend(_instance, _recent_press, _recent_temp);
-        _has_sample = false;
-        _sem.give();
+    if (!_has_sample) {
+        return;
     }
+
+    WITH_SEMAPHORE(_sem);
+    _copy_to_frontend(_instance, _recent_press, _recent_temp);
+    _has_sample = false;
 }
 
 #endif  // CONFIG_HAL_BOARD

--- a/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
@@ -19,7 +19,7 @@ UC_REGISTRY_BINDER(PressureCb, uavcan::equipment::air_data::StaticPressure);
 UC_REGISTRY_BINDER(TemperatureCb, uavcan::equipment::air_data::StaticTemperature);
 
 AP_Baro_UAVCAN::DetectedModules AP_Baro_UAVCAN::_detected_modules[] = {0};
-AP_HAL::Semaphore* AP_Baro_UAVCAN::_sem_registry = nullptr;
+HAL_Semaphore AP_Baro_UAVCAN::_sem_registry;
 
 /*
   constructor - registers instance at top Baro driver
@@ -57,15 +57,12 @@ void AP_Baro_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
 
 bool AP_Baro_UAVCAN::take_registry()
 {
-    if (_sem_registry == nullptr) {
-        _sem_registry = hal.util->new_semaphore();
-    }
-    return _sem_registry->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+    return _sem_registry.take(HAL_SEMAPHORE_BLOCK_FOREVER);
 }
 
 void AP_Baro_UAVCAN::give_registry()
 {
-    _sem_registry->give();
+    _sem_registry.give();
 }
 
 AP_Baro_Backend* AP_Baro_UAVCAN::probe(AP_Baro &baro)

--- a/libraries/AP_Baro/AP_Baro_UAVCAN.h
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.h
@@ -47,5 +47,5 @@ private:
         AP_Baro_UAVCAN* driver;
     } _detected_modules[BARO_MAX_DRIVERS];
 
-    static AP_HAL::Semaphore *_sem_registry;
+    static HAL_Semaphore _sem_registry;
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -143,7 +143,7 @@ AP_BattMonitor::BatteryFailsafe AP_BattMonitor_Backend::update_failsafes(void)
     return AP_BattMonitor::BatteryFailsafe_None;
 }
 
-bool update_check(size_t buflen, char *buffer, bool failed, const char *message)
+static bool update_check(size_t buflen, char *buffer, bool failed, const char *message)
 {
     if (failed) {
         strncpy(buffer, message, buflen);

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -454,6 +454,10 @@ private:
 
         // board specific orientation
         enum Rotation rotation;
+
+        // accumulated samples, protected by _sem, used by AP_Compass_Backend
+        Vector3f accum;
+        uint32_t accum_count;
     } _state[COMPASS_MAX_INSTANCES];
 
     AP_Int16 _offset_max;

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -11,7 +11,6 @@ extern const AP_HAL::HAL& hal;
 AP_Compass_Backend::AP_Compass_Backend()
     : _compass(AP::compass())
 {
-    _sem = hal.util->new_semaphore();
 }
 
 void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)
@@ -126,12 +125,9 @@ void AP_Compass_Backend::accumulate_sample(Vector3f &field, uint8_t instance,
 void AP_Compass_Backend::drain_accumulated_samples(uint8_t instance,
                                                    const Vector3f *scaling)
 {
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
+    WITH_SEMAPHORE(_sem);
 
     if (_accum_count == 0) {
-        _sem->give();
         return;
     }
 
@@ -144,8 +140,6 @@ void AP_Compass_Backend::drain_accumulated_samples(uint8_t instance,
 
     _accum.zero();
     _accum_count = 0;
-
-    _sem->give();
 }
 
 /*

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -110,7 +110,7 @@ protected:
     Compass &_compass;
 
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *_sem;
+    HAL_Semaphore_Recursive _sem;
 
     // accumulated samples, protected by _sem
     Vector3f    _accum;

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -112,10 +112,6 @@ protected:
     // semaphore for access to shared frontend data
     HAL_Semaphore_Recursive _sem;
 
-    // accumulated samples, protected by _sem
-    Vector3f    _accum;
-    uint32_t    _accum_count;
-
     // Check that the compass field is valid by using a mean filter on the vector length
     bool field_ok(const Vector3f &field);
     

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -200,10 +200,6 @@ void AP_Compass_QMC5883L::timer()
 
 void AP_Compass_QMC5883L::read()
 {
-    if (!_sem->take_nonblocking()) {
-        return;
-    }
-
     drain_accumulated_samples(_instance);
 }
 

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -32,11 +32,7 @@ private:
     VectorN<readings_compass,buffer_length> buffer;
 
     void _timer();
-    bool _has_sample;
     uint32_t _last_sample_time;
-
-    Vector3f _mag_accum[SITL_NUM_COMPASSES];
-    uint32_t _accum_count;
 
     void _setup_eliptical_correcion();
     

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.cpp
@@ -36,7 +36,7 @@ UC_REGISTRY_BINDER(MagCb, uavcan::equipment::ahrs::MagneticFieldStrength);
 UC_REGISTRY_BINDER(Mag2Cb, uavcan::equipment::ahrs::MagneticFieldStrength2);
 
 AP_Compass_UAVCAN::DetectedModules AP_Compass_UAVCAN::_detected_modules[] = {0};
-AP_HAL::Semaphore* AP_Compass_UAVCAN::_sem_registry = nullptr;
+HAL_Semaphore AP_Compass_UAVCAN::_sem_registry;
 
 AP_Compass_UAVCAN::AP_Compass_UAVCAN(AP_UAVCAN* ap_uavcan, uint8_t node_id, uint8_t sensor_id)
     : _ap_uavcan(ap_uavcan)
@@ -72,15 +72,12 @@ void AP_Compass_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
 
 bool AP_Compass_UAVCAN::take_registry()
 {
-    if (_sem_registry == nullptr) {
-        _sem_registry = hal.util->new_semaphore();
-    }
-    return _sem_registry->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+    return _sem_registry.take(HAL_SEMAPHORE_BLOCK_FOREVER);
 }
 
 void AP_Compass_UAVCAN::give_registry()
 {
-    _sem_registry->give();
+    _sem_registry.give();
 }
 
 AP_Compass_Backend* AP_Compass_UAVCAN::probe()

--- a/libraries/AP_Compass/AP_Compass_UAVCAN.h
+++ b/libraries/AP_Compass/AP_Compass_UAVCAN.h
@@ -48,5 +48,5 @@ private:
         AP_Compass_UAVCAN *driver;
     } _detected_modules[COMPASS_MAX_BACKEND];
 
-    static AP_HAL::Semaphore *_sem_registry;
+    static HAL_Semaphore _sem_registry;
 };

--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -30,7 +30,7 @@ private:
     Vector3f mag_ef;
 
     // semaphore for access to shared data with IO thread
-    AP_HAL::Semaphore *sem;    
+    HAL_Semaphore sem;
     
     struct sample {
         // milliGauss body field and offsets

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.cpp
@@ -36,7 +36,7 @@ UC_REGISTRY_BINDER(FixCb, uavcan::equipment::gnss::Fix);
 UC_REGISTRY_BINDER(AuxCb, uavcan::equipment::gnss::Auxiliary);
 
 AP_GPS_UAVCAN::DetectedModules AP_GPS_UAVCAN::_detected_modules[] = {0};
-AP_HAL::Semaphore* AP_GPS_UAVCAN::_sem_registry = nullptr;
+HAL_Semaphore AP_GPS_UAVCAN::_sem_registry;
 
 // Member Methods
 AP_GPS_UAVCAN::AP_GPS_UAVCAN(AP_GPS &_gps, AP_GPS::GPS_State &_state) :
@@ -78,15 +78,12 @@ void AP_GPS_UAVCAN::subscribe_msgs(AP_UAVCAN* ap_uavcan)
 
 bool AP_GPS_UAVCAN::take_registry()
 {
-    if (_sem_registry == nullptr) {
-        _sem_registry = hal.util->new_semaphore();
-    }
-    return _sem_registry->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+    return _sem_registry.take(HAL_SEMAPHORE_BLOCK_FOREVER);
 }
 
 void AP_GPS_UAVCAN::give_registry()
 {
-    _sem_registry->give();
+    _sem_registry.give();
 }
 
 AP_GPS_Backend* AP_GPS_UAVCAN::probe(AP_GPS &_gps, AP_GPS::GPS_State &_state)

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.h
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.h
@@ -65,5 +65,5 @@ private:
         AP_GPS_UAVCAN* driver;
     } _detected_modules[GPS_MAX_RECEIVERS];
 
-    static AP_HAL::Semaphore *_sem_registry;
+    static HAL_Semaphore _sem_registry;
 };

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -99,9 +99,6 @@ public:
     virtual void perf_end(perf_counter_t h) {}
     virtual void perf_count(perf_counter_t h) {}
 
-    // create a new semaphore
-    virtual Semaphore *new_semaphore(void) { return nullptr; }
-
     // allocate and free DMA-capable memory if possible. Otherwise return normal memory
     enum Memory_Type {
         MEM_DMA_SAFE,

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "ch.h"
 #include "hal.h"
+#include <AP_Common/Semaphore.h>
 
 #if HAL_USE_ADC == TRUE
 
@@ -76,24 +77,22 @@ AnalogSource::AnalogSource(int16_t pin, float initial_value) :
     _sum_value(0),
     _sum_ratiometric(0)
 {
-    _semaphore = hal.util->new_semaphore();
 }
 
 
 float AnalogSource::read_average() 
 {
-    if (_semaphore->take(1)) {
-        if (_sum_count == 0) {
-            _semaphore->give();
-            return _value;
-        }
-        _value = _sum_value / _sum_count;
-        _value_ratiometric = _sum_ratiometric / _sum_count;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    if (_sum_count == 0) {
+        return _value;
     }
+    _value = _sum_value / _sum_count;
+    _value_ratiometric = _sum_ratiometric / _sum_count;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+
     return _value;
 }
 
@@ -148,16 +147,14 @@ void AnalogSource::set_pin(uint8_t pin)
     if (_pin == pin) {
         return;
     }
-    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _pin = pin;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _latest_value = 0;
-        _value = 0;
-        _value_ratiometric = 0;
-        _semaphore->give();
-    }
+    WITH_SEMAPHORE(_semaphore);
+    _pin = pin;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+    _latest_value = 0;
+    _value = 0;
+    _value_ratiometric = 0;
 }
 
 /*
@@ -165,23 +162,22 @@ void AnalogSource::set_pin(uint8_t pin)
  */
 void AnalogSource::_add_value(float v, float vcc5V)
 {
-    if (_semaphore->take(1)) {
-        _latest_value = v;
-        _sum_value += v;
-        if (vcc5V < 3.0f) {
-            _sum_ratiometric += v;
-        } else {
-            // this compensates for changes in the 5V rail relative to the
-            // 3.3V reference used by the ADC.
-            _sum_ratiometric += v * 5.0f / vcc5V;
-        }
-        _sum_count++;
-        if (_sum_count == 254) {
-            _sum_value /= 2;
-            _sum_ratiometric /= 2;
-            _sum_count /= 2;
-        }
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    _latest_value = v;
+    _sum_value += v;
+    if (vcc5V < 3.0f) {
+        _sum_ratiometric += v;
+    } else {
+        // this compensates for changes in the 5V rail relative to the
+        // 3.3V reference used by the ADC.
+        _sum_ratiometric += v * 5.0f / vcc5V;
+    }
+    _sum_count++;
+    if (_sum_count == 254) {
+        _sum_value /= 2;
+        _sum_ratiometric /= 2;
+        _sum_count /= 2;
     }
 }
 

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -50,7 +50,7 @@ private:
     float _sum_ratiometric;
     void _add_value(float v, float vcc5V);
     float _pin_scaler();
-    AP_HAL::Semaphore *_semaphore;
+    HAL_Semaphore _semaphore;
 };
 
 class ChibiOS::AnalogIn : public AP_HAL::AnalogIn {

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -27,7 +27,6 @@ public:
     }
 
     bool run_debug_shell(AP_HAL::BetterStream *stream) override { return false; }
-    AP_HAL::Semaphore *new_semaphore(void) override { return new ChibiOS::Semaphore; }
     uint32_t available_memory() override;
 
     // Special Allocation Routines

--- a/libraries/AP_HAL_F4Light/Util.h
+++ b/libraries/AP_HAL_F4Light/Util.h
@@ -48,9 +48,6 @@ public:
         return true;
     }
     
-    // create a new semaphore
-    Semaphore *new_semaphore(void)  override { return new F4Light::Semaphore; } 
-
     void *malloc_type(size_t size, Memory_Type mem_type) override;
     void free_type(void *ptr, size_t size, Memory_Type mem_type) override;
     

--- a/libraries/AP_HAL_Linux/AnalogIn_IIO.h
+++ b/libraries/AP_HAL_Linux/AnalogIn_IIO.h
@@ -42,7 +42,7 @@ private:
     int16_t     _pin;
     int         _pin_fd;
     int         fd_analog_sources[IIO_ANALOG_IN_COUNT];
-    AP_HAL::Semaphore *_semaphore;
+    HAL_Semaphore _semaphore;
 
     void init_pins(void);
     void select_pin(void);

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -90,9 +90,6 @@ public:
         return Perf::get_instance()->count(perf);
     }
 
-    // create a new semaphore
-    AP_HAL::Semaphore *new_semaphore(void) override { return new Semaphore; }
-
     int get_hw_arm32();
 
     bool toneAlarm_init() override { return _toneAlarm.init(); }

--- a/libraries/AP_HAL_PX4/AnalogIn.cpp
+++ b/libraries/AP_HAL_PX4/AnalogIn.cpp
@@ -17,6 +17,7 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <errno.h>
 #include "GPIO.h"
+#include <AP_Common/Semaphore.h>
 
 #define ANLOGIN_DEBUGGING 0
 
@@ -79,7 +80,6 @@ PX4AnalogSource::PX4AnalogSource(int16_t pin, float initial_value) :
     _sum_value(0),
     _sum_ratiometric(0)
 {
-    _semaphore = hal.util->new_semaphore();
 #ifdef PX4_ANALOG_VCC_5V_PIN
     if (_pin == ANALOG_INPUT_BOARD_VCC) {
         _pin = PX4_ANALOG_VCC_5V_PIN;
@@ -94,19 +94,17 @@ void PX4AnalogSource::set_stop_pin(uint8_t p)
 
 float PX4AnalogSource::read_average() 
 {
-    if (_semaphore->take(1)) {
-        if (_sum_count == 0) {
-            _semaphore->give();
-            return _value;
-        }
-        _value = _sum_value / _sum_count;
-        _value_ratiometric = _sum_ratiometric / _sum_count;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    if (_sum_count == 0) {
         return _value;
     }
+    _value = _sum_value / _sum_count;
+    _value_ratiometric = _sum_ratiometric / _sum_count;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+
     return _value;
 }
 
@@ -162,16 +160,15 @@ void PX4AnalogSource::set_pin(uint8_t pin)
     if (_pin == pin) {
         return;
     }
-    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _pin = pin;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _latest_value = 0;
-        _value = 0;
-        _value_ratiometric = 0;
-        _semaphore->give();
-    }
+
+    WITH_SEMAPHORE(_semaphore);
+    _pin = pin;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+    _latest_value = 0;
+    _value = 0;
+    _value_ratiometric = 0;
 }
 
 /*
@@ -179,23 +176,22 @@ void PX4AnalogSource::set_pin(uint8_t pin)
  */
 void PX4AnalogSource::_add_value(float v, float vcc5V)
 {
-    if (_semaphore->take(1)) {
-        _latest_value = v;
-        _sum_value += v;
-        if (vcc5V < 3.0f) {
-            _sum_ratiometric += v;
-        } else {
-            // this compensates for changes in the 5V rail relative to the
-            // 3.3V reference used by the ADC.
-            _sum_ratiometric += v * 5.0f / vcc5V;
-        }
-        _sum_count++;
-        if (_sum_count == 254) {
-            _sum_value /= 2;
-            _sum_ratiometric /= 2;
-            _sum_count /= 2;
-        }
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    _latest_value = v;
+    _sum_value += v;
+    if (vcc5V < 3.0f) {
+        _sum_ratiometric += v;
+    } else {
+        // this compensates for changes in the 5V rail relative to the
+        // 3.3V reference used by the ADC.
+        _sum_ratiometric += v * 5.0f / vcc5V;
+    }
+    _sum_count++;
+    if (_sum_count == 254) {
+        _sum_value /= 2;
+        _sum_ratiometric /= 2;
+        _sum_count /= 2;
     }
 }
 

--- a/libraries/AP_HAL_PX4/AnalogIn.h
+++ b/libraries/AP_HAL_PX4/AnalogIn.h
@@ -47,7 +47,7 @@ private:
     float _sum_ratiometric;
     void _add_value(float v, float vcc5V);
     float _pin_scaler();
-    AP_HAL::Semaphore *_semaphore;
+    HAL_Semaphore _semaphore;
 };
 
 class PX4::PX4AnalogIn : public AP_HAL::AnalogIn {

--- a/libraries/AP_HAL_PX4/Util.h
+++ b/libraries/AP_HAL_PX4/Util.h
@@ -50,9 +50,6 @@ public:
     void perf_end(perf_counter_t) override;
     void perf_count(perf_counter_t) override;
     
-    // create a new semaphore
-    AP_HAL::Semaphore *new_semaphore(void) override { return new PX4::Semaphore; }
-
     void set_imu_temp(float current) override;
     void set_imu_target_temp(int8_t *target) override;
 

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -22,9 +22,6 @@ public:
         return 0x20000;
     }
 
-    // create a new semaphore
-    AP_HAL::Semaphore *new_semaphore(void) override { return new HALSITL::Semaphore; }
-
     // get path to custom defaults file for AP_Param
     const char* get_custom_defaults_file() const override {
         return sitlState->defaults_path;

--- a/libraries/AP_HAL_VRBRAIN/AnalogIn.cpp
+++ b/libraries/AP_HAL_VRBRAIN/AnalogIn.cpp
@@ -68,7 +68,6 @@ VRBRAINAnalogSource::VRBRAINAnalogSource(int16_t pin, float initial_value) :
     _sum_value(0),
     _sum_ratiometric(0)
 {
-    _semaphore = hal.util->new_semaphore();
 }
 
 void VRBRAINAnalogSource::set_stop_pin(uint8_t p)
@@ -78,19 +77,17 @@ void VRBRAINAnalogSource::set_stop_pin(uint8_t p)
 
 float VRBRAINAnalogSource::read_average()
 {
-    if (_semaphore->take(1)) {
-        if (_sum_count == 0) {
-            _semaphore->give();
-            return _value;
-        }
-        _value = _sum_value / _sum_count;
-        _value_ratiometric = _sum_ratiometric / _sum_count;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    if (_sum_count == 0) {
         return _value;
     }
+    _value = _sum_value / _sum_count;
+    _value_ratiometric = _sum_ratiometric / _sum_count;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+
     return _value;
 }
 
@@ -146,16 +143,16 @@ void VRBRAINAnalogSource::set_pin(uint8_t pin)
     if (_pin == pin) {
         return;
     }
-    if (_semaphore->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _pin = pin;
-        _sum_value = 0;
-        _sum_ratiometric = 0;
-        _sum_count = 0;
-        _latest_value = 0;
-        _value = 0;
-        _value_ratiometric = 0;
-        _semaphore->give();
-    }
+
+    WITH_SEMAPHORE(_semaphore);
+
+    _pin = pin;
+    _sum_value = 0;
+    _sum_ratiometric = 0;
+    _sum_count = 0;
+    _latest_value = 0;
+    _value = 0;
+    _value_ratiometric = 0;
 }
 
 /*
@@ -163,23 +160,22 @@ void VRBRAINAnalogSource::set_pin(uint8_t pin)
  */
 void VRBRAINAnalogSource::_add_value(float v, float vcc5V)
 {
-    if (_semaphore->take(1)) {
-        _latest_value = v;
-        _sum_value += v;
-        if (vcc5V < 3.0f) {
-            _sum_ratiometric += v;
-        } else {
-            // this compensates for changes in the 5V rail relative to the
-            // 3.3V reference used by the ADC.
-            _sum_ratiometric += v * 5.0f / vcc5V;
-        }
-        _sum_count++;
-        if (_sum_count == 254) {
-            _sum_value /= 2;
-            _sum_ratiometric /= 2;
-            _sum_count /= 2;
-        }
-        _semaphore->give();
+    WITH_SEMAPHORE(_semaphore);
+
+    _latest_value = v;
+    _sum_value += v;
+    if (vcc5V < 3.0f) {
+        _sum_ratiometric += v;
+    } else {
+        // this compensates for changes in the 5V rail relative to the
+        // 3.3V reference used by the ADC.
+        _sum_ratiometric += v * 5.0f / vcc5V;
+    }
+    _sum_count++;
+    if (_sum_count == 254) {
+        _sum_value /= 2;
+        _sum_ratiometric /= 2;
+        _sum_count /= 2;
     }
 }
 

--- a/libraries/AP_HAL_VRBRAIN/AnalogIn.h
+++ b/libraries/AP_HAL_VRBRAIN/AnalogIn.h
@@ -48,7 +48,7 @@ private:
     float _sum_ratiometric;
     void _add_value(float v, float vcc5V);
     float _pin_scaler();
-    AP_HAL::Semaphore *_semaphore;
+    HAL_Semaphore _semaphore;
 };
 
 class VRBRAIN::VRBRAINAnalogIn : public AP_HAL::AnalogIn {

--- a/libraries/AP_HAL_VRBRAIN/Util.h
+++ b/libraries/AP_HAL_VRBRAIN/Util.h
@@ -50,9 +50,6 @@ public:
     void perf_end(perf_counter_t) override;
     void perf_count(perf_counter_t) override;
     
-    // create a new semaphore
-    AP_HAL::Semaphore *new_semaphore(void) override { return new VRBRAIN::Semaphore; }
-
     void set_imu_temp(float current) override;
     void set_imu_target_temp(int8_t *target) override;
 

--- a/libraries/AP_IRLock/AP_IRLock_I2C.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_I2C.cpp
@@ -43,8 +43,6 @@ void AP_IRLock_I2C::init(int8_t bus)
         return;
     }
 
-    sem = hal.util->new_semaphore();
-
     // read at 50Hz
     printf("Starting IRLock on I2C\n");
 
@@ -132,14 +130,15 @@ void AP_IRLock_I2C::read_frames(void)
     pixel_to_1M_plane(corner1_pix_x, corner1_pix_y, corner1_pos_x, corner1_pos_y);
     pixel_to_1M_plane(corner2_pix_x, corner2_pix_y, corner2_pos_x, corner2_pos_y);
 
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    {
+        WITH_SEMAPHORE(sem);
+
         /* convert to angles */
         _target_info.timestamp = AP_HAL::millis();
         _target_info.pos_x = 0.5f*(corner1_pos_x+corner2_pos_x);
         _target_info.pos_y = 0.5f*(corner1_pos_y+corner2_pos_y);
         _target_info.size_x = corner2_pos_x-corner1_pos_x;
         _target_info.size_y = corner2_pos_y-corner1_pos_y;
-        sem->give();
     }
 
 #if 0
@@ -158,17 +157,17 @@ void AP_IRLock_I2C::read_frames(void)
 bool AP_IRLock_I2C::update()
 {
     bool new_data = false;
-    if (!dev || !sem) {
+    if (!dev) {
         return false;
     }
-    if (sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        if (_last_update_ms != _target_info.timestamp) {
-            new_data = true;
-        }
-        _last_update_ms = _target_info.timestamp;
-        _flags.healthy = (AP_HAL::millis() - _last_read_ms < 100);
-        sem->give();
+    WITH_SEMAPHORE(sem);
+
+    if (_last_update_ms != _target_info.timestamp) {
+        new_data = true;
     }
+    _last_update_ms = _target_info.timestamp;
+    _flags.healthy = (AP_HAL::millis() - _last_read_ms < 100);
+
     // return true if new data found
     return new_data;
 }

--- a/libraries/AP_IRLock/AP_IRLock_I2C.h
+++ b/libraries/AP_IRLock/AP_IRLock_I2C.h
@@ -35,6 +35,6 @@ private:
 
     void pixel_to_1M_plane(float pix_x, float pix_y, float &ret_x, float &ret_y);
 
-    AP_HAL::Semaphore *sem;
+    HAL_Semaphore sem;
     uint32_t _last_read_ms;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -14,7 +14,6 @@ const extern AP_HAL::HAL& hal;
 AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
     _imu(imu)
 {
-    _sem = hal.util->new_semaphore();
 }
 
 /*
@@ -192,7 +191,8 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
     delta_coning = delta_coning % delta_angle;
     delta_coning *= 0.5f;
 
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    {
+        WITH_SEMAPHORE(_sem);
         // integrate delta angle accumulator
         // the angles and coning corrections are accumulated separately in the
         // referenced paper, but in simulation little difference was found between
@@ -209,7 +209,6 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
             _imu._gyro_filter[instance].reset();
         }
         _imu._new_gyro_data[instance] = true;
-        _sem->give();
     }
 
     log_gyro_raw(instance, sample_us, gyro);
@@ -310,7 +309,9 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     
     _imu.calc_vibration_and_clipping(instance, accel, dt);
 
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    {
+        WITH_SEMAPHORE(_sem);
+
         // delta velocity
         _imu._delta_velocity_acc[instance] += accel * dt;
         _imu._delta_velocity_acc_dt[instance] += dt;
@@ -323,7 +324,6 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
         _imu.set_accel_peak_hold(instance, _imu._accel_filtered[instance]);
 
         _imu._new_accel_data[instance] = true;
-        _sem->give();
     }
 
     log_accel_raw(instance, sample_us, accel);
@@ -426,9 +426,7 @@ void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float tem
  */
 void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
 {    
-    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        return;
-    }
+    WITH_SEMAPHORE(_sem);
 
     if (_imu._new_gyro_data[instance]) {
         _publish_gyro(instance, _imu._gyro_filtered[instance]);
@@ -440,8 +438,6 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
         _imu._gyro_filter[instance].set_cutoff_frequency(_gyro_raw_sample_rate(instance), _gyro_filter_cutoff());
         _last_gyro_filter_hz[instance] = _gyro_filter_cutoff();
     }
-
-    _sem->give();
 }
 
 /*
@@ -449,9 +445,7 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
  */
 void AP_InertialSensor_Backend::update_accel(uint8_t instance)
 {    
-    if (!_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        return;
-    }
+    WITH_SEMAPHORE(_sem);
 
     if (_imu._new_accel_data[instance]) {
         _publish_accel(instance, _imu._accel_filtered[instance]);
@@ -463,8 +457,6 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance)
         _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());
         _last_accel_filter_hz[instance] = _accel_filter_cutoff();
     }
-
-    _sem->give();
 }
 
 bool AP_InertialSensor_Backend::should_log_imu_raw() const

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -113,7 +113,7 @@ protected:
     AP_InertialSensor &_imu;
 
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *_sem;
+    HAL_Semaphore_Recursive _sem;
 
     void _rotate_and_correct_accel(uint8_t instance, Vector3f &accel);
     void _rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro);

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -18,6 +18,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Common/Semaphore.h>
 
 #include "ToneAlarm.h"
 #include "AP_Notify.h"
@@ -100,8 +101,6 @@ bool AP_ToneAlarm::init()
         return false;
     }
 
-    _sem = hal.util->new_semaphore();
-
     // set initial boot states. This prevents us issuing a arming
     // warning in plane and rover on every boot
     flags.armed = AP_Notify::flags.armed;
@@ -131,21 +130,18 @@ void AP_ToneAlarm::play_tone(const uint8_t tone_index)
 
 void AP_ToneAlarm::_timer_task()
 {
-    if (_sem && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mml_player.update();
-        _sem->give();
-    }
+    WITH_SEMAPHORE(_sem);
+    _mml_player.update();
 }
 
 void AP_ToneAlarm::play_string(const char *str)
 {
-    if (_sem && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mml_player.stop();
-        strncpy(_tone_buf, str, AP_NOTIFY_TONEALARM_TONE_BUF_SIZE);
-        _tone_buf[AP_NOTIFY_TONEALARM_TONE_BUF_SIZE-1] = 0;
-        _mml_player.play(_tone_buf);
-        _sem->give();
-    }
+    WITH_SEMAPHORE(_sem);
+
+    _mml_player.stop();
+    strncpy(_tone_buf, str, AP_NOTIFY_TONEALARM_TONE_BUF_SIZE);
+    _tone_buf[AP_NOTIFY_TONEALARM_TONE_BUF_SIZE-1] = 0;
+    _mml_player.play(_tone_buf);
 }
 
 void AP_ToneAlarm::stop_cont_tone()
@@ -390,17 +386,16 @@ void AP_ToneAlarm::handle_play_tune(mavlink_message_t *msg)
 
     mavlink_msg_play_tune_decode(msg, &packet);
 
-    if (_sem && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        _mml_player.stop();
+    WITH_SEMAPHORE(_sem);
 
-        strncpy(_tone_buf, packet.tune, MIN(sizeof(packet.tune), sizeof(_tone_buf)-1));
-        _tone_buf[sizeof(_tone_buf)-1] = 0;
-        uint8_t len = strlen(_tone_buf);
-        uint8_t len2 = strnlen(packet.tune2, sizeof(packet.tune2));
-        len2 = MIN((sizeof(_tone_buf)-1)-len, len2);
-        strncpy(_tone_buf+len, packet.tune2, len2);
-        _tone_buf[sizeof(_tone_buf)-1] = 0;
-        _mml_player.play(_tone_buf);
-        _sem->give();
-    }
+    _mml_player.stop();
+
+    strncpy(_tone_buf, packet.tune, MIN(sizeof(packet.tune), sizeof(_tone_buf)-1));
+    _tone_buf[sizeof(_tone_buf)-1] = 0;
+    uint8_t len = strlen(_tone_buf);
+    uint8_t len2 = strnlen(packet.tune2, sizeof(packet.tune2));
+    len2 = MIN((sizeof(_tone_buf)-1)-len, len2);
+    strncpy(_tone_buf+len, packet.tune2, len2);
+    _tone_buf[sizeof(_tone_buf)-1] = 0;
+    _mml_player.play(_tone_buf);
 }

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -77,7 +77,7 @@ private:
 
     const static Tone _tones[];
 
-    AP_HAL::Semaphore* _sem;
+    HAL_Semaphore _sem;
     MMLPlayer _mml_player;
     char _tone_buf[AP_NOTIFY_TONEALARM_TONE_BUF_SIZE];
 };

--- a/libraries/AP_Notify/ToshibaLED_I2C.cpp
+++ b/libraries/AP_Notify/ToshibaLED_I2C.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Common/Semaphore.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -48,16 +49,16 @@ bool ToshibaLED_I2C::hw_init(void)
 {
     // first look for led on external bus
     _dev = std::move(hal.i2c_mgr->get_device(_bus, TOSHIBA_LED_I2C_ADDR));
-    if (!_dev || !_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (!_dev) {
         return false;
     }
+    WITH_SEMAPHORE(_dev->get_semaphore());
 
     _dev->set_retries(10);
 
     // enable the led
     bool ret = _dev->write_register(TOSHIBA_LED_ENABLE, 0x03);
     if (!ret) {
-        _dev->get_semaphore()->give();
         return false;
     }
 
@@ -66,9 +67,6 @@ bool ToshibaLED_I2C::hw_init(void)
     ret = _dev->transfer(val, sizeof(val), nullptr, 0);
 
     _dev->set_retries(1);
-
-    // give back i2c semaphore
-    _dev->get_semaphore()->give();
 
     if (ret) {
         _dev->register_periodic_callback(20000, FUNCTOR_BIND_MEMBER(&ToshibaLED_I2C::_timer, void));

--- a/libraries/AP_OSD/AP_OSD_SITL.cpp
+++ b/libraries/AP_OSD/AP_OSD_SITL.cpp
@@ -103,21 +103,20 @@ void AP_OSD_SITL::write(uint8_t x, uint8_t y, const char* text)
     if (y >= video_lines || text == nullptr) {
         return;
     }
-    mutex->take_blocking();
+    WITH_SEMAPHORE(mutex);
+
     while ((x < video_cols) && (*text != 0)) {
         buffer[y][x] = *text;
         ++text;
         ++x;
     }
-    mutex->give();
 }
 
 void AP_OSD_SITL::clear(void)
 {
     AP_OSD_Backend::clear();
-    mutex->take_blocking();
+    WITH_SEMAPHORE(mutex);
     memset(buffer, 0, sizeof(buffer));
-    mutex->give();
 }
 
 void AP_OSD_SITL::flush(void)
@@ -150,9 +149,10 @@ void AP_OSD_SITL::update_thread(void)
         last_counter = counter;
 
         uint8_t buffer2[video_lines][video_cols];
-        mutex->take_blocking();
-        memcpy(buffer2, buffer, sizeof(buffer2));
-        mutex->give();
+        {
+            WITH_SEMAPHORE(mutex);
+            memcpy(buffer2, buffer, sizeof(buffer2));
+        }
         w->clear();
 
         for (uint8_t y=0; y<video_lines; y++) {
@@ -186,7 +186,6 @@ void *AP_OSD_SITL::update_thread_start(void *obj)
 // initialise backend
 bool AP_OSD_SITL::init(void)
 {
-    mutex = hal.util->new_semaphore();
     pthread_create(&thread, NULL, update_thread_start, this);
     return true;
 }

--- a/libraries/AP_OSD/AP_OSD_SITL.h
+++ b/libraries/AP_OSD/AP_OSD_SITL.h
@@ -68,7 +68,7 @@ private:
     void load_font();
 
     pthread_t thread;
-    AP_HAL::Semaphore *mutex;
+    HAL_Semaphore mutex;
     uint32_t counter;
     uint32_t last_counter;
 };

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -71,12 +71,10 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
             if (!tdev) {
                 continue;
             }
-            if (!tdev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-                continue;
-            }
+            WITH_SEMAPHORE(tdev->get_semaphore());
+
             struct i2c_integral_frame frame;
             success = tdev->read_registers(REG_INTEGRAL_FRAME, (uint8_t *)&frame, sizeof(frame));
-            tdev->get_semaphore()->give();
             if (success) {
                 printf("Found PX4Flow on bus %u\n", bus);
                 dev = std::move(tdev);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -107,9 +107,7 @@ bool AP_OpticalFlow_Pixart::setup_sensor(void)
     if (!_dev) {
         return false;
     }
-    if (!_dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        AP_HAL::panic("Unable to get bus semaphore");
-    }
+    WITH_SEMAPHORE(_dev->get_semaphore());
 
     uint8_t id;
     uint16_t crc;
@@ -133,7 +131,7 @@ bool AP_OpticalFlow_Pixart::setup_sensor(void)
         model = PIXART_3901;
     } else {
         debug("Not a recognised device\n");
-        goto failed;
+        return false;
     }
 
     if (model == PIXART_3900) {
@@ -142,7 +140,7 @@ bool AP_OpticalFlow_Pixart::setup_sensor(void)
         id = reg_read(PIXART_REG_SROM_ID);
         if (id != srom_id) {
             debug("Pixart: bad SROM ID: 0x%02x\n", id);
-            goto failed;
+            return false;
         }
         
         reg_write(PIXART_REG_SROM_EN, 0x15);
@@ -151,7 +149,7 @@ bool AP_OpticalFlow_Pixart::setup_sensor(void)
         crc = reg_read16u(PIXART_REG_DOUT_L);
         if (crc != 0xBEEF) {
             debug("Pixart: bad SROM CRC: 0x%04x\n", crc);
-            goto failed;
+            return false;
         }
     }
 
@@ -167,16 +165,10 @@ bool AP_OpticalFlow_Pixart::setup_sensor(void)
 
     debug("Pixart %s ready\n", model==PIXART_3900?"3900":"3901");
 
-    _dev->get_semaphore()->give();
-
     integral.last_frame_us = AP_HAL::micros();
 
     _dev->register_periodic_callback(2000, FUNCTOR_BIND_MEMBER(&AP_OpticalFlow_Pixart::timer, void));
     return true;
-
-failed:
-    _dev->get_semaphore()->give();
-    return false;
 }
 
 
@@ -299,13 +291,14 @@ void AP_OpticalFlow_Pixart::timer(void)
     float dt = dt_us * 1.0e-6;
     const Vector3f &gyro = get_ahrs().get_gyro();
 
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    {
+        WITH_SEMAPHORE(_sem);
+
         integral.sum.x += burst.delta_x;
         integral.sum.y += burst.delta_y;
         integral.sum_us += dt_us;
         integral.last_frame_us = last_burst_us;
         integral.gyro += Vector2f(gyro.x, gyro.y) * dt;
-        _sem->give();
     }
     
 #if 0
@@ -344,7 +337,9 @@ void AP_OpticalFlow_Pixart::update(void)
     state.device_id = 1;
     state.surface_quality = burst.squal;
     
-    if (integral.sum_us > 0 && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (integral.sum_us > 0) {
+        WITH_SEMAPHORE(_sem);
+
         const Vector2f flowScaler = _flowScaler();
         float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;
         float flowScaleFactorY = 1.0f + 0.001f * flowScaler.y;
@@ -362,7 +357,6 @@ void AP_OpticalFlow_Pixart::update(void)
         integral.sum.zero();
         integral.sum_us = 0;
         integral.gyro.zero();
-        _sem->give();
     } else {
         state.flowRate.zero();
         state.bodyRate.zero();

--- a/libraries/AP_OpticalFlow/OpticalFlow_backend.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow_backend.cpp
@@ -20,14 +20,10 @@ extern const AP_HAL::HAL& hal;
 OpticalFlow_backend::OpticalFlow_backend(OpticalFlow &_frontend) :
     frontend(_frontend)
 {
-    _sem = hal.util->new_semaphore();    
 }
 
 OpticalFlow_backend::~OpticalFlow_backend(void)
 {
-    if (_sem) {
-        delete _sem;
-    }
 }
 
 // update the frontend

--- a/libraries/AP_OpticalFlow/OpticalFlow_backend.h
+++ b/libraries/AP_OpticalFlow/OpticalFlow_backend.h
@@ -58,5 +58,5 @@ protected:
     uint8_t get_address(void) const { return frontend._address; }
     
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *_sem;
+    HAL_Semaphore _sem;
 };

--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "AP_RAMTRON.h"
+#include <AP_Common/Semaphore.h>
 
 extern const AP_HAL::HAL &hal;
 
@@ -38,9 +39,10 @@ const AP_RAMTRON::ramtron_id AP_RAMTRON::ramtron_ids[] = {
 bool AP_RAMTRON::init(void)
 {
     dev = hal.spi->get_device("ramtron");
-    if (!dev || !dev->get_semaphore()->take(0)) {
+    if (!dev) {
         return false;
     }
+    WITH_SEMAPHORE(dev->get_semaphore());
 
     struct rdid {
         uint8_t manufacturer[6];
@@ -49,10 +51,8 @@ bool AP_RAMTRON::init(void)
         uint8_t id2;
     } rdid;
     if (!dev->read_registers(RAMTRON_RDID, (uint8_t *)&rdid, sizeof(rdid))) {
-        dev->get_semaphore()->give();
         return false;
     }
-    dev->get_semaphore()->give();
 
     for (uint8_t i=0; i<ARRAY_SIZE(ramtron_ids); i++) {
         if (ramtron_ids[i].id1 == rdid.id1 &&
@@ -93,9 +93,8 @@ bool AP_RAMTRON::read(uint32_t offset, uint8_t *buf, uint32_t size)
         size -= maxread;
     }
 
-    if (!dev->get_semaphore()->take(0)) {
-        return false;
-    }
+    WITH_SEMAPHORE(dev->get_semaphore());
+
     dev->set_chip_select(true);
 
     send_offset(RAMTRON_READ, offset);
@@ -104,7 +103,6 @@ bool AP_RAMTRON::read(uint32_t offset, uint8_t *buf, uint32_t size)
     dev->transfer(nullptr, 0, buf, size);
 
     dev->set_chip_select(false);
-    dev->get_semaphore()->give();
 
     return true;
 }
@@ -112,9 +110,8 @@ bool AP_RAMTRON::read(uint32_t offset, uint8_t *buf, uint32_t size)
 // write to device
 bool AP_RAMTRON::write(uint32_t offset, const uint8_t *buf, uint32_t size)
 {
-    if (!dev->get_semaphore()->take(0)) {
-        return false;
-    }
+    WITH_SEMAPHORE(dev->get_semaphore());
+
     // write enable
     uint8_t r = RAMTRON_WREN;
     dev->transfer(&r, 1, nullptr, 0);
@@ -127,6 +124,5 @@ bool AP_RAMTRON::write(uint32_t offset, const uint8_t *buf, uint32_t size)
 
     dev->set_chip_select(false);
 
-    dev->get_semaphore()->give();
     return true;
 }

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -190,11 +190,11 @@ float AP_RSSI::read_pin_rssi()
 // read the RSSI value from a PWM value on a RC channel
 float AP_RSSI::read_channel_rssi()
 {
-    RC_Channel *ch = rc().channel(rssi_channel-1);
-    if (ch == nullptr) {
+    RC_Channel *c = rc().channel(rssi_channel-1);
+    if (c == nullptr) {
         return 0.0f;
     }
-    uint16_t rssi_channel_value = ch->get_radio_in();
+    uint16_t rssi_channel_value = c->get_radio_in();
     float channel_rssi = scale_and_constrain_float_rssi(rssi_channel_value, rssi_channel_low_pwm_value, rssi_channel_high_pwm_value);
     return channel_rssi;    
 }

--- a/libraries/AP_Radio/AP_Radio_cc2500.h
+++ b/libraries/AP_Radio/AP_Radio_cc2500.h
@@ -87,7 +87,7 @@ private:
     void radio_init(void);
 
     // semaphore between ISR and main thread
-    AP_HAL::Semaphore *sem;    
+    HAL_Semaphore sem;
 
     AP_Radio::stats stats;
     AP_Radio::stats last_stats;

--- a/libraries/AP_Radio/AP_Radio_cypress.h
+++ b/libraries/AP_Radio/AP_Radio_cypress.h
@@ -169,7 +169,7 @@ private:
     };
 
     // semaphore between ISR and main thread
-    AP_HAL::Semaphore *sem;    
+    HAL_Semaphore sem;
     
     // dsm config data and status
     struct {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -27,6 +27,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
+#include <AP_Common/Semaphore.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -130,12 +131,10 @@ void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 {
     uint16_t d;
     if (get_reading(d)) {
-        if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-            distance = d;
-            new_distance = true;
-            state.last_reading_ms = AP_HAL::millis();
-            _sem->give();
-        }
+        WITH_SEMAPHORE(_sem);
+        distance = d;
+        new_distance = true;
+        state.last_reading_ms = AP_HAL::millis();
     }
 }
 
@@ -144,15 +143,13 @@ void AP_RangeFinder_MaxsonarI2CXL::_timer(void)
 */
 void AP_RangeFinder_MaxsonarI2CXL::update(void)
 {
-    if (_sem->take_nonblocking()) {
-        if (new_distance) {
-            state.distance_cm = distance;
-            new_distance = false;
-            update_status();
-        } else if (AP_HAL::millis() - state.last_reading_ms > 300) {
-            // if no updates for 0.3 seconds set no-data
-            set_status(RangeFinder::RangeFinder_NoData);
-        }
-        _sem->give();
+    WITH_SEMAPHORE(_sem);
+    if (new_distance) {
+        state.distance_cm = distance;
+        new_distance = false;
+        update_status();
+    } else if (AP_HAL::millis() - state.last_reading_ms > 300) {
+        // if no updates for 0.3 seconds set no-data
+        set_status(RangeFinder::RangeFinder_NoData);
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/crc.h>
+#include <AP_Common/Semaphore.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -159,12 +160,13 @@ void AP_RangeFinder_TeraRangerI2C::timer(void)
     uint16_t _raw_distance = 0;
     uint16_t _distance_cm = 0;
 
-    if (collect_raw(_raw_distance) && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+    if (collect_raw(_raw_distance)) {
+        WITH_SEMAPHORE(_sem);
+
         if (process_raw_measure(_raw_distance, _distance_cm)){
             accum.sum += _distance_cm;
             accum.count++;
         }
-        _sem->give();
     }
     // and immediately ask for a new reading
     measure();
@@ -175,16 +177,15 @@ void AP_RangeFinder_TeraRangerI2C::timer(void)
 */
 void AP_RangeFinder_TeraRangerI2C::update(void)
 {
-    if (_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        if (accum.count > 0) {
-            state.distance_cm = accum.sum / accum.count;
-            state.last_reading_ms = AP_HAL::millis();
-            accum.sum = 0;
-            accum.count = 0;
-            update_status();
-        } else {
-            set_status(RangeFinder::RangeFinder_NoData);
-        }
-        _sem->give();
+    WITH_SEMAPHORE(_sem);
+
+    if (accum.count > 0) {
+        state.distance_cm = accum.sum / accum.count;
+        state.last_reading_ms = AP_HAL::millis();
+        accum.sum = 0;
+        accum.count = 0;
+        update_status();
+    } else {
+        set_status(RangeFinder::RangeFinder_NoData);
     }
 }

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
@@ -27,7 +27,6 @@ extern const AP_HAL::HAL& hal;
 AP_RangeFinder_Backend::AP_RangeFinder_Backend(RangeFinder::RangeFinder_State &_state) :
         state(_state)
 {
-    _sem = hal.util->new_semaphore();    
 }
 
 MAV_DISTANCE_SENSOR AP_RangeFinder_Backend::get_mav_distance_sensor_type() const {

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -69,7 +69,7 @@ protected:
     RangeFinder::RangeFinder_State &state;
 
     // semaphore for access to shared frontend data
-    AP_HAL::Semaphore *_sem;    
+    HAL_Semaphore _sem;
 
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const = 0;
 };

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -103,12 +103,12 @@ AP_SBusOut::update()
         /* construct sbus frame representing channels 1 through 16 (max) */
         uint8_t nchan = MIN(NUM_SERVO_CHANNELS, SBUS_CHANNELS);
         for (unsigned i = 0; i < nchan; ++i) {
-            SRV_Channel *ch = SRV_Channels::srv_channel(i);
-            if (ch == nullptr) {
+            SRV_Channel *c = SRV_Channels::srv_channel(i);
+            if (c == nullptr) {
                 continue;
             }
             /*protect from out of bounds values and limit to 11 bits*/
-            uint16_t pwmval = MAX(ch->get_output_pwm(), SBUS_MIN);
+            uint16_t pwmval = MAX(c->get_output_pwm(), SBUS_MIN);
             value = (uint16_t)((pwmval - SBUS_MIN) * SBUS_SCALE);
             if (value > 0x07ff) {
                 value = 0x07ff;

--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -95,12 +95,6 @@ void AP_SmartRTL::init()
         return;
     }
 
-    // create semaphore
-    _path_sem = hal.util->new_semaphore();
-    if (_path_sem == nullptr) {
-        return;
-    }
-
     // allocate arrays
     _path = (Vector3f*)calloc(_points_max, sizeof(Vector3f));
 
@@ -144,14 +138,14 @@ bool AP_SmartRTL::pop_point(Vector3f& point)
     }
 
     // get semaphore
-    if (!_path_sem->take_nonblocking()) {
+    if (!_path_sem.take_nonblocking()) {
         log_action(SRTL_POP_FAILED_NO_SEMAPHORE);
         return false;
     }
 
     // check we have another point
     if (_path_points_count == 0) {
-        _path_sem->give();
+        _path_sem.give();
         return false;
     }
 
@@ -161,7 +155,7 @@ bool AP_SmartRTL::pop_point(Vector3f& point)
     // record count of last point popped
     _path_points_completed_limit = _path_points_count;
 
-    _path_sem->give();
+    _path_sem.give();
     return true;
 }
 
@@ -287,7 +281,7 @@ void AP_SmartRTL::cancel_request_for_thorough_cleanup()
 bool AP_SmartRTL::add_point(const Vector3f& point)
 {
     // get semaphore
-    if (!_path_sem->take_nonblocking()) {
+    if (!_path_sem.take_nonblocking()) {
         log_action(SRTL_ADD_FAILED_NO_SEMAPHORE, point);
         return false;
     }
@@ -296,14 +290,14 @@ bool AP_SmartRTL::add_point(const Vector3f& point)
     if (_path_points_count > 0) {
         const Vector3f& last_pos = _path[_path_points_count-1];
         if (last_pos.distance_squared(point) < sq(_accuracy.get())) {
-            _path_sem->give();
+            _path_sem.give();
             return true;
         }
     }
 
     // check we have space in the path
     if (_path_points_count >= _path_points_max) {
-        _path_sem->give();
+        _path_sem.give();
         log_action(SRTL_ADD_FAILED_PATH_FULL, point);
         return false;
     }
@@ -312,7 +306,7 @@ bool AP_SmartRTL::add_point(const Vector3f& point)
     _path[_path_points_count++] = point;
     log_action(SRTL_POINT_ADD, point);
 
-    _path_sem->give();
+    _path_sem.give();
     return true;
 }
 
@@ -324,14 +318,14 @@ void AP_SmartRTL::run_background_cleanup()
     }
 
     // get semaphore
-    if (!_path_sem->take_nonblocking()) {
+    if (!_path_sem.take_nonblocking()) {
         return;
     }
     // local copy of _path_points_count and _path_points_completed_limit
     const uint16_t path_points_count = _path_points_count;
     const uint16_t path_points_completed_limit = _path_points_completed_limit;
     _path_points_completed_limit = SMARTRTL_POINTS_MAX;
-    _path_sem->give();
+    _path_sem.give();
 
     // check if thorough cleanup is required
     if (_thorough_clean_request_ms > 0) {
@@ -623,7 +617,7 @@ void AP_SmartRTL::reset_pruning()
 void AP_SmartRTL::remove_points_by_simplify_bitmask()
 {
     // get semaphore before modifying path
-    if (!_path_sem->take_nonblocking()) {
+    if (!_path_sem.take_nonblocking()) {
         return;
     }
     uint16_t dest = 1;
@@ -648,7 +642,7 @@ void AP_SmartRTL::remove_points_by_simplify_bitmask()
         deactivate(SRTL_DEACTIVATED_PROGRAM_ERROR, "program error");
     }
 
-    _path_sem->give();
+    _path_sem.give();
 
     // flag point removal is complete
     _simplify.bitmask.setall();
@@ -666,7 +660,7 @@ bool AP_SmartRTL::remove_points_by_loops(uint16_t num_points_to_remove)
     }
 
     // get semaphore before modifying path
-    if (!_path_sem->take_nonblocking()) {
+    if (!_path_sem.take_nonblocking()) {
         return false;
     }
 
@@ -692,7 +686,7 @@ bool AP_SmartRTL::remove_points_by_loops(uint16_t num_points_to_remove)
         } else {
             // this is an error that should never happen so deactivate
             deactivate(SRTL_DEACTIVATED_PROGRAM_ERROR, "program error");
-            _path_sem->give();
+            _path_sem.give();
             // we return true so thorough_cleanup does not get stuck
             return true;
         }
@@ -712,7 +706,7 @@ bool AP_SmartRTL::remove_points_by_loops(uint16_t num_points_to_remove)
         _prune.loops_count--;
     }
 
-    _path_sem->give();
+    _path_sem.give();
     return true;
 }
 

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -184,7 +184,7 @@ private:
     uint16_t _path_points_max;  // after the array has been allocated, we will need to know how big it is. We can't use the parameter, because a user could change the parameter in-flight
     uint16_t _path_points_count;// number of points in the path array
     uint16_t _path_points_completed_limit;  // set by main thread to the path_point_count when a point is popped.  used by simplify and prune algorithms to detect path shrinking
-    AP_HAL::Semaphore *_path_sem;   // semaphore for updating path
+    HAL_Semaphore _path_sem;   // semaphore for updating path
 
     // Simplify
     // structure and buffer to hold the "to-do list" for the simplify algorithm.

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -108,9 +108,6 @@ AP_UAVCAN::AP_UAVCAN() :
         _SRV_conf[i].servo_pending = false;
     }
 
-    SRV_sem = hal.util->new_semaphore();
-    _led_out_sem = hal.util->new_semaphore();
-
     debug_uavcan(2, "AP_UAVCAN constructed\n\r");
 }
 
@@ -289,7 +286,7 @@ void AP_UAVCAN::SRV_send_actuator(void)
     uint8_t starting_servo = 0;
     bool repeat_send;
 
-    SRV_sem->take_blocking();
+    WITH_SEMAPHORE(SRV_sem);
 
     do {
         repeat_send = false;
@@ -332,8 +329,6 @@ void AP_UAVCAN::SRV_send_actuator(void)
             }
         }
     } while (repeat_send);
-
-    SRV_sem->give();
 }
 
 void AP_UAVCAN::SRV_send_esc(void)
@@ -344,7 +339,7 @@ void AP_UAVCAN::SRV_send_esc(void)
     uint8_t active_esc_num = 0, max_esc_num = 0;
     uint8_t k = 0;
 
-    SRV_sem->take_blocking();
+    WITH_SEMAPHORE(SRV_sem);
 
     // find out how many esc we have enabled and if they are active at all
     for (uint8_t i = 0; i < UAVCAN_SRV_NUMBER; i++) {
@@ -377,13 +372,11 @@ void AP_UAVCAN::SRV_send_esc(void)
 
         esc_raw[_driver_index]->broadcast(esc_msg);
     }
-
-    SRV_sem->give();
 }
 
 void AP_UAVCAN::SRV_push_servos()
 {
-    SRV_sem->take_blocking();
+    WITH_SEMAPHORE(SRV_sem);
 
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
         // Check if this channels has any function assigned
@@ -393,8 +386,6 @@ void AP_UAVCAN::SRV_push_servos()
             _SRV_conf[i].servo_pending = true;
         }
     }
-
-    SRV_sem->give();
 
     _SRV_armed = hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED;
 }
@@ -410,29 +401,25 @@ void AP_UAVCAN::led_out_send()
         return;
     }
 
-    if (!_led_out_sem->take(1)) {
-        return;
-    }
-
-
-    if (_led_conf.devices_count == 0) {
-        _led_out_sem->give();
-        return;
-    }
-
     uavcan::equipment::indication::LightsCommand msg;
-    uavcan::equipment::indication::SingleLightCommand cmd;
+    {
+        WITH_SEMAPHORE(_led_out_sem);
 
-    for (uint8_t i = 0; i < _led_conf.devices_count; i++) {
-        cmd.light_id =_led_conf.devices[i].led_index;
-        cmd.color.red = _led_conf.devices[i].red >> 3;
-        cmd.color.green = _led_conf.devices[i].green >> 2;
-        cmd.color.blue = _led_conf.devices[i].blue >> 3;
+        if (_led_conf.devices_count == 0) {
+            return;
+        }
 
-        msg.commands.push_back(cmd);
+        uavcan::equipment::indication::SingleLightCommand cmd;
+
+        for (uint8_t i = 0; i < _led_conf.devices_count; i++) {
+            cmd.light_id =_led_conf.devices[i].led_index;
+            cmd.color.red = _led_conf.devices[i].red >> 3;
+            cmd.color.green = _led_conf.devices[i].green >> 2;
+            cmd.color.blue = _led_conf.devices[i].blue >> 3;
+
+            msg.commands.push_back(cmd);
+        }
     }
-
-    _led_out_sem->give();
 
     rgb_led[_driver_index]->broadcast(msg);
     _led_conf.last_update = now;
@@ -444,9 +431,7 @@ bool AP_UAVCAN::led_write(uint8_t led_index, uint8_t red, uint8_t green, uint8_t
         return false;
     }
 
-    if (!_led_out_sem->take(1)) {
-        return false;
-    }
+    WITH_SEMAPHORE(_led_out_sem);
 
     // check if a device instance exists. if so, break so the instance index is remembered
     uint8_t instance = 0;
@@ -469,8 +454,6 @@ bool AP_UAVCAN::led_write(uint8_t led_index, uint8_t red, uint8_t green, uint8_t
     if (instance == _led_conf.devices_count) {
         _led_conf.devices_count++;
     }
-
-    _led_out_sem->give();
 
     return true;
 }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -169,7 +169,7 @@ private:
 
     uint8_t _SRV_armed;
     uint32_t _SRV_last_send_us;
-    AP_HAL::Semaphore *SRV_sem;
+    HAL_Semaphore SRV_sem;
 
     ///// LED /////
     struct led_device {
@@ -185,7 +185,7 @@ private:
         uint64_t last_update;
     } _led_conf;
 
-    AP_HAL::Semaphore *_led_out_sem;
+    HAL_Semaphore _led_out_sem;
 };
 
 #endif /* AP_UAVCAN_H_ */

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -67,21 +67,21 @@ void AP_Volz_Protocol::update()
         // check if current channel is needed for Volz protocol
         if (last_used_bitmask & (1U<<i)) {
 
-            SRV_Channel *ch = SRV_Channels::srv_channel(i);
-            if (ch == nullptr) {
+            SRV_Channel *c = SRV_Channels::srv_channel(i);
+            if (c == nullptr) {
                 continue;
             }
             
             // check if current channel PWM is within range
-            if (ch->get_output_pwm() < ch->get_output_min()) {
+            if (c->get_output_pwm() < c->get_output_min()) {
                 value = 0;
             } else {
-                value = ch->get_output_pwm() - ch->get_output_min();
+                value = c->get_output_pwm() - c->get_output_min();
             }
 
             // scale the PWM value to Volz value
             value = value + VOLZ_EXTENDED_POSITION_MIN;
-            value = value * VOLZ_SCALE_VALUE / (ch->get_output_max() - ch->get_output_min());
+            value = value * VOLZ_SCALE_VALUE / (c->get_output_max() - c->get_output_min());
 
             // make sure value stays in range
             if (value > VOLZ_EXTENDED_POSITION_MAX) {

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -109,8 +109,8 @@ private:
     char *_log_file_name_long(const uint16_t log_num) const;
     char *_log_file_name_short(const uint16_t log_num) const;
     char *_lastlog_file_name() const;
-    uint32_t _get_log_size(const uint16_t log_num) const;
-    uint32_t _get_log_time(const uint16_t log_num) const;
+    uint32_t _get_log_size(const uint16_t log_num);
+    uint32_t _get_log_time(const uint16_t log_num);
 
     void stop_logging(void) override;
 
@@ -146,11 +146,11 @@ private:
     const uint32_t _free_space_min_avail = 8388608; // bytes
 
     // semaphore mediates access to the ringbuffer
-    AP_HAL::Semaphore *semaphore;
+    HAL_Semaphore semaphore;
     // write_fd_semaphore mediates access to write_fd so the frontend
     // can open/close files without causing the backend to write to a
     // bad fd
-    AP_HAL::Semaphore *write_fd_semaphore;
+    HAL_Semaphore write_fd_semaphore;
     
     // performance counters
     AP_HAL::Util::perf_counter_t  _perf_write;

--- a/libraries/DataFlash/DataFlash_File_sd.cpp
+++ b/libraries/DataFlash/DataFlash_File_sd.cpp
@@ -58,13 +58,6 @@ void DataFlash_File::Init()
 
     if(HAL_F4Light::state.sd_busy) return; // SD mounted via USB
 
-    semaphore = hal.util->new_semaphore();
-    if (semaphore == nullptr) {
-        AP_HAL::panic("Failed to create DataFlash_File semaphore");
-        return;
-    }
-
-
     // create the log directory if need be
     const char* custom_dir = hal.util->get_custom_log_directory();
     if (custom_dir != nullptr){
@@ -457,7 +450,7 @@ bool DataFlash_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
         return false;
     }
 
-    if (!semaphore->take(1)) {
+    if (!semaphore.take(1)) {
         return false;
     }
         
@@ -471,7 +464,7 @@ bool DataFlash_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
         // things:
         if (space < non_messagewriter_message_reserved_space()) {
             // this message isn't dropped, it will be sent again...
-            semaphore->give();
+            semaphore.give();
             return false;
         }
     } else {
@@ -479,7 +472,7 @@ bool DataFlash_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
         if (!is_critical && space < critical_message_reserved_space()) {
 //            printf("dropping NC block! size=%d\n", size);
             _dropped++;
-            semaphore->give();
+            semaphore.give();
             return false;
         }
     }
@@ -490,14 +483,14 @@ bool DataFlash_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
         printf("dropping block! size=%d\n", size);
 
         _dropped++;
-        semaphore->give();
+        semaphore.give();
         return false;
     }
 
     _writebuf.write((uint8_t*)pBuffer, size);
     has_data=true;
     
-    semaphore->give();
+    semaphore.give();
     return true;
 }
 

--- a/libraries/DataFlash/DataFlash_File_sd.h
+++ b/libraries/DataFlash/DataFlash_File_sd.h
@@ -97,7 +97,7 @@ private:
     /* construct a file name given a log number. Caller must free. */
     char *_log_file_name(const uint16_t log_num) const;
     char *_lastlog_file_name() const;
-    uint32_t _get_log_size(const uint16_t log_num) const;
+    uint32_t _get_log_size(const uint16_t log_num);
     uint32_t _get_log_time(const uint16_t log_num) const;
 
     void stop_logging(void);
@@ -127,7 +127,7 @@ private:
 
     float avail_space_percent(uint32_t *free = NULL);
 
-    AP_HAL::Semaphore *semaphore;
+    HAL_Semaphore semaphore;
 
     bool has_data;
 

--- a/libraries/DataFlash/DataFlash_MAVLink.h
+++ b/libraries/DataFlash/DataFlash_MAVLink.h
@@ -178,7 +178,7 @@ private:
     AP_HAL::Util::perf_counter_t  _perf_packing;
     AP_HAL::Util::perf_counter_t  _perf_overruns;
 
-    AP_HAL::Semaphore *semaphore;
+    HAL_Semaphore semaphore;
 };
 
 #endif // DATAFLASH_MAVLINK_SUPPORT

--- a/libraries/DataFlash/DataFlash_Revo.cpp
+++ b/libraries/DataFlash/DataFlash_Revo.cpp
@@ -387,14 +387,13 @@ void DataFlash_Revo::Init()
     }
 
     
+    {
+        WITH_SEMAPHORE(_spi_sem);
+        _spi->set_speed(AP_HAL::Device::SPEED_LOW);
 
-    _spi_sem->take(10);
-    _spi->set_speed(AP_HAL::Device::SPEED_LOW);
-
-    DataFlash_Backend::Init();
+        DataFlash_Backend::Init();
+    }
     
-    _spi_sem->give();
-
     df_NumPages   = BOARD_DATAFLASH_PAGES - 1;     // reserve last page for config information
 
     ReadManufacturerID();

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -104,9 +104,6 @@ FlightAxis::FlightAxis(const char *home_str, const char *frame_str) :
         }
     }
 
-    /* Create the thread that will be waiting for data from FlightAxis */
-    mutex = hal.util->new_semaphore();
-
     int ret = pthread_create(&thread, NULL, update_thread, this);
     if (ret != 0) {
         AP_HAL::panic("SIM_FlightAxis: failed to create thread");
@@ -139,9 +136,10 @@ void FlightAxis::update_loop(void)
 {
     while (true) {
         struct sitl_input new_input;
-        mutex->take(HAL_SEMAPHORE_BLOCK_FOREVER);
-        new_input = last_input;
-        mutex->give();
+        {
+            WITH_SEMAPHORE(mutex);
+            new_input = last_input;
+        }
         exchange_data(new_input);
     }
 }
@@ -339,7 +337,7 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
                                scaled_servos[7]);
 
     if (reply) {
-        mutex->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+        WITH_SEMAPHORE(mutex);
         double lastt_s = state.m_currentPhysicsTime_SEC;
         parse_reply(reply);
         double dt = state.m_currentPhysicsTime_SEC - lastt_s;
@@ -350,7 +348,6 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
             average_frame_time_s = average_frame_time_s * 0.98 + dt * 0.02;
         }
         socket_frame_counter++;
-        mutex->give();
         free(reply);
     }
 }
@@ -361,7 +358,7 @@ void FlightAxis::exchange_data(const struct sitl_input &input)
  */
 void FlightAxis::update(const struct sitl_input &input)
 {
-    mutex->take(HAL_SEMAPHORE_BLOCK_FOREVER);
+    WITH_SEMAPHORE(mutex);
     
     last_input = input;
     
@@ -371,7 +368,6 @@ void FlightAxis::update(const struct sitl_input &input)
         initial_time_s = time_now_us * 1.0e-6f;
         last_time_s = state.m_currentPhysicsTime_SEC;
         position_offset.zero();
-        mutex->give();
         return;
     }
     if (dt_seconds < 0.00001f) {
@@ -382,14 +378,12 @@ void FlightAxis::update(const struct sitl_input &input)
         }
         if (delta_time <= 0) {
             usleep(1000);
-            mutex->give();
             return;
         }
         time_now_us += delta_time * 1.0e6;
         extrapolate_sensors(delta_time);
         update_position();
         update_mag_field_bf();
-        mutex->give();
         usleep(delta_time*1.0e6);
         extrapolated_s += delta_time;
         report_FPS();
@@ -481,7 +475,6 @@ void FlightAxis::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
-    mutex->give();
 
     report_FPS();
 }

--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -181,7 +181,7 @@ private:
     uint16_t controller_port = 18083;
 
     pthread_t thread;
-    AP_HAL::Semaphore *mutex;
+    HAL_Semaphore mutex;
 };
 
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -291,9 +291,9 @@ SRV_Channels::set_failsafe_pwm(SRV_Channel::Aux_servo_function_t function, uint1
         return;
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        const SRV_Channel &ch = channels[i];
-        if (ch.function.get() == function) {
-            hal.rcout->set_failsafe_pwm(1U<<ch.ch_num, pwm);
+        const SRV_Channel &c = channels[i];
+        if (c.function.get() == function) {
+            hal.rcout->set_failsafe_pwm(1U<<c.ch_num, pwm);
         }
     }
 }
@@ -308,10 +308,10 @@ SRV_Channels::set_failsafe_limit(SRV_Channel::Aux_servo_function_t function, SRV
         return;
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        const SRV_Channel &ch = channels[i];
-        if (ch.function.get() == function) {
-            uint16_t pwm = ch.get_limit_pwm(limit);
-            hal.rcout->set_failsafe_pwm(1U<<ch.ch_num, pwm);
+        const SRV_Channel &c = channels[i];
+        if (c.function.get() == function) {
+            uint16_t pwm = c.get_limit_pwm(limit);
+            hal.rcout->set_failsafe_pwm(1U<<c.ch_num, pwm);
         }
     }
 }
@@ -326,10 +326,10 @@ SRV_Channels::set_safety_limit(SRV_Channel::Aux_servo_function_t function, SRV_C
         return;
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        const SRV_Channel &ch = channels[i];
-        if (ch.function.get() == function) {
-            uint16_t pwm = ch.get_limit_pwm(limit);
-            hal.rcout->set_safety_pwm(1U<<ch.ch_num, pwm);
+        const SRV_Channel &c = channels[i];
+        if (c.function.get() == function) {
+            uint16_t pwm = c.get_limit_pwm(limit);
+            hal.rcout->set_safety_pwm(1U<<c.ch_num, pwm);
         }
     }
 }
@@ -344,16 +344,16 @@ SRV_Channels::set_output_limit(SRV_Channel::Aux_servo_function_t function, SRV_C
         return;
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &ch = channels[i];
-        if (ch.function.get() == function) {
-            uint16_t pwm = ch.get_limit_pwm(limit);
-            ch.set_output_pwm(pwm);
-            if (ch.function.get() == SRV_Channel::k_manual) {
-                RC_Channel *c = rc().channel(ch.ch_num);
-                if (c != nullptr) {
+        SRV_Channel &c = channels[i];
+        if (c.function.get() == function) {
+            uint16_t pwm = c.get_limit_pwm(limit);
+            c.set_output_pwm(pwm);
+            if (c.function.get() == SRV_Channel::k_manual) {
+                RC_Channel *cin = rc().channel(c.ch_num);
+                if (cin != nullptr) {
                     // in order for output_ch() to work for k_manual we
                     // also have to override radio_in
-                    c->set_radio_in(pwm);
+                    cin->set_radio_in(pwm);
                 }
             }
         }
@@ -386,11 +386,11 @@ SRV_Channels::move_servo(SRV_Channel::Aux_servo_function_t function,
     float v = float(value - angle_min) / float(angle_max - angle_min);
     v = constrain_float(v, 0.0f, 1.0f);
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &ch = channels[i];
-        if (ch.function.get() == function) {
-            float v2 = ch.get_reversed()? (1-v) : v;
-            uint16_t pwm = ch.servo_min + v2 * (ch.servo_max - ch.servo_min);
-            ch.set_output_pwm(pwm);
+        SRV_Channel &c = channels[i];
+        if (c.function.get() == function) {
+            float v2 = c.get_reversed()? (1-v) : v;
+            uint16_t pwm = c.servo_min + v2 * (c.servo_max - c.servo_min);
+            c.set_output_pwm(pwm);
         }
     }
 }
@@ -618,21 +618,21 @@ void SRV_Channels::limit_slew_rate(SRV_Channel::Aux_servo_function_t function, f
         return;
     }
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &ch = channels[i];
-        if (ch.function == function) {
-            ch.calc_pwm(functions[function].output_scaled);
-            uint16_t last_pwm = hal.rcout->read_last_sent(ch.ch_num);
-            if (last_pwm == ch.output_pwm) {
+        SRV_Channel &c = channels[i];
+        if (c.function == function) {
+            c.calc_pwm(functions[function].output_scaled);
+            uint16_t last_pwm = hal.rcout->read_last_sent(c.ch_num);
+            if (last_pwm == c.output_pwm) {
                 continue;
             }
-            uint16_t max_change = (ch.get_output_max() - ch.get_output_min()) * slew_rate * dt * 0.01f;
+            uint16_t max_change = (c.get_output_max() - c.get_output_min()) * slew_rate * dt * 0.01f;
             if (max_change == 0 || dt > 1) {
                 // always allow some change. If dt > 1 then assume we
                 // are just starting out, and only allow a small
                 // change for this loop
                 max_change = 1;
             }
-            ch.output_pwm = constrain_int16(ch.output_pwm, last_pwm-max_change, last_pwm+max_change);
+            c.output_pwm = constrain_int16(c.output_pwm, last_pwm-max_change, last_pwm+max_change);
         }
     }
 }
@@ -672,9 +672,9 @@ void SRV_Channels::set_output_min_max(SRV_Channel::Aux_servo_function_t function
 void SRV_Channels::constrain_pwm(SRV_Channel::Aux_servo_function_t function)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &ch = channels[i];
-        if (ch.function == function) {
-            ch.output_pwm = constrain_int16(ch.output_pwm, ch.servo_min, ch.servo_max);
+        SRV_Channel &c = channels[i];
+        if (c.function == function) {
+            c.output_pwm = constrain_int16(c.output_pwm, c.servo_min, c.servo_max);
         }
     }
 }
@@ -863,9 +863,9 @@ void SRV_Channels::set_rc_frequency(SRV_Channel::Aux_servo_function_t function, 
 {
     uint16_t mask = 0;
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &ch = channels[i];
-        if (ch.function == function) {
-            mask |= (1U<<ch.ch_num);
+        SRV_Channel &c = channels[i];
+        if (c.function == function) {
+            mask |= (1U<<c.ch_num);
         }
     }
     if (mask != 0) {


### PR DESCRIPTION
This removes the dynamic allocation of semaphores, moving to HAL_Semaphore everywhere.

Note that this PR changes several drivers from using non-blocking to blocking waits for semaphores. That is quite deliberate, and is done with careful checking that the semaphore is only held across small computation blocks. The change is actually a bugfix for a situation where pathological timing of thread switching could cause us to lose sensor data.

Also note the use of HAL_Semaphore_Recursive for baro, compass and ins backends. These are not strictly needed right now, but the cost is low and it protects against an easy programming error where backend functions may take a semaphore while is already held by the calling function.
