### PR TITLE
Plane/Rover: move read_airspeed into AP_Airspeed library

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -246,19 +246,7 @@ void Rover::init_proximity(void)
  */
 void Rover::read_airspeed(void)
 {
-    if (g2.airspeed.enabled()) {
-        g2.airspeed.read();
-        if (should_log(MASK_LOG_IMU)) {
-            DataFlash.Log_Write_Airspeed(g2.airspeed);
-        }
-
-        // supply a new temperature to the barometer from the digital
-        // airspeed sensor if we can
-        float temperature;
-        if (g2.airspeed.get_temperature(temperature)) {
-            barometer.set_external_temperature(temperature);
-        }
-    }
+    g2.airspeed.update(should_log(MASK_LOG_IMU));
 }
 
 // update error mask of sensors and subsystems. The mask

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -65,19 +65,7 @@ void Plane::accel_cal_update() {
  */
 void Plane::read_airspeed(void)
 {
-    if (airspeed.enabled()) {
-        airspeed.read();
-        if (should_log(MASK_LOG_IMU)) {
-            DataFlash.Log_Write_Airspeed(airspeed);
-        }
-
-        // supply a new temperature to the barometer from the digital
-        // airspeed sensor if we can
-        float temperature;
-        if (airspeed.get_temperature(temperature)) {
-            barometer.set_external_temperature(temperature);
-        }
-    }
+    airspeed.update(should_log(MASK_LOG_IMU));
 
     // we calculate airspeed errors (and thus target_airspeed_cm) even
     // when airspeed is disabled as TECS may be using synthetic

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -22,6 +22,7 @@
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <DataFlash/DataFlash.h>
 #include <utility>
 #include "AP_Airspeed.h"
 #include "AP_Airspeed_MS4525.h"
@@ -197,6 +198,12 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
     AP_GROUPEND
 };
 
+/*
+  this scaling factor converts from the old system where we used a
+  0 to 4095 raw ADC value for 0-5V to the new system which gets the
+  voltage in volts directly from the ADC driver
+ */
+#define SCALING_OLD_CALIBRATION 819 // 4095/5
 
 AP_Airspeed::AP_Airspeed()
 {
@@ -210,14 +217,6 @@ AP_Airspeed::AP_Airspeed()
     }
     _singleton = this;
 }
-
-
-/*
-  this scaling factor converts from the old system where we used a
-  0 to 4095 raw ADC value for 0-5V to the new system which gets the
-  voltage in volts directly from the ADC driver
- */
-#define SCALING_OLD_CALIBRATION 819 // 4095/5
 
 void AP_Airspeed::init()
 {
@@ -415,7 +414,7 @@ void AP_Airspeed::read(uint8_t i)
 }
 
 // read all airspeed sensors
-void AP_Airspeed::read(void)
+void AP_Airspeed::update(bool log)
 {
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
         read(i);
@@ -427,6 +426,13 @@ void AP_Airspeed::read(void)
         gcs().send_named_float("AS2", get_airspeed(1));
     }
 #endif
+
+    if (log) {
+        DataFlash_Class *_dataflash = DataFlash_Class::instance();
+        if (_dataflash != nullptr) {
+            _dataflash->Log_Write_Airspeed(*this);
+        }
+    }
 
     // setup primary
     if (healthy(primary_sensor.get())) {

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -43,7 +43,7 @@ public:
     void init(void);
 
     // read the analog source and update airspeed
-    void read(void);
+    void update(bool log);
 
     // calibrate the airspeed. This must be called on startup if the
     // altitude/climb_rate/acceleration interfaces are ever used

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -29,7 +29,6 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 float temperature;
-
 AP_Airspeed airspeed;
 static AP_BoardConfig board_config;
 
@@ -65,7 +64,7 @@ void loop(void)
     static uint32_t timer;
     if ((AP_HAL::millis() - timer) > 100) {
         timer = AP_HAL::millis();
-        airspeed.read();
+        airspeed.update(false);
         airspeed.get_temperature(temperature);
 
         hal.console->printf("airspeed %5.2f temperature %6.2f healthy = %u\n",

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -382,9 +382,20 @@ float AP_Baro::get_external_temperature(const uint8_t instance) const
     if (_last_external_temperature_ms != 0 && AP_HAL::millis() - _last_external_temperature_ms < 10000) {
         return _external_temperature;
     }
-    // if we don't have an external temperature then use the minimum
-    // of the barometer temperature and 35 degrees C. The reason for
-    // not just using the baro temperature is it tends to read high,
+    
+    // if we don't have an external temperature then try to use temperature
+    // from the airspeed sensor
+    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    if (airspeed != nullptr) {
+        float temperature;
+        if (airspeed->healthy() && airspeed->get_temperature(temperature)) {
+            return temperature;
+        }
+    }
+    
+    // if we don't have an external temperature and airspeed temperature
+    // then use the minimum of the barometer temperature and 35 degrees C.
+    // The reason for not just using the baro temperature is it tends to read high,
     // often 30 degrees above the actual temperature. That means the
     // EAS2TAS tends to be off by quite a large margin, as well as
     // the calculation of altitude difference betweeen two pressures


### PR DESCRIPTION
Addresses https://github.com/ArduPilot/ardupilot/issues/9675

Few comments:
- plane, rover - no need to check if airspeed enabled. It reads enable on primary but actually update needs to be executed to determine healthy/unhealthy primary. Also AP_Airspeed itself checks enabled in update.
- UAVCAN baro is the only one that reports external temperature, so it now uses set_external_temperature. In rest of cases - baro accesses the airspeed singleton.

The bug:
In UAVCAN baro, external temperature was set in baro backend AP_Baro_UAVCAN::update, and also it got rewritten in sensor.cpp with temperature from airspeed sensor.