### PR TITLE
All Vehicles: Reset all storage when parameters are reset

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -747,6 +747,7 @@ void Rover::load_parameters(void)
          g.format_version != Parameters::k_format_version) {
         // erase all parameters
         hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -392,6 +392,7 @@ void Tracker::load_parameters(void)
 
         // erase all parameters
         hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1068,6 +1068,7 @@ void Copter::load_parameters(void)
 
         // erase all parameters
         hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1291,6 +1291,7 @@ void Plane::load_parameters(void)
 
         // erase all parameters
         hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -670,6 +670,7 @@ void Sub::load_parameters()
 
         // erase all parameters
         hal.console->printf("Firmware change: erasing EEPROM...\n");
+        StorageManager::erase();
         AP_Param::erase_all();
 
         // save the current format version


### PR DESCRIPTION
This fixes a problem with reading random uninitialized data out of FRAM when we do parameter resets. This helps close a small vulnerability with reading invalid rally points out of storage during parameter uploads. This has the side benefit of also making the text message correct :)