### PR TITLE
Plane: Update plane main parameter descriptions

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -62,7 +62,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: KFF_RDDRMIX
     // @DisplayName: Rudder Mix
-    // @Description: Percentage of rudder to add during aileron movement. Increase if nose initially yaws away from roll. Coordinates turns.
+    // @Description: Amount of rudder to add during aileron movement. Increase if nose initially yaws away from roll. Reduces adverse yaw.
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Standard
@@ -585,8 +585,8 @@ const AP_Param::Info Plane::var_info[] = {
     GSCALAR(initial_mode,        "INITIAL_MODE",     MANUAL),
 
     // @Param: LIM_ROLL_CD
-    // @DisplayName: Maximum bank angle commanded in modes with stabilized limits. Increase this value for sharper turns, but decrease to prevent accelerated stalls.
-    // @Description: 
+    // @DisplayName: Maximum Bank Angle
+    // @Description: Maximum bank angle commanded in modes with stabilized limits. Increase this value for sharper turns, but decrease to prevent accelerated stalls.
     // @Units: cdeg
     // @Range: 0 9000
     // @Increment: 1

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -38,7 +38,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: AUTOTUNE_LEVEL
     // @DisplayName: Autotune level
-    // @Description: Level of aggressiveness for autotune. When autotune is run a lower AUTOTUNE_LEVEL will result in a 'softer' tune, with less aggressive gains. For most users a level of 6 is recommended.
+    // @Description: Level of aggressiveness of pitch and roll PID gains. Lower values result in a 'softer' tune. Level 6 recommended for most planes.
     // @Range: 1 10
     // @Increment: 1
     // @User: Standard
@@ -62,7 +62,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: KFF_RDDRMIX
     // @DisplayName: Rudder Mix
-    // @Description: The amount of rudder mix to apply during aileron movement 0 = 0 %, 1 = 100%
+    // @Description: Percentage of rudder to add during aileron movement. Increase if nose initially yaws away from roll. Coordinates turns.
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Standard
@@ -70,7 +70,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: KFF_THR2PTCH
     // @DisplayName: Throttle to Pitch Mix
-    // @Description: Throttle to pitch feed-forward gain.
+    // @Description: Degrees of elevator added for full throttle application. Increase to compensate for throttle causing down pitch.
     // @Range: 0 5
     // @Increment: 0.01
     // @User: Advanced
@@ -78,7 +78,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: STAB_PITCH_DOWN
     // @DisplayName: Low throttle pitch down trim 
-    // @Description: This controls the amount of down pitch to add in FBWA and AUTOTUNE modes when at low throttle. No down trim is added when throttle is above TRIM_THROTTLE. Below TRIM_THROTTLE downtrim is added in proportion to the amount the throttle is below TRIM_THROTTLE. At zero throttle the full downpitch specified in this parameter is added. This parameter is meant to help keep airspeed up when flying in FBWA mode with low throttle, such as when on a landing approach, without relying on an airspeed sensor. A value of 2 degrees is good for many planes, although a higher value may be needed for high drag aircraft.
+    // @Description: Degrees of down pitch added when throttle is below TRIM_THROTTLE in FBWA and AUTOTUNE modes. Scales linearly so full value is added when THR_MIN is reached. Helps to keep airspeed higher in glides or landing approaches and prevents accidental stalls. 2 degrees recommended for most planes.
     // @Range: 0 15
     // @Increment: 0.1
     // @Units: deg
@@ -343,14 +343,14 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: STALL_PREVENTION
     // @DisplayName: Enable stall prevention
-    // @Description: This controls the use of stall prevention techniques, including roll limits at low speed and raising the minimum airspeed in turns. The limits are based on the aerodynamic load factor of a banked turn. This option relies on the correct ARSPD_FBW_MIN value being set correctly. Note that if you don't have an airspeed sensor then stall prevention will use an airspeed estimate based on the ground speed plus a wind estimate taken from the response of the autopilot banked turns. That synthetic airspeed estimate may be inaccurate, so you should not assume that stall prevention with no airspeed sensor will be effective.
+    // @Description: Enables roll limits at low airspeed in roll limiting flight modes. Roll limits based on aerodynamic load factor in turns and scale on ARSPD_FBW_MIN that must be set correctly. Without airspeed sensor, uses synthetic airspeed from wind speed estimate that may both be inaccurate.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
     ASCALAR(stall_prevention, "STALL_PREVENTION",  1),
 
     // @Param: ARSPD_FBW_MIN
     // @DisplayName: Minimum Airspeed
-    // @Description: This is the minimum airspeed you want to fly at in modes where the autopilot controls the airspeed. This should be set to a value around 20% higher than the level flight stall speed for the airframe. This value is also used in the STALL_PREVENTION code.
+    // @Description: Minimum airspeed demanded in automatic throttle modes. Should be set to 20% higher than level flight stall speed.
     // @Units: m/s
     // @Range: 5 100
     // @Increment: 1
@@ -359,7 +359,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: ARSPD_FBW_MAX
     // @DisplayName: Maximum Airspeed
-    // @Description: This is the maximum airspeed that you want to allow for your airframe in auto-throttle modes. You should ensure that this value is sufficiently above the ARSPD_FBW_MIN value to allow for a sufficient flight envelope to accurately control altitude using airspeed. A value at least 50% above ARSPD_FBW_MIN is recommended.
+    // @Description: Maximum airspeed demanded in automatic throttle modes. Should be set slightly less than level flight speed at THR_MAX and also at least 50% above ARSPD_FBW_MAX to allow for accurate TECS altitude control.
     // @Units: m/s
     // @Range: 5 100
     // @Increment: 1
@@ -401,7 +401,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: THR_MIN
     // @DisplayName: Minimum Throttle
-    // @Description: The minimum throttle setting (as a percentage) which the autopilot will apply. For the final stage of an automatic landing this is always zero. If your ESC supports reverse, use a negative value to configure for reverse thrust.
+    // @Description: Minimum throttle percentage used in automatic throttle modes. Negative values allow reverse thrust if hardware supports it.
     // @Units: %
     // @Range: -100 100
     // @Increment: 1
@@ -410,7 +410,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: THR_MAX
     // @DisplayName: Maximum Throttle
-    // @Description: The maximum throttle setting (as a percentage) which the autopilot will apply.
+    // @Description: Maximum throttle percentage used in automatic throttle modes.
     // @Units: %
     // @Range: 0 100
     // @Increment: 1
@@ -428,7 +428,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate
-    // @Description: maximum percentage change in throttle per second. A setting of 10 means to not change the throttle by more than 10% of the full throttle range in one second. Note that the minimum throttle change is 1 microsecond per loop, which provides a lower limit on the throttle slew rate, especially for quadplanes that run at 300 loops per second by default.
+    // @Description: Maximum change in throttle percentage per second. Lower limit  based on 1 microsend of servo increase per loop. Divide SCHED_LOOP_RATE by approximately 10 to determine minimum achievable value.
     // @Units: %/s
     // @Range: 0 127
     // @Increment: 1
@@ -476,7 +476,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: TRIM_THROTTLE
     // @DisplayName: Throttle cruise percentage
-    // @Description: The target percentage of throttle to apply for normal flight
+    // @Description: Target percentage of throttle to apply for flight in automatic throttle modes and throttle percentage that maintains TRIM_ARSPD_CM. Caution: low battery voltages at the end of flights may require higher throttle to maintain airspeed.
     // @Units: %
     // @Range: 0 100
     // @Increment: 1
@@ -585,8 +585,8 @@ const AP_Param::Info Plane::var_info[] = {
     GSCALAR(initial_mode,        "INITIAL_MODE",     MANUAL),
 
     // @Param: LIM_ROLL_CD
-    // @DisplayName: Maximum Bank Angle
-    // @Description: The maximum commanded bank angle in either direction
+    // @DisplayName: Maximum bank angle commanded in modes with stabilized limits. Increase this value for sharper turns, but decrease to prevent accelerated stalls.
+    // @Description: 
     // @Units: cdeg
     // @Range: 0 9000
     // @Increment: 1
@@ -595,7 +595,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: LIM_PITCH_MAX
     // @DisplayName: Maximum Pitch Angle
-    // @Description: The maximum commanded pitch up angle
+    // @Description: Maximum pitch up angle commanded in modes with stabilized limits.
     // @Units: cdeg
     // @Range: 0 9000
     // @Increment: 1
@@ -604,7 +604,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: LIM_PITCH_MIN
     // @DisplayName: Minimum Pitch Angle
-    // @Description: The minimum commanded pitch down angle
+    // @Description: Maximum pitch down angle commanded in modes with stabilized limits
     // @Units: cdeg
     // @Range: -9000 0
     // @Increment: 1
@@ -656,7 +656,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: TRIM_AUTO
     // @DisplayName: Automatic trim adjustment
-    // @Description: Set RC trim PWM levels to current levels when switching away from manual mode. When this option is enabled and you change from MANUAL to any other mode then the APM will take the current position of the control sticks as the trim values for aileron, elevator and rudder. It will use those to set the SERVOn_TRIM values and the RCn_TRIM values. This option is disabled by default as if a pilot is not aware of this option and changes from MANUAL to another mode while control inputs are not centered then the trim could be changed to a dangerously bad value. You can enable this option to assist with trimming your plane, by enabling it before takeoff then switching briefly to MANUAL in flight, and seeing how the plane reacts. You can then switch back to FBWA, trim the surfaces then again test MANUAL mode. Each time you switch from MANUAL the APM will take your control inputs as the new trim. After you have good trim on your aircraft you can disable TRIM_AUTO for future flights. You should also see the newer and much safer SERVO_AUTO_TRIM parameter.
+    // @Description: Enables the setting SERVOn_TRIM values to current levels when switching out of MANUAL mode. Should not be left on as mode switches while the plane is rolling or pitching can cause invalid trim values and subsequent unstable behavior. See newer and safer SERVO_AUTO_TRIM parameter for automated results.
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
     GSCALAR(auto_trim,              "TRIM_AUTO",      AUTO_TRIM),
@@ -714,13 +714,13 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: RST_MISSION_CH
     // @DisplayName: Reset Mission Channel
-    // @Description: RC channel to use to reset the mission to the first waypoint. When this channel goes above 1750 the mission is reset. Set RST_MISSION_CH to 0 to disable.
+    // @Description: Enables a channel to reset the mission to the first waypoint. Mission restart is triggered by channel rising above 1750 PWM. 0 disables.
     // @User: Advanced
     GSCALAR(reset_mission_chan,      "RST_MISSION_CH",  0),
 
     // @Param: TRIM_ARSPD_CM
     // @DisplayName: Target airspeed
-    // @Description: Airspeed in cm/s to aim for when airspeed is enabled in auto mode. This is a calibrated (apparent) airspeed.
+    // @Description: Target airspeed in cm/s in automatic throttle modes. Value is as an indicated (calibrated/apparent) airspeed.
     // @Units: cm/s
     // @User: User
     ASCALAR(airspeed_cruise_cm,     "TRIM_ARSPD_CM",  AIRSPEED_CRUISE_CM),
@@ -741,14 +741,14 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: TRIM_PITCH_CD
     // @DisplayName: Pitch angle offset
-    // @Description: offset to add to pitch - used for in-flight pitch trimming. It is recommended that instead of using this parameter you level your plane correctly on the ground for good flight attitude.
+    // @Description: Offset applied to AHRS pitch used for in-flight pitch trimming. Correct ground leveling is better than changing this parameter.
     // @Units: cdeg
     // @User: Advanced
     GSCALAR(pitch_trim_cd,        "TRIM_PITCH_CD",  0),
 
     // @Param: ALT_HOLD_RTL
     // @DisplayName: RTL altitude
-    // @Description: Return to launch target altitude. This is the relative altitude the plane will aim for and loiter at when returning home. If this is negative (usually -1) then the plane will use the current altitude at the time of entering RTL. Note that when transiting to a Rally Point the altitude of the Rally Point is used instead of ALT_HOLD_RTL.
+    // @Description: Target altitude above home for RTL mode. Maintains current altitude if set to -1. Rally point altitudes are used if plane does not return to home.
     // @Units: cm
     // @User: User
     GSCALAR(RTL_altitude_cm,        "ALT_HOLD_RTL",   ALT_HOLD_HOME_CM),
@@ -1229,10 +1229,10 @@ ParametersG2::ParametersG2(void) :
   parameters and will copy them across to the new parameters if the
   new parameter does not yet have a saved value. It then saves the new
   value.
-
+  
   Note that this works even if the old parameter has been removed. It
   relies on the old k_param index not being removed
-
+  
   The second column below is the index in the var_info[] table for the
   old object. This should be zero for top level parameters.
  */

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -3,12 +3,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: TCONST
 	// @DisplayName: Pitch Time Constant
-	// @Description: This controls the time constant in seconds from demanded to achieved pitch angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
+	// @Description: Time constant in seconds from demanded to achieved pitch angle. Most models respond well to 0.5. May be reduced for faster responses, but setting lower than a model can achieve will not help.
 	// @Range: 0.4 1.0
 	// @Units: s
 	// @Increment: 0.1
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: P
 	// @DisplayName: Proportional Gain
-	// @Description: This is the gain from pitch angle to elevator. This gain works the same way as PTCH2SRV_P in the old PID controller and can be set to the same value.
+	// @Description: Proportional gain from pitch angle demands to elevator. Higher values allow more servo response but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
 	// @Range: 0.1 3.0
 	// @Increment: 0.1
 	// @User: User
@@ -42,15 +42,15 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: D
 	// @DisplayName: Damping Gain
-	// @Description: This is the gain from pitch rate to elevator. This adjusts the damping of the pitch control loop. It has the same effect as PTCH2SRV_D in the old PID controller and can be set to the same value, but without the spikes in servo demands. This gain helps to reduce pitching in turbulence. Some airframes such as flying wings that have poor pitch damping can benefit from increasing this gain term. This should be increased in 0.01 increments as too high a value can lead to a high frequency pitch oscillation that could overstress the airframe.
-	// @Range: 0 0.1
+	// @Description: Damping gain from pitch acceleration to elevator. Higher values reduce pitching in turbulence, but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
+	// @Range: 0 0.2
 	// @Increment: 0.01
 	// @User: User
     AP_GROUPINFO("D",        2, AP_PitchController, gains.D,        0.04f),
 
 	// @Param: I
 	// @DisplayName: Integrator Gain
-	// @Description: This is the gain applied to the integral of pitch angle. It has the same effect as PTCH2SRV_I in the old PID controller and can be set to the same value. Increasing this gain causes the controller to trim out constant offsets between demanded and measured pitch angle.
+	// @Description: Integrator gain from long-term pitch angle offsets to elevator. Higher values "trim" out offsets faster but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
 	// @Range: 0 0.5
 	// @Increment: 0.05
 	// @User: User
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: RMAX_UP
 	// @DisplayName: Pitch up max rate
-	// @Description: This sets the maximum nose up pitch rate that the controller will demand (degrees/sec). Setting it to zero disables the limit.
+	// @Description: Maximum pitch up rate that the pitch controller demands (degrees/sec) in ACRO mode.
 	// @Range: 0 100
 	// @Units: deg/s
 	// @Increment: 1
@@ -76,7 +76,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: RLL
 	// @DisplayName: Roll compensation
-	// @Description: This is the gain term that is applied to the pitch rate offset calculated as required to keep the nose level during turns. The default value is 1 which will work for all models. Advanced users can use it to correct for height variation in turns. If height is lost initially in turns this can be increased in small increments of 0.05 to compensate. If height is gained initially in turns then it can be decreased.
+	// @Description: Gain added to pitch to keep aircraft from descending or ascending in turns. Increase in increments of 0.05 to reduce altitude loss. Decrease for altitude gain.
 	// @Range: 0.7 1.5
 	// @Increment: 0.05
 	// @User: User
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: IMAX
 	// @DisplayName: Integrator limit
-	// @Description: This limits the number of centi-degrees of elevator over which the integrator will operate. At the default setting of 3000 centi-degrees, the integrator will be limited to +- 30 degrees of servo travel. The maximum servo deflection is +- 45 degrees, so the default value represents a 2/3rd of the total control throw which is adequate for most aircraft unless they are severely out of trim or have very limited elevator control effectiveness.
+	// @Description: Limit of pitch integrator gain in centi-degrees of servo travel. Servos are assumed to have +/- 4500 centi-degrees of travel, so a value of 3000 allows trim of up to 2/3 of servo travel range.
 	// @Range: 0 4500
 	// @Increment: 1
 	// @User: Advanced
@@ -92,7 +92,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
 	// @Param: FF
 	// @DisplayName: Feed forward Gain
-	// @Description: This is the gain from demanded rate to elevator output. 
+	// @Description: Gain from demanded rate to elevator output.
 	// @Range: 0.1 4.0
 	// @Increment: 0.1
 	// @User: User
@@ -248,7 +248,7 @@ int32_t AP_PitchController::get_rate_out(float desired_rate, float scaler)
 /*
   get the rate offset in degrees/second needed for pitch in body frame
   to maintain height in a coordinated turn.
-
+  
   Also returns the inverted flag and the estimated airspeed in m/s for
   use by the rest of the pitch controller
  */

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -3,12 +3,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,7 +25,7 @@ extern const AP_HAL::HAL& hal;
 const AP_Param::GroupInfo AP_RollController::var_info[] = {
 	// @Param: TCONST
 	// @DisplayName: Roll Time Constant
-	// @Description: This controls the time constant in seconds from demanded to achieved bank angle. A value of 0.5 is a good default and will work with nearly all models. Advanced users may want to reduce this time to obtain a faster response but there is no point setting a time less than the aircraft can achieve.
+	// @Description: Time constant in seconds from demanded to achieved roll angle. Most models respond well to 0.5. May be reduced for faster responses, but setting lower than a model can achieve will not help.
 	// @Range: 0.4 1.0
 	// @Units: s
 	// @Increment: 0.1
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 	// @Param: P
 	// @DisplayName: Proportional Gain
-	// @Description: This is the gain from bank angle error to aileron.
+	// @Description: Proportional gain from roll angle demands to ailerons. Higher values allow more servo response but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
 	// @Range: 0.1 4.0
 	// @Increment: 0.1
 	// @User: User
@@ -42,15 +42,15 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 	// @Param: D
 	// @DisplayName: Damping Gain
-	// @Description: This is the gain from roll rate to aileron. This adjusts the damping of the roll control loop. It has the same effect as RLL2SRV_D in the old PID controller but without the spikes in servo demands. This gain helps to reduce rolling in turbulence. It should be increased in 0.01 increments as too high a value can lead to a high frequency roll oscillation that could overstress the airframe.
-	// @Range: 0 0.1
+	// @Description: Damping gain from roll acceleration to ailerons. Higher values reduce rolling in turbulence, but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
+	// @Range: 0 0.2
 	// @Increment: 0.01
 	// @User: User
 	AP_GROUPINFO("D",        2, AP_RollController, gains.D,        0.08f),
 
 	// @Param: I
 	// @DisplayName: Integrator Gain
-	// @Description: This is the gain from the integral of bank angle to aileron. It has the same effect as RLL2SRV_I in the old PID controller. Increasing this gain causes the controller to trim out steady offsets due to an out of trim aircraft.
+	// @Description: Integrator gain from long-term roll angle offsets to ailerons. Higher values "trim" out offsets faster but can cause oscillations. Automatically set and adjusted by AUTOTUNE mode.
 	// @Range: 0 1.0
 	// @Increment: 0.05
 	// @User: User
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 	// @Param: RMAX
 	// @DisplayName: Maximum Roll Rate
-	// @Description: This sets the maximum roll rate that the controller will demand (degrees/sec). Setting it to zero disables the limit. If this value is set too low, then the roll can't keep up with the navigation demands and the plane will start weaving. If it is set too high (or disabled by setting to zero) then ailerons will get large inputs at the start of turns. A limit of 60 degrees/sec is a good default.
+	// @Description: Maximum roll rate that the roll controller demands (degrees/sec) in ACRO mode.
 	// @Range: 0 180
 	// @Units: deg/s
 	// @Increment: 1
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 	// @Param: IMAX
 	// @DisplayName: Integrator limit
-	// @Description: This limits the number of degrees of aileron in centi-degrees over which the integrator will operate. At the default setting of 3000 centi-degrees, the integrator will be limited to +- 30 degrees of servo travel. The maximum servo deflection is +- 45 centi-degrees, so the default value represents a 2/3rd of the total control throw which is adequate unless the aircraft is severely out of trim.
+	// @Description: Limit of roll integrator gain in centi-degrees of servo travel. Servos are assumed to have +/- 4500 centi-degrees of travel, so a value of 3000 allows trim of up to 2/3 of servo travel range.
 	// @Range: 0 4500
 	// @Increment: 1
 	// @User: Advanced
@@ -75,7 +75,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 	// @Param: FF
 	// @DisplayName: Feed forward Gain
-	// @Description: This is the gain from demanded rate to aileron output. 
+	// @Description: Gain from demanded rate to aileron output. 
 	// @Range: 0.1 4.0
 	// @Increment: 0.1
 	// @User: User
@@ -216,4 +216,3 @@ void AP_RollController::reset_I()
 {
 	_pid_info.I = 0;
 }
-

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -3,12 +3,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 	// @Param: SLIP
 	// @DisplayName: Sideslip control gain
-	// @Description: This is the gain from measured lateral acceleration to demanded yaw rate. It should be set to zero unless active control of sideslip is desired. This will only work effectively if there is enough fuselage side area to generate a measureable lateral acceleration when the model sideslips. Flying wings and most gliders cannot use this term. This term should only be adjusted after the basic yaw damper gain YAW2SRV_DAMP is tuned and the YAW2SRV_INT integrator gain has been set. Set this gain to zero if only yaw damping is required.
+	// @Description: Gain from lateral acceleration to demanded yaw rate for aircraft with enough fuselage area to detect lateral acceleration and sideslips. Do not enable for flying wings and gliders. Actively coordinates flight more than just yaw damping. Set after YAW2SRV_DAMP and YAW2SRV_INT are tuned.
 	// @Range: 0 4
 	// @Increment: 0.25
     // @User: Advanced
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 	// @Param: INT
 	// @DisplayName: Sideslip control integrator
-	// @Description: This is the integral gain from lateral acceleration error. This gain should only be non-zero if active control over sideslip is desired. If active control over sideslip is required then this can be set to 1.0 as a first try.
+	// @Description: Integral gain from lateral acceleration error. Effectively trims rudder to eliminate long-term sideslip.
 	// @Range: 0 2
 	// @Increment: 0.25
     // @User: Advanced
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 	// @Param: DAMP
 	// @DisplayName: Yaw damping
-	// @Description: This is the gain from yaw rate to rudder. It acts as a damper on yaw motion. If a basic yaw damper is required, this gain term can be incremented, whilst leaving the YAW2SRV_SLIP and YAW2SRV_INT gains at zero. Note that unlike with a standard PID controller, if this damping term is zero then the integrator will also be disabled.
+	// @Description: Gain from yaw rate to rudder. Most effective at yaw damping and should be tuned after KFF_RDDRMIX. Also disables YAW2SRV_INT if set to 0.
 	// @Range: 0 2
 	// @Increment: 0.25
     // @User: Advanced
@@ -50,7 +50,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 	// @Param: RLL
 	// @DisplayName: Yaw coordination gain
-	// @Description: This is the gain term that is applied to the yaw rate offset calculated as required to keep the yaw rate consistent with the turn rate for a coordinated turn. The default value is 1 which will work for all models. Advanced users can use it to correct for any tendency to yaw away from or into the turn once the turn is established. Increase to make the model yaw more initially and decrease to make the model yaw less initially. If values greater than 1.1 or less than 0.9 are required then it normally indicates a problem with the airspeed calibration.
+	// @Description: Gain to the yaw rate required to keep it consistent with the turn rate in a coordinated turn. Corrects for yaw tendencies after the turn is established. Increase yaw into the turn by raising. Increase yaw out of the turn by decreasing. Values outside of 0.9-1.1 range indicate airspeed calibration problems.
 	// @Range: 0.8 1.2
 	// @Increment: 0.05
     // @User: Advanced
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 	// @Param: IMAX
 	// @DisplayName: Integrator limit
-	// @Description: This limits the number of centi-degrees of rudder over which the integrator will operate. At the default setting of 1500 centi-degrees, the integrator will be limited to +- 15 degrees of servo travel. The maximum servo deflection is +- 45 degrees, so the default value represents a 1/3rd of the total control throw which is adequate for most aircraft unless they are severely out of trim or have very limited rudder control effectiveness.
+	// @Description: Limit of yaw integrator gain in centi-degrees of servo travel. Servos are assumed to have +/- 4500 centi-degrees of travel, so a value of 1500 allows trim of up to 1/3 of servo travel range.
 	// @Range: 0 4500
 	// @Increment: 1
 	// @User: Advanced

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -3,12 +3,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -65,8 +65,8 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // @Param: _USE
     // @DisplayName: Airspeed use
-    // @Description: use airspeed for flight control. When set to 0 airspeed sensor can be logged and displayed on a GCS but won't be used for flight. When set to 1 it will be logged and used. When set to 2 it will be only used when the throttle is zero, which can be useful in gliders with airspeed sensors behind a propeller
-    // @Values: 0:Don't Use,1:use,2:UseWhenZeroThrottle
+    // @Description: Enables airspeed use for automatic throttle modes and replaces control from THR_TRIM. Continues to display and log airspeed if set to 0. Uses airspeed for control if set to 1. Only uses airspeed when throttle = 0 if set to 2 (useful for gliders with airspeed sensors behind propellers).
+    // @Values: 0:DoNotUse,1:Use,2:UseWhenZeroThrottle
     // @User: Standard
     AP_GROUPINFO("_USE",    1, AP_Airspeed, param[0].use, 0),
 
@@ -79,7 +79,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // @Param: _RATIO
     // @DisplayName: Airspeed ratio
-    // @Description: Airspeed calibration ratio
+    // @Description: Calibrates pitot tube pressure to velocity. Increasing this value will indicate a higher airspeed at any given dynamic pressure.
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("_RATIO",  3, AP_Airspeed, param[0].ratio, 1.9936f),
@@ -92,13 +92,13 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // @Param: _AUTOCAL
     // @DisplayName: Automatic airspeed ratio calibration
-    // @Description: If this is enabled then the autopilot will automatically adjust the ARSPD_RATIO during flight, based upon an estimation filter using ground speed and true airspeed. The automatic calibration will save the new ratio to EEPROM every 2 minutes if it changes by more than 5%. This option should be enabled for a calibration flight then disabled again when calibration is complete. Leaving it enabled all the time is not recommended.
+    // @Description: Enables automatic adjustment of ARSPD_RATIO during a calibration flight based on estimation of ground speed and true airspeed. New ratio saved every 2 minutes if change is > 5%. Should not be left enabled.
     // @User: Advanced
     AP_GROUPINFO("_AUTOCAL",  5, AP_Airspeed, param[0].autocal, 0),
 
     // @Param: _TUBE_ORDER
     // @DisplayName: Control pitot tube order
-    // @Description: This parameter allows you to control whether the order in which the tubes are attached to your pitot tube matters. If you set this to 0 then the top connector on the sensor needs to be the dynamic pressure. If set to 1 then the bottom connector needs to be the dynamic pressure. If set to 2 (the default) then the airspeed driver will accept either order. The reason you may wish to specify the order is it will allow your airspeed sensor to detect if the aircraft it receiving excessive pressure on the static port, which would otherwise be seen as a positive airspeed.
+    // @Description: Changes the pitot tube order to specify the dynamic pressure side of the sensor. Accepts either if set to 2. Accepts only one side if set to 0 or 1 and can help detect excessive pressure on the static port without indicating positive airspeed.
     // @User: Advanced
     AP_GROUPINFO("_TUBE_ORDER",  6, AP_Airspeed, param[0].tube_order, 2),
 
@@ -117,7 +117,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // @Param: _BUS
     // @DisplayName: Airspeed I2C bus
-    // @Description: The bus number of the I2C bus to look for the sensor on
+    // @Description: Bus number of the I2C bus where the airspeed sensor is connected
     // @Values: 0:Bus0(internal),1:Bus1(external),2:Bus2(auxillary)
     // @User: Advanced
     AP_GROUPINFO("_BUS",  9, AP_Airspeed, param[0].bus, 1),
@@ -159,7 +159,7 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
     // @Param: 2_PIN
     // @DisplayName: Airspeed pin for 2nd airspeed sensor
-    // @Description: The pin number that the airspeed sensor is connected to for analog sensors. Set to 15 on the Pixhawk for the analog airspeed port. 
+    // @Description: Pin number indicating location of analog airspeed sensors. Pixhawk/Cube if set to 15. 
     // @User: Advanced
     AP_GROUPINFO("2_PIN",  15, AP_Airspeed, param[1].pin, 0),
 
@@ -487,4 +487,3 @@ bool AP_Airspeed::all_healthy(void) const
 
 // singleton instance
 AP_Airspeed *AP_Airspeed::_singleton;
-

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: CLMB_MAX
     // @DisplayName: Maximum Climb Rate (metres/sec)
-    // @Description: This is the best climb rate that the aircraft can achieve with the throttle set to THR_MAX and the airspeed set to the default value. For electric aircraft make sure this number can be achieved towards the end of flight when the battery voltage has reduced. The setting of this parameter can be checked by commanding a positive altitude change of 100m in loiter, RTL or guided mode. If the throttle required to climb is close to THR_MAX and the aircraft is maintaining airspeed, then this parameter is set correctly. If the airspeed starts to reduce, then the parameter is set to high, and if the throttle demand require to climb and maintain speed is noticeably less than THR_MAX, then either CLMB_MAX should be increased or THR_MAX reduced.
+    // @Description: Maximum demanded climb rate. Do not set higher than the climb speed at THR_MAX at TRIM_ARSPD_CM when the battery is at low voltage. Reduce value if airspeed cannot be maintained on ascent. Increase value if throttle does not increase significantly to ascend.
     // @Increment: 0.1
     // @Range: 0.1 20.0
     // @User: Standard
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: SINK_MIN
     // @DisplayName: Minimum Sink Rate (metres/sec)
-    // @Description: This is the sink rate of the aircraft with the throttle set to THR_MIN and the same airspeed as used to measure CLMB_MAX.
+    // @Description: Minimum sink rate when at THR_MIN and TRIM_ARSPD_CM.
     // @Increment: 0.1
     // @Range: 0.1 10.0
     // @User: Standard
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: TIME_CONST
     // @DisplayName: Controller time constant (sec)
-    // @Description: This is the time constant of the TECS control algorithm. Smaller values make it faster to respond, large values make it slower to respond.
+    // @Description: Time constant of the TECS control algorithm. Small values make faster altitude corrections but can cause overshoot and aggressive behavior.
     // @Range: 3.0 10.0
     // @Increment: 0.2
     // @User: Advanced
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: THR_DAMP
     // @DisplayName: Controller throttle damping
-    // @Description: This is the damping gain for the throttle demand loop. Increase to add damping  to correct for oscillations in speed and height.
+    // @Description: Damping gain for throttle demand loop. Slows the throttle response to correct for speed and height oscillations.
     // @Range: 0.1 1.0
     // @Increment: 0.1
     // @User: Advanced
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: INTEG_GAIN
     // @DisplayName: Controller integrator
-    // @Description: This is the integrator gain on the control loop. Increase to increase the rate at which speed and height offsets are trimmed out
+    // @Description: Integrator gain to trim out long-term speed and height errors.
     // @Range: 0.0 0.5
     // @Increment: 0.02
     // @User: Advanced
@@ -56,7 +56,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: VERT_ACC
     // @DisplayName: Vertical Acceleration Limit (metres/sec^2)
-    // @Description: This is the maximum vertical acceleration either up or down that the  controller will use to correct speed or height errors.
+    // @Description: Maximum vertical acceleration used to correct speed or height errors.
     // @Range: 1.0 10.0
     // @Increment: 0.5
     // @User: Advanced
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: RLL2THR
     // @DisplayName: Bank angle compensation gain
-    // @Description: Increasing this gain turn increases the amount of throttle that will be used to compensate for the additional drag created by turning. Ideally this should be set to approximately 10 x the extra sink rate in m/s created by a 45 degree bank turn. Increase this gain if the aircraft initially loses energy in turns and reduce if the aircraft initially gains energy in turns. Efficient high aspect-ratio aircraft (eg powered sailplanes) can use a lower value, whereas inefficient low aspect-ratio models (eg delta wings) can use a higher value.
+    // @Description: Gain from bank angle to throttle to compensate for loss of airspeed from drag in turns. Set to approximately 10x the sink rate in m/s caused by a 45-degree turn. High efficiency models may need less while less efficient aircraft may need more. Should be tuned in an automatic mission with waypoints and turns greater than 90 degrees. Tune with PTCH2SV_RLL and KFF_RDDRMIX to achieve constant airspeed, constant altitude turns.
     // @Range: 5.0 30.0
     // @Increment: 1.0
     // @User: Advanced
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: SPDWEIGHT
     // @DisplayName: Weighting applied to speed control
-    // @Description: This parameter adjusts the amount of weighting that the pitch control applies to speed vs height errors. Setting it to 0.0 will cause the pitch control to control height and ignore speed errors. This will normally improve height accuracy but give larger airspeed errors. Setting it to 2.0 will cause the pitch control loop to control speed and ignore height errors. This will normally reduce airsped errors, but give larger height errors.	A value of 1.0 gives a balanced response and is the default.
+    // @Description: Mixing of pitch and throttle correction for height and airspeed errors. Pitch controls altitude and throttle controls airspeed if set to 0. Pitch controls airspeed and throttle controls altitude if set to 2 (good for gliders). Blended if set to 1.
     // @Range: 0.0 2.0
     // @Increment: 0.1
     // @User: Advanced
@@ -96,7 +96,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: PTCH_DAMP
     // @DisplayName: Controller pitch damping
-    // @Description: This is the damping gain for the pitch demand loop. Increase to add damping  to correct for oscillations in speed and height.
+    // @Description: Damping gain for pitch control from TECS control.  Increasing may correct for oscillations in speed and height, but too much may cause additional oscillation and degraded control.
     // @Range: 0.1 1.0
     // @Increment: 0.1
     // @User: Advanced
@@ -104,7 +104,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: SINK_MAX
     // @DisplayName: Maximum Descent Rate (metres/sec)
-    // @Description: This sets the maximum descent rate that the controller will use.  If this value is too large, the aircraft will reach the pitch angle limit first and be unable to achieve the descent rate. This should be set to a value that can be achieved at the lower pitch angle limit.
+    // @Description: Maximum demanded descent rate. Do not set higher than the vertical speed the aircraft can maintain at THR_MIN, TECS_PITCH_MIN, and ARSPD_FBW_MAX.
     // @Increment: 0.1
     // @Range: 0.0 20.0
     // @User: User
@@ -136,7 +136,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: PITCH_MAX
     // @DisplayName: Maximum pitch in auto flight
-    // @Description: This controls maximum pitch up in automatic throttle modes. If this is set to zero then LIM_PITCH_MAX is used instead. The purpose of this parameter is to allow the use of a smaller pitch range when in automatic flight than what is used in FBWA mode.
+    // @Description: Overrides LIM_PITCH_MAX in automatic throttle modes to reduce climb rates. Uses LIM_PITCH_MAX if set to 0. For poper TECS tuning, set to the angle that the aircraft can climb at TRIM_ARSPD_CM and THR_MAX.
     // @Range: 0 45
     // @Increment: 1
     // @User: Advanced
@@ -144,7 +144,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: PITCH_MIN
     // @DisplayName: Minimum pitch in auto flight
-    // @Description: This controls minimum pitch in automatic throttle modes. If this is set to zero then LIM_PITCH_MIN is used instead. The purpose of this parameter is to allow the use of a smaller pitch range when in automatic flight than what is used in FBWA mode. Note that TECS_PITCH_MIN should be a negative number.
+    // @Description: Overrides LIM_PITCH_MIN in automatic throttle modes to reduce descent rates. Uses LIM_PITCH_MIN if set to 0. For poper TECS tuning, set to the angle that the aircraft can descend at without overspeeding.
     // @Range: -45 0
     // @Increment: 1
     // @User: Advanced

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -136,7 +136,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: PITCH_MAX
     // @DisplayName: Maximum pitch in auto flight
-    // @Description: Overrides LIM_PITCH_MAX in automatic throttle modes to reduce climb rates. Uses LIM_PITCH_MAX if set to 0. For poper TECS tuning, set to the angle that the aircraft can climb at TRIM_ARSPD_CM and THR_MAX.
+    // @Description: Overrides LIM_PITCH_MAX in automatic throttle modes to reduce climb rates. Uses LIM_PITCH_MAX if set to 0. For proper TECS tuning, set to the angle that the aircraft can climb at TRIM_ARSPD_CM and THR_MAX.
     // @Range: 0 45
     // @Increment: 1
     // @User: Advanced
@@ -144,7 +144,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: PITCH_MIN
     // @DisplayName: Minimum pitch in auto flight
-    // @Description: Overrides LIM_PITCH_MIN in automatic throttle modes to reduce descent rates. Uses LIM_PITCH_MIN if set to 0. For poper TECS tuning, set to the angle that the aircraft can descend at without overspeeding.
+    // @Description: Overrides LIM_PITCH_MIN in automatic throttle modes to reduce descent rates. Uses LIM_PITCH_MIN if set to 0. For proper TECS tuning, set to the angle that the aircraft can descend at without overspeeding.
     // @Range: -45 0
     // @Increment: 1
     // @User: Advanced


### PR DESCRIPTION
I focused on parameters that are most commonly changed in the first ~5 flights when setting up a new aircraft. I follow these guidelines to improve new user experience with parameters:

- Remove referenced wording, especially "you, this, that, changes, etc"
- Avoid repeating other information (such as the range or values already listed)
- Only give default setting in the description when critical
- Keep most language in the present tense
- Help users tune in the field without having to print or browse a wiki page