### PR TITLE
Arming: Add opt in checks for mission items

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1212,15 +1212,6 @@ AP_VisualOdom *GCS_MAVLINK_Rover::get_visual_odom() const
 #endif
 }
 
-AP_Rally *GCS_MAVLINK_Rover::get_rally() const
-{
-#if AP_RALLY == ENABLED
-    return &rover.g2.rally;
-#else
-    return nullptr;
-#endif
-}
-
 bool GCS_MAVLINK_Rover::set_mode(const uint8_t mode)
 {
     Mode *new_mode = rover.mode_from_mode_num((enum Mode::Number)mode);

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -13,7 +13,6 @@ protected:
 
     uint32_t telem_delay() const override;
 
-    AP_Rally *get_rally() const override;
     AP_AdvancedFailsafe *get_advanced_failsafe() const override;
     AP_VisualOdom *get_visual_odom() const override;
 

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -17,8 +17,6 @@ protected:
     // as currently Tracker may brick XBees
     uint32_t telem_delay() const override { return 0; }
 
-    AP_Rally *get_rally() const override { return nullptr; };
-
     uint8_t sysid_my_gcs() const override;
 
     bool set_mode(uint8_t mode) override;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1497,15 +1497,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_flight_termination(const mavlink_command_l
     return result;
 }
 
-AP_Rally *GCS_MAVLINK_Copter::get_rally() const
-{
-#if AC_RALLY == ENABLED
-    return &copter.rally;
-#else
-    return nullptr;
-#endif
-}
-
 bool GCS_MAVLINK_Copter::set_mode(const uint8_t mode)
 {
 #ifdef DISALLOW_GCS_MODE_CHANGE_DURING_RC_FAILSAFE

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -14,7 +14,6 @@ protected:
 
     uint32_t telem_delay() const override;
 
-    AP_Rally *get_rally() const override;
     MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet) override;
     AP_AdvancedFailsafe *get_advanced_failsafe() const override;
     AP_VisualOdom *get_visual_odom() const override;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1533,11 +1533,6 @@ AP_AdvancedFailsafe *GCS_MAVLINK_Plane::get_advanced_failsafe() const
     return &plane.afs;
 }
 
-AP_Rally *GCS_MAVLINK_Plane::get_rally() const
-{
-    return &plane.rally;
-}
-
 /*
   set_mode() wrapper for MAVLink SET_MODE
  */

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -17,7 +17,6 @@ protected:
     void handle_mission_set_current(AP_Mission &mission, mavlink_message_t *msg) override;
 
     AP_AdvancedFailsafe *get_advanced_failsafe() const override;
-    AP_Rally *get_rally() const override;
 
     uint8_t sysid_my_gcs() const override;
     bool sysid_enforce() const override;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1162,15 +1162,6 @@ void Sub::mavlink_delay_cb()
     DataFlash.EnableWrites(true);
 }
 
-AP_Rally *GCS_MAVLINK_Sub::get_rally() const
-{
-#if AC_RALLY == ENABLED
-    return &sub.rally;
-#else
-    return nullptr;
-#endif
-}
-
 MAV_RESULT GCS_MAVLINK_Sub::handle_flight_termination(const mavlink_command_long_t &packet) {
     if (packet.param1 > 0.5f) {
         sub.init_disarm_motors();

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -12,8 +12,6 @@ protected:
         return 0;
     };
 
-    AP_Rally *get_rally() const override;
-
     MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet) override;
 
     uint8_t sysid_my_gcs() const override;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -18,6 +18,8 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_Mission/AP_Mission.h>
+#include <AP_Rally/AP_Rally.h>
 
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
 #define AP_ARMING_COMPASS_MAGFIELD_MIN  185     // 0.35 * 530 milligauss
@@ -76,6 +78,15 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
                                                                                            AP_PARAM_FRAME_COPTER |
                                                                                            AP_PARAM_FRAME_TRICOPTER |
                                                                                            AP_PARAM_FRAME_HELI),
