### PR TITLE
Tools: autotest: disable terrain in optical flow test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1025,6 +1025,7 @@ class AutoTestCopter(AutoTest):
             self.set_parameter("RNGFND_SCALING", 12.12, epsilon=0.01)
 
             self.set_parameter("SIM_GPS_DISABLE", 1)
+            self.set_parameter("SIM_TERRAIN", 0)
 
             self.reboot_sitl()
 


### PR DESCRIPTION
It is possible this is the cause of the unreliability of this test; the
rangefinder sees step-jumps in its readings.