### PR TITLE
AP_BLHeli: add motor pole parameter

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -101,6 +101,13 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("PORT",  8, AP_BLHeli, control_port, 0),
     
+    // @Param: POLES
+    // @DisplayName: Motor Poles
+    // @Description: This allows calculation of true RPM from ESC's eRPM. The default is 14.
+    // @Values: 1-127
+    // @User: Advanced
+    AP_GROUPINFO("POLES",  9, AP_BLHeli, motor_poles, 14),
+    
     AP_GROUPEND
 };
 
@@ -1327,7 +1334,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     td.voltage = (buf[1]<<8) | buf[2];
     td.current = (buf[3]<<8) | buf[4];
     td.consumption = (buf[5]<<8) | buf[6];
-    td.rpm = (buf[7]<<8) | buf[8];
+    td.rpm = ((buf[7]<<8) | buf[8]) * motor_poles;
     td.timestamp_ms = AP_HAL::millis();
 
     last_telem[last_telem_esc] = td;

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -77,6 +77,7 @@ private:
     AP_Int8 debug_level;
     AP_Int8 output_type;
     AP_Int8 control_port;
+    AP_Int8 motor_poles;
     
     enum mspState {
         MSP_IDLE=0,

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -752,9 +752,7 @@ void AP_OSD_Screen::draw_blh_rpm(uint8_t x, uint8_t y)
         if (!blheli->get_telem_data(0, td)) {
             return;
         }
-
-        int esc_rpm = td.rpm * 14;   // hard-wired assumption for now that motor has 14 poles, so multiply eRPM * 14 to get motor RPM.
-        backend->write(x, y, false, "%5d%c", esc_rpm, SYM_RPM);
+        backend->write(x, y, false, "%5d%c", td.rpm, SYM_RPM);
     }
 }
 


### PR DESCRIPTION
- allows conversion of ESC's eRPM to true motor RPM
- fixes BLH RPM logging and display on GCSes
- removes hardcoded multiplier 14 from AP_OSD BLH_RPM item