### PR TITLE
Solo: fixed a problem with "twitches" on Solo gimbal

### DIFF
--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -51,6 +51,8 @@ void SoloGimbal::receive_feedback(mavlink_channel_t chan, const mavlink_message_
 
     if (report_msg.target_system != 1) {
         _state = GIMBAL_STATE_NOT_PRESENT;
+    } else {
+        GCS_MAVLINK::set_channel_private(chan);
     }
 
     switch(_state) {
@@ -111,8 +113,10 @@ void SoloGimbal::send_controls(mavlink_channel_t chan)
                 if (_ang_vel_dem_radsLen > radians(400)) {
                     _ang_vel_dem_rads *= radians(400)/_ang_vel_dem_radsLen;
                 }
-                mavlink_msg_gimbal_control_send(chan, mavlink_system.sysid, _compid,
-                                                _ang_vel_dem_rads.x, _ang_vel_dem_rads.y, _ang_vel_dem_rads.z);
+                if (HAVE_PAYLOAD_SPACE(chan, GIMBAL_CONTROL)) {
+                    mavlink_msg_gimbal_control_send(chan, mavlink_system.sysid, _compid,
+                                                    _ang_vel_dem_rads.x, _ang_vel_dem_rads.y, _ang_vel_dem_rads.z);
+                }
                 break;
             }
             case GIMBAL_MODE_STABILIZE: {
@@ -124,8 +128,10 @@ void SoloGimbal::send_controls(mavlink_channel_t chan)
                 if (ang_vel_dem_norm > radians(400)) {
                     _ang_vel_dem_rads *= radians(400)/ang_vel_dem_norm;
                 }
-                mavlink_msg_gimbal_control_send(chan, mavlink_system.sysid, _compid,
-                                                _ang_vel_dem_rads.x, _ang_vel_dem_rads.y, _ang_vel_dem_rads.z);
+                if (HAVE_PAYLOAD_SPACE(chan, GIMBAL_CONTROL)) {
+                    mavlink_msg_gimbal_control_send(chan, mavlink_system.sysid, _compid,
+                                                    _ang_vel_dem_rads.x, _ang_vel_dem_rads.y, _ang_vel_dem_rads.z);
+                }
                 break;
             }
             default:

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -207,6 +207,18 @@ public:
     // return a bitmap of streaming channels
     static uint8_t streaming_channel_mask(void) { return chan_is_streaming; }
 
+    // set a channel as private. Private channels get sent heartbeats, but
+    // don't get broadcast packets or forwarded packets
+    static void set_channel_private(mavlink_channel_t chan);
+
+    // return true if channel is private
+    static bool is_private(mavlink_channel_t _chan) {
+        return (mavlink_private & (1U<<(unsigned)_chan)) != 0;
+    }
+    
+    // return true if channel is private
+    bool is_private(void) const { return is_private(chan); }
+
     // send queued parameters if needed
     void send_queued_parameters(void);
 
@@ -463,6 +475,9 @@ private:
     
     // bitmask of what mavlink channels are active
     static uint8_t mavlink_active;
+
+    // bitmask of what mavlink channels are private
+    static uint8_t mavlink_private;
 
     // bitmask of what mavlink channels are streaming
     static uint8_t chan_is_streaming;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -50,6 +50,10 @@ uint8_t GCS_MAVLINK::mavlink_active = 0;
 uint8_t GCS_MAVLINK::chan_is_streaming = 0;
 uint32_t GCS_MAVLINK::reserve_param_space_start_ms;
 
+// private channels are ones used for point-to-point protocols, and
+// don't get broadcasts or fwded packets
+uint8_t GCS_MAVLINK::mavlink_private = 0;
+
 GCS *GCS::_singleton = nullptr;
 
 GCS_MAVLINK::GCS_MAVLINK()
@@ -900,7 +904,10 @@ void GCS_MAVLINK::packetReceived(const mavlink_status_t &status,
     // we exclude radio packets because we historically used this to
     // make it possible to use the CLI over the radio
     if (msg.msgid != MAVLINK_MSG_ID_RADIO && msg.msgid != MAVLINK_MSG_ID_RADIO_STATUS) {
-        mavlink_active |= (1U<<(chan-MAVLINK_COMM_0));
+        const uint8_t mask = (1U<<(chan-MAVLINK_COMM_0));
+        if (!(mask & mavlink_private)) {
+            mavlink_active |= mask;
+        }
     }
     if (!(status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) &&
         (status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) &&
@@ -985,7 +992,7 @@ GCS_MAVLINK::update(uint32_t max_time_us)
 
     // send a timesync message every 10 seconds; this is for data
     // collection purposes
-    if (tnow - _timesync_request.last_sent_ms > _timesync_request.interval_ms) {
+    if (tnow - _timesync_request.last_sent_ms > _timesync_request.interval_ms && !is_private()) {
         if (HAVE_PAYLOAD_SPACE(chan, TIMESYNC)) {
             send_timesync();
             _timesync_request.last_sent_ms = tnow;

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -69,6 +69,15 @@ void GCS_MAVLINK::lock_channel(mavlink_channel_t _chan, bool lock)
     }
 }
 
+// set a channel as private. Private channels get sent heartbeats, but
+// don't get broadcast packets or forwarded packets
+void GCS_MAVLINK::set_channel_private(mavlink_channel_t _chan)
+{
+    const uint8_t mask = (1U<<(unsigned)_chan);
+    mavlink_private |= mask;
+    mavlink_active &= ~mask;
+}
+
 // return a MAVLink variable type given a AP_Param type
 uint8_t mav_var_type(enum ap_var_type t)
 {

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -143,7 +143,9 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
                                  (broadcast_component || 
                                   target_component == routes[i].compid ||
                                   !match_system))) {
-            if (in_channel != routes[i].channel && !sent_to_chan[routes[i].channel]) {
+            if (in_channel != routes[i].channel &&
+                !sent_to_chan[routes[i].channel] &&
+                !GCS_MAVLINK::is_private(routes[i].channel)) {
                 if (comm_get_txspace(routes[i].channel) >= ((uint16_t)msg->len) +
                     GCS_MAVLINK::packet_overhead_chan(routes[i].channel)) {
 #if ROUTING_DEBUG

--- a/libraries/SITL/SIM_Gimbal.cpp
+++ b/libraries/SITL/SIM_Gimbal.cpp
@@ -174,12 +174,78 @@ void Gimbal::update(void)
     send_report();
 }
 
+static struct gimbal_param {
+    const char *name;
+    float value;
+} gimbal_params[] = {
+    {"GMB_OFF_ACC_X", 0},
+    {"GMB_OFF_ACC_Y", 0},
+    {"GMB_OFF_ACC_Z", 0},
+    {"GMB_GN_ACC_X", 0},
+    {"GMB_GN_ACC_Y", 0},
+    {"GMB_GN_ACC_Z", 0},
+    {"GMB_OFF_GYRO_X", 0},
+    {"GMB_OFF_GYRO_Y", 0},
+    {"GMB_OFF_GYRO_Z", 0},
+    {"GMB_OFF_JNT_X", 0},
+    {"GMB_OFF_JNT_Y", 0},
+    {"GMB_OFF_JNT_Z", 0},
+    {"GMB_K_RATE", 0},
+    {"GMB_POS_HOLD", 0},
+    {"GMB_MAX_TORQUE", 0},
+    {"GMB_SND_TORQUE", 0},
+    {"GMB_SYSID", 0},
+    {"GMB_FLASH", 0},
+};
+
+/*
+  find a parameter structure
+ */
+struct gimbal_param *Gimbal::param_find(const char *name)
+{
+    for (uint8_t i=0; i<ARRAY_SIZE(gimbal_params); i++) {
+        if (strncmp(name, gimbal_params[i].name, 16) == 0) {
+            return &gimbal_params[i];
+        }
+    }
+    return nullptr;
+}
+    
+/*
+  send a parameter to flight board
+ */
+void Gimbal::param_send(const struct gimbal_param *p)
+{
+    mavlink_message_t msg;
+    mavlink_param_value_t param_value;
+    strncpy(param_value.param_id, p->name, sizeof(param_value.param_id));
+    param_value.param_value = p->value;
+    param_value.param_count = 0;
+    param_value.param_index = 0;
+
+    mavlink_status_t *chan0_status = mavlink_get_channel_status(MAVLINK_COMM_0);
+    uint8_t saved_seq = chan0_status->current_tx_seq;
+    chan0_status->current_tx_seq = mavlink.seq;
+    uint16_t len = mavlink_msg_param_value_encode(vehicle_system_id,
+                                                  vehicle_component_id,
+                                                  &msg, &param_value);
+    chan0_status->current_tx_seq = saved_seq;
+
+    uint8_t msgbuf[len];
+    len = mavlink_msg_to_send_buffer(msgbuf, &msg);
+    if (len > 0) {
+        mav_socket.send(msgbuf, len);
+    }
+}
+
+    
 /*
   send a report to the vehicle control code over MAVLink
 */
 void Gimbal::send_report(void)
 {
-    if (AP_HAL::millis() < 10000) {
+    uint32_t now = AP_HAL::millis();
+    if (now < 10000) {
         // don't send gimbal reports until 10s after startup. This
         // avoids a windows threading issue with non-blocking sockets
         // and the initial wait on uartA
@@ -191,6 +257,14 @@ void Gimbal::send_report(void)
     }
     if (!mavlink.connected) {
         return;
+    }
+
+    if (param_send_last_ms && now - param_send_last_ms > 100) {
+        param_send(&gimbal_params[param_send_idx]);
+        if (++param_send_idx == ARRAY_SIZE(gimbal_params)) {
+            printf("Finished sending parameters\n");
+            param_send_last_ms = 0;
+        }
     }
 
     // check for incoming MAVLink messages
@@ -237,24 +311,23 @@ void Gimbal::send_report(void)
                     mavlink_msg_param_set_decode(&msg, &pkt);
                     printf("Gimbal got PARAM_SET %.16s %f\n", pkt.param_id, pkt.param_value);
 
-                    mavlink_param_value_t param_value;
-                    memcpy(param_value.param_id, pkt.param_id, sizeof(pkt.param_id));
-                    param_value.param_value = pkt.param_value;
-                    param_value.param_count = 0;
-                    param_value.param_index = 0;
-                    mavlink_status_t *chan0_status = mavlink_get_channel_status(MAVLINK_COMM_0);
-                    uint8_t saved_seq = chan0_status->current_tx_seq;
-                    chan0_status->current_tx_seq = mavlink.seq;
-                    uint16_t len = mavlink_msg_param_value_encode(vehicle_system_id,
-                                                                  vehicle_component_id,
-                                                                  &msg, &param_value);
-                    chan0_status->current_tx_seq = saved_seq;
-
-                    uint8_t msgbuf[len];
-                    len = mavlink_msg_to_send_buffer(msgbuf, &msg);
-                    if (len > 0) {
-                        mav_socket.send(msgbuf, len);
+                    struct gimbal_param *p = param_find(pkt.param_id);
+                    if (p) {
+                        p->value = pkt.param_value;
+                        param_send(p);
                     }
+
+                    break;
+                }
+                case MAVLINK_MSG_ID_PARAM_REQUEST_LIST: {
+                    mavlink_param_request_list_t pkt;
+                    mavlink_msg_param_request_list_decode(&msg, &pkt);
+                    if (pkt.target_system == 0 && pkt.target_component == MAV_COMP_ID_GIMBAL) {
+                        // start param send
+                        param_send_idx = 0;
+                        param_send_last_ms = AP_HAL::millis();
+                    }
+                    printf("Gimbal sending %u parameters\n", (unsigned)ARRAY_SIZE(gimbal_params));
                     break;
                 }
                 default:
@@ -268,7 +341,6 @@ void Gimbal::send_report(void)
     if (!seen_heartbeat) {
         return;
     }
-    uint32_t now = AP_HAL::millis();
     mavlink_message_t msg;
     uint16_t len;
 

--- a/libraries/SITL/SIM_Gimbal.h
+++ b/libraries/SITL/SIM_Gimbal.h
@@ -102,7 +102,12 @@ private:
         uint8_t seq;
     } mavlink;
 
+    uint32_t param_send_last_ms;
+    uint8_t param_send_idx;
+
     void send_report(void);
+    void param_send(const struct gimbal_param *p);
+    struct gimbal_param *param_find(const char *name);
 };
 
 }  // namespace SITL


### PR DESCRIPTION
The solo gimbal is very sensitive to receiving MAVLink packets it isn't expecting, and can "twitch" when it gets them. This sets up the mavlink channel as "private", preventing broadcast and routed packets from being sent to the Gimbal

Note that this problem happens with both NuttX and ChibiOS builds, but for some reason happens much more often with ChibiOS, perhaps related to thread timing. You can make it happen with NuttX builds by asking the GCS to send heartbeats more often. Those fwded heartbeats can cause the gimbal to twitch

ping @Pedals2Paddles 