### PR TITLE
ChibiOS: added BRD_SD_SLOWDOWN parameter

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -236,7 +236,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Description: Minimum voltage on the autopilot power rail to allow the aircraft to arm. 0 to disable the check.
     // @Units: V
     // @Range: 4.0 5.5
-    // Increment 0.1
+    // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("VBUS_MIN",    15,     AP_BoardConfig,  _vbus_min,  BOARD_CONFIG_BOARD_VOLTAGE_MIN),
 
@@ -248,7 +248,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Description: Minimum voltage on the servo rail to allow the aircraft to arm. 0 to disable the check.
     // @Units: V
     // @Range: 3.3 12.0
-    // Increment 0.1
+    // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("VSERVO_MIN",    16,     AP_BoardConfig, _vservo_min,  0),
 #endif

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -156,6 +156,12 @@ public:
         return instance?instance->_vservo_min.get():0;
     }
 #endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    static uint8_t get_sdcard_slowdown(void) {
+        return instance?instance->_sdcard_slowdown.get():0;
+    }
+#endif
     
 private:
     static AP_BoardConfig *instance;
@@ -227,5 +233,9 @@ private:
 
 #if HAL_HAVE_SERVO_VOLTAGE
     AP_Float _vservo_min;
+#endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+    AP_Int8 _sdcard_slowdown;
 #endif
 };

--- a/libraries/AP_HAL/SPIDevice.h
+++ b/libraries/AP_HAL/SPIDevice.h
@@ -61,6 +61,9 @@ public:
     /* See Device::adjust_periodic_callback() */
     virtual bool adjust_periodic_callback(
         PeriodicHandle h, uint32_t period_usec) override { return false; }
+
+    // setup a bus clock slowdown factor (optional interface)
+    virtual void set_slowdown(uint8_t slowdown) {}
 };
 
 class SPIDeviceManager {

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -113,6 +113,11 @@ public:
      */
     virtual uint32_t available_memory(void) { return 4096; }
 
+    /*
+      initialise (or re-initialise) filesystem storage
+     */
+    virtual bool fs_init(void) { return false; }
+
 protected:
     // we start soft_armed false, so that actuators don't send any
     // values until the vehicle code has fully started

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -170,9 +170,6 @@ static void main_loop()
     ChibiOS::SPIDevice::test_clock_freq();
 #endif 
 
-    //Setup SD Card and Initialise FATFS bindings
-    sdcard_init();
-
     hal.uartB->begin(38400);
     hal.uartC->begin(57600);
     hal.analogin->init();

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -15,6 +15,7 @@
 #include "SPIDevice.h"
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <AP_HAL/utility/OwnPtr.h>
 #include "Util.h"
 #include "Scheduler.h"
@@ -136,6 +137,15 @@ bool SPIDevice::set_speed(AP_HAL::Device::Speed speed)
         break;
     }
     return true;
+}
+
+/*
+  setup a bus slowdown factor for high speed mode
+ */
+void SPIDevice::set_slowdown(uint8_t slowdown)
+{
+    slowdown = constrain_int16(slowdown+1, 1, 32);
+    freq_flag_high = derive_freq_flag(device_desc.highspeed / slowdown);
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -36,6 +36,7 @@ public:
     void dma_allocate(Shared_DMA *ctx);
     void dma_deallocate(Shared_DMA *ctx);
     bool spi_started;
+    uint8_t slowdown;
     
     // we need an additional lock in the dma_allocate and
     // dma_deallocate functions to cope with 3-way contention as we
@@ -110,7 +111,10 @@ public:
     // used to measure clock frequencies
     static void test_clock_freq(void);
 #endif
-    
+
+    // setup a bus clock slowdown factor
+    void set_slowdown(uint8_t slowdown) override;
+
 private:
     SPIBus &bus;
     SPIDesc &device_desc;

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -359,6 +359,7 @@ void Scheduler::_io_thread(void* arg)
             // thread when disarmed
             uint32_t now = AP_HAL::millis();
             if (now - last_sd_start_ms > 3000) {
+                last_sd_start_ms = now;
                 sdcard_retry();
             }
         }

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -347,11 +347,21 @@ void Scheduler::_io_thread(void* arg)
     while (!sched->_hal_initialized) {
         sched->delay_microseconds(1000);
     }
+    uint32_t last_sd_start_ms = AP_HAL::millis();
     while (true) {
         sched->delay_microseconds(1000);
 
         // run registered IO processes
         sched->_run_io();
+
+        if (!hal.util->get_soft_armed()) {
+            // if sdcard hasn't mounted then retry it every 3s in the IO
+            // thread when disarmed
+            uint32_t now = AP_HAL::millis();
+            if (now - last_sd_start_ms > 3000) {
+                sdcard_retry();
+            }
+        }
     }
 }
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -23,6 +23,7 @@
 #include "hwdef/common/stm32_util.h"
 #include "hwdef/common/flash.h"
 #include <AP_ROMFS/AP_ROMFS.h>
+#include "sdcard.h"
 
 #if HAL_WITH_IO_MCU
 #include <AP_BoardConfig/AP_BoardConfig.h>
@@ -260,3 +261,13 @@ bool Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
     memcpy(buf, (const void *)UDID_START, len);
     return true;
 }
+
+#ifdef USE_POSIX
+/*
+  initialise filesystem
+ */
+bool Util::fs_init(void)
+{
+    return sdcard_init();
+}
+#endif

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -51,6 +51,13 @@ public:
     void toneAlarm_set_buzzer_tone(float frequency, float volume, uint32_t duration_ms) override;
 #endif
 
