### PR TITLE
Copter : possible solution for the spline waypoint bug

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -704,7 +704,7 @@ bool AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const V
     // calculate spline velocity at origin
     if (stopped_at_start || !prev_segment_exists) {
     	// if vehicle is stopped at the origin, set origin velocity to 0.02 * distance vector from origin to destination
-    	_spline_origin_vel = (destination - origin) * dt;
+    	_spline_origin_vel = (destination - origin) * 0.02f;
     	_spline_time = 0.0f;
     	_spline_vel_scaler = 0.0f;
     }else{
@@ -742,13 +742,13 @@ bool AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const V
     case SEGMENT_END_STRAIGHT:
         // if next segment is straight, vehicle's final velocity should face along the next segment's position
         _spline_destination_vel = (next_destination - destination);
-        _flags.fast_waypoint = true;
+        _flags.fast_waypoint = false;
         break;
 
     case SEGMENT_END_SPLINE:
         // if next segment is splined, vehicle's final velocity should face parallel to the line from the origin to the next destination
         _spline_destination_vel = (next_destination - origin);
-        _flags.fast_waypoint = true;
+        _flags.fast_waypoint = false;
         break;
     }
 


### PR DESCRIPTION
This patch is to solve issue https://github.com/ArduPilot/ardupilot/issues/9657

As far as dig into, commit that pointed in the issue is doing it's job very well.
The actual problem behind this is spline waypoint does not update initial hermite spline solution necessary to avoid zero velocity.
This issue possibly due to zero time delta(dt) from position controller update at starts, initial patch here is using constant 0.02 instead of dt as in the comment. 
This can be further improved but I have no idea to avoid zero velocity vector at start.

In addition, fast waypoint feature with spline does not work well as pictures below, It does not go even close to waypoint that user defined, so I have temporarily disabled it.

With this patch, no waypoint is ignored with spline waypoints as below : 

![spline possible solution](https://user-images.githubusercontent.com/13569579/48052428-3eaeb000-e1eb-11e8-9fc3-3243baa03fca.png)


With fast waypoint disabled :

![spline solution no fwp](https://user-images.githubusercontent.com/13569579/48053108-293a8580-e1ed-11e8-9a61-aae638d2c7a7.png)
