### PR TITLE
Plane: Disallow arming if quadplane has been requested but isn't available

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -53,6 +53,11 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         ret = false;
     }
 
+    if (plane.quadplane.enabled() && !plane.quadplane.available()) {
+        check_failed(ARMING_CHECK_NONE, display_failure, "Quadplane enabled but not running");
+        ret = false;
+    }
+
     if (plane.quadplane.available() && plane.scheduler.get_loop_rate_hz() < 100) {
         check_failed(ARMING_CHECK_NONE, display_failure, "quadplane needs SCHED_LOOP_RATE >= 100");
         ret = false;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -116,6 +116,9 @@ public:
 
     // return true if the wp_nav controller is being updated
     bool using_wp_nav(void) const;
+
+    // return true if the user has set ENABLE
+    bool enabled(void) const { return enable != 0; }
     
     struct PACKED log_QControl_Tuning {
         LOG_PACKET_HEADER;


### PR DESCRIPTION
If we want quadplanes, but they aren't available (either due to late setting of the parameter and not rebooting, or insufficent RAM) we should inhibit arming, as it can lead to surprising things in flight.