### PR TITLE
CI: add Azure pipelines

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -1,0 +1,46 @@
+parameters:
+  action: 'fly'
+
+jobs:
+- job: sitl_${{ parameters.name }}_test
+  displayName: ${{ format('Cygwin SITL {0} test', parameters.name) }}
+  pool:
+    vmImage: 'win1803'
+  condition: eq(variables['Build.Reason'], 'Schedule')
+  steps:
+  - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
+    displayName: 'Install Cygwin'
+  - script: choco install gcc-g++ python2 python2-devel python2-future python2-lxml python2-pip python2-pexpect python2-numpy git gettext --source cygwin
+    displayName: 'Install Cygwin packages'
+  - script: git submodule update --recursive --init modules/mavlink
+    displayName: Initialize MAVLink submodule
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%')/modules/mavlink/pymavlink && python setup.py build install --user"
+    displayName: 'Install pymavlink from submodule'
+  - script: C:\Cygwin\bin\bash --login -c "pip2 install MAVProxy"
+    displayName: 'Install MAVProxy in Cygwin'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && Tools/autotest/autotest.py ${{ format('build.{0} {1}.{2}', parameters.build_target, parameters.action, parameters.action_target) }}"
+    displayName: ${{ format('Run {0} autotest', parameters.name) }}
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cp $(cygcheck.exe build/sitl/bin/* | grep Cygwin | grep -v '.exe' | sed 's/^[ \t]*//' | sort | uniq) build/sitl/bin/"
+    displayName: 'Copy dependencies to build dir'
+  - task: PublishBuildArtifacts@1
+#  - task: PublishPipelineArtifact@0
+    displayName: 'Publish build artifacts'
+    inputs:
+      artifactName: 'Cygwin SITL binaries'
+      pathtoPublish: 'build/sitl/bin'
+#      targetPath: 'build/sitl/bin'
+  - task: PublishBuildArtifacts@1
+#  - task: PublishPipelineArtifact@0
+    displayName: 'Publish test folder'
+    inputs:
+      artifactName: ${{ format('{0} Test folder', parameters.name) }}
+      pathtoPublish: ${{ format('test.{0}', parameters.action_target) }}
+#      targetPath: ${{ format('test.{0}', parameters.action_target) }}
+  - task: PublishBuildArtifacts@1
+#  - task: PublishPipelineArtifact@0
+    displayName: 'Publish logs'
+    inputs:
+      artifactName: ${{ format('{0} Logs', parameters.name) }}
+      pathtoPublish: '../buildlogs'
+#      targetPath: '../buildlogs'
+

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -7,9 +7,9 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
+  - script: choco install cygwin32-gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
-  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && ./waf --board sitl configure bin"
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && CC=i686-pc-cygwin-gcc CXX=i686-pc-cygwin-g++.exe ./waf --board sitl configure bin"
     displayName: 'Build SITL'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cp $(cygcheck.exe build/sitl/bin/* | grep Cygwin | grep -v '.exe' | sed 's/^[ \t]*//' | sort | uniq) build/sitl/bin/"
     displayName: 'Copy dependencies to build dir'

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -1,0 +1,55 @@
+jobs:
+- job: sitl
+  displayName: 'Cygwin SITL build'
+  pool:
+    vmImage: 'win1803'
+  condition: ne(variables['Build.Reason'], 'Schedule')
+  steps:
+  - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
+    displayName: 'Install Cygwin'
+  - script: choco install gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
+    displayName: 'Install Cygwin packages'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && ./waf --board sitl configure bin"
+    displayName: 'Build SITL'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cp $(cygcheck.exe build/sitl/bin/* | grep Cygwin | grep -v '.exe' | sed 's/^[ \t]*//' | sort | uniq) build/sitl/bin/"
+    displayName: 'Copy dependencies to build dir'
+  - task: PublishBuildArtifacts@1
+#  - task: PublishPipelineArtifact@0
+    displayName: 'Publish build artifacts'
+    inputs:
+      artifactName: 'Cygwin SITL binaries'
+      pathtoPublish: 'build/sitl/bin'
+#      targetPath: 'build/sitl/bin'
+
+- template: autotest_template.yml
+  parameters:
+    name: 'Copter'
+    build_target: 'ArduCopter'
+    action_target: 'ArduCopter'
+
+- template: autotest_template.yml
+  parameters:
+    name: 'Plane'
+    build_target: 'ArduPlane'
+    action_target: 'ArduPlane'
+
+- template: autotest_template.yml
+  parameters:
+    name: 'Quadplane'
+    build_target: 'ArduPlane'
+    action_target: 'QuadPlane'
+
+- template: autotest_template.yml
+  parameters:
+    name: 'Rover'
+    build_target: 'APMrover2'
+    action: 'drive'
+    action_target: 'APMrover2'
+
+- template: autotest_template.yml
+  parameters:
+    name: 'Sub'
+    build_target: 'ArduSub'
+    action: 'dive'
+    action_target: 'ArduSub'
+

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -11,6 +11,8 @@ jobs:
     displayName: 'Install Cygwin packages'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && CC=i686-pc-cygwin-gcc CXX=i686-pc-cygwin-g++.exe ./waf --board sitl configure bin"
     displayName: 'Build SITL'
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cygcheck.exe build/sitl/bin/*"
+    displayName: 'Copy dependencies to build dir'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cp $(cygcheck.exe build/sitl/bin/* | grep Cygwin | grep -v '.exe' | sed 's/^[ \t]*//' | sort | uniq) build/sitl/bin/"
     displayName: 'Copy dependencies to build dir'
   - task: PublishBuildArtifacts@1

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -5,14 +5,14 @@ jobs:
     vmImage: 'win1803'
   condition: ne(variables['Build.Reason'], 'Schedule')
   steps:
-  - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
+  - script: choco install --forceX86 cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
+  - script: choco install --forceX86 gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && ./waf --board sitl configure bin"
     displayName: 'Build SITL'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cygcheck.exe build/sitl/bin/*"
-    displayName: 'Copy dependencies to build dir'
+    displayName: 'Check dependencies'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cp $(cygcheck.exe build/sitl/bin/* | grep Cygwin | grep -v '.exe' | sed 's/^[ \t]*//' | sort | uniq) build/sitl/bin/"
     displayName: 'Copy dependencies to build dir'
   - task: PublishBuildArtifacts@1

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -7,9 +7,9 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install cygwin32-gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
+  - script: choco install gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
-  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && CC=i686-pc-cygwin-gcc CXX=i686-pc-cygwin-g++.exe ./waf --board sitl configure bin"
+  - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && ./waf --board sitl configure bin"
     displayName: 'Build SITL'
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') && cygcheck.exe build/sitl/bin/*"
     displayName: 'Copy dependencies to build dir'

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ArduPilot/ardupilot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build SemaphoreCI](https://semaphoreci.com/api/v1/ardupilot/ardupilot/branches/master/badge.svg)](https://semaphoreci.com/ardupilot/ardupilot)
-
-[![Build Travis](https://travis-ci.org/ArduPilot/ardupilot.svg?branch=master)](https://travis-ci.org/ArduPilot/ardupilot)
+[![Build Travis](https://travis-ci.org/ArduPilot/ardupilot.svg?branch=master)](https://travis-ci.org/ArduPilot/ardupilot) [![Build SemaphoreCI](https://semaphoreci.com/api/v1/ardupilot/ardupilot/branches/master/badge.svg)](https://semaphoreci.com/ardupilot/ardupilot) [![Build Status](https://dev.azure.com/ardupilot-org/ardupilot/_apis/build/status/ArduPilot.ardupilot?branchName=master)](https://dev.azure.com/ardupilot-org/ardupilot/_build/latest?definitionId=1&branchName=master)
 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5331/badge.svg)](https://scan.coverity.com/projects/ardupilot-ardupilot)
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -201,6 +201,7 @@ def ap_common_vehicle_libraries(bld):
     if bld.env.DEST_BINFMT == 'pe':
         libraries += [
             'AC_Fence',
+            'AC_AttitudeControl',
         ]
 
     return libraries

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -902,6 +902,7 @@ class AutoTestPlane(AutoTest):
              "Log download",
              lambda: self.log_download(
                  self.buildlogs_path("ArduPlane-log.bin"),
+                 timeout=450,
                  upload_logs=True))
         ])
         return ret

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -501,6 +501,8 @@ class AutoTest(ABC):
         f1 = open(file1)
         f2 = open(file2)
         for l1, l2 in itertools.izip(f1, f2):
+            l1 = l1.rstrip("\r\n")
+            l2 = l2.rstrip("\r\n")
             if l1 == l2:
                 # e.g. the first "QGC WPL 110" line
                 continue


### PR DESCRIPTION
Long time coming support for building ArduPilot in Cygwin using the recent Azure Pipelines offer (10 free parallel jobs, Windows, Linux and macOS).

Explaining commits:

- AC_Avoidance was added as an always included library, but it depends on AC_AttitudeControl, which AntennaTracker doesn't include - that would give a linking error in Cygwin; this is only an issue in PE format because the GNU ld linker can't properly garbage collect unused sections for that format; some time ago I added support for only including libraries when building for PE, so use it to include the needed library

- As known, Windows and Linux use different newline characters, autotest would fail because mission files wouldn't match; this was due to different newline characters, so just remove those before comparing lines
- Timeout for Plane log download wasn't enough in Azure Pipelines so increase it
- Azure Pipelines support templates for jobs, so there is one file for an autotest template and another for the actual jobs definition - I think everything is pretty straightforward but if you have any doubt, ask.<br/>
Usually only building all vehicles will happen: examples don't build on Cygwin and autotest is too slow to run every time; every day at 4AM UTC, autotest will run on master branch - this at least allows us to know if Cygwin build is crashing (as was happening before #10000).

@tridge @peterbarker Autotest periodically fails in Cygwin/Azure due to MAVProxy only trying to reconnect 3 times after a SITL reboot (https://github.com/ArduPilot/pymavlink/blob/master/mavutil.py#L1147). I tried finding a way to increase this (or even better, make it keep retrying like it does with serial) but it doesn't look easy, any hints?

I've already setup ArduPilot organization in Azure (unfortunately ArduPilot was taken, so had to use ardupilot-org for name) and I'm hoping this PR will actually build there (not completely sure). Anyone wanting to be added to the organization send me a private message with your Microsoft Account e-mail.

P.S.: The commented lines on YAML files are due to a coming change in the task to publish artifacts (I didn't want to look it all up again). At the moment the new task is still in beta and doesn't have all the features of the current one (for example, new task doesn't allow anonymous/public access to artifacts, which current one does).