### PR TITLE
Copter: Common to return

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -497,10 +497,8 @@ bool AP_Arming_Copter::pre_arm_proximity_check(bool display_failure)
     }
 #endif
 
-    return true;
-#else
-    return true;
 #endif
+    return true;
 }
 
 // arm_checks - perform final checks before arming


### PR DESCRIPTION
I decided that I can do it in common because the return values are separated by preprocessor.