### PR TITLE
RangeFinder: Added statement FALLTHROUGH

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -111,7 +111,7 @@ void AP_RangeFinder_PulsedLightLRF::timer(void)
             break;
         }
     }
-
+    FALLTHROUGH;
     case PHASE_MEASURE:
         if (_dev->write_register(LL40LS_MEASURE_REG, LL40LS_MSRREG_ACQUIRE)) {
             phase = PHASE_COLLECT;


### PR DESCRIPTION
LiDAR Lite V3HP will continue processing from phase "PHASE_COLLECT" to "PHASE_MEASURE".
I would like to clarify that it does not break in case of LiDAR Lite V3HP.
I added "FALLTHROUGH" for clarity.