### PR TITLE
AP_RangeFinder: Changed RangeFinder.h to support 4 lidars

### DIFF
--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -21,7 +21,7 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 
 // Maximum number of range finder instances available on this platform
-#define RANGEFINDER_MAX_INSTANCES 2
+#define RANGEFINDER_MAX_INSTANCES 4
 #define RANGEFINDER_GROUND_CLEARANCE_CM_DEFAULT 10
 #define RANGEFINDER_PREARM_ALT_MAX_CM           200
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
Changed RANGEFINDER_MAX_INSTANCES to 4 and ran all tests. Checked RangeFinder.cpp for compatibility and found that var_info variable has support for 4 lidars.