### PR TITLE
Rover: More explicit check for old wheel encoder updates.

### DIFF
--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -102,11 +102,11 @@ void Rover::update_wheel_encoder()
         // calculate delta time
         float delta_time;
         const uint32_t latest_sensor_update_ms = g2.wheel_encoder.get_last_reading_ms(i);
-        const uint32_t sensor_diff_ms = latest_sensor_update_ms - wheel_encoder_last_update_ms[i];
+        const int32_t sensor_diff_ms = latest_sensor_update_ms - wheel_encoder_last_update_ms[i];
 
         // if we have not received any sensor updates, or time difference is too high then use time since last update to the ekf
         // check for old or insane sensor update times
-        if (sensor_diff_ms == 0 || sensor_diff_ms > 100) {
+        if (sensor_diff_ms <= 0 || sensor_diff_ms > 100) {
             delta_time = system_dt;
             wheel_encoder_last_update_ms[i] = wheel_encoder_last_ekf_update_ms;
         } else {


### PR DESCRIPTION
In some cases [sensor_diff_ms](https://github.com/ArduPilot/ardupilot/blob/1e033e616f505844163116bb8669d963bc37209b/APMrover2/sensors.cpp#L105) variable defined as `uint32_t` can get negative.
For example when wheel is not rotating, the `wheel_encoder.get_last_reading_ms(i)` reports some old time stamp, while `wheel_encoder_last_update_ms[i]` is updated with the last EKF update timestamp (`wheel_encoder_last_ekf_update_ms`).
In this case unsigned `sensor_diff_ms` gives huge value which is not what it is supposed to be.
This PR fixes this. It was formerly part of outdated PR #7252 and was shortly discussed [here](https://github.com/ArduPilot/ardupilot/pull/7252#discussion_r152001619).