### PR TITLE
AP_Notify: extra options for buzzer

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -122,7 +122,7 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @Param: BUZZ_ENABLE
     // @DisplayName: Buzzer enable
     // @Description: Enable or disable the buzzer.
-    // @Values: 0:Disable,1:Enable
+    // @Values: 0:Disable,1:Enable,2:Enable when disarmed only,3:Enable when armed only
     // @User: Advanced
     AP_GROUPINFO("BUZZ_ENABLE", 1, AP_Notify, _buzzer_enable, BUZZER_ENABLE_DEFAULT),
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -138,7 +138,9 @@ public:
     // handle a PLAY_TUNE message
     static void handle_play_tune(mavlink_message_t* msg);
 
-    bool buzzer_enabled() const { return _buzzer_enable; }
+    bool buzzer_enabled() const { return _buzzer_enable == 1                // 1: Always enabled
+                                 || (_buzzer_enable == 2 && !flags.armed)   // 2: Only when disarmed 
+                                 || (_buzzer_enable == 3 && flags.armed); } // 3: Only when armed 
 
     // set flight mode string
     void set_flight_mode_str(const char *str);

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -33,9 +33,6 @@ extern const AP_HAL::HAL& hal;
 
 bool Buzzer::init()
 {
-    if (pNotify->buzzer_enabled() == false) {
-        return false;
-    }
 #if defined(HAL_BUZZER_PIN)
     _pin = HAL_BUZZER_PIN;
 #else
@@ -54,7 +51,7 @@ bool Buzzer::init()
     return true;
 }
 
-// update - updates led according to timed_updated.  Should be called at 50Hz
+// update - updates buzzer according to timed_updated.  Should be called at 50Hz
 void Buzzer::update()
 {
     // check for arming failed event
@@ -207,6 +204,10 @@ void Buzzer::update()
 // on - turns the buzzer on or off
 void Buzzer::on(bool turn_on)
 {
+    if (!pNotify->buzzer_enabled())	{
+		turn_on = false;
+	}
+	
     // return immediately if nothing to do
     if (_flags.on == turn_on) {
         return;


### PR DESCRIPTION
Impl. for https://github.com/ArduPilot/ardupilot/issues/9416

Two more options added for BUZZ_ENABLE parameter:
2 - Buzzer is active only when vehicle is disarmed
3 - Buzzer is active only if armed