### PR TITLE
WIP: AP_HAL_ChibiOS: add stepper motor step output

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -29,6 +29,11 @@
 #define CH_NONE 255
 #endif
 
+// Define stepper parameters
+#define STEPPER_MAX_PERIOD 100000  // us -> 10 Hz, this defines the slowest to output step signals, and therefore the minimum update rate
+#define STEPPER_HIGH_TIME 100 // us, this also defines max speed (2 * 100) = 200us -> 5KHz
+#define STEPPER_DEFUALT_UPDATE_RATE 20000  // us -> 50 Hz, stepper output will be called at this frequency if no output is needed
+
 class ByteBuffer;
 
 class AP_HAL::RCOutput {
@@ -171,7 +176,7 @@ public:
     virtual void serial_end(void) {}
     
     /*
-      output modes. Allows for support of PWM, oneshot and dshot 
+      output modes. Allows for support of PWM, oneshot, dshot and stepper
      */
     enum output_mode {
         MODE_PWM_NONE,
@@ -183,6 +188,7 @@ public:
         MODE_PWM_DSHOT300,
         MODE_PWM_DSHOT600,
         MODE_PWM_DSHOT1200,
+        MODE_STEPPER,
     };
     virtual void    set_output_mode(uint16_t mask, enum output_mode mode) {}
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -93,8 +93,8 @@ void RCOutput::init()
  */
 void RCOutput::set_freq_group(pwm_group &group)
 {
-    if (mode_requires_dma(group.current_mode)) {
-        // speed setup in DMA handler
+    if (mode_requires_dma(group.current_mode) || group.current_mode = MODE_STEPPER) {
+        // speed setup in DMA handler, steppers do not use pwm
         return;
     }
     
@@ -631,6 +631,7 @@ void RCOutput::set_group_mode(pwm_group &group)
 
     case MODE_PWM_NORMAL:
     case MODE_PWM_NONE:
+    case MODE_STEPPER
         // nothing needed
         break;
     }
@@ -638,6 +639,7 @@ void RCOutput::set_group_mode(pwm_group &group)
     set_freq_group(group);
     
     if (group.current_mode != MODE_PWM_NONE &&
+        group.current_mode != MODE_STEPPER &&
         !group.pwm_started) {
         pwmStart(group.pwm_drv, &group.pwm_cfg);
         group.pwm_started = true;
@@ -671,6 +673,22 @@ void RCOutput::set_output_mode(uint16_t mask, enum output_mode mode)
             set_group_mode(group);
         }
     }
+
+    // Check for steppers up to a maximum of 4
+    if (mode == MODE_STEPPER) {
+        uint8_t num_steppers
+        for (uint8_t i = 0; i < 16; i++ ) {
+            if ((mask & (1U<<i)) && num_steppers < 4) {
+                // initialize virtual timer for stepper output
+                chVTObjectInit(stepper_on_timer);
+                stepper_timmer[i] = chVTObjectInit(stepper_timer);
+                chVTSet(&stepper_timmer[i], US2ST(STEPPER_DEFUALT_UPDATE_RATE), stepper_step, i);
+
+                num_steppers += 1;
+            }
+        }
+    }
+
 #if HAL_WITH_IO_MCU
     if ((mode == MODE_PWM_ONESHOT ||
          mode == MODE_PWM_ONESHOT125) &&
@@ -1506,6 +1524,61 @@ void RCOutput::set_failsafe_pwm(uint32_t chmask, uint16_t period_us)
         iomcu.set_failsafe_pwm(chmask, period_us);
     }
 #endif
+}
+
+void RCOutput::stepper_step(uint8_t chan)
+{
+    chSysLockFromISR();
+    uint16_t step_period = period[chan]
+
+    // should be switched off
+    if (step_period == 0 || step_period > STEPPER_MAX_PERIOD) {
+        // recall in default time to see if we should do anything then
+        chVTSet(&stepper_timmer[chan], US2ST(STEPPER_DEFUALT_UPDATE_RATE), stepper_step, chan);
+
+        chSysUnlockFromISR();
+        return;
+    }
+
+    // check were not trying to go too fast
+    step_period = max(step_period, STEPPER_HIGH_TIME * 2);
+
+    // set output high and start timer to turn it off again
+    const int16_t chanel_output_pin = ; // ??
+    hal.gpio->write(chanel_output_pin, 1);
+    chVTSet(&stepper_on_timer, US2ST(STEPPER_HIGH_TIME), stepper_high_timer, chan);
+
+    /*
+    increment a counter to keep track of stepper position
+    need to poll appropriate relay pin to see which direction the stepper is turning
+    so we know whether to add or subtract
+
+    relay numbers are hard coded in rover for this so just need to get the correct pin from the parameters??
+    */
+    const int16_t relay_pin = ; // ??
+    const int8_t dir = hal.gpio->read(relay_pin)?1:-1;
+    stepper_count[chan] += dir;
+
+    // recall in period
+    chVTSet(&stepper_timmer[chan], US2ST(step_period), stepper_step, chan);
+
+    chSysUnlockFromISR();
+}
+
+// turn off the stepper output after its on time
+void RCOutput::stepper_high_timer(uint8_t chan)
+{
+    chSysLockFromISR();
+    const int16_t chanel_output_pin = ; // ??
+    hal.gpio->write(chanel_output_pin, 0);
+    chSysUnlockFromISR();
+}
+
+int16_t RCOutput::get_stepper_count(uint8_t chan)
+{
+    const int16_t step_count = stepper_count[chan];
+    stepper_count[chan] = 0;
+    return step_count
 }
 
 #endif // HAL_USE_PWM

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -154,7 +154,10 @@ public:
     void set_reversible_mask(uint16_t chanmask) override {
         reversible_mask |= chanmask;
     }
-    
+
+    // return number of steps of stepper since last polled
+    int16_t get_stepper_count(uint8_t chan);
+
 private:
     struct pwm_group {
         // only advanced timers can do high clocks needed for more than 400Hz
@@ -258,6 +261,8 @@ private:
     uint16_t period[max_channels];
     uint16_t safe_pwm[max_channels]; // pwm to use when safety is on
     bool corked;
+    stepper_timmer *stepper_timmer[max_channels]; // pointer for virtual timers
+    int16_t stepper_count[max_channels]; 
     // mask of channels that are running in high speed
     uint16_t fast_channel_mask;
     uint16_t io_fast_channel_mask;
@@ -298,7 +303,11 @@ private:
 
     // update safety switch and LED
     void safety_update(void);
-    
+
+    // interrupts for stepper output
+    void stepper_step(uint8_t chan)
+    void stepper_high_timer(uint8_t chan)
+
     /*
       DShot handling
      */


### PR DESCRIPTION
This is my attempt to add stepper motor support to the Chibios hal. 

It turn out more complicated than I had expected, so I'm in abit over my head. This is more of a first draft than anything, I was hopping for some feedback as to whether I am going about it in a sensible way. 

Stepper motor drivers require a step signal of varying frequency to tell them to move and a direction signal to tell them the direction. The direction is taken care of by rovers relay pins for the existing brushed_with_relay motor type so this PR is a attempt to add the variable frequency output for the step signal. 

If this seems like a OK starting point I would be great full of some advice on how to do the timer pointers correctly and sorting out which hardware pins to use. Also i'm not sure I have turned off the pwm output for the stepper pin correctly. 

If we can get all this sorted I can then add stepper support to the main rover code. 

Thanks all!
