### PR TITLE
CI: Run flake8 on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,3 +70,12 @@ matrix:
     - if: type != cron
       compiler: "clang"
       env: CI_BUILD_TARGET="sitltest-rover sitltest-sub""
+    - language: python
+      python: 3.7
+      addons:  # speedup: This test does not need addons
+      compiler:
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      before_install: pip install flake8
+      script:
+        - EXCLUDE=./.*,./modules/gtest,./modules/ChibiOS/test,./modules/uavcan/libuavcan
+        - flake8 . --count --exclude=$EXCLUDE --select=E901,E999,F821,F822,F823 --show-source --statistics


### PR DESCRIPTION
Yet another attempt at #7131 because without automated testing, these syntax errors and undefined names keep creeping back into the codebase: #9225, #9226, #9229, #9788, #10038, and now these new ones... https://travis-ci.org/ArduPilot/ardupilot/jobs/481311021#L244

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree