### PR TITLE
Plane: Remove some redundant code/state resets

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -559,7 +559,6 @@ void Plane::update_flight_mode(void)
     case FLY_BY_WIRE_A: {
         // set nav_roll and nav_pitch using sticks
         nav_roll_cd  = channel_roll->norm_input() * roll_limit_cd;
-        nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
         update_load_factor();
         float pitch_input = channel_pitch->norm_input();
         if (pitch_input > 0) {
@@ -594,7 +593,6 @@ void Plane::update_flight_mode(void)
     case FLY_BY_WIRE_B:
         // Thanks to Yury MonZon for the altitude limit code!
         nav_roll_cd = channel_roll->norm_input() * roll_limit_cd;
-        nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
         update_load_factor();
         update_fbwb_speed_height();
         break;
@@ -612,7 +610,6 @@ void Plane::update_flight_mode(void)
         
         if (!cruise_state.locked_heading) {
             nav_roll_cd = channel_roll->norm_input() * roll_limit_cd;
-            nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
             update_load_factor();
         } else {
             calc_nav_roll();

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -644,7 +644,7 @@ void Plane::update_load_factor(void)
         // our airspeed is below the minimum airspeed. Limit roll to
         // 25 degrees
         nav_roll_cd = constrain_int32(nav_roll_cd, -2500, 2500);
-        roll_limit_cd = constrain_int32(roll_limit_cd, -2500, 2500);
+        roll_limit_cd = MIN(roll_limit_cd, 2500);
     } else if (max_load_factor < aerodynamic_load_factor) {
         // the demanded nav_roll would take us past the aerodymamic
         // load limit. Limit our roll to a bank angle that will keep
@@ -657,6 +657,6 @@ void Plane::update_load_factor(void)
             roll_limit = 2500;
         }
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
-        roll_limit_cd = constrain_int32(roll_limit_cd, -roll_limit, roll_limit);
+        roll_limit_cd = MIN(roll_limit_cd, roll_limit);
     }    
 }

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -64,8 +64,6 @@ void Plane::set_next_WP(const struct Location &loc)
 
     setup_glide_slope();
     setup_turn_angle();
-
-    loiter_angle_reset();
 }
 
 void Plane::set_guided_WP(void)


### PR DESCRIPTION
A couple of small things that were bugging me:

- `RC_Channel::norm_input(void)` must already be within [-1, 1], so there isn't any need to constrain the result to the multiplied value.
- `roll_limit_cd` must be positive or we have all kinds of problems, so we don't need a constrain with a negative number, simply selecting the lower number is safe. (You could make the argument to use a 0 in the constraint to ensure we never produce a negative number which will have it's own problems, but a 0 isn't any better, as you still fly away. Since this hasn't been a historical problem MIN is just faster).
- `Plane::loiter_anggle_reset(void)` was being called twice, and I can't find any path in the middle that justifies that. It looks to just be a legacy of code rejuggling.