### PR TITLE
WIP: Support pixart pmw3901 linux

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDevice.h
+++ b/libraries/AP_HAL_Linux/SPIDevice.h
@@ -57,11 +57,15 @@ public:
     bool adjust_periodic_callback(
         AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 
+    /* See AP_HAL::Device::set_chip_select() */
+    bool set_chip_select(bool set) override;
+
 protected:
     SPIBus &_bus;
     SPIDesc &_desc;
     AP_HAL::DigitalSource *_cs;
     uint32_t _speed;
+    bool _caller_ctrl_cs;
 
     /*
      * Select device if using userspace CS

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -111,10 +111,11 @@ void OpticalFlow::init(uint32_t log_bit)
         backend = new AP_OpticalFlow_SITL(*this);
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
         backend = new AP_OpticalFlow_Onboard(*this);
+#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412 || \
+    CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH
+        backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
         backend = AP_OpticalFlow_PX4Flow::detect(*this);
-#elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_CHIBIOS_SKYVIPER_F412
-        backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #elif defined(HAL_HAVE_PIXARTFLOW_SPI)
         backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #endif


### PR DESCRIPTION
Saw a discussion about PMW3901 optical flow [here](https://discuss.ardupilot.org/t/breakout-board-for-pmw3901-optical-flow-sensor/30613), I tried to support it under general Linux. With this PR, I could see OPTFLOW data from GCS, which connected to RPI3+[BH board](https://bithollow.com/portfolio/bh-pilot/)

Haven't tested it thoroughly, so titled this PR as WIP.

One more thing is that I changed the periodic callback (producer) interval from 2000usec to 5000usec, because in ArduCopter.cpp, optflow update (consumer) rate is 200Hz. When the interval is 2000usec, it consumes ~21% of cpu (RPI3), I think it is unnecessary. Correct me if I'm wrong.