### PR TITLE
AP_Proximity: Return maximum distance and minimum distance with Proximity type

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Proximity type
     // @Description: What type of proximity sensor is connected
-    // @Values: 0:None,1:LightWareSF40C,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,10:SITL,11:MorseSITL
+    // @Values: 0:None,1:LightWareSF40C,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2M6-R3,6:TeraRangerTowerEvo,10:SITL,11:MorseSITL,12:RPLidarA2M6-R4,13:RPLidarA2M4,14:RPLidarA2M8-R3,15:RPLidarA2M8-R4,16:RPLidarA1M8-R4,17:RPLidarA1M8-R5,18:RPLidarA3M1
     // @RebootRequired: True
     // @User: Standard
     AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
@@ -148,6 +148,24 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_IGN_WID6", 15, AP_Proximity, _ignore_width_deg[5], 0),
 
+    // @Param: _DISTMAX_M
+    // @DisplayName: maximum distance (in meters) of sensor
+    // @Description: maximum distance (in meters) of sensor
+    // @Units: m
+    // @Range: 0.00 25.00
+    // @Increment: 0.01
+    // @User: Standard
+    AP_GROUPINFO("_DISTMAX_M", 19, AP_Proximity, _distance_max[0], 16.00f),
+
+    // @Param: __DISTMIN_M
+    // @DisplayName: minimum distance (in meters) of sensor
+    // @Description: minimum distance (in meters) of sensor
+    // @Units: m
+    // @Range: 0.00 25.00
+    // @Increment: 0.01
+    // @User: Standard
+    AP_GROUPINFO("__DISTMIN_M", 20, AP_Proximity, _distance_min[0], 0.20f),
+
 #if PROXIMITY_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Proximity type
@@ -171,6 +189,24 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Range: -180 180
     // @User: Standard
     AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
+
+    // @Param: _DISTMAX_M
+    // @DisplayName: maximum distance (in meters) of sensor
+    // @Description: maximum distance (in meters) of sensor
+    // @Units: m
+    // @Range: 0.00 25.00
+    // @Increment: 0.01
+    // @User: Standard
+    AP_GROUPINFO("_DISTMAX_M", 21, AP_Proximity, _distance_max[1], 16.00f),
+
+    // @Param: _DISTMIN_M
+    // @DisplayName: minimum distance (in meters) of sensor
+    // @Description: minimum distance (in meters) of sensor
+    // @Units: m
+    // @Range: 0.00 25.00
+    // @Increment: 0.01
+    // @User: Standard
+    AP_GROUPINFO("_DISTMIN_M", 22, AP_Proximity, _distance_min[1], 0.20f),
 #endif
 
     AP_GROUPEND
@@ -251,6 +287,26 @@ int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
     return _yaw_correction[instance].get();
 }
 
+// return sensor maximum distance (in meters)
+float AP_Proximity::get_distance_max(uint8_t instance) const
+{
+    if (instance >= PROXIMITY_MAX_INSTANCES) {
+        return 16.0f;
+    }
+
+    return _distance_max[instance].get();
+}
+
+// return sensor minimum distance (in meters)
+float AP_Proximity::get_distance_min(uint8_t instance) const
+{
+    if (instance >= PROXIMITY_MAX_INSTANCES) {
+        return 0.20f;
+    }
+
+    return _distance_min[instance].get();
+}
+
 // return sensor health
 AP_Proximity::Proximity_Status AP_Proximity::get_status(uint8_t instance) const
 {
@@ -288,12 +344,23 @@ void AP_Proximity::detect_instance(uint8_t instance)
             return;
         }
     }
