### PR TITLE
AP_Motors: Dualheli- fix bug for scaling second swashplate

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -475,17 +475,16 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
         limit.throttle_upper = true;
     }
 
-    // Set rear collective to midpoint if required
-    float collective2_out = collective_out;
-    if (_servo_mode == SERVO_CONTROL_MODE_MANUAL_CENTER) {
-        collective2_out = _collective2_mid_pct;
-    }
-
-
     // ensure not below landed/landing collective
     if (_heliflags.landing_collective && collective_out < (_land_collective_min*0.001f)) {
         collective_out = _land_collective_min*0.001f;
         limit.throttle_lower = true;
+    }
+
+    // Set rear collective to midpoint if required
+    float collective2_out = collective_out;
+    if (_servo_mode == SERVO_CONTROL_MODE_MANUAL_CENTER) {
+        collective2_out = _collective2_mid_pct;
     }
 
     // scale collective pitch for front swashplate (servos 1,2,3)
@@ -509,9 +508,13 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     // swashplate servos
     float servo_out[AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS];
     
-    for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {
-        servo_out[i] = (_rollFactor[i] * roll_out + _pitchFactor[i] * pitch_out + _yawFactor[i] * yaw_out)*0.45f + _collectiveFactor[i] * collective_out_scaled;
-    }
+    servo_out[CH_1] = (_rollFactor[CH_1] * roll_out + _pitchFactor[CH_1] * pitch_out + _yawFactor[CH_1] * yaw_out)*0.45f + _collectiveFactor[CH_1] * collective_out_scaled;
+    servo_out[CH_2] = (_rollFactor[CH_2] * roll_out + _pitchFactor[CH_2] * pitch_out + _yawFactor[CH_2] * yaw_out)*0.45f + _collectiveFactor[CH_2] * collective_out_scaled;
+    servo_out[CH_3] = (_rollFactor[CH_3] * roll_out + _pitchFactor[CH_3] * pitch_out + _yawFactor[CH_3] * yaw_out)*0.45f + _collectiveFactor[CH_3] * collective_out_scaled;
+
+    servo_out[CH_4] = (_rollFactor[CH_4] * roll_out + _pitchFactor[CH_4] * pitch_out + _yawFactor[CH_4] * yaw_out)*0.45f + _collectiveFactor[CH_4] * collective2_out_scaled;
+    servo_out[CH_5] = (_rollFactor[CH_5] * roll_out + _pitchFactor[CH_5] * pitch_out + _yawFactor[CH_5] * yaw_out)*0.45f + _collectiveFactor[CH_5] * collective2_out_scaled;
+    servo_out[CH_6] = (_rollFactor[CH_6] * roll_out + _pitchFactor[CH_6] * pitch_out + _yawFactor[CH_6] * yaw_out)*0.45f + _collectiveFactor[CH_6] * collective2_out_scaled;
 
     // rescale from -1..1, so we can use the pwm calc that includes trim
     for (uint8_t i=0; i<AP_MOTORS_HELI_DUAL_NUM_SWASHPLATE_SERVOS; i++) {


### PR DESCRIPTION
This PR is being submitted to fix an issue found with the second swashplate not being scaled to the H_COL2_MIN and H_COL2_MAX parameters.  Discuss Forum user Tudole posted the issue [here](https://discuss.ardupilot.org/t/possible-bug-in-dual-rotor/36368)

This issue was a result of the code change associated with the PR #8739.  the servo position calculations for each swashplate are now broken out as they were prior to PR#8739 so as to account for the different scaling between the two swashplates.

In addition I moved the if statement that applies the H_LAND_COL_MIN  parameter to the collective so that it is applied to both of the swashplates.

I conducted a functional check in the SITL to ensure there were no issues with the change.  I verified that the limits of each swashplate were dictated by the corresponding parameters.  IMO, no flight test is required.