### PR TITLE
AP_HAL_ChibOS: fmuv4 add pixartflow to hwdef.dat

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
@@ -223,5 +223,5 @@ define HAL_SERIAL5_BAUD 921600
 define BOARD_PWM_COUNT_DEFAULT 6
 
 # Add pixartflow define.  Un-comment to enable
-# define HAL_HAS_PIXARTFLOW_SPI
+# define HAL_HAVE_PIXARTFLOW_SPI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv4/hwdef.dat
@@ -82,10 +82,18 @@ PE10 8266_CTS INPUT
 
 # make GPIOs for ESP8266 available via mavlink relay control as pins
 # 60 to 63
+# comment out these 4 lines to enable SPI
 PB4 8266_GPIO2 OUTPUT GPIO(60)
 PE2 8266_GPI0 INPUT PULLUP GPIO(61)
 PE5 8266_PD OUTPUT HIGH GPIO(62)
 PE6 8266_RST OUTPUT HIGH GPIO(63)
+
+# set up GPIOs as SPI4 for pixartflow
+#uncomment these 4 lines and the defines further down to enable pixartflow
+# PB4 FLOW_CS CS
+# PE2 SPI4_SCK SPI4
+# PE5 SPI4_MISO SPI4
+# PE6 SPI4_MOSI SPI4
 
 PB8 I2C1_SCL I2C1
 PB9 I2C1_SDA I2C1
@@ -164,6 +172,8 @@ SPIDEV icm20608    SPI1 DEVID6  20608_CS   MODE3   2*MHZ   8*MHZ
 SPIDEV hmc5843     SPI1 DEVID5  MAG_CS     MODE3  11*MHZ  11*MHZ
 SPIDEV lis3mdl     SPI1 DEVID5  MAG_CS     MODE3 500*KHZ 500*KHZ
 SPIDEV ramtron     SPI2 DEVID10 FRAM_CS    MODE3   8*MHZ   8*MHZ
+# Un-comment the line below for pixartflow
+# SPIDEV pixartflow  SPI4 DEVID2  FLOW_CS    MODE2   2*MHZ   2*MHZ
 
 define HAL_CHIBIOS_ARCH_FMUV4 1
 
@@ -211,4 +221,7 @@ define HAL_SERIAL5_BAUD 921600
 
 # 6 PWM available by default
 define BOARD_PWM_COUNT_DEFAULT 6
+
+# Add pixartflow define.  Un-comment to enable
+# define HAL_HAS_PIXARTFLOW_SPI
 


### PR DESCRIPTION
As presented this has no functional change.
This puts in the necessary assignments and defines to enable building with pixartflow, but comments them out.
Intent is to make it easier for users to add the device if they want to, but doesn't change anything for default builds.