### PR TITLE
 AP_Proximity: Determine UART read error

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -251,8 +251,13 @@ void AP_Proximity_RPLidarA2::get_readings()
     uint32_t nbytes = _uart->available();
 
     while (nbytes-- > 0) {
-
-        uint8_t c = _uart->read();
+        int16_t readChar = _uart->read();
+        uint8_t c;
+        if (readChar < 0) {
+            continue;
+        } else {
+            c = readChar & 0xff;
+        }
         Debug(2, "UART READ %x <%c>", c, c); //show HEX values
 
         STATE:

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -245,16 +245,14 @@ void AP_Proximity_RPLidarA2::get_readings()
         return;
     }
     Debug(2, "             CURRENT STATE: %d ", _rp_state);
-    uint32_t nbytes = _uart->available();
+    int32_t nbytes = _uart->available();
 
     while (nbytes-- > 0) {
         int16_t readChar = _uart->read();
-        uint8_t c;
         if (readChar < 0) {
             continue;
-        } else {
-            c = readChar & 0xff;
         }
+        const uint8_t c = readChar;
         Debug(2, "UART READ %x <%c>", c, c); //show HEX values
 
         STATE:

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -78,9 +78,6 @@ AP_Proximity_RPLidarA2::AP_Proximity_RPLidarA2(AP_Proximity &_frontend,
     if (_uart != nullptr) {
         _uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar360, 0));
     }
-    _cnt = 0 ;
-    _sync_error = 0 ;
-    _byte_count = 0;
 }
 
 // detect if a RPLidarA2 proximity sensor is connected by looking for a configured serial port


### PR DESCRIPTION
I return a negative value when UART's read method detects an error.
We have already dealt with RangeFinder's UART device.
I think the same action is necessary.
Also, since the variable initialized by the constructor is a bss variable, it becomes the value of 0 at startup.
So, I think this 0 clear is unnecessary.