### PR TITLE
Tools: autotest: make reboot detection more reliable

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -107,6 +107,8 @@ class AutoTestCopter(AutoTest):
         self.progress("WAITING FOR PARAMETERS")
         self.mavproxy.expect('Received [0-9]+ parameters')
 
+        self.get_mavlink_connection_going()
+
         self.apply_defaultfile_parameters()
 
         util.expect_setup_callback(self.mavproxy, self.expect_callback)
@@ -115,8 +117,6 @@ class AutoTestCopter(AutoTest):
         self.expect_list_extend([self.sitl, self.mavproxy])
 
         self.progress("Started simulator")
-
-        self.get_mavlink_connection_going()
 
         self.hasInit = True
         self.progress("Ready to start testing!")

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -153,6 +153,15 @@ class AutoTestSub(AutoTest):
         if ex is not None:
             raise ex
 
+    def reboot_sitl(self):
+        """Reboot SITL instance and wait it to reconnect."""
+        self.mavproxy.send("reboot\n")
+        self.mavproxy.expect("Initialising APM")
+        # empty mav to avoid getting old timestamps:
+        while self.mav.recv_match(blocking=False):
+            pass
+        self.initialise_after_reboot_sitl()
+
     def autotest(self):
         """Autotest ArduSub in SITL."""
         self.check_test_syntax(test_file=os.path.realpath(__file__))


### PR DESCRIPTION
@jaxxzer This might be the best way to detect reboot.  No `AP_Stats` in Sub, 'though.
