### PR TITLE
RangeFinder: change benewake driver to hold buffer as uint8_t instead of char

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -85,7 +85,11 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm)
     // read any available lines from the lidar
     int16_t nbytes = uart->available();
     while (nbytes-- > 0) {
-        char c = uart->read();
+        int16_t r = uart->read();
+        if (r < 0) {
+            continue;
+        }
+        uint8_t c = (uint8_t)r;
         // if buffer is empty and this byte is 0x59, add to buffer
         if (linebuf_len == 0) {
             if (c == BENEWAKE_FRAME_HEADER) {
@@ -107,10 +111,10 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm)
                 // calculate checksum
                 uint8_t checksum = 0;
                 for (uint8_t i=0; i<BENEWAKE_FRAME_LENGTH-1; i++) {
-                    checksum += (uint8_t)linebuf[i];
+                    checksum += linebuf[i];
                 }
                 // if checksum matches extract contents
-                if (checksum == (uint8_t)linebuf[BENEWAKE_FRAME_LENGTH-1]) {
+                if (checksum == linebuf[BENEWAKE_FRAME_LENGTH-1]) {
                     // calculate distance
                     uint16_t dist = ((uint16_t)linebuf[3] << 8) | linebuf[2];
                     if (dist >= BENEWAKE_DIST_MAX_CM) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.h
@@ -39,6 +39,6 @@ private:
 
     AP_HAL::UARTDriver *uart = nullptr;
     benewake_model_type model_type;
-    char linebuf[10];
+    uint8_t linebuf[10];
     uint8_t linebuf_len;
 };


### PR DESCRIPTION
The saga continues with the Benewake driver with another minor change to the driver based on feedback on [the previous PR](https://github.com/ArduPilot/ardupilot/pull/9778) from @OXINARF and testing from Patrick Poirier.

In this PR we change the buffer used to store data from the sensor to use uint8_t instead of char.

Before the change [this line](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp#L115) was likely the issue because the right side was not being cast to uint8_t.

> uint16_t dist = ((uint16_t)linebuf[3] << 8) | linebuf[2];

Here is a screen shot of the distance measurements taken during testing:
![randy-benewaketfmini-test2](https://user-images.githubusercontent.com/1498098/48681887-90dad280-ebe8-11e8-9272-ad89a972db02.png)
