### PR TITLE
AP_Baro_UAVCAN: fix temperature

### DIFF
--- a/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
+++ b/libraries/AP_Baro/AP_Baro_UAVCAN.cpp
@@ -165,7 +165,7 @@ void AP_Baro_UAVCAN::handle_temperature(AP_UAVCAN* ap_uavcan, uint8_t node_id, c
         }
         {
             WITH_SEMAPHORE(driver->_sem_baro);
-            driver->_temperature = cb.msg->static_temperature;
+            driver->_temperature = cb.msg->static_temperature - C_TO_KELVIN;
         }
         give_registry();
     }


### PR DESCRIPTION
I got really surprised when I saw extremely high altitude.

![image](https://user-images.githubusercontent.com/7996972/46892313-a6384080-ce75-11e8-8f80-eeddcb184dd6.png)

2 baros are giving high temperatures, 1 baro is normal.

The problem was here: https://github.com/ArduPilot/ardupilot/commit/5ef553737192fd4e0b75ca64d6ffdf95e7b48a53#diff-ceee283277029c29c750143f987a85c7L78

UAVCAN gives temperature in Kelvin and Ardupilot expects it to be in Celcius.

I really love what @bugobliterator does, but please flight test before merging as I don't have a possibility to flight test a lot now.