### PR TITLE
Copter: fix snprintf size warning

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1240,7 +1240,7 @@ void Copter::convert_lgr_parameters(void)
     snprintf(pname, sizeof(pname), "SERVO%u_TRIM", chan);
     servo_trim = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
-    snprintf(pname, sizeof(pname), "SERVO%u_REVERSED", chan);
+    snprintf(pname, sizeof(pname), "SERVO%u_REVERSED", chan & 0x32);
     servo_reversed = (AP_Int16 *)AP_Param::find(pname, &ptype);
 
     if (!servo_min || !servo_max || !servo_trim || !servo_reversed) {


### PR DESCRIPTION
fix warning : 
````
[478/527] Compiling ArduCopter/Parameters.cpp
../../ArduCopter/Parameters.cpp: In member function ‘void Copter::convert_lgr_parameters()’:
../../ArduCopter/Parameters.cpp:1218:6: warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
 void Copter::convert_lgr_parameters(void)
      ^~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from ../../ArduCopter/Copter.h:25,
                 from ../../ArduCopter/Parameters.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:65:44: note: ‘__builtin___snprintf_chk’ output between 16 and 18 bytes into a destination of size 17
        __bos (__s), __fmt, __va_arg_pack ());
````

I limit to 99, maybe is it better to cap it to NUM_SERVO_CHANNELS ?