### PR TITLE
AP_RangeFinder: Correspond to issue # 9920

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -31,4 +31,6 @@ private:
     // get a reading
     bool get_reading(uint16_t &reading_cm);
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+    uint32_t _sum_cm;
+    uint32_t _counter;
 };


### PR DESCRIPTION
Issue #9920 
I think that it should be treated as an error if it is a transient phenomenon.
I tried to make it a reading error and stagnate at the last measured altitude.
If it is transient, the normal value should be displayed next time.