### PR TITLE
Rover: proximity and avoidance fix

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -88,17 +88,5 @@ bool AP_Arming_Rover::proximity_check(bool report)
         return false;
     }
 
-    // get closest object if we might use it for avoidance
-    float angle_deg, distance;
-    if (rover.g2.avoid.proximity_avoidance_enabled() && rover.g2.proximity.get_closest_object(angle_deg, distance)) {
-        // display error if something is within 60cm
-        if (distance <= 0.6f) {
-            if (report) {
-                gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: Proximity %d deg, %4.2fm", static_cast<int32_t>(angle_deg), static_cast<double>(distance));
-            }
-            return false;
-        }
-    }
-
     return true;
 }

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -435,7 +435,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
 
     // for stopping
     float speed = safe_vel.length();
-    Vector2f stopping_point = position_xy + safe_vel*((2.0f + get_stopping_distance(kP, accel_cmss, speed))/speed);
+    Vector2f stopping_point_plus_margin = position_xy + safe_vel*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
 
     uint16_t i, j;
     for (i = 0, j = num_points-1; i < num_points; j = i++) {
@@ -460,7 +460,7 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
         } else {
             // find intersection with line segment
             Vector2f intersection;
-            if (Vector2f::segment_intersection(position_xy, stopping_point, start, end, intersection)) {
+            if (Vector2f::segment_intersection(position_xy, stopping_point_plus_margin, start, end, intersection)) {
                 // vector from current position to point on current edge
                 Vector2f limit_direction = intersection - position_xy;
                 const float limit_distance_cm = limit_direction.length();

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -68,7 +68,7 @@ void AC_Avoid::adjust_velocity(float kP, float accel_cmss, Vector2f &desired_vel
     }
 
     // limit acceleration
-    float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
+    const float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
         adjust_velocity_circle_fence(kP, accel_cmss_limited, desired_vel_cms, dt);
@@ -128,7 +128,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
     }
 
     // limit acceleration
-    float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
+    const float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     bool limit_alt = false;
     float alt_diff = 0.0f;   // distance from altitude limit to vehicle in metres (positive means vehicle is below limit)
@@ -283,7 +283,7 @@ void AC_Avoid::adjust_velocity_circle_fence(float kP, float accel_cmss, Vector2f
     }
     position_xy *= 100.0f; // m -> cm
 
-    float speed = desired_vel_cms.length();
+    const float speed = desired_vel_cms.length();
     // get the fence radius in cm
     const float fence_radius = _fence.get_radius() * 100.0f;
     // get the margin to the fence in cm
@@ -341,7 +341,7 @@ void AC_Avoid::adjust_velocity_polygon_fence(float kP, float accel_cmss, Vector2
     // get polygon boundary
     // Note: first point in list is the return-point (which copter does not use)
     uint16_t num_points;
-    Vector2f* boundary = _fence.get_polygon_points(num_points);
+    const Vector2f* boundary = _fence.get_polygon_points(num_points);
 
     // adjust velocity using polygon
     adjust_velocity_polygon(kP, accel_cmss, desired_vel_cms, boundary, num_points, true, _fence.get_margin(), dt);
@@ -431,11 +431,11 @@ void AC_Avoid::adjust_velocity_polygon(float kP, float accel_cmss, Vector2f &des
     }
 
     // calc margin in cm
-    float margin_cm = MAX(margin * 100.0f, 0.0f);
+    const float margin_cm = MAX(margin * 100.0f, 0.0f);
 
     // for stopping
-    float speed = safe_vel.length();
-    Vector2f stopping_point_plus_margin = position_xy + safe_vel*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
+    const float speed = safe_vel.length();
+    const Vector2f stopping_point_plus_margin = position_xy + safe_vel*((2.0f + margin_cm + get_stopping_distance(kP, accel_cmss, speed))/speed);
 
     uint16_t i, j;
     for (i = 0, j = num_points-1; i < num_points; j = i++) {
@@ -538,7 +538,7 @@ void AC_Avoid::get_proximity_roll_pitch_pct(float &roll_positive, float &roll_ne
         return;
     }
 
-    uint8_t obj_count = _proximity.get_object_count();
+    const uint8_t obj_count = _proximity.get_object_count();
 
     // if no objects return
     if (obj_count == 0) {

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -449,8 +449,12 @@ void AC_Fence::manual_recovery_start()
 /// returns pointer to array of polygon points and num_points is filled in with the total number
 Vector2f* AC_Fence::get_polygon_points(uint16_t& num_points) const
 {
-    num_points = _boundary_num_points;
-    return _boundary;
+    // return array minus the first point which holds the return location
+    num_points = (_boundary_num_points <= 1) ? 0 : _boundary_num_points - 1;
+    if ((_boundary == nullptr) || (num_points == 0)) {
+        return nullptr;
+    }
+    return &_boundary[1];
 }
 
 /// returns true if we've breached the polygon boundary.  simple passthrough to underlying _poly_loader object

--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -21,6 +21,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+#define PROXIMITY_MAV_TIMEOUT_MS    500 // distance messages must arrive within this many milliseconds
+
 /* 
    The constructor also initialises the proximity sensor. Note that this
    constructor is not called until detect() returns true, so we

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -3,8 +3,6 @@
 #include "AP_Proximity.h"
 #include "AP_Proximity_Backend.h"
 
-#define PROXIMITY_MAV_TIMEOUT_MS    200 // requests timeout after 0.2 seconds
-
 class AP_Proximity_MAV : public AP_Proximity_Backend
 {
 


### PR DESCRIPTION
This PR fixes a few issues found while setting up simple object avoidance to work with ROS. The fixes are:

- remove the proximity checks from the Rover arming checks.  For copters these proximity checks mostly so that the pilot is aware of objects on the frame itself that may be obstructing the proximity sensor.   These obstructions could stop the vehicle from being able to move in certain directions after takeoff.  With Rovers this problem is much less important.
- ROS/mavros can provide OBSTACLE_DISTANCE messages to the AP_Proximity library but the update rate (even on an NVidia TX2) seems to be relatively low and irratic so I've increased the timeout to 0.5sec.  There are of course better solutions (such as improving the performance somehow of the ROS/mavros portion) but in general, I think the 200ms we had before was too low.
- AC_Avoid bug fix when using the "stop" method.  When looking for the intersection point with a polygon boundary we need to include the "margin" or else we will often not find the intersection point until long after the vehicle should have started slowing down.
- AC_Fence change to *not* return the 1st point in the _boundary array which is the "return to" point (that copter never uses).  This fix resolves an issue introduced by [this PR that was just merged to master](https://github.com/ArduPilot/ardupilot/pull/8790).

The AP_Avoid and AC_Fence changes should be included in Copter-3.6 although most Copter users stick with the default "slide" object avoidance.

This stop avoidance using a 360 lidar has been tested on a real rover.  The polygon fence change has been tested on a Copter in SITL.