### PR TITLE
AP_NavEKF2: GPS quality measurement time can be specified.

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -553,6 +553,81 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("GPS_QTIME", 50, NavEKF2, _gpsQualityTime, 10),
 
+    // @Param: GPS_QUAL_DRIFT
+    // @DisplayName: GPS quality drift rate
+    // @Description: Drift rate to confirm GPS quality stability.
+    // @Units: m
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QDRIFT", 51, NavEKF2, _gpsQualityDrift, 3.0f),
+
+    // @Param: GPS_QUAL_VVEL
+    // @DisplayName: GPS quality vertical velocity
+    // @Description: Vertical velocity to confirm GPS quality stability.
+    // @Units: m/s
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QVVEL", 52, NavEKF2, _gpsQualityVerticalVelocity, 0.3f),
+
+    // @Param: GPS_QUAL_HVEL
+    // @DisplayName: GPS quality horizontal velocity
+    // @Description: horizontal velocity to confirm GPS quality stability.
+    // @Units: m/s
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QHVEL", 53, NavEKF2, _gpsQualityHorizontalVelocity, 0.3f),
+
+    // @Param: GPS_QUAL_HACC
+    // @DisplayName: GPS quality horiziontal position accuracy
+    // @Description: horiziontal position accuracy to confirm GPS quality stability.
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QHACC", 54, NavEKF2, _gpsQualityHoriziontalAccuracy, 5.0f),
+
+    // @Param: GPS_QUAL_VACC
+    // @DisplayName: GPS quality vertical position accuracy
+    // @Description: vertical position accuracy to confirm GPS quality stability.
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QVACC", 55, NavEKF2, _gpsQualityVerticalAccuracy, 7.5f),
+
+    // @Param: GPS_QUAL_SACC
+    // @DisplayName: GPS quality speed accuracy
+    // @Description: speed accuracy to confirm GPS quality stability.
+    // @Range: 0.0 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QSACC", 56, NavEKF2, _gpsQualitySpeedAccuracy, 1.0f),
+
+    // @Param: GPS_QUAL_HDOP
+    // @DisplayName: GPS quality satellite geometry
+    // @Description: satellite geometry to confirm GPS quality stability.
+    // @Range: 0.00 10.00
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QHDOP", 57, NavEKF2, _gpsQualitySatelliteGeometry, 2.50f),
+
+    // @Param: GPS_QUAL_NSAT
+    // @DisplayName: GPS quality satellite numbers
+    // @Description: satellite numbers to confirm GPS quality stability.
+    // @Range: 3 127
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QNSAT", 58, NavEKF2, _gpsQualitySatelliteNumbers, 6),
+
+    // @Param: GPS_QUAL_YAW
+    // @DisplayName: GPS quality yaw test rate
+    // @Description: yaw test rate to confirm GPS quality stability.
+    // @Range: 0.0 10.0f
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QYAW", 59, NavEKF2, _gpsQualitYawTestRate, 1.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -544,6 +544,15 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("OGN_HGT_MASK", 49, NavEKF2, _originHgtMode, 0),
 
+    // @Param: GPS_QUAL_TIME
+    // @DisplayName: GPS quality duration
+    // @Description: Designate the time to confirm GPS quality stability.
+    // @Units: s
+    // @Range: 1 20
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_QTIME", 50, NavEKF2, _gpsQualityTime, 10),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -395,6 +395,7 @@ private:
     AP_Float _useRngSwSpd;          // Maximum horizontal ground speed to use range finder as the primary height source (m/s)
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
+    AP_Int8 _gpsQualityTime;        // GPS quality duration
 
     // Tuning parameters
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -396,6 +396,15 @@ private:
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
     AP_Int8 _gpsQualityTime;        // GPS quality duration
+    AP_Float _gpsQualityDrift;      // GPS quality drift rate
+    AP_Float _gpsQualityVerticalVelocity;  // GPS quality vertical velocity
+    AP_Float _gpsQualityHorizontalVelocity;  // GPS quality horizontal velocity
+    AP_Float _gpsQualityHoriziontalAccuracy;  // GPS quality horiziontal position accuracy
+    AP_Float _gpsQualityVerticalAccuracy;  // GPS quality vertical position accuracy
+    AP_Float _gpsQualitySpeedAccuracy;  // GPS quality speed accuracy
+    AP_Float _gpsQualitySatelliteGeometry;  // GPS quality satellite geometry
+    AP_Int8 _gpsQualitySatelliteNumbers;  // GPS quality satellite numbers
+    AP_Float _gpsQualitYawTestRate;  // GPS quality yaw test rate
 
     // Tuning parameters
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -230,7 +230,7 @@ bool NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // continuous period without fail required to return a healthy status
-    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
+    if (imuSampleTime_ms - lastGpsVelFail_ms > (static_cast<uint8_t>(frontend->_gpsQualityTime) * 1000)) {
         return true;
     }
     return false;


### PR DESCRIPTION
I do not get the GPS check OK at the prearm check until the GPS quality exceeds 10 seconds.
I could not read from the source or the time that 10 seconds really needed.
I know that empirical values are used in judgment values.
I would like to be able to tune the duration.

Add
I would like to be able to tune other GPS quality judgment values.