+
+    // @Param: MIS_ITEMS
+    // @DisplayName: Required mission items
+    // @Description: Bitmask of mission items that are required to be planned in order to arm the aircraft
+    // @Bitmask: 0:Land,1:VTOL Land,2:DO_LAND_START,3:Takeoff,4:VTOL Takeoff,5:Rallypoint
+    // @User: Advanced
+    AP_GROUPINFO("MIS_ITEMS",    7,     AP_Arming, _required_mission_items, 0),
+
+    // index 4 was VOLT_MIN, moved to AP_BattMonitor
     AP_GROUPEND
 };
 
@@ -493,6 +504,63 @@ bool AP_Arming::manual_transmitter_checks(bool report)
     return true;
 }
 
+bool AP_Arming::mission_checks(bool report)
+{
+    if (((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_MISSION)) &&
+        _required_mission_items) {
+        AP_Mission *mission = AP::mission();
+        if (mission == nullptr) {
+            check_failed(ARMING_CHECK_MISSION, report, "No mission library present");
+            #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+                AP_HAL::panic("Mission checks requested, but no mission was allocated");
+            #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            return false;
+        }
+        AP_Rally *rally = AP::rally();
+        if (rally == nullptr) {
+            check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
+            #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+                AP_HAL::panic("Mission checks requested, but no rally was allocated");
+            #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            return false;
+        }
+
+        const struct MisItemTable {
+          MIS_ITEM_CHECK check;
+          MAV_CMD mis_item_type;
+          const char *type;
+        } misChecks[5] = {
+          {MIS_ITEM_CHECK_LAND,          MAV_CMD_NAV_LAND,           "land"},
+          {MIS_ITEM_CHECK_VTOL_LAND,     MAV_CMD_NAV_VTOL_LAND,      "vtol land"},
+          {MIS_ITEM_CHECK_DO_LAND_START, MAV_CMD_DO_LAND_START,      "do land start"},
+          {MIS_ITEM_CHECK_TAKEOFF,       MAV_CMD_NAV_TAKEOFF,        "takeoff"},
+          {MIS_ITEM_CHECK_VTOL_TAKEOFF,  MAV_CMD_NAV_VTOL_TAKEOFF,   "vtol takeoff"},
+        };
+        for (uint8_t i = 0; i < ARRAY_SIZE(misChecks); i++) {
+            if (_required_mission_items & misChecks[i].check) {
+                if (!mission->contains_item(misChecks[i].mis_item_type)) {
+                    check_failed(ARMING_CHECK_MISSION, report, "Missing mission item: %s", misChecks[i].type);
+                    return false;
+                }
+            }
+        }
+        if (_required_mission_items & MIS_ITEM_CHECK_RALLY) {
+            Location ahrs_loc;
+            if (!AP::ahrs().get_position(ahrs_loc)) {
+                check_failed(ARMING_CHECK_MISSION, report, "Can't check rally without position");
+                return false;
+            }
+            RallyLocation rally_loc = {};
+            if (!rally->find_nearest_rally_point(ahrs_loc, rally_loc)) {
+                check_failed(ARMING_CHECK_MISSION, report, "No sufficently close rally point located");
+                return false;
+            }
+          }
+    }
+
+    return true;
+}
+
 bool AP_Arming::servo_checks(bool report) const
 {
     bool check_passed = true;
@@ -583,6 +651,7 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  battery_checks(report)
         &  logging_checks(report)
         &  manual_transmitter_checks(report)
+        &  mission_checks(report)
         &  servo_checks(report)
         &  board_voltage_checks(report)
         &  system_checks(report);

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -32,6 +32,7 @@ public:
         ARMING_CHECK_SWITCH     = 0x0800,
         ARMING_CHECK_GPS_CONFIG = 0x1000,
         ARMING_CHECK_SYSTEM     = 0x2000,
+        ARMING_CHECK_MISSION    = 0x4000,
     };
 
     enum ArmingMethod {
@@ -84,6 +85,7 @@ protected:
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
+    AP_Int32                 _required_mission_items;
 
     // internal members
     bool                    armed:1;
@@ -113,6 +115,8 @@ protected:
 
     bool manual_transmitter_checks(bool report);
 
+    bool mission_checks(bool report);
+
     virtual bool system_checks(bool report);
     
     bool servo_checks(bool report) const;
@@ -130,4 +134,13 @@ private:
     bool ins_accels_consistent(const AP_InertialSensor &ins);
     bool ins_gyros_consistent(const AP_InertialSensor &ins);
 
+    enum MIS_ITEM_CHECK {
+        MIS_ITEM_CHECK_LAND          = (1 << 0),
+        MIS_ITEM_CHECK_VTOL_LAND     = (1 << 1),
+        MIS_ITEM_CHECK_DO_LAND_START = (1 << 2),
+        MIS_ITEM_CHECK_TAKEOFF       = (1 << 3),
+        MIS_ITEM_CHECK_VTOL_TAKEOFF  = (1 << 4),
+        MIS_ITEM_CHECK_RALLY         = (1 << 5),
+        MIS_ITEM_CHECK_MAX
+    };
 };

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1856,6 +1856,20 @@ const char *AP_Mission::Mission_Command::type() const {
     }
 }
 
