### PR TITLE
AP_RangeFinder: Benewake driver discards distances over 327m

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -23,6 +23,7 @@ extern const AP_HAL::HAL& hal;
 
 #define BENEWAKE_FRAME_HEADER 0x59
 #define BENEWAKE_FRAME_LENGTH 9
+#define BENEWAKE_DIST_MAX_CM 32768
 
 // format of serial packets received from benewake lidar
 //
@@ -112,7 +113,7 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm, bool &signal_ok)
                     signal_ok = true;
                     // calculate distance and add to sum
                     uint16_t dist = ((uint16_t)linebuf[3] << 8) | linebuf[2];
-                    if (dist != 0xFFFF) {
+                    if (dist < BENEWAKE_DIST_MAX_CM) {
                         // TFmini has short distance mode (mm)
                         if (model_type == BENEWAKE_TFmini) {
                             if (linebuf[6] == 0x02) {


### PR DESCRIPTION
This PR fixes resolves [this issue](https://github.com/ArduPilot/ardupilot/issues/9652) the Benewake TFmini and TF02 drivers.  Below are a couple of graphs of before and after results when a TFmini is rotated back and forth in my office and you can see that the jumps are missing.  Similar improvements have been seen when I tested the TF02.

![before-after](https://user-images.githubusercontent.com/1498098/47993376-a94fe500-e132-11e8-9271-5f373fb67973.png)

The people from Benewake say:

> TFmini will return -1(HEX is FF FF),and other value i.e. -2,-3,-4, means: bad Lidar health. But TF02 will return 2200. 

.. but note that in my tests, the TF02 doesn't return 2200 when it can't find a distance, instead it, like the TFmini, returns 65535 (or similar) so this PR seems to fix issues with both drivers.
