### PR TITLE
EKF2: optical is not used but rangfinder is used 

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -93,7 +93,8 @@ void NavEKF2_core::readRangeFinder(void)
                 // indicate we have updated the measurement
                 rngValidMeaTime_ms = imuSampleTime_ms;
 
-            } else if (!takeOffDetected && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+            } else if (onGround && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
+
                 // before takeoff we assume on-ground range value if there is no data
                 rangeDataNew.time_ms = imuSampleTime_ms;
                 rangeDataNew.rng = rngOnGnd;


### PR DESCRIPTION
When do not use the optical but use the range finder, `takeOffDetected` will not updated (be false all the time) when vehicle takeoff, so if the rangefinder not work now, it will update and store `rangeDataNew.rng = rngOnGnd` to the storedRange.