### PR TITLE
AP_RPM: treat RPM_TYPE 1 as type 2 on non-PX4

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -105,11 +105,16 @@ void AP_RPM::init(void)
         return;
     }
     for (uint8_t i=0; i<RPM_MAX_INSTANCES; i++) {
-        const uint8_t type = _type[i];
+        uint8_t type = _type[i];
 
 #if (CONFIG_HAL_BOARD == HAL_BOARD_PX4) || ((CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN) && (!defined(CONFIG_ARCH_BOARD_VRBRAIN_V51) && !defined(CONFIG_ARCH_BOARD_VRUBRAIN_V52)))
         if (type == RPM_TYPE_PX4_PWM) {
             drivers[i] = new AP_RPM_PX4_PWM(*this, i, state[i]);
+        }
+#else
+        if (type == RPM_TYPE_PX4_PWM) {
+            // on non-PX4 treat PX4-pin as AUXPIN option, for upgrade
+            type = RPM_TYPE_PIN;
         }
 #endif
         if (type == RPM_TYPE_PIN) {


### PR DESCRIPTION
makes upgrades easier