### PR TITLE
Create new GET_MESSAGE_INTERVALS message + support

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -346,6 +346,8 @@ protected:
 
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_get_message_interval(const mavlink_command_long_t &packet);
+    bool get_ap_message_interval(ap_message id, uint16_t &interval_ms) const;
 
     MAV_RESULT handle_rc_bind(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -65,6 +65,7 @@ enum ap_message : uint8_t {
     MSG_SERVO_OUT,
     MSG_NEXT_MISSION_REQUEST,
     MSG_NEXT_PARAM,
+    MSG_MESSAGE_INTERVALS,
     MSG_FENCE_STATUS,
     MSG_AHRS,
     MSG_SIMSTATE,
@@ -347,7 +348,12 @@ protected:
     // reset a message interval via mavlink:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_message_interval(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_get_message_intervals(const mavlink_command_long_t &packet);
     bool get_ap_message_interval(ap_message id, uint16_t &interval_ms) const;
+
+    struct {
+        int8_t ofs = -1; // offset into map of next interval to send; -1 means not sending
+    } _getting_message_intervals;
 
     MAV_RESULT handle_rc_bind(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet);
@@ -411,6 +417,7 @@ protected:
     bool try_send_mission_message(enum ap_message id);
     void send_hwstatus();
     void handle_data_packet(mavlink_message_t *msg);
+    void send_message_intervals();
 
     virtual bool vehicle_initialised() const { return true; }
 
@@ -492,9 +499,10 @@ private:
         const ap_message id;
         uint16_t interval_ms;
         uint16_t last_sent_ms; // from AP_HAL::millis16()
-    } deferred_message[2] = {
+    } deferred_message[3] = {
         { MSG_HEARTBEAT, },
         { MSG_NEXT_PARAM, },
+        { MSG_MESSAGE_INTERVALS, },
     };
     // returns index of id in deferred_message[] or -1 if not present
     int8_t get_deferred_message_index(const ap_message id) const;


### PR DESCRIPTION
This is a WIP for a new way of getting message information from the autopilot.

Currently you can set a message interval (by 24-bit mavlink message id passed in float field) using `SET_MESSAGE_INTERVAL` (takes a float microseconds interval).  You can get that interval with a `MAV_CMD` `GET_MESSAGE_INTERVAL`, which causes the autopilot to emit a `MESSAGE_INTERVAL` (contains 16-bit message ID and interval in microseconds in an int32_t (about 36 minutes if you are wondering...).

What you can't do is work out what messages the autopilot can stream out.

This PR proposes a new message to pass that information down, while eliminating the `GET_MESSAGE_INTERVAL` mess.

On ArduPilot this requires 4 packets of ~130 bytes.

The mavlink message is here: https://github.com/peterbarker/mavlink/blob/get-message-intervals/message_definitions/v1.0/common.xml#L4257

Here's a copy which will get rather out of date:
```
    <message id="235" name="MESSAGE_INTERVALS">
      <description>Contains packed data on streamable messages</description>
      <field type="uint8_t" name="seq">Sequence Number (starting at 0)</field>
      <field type="uint8_t" name="seq_max">Maximum Sequence Number to expect in this reponse</field>
      <field type="uint8_t" name="num">number of valid IDs in this packet</field>
      <field type="uint32_t[16]" name="ids">24-bit ID numbers of streamable mavlink messages.  The top 8 bits are reserved for future options and should be masked off by any consumer.</field>
      <field type="float[16]" name="intervals" units="us">Intervals of streamable messages</field>
    </message>
```

I've realised I could save a byte in the message definition by passing ofs and ofs_max rather than seq / seq_max / num.

```
STABILIZE> long GET_MESSAGE_INTERVALS
STABILIZE> Got MAVLink msg: COMMAND_ACK {command : 512, result : 0}
status MESSAGE_INTERVALS
STABILIZE> 4: MESSAGE_INTERVALS {seq : 3, seq_max : 3, num : 6, ids : [46, 87, 246, 147, 11020, 195, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], intervals : [-1.0, 250000.0, 250000.0, 250000.0, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}
```

The convention used for interval is the same as for `MESSAGE_INTERVAL` - -1 meaning disabled, and the time in microseconds.
