### PR TITLE
AP_RangeFinder: benewake reports at least 12m or 23m when out-of-range

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -105,12 +105,12 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm)
             // if buffer now has 9 items try to decode it
             if (linebuf_len == BENEWAKE_FRAME_LENGTH) {
                 // calculate checksum
-                uint16_t checksum = 0;
+                uint8_t checksum = 0;
                 for (uint8_t i=0; i<BENEWAKE_FRAME_LENGTH-1; i++) {
-                    checksum += linebuf[i];
+                    checksum += (uint8_t)linebuf[i];
                 }
                 // if checksum matches extract contents
-                if ((uint8_t)(checksum & 0xFF) == linebuf[BENEWAKE_FRAME_LENGTH-1]) {
+                if (checksum == (uint8_t)linebuf[BENEWAKE_FRAME_LENGTH-1]) {
                     // calculate distance
                     uint16_t dist = ((uint16_t)linebuf[3] << 8) | linebuf[2];
                     if (dist >= BENEWAKE_DIST_MAX_CM) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -24,6 +24,8 @@ extern const AP_HAL::HAL& hal;
 #define BENEWAKE_FRAME_HEADER 0x59
 #define BENEWAKE_FRAME_LENGTH 9
 #define BENEWAKE_DIST_MAX_CM 32768
+#define BENEWAKE_TFMINI_OUT_OF_RANGE_CM 1200
+#define BENEWAKE_TF02_OUT_OF_RANGE_CM 2200
 #define BENEWAKE_OUT_OF_RANGE_ADD_CM 100
 
 // format of serial packets received from benewake lidar
@@ -147,8 +149,10 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm)
     }
 
     if (count_out_of_range > 0) {
-        // if only out of range readings return max range + 1m
-        reading_cm = max_distance_cm() + BENEWAKE_OUT_OF_RANGE_ADD_CM;
+        // if only out of range readings return larger of
+        // driver defined maximum range for the model and user defined max range + 1m
+        float model_dist_max_cm = (model_type == BENEWAKE_TFmini) ? BENEWAKE_TFMINI_OUT_OF_RANGE_CM : BENEWAKE_TF02_OUT_OF_RANGE_CM;
+        reading_cm = MAX(model_dist_max_cm, max_distance_cm() + BENEWAKE_OUT_OF_RANGE_ADD_CM);
         return true;
     }
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -188,8 +188,10 @@ void DataFlash_Class::Log_Write_RFND(const RangeFinder &rangefinder)
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_RFND_MSG)),
         time_us       : AP_HAL::micros64(),
         dist1         : s0 ? s0->distance_cm() : (uint16_t)0,
+        status1       : s0 ? (uint8_t)s0->status() : (uint8_t)0,
         orient1       : s0 ? s0->orientation() : ROTATION_NONE,
         dist2         : s1 ? s1->distance_cm() : (uint16_t)0,
+        status2       : s1 ? (uint8_t)s1->status() : (uint8_t)0,
         orient2       : s1 ? s1->orientation() : ROTATION_NONE,
     };
     WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -732,8 +732,10 @@ struct PACKED log_RFND {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint16_t dist1;
+    uint8_t status1;
     uint8_t orient1;
     uint16_t dist2;
+    uint8_t status2;
     uint8_t orient2;
 };
 
@@ -1275,7 +1277,7 @@ Format characters in the format string for binary log messages
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
-      "RFND", "QCBCB", "TimeUS,Dist1,Orient1,Dist2,Orient2", "sm-m-", "FB-B-" }, \
+      "RFND", "QCBBCBB", "TimeUS,Dist1,Stat1,Orient1,Dist2,Stat2,Orient2", "sm--m--", "FB--B--" }, \
     { LOG_DF_MAV_STATS, sizeof(log_DF_MAV_Stats), \
       "DMS", "IIIIIBBBBBBBBBB",         "TimeMS,N,Dp,RT,RS,Er,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s--------------", "C--------------" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \


### PR DESCRIPTION
This PR has two minor improvements:

- the Benewake TFmini and TF02 driver reports **at least** 12m (for the TFmini) or 23m (for the TF02) when the Lidar cannot return a reading (i.e. when it goes out of range or passes over something shiny).  This has no impact on how the vehicle code uses the lidar (the vehicle code does not use the lidar range when it's status is anything but "4"/"Good") but avoids an edge case where the lidar could return a **shorter** value when it goes out of range.  This is the scenario:
   - user sets up the RNGFND_MAX_CM = 400 (i.e. 4m) even though the lidar can read up to 1000 (i.e. 10m)
   - the vehicle is flying at 6m and the lidar reports 6m even though the vehicle code doesn't use the lidar because it is out-of-range.
   - the vehicle momentarily passes over something shiny, the lidar cannot read the distance so it returns 400+100 = 5m.  I.e. the range drops as it passes over something shiny which the user would find odd.  With this change the lidar would instead return 12m.
- the dataflash RFND message records the range finders status so that we can more easily see whether the vehicle code will be using the lidar or not.

Here is a screen shot of the RFND message during a bench test with the Benewake TFmini lidar
![benewake-fix3-test](https://user-images.githubusercontent.com/1498098/48459537-dd4f9800-e80d-11e8-9024-8136f1111db6.png)

