### PR TITLE
AP_Mount: fix SToRM32 protocol delay

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -46,6 +46,7 @@ void AP_Mount_SToRM32::update()
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            resend_now = true;
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -60,6 +60,7 @@ void AP_Mount_SToRM32_serial::update()
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
+            resend_now = true;
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS


### PR DESCRIPTION
The packets to a SToRM32 gimbal via Serial protocol were being sent at 1s
intervals when in MAVLINK targeting mode. As this protocol is not
MAVLINK based, we need to resend the packets manually in this mode.

This change has been bench-tested on a Pixracer connected to SToRM32 v1.30 gimbal
running 2.40 nt firmware with targeting commands sent from dronekit-python.