### PR TITLE
AP_Airspeed: Temperature conversion in consistence with other libraries

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.cpp
@@ -129,7 +129,7 @@ void AP_Airspeed_UAVCAN::handle_airspeed(AP_UAVCAN* ap_uavcan, uint8_t node_id, 
         if (driver != nullptr) {
             WITH_SEMAPHORE(driver->_sem_airspeed);
             driver->_pressure = cb.msg->differential_pressure;
-            driver->_temperature = cb.msg->static_air_temperature;
+            driver->_temperature = cb.msg->static_air_temperature - C_TO_KELVIN;
             driver->_last_sample_time_ms = AP_HAL::millis();
         }
 
@@ -164,7 +164,7 @@ bool AP_Airspeed_UAVCAN::get_temperature(float &temperature)
         return false;
     }
 
-    temperature = _temperature - C_TO_KELVIN;
+    temperature = _temperature;
 
     return true;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_UAVCAN.h
@@ -32,7 +32,7 @@ private:
     static AP_Airspeed_UAVCAN* get_uavcan_backend(AP_UAVCAN* ap_uavcan, uint8_t node_id);
 
     float _pressure; // Pascal
-    float _temperature; // Kelvin
+    float _temperature; // Celcius
     uint32_t _last_sample_time_ms;
 
     HAL_Semaphore _sem_airspeed;


### PR DESCRIPTION
Thanks to @olliw42 fixes inconsistency with conversion from Kelvins to Celcius between different libraries.
The temperature is stored in driver in AP style in Celcius.

Addresses: https://github.com/ArduPilot/ardupilot/issues/9566