### PR TITLE
waf: fixed ROMFS compression to use zero timestamp

### DIFF
--- a/Tools/ardupilotwaf/embed.py
+++ b/Tools/ardupilotwaf/embed.py
@@ -23,8 +23,10 @@ def embed_file(out, f, idx):
 
     # compress it
     compressed = tempfile.NamedTemporaryFile()
-    with gzip.open(compressed.name, mode='wb', compresslevel=9) as g:
+    f = open(compressed.name, "wb")
+    with gzip.GzipFile(fileobj=f, mode='wb', filename='', compresslevel=9, mtime=0) as g:
         g.write(contents)
+    f.close()
 
     compressed.seek(0)
     b = bytearray(compressed.read())


### PR DESCRIPTION
this makes the apj file indepenent of build date, which fixes this
issue:

https://discuss.ardupilot.org/t/arducopter-waf-build-repeatability/37182