### PR TITLE
Tools: Undefined name: 'AutoTestTimeoutException'

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -9,6 +9,7 @@ import time
 
 from common import AutoTest
 
+from common import AutoTestTimeoutException
 from common import MsgRcvTimeoutException
 from common import NotAchievedException
 from common import PreconditionFailedException


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/ArduPilot/ardupilot on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Tools/autotest/apmrover2.py:688:27: F821 undefined name 'AutoTestTimeoutException'
                    raise AutoTestTimeoutException("Did not reach speed")
                          ^
./Tools/autotest/apmrover2.py:717:27: F821 undefined name 'AutoTestTimeoutException'
                    raise AutoTestTimeoutException("Did not stop")
                          ^
2     F821 undefined name 'AutoTestTimeoutException'
2
```