### PR TITLE
RPLidar A2 updates: RESET behaviour, error processing, scan quality control, PRX_YAW_CORR usage

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -106,7 +106,6 @@ private:
     uint8_t   _last_sector;                   ///< last sector requested
     uint32_t  _last_request_ms;               ///< system time of last request
     uint32_t  _last_distance_received_ms;     ///< system time of last distance measurement received from sensor
-    uint32_t  _last_reset_ms;
 
     // sector related variables
     int16_t _forward_direction;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -54,7 +54,7 @@ public:
 private:
     enum rp_state {
             rp_unknown = 0,
-            rp_resetted,
+            rp_reseted,
             rp_responding,
             rp_measurements,
             rp_health,
@@ -72,15 +72,17 @@ private:
     // initialise sensor (returns true if sensor is successfully initialised)
     bool initialise();
     void init_sectors();
-    void set_scan_mode();
 
     // send request for something from sensor
+    void send_request_for_reset();
+    void send_request_for_force_scan();
+    void send_request_for_scan();
     void send_request_for_health();
     void send_request_for_rate();
-    void parse_response_data();
-    void parse_response_descriptor();
+    // process the response
     void get_readings();
-    void reset_rplidar();
+    void parse_response_descriptor();
+    void parse_response_data();
 
     // reply related variables
     AP_HAL::UARTDriver *_uart;
@@ -88,7 +90,7 @@ private:
     char _rp_systeminfo[63];
     bool _descriptor_data;
     bool _information_data;
-    bool _resetted;
+    bool _reseted;
     bool _initialised;
     bool _sector_initialised;
 

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -57,14 +57,16 @@ private:
             rp_resetted,
             rp_responding,
             rp_measurements,
-            rp_health
+            rp_health,
+            rp_rate
         };
 
     enum ResponseType {
         ResponseType_Descriptor = 0,
         ResponseType_SCAN,
         ResponseType_EXPRESS,
-        ResponseType_Health
+        ResponseType_HEALTH,
+        ResponseType_RATE
     };
 
     // initialise sensor (returns true if sensor is successfully initialised)
@@ -74,6 +76,7 @@ private:
 
     // send request for something from sensor
     void send_request_for_health();
+    void send_request_for_rate();
     void parse_response_data();
     void parse_response_descriptor();
     void get_readings();
@@ -120,9 +123,15 @@ private:
         uint16_t error_code;                  ///< the related error code
     };
 
+    struct PACKED _sensor_rate {
+        uint16_t t_standard;                  ///< The time used when RPLIDAR takes a single laser ranging in uS (valid for SCAN mode)
+        uint16_t t_express;                   ///< The time used when RPLIDAR takes a single laser ranging in uS (valid for EXPRESS_SCAN mode)
+    };
+
     union PACKED {
         DEFINE_BYTE_ARRAY_METHODS
         _sensor_scan sensor_scan;
         _sensor_health sensor_health;
+        _sensor_rate sensor_rate;
     } payload;
 };

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -54,7 +54,7 @@ public:
 private:
     enum rp_state {
             rp_unknown = 0,
-            rp_reseted,
+            rp_reset,
             rp_responding,
             rp_measurements,
             rp_health,
@@ -91,7 +91,7 @@ private:
     char _rp_systeminfo[63];
     bool _descriptor_data;
     bool _information_data;
-    bool _reseted;
+    bool _reset;
     bool _initialised;
     bool _sector_initialised;
 

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -79,6 +79,7 @@ private:
     void send_request_for_scan();
     void send_request_for_health();
     void send_request_for_rate();
+
     // process the response
     void get_readings();
     void parse_response_descriptor();
@@ -108,6 +109,7 @@ private:
     uint32_t  _last_reset_ms;
 
     // sector related variables
+    int16_t _forward_direction;
     float _angle_deg_last;
     float _distance_m_last;
 


### PR DESCRIPTION
A number of updates on RPLidar A2. These were tested on RPLidar A1M1 which is stated to have the same communication protocol, but validation on A2 device would be desired.

## UPDATES INCLUDE

1. Changed RESET behavior -  instead of collecting a fixed number of bytes for a "welcome message" (not documented and varying in different models), we are just waiting 20ms since the first byte until the message passes. Next, HEALTH request is sent and if the response says everything's OK, a SCAN mode is started. Another RESET otherwise (never happened to me). Also, the timeout is there if we don't get any response within reasonable time.

2. Fixed error processing when measurement bytes get out of sync (usually happens if the RX buffer overflows during high CPU usage). Instead of checking only the first two bits that signify a new revolution, a checkbit in second byte is verified too.

3. Added a control over scan quality. Measurements with quality below 10 are rejected (not sure what a valid range is as I couldn't find any details in the documentation, but most scans are well over it).

4. Added yaw correction (defined by PRX_YAW_CORR parameter), so that the lidar can be mounted at any orientation to the front.

5. Added the request for scan RATE. Acts analogously to HEALTH request, but it's not operated by my A1 Lidar so I couldn't verify it...

6. Added the request for FORCE_SCAN. Same as SCAN, just the command is different.

_______________________________________________________________________________________________________

 ## MAJOR BUG FOUND
What I noticed is that the function to update RPLidar takes about 2ms to execute, what is well over the AP_Scheduler's limit. It makes things work at the edge of stability - adding a few debug prints can block the CPU, what shows in getting out of sync errors thrown all over (probably a RX buffer overflows and random bytes are lost) and measurements going mad.

The problem requires a thorough refactor, thus I didn't deal with it now. Seems like the amount of data collected is overwhelming. Each read of single byte from UART buffer takes about 6us, times 120 bytes per execution = over 700us (already too long). Plus some more time to process those bytes. And then the interrupts come in, adding another 1ms to the already prolonged function (yes, disabling interrupts for the time of processing reduced execution time that much).