### PR TITLE
Tools: waf: use ctx rather than build for fatal errors

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -249,7 +249,7 @@ class Board:
                     ctx.env.ROMFS_FILES[i] = (name,filename);
         header = ctx.bldnode.make_node('ap_romfs_embedded.h').abspath()
         if not embed.create_embedded_h(header, ctx.env.ROMFS_FILES):
-            bld.fatal("Failed to created ap_romfs_embedded.h")
+            ctx.fatal("Failed to created ap_romfs_embedded.h")
 
 Board = BoardMeta('Board', Board.__bases__, dict(Board.__dict__))
 


### PR DESCRIPTION
.... it's even called "bld" in the caller...
