### PR TITLE
AP_RangeFinder: Change abnormal value judgment value

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -780,7 +780,7 @@ void AP_RangeFinder_VL53L0X::update(void)
 void AP_RangeFinder_VL53L0X::timer(void)
 {
     uint16_t range_mm;
-    if (get_reading(range_mm) && range_mm < 8000) {
+    if (get_reading(range_mm) && range_mm <= (state.max_distance_cm * 10)) {
         sum_mm += range_mm;
         counter++;
     }


### PR DESCRIPTION
I think the maximum range of VL 53L 0X is 200 cm.
I think that it is better to treat it as abnormal if you get more than the performance value.