### PR TITLE
scripts: Default key is Y, accept empty enter in Install-prereqs-arch.sh

### DIFF
--- a/Tools/scripts/install-prereqs-arch.sh
+++ b/Tools/scripts/install-prereqs-arch.sh
@@ -26,7 +26,7 @@ ARDUPILOT_TOOLS="ardupilot/Tools/autotest"
 
 function prompt_user() {
       read -p "$1"
-      if [[ $REPLY =~ ^[Yy]$ ]]; then
+      if [[ $REPLY =~ ^[Yy'']$ || $REPLY == '' ]]; then
           return 0
       else
           return 1


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>