### PR TITLE
Remove unneeded AP_Buffer includes

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -33,7 +33,6 @@
 #include <AP_Beacon/AP_Beacon.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_BoardConfig/AP_BoardConfig_CAN.h>
-#include <AP_Buffer/AP_Buffer.h>                    // FIFO buffer library
 #include <AP_Button/AP_Button.h>
 #include <AP_Camera/AP_Camera.h>                    // Camera triggering
 #include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -38,7 +38,6 @@
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_AHRS/AP_AHRS.h>         // ArduPilot Mega DCM Library
 #include <Filter/Filter.h>                     // Filter library
-#include <AP_Buffer/AP_Buffer.h>      // APM FIFO Buffer
 
 #include <AP_SerialManager/AP_SerialManager.h>   // Serial manager library
 #include <AP_Declination/AP_Declination.h> // ArduPilot Mega Declination Helper Library

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -59,7 +59,6 @@
 #include <AP_Stats/AP_Stats.h>     // statistics library
 #include <AP_RSSI/AP_RSSI.h>                   // RSSI Library
 #include <Filter/Filter.h>             // Filter library
-#include <AP_Buffer/AP_Buffer.h>          // APM FIFO Buffer
 #include <AP_Relay/AP_Relay.h>           // APM relay
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 #include <AP_Airspeed/AP_Airspeed.h>        // needed for AHRS build

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -8,6 +8,7 @@ def build(bld):
         ap_vehicle=vehicle,
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_ADSB',
+            'AP_Buffer',
             'AC_AttitudeControl',
             'AC_InputManager',
             'AC_Fence',

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -43,7 +43,6 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>     // Range finder library
 #include <Filter/Filter.h>                     // Filter library
-#include <AP_Buffer/AP_Buffer.h>      // APM FIFO Buffer
 #include <AP_Relay/AP_Relay.h>       // APM relay
 #include <AP_Camera/AP_Camera.h>          // Photo or video camera
 #include <AP_Airspeed/AP_Airspeed.h>

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -10,6 +10,7 @@ def build(bld):
             'APM_Control',
             'AP_AdvancedFailsafe',
             'AP_ADSB',
+            'AP_Buffer',
             'AP_Avoidance',
             'AP_Arming',
             'AP_Camera',

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -23,7 +23,6 @@
 #include <AP_AccelCal/AP_AccelCal.h>
 #include <AP_Declination/AP_Declination.h>
 #include <Filter/Filter.h>
-#include <AP_Buffer/AP_Buffer.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_Notify/AP_Notify.h>

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -25,7 +25,6 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Baro',
     'AP_BattMonitor',
     'AP_BoardConfig',
-    'AP_Buffer',
     'AP_Common',
     'AP_Compass',
     'AP_Declination',

--- a/libraries/AP_Declination/examples/AP_Declination_test/AP_Declination_test.cpp
+++ b/libraries/AP_Declination/examples/AP_Declination_test/AP_Declination_test.cpp
@@ -5,7 +5,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Declination/AP_Declination.h>
-#include <AP_Buffer/AP_Buffer.h>
 #include <Filter/Filter.h>
 
 void setup();

--- a/libraries/AP_IOMCU/iofirmware/wscript
+++ b/libraries/AP_IOMCU/iofirmware/wscript
@@ -6,7 +6,6 @@ def build(bld):
         name= 'iofirmware_libs',
         ap_vehicle='iofirmware',
         ap_libraries= [
-        'AP_Buffer',
         'AP_Common',
         'AP_HAL',
         'AP_HAL_Empty',

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -3,7 +3,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>          // ArduPilot Mega IMU Library
 #include <AP_Baro/AP_Baro.h>                    // ArduPilot Mega Barometer Library
-#include <AP_Buffer/AP_Buffer.h>                  // FIFO buffer library
 #include <AP_NavEKF/AP_Nav_Common.h> // definitions shared by inertial and ekf nav filters
 
 /*

--- a/libraries/AP_Mount/examples/trivial_AP_Mount/trivial_AP_Mount.cpp
+++ b/libraries/AP_Mount/examples/trivial_AP_Mount/trivial_AP_Mount.cpp
@@ -11,7 +11,6 @@
 #include <AP_Declination/AP_Declination.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Baro/AP_Baro.h>
-#include <AP_Buffer/AP_Buffer.h>
 #include <Filter/Filter.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Mission/AP_Mission.h>

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <AP_Buffer/AP_Buffer.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/Bitmask.h>
 #include <AP_Math/AP_Math.h>


### PR DESCRIPTION
`AP_Buffer` is only needed for `AP_ADSB`, don't bother including it when we don't need it.