### PR TITLE
Rover: add DShot support and default SERVO_BLH_TRATE to 10hz

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @Param: PWM_TYPE
     // @DisplayName: Motor Output PWM type
     // @Description: This selects the output PWM type as regular PWM, OneShot, Brushed motor support using PWM (duty cycle) with separated direction signal, Brushed motor support with separate throttle and direction PWM (duty cyle)
-    // @Values: 0:Normal,1:OneShot,2:OneShot125,3:BrushedWithRelay,4:BrushedBiPolar
+    // @Values: 0:Normal,1:OneShot,2:OneShot125,3:BrushedWithRelay,4:BrushedBiPolar,5:DShot150,6:DShot300,7:DShot600,8:DShot1200
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PWM_TYPE", 1, AP_MotorsUGV, _pwm_type, PWM_TYPE_NORMAL),
@@ -537,7 +537,7 @@ void AP_MotorsUGV::setup_pwm_type()
     for (uint8_t i=0; i<_motors_num; i++) {
         motor_mask |= SRV_Channels::get_output_channel_mask(SRV_Channels::get_motor_function(i));
     }
-    
+
     switch (_pwm_type) {
     case PWM_TYPE_ONESHOT:
         hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT);
@@ -549,6 +549,18 @@ void AP_MotorsUGV::setup_pwm_type()
     case PWM_TYPE_BRUSHED_BIPOLAR:
         hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_BRUSHED);
         hal.rcout->set_freq(motor_mask, uint16_t(_pwm_freq * 1000));
+        break;
+    case PWM_TYPE_DSHOT150:
+        hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT150);
+        break;
+    case PWM_TYPE_DSHOT300:
+        hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT300);
+        break;
+    case PWM_TYPE_DSHOT600:
+        hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT600);
+        break;
+    case PWM_TYPE_DSHOT1200:
+        hal.rcout->set_output_mode(motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT1200);
         break;
     default:
         // do nothing

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -16,6 +16,10 @@ public:
         PWM_TYPE_ONESHOT125 = 2,
         PWM_TYPE_BRUSHED_WITH_RELAY = 3,
         PWM_TYPE_BRUSHED_BIPOLAR = 4,
+        PWM_TYPE_DSHOT150 = 5,
+        PWM_TYPE_DSHOT300 = 6,
+        PWM_TYPE_DSHOT600 = 7,
+        PWM_TYPE_DSHOT1200 = 8
      };
 
     enum motor_test_order {

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -78,7 +78,7 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     // @Units: Hz
     // @Range: 0 500
     // @User: Standard
-    AP_GROUPINFO("TRATE",  5, AP_BLHeli, telem_rate, 0),
+    AP_GROUPINFO("TRATE",  5, AP_BLHeli, telem_rate, 10),
 
     // @Param: DEBUG
     // @DisplayName: BLHeli debug level


### PR DESCRIPTION
This PR makes two unrelated DShot/BLHeli related changes:

- Rover gets basic support for DShot.  This has been bench successfully tested on a pixhawk flight controller.  There are two known issues issues which we can handle through documentation and future PRs:
  - We should force the SERVOx_MIN/MAX to be 1000 to 2000.  In the short-term we can handle this through documentation but longer term we should address this ([issue here](https://github.com/ArduPilot/ardupilot/issues/10043)).
  - BLHeli passthrough fails unless MOT_SAFE_DISARM = 1 ([issue here](https://github.com/ArduPilot/ardupilot/issues/10044))
- Change the SERVO_BLH_TRATE parameter default from 0 to 10.  This has no effect unless the BLHeli telemetry has been enabled and saves the user from having to manually set this parameter.  This is the suggested value written in [the wiki](http://ardupilot.org/copter/docs/common-dshot.html).