### PR TITLE
AP_IOMCU: Correct from uint16_t to uint32_t

### DIFF
--- a/libraries/AP_IOMCU/iofirmware/ioprotocol.h
+++ b/libraries/AP_IOMCU/iofirmware/ioprotocol.h
@@ -99,7 +99,7 @@ struct PACKED page_config {
 };
 
 struct PACKED page_reg_status {
-    uint16_t freemem;
+    uint32_t freemem;
     uint16_t cpuload;
 
     // status flags


### PR DESCRIPTION
I know that the free memory value is an unsigned 32 bit value.
However, the value is set to an unsigned 16 bit variable.
Currently, the free memory size is 79816.


fmuv3 003D0024 30385108 31353236
ChibiOS: 57801550
ArduCopter V3.7.0-dev (e66a360e)

![eee](https://user-images.githubusercontent.com/646194/50380556-44365b80-06ae-11e9-98c3-fec9de36875a.png)

    // we do no allocations after setup completes
    reg_status.freemem = hal.util->available_memory();