### PR TITLE
SITL: fixed JSBSim backend to work with latest releases

### DIFF
--- a/Tools/autotest/aircraft/Rascal/Rascal.xml
+++ b/Tools/autotest/aircraft/Rascal/Rascal.xml
@@ -88,8 +88,8 @@
                 <y> 0 </y>
                 <z> -4 </z>
             </location>
-            <static_friction> 8.0 </static_friction>
-            <dynamic_friction> 5.0 </dynamic_friction>
+            <static_friction> 0.8 </static_friction>
+            <dynamic_friction> 0.5 </dynamic_friction>
             <rolling_friction> 0.1 </rolling_friction>
             <spring_coeff unit="LBS/FT"> 480 </spring_coeff>
             <damping_coeff unit="LBS/FT/SEC"> 100 </damping_coeff>
@@ -519,4 +519,15 @@
             </function>
         </axis>
     </aerodynamics>
+
+    <!-- <output name="RascalOutputFile.csv" type="CSV" rate="10">
+        <rates> ON </rates>
+        <velocities> ON </velocities>
+        <position> ON </position>
+        <fcs> ON </fcs>
+        <propulsion> ON </propulsion>
+    </output> -->
+
+  <input port="5505"/>
+
 </fdm_config>

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -252,34 +252,6 @@ def kill_tasks():
         progress("kill_tasks failed: {}".format(str(e)))
 
 
-def check_jsbsim_version():
-    """Assert that the JSBSim we will run is the one we expect to run"""
-    jsbsim_cmd = ["JSBSim", "--version"]
-    progress_cmd("Get JSBSim version", jsbsim_cmd)
-    try:
-        jsbsim = subprocess.Popen(jsbsim_cmd, stdout=subprocess.PIPE)
-        jsbsim_version = jsbsim.communicate()[0]
-    except OSError:
-        # this value will trigger the ".index" check below and produce
-        # a reasonable error message:
-        jsbsim_version = ''
-    try:
-        jsbsim_version.index(b"ArduPilot")
-    except ValueError:
-        print(r"""
-=========================================================
-You need the latest ArduPilot version of JSBSim installed
-and in your \$PATH
-
-Please get it from git://github.com/tridge/jsbsim.git
-See
-http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html
-for more details
-=========================================================
-""")
-        sys.exit(1)
-
-
 def progress(text):
     """Display sim_vehicle progress text"""
     print("SIM_VEHICLE: " + text)
@@ -1005,9 +977,6 @@ simout_port = "127.0.0.1:" + str(5501 + 10 * cmd_opts.instance)
 frame_infos = vinfo.options_for_frame(cmd_opts.frame,
                                       cmd_opts.vehicle,
                                       cmd_opts)
