### PR TITLE
Sending frame1 and frame2 of FrskyD @ 5Hz

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -303,8 +303,8 @@ void AP_Frsky_Telem::send_D(void)
         send_uint16(DATA_ID_BARO_ALT_BP, _gps.alt_nav_meters); // send nav altitude integer part
         send_uint16(DATA_ID_BARO_ALT_AP, _gps.alt_nav_cm); // send nav altitude decimal part
     }
-    // send frame2 every second
-    if (now - _D.last_1000ms_frame >= 1000) {
+    // send frame2 every 100ms
+    if (now - _D.last_1000ms_frame >= 200) {
         _D.last_1000ms_frame = now;
         send_uint16(DATA_ID_GPS_COURS_BP, (uint16_t)((_ahrs.yaw_sensor / 100) % 360)); // send heading in degree based on AHRS and not GPS
         calc_gps_position();


### PR DESCRIPTION
As current as possible GPS/Altitude data are essential for proper antenna tracking on the ground. There are a few antenna tracking projects which understand FrskyD.  Openlrsng supports only FrskyD well, makes for very easy and reliable telemetry downlink.