### PR TITLE
ChibiOS: support inverting uarts

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -44,7 +44,15 @@ public:
     // write to a locked port. If port is locked and key is not correct then 0 is returned
     // and write is discarded
     virtual size_t write_locked(const uint8_t *buffer, size_t size, uint32_t key) { return 0; }
-    
+
+    // control optional features
+    virtual bool set_options(uint8_t options) { return options==0; }
+
+    enum {
+        OPTION_RXINV=(1U<<0), // invert RX line
+        OPTION_TXINV=(1U<<1), // invert TX line
+    };
+
     enum flow_control {
         FLOW_CONTROL_DISABLE=0, FLOW_CONTROL_ENABLE=1, FLOW_CONTROL_AUTO=2
     };

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -49,8 +49,9 @@ public:
     virtual bool set_options(uint8_t options) { return options==0; }
 
     enum {
-        OPTION_RXINV=(1U<<0), // invert RX line
-        OPTION_TXINV=(1U<<1), // invert TX line
+        OPTION_RXINV=(1U<<0),  // invert RX line
+        OPTION_TXINV=(1U<<1),  // invert TX line
+        OPTION_HDPLEX=(1U<<2), // half-duplex (one-wire) mode
     };
 
     enum flow_control {

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -52,6 +52,9 @@ public:
     // lock a port for exclusive use. Use a key of 0 to unlock
     bool lock_port(uint32_t key) override;
 
+    // control optional features
+    bool set_options(uint8_t options) override;
+
     // write to a locked port. If port is locked and key is not correct then 0 is returned
     // and write is discarded
     size_t write_locked(const uint8_t *buffer, size_t size, uint32_t key) override;
@@ -66,6 +69,10 @@ public:
         uint8_t dma_tx_stream_id;
         uint32_t dma_tx_channel_id; 
         ioline_t rts_line;
+        int8_t rxinv_gpio;
+        uint8_t rxinv_polarity;
+        int8_t txinv_gpio;
+        uint8_t txinv_polarity;
         uint8_t get_index(void) const {
             return uint8_t(this - &_serial_tab[0]);
         }

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -169,7 +169,11 @@ private:
     uint32_t _last_write_completed_us;
     uint32_t _first_write_started_us;
     uint32_t _total_written;
-    
+
+    // we remember cr2 and cr2 options from set_options to apply on sdStart()
+    uint32_t _cr3_options;
+    uint32_t _cr2_options;
+
     // set to true for unbuffered writes (low latency writes)
     bool unbuffered_writes;
     

--- a/libraries/AP_HAL_ChibiOS/hwdef/DrotekP3Pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DrotekP3Pro/hwdef.dat
@@ -74,7 +74,6 @@ PE15 MAG_CS CS
 PH5 EEPROM_CS CS
 
 PA9 VBUS INPUT OPENDRAIN
-PA10 FRSKY_INV OUTPUT GPIO(78)
 
 # now we define the pins that USB is connected on
 PA11 OTG_FS_DM OTG1
@@ -172,6 +171,11 @@ PD15 MPU9250_DRDY INPUT
 # UART8 serial4 FrSky
 PE0 UART8_RX UART8
 PE1 UART8_TX UART8
+# allow this uart to be inverted for transmit under user control
+# the polarity is the value to use on the GPIO to change the polarity
+# to the opposite of the default
+PA10 UART8_TXINV OUTPUT HIGH GPIO(78) POL(0)
+
 PE3 VDD_SENSORS_EN OUTPUT HIGH
 
 # start peripheral power off, then enable after init

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
@@ -48,7 +48,6 @@ PA6 SPI1_MISO SPI1
 PA7 SPI1_MOSI SPI1
 
 PA9 VBUS INPUT
-PA10 FRSKY_INV OUTPUT GPIO(78)
 
 PA11 OTG_FS_DM OTG1
 PA12 OTG_FS_DP OTG1
@@ -142,6 +141,12 @@ PD15 MPU9250_DRDY INPUT
 # UART8 serial4 FrSky
 PE0 UART8_RX UART8
 PE1 UART8_TX UART8
+
+# allow this uart to be inverted for transmit under user control
+# the polarity is the value to use on the GPIO to change the polarity
+# to the opposite of the default
+PA10 UART8_TXINV OUTPUT HIGH GPIO(78) POL(0)
+
 PE3 VDD_SENSORS_EN OUTPUT HIGH
 
 # UART7 is debug

--- a/libraries/AP_HAL_ChibiOS/hwdef/mindpx-v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mindpx-v2/hwdef.dat
@@ -99,8 +99,6 @@ PB9 I2C1_SDA I2C1
 PB10 I2C2_SCL I2C2
 PB11 I2C2_SDA I2C2
 
-PB12 FRSKY_INV OUTPUT
-
 # SPI2 is external SPI (radio NRF)
 PB13 SPI2_SCK SPI2
 PB14 SPI2_MISO SPI2
@@ -145,6 +143,11 @@ PD11 ACCEL_MAG_CS CS
 # UART8 is FrSky
 PE0 UART8_RX UART8
 PE1 UART8_TX UART8
+
+# allow this uart to be inverted for transmit under user control
+# the polarity is the value to use on the GPIO to change the polarity
+# to the opposite of the default
+PB12 UART8_TXINV OUTPUT HIGH GPIO(78) POL(0)
 
 # SPI4 is M_SPI (main sensors)
 PE2 SPI4_SCK SPI4

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -151,48 +151,48 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
 
     // @Param: 1_OPTIONS
     // @DisplayName: Telem1 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("1_OPTIONS",  14, AP_SerialManager, state[1].options, 0),
 
     // @Param: 2_OPTIONS
     // @DisplayName: Telem2 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("2_OPTIONS",  15, AP_SerialManager, state[2].options, 0),
 
     // @Param: 3_OPTIONS
     // @DisplayName: Serial3 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("3_OPTIONS",  16, AP_SerialManager, state[3].options, 0),
 
     // @Param: 4_OPTIONS
     // @DisplayName: Serial4 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("4_OPTIONS",  17, AP_SerialManager, state[4].options, 0),
 
     // @Param: 5_OPTIONS
     // @DisplayName: Serial5 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("5_OPTIONS",  18, AP_SerialManager, state[5].options, 0),
 
     // @Param: 6_OPTIONS
     // @DisplayName: Serial6 options
-    // @Description: Control over UART options
-    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @Description: Control over UART options. The InvertRX option controls invert of the receive pin. The InvertTX option controls invert of the transmit pin. The HalfDuplex option controls half-duplex (onewire) mode, where both transmit and receive is done on the transmit wire.
+    // @Bitmask: 0:InvertRX, 1:InvertTX, 2:HalfDuplex
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("6_OPTIONS",  19, AP_SerialManager, state[6].options, 0),

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -148,7 +148,55 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Values: 1:1200,2:2400,4:4800,9:9600,19:19200,38:38400,57:57600,111:111100,115:115200,500:500000,921:921600,1500:1500000
     // @User: Standard
     AP_GROUPINFO("6_BAUD", 13, AP_SerialManager, state[6].baud, SERIAL6_BAUD),
-    
+
+    // @Param: 1_OPTIONS
+    // @DisplayName: Telem1 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("1_OPTIONS",  14, AP_SerialManager, state[1].options, 0),
+
+    // @Param: 2_OPTIONS
+    // @DisplayName: Telem2 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("2_OPTIONS",  15, AP_SerialManager, state[2].options, 0),
+
+    // @Param: 3_OPTIONS
+    // @DisplayName: Serial3 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("3_OPTIONS",  16, AP_SerialManager, state[3].options, 0),
+
+    // @Param: 4_OPTIONS
+    // @DisplayName: Serial4 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("4_OPTIONS",  17, AP_SerialManager, state[4].options, 0),
+
+    // @Param: 5_OPTIONS
+    // @DisplayName: Serial5 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("5_OPTIONS",  18, AP_SerialManager, state[5].options, 0),
+
+    // @Param: 6_OPTIONS
+    // @DisplayName: Serial6 options
+    // @Description: Control over UART options
+    // @Bitmask: 0:InvertRX,1:InvertTX
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("6_OPTIONS",  19, AP_SerialManager, state[6].options, 0),
+
     AP_GROUPEND
 };
 
