### PR TITLE
HAL_ChibiOS: Add hwdef for Solo's Cube Black & Green

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/README.md
@@ -1,0 +1,13 @@
+# CubeBlack-solo variant of the CubeBlack Flight Controller
+
+The `CubeBlack-solo` build is identical to the CubeBlack build, but includes a large set of default parameters required by the Solo.
+
+- For use in ArduCopter 3.7 and higher. Not compatible with any previous versions of ArduCopter or with other vehicle types.
+- For data on the Hex CubeBlack flight controller, see the [Hex CubeBlack hwdef readme](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md)
+- For the parameter list used by this build, see [Tools/Fram_params/Solo_Copter-3.7_BlackCube.param](https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/Solo_Copter-3.7_BlackCube.param)
+
+### Using this build in waf
+
+- `./waf configure --board CubeBlack-solo`
+- `./waf copter`
+- The completed firmware binary will be located in `/ardupilot/build/CubeBlack-solo/bin/arducopter.apj`

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/hwdef-bl.dat
@@ -1,0 +1,5 @@
+# hw definition file for processing by chibios_hwdef.py
+# for The CUBE Black and the Cube Purple hardware in a 3DR Solo
+# this is based on the CubeBlack hwdef-bl, with Solo's required parameter defaults
+
+include ../CubeBlack/hwdef-bl.dat

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack-solo/hwdef.dat
@@ -1,0 +1,10 @@
+# hw definition file for processing by chibios_hwdef.py
+# for The CUBE Black and the Cube Purple hardware in a 3DR Solo
+# this is based on the CubeBlack hwdef, with Solo's required parameter defaults
+# do not use this hwdef with any configuration other than a 3DR Solo with a stock or black cube running Copter 3.7.
+
+include ../CubeBlack/hwdef.dat
+
+# pull Solo's default parameters from /Tools/Frame_params
+# these are parameters the Solo requires for proper operation that are differnet from the 3.7 standard defaults.
+env DEFAULT_PARAMETERS 'Tools/Frame_params/Solo_Copter-3.7_BlackCube.param'

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/README.md
@@ -1,0 +1,13 @@
+# CubeGreen-solo variant of the CubeBlack Flight Controller
+
+The `CubeGreen-solo` build is identical to the CubeBlack build, but includes a large set of default parameters required by the Solo equipped with a new Hex Green Cube.
+
+- For use in ArduCopter 3.7 and higher. Not compatible with any previous versions of ArduCopter or with other vehicle types.
+- For data on the Hex CubeBlack flight controller, see the [Hex CubeBlack hwdef readme](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md)
+- For the parameter list used by this build, see [Tools/Fram_params/Solo_Copter-3.7_GreenCube.param](https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/Solo_Copter-3.7_GreenkCube.param)
+
+### Using this build in waf
+
+- `./waf configure --board CubeGreen-solo`
+- `./waf copter`
+- The completed firmware binary will be located in `/ardupilot/build/CubeGreen-solo/bin/arducopter.apj`

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/hwdef-bl.dat
@@ -1,0 +1,6 @@
+# hw definition file for processing by chibios_hwdef.py
+# for The CUBE Green hardware in a 3DR Solo
+# this is based on the CubeBlack hwdef-bl, with Solo's required parameter defaults
+# The CUBE green is identical to a CUBE Black, but uses 5v signalling for the Solo ESC issues
+
+include ../CubeBlack/hwdef-bl.dat

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/hwdef.dat
@@ -1,0 +1,11 @@
+# hw definition file for processing by chibios_hwdef.py
+# for The CUBE Green hardware in a 3DR Solo
+# this is based on the CubeBlack hwdef, with Solo's required parameter defaults
+# The CUBE green is identical to a CUBE Black, but uses 5v signalling for the Solo ESC issues
+# do not use this hwdef with any configuration other than a 3DR Solo with a Green Cube running Copter 3.7.
+
+include ../CubeBlack/hwdef.dat
+
+# pull Solo's default parameters from /Tools/Frame_params
+# these are parameters the Solo requires for proper operation that are differnet from the 3.7 standard defaults.
+env DEFAULT_PARAMETERS 'Tools/Frame_params/Solo_Copter-3.7_GreenCube.param'


### PR DESCRIPTION
Adds hwdef files for the 3DR Solo.  CubeBlack-solo is based on the CubeBlack hwdef, with the only difference being default parameters required by the Solo.  CubeGreen-solo is is also identical to CubeBlack, but has default parameters required by those with a Green Cube in their Solo.

Parameter default files are pulled from the Tools\Frame_Parms directory where the Solo's parameter files are maintained.