### PR TITLE
Follow: improved timing of position data from target

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -152,7 +152,7 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
     // project the vehicle position
     Location last_loc = _target_location;
     location_offset(last_loc, vel_ned.x * dt, vel_ned.y * dt);
-    last_loc.alt -= vel_ned.z * 10.0f * dt; // convert m/s to cm/s, multiply by dt.  minus because NED
+    last_loc.alt -= vel_ned.z * 100.0f * dt; // convert m/s to cm/s, multiply by dt.  minus because NED
 
     // return latest position estimate
     loc = last_loc;

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -21,6 +21,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AC_PID/AC_P.h>
+#include <AP_RTC/JitterCorrection.h>
 
 class AP_Follow
 {
@@ -124,4 +125,7 @@ private:
     bool _automatic_sysid;          // did we lock onto a sysid automatically?
     float   _dist_to_target;        // latest distance to target in meters (for reporting purposes)
     float   _bearing_to_target;     // latest bearing to target in degrees (for reporting purposes)
+
+    // setup jitter correction with max transport lag of 3s
+    JitterCorrection _jitter{3000};
 };

--- a/libraries/AP_RTC/JitterCorrection.cpp
+++ b/libraries/AP_RTC/JitterCorrection.cpp
@@ -87,3 +87,14 @@ uint64_t JitterCorrection::correct_offboard_timestamp_usec(uint64_t offboard_use
     
     return uint64_t(estimate_us);
 }
+
+/*
+  correct an offboard timestamp in microseconds into a local
+  timestamp, removing timing jitter caused by the transport. 
+
+  Return a value in milliseconds since boot in the local time domain
+ */
+uint32_t JitterCorrection::correct_offboard_timestamp_msec(uint32_t offboard_ms, uint32_t local_ms)
+{
+    return correct_offboard_timestamp_usec(offboard_ms*1000ULL, local_ms*1000ULL) / 1000ULL;
+}

--- a/libraries/AP_RTC/JitterCorrection.h
+++ b/libraries/AP_RTC/JitterCorrection.h
@@ -13,6 +13,10 @@ public:
     // timestamp. See JitterCorrection.cpp for details
     uint64_t correct_offboard_timestamp_usec(uint64_t offboard_usec, uint64_t local_usec);
 
+    // correct an offboard timestamp to a jitter-free local
+    // timestamp. See JitterCorrection.cpp for details
+    uint32_t correct_offboard_timestamp_msec(uint32_t offboard_ms, uint32_t local_ms);
+    
 private:
     const uint16_t max_lag_ms;
     const uint16_t convergence_loops;


### PR DESCRIPTION
Use timing jitter correction to give better timestamps, which reduces jitter in the estimate of the targets position and velocity
This also fixes a bug in conversion from m/s to cm/s in altitude calculation