### PR TITLE
AP_Landing: abort landing if gear was not deployed

### DIFF
--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -169,7 +169,6 @@ AP_Landing::AP_Landing(AP_Mission &_mission, AP_AHRS &_ahrs, AP_SpdHgtControl *_
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-
 void AP_Landing::do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
 {
     Log(); // log old state so we get a nice transition from old to new here
@@ -219,7 +218,6 @@ bool AP_Landing::verify_land(const Location &prev_WP_loc, Location &next_WP_loc,
     Log();
     return success;
 }
-
 
 bool AP_Landing::verify_abort_landing(const Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc,
     const int32_t auto_state_takeoff_altitude_rel_cm, bool &throttle_suppressed)

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -20,6 +20,7 @@
 #include "AP_Landing.h"
 #include <GCS_MAVLink/GCS.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_LandingGear/AP_LandingGear.h>
 
 void AP_Landing::type_slope_do_land(const AP_Mission::Mission_Command& cmd, const float relative_altitude)
 {
@@ -40,7 +41,6 @@ void AP_Landing::type_slope_verify_abort_landing(const Location &prev_WP_loc, Lo
     throttle_suppressed = false;
     nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
 }
-
 
 /*
   update navigation for landing. Called when on landing approach or
@@ -65,7 +65,6 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
             type_slope_stage = SLOPE_STAGE_APPROACH;
         }
     }
-
 
     /* Set land_complete (which starts the flare) under 3 conditions:
        1) we are within LAND_FLARE_ALT meters of the landing altitude
@@ -103,9 +102,17 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
                                   (double)AP::gps().ground_speed(),
                                   (double)get_distance(current_loc, next_WP_loc));
             }
+            
             type_slope_stage = SLOPE_STAGE_FINAL;
+            
+            // Check if the landing gear was deployed before landing
+            // If not - go around
+            AP_LandingGear *LG_inst = AP_LandingGear::instance();
+            if (LG_inst != nullptr && !LG_inst->check_before_land()) {
+                type_slope_request_go_around();
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "Landing gear was not deployed");
+            }
         }
-
 
         if (AP::gps().ground_speed() < 3) {
             // reload any airspeed or groundspeed parameters that may have
@@ -206,7 +213,6 @@ void AP_Landing::type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle
     }
 }
 
-
 bool AP_Landing::type_slope_request_go_around(void)
 {
     flags.commanded_go_around = true;
@@ -221,7 +227,6 @@ bool AP_Landing::type_slope_request_go_around(void)
   itself as that leads to discontinuities close to the landing point,
   which can lead to erratic pitch control
  */
-
 void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm)
 {
     float total_distance = get_distance(prev_WP_loc, next_WP_loc);
@@ -268,7 +273,6 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
         gcs().send_text(MAV_SEVERITY_INFO, "Landing glide slope %.1f degrees", (double)degrees(atanf(slope)));
     }
 
-
     // time before landing that we will flare
     float flare_time = aim_height / SpdHgt_Controller->get_land_sinkrate();
 
@@ -309,8 +313,8 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     constrain_target_altitude_location_fn(loc, prev_WP_loc);
 }
 
-int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
-
+int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
+{
     // we're landing, check for custom approach and
     // pre-flare airspeeds. Also increase for head-winds
 
@@ -345,7 +349,8 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void) {
     return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, aparm.airspeed_cruise_cm);
 }
 
-int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd) {
+int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd)
+{
     if (type_slope_stage == SLOPE_STAGE_FINAL) {
         return constrain_int32(desired_roll_cd, level_roll_limit_cd * -1, level_roll_limit_cd);
     } else {
@@ -357,7 +362,6 @@ bool AP_Landing::type_slope_is_flaring(void) const
 {
     return (type_slope_stage == SLOPE_STAGE_FINAL);
 }
-
 
 bool AP_Landing::type_slope_is_on_approach(void) const
 {

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -198,7 +198,11 @@ void AP_LandingGear::update(float height_above_ground_m)
     
     if (_pin_deployed == -1) {
         last_gear_event_ms = 0;
-        gear_state_current = (_deployed == true ? LG_DEPLOYED : LG_RETRACTED);
+        
+        // If there was no pilot input and state is still unknown - leave it as it is
+        if (gear_state_current != LG_UNKNOWN) {
+            gear_state_current = (_deployed == true ? LG_DEPLOYED : LG_RETRACTED);
+        }
     } else {
         LG_LandingGear_State gear_state_new;
         
@@ -249,4 +253,15 @@ void AP_LandingGear::log_wow_state(LG_WOW_State state)
     DataFlash_Class::instance()->Log_Write("LGR", "TimeUS,LandingGear,WeightOnWheels", "Qbb",
                                            AP_HAL::micros64(),
                                            (int8_t)gear_state_current, (int8_t)state);
+}
+
+bool AP_LandingGear::check_before_land(void)
+{
+    // If the landing gear state is not known (most probably as it is not used)
+    if (get_state() == LG_UNKNOWN) {
+        return true;
+    }
+    
+    // If the landing gear was not used - return true, otherwise - check for deployed
+    return (get_state() == LG_DEPLOYED);
 }

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -82,6 +82,8 @@ public:
     static const struct AP_Param::GroupInfo        var_info[];
     
     void update(float height_above_ground_m);
+    
+    bool check_before_land(void);
 
 private:
     // Parameters


### PR DESCRIPTION
Checks the state of the gear before entering final stage of landing.