### PR TITLE
Copter: Added Radio input values check

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -56,6 +56,7 @@ bool AP_Arming_Copter::pre_arm_checks(bool display_failure)
     return fence_checks(display_failure)
         & parameter_checks(display_failure)
         & motor_checks(display_failure)
+        & radio_checks(display_failure)
         & pilot_throttle_checks(display_failure) &
         AP_Arming::pre_arm_checks(display_failure);
 }
@@ -317,6 +318,22 @@ bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
             const char *failmsg = "Throttle below Failsafe";
             #endif
             check_failed(ARMING_CHECK_RC, display_failure, failmsg);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool AP_Arming_Copter::radio_checks(bool display_failure)
+{
+    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
+        if (copter.channel_throttle->get_radio_in() < copter.channel_throttle->get_radio_min() ||
+            copter.channel_roll->get_radio_in() < copter.channel_roll->get_radio_min() ||
+            copter.channel_pitch->get_radio_in() < copter.channel_pitch->get_radio_min() ||
+            copter.channel_yaw->get_radio_in() < copter.channel_yaw->get_radio_min()) {
+            const char *failmsg = "Radio Failsafe";
+            check_failed(ARMING_CHECK_NONE, display_failure, failmsg);
             return false;
         }
     }

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -43,6 +43,7 @@ protected:
     bool fence_checks(bool display_failure);
     bool parameter_checks(bool display_failure);
     bool motor_checks(bool display_failure);
+    bool radio_checks(bool display_failure);
     bool pilot_throttle_checks(bool display_failure);
 
     void set_pre_arm_check(bool b);


### PR DESCRIPTION
I will be informed that "PreArm: Throttle below Failsafe" when I turn on the airplane without turning on the power of the propo.
I think that this message should be notified when the power of the propo is turned on.
I think that it would be clearer to make a radio error if the input values of CH1, CH2, CH3, and CH4 are smaller than the calibration value.

The input values of CH1 to CH4 are 0.
![ddd](https://user-images.githubusercontent.com/646194/48347876-ec75ff00-e6c2-11e8-9be2-5204c2cd388b.png)

I confirmed that "PreArm: Radio Failsafe" will be displayed after the change.
