### PR TITLE
AP_motors: add dualcopter/Bicopter

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -845,7 +845,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_CLASS
     // @DisplayName: Frame Class
     // @Description: Controls major frame class for multicopter component
-    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad
+    // @Values: 0:Undefined, 1:Quad, 2:Hexa, 3:Octa, 4:OctaQuad, 5:Y6, 6:Heli, 7:Tri, 8:SingleCopter, 9:CoaxCopter, 10:BiCopter, 11:Heli_Dual, 12:DodecaHexa, 13:HeliQuad
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_CLASS", 15, ParametersG2, frame_class, 0),

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -52,19 +52,21 @@ void QuadPlane::tailsitter_output(void)
     if (!is_tailsitter()) {
         return;
     }
+
+    float tilt_left = 0.0f;
+    float tilt_right = 0.0f;
+
     if (!tailsitter_active() || in_tailsitter_vtol_transition()) {
         if (tailsitter.vectored_forward_gain > 0) {
             // thrust vectoring in fixed wing flight
             float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
             float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
-            float tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain;
-            float tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
-        } else {
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, 0);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 0);
+            tilt_left  = (elevator + aileron) * tailsitter.vectored_forward_gain;
+            tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
         }
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
+        
         if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying() && hal.util->get_soft_armed()) {
             /*
               during transitions to vtol mode set the throttle to the
@@ -90,11 +92,10 @@ void QuadPlane::tailsitter_output(void)
         tailsitter_speed_scaling();
     }
 
-    
     if (tailsitter.vectored_hover_gain > 0) {
         // thrust vectoring VTOL modes
-        float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
-        float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
+        tilt_left = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorLeft);
+        tilt_right = SRV_Channels::get_output_scaled(SRV_Channel::k_tiltMotorRight);
         /*
           apply extra elevator when at high pitch errors, using a
           power law. This allows the motors to point straight up for
@@ -104,8 +105,8 @@ void QuadPlane::tailsitter_output(void)
         float extra_pitch = constrain_float(pitch_error_cd, -4500, 4500) / 4500.0;
         float extra_sign = extra_pitch > 0?1:-1;
         float extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter.vectored_hover_power) * 4500;
-        float tilt_left  = extra_elevator + (elevator + aileron) * tailsitter.vectored_hover_gain;
-        float tilt_right = extra_elevator + (elevator - aileron) * tailsitter.vectored_hover_gain;
+        tilt_left  = extra_elevator + tilt_left * tailsitter.vectored_hover_gain;
+        tilt_right = extra_elevator + tilt_right * tailsitter.vectored_hover_gain;
         if (fabsf(tilt_left) >= 4500 || fabsf(tilt_right) >= 4500) {
             // prevent integrator windup
             motors->limit.roll_pitch = 1;
@@ -114,8 +115,8 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
     }
-    
-    
+
+
     if (tailsitter.input_mask_chan > 0 &&
         tailsitter.input_mask > 0 &&
         RC_Channels::get_radio_in(tailsitter.input_mask_chan-1) > 1700) {
@@ -217,9 +218,11 @@ void QuadPlane::tailsitter_speed_scaling(void)
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
 
-    const SRV_Channel::Aux_servo_function_t functions[2] = {
+    const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
-        SRV_Channel::Aux_servo_function_t::k_elevator};
+        SRV_Channel::Aux_servo_function_t::k_elevator,
+        SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft,
+        SRV_Channel::Aux_servo_function_t::k_tiltMotorRight};
     for (uint8_t i=0; i<ARRAY_SIZE(functions); i++) {
         int32_t v = SRV_Channels::get_output_scaled(functions[i]);
         v *= scaling;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -615,6 +615,9 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
                 rc_write(i, pwm_out);
             }
         }
+        // send pwm output to channels used by bicopter
+        SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, pwm_out);
+        SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, pwm_out);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -14,7 +14,7 @@
  */
 
 /*
- *       AP_MotorsTailsitter.cpp - ArduCopter motors library for tailsitters
+ *       AP_MotorsTailsitter.cpp - ArduCopter motors library for tailsitters and bicopters
  *
  */
 
@@ -31,6 +31,16 @@ extern const AP_HAL::HAL& hal;
 // init
 void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type frame_type)
 {
+    // make sure 4 output channels are mapped
+    add_motor_num(AP_MOTORS_THROTTLE_LEFT);
+    add_motor_num(AP_MOTORS_THROTTLE_RIGHT);
+    add_motor_num(AP_MOTORS_TILT_LEFT);
+    add_motor_num(AP_MOTORS_TILT_RIGHT);
+
+    // set the motor_enabled flag so that the main ESC can be calibrated like other frame types
+    motor_enabled[AP_MOTORS_THROTTLE_LEFT] = true;
+    motor_enabled[AP_MOTORS_THROTTLE_RIGHT] = true;
+
     // record successful initialisation if what we setup was the desired frame_class
     _flags.initialised_ok = (frame_class == MOTOR_FRAME_TAILSITTER);
 }
