### PR TITLE
Rover: shorten radio and GCS failsafe timeouts

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -196,9 +196,13 @@ void Rover::ahrs_update()
  */
 void Rover::gcs_failsafe_check(void)
 {
-    if (g.fs_gcs_enabled) {
-        failsafe_trigger(FAILSAFE_EVENT_GCS, failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000);
+    if (!g.fs_gcs_enabled) {
+        // gcs failsafe disabled
+        return;
     }
+
+    // check for updates from GCS within 2 seconds
+    failsafe_trigger(FAILSAFE_EVENT_GCS, failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000);
 }
 
 /*

--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -197,7 +197,7 @@ void Rover::ahrs_update()
 void Rover::gcs_failsafe_check(void)
 {
     if (g.fs_gcs_enabled) {
-        failsafe_trigger(FAILSAFE_EVENT_GCS, last_heartbeat_ms != 0 && (millis() - last_heartbeat_ms) > 2000);
+        failsafe_trigger(FAILSAFE_EVENT_GCS, failsafe.last_heartbeat_ms != 0 && (millis() - failsafe.last_heartbeat_ms) > 2000);
     }
 }
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -780,6 +780,8 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
         RC_Channels::set_override(6, packet.chan7_raw, tnow);
         RC_Channels::set_override(7, packet.chan8_raw, tnow);
 
+        // an RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes
+        rover.failsafe.last_heartbeat_ms = tnow;
         break;
     }
 
@@ -803,18 +805,18 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
         RC_Channels::set_override(uint8_t(rover.rcmap.roll() - 1), roll, tnow);
         RC_Channels::set_override(uint8_t(rover.rcmap.throttle() - 1), throttle, tnow);
 
+        // a manual control message is considered to be a 'heartbeat' from the ground station for failsafe purposes
+        rover.failsafe.last_heartbeat_ms = tnow;
         break;
     }
 
     case MAVLINK_MSG_ID_HEARTBEAT:
         {
-            // We keep track of the last time we received a heartbeat from our GCS for failsafe purposes
+            // we keep track of the last time we received a heartbeat from our GCS for failsafe purposes
             if (msg->sysid != rover.g.sysid_my_gcs) {
                 break;
             }
-
             rover.failsafe.last_heartbeat_ms = AP_HAL::millis();
-            rover.failsafe_trigger(FAILSAFE_EVENT_GCS, false);
             break;
         }
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -813,7 +813,7 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                 break;
             }
 
-            rover.last_heartbeat_ms = AP_HAL::millis();
+            rover.failsafe.last_heartbeat_ms = AP_HAL::millis();
             rover.failsafe_trigger(FAILSAFE_EVENT_GCS, false);
             break;
         }

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -134,10 +134,12 @@ const AP_Param::Info Rover::var_info[] = {
 
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout
-    // @Description: How long a failsafe event need to happen for before we trigger the failsafe action
+    // @Description: The time in seconds that a failsafe condition must persist before the failsafe action is triggered
     // @Units: s
+    // @Range: 1 100
+    // @Increment: 0.5
     // @User: Standard
-    GSCALAR(fs_timeout,    "FS_TIMEOUT",     5),
+    GSCALAR(fs_timeout,    "FS_TIMEOUT",     1.5),
 
     // @Param: FS_THR_ENABLE
     // @DisplayName: Throttle Failsafe Enable

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -265,6 +265,7 @@ private:
         uint32_t start_time;
         uint8_t triggered;
         uint32_t last_valid_rc_ms;
+        uint32_t last_heartbeat_ms;
     } failsafe;
 
     // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
@@ -272,9 +273,6 @@ private:
 
     // true if we have a position estimate from AHRS
     bool have_position;
-
-    // the time when the last HEARTBEAT message arrived from a GCS
-    uint32_t last_heartbeat_ms;
 
     // obstacle detection information
     struct {

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -513,7 +513,7 @@ private:
     void init_rc_out();
     void rudder_arm_disarm_check();
     void read_radio();
-    void control_failsafe(uint16_t pwm);
+    void radio_failsafe_check(uint16_t pwm);
     bool trim_radio();
 
     // sailboat.cpp

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -138,6 +138,6 @@ void Rover::handle_battery_failsafe(const char* type_str, const int8_t action)
 void Rover::afs_fs_check(void)
 {
     // perform AFS failsafe checks
-    g2.afs.check(rover.last_heartbeat_ms, rover.g2.fence.get_breaches() != 0, failsafe.last_valid_rc_ms);
+    g2.afs.check(failsafe.last_heartbeat_ms, g2.fence.get_breaches() != 0, failsafe.last_valid_rc_ms);
 }
 #endif

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -69,6 +69,10 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         control_mode != &mode_hold) {
         failsafe.triggered = failsafe.bits;
         gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", static_cast<uint32_t>(failsafe.triggered));
+
+        // clear rc overrides
+        RC_Channels::clear_overrides();
+
         switch (g.fs_action) {
             case 0:
                 break;

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -131,7 +131,7 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     }
 
     bool failed = pwm < static_cast<uint16_t>(g.fs_throttle_value);
-    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 1000) {
+    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 200) {
         failed = true;
     }
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -131,7 +131,7 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     }
 
     bool failed = pwm < static_cast<uint16_t>(g.fs_throttle_value);
-    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 2000) {
+    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 1000) {
         failed = true;
     }
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -111,22 +111,22 @@ void Rover::read_radio()
 {
     if (!rc().read_input()) {
         // check if we lost RC link
-        control_failsafe(channel_throttle->get_radio_in());
+        radio_failsafe_check(channel_throttle->get_radio_in());
         return;
     }
 
     failsafe.last_valid_rc_ms = AP_HAL::millis();
     // check that RC value are valid
-    control_failsafe(channel_throttle->get_radio_in());
+    radio_failsafe_check(channel_throttle->get_radio_in());
 
     // check if we try to do RC arm/disarm
     rudder_arm_disarm_check();
 }
 
-void Rover::control_failsafe(uint16_t pwm)
+void Rover::radio_failsafe_check(uint16_t pwm)
 {
     if (!g.fs_throttle_enabled) {
-        // no throttle failsafe
+        // radio failsafe disabled
         return;
     }
 


### PR DESCRIPTION
This PR improves the Rover failsafe in a few ways brought up in this issue https://github.com/ArduPilot/ardupilot/issues/6623:

- reduce default failsafe timeouts for radio and GCS failsafes.  Note the timeout for each includes a hardcoded 1 or 2 seconds plus the value held in FS_TIMEOUT meaning the real default timeouts are:
  - radio/throttle failsafe default timeout = 2.5sec (1sec + FS_TIMEOUT)
  - GCS failsafe default timeout = 3.5 sec (2sec + FS_TIMEOUT)
- GCS failsafe will not trigger if RC_OVERRIDE or MANUAL_CONTROL messages are arriving.  This helps reduce false positives when a joystick is being used which may use up much of the bandwidth and lead to HEARTBEAT messages arriving more slowly than 1hz.
- non-functional parameter description updates, renamed a function, moved a variable to a structure, etc

This PR does not attempt to solve all the problems in the Rover failsafe code.  It's just some small improvements that came out of an investigation into [this Mission Planner issue](https://github.com/ArduPilot/MissionPlanner/issues/1972).

