### PR TITLE
AC_AutoTune: fixed testing of gains with aux switch

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -190,8 +190,6 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
 // stop - should be called when the ch7/ch8 switch is switched OFF
 void AC_AutoTune::stop()
 {
-    axes_completed = 0;
-
     // set gains to their original values
     load_gains(GAIN_ORIGINAL);
 


### PR DESCRIPTION
this fixes the use of an aux switch for autotune to test gains before
disarm.

Many thanks to Mark Whitehorn for noticing this regression