### PR TITLE
Rover: fix auto enter check

### DIFF
--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -10,7 +10,7 @@ ModeAuto::ModeAuto(ModeRTL& mode_rtl) :
 bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
-    if (mission.num_commands() == 0) {
+    if (mission.num_commands() <= 1) {
         gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
         return false;
     }


### PR DESCRIPTION
This fixes a [bug reported here](https://discuss.ardupilot.org/t/3-5rc1-strange-behavior-on-the-bench/35675) as part of Rover-3.5.0 beta testing.

The issue is that the check that we have a mission misses the fact that we store the AHRS home as the first waypoint.  This means we need to check that there are at least 2 commands for the mission to be valid.  [The equivalent check for Copter can be seen here](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_auto.cpp#L25).