### PR TITLE
RC_Channel: avoid using out-of-range aux switch values

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -238,7 +238,7 @@ private:
     static const uint16_t AUX_PWM_TRIGGER_HIGH = 1800;
     // pwm value below which the option will be disabled:
     static const uint16_t AUX_PWM_TRIGGER_LOW = 1200;
-    aux_switch_pos_t read_3pos_switch() const;
+    bool read_3pos_switch(aux_switch_pos_t &ret) const WARN_IF_UNUSED;
 
     //Documentation of Aux Switch Flags:
     // 0 is low or false, 1 is center or true, 2 is high


### PR DESCRIPTION
We already use these ranges for the mode switch


This is an alternative to https://github.com/ArduPilot/ardupilot/pull/10166 - as discussed over there and on the devcall.

