### PR TITLE
OpticalFlow: cheerson CXOF sensor driver

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -1,0 +1,201 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+   driver for Cheerson CX-OF optical flow sensor
+
+   CXOF serial packet description
+   byte0: header (0xFE)
+   byte1: reserved
+   byte2: x-motion high byte;
+   byte3: x-motion low byte;
+   byte4: y-motion high byte;
+   byte5: y-motion low byte;
+   byte6: t-motion
+   byte7: surface quality
+   byte8: footer (0xAA)
+
+   sensor sends packets at 25hz
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_OpticalFlow_CXOF.h"
+#include <AP_Math/edc.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <utility>
+#include "OpticalFlow.h"
+#include <stdio.h>
+
+#define CXOF_HEADER         (uint8_t)0xFE
+#define CXOF_FOOTER         (uint8_t)0xAA
+#define CXOF_FRAME_LENGTH               9
+#define CXOF_PIXEL_SCALING      (1.76e-3)
+#define CXOF_TIMEOUT_SEC             0.3f
+
+extern const AP_HAL::HAL& hal;
+
+// constructor
+AP_OpticalFlow_CXOF::AP_OpticalFlow_CXOF(OpticalFlow &_frontend, AP_HAL::UARTDriver *_uart) :
+    OpticalFlow_backend(_frontend),
+    uart(_uart)
+{
+}
+
+// detect the device
+AP_OpticalFlow_CXOF *AP_OpticalFlow_CXOF::detect(OpticalFlow &_frontend)
+{
+    AP_SerialManager *serial_manager = AP::serialmanager().get_instance();
+    if (serial_manager == nullptr) {
+        return nullptr;
+    }
+
+    // look for first serial driver with protocol defined as OpticalFlow
+    // this is the only optical flow sensor which uses the serial protocol
+    AP_HAL::UARTDriver *uart = serial_manager->find_serial(AP_SerialManager::SerialProtocol_OpticalFlow, 0);
+    if (uart == nullptr) {
+        return nullptr;
+    }
+
+    // we have found a serial port so use it
+    AP_OpticalFlow_CXOF *sensor = new AP_OpticalFlow_CXOF(_frontend, uart);
+    return sensor;
+}
+
+// initialise the sensor
+void AP_OpticalFlow_CXOF::init()
+{
+    // sanity check uart
+    if (uart == nullptr) {
+        return;
+    }
+
+    // open serial port with baud rate of 19200
+    uart->begin(19200);
+
+    last_frame_us = AP_HAL::micros();
+}
+
+// read latest values from sensor and fill in x,y and totals.
+void AP_OpticalFlow_CXOF::update(void)
+{
+    // sanity check uart
+    if (uart == nullptr) {
+        return;
+    }
+
+    // record gyro values as long as they are being used
+    if (gyro_sum_count < 1000) {
+        const Vector3f& gyro = AP::ahrs_navekf().get_gyro();
+        gyro_sum.x += gyro.x;
+        gyro_sum.y += gyro.y;
+        gyro_sum_count++;
+    }
+
+    // sensor values
+    int32_t x_sum = 0;
+    int32_t y_sum = 0;
+    uint16_t qual_sum = 0;
+    uint16_t count = 0;
+
+    // read any available characters in the serial buffer
+    int16_t nbytes = uart->available();
+    while (nbytes-- > 0) {
+        int16_t r = uart->read();
+        if (r < 0) {
+            continue;
+        }
+        uint8_t c = (uint8_t)r;
+        // if buffer is empty and this byte is header, add to buffer
+        if (buf_len == 0) {
+            if (c == CXOF_HEADER) {
+                buf[buf_len++] = c;
+            }
+        } else {
+            // add character to buffer
+            buf[buf_len++] = c;
+
+            // if buffer has 9 items try to decode it
+            if (buf_len >= CXOF_FRAME_LENGTH) {
+                // check last character matches footer
+                if (buf[buf_len-1] != CXOF_FOOTER) {
+                    buf_len = 0;
+                    continue;
+                }
+
+                // decode package
+                int16_t x_raw = (int16_t)((uint16_t)buf[3] << 8) | buf[2];
+                int16_t y_raw = (int16_t)((uint16_t)buf[5] << 8) | buf[4];
+
+                // add to sum of all readings from sensor this iteration
+                count++;
+                x_sum += x_raw;
+                y_sum += y_raw;
+                qual_sum += buf[7];
+
+                // clear buffer
+                buf_len = 0;
+            }
+        }
+    }
+
+    // return without updating state if no readings
+    if (count == 0) {
+        return;
+    }
+
+    struct OpticalFlow::OpticalFlow_state state {};
+    state.device_id = 0x43; // 'C'
+
+    // average surface quality scaled to be between 0 and 255
+    state.surface_quality = (constrain_int16(qual_sum / count, 64, 78) - 64) * 255 / 14;
+
+    // calculate dt
+    uint64_t this_frame_us = uart->receive_time_constraint_us(CXOF_FRAME_LENGTH);
+    if (this_frame_us == 0) {
+        // for HAL that cannot estimate arrival time in serial buffer use current time
+        this_frame_us = AP_HAL::micros();
+    }
+    float dt = (this_frame_us - last_frame_us) * 1.0e-6;
+    last_frame_us = this_frame_us;
+
+    if ((dt > 0.0f) && (dt < CXOF_TIMEOUT_SEC)) {
+        // calculate flow values
+        const Vector2f flowScaler = _flowScaler();
+        float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;
+        float flowScaleFactorY = 1.0f + 0.001f * flowScaler.y;
+
+        // copy flow rates to state structure
+        state.flowRate = Vector2f(((float)x_sum / count) * flowScaleFactorX,
+                                  ((float)y_sum / count) * flowScaleFactorY);
+        state.flowRate *= CXOF_PIXEL_SCALING / dt;
+
+        // copy average body rate to state structure
+        state.bodyRate = Vector2f(gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count);
+
+        _applyYaw(state.flowRate);
+        _applyYaw(state.bodyRate);
+    } else {
+        // first frame received in some time so cannot calculate flow values
+        state.flowRate.zero();
+        state.bodyRate.zero();
+    }
+
+    _update_frontend(state);
+
+    // reset gyro sum
+    gyro_sum.zero();
+    gyro_sum_count = 0;
+}

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -97,6 +97,7 @@ void AP_OpticalFlow_CXOF::update(void)
     }
 
     // record gyro values as long as they are being used
