### PR TITLE
WIP: add support for quadmotor tailsitters

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -39,6 +39,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(update_flight_mode,    400,    100),
     SCHED_TASK(stabilize,             400,    100),
     SCHED_TASK(set_servos,            400,    100),
+    SCHED_TASK(update_throttle_hover, 100,     90),
     SCHED_TASK(read_control_switch,     7,    100),
     SCHED_TASK(update_GPS_50Hz,        50,    300),
     SCHED_TASK(update_GPS_10Hz,        10,    400),

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1016,6 +1016,7 @@ private:
     void calc_nav_yaw_ground(void);
     void throttle_slew_limit(void);
     bool suppress_throttle(void);
+    void update_throttle_hover();
     void channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
                                 SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out);
     void flaperon_update(int8_t flap_percent);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1596,6 +1596,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
     // see if motors should be shut down
     check_throttle_suppression();
     
+    // this eventually calls the AP_MotorsMulticopter child class output_to_motors()
     motors->output();
     if (motors->armed()) {
         plane.DataFlash.Log_Write_Rate(plane.ahrs, *motors, *attitude_control, *pos_control);

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -74,6 +74,7 @@ public:
     bool verify_vtol_land(void);
     bool in_vtol_auto(void) const;
     bool in_vtol_mode(void) const;
+    void update_throttle_hover();
 
     // vtol help for is_flying()
     bool is_flying(void);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -781,6 +781,11 @@ void Plane::servos_output(void)
     }
 }
 
+void Plane::update_throttle_hover() {
+    // update hover throttle at 100Hz
+    quadplane.update_throttle_hover();
+}
+
 /*
   implement automatic persistent trim of control surfaces with
   AUTO_TRIM=2, only available when SERVO_RNG_ENABLE=1 as otherwise it

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -61,6 +61,17 @@ void QuadPlane::tailsitter_output(void)
             float tilt_right = (elevator - aileron) * tailsitter.vectored_forward_gain;
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
+            // differential thrust on pitch axis for quad tailsitter
+            // Must suppress this if not armed
+            if (hal.util->get_soft_armed()) {
+                float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+                // normalize elevator to range [-100,100] by dividing by 45
+                float elev_norm = elevator * (1.0f / 45.0f);
+                float throttleTop = (throttle - elev_norm * tailsitter.vectored_forward_gain);
+                float throttleBot = (throttle + elev_norm * tailsitter.vectored_forward_gain);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleTop, throttleTop);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleBot, throttleBot);
+            }
         } else {
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, 0);
             SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 0);
@@ -75,6 +86,8 @@ void QuadPlane::tailsitter_output(void)
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleTop, throttle);
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleBot, throttle);
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
         }
@@ -216,7 +229,20 @@ void QuadPlane::tailsitter_speed_scaling(void)
     } else {
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
-
+    
+    // reduce throws if in VTOL mode at large pitch angles (implies high airspeed)
+    const float magic_attenuation = 0.5f;
+    const float magic_roll_thresh = 30.0f;
+    if (in_vtol_mode()) {
+        float roll = labs(ahrs_view->roll_sensor) / 100.0f;
+        float pitch = labs(ahrs_view->pitch_sensor) / 100.0f;
+        if (pitch > tailsitter.transition_angle) {
+            scaling = constrain_float(magic_attenuation * (float)(tailsitter.transition_angle) / pitch, 0.25f, 1.0f);
+        }
+        else if (roll > 30) {
+            scaling = constrain_float(magic_attenuation * magic_roll_thresh / roll, 0.25f, 1.0f);
+        }
+    }
     const SRV_Channel::Aux_servo_function_t functions[2] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator};

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -559,6 +559,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
     Quaternion desired_ang_vel_quat = to_to_from_quat.inverse()*attitude_target_ang_vel_quat*to_to_from_quat;
 
     // Correct the thrust vector and smoothly add feedforward and yaw input
+    // prioritize roll/pitch over yaw when _thrust_error_angle is large
     if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE*2.0f){
         _rate_target_ang_vel.z = _ahrs.get_gyro().z;
     }else if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE){

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -26,7 +26,8 @@
 #define AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX          1.0f    // body-frame rate controller maximum output (for roll-pitch axis)
 #define AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX         1.0f    // body-frame rate controller maximum output (for yaw axis)
 
-#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(30.0f) // Thrust angle error above which yaw corrections are limited
+// disable yaw rate setpoint unlocking with error angle limit of 180 degrees
+#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(180.0f) // Thrust angle error above which yaw corrections are limited
 
 #define AC_ATTITUDE_400HZ_DT                            0.0025f // delta time in seconds for 400hz update rate
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -90,6 +90,8 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     virtual uint16_t    get_motor_mask() override;
 
+    void enable_motor(uint8_t i, bool v) {motor_enabled[i] = v;}
+
     // get minimum or maximum pwm value that can be output to motors
     int16_t             get_pwm_output_min() const;
     int16_t             get_pwm_output_max() const;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -17,6 +17,7 @@ public:
     // init
     void init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
+    // *** note that the following 2 methods are empty => frame_type and speed_hz are ignored ***
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {}
     void set_update_rate( uint16_t speed_hz ) override {}

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -142,6 +142,8 @@ public:
         k_scripting14           = 107,
         k_scripting15           = 108,
         k_scripting16           = 109,
+        k_throttleTop           = 110,
+        k_throttleBot           = 111,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -119,6 +119,8 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_throttle:
     case k_throttleLeft:
     case k_throttleRight:
+    case k_throttleTop:
+    case k_throttleBot:
         // fixed wing throttle
         set_range(100);
         break;


### PR DESCRIPTION
The first 3 commits add servo functions k_throttleTop and k_throttleBot for 2 additional motors in a "plus" configuration. Differential thrust from the new top and bottom motors aid the elevons in pitch control when in VTOL modes. In fixed-wing modes, the top and bottom motors are disabled; their ESCs should have braking ON in order to stop the props and reduce drag.

The 4th commit adds hover throttle learning for tailsitters only; it is controlled by parameter Q_M_HOVER_LEARN: 0 is disabled, 1 is learn, 2 is learn and save.  The hover thrust value is saved to parameter Q_M_THST_HOVER

The 5th commit disables yaw setpoint unlocking when yaw control error is large; this is currently controlled by a hardwired parameter: AC_ATTITUDE_THRUST_ERROR_ANGLE and is set to 30 degrees.
I haven't seen an issue with this in SITL, but have often encountered it with real tailsitters; the net effect feels like "uncommanded yaw" and is quite disorienting for this pilot. I expect this behavior is useful for multicopters which end up in "unusual" attitudes, but it seems to have no advantage for tailsitters.

