### PR TITLE
GCS_MAVLink: disable reboot when armed

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1863,6 +1863,11 @@ void GCS_MAVLINK::disable_overrides()
  */
 MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &packet)
 {
+    if (hal.util->get_soft_armed()) {
+        // refuse reboot when armed
+        return MAV_RESULT_FAILED;
+    }
+
     if (!(is_equal(packet.param1, 1.0f) || is_equal(packet.param1, 3.0f))) {
         // param1 must be 1 or 3 - 1 being reboot, 3 being reboot-to-bootloader
         return MAV_RESULT_UNSUPPORTED;


### PR DESCRIPTION
this prevents reboot on vehicles that have ARMING_REQUIRE=0, which
applies to some planes, but those vehicles tend to not use MAVLink
reboot anyway.

This PR was requested by Edin from Aeronavics after an incident where a reboot was accidentally requested while flying