+    // the sanity check of dt below ensures old gyro values are not used
     if (gyro_sum_count < 1000) {
         const Vector3f& gyro = AP::ahrs_navekf().get_gyro();
         gyro_sum.x += gyro.x;
@@ -171,7 +172,8 @@ void AP_OpticalFlow_CXOF::update(void)
     float dt = (this_frame_us - last_frame_us) * 1.0e-6;
     last_frame_us = this_frame_us;
 
-    if ((dt > 0.0f) && (dt < CXOF_TIMEOUT_SEC)) {
+    // sanity check dt
+    if (is_positive(dt) && (dt < CXOF_TIMEOUT_SEC)) {
         // calculate flow values
         const Vector2f flowScaler = _flowScaler();
         float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
@@ -20,10 +20,10 @@ public:
 
 private:
 
-    AP_HAL::UARTDriver *uart = nullptr; // uart connected to flow sensor
+    AP_HAL::UARTDriver *uart;           // uart connected to flow sensor
     uint64_t last_frame_us;             // system time of last message from flow sensor
     uint8_t buf[10];                    // buff of characters received from flow sensor
-    uint8_t buf_len = 0;                // number of characters in buffer
+    uint8_t buf_len;                    // number of characters in buffer
     Vector2f gyro_sum;                  // sum of gyro sensor values since last frame from flow sensor
-    uint16_t gyro_sum_count = 0;        // number of gyro sensor values in sum
+    uint16_t gyro_sum_count;            // number of gyro sensor values in sum
 };

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "OpticalFlow.h"
+#include <AP_HAL/utility/OwnPtr.h>
+
+class AP_OpticalFlow_CXOF : public OpticalFlow_backend
+{
+public:
+    /// constructor
+    AP_OpticalFlow_CXOF(OpticalFlow &_frontend, AP_HAL::UARTDriver *uart);
+
+    // initialise the sensor
+    void init() override;
+
+    // read latest values from sensor and fill in x,y and totals.
+    void update(void) override;
+
+    // detect if the sensor is available
+    static AP_OpticalFlow_CXOF *detect(OpticalFlow &_frontend);
+
+private:
+
+    AP_HAL::UARTDriver *uart = nullptr; // uart connected to flow sensor
+    uint64_t last_frame_us;             // system time of last message from flow sensor
+    uint8_t buf[10];                    // buff of characters received from flow sensor
+    uint8_t buf_len = 0;                // number of characters in buffer
+    Vector2f gyro_sum;                  // sum of gyro sensor values since last frame from flow sensor
+    uint16_t gyro_sum_count = 0;        // number of gyro sensor values in sum
+};

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -4,6 +4,7 @@
 #include "AP_OpticalFlow_SITL.h"
 #include "AP_OpticalFlow_Pixart.h"
 #include "AP_OpticalFlow_PX4Flow.h"
+#include "AP_OpticalFlow_CXOF.h"
 #include <DataFlash/DataFlash.h>
 
 extern const AP_HAL::HAL& hal;
@@ -99,6 +100,9 @@ void OpticalFlow::init(uint32_t log_bit)
         }
         if (backend == nullptr) {
             backend = AP_OpticalFlow_PX4Flow::detect(*this);
+        }
+        if (backend == nullptr) {
+            backend = AP_OpticalFlow_CXOF::detect(*this);
         }
 #elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
         backend = new AP_OpticalFlow_SITL(*this);

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL_DEFAULT),
@@ -96,7 +96,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SerialProtocol_GPS),
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SerialProtocol_GPS),
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -101,6 +101,7 @@ public:
         SerialProtocol_Sbus1 = 15,
         SerialProtocol_ESCTelemetry = 16,
         SerialProtocol_Devo_Telem = 17,