@@ -44,56 +54,55 @@ AP_MotorsTailsitter::AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz) 
     SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleRight, speed_hz);
 }
 
+
+// set update rate to motors - a value in hertz
+void AP_MotorsTailsitter::set_update_rate( uint16_t speed_hz )
+{
+    // record requested speed
+    _speed_hz = speed_hz;
+
+    uint32_t mask =
+        1U << AP_MOTORS_THROTTLE_LEFT |
+        1U << AP_MOTORS_THROTTLE_RIGHT;
+    rc_set_freq(mask, _speed_hz);
+}
+
 void AP_MotorsTailsitter::output_to_motors()
 {
     if (!_flags.initialised_ok) {
         return;
     }
-    float throttle = _throttle;
-    float throttle_left  = 0;
-    float throttle_right = 0;
-    
+    float throttle = 0.0f;
+
     switch (_spool_mode) {
         case SHUT_DOWN:
-            throttle = 0;
-            // set limits flags
-            limit.roll_pitch = true;
-            limit.yaw = true;
-            limit.throttle_lower = true;
-            limit.throttle_upper = true;
+            throttle = get_pwm_output_min();
+            rc_write(AP_MOTORS_THROTTLE_LEFT, get_pwm_output_min());
+            rc_write(AP_MOTORS_THROTTLE_RIGHT, get_pwm_output_min());
             break;
         case SPIN_WHEN_ARMED:
-            // sends output to motors when armed but not flying
             throttle = constrain_float(_spin_up_ratio, 0.0f, 1.0f) * _spin_min;
-            // set limits flags
-            limit.roll_pitch = true;
-            limit.yaw = true;
-            limit.throttle_lower = true;
-            limit.throttle_upper = true;
+            rc_write(AP_MOTORS_THROTTLE_LEFT, calc_spin_up_to_pwm());
+            rc_write(AP_MOTORS_THROTTLE_RIGHT, calc_spin_up_to_pwm());
             break;
         case SPOOL_UP:
         case THROTTLE_UNLIMITED:
-        case SPOOL_DOWN: {
-            throttle = _spin_min + throttle * (1 - _spin_min);
-            throttle_left  = constrain_float(throttle + _rudder*0.5, _spin_min, 1);
-            throttle_right = constrain_float(throttle - _rudder*0.5, _spin_min, 1);
-            // initialize limits flags
-            limit.roll_pitch = false;
-            limit.yaw = false;
-            limit.throttle_lower = false;
-            limit.throttle_upper = false;
+        case SPOOL_DOWN:
+            throttle = calc_thrust_to_pwm(_throttle);
+            rc_write(AP_MOTORS_THROTTLE_LEFT, calc_thrust_to_pwm(_thrust_left));
+            rc_write(AP_MOTORS_THROTTLE_RIGHT, calc_thrust_to_pwm(_thrust_right));
             break;
-        }
     }
-    // outputs are setup here, and written to the HAL by the plane servos loop
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron,  _aileron*SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _elevator*SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder,   _rudder*SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle*THROTTLE_RANGE);
 
-    // also support differential roll with twin motors
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft,  throttle_left*THROTTLE_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle_right*THROTTLE_RANGE);
+    // Always output to tilts
+    rc_write_angle(AP_MOTORS_TILT_LEFT, _tilt_left*SERVO_OUTPUT_RANGE);
+    rc_write_angle(AP_MOTORS_TILT_RIGHT, _tilt_right*SERVO_OUTPUT_RANGE);
+
+    // plane outputs for Qmodes are setup here, and written to the HAL by the plane servos loop
+    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, -_yaw_in*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _pitch_in*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, _roll_in*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, throttle);
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
     SRV_Channels::calc_pwm();