-    if (type == Proximity_Type_RPLidarA2) {
+    switch (type) {
+    case Proximity_Type_RPLidarA2M6R3:
+    case Proximity_Type_RPLidarA2M6R4:
+    case Proximity_Type_RPLidarA2M4:
+    case Proximity_Type_RPLidarA2M8R3:
+    case Proximity_Type_RPLidarA2M8R4:
+    case Proximity_Type_RPLidarA1M8R4:
+    case Proximity_Type_RPLidarA1M8R5:
+    case Proximity_Type_RPLidarA3M1:
         if (AP_Proximity_RPLidarA2::detect(serial_manager)) {
             state[instance].instance = instance;
             drivers[instance] = new AP_Proximity_RPLidarA2(*this, state[instance], serial_manager);
             return;
         }
+        break;
+    default:
+        break;
     }
     if (type == Proximity_Type_MAV) {
         state[instance].instance = instance;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -148,24 +148,6 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_IGN_WID6", 15, AP_Proximity, _ignore_width_deg[5], 0),
 
-    // @Param: _DISTMAX_M
-    // @DisplayName: maximum distance (in meters) of sensor
-    // @Description: maximum distance (in meters) of sensor
-    // @Units: m
-    // @Range: 0.00 25.00
-    // @Increment: 0.01
-    // @User: Standard
-    AP_GROUPINFO("_DISTMAX_M", 19, AP_Proximity, _distance_max[0], 16.00f),
-
-    // @Param: __DISTMIN_M
-    // @DisplayName: minimum distance (in meters) of sensor
-    // @Description: minimum distance (in meters) of sensor
-    // @Units: m
-    // @Range: 0.00 25.00
-    // @Increment: 0.01
-    // @User: Standard
-    AP_GROUPINFO("__DISTMIN_M", 20, AP_Proximity, _distance_min[0], 0.20f),
-
 #if PROXIMITY_MAX_INSTANCES > 1
     // @Param: 2_TYPE
     // @DisplayName: Second Proximity type
@@ -189,24 +171,6 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Range: -180 180
     // @User: Standard
     AP_GROUPINFO("2_YAW_CORR", 18, AP_Proximity, _yaw_correction[1], PROXIMITY_YAW_CORRECTION_DEFAULT),
-
-    // @Param: _DISTMAX_M
-    // @DisplayName: maximum distance (in meters) of sensor
-    // @Description: maximum distance (in meters) of sensor
-    // @Units: m
-    // @Range: 0.00 25.00
-    // @Increment: 0.01
-    // @User: Standard
-    AP_GROUPINFO("_DISTMAX_M", 21, AP_Proximity, _distance_max[1], 16.00f),
-
-    // @Param: _DISTMIN_M
-    // @DisplayName: minimum distance (in meters) of sensor
-    // @Description: minimum distance (in meters) of sensor
-    // @Units: m
-    // @Range: 0.00 25.00
-    // @Increment: 0.01
-    // @User: Standard
-    AP_GROUPINFO("_DISTMIN_M", 22, AP_Proximity, _distance_min[1], 0.20f),
 #endif
 
     AP_GROUPEND
@@ -285,26 +249,6 @@ int16_t AP_Proximity::get_yaw_correction(uint8_t instance) const
     }
 
     return _yaw_correction[instance].get();
-}
-
-// return sensor maximum distance (in meters)
-float AP_Proximity::get_distance_max(uint8_t instance) const
-{
-    if (instance >= PROXIMITY_MAX_INSTANCES) {
-        return 16.0f;
-    }
-
-    return _distance_max[instance].get();
-}
-
-// return sensor minimum distance (in meters)
-float AP_Proximity::get_distance_min(uint8_t instance) const
-{
-    if (instance >= PROXIMITY_MAX_INSTANCES) {
-        return 0.20f;
-    }
-
-    return _distance_min[instance].get();
 }
 
 // return sensor health

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -85,10 +85,6 @@ public:
     uint8_t get_orientation(uint8_t instance) const;
     int16_t get_yaw_correction(uint8_t instance) const;
 
-    // return sensor maximum and minimum distance (in meters)
-    float get_distance_max(uint8_t instance) const;
-    float get_distance_min(uint8_t instance) const;
-
     // return sensor health
     Proximity_Status get_status(uint8_t instance) const;
     Proximity_Status get_status() const;
@@ -168,8 +164,6 @@ private:
     AP_Int16 _yaw_correction[PROXIMITY_MAX_INSTANCES];
     AP_Int16 _ignore_angle_deg[PROXIMITY_MAX_IGNORE];   // angle (in degrees) of area that should be ignored by sensor (i.e. leg shows up)
     AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
-    AP_Float _distance_max[PROXIMITY_MAX_INSTANCES];  // maximum distance (in meters) of sensor
-    AP_Float _distance_min[PROXIMITY_MAX_INSTANCES];  // minimum distance (in meters) of sensor
 
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);  

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -46,10 +46,17 @@ public:
         Proximity_Type_MAV     = 2,
         Proximity_Type_TRTOWER = 3,
         Proximity_Type_RangeFinder = 4,
-        Proximity_Type_RPLidarA2 = 5,
+        Proximity_Type_RPLidarA2M6R3 = 5,
         Proximity_Type_TRTOWEREVO = 6,
         Proximity_Type_SITL    = 10,
         Proximity_Type_MorseSITL = 11,
