### PR TITLE
AP_SmartRTL: increase default pts to 300

### DIFF
--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -10,7 +10,7 @@
 
 // definitions and macros
 #define SMARTRTL_ACCURACY_DEFAULT        2.0f   // default _ACCURACY parameter value.  Points will be no closer than this distance (in meters) together.
-#define SMARTRTL_POINTS_DEFAULT          150    // default _POINTS parameter value.  High numbers improve path pruning but use more memory and CPU for cleanup. Memory used will be 20bytes * this number.
+#define SMARTRTL_POINTS_DEFAULT          300    // default _POINTS parameter value.  High numbers improve path pruning but use more memory and CPU for cleanup. Memory used will be 20bytes * this number.
 #define SMARTRTL_POINTS_MAX              500    // the absolute maximum number of points this library can support.
 #define SMARTRTL_TIMEOUT                 15000  // the time in milliseconds with no points saved to the path (for whatever reason), before SmartRTL is disabled for the flight
 #define SMARTRTL_CLEANUP_POINT_TRIGGER   50     // simplification will trigger when this many points are added to the path


### PR DESCRIPTION
I've raised this PR because I want to increase awareness that I'd like to use up about 2.5K of RAM to increase the default maximum number of SmartRTL points from 150 to 300.  It's a fair chunk of RAM and it's theoretically possible to give up some accuracy to reduce that a bit but it also greatly increases the maximum distance a vehicle can travel and still return using Smart RTL.  It depends upon the flight but it's an increase from about 1.5km to about 3km.

![before-after](https://user-images.githubusercontent.com/1498098/50194846-0076e580-0380-11e9-9f5b-fb6cc7e79eb3.png)
