### PR TITLE
AP_Frsky_Telem: added waypoints to FrSky PassThrough telemetry at 0x5009

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -103,6 +103,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(afs_fs_check,           10,    200),
 #endif
     SCHED_TASK(read_airspeed,          10,    100),
+#if FRSKY_TELEM_ENABLED == ENABLED
+    SCHED_TASK(update_nav_info,         1,    10),
+#endif    
 };
 
 constexpr int8_t Rover::_failsafe_priorities[7];
@@ -322,5 +325,18 @@ void Rover::update_current_mode(void)
 {
     control_mode->update();
 }
+
+#if FRSKY_TELEM_ENABLED == ENABLED
+void Rover::update_nav_info()
+{
+    AP_Frsky_Telem::NavInfo nav_info;
+    nav_info.wp_distance = control_mode->get_distance_to_destination();
+    nav_info.wp_bearing = nav_controller->nav_bearing_cd();
+    nav_info.wp_xtrack_error = nav_controller->crosstrack_error();
+    nav_info.wp_number = mission.get_current_nav_index();
+    nav_info.wp_count = mission.num_commands();
+    frsky_telemetry.set_nav_info(nav_info);
+}
+#endif
 
 AP_HAL_MAIN_CALLBACKS(&rover);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -489,6 +489,10 @@ private:
     void read_rangefinders(void);
     void init_proximity();
     void read_airspeed();
+    void update_sensor_status_flags(void);
+#if FRSKY_TELEM_ENABLED == ENABLED
+    void update_nav_info();
+#endif    
 
     // Steering.cpp
     bool use_pivot_steering_at_next_WP(float yaw_error_cd);

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -194,6 +194,9 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if OSD_ENABLED == ENABLED
     SCHED_TASK(publish_osd_info, 1, 10),
 #endif
+#if FRSKY_TELEM_ENABLED == ENABLED
+    SCHED_TASK(update_nav_info, 1, 10),
+#endif
 };
 
 constexpr int8_t Copter::_failsafe_priorities[7];
@@ -584,6 +587,19 @@ void Copter::publish_osd_info()
     nav_info.wp_xtrack_error = flightmode->crosstrack_error() * 1.0e-2f;
     nav_info.wp_number = mode_auto.mission.get_current_nav_index();
     osd.set_nav_info(nav_info);
+}
+#endif
+
+#if FRSKY_TELEM_ENABLED == ENABLED
+void Copter::update_nav_info()
+{
+    AP_Frsky_Telem::NavInfo nav_info;
+    nav_info.wp_distance = flightmode->wp_distance() * 1.0e-2f;
+    nav_info.wp_bearing = flightmode->wp_bearing();
+    nav_info.wp_xtrack_error = flightmode->crosstrack_error() * 1.0e-2f;
+    nav_info.wp_number = mode_auto.mission.get_current_nav_index();
+    nav_info.wp_count = mode_auto.mission.num_commands();
+    frsky_telemetry.set_nav_info(nav_info);
 }
 #endif
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -873,6 +873,9 @@ private:
 #if OSD_ENABLED == ENABLED
     void publish_osd_info();
 #endif
+#if FRSKY_TELEM_ENABLED == ENABLED
+    void update_nav_info();
+#endif
 
 #include "mode.h"
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -104,6 +104,9 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if LANDING_GEAR_ENABLED == ENABLED
     SCHED_TASK(landing_gear_update, 5, 50),
 #endif
+#if FRSKY_TELEM_ENABLED == ENABLED
+    SCHED_TASK(update_nav_info, 1, 10),
+#endif
 };
 
 constexpr int8_t Plane::_failsafe_priorities[6];
@@ -950,6 +953,19 @@ void Plane::publish_osd_info()
     nav_info.wp_xtrack_error = nav_controller->crosstrack_error();
     nav_info.wp_number = mission.get_current_nav_index();
     osd.set_nav_info(nav_info);
