### PR TITLE
RC_Channel: input value watchdog

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -109,6 +109,8 @@ public:
     void init_aux();
     void read_aux();
 
+    bool healthy(void) const { return rc_healthy; }
+    
     // Aux Switch enumeration
     enum aux_func {
         DO_NOTHING =           0, // aux switch disabled
@@ -226,7 +228,14 @@ private:
 
     // the input channel this corresponds to
     uint8_t     ch_in;
-
+	
+	// rc input watchdog
+    AP_Int8     rc_watchdog_timeout_sec;
+    uint32_t    rc_watchdog_valid_time_sec;    
+    bool watchdog_check(int16_t new_rc_value);
+    
+    bool rc_healthy;    
+    
     // overrides
     uint16_t override_value;
     uint32_t last_override_time;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -80,12 +80,15 @@ bool RC_Channels::read_input(void)
 
     has_new_overrides = false;
 
-    bool success = false;
+    bool any_updated = false;
+    bool all_healthy = true;
+    
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
-        success |= channel(i)->update();
+        any_updated |= channel(i)->update();
+        all_healthy &= channel(i)->healthy();
     }
 
-    return success;
+    return any_updated && all_healthy;
 }
 
 uint8_t RC_Channels::get_valid_channel_count(void)


### PR DESCRIPTION
Impl. for https://github.com/ArduPilot/ardupilot/issues/5375
Personally I've never faced such issues but there is a real risk exists taking into account RC receivers are complex devices and some Vendors does publish not very stable firmware.

It is supposed that user will set the TIMEOUT parameter for one or several channels so they will be monitored. And if any of the monitored channels got stuck with the exact same value then Radio FS should kick in.