### PR TITLE
Remove bitmask copy constructor/assignment operator

### DIFF
--- a/libraries/AP_Common/Bitmask.h
+++ b/libraries/AP_Common/Bitmask.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <string.h>
+
 class Bitmask {
 public:
     Bitmask(uint16_t num_bits) :
@@ -29,6 +32,9 @@ public:
     ~Bitmask(void) {
         delete[] bits;
     }
+
+    Bitmask &operator=(const Bitmask&other) = delete;
+    Bitmask(const Bitmask &other) = delete;
 
     // set given bitnumber
     void set(uint16_t bit) {

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -200,7 +200,7 @@ private:
         simplify_start_finish_t* stack;
         uint16_t stack_max;     // maximum number of elements in the _simplify_stack array
         uint16_t stack_count;   // number of elements in _simplify_stack array
-        Bitmask bitmask = Bitmask(SMARTRTL_POINTS_MAX);  // simplify algorithm clears bits for each point that can be removed
+        Bitmask bitmask{SMARTRTL_POINTS_MAX};  // simplify algorithm clears bits for each point that can be removed
     } _simplify;
 
     // Pruning


### PR DESCRIPTION
I will be implementing the assignment operator in a later PR.  But safest to not have it ATM.
