### PR TITLE
AP_Landing: disable ground steering on landing approach

### DIFF
--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -323,7 +323,7 @@ bool AP_Landing::is_ground_steering_allowed(void) const
 
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
-        return type_slope_is_on_approach();
+        return !type_slope_is_on_approach();
     case TYPE_DEEPSTALL:
         return false;
     default:


### PR DESCRIPTION
When the plane is on approach, the grounding steering have to be
disabled to prevent steering controller windup.