### PR TITLE
Reset last update

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -154,7 +154,7 @@ void AC_WPNav::wp_and_spline_init()
     _pos_control.set_max_accel_z(_wp_accel_z_cmss);
     _pos_control.calc_leash_length_xy();
     _pos_control.calc_leash_length_z();
-
+    _wp_last_update = 0;
     // initialise yaw heading to current heading target
     _flags.wp_yaw_set = false;
 }


### PR DESCRIPTION
Fix https://discuss.ardupilot.org/t/desired-altitude-goes-to-zero-then-all-the-way-up-when-stabilize-guided/35212/12 and https://github.com/ArduPilot/ardupilot/issues/7519 
In case of rapid mode switching the pos_target aren't resetted. 
For example: doing RTL -> STABILIZE -> RTL . 
Going into stabilize will set pos_target.z to 0 : https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_stabilize.cpp#L16
Now ModeRTL::init call wp_nav->wp_and_spline_init() that don't reset z target and continue to climb_start() that calls wp_nav->set_wp_destination(). Since ((AP_HAL::millis() - _wp_last_update) < 1000) is true, it get the origin from the pos_controller https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_WPNav/AC_WPNav.cpp#L218, and that origin is false ... leading to a rapid descent to ground. 

The same behavior can be seen with GUIDED -> STABILIZE -> GUIDED

I think it is safe to reset the _last_update both on wp_nav and pos_controler each time we reinit the controler.
