### PR TITLE
AC_PosControl: set-alt-target-with-slew sets desired to 0 once at target

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -286,6 +286,9 @@ void AC_PosControl::set_alt_target_with_slew(float alt_cm, float dt)
             _pos_target.z += climb_rate_cms*dt;
             _vel_desired.z = climb_rate_cms;    // recorded for reporting purposes
         }
+    } else {
+        // recorded for reporting purposes
+        _vel_desired.z = 0.0f;
     }
 
     // do not let target get too far from current altitude


### PR DESCRIPTION
This resolves an issue with the AC_PosControl::set-alt-target-with-slew() method which was leaving the z-axis **desired velocity** at the max speed-up or speed-down when the vehicle had reached the target altitude.  This method is only used in RTL when the RTL_ALT_FINAL != 0 (i.e the vehicle will hover a couple of meters above home instead of landing).

Leaving the desired velocity incorrectly set causes a jump in the climb rate and throttle when the user switches to another mode (like Loiter).  It causes a jump because Loiter uses z-axis "feed forward" so the old desired velocity was momentarily being used.  It is also related to Loiter (and other modes) not fully resetting the position controller's state because it views the position controller as "active".

This issue can be reproduced in SITL by doing the following:

- set RTL_ALT_FINAL = 200
- arm and takeoff to 10m in Loiter, return rc3 to 1500 (mid stick)
- switch to RTL mode and let vehicle descend to 2m
- switch to Loiter
- the twitch is visible in both the CTUN.ThO and CTUN.DCr

Below is a graph from the desired climb rate before and after the fix
![rtl-to-loiter-twitch-before-after](https://user-images.githubusercontent.com/1498098/48962946-eee22e00-efcb-11e8-808e-fe7868a0c4da.png)


This issue has been [discussed here in the forums](https://discuss.ardupilot.org/t/throttle-drop-when-switching-to-loiter-from-rtl/34388/43).