### PR TITLE
Rover: fix to use defined value of failsafe action

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -130,7 +130,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Description: What to do on a failsafe event
     // @Values: 0:Nothing,1:RTL,2:Hold,3:SmartRTL or RTL,4:SmartRTL or Hold
     // @User: Standard
-    GSCALAR(fs_action,    "FS_ACTION",     2),
+    GSCALAR(fs_action,    "FS_ACTION",     Failsafe_Action_Hold),
 
     // @Param: FS_TIMEOUT
     // @DisplayName: Failsafe timeout

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -74,24 +74,24 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         RC_Channels::clear_overrides();
 
         switch (g.fs_action) {
-            case 0:
+            case Failsafe_Action_None:
                 break;
-            case 1:
+            case Failsafe_Action_RTL:
                 if (!set_mode(mode_rtl, MODE_REASON_FAILSAFE)) {
                     set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 }
                 break;
-            case 2:
+            case Failsafe_Action_Hold:
                 set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 break;
-            case 3:
+            case Failsafe_Action_SmartRTL:
                 if (!set_mode(mode_smartrtl, MODE_REASON_FAILSAFE)) {
                     if (!set_mode(mode_rtl, MODE_REASON_FAILSAFE)) {
                         set_mode(mode_hold, MODE_REASON_FAILSAFE);
                     }
                 }
                 break;
-            case 4:
+            case Failsafe_Action_SmartRTL_Hold:
                 if (!set_mode(mode_smartrtl, MODE_REASON_FAILSAFE)) {
                     set_mode(mode_hold, MODE_REASON_FAILSAFE);
                 }


### PR DESCRIPTION
I fixed to use Failsafe_Action enum in failsafe.cpp  