### PR TITLE
AP_GPS: fix SBAS mode in the SBP2 driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -337,6 +337,9 @@ AP_GPS_SBP2::_attempt_state_update()
             case 4:
                 state.status = AP_GPS::GPS_OK_FIX_3D_RTK_FIXED;
                 break;
+            case 6:
+                state.status = AP_GPS::GPS_OK_FIX_3D_DGPS;
+                break;
             default:
                 state.status = AP_GPS::NO_FIX;
                 break;


### PR DESCRIPTION
If the Piksi Multi was outputting an SBAS position, it was previously interpreted as a "No Fix". This fixes this behavior, matching SBAS mode with "3D DGPS".