### PR TITLE
QuadPlane: Allow separate FW landing approach radius and airspeed.

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -358,6 +358,7 @@ private:
 
     enum Landing_ApproachStage {
         LOITER_TO_ALT,
+        ENSURE_RADIUS,
         WAIT_FOR_BREAKOUT,
         APPROACH_LINE,
         VTOL_LANDING,

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -862,10 +862,10 @@ private:
     void set_home(const Location &loc);
     void do_RTL(int32_t alt);
     bool verify_takeoff();
-    bool verify_loiter_unlim();
+    bool verify_loiter_unlim(const AP_Mission::Mission_Command &cmd);
     bool verify_loiter_time();
-    bool verify_loiter_turns();
-    bool verify_loiter_to_alt();
+    bool verify_loiter_turns(const AP_Mission::Mission_Command &cmd);
+    bool verify_loiter_to_alt(const AP_Mission::Mission_Command &cmd);
     bool verify_RTL();
     bool verify_continue_and_change_alt();
     bool verify_wait_delay();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -430,8 +430,6 @@ void Plane::do_landing_vtol_approach(const AP_Mission::Mission_Command& cmd)
     }
 
     vtol_approach_s.approach_stage = LOITER_TO_ALT;
-
-    set_flight_stage(AP_Vehicle::FixedWing::FLIGHT_LAND);
 }
 
 void Plane::loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -173,19 +173,19 @@ void Plane::calc_airspeed_errors()
 
 void Plane::calc_gndspeed_undershoot()
 {
- 	// Use the component of ground speed in the forward direction
-	// This prevents flyaway if wind takes plane backwards
+    // Use the component of ground speed in the forward direction
+    // This prevents flyaway if wind takes plane backwards
     if (gps.status() >= AP_GPS::GPS_OK_FIX_2D) {
-	    Vector2f gndVel = ahrs.groundspeed_vector();
-		const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
-		Vector2f yawVect = Vector2f(rotMat.a.x,rotMat.b.x);
+	      Vector2f gndVel = ahrs.groundspeed_vector();
+        const Matrix3f &rotMat = ahrs.get_rotation_body_to_ned();
+        Vector2f yawVect = Vector2f(rotMat.a.x,rotMat.b.x);
         if (!yawVect.is_zero()) {
             yawVect.normalize();
             float gndSpdFwd = yawVect * gndVel;
             groundspeed_undershoot = (aparm.min_gndspeed_cm > 0) ? (aparm.min_gndspeed_cm - gndSpdFwd*100) : 0;
         }
     } else {
-    	groundspeed_undershoot = 0;
+        groundspeed_undershoot = 0;
     }
 }
 

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -139,7 +139,17 @@ void Plane::calc_airspeed_errors()
     } else if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
         // Landing airspeed target
         target_airspeed_cm = landing.get_target_airspeed_cm();
-
+    } else if ((control_mode == AUTO) &&
+               (quadplane.options & QuadPlane::OPTION_MISSION_LAND_FW_APPROACH) &&
+							 ((vtol_approach_s.approach_stage == Landing_ApproachStage::APPROACH_LINE) ||
+							  (vtol_approach_s.approach_stage == Landing_ApproachStage::VTOL_LANDING))) {
+        float land_airspeed = SpdHgt_Controller->get_land_airspeed();
+        if (is_positive(land_airspeed)) {
+            target_airspeed_cm = SpdHgt_Controller->get_land_airspeed() * 100;
+        } else {
+            // fallover to normal airspeed
+            target_airspeed_cm = aparm.airspeed_cruise_cm;
+        }
     } else {
         // Normal airspeed target
         target_airspeed_cm = aparm.airspeed_cruise_cm;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -383,6 +383,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     AP_SUBGROUPINFO(qautotune, "AUTOTUNE_",  6, QuadPlane, QAutoTune),
 #endif
 
+    // @Param: FW_LND_APR_RAD
+    // @DisplayName: Quadplane fixed wing landing approach radius
+    // @Description: This provides the radius used, when using a fixed wing landing approach. If set to 0 then the WP_LOITER_RAD will be selected.
+    // @Units: m
+    // @Range: 0 200
+    // @Increment: 5
+    // @User: Advanced
+    AP_GROUPINFO("FW_LND_APR_RAD", 7, QuadPlane, fw_land_approach_radius, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -235,6 +235,9 @@ private:
     // Quadplane trim, degrees
     AP_Float ahrs_trim_pitch;
 
+    // fw landing approach radius
+    AP_Float fw_land_approach_radius;
+
     AP_Int16 rc_speed;
 
     // min and max PWM for throttle

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -162,7 +162,7 @@ bool AP_Arming::airspeed_checks(bool report)
         }
         for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
             if (airspeed->enabled(i) && airspeed->use(i) && !airspeed->healthy(i)) {
-                check_failed(ARMING_CHECK_AIRSPEED, report, "Airspeed[%s] not healthy", i);
+                check_failed(ARMING_CHECK_AIRSPEED, report, "Airspeed %d not healthy", i + 1);
                 return false;
             }
         }

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -336,7 +336,7 @@ void AP_L1_Control::update_loiter(const struct Location &center_WP, float radius
 
     // scale loiter radius with square of EAS2TAS to allow us to stay
     // stable at high altitude
-    radius = loiter_radius(radius);
+    radius = loiter_radius(fabsf(radius));
 
     // Calculate guidance gains used by PD loop (used during circle tracking)
     float omega = (6.2832f / _L1_period);


### PR DESCRIPTION
This is the refinement of #9707. It allows quadplanes to have a separate radius when shooting a fixed wing approach to a `NAV_VTOL_LAND` waypoint, and includes  a separate land airspeed parameter. It has not been flown outside of the simulator yet. This does not provide any form of automatic radius calculation at the moment, as the existing `AP_Navigation::turn_distance()` function is unsuitable.

Other changes presented:
  - Fixed some whitespace that was bugging me
  - Pass the const reference to the mission command we already have for verifying the loiter commands rather then asking the mission library what it is.

Outside of real world flight testing things I'm considering on this (but haven't implemented):
  - Ensure that the selected radius is at least capable of giving us enough distance to do a into wind detransition + a minimum margin