### PR TITLE
Update Copter PID validation 

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -239,67 +239,19 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             return false;
         }
 
-        // Check for 0 value PID's - some items can / should be 0 and as such are not checked.
-        // If the ATC_RAT_*_FF is non zero then the corresponding ATC_RAT_* PIDS can be 0.
-        if (is_zero(copter.pos_control->get_pos_xy_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "PSC_POSXY_P");
+        // ensure controllers are OK with us arming:
+        char failure_msg[50];
+        if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
-        } else if (is_zero(copter.pos_control->get_pos_z_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "PSC_POSZ_P");
-            return false;
-        } else if (is_zero(copter.pos_control->get_vel_z_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "PSC_VELZ_P");
-            return false;
-        } else if (is_zero(copter.pos_control->get_accel_z_pid().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "PSC_ACCZ_P");
-            return false;
-        } else if (is_zero(copter.pos_control->get_accel_z_pid().kI())) {
-            parameter_checks_pid_warning_message(display_failure, "PSC_ACCZ_I");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_roll_pid().kP()) && is_zero(copter.attitude_control->get_rate_roll_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_RLL_P");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_roll_pid().kI()) && is_zero(copter.attitude_control->get_rate_roll_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_RLL_I");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_roll_pid().kD()) && is_zero(copter.attitude_control->get_rate_roll_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_RLL_D");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_pitch_pid().kP()) && is_zero(copter.attitude_control->get_rate_pitch_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_PIT_P");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_pitch_pid().kI()) && is_zero(copter.attitude_control->get_rate_pitch_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_PIT_I");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_pitch_pid().kD()) && is_zero(copter.attitude_control->get_rate_pitch_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_PIT_D");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_yaw_pid().kP()) && is_zero(copter.attitude_control->get_rate_yaw_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_YAW_P");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_rate_yaw_pid().kI()) && is_zero(copter.attitude_control->get_rate_yaw_pid().ff())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_RAT_YAW_I");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_angle_pitch_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_ANG_PIT_P");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_angle_roll_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_ANG_RLL_P");
-            return false;
-        } else if (is_zero(copter.attitude_control->get_angle_yaw_p().kP())) {
-            parameter_checks_pid_warning_message(display_failure, "ATC_ANG_YAW_P");
+        }
+        if (!copter.attitude_control->pre_arm_checks("ATC", failure_msg, ARRAY_SIZE(failure_msg))) {
+            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
         }
     }
 
     return true;
-}
-
-void AP_Arming_Copter::parameter_checks_pid_warning_message(bool display_failure, const char *error_msg)
-{
-    check_failed(ARMING_CHECK_PARAMETERS,
-                 display_failure,
-                 "Check PIDs - %s", error_msg);
 }
 
 // check motor setup was successful

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -49,5 +49,4 @@ protected:
 
 private:
 
-    void parameter_checks_pid_warning_message(bool display_failure, const char *error_msg);
 };

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2750,6 +2750,33 @@ class AutoTestCopter(AutoTest):
 
         super(AutoTestCopter, self).test_arm_feature()
 
+    def test_parameter_checks(self):
+        self.wait_ready_to_arm()
+        self.context_push()
+        self.set_parameter("PSC_POSXY_P", -1)
+        self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                     1,  # ARM
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     timeout=2,
+                     want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+        self.context_pop()
+        self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                     1,  # ARM
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     timeout=2,
+                     want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED)
+        self.disarm_vehicle()
+
     def initial_mode(self):
         return "STABILIZE"
 
@@ -2904,6 +2931,10 @@ class AutoTestCopter(AutoTest):
             ("Parachute",
              "Test Parachute Functionality",
              self.test_parachute),
+
+            ("ParameterChecks",
+             "Test Arming Parameter Checks",
+             self.test_parameter_checks),
 
             ("LogDownLoad",
              "Log download",

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -223,6 +223,7 @@ def alarm_handler(signum, frame):
     """Handle test timeout."""
     global results, opts
     try:
+        print("Alarm handler called")
         results.add('TIMEOUT',
                     '<span class="failed-text">FAILED</span>',
                     opts.timeout)

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -6,7 +6,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_AHRS/AP_AHRS_View.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AC_PID/AC_PID.h>
@@ -290,6 +289,11 @@ public:
 
     // passthrough_bf_roll_pitch_rate_yaw - roll and pitch are passed through directly, body-frame rate target for yaw
     virtual void passthrough_bf_roll_pitch_rate_yaw(float roll_passthrough, float pitch_passthrough, float yaw_rate_bf_cds) {};
+
+    // provide feedback on whether arming would be a good idea right now:
+    bool pre_arm_checks(const char *param_prefix,
+                        char *failure_msg,
+                        const uint8_t failure_msg_len);
 
     // enable inverted flight on backends that support it
     virtual void set_inverted_flight(bool inverted) {}

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -294,6 +294,11 @@ public:
     // write log to dataflash
     void write_log();
 
+    // provide feedback on whether arming would be a good idea right now:
+    bool pre_arm_checks(const char *param_prefix,
+                        char *failure_msg,
+                        const uint8_t failure_msg_len);
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:


### PR DESCRIPTION
This additionally checks that the D term on the rate yaw pid is non-negative.

My logic needs checking here.

I hope I'm saying that if we have a FF term then P and I must be non-negative.  If we have no FF then P and I must be positive.

D must always be non-negative.
