### PR TITLE
Add missing override keyword in many places

### DIFF
--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -243,7 +243,7 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
-    void calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled);
+    void calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_enabled) override;
 
     // attributes of the mode
     bool is_autopilot_mode() const override { return true; }
@@ -252,7 +252,7 @@ public:
     float get_distance_to_destination() const override;
 
     // set desired location, heading and speed
-    void set_desired_location(const struct Location& destination, float next_leg_bearing_cd = MODE_NEXT_HEADING_UNKNOWN);
+    void set_desired_location(const struct Location& destination, float next_leg_bearing_cd = MODE_NEXT_HEADING_UNKNOWN) override;
     bool reached_destination() override;
 
     // heading and speed control
@@ -304,7 +304,7 @@ public:
     float get_distance_to_destination() const override;
 
     // set desired location, heading and speed
-    void set_desired_location(const struct Location& destination);
+    void set_desired_location(const struct Location& destination, float next_leg_bearing_cd = MODE_NEXT_HEADING_UNKNOWN) override;
     void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed) override;
 
     // set desired heading-delta, turn-rate and speed

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -90,10 +90,11 @@ float ModeGuided::get_distance_to_destination() const
 }
 
 // set desired location
-void ModeGuided::set_desired_location(const struct Location& destination)
+void ModeGuided::set_desired_location(const struct Location& destination,
+                                      float next_leg_bearing_cd)
 {
     // call parent
-    Mode::set_desired_location(destination);
+    Mode::set_desired_location(destination, next_leg_bearing_cd);
 
     // handle guided specific initialisation and logging
     _guided_mode = ModeGuided::Guided_WP;

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -27,7 +27,7 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration_baro() override;
     MAV_RESULT handle_command_long_packet(const mavlink_command_long_t &packet) override;
 
-    int32_t global_position_int_relative_alt() const {
+    int32_t global_position_int_relative_alt() const override {
         return 0; // what if we have been picked up and carried somewhere?
     }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -281,7 +281,7 @@ public:
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return false; };
-    bool in_guided_mode() const { return mode() == Auto_NavGuided; }
+    bool in_guided_mode() const override { return mode() == Auto_NavGuided; }
 
     // Auto
     AutoMode mode() const { return _mode; }
@@ -303,7 +303,7 @@ public:
 
     // return true if this flight mode supports user takeoff
     //  must_nagivate is true if mode must also control horizontal position
-    virtual bool has_user_takeoff(bool must_navigate) const { return false; }
+    virtual bool has_user_takeoff(bool must_navigate) const override { return false; }
 
     void payload_place_start();
 
@@ -804,7 +804,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return from_gcs; }
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const { return true; }
+    bool in_guided_mode() const override { return true; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
 
     void set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -57,9 +57,9 @@ public:
         }
 
     // pid accessors
-    AC_PID& get_rate_roll_pid() { return _pid_rate_roll; }
-    AC_PID& get_rate_pitch_pid() { return _pid_rate_pitch; }
-    AC_PID& get_rate_yaw_pid() { return _pid_rate_yaw; }
+    AC_PID& get_rate_roll_pid() override { return _pid_rate_roll; }
+    AC_PID& get_rate_pitch_pid() override { return _pid_rate_pitch; }
+    AC_PID& get_rate_yaw_pid() override { return _pid_rate_yaw; }
 
     // passthrough_bf_roll_pitch_rate_yaw - roll and pitch are passed through directly, body-frame rate target for yaw
     void passthrough_bf_roll_pitch_rate_yaw(float roll_passthrough, float pitch_passthrough, float yaw_rate_bf_cds) override;
@@ -72,7 +72,7 @@ public:
 
 	// rate_controller_run - run lowest level body-frame rate controller and send outputs to the motors
 	// should be called at 100hz or more
-	virtual void rate_controller_run();
+	virtual void rate_controller_run() override;
 
     // Update Alt_Hold angle maximum
     void update_althold_lean_angle_max(float throttle_in) override;
@@ -143,7 +143,7 @@ private:
     int16_t _passthrough_yaw;
 
     // get_roll_trim - angle in centi-degrees to be added to roll angle. Used by helicopter to counter tail rotor thrust in hover
-    float get_roll_trim_rad() { return constrain_float(radians(_hover_roll_trim_scalar * _hover_roll_trim * 0.01f), -radians(10.0f),radians(10.0f));}
+    float get_roll_trim_rad() override { return constrain_float(radians(_hover_roll_trim_scalar * _hover_roll_trim * 0.01f), -radians(10.0f),radians(10.0f));}
 
     // internal variables
     float _hover_roll_trim_scalar = 0;              // scalar used to suppress Hover Roll Trim

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -47,9 +47,9 @@ public:
 	virtual ~AC_AttitudeControl_Multi() {}
 
     // pid accessors
-    AC_PID& get_rate_roll_pid() { return _pid_rate_roll; }
-    AC_PID& get_rate_pitch_pid() { return _pid_rate_pitch; }
-    AC_PID& get_rate_yaw_pid() { return _pid_rate_yaw; }
+    AC_PID& get_rate_roll_pid() override { return _pid_rate_roll; }
+    AC_PID& get_rate_pitch_pid() override { return _pid_rate_pitch; }
+    AC_PID& get_rate_yaw_pid() override { return _pid_rate_yaw; }
 
     // Update Alt_Hold angle maximum
     void update_althold_lean_angle_max(float throttle_in) override;
@@ -73,10 +73,10 @@ public:
     bool is_throttle_mix_min() const override { return (_throttle_rpy_mix < 1.25f*_thr_mix_min); }
 
     // run lowest level body-frame rate controller and send outputs to the motors
-    void rate_controller_run();
+    void rate_controller_run() override;
 
     // sanity check parameters.  should be called once before take-off
-    void parameter_sanity_check();
+    void parameter_sanity_check() override;
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
@@ -31,9 +31,9 @@ public:
     virtual ~AC_AttitudeControl_Sub() {}
 
     // pid accessors
-    AC_PID& get_rate_roll_pid() { return _pid_rate_roll; }
-    AC_PID& get_rate_pitch_pid() { return _pid_rate_pitch; }
-    AC_PID& get_rate_yaw_pid() { return _pid_rate_yaw; }
+    AC_PID& get_rate_roll_pid() override { return _pid_rate_roll; }
+    AC_PID& get_rate_pitch_pid() override { return _pid_rate_pitch; }
+    AC_PID& get_rate_yaw_pid() override { return _pid_rate_yaw; }
 
     // Update Alt_Hold angle maximum
     void update_althold_lean_angle_max(float throttle_in) override;
@@ -55,10 +55,10 @@ public:
     bool is_throttle_mix_min() const override { return (_throttle_rpy_mix < 1.25f*_thr_mix_min); }
 
     // run lowest level body-frame rate controller and send outputs to the motors
-    void rate_controller_run();
+    void rate_controller_run() override;
 
     // sanity check parameters.  should be called once before take-off
-    void parameter_sanity_check();
+    void parameter_sanity_check() override;
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Baro/AP_Baro_BMP085.h
+++ b/libraries/AP_Baro/AP_Baro_BMP085.h
@@ -16,7 +16,7 @@ public:
     AP_Baro_BMP085(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
     /* AP_Baro public interface: */
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 

--- a/libraries/AP_Baro/AP_Baro_BMP280.h
+++ b/libraries/AP_Baro/AP_Baro_BMP280.h
@@ -19,7 +19,7 @@ public:
     AP_Baro_BMP280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
     /* AP_Baro public interface: */
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 

--- a/libraries/AP_Baro/AP_Baro_DPS280.h
+++ b/libraries/AP_Baro/AP_Baro_DPS280.h
@@ -18,7 +18,7 @@ public:
     AP_Baro_DPS280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
     /* AP_Baro public interface: */
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 

--- a/libraries/AP_Baro/AP_Baro_FBM320.h
+++ b/libraries/AP_Baro/AP_Baro_FBM320.h
@@ -19,7 +19,7 @@ public:
     AP_Baro_FBM320(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
     /* AP_Baro public interface: */
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 

--- a/libraries/AP_Baro/AP_Baro_HIL.h
+++ b/libraries/AP_Baro/AP_Baro_HIL.h
@@ -10,7 +10,7 @@ class AP_Baro_HIL : public AP_Baro_Backend
 {
 public:
     AP_Baro_HIL(AP_Baro &baro);
-    void update(void);
+    void update(void) override;
 
 private:
     uint8_t _instance;

--- a/libraries/AP_Baro/AP_Baro_ICM20789.h
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.h
@@ -15,7 +15,7 @@
 class AP_Baro_ICM20789 : public AP_Baro_Backend
 {
 public:
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, AP_HAL::OwnPtr<AP_HAL::Device> dev_imu);
     

--- a/libraries/AP_Baro/AP_Baro_KellerLD.h
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.h
@@ -38,7 +38,7 @@
 class AP_Baro_KellerLD : public AP_Baro_Backend
 {
 public:
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.h
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.h
@@ -24,7 +24,7 @@ public:
     AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
 
     /* AP_Baro public interface: */
-    void update();
+    void update() override;
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
     static AP_Baro_Backend *probe_InvensenseIMU(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev, uint8_t imu_address);

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -29,7 +29,7 @@
 class AP_Baro_MS56XX : public AP_Baro_Backend
 {
 public:
-    void update();
+    void update() override;
 
     enum MS56XX_TYPE {
         BARO_MS5611 = 0,

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.h
@@ -112,7 +112,7 @@ public:
     AP_BattMonitor_Analog(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
 
     /// Read the battery voltage and current.  Should be called at 10hz
-    void read();
+    void read() override;
 
     /// returns true if battery monitor provides consumed energy info
     bool has_consumed_energy() const override { return has_current(); }

--- a/libraries/AP_Beacon/AP_Beacon_Marvelmind.h
+++ b/libraries/AP_Beacon/AP_Beacon_Marvelmind.h
@@ -32,10 +32,10 @@ public:
     AP_Beacon_Marvelmind(AP_Beacon &frontend, AP_SerialManager &serial_manager);
 
     // return true if sensor is basically healthy (we are receiving data)
-    bool healthy();
+    bool healthy() override;
 
     // update
-    void update();
+    void update() override;
 
 private:
     // Variables for Marvelmind

--- a/libraries/AP_Beacon/AP_Beacon_Pozyx.h
+++ b/libraries/AP_Beacon/AP_Beacon_Pozyx.h
@@ -17,10 +17,10 @@ public:
     AP_Beacon_Pozyx(AP_Beacon &frontend, AP_SerialManager &serial_manager);
 
     // return true if sensor is basically healthy (we are receiving data)
-    bool healthy();
+    bool healthy() override;
 
     // update
-    void update();
+    void update() override;
 
 private:
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -122,8 +122,8 @@ public:
     
     AP_HAL::Semaphore  *get_semaphore() override;
 
-    bool configure();
-    bool start_measurements();
+    bool configure() override;
+    bool start_measurements() override;
 
     // set device type within a device class
     void set_device_type(uint8_t devtype) override;

--- a/libraries/AP_Compass/AP_Compass_HIL.h
+++ b/libraries/AP_Compass/AP_Compass_HIL.h
@@ -8,7 +8,7 @@ class AP_Compass_HIL : public AP_Compass_Backend
 {
 public:
     AP_Compass_HIL();
-    void read(void);
+    void read(void) override;
     bool init(void);
 
     // detect the sensor

--- a/libraries/AP_GPS/AP_GPS_ERB.h
+++ b/libraries/AP_GPS/AP_GPS_ERB.h
@@ -30,11 +30,11 @@ public:
     AP_GPS_ERB(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
     // Methods
-    bool read();
+    bool read() override;
 
-    AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
-    bool supports_mavlink_gps_rtk_message() { return true; }
+    bool supports_mavlink_gps_rtk_message() override { return true; }
 
     static bool _detect(struct ERB_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -27,12 +27,12 @@ class AP_GPS_GSOF : public AP_GPS_Backend
 public:
     AP_GPS_GSOF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    AP_GPS::GPS_Status highest_supported_status(void) {
+    AP_GPS::GPS_Status highest_supported_status(void) override {
         return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED;
     }
 
     // Methods
-    bool read();
+    bool read() override;
 
     const char *name() const override { return "GSOF"; }
 

--- a/libraries/AP_GPS/AP_GPS_MAV.h
+++ b/libraries/AP_GPS/AP_GPS_MAV.h
@@ -29,11 +29,11 @@ class AP_GPS_MAV : public AP_GPS_Backend {
 public:
     AP_GPS_MAV(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    bool read();
+    bool read() override;
 
     static bool _detect(struct MAV_detect_state &state, uint8_t data);
 
-    void handle_msg(const mavlink_message_t *msg);
+    void handle_msg(const mavlink_message_t *msg) override;
 
     const char *name() const override { return "MAV"; }
 

--- a/libraries/AP_GPS/AP_GPS_MTK.h
+++ b/libraries/AP_GPS/AP_GPS_MTK.h
@@ -31,7 +31,7 @@ class AP_GPS_MTK : public AP_GPS_Backend {
 public:
     AP_GPS_MTK(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    bool read(void);
+    bool read(void) override;
 
     static bool _detect(struct MTK_detect_state &state, uint8_t data);
     static void send_init_blob(uint8_t instance, AP_GPS &gps);

--- a/libraries/AP_GPS/AP_GPS_MTK19.h
+++ b/libraries/AP_GPS/AP_GPS_MTK19.h
@@ -32,7 +32,7 @@ class AP_GPS_MTK19 : public AP_GPS_Backend {
 public:
     AP_GPS_MTK19(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    bool        read(void);
+    bool        read(void) override;
 
     static bool _detect(struct MTK19_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -58,7 +58,7 @@ public:
     /// Checks the serial receive buffer for characters,
     /// attempts to parse NMEA data and updates internal state
     /// accordingly.
-    bool        read();
+    bool        read() override;
 
 	static bool _detect(struct NMEA_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_NOVA.h
+++ b/libraries/AP_GPS/AP_GPS_NOVA.h
@@ -27,10 +27,10 @@ class AP_GPS_NOVA : public AP_GPS_Backend
 public:
     AP_GPS_NOVA(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
     // Methods
-    bool read();
+    bool read() override;
 
     void inject_data(const uint8_t *data, uint16_t len) override;
 

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -32,10 +32,10 @@ class AP_GPS_SBF : public AP_GPS_Backend
 public:
     AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
     // Methods
-    bool read();
+    bool read() override;
 
     const char *name() const override { return "SBF"; }
 

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -29,12 +29,12 @@ class AP_GPS_SBP : public AP_GPS_Backend
 public:
     AP_GPS_SBP(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
-    bool supports_mavlink_gps_rtk_message() { return true; }
+    bool supports_mavlink_gps_rtk_message() override { return true; }
 
     // Methods
-    bool read();
+    bool read() override;
 
     void inject_data(const uint8_t *data, uint16_t len) override;
 

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -31,7 +31,7 @@ class AP_GPS_SIRF : public AP_GPS_Backend {
 public:
 	AP_GPS_SIRF(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
-    bool read();
+    bool read() override;
 
 	static bool _detect(struct SIRF_detect_state &state, uint8_t data);
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -95,13 +95,13 @@ public:
 	AP_GPS_UBLOX(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UARTDriver *_port);
 
     // Methods
-    bool read();
+    bool read() override;
 
-    AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
+    AP_GPS::GPS_Status highest_supported_status(void) override { return AP_GPS::GPS_OK_FIX_3D_RTK_FIXED; }
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
 
-    bool is_configured(void) {
+    bool is_configured(void) override {
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
         if (!gps._auto_config) {
             return true;

--- a/libraries/AP_Gripper/AP_Gripper_Servo.h
+++ b/libraries/AP_Gripper/AP_Gripper_Servo.h
@@ -37,7 +37,7 @@ public:
     bool released() const override;
 
     // valid - returns true if the backend should be working
-    bool valid() const;
+    bool valid() const override;
 
 protected:
 

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.h
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.h
@@ -30,14 +30,14 @@ class ChibiOS::AnalogSource : public AP_HAL::AnalogSource {
 public:
     friend class ChibiOS::AnalogIn;
     AnalogSource(int16_t pin, float initial_value);
-    float read_average();
-    float read_latest();
-    void set_pin(uint8_t p);
-    float voltage_average();
-    float voltage_latest();
-    float voltage_average_ratiometric();
-    void set_stop_pin(uint8_t p) {}
-    void set_settle_time(uint16_t settle_time_ms) {}
+    float read_average() override;
+    float read_latest() override;
+    void set_pin(uint8_t p) override;
+    float voltage_average() override;
+    float voltage_latest() override;
+    float voltage_average_ratiometric() override;
+    void set_stop_pin(uint8_t p) override {}
+    void set_settle_time(uint16_t settle_time_ms) override {}
 
 private:
     // what value it has

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -29,14 +29,14 @@
 class ChibiOS::GPIO : public AP_HAL::GPIO {
 public:
     GPIO();
-    void    init();
-    void    pinMode(uint8_t pin, uint8_t output);
-    uint8_t read(uint8_t pin);
-    void    write(uint8_t pin, uint8_t value);
-    void    toggle(uint8_t pin);
+    void    init() override;
+    void    pinMode(uint8_t pin, uint8_t output) override;
+    uint8_t read(uint8_t pin) override;
+    void    write(uint8_t pin, uint8_t value) override;
+    void    toggle(uint8_t pin) override;
 
     /* Alternative interface: */
-    AP_HAL::DigitalSource* channel(uint16_t n);
+    AP_HAL::DigitalSource* channel(uint16_t n) override;
 
     /* Interrupt interface - fast, for RCOutput and SPI radios */
     bool    attach_interrupt(uint8_t interrupt_num,
@@ -66,10 +66,10 @@ private:
 class ChibiOS::DigitalSource : public AP_HAL::DigitalSource {
 public:
     DigitalSource(ioline_t line);
-    void    mode(uint8_t output);
-    uint8_t read();
-    void    write(uint8_t value);
-    void    toggle();
+    void    mode(uint8_t output) override;
+    uint8_t read() override;
+    void    write(uint8_t value) override;
+    void    toggle() override;
 private:
     ioline_t line;
 };

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -29,14 +29,14 @@
 
 class ChibiOS::RCOutput : public AP_HAL::RCOutput {
 public:
-    void     init();
-    void     set_freq(uint32_t chmask, uint16_t freq_hz);
-    uint16_t get_freq(uint8_t ch);
-    void     enable_ch(uint8_t ch);
-    void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
-    uint16_t read(uint8_t ch);
-    void     read(uint16_t* period_us, uint8_t len);
+    void     init() override;
+    void     set_freq(uint32_t chmask, uint16_t freq_hz) override;
+    uint16_t get_freq(uint8_t ch) override;
+    void     enable_ch(uint8_t ch) override;
+    void     disable_ch(uint8_t ch) override;
+    void     write(uint8_t ch, uint16_t period_us) override;
+    uint16_t read(uint8_t ch) override;
+    void     read(uint16_t* period_us, uint8_t len) override;
     uint16_t read_last_sent(uint8_t ch) override;
     void     read_last_sent(uint16_t* period_us, uint8_t len) override;
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm) override {
@@ -129,7 +129,7 @@ public:
       enable telemetry request for a mask of channels. This is used
       with DShot to get telemetry feedback
      */
-    void set_telem_request_mask(uint16_t mask) { telem_request_mask = (mask >> chan_offset); }
+    void set_telem_request_mask(uint16_t mask) override { telem_request_mask = (mask >> chan_offset); }
 
     /*
       get safety switch state, used by Util.cpp

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -134,7 +134,7 @@ public:
         return static_cast<SPIDeviceManager*>(spi_mgr);
     }
 
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name);
+    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
 
 private:
     static SPIDesc device_table[];

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -76,7 +76,7 @@ public:
     /* AP_HAL::Scheduler methods */
 
 
-    void     init();
+    void     init() override;
     void     delay(uint16_t ms) override;
     void     delay_microseconds(uint16_t us) override;
     void     delay_microseconds_boost(uint16_t us) override;
@@ -87,7 +87,7 @@ public:
     void     reboot(bool hold_in_bootloader) override;
 
     bool     in_main_thread() const override;
-    void     system_initialized();
+    void     system_initialized() override;
     void     hal_initialized() { _hal_initialized = true; }
 
     bool     check_called_boost(void);

--- a/libraries/AP_HAL_ChibiOS/Storage.h
+++ b/libraries/AP_HAL_ChibiOS/Storage.h
@@ -36,9 +36,9 @@
 
 class ChibiOS::Storage : public AP_HAL::Storage {
 public:
-    void init() {}
-    void read_block(void *dst, uint16_t src, size_t n);
-    void write_block(uint16_t dst, const void* src, size_t n);
+    void init() override {}
+    void read_block(void *dst, uint16_t src, size_t n) override;
+    void write_block(uint16_t dst, const void* src, size_t n) override;
 
     void _timer_tick(void) override;
     bool healthy(void) override;

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -32,13 +32,13 @@ class ChibiOS::UARTDriver : public AP_HAL::UARTDriver {
 public:
     UARTDriver(uint8_t serial_num);
 
-    void begin(uint32_t b);
-    void begin(uint32_t b, uint16_t rxS, uint16_t txS);
-    void end();
-    void flush();
-    bool is_initialized();
-    void set_blocking_writes(bool blocking);
-    bool tx_pending();
+    void begin(uint32_t b) override;
+    void begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
+    void end() override;
+    void flush() override;
+    bool is_initialized() override;
+    void set_blocking_writes(bool blocking) override;
+    bool tx_pending() override;
 
 
     uint32_t available() override;
@@ -46,8 +46,8 @@ public:
     int16_t read() override;
     void _timer_tick(void) override;
 
-    size_t write(uint8_t c);
-    size_t write(const uint8_t *buffer, size_t size);
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
 
     // lock a port for exclusive use. Use a key of 0 to unlock
     bool lock_port(uint32_t key) override;

--- a/libraries/AP_HAL_Empty/AnalogIn.h
+++ b/libraries/AP_HAL_Empty/AnalogIn.h
@@ -5,14 +5,14 @@
 class Empty::AnalogSource : public AP_HAL::AnalogSource {
 public:
     AnalogSource(float v);
-    float read_average();
-    float read_latest();
-    void set_pin(uint8_t p);
-    void set_stop_pin(uint8_t p);
-    void set_settle_time(uint16_t settle_time_ms);
-    float voltage_average();
-    float voltage_latest();
-    float voltage_average_ratiometric() { return voltage_average(); }
+    float read_average() override;
+    float read_latest() override;
+    void set_pin(uint8_t p) override;
+    void set_stop_pin(uint8_t p) override;
+    void set_settle_time(uint16_t settle_time_ms) override;
+    float voltage_average() override;
+    float voltage_latest() override;
+    float voltage_average_ratiometric() override { return voltage_average(); }
 private:
     float _v;
 };
@@ -20,7 +20,7 @@ private:
 class Empty::AnalogIn : public AP_HAL::AnalogIn {
 public:
     AnalogIn();
-    void init();
-    AP_HAL::AnalogSource* channel(int16_t n);
-    float board_voltage(void);
+    void init() override;
+    AP_HAL::AnalogSource* channel(int16_t n) override;
+    float board_voltage(void) override;
 };

--- a/libraries/AP_HAL_Empty/GPIO.h
+++ b/libraries/AP_HAL_Empty/GPIO.h
@@ -5,26 +5,26 @@
 class Empty::GPIO : public AP_HAL::GPIO {
 public:
     GPIO();
-    void    init();
-    void    pinMode(uint8_t pin, uint8_t output);
-    uint8_t read(uint8_t pin);
-    void    write(uint8_t pin, uint8_t value);
-    void    toggle(uint8_t pin);
+    void    init() override;
+    void    pinMode(uint8_t pin, uint8_t output) override;
+    uint8_t read(uint8_t pin) override;
+    void    write(uint8_t pin, uint8_t value) override;
+    void    toggle(uint8_t pin) override;
 
     /* Alternative interface: */
-    AP_HAL::DigitalSource* channel(uint16_t n);
+    AP_HAL::DigitalSource* channel(uint16_t n) override;
 
     /* return true if USB cable is connected */
-    bool    usb_connected(void);
+    bool    usb_connected(void) override;
 };
 
 class Empty::DigitalSource : public AP_HAL::DigitalSource {
 public:
     DigitalSource(uint8_t v);
-    void    mode(uint8_t output);
-    uint8_t read();
-    void    write(uint8_t value); 
-    void    toggle();
+    void    mode(uint8_t output) override;
+    uint8_t read() override;
+    void    write(uint8_t value) override;
+    void    toggle() override;
 private:
     uint8_t _v;
 };

--- a/libraries/AP_HAL_Empty/I2CDevice.h
+++ b/libraries/AP_HAL_Empty/I2CDevice.h
@@ -51,7 +51,7 @@ public:
     }
 
     bool read_registers_multiple(uint8_t first_reg, uint8_t *recv,
-                                 uint32_t recv_len, uint8_t times)
+                                 uint32_t recv_len, uint8_t times) override
     {
         return true;
     }
@@ -61,7 +61,7 @@ public:
     bool set_speed(enum AP_HAL::Device::Speed speed) override { return true; }
 
     /* See AP_HAL::Device::get_semaphore() */
-    AP_HAL::Semaphore *get_semaphore() { return nullptr; }
+    AP_HAL::Semaphore *get_semaphore() override { return nullptr; }
 
     /* See AP_HAL::Device::register_periodic_callback() */
     AP_HAL::Device::PeriodicHandle register_periodic_callback(

--- a/libraries/AP_HAL_Empty/OpticalFlow.h
+++ b/libraries/AP_HAL_Empty/OpticalFlow.h
@@ -16,8 +16,8 @@
 
 class Empty::OpticalFlow : public AP_HAL::OpticalFlow {
 public:
-    void init() { }
-    bool read(Data_Frame& frame) { return false; }
-    void push_gyro(float gyro_x, float gyro_y, float dt) { };
-    void push_gyro_bias(float gyro_bias_x, float gyro_bias_y) { }
+    void init() override { }
+    bool read(Data_Frame& frame) override { return false; }
+    void push_gyro(float gyro_x, float gyro_y, float dt) override { };
+    void push_gyro_bias(float gyro_bias_x, float gyro_bias_y) override { }
 };

--- a/libraries/AP_HAL_Empty/RCInput.h
+++ b/libraries/AP_HAL_Empty/RCInput.h
@@ -5,9 +5,9 @@
 class Empty::RCInput : public AP_HAL::RCInput {
 public:
     RCInput();
-    void init();
-    bool  new_input();
-    uint8_t num_channels();
-    uint16_t read(uint8_t ch);
-    uint8_t read(uint16_t* periods, uint8_t len);
+    void init() override;
+    bool  new_input() override;
+    uint8_t num_channels() override;
+    uint16_t read(uint8_t ch) override;
+    uint8_t read(uint16_t* periods, uint8_t len) override;
 };

--- a/libraries/AP_HAL_Empty/RCOutput.h
+++ b/libraries/AP_HAL_Empty/RCOutput.h
@@ -3,14 +3,14 @@
 #include "AP_HAL_Empty.h"
 
 class Empty::RCOutput : public AP_HAL::RCOutput {
-    void     init();
-    void     set_freq(uint32_t chmask, uint16_t freq_hz);
-    uint16_t get_freq(uint8_t ch);
-    void     enable_ch(uint8_t ch);
-    void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
-    uint16_t read(uint8_t ch);
-    void     read(uint16_t* period_us, uint8_t len);
+    void     init() override;
+    void     set_freq(uint32_t chmask, uint16_t freq_hz) override;
+    uint16_t get_freq(uint8_t ch) override;
+    void     enable_ch(uint8_t ch) override;
+    void     disable_ch(uint8_t ch) override;
+    void     write(uint8_t ch, uint16_t period_us) override;
+    uint16_t read(uint8_t ch) override;
+    void     read(uint16_t* period_us, uint8_t len) override;
     void     cork(void) override {}
     void     push(void) override {}
 };

--- a/libraries/AP_HAL_Empty/SPIDevice.h
+++ b/libraries/AP_HAL_Empty/SPIDevice.h
@@ -56,7 +56,7 @@ public:
     }
 
     /* See AP_HAL::Device::get_semaphore() */
-    AP_HAL::Semaphore *get_semaphore()
+    AP_HAL::Semaphore *get_semaphore() override
     {
         return &_semaphore;
     }

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -5,16 +5,16 @@
 class Empty::Scheduler : public AP_HAL::Scheduler {
 public:
     Scheduler();
-    void     init();
-    void     delay(uint16_t ms);
-    void     delay_microseconds(uint16_t us);
-    void     register_timer_process(AP_HAL::MemberProc);
-    void     register_io_process(AP_HAL::MemberProc);
+    void     init() override;
+    void     delay(uint16_t ms) override;
+    void     delay_microseconds(uint16_t us) override;
+    void     register_timer_process(AP_HAL::MemberProc) override;
+    void     register_io_process(AP_HAL::MemberProc) override;
 
-    void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
+    void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
 
-    void     system_initialized();
+    void     system_initialized() override;
 
-    void     reboot(bool hold_in_bootloader);
+    void     reboot(bool hold_in_bootloader) override;
 
 };

--- a/libraries/AP_HAL_Empty/Semaphores.h
+++ b/libraries/AP_HAL_Empty/Semaphores.h
@@ -5,9 +5,9 @@
 class Empty::Semaphore : public AP_HAL::Semaphore {
 public:
     Semaphore() : _taken(false) {}
-    bool give();
-    bool take(uint32_t timeout_ms);
-    bool take_nonblocking();
+    bool give() override;
+    bool take(uint32_t timeout_ms) override;
+    bool take_nonblocking() override;
 private:
     bool _taken;
 };

--- a/libraries/AP_HAL_Empty/Storage.h
+++ b/libraries/AP_HAL_Empty/Storage.h
@@ -5,7 +5,7 @@
 class Empty::Storage : public AP_HAL::Storage {
 public:
     Storage();
-    void init();
-    void read_block(void *dst, uint16_t src, size_t n);
-    void write_block(uint16_t dst, const void* src, size_t n);
+    void init() override;
+    void read_block(void *dst, uint16_t src, size_t n) override;
+    void write_block(uint16_t dst, const void* src, size_t n) override;
 };

--- a/libraries/AP_HAL_Empty/UARTDriver.h
+++ b/libraries/AP_HAL_Empty/UARTDriver.h
@@ -6,13 +6,13 @@ class Empty::UARTDriver : public AP_HAL::UARTDriver {
 public:
     UARTDriver();
     /* Empty implementations of UARTDriver virtual methods */
-    void begin(uint32_t b);
-    void begin(uint32_t b, uint16_t rxS, uint16_t txS);
-    void end();
-    void flush();
-    bool is_initialized();
-    void set_blocking_writes(bool blocking);
-    bool tx_pending();
+    void begin(uint32_t b) override;
+    void begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
+    void end() override;
+    void flush() override;
+    bool is_initialized() override;
+    void set_blocking_writes(bool blocking) override;
+    bool tx_pending() override;
 
     /* Empty implementations of Stream virtual methods */
     uint32_t available() override;
@@ -20,6 +20,6 @@ public:
     int16_t read() override;
 
     /* Empty implementations of Print virtual methods */
-    size_t write(uint8_t c);
-    size_t write(const uint8_t *buffer, size_t size);
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
 };

--- a/libraries/AP_HAL_Empty/Util.h
+++ b/libraries/AP_HAL_Empty/Util.h
@@ -5,5 +5,5 @@
 
 class Empty::Util : public AP_HAL::Util {
 public:
-    bool run_debug_shell(AP_HAL::BetterStream *stream) { return false; }
+    bool run_debug_shell(AP_HAL::BetterStream *stream) override { return false; }
 };

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -38,7 +38,7 @@ public:
     }
 
     void set_flow_control(enum flow_control flow_control);
-    enum flow_control get_flow_control(void) { return _flow_control; }
+    enum flow_control get_flow_control(void) override { return _flow_control; }
 
     void configure_parity(uint8_t v);
     void set_stop_bits(int n);

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -15,8 +15,8 @@ public:
     void write(uint8_t ch, uint16_t period_us) override;
     uint16_t read(uint8_t ch) override;
     void read(uint16_t* period_us, uint8_t len) override;
-    void cork(void);
-    void push(void);
+    void cork(void) override;
+    void push(void) override;
 
 private:
     SITL_State *_sitlState;

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -18,19 +18,19 @@ public:
 
     /* AP_HAL::Scheduler methods */
 
-    void init();
-    void delay(uint16_t ms);
-    void delay_microseconds(uint16_t us);
+    void init() override;
+    void delay(uint16_t ms) override;
+    void delay_microseconds(uint16_t us) override;
 
-    void register_timer_process(AP_HAL::MemberProc);
-    void register_io_process(AP_HAL::MemberProc);
+    void register_timer_process(AP_HAL::MemberProc) override;
+    void register_io_process(AP_HAL::MemberProc) override;
 
-    void register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
+    void register_timer_failsafe(AP_HAL::Proc, uint32_t period_us) override;
 
     bool in_main_thread() const override;
-    void system_initialized();
+    void system_initialized() override;
 
-    void reboot(bool hold_in_bootloader);
+    void reboot(bool hold_in_bootloader) override;
 
     bool interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;
@@ -72,7 +72,7 @@ private:
     static bool _in_timer_proc;
     static bool _in_io_proc;
 
-    void stop_clock(uint64_t time_usec);
+    void stop_clock(uint64_t time_usec) override;
 
     static void *thread_create_trampoline(void *ctx);
     static void check_thread_stacks(void);

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -26,22 +26,22 @@ public:
     }
     
     /* Implementations of UARTDriver virtual methods */
-    void begin(uint32_t b) {
+    void begin(uint32_t b) override {
         begin(b, 0, 0);
     }
-    void begin(uint32_t b, uint16_t rxS, uint16_t txS);
-    void end();
-    void flush();
-    bool is_initialized() {
+    void begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
+    void end() override;
+    void flush() override;
+    bool is_initialized() override {
         return true;
     }
 
-    void set_blocking_writes(bool blocking)
+    void set_blocking_writes(bool blocking) override
     {
         _nonblocking_writes = !blocking;
     }
 
-    bool tx_pending() {
+    bool tx_pending() override {
         return false;
     }
 
@@ -51,21 +51,21 @@ public:
     int16_t read() override;
 
     /* Implementations of Print virtual methods */
-    size_t write(uint8_t c);
-    size_t write(const uint8_t *buffer, size_t size);
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
 
     // file descriptor, exposed so SITL_State::loop_hook() can use it
     int _fd;
 
     bool _unbuffered_writes;
 
-    enum flow_control get_flow_control(void) { return FLOW_CONTROL_ENABLE; }
+    enum flow_control get_flow_control(void) override { return FLOW_CONTROL_ENABLE; }
 
     void configure_parity(uint8_t v) override;
     void set_stop_bits(int n) override;
     bool set_unbuffered_writes(bool on) override;
 
-    void _timer_tick(void);
+    void _timer_tick(void) override;
 
     /*
       return timestamp estimate in microseconds for when the start of

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -10,7 +10,7 @@ public:
     Util(SITL_State *_sitlState) :
         sitlState(_sitlState) {}
     
-    bool run_debug_shell(AP_HAL::BetterStream *stream) {
+    bool run_debug_shell(AP_HAL::BetterStream *stream) override {
         return false;
     }
 

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.h
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.h
@@ -38,7 +38,7 @@ public:
     }
 
     void set_flow_control(enum flow_control flow_control);
-    enum flow_control get_flow_control(void) { return _flow_control; }
+    enum flow_control get_flow_control(void) override { return _flow_control; }
 
     void configure_parity(uint8_t v);
     void set_stop_bits(int n);

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -20,19 +20,19 @@ public:
     /**
        update internal state
     */
-    void        update(float dt);
+    void        update(float dt) override;
 
     /**
      * get_filter_status - returns filter status as a series of flags
      */
-    nav_filter_status get_filter_status() const;
+    nav_filter_status get_filter_status() const override;
 
     /**
      * get_origin - returns the inertial navigation origin in lat/lon/alt
      *
      * @return origin Location
      */
-    struct Location get_origin() const;
+    struct Location get_origin() const override;
 
     /**
      * get_position - returns the current position relative to the home location in cm.
@@ -41,24 +41,24 @@ public:
      *
      * @return
      */
-    const Vector3f&    get_position() const;
+    const Vector3f&    get_position() const override;
 
     /**
      * get_llh - updates the provided location with the latest calculated location including absolute altitude
      *  returns true on success (i.e. the EKF knows it's latest position), false on failure
      */
-    bool get_location(struct Location &loc) const;
+    bool get_location(struct Location &loc) const override;
 
     /**
      * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
      */
-    int32_t     get_latitude() const;
+    int32_t     get_latitude() const override;
 
     /**
      * get_longitude - returns the longitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
      * @return
      */
-    int32_t     get_longitude() const;
+    int32_t     get_longitude() const override;
 
     /**
      * get_velocity - returns the current velocity in cm/s
@@ -68,7 +68,7 @@ public:
      * 				.y : longitude velocity in cm/s
      * 				.z : vertical  velocity in cm/s
      */
-    const Vector3f&    get_velocity() const;
+    const Vector3f&    get_velocity() const override;
 
     /**
      * get_pos_z_derivative - returns the derivative of the z position in cm/s
@@ -80,13 +80,13 @@ public:
      *
      * @returns the current horizontal velocity in cm/s
      */
-    float        get_velocity_xy() const;
+    float        get_velocity_xy() const override;
 
     /**
      * get_altitude - get latest altitude estimate in cm
      * @return
      */
-    float       get_altitude() const;
+    float       get_altitude() const override;
 
     /**
      * get_velocity_z - returns the current climbrate.
@@ -95,7 +95,7 @@ public:
      *
      * @return climbrate in cm/s
      */
-    float       get_velocity_z() const;
+    float       get_velocity_z() const override;
 
 private:
     Vector3f _relpos_cm;   // NEU

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -562,11 +562,11 @@ private:
     AccelCalibrator *_accel_calibrator;
 
     //save accelerometer bias and scale factors
-    void _acal_save_calibrations();
-    void _acal_event_failure();
+    void _acal_save_calibrations() override;
+    void _acal_event_failure() override;
 
     // Returns AccelCalibrator objects pointer for specified acceleromter
-    AccelCalibrator* _acal_get_calibrator(uint8_t i) { return i<get_accel_count()?&(_accel_calibrator[i]):nullptr; }
+    AccelCalibrator* _acal_get_calibrator(uint8_t i) override { return i<get_accel_count()?&(_accel_calibrator[i]):nullptr; }
 
     float _trim_pitch;
     float _trim_roll;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_HIL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_HIL.h
@@ -9,7 +9,7 @@ public:
     AP_InertialSensor_HIL(AP_InertialSensor &imu);
 
     /* update accel and gyro state */
-    bool update();
+    bool update() override;
 
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -20,7 +20,7 @@ public:
     AP_InertialSensor_PX4(AP_InertialSensor &imu);
 
     /* update accel and gyro state */
-    bool update();
+    bool update() override;
 
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -13,7 +13,7 @@ public:
     AP_InertialSensor_SITL(AP_InertialSensor &imu);
 
     /* update accel and gyro state */
-    bool update();
+    bool update() override;
 
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -29,13 +29,13 @@ public:
     };
 
     // init
-    void                init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void                set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set update rate to motors - a value in hertz
-    void                set_update_rate( uint16_t speed_hz );
+    void                set_update_rate( uint16_t speed_hz ) override;
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
@@ -43,7 +43,7 @@ public:
     virtual void        output_test_seq(uint8_t motor_seq, int16_t pwm) override;
 
     // output_to_motors - sends minimum values out to the motors
-    virtual void        output_to_motors();
+    virtual void        output_to_motors() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -51,7 +51,7 @@ public:
 
 protected:
     // output - sends commands to the motors
-    void                output_armed_stabilizing();
+    void                output_armed_stabilizing() override;
 
     float               _actuator_out[NUM_ACTUATORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range
     float               _thrust_yt_ccw;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -59,16 +59,16 @@ public:
     };
 
     // init
-    void init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type);
+    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set update rate to motors - a value in hertz
-    virtual void set_update_rate( uint16_t speed_hz ) = 0;
+    virtual void set_update_rate( uint16_t speed_hz ) override = 0;
 
     // output_min - sets servos to neutral point with motors stopped
-    void output_min();
+    void output_min() override;
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
@@ -114,7 +114,7 @@ public:
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-    virtual uint16_t get_motor_mask() = 0;
+    virtual uint16_t get_motor_mask() override = 0;
 
     virtual void set_acro_tail(bool set) {}
 
@@ -122,12 +122,12 @@ public:
     virtual void ext_gyro_gain(float gain) {}
 
     // output - sends commands to the motors
-    void output();
+    void output() override;
 
     // supports_yaw_passthrough
     virtual bool supports_yaw_passthrough() const { return false; }
 
-    float get_throttle_hover() const { return 0.5f; }
+    float get_throttle_hover() const override { return 0.5f; }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -145,7 +145,7 @@ protected:
     };
 
     // output - sends commands to the motors
-    void output_armed_stabilizing();
+    void output_armed_stabilizing() override;
     void output_armed_zero_throttle();
     void output_disarmed();
 
@@ -156,7 +156,7 @@ protected:
     void reset_flight_controls();
 
     // update the throttle input filter
-    void update_throttle_filter();
+    void update_throttle_filter() override;
 
     // move_actuators - moves swash plate and tail rotor
     virtual void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) = 0;

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -20,14 +20,14 @@ public:
     {};
 
     // init
-    void                init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void                set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set update rate to motors - a value in hertz
     // you must have setup_motors before calling this
-    void                set_update_rate(uint16_t speed_hz);
+    void                set_update_rate(uint16_t speed_hz) override;
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
@@ -42,18 +42,18 @@ public:
     bool                output_test_num(uint8_t motor, int16_t pwm);
 
     // output_to_motors - sends minimum values out to the motors
-    void                output_to_motors();
+    void                output_to_motors() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t            get_motor_mask() override;
 
     // return number of motor that has failed.  Should only be called if get_thrust_boost() returns true
-    uint8_t             get_lost_motor() const { return _motor_lost_index; }
+    uint8_t             get_lost_motor() const override { return _motor_lost_index; }
 
 protected:
     // output - sends commands to the motors
-    void                output_armed_stabilizing();
+    void                output_armed_stabilizing() override;
 
     // check for failed motor
     void                check_for_failed_motor(float throttle_thrust_best);

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -37,10 +37,10 @@ public:
     AP_MotorsMulticopter(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 
     // output - sends commands to the motors
-    virtual void        output();
+    virtual void        output() override;
 
     // output_min - sends minimum values out to the motors
-    void                output_min();
+    void                output_min() override;
 
     // set_yaw_headroom - set yaw headroom (yaw is given at least this amount of pwm)
     void                set_yaw_headroom(int16_t pwm) { _yaw_headroom = pwm; }
@@ -51,7 +51,7 @@ public:
 
     // update estimated throttle required to hover
     void                update_throttle_hover(float dt);
-    virtual float       get_throttle_hover() const { return _throttle_hover; }
+    virtual float       get_throttle_hover() const override { return _throttle_hover; }
 
     // spool up states
     enum spool_up_down_mode {
@@ -112,7 +112,7 @@ protected:
     virtual void        output_to_motors() = 0;
 
     // update the throttle input filter
-    virtual void        update_throttle_filter();
+    virtual void        update_throttle_filter() override;
 
     // return current_limit as a number from 0 ~ 1 in the range throttle_min to throttle_max
     virtual float       get_current_limit_max_throttle();
@@ -139,7 +139,7 @@ protected:
     virtual void        output_boost_throttle(void);
     
     // save parameters as part of disarming
-    void save_params_on_disarm();
+    void save_params_on_disarm() override;
 
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -29,13 +29,13 @@ public:
     };
 
     // init
-    void                init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type);
+    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set update rate to motors - a value in hertz
-    void                set_update_rate( uint16_t speed_hz );
+    void                set_update_rate( uint16_t speed_hz ) override;
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
@@ -43,7 +43,7 @@ public:
     virtual void        output_test_seq(uint8_t motor_seq, int16_t pwm) override;
 
     // output_to_motors - sends minimum values out to the motors
-    virtual void        output_to_motors();
+    virtual void        output_to_motors() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -51,7 +51,7 @@ public:
 
 protected:
     // output - sends commands to the motors
-    void                output_armed_stabilizing();
+    void                output_armed_stabilizing() override;
 
     int16_t             _throttle_radio_output;   // total throttle pwm value, summed onto throttle channel minimum, typically ~1100-1900
     float               _actuator_out[NUM_ACTUATORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -15,23 +15,23 @@ public:
     AP_MotorsTailsitter(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 
     // init
-    void init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) {}
-    void set_update_rate( uint16_t speed_hz ) {}
+    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {}
+    void set_update_rate( uint16_t speed_hz ) override {}
 
     virtual void output_test_seq(uint8_t motor_seq, int16_t pwm) override {}
 
     // output_to_motors - sends output to named servos
-    void output_to_motors();
+    void output_to_motors() override;
 
     // return 0 motor mask
     uint16_t get_motor_mask() override { return 0; }
 
 protected:
     // calculate motor outputs
-    void output_armed_stabilizing();
+    void output_armed_stabilizing() override;
 
     // calculated outputs
     float _aileron;  // -1..1

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -24,13 +24,13 @@ public:
     };
 
     // init
-    void                init(motor_frame_class frame_class, motor_frame_type frame_type);
+    void                init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type);
+    void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
     // set update rate to motors - a value in hertz
-    void                set_update_rate( uint16_t speed_hz );
+    void                set_update_rate( uint16_t speed_hz ) override;
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
@@ -38,7 +38,7 @@ public:
     virtual void        output_test_seq(uint8_t motor_seq, int16_t pwm) override;
 
     // output_to_motors - sends minimum values out to the motors
-    virtual void        output_to_motors();
+    virtual void        output_to_motors() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -51,7 +51,7 @@ public:
     
 protected:
     // output - sends commands to the motors
-    void                output_armed_stabilizing();
+    void                output_armed_stabilizing() override;
 
     // call vehicle supplied thrust compensation if set
     void                thrust_compensation(void) override;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -71,16 +71,16 @@ public:
     {}
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);
+    virtual void init(const AP_SerialManager& serial_manager) override;
 
     // update mount position - should be called periodically
-    virtual void update();
+    virtual void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    virtual bool has_pan_control() const;
+    virtual bool has_pan_control() const override;
 
     // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode) ;
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) override;
 
     // send_mount_status - called to allow mounts to send their status to GCS via MAVLink
     virtual void send_mount_status(mavlink_channel_t chan) override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -25,16 +25,16 @@ public:
     AP_Mount_SToRM32(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager) {}
+    virtual void init(const AP_SerialManager& serial_manager) override {}
 
     // update mount position - should be called periodically
-    virtual void update();
+    virtual void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    virtual bool has_pan_control() const;
+    virtual bool has_pan_control() const override;
 
     // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode);
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) override;
 
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     virtual void send_mount_status(mavlink_channel_t chan) override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -23,19 +23,19 @@ public:
     AP_Mount_SToRM32_serial(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);
+    virtual void init(const AP_SerialManager& serial_manager) override;
 
     // update mount position - should be called periodically
-    virtual void update();
+    virtual void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    virtual bool has_pan_control() const;
+    virtual bool has_pan_control() const override;
 
     // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode);
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) override;
 
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
-    virtual void send_mount_status(mavlink_channel_t chan);
+    virtual void send_mount_status(mavlink_channel_t chan) override;
 
 private:
 

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -25,16 +25,16 @@ public:
     }
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);
+    virtual void init(const AP_SerialManager& serial_manager) override;
 
     // update mount position - should be called periodically
-    virtual void update();
+    virtual void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    virtual bool has_pan_control() const { return _flags.pan_control; }
+    virtual bool has_pan_control() const override { return _flags.pan_control; }
 
     // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode);
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) override;
 
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     virtual void send_mount_status(mavlink_channel_t chan) override;

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -25,16 +25,16 @@ public:
     AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance);
 
     // init - performs any required initialisation for this instance
-    virtual void init(const AP_SerialManager& serial_manager);
+    virtual void init(const AP_SerialManager& serial_manager) override;
 
     // update mount position - should be called periodically
-    virtual void update();
+    virtual void update() override;
 
     // has_pan_control - returns true if this mount can control it's pan (required for multicopters)
-    virtual bool has_pan_control() const;
+    virtual bool has_pan_control() const override;
 
     // set_mode - sets mount's mode
-    virtual void set_mode(enum MAV_MOUNT_MODE mode);
+    virtual void set_mode(enum MAV_MOUNT_MODE mode) override;
 
     // send_mount_status - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     virtual void send_mount_status(mavlink_channel_t chan) override;
@@ -47,7 +47,7 @@ public:
     // send a GIMBAL_REPORT message to the GCS
     void send_gimbal_report(mavlink_channel_t chan) override;
 
-    virtual void update_fast();
+    virtual void update_fast() override;
 
 private:
     // internal variables

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -95,10 +95,10 @@ private:
 
     void readVehicleDeltaAngle(uint8_t ins_index, Vector3f &dAng);
 
-    void _acal_save_calibrations();
-    bool _acal_get_ready_to_sample();
-    bool _acal_get_saving();
-    AccelCalibrator* _acal_get_calibrator(uint8_t instance);
+    void _acal_save_calibrations() override;
+    bool _acal_get_ready_to_sample() override;
+    bool _acal_get_saving() override;
+    AccelCalibrator* _acal_get_calibrator(uint8_t instance) override;
 
     gimbal_mode_t get_mode();
 

--- a/libraries/AP_Notify/AP_BoardLED.h
+++ b/libraries/AP_Notify/AP_BoardLED.h
@@ -26,10 +26,10 @@ class AP_BoardLED: public NotifyDevice
 {
 public:
     // initialise the LED driver
-    bool init(void);
+    bool init(void) override;
 
     // should be called at 50Hz
-    void update(void);
+    void update(void) override;
 
 private:
     // counter incremented at 50Hz

--- a/libraries/AP_Notify/AP_BoardLED2.h
+++ b/libraries/AP_Notify/AP_BoardLED2.h
@@ -28,10 +28,10 @@ class AP_BoardLED2: public NotifyDevice
 {
 public:
     // initialise the LED driver
-    bool init(void);
+    bool init(void) override;
 
     // should be called at 50Hz
-    void update(void);
+    void update(void) override;
 
 private:
     // counter incremented at 50Hz

--- a/libraries/AP_Notify/Buzzer.h
+++ b/libraries/AP_Notify/Buzzer.h
@@ -30,10 +30,10 @@ public:
     Buzzer() {}
 
     /// init - initialise the buzzer
-    bool init(void);
+    bool init(void) override;
 
     /// update - updates buzzer according to timed_updated.  Should be called at 50Hz
-    void update();
+    void update() override;
 
     /// on - turns the buzzer on or off
     void on(bool on_off);

--- a/libraries/AP_Notify/Display.h
+++ b/libraries/AP_Notify/Display.h
@@ -13,8 +13,8 @@ class Display: public NotifyDevice {
 public:
     friend class Display_Backend;
 
-    bool init(void);
-    void update();
+    bool init(void) override;
+    void update() override;
 
 private:
     void draw_char(uint16_t x, uint16_t y, const char c);

--- a/libraries/AP_Notify/ExternalLED.h
+++ b/libraries/AP_Notify/ExternalLED.h
@@ -31,10 +31,10 @@ public:
     ExternalLED() : _pattern(NONE) {}
 
     // initialise the LED driver
-    bool init(void);
+    bool init(void) override;
 
     // should be called at 50Hz
-    void update(void);
+    void update(void) override;
 
 private:
 

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -27,14 +27,14 @@ public:
     RGBLed(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, uint8_t led_dim);
 
     // init - initialised the LED
-    virtual bool init(void);
+    virtual bool init(void) override;
 
     // set_rgb - set color as a combination of red, green and blue levels from 0 ~ 15
     virtual void set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
     // update - updates led according to timed_updated.  Should be
     // called at 50Hz
-    virtual void update();
+    virtual void update() override;
 
     // handle LED control, only used when LED_OVERRIDE=1
     virtual void handle_led_control(mavlink_message_t *msg) override;

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -30,10 +30,10 @@ public:
     bool init(void) override;
 
     /// update - updates led according to timed_updated.  Should be called at 50Hz
-    void update();
+    void update() override;
 
     // handle a PLAY_TUNE message
-    void handle_play_tune(mavlink_message_t *msg);
+    void handle_play_tune(mavlink_message_t *msg) override;
 
 private:
     /// play_tune - play one of the pre-defined tunes

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Onboard.h
@@ -25,8 +25,8 @@ class AP_OpticalFlow_Onboard : public OpticalFlow_backend
 {
 public:
     AP_OpticalFlow_Onboard(OpticalFlow &_frontend);
-    void init(void);
-    void update(void);
+    void init(void) override;
+    void update(void) override;
 private:
     uint32_t _last_read_ms;
 };

--- a/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
+++ b/libraries/AP_Proximity/AP_Proximity_LightWareSF40C.h
@@ -16,11 +16,11 @@ public:
     static bool detect(AP_SerialManager &serial_manager);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const;
-    float distance_min() const;
+    float distance_max() const override;
+    float distance_min() const override;
 
 private:
 

--- a/libraries/AP_Proximity/AP_Proximity_MAV.h
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.h
@@ -11,14 +11,14 @@ public:
     AP_Proximity_MAV(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const { return _distance_max; }
-    float distance_min() const { return _distance_min; };
+    float distance_max() const override { return _distance_max; }
+    float distance_min() const override { return _distance_min; };
 
     // get distance upwards in meters. returns true on success
-    bool get_upward_distance(float &distance) const;
+    bool get_upward_distance(float &distance) const override;
 
     // handle mavlink DISTANCE_SENSOR messages
     void handle_msg(mavlink_message_t *msg) override;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -45,11 +45,11 @@ public:
     static bool detect(AP_SerialManager &serial_manager);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const;
-    float distance_min() const;
+    float distance_max() const override;
+    float distance_min() const override;
 
 private:
     enum rp_state {

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
@@ -13,14 +13,14 @@ public:
     AP_Proximity_RangeFinder(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const { return _distance_max; }
-    float distance_min() const { return _distance_min; }
+    float distance_max() const override { return _distance_max; }
+    float distance_min() const override { return _distance_min; }
 
     // get distance upwards in meters. returns true on success
-    bool get_upward_distance(float &distance) const;
+    bool get_upward_distance(float &distance) const override;
 
 private:
 

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -17,11 +17,11 @@ public:
     void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const;
-    float distance_min() const;
+    float distance_max() const override;
+    float distance_min() const override;
 
     // get distance upwards in meters. returns true on success
-    bool get_upward_distance(float &distance) const;
+    bool get_upward_distance(float &distance) const override;
 
 private:
     SITL::SITL *sitl;

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.h
@@ -16,11 +16,11 @@ public:
     static bool detect(AP_SerialManager &serial_manager);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const;
-    float distance_min() const;
+    float distance_max() const override;
+    float distance_min() const override;
 
 private:
 

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.h
@@ -15,11 +15,11 @@ public:
     static bool detect(AP_SerialManager &serial_manager);
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // get maximum and minimum distances (in meters) of sensor
-    float distance_max() const;
-    float distance_min() const; 
+    float distance_max() const override;
+    float distance_min() const override;
 
 private:
 

--- a/libraries/AP_RPM/RPM_PX4_PWM.h
+++ b/libraries/AP_RPM/RPM_PX4_PWM.h
@@ -29,7 +29,7 @@ public:
     ~AP_RPM_PX4_PWM(void);
     
     // update state
-    void update(void);
+    void update(void) override;
 
 private:
     int _fd = -1;

--- a/libraries/AP_RPM/RPM_Pin.h
+++ b/libraries/AP_RPM/RPM_Pin.h
@@ -27,7 +27,7 @@ public:
     AP_RPM_Pin(AP_RPM &ranger, uint8_t instance, AP_RPM::RPM_State &_state);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 private:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
@@ -27,7 +27,7 @@ public:
     static bool detect();
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
@@ -23,7 +23,7 @@ public:
     static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.h
@@ -50,7 +50,7 @@ public:
     static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -13,7 +13,7 @@ public:
                                           AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -16,7 +16,7 @@ public:
     static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
@@ -17,10 +17,10 @@ public:
     static bool detect();
 
     // update state
-    void update(void);
+    void update(void) override;
 
     // Get update from mavlink
-    void handle_msg(mavlink_message_t *msg);
+    void handle_msg(mavlink_message_t *msg) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
@@ -15,7 +15,7 @@ public:
                                           AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarSerialLV.h
@@ -16,7 +16,7 @@ public:
     static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
@@ -30,7 +30,7 @@ public:
     static bool detect();
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
@@ -30,7 +30,7 @@ public:
     static bool detect();
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.h
@@ -12,7 +12,7 @@ public:
                                           AP_HAL::OwnPtr<AP_HAL::I2CDevice> i2c_dev);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.h
@@ -12,7 +12,7 @@ public:
     static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.h
@@ -13,7 +13,7 @@ public:
     static bool detect(RangeFinder::RangeFinder_State &_state);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.h
@@ -16,7 +16,7 @@ public:
     static bool detect(AP_SerialManager &serial_manager, uint8_t serial_instance);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 protected:
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Quadrature.h
@@ -26,7 +26,7 @@ public:
     AP_WheelEncoder_Quadrature(AP_WheelEncoder &frontend, uint8_t instance, AP_WheelEncoder::WheelEncoder_State &state);
 
     // update state
-    void update(void);
+    void update(void) override;
 
 private:
 

--- a/libraries/DataFlash/DFMessageWriter.h
+++ b/libraries/DataFlash/DFMessageWriter.h
@@ -24,8 +24,8 @@ protected:
 class DFMessageWriter_WriteSysInfo : public DFMessageWriter {
 public:
 
-    void reset();
-    void process();
+    void reset() override;
+    void process() override;
 
 private:
     enum write_sysinfo_blockwriter_stage {
@@ -40,8 +40,8 @@ private:
 class DFMessageWriter_WriteEntireMission : public DFMessageWriter {
 public:
 
-    void reset();
-    void process();
+    void reset() override;
+    void process() override;
 
     void set_mission(const AP_Mission *mission);
 
@@ -66,14 +66,14 @@ public:
         {
         }
 
-    virtual void set_dataflash_backend(class DataFlash_Backend *backend) {
+    virtual void set_dataflash_backend(class DataFlash_Backend *backend) override {
         DFMessageWriter::set_dataflash_backend(backend);
         _writesysinfo.set_dataflash_backend(backend);
         _writeentiremission.set_dataflash_backend(backend);
     }
 
-    void reset();
-    void process();
+    void reset() override;
+    void process() override;
     bool fmt_done() { return _fmt_done; }
 
     void set_mission(const AP_Mission *mission);

--- a/libraries/Filter/AverageFilter.h
+++ b/libraries/Filter/AverageFilter.h
@@ -33,7 +33,7 @@ public:
     };
 
     // apply - Add a new raw value to the filter, retrieve the filtered result
-    virtual T        apply(T sample);
+    virtual T        apply(T sample) override;
 
     // reset - clear the filter
     virtual void        reset();

--- a/libraries/Filter/DerivativeFilter.h
+++ b/libraries/Filter/DerivativeFilter.h
@@ -39,7 +39,7 @@ public:
     float slope(void);
 
     // reset - clear the filter
-    virtual void        reset();
+    virtual void        reset() override;
 
 private:
     bool            _new_data;

--- a/libraries/Filter/FilterWithBuffer.h
+++ b/libraries/Filter/FilterWithBuffer.h
@@ -31,10 +31,10 @@ public:
     FilterWithBuffer();
 
     // apply - Add a new raw value to the filter, retrieve the filtered result
-    virtual T apply(T sample);
+    virtual T apply(T sample) override;
 
     // reset - clear the filter
-    virtual void reset();
+    virtual void reset() override;
 
     // get filter size
     uint8_t get_filter_size() const {

--- a/libraries/Filter/ModeFilter.h
+++ b/libraries/Filter/ModeFilter.h
@@ -30,7 +30,7 @@ public:
     ModeFilter(uint8_t return_element);
 
     // apply - Add a new raw value to the filter, retrieve the filtered result
-    virtual T        apply(T sample);
+    virtual T        apply(T sample) override;
 
     // get - get latest filtered value from filter (equal to the value returned by latest call to apply method)
     virtual T        get() const {

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -34,7 +34,7 @@ public:
     Submarine(const char *home_str, const char *frame_str);
 
     /* update model by one time step */
-    void update(const struct sitl_input &input);
+    void update(const struct sitl_input &input) override;
 
     /* static object creator */
     static Aircraft *create(const char *home_str, const char *frame_str) {


### PR DESCRIPTION
I used a pair of compiler options to find these (https://github.com/peterbarker/ardupilot/tree/missing-override-fatal)

Those compiler options can't be standard at the moment; I don't have a cross-compiling setup for clang++, and attempting a ChibiOS build with the option breaks somewhere in the ChibiOS submodule.

@rmackay9 see the fix for the set_target_location thing we noticed a few weeks back in Rover.
