### PR TITLE
AP_RangeFinder: check I2C dev during detect

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -37,6 +37,10 @@ AP_RangeFinder_LightWareI2C::AP_RangeFinder_LightWareI2C(RangeFinder::RangeFinde
 */
 AP_RangeFinder_Backend *AP_RangeFinder_LightWareI2C::detect(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
 {
+    if (!dev) {
+        return nullptr;
+    }
+
     AP_RangeFinder_LightWareI2C *sensor
         = new AP_RangeFinder_LightWareI2C(_state, std::move(dev));
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -51,6 +51,10 @@ AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder::RangeFin
 AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder::RangeFinder_State &_state,
                                                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
 {
+    if (!dev) {
+        return nullptr;
+    }
+
     AP_RangeFinder_MaxsonarI2CXL *sensor
         = new AP_RangeFinder_MaxsonarI2CXL(_state, std::move(dev));
     if (!sensor) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -49,6 +49,10 @@ AP_RangeFinder_TeraRangerI2C::AP_RangeFinder_TeraRangerI2C(RangeFinder::RangeFin
 AP_RangeFinder_Backend *AP_RangeFinder_TeraRangerI2C::detect(RangeFinder::RangeFinder_State &_state,
                                                              AP_HAL::OwnPtr<AP_HAL::I2CDevice> i2c_dev)
 {
+    if (!i2c_dev) {
+        return nullptr;
+    }
+
     AP_RangeFinder_TeraRangerI2C *sensor = new AP_RangeFinder_TeraRangerI2C(_state, std::move(i2c_dev));
     if (!sensor) {
         return nullptr;


### PR DESCRIPTION
This should resolve [this issue](https://github.com/ArduPilot/ardupilot/issues/9602) found during Copter-3.6 testing in which omnibus boards (which apparently only have a single I2C bus) fail if the board is configured to use a MaxbotixI2C sonar but one is not actually connected.  The issue is the range finder driver was not checking that the I2C device passed in was valid before trying to use it.

I was unable to replicate the original issue on a Pixhawk even after setting the device to nullptr here but I hope to get the user who reported the issue to test the fix.