### PR TITLE
AP_RangeFinder: benewake tfmini always provide cm distances

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake.cpp
@@ -121,10 +121,6 @@ bool AP_RangeFinder_Benewake::get_reading(uint16_t &reading_cm)
                         // this reading is out of range
                         count_out_of_range++;
                     } else if (model_type == BENEWAKE_TFmini) {
-                        // TFmini has short distance mode (mm)
-                        if (linebuf[6] == 0x02) {
-                            dist *= 0.1f;
-                        }
                         // no signal byte from TFmini so add distance to sum
                         sum_cm += dist;
                         count++;


### PR DESCRIPTION
Fourth time lucky?

Another small fix to the Benewake TFmini driver.  Somehow I misunderstood the data sheet regarding "mode 2" (short distance mode) and thought that in this mode the distances were provided in millimeters.  In fact, the sensor always provides the distance in cm.

In case it matters, there are apparently two versions of the firmware for the Benewake TFmini lidar, and the version that I have never goes into "mode 2" which somewhat explains why I never noticed the problem during testing.