@@ -101,24 +110,103 @@ void AP_MotorsTailsitter::output_to_motors()
 #endif
 }
 
+// get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+//  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+uint16_t AP_MotorsTailsitter::get_motor_mask()
+{
+    uint32_t motor_mask =
+        1U << AP_MOTORS_THROTTLE_LEFT |
+        1U << AP_MOTORS_THROTTLE_RIGHT |
+        1U << AP_MOTORS_TILT_LEFT |
+        1U << AP_MOTORS_TILT_RIGHT;
+    uint16_t mask = rc_map_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
+}
+
 // calculate outputs to the motors
 void AP_MotorsTailsitter::output_armed_stabilizing()
 {
-    _aileron = -_yaw_in;
-    _elevator = _pitch_in;
-    _rudder = _roll_in;
-    _throttle = get_throttle();
+    float   roll_thrust;                // roll thrust input value, +/- 1.0
+    float   pitch_thrust;               // pitch thrust input value, +/- 1.0
+    float   yaw_thrust;                 // yaw thrust input value, +/- 1.0
+    float   throttle_thrust;            // throttle thrust input value, 0.0 - 1.0
+    float   thrust_max;                 // highest motor value
+    float   thr_adj = 0.0f;             // the difference between the pilot's desired throttle and throttle_thrust_best_rpy
+
+    // apply voltage and air pressure compensation
+    const float compensation_gain = get_compensation_gain();
+    roll_thrust = _roll_in * compensation_gain;
+    pitch_thrust = _pitch_in * compensation_gain;
+    yaw_thrust = _yaw_in * compensation_gain;
+    throttle_thrust = get_throttle() * compensation_gain;
+
 
     // sanity check throttle is above zero and below current limited throttle
-    if (_throttle <= 0.0f) {
-        _throttle = 0.0f;
+    if (throttle_thrust <= 0.0f) {
+        throttle_thrust = 0.0f;
         limit.throttle_lower = true;
     }
-    if (_throttle >= _throttle_thrust_max) {
-        _throttle = _throttle_thrust_max;
+    if (throttle_thrust >= _throttle_thrust_max) {
+        throttle_thrust = _throttle_thrust_max;
         limit.throttle_upper = true;
     }
 
-    _throttle = constrain_float(_throttle, 0.1, 1);
+    // caculate left and right throttle outputs
+    _thrust_left  = throttle_thrust + roll_thrust*0.5;
+    _thrust_right = throttle_thrust - roll_thrust*0.5;
+
+    // if max thrust is more than one reduce average throttle
+    thrust_max = MAX(_thrust_right,_thrust_left);
+    if (thrust_max > 1.0f) {
+        thr_adj = 1.0f - thrust_max;
+        limit.throttle_upper = true;
+        limit.roll_pitch = true;
+    }
+
+    // Add ajustment to reduce average throttle
+    _thrust_left  = constrain_float(_thrust_left  + thr_adj, 0.0f, 1.0f);
+    _thrust_right = constrain_float(_thrust_right + thr_adj, 0.0f, 1.0f);
+    _throttle = throttle_thrust + thr_adj;
+
+    // thrust vectoring
+    _tilt_left  = pitch_thrust - yaw_thrust;
+    _tilt_right = pitch_thrust + yaw_thrust;
 }
 
+// output_test_seq - spin a motor at the pwm value specified
+//  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
+//  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
+void AP_MotorsTailsitter::output_test_seq(uint8_t motor_seq, int16_t pwm)
+{
+    // exit immediately if not armed
+    if (!armed()) {
+        return;
+    }
+
+    // output to motors and servos
+    switch (motor_seq) {
+        case 1:
+            // throttle left
+            rc_write(AP_MOTORS_THROTTLE_LEFT, pwm);
+            break;
+        case 2:
+            // throttle right
+            rc_write(AP_MOTORS_THROTTLE_RIGHT, pwm);
+            break;
+        case 3:
+            // tilt left
+            rc_write(AP_MOTORS_TILT_LEFT, pwm);
+            break;
+        case 4:
+            // tilt right
+            rc_write(AP_MOTORS_TILT_RIGHT, pwm);
+            break;
+        default:
+            // do nothing
+            break;
+    }
+}

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -104,8 +104,8 @@ void AP_MotorsTailsitter::output_to_motors()
     }
 
     // Always output to tilt servos
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, _tilt_left*SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, _tilt_right*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, _tilt_left*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, _tilt_right*SERVO_OUTPUT_RANGE);
 
     // plane outputs for Qmodes are setup here, and written to the HAL by the plane servos loop
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, -_yaw_in*SERVO_OUTPUT_RANGE);

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -56,7 +56,7 @@ AP_MotorsTailsitter::AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz) 
 
 
 // set update rate to motors - a value in hertz
