### PR TITLE
Copter 3.5.7 Modifications

### DIFF
--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -663,6 +663,14 @@ void Copter::guided_set_desired_velocity_with_accel_and_fence_limits(const Vecto
 
     // exit immediately if already equal
     if (curr_vel_des == vel_des) {
+#if AC_AVOID_ENABLED
+        // limit the velocity to prevent fence violations
+        avoid.adjust_velocity(pos_control->get_pos_xy_kP(), pos_control->get_accel_xy(), curr_vel_des);
+        // get avoidance adjusted climb rate
+        curr_vel_des.z = get_avoidance_adjusted_climbrate(curr_vel_des.z);
+#endif
+        // update position controller with new target
+        pos_control->set_desired_velocity(curr_vel_des);
         return;
     }
 
@@ -686,6 +694,8 @@ void Copter::guided_set_desired_velocity_with_accel_and_fence_limits(const Vecto
 #if AC_AVOID_ENABLED
     // limit the velocity to prevent fence violations
     avoid.adjust_velocity(pos_control->get_pos_xy_kP(), pos_control->get_accel_xy(), curr_vel_des);
+    // get avoidance adjusted climb rate
+    curr_vel_des.z = get_avoidance_adjusted_climbrate(curr_vel_des.z);
 #endif
 
     // update position controller with new target

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -486,6 +486,7 @@ enum DevOptions {
 #define FS_GCS_DISABLED                     0
 #define FS_GCS_ENABLED_ALWAYS_RTL           1
 #define FS_GCS_ENABLED_CONTINUE_MISSION     2
+#define FS_GCS_ENABLED_LOITER               3
 
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -115,7 +115,9 @@ void Copter::failsafe_gcs_check()
     } else {
         if (control_mode == AUTO && g.failsafe_gcs == FS_GCS_ENABLED_CONTINUE_MISSION) {
             // continue mission
-        } else if (g.failsafe_gcs != FS_GCS_DISABLED) {
+        } else if (g.failsafe_gcs == FS_GCS_ENABLED_LOITER) {
+            set_mode(LOITER, MODE_REASON_GCS_FAILSAFE);
+        } else { // g.failsafe_gcs == FS_GCS_ENABLED_ALWAYS_RTL
             set_mode_RTL_or_land_with_pause(MODE_REASON_GCS_FAILSAFE);
         }
     }

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -33,8 +33,11 @@ void Copter::fence_check()
             if (ap.land_complete || (mode_has_manual_throttle(control_mode) && ap.throttle_zero && !failsafe.radio && ((fence.get_breaches() & AC_FENCE_TYPE_ALT_MAX)== 0))){
                 init_disarm_motors();
             }else{
+                if (fence.get_action() == AC_FENCE_ACTION_LOITER) {
+                    set_mode(LOITER, MODE_REASON_FENCE_BREACH);
+                }
                 // if we are within 100m of the fence, RTL
-                if (fence.get_breach_distance(new_breaches) <= AC_FENCE_GIVE_UP_DISTANCE) {
+                else if (fence.get_breach_distance(new_breaches) <= AC_FENCE_GIVE_UP_DISTANCE) {
                     if (!set_mode(RTL, MODE_REASON_FENCE_BREACH)) {
                         set_mode(LAND, MODE_REASON_FENCE_BREACH);
                     }

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -312,6 +312,11 @@ void Copter::update_sensor_status_flags(void)
     if (copter.battery.healthy()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_BATTERY;
     }
+#if AC_FENCE == ENABLED
+    if (copter.fence.sys_status_present()) {
+        control_sensors_present |= MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
 
 
     // all present sensors enabled by default except altitude and position control and motors which we will set individually
@@ -319,7 +324,8 @@ void Copter::update_sensor_status_flags(void)
                                                          ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL &
                                                          ~MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS &
                                                          ~MAV_SYS_STATUS_LOGGING &
-                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY);
+                                                         ~MAV_SYS_STATUS_SENSOR_BATTERY &
+                                                         ~MAV_SYS_STATUS_GEOFENCE);
 
     switch (control_mode) {
     case AUTO:
@@ -358,7 +364,11 @@ void Copter::update_sensor_status_flags(void)
     if (g.fs_batt_voltage > 0 || g.fs_batt_mah > 0) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_BATTERY;
     }
-
+#if AC_FENCE == ENABLED
+    if (copter.fence.sys_status_enabled()) {
+        control_sensors_enabled |= MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
 
 
     // default to all healthy
@@ -447,7 +457,13 @@ void Copter::update_sensor_status_flags(void)
     }
 
     if (copter.failsafe.battery) {
-         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_BATTERY;                                                                    }
+         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_BATTERY;                                                                    
+    }
+#if AC_FENCE == ENABLED
+    if (copter.fence.sys_status_failed()) {
+        control_sensors_health &= ~MAV_SYS_STATUS_GEOFENCE;
+    }
+#endif
     
 #if FRSKY_TELEM_ENABLED == ENABLED
     // give mask of error flags to Frsky_Telemetry

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -19,6 +19,7 @@
 // valid actions should a fence be breached
 #define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
 #define AC_FENCE_ACTION_RTL_AND_LAND                1       // return to launch and, if that fails, land
+#define AC_FENCE_ACTION_LOITER                      2       // Loiter
 
 // default boundaries
 #define AC_FENCE_ALT_MAX_DEFAULT                    100.0f  // default max altitude is 100m
@@ -115,6 +116,11 @@ public:
     void handle_msg(mavlink_channel_t chan, mavlink_message_t* msg);
 
     static const struct AP_Param::GroupInfo var_info[];
+    
+    // methods for mavlink SYS_STATUS message (send_extended_status1)
+    bool sys_status_present() const;
+    bool sys_status_enabled() const;
+    bool sys_status_failed() const;
 
 private:
 


### PR DESCRIPTION
1) Option for Drone to Loiter when breaching Geofence, this is set in FENCE_ACTION Parameter
2) Option for Drone to Loiter when losing comms with GCS, this is set in FS_GCS_ENABLE Parameter 
3) Cherry Picked Geofence sensor status into Copter-3.5.7
4) Cherry Picked ability to avoid Geofence when using Velocity Controller for Drone

Tested all functionality with SITL and working as expected. Vehicle will Loiter when breaching Geofence and/or losing comms with GCS when Parameters are set correctly.
Geofence health is properly reported back through the SYS_STATUS message for Copter-3.5.7
Drone stops at Geofence when using Velocity Controller

Successfully passed build_all.sh script.