### PR TITLE
Copter: make mavlink rangefinder health bit depend just on data avail…

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -397,7 +397,7 @@ void Copter::update_sensor_status_flags(void)
 #if RANGEFINDER_ENABLED == ENABLED
     if (rangefinder_state.enabled) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        if (!rangefinder_state.alt_healthy) {
+        if (rangefinder.has_data_orient(ROTATION_PITCH_270)) {
             control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
     }


### PR DESCRIPTION
…able

This means the sensor is healthy even if it is out of range.

This is a partial revert of commit https://github.com/ArduPilot/ardupilot/commit/724f34c7e72c7c763e6139dbfe241be5a64d8151#diff-577a72d2550199fabbdfd77fa5890368R408


This commit is already in Copter-3.6.1
