### PR TITLE
Plane: Gliding with TECS

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -580,13 +580,6 @@ void Plane::update_alt()
         if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND && current_loc.past_interval_finish_line(prev_WP_loc, next_WP_loc)) {
             distance_beyond_land_wp = current_loc.get_distance(next_WP_loc);
         }
-
-        bool soaring_active = false;
-#if SOARING_ENABLED == ENABLED
-        if (g2.soaring_controller.is_active() && g2.soaring_controller.get_throttle_suppressed()) {
-            soaring_active = true;
-        }
-#endif
         
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
@@ -595,8 +588,7 @@ void Plane::update_alt()
                                                  get_takeoff_pitch_min_cd(),
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
-                                                 aerodynamic_load_factor,
-                                                 soaring_active);
+                                                 aerodynamic_load_factor);
     }
 }
 

--- a/ArduPlane/mode_loiter.cpp
+++ b/ArduPlane/mode_loiter.cpp
@@ -9,7 +9,8 @@ bool ModeLoiter::_enter()
     plane.do_loiter_at_location();
 
 #if SOARING_ENABLED == ENABLED
-    if (plane.g2.soaring_controller.is_active() && plane.g2.soaring_controller.suppress_throttle()) {
+    if (plane.g2.soaring_controller.is_active() &&
+       (plane.g2.soaring_controller.suppress_throttle() || plane.aparm.throttle_max==0)) {
         plane.g2.soaring_controller.init_thermalling();
         plane.g2.soaring_controller.get_target(plane.next_WP_loc); // ahead on flight path
     }

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -456,16 +456,6 @@ void Plane::set_servos_controlled(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 
             constrain_int16(quadplane.forward_throttle_pct(), min_throttle, max_throttle));
     }
