### PR TITLE
Plane: add rudder differential thrust to tilt-rotors in forward flight 

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -797,7 +797,10 @@ private:
     // the crc of the last created PX4Mixer
     int32_t last_mixer_crc = -1;
 #endif // CONFIG_HAL_BOARD
-    
+
+    // rudder mixing gain for differential thrust (0 - 1)
+    float rudder_dt;
+
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
     void send_fence_status(mavlink_channel_t chan);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -559,25 +559,25 @@ void Plane::servos_twin_engine_mix(void)
 {
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
     float rud_gain = float(plane.g2.rudd_dt_gain) / 100;
-    float rudder = rud_gain * SRV_Channels::get_output_scaled(SRV_Channel::k_rudder) / float(SERVO_MAX);
+    rudder_dt = rud_gain * SRV_Channels::get_output_scaled(SRV_Channel::k_rudder) / float(SERVO_MAX);
 
     if (afs.should_crash_vehicle()) {
         // when in AFS failsafe force rudder input for differential thrust to zero
-        rudder = 0;
+        rudder_dt = 0;
     }
 
     float throttle_left, throttle_right;
 
     if (throttle < 0 && have_reverse_thrust() && allow_reverse_thrust()) {
         // doing reverse thrust
-        throttle_left  = constrain_float(throttle + 50 * rudder, -100, 0);
-        throttle_right = constrain_float(throttle - 50 * rudder, -100, 0);
+        throttle_left  = constrain_float(throttle + 50 * rudder_dt, -100, 0);
+        throttle_right = constrain_float(throttle - 50 * rudder_dt, -100, 0);
     } else if (throttle <= 0) {
         throttle_left  = throttle_right = 0;
     } else {
         // doing forward thrust
-        throttle_left  = constrain_float(throttle + 50 * rudder, 0, 100);
-        throttle_right = constrain_float(throttle - 50 * rudder, 0, 100);
+        throttle_left  = constrain_float(throttle + 50 * rudder_dt, 0, 100);
+        throttle_right = constrain_float(throttle - 50 * rudder_dt, 0, 100);
     }
     if (!hal.util->get_soft_armed()) {
         if (arming.arming_required() == AP_Arming::YES_ZERO_PWM) {

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -80,7 +80,7 @@ void QuadPlane::tiltrotor_continuous_update(void)
         } else {
             // the motors are all the way forward, start using them for fwd thrust
             uint8_t mask = is_zero(tilt.current_throttle)?0:(uint8_t)tilt.tilt_mask.get();
-            motors->output_motor_mask(tilt.current_throttle, mask);
+            motors->output_motor_mask(tilt.current_throttle, mask, plane.rudder_dt);
             // prevent motor shutdown
             tilt.motors_active = true;
         }
@@ -167,7 +167,7 @@ void QuadPlane::tiltrotor_binary_update(void)
         if (tilt.current_tilt >= 1) {
             uint8_t mask = is_zero(new_throttle)?0:(uint8_t)tilt.tilt_mask.get();
             // the motors are all the way forward, start using them for fwd thrust
-            motors->output_motor_mask(new_throttle, mask);
+            motors->output_motor_mask(new_throttle, mask, plane.rudder_dt);
         }
     } else {
         tiltrotor_binary_slew(false);

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -51,6 +51,10 @@ public:
     // return number of motor that has failed.  Should only be called if get_thrust_boost() returns true
     uint8_t             get_lost_motor() const override { return _motor_lost_index; }
 
+    // return the roll factor of any motor, this is used for tilt rotors and tail sitters
+    // using copter motors for forward flight
+    float               get_roll_factor(uint8_t i) override { return _roll_factor[i]; }
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -624,13 +624,20 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // output a thrust to all motors that match a given motor mask. This
 // is used to control tiltrotor motors in forward flight. Thrust is in
 // the range 0 to 1
-void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask)
+void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
 {
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             int16_t motor_out;
             if (mask & (1U<<i)) {
-                motor_out = calc_thrust_to_pwm(thrust);
+                /*
+                    apply rudder mixing differential thrust
+                    copter frame roll is plane frame yaw as this only
+                    apples to either tilted motors or tailsitters
+                */
+                float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
+
+                motor_out = calc_thrust_to_pwm(thrust + diff_thrust);
             } else {
                 motor_out = get_pwm_output_min();
             }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -84,7 +84,7 @@ public:
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
-    virtual void        output_motor_mask(float thrust, uint8_t mask);
+    virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt);
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -323,11 +323,29 @@ void AP_MotorsTri::thrust_compensation(void)
 /*
   override tricopter tail servo output in output_motor_mask
  */
-void AP_MotorsTri::output_motor_mask(float thrust, uint8_t mask)
+void AP_MotorsTri::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
 {
     // normal multicopter output
-    AP_MotorsMulticopter::output_motor_mask(thrust, mask);
+    AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt);
 
     // and override yaw servo
     rc_write(AP_MOTORS_CH_TRI_YAW, _yaw_servo->get_trim());
+}
+
+float AP_MotorsTri::get_roll_factor(uint8_t i)
+{
+    float ret = 0.0f;
+
+    switch (i) {
+        // right motor
+        case AP_MOTORS_MOT_1:
+            ret = -1.0f;
+            break;
+        // left motor
+        case AP_MOTORS_MOT_2:
+            ret = 1.0f;
+            break;
+    }
+
+    return ret;
 }

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -47,8 +47,13 @@ public:
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
-    void                output_motor_mask(float thrust, uint8_t mask) override;
-    
+    // rudder_dt applys diffential thrust for yaw in the range 0 to 1
+    void                output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
+
+    // return the roll factor of any motor, this is used for tilt rotors and tail sitters
+    // using copter motors for forward flight
+    float               get_roll_factor(uint8_t i) override;
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -157,6 +157,10 @@ public:
     // set loop rate. Used to support loop rate as a parameter
     void                set_loop_rate(uint16_t loop_rate) { _loop_rate = loop_rate; }
 
+    // return the roll factor of any motor, this is used for tilt rotors and tail sitters
+    // using copter motors for forward flight
+    virtual float       get_roll_factor(uint8_t i) { return 0.0f; }
+
     enum pwm_type { PWM_TYPE_NORMAL     = 0,
                     PWM_TYPE_ONESHOT    = 1,
                     PWM_TYPE_ONESHOT125 = 2,


### PR DESCRIPTION
This adds rudder differential thrust via the RUDD_DT_GAIN to Quadplanes using copter motors in forward flight. 

Fix for https://github.com/ArduPilot/ardupilot/issues/10039

Tested for a tricopter style tilt quadplane in SITL, but probibly should be tested on some other types. 