### PR TITLE
AC_AttitudeControl: Fix copy paste param doc error

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -124,8 +124,8 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     AP_GROUPINFO("RATE_P_MAX", 18, AC_AttitudeControl, _ang_vel_pitch_max, 0.0f),
 
     // @Param: RATE_Y_MAX
-    // @DisplayName: Angular Velocity Max for Pitch
-    // @Description: Maximum angular velocity in pitch axis
+    // @DisplayName: Angular Velocity Max for Yaw
+    // @Description: Maximum angular velocity in yaw axis
     // @Units: deg/s
     // @Range: 0 1080
     // @Increment: 1


### PR DESCRIPTION
Straightforward copy paste error. I have some other slight questions about the docs, but the axis part was definitely wrong.