### PR TITLE
Tools: Undefined name: AutoTestTimeoutException

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -12,6 +12,7 @@ from pymavlink import mavutil
 from pysim import util
 
 from common import AutoTest
+from common import AutoTestTimeoutException
 from common import NotAchievedException
 from common import PreconditionFailedException
 


### PR DESCRIPTION
An __AutoTestTimeoutException()__ is created on line 324 but that Exception is never imported which causes an _undefined name_ which has the potential to raise __NameError__ at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/ArduPilot/ardupilot on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Tools/ardupilotwaf/boards.py:252:13: F821 undefined name 'bld'
            bld.fatal("Failed to created ap_romfs_embedded.h")
            ^
./Tools/autotest/arducopter.py:1511:30: F821 undefined name 'hours'
                st.param2 == hours and
                             ^
./Tools/autotest/arducopter.py:1512:30: F821 undefined name 'mins'
                st.param3 == mins and
                             ^
./Tools/autotest/arducopter.py:1513:30: F821 undefined name 'secs'
                st.param4 == secs):
                             ^
./Tools/autotest/arduplane.py:323:27: F821 undefined name 'AutoTestTimeoutException'
                    raise AutoTestTimeoutException("Manuevers not completed")
                          ^
5     F821 undefined name 'bld'
5
```