+        SerialProtocol_OpticalFlow = 18,
     };
 
     // get singleton instance

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1518,8 +1518,8 @@ void GCS_MAVLINK::send_opticalflow()
         0, // sensor id is zero
         flowRate.x,
         flowRate.y,
-        bodyRate.x,
-        bodyRate.y,
+        flowRate.x - bodyRate.x,
+        flowRate.y - bodyRate.y,
         optflow->quality(),
         hagl,  // ground distance (in meters) set to zero
         flowRate.x,


### PR DESCRIPTION
This PR adds support for the [Cheerson CX-OF optical flow sensor](https://www.banggood.com/Cheerson-CX-OF-CXOF-RC-Quadcopter-Spare-Parts-Optical-Flow-Module-p-1215911.html) which is based on the Pixart sensor we already support but it has a serial interface that provides updates at 25hz.

Here is a screenshot of a short desktop test where I rotated the sensor and flight controller together in the x and y axis and the values line up pretty well.
![desktop-test](https://user-images.githubusercontent.com/1498098/49000355-9ca43700-f19c-11e8-9539-c5cd18e3c99c.png)

This is how the sensor can be attached to a pixhawk.  The sensor requires 3.3V power supply which explains the odd use of the switch pin.  We will likely change this to recommend a regulator and/or the SPKT/DSM port's power pin.
![cheerson-pixhawk-wiring](https://user-images.githubusercontent.com/1498098/49000465-f86ec000-f19c-11e8-8c9f-3dd80b700188.png)

There is also a small fix to the values we send in the [OPTICAL_FLOW mavlink message](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW).  The flow_comp_m_x and flow_comp_m_y fields we were simply sending the vehicle's gyro values which doesn't seem useful.  We should instead be sending the flow rates - the vehicle's gyro values so that the number if a vehicle rotation corrected flow rate.

I plan to test this on a real vehicle within the new few days.

[Discussion with some other developers and users is here.](https://discuss.ardupilot.org/t/integration-of-pixracer-with-optical-flow-pmw-3901)