### PR TITLE
Rover: enable avoidance in Autonomous modes

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -221,11 +221,14 @@ void Rover::update_logging1(void)
     if (should_log(MASK_LOG_THR)) {
         Log_Write_Throttle();
         DataFlash.Log_Write_Beacon(g2.beacon);
-        Log_Write_Proximity();
     }
 
     if (should_log(MASK_LOG_NTUN)) {
         Log_Write_Nav_Tuning();
+    }
+
+    if (should_log(MASK_LOG_RANGEFINDER)) {
+        DataFlash.Log_Write_Proximity(g2.proximity);
     }
 }
 

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -157,11 +157,6 @@ void Rover::Log_Write_Nav_Tuning()
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
-void Rover::Log_Write_Proximity()
-{
-    DataFlash.Log_Write_Proximity(g2.proximity);
-}
-
 void Rover::Log_Write_Sail()
 {
     // only log sail if present
@@ -392,7 +387,6 @@ void Rover::Log_Write_Depth() {}
 void Rover::Log_Write_Error(uint8_t sub_system, uint8_t error_code) {}
 void Rover::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target) {}
 void Rover::Log_Write_Nav_Tuning() {}
-void Rover::Log_Write_Proximity() {}
 void Rover::Log_Write_Sail() {}
 void Rover::Log_Write_Startup(uint8_t type) {}
 void Rover::Log_Write_Throttle() {}

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -446,7 +446,6 @@ private:
     void Log_Write_Error(uint8_t sub_system, uint8_t error_code);
     void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
     void Log_Write_Nav_Tuning();
-    void Log_Write_Proximity();
     void Log_Write_Sail();
     void Log_Write_Startup(uint8_t type);
     void Log_Write_Steering();

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -53,7 +53,7 @@ void ModeAuto::update()
             if (!_reached_destination || (rover.is_boat() && !near_wp)) {
                 // continue driving towards destination
                 calc_steering_to_waypoint(_reached_destination ? rover.current_loc : _origin, _destination, _reversed);
-                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, false);
+                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, true);
             } else {
                 // we have reached the destination so stop
                 stop_vehicle();
@@ -66,7 +66,7 @@ void ModeAuto::update()
             if (!_reached_heading) {
                 // run steering and throttle controllers
                 calc_steering_to_heading(_desired_yaw_cd);
-                calc_throttle(_desired_speed, true, false);
+                calc_throttle(_desired_speed, true, true);
                 // check if we have reached within 5 degrees of target
                 _reached_heading = (fabsf(_desired_yaw_cd - ahrs.yaw_sensor) < 500);
             } else {

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -37,7 +37,7 @@ void ModeRTL::update()
     if (!_reached_destination || (rover.is_boat() && !near_wp)) {
         // continue driving towards destination
         calc_steering_to_waypoint(_reached_destination ? rover.current_loc :_origin, _destination, _reversed);
-        calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, false);
+        calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, true);
     } else {
         // we've reached destination so stop
         stop_vehicle();

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -65,7 +65,7 @@ void ModeSmartRTL::update()
             }
             // continue driving towards destination
             calc_steering_to_waypoint(_origin, _destination, _reversed);
-            calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, false);
+            calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, true);
             break;
 
         case SmartRTL_StopAtHome:
@@ -74,7 +74,7 @@ void ModeSmartRTL::update()
             if (rover.is_boat()) {
                 // boats attempt to hold position at home
                 calc_steering_to_waypoint(rover.current_loc, _destination, _reversed);
-                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, false);
+                calc_throttle(calc_reduced_speed_for_turn_or_distance(_reversed ? -_desired_speed : _desired_speed), true, true);
             } else {
                 // rovers stop
                 stop_vehicle();

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -122,7 +122,7 @@ public:
     };
 
     //
-    // support for upwardward facing sensors
+    // support for upward facing sensors
     //
 
     // get distance upwards in meters. returns true on success

--- a/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MorseSITL.cpp
@@ -64,7 +64,7 @@ void AP_Proximity_MorseSITL::update(void)
         }
         float angle_deg = wrap_360(degrees(atan2f(-point.y, point.x)));
         uint16_t angle_rounded = uint16_t(angle_deg+0.5);
-        uint8_t sector = angle_rounded / degrees_per_sector;
+        uint8_t sector = wrap_360(angle_rounded + 22.5f) / degrees_per_sector;
         if (!_distance_valid[sector] || range < _distance[sector]) {
             _distance_valid[sector] = true;
             _distance[sector] = range;


### PR DESCRIPTION
This PR makes the following changes:

- Rover's object avoidance feature is enabled in Auto, RTL and SmartRTL.
  - existing behaviour allows the user to disable the proximity sensor based object avoidance using an auxiliary switch
  - this raises one issue in that the vehicle may get stuck at the fence if a mission is created that goes outside the fence.  Previously it would breach the fence and then RTL (or Hold).  We will resolve this in the future by incorporate better object avoidance code based on Canberra UAV's avoidance code for Plane.
- Rover proximity sensor logging is based on the LOG_BITMASK for RangeFinders which is more appropriate than the Throttle bit.
- Morse proximity sensor sector fix.  With this fix, the simulated vehicle more reliably stops before hitting objects.