+}
+#endif
+
+#if FRSKY_TELEM_ENABLED == ENABLED
+void Plane::update_nav_info()
+{
+    AP_Frsky_Telem::NavInfo nav_info;
+    nav_info.wp_distance = auto_state.wp_distance;
+    nav_info.wp_bearing = nav_controller->target_bearing_cd();
+    nav_info.wp_xtrack_error = nav_controller->crosstrack_error();
+    nav_info.wp_number = mission.get_current_nav_index();
+    nav_info.wp_count = mission.num_commands();
+    frsky_telemetry.set_nav_info(nav_info);
 }
 #endif
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1035,6 +1035,9 @@ private:
 #if OSD_ENABLED == ENABLED
     void publish_osd_info();
 #endif
+#if FRSKY_TELEM_ENABLED == ENABLED
+    void update_nav_info();
+#endif
     void accel_cal_update(void);
     void update_soft_armed();
 #if SOARING_ENABLED == ENABLED

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -108,6 +108,15 @@ for FrSky SPort Passthrough
 #define ATTIANDRNG_PITCH_LIMIT      0x3FF
 #define ATTIANDRNG_PITCH_OFFSET     11
 #define ATTIANDRNG_RNGFND_OFFSET    21
+// for waypoint number,distance, xtrack error and bearing
+#define WAYPOINT_NUMBER_LIMIT       0x3FF
+#define WAYPOINT_DISTANCE_LIMIT     102300
+#define WAYPOINT_DISTANCE_OFFSET    10
+#define WAYPOINT_XTRACK_LIMIT       0x7F
+#define WAYPOINT_XTRACK_OFFSET      22
+#define WAYPOINT_BEARING_LIMIT      0x7
+#define WAYPOINT_BEARING_OFFSET     29
+#define WAYPOINT_ARROW_COUNT        8
 
 
 
@@ -143,6 +152,16 @@ public:
     static ObjectArray<mavlink_statustext_t> _statustext_queue;
 
     void set_frame_string(const char *string) { _frame_string = string; }
+
+    struct NavInfo {
+        float wp_distance;
+        int32_t wp_bearing;
+        float wp_xtrack_error;
+        uint16_t wp_number;
+        uint16_t wp_count;
+    };
+
+    void set_nav_info(NavInfo &nav_info);
 
 private:
     AP_HAL::UARTDriver *_port;                  // UART used to send data to FrSky receiver
@@ -197,6 +216,7 @@ private:
         uint32_t home_timer;
         uint32_t velandyaw_timer;
         uint32_t gps_latlng_timer;
+        uint32_t waypoint_timer;
     } _passthrough;
     
     struct
@@ -221,6 +241,8 @@ private:
         uint8_t char_index; // index of which character to get in the message
     } _msg_chunk;
     
+    struct NavInfo _nav_info;
+
     // main transmission function when protocol is FrSky SPort Passthrough (OpenTX)
     void send_SPort_Passthrough(void);
     // main transmission function when protocol is FrSky SPort
@@ -249,6 +271,7 @@ private:
     uint32_t calc_home(void);
     uint32_t calc_velandyaw(void);
     uint32_t calc_attiandrng(void);
+    uint32_t calc_wp(void);    
     uint16_t prep_number(int32_t number, uint8_t digits, uint8_t power);
 
     // methods to convert flight controller data to FrSky D or SPort format


### PR DESCRIPTION
This adds waypoint data to the frsky passthrough protocol.
All navigation information is updated from vehicle code with a callback that updates the _nav_info struct, the approach is similar to what the osd code does, it supports Copter, Plane and Rover.
The new 32bit telemetry packet holds

- wp number encoded as 10bits (1023 waypoints max)
- wp distance encoded as 12 bits (102.3Km max, 10bits + 2 for 10^power)
- wp xtrack error encoded as 6 bits (+/- 150m, 4 bits + 1 for 10^power +1 for sign)
- wp bearing offset from cog in 45° multiples encoded as 3 bits

The new packet is sent at 1Hz with DIY id 0x5009

The total number of mission commands is sent as parameter 6.

Code has been tested in SITL and flown on copter 3.6