### PR TITLE
Tools: Remove hard-coded path to MAVProxy

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -609,7 +609,7 @@ def start_mavproxy(opts, stuff):
     if under_cygwin():
         cmd.append("/usr/bin/cygstart")
         cmd.append("-w")
-        cmd.append("/cygdrive/c/Program Files (x86)/MAVProxy/mavproxy.exe")
+        cmd.append("mavproxy.exe")
     else:
         cmd.append("mavproxy.py")
 


### PR DESCRIPTION
The Windows installer for MAVProxy (https://github.com/ArduPilot/MAVProxy/blob/master/windows/mavproxy.iss) automatically adds mavproxy to the system path. So a hard-coded path to the install dir is no longer required.

This also allows for users to install MAVProxy in a non-standed folder and sim_vehicle.py will still work.

EDIT: MAVProxy Windows installer has had this feature for some time now.