### PR TITLE
AP_Airspeed: removed #include duplicates

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
@@ -23,7 +23,6 @@
 #include <utility>
 
 #include "AP_Airspeed_Backend.h"
-#include <AP_HAL/I2CDevice.h>
 
 class AP_Airspeed_DLVR : public AP_Airspeed_Backend
 {

--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.h
@@ -25,7 +25,6 @@
 #include <utility>
 
 #include "AP_Airspeed_Backend.h"
-#include <AP_HAL/I2CDevice.h>
 
 class AP_Airspeed_MS4525 : public AP_Airspeed_Backend
 {

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
@@ -25,7 +25,6 @@
 #include <utility>
 
 #include "AP_Airspeed_Backend.h"
-#include <AP_HAL/I2CDevice.h>
 
 class AP_Airspeed_MS5525 : public AP_Airspeed_Backend
 {


### PR DESCRIPTION
I think there is no need to include twice.