### PR TITLE
Plane: Add support for a loiter to alt approach to VTOL landing

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1215,16 +1215,6 @@ ParametersG2::ParametersG2(void) :
   old object. This should be zero for top level parameters.
  */
 const AP_Param::ConversionInfo conversion_table[] = {
-    { Parameters::k_param_pidServoRoll, 0, AP_PARAM_FLOAT, "RLL2SRV_P" },
-    { Parameters::k_param_pidServoRoll, 1, AP_PARAM_FLOAT, "RLL2SRV_I" },
-    { Parameters::k_param_pidServoRoll, 2, AP_PARAM_FLOAT, "RLL2SRV_D" },
-    { Parameters::k_param_pidServoRoll, 3, AP_PARAM_FLOAT, "RLL2SRV_IMAX" },
-
-    { Parameters::k_param_pidServoPitch, 0, AP_PARAM_FLOAT, "PTCH2SRV_P" },
-    { Parameters::k_param_pidServoPitch, 1, AP_PARAM_FLOAT, "PTCH2SRV_I" },
-    { Parameters::k_param_pidServoPitch, 2, AP_PARAM_FLOAT, "PTCH2SRV_D" },
-    { Parameters::k_param_pidServoPitch, 3, AP_PARAM_FLOAT, "PTCH2SRV_IMAX" },
-
     { Parameters::k_param_log_bitmask_old,    0,      AP_PARAM_INT16, "LOG_BITMASK" },
     { Parameters::k_param_rally_limit_km_old, 0,      AP_PARAM_FLOAT, "RALLY_LIMIT_KM" },
     { Parameters::k_param_rally_total_old,    0,      AP_PARAM_INT8, "RALLY_TOTAL" },

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -354,6 +354,19 @@ private:
         uint32_t AFS_last_valid_rc_ms;
     } failsafe;
 
+    enum Landing_ApproachStage {
+        LOITER_TO_ALT,
+        WAIT_FOR_BREAKOUT,
+        APPROACH_LINE,
+        VTOL_LANDING,
+    };
+
+    // Landing
+    struct {
+        enum Landing_ApproachStage approach_stage;
+        float approach_direction_deg;
+    } vtol_approach_s;
+
     bool any_failsafe_triggered() {
         return failsafe.state != FAILSAFE_NONE || battery.has_failsafed() || failsafe.adsb;
     }
@@ -1004,6 +1017,7 @@ private:
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);
     void do_land(const AP_Mission::Mission_Command& cmd);
+    void do_landing_vtol_approach(const AP_Mission::Mission_Command& cmd);
     void loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd);
     void do_loiter_unlimited(const AP_Mission::Mission_Command& cmd);
     void do_loiter_turns(const AP_Mission::Mission_Command& cmd);
@@ -1014,6 +1028,7 @@ private:
     void do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_vtol_land(const AP_Mission::Mission_Command& cmd);
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
+    bool verify_landing_vtol_approach(const AP_Mission::Mission_Command& cmd);
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -95,8 +95,17 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         return quadplane.do_vtol_takeoff(cmd);
 
     case MAV_CMD_NAV_VTOL_LAND:
-        crash_state.is_crashed = false;
-        return quadplane.do_vtol_land(cmd);
+        if (quadplane.options & QuadPlane::OPTION_MISSION_LAND_FW_APPROACH) {
+            // the user wants to approach the landing in a fixed wing flight mode
+            // the waypoint will be used as a loiter_to_alt
+            // after which point the plane will compute the optimal into the wind direction
+            // and fly in on that direction towards the landing waypoint
+            // it will then transition to VTOL and do a normal quadplane landing
+            do_landing_vtol_approach(cmd);
+            break;
+        } else {
+            return quadplane.do_vtol_land(cmd);
+        }
         
     // Conditional commands
 
@@ -261,7 +270,13 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
         return quadplane.verify_vtol_takeoff(cmd);
 
     case MAV_CMD_NAV_VTOL_LAND:
-        return quadplane.verify_vtol_land();
+        if ((quadplane.options & QuadPlane::OPTION_MISSION_LAND_FW_APPROACH) && !verify_landing_vtol_approach(cmd)) {
+            // verify_landing_vtol_approach will return true once we have completed the approach,
+            // in which case we fall over to normal vtol landing code
+            return false;
+        } else {
+            return quadplane.verify_vtol_land();
+        }
 
     // Conditional commands
 
@@ -399,6 +414,15 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
         }
     }
 #endif
+}
+
+void Plane::do_landing_vtol_approach(const AP_Mission::Mission_Command& cmd)
+{
+    do_loiter_to_alt(cmd);
+
+    vtol_approach_s.approach_stage = LOITER_TO_ALT;
+
+    set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_LAND);
 }
 
 void Plane::loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd)
