### PR TITLE
Copter: log and notify when manual land repositionning is active

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -336,6 +336,7 @@ enum LoggingParameters {
 #define DATA_WINCH_RATE_CONTROL             70
 #define DATA_ZIGZAG_STORE_A                 71
 #define DATA_ZIGZAG_STORE_B                 72
+#define DATA_LAND_REPO_ACTIVE               73
 
 // Error message sub systems and error codes
 #define ERROR_SUBSYSTEM_MAIN                1

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -478,6 +478,9 @@ void Copter::Mode::land_run_horizontal_control()
 
             // record if pilot has overriden roll or pitch
             if (!is_zero(target_roll) || !is_zero(target_pitch)) {
+                if (!ap.land_repo_active) {
+                    copter.Log_Write_Event(DATA_LAND_REPO_ACTIVE);
+                }
                 ap.land_repo_active = true;
             }
         }

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -289,6 +289,9 @@ void Copter::ModeRTL::descent_run()
 
             // record if pilot has overriden roll or pitch
             if (!is_zero(target_roll) || !is_zero(target_pitch)) {
+                if (!ap.land_repo_active) {
+                    copter.Log_Write_Event(DATA_LAND_REPO_ACTIVE);
+                }
                 ap.land_repo_active = true;
             }
         }


### PR DESCRIPTION
This is need for precland test where radio are present.... it will log and try to notify once when we switch to manual land repositionning