+bool AP_Mission::contains_item(MAV_CMD command) const
+{
+    for (int i = 1; i < num_commands(); i++) {
+        Mission_Command tmp;
+        if (!read_cmd_from_storage(i, tmp)) {
+            continue;
+        }
+        if (tmp.id == command) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // singleton instance
 AP_Mission *AP_Mission::_singleton;
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -478,6 +478,9 @@ public:
         return _rsem;
     }
 
+    // returns true if the mission contains the requested items
+    bool contains_item(MAV_CMD command) const;
+
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -52,6 +52,12 @@ AP_Rally::AP_Rally(AP_AHRS &ahrs)
     : _ahrs(ahrs)
     , _last_change_time_ms(0xFFFFFFFF)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (_singleton != nullptr) {
+        AP_HAL::panic("Rally must be singleton");
+    }
+#endif
+    _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
 }
 
@@ -160,4 +166,16 @@ Location AP_Rally::calc_best_rally_or_home_location(const Location &current_loc,
     }
 
     return return_loc;
+}
+
+// singleton instance
+AP_Rally *AP_Rally::_singleton;
+
+namespace AP {
+
+AP_Rally *rally()
+{
+    return AP_Rally::get_singleton();
+}
+
 }

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -118,7 +118,6 @@ Location AP_Rally::rally_location_to_location(const RallyLocation &rally_loc) co
 bool AP_Rally::find_nearest_rally_point(const Location &current_loc, RallyLocation &return_loc) const
 {
     float min_dis = -1;
-    const struct Location &home_loc = _ahrs.get_home();
 
     for (uint8_t i = 0; i < (uint8_t) _rally_point_total_count; i++) {
         RallyLocation next_rally;
@@ -134,13 +133,8 @@ bool AP_Rally::find_nearest_rally_point(const Location &current_loc, RallyLocati
         }
     }
 
-    // if home is included, return false (meaning use home) if it is closer than all rally points
-    if (_rally_incl_home && (get_distance(current_loc, home_loc) < min_dis)) {
-        return false;
-    }
-
     // if a limit is defined and all rally points are beyond that limit, use home if it is closer
-    if ((_rally_limit_km > 0) && (min_dis > _rally_limit_km*1000.0f) && (get_distance(current_loc, home_loc) < min_dis)) {
+    if ((_rally_limit_km > 0) && (min_dis > _rally_limit_km*1000.0f)) {
         return false; // use home position
     }
 
@@ -155,14 +149,17 @@ Location AP_Rally::calc_best_rally_or_home_location(const Location &current_loc,
     Location return_loc = {};
     const struct Location &home_loc = _ahrs.get_home();
     
+    // no valid rally point, return home position
+    return_loc = home_loc;
+    return_loc.alt = rtl_home_alt;
+    return_loc.flags.relative_alt = false; // read_alt_to_hold returns an absolute altitude
+
     if (find_nearest_rally_point(current_loc, ral_loc)) {
-        // valid rally point found
-        return_loc = rally_location_to_location(ral_loc);
-    } else {
-        // no valid rally point, return home position
-        return_loc = home_loc;
-        return_loc.alt = rtl_home_alt;
-        return_loc.flags.relative_alt = false; // read_alt_to_hold returns an absolute altitude
+        Location loc = rally_location_to_location(ral_loc);
+        // use the rally point if it's closer then home, or we aren't generally considering home as acceptable
+        if (!_rally_incl_home  || (get_distance(current_loc, loc) < get_distance(current_loc, return_loc))) {
+            return_loc = rally_location_to_location(ral_loc);
+        }
     }
 
     return return_loc;

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -62,7 +62,13 @@ public:
     // parameter block
     static const struct AP_Param::GroupInfo var_info[];
 
+    // get singleton instance
+    static AP_Rally *get_singleton() { return _singleton; }
+
+
 private:
+    static AP_Rally *_singleton;
+
     virtual bool is_valid(const Location &rally_point) const { return true; }
 
     static StorageAccess _storage;
@@ -76,4 +82,8 @@ private:
     AP_Int8  _rally_incl_home;
 
     uint32_t _last_change_time_ms;
+};
+
+namespace AP {
+    AP_Rally *rally();
 };

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -280,7 +280,6 @@ protected:
     // overridable method to check for packet acceptance. Allows for
     // enforcement of GCS sysid
     bool accept_packet(const mavlink_status_t &status, mavlink_message_t &msg);
-    virtual AP_Rally *get_rally() const = 0;
     virtual AP_AdvancedFailsafe *get_advanced_failsafe() const { return nullptr; };
     virtual AP_VisualOdom *get_visual_odom() const { return nullptr; }
     virtual bool set_mode(uint8_t mode) = 0;

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -24,8 +24,6 @@ class GCS_MAVLINK_Dummy : public GCS_MAVLINK
 
 protected:
 
-    AP_Rally *get_rally() const override { return nullptr; };
-
     uint8_t sysid_my_gcs() const override { return 1; }
     bool set_mode(uint8_t mode) override { return false; };
 

--- a/libraries/GCS_MAVLink/GCS_Rally.cpp
+++ b/libraries/GCS_MAVLink/GCS_Rally.cpp
@@ -19,7 +19,7 @@
 
 void GCS_MAVLINK::handle_rally_point(mavlink_message_t *msg)
 {
-    AP_Rally *r = get_rally();
+    AP_Rally *r = AP::rally();
     if (r == nullptr) {
         return;
     }
@@ -58,7 +58,7 @@ void GCS_MAVLINK::handle_rally_point(mavlink_message_t *msg)
 
 void GCS_MAVLINK::handle_rally_fetch_point(mavlink_message_t *msg)
 {
-    AP_Rally *r = get_rally();
+    AP_Rally *r = AP::rally();
     if (r == nullptr) {
         return;
     }

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -30,7 +30,6 @@ public:
 protected:
 
     uint32_t telem_delay() const override { return 0; }
-    AP_Rally *get_rally() const override { return nullptr; }
     uint8_t sysid_my_gcs() const override { return 1; }
     bool set_mode(uint8_t mode) override { return false; };
 


### PR DESCRIPTION
This adds opt in checks for required mission items. The overall target for this is to catch normally expected mission items and check that they are present in an effort to make sure that the user planned appropriately. (Rally points have the extra restriction of actually being close enough that you could actually select them in RTL).

If there is anything else anyone wants we can add it to the list, the only other one I am loosely planning on was adding `MAV_CMD_DO_GO_AROUND`. If people want we can add a bit for just "are there any items planned".

This also brings in a singleton for AP_Rally because it made life easier.

Final (and off topic notes): This would actually best be implemented as a list of `MAV_CMD` items on the SD card that we scan, but then the check wouldn't function on targets without an SD card, and you would need a check to make sure the file was actually present. 