### PR TITLE
Remove PX4-specific GCS-override code 

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -765,11 +765,6 @@ void GCS_MAVLINK_Plane::packetReceived(const mavlink_status_t &status,
     GCS_MAVLINK::packetReceived(status, msg);
 }
 
-bool GCS_MAVLINK_Plane::should_disable_overrides_on_reboot() const
-{
-    return (plane.quadplane.enable != 0);
-}
-
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_int_t &packet)
 {

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -22,7 +22,6 @@ protected:
     bool sysid_enforce() const override;
 
     bool set_mode(uint8_t mode) override;
-    bool should_disable_overrides_on_reboot() const override;
 
     MAV_RESULT handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -341,10 +341,8 @@ protected:
     void handle_common_message(mavlink_message_t *msg);
     void handle_set_gps_global_origin(const mavlink_message_t *msg);
     void handle_setup_signing(const mavlink_message_t *msg);
-    virtual bool should_disable_overrides_on_reboot() const { return true; }
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
     MAV_RESULT handle_preflight_reboot(const mavlink_command_long_t &packet);
-    void disable_overrides();
 
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);


### PR DESCRIPTION
This isn't running on any current platform, and @tridge believes we handle reboots appropriately (and in a more simple fashion!) than we did.
