### PR TITLE
Update build-jsbsim.sh

### DIFF
--- a/Tools/scripts/build-jsbsim.sh
+++ b/Tools/scripts/build-jsbsim.sh
@@ -13,7 +13,7 @@ else
     echo "$JSBBINARY does not exist, building it in your home folder:"
     cd ~ 
     rm -rf jsbsim
-    git clone git://jsbsim.git.sourceforge.net/gitroot/jsbsim/jsbsim
+    git clone git://github.com/JSBSim-Team/jsbsim.git
     cd jsbsim
     mkdir build
     cd build

--- a/Tools/scripts/build-jsbsim.sh
+++ b/Tools/scripts/build-jsbsim.sh
@@ -17,7 +17,7 @@ else
     cd jsbsim
     mkdir build
     cd build
-    cmake ..
+    cmake -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_BUILD_TYPE=Release ..
     make -j2
 fi
 echo "---------- $0 end ----------"

--- a/Tools/scripts/build-jsbsim.sh
+++ b/Tools/scripts/build-jsbsim.sh
@@ -6,16 +6,20 @@ echo "---------- $0 start ----------"
 
 # don't waste time rebuilding jsbsim if we already have a working copy of it
 # this can save ~10 or minutes on some hardware
-JSBBINARY=~/jsbsim/src/JSBSim
+JSBBINARY=~/jsbsim/build/src/JSBSim
 if [ -f $JSBBINARY ]; then
     echo "$JSBBINARY exists, skipping build. (to force rebuild then remove this file and re-run) "
 else
     echo "$JSBBINARY does not exist, building it in your home folder:"
     cd ~ 
     rm -rf jsbsim
-    git clone https://github.com/tridge/jsbsim.git
+    git clone git://jsbsim.git.sourceforge.net/gitroot/jsbsim/jsbsim
+    sudo apt-get install cmake
     cd jsbsim
-    ./autogen.sh
+    mkdir build
+    cd build
+    cmake ..
     make -j2
+    sudo make install
 fi
 echo "---------- $0 end ----------"

--- a/Tools/scripts/build-jsbsim.sh
+++ b/Tools/scripts/build-jsbsim.sh
@@ -14,12 +14,10 @@ else
     cd ~ 
     rm -rf jsbsim
     git clone git://jsbsim.git.sourceforge.net/gitroot/jsbsim/jsbsim
-    sudo apt-get install cmake
     cd jsbsim
     mkdir build
     cd build
     cmake ..
     make -j2
-    sudo make install
 fi
 echo "---------- $0 end ----------"

--- a/Tools/vagrant/initvagrant-trusty64.sh
+++ b/Tools/vagrant/initvagrant-trusty64.sh
@@ -20,7 +20,7 @@ source /vagrant/Tools/vagrant/shellinit.sh
 # This allows the PX4NuttX build to proceed when the underlying fs is on windows
 # It is only marginally less efficient on Linux
 export PX4_WINTOOL=y
-export PATH=\$PATH:\$HOME/jsbsim/src
+export PATH=\$PATH:\$HOME/jsbsim/build/src
 export BUILDLOGS=/tmp/buildlogs
 "
 

--- a/Tools/vagrant/shellinit.sh
+++ b/Tools/vagrant/shellinit.sh
@@ -3,7 +3,7 @@
 # This allows the PX4NuttX build to proceed when the underlying fs is on windows
 # It is only marginally less efficient on Linux
 export PX4_WINTOOL=y
-export PATH=$PATH:$HOME/jsbsim/src
+export PATH=$PATH:$HOME/jsbsim/build/src
 export BUILDLOGS=/tmp/buildlogs
 
 export APMROOT=/vagrant


### PR DESCRIPTION
According to http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html

"
In the past ArduPilot required a special version of JSBSim. As of December 2018 that is no longer the case, and we can use the standard JSBSim releases.
"

Moreover currently build-jsbsim.sh is failing with error:

../../src/models/propulsion/FGTurbine.h:297:3: error: ‘FGParameter’ does not name a type; did you mean ‘FGThruster’?
   FGParameter *N1SpoolUp;
   ^~~~~~~~~~~

Complete log from compiler:

Making all in src
make[1]: Entering directory '/home/vagrant/jsbsim/src'
Making all in initialization
make[2]: Entering directory '/home/vagrant/jsbsim/src/initialization'
  CXX      FGSimplexTrim.o
In file included from ../../src/math/FGStateSpace.h:27:0,
                 from FGSimplexTrim.h:23,
                 from FGSimplexTrim.cpp:20:
../../src/models/propulsion/FGTurbine.h:297:3: error: ‘FGParameter’ does not name a type; did you mean ‘FGThruster’?
   FGParameter *N1SpoolUp;
   ^~~~~~~~~~~
   FGThruster
../../src/models/propulsion/FGTurbine.h:298:3: error: ‘FGParameter’ does not name a type; did you mean ‘FGThruster’?
   FGParameter *N1SpoolDown;
   ^~~~~~~~~~~
   FGThruster
../../src/models/propulsion/FGTurbine.h:299:3: error: ‘FGParameter’ does not name a type; did you mean ‘FGThruster’?
   FGParameter *N2SpoolUp;
   ^~~~~~~~~~~
   FGThruster
../../src/models/propulsion/FGTurbine.h:300:3: error: ‘FGParameter’ does not name a type; did you mean ‘FGThruster’?
   FGParameter *N2SpoolDown;
   ^~~~~~~~~~~
   FGThruster
../../src/models/propulsion/FGTurbine.h:310:1: error: expected class-name before ‘{’ token
 {
 ^
Makefile:445: recipe for target 'FGSimplexTrim.o' failed
make[2]: *** [FGSimplexTrim.o] Error 1
make[2]: Leaving directory '/home/vagrant/jsbsim/src/initialization'
Makefile:612: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/vagrant/jsbsim/src'
Makefile:387: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1

Tested with vagrant on MacOS with command:
vagrant up && vagrant ssh -c "sim_vehicle.py -j 2 -v ArduPlane -f jsbsim"