@@ -201,6 +249,12 @@ void AP_SerialManager::init()
 #endif
         
         if (state[i].uart != nullptr) {
+
+            // see if special options have been requested
+            if (state[i].protocol != SerialProtocol_None && state[i].options) {
+                set_options(i);
+            }
+
             switch (state[i].protocol) {
                 case SerialProtocol_None:
                     break;
@@ -423,6 +477,16 @@ bool AP_SerialManager::protocol_match(enum SerialProtocol protocol1, enum Serial
     }
 
     return false;
+}
+
+// setup any special options
+void AP_SerialManager::set_options(uint8_t i)
+{
+    struct UARTState &opt = state[i];
+    // pass through to HAL
+    if (!opt.uart->set_options(opt.options)) {
+        hal.console->printf("Unable to setup options for Serial%u\n", i);
+    }
 }
 
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -147,6 +147,7 @@ private:
         AP_Int8 protocol;
         AP_Int32 baud;
         AP_HAL::UARTDriver* uart;
+        AP_Int16 options;
     } state[SERIALMANAGER_NUM_PORTS];
 
     // search through managed serial connections looking for the
@@ -158,6 +159,9 @@ private:
 
     // protocol_match - returns true if the protocols match
     bool protocol_match(enum SerialProtocol protocol1, enum SerialProtocol protocol2) const;
+
+    // setup any special options
+    void set_options(uint8_t i);
 };
 
 namespace AP {


### PR DESCRIPTION
This adds SERIALn_OPTIONS parameters to control inversion of uarts. 

This works on all uarts on all STM32F7 boards, plus on uarts that have external pins for inversion on STM32F4 boards. That is used for controlling inversion of FrSky output UART on a few boards.

Testers, to try this option you need to set the SERIALn_OPTIONS parameter for the serial port you want to change. For example, use SERIAL4_OPTIONS for SERIAL4.

- To invert the reveive set SERIALn_OPTIONS=1
- To invert the transmit set SERIALn_OPTIONS=2
- To invert both set SERIALn_OPTIONS=3

It will only work if supported by the hardware. All uarts on STM32F7xx can be inverted.

Update: now also supports HalfDuplex using the 3rd bit. This means you can set SERIALn_OPTIONS=7 to get FrSky protocol support (half-duplex, both TX and RX inverted). Works nicely with a single wire from a KakuteF7 to a FrSky receiver
