### PR TITLE
Added serial pass-thru support

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -865,7 +865,7 @@ void AP_BLHeli::blheli_process_command(void)
         }
         if (uart_locked) {
             debug("Unlocked UART");
-            uart->lock_port(0);
+            uart->lock_port(0, 0);
             uart_locked = false;
         }
         memset(blheli.connected, 0, sizeof(blheli.connected));
@@ -1079,7 +1079,7 @@ bool AP_BLHeli::process_input(uint8_t b)
         if (blheli.state == BLHELI_COMMAND_RECEIVED) {
             valid_packet = true;
             last_valid_ms = AP_HAL::millis();
-            if (uart->lock_port(BLHELI_UART_LOCK_KEY)) {
+            if (uart->lock_port(BLHELI_UART_LOCK_KEY, 0)) {
                 uart_locked = true;
             }
             blheli_process_command();
@@ -1089,7 +1089,7 @@ bool AP_BLHeli::process_input(uint8_t b)
     } else if (msp.state == MSP_COMMAND_RECEIVED) {
         if (msp.packetType == MSP_PACKET_COMMAND) {
             valid_packet = true;
-            if (uart->lock_port(BLHELI_UART_LOCK_KEY)) {
+            if (uart->lock_port(BLHELI_UART_LOCK_KEY, 0)) {
                 uart_locked = true;
             }
             last_valid_ms = AP_HAL::millis();
@@ -1185,7 +1185,7 @@ void AP_BLHeli::update(void)
             SRV_Channels::set_disabled_channel_mask(0);            
         }
         debug("Unlocked UART");
-        uart->lock_port(0);
+        uart->lock_port(0, 0);
         uart_locked = false;
     }
     if (initialised || (channel_mask.get() == 0 && channel_auto.get() == 0)) {

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -39,12 +39,15 @@ public:
     virtual bool tx_pending() = 0;
 
     // lock a port for exclusive use. Use a key of 0 to unlock
-    virtual bool lock_port(uint32_t key) { return false; }
+    virtual bool lock_port(uint32_t write_key, uint32_t read_key) { return false; }
 
     // write to a locked port. If port is locked and key is not correct then 0 is returned
     // and write is discarded
     virtual size_t write_locked(const uint8_t *buffer, size_t size, uint32_t key) { return 0; }
 
+    // read from a locked port. If port is locked and key is not correct then 0 is returned
+    virtual int16_t read_locked(uint32_t key) { return -1; }
+    
     // control optional features
     virtual bool set_options(uint8_t options) { return options==0; }
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -44,13 +44,14 @@ public:
     uint32_t available() override;
     uint32_t txspace() override;
     int16_t read() override;
+    int16_t read_locked(uint32_t key) override;
     void _timer_tick(void) override;
 
     size_t write(uint8_t c) override;
     size_t write(const uint8_t *buffer, size_t size) override;
 
     // lock a port for exclusive use. Use a key of 0 to unlock
-    bool lock_port(uint32_t key) override;
+    bool lock_port(uint32_t write_key, uint32_t read_key) override;
 
     // control optional features
     bool set_options(uint8_t options) override;
@@ -125,8 +126,9 @@ private:
     uint8_t serial_num;
 
     // key for a locked port
-    uint32_t lock_key;
-    
+    uint32_t lock_write_key;
+    uint32_t lock_read_key;
+
     uint32_t _baudrate;
     uint16_t tx_len;
 #if HAL_USE_SERIAL == TRUE
@@ -173,6 +175,13 @@ private:
     // we remember cr2 and cr2 options from set_options to apply on sdStart()
     uint32_t _cr3_options;
     uint32_t _cr2_options;
+
+    // half duplex control. After writing we throw away bytes for 4 byte widths to
+    // prevent reading our own bytes back
+    bool half_duplex;
+    uint32_t hd_read_delay_us;
+    uint32_t hd_write_us;
+    void half_duplex_setup_delay(uint16_t len);
 
     // set to true for unbuffered writes (low latency writes)
     bool unbuffered_writes;

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -206,14 +206,14 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: _PASS1
     // @DisplayName: Serial passthru first port
     // @Description: This sets one side of pass-through between two serial ports. Once both sides are set then all data received on either port will be passed to the other port
-    // @Values: -1:Disabled,1:Serial1,2:Serial2,3:Serial3,4:Serial4,5:Serial5,6:Serial6
+    // @Values: -1:Disabled,0:Serial0,1:Serial1,2:Serial2,3:Serial3,4:Serial4,5:Serial5,6:Serial6
     // @User: Advanced
     AP_GROUPINFO("_PASS1",  20, AP_SerialManager, passthru_port1, 0),
 
     // @Param: _PASS2
     // @DisplayName: Serial passthru second port
     // @Description: This sets one side of pass-through between two serial ports. Once both sides are set then all data received on either port will be passed to the other port
-    // @Values: -1:Disabled,1:Serial1,2:Serial2,3:Serial3,4:Serial4,5:Serial5,6:Serial6
+    // @Values: -1:Disabled,0:Serial0,1:Serial1,2:Serial2,3:Serial3,4:Serial4,5:Serial5,6:Serial6
     // @User: Advanced
     AP_GROUPINFO("_PASS2",  21, AP_SerialManager, passthru_port2, -1),
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -141,6 +141,12 @@ public:
     // set_blocking_writes_all - sets block_writes on or off for all serial channels
     void set_blocking_writes_all(bool blocking);
 
+    // get the passthru ports if enabled
+    bool get_passthru(AP_HAL::UARTDriver *&port1, AP_HAL::UARTDriver *&port2, uint8_t &timeout_s) const;
+
+    // disable passthru by settings SERIAL_PASS2 to -1
+    void disable_passthru(void);
+    
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -154,6 +160,11 @@ private:
         AP_HAL::UARTDriver* uart;
         AP_Int16 options;
     } state[SERIALMANAGER_NUM_PORTS];
+
+    // pass-through serial support
+    AP_Int8 passthru_port1;
+    AP_Int8 passthru_port2;
+    AP_Int8 passthru_timeout;
 
     // search through managed serial connections looking for the
     // instance-nth UART which is running protocol protocol

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -754,6 +754,9 @@ public:
     // get the VFR_HUD throttle
     int16_t get_hud_throttle(void) const { return num_gcs()>0?chan(0).vfr_hud_throttle():0; }
 
+    // update uart pass-thru
+    void update_passthru();
+
 private:
 
     static GCS *_singleton;
@@ -778,6 +781,22 @@ private:
 
     // true if we are running short on time in our main loop
     bool _out_of_time;
+
+    // handle passthru between two UARTs
+    struct {
+        bool enabled;
+        bool timer_installed;
+        AP_HAL::UARTDriver *port1;
+        AP_HAL::UARTDriver *port2;
+        uint32_t start_ms;
+        uint32_t last_ms;
+        uint32_t last_port1_data_ms;
+        uint8_t timeout_s;
+        HAL_Semaphore sem;
+    } _passthru;
+
+    // timer called to implement pass-thru
+    void passthru_timer();
 };
 
 GCS &gcs();


### PR DESCRIPTION
This adds arbitrary serial pass-thru support, allowing the user to configure two serial ports to pass-through to each other.
This is useful for using external config tools, such as the Robotis manager tool, or u-Center for uBlox GPSes. With this enabled you can attach to USB and control serial on any serial device. It also allows for baudrate changing, pin swapping, half-duplex and inversion, allowing ArduPilot to be a very flexible adapter

To use this:
 - set SERIAL_PASS1 to the first serial port, usually 0 for USB
 - set SERIAL_PASSTMO to the timeout you want for pass-thru to auto-disable. Zero for no timeout
 - set SERIAL_PASS2 to the 2nd serial port, for example a GPS or serial servo
 - as soon as you set SERIAL_PASS2 then the port will be locked (so if it is USB then your USB GCS connection will stop working). It will unlock on timeout or reboot
 - connect your external config tool directly to the port you specified in SERIAL_PASS1, usually USB
 - the baudrate and serial options (inversion, half-duplex etc) are honoured for both ports
