### PR TITLE
Copter: Change Radio failsafe message

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -314,7 +314,7 @@ bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
             #if FRAME_CONFIG == HELI_FRAME
             const char *failmsg = "Collective below Failsafe";
             #else
-            const char *failmsg = "Throttle below Failsafe";
+            const char *failmsg = "Radio below Failsafe";
             #endif
             check_failed(ARMING_CHECK_RC, display_failure, failmsg);
             return false;


### PR DESCRIPTION
I switched on the airplane with the power of the propo off and saw "PreArm: Throttle below Failsafe" message.
However, other signals also indicate abnormal values.
In addition, it is posted like this in the following URL.

" Radio failsafe "was previously called" Throttle failsafe "

I would like to make it "Radio below failsafe".

http://ardupilot.org/copter/docs/radio-failsafe.html