### PR TITLE
HAL: remove debug when device not found on SPI

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -320,7 +320,6 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (i == ARRAY_SIZE(device_table)) {
-        printf("SPI: Invalid device name: %s\n", name);
         return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
     }
 

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -449,7 +449,6 @@ SPIDeviceManager::get_device(const char *name)
     }
 
     if (!desc) {
-        printf("SPI: Invalid device name: %s\n", name);
         return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
     }
 

--- a/libraries/AP_HAL_PX4/SPIDevice.cpp
+++ b/libraries/AP_HAL_PX4/SPIDevice.cpp
@@ -297,7 +297,6 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (device_table[i].name == nullptr) {
-        printf("SPI: Invalid device name: %s\n", name);
         return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
     }
 

--- a/libraries/AP_HAL_VRBRAIN/SPIDevice.cpp
+++ b/libraries/AP_HAL_VRBRAIN/SPIDevice.cpp
@@ -298,7 +298,6 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (device_table[i].name == nullptr) {
-        printf("SPI: Invalid device name: %s\n", name);
         return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
     }
 


### PR DESCRIPTION
This PR removes messages like below from appearing on the console on startup.  This is normal behaviour and the board isn't panicing so it doesn't seem useful to have these messages because to those few people who see it, it seems like something might be wrong when actually nothing is wrong.

> SPI: Invalid device name: mpu6000_ext
> SPI: Invalid device name: mpu6000_ext
> SPI: Invalid device name: icm20608_ext
> SPI: Invalid device name: icm20608_ext