### PR TITLE
AP_Common: fail nuttx build

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -159,3 +159,8 @@ bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 #else
 #define SITL_printf(fmt, args ...)
 #endif
+
+// fail nuttx builds
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+  #error NuttX builds have been deprecated in favour of ChibiOS.  Please use alternative build targets including fmuv2, fmuv3, fmuv4, fmuv5.
+#endif


### PR DESCRIPTION
This is my guess as to how we can fail the NuttX builds ahead of removing NuttX from the build environment.  Perhaps there are other ways including failing during ./waf's configure step which would save some time for the developer because this compile time failure can take a couple of minutes to appear.

This causes an error to be printed on the console when the build fails, 

> NuttX builds have been deprecated in favour of ChibiOS.  Please use alternative build targets including fmuv2, fmuv3, fmuv4, fmuv5.