### PR TITLE
Make capability order consistent, and fix late capability set

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -27,6 +27,8 @@ void Rover::init_ardupilot()
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());
 
+    init_capabilities();
+
     //
     // Check the EEPROM format version before loading any parameters from EEPROM.
     //
@@ -141,8 +143,6 @@ void Rover::init_ardupilot()
 
     // initialize SmartRTL
     g2.smart_rtl.init();
-
-    init_capabilities();
 
     startup_ground();
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -17,6 +17,8 @@ void Tracker::init_tracker()
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());
 
+    init_capabilities();
+
     // Check the EEPROM format version before loading any parameters from EEPROM
     load_parameters();
 
@@ -99,8 +101,6 @@ void Tracker::init_tracker()
     if (current_loc.lat == 0 && current_loc.lng == 0) {
         get_home_eeprom(current_loc);
     }
-
-    init_capabilities();
 
     gcs().send_text(MAV_SEVERITY_INFO,"Ready to track");
     hal.scheduler->delay(1000); // Why????

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -23,13 +23,12 @@ void Copter::init_ardupilot()
     // initialise serial port
     serial_manager.init_console();
 
-    // init vehicle capabilties
-    init_capabilities();
-
     hal.console->printf("\n\nInit %s"
                         "\n\nFree RAM: %u\n",
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());
+
+    init_capabilities();
 
     //
     // Report firmware version code expect on console (check of actual EEPROM format version is done in load_parameters function)

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -27,6 +27,7 @@ void Plane::init_ardupilot()
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());
 
+    init_capabilities();
 
     //
     // Check the EEPROM format version before loading any parameters from EEPROM
@@ -179,8 +180,6 @@ void Plane::init_ardupilot()
      *  the RC library being initialised.
      */
     hal.scheduler->register_timer_failsafe(failsafe_check_static, 1000);
-
-    init_capabilities();
 
     quadplane.setup();
 

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -27,6 +27,8 @@ void Sub::init_ardupilot()
                         AP::fwversion().fw_string,
                         (unsigned)hal.util->available_memory());
 
+    init_capabilities();
+
     // load parameters from EEPROM
     load_parameters();
 
@@ -202,9 +204,6 @@ void Sub::init_ardupilot()
     mainloop_failsafe_enable();
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
-
-    // init vehicle capabilties
-    init_capabilities();
 
     // disable safety if requested
     BoardConfig.init_safety();    


### PR DESCRIPTION
This makes the vehicles consistently set their capability bits, and ensures it is always set before letting a MAVLink stream start. On plane (and everything except copter should be vulnerable to this) I've been able to connect multiple times before the capabilities are set, and the GCS refuses the connection because required capability bits have not been set.