### PR TITLE
AP_BattMonitor: Add smart battery cell voltage minimum and diff monitoring

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -369,8 +369,12 @@ void AP_BattMonitor::check_failsafes(void)
                     break;
             }
 
-            gcs().send_text(MAV_SEVERITY_WARNING, "Battery %d is %s %.2fV used %.0f mAh", i + 1, type_str,
-                            (double)voltage(i), (double)consumed_mah(i));
+            if (has_cell_voltages(i)) {
+                gcs().send_text(MAV_SEVERITY_WARNING, "Batt%d %s %.1fV %.0fmAh used; %dmV cell diff", i + 1, type_str, (double)voltage(i), (double)consumed_mah(i), (uint16_t)state[i].cell_diff_mv);
+            } else {
+                gcs().send_text(MAV_SEVERITY_WARNING, "Battery %d is %s %.2fV used %.0f mAh", i + 1, type_str, (double)voltage(i), (double)consumed_mah(i));
+            }
+
             _has_triggered_failsafe = true;
             AP_Notify::flags.failsafe_battery = true;
             state[i].failsafe = type;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -78,6 +78,7 @@ public:
         float       resistance;                // resistance, in Ohms, calculated by comparing resting voltage vs in flight voltage
         BatteryFailsafe failsafe;              // stage failsafe the battery is in
         bool        healthy;                   // battery monitor is communicating correctly
+        uint16_t    cell_diff_mv;              // smart battery cell voltage differential
     };
 
     // Return the number of battery monitor instances

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -65,7 +65,7 @@ protected:
     AP_BattMonitor_Params               &_params;   // reference to this instances parameters (held in the front-end)
 
     // checks what failsafes could be triggered
-    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const;
+    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity, bool &low_cell_voltage, bool &critical_cell_voltage) const;
 
 private:
     // resistance estimate

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -162,6 +162,22 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ARM_MAH", 19, AP_BattMonitor_Params, _arming_minimum_capacity, 0),
 
+    // @Param: LOW_CELLD
+    // @DisplayName: Smart battery cell lowest-to-highest max voltage difference
+    // @Description: Smart battery cell voltage difference between highest and lowest cell that triggers a low battery failsafe. Set to 0 to disable. If the difference between the highest lowest cell voltage rises above this voltage continuously for more then the period specified by the @PREFIX@LOW_TIMER parameter then the vehicle will perform the failsafe specified by the @PREFIX@FS_LOW_ACT parameter.
+    // @Units: V
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("LOW_CELLD", 20, AP_BattMonitor_Params, _low_cell_voltage_diff, 0),
+
+    // @Param: CRT_CELLD
+    // @DisplayName: Smart battery cell lowest-to-highest max voltage difference
+    // @Description: Smart battery cell voltage difference between highest and lowest cell that triggers a critical battery failsafe. Set to 0 to disable. If the difference between the highest lowest cell voltage rises above this voltage continuously for more then the period specified by the @PREFIX@LOW_TIMER parameter then the vehicle will perform the failsafe specified by the @PREFIX@FS_CRT_ACT parameter.
+    // @Units: V
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("CRT_CELLD", 21, AP_BattMonitor_Params, _crt_cell_voltage_diff, 0),
+
     AP_GROUPEND
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -53,5 +53,7 @@ public:
     AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
     AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
     AP_Float _arming_minimum_voltage;   /// voltage level required to arm
+    AP_Float _low_cell_voltage_diff;         /// cell voltage level used to trigger a low battery failsafe
+    AP_Float _crt_cell_voltage_diff;         /// cell voltage level used to trigger a critical battery failsafe
 
 };


### PR DESCRIPTION
This adds checking of individual cell voltages to the low/critical failsafes.  The low and critical battery failsafes will trigger if the lowest cell voltage drops below a threshold.  And the low battery failsafe will also trigger if the difference between the lowest and highest cell voltage increases beyond a threshold. I extended the methods used for the existing checks into the cell voltage and difference.

And.... it works!

_Updated after discussing with MDB_
- Adds parameters `_CELL_V_LOW`, `_CELL_V_CRT`, & `_CELL_V_DIF`.  The default for all 3 is 0, which is disabled.  These are the threshold voltages for low, critical, and high-to-low difference.  Low cell would typically be 3.45v, critical cell 3.30v, and diff I think maybe 0.15 or something.

- Adds checking the lowest cell voltage to the low and critical battery failsafes.  Adds checking the difference between the highest and lowest cell to the **low** battery failsafe.  It didn't make sense to add a whole other type of failsafe for this.  If the diff is too great, one of the cells is obviously too low, so it is an appropriate place for it.  

To-Do: Cell data is too much for the existing send_text that goes out when the failsafe trips.  Needs something else.