### PR TITLE
autotest: allow sim_vehicle with valgrind to cope with new operator

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -538,7 +538,10 @@ def start_vehicle(binary, autotest, opts, stuff, loc):
     cmd = []
     if opts.valgrind:
         cmd_name += " (valgrind)"
-        cmd.append("valgrind")
+        # adding this option allows valgrind to cope with the overload
+        # of operator new
+        valgrind_opts = "--soname-synonyms=somalloc=nouserintercepts"
+        cmd.append("valgrind " + valgrind_opts)
     if opts.callgrind:
         cmd_name += " (callgrind)"
         cmd.append("valgrind --tool=callgrind")


### PR DESCRIPTION
this is needed for recent versions of valgrind. Without it valgrind
doesn't know that new clears memory