-
-#if SOARING_ENABLED == ENABLED
-    // suppress throttle when soaring is active
-    if ((control_mode == &mode_fbwb || control_mode == &mode_cruise ||
-        control_mode == &mode_auto || control_mode == &mode_loiter) &&
-        g2.soaring_controller.is_active() &&
-        g2.soaring_controller.get_throttle_suppressed()) {
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
-    }
-#endif
 }
 
 /*

--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -82,14 +82,13 @@ public:
     void update_thermalling();
     void update_cruising();
     bool is_active() const;
+    void set_throttle_suppressed(bool suppressed);
+
     bool get_throttle_suppressed() const
     {
         return _throttle_suppressed;
     }
-    void set_throttle_suppressed(bool suppressed)
-    {
-        _throttle_suppressed = suppressed;
-    }
+
     float get_vario_reading() const
     {
         return _vario.displayed_reading;

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -32,8 +32,7 @@ public:
 										int32_t ptchMinCO_cd,
 										int16_t throttle_nudge,
                                         float hgt_afe,
-										float load_factor,
-                                        bool soaring_active) = 0;
+										float load_factor) = 0;
 
 	// demanded throttle in percentage
 	// should return 0 to 100
@@ -63,6 +62,12 @@ public:
 
 	// set path_proportion accessor
     virtual void set_path_proportion(float path_proportion) = 0;
+
+    // set gliding requested flag
+    virtual void set_gliding_requested_flag(bool gliding_requested) = 0;
+
+    // set propulsion failed flag
+    virtual void set_propulsion_failed_flag(bool propulsion_failed) = 0;
 
 	// add new controllers to this enum. Users can then
 	// select which controller to use by setting the

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -852,7 +852,7 @@ void AP_TECS::_update_pitch(void)
     // integrator has to catch up before the nose can be raised to reduce speed during climbout.
     // During flare a different damping gain is used
     float gainInv = (_TAS_state * timeConstant() * GRAVITY_MSS);
-    float temp = SEB_error + SEBdot_dem * timeConstant();
+    float temp = SEB_error + 0.5*SEBdot_dem * timeConstant();
 
     float pitch_damp = _ptchDamp;
     if (_landing.is_flaring()) {

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -238,6 +238,21 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Values: 0:Disable,1:Enable
     // @User: Advanced
     AP_GROUPINFO("SYNAIRSPEED", 27, AP_TECS, _use_synthetic_airspeed, 0),
+
+
+    // @Param: PTCH_FF_V0
+    // @DisplayName: Baseline airspeed for pitch feed-forward.
+    // @Description: This parameter sets the airspeed at which no feed-forward is applied between demanded airspeed and pitch. It should correspond to the airspeed at which the plane glides at zero pitch.
+    // @Range 5.0 50.0
+    // @User: Advanced
+    AP_GROUPINFO("PTCH_FF_V0", 28, AP_TECS, _pitch_ff_v0, 12.0),
+
+    // @Param: PTCH_FF_K
+    // @DisplayName: Gain for pitch feed-forward.
+    // @Description: This parameter sets the gain between demanded airspeed and pitch. It should generally be negative.
+    // @Range -5.0 0.0
+    // @User: Advanced
+    AP_GROUPINFO("PTCH_FF_K", 29, AP_TECS, _pitch_ff_k, -0.035),
     
     AP_GROUPEND
 };
@@ -875,6 +890,10 @@ void AP_TECS::_update_pitch(void)
 
     // Calculate pitch demand from specific energy balance signals
     _pitch_dem_unc = (temp + _integSEB_state) / gainInv;
+
+
+    // Add a feedforward term from demanded airspeed to pitch.
+    _pitch_dem_unc += (_TAS_dem_adj - _pitch_ff_v0) * _pitch_ff_k;
 
     // Constrain pitch demand
     _pitch_dem = constrain_float(_pitch_dem_unc, _PITCHminf, _PITCHmaxf);

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -632,6 +632,10 @@ void AP_TECS::_update_throttle_with_airspeed(void)
     {
         _throttle_dem = 1.0f;
     }
+    else if (_flags.is_gliding)
+    {
+        _throttle_dem = 0.0f;
+    }
     else
     {
         // Calculate gain scaler from specific energy error to throttle
@@ -746,6 +750,11 @@ void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge)
         _throttle_dem = nomThr;
     }
 
+    if (_flags.is_gliding)
+    {
+        _throttle_dem = 0.0f;
+    }
+
     // Calculate additional throttle for turn drag compensation including throttle nudging
     const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
     // Use the demanded rate of change of total energy as the feed-forward demand, but add
@@ -771,7 +780,7 @@ void AP_TECS::_detect_bad_descent(void)
     // 2) Specific total energy error > 0
     // This mode will produce an undulating speed and height response as it cuts in and out but will prevent the aircraft from descending into the ground if an unachievable speed demand is set
     float STEdot = _SPEdot + _SKEdot;
-    if ((!_flags.underspeed && (_STE_error > 200.0f) && (STEdot < 0.0f) && (_throttle_dem >= _THRmaxf * 0.9f)) || (_flags.badDescent && !_flags.underspeed && (_STE_error > 0.0f)))
+    if (((!_flags.underspeed && (_STE_error > 200.0f) && (STEdot < 0.0f) && (_throttle_dem >= _THRmaxf * 0.9f)) || (_flags.badDescent && !_flags.underspeed && (_STE_error > 0.0f))) && !_flags.is_gliding)
     {
         _flags.badDescent = true;
     }
@@ -798,7 +807,7 @@ void AP_TECS::_update_pitch(void)
         // height. This is needed as the usual relationship of speed
         // and height is broken by the VTOL motors
         SKE_weighting = 0.0f;        
-    } else if ( _flags.underspeed || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND) {
+    } else if ( _flags.underspeed || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_TAKEOFF || _flight_stage == AP_Vehicle::FixedWing::FLIGHT_ABORT_LAND || _flags.is_gliding) {
         SKE_weighting = 2.0f;
     } else if (_flags.is_doing_auto_land) {
         if (_spdWeightLand < 0) {
@@ -893,7 +902,9 @@ void AP_TECS::_update_pitch(void)
 
 
     // Add a feedforward term from demanded airspeed to pitch.
-    _pitch_dem_unc += (_TAS_dem_adj - _pitch_ff_v0) * _pitch_ff_k;
+    if (_flags.is_gliding) {
+        _pitch_dem_unc += (_TAS_dem_adj - _pitch_ff_v0) * _pitch_ff_k;
+    }
 
     // Constrain pitch demand
     _pitch_dem = constrain_float(_pitch_dem_unc, _PITCHminf, _PITCHmaxf);
@@ -970,14 +981,14 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     int32_t ptchMinCO_cd,
                                     int16_t throttle_nudge,
                                     float hgt_afe,
-                                    float load_factor,
-                                    bool soaring_active)
+                                    float load_factor)
 {
     // Calculate time in seconds since last update
     uint64_t now = AP_HAL::micros64();
     _DT = (now - _update_pitch_throttle_last_usec) * 1.0e-6f;
     _update_pitch_throttle_last_usec = now;
 
+    _flags.is_gliding = _flags.gliding_requested || _flags.propulsion_failed || aparm.throttle_max==0;
     _flags.is_doing_auto_land = (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND);
     _distance_beyond_land_wp = distance_beyond_land_wp;
     _flight_stage = flight_stage;
@@ -1096,11 +1107,6 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 
     // Detect bad descent due to demanded airspeed being too high
     _detect_bad_descent();
-
-    // when soaring is active we never trigger a bad descent
-    if (soaring_active) {
-        _flags.badDescent = false;        
-    }
 
     // Calculate pitch demand
     _update_pitch();

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -75,7 +75,7 @@ public:
 
     // return current target airspeed
     float get_target_airspeed(void) const override {
-        return _TAS_dem / _ahrs.get_EAS2TAS();
+        return _TAS_dem_adj / _ahrs.get_EAS2TAS();
     }
 
     // return maximum climb rate

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -53,8 +53,7 @@ public:
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
                                float hgt_afe,
-                               float load_factor,
-                               bool soaring_active) override;
+                               float load_factor) override;
 
     // demanded throttle in percentage
     // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
@@ -107,6 +106,17 @@ public:
     void set_path_proportion(float path_proportion) override {
         _path_proportion = constrain_float(path_proportion, 0.0f, 1.0f);
     }
+
+    // set soaring flag
+    void set_gliding_requested_flag(bool gliding_requested) override {
+        _flags.gliding_requested = gliding_requested;
+    }
+
+    // set propulsion failed flag
+    void set_propulsion_failed_flag(bool propulsion_failed) override {
+        _flags.propulsion_failed = propulsion_failed;
+    }
+
 
     // set pitch max limit in degrees
     void set_pitch_max_limit(int8_t pitch_limit) {
@@ -262,6 +272,18 @@ private:
 
         // true when we have reached target speed in takeoff
         bool reached_speed_takeoff:1;
+
+        // true if the soaring feature has requested gliding flight
+        bool gliding_requested:1;
+
+        // true when we are in gliding flight, in one of three situations;
+        //   - THR_MAX=0
+        //   - gliding has been requested e.g. by soaring feature
+        //   - engine failure detected (detection not implemented currently)
+        bool is_gliding:1;
+
+        // true if a propulsion failure is detected.
+        bool propulsion_failed:1;
     };
     union {
         struct flags _flags;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -167,6 +167,8 @@ private:
     AP_Int8  _pitch_min;
     AP_Int8  _land_pitch_max;
     AP_Float _maxSinkRate_approach;
+    AP_Float _pitch_ff_v0;
+    AP_Float _pitch_ff_k;
 
     // temporary _pitch_max_limit. Cleared on each loop. Clear when >= 90
     int8_t _pitch_max_limit = 90;


### PR DESCRIPTION
This PR enhances the TECS airspeed/pitch handling when in pure gliding flight. 

- Changes the Mavlink message to send the rate-limited target airspeed rather than the raw target airspeed. 
- Adds a feed-forward term to apply pitch based on demanded airspeed.
- Fixes an error in the feed-forward term for rate of change of airspeed.
- Uses the FLIGHT_STAGE mechanism to handle gliding rather than using the soaring_active flag.

Using FLIGHT_STAGE makes the gliding capability independent of the soaring feature. This will be useful for future features e.g. automated response to engine failure. 

The changes to pitch control improve the response to demanded airspeed changes. This is particularly important for soaring as large airspeed changes are typically made. In a glider airspeed is 100% controlled by pitch, so it is appropriate to set the pitch approximately (a linear dependence is assumed) and allow the integrator to trim about this. This is a lot quicker than waiting for the pitch integrator to adjust attitude by itself.

The effect of the changes to the pitch control are shown in the plot below. A step change in target airspeed from 8m/s to 20m/s is applied (in simulation).

![tecspitchcontrol2](https://user-images.githubusercontent.com/822451/47603763-7433ec00-d9e8-11e8-9e26-6106d36ed12b.png)

In the "Baseline" case, too much nose-down pitch is applied in response to the demanded acceleration. This is compensated for by an increase in the pitch integrator. When the rate-limited target airspeed reaches 20m/s and demanded acceleration goes to zero, the FF term goes to zero and the integrator build-up causes a nose-up pitch. The airspeed hasn't reached the target, and the pitch integrator must now unwind and go negative to get the nose down. The result is a slow response to the step change in target airspeed.

In the "Bugfix" case, the applied pitch FF is appropriate for the demanded acceleration. This removes the positive integrator build-up, but the integrator still needs to go negative to get the nose down. The response is improved.

In the "Pitch FF" case, a nose-down pitch angle is applied based on the (rate-limited) target airspeed. This avoids the need for the integrator to build up to achieve the target airspeed. The response is further improved.