-void AP_MotorsTailsitter::set_update_rate( uint16_t speed_hz )
+void AP_MotorsTailsitter::set_update_rate(uint16_t speed_hz)
 {
     // record requested speed
     _speed_hz = speed_hz;
@@ -144,7 +144,6 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
     yaw_thrust = _yaw_in * compensation_gain;
     throttle_thrust = get_throttle() * compensation_gain;
 
-
     // sanity check throttle is above zero and below current limited throttle
     if (throttle_thrust <= 0.0f) {
         throttle_thrust = 0.0f;
@@ -155,7 +154,7 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
         limit.throttle_upper = true;
     }
 
-    // caculate left and right throttle outputs
+    // calculate left and right throttle outputs
     _thrust_left  = throttle_thrust + roll_thrust*0.5;
     _thrust_right = throttle_thrust - roll_thrust*0.5;
 
@@ -167,7 +166,7 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
         limit.roll_pitch = true;
     }
 
-    // Add ajustment to reduce average throttle
+    // Add adjustment to reduce average throttle
     _thrust_left  = constrain_float(_thrust_left  + thr_adj, 0.0f, 1.0f);
     _thrust_right = constrain_float(_thrust_right + thr_adj, 0.0f, 1.0f);
     _throttle = throttle_thrust + thr_adj;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -26,20 +26,32 @@
 extern const AP_HAL::HAL& hal;
 
 #define SERVO_OUTPUT_RANGE  4500
-#define THROTTLE_RANGE       100
 
 // init
 void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type frame_type)
 {
-    // make sure 4 output channels are mapped
-    add_motor_num(AP_MOTORS_THROTTLE_LEFT);
-    add_motor_num(AP_MOTORS_THROTTLE_RIGHT);
-    add_motor_num(AP_MOTORS_TILT_LEFT);
-    add_motor_num(AP_MOTORS_TILT_RIGHT);
+    // setup default motor and servo mappings
+    uint8_t chan;
 
-    // set the motor_enabled flag so that the main ESC can be calibrated like other frame types
-    motor_enabled[AP_MOTORS_THROTTLE_LEFT] = true;
-    motor_enabled[AP_MOTORS_THROTTLE_RIGHT] = true;
+    // right throttle defaults to servo output 1
+    SRV_Channels::set_aux_channel_default(SRV_Channel::k_throttleRight, CH_1);
+    if (SRV_Channels::find_channel(SRV_Channel::k_throttleRight, chan)) {
+        motor_enabled[chan] = true;
+    }
+
+    // left throttle defaults to servo output 2
+    SRV_Channels::set_aux_channel_default(SRV_Channel::k_throttleLeft, CH_2);
+    if (SRV_Channels::find_channel(SRV_Channel::k_throttleLeft, chan)) {
+        motor_enabled[chan] = true;
+    }
+
+    // right servo defaults to servo output 3
+    SRV_Channels::set_aux_channel_default(SRV_Channel::k_tiltMotorRight, CH_3);
+    SRV_Channels::set_angle(SRV_Channel::k_tiltMotorRight, SERVO_OUTPUT_RANGE);
+
+    // left servo defaults to servo output 4
+    SRV_Channels::set_aux_channel_default(SRV_Channel::k_tiltMotorLeft, CH_4);
+    SRV_Channels::set_angle(SRV_Channel::k_tiltMotorLeft, SERVO_OUTPUT_RANGE);
 
     // record successful initialisation if what we setup was the desired frame_class
     _flags.initialised_ok = (frame_class == MOTOR_FRAME_TAILSITTER);
@@ -50,8 +62,7 @@ void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type f
 AP_MotorsTailsitter::AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz) :
     AP_MotorsMulticopter(loop_rate, speed_hz)
 {
-    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleLeft, speed_hz);
-    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleRight, speed_hz);
+    set_update_rate(speed_hz);
 }
 
 