+#ifdef USE_POSIX
+    /*
+      initialise (or re-initialise) filesystem storage
+     */
+    bool fs_init(void) override;
+#endif
+    
 private:
 #ifdef HAL_PWM_ALARM
     struct ToneAlarmPwmGroup {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -238,11 +238,8 @@ void __late_init(void) {
  * @brief   SDC card detection.
  */
 bool sdc_lld_is_card_inserted(SDCDriver *sdcp) {
-  static bool last_status = false;
-
-  if (blkIsTransferring(sdcp))
-    return last_status;
-  return last_status = (bool)palReadPad(GPIOC, 11);
+    (void)sdcp;
+    return true;
 }
 
 /**

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -17,60 +17,83 @@
 #include "SPIDevice.h"
 #include "sdcard.h"
 #include "hwdef/common/spi_hook.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL& hal;
 
 #ifdef USE_POSIX
 static FATFS SDC_FS; // FATFS object
-static bool sdcard_init_done;
+static bool sdcard_running;
 #endif
 
-#if HAL_USE_MMC_SPI
+#if HAL_USE_SDC
+static SDCConfig sdcconfig = {
+  NULL,
+  SDC_MODE_4BIT,
+  0
+};
+#elif HAL_USE_MMC_SPI
 MMCDriver MMCD1;
 static AP_HAL::OwnPtr<AP_HAL::SPIDevice> device;
 static MMCConfig mmcconfig;
 static SPIConfig lowspeed;
 static SPIConfig highspeed;
-static bool sdcard_running;
 #endif
 
 /*
-  initialise microSD card if avaialble
+  initialise microSD card if avaialble. This is called during
+  AP_BoardConfig initialisation. The parameter BRD_SD_SLOWDOWN
+  controls a scaling factor on the microSD clock
  */
-void sdcard_init()
+bool sdcard_init()
 {
 #ifdef USE_POSIX
-    if (sdcard_init_done) {
-        return;
-    }
-    sdcard_init_done = true;
+    uint8_t sd_slowdown = AP_BoardConfig::get_sdcard_slowdown();
 #if HAL_USE_SDC
 
-    bouncebuffer_init(&SDCD1.bouncebuffer, 512);
-    
-    sdcStart(&SDCD1, NULL);
+    if (SDCD1.bouncebuffer == nullptr) {
+        bouncebuffer_init(&SDCD1.bouncebuffer, 512);
+    }
 
-    if(sdcConnect(&SDCD1) == HAL_FAILED) {
-        printf("Err: Failed to initialize SDIO!\n");
-    } else {
-        if (f_mount(&SDC_FS, "/", 1) != FR_OK) {
-            printf("Err: Failed to mount SD Card!\n");
-            sdcDisconnect(&SDCD1);
-        } else {
-            printf("Successfully mounted SDCard..\n");
+    if (sdcard_running) {
+        sdcard_stop();
+    }
+
+    const uint8_t tries = 3;
+    for (uint8_t i=0; i<tries; i++) {
+        hal.scheduler->delay(10);
+        sdcconfig.slowdown = sd_slowdown;
+        sdcStart(&SDCD1, &sdcconfig);
+        if(sdcConnect(&SDCD1) == HAL_FAILED) {
+            sdcStop(&SDCD1);
+            continue;
         }
-        //Create APM Directory
+        if (f_mount(&SDC_FS, "/", 1) != FR_OK) {
+            sdcDisconnect(&SDCD1);
+            sdcStop(&SDCD1);
+            continue;
+        }
+        printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
+
+        // Create APM Directory if needed
         mkdir("/APM", 0777);
+        sdcard_running = true;
+        return true;
     }
 #elif HAL_USE_MMC_SPI
+    if (sdcard_running) {
+        sdcard_stop();
+    }
+
+    sdcard_running = true;
+
     device = AP_HAL::get_HAL().spi->get_device("sdcard");
     if (!device) {
         printf("No sdcard SPI device found\n");
-        return;
+        return false;
     }
+    device->set_slowdown(sd_slowdown);
     
-    sdcard_running = true;
-
     mmcObjectInit(&MMCD1);
 
     mmcconfig.spip =
@@ -82,33 +105,29 @@ void sdcard_init()
       try up to 3 times to init microSD interface
      */
     const uint8_t tries = 3;
-    bool start_ok = false;
     for (uint8_t i=0; i<tries; i++) {
+        hal.scheduler->delay(10);
         mmcStart(&MMCD1, &mmcconfig);
 
-        if (mmcConnect(&MMCD1) != HAL_FAILED) {
-            start_ok = true;
-            break;
+        if (mmcConnect(&MMCD1) == HAL_FAILED) {
+            mmcStop(&MMCD1);
+            continue;
         }
-        mmcStop(&MMCD1);
-        hal.scheduler->delay(100);
-    }
-
-    if (!start_ok) {
-        printf("Err: Failed to initialize SDCARD_SPI!\n");
-        sdcard_running = false;
-    } else {
         if (f_mount(&SDC_FS, "/", 1) != FR_OK) {
-            printf("Err: Failed to mount SD Card!\n");
             mmcDisconnect(&MMCD1);
-        } else {
-            printf("Successfully mounted SDCard..\n");
+            mmcStop(&MMCD1);
+            continue;
         }
-        //Create APM Directory
+        printf("Successfully mounted SDCard (slowdown=%u)\n", (unsigned)sd_slowdown);
+
+        // Create APM Directory if needed
         mkdir("/APM", 0777);
+        return true;
     }
+    sdcard_running = false;
 #endif
 #endif
+    return false;
 }
 
 /*
@@ -120,7 +139,13 @@ void sdcard_stop(void)
     // unmount
     f_mount(nullptr, "/", 1);
 #endif
-#if HAL_USE_MMC_SPI
+#if HAL_USE_SDC
+    if (sdcard_running) {
+        sdcDisconnect(&SDCD1);
+        sdcStop(&SDCD1);
+        sdcard_running = false;
+    }
+#elif HAL_USE_MMC_SPI
     if (sdcard_running) {
         mmcDisconnect(&MMCD1);
         mmcStop(&MMCD1);

--- a/libraries/AP_HAL_ChibiOS/sdcard.h
+++ b/libraries/AP_HAL_ChibiOS/sdcard.h
@@ -17,3 +17,4 @@
 
 bool sdcard_init();
 void sdcard_stop();
+void sdcard_retry();

--- a/libraries/AP_HAL_ChibiOS/sdcard.h
+++ b/libraries/AP_HAL_ChibiOS/sdcard.h
@@ -15,5 +15,5 @@
  */
 #pragma once
 
-void sdcard_init();
+bool sdcard_init();
 void sdcard_stop();

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -123,7 +123,6 @@ void DataFlash_File::Init()
     }
     if (ret == -1) {
         printf("Failed to create log directory %s : %s\n", _log_directory, strerror(errno));
-        return;
     }
 
     // determine and limit file backend buffersize


### PR DESCRIPTION
This adds a BRD_SD_SLOWDOWN parameter that allows the microSD clock rate to be slowed down. This is useful for marginal microSD card setups