@@ -941,6 +965,69 @@ void Plane::exit_mission_callback()
         set_mode(RTL, MODE_REASON_MISSION_END);
         gcs().send_text(MAV_SEVERITY_INFO, "Mission complete, changing mode to RTL");
     }
+}
+
+bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
+{
+    switch (vtol_approach_s.approach_stage) {
+        case LOITER_TO_ALT:
+            if (verify_loiter_to_alt()) {
+                Vector3f wind = ahrs.wind_estimate();
+                vtol_approach_s.approach_direction_deg = degrees(atan2f(-wind.y, -wind.x));
+                gcs().send_text(MAV_SEVERITY_INFO, "Selected an approach path of %.1f", (double)vtol_approach_s.approach_direction_deg);
+                // select target approach direction
+                // select detransition distance (add in extra distance if the approach does not fit in the required space)
+                // validate turn
+                vtol_approach_s.approach_stage = WAIT_FOR_BREAKOUT;
+            }
+            break;
+        case WAIT_FOR_BREAKOUT:
+            {
+                const float breakout_direction_rad = radians(wrap_180(vtol_approach_s.approach_direction_deg + 270));
+
+                nav_controller->update_loiter(cmd.content.location, aparm.loiter_radius, cmd.content.location.flags.loiter_ccw ? -1 : 1);
+
+                // breakout when within 5 degrees of the opposite direction
+                if (fabsf(ahrs.yaw - breakout_direction_rad) < radians(5.0f)) {
+                    gcs().send_text(MAV_SEVERITY_INFO, "Starting VTOL land approach path");
+                    vtol_approach_s.approach_stage = APPROACH_LINE;
+                    set_next_WP(cmd.content.location);
+                    // fallthrough
+                } else {
+                    break;
+                }
+                FALLTHROUGH;
+            }
+        case APPROACH_LINE:
+            {
+                // project an apporach path
+                Location start = cmd.content.location;
+                Location end = cmd.content.location;
+
+                // project a 1km waypoint to either side of the landing location
+                location_update(start, vtol_approach_s.approach_direction_deg + 180, 1000);
+                location_update(end, vtol_approach_s.approach_direction_deg, 1000);
+
+                nav_controller->update_waypoint(start, end);
+
+                // check if we should move on to the next waypoint
+                Location breakout_loc = cmd.content.location;
+                location_update(breakout_loc, vtol_approach_s.approach_direction_deg + 180, quadplane.stopping_distance());
+                if(location_passed_point(current_loc, start, breakout_loc)) {
+                    vtol_approach_s.approach_stage = VTOL_LANDING;
+                    quadplane.do_vtol_land(cmd);
+                    // fallthrough
+                } else {
+                    break;
+                }
+                FALLTHROUGH;
+            }
+        case VTOL_LANDING:
+            // nothing to do here, we should be into the quadplane landing code
+            return true;
+    }
+
+    return false;
 }
 
 bool Plane::verify_loiter_heading(bool init)

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <AP_Motors/AP_Motors.h>
 #include <AC_PID/AC_PID.h>
 #include <AC_AttitudeControl/AC_AttitudeControl_Multi.h> // Attitude control library
@@ -454,6 +456,7 @@ private:
         OPTION_ALLOW_FW_TAKEOFF=(1<<1),
         OPTION_ALLOW_FW_LAND=(1<<2),
         OPTION_RESPECT_TAKEOFF_FRAME=(1<<3),
+        OPTION_MISSION_LAND_FW_APPROACH=(1<<4),
     };
 
     /*


### PR DESCRIPTION
This adds an automated loiter to alt, and into wind detransition for quadplane landing. Behavior is opt into with `Q_OPTION`. The detransition will account for the effect of wind/ground speed. It will however not account for the loiter radius being inside the required transition distance.

This has been flown quite a lot in a different form using an extra MAVLink command. However since collapsing this to be implicit with the `MAV_CMD_NAV_VTOL_LAND` waypoint it has only been flown in SITL. Collapsing this into the VTOL_LAND waypoint is a lot more challenging on an autopilot code side, but is a lot easier for users (and avoids a serious MAVLink enum selection problem)

For a more detailed description of what will happen with this (assuming you had enabled the `Q_OPTION`:
- The vehicle in fixed wing mode will loiter around the landing waypoint, and descend to the altitude on the `MAV_CMD_NAV_VTOL_LAND` waypoint. (This looks identical to a loiter to altitude command).
- The vehicle will then select the course it believes is into the wind
- The vehicle will turn in towards the landing waypoint on the into wind heading (still in fixed wing mode)
- When the vehicle is the required distance from the landing location it will transition into VTOL mode and do a normal VTOL landing. (The math for selecting this distance is based on `Q_TRANS_DECEL`)

EDIT: Snuck in the removal of param conversion code that predated the battery stuff that was just removed. (Overall drive was it was an easy way to shrink this to fit into px4-v2).