@@ -61,10 +72,8 @@ void AP_MotorsTailsitter::set_update_rate(uint16_t speed_hz)
     // record requested speed
     _speed_hz = speed_hz;
 
-    uint32_t mask =
-        1U << AP_MOTORS_THROTTLE_LEFT |
-        1U << AP_MOTORS_THROTTLE_RIGHT;
-    rc_set_freq(mask, _speed_hz);
+    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleLeft, speed_hz);
+    SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleRight, speed_hz);
 }
 
 void AP_MotorsTailsitter::output_to_motors()
@@ -72,59 +81,56 @@ void AP_MotorsTailsitter::output_to_motors()
     if (!_flags.initialised_ok) {
         return;
     }
-    float throttle = 0.0f;
+    float throttle_pwm = 0.0f;
 
     switch (_spool_mode) {
         case SHUT_DOWN:
-            throttle = get_pwm_output_min();
-            rc_write(AP_MOTORS_THROTTLE_LEFT, get_pwm_output_min());
-            rc_write(AP_MOTORS_THROTTLE_RIGHT, get_pwm_output_min());
+            throttle_pwm = get_pwm_output_min();
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, get_pwm_output_min());
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, get_pwm_output_min());
             break;
         case SPIN_WHEN_ARMED:
-            throttle = constrain_float(_spin_up_ratio, 0.0f, 1.0f) * _spin_min;
-            rc_write(AP_MOTORS_THROTTLE_LEFT, calc_spin_up_to_pwm());
-            rc_write(AP_MOTORS_THROTTLE_RIGHT, calc_spin_up_to_pwm());
+            throttle_pwm = calc_spin_up_to_pwm();
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, calc_spin_up_to_pwm());
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, calc_spin_up_to_pwm());
             break;
         case SPOOL_UP:
         case THROTTLE_UNLIMITED:
         case SPOOL_DOWN:
-            throttle = calc_thrust_to_pwm(_throttle);
-            rc_write(AP_MOTORS_THROTTLE_LEFT, calc_thrust_to_pwm(_thrust_left));
-            rc_write(AP_MOTORS_THROTTLE_RIGHT, calc_thrust_to_pwm(_thrust_right));
+            throttle_pwm = calc_thrust_to_pwm(_throttle);
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, calc_thrust_to_pwm(_thrust_left));
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, calc_thrust_to_pwm(_thrust_right));
             break;
     }
 
-    // Always output to tilts
-    rc_write_angle(AP_MOTORS_TILT_LEFT, _tilt_left*SERVO_OUTPUT_RANGE);
-    rc_write_angle(AP_MOTORS_TILT_RIGHT, _tilt_right*SERVO_OUTPUT_RANGE);
+    // Always output to tilt servos
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, _tilt_left*SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, _tilt_right*SERVO_OUTPUT_RANGE);
 
     // plane outputs for Qmodes are setup here, and written to the HAL by the plane servos loop
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, -_yaw_in*SERVO_OUTPUT_RANGE);
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _pitch_in*SERVO_OUTPUT_RANGE);
     SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, _roll_in*SERVO_OUTPUT_RANGE);
-    SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, throttle);
-
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-    SRV_Channels::calc_pwm();
-    SRV_Channels::output_ch_all();
-#endif
+    SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, throttle_pwm);
 }
 
-// get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+// get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
 uint16_t AP_MotorsTailsitter::get_motor_mask()
 {
-    uint32_t motor_mask =
-        1U << AP_MOTORS_THROTTLE_LEFT |
-        1U << AP_MOTORS_THROTTLE_RIGHT |
-        1U << AP_MOTORS_TILT_LEFT |
-        1U << AP_MOTORS_TILT_RIGHT;
-    uint16_t mask = rc_map_mask(motor_mask);
+    uint32_t motor_mask = 0;
+    uint8_t chan;
+    if (SRV_Channels::find_channel(SRV_Channel::k_throttleLeft, chan)) {
+        motor_mask |= 1U << chan;
+    }
+    if (SRV_Channels::find_channel(SRV_Channel::k_throttleRight, chan)) {
+        motor_mask |= 1U << chan;
+    }
 
     // add parent's mask
-    mask |= AP_MotorsMulticopter::get_motor_mask();
+    motor_mask |= AP_MotorsMulticopter::get_motor_mask();
 
-    return mask;
+    return motor_mask;
 }
 
 // calculate outputs to the motors
