### PR TITLE
Copter: add all rotating Monocopter heli frame type 

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -38,6 +38,8 @@ protected:
 
     void handle_mount_message(const mavlink_message_t* msg) override;
 
+    void send_attitude() const override;
+
 private:
 
     void handleMessage(mavlink_message_t * msg) override;

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -375,13 +375,13 @@ void AP_AHRS::update_cd_values(void)
 /*
   create a rotated view of AP_AHRS with optional pitch trim
  */
-AP_AHRS_View *AP_AHRS::create_view(enum Rotation rotation, float pitch_trim_deg)
+AP_AHRS_View *AP_AHRS::create_view(enum Rotation rotation, float pitch_trim_deg, bool unspin)
 {
     if (_view != nullptr) {
         // can only have one
         return nullptr;
     }
-    _view = new AP_AHRS_View(*this, rotation, pitch_trim_deg);
+    _view = new AP_AHRS_View(*this, rotation, pitch_trim_deg, unspin);
     return _view;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -546,7 +546,7 @@ public:
     }
 
     // create a view
-    AP_AHRS_View *create_view(enum Rotation rotation, float pitch_trim_deg=0);
+    AP_AHRS_View *create_view(enum Rotation rotation, float pitch_trim_deg=0, bool unspin = false);
 
     // return calculated AOA
     float getAOA(void);

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -21,10 +21,12 @@
 #include "AP_AHRS_View.h"
 #include <stdio.h>
 
-AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_trim_deg) :
+AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_trim_deg, bool unspin) :
     rotation(_rotation),
     ahrs(_ahrs)
 {
+    _unspin = unspin;
+
     switch (rotation) {
     case ROTATION_NONE:
         y_angle = 0;
@@ -64,6 +66,12 @@ void AP_AHRS_View::update(bool skip_ins_update)
 
     rot_body_to_ned.to_euler(&roll, &pitch, &yaw);
 
+    // unspin and recalculate NED rotations
+    if (_unspin) {
+        unspin_update();
+        rot_body_to_ned.from_euler(roll, pitch, yaw);
+    }
+
     roll_sensor  = degrees(roll) * 100;
     pitch_sensor = degrees(pitch) * 100;
     yaw_sensor   = degrees(yaw) * 100;
@@ -77,7 +85,12 @@ void AP_AHRS_View::update(bool skip_ins_update)
 }
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
-Vector3f AP_AHRS_View::get_gyro_latest(void) const {
+Vector3f AP_AHRS_View::get_gyro_latest(void) const
+{
+    if (_unspin) {
+        return gyro;
+    }
+
     Vector3f gyro_latest = ahrs.get_gyro_latest();
     gyro_latest.rotate(rotation);
     return gyro_latest;
@@ -95,4 +108,137 @@ Vector2f AP_AHRS_View::rotate_body_to_earth2D(const Vector2f &bf) const
 {
     return Vector2f(bf.x * trig.cos_yaw - bf.y * trig.sin_yaw,
                     bf.x * trig.sin_yaw + bf.y * trig.cos_yaw);
+}
+
+
+// Create 'un-spinned' view for all rotating vehicles such as monocopter
+void AP_AHRS_View::unspin_update(void)
+{
+    // buffer index, increment one for each sample
+    const uint16_t last_end_index = end_index;
+    end_index++;
+    if (end_index > BUFFER_LENGTH - 1) {
+        end_index = 0;
+    }
+
+    // insure buffer does not overlap
+    if (end_index == start_index) {
+        start_index++;
+        if (start_index > BUFFER_LENGTH - 1) {
+            start_index = 0;
+        }
+    }
+
+    // rotate so pitch and roll are relative to fixed 'virtual' yaw
+    const float sin_yaw = sinf(yaw - vitual_forward);
+    const float cos_yaw = cosf(yaw - vitual_forward);
+    virtual_roll[end_index] =  cos_yaw*roll - sin_yaw*pitch;
+    virtual_pitch[end_index] = sin_yaw*roll + cos_yaw*pitch;
+    virtual_roll_rate[end_index] =  cos_yaw*gyro.x - sin_yaw*gyro.y;
+    virtual_pitch_rate[end_index] = sin_yaw*gyro.x + cos_yaw*gyro.y;
+
+    // keep track of rotation angle
+    yaw_diff[end_index] = wrap_PI(yaw - true_yaw);
+    true_yaw = yaw;
+    rotation_angle = wrap_2PI(vitual_forward - true_yaw);
+
+    // keep track of time
+    time[end_index] = AP_HAL::micros64();
+
+    // Integrate virtual roll and pitch - trapezium rule
+    roll_int[end_index] = (virtual_roll[end_index] + virtual_roll[last_end_index]) * 0.5f * (time[end_index] - time[last_end_index]);
+    pitch_int[end_index] = (virtual_pitch[end_index] + virtual_pitch[last_end_index]) * 0.5f * (time[end_index] - time[last_end_index]);
+    roll_rate_int[end_index] = (virtual_roll_rate[end_index] + virtual_roll_rate[last_end_index]) * 0.5f * (time[end_index] - time[last_end_index]);
+    pitch_rate_int[end_index] = (virtual_pitch_rate[end_index] + virtual_pitch_rate[last_end_index]) * 0.5f * (time[end_index] - time[last_end_index]);
+
+    // add up all since last full rotation
+    int16_t i = start_index;
+    float yaw_sum = 0.0f;
+    float roll_int_sum = 0.0f;
+    float pitch_int_sum = 0.0f;
+    float roll_rate_int_sum = 0.0f;
+    float pitch_rate_int_sum = 0.0f;
+    while (i != end_index) {
+        yaw_sum += yaw_diff[i];
+        roll_int_sum += roll_int[i];
+        pitch_int_sum += pitch_int[i];
+        roll_rate_int_sum += roll_rate_int[i];
+        pitch_rate_int_sum += pitch_rate_int[i];
+        i++;
+        if (i > BUFFER_LENGTH - 1) {
+            i = 0;
+        }
+    }
+    yaw_sum += yaw_diff[end_index];
+    roll_int_sum += roll_int[end_index];
+    pitch_int_sum += pitch_int[end_index];
+    roll_rate_int_sum += roll_rate_int[end_index];
+    pitch_rate_int_sum += pitch_rate_int[end_index];
+
+    // take off oldest until less than 360
+    while (abs(yaw_sum - yaw_diff[start_index]) > M_2PI) {
+        yaw_sum -= yaw_diff[start_index];
+        roll_int_sum -= roll_int[start_index];
+        pitch_int_sum -= pitch_int[start_index];
+        roll_rate_int_sum -= roll_rate_int[start_index];
+        pitch_rate_int_sum -= pitch_rate_int[start_index];
+        start_index++;
+        if (start_index > BUFFER_LENGTH - 1) {
+            start_index = 0;
+        }
+    }
+
+    // Find time exactly 1 rotation ago, provided one rotation has past
+    // this allows rolling integration for exactly one rotation
+    const float yaw_sum_less_one = abs(yaw_sum - yaw_diff[start_index]);
+    yaw_sum = abs(yaw_sum);
+    rpm = 0.0f;
+    if (yaw_sum > M_2PI) {
+        // match virtual yaw rate to desired
+        vitual_forward += yaw_rate * (time[end_index] - time[last_end_index]) * 0.000001f;
+        vitual_forward = wrap_2PI(vitual_forward);
+        yaw = vitual_forward;
+        gyro.z = yaw_rate;
+
+        // Calculate Interpolation factors
+        const float interp_0 = (yaw_sum_less_one - M_2PI)/(yaw_sum_less_one - yaw_sum);
+        const float interp_1 = 1 - interp_0;
+
+        // Error caused by misalignment of arrays for values and difference/integrals
+        // i.e. diff array one element shorter than values
+        int16_t start_index_a = start_index - 1;
+        if (start_index_a < 0) {
+            start_index_a = BUFFER_LENGTH - 1;
+        }
+
+        // Interpolation time, roll and pitch exactly one rotation ago
+        const float Cross_time = time[start_index_a] * interp_0 + time[start_index] * interp_1;
+        const float Cross_roll = virtual_roll[start_index_a] * interp_0 + virtual_roll[start_index] * interp_1;
+        const float Cross_pitch = virtual_pitch[start_index_a] * interp_0 + virtual_pitch[start_index] * interp_1;
+        const float Cross_roll_rate = virtual_roll_rate[start_index_a] * interp_0 + virtual_roll_rate[start_index] * interp_1;
+        const float Cross_pitch_rate = virtual_pitch_rate[start_index_a] * interp_0 + virtual_pitch_rate[start_index] * interp_1;
+
+        // Trapezium rule integration from cross point to next point
+        const float Cross_roll_int = (Cross_roll + virtual_roll[start_index]) * 0.5f * (time[start_index] - Cross_time);
+        const float Cross_pitch_int = (Cross_pitch + virtual_pitch[start_index]) * 0.5f * (time[start_index] - Cross_time);
+        const float Cross_roll_rate_int = (Cross_roll_rate + virtual_roll_rate[start_index]) * 0.5f * (time[start_index] - Cross_time);
+        const float Cross_pitch_rate_int = (Cross_pitch_rate + virtual_pitch_rate[start_index]) * 0.5f * (time[start_index] - Cross_time);
+
+        // rotation time
+        const float rotation_time = time[end_index] - Cross_time;
+        rpm = 60000000.0f / rotation_time;
+
+        // Calculate total integrated roll and pitch and divide by rotation time
+        roll = (roll_int_sum - roll_int[start_index] + Cross_roll_int) / rotation_time;
+        pitch = (pitch_int_sum - pitch_int[start_index] + Cross_pitch_int) / rotation_time;
+        gyro.x = (roll_rate_int_sum - roll_rate_int[start_index] + Cross_roll_rate_int) / rotation_time;
+        gyro.y = (pitch_rate_int_sum - pitch_rate_int[start_index] + Cross_pitch_rate_int) / rotation_time;
+
+        roll = wrap_PI(roll);
+        pitch = wrap_PI(pitch);
+
+    } else if (abs(gyro.z) < 0.01f) {
+        // if were not in rotation 'lock' and not rotating then set current yaw as the new 'virtual forward' direction
+        vitual_forward = yaw;
+    }
 }

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -21,12 +21,13 @@
  */
 
 #include "AP_AHRS.h"
+#define BUFFER_LENGTH 1000
 
 class AP_AHRS_View
 {
 public:
     // Constructor
-    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim_deg=0);
+    AP_AHRS_View(AP_AHRS &ahrs, enum Rotation rotation, float pitch_trim_deg=0, bool unspin = false);
 
     // update state
     void update(bool skip_ins_update=false);
@@ -164,13 +165,22 @@ public:
     float get_error_yaw(void) const {
         return ahrs.get_error_yaw();
     }
-    
+
+    // set the change in virtual yaw angle
+    void set_yaw_rate(float yaw_rate_in) const {
+        // convert from cd/s to rad/s
+        yaw_rate = radians(yaw_rate_in * 0.01f);
+    }
+
     float roll;
     float pitch;
     float yaw;
     int32_t roll_sensor;
     int32_t pitch_sensor;
     int32_t yaw_sensor;
+
+    float rpm;
+    float rotation_angle;
 
 private:
     const enum Rotation rotation;
@@ -190,4 +200,23 @@ private:
     } trig;
 
     float y_angle;
+
+    // Un-spinning algorithm for all rotating vehicles
+    void unspin_update();
+    bool _unspin;
+    mutable float yaw_rate;
+    uint16_t start_index;
+    uint16_t end_index;
+    float true_yaw;
+    float vitual_forward;
+    float virtual_roll[BUFFER_LENGTH];
+    float virtual_pitch[BUFFER_LENGTH];
+    float roll_int[BUFFER_LENGTH];
+    float pitch_int[BUFFER_LENGTH];
+    float yaw_diff[BUFFER_LENGTH];
+    uint64_t time[BUFFER_LENGTH];
+    float virtual_roll_rate[BUFFER_LENGTH];
+    float virtual_pitch_rate[BUFFER_LENGTH];
+    float roll_rate_int[BUFFER_LENGTH];
+    float pitch_rate_int[BUFFER_LENGTH];
 };

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -11,3 +11,4 @@
 #include "AP_MotorsCoax.h"
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
+#include "AP_MotorsHeli_Mono.h"

--- a/libraries/AP_Motors/AP_MotorsHeli_Mono.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Mono.cpp
@@ -1,0 +1,330 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *       AP_MotorsHeli_Mono.cpp - ArduCopter motors library for monocopters (all rotating with single wing or wings)
+ *
+ */
+
+#include <stdlib.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS_View.h>
+
+#include "AP_MotorsHeli_Mono.h"
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_MotorsHeli_Mono::var_info[] = {
+    AP_NESTEDGROUPINFO(AP_MotorsHeli, 0),
+
+    // Indices 1-3 were used by RSC_PWM_MIN, RSC_PWM_MAX and RSC_PWM_REV and should not be used
+
+    // @Param: PHZ_OFFST
+    // @DisplayName: Monocopter phase offset
+    // @Description: Angular offset of attitude correction commands
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Standard
+    // @Increment: 1
+    AP_GROUPINFO("PHZ_OFFST", 1, AP_MotorsHeli_Mono, _phase_offset, 0.0f),
+
+    // @Param: HOVER_RPM
+    // @DisplayName: Monocopter hover rpm
+    // @Description: Hover rpm, used to scale gain
+    // @Range: 0 1000
+    // @User: Standard
+    // @Increment: 1
+    AP_GROUPINFO("HOVER_RPM", 2, AP_MotorsHeli_Mono, _hover_rpm, 180.0f),
+
+    // @Param: SYNC_PIN
+    // @DisplayName: pin to sync with zero crossing of yaw and virtual yaw
+    // @Description: gives a rising output when monocopter is yaw forwards, used for orientation LED, falling ouput at yaw 180
+    // @User: Standard
+    // @Values: -1:Disabled,49:BB Blue GP0 pin 4,50:Pixhawk AUXOUT1,51:Pixhawk AUXOUT2,52:Pixhawk AUXOUT3,53:Pixhawk AUXOUT4,54:Pixhawk AUXOUT5,55:Pixhawk AUXOUT6,57:BB Blue GP0 pin 3,111:PX4 FMU Relay1,112:PX4 FMU Relay2,113:PX4IO Relay1/BB Blue GP0 pin 6,114:PX4IO Relay2,115:PX4IO ACC1,116:PX4IO ACC2/BB Blue GP0 pin 5
+    AP_GROUPINFO("SYNC_PIN", 3, AP_MotorsHeli_Mono, _sync_pin, -1),
+
+    // @Param: SYNC_PHZ
+    // @DisplayName: phase offset for sync pulse
+    // @Description: used to account for any offset in led mounting from forwards direction
+    // @Range: -180 180
+    // @Units: deg
+    // @User: Standard
+    AP_GROUPINFO("SYNC_PHZ", 4, AP_MotorsHeli_Mono, _sync_phase_offset, 0.0f),
+
+    AP_GROUPEND
+};
+
+#define SERVO_OUTPUT_RANGE  4500
+
+// set update rate to motors - a value in hertz
+void AP_MotorsHeli_Mono::set_update_rate(uint16_t speed_hz)
+{
+    // record requested speed
+    _speed_hz = speed_hz;
+
+    SRV_Channels::set_rc_frequency(SRV_Channel::k_motor1, speed_hz);
+}
+
+// init
+bool AP_MotorsHeli_Mono::init_outputs()
+{
+    if (_flags.initialised_ok) {
+        return true;
+    }
+
+    SRV_Channels::set_aux_channel_default(SRV_Channel::k_motor1, CH_2);
+    SRV_Channels::set_angle(SRV_Channel::k_motor1, SERVO_OUTPUT_RANGE);
+
+    // set rotor servo range
+    _rotor.init_servo();
+
+    _flags.initialised_ok = true;
+
+    // init sync pulse pin
+    if (_sync_pin != -1) {
+        sync_on = true;
+        hal.gpio->pinMode(_sync_pin, HAL_GPIO_OUTPUT);
+    }
+
+    return true;
+}
+
+// output_test_seq - spin a motor at the pwm value specified
+//  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
+//  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
+void AP_MotorsHeli_Mono::output_test_seq(uint8_t motor_seq, int16_t pwm)
+{
+    // exit immediately if not armed
+    if (!armed()) {
+        return;
+    }
+
+    // output to motors and servos
+    switch (motor_seq) {
+        case 1:
+            // throttle
+            rc_write(AP_MOTORS_HELI_DUAL_RSC, pwm);
+
+            break;
+        case 2:
+            // 'aileron'
+           rc_write(AP_MOTORS_MOT_1, pwm);
+            break;
+        default:
+            // do nothing
+            break;
+    }
+}
+
+// set_desired_rotor_speed
+void AP_MotorsHeli_Mono::set_desired_rotor_speed(float desired_speed)
+{
+    _rotor.set_desired_speed(desired_speed);
+}
+
+// calculate_armed_scalars
+void AP_MotorsHeli_Mono::calculate_armed_scalars()
+{
+    float thrcrv[5];
+    for (uint8_t i = 0; i < 5; i++) {
+        thrcrv[i]=_rsc_thrcrv[i]*0.001f;
+    }
+    _rotor.set_ramp_time(_rsc_ramp_time);
+    _rotor.set_runup_time(_rsc_runup_time);
+    _rotor.set_critical_speed(_rsc_critical*0.001f);
+    _rotor.set_idle_output(_rsc_idle_output*0.001f);
+    _rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
+}
+
+// calculate_scalars
+void AP_MotorsHeli_Mono::calculate_scalars()
+{
+    // range check collective min, max and mid
+    if( _collective_min >= _collective_max ) {
+        _collective_min = AP_MOTORS_HELI_COLLECTIVE_MIN;
+        _collective_max = AP_MOTORS_HELI_COLLECTIVE_MAX;
+    }
+
+    _collective_mid = constrain_int16(_collective_mid, _collective_min, _collective_max);
+
+    // calculate collective mid point as a number from 0 to 1000
+    _collective_mid_pct = ((float)(_collective_mid-_collective_min))/((float)(_collective_max-_collective_min));
+
+    // calculate factors based on swash type and servo position
+    calculate_roll_pitch_collective_factors();
+
+    // set mode of main rotor controller and trigger recalculation of scalars
+    _rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    calculate_armed_scalars();
+}
+
+// get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
+//  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+uint16_t AP_MotorsHeli_Mono::get_motor_mask()
+{
+    uint32_t mask = 0;
+
+    mask |= 1U << AP_MOTORS_MOT_1;
+    mask |= 1U << CH_1;
+
+    return mask;
+}
+
+// update_motor_controls - sends commands to motor controllers
+void AP_MotorsHeli_Mono::update_motor_control(RotorControlState state)
+{
+    // Send state update to motors
+    _rotor.output(state);
+
+    if (state == ROTOR_CONTROL_STOP) {
+        // set engine run enable aux output to not run position to kill engine when disarmed
+        SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
+    } else {
+        // else if armed, set engine run enable output to run position
+        SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::SRV_CHANNEL_LIMIT_MAX);
+    }
+
+    // Check if rotors are run-up
+    _heliflags.rotor_runup_complete = _rotor.is_runup_complete();
+}
+
+// calculate output to elevator
+void AP_MotorsHeli_Mono::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
+{
+    // initialize limits flag
+    limit.roll_pitch = false;
+    limit.yaw = false;
+    limit.throttle_lower = false;
+    limit.throttle_upper = false;
+
+    // constrain collective input
+    float collective_out = collective_in;
+    if (collective_out <= 0.0f) {
+        collective_out = 0.0f;
+        limit.throttle_lower = true;
+    }
+    if (collective_out >= 1.0f) {
+        collective_out = 1.0f;
+        limit.throttle_upper = true;
+    }
+
+    // ensure not below landed/landing collective
+    if (_heliflags.landing_collective && collective_out < (_land_collective_min*0.001f)) {
+        collective_out = _land_collective_min*0.001f;
+        limit.throttle_lower = true;
+    }
+
+    float collective_range = (_collective_max - _collective_min)*0.001f;
+
+    // feed power estimate into main rotor controller
+    _rotor.set_collective(fabsf(collective_out));
+
+    // scale collective to -1 to 1
+    collective_out = collective_out*2-1;
+
+    // reserve some collective for attitude control
+    collective_out *= collective_range;
+
+    // rotate virtual forward
+    // as controller targets rates we must convert back to angle
+    // with PID's of zero and ff of 1 this should give a 1:1 match of desired to actual
+    const uint64_t now = AP_HAL::micros64();
+    _last_update_us = now;
+
+    // give the AHRS unspiner the desired yaw rate and get the current rotation relative to virtual forwards
+    const float yaw_angle = _ahrs.rotation_angle;
+    // set yaw rate in cds
+    _ahrs.set_yaw_rate(_yaw_in * SERVO_OUTPUT_RANGE);
+
+    /*
+    Calculate 'Cyclic' output
+    offset to account for servo response time and other forces can be done via AHRS rotation angles
+    aerodynamically it should be zero, when also considering gyroscopic forces it should be +-90
+    depending on craft rotation direction, probably it will be somewhere between
+    */
+    const float desired_travel_direction = atan2f(_roll_in,_pitch_in); //atan2f(_pitch_in,_roll_in) + radians(180);
+    const float desired_travel_magnitude = sqrt(powf(_roll_in,2.0f) + powf(_pitch_in,2.0f));
+    const float cyclic = cosf(wrap_PI(yaw_angle - desired_travel_direction + radians(_phase_offset)));
+
+    /*
+     apply 'Cyclic' output to aileron
+     maybe also the motor?
+     maybe should do some speed scaling based on rotation rate?
+    */
+    _aileron = cyclic * desired_travel_magnitude;
+
+    // Apply collective
+    _aileron += collective_out;
+
+    // rotation rate scaling
+    const float rpm = _ahrs.rpm;
+    float scaleing = 1.5f;
+    if (!is_zero(rpm)) {
+        scaleing = MIN(scaleing,_hover_rpm / rpm);
+    }
+
+    _aileron = constrain_float(_aileron * scaleing,-1.0f,1.0f);
+
+    /*
+    output to LED sync pin for orientation
+    would quite like to do this at more than 400hz, if rotating fast can be 10's of degrees off
+    may reach EKF or aileron servo speed limit first so it's OK for the time being
+    */
+    if (sync_on) {
+        const float sync = wrap_PI(yaw_angle + _sync_phase_offset);
+        if (is_positive(sync)) {
+            hal.gpio->write(_sync_pin, 1);
+        } else {
+            hal.gpio->write(_sync_pin, 0);
+        }
+    }
+}
+
+void AP_MotorsHeli_Mono::output_to_motors()
+{
+    if (!_flags.initialised_ok) {
+        return;
+    }
+
+    rc_write_angle(AP_MOTORS_MOT_1, _aileron * SERVO_OUTPUT_RANGE);
+
+    switch (_spool_mode) {
+        case SHUT_DOWN:
+            // sends minimum values out to the motors
+            update_motor_control(ROTOR_CONTROL_STOP);
+            break;
+        case GROUND_IDLE:
+            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
+            update_motor_control(ROTOR_CONTROL_IDLE);
+            break;
+        case SPOOL_UP:
+        case THROTTLE_UNLIMITED:
+            // set motor output based on thrust requests
+            update_motor_control(ROTOR_CONTROL_ACTIVE);
+            break;
+        case SPOOL_DOWN:
+            // sends idle output to motors and wait for rotor to stop
+            update_motor_control(ROTOR_CONTROL_IDLE);
+            break;
+    }
+}
+
+// servo_test - move servos through full range of movement
+void AP_MotorsHeli_Mono::servo_test()
+{
+    // not implemented
+}

