### PR TITLE
AP_OpticalFlow: add defined(HAL_HAVE_PIXARTFLOW_SPI)

### DIFF
--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -105,6 +105,8 @@ void OpticalFlow::init(void)
         backend = AP_OpticalFlow_PX4Flow::detect(*this);
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412
         backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
+#elif defined(HAL_HAVE_PIXARTFLOW_SPI)
+        backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #endif
     }
 


### PR DESCRIPTION
This addition will build in support for the Pixart pmw3901 if it is included in the hwdef.dat for a board(done via setting up the SPI bus for it, and adding "define HAL_HAVE_PIXARTFLOW_SPI" in the board defines).