### PR TITLE
Libraries: Match output type and variable type

### DIFF
--- a/libraries/AP_HAL/utility/dsm.cpp
+++ b/libraries/AP_HAL/utility/dsm.cpp
@@ -183,7 +183,7 @@ dsm_guess_format(bool reset, const uint8_t dsm_frame[16])
 	}
 
 	/* call ourselves to reset our state ... we have to try again */
-	debug("DSM: format detect fail, 10: 0x%08x %d 11: 0x%08x %d", cs10, votes10, cs11, votes11);
+	debug("DSM: format detect fail, 10: 0x%08x %u 11: 0x%08x %u", cs10, votes10, cs11, votes11);
 	dsm_guess_format(true, dsm_frame);
 }
 

--- a/libraries/AP_HAL/utility/sumd.cpp
+++ b/libraries/AP_HAL/utility/sumd.cpp
@@ -349,7 +349,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 			for (i = 4; i < _rxpacket.length; i++) {
 				if (_debug) {
-					printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
+					printf("ch[%u] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
 					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,
 					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3);
 				}

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -623,7 +623,7 @@ uint8_t AP_Param::type_size(enum ap_var_type type)
     case AP_PARAM_VECTOR3F:
         return 3*4;
     }
-    Debug("unknown type %u\n", type);
+    Debug("unknown type %d\n", type);
     return 0;
 }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
@@ -169,7 +169,7 @@ void AP_RCProtocol_DSM::dsm_guess_format(bool reset, const uint8_t dsm_frame[16]
     }
 
     /* call ourselves to reset our state ... we have to try again */
-    debug("DSM: format detect fail, 10: 0x%08x %d 11: 0x%08x %d", cs10, votes10, cs11, votes11);
+    debug("DSM: format detect fail, 10: 0x%08x %u 11: 0x%08x %u", cs10, votes10, cs11, votes11);
     dsm_guess_format(true, dsm_frame);
 }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
@@ -296,7 +296,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
 
             for (i = 4; i < _rxpacket.length; i++) {
 #ifdef SUMD_DEBUG
-                hal.console->printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
+                hal.console->printf("ch[%u] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
                                     ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,
                                     ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3);
 #endif

--- a/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
@@ -94,7 +94,7 @@ void loop()
 
     if (count++ == 0) {
         for (int i=0; i<RC_CHANNELS_TO_DISPLAY; i++) {
-            hal.console->printf("Ch %02d ", (unsigned)i+1);
+            hal.console->printf("Ch %02u ", (unsigned)i+1);
         }
         hal.console->printf("\n");
     }


### PR DESCRIPTION
I was detected with the cppcheck command that there was no output type and variable type.
I think that matching the type will increase the authenticity of the message.