### PR TITLE
AP_RCProtocol: on DSM sync error don't reset channel count

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.cpp
@@ -405,7 +405,6 @@ bool AP_RCProtocol_DSM::dsm_parse_byte(uint32_t frame_time_ms, uint8_t b, uint16
         if ((frame_time_ms - last_rx_time_ms) >= 5) {
             dsm_decode_state = DSM_DECODE_STATE_SYNC;
             byte_input.ofs = 0;
-            chan_count = 0;
             byte_input.buf[byte_input.ofs++] = b;
         }
         break;


### PR DESCRIPTION
this fixes the issue noticed by Andreyl in 3.6.5rc1

see https://discuss.ardupilot.org/t/copter-3-6-5-rc1-available-for-beta-testing/37267/4