-
-if frame_infos["model"] == "jsbsim":
-    check_jsbsim_version()
 
 vehicle_dir = os.path.realpath(os.path.join(find_root_dir(), cmd_opts.vehicle))
 if not os.path.exists(vehicle_dir):

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -141,7 +141,7 @@ bool JSBSim::create_templates(void)
     fprintf(f,
             "<?xml version=\"1.0\"?>\n"
             "<initialize name=\"Start up location\">\n"
-            "  <latitude unit=\"DEG\"> %f </latitude>\n"
+            "  <latitude unit=\"DEG\" type=\"geodetic\"> %f </latitude>\n"
             "  <longitude unit=\"DEG\"> %f </longitude>\n"
             "  <altitude unit=\"M\"> 1.3 </altitude>\n"
             "  <vt unit=\"FT/SEC\"> 0.0 </vt>\n"
@@ -291,7 +291,7 @@ bool JSBSim::open_control_socket(void)
     char startup[] =
         "info\n"
         "resume\n"
-        "step\n"
+        "iterate 1\n"
         "set atmosphere/turb-type 4\n";
     sock_control.send(startup, strlen(startup));
     return true;
@@ -351,7 +351,7 @@ void JSBSim::send_servos(const struct sitl_input &input)
              "set atmosphere/wind-mag-fps %f\n"
              "set atmosphere/turbulence/milspec/windspeed_at_20ft_AGL-fps %f\n"
              "set atmosphere/turbulence/milspec/severity %f\n"
-             "step\n",
+             "iterate 1\n",
              aileron, elevator, rudder, throttle,
              radians(input.wind.direction),
              wind_speed_fps,

--- a/libraries/SITL/SIM_JSBSim.h
+++ b/libraries/SITL/SIM_JSBSim.h
@@ -99,28 +99,25 @@ public:
     double longitude;		// geodetic (radians)
     double latitude;		// geodetic (radians)
     double altitude;		// above sea level (meters)
-    float agl;			// above ground level (meters)
-    float phi;			// roll (radians)
-    float theta;		// pitch (radians)
-    float psi;			// yaw or true heading (radians)
-    float alpha;                // angle of attack (radians)
-    float beta;                 // side slip angle (radians)
+    float agl;			    // above ground level (meters)
+    float phi;			    // roll (radians)
+    float theta;		    // pitch (radians)
+    float psi;			    // yaw or true heading (radians)
+    float alpha;        // angle of attack (radians)
+    float beta;         // side slip angle (radians)
 
     // Velocities
-    float phidot;		// roll rate (radians/sec)
-    float thetadot;		// pitch rate (radians/sec)
-    float psidot;		// yaw rate (radians/sec)
-    float vcas;             // calibrated airspeed
-    float climb_rate;		// feet per second
-    float v_north;              // north velocity in local/body frame, fps
-    float v_east;               // east velocity in local/body frame, fps
-    float v_down;               // down/vertical velocity in local/body frame, fps
-    float v_wind_body_north;    // north velocity in local/body frame
-                                // relative to local airmass, fps
-    float v_wind_body_east;     // east velocity in local/body frame
-                                // relative to local airmass, fps
-    float v_wind_body_down;     // down/vertical velocity in local/body
-                                // frame relative to local airmass, fps
+    float phidot;		     // roll rate (radians/sec)
+    float thetadot;		   // pitch rate (radians/sec)
+    float psidot;		     // yaw rate (radians/sec)
+    float vcas;          // calibrated airspeed
+    float climb_rate;		 // feet per second
+    float v_north;       // north velocity in local/body frame, fps
+    float v_east;        // east velocity in local/body frame, fps
+    float v_down;        // down/vertical velocity in local/body frame, fps
+    float v_body_u;      // ECEF velocity in body axis
+    float v_body_v;      // ECEF velocity in body axis
+    float v_body_w;      // ECEF velocity in body axis
 
     // Accelerations
     float A_X_pilot;		// X accel in body frame ft/sec^2
@@ -128,26 +125,26 @@ public:
     float A_Z_pilot;		// Z accel in body frame ft/sec^2
 
     // Stall
-    float stall_warning;        // 0.0 - 1.0 indicating the amount of stall
-    float slip_deg;		// slip ball deflection
+    float stall_warning;  // 0.0 - 1.0 indicating the amount of stall
+    float slip_deg;		    // slip ball deflection
 
     // Pressure
 
     // Engine status
-    uint32_t num_engines;        // Number of valid engines
-    uint32_t eng_state[FG_MAX_ENGINES];// Engine state (off, cranking, running)
-    float rpm[FG_MAX_ENGINES];       // Engine RPM rev/min
-    float fuel_flow[FG_MAX_ENGINES]; // Fuel flow gallons/hr
-    float fuel_px[FG_MAX_ENGINES];   // Fuel pressure psi
-    float egt[FG_MAX_ENGINES];       // Exhuast gas temp deg F
-    float cht[FG_MAX_ENGINES];       // Cylinder head temp deg F
-    float mp_osi[FG_MAX_ENGINES];    // Manifold pressure
-    float tit[FG_MAX_ENGINES];       // Turbine Inlet Temperature
-    float oil_temp[FG_MAX_ENGINES];  // Oil temp deg F
-    float oil_px[FG_MAX_ENGINES];    // Oil pressure psi
+    uint32_t num_engines;               // Number of valid engines
+    uint32_t eng_state[FG_MAX_ENGINES]; // Engine state (off, cranking, running)
+    float rpm[FG_MAX_ENGINES];          // Engine RPM rev/min
+    float fuel_flow[FG_MAX_ENGINES];    // Fuel flow gallons/hr
+    float fuel_px[FG_MAX_ENGINES];      // Fuel pressure psi
+    float egt[FG_MAX_ENGINES];          // Exhuast gas temp deg F
+    float cht[FG_MAX_ENGINES];          // Cylinder head temp deg F
+    float mp_osi[FG_MAX_ENGINES];       // Manifold pressure
+    float tit[FG_MAX_ENGINES];          // Turbine Inlet Temperature
+    float oil_temp[FG_MAX_ENGINES];     // Oil temp deg F
+    float oil_px[FG_MAX_ENGINES];       // Oil pressure psi
 
     // Consumables
-    uint32_t num_tanks;		// Max number of fuel tanks
+    uint32_t num_tanks;		              // Max number of fuel tanks
     float fuel_quantity[FG_MAX_TANKS];
 
     // Gear status
@@ -175,6 +172,7 @@ public:
     float speedbrake;
     float spoilers;
 
+    // nasty hack .... JSBSim sends in little-endian
     void ByteSwap(void);
 };
 


### PR DESCRIPTION
This is based on work by Willem Eerland to make the ArduPilot JSBSim SITL backend work with the latest JSBSim releases, which now have a way to do lock-step scheduling without modifications
