### PR TITLE
Universal emergency stop

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -320,6 +320,12 @@ void Rover::update_GPS(void)
 
 void Rover::update_current_mode(void)
 {
+    // check for emergency stop
+    if (SRV_Channels::get_emergency_stop()) {
+        // relax controllers, motor stopping done at output level
+        g2.attitude_control.relax_I();
+    }
+
     control_mode->update();
 }
 

--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -71,6 +71,13 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
 bool AP_Arming_Rover::pre_arm_checks(bool report)
 {
+    if (SRV_Channels::get_emergency_stop()) {
+        if (report) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Motors Emergency Stopped");
+        }
+        return false;
+    }
+
     return (AP_Arming::pre_arm_checks(report)
             & rover.g2.motors.pre_arm_check(report)
             & fence_checks(report)

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -565,9 +565,9 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::ArmingMethod 
     // if we are not using Emergency Stop switch option, force Estop false to ensure motors
     // can run normally
     if (!rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP)){
-        copter.set_motor_emergency_stop(false);
+        SRV_Channels::set_emergency_stop(false);
         // if we are using motor Estop switch, it must not be in Estop position
-    } else if (rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP) && copter.ap.motor_emergency_stop){
+    } else if (rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP) && SRV_Channels::get_emergency_stop()){
         gcs().send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Emergency Stopped");
         return false;
     }

--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -89,17 +89,3 @@ void Copter::update_using_interlock()
     ap.using_interlock = rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_INTERLOCK) != nullptr;
 #endif
 }
-
-void Copter::set_motor_emergency_stop(bool b)
-{
-    if(ap.motor_emergency_stop != b) {
-        ap.motor_emergency_stop = b;
-    }
-
-    // Log new status
-    if (ap.motor_emergency_stop){
-        Log_Write_Event(DATA_MOTORS_EMERGENCY_STOPPED);
-    } else {
-        Log_Write_Event(DATA_MOTORS_EMERGENCY_STOP_CLEARED);
-    }
-}

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -313,14 +313,13 @@ private:
             uint8_t system_time_set_unused  : 1; // 16      // true if the system time has been set from the GPS
             uint8_t gps_glitching           : 1; // 17      // true if GPS glitching is affecting navigation accuracy
             uint8_t using_interlock         : 1; // 20      // aux switch motor interlock function is in use
-            uint8_t motor_emergency_stop    : 1; // 21      // motor estop switch, shuts off motors when enabled
-            uint8_t land_repo_active        : 1; // 22      // true if the pilot is overriding the landing position
-            uint8_t motor_interlock_switch  : 1; // 23      // true if pilot is requesting motor interlock enable
-            uint8_t in_arming_delay         : 1; // 24      // true while we are armed but waiting to spin motors
-            uint8_t initialised_params      : 1; // 25      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
-            uint8_t compass_init_location   : 1; // 26      // true when the compass's initial location has been set
-            uint8_t unused2                 : 1; // 27      // aux switch rc_override is allowed
-            uint8_t armed_with_switch       : 1; // 28      // we armed using a arming switch
+            uint8_t land_repo_active        : 1; // 21      // true if the pilot is overriding the landing position
+            uint8_t motor_interlock_switch  : 1; // 22      // true if pilot is requesting motor interlock enable
+            uint8_t in_arming_delay         : 1; // 23      // true while we are armed but waiting to spin motors
+            uint8_t initialised_params      : 1; // 24      // true when the all parameters have been initialised. we cannot send parameters to the GCS until this is done
+            uint8_t compass_init_location   : 1; // 25      // true when the compass's initial location has been set
+            uint8_t unused2                 : 1; // 26      // aux switch rc_override is allowed
+            uint8_t armed_with_switch       : 1; // 27      // we armed using a arming switch
         };
         uint32_t value;
     } ap_t;
@@ -613,7 +612,6 @@ private:
     void set_failsafe_radio(bool b);
     void set_failsafe_gcs(bool b);
     void update_using_interlock();
-    void set_motor_emergency_stop(bool b);
 
     // ArduCopter.cpp
     void fast_loop();

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -74,7 +74,6 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
     case MISSION_RESET:
     case ATTCON_FEEDFWD:
     case ATTCON_ACCEL_LIM:
-    case MOTOR_ESTOP:
     case MOTOR_INTERLOCK:
     case AVOID_ADSB:
     case PRECISION_LOITER:
@@ -352,11 +351,6 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
                     break;
             }
 #endif
-            break;
-
-        case MOTOR_ESTOP:
-            // Turn on Emergency Stop logic when channel is high
-            copter.set_motor_emergency_stop(ch_flag == HIGH);
             break;
 
         case MOTOR_INTERLOCK:

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -102,7 +102,7 @@ void Copter::auto_disarm_check()
 #endif
 
     // always allow auto disarm if using interlock switch or motors are Emergency Stopped
