### PR TITLE
Tools: updated STM Tools url for ubuntu/arch install scripts

### DIFF
--- a/Tools/scripts/install-prereqs-arch.sh
+++ b/Tools/scripts/install-prereqs-arch.sh
@@ -17,8 +17,8 @@ ARCH_AUR_PKGS="genromfs"
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)
-ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
-ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
+ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
+ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
 ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools

--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -24,8 +24,8 @@ fi
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)
-ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
-ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
+ARM_ROOT="gcc-arm-none-eabi-6-2017-q2-update"
+ARM_TARBALL="$ARM_ROOT-linux.tar.bz2"
 ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/$ARM_TARBALL"
 
 # Ardupilot Tools


### PR DESCRIPTION
For the Ubuntu and Arch pre-req install scripts, updated the STM Tools to latest (4.9 -> 6) in Ardupilot site.

Have successfully tested in a fresh Ubuntu 18.10 VM.