### PR TITLE
AP_HAL_ChibiOS: fixed F405 PE15 afnum, should be 15 and not 1

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
@@ -382,7 +382,7 @@ AltFunction_map = {
 	"PE14:TIM1_CH4"     	:	1,
 	"PE15:TIM1_BKIN"    	:	1,
 	"PE15:FSMC_D12"    	:	12,
-	"PE15:EVENTOUT"    	:	1,
+	"PE15:EVENTOUT"    	:	15,
 	"PE1:DCMI_D3"       	:	13,
 	"PE1:EVENTOUT"      	:	15,
 	"PE1:FSMC_NBL1"     	:	12,


### PR DESCRIPTION
While working on waf build scripts. Noticed bug that defines afnum for PE15 wrong. EVENTOUT is 15 and not 1. 1 is reserved for timers