### PR TITLE
Tools: autotest: reduce dummy streamrate

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -208,7 +208,7 @@ class AutoTest(ABC):
             tstart = self.get_sim_time()
         while True:
 
-            self.mavproxy.send("set streamrate %u\n" % (self.sitl_streamrate()*2))
+            self.mavproxy.send("set streamrate %u\n" % (self.sitl_streamrate()+1))
             if self.mav is None:
                 break
 


### PR DESCRIPTION
Given we have trouble with the amount of data flowing around, doubling
this seems somewhat unfortunate.