### PR TITLE
AP_Arming: allow arming checks ALL to pass when logging is disabled

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -200,6 +200,10 @@ bool AP_Arming::logging_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_LOGGING)) {
+        if (!AP::logger().logging_present()) {
+            // Logging is disabled, so nothing to check.
+            return true;
+        }
         if (AP::logger().logging_failed()) {
             check_failed(ARMING_CHECK_LOGGING, report, "Logging failed");
             return false;
@@ -722,11 +726,18 @@ bool AP_Arming::arm_checks(ArmingMethod method)
     
     // note that this will prepare AP_Logger to start logging
     // so should be the last check to be done before arming
-    if ((checks_to_perform & ARMING_CHECK_ALL) ||
-        (checks_to_perform & ARMING_CHECK_LOGGING)) {
-        AP_Logger *df = AP_Logger::instance();
+
+    // Note also that we need to PrepForArming() regardless of whether
+    // the arming check flag is set - disabling the arming check
+    // should not stop logging from working.
+
+    AP_Logger *df = AP_Logger::instance();
+    if (df->logging_present()) {
+        // If we're configured to log, prep it
         df->PrepForArming();
-        if (!df->logging_started()) {
+        if (!df->logging_started() &&
+            ((checks_to_perform & ARMING_CHECK_ALL) ||
+             (checks_to_perform & ARMING_CHECK_LOGGING))) {
             check_failed(ARMING_CHECK_LOGGING, true, "Logging not started");
             return false;
         }


### PR DESCRIPTION
When ARMING_CHECKS is ARMING_CHECK_ALL but not ARMING_CHECK_LOGGING,
consider having no logging backend to be valid.

When LOG_BACKEND_TYPE is set to 0 (disabling all logging) and
ARMING_CHECKS is set to 1 (all arming checks), several people have
expected the craft to be armable, in much the same way that if
COMPASS_USE*=0 on all compasses and ARMING_CHECKS=1, the craft is armable.

There has been some opinions (see
https://github.com/ArduPilot/ardupilot/issues/10006 and
https://github.com/ArduPilot/ardupilot/issues/7634) that by setting
the ARMING_CHECK_LOGGING bit in ARMING_CHECKS you are specifying that
you don't want to be able to arm unless logging is working, and I
agree. But when ARMING_CHECKS is 1 I think most people expect that to
mean "Make sure that everything is working as expected", and when
LOG_BACKEND_TYPE=0, working as expected means you have no logging.

Note that I also think that if you set ARMING_CHECK_COMPASS in
ARMING_CHECKS and COMPASS_USE*=0 the craft should fail to arm because
there's no compasses and you've explicitly stated that you should have
one. But that's another PR.
