### PR TITLE
AP_Follow: remove debug

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -107,12 +107,12 @@ void Rover::send_nav_controller_output(mavlink_channel_t chan)
         chan,
         0,  // roll
         degrees(g2.attitude_control.get_desired_pitch()),
-        nav_controller->nav_bearing_cd() * 0.01f,
-        nav_controller->target_bearing_cd() * 0.01f,
+        control_mode->nav_bearing(),
+        control_mode->wp_bearing(),
         MIN(control_mode->get_distance_to_destination(), UINT16_MAX),
         0,
         control_mode->speed_error(),
-        nav_controller->crosstrack_error());
+        control_mode->crosstrack_error());
 }
 
 void Rover::send_servo_out(mavlink_channel_t chan)
@@ -329,10 +329,8 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
         break;
 
     case MSG_NAV_CONTROLLER_OUTPUT:
-        if (rover.control_mode->is_autopilot_mode()) {
-            CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
-            rover.send_nav_controller_output(chan);
-        }
+        CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
+        rover.send_nav_controller_output(chan);
         break;
 
     case MSG_SERVO_OUT:

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -105,8 +105,8 @@ void Rover::send_nav_controller_output(mavlink_channel_t chan)
 {
     mavlink_msg_nav_controller_output_send(
         chan,
-        g2.attitude_control.get_desired_lat_accel(),
-        ahrs.groundspeed() * ins.get_gyro().z,  // use nav_pitch to hold actual Y accel
+        0,  // roll
+        degrees(g2.attitude_control.get_desired_pitch()),
         nav_controller->nav_bearing_cd() * 0.01f,
         nav_controller->target_bearing_cd() * 0.01f,
         MIN(control_mode->get_distance_to_destination(), UINT16_MAX),

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -163,6 +163,33 @@ void Mode::get_pilot_desired_heading_and_speed(float &heading_out, float &speed_
     speed_out = throttle * calc_speed_max(g.speed_cruise, g.throttle_cruise * 0.01f);
 }
 
+// return heading (in degrees) to target destination (aka waypoint)
+float Mode::wp_bearing() const
+{
+    if (!is_autopilot_mode()) {
+        return 0.0f;
+    }
+    return rover.nav_controller->target_bearing_cd() * 0.01f;
+}
+
+// return short-term target heading in degrees (i.e. target heading back to line between waypoints)
+float Mode::nav_bearing() const
+{
+    if (!is_autopilot_mode()) {
+        return 0.0f;
+    }
+    return rover.nav_controller->nav_bearing_cd() * 0.01f;
+}
+
+// return cross track error (i.e. vehicle's distance from the line between waypoints)
+float Mode::crosstrack_error() const
+{
+    if (!is_autopilot_mode()) {
+        return 0.0f;
+    }
+    return rover.nav_controller->crosstrack_error();
+}
+
 // set desired location
 void Mode::set_desired_location(const struct Location& destination, float next_leg_bearing_cd)
 {
@@ -406,9 +433,9 @@ float Mode::calc_reduced_speed_for_turn_or_distance(float desired_speed)
 
     // calculate distance from vehicle to line + wp_overshoot
     const float line_yaw_diff = wrap_180_cd(get_bearing_cd(_origin, _destination) - heading_cd);
-    const float crosstrack_error = rover.nav_controller->crosstrack_error();
-    const float dist_from_line = fabsf(crosstrack_error);
-    const bool heading_away = is_positive(line_yaw_diff) == is_positive(crosstrack_error);
+    const float xtrack_error = rover.nav_controller->crosstrack_error();
+    const float dist_from_line = fabsf(xtrack_error);
+    const bool heading_away = is_positive(line_yaw_diff) == is_positive(xtrack_error);
     const float wp_overshoot_adj = heading_away ? -dist_from_line : dist_from_line;
 
     // calculate radius of circle that touches vehicle's current position and heading and target position and heading

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -363,6 +363,14 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    // attributes of the mode
+    bool is_autopilot_mode() const override { return true; }
+
+    // return desired heading (in degrees) and cross track error (in meters) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
+    float wp_bearing() const override { return _desired_yaw_cd; }
+    float nav_bearing() const override { return _desired_yaw_cd; }
+    float crosstrack_error() const override { return 0.0f; }
+
     // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -79,6 +79,11 @@ public:
     virtual bool requires_position() const { return true; }
     virtual bool requires_velocity() const { return true; }
 
+    // return heading (in degrees) and cross track error (in meteres) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
+    float wp_bearing() const;
+    float nav_bearing() const;
+    float crosstrack_error() const;
+
     //
     // navigation methods
     //

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -79,10 +79,10 @@ public:
     virtual bool requires_position() const { return true; }
     virtual bool requires_velocity() const { return true; }
 
-    // return heading (in degrees) and cross track error (in meteres) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
-    float wp_bearing() const;
-    float nav_bearing() const;
-    float crosstrack_error() const;
+    // return heading (in degrees) and cross track error (in meters) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
+    virtual float wp_bearing() const;
+    virtual float nav_bearing() const;
+    virtual float crosstrack_error() const;
 
     //
     // navigation methods
@@ -492,6 +492,17 @@ public:
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
+
+    // attributes of the mode
+    bool is_autopilot_mode() const override { return true; }
+
+    // return desired heading (in degrees) and cross track error (in meters) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
+    float wp_bearing() const override;
+    float nav_bearing() const override { return wp_bearing(); }
+    float crosstrack_error() const override { return 0.0f; }
+
+    // return distance (in meters) to destination
+    float get_distance_to_destination() const override;
 
 protected:
 

--- a/APMrover2/mode_follow.cpp
+++ b/APMrover2/mode_follow.cpp
@@ -71,3 +71,15 @@ void ModeFollow::update()
     calc_steering_to_heading(_desired_yaw_cd);
     calc_throttle(calc_reduced_speed_for_turn_or_distance(desired_speed), false, true);
 }
+
+// return desired heading (in degrees) for reporting to ground station (NAV_CONTROLLER_OUTPUT message)
+float ModeFollow::wp_bearing() const
+{
+    return g2.follow.get_bearing_to_target();
+}
+
+// return distance (in meters) to destination
+float ModeFollow::get_distance_to_destination() const
+{
+    return g2.follow.get_distance_to_target();
+}

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1252,6 +1252,8 @@ protected:
 
     const char *name() const override { return "FOLLOW"; }
     const char *name4() const override { return "FOLL"; }
+    uint32_t wp_distance() const override;
+    int32_t wp_bearing() const override;
 
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -13,25 +13,14 @@
  * TODO: ensure AC_AVOID_ENABLED is true because we rely on it velocity limiting functions
  */
 
-#if 1
-#define Debug(fmt, args ...)  do {                                      \
-        gcs().send_text(MAV_SEVERITY_WARNING, fmt, ## args);            \
-    } while(0)
-#elif 0
-#define Debug(fmt, args ...)  do {                                      \
-    ::fprintf(stderr, "%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args);
-#else
-#define Debug(fmt, args ...)
-#endif
-
 // initialise follow mode
 bool Copter::ModeFollow::init(const bool ignore_checks)
 {
-    // re-use guided mode
-    gcs().send_text(MAV_SEVERITY_WARNING, "Follow-mode init");
     if (!g2.follow.enabled()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Set FOLL_ENABLE = 1");
         return false;
     }
+    // re-use guided mode
     return Copter::ModeGuided::init(ignore_checks);
 }
 
@@ -56,14 +45,6 @@ void Copter::ModeFollow::run()
     Vector3f dist_vec_offs;  // vector to lead vehicle + offset
     Vector3f vel_of_target;  // velocity of lead vehicle
     if (g2.follow.get_target_dist_and_vel_ned(dist_vec, dist_vec_offs, vel_of_target)) {
-        // debug
-        static uint16_t counter = 0;
-        counter++;
-        if (counter >= 400) {
-            counter = 0;
-            Debug("dist to veh: %f %f %f", (double)dist_vec.x, (double)dist_vec.y, (double)dist_vec.z);
-        }
-
         // convert dist_vec_offs to cm in NEU
         const Vector3f dist_vec_offs_neu(dist_vec_offs.x * 100.0f, dist_vec_offs.y * 100.0f, -dist_vec_offs.z * 100.0f);
 

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -150,4 +150,14 @@ void Copter::ModeFollow::run()
     Copter::ModeGuided::run();
 }
 
+uint32_t Copter::ModeFollow::wp_distance() const
+{
+    return g2.follow.get_distance_to_target() * 100;
+}
+
+int32_t Copter::ModeFollow::wp_bearing() const
+{
+    return g2.follow.get_bearing_to_target() * 100;
+}
+
 #endif // MODE_FOLLOW_ENABLED == ENABLED

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -23,7 +23,6 @@ extern const AP_HAL::HAL& hal;
 
 #define AP_FOLLOW_TIMEOUT_MS    3000    // position estimate timeout after 1 second
 #define AP_FOLLOW_SYSID_TIMEOUT_MS 10000 // forget sysid we are following if we haave not heard from them in 10 seconds
-#define AP_GCS_INTERVAL_MS 1000 // interval between updating GCS on position of vehicle
 
 #define AP_FOLLOW_OFFSET_TYPE_NED       0   // offsets are in north-east-down frame
 #define AP_FOLLOW_OFFSET_TYPE_RELATIVE  1   // offsets are relative to lead vehicle's heading
@@ -292,14 +291,6 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
         if (_sysid == 0) {
             _sysid.set(msg.sysid);
             _automatic_sysid = true;
-        }
-        if ((now - _last_location_sent_to_gcs) > AP_GCS_INTERVAL_MS) {
-            _last_location_sent_to_gcs = now;
-            gcs().send_text(MAV_SEVERITY_INFO, "Foll: %u %ld %ld %4.2f\n",
-                            (unsigned)_sysid.get(),
-                            (long)_target_location.lat,
-                            (long)_target_location.lng,
-                            (double)(_target_location.alt * 0.01f));    // cm to m
         }
 
         // log lead's estimated vs reported position

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -38,6 +38,9 @@ public:
     // constructor
     AP_Follow();
 
+    // returns true if library is enabled
+    bool enabled() const { return _enabled; }
+
     // set which target to follow
     void set_target_sysid(uint8_t sysid) { _sysid = sysid; }
 
@@ -72,9 +75,6 @@ public:
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
-
-    // returns true if library is enabled
-    bool enabled() const { return _enabled; }
 
 private:
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -108,7 +108,5 @@ private:
     Vector3f _target_accel_ned;     // last known acceleration of target in NED frame in m/s/s
     uint32_t _last_heading_update_ms;   // system time of last heading update
     float _target_heading;          // heading in degrees
-    uint32_t _last_location_sent_to_gcs; // last time GCS was told position
-
     bool _automatic_sysid;          // did we lock onto a sysid automatically?
 };

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -73,6 +73,16 @@ public:
     // parse mavlink messages which may hold target's position, velocity and attitude
     void handle_msg(const mavlink_message_t &msg);
 
+    //
+    // GCS reporting functions
+    //
+
+    // get horizontal distance to target (including offset) in meters (for reporting purposes)
+    float get_distance_to_target() const { return _dist_to_target; }
+
+    // get bearing to target (including offset) in degrees (for reporting purposes)
+    float get_bearing_to_target() const { return _bearing_to_target; }
+
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -89,6 +99,9 @@ private:
 
     // rotate 3D vector clockwise by specified angle (in degrees)
     Vector3f rotate_vector(const Vector3f &vec, float angle_deg) const;
+
+    // set recorded distance and bearing to target to zero
+    void clear_dist_and_bearing_to_target();
 
     // parameters
     AP_Int8     _enabled;           // 1 if this subsystem is enabled
@@ -109,4 +122,6 @@ private:
     uint32_t _last_heading_update_ms;   // system time of last heading update
     float _target_heading;          // heading in degrees
     bool _automatic_sysid;          // did we lock onto a sysid automatically?
+    float   _dist_to_target;        // latest distance to target in meters (for reporting purposes)
+    float   _bearing_to_target;     // latest bearing to target in degrees (for reporting purposes)
 };


### PR DESCRIPTION
This disables a few places where Follow mode would send_text to the ground station regardless of whether everything was working well or not

- Copter was sending "Follow-mode init" whenever the vehicle entered Follow mode.  Now it sends a slightly more useful "Set FOLL_ENABLE = 1" message to indicate why the mode change failed.
- Copter was sending 1hz updates with the distance to the lead vehicle
- AP_Follow (the library) was also sending 1hz updates with the distance to the lead vehicle

Following on from suggestions from @peterbarker, I've improved the contents of the NAV_CONTROLLER_OUTPUT message to the ground station so that follow mode reports the heading and distance to the target position (i.e. vehicle + offset).  I've also improved reporting for Rover's Loiter mode.

Here are before and after pictures of the target heading reporting while Rover is in Follow mode.  The key point is that in the BEFORE picture, the orange lines (which come from the NAV_CONTROLLER_OUTPUT.target_bearing) are all pointing straight up.  In the AFTER picture, the lines point correctly towards the position target which is behind the lead vehicle.  Note that the red line (the vehicle's current heading) doesn't point directly towards the position target but this is normal for Follow mode because the follow control uses a combination of the lead vehicle's velocity + position correction.
![follow-nav-control-output-test](https://user-images.githubusercontent.com/1498098/49844905-f6953580-fe07-11e8-9771-c7e7ca59e005.png)
