### PR TITLE
Plane: Allow users to force target airspeed in cruise or FBWB

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1173,7 +1173,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FLIGHT_OPTIONS
     // @DisplayName: Flight mode options
     // @Description: Flight mode specific options
-    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming
+    // @Bitmask: 0:Rudder mixing in direct flight modes only (Manual / Stabilize / Acro),1:Use centered throttle in Cruise or FBWB to indicate trim airspeed, 2:Disable attitude check for takeoff arming, 3:Force target airspeed to trim airspeed in Cruise or FBWB
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -203,4 +203,5 @@ enum FlightOptions {
     DIRECT_RUDDER_ONLY   = (1 << 0),
     CRUISE_TRIM_THROTTLE = (1 << 1),
     DISABLE_TOFF_ATTITUDE_CHK = (1 << 2),
+    CRUISE_TRIM_AIRSPEED = (1 << 3),
 };

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -109,7 +109,9 @@ void Plane::calc_airspeed_errors()
 
     // FBW_B/cruise airspeed target
     if (!failsafe.rc_failsafe && (control_mode == FLY_BY_WIRE_B || control_mode == CRUISE)) {
-        if (g2.flight_options & FlightOptions::CRUISE_TRIM_THROTTLE) {
+        if (g2.flight_options & FlightOptions::CRUISE_TRIM_AIRSPEED) {
+            target_airspeed_cm = aparm.airspeed_cruise_cm;
+        } else if (g2.flight_options & FlightOptions::CRUISE_TRIM_THROTTLE) {
             float control_min = 0.0f;
             float control_mid = 0.0f;
             const float control_max = channel_throttle->get_range();


### PR DESCRIPTION
I've been having trouble with a number of users recently who keep getting confused with the throttle control in these modes, (inexperienced people keep getting confused where to put it/remembering if it's airspeed or groundspeed, experienced RC pilots keep moving it like it's a throttle stick, even though that generally doesn't get the reaction out of the system they want (IE they lower throttle when they want to descend)).

This simply allows you to turn cruise or FBWB into a one stick flying experience, which also works well with non standard controllers/gamepads.