### PR TITLE
Balancebot: Support for Acro, Guided, Auto and RTL modes

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -680,7 +680,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: MIS_DONE_BEHAVE
     // @DisplayName: Mission done behave
     // @Description: Mode to become after mission done
-    // @Values: 0:Hold,1:Loiter
+    // @Values: 0:Hold,1:Loiter, 2:Acro
     // @User: Standard
     AP_GROUPINFO("MIS_DONE_BEHAVE", 38, ParametersG2, mis_done_behave, 0),
 

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -684,6 +684,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("MIS_DONE_BEHAVE", 38, ParametersG2, mis_done_behave, 0),
 
+    // @Param: BAL_ZERO_OFFSET
+    // @DisplayName: Balance Bot zero angle offset
+    // @Description: Zero/Equilibrium angle for balancing. Used when center of mass is not along roll axis. This offsets the tilt of the center of mass.
+    // @Units: deg
+    // @Range: -2 2
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("BAL_ZERO_OFFSET", 39, ParametersG2, bal_zero_offset, 0),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -391,6 +391,9 @@ public:
 
     // mission behave
     AP_Int8 mis_done_behave;
+
+    // zero point offset for balance bots
+    AP_Float bal_zero_offset;
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/balance_bot.cpp
+++ b/APMrover2/balance_bot.cpp
@@ -5,7 +5,7 @@
 void Rover::balancebot_pitch_control(float &throttle)
 {
     // calculate desired pitch angle
-    const float demanded_pitch = radians(-throttle * 0.01f * g2.bal_pitch_max);
+    const float demanded_pitch = radians(-throttle * 0.01f * g2.bal_pitch_max) + radians(g2.bal_zero_offset);
 
     // calculate speed from wheel encoders
     float veh_speed_pct = 0.0f;

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -112,6 +112,11 @@ void ModeAuto::exit_mission()
     if (g2.mis_done_behave == MIS_DONE_BEHAVE_LOITER && rover.set_mode(rover.mode_loiter, MODE_REASON_MISSION_END)) {
         return;
     }
+
+    if (g2.mis_done_behave == MIS_DONE_BEHAVE_ACRO && rover.set_mode(rover.mode_acro, MODE_REASON_MISSION_END)) {
+        return;
+    }
+
     rover.set_mode(rover.mode_hold, MODE_REASON_MISSION_END);
 }
 

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -308,7 +308,7 @@ void Mode::calc_throttle(float target_speed, bool nudge_allowed, bool avoidance_
     float throttle_out;
 
     // call speed or stop controller
-    if (is_zero(target_speed)) {
+    if (is_zero(target_speed) && !rover.is_balancebot()) {
         bool stopped;
         throttle_out = 100.0f * attitude_control.get_throttle_out_stop(g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, g.speed_cruise, g.throttle_cruise * 0.01f, rover.G_Dt, stopped);
     } else {
@@ -336,6 +336,7 @@ bool Mode::stop_vehicle()
 
     // if vehicle is balance bot, calculate actual throttle required for balancing
     if (rover.is_balancebot()) {
+        throttle_out = 100.0f * attitude_control.get_throttle_out_speed(0, g2.motors.limit.throttle_lower, g2.motors.limit.throttle_upper, g.speed_cruise, g.throttle_cruise * 0.01f, rover.G_Dt);
         rover.balancebot_pitch_control(throttle_out);
     }
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -318,7 +318,8 @@ private:
 
     enum Mis_Done_Behave {
         MIS_DONE_BEHAVE_HOLD      = 0,
-        MIS_DONE_BEHAVE_LOITER    = 1
+        MIS_DONE_BEHAVE_LOITER    = 1,
+        MIS_DONE_BEHAVE_ACRO      = 2
     };
 
     // Loiter control


### PR DESCRIPTION
- added a parameter for offsetting the balance point(equilibrium angle). This helps when the bot is not symmetric
- Minor balance bot specific code changes to support acro, auto, guided and rtl modes
- Added acro mode to MIS_DONE_BEHAVE