### PR TITLE
AP_Logger: Prepare the maximum number of log files in the config parameter

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -102,6 +102,14 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_FILE_MB_FREE",  7, AP_Logger, _params.min_MB_free, 500),
 
+    // @Param: _MAX_FILES
+    // @DisplayName: Maximum number of log files
+    // @Description: Maximum number of log files
+    // @Range: 1 32767
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("_MAX_FILES", 8, AP_Logger, _params.max_log_files, 500),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -345,6 +345,7 @@ public:
         AP_Int8 mav_bufsize; // in kilobytes
         AP_Int16 file_timeout; // in seconds
         AP_Int16 min_MB_free;
+        AP_Int16 max_log_files;
     } _params;
 
     const struct LogStructure *structure(uint16_t num) const;

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -228,7 +228,7 @@ uint16_t AP_Logger_File::find_oldest_log()
         }
 
         uint16_t thisnum = strtoul(de->d_name, nullptr, 10);
-        if (thisnum > MAX_LOG_FILES) {
+        if (thisnum > _front._params.max_log_files) {
             // ignore files above our official maximum...
             continue;
         }
@@ -283,7 +283,7 @@ void AP_Logger_File::Prep_MinSpace()
         if (avail >= target_free) {
             break;
         }
-        if (count++ > MAX_LOG_FILES+10) {
+        if (count++ > _front._params.max_log_files+10) {
             // *way* too many deletions going on here.  Possible internal error.
             INTERNAL_ERROR(AP_InternalError::error_t::logger_too_many_deletions);
             break;
@@ -312,7 +312,7 @@ void AP_Logger_File::Prep_MinSpace()
             }
         }
         log_to_remove++;
-        if (log_to_remove > MAX_LOG_FILES) {
+        if (log_to_remove > _front._params.max_log_files) {
             log_to_remove = 1;
         }
     } while (log_to_remove != first_log_to_remove);
@@ -423,7 +423,7 @@ void AP_Logger_File::EraseAll()
     const bool was_logging = (_write_fd != -1);
     stop_logging();
 
-    for (uint16_t log_num=1; log_num<=MAX_LOG_FILES; log_num++) {
+    for (uint16_t log_num=1; log_num<=_front._params.max_log_files; log_num++) {
         char *fname = _log_file_name(log_num);
         if (fname == nullptr) {
             break;
@@ -705,7 +705,7 @@ uint16_t AP_Logger_File::get_num_logs()
         ret++;
     }
     if (i == 0) {
-        for (i=MAX_LOG_FILES; i>high; i--) {
+        for (i=_front._params.max_log_files; i>high; i--) {
             if (! log_exists(i)) {
                 break;
             }
@@ -770,7 +770,7 @@ void AP_Logger_File::start_new_log(void)
     if (_get_log_size(log_num) > 0 || log_num == 0) {
         log_num++;
     }
-    if (log_num > MAX_LOG_FILES) {
+    if (log_num > _front._params.max_log_files) {
         log_num = 1;
     }
     if (!write_fd_semaphore.take(1)) {


### PR DESCRIPTION
I am using 128 G with micro SD card.
It is inconvenient for me to fix a maximum of 500 log files.
Depending on the micro SD card size, I think that it is better to change it.
I know that SD card is FAT32. For FAT32, 500 is not a limit.