### PR TITLE
Rover: add ekf failsafe support

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -60,6 +60,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(update_mission,         50,    200),
     SCHED_TASK(update_logging1,        10,    200),
     SCHED_TASK(update_logging2,        10,    200),
+    SCHED_TASK(ekf_check,              10,     75),
     SCHED_TASK(gcs_retry_deferred,     50,    500),
     SCHED_TASK(gcs_update,             50,    500),
     SCHED_TASK(gcs_data_stream_send,   50,   1000),

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -163,6 +163,13 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Standard
     GSCALAR(fs_gcs_enabled, "FS_GCS_ENABLE",   FS_GCS_DISABLED),
 
+    // @Param: FS_EKF_THRESH
+    // @DisplayName: EKF failsafe variance threshold
+    // @Description: Allows setting the maximum acceptable compass and velocity variance
+    // @Values: 0.6:Strict, 0.8:Default, 1.0:Relaxed
+    // @User: Advanced
+    GSCALAR(fs_ekf_thresh, "FS_EKF_THRESH",    FS_EKF_THRESHOLD_DEFAULT),
+
     // @Param: FS_CRASH_CHECK
     // @DisplayName: Crash check action
     // @Description: What to do on a crash event. When enabled the rover will go to hold if a crash is detected.

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -55,6 +55,7 @@ public:
         k_param_serial0_baud,   // deprecated, can be deleted
         k_param_serial1_baud,   // deprecated, can be deleted
         k_param_serial2_baud,   // deprecated, can be deleted
+        k_param_fs_ekf_thresh,
 
         // 97: RSSI
         k_param_rssi = 97,
@@ -249,6 +250,7 @@ public:
     AP_Int16    fs_throttle_value;
     AP_Int8     fs_gcs_enabled;
     AP_Int8     fs_crash_check;
+    AP_Float    fs_ekf_thresh;
 
     // obstacle avoidance control
     AP_Int16    rangefinder_trigger_cm;

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -263,6 +263,7 @@ private:
         uint8_t triggered;          // bit flags of failsafes that have triggered an action
         uint32_t last_valid_rc_ms;  // system time of most recent RC input from pilot
         uint32_t last_heartbeat_ms; // system time of most recent heartbeat from ground station
+        uint8_t ekf            : 1; // true if ekf failsafe has occurred
     } failsafe;
 
     // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
@@ -457,6 +458,12 @@ private:
     void cruise_learn_update();
     void cruise_learn_complete();
 
+    // ekf_check.cpp
+    void ekf_check();
+    bool ekf_over_threshold();
+    void failsafe_ekf_event();
+    void failsafe_ekf_off_event(void);
+
     // failsafe.cpp
     void failsafe_trigger(uint8_t failsafe_type, bool on);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
@@ -559,6 +566,7 @@ private:
     bool is_boat() const;
     void read_mode_switch();
     void read_aux_all();
