### PR TITLE
Copter/Sub: Add patch number to VERSION notation

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V3.7-dev"
+#define THISFIRMWARE "ArduCopter V3.7.0-dev"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 3,7,0,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduSub/version.h
+++ b/ArduSub/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduSub V3.6-dev"
+#define THISFIRMWARE "ArduSub V3.6.0-dev"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 3,6,0,FIRMWARE_VERSION_TYPE_DEV


### PR DESCRIPTION
I have patch numbers in tracker, rover, plane development version notation.
However, patch numbers are not attached to Copter and Submarine.
I thought it would be better to combine with other projects.

Mission Planner message display:
ArduCopter V3.7.0-dev (7a3f8456)