### PR TITLE
Rover: Fix sail motor test not being reachable

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -356,7 +356,7 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
 bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
 {
     // check if the motor_seq is valid
-    if (motor_seq > MOTOR_TEST_THROTTLE_RIGHT) {
+    if (motor_seq >= MOTOR_TEST_LAST) {
         return false;
     }
     pct = constrain_float(pct, -100.0f, 100.0f);
@@ -404,7 +404,7 @@ bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
             }
             break;
         }
-        default:
+        case MOTOR_TEST_LAST:
             return false;
     }
     SRV_Channels::calc_pwm();

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -23,7 +23,8 @@ public:
         MOTOR_TEST_STEERING = 2,
         MOTOR_TEST_THROTTLE_LEFT = 3,
         MOTOR_TEST_THROTTLE_RIGHT = 4,
-        MOTOR_TEST_MAINSAIL = 5
+        MOTOR_TEST_MAINSAIL = 5,
+        MOTOR_TEST_LAST
     };
 
     // supported custom motor configurations


### PR DESCRIPTION
Rover motor sail test was unreachable. Found by coverity CID: 325623