--- a/libraries/AP_Motors/AP_MotorsHeli_Mono.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Mono.h
@@ -1,0 +1,103 @@
+/// @file	AP_MotorsHeli_Mono.h
+/// @brief	Motor control class for monocopters
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <RC_Channel/RC_Channel.h>
+
+#include "AP_MotorsHeli.h"
+#include "AP_MotorsHeli_RSC.h"
+
+
+/// @class      AP_MotorsHeli_Mono
+class AP_MotorsHeli_Mono : public AP_MotorsHeli {
+public:
+
+    /// Constructor
+    AP_MotorsHeli_Mono(AP_AHRS_View &ahrs,
+                       uint16_t loop_rate,
+                       uint16_t speed_hz = AP_MOTORS_HELI_SPEED_DEFAULT) :
+        AP_MotorsHeli(loop_rate, speed_hz),
+        _ahrs(ahrs),
+        _rotor(SRV_Channel::k_heli_rsc, CH_1)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
+
+    // set update rate to motors - a value in hertz
+    void set_update_rate( uint16_t speed_hz ) override; 
+
+    // spin a motor at the pwm value specified
+    void output_test_seq(uint8_t motor_seq, int16_t pwm) override;
+
+    // output_to_motors - sends values out to the motors
+    void output_to_motors() override;
+
+    // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
+    void set_desired_rotor_speed(float desired_speed) override;
+
+    // get_estimated_rotor_speed - gets estimated rotor speed as a number from 0 ~ 1000
+    float get_main_rotor_speed() const  override { return _rotor.get_rotor_speed(); }
+
+    // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1000
+    float get_desired_rotor_speed() const  override { return _rotor.get_rotor_speed(); }
+
+    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
+    bool rotor_speed_above_critical() const  override { return _rotor.get_rotor_speed() > _rotor.get_critical_speed(); }
+
+    // calculate_scalars - recalculates various scalars used
+    void calculate_scalars() override;
+
+    // calculate_armed_scalars - recalculates scalars that can change while armed
+    void calculate_armed_scalars() override;
+
+    // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+    //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+    uint16_t get_motor_mask() override;
+
+    // has_flybar - returns true if we have a mechanical flybar
+    bool has_flybar() const  override { return true; }
+
+    // supports_yaw_passthrought - returns true - monocopters use yaw pass through to set the virtual yaw
+    bool supports_yaw_passthrough() const  override { return true; }
+
+    // servo_test - move servos through full range of movement
+    void servo_test() override;
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+
+    // init_outputs
+    bool init_outputs () override;
+
+    // update_motor_controls - sends commands to motor controllers
+    void update_motor_control(RotorControlState state) override;
+
+    // calculate_roll_pitch_collective_factors - setup rate factors
+    void calculate_roll_pitch_collective_factors () override {};
+
+    // move_actuators - moves swash plate to attitude of parameters passed in
+    void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out)  override;
+
+    // calculated outputs
+    float _aileron = 0.0f; // -1..1
+
+    // last time called
+    uint64_t _last_update_us;
+
+    //  objects we depend upon
+    AP_MotorsHeli_RSC           _rotor;   // main rotor controller
+    AP_AHRS_View&               _ahrs;    // ahrs for rotating craft
+
+    // parameters
+    AP_Float _phase_offset;
+    AP_Float _hover_rpm;
+    AP_Int8 _sync_pin;
+    AP_Float _sync_phase_offset;
+
+    bool sync_on = false;
+
+};

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -26,6 +26,7 @@ public:
     friend class AP_MotorsHeli_Single;
     friend class AP_MotorsHeli_Dual;
     friend class AP_MotorsHeli_Quad;
+    friend class AP_MotorsHeli_Mono;
 
     AP_MotorsHeli_RSC(SRV_Channel::Aux_servo_function_t aux_fn,
                       uint8_t default_channel) :

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -44,6 +44,7 @@ public:
         MOTOR_FRAME_HELI_DUAL = 11,
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
+        MOTOR_FRAME_HELI_MONO = 14,
     };
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,


### PR DESCRIPTION
This adds a AHRS that 'unspins' the roll and pitch for all rotating vehicles and a monocopter frame type that uses it. The monocopter is a wing with a single motor and a single control surface. 

https://youtu.be/BbZSmPiyiSs

I'm quite happy with how this functions however it needs the time history for ten values. The length of this history determines the minimum rotation rate it can 'lock' at. Currently i'm using 1000 element arrays, so it will use loads of memory. I need some advice on what a acceptable length would be. We will raise the minimum rotation rate as we shorten the buffers but we should be able to get it back again by lowering the loop rate at the expense of resolution at higher rotation rates. Also I think the way I have it at the moment means the arrays are there for all vehicle using AHRS_VIEW even if they are not used, this is not ideal. 