### PR TITLE
Rover: define FS_ACTION enum

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -130,7 +130,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Description: What to do on a failsafe event
     // @Values: 0:Nothing,1:RTL,2:Hold,3:SmartRTL or RTL,4:SmartRTL or Hold
     // @User: Standard
-    GSCALAR(fs_action,    "FS_ACTION",     2),
+    GSCALAR(fs_action,    "FS_ACTION",     FS_ACTION_HOLD),
 
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -77,6 +77,15 @@
 // subsystem specific error codes -- crash checker
 #define ERROR_CODE_CRASH_CHECK_CRASH 1
 
+// failsafe action enum used for radio and gcs failsafe
+enum fs_action {
+    FS_ACTION_NONE             = 0,
+    FS_ACTION_RTL              = 1,
+    FS_ACTION_HOLD             = 2,
+    FS_ACTION_SMARTRTL_OR_RTL  = 3,
+    FS_ACTION_SMARTRTL_OR_HOLD = 4,
+};
+
 enum fs_crash_action {
   FS_CRASH_DISABLE = 0,
   FS_CRASH_HOLD = 1,

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -74,24 +74,24 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         RC_Channels::clear_overrides();
 
         switch (g.fs_action) {
-            case 0:
+            case FS_ACTION_NONE:
                 break;
-            case 1:
+            case FS_ACTION_RTL:
                 if (!set_mode(mode_rtl, MODE_REASON_FAILSAFE)) {
                     set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 }
                 break;
-            case 2:
+            case FS_ACTION_HOLD:
                 set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 break;
-            case 3:
+            case FS_ACTION_SMARTRTL_OR_RTL:
                 if (!set_mode(mode_smartrtl, MODE_REASON_FAILSAFE)) {
                     if (!set_mode(mode_rtl, MODE_REASON_FAILSAFE)) {
                         set_mode(mode_hold, MODE_REASON_FAILSAFE);
                     }
                 }
                 break;
-            case 4:
+            case FS_ACTION_SMARTRTL_OR_HOLD:
                 if (!set_mode(mode_smartrtl, MODE_REASON_FAILSAFE)) {
                     set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 }


### PR DESCRIPTION
I defined FS_ACTION enum for Rover.
FS_ACTION is used in common for radio and GCS failsafe in Rover.

I referred to the Copter code.
https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/defines.h#L403-L409