### PR TITLE
Added NTC3950 thermistor support

### DIFF
--- a/libraries/AP_TemperatureSensor/NTC3950.cpp
+++ b/libraries/AP_TemperatureSensor/NTC3950.cpp
@@ -1,0 +1,47 @@
+#include "NTC3950.h"
+
+#include <utility>
+#include <stdio.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+
+extern const AP_HAL::HAL &hal;
+
+static const uint8_t NTC3950_PIN = 13;
+static const uint8_t NOMINAL_TEMPERATURE = 25;      // 25°C
+static const uint16_t NOMINAL_RESISTANCE = 100000;  // R=100kΩ at 25°C
+static const uint16_t ADC_RESOLUTION = 4096;
+static const uint16_t RESISTOR_SERIAL = 100000;     // 100kΩ resistor between the thermistor and ground
+static const uint16_t BETA_COEFFICIENT = 3950;      // value taken from ntc3950 calibration sheet
+
+bool NTC3950::init()
+{
+    _analog_source = std::move(hal.analogin->channel(NTC3950_PIN));
+    if (!_analog_source) {
+        printf("NTC3950 device is null!");
+        return false;
+    }
+
+    return true;
+}
+
+void NTC3950::update_reading()
+{
+    float reading = _analog_source->voltage_average();
+    
+    /// TBD health check over temperature value
+    
+    // convert a (average) voltage value to resistance
+    reading = ADC_RESOLUTION / reading - 1;
+    reading = RESISTOR_SERIAL * reading;
+ 
+    // https://en.wikipedia.org/wiki/Steinhart–Hart_equation
+    float steinhart;
+    steinhart = reading / NOMINAL_RESISTANCE;               // (R/Ro)
+    steinhart /= BETA_COEFFICIENT;                          // 1/B * ln(R/Ro)
+    steinhart += 1.0 / (NOMINAL_TEMPERATURE + 273.15);      // + (1/To)
+    steinhart = 1.0 / steinhart;                            // Invert
+    steinhart -= 273.15;                                    // convert to C
+ 
+    _temperature = steinhart;
+}

--- a/libraries/AP_TemperatureSensor/NTC3950.h
+++ b/libraries/AP_TemperatureSensor/NTC3950.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/Semaphores.h>
+#include <AP_HAL/Device.h>
+
+class NTC3950 {
+public:
+
+    bool init(void);
+    float temperature(void) { return _temperature; } // temperature in degrees C
+    bool healthy(void) { // do we have a valid temperature reading?
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        return true;
+#endif
+        return _healthy;
+    }
+    void update_reading(void);
+
+    AP_HAL::OwnPtr<AP_HAL::AnalogSource> _analog_source;
+
+private:
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    float _temperature = 42.42; // degrees C
+#else
+    float _temperature; // degrees C
+#endif
+    bool _healthy;
+};


### PR DESCRIPTION
This is my first contribution, I simply added support for a very common thermistor commonly used in 3D printers.
A possible usage can be to check batteries, motor(s) or ESC temperature all those critical elements that can be ruined by excessive heat.

I need a reliable way of testing because in the issue #1799 user @vierfuffzig reported seeing too much RF noise coming from the sensor; a possible solution could be to tightly join the two ends of the thermistor insulated wire in order to reduce RF noise.

The "healthy" function is kept for compatibility with other sensor drivers, however at the moment I cannot think of a reliable way of testing the sensor working condition.