### PR TITLE
Fixed mavlink param handling when in sensor error

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -313,6 +313,7 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     // wants to fire then don't send a mavlink message. We want to
     // prioritise the main flight control loop over communications
     if (!hal.scheduler->in_delay_callback() &&
+        !AP_BoardConfig::in_sensor_config_error() &&
         rover.scheduler.time_available_usec() < 200) {
         gcs().set_out_of_time(true);
         return false;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -427,6 +427,7 @@ bool GCS_MAVLINK_Plane::try_send_message(enum ap_message id)
     // wants to fire then don't send a mavlink message. We want to
     // prioritise the main flight control loop over communications
     if (!hal.scheduler->in_delay_callback() &&
+        !AP_BoardConfig::in_sensor_config_error() &&
         plane.scheduler.time_available_usec() < 200) {
         gcs().set_out_of_time(true);
         return false;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -327,9 +327,21 @@ void AP_BoardConfig::sensor_config_error(const char *reason)
       before this, so the user can change parameters (and in
       particular BRD_TYPE if needed)
     */
+    uint32_t last_print_ms = 0;
+    bool have_gcs = GCS::instance() != nullptr;
     while (true) {
-        printf("Sensor failure: %s\n", reason);
-        gcs().send_text(MAV_SEVERITY_ERROR, "Check BRD_TYPE: %s", reason);
-        hal.scheduler->delay(3000);
+        uint32_t now = AP_HAL::millis();
+        if (now - last_print_ms >= 3000) {
+            last_print_ms = now;
+            printf("Sensor failure: %s\n", reason);
+            if (have_gcs) {
+                gcs().send_text(MAV_SEVERITY_ERROR, "Check BRD_TYPE: %s", reason);
+            }
+        }
+        if (have_gcs) {
+            gcs().update_receive();
+            gcs().update_send();
+        }
+        hal.scheduler->delay(5);
     }
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -959,7 +959,7 @@ bool GCS_MAVLINK::should_send_message_in_delay_callback(const ap_message id) con
     // No ID we return true for may take more than a few hundred
     // microseconds to return!
 
-    if (id == MSG_HEARTBEAT) {
+    if (id == MSG_HEARTBEAT || id == MSG_NEXT_PARAM) {
         return true;
     }
 


### PR DESCRIPTION
When we have a sensor error the user needs to be able to set parameters (such as BRD_TYPE or baro/compass type) to recover. 
