### PR TITLE
AP_BattMonitor: Increase solo's power off button delay time

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -8,9 +8,8 @@
 
 #define BATTMONITOR_SMBUS_SOLO_CELL_VOLTAGE         0x28    // cell voltage register
 #define BATTMONITOR_SMBUS_SOLO_CURRENT              0x2a    // current register
-#define BATTMONITOR_SMBUS_SOLO_BUTTON_DEBOUNCE      3       // button held down for 3 intervals will cause a power off event
-
-#define BATTMONITOR_SMBUS_SOLO_NUM_CELLS 4
+#define BATTMONITOR_SMBUS_SOLO_BUTTON_DEBOUNCE      6       // button held down for 5 intervals will cause a power off event
+#define BATTMONITOR_SMBUS_SOLO_NUM_CELLS            4       // solo's battery back is 4S
 
 /*
  * Other potentially useful registers, listed here for future use
@@ -134,4 +133,3 @@ uint8_t AP_BattMonitor_SMBus_Solo::read_block(uint8_t reg, uint8_t* data, uint8_
     // return success
     return bufflen;
 }
-


### PR DESCRIPTION
The Solo battery's power button needs to be held to power off. The debounce time before it plays the power off tone is too low. Occasionally it causes the user to not hold the button long enough. This corrects the delay before playing the power off tone.