### PR TITLE
AP_RangeFinder: Adjust measurement time and call back time

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
@@ -143,11 +143,11 @@ bool AP_RangeFinder_VL53L1X::init()
                      read_register16(MM_CONFIG__OUTER_OFFSET_MM) * 4);
 
     // set continuous mode
-    startContinuous(50);
+    startContinuous(MEASUREMENT_TIME);
     calibrated = false;
 
     // call timer() every 50ms. We expect new data to be available every 50ms
-    dev->register_periodic_callback(50000,
+    dev->register_periodic_callback(MEASUREMENT_TIME * 1000,
                                     FUNCTOR_BIND_MEMBER(&AP_RangeFinder_VL53L1X::timer, void));
 
     return true;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
@@ -4,6 +4,8 @@
 #include "RangeFinder_Backend.h"
 #include <AP_HAL/I2CDevice.h>
 
+#define MEASUREMENT_TIME 50 // Start continuous readings at a rate of one measurement every 50 ms
+
 class AP_RangeFinder_VL53L1X : public AP_RangeFinder_Backend
 {
 


### PR DESCRIPTION
I think it is better to combine the measurement time and call back time.