### PR TITLE
WIP: servo analog feedback first steps

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -169,6 +169,11 @@ public:
         return servo_trim;
     }
 
+    // is feedback enabled
+    uint8_t feedback_enabled(void) const {
+        return feedback_pin != 0;
+    }
+
     // return true if function is for a multicopter motor
     static bool is_motor(SRV_Channel::Aux_servo_function_t function);
 
@@ -193,7 +198,9 @@ public:
     bool function_configured(void) const {
         return function.configured();
     }
-    
+
+    uint16_t get_feedback_scaled(void);
+
 private:
     AP_Int16 servo_min;
     AP_Int16 servo_max;
@@ -201,6 +208,13 @@ private:
     // reversal, following convention that 1 means reversed, 0 means normal
     AP_Int8 reversed;
     AP_Int8 function;
+
+    // feeback params
+    AP_Int8 feedback_pin;
+    AP_Float min_feedback_volt;
+    AP_Float max_feedback_volt;
+    AP_Float trim_feedback_volt;
+    AP_Float feedback_rate;
 
     // a pending output value as PWM
     uint16_t output_pwm;
@@ -286,7 +300,10 @@ public:
 
     // get output channel mask for a function
     static uint16_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);
-    
+
+    // get scaled feedback for a function
+    static int16_t get_feedback_scaled(SRV_Channel::Aux_servo_function_t function);
+
     // limit slew rate to given limit in percent per second
     static void limit_slew_rate(SRV_Channel::Aux_servo_function_t function, float slew_rate, float dt);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -607,6 +607,21 @@ float SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t function)
     return channels[chan].get_output_norm();
 }
 
+// return the servo angle as read by analog pin or vitual feedback
+int16_t SRV_Channels::get_feedback_scaled(SRV_Channel::Aux_servo_function_t function)
+{
+    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
+        if (channels[i].function == function) {
+            if (channels[i].feedback_enabled()) {
+                return channels[i].get_feedback_scaled();
+            //} else {
+            //    return channels[i].get_virtual_feedback_scaled();
+            }
+        }
+    }
+    return 0;
+}
+
 /*
   limit slew rate for an output function to given rate in percent per
   second. This assumes output has not yet done to the hal


### PR DESCRIPTION
This is the first steps towards adding analog servo feedback. The original idea was to more accurately get the position of a couple of servos for better control of thrust vectoring for tricopters and bicopters.  https://github.com/ArduPilot/ardupilot/issues/4294

@WickedShell Suggested this feedback would also be useful for detecting stuck servos so I have made a start on implementing it in a more universal way. 

The idea is that a sense wire is added to the potentiometer with in the servo (or you could add a second potentiometer directly to the control surface) this is the read by an analog pin. We can then tell exactly what angle the servo is at. In order to monitor a large number of servos a external ADC driver will have to be added. 

My plan is to have a 'virtual' servo that is more or less a low pass on the output signal, if the feedback signal deviates too far from the virtual servo we can flash a alert or trigger a fail-safe. Also as a arming check the craft could do a full sweep of motion on all servos and check are moving freely. 

Would be great to have some feed back on whether this is worth implementing for all servos and some advice on the code. I was planning on doing something more basic for just two servos so am a little out of my depth. 

Thanks!