### PR TITLE
Auto Build: Add Solo build targets

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -511,6 +511,8 @@ is bob we will attempt to checkout bob-AVR'''
                 "airbotf4",
                 "revo-mini",
                 "CubeBlack",
+                "CubeBlack-solo",
+                "CubeGreen-solo",
                 "Pixhawk1",
                 "Pixhawk4",
                 "PH4-mini",


### PR DESCRIPTION
Per the dev call this evening, adds Solo builds for the Cube Black and Cube Green to auto build.  Thank you everyone that's been helping out on this effort!