### PR TITLE
Fix bug of merged PR #7234

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -40,7 +40,7 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(one_hz_loop,            1,    100),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_receive,     400, 180),
     SCHED_TASK(gcs_send_heartbeat,     1,    110),
-    SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_send,        4000, 550),
+    SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_send,        400, 550),
 #if MOUNT == ENABLED
     SCHED_TASK_CLASS(AP_Mount,            &sub.camera_mount, update,              50,  75),
 #endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1236,6 +1236,11 @@ void GCS_MAVLINK::update_send()
 void GCS_MAVLINK::remove_message_from_bucket(int8_t bucket, ap_message id)
 {
     deferred_message_bucket[bucket].ap_message_ids.clear(id);
+
+    if (bucket == sending_bucket_id) {
+        bucket_message_ids_to_send.clear(id);
+    }
+
     if (deferred_message_bucket[bucket].ap_message_ids.count() == 0) {
         // bucket empty.  Free it:
         deferred_message_bucket[bucket].interval_ms = 0;
@@ -1243,10 +1248,6 @@ void GCS_MAVLINK::remove_message_from_bucket(int8_t bucket, ap_message id)
         if (sending_bucket_id == bucket) {
             find_next_bucket_to_send();
         }
-    }
-
-    if (bucket == sending_bucket_id) {
-        bucket_message_ids_to_send.clear(id);
     }
 }
 


### PR DESCRIPTION
There was an error in Sub scheduled task rate.

The other commit changes the order in which it removes a message from the current sending IDs. It's not a bug now, but the meaning is a bit wrong: we want to remove the message from `bucket_message_ids_to_send` if it is the current sending bucket, not after potentially changing bucket.
It's also possible a future change to `find_next_bucket_to_send` would make it actually become a bug.