### PR TITLE
Store landing abort sequences in a mission

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -937,21 +937,38 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         return MAV_RESULT_FAILED;
 
     case MAV_CMD_DO_GO_AROUND:
-        if (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) {
-            // Initiate an aborted landing. This will trigger a pitch-up and
-            // climb-out to a safe altitude holding heading then one of the
-            // following actions will occur, check for in this order:
-            // - If MAV_CMD_CONTINUE_AND_CHANGE_ALT is next command in mission,
-            //      increment mission index to execute it
-            // - else if DO_LAND_START is available, jump to it
-            // - else decrement the mission index to repeat the landing approach
+        {
+            uint16_t mission_id = plane.mission.get_current_nav_cmd().id;
+            bool is_in_landing = (plane.flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND) ||
+                                 (mission_id == MAV_CMD_NAV_LAND) ||
+                                 (mission_id == MAV_CMD_NAV_VTOL_LAND);
+            if (is_in_landing) {
+                // fly a user planned abort pattern if available
+                if (plane.mission.jump_to_abort_landing_sequence()) {
+                    return MAV_RESULT_ACCEPTED;
+                }
 
-            if (!is_zero(packet.param1)) {
-                plane.auto_state.takeoff_altitude_rel_cm = packet.param1 * 100;
-            }
-            if (plane.landing.request_go_around()) {
-                plane.auto_state.next_wp_crosstrack = false;
-                return MAV_RESULT_ACCEPTED;
+                // only fly a fixed wing abort if we aren't doing quadplane stuff, or potentially
+                // shooting a quadplane approach
+                if ((!plane.quadplane.available()) ||
+                    ((!plane.quadplane.in_vtol_auto()) &&
+                     (!(plane.quadplane.options & QuadPlane::OPTION_MISSION_LAND_FW_APPROACH)))) {
+                    // Initiate an aborted landing. This will trigger a pitch-up and
+                    // climb-out to a safe altitude holding heading then one of the
+                    // following actions will occur, check for in this order:
+                    // - If MAV_CMD_CONTINUE_AND_CHANGE_ALT is next command in mission,
+                    //      increment mission index to execute it
+                    // - else if DO_LAND_START is available, jump to it
+                    // - else decrement the mission index to repeat the landing approach
+
+                    if (!is_zero(packet.param1)) {
+                        plane.auto_state.takeoff_altitude_rel_cm = packet.param1 * 100;
+                    }
+                    if (plane.landing.request_go_around()) {
+                        plane.auto_state.next_wp_crosstrack = false;
+                        return MAV_RESULT_ACCEPTED;
+                    }
+                }
             }
         }
         return MAV_RESULT_FAILED;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -469,6 +469,9 @@ public:
     // available.
     bool jump_to_landing_sequence(void);
 
+    // jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
+    bool jump_to_abort_landing_sequence(void);
+
     // get a reference to the AP_Mission semaphore, allowing an external caller to lock the
     // storage while working with multiple waypoints
     HAL_Semaphore_Recursive &get_semaphore(void) {


### PR DESCRIPTION
This allows you to store a preplanned landing abort sequence as part of a mission plan. This is particularly valuable as it allows quadplanes to preform preplanned landing aborts, which allows quadplanes to have some form of landing abort. If the user hasn't planned any aborts then the abort will be nacked the same as it is currently.

As presented this only applies to MAVLink abort requests, it would make the most sense for this to also apply to throttle or automatic aborting, I haven't figured out the a good place to wrap that logic however due to the separation of AP_Landing, the bolt on nature of quadplane, and the poor mapping of flight stages to reflect VTOL takeoff/landings. Any suggestions @magicrub or @tridge?