+        Proximity_Type_RPLidarA2M6R4 = 12,
+        Proximity_Type_RPLidarA2M4 = 13,
+        Proximity_Type_RPLidarA2M8R3 = 14,
+        Proximity_Type_RPLidarA2M8R4 = 15,
+        Proximity_Type_RPLidarA1M8R4 = 16,
+        Proximity_Type_RPLidarA1M8R5 = 17,
+        Proximity_Type_RPLidarA3M1 = 18,
     };
 
     enum Proximity_Status {
@@ -77,6 +84,10 @@ public:
     // return sensor orientation and yaw correction
     uint8_t get_orientation(uint8_t instance) const;
     int16_t get_yaw_correction(uint8_t instance) const;
+
+    // return sensor maximum and minimum distance (in meters)
+    float get_distance_max(uint8_t instance) const;
+    float get_distance_min(uint8_t instance) const;
 
     // return sensor health
     Proximity_Status get_status(uint8_t instance) const;
@@ -157,6 +168,8 @@ private:
     AP_Int16 _yaw_correction[PROXIMITY_MAX_INSTANCES];
     AP_Int16 _ignore_angle_deg[PROXIMITY_MAX_IGNORE];   // angle (in degrees) of area that should be ignored by sensor (i.e. leg shows up)
     AP_Int8 _ignore_width_deg[PROXIMITY_MAX_IGNORE];    // width of beam (in degrees) that should be ignored
+    AP_Float _distance_max[PROXIMITY_MAX_INSTANCES];  // maximum distance (in meters) of sensor
+    AP_Float _distance_min[PROXIMITY_MAX_INSTANCES];  // minimum distance (in meters) of sensor
 
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);  

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -78,9 +78,6 @@ AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(AP_Proximity &_frontend,
     if (_uart != nullptr) {
         _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
     }
-    _cnt = 0 ;
-    _sync_error = 0 ;
-    _byte_count = 0;
 }
 
 // detect if a RPLidarA2 proximity sensor is connected by looking for a configured serial port
@@ -118,13 +115,57 @@ void AP_Proximity_RPLidarA2::update(void)
 // get maximum distance (in meters) of sensor
 float AP_Proximity_RPLidarA2::distance_max() const
 {
-    return 16.0f;  //16m max range RPLIDAR2, if you want to support the 8m version this is the only line to change
+    float distMax = 0.0f;
+    switch (frontend.get_type(state.instance)) {
+    case AP_Proximity::Proximity_Type_RPLidarA3M1:
+        distMax = 25.0f;
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M6R4:
+        distMax = 18.0f;
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M6R3:
+        distMax = 16.0f;  // 16m max range RPLIDAR2, if you want to support the 8m version this is the only line to change;
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M8R4:
+    case AP_Proximity::Proximity_Type_RPLidarA1M8R5:
+        distMax = 12.0f;
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M8R3:
+        distMax = 8.0f;
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M4:
+    case AP_Proximity::Proximity_Type_RPLidarA1M8R4:
+        distMax = 6.0f;
+        break;
+    default:
+        break;  // This process has not been implemented
+    }
+
+    return distMax;
 }
 
 // get minimum distance (in meters) of sensor
 float AP_Proximity_RPLidarA2::distance_min() const
 {
-    return 0.20f;  //20cm min range RPLIDAR2
+    float distMin = 0.0f;
+    switch (frontend.get_type(state.instance)) {
+    case AP_Proximity::Proximity_Type_RPLidarA3M1:  // Interim. It is not written in the data sheet
+    case AP_Proximity::Proximity_Type_RPLidarA2M6R3:
+    case AP_Proximity::Proximity_Type_RPLidarA2M6R4:
+        distMin = 0.20f;  //20cm min range RPLIDAR2
+        break;
+    case AP_Proximity::Proximity_Type_RPLidarA2M4:
+    case AP_Proximity::Proximity_Type_RPLidarA2M8R3:
+    case AP_Proximity::Proximity_Type_RPLidarA2M8R4:
+    case AP_Proximity::Proximity_Type_RPLidarA1M8R4:
+    case AP_Proximity::Proximity_Type_RPLidarA1M8R5:
+        distMin = 0.15f;
+        break;
+    default:
+        break;  // This process has not been implemented
+    }
+
+    return distMin;
 }
 
 bool AP_Proximity_RPLidarA2::initialise()


### PR DESCRIPTION
I will make it possible to set the maximum and minimum values of A2 series by config parameter.
Also consider the correspondence to A1M8 and A3M1 of the same protocol.
I have A2 series, A2M4, A2M6(-R3, -R4), A2M8 kind in the A2 series.
For each type, the minimum and maximum values are different.
This driver sets the maximum and minimum values of A2M6-R3 to fixed values.

and-
I initialize the class variable in the constructor.
This variable is initialized to activation level.
Therefore, I do not think you need to initialize it with the constructor.