### PR TITLE
AP_OSD: normalize whitespace symbols

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -497,10 +497,14 @@ void AP_OSD_Screen::draw_message(uint8_t x, uint8_t y)
             strncpy(buffer, notify->get_text(), sizeof(buffer));
             int16_t len = strnlen(buffer, sizeof(buffer));
 
-            //converted to uppercase,
-            //because we do not have small letter chars inside used font
             for (int16_t i=0; i<len; i++) {
+                //converted to uppercase,
+                //because we do not have small letter chars inside used font
                 buffer[i] = toupper(buffer[i]);
+                //normalize whitespace
+                if (isspace(buffer[i])) {
+                    buffer[i] = ' ';
+                }
             }
 
             int16_t start_position = 0;


### PR DESCRIPTION
This fixes garbage on the screen (\n and \r symbols are not mapped
inside used fonts).
Thanks to @atshort for reporting the issue.
https://github.com/ArduPilot/ardupilot/issues/10098