### PR TITLE
Rover: convert ch7_option param to rc7_option

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -805,6 +805,17 @@ void Rover::load_parameters(void)
     // set a more reasonable default NAVL1_PERIOD for rovers
     L1_controller.set_default_period(NAVL1_PERIOD);
 
+    // convert CH7_OPTION to RC7_OPTION for Rover-3.4 to 3.5 upgrade
+    const AP_Param::ConversionInfo ch7_option_info = { Parameters::k_param_ch7_option, 0, AP_PARAM_INT8, "RC7_OPTION" };
+    AP_Int8 ch7_opt_old;
+    if (AP_Param::find_old_parameter(&ch7_option_info, &ch7_opt_old)) {
+        const uint8_t ch7_opt_map[] = {0,7,50,41,51,52,53,54,16,4,42,55,56};
+        const uint8_t ch7_opt_old_val = (uint8_t)ch7_opt_old.get();
+        if (ch7_opt_old_val < ARRAY_SIZE(ch7_opt_map)) {
+            AP_Param::set_default_by_name(ch7_option_info.new_name, ch7_opt_map[ch7_opt_old_val]);
+        }
+    }
+
     // configure safety switch to allow stopping the motors while armed
 #if HAL_HAVE_SAFETY_SWITCH
     AP_Param::set_default_by_name("BRD_SAFETYOPTION", AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF|

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -108,7 +108,7 @@ public:
         k_param_speed_cruise,
         k_param_speed_turn_gain,    // unused
         k_param_speed_turn_dist,    // unused
-        k_param_ch7_option,
+        k_param_ch7_option,         // unused
         k_param_auto_trigger_pin,
         k_param_auto_kickstart,
         k_param_turn_circle,  // unused


### PR DESCRIPTION
This converts the CH7_OPTION parameter value used in Rover-3.4.x to the RC7_OPTION parameter used in Rover-3.5.  I've tested this on a Pixhawk1 for the single value of "Arm/Disarm" but I'm pretty sure I've got the mapping correctly done for all values.

Rover-3.4 values for CH7_OPTION
-----------------------------------
0:Nothing1:SaveWaypoint,2:LearnCruiseSpeed,3:ArmDisarm,4:Manual,5:Acro,6:Steering,7:Hold,8:Auto,9:RTL,10:SmartRTL,11:Guided,12:Loiter

Rover-3.5 values for RC7_OPTION
-----------------------------------
Rover-3.5: 0:Do Nothing, 4:RTL, 7:Save WP, 9:Camera Trigger, 16:Auto, 28:Relay On/Off, 30:Lost Rover Sound, 34:Relay2 On/Off, 35:Relay3 On/Off, 36:Relay4 On/Off, 40:Proximity Avoidance, 41:ArmDisarm, 42:SmartRTL, 46:RC Override Enable, 50:LearnCruise, 51:Manual, 52:Acro, 53:Steering, 54:Hold, 55:Guided, 56:Loiter, 57:Follow, 58:Clear Waypoints, 59:Simple, 62:Compass Learn, 63:Sailboat Tack, 65:GPS Disable, 66: Relay5, 67: Relay6