+    bool ekf_position_ok();
 
     enum Failsafe_Action {
         Failsafe_Action_None          = 0,

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -146,6 +146,11 @@
 
 #define DEFAULT_LOG_BITMASK    0xffff
 
+//////////////////////////////////////////////////////////////////////////////
+//  EKF Failsafe
+#ifndef FS_EKF_THRESHOLD_DEFAULT
+ # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Developer Items

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -21,6 +21,10 @@
 #define FAILSAFE_EVENT_THROTTLE (1<<0)
 #define FAILSAFE_EVENT_GCS      (1<<1)
 
+// EKF check definitions
+#define ERROR_CODE_EKFCHECK_BAD_VARIANCE       2
+#define ERROR_CODE_EKFCHECK_VARIANCE_CLEARED   0
+
 //  Logging parameters
 #define LOG_THR_MSG             0x01
 #define LOG_NTUN_MSG            0x02
@@ -71,11 +75,16 @@
 // general error codes
 #define ERROR_CODE_ERROR_RESOLVED       0
 // Error message sub systems and error codes
-#define ERROR_SUBSYSTEM_FAILSAFE_FENCE  9
-#define ERROR_SUBSYSTEM_FLIGHT_MODE     10
-#define ERROR_SUBSYSTEM_CRASH_CHECK     12
+#define ERROR_SUBSYSTEM_FAILSAFE_FENCE      9
+#define ERROR_SUBSYSTEM_FLIGHT_MODE         10
+#define ERROR_SUBSYSTEM_CRASH_CHECK         12
+#define ERROR_SUBSYSTEM_EKFCHECK            16
+#define ERROR_SUBSYSTEM_FAILSAFE_EKFINAV    17
 // subsystem specific error codes -- crash checker
 #define ERROR_CODE_CRASH_CHECK_CRASH 1
+// subsystem specific error codes -- gps
+#define ERROR_CODE_FAILSAFE_RESOLVED        0
+#define ERROR_CODE_FAILSAFE_OCCURRED        1
 
 // radio failsafe enum (FS_THR_ENABLE parameter)
 enum fs_thr_enable {

--- a/APMrover2/ekf_check.cpp
+++ b/APMrover2/ekf_check.cpp
@@ -1,0 +1,160 @@
+#include "Rover.h"
+
+/**
+ *
+ * Detects failures of the ekf or inertial nav system triggers an alert
+ * to the pilot and helps take countermeasures
+ *
+ */
+
+#ifndef EKF_CHECK_ITERATIONS_MAX
+ # define EKF_CHECK_ITERATIONS_MAX          10      // 1 second (ie. 10 iterations at 10hz) of bad variances signals a failure
+#endif
+
+#ifndef EKF_CHECK_WARNING_TIME
+ # define EKF_CHECK_WARNING_TIME            (30*1000)   // warning text messages are sent to ground no more than every 30 seconds
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// EKF_check strucutre
+////////////////////////////////////////////////////////////////////////////////
+static struct {
+    uint8_t fail_count;         // number of iterations ekf or dcm have been out of tolerances
+    uint8_t bad_variance : 1;   // true if ekf should be considered untrusted (fail_count has exceeded EKF_CHECK_ITERATIONS_MAX)
+    uint32_t last_warn_time;    // system time of last warning in milliseconds.  Used to throttle text warnings sent to GCS
+} ekf_check_state;
+
+
+// ekf_check - detects if ekf variance are out of tolerance and triggers failsafe
+// should be called at 10hz
+void Rover::ekf_check()
+{
+    // exit immediately if ekf has no origin yet - this assumes the origin can never become unset
+    Location temp_loc;
+    if (!ahrs.get_origin(temp_loc)) {
+        return;
+    }
+
+    // return immediately if motors are not armed, or ekf check is disabled
+    if (!arming.is_armed() || (g.fs_ekf_thresh <= 0.0f)) {
+        ekf_check_state.fail_count = 0;
+        ekf_check_state.bad_variance = false;
+        AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
+        failsafe_ekf_off_event();   // clear failsafe
+        return;
+    }
+
+    // compare compass and velocity variance vs threshold
+    if (ekf_over_threshold()) {
+        // if compass is not yet flagged as bad
+        if (!ekf_check_state.bad_variance) {
+            // increase counter
+            ekf_check_state.fail_count++;
+            // if counter above max then trigger failsafe
+            if (ekf_check_state.fail_count >= EKF_CHECK_ITERATIONS_MAX) {
+                // limit count from climbing too high
+                ekf_check_state.fail_count = EKF_CHECK_ITERATIONS_MAX;
+                ekf_check_state.bad_variance = true;
+                // log an error in the dataflash
+                Log_Write_Error(ERROR_SUBSYSTEM_EKFCHECK, ERROR_CODE_EKFCHECK_BAD_VARIANCE);
+                // send message to gcs
+                if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
+                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    ekf_check_state.last_warn_time = AP_HAL::millis();
+                }
+                failsafe_ekf_event();
+            }
+        }
+    } else {
+        // reduce counter
+        if (ekf_check_state.fail_count > 0) {
+            ekf_check_state.fail_count--;
+
+            // if compass is flagged as bad and the counter reaches zero then clear flag
+            if (ekf_check_state.bad_variance && ekf_check_state.fail_count == 0) {
+                ekf_check_state.bad_variance = false;
+                // log recovery in the dataflash
+                Log_Write_Error(ERROR_SUBSYSTEM_EKFCHECK, ERROR_CODE_EKFCHECK_VARIANCE_CLEARED);
+                // clear failsafe
+                failsafe_ekf_off_event();
+            }
+        }
+    }
+
+    // set AP_Notify flags
+    AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
+
+    // To-Do: add ekf variances to extended status
+}
+
+// ekf_over_threshold - returns true if the ekf's variance are over the tolerance
+bool Rover::ekf_over_threshold()
+{
+    // return false immediately if disabled
+    if (g.fs_ekf_thresh <= 0.0f) {
+        return false;
+    }
+
+    // use EKF to get variance
+    float position_variance, vel_variance, height_variance, tas_variance;
+    Vector3f mag_variance;
+    Vector2f offset;
+    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset);
+
+    // return true if two of compass, velocity and position variances are over the threshold
+    uint8_t over_thresh_count = 0;
+    if (mag_variance.length() >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+    if (vel_variance >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+    if (position_variance >= g.fs_ekf_thresh) {
+        over_thresh_count++;
+    }
+
+    if (over_thresh_count >= 2) {
+        return true;
+    }
+
+    if (ekf_position_ok()) {
+        return false;
+    }
+
+    return true;
+}
+
+
+// failsafe_ekf_event - perform ekf failsafe
+void Rover::failsafe_ekf_event()
+{
+    // return immediately if ekf failsafe already triggered
+    if (failsafe.ekf) {
+        return;
+    }
+
+    // EKF failsafe event has occurred
+    failsafe.ekf = true;
+    Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_EKFINAV, ERROR_CODE_FAILSAFE_OCCURRED);
+
+    // does this mode require position?
+    if (!rover.control_mode->requires_position() && !rover.control_mode->requires_velocity()) {
+        return;
+    }
+
+    // take action
+    set_mode(mode_hold, MODE_REASON_FAILSAFE);
+}
+
+// failsafe_ekf_off_event - actions to take when EKF failsafe is cleared
+void Rover::failsafe_ekf_off_event(void)
+{
+    // return immediately if not in ekf failsafe
+    if (!failsafe.ekf) {
+        return;
+    }
+
+    // clear flag and log recovery
+    failsafe.ekf = false;
+    Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_EKFINAV, ERROR_CODE_FAILSAFE_RESOLVED);
+}


### PR DESCRIPTION
I added ekf(gps) failsafe function.
The issue is #5421.

Many codes are from Copter's EKF failsafe.