### PR TITLE
AP_HAL_ChibiOS: Fix FMUv2 LED lighting up

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -372,8 +372,8 @@ PE3 VDD_3V3_SENSORS_EN OUTPUT HIGH
 PE7 UART7_RX UART7
 PE8 UART7_TX UART7
 
-# Define a LED, mapping it to GPIO(0).
-PE12 FMU_LED_AMBER OUTPUT GPIO(0)
+# Define a LED, mapping it to GPIO(0). LOW will illuminate the LED
+PE12 FMU_LED_AMBER OUTPUT HIGH OPENDRAIN GPIO(0)
 
 # Power flag pins: these tell the MCU the status of the various power
 # supplies that are available. The pin names need to exactly match the


### PR DESCRIPTION
This resolves the amber LED being partially illuminated in the corner of the cube. PX4 was forcing this to an open drain low on start, then immediately swapping to high after booting. Might as well just start in the high state at that point.