### PR TITLE
HAL_ChibiOS: default the battery2 pins correctly for CubeBlack

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/defaults.parm
@@ -1,0 +1,7 @@
+# setup correct defaults for battery monitoring for cube power brick
+BATT2_CURR_PIN 14
+BATT2_VOLT_PIN 13
+BATT_AMP_PERVLT 39.877
+BATT_VOLT_MULT 12.02
+BATT2_AMP_PERVLT 39.877
+BATT2_VOLT_MULT 12.02


### PR DESCRIPTION
@bugobliterator can you tell me what we should default the voltage and current scaling to for the power bricks that come with the Cube? I'd like to add those as well

