### PR TITLE
SITL: parse home string as double (not float) to avoid precision loss

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -126,9 +126,9 @@ bool Aircraft::parse_home(const char *home_str, Location &loc, float &yaw_degree
     }
 
     memset(&loc, 0, sizeof(loc));
-    loc.lat = static_cast<int32_t>(strtof(lat_s, nullptr) * 1.0e7f);
-    loc.lng = static_cast<int32_t>(strtof(lon_s, nullptr) * 1.0e7f);
-    loc.alt = static_cast<int32_t>(strtof(alt_s, nullptr) * 1.0e2f);
+    loc.lat = static_cast<int32_t>(strtod(lat_s, nullptr) * 1.0e7);
+    loc.lng = static_cast<int32_t>(strtod(lon_s, nullptr) * 1.0e7);
+    loc.alt = static_cast<int32_t>(strtod(alt_s, nullptr) * 1.0e2);
 
     if (loc.lat == 0 && loc.lng == 0) {
         // default to CMAC instead of middle of the ocean. This makes


### PR DESCRIPTION
Hello everybody!

This patch makes SITL initialization code use double precision, instead of float, when it parses the home coordinates (i.e. `--home LAT,LON,ALT,HDG` e.g. `--home 37.4003371,-122.0800351,0,353`).

The current implementation, which treats those numbers as float, causes SITL's simulated GPS to appear to have a constant offset, which corresponds to the error in the parsed home coordinates. 

Such an offset (whose magnitude is around 0.5 m) can cause incoherences when ArduPilot SITL is part of a wider robot simulation environment (e.g. I found this issue while working on a Gazebo-based simulation), because the simulated RTK GPS does not produce correct output if compared to the actual robot position in the virtual world.

Please note that this section of code is not performance-critical, because it only runs once during SITL initialization.
