### PR TITLE
Plane: Add QLand Battery Failsafe

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -106,7 +106,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #endif
 };
 
-constexpr int8_t Plane::_failsafe_priorities[5];
+constexpr int8_t Plane::_failsafe_priorities[6];
 
 void Plane::setup() 
 {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1074,12 +1074,14 @@ private:
         Failsafe_Action_None      = 0,
         Failsafe_Action_RTL       = 1,
         Failsafe_Action_Land      = 2,
-        Failsafe_Action_Terminate = 3
+        Failsafe_Action_Terminate = 3,
+        Failsafe_Action_QLand     = 4,
     };
 
     // list of priorities, highest priority first
     static constexpr int8_t _failsafe_priorities[] = {
                                                       Failsafe_Action_Terminate,
+                                                      Failsafe_Action_QLand,
                                                       Failsafe_Action_Land,
                                                       Failsafe_Action_RTL,
                                                       Failsafe_Action_None,

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -141,17 +141,23 @@ void Plane::failsafe_long_off_event(mode_reason_t reason)
 void Plane::handle_battery_failsafe(const char *type_str, const int8_t action)
 {
     switch ((Failsafe_Action)action) {
+        case Failsafe_Action_QLand:
+            if (quadplane.available()) {
+                plane.set_mode(QLAND, MODE_REASON_BATTERY_FAILSAFE);
+                break;
+            }
+            FALLTHROUGH;
         case Failsafe_Action_Land:
-            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND || control_mode == QLAND) {
                 // never stop a landing if we were already committed
                 if (plane.mission.jump_to_landing_sequence()) {
-                    plane.set_mode(AUTO, MODE_REASON_UNKNOWN);
+                    plane.set_mode(AUTO, MODE_REASON_BATTERY_FAILSAFE);
                     break;
                  }
             }
             FALLTHROUGH;
         case Failsafe_Action_RTL:
-            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND) {
+            if (flight_stage != AP_Vehicle::FixedWing::FLIGHT_LAND || control_mode == QLAND ) {
                 // never stop a landing if we were already committed
                 set_mode(RTL, MODE_REASON_BATTERY_FAILSAFE);
                 aparm.throttle_cruise.load();

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: FS_LOW_ACT
     // @DisplayName: Low battery failsafe action
     // @Description: What action the vehicle should perform if it hits a low battery failsafe
-    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate
+    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand
     // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate
     // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
     // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate
@@ -138,7 +138,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: FS_CRT_ACT
     // @DisplayName: Critical battery failsafe action
     // @Description: What action the vehicle should perform if it hits a critical battery failsafe
-    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate
+    // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand
     // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate
     // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
     // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate


### PR DESCRIPTION
This allows you to specify `QLAND` as a failsafe action on quadplane. It's most useful when you have a separate power source for your forward propulsion and your vertical propulsion, as it allows you to give up on a normal landing approach and use the quadplane motors exclusively if the forward power source has been excessively rundown.

Also fixes:
  - The vehicle could be in `QLAND` and  then execute a normal fixed wing landing, which if close to the ground could be catastrophic. 
  - Incorrect logging of `MODE_REASON_UNKNOWN` when we know it's due to a battery failsafe.