-    if ((ap.using_interlock && !motors->get_interlock()) || ap.motor_emergency_stop) {
+    if ((ap.using_interlock && !motors->get_interlock()) || SRV_Channels::get_emergency_stop()) {
 #if FRAME_CONFIG != HELI_FRAME
         // use a shorter delay if using throttle interlock switch or Emergency Stop, because it is less
         // obvious the copter is armed as the motors will not be spinning
@@ -330,7 +330,7 @@ void Copter::motors_output()
     if (ap.motor_test) {
         motor_test_output();
     } else {
-        bool interlock = motors->armed() && !ap.in_arming_delay && (!ap.using_interlock || ap.motor_interlock_switch) && !ap.motor_emergency_stop;
+        bool interlock = motors->armed() && !ap.in_arming_delay && (!ap.using_interlock || ap.motor_interlock_switch) && !SRV_Channels::get_emergency_stop();
         if (!motors->get_interlock() && interlock) {
             motors->set_interlock(true);
             Log_Write_Event(DATA_MOTORS_INTERLOCK_ENABLED);

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -191,7 +191,7 @@ void Copter::set_throttle_zero_flag(int16_t throttle_control)
     // if not using throttle interlock and non-zero throttle and not E-stopped,
     // or using motor interlock and it's enabled, then motors are running, 
     // and we are flying. Immediately set as non-zero
-    if ((!ap.using_interlock && (throttle_control > 0) && !ap.motor_emergency_stop) ||
+    if ((!ap.using_interlock && (throttle_control > 0) && !SRV_Channels::get_emergency_stop()) ||
         (ap.using_interlock && motors->get_interlock()) ||
         ap.armed_with_switch) {
         last_nonzero_throttle_ms = tnow_ms;

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -74,6 +74,11 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
         ret = false;
     }
 
+    if (SRV_Channels::get_emergency_stop()) {
+        check_failed(ARMING_CHECK_NONE, display_failure,"Motors Emergency Stopped");
+        ret = false;
+    }
+
     return ret;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1479,6 +1479,10 @@ void QuadPlane::update(void)
         return;
     }
 
+    if (SRV_Channels::get_emergency_stop()) {
+        attitude_control->reset_rate_controller_I_terms();
+    }
+
     if (!hal.util->get_soft_armed()) {
         /*
           make sure we don't have any residual control from previous flight stages
@@ -1649,7 +1653,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
         attitude_control->rate_controller_run();
     }
 
-    if (!hal.util->get_soft_armed() || plane.afs.should_crash_vehicle()) {
+    if (!hal.util->get_soft_armed() || plane.afs.should_crash_vehicle() || SRV_Channels::get_emergency_stop()) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
         motors->output();
         return;

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -748,3 +748,11 @@ float AR_AttitudeControl::get_stopping_distance(float speed) const
     // assume linear deceleration
     return 0.5f * sq(speed) / accel_max;
 }
+
+// relax I terms of throttle and steering controllers
+void AR_AttitudeControl::relax_I()
+{
+    _steer_rate_pid.reset_I();
+    _throttle_speed_pid.reset_I();
+    _pitch_to_throttle_pid.reset_I();
+}

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -139,6 +139,9 @@ public:
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];
 
+    // relax I terms of throttle and steering controllers
+    void relax_I();
+
 private:
 
     // external references

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -112,6 +112,12 @@ void SRV_Channel::calc_pwm(int16_t output_scaled)
     if (have_pwm_mask & (1U<<ch_num)) {
         return;
     }
+
+    // check for E - stop
+    if (SRV_Channel::should_e_stop(get_function()) && SRV_Channels::emergency_stop) {
+        output_scaled = 0;
+    }
+
     uint16_t pwm;
     if (type_angle) {
         pwm = pwm_from_angle(output_scaled);
@@ -186,4 +192,14 @@ bool SRV_Channel::is_motor(SRV_Channel::Aux_servo_function_t function)
 {
     return ((function >= SRV_Channel::k_motor1 && function <= SRV_Channel::k_motor8) ||
             (function >= SRV_Channel::k_motor9 && function <= SRV_Channel::k_motor12));
+}
+
+// return true if function is for anything that should be stopped in a e-stop situation, ie is dangerous
+bool SRV_Channel::should_e_stop(SRV_Channel::Aux_servo_function_t function)
+{
+    return ((function >= SRV_Channel::k_heli_rsc && function <= SRV_Channel::k_motor8) ||
+            function == SRV_Channel::k_starter || function == SRV_Channel::k_throttle ||
+            function == SRV_Channel::k_throttleLeft || function == SRV_Channel::k_throttleRight ||
+            (function >= SRV_Channel::k_boost_throttle && function <= SRV_Channel::k_motor12) ||
+            function == k_engine_run_enable);
 }

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -193,6 +193,9 @@ public:
     // return true if function is for a multicopter motor
     static bool is_motor(SRV_Channel::Aux_servo_function_t function);
 
+    // return true if function is for anything that should be stopped in a e-stop situation, ie is dangerous
+    static bool should_e_stop(SRV_Channel::Aux_servo_function_t function);
+
     // return the function of a channel
     SRV_Channel::Aux_servo_function_t get_function(void) const {
         return (SRV_Channel::Aux_servo_function_t)function.get();
@@ -456,7 +459,15 @@ public:
     static void set_digital_mask(uint16_t mask) {
         digital_mask |= mask;
     }
-    
+
+    // Set E - stop
+    static void set_emergency_stop(bool state) {
+        emergency_stop = state;
+    }
+
+    // get E - stop
+    static bool get_emergency_stop() { return emergency_stop;}
+
 private:
     struct {
         bool k_throttle_reversible:1;
@@ -516,4 +527,6 @@ private:
     static bool passthrough_disabled(void) {
         return disabled_passthrough;
     }
+
+    static bool emergency_stop;
 };

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -51,6 +51,7 @@ uint16_t SRV_Channels::reversible_mask;
 
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;
+bool SRV_Channels::emergency_stop;
 Bitmask SRV_Channels::function_mask{SRV_Channel::k_nr_aux_servo_functions};
 SRV_Channels::srv_function SRV_Channels::functions[SRV_Channel::k_nr_aux_servo_functions];
 


### PR DESCRIPTION
This is the first bit of adding a universal E-stop for all vehicles. This sets any motor function to minimum pwm limit. I think this is the correct thing to do, also I have included k_starter and k_engine_run_enable as 'motors' as well as all the obvious ones, maybe there are some others that should also be included?

If this implementation is OK so far I will go through and replace the existing copter E-stop and add one to rover and plane. 