@@ -189,20 +195,20 @@ void AP_MotorsTailsitter::output_test_seq(uint8_t motor_seq, int16_t pwm)
     // output to motors and servos
     switch (motor_seq) {
         case 1:
-            // throttle left
-            rc_write(AP_MOTORS_THROTTLE_LEFT, pwm);
+            // right throttle
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, pwm);
             break;
         case 2:
-            // throttle right
-            rc_write(AP_MOTORS_THROTTLE_RIGHT, pwm);
+            // right tilt servo
+            SRV_Channels::set_output_pwm(SRV_Channel::k_tiltMotorRight, pwm);
             break;
         case 3:
-            // tilt left
-            rc_write(AP_MOTORS_TILT_LEFT, pwm);
+            // left throttle
+            SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, pwm);
             break;
         case 4:
-            // tilt right
-            rc_write(AP_MOTORS_TILT_RIGHT, pwm);
+            // left tilt servo
+            SRV_Channels::set_output_pwm(SRV_Channel::k_tiltMotorLeft, pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -161,8 +161,8 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
     }
 
     // calculate left and right throttle outputs
-    _thrust_left  = throttle_thrust + roll_thrust*0.5;
-    _thrust_right = throttle_thrust - roll_thrust*0.5;
+    _thrust_left  = throttle_thrust + roll_thrust*0.5f;
+    _thrust_right = throttle_thrust - roll_thrust*0.5f;
 
     // if max thrust is more than one reduce average throttle
     thrust_max = MAX(_thrust_right,_thrust_left);

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -23,7 +23,8 @@ public:
     // set update rate to motors - a value in hertz
     void set_update_rate( uint16_t speed_hz ) override;
 
-    virtual void output_test_seq(uint8_t motor_seq, int16_t pwm) override;
+    // spin a motor at the pwm value specified
+    void output_test_seq(uint8_t motor_seq, int16_t pwm) override;
 
     // output_to_motors - sends output to named servos
     void output_to_motors() override;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -1,5 +1,5 @@
 /// @file	AP_MotorsTailsitter.h
-/// @brief	Motor control class for tailsitters
+/// @brief	Motor control class for tailsitters and bicopters
 #pragma once
 
 #include <AP_Common/AP_Common.h>
@@ -19,23 +19,27 @@ public:
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {}
-    void set_update_rate( uint16_t speed_hz ) override {}
 
-    virtual void output_test_seq(uint8_t motor_seq, int16_t pwm) override {}
+    // set update rate to motors - a value in hertz
+    void set_update_rate( uint16_t speed_hz ) override;
+
+    virtual void output_test_seq(uint8_t motor_seq, int16_t pwm) override;
 
     // output_to_motors - sends output to named servos
     void output_to_motors() override;
 
-    // return 0 motor mask
-    uint16_t get_motor_mask() override { return 0; }
+    // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+    //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+    uint16_t get_motor_mask() override;
 
 protected:
     // calculate motor outputs
     void output_armed_stabilizing() override;
 
     // calculated outputs
-    float _aileron;  // -1..1
-    float _elevator; // -1..1
-    float _rudder;   // -1..1
     float _throttle; // 0..1
+    float _tilt_left;  // -1..1
+    float _tilt_right;  // -1..1
+    float _thrust_left;  // 0..1
+    float _thrust_right;  // 0..1
 };


### PR DESCRIPTION
This is more of a rearranging than adding a new frame type. The tail-sitter output mixers for thrust vectoring are moved up to AP_MotorTailsitter. This then allows copter to use them for bicopter. Then rename tailsitter to dual and enable in copter 

The longer term goal is to improve the mixers to work well for a bicopter to benefit thrust vectored tail-sitters. 

I have tested a thrust vectored tail-sitter in plane and a bi copter in copter, both in SITL. There should be no change to tail-sitter behavior.  New bicopter for copter fly's OK but is not fantastically stable but did successfully complete a auto-tune. 

https://youtu.be/PtJzx_vx7N0

I have not looked that deeply into Copter to see if there is anything else I should change to support the new frame type, possibly I have missed some stuff