### PR TITLE
AP_Arming: Allow disarming to force the safety switch

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -729,6 +729,14 @@ bool AP_Arming::disarm()
 
     gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
+#if HAL_HAVE_SAFETY_SWITCH
+    AP_BoardConfig *board_cfg = AP_BoardConfig::get_instance();
+    if ((board_cfg != nullptr) &&
+        (board_cfg->get_safety_button_options() & AP_BoardConfig::BOARD_SAFETY_OPTION_SAFETY_ON_DISARM)) {
+        hal.rcout->force_safety_on();
+    }
+#endif // HAL_HAVE_SAFETY_SWITCH
+
     //TODO: Log motor disarming to the dataflash
     //Can't do this from this class until there is a unified logging library.
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -221,7 +221,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: SAFETYOPTION
     // @DisplayName: Options for safety button behavior
     // @Description: This controls the activation of the safety button. It allows you to control if the safety button can be used for safety enable and/or disable, and whether the button is only active when disarmed
-    // @Bitmask: 0:ActiveForSafetyEnable,1:ActiveForSafetyDisable,2:ActiveWhenArmed
+    // @Bitmask: 0:ActiveForSafetyEnable,1:ActiveForSafetyDisable,2:ActiveWhenArmed,3:Force safety on when the aircraft disarms
     // @User: Standard
     AP_GROUPINFO("SAFETYOPTION",   13, AP_BoardConfig, state.safety_option, BOARD_SAFETY_OPTION_DEFAULT),
 #endif

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -123,9 +123,10 @@ public:
 
 #if HAL_HAVE_SAFETY_SWITCH
     enum board_safety_button_option {
-        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF=1,
-        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON=2,
-        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_ARMED=4,
+        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF= (1 << 0),
+        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_ON=  (1 << 1),
+        BOARD_SAFETY_OPTION_BUTTON_ACTIVE_ARMED=      (1 << 2),
+        BOARD_SAFETY_OPTION_SAFETY_ON_DISARM=         (1 << 3),
     };
 
     // return safety button options. Bits are in enum board_safety_button_option


### PR DESCRIPTION
I should have made this a long time ago, as this is a continual confusion/pain point for users. The overall principle is that when the vehicle autolands and disarms it self to be safe on the ground we should take this as far as possible and also force the safety switch state to the disarmed position. It also fixes a number of problems with users forgetting to use the button to help make the vehicle safe again/bumping outputs, and general handling/confusion.

(This also helps make it easier to treat the button as a pre arm only step)