### PR TITLE
Add support for tailsitter quadplanes based on standard copter frames

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -45,7 +45,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Increment: 10
     // @User: Standard
     AP_GROUPINFO("VELZ_MAX", 18, QuadPlane, pilot_velocity_z_max, 250),
-    
+
     // @Param: ACCEL_Z
     // @DisplayName: Pilot vertical acceleration
     // @Description: The vertical acceleration used when pilot is controlling the altitude
@@ -244,7 +244,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Values: 0:Disabled,1:Enabled
     // @User: Standard
     AP_GROUPINFO("LAND_ICE_CUT", 44, QuadPlane, land_icengine_cut,  1),
-    
+
     // @Param: ASSIST_ANGLE
     // @DisplayName: Quadplane assistance angle
     // @Description: This is the angular error in attitude beyond which the quadplane VTOL motors will provide stability assistance. This will only be used if Q_ASSIST_SPEED is also non-zero. Assistance will be given if the attitude is outside the normal attitude limits by at least 5 degrees and the angular error in roll or pitch is greater than this angle for at least 1 second. Set to zero to disable angle assistance.
@@ -274,7 +274,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Range: 10 300
     // @User: Standard
     AP_GROUPINFO("TILT_RATE_DN", 49, QuadPlane, tilt.max_rate_down_dps, 0),
-        
+
     // @Param: TAILSIT_INPUT
     // @DisplayName: Tailsitter input type
     // @Description: This controls whether stick input when hovering as a tailsitter follows the conventions for fixed wing hovering or multicopter hovering. When multicopter input is selected the roll stick will roll the aircraft in earth frame and yaw stick will yaw in earth frame. When using fixed wing input the roll and yaw sticks will control the aircraft in body frame.
@@ -355,7 +355,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
 
     // @Param: TAILSIT_THSCMX
     // @DisplayName: Maximum control throttle scaling value
-    // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low thorottle D ossilaitons 
+    // @Description: Maximum value of throttle scaling for tailsitter velocity scaling, reduce this value to remove low thorottle D ossilaitons
     // @Range: 1 5
     // @User: Standard
     AP_GROUPINFO("TAILSIT_THSCMX", 3, QuadPlane, tailsitter.throttle_scale_max, 5),
@@ -484,7 +484,7 @@ void QuadPlane::setup_default_channels(uint8_t num_motors)
         SRV_Channels::set_aux_channel_default(SRV_Channels::get_motor_function(i), CH_5+i);
     }
 }
-    
+
 
 bool QuadPlane::setup(void)
 {
@@ -498,7 +498,7 @@ bool QuadPlane::setup(void)
 
     enum AP_Motors::motor_frame_class motor_class;
     enum Rotation rotation = ROTATION_NONE;
-        
+
     /*
       cope with upgrade from old AP_Motors values for frame_class
      */
@@ -526,7 +526,7 @@ bool QuadPlane::setup(void)
         }
         frame_class.set_and_save(new_value);
     }
-    
+
     if (hal.util->available_memory() <
         4096 + sizeof(*motors) + sizeof(*attitude_control) + sizeof(*pos_control) + sizeof(*wp_nav) + sizeof(*ahrs_view) + sizeof(*loiter_nav)) {
         gcs().send_text(MAV_SEVERITY_INFO, "Not enough memory for quadplane");
@@ -648,16 +648,19 @@ bool QuadPlane::setup(void)
         SRV_Channels::set_range(SRV_Channel::k_tiltMotorLeft,  1000);
         SRV_Channels::set_range(SRV_Channel::k_tiltMotorRight, 1000);
     }
+    if (tailsitter.motor_mask != 0) {
+        motors->disable_yaw_torque();
+    }
 
-    
+
     setup_defaults();
 
     AP_Param::convert_old_parameters(&q_conversion_table[0], ARRAY_SIZE(q_conversion_table));
-    
+
     gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised");
     initialised = true;
     return true;
-    
+
 failed:
     initialised = false;
     enable.set(0);
@@ -677,7 +680,7 @@ void QuadPlane::setup_defaults(void)
     if (motor_class == AP_Motors::MOTOR_FRAME_TAILSITTER) {
         AP_Param::set_defaults_from_table(defaults_table_tailsitter, ARRAY_SIZE(defaults_table_tailsitter));
     }
-    
+
     // reset ESC calibration
     if (esc_calibration != 0) {
         esc_calibration.set_and_save(0);
@@ -709,7 +712,7 @@ void QuadPlane::run_esc_calibration(void)
 }
 
 
-// init quadplane stabilize mode 
+// init quadplane stabilize mode
 void QuadPlane::init_stabilize(void)
 {
     throttle_wait = false;
@@ -739,7 +742,7 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
 
 // hold in stabilize with given throttle
 void QuadPlane::hold_stabilize(float throttle_in)
-{    
+{
     // call attitude controller
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds());
 
@@ -786,7 +789,7 @@ void QuadPlane::run_z_controller(void)
         // initialize vertical speeds and leash lengths
         pos_control->set_max_speed_z(-pilot_velocity_z_max, pilot_velocity_z_max);
         pos_control->set_max_accel_z(pilot_accel_z);
-        
+
         // it has been two seconds since we last ran the Z
         // controller. We need to assume the integrator may be way off
 
@@ -797,7 +800,7 @@ void QuadPlane::run_z_controller(void)
         last_pidz_init_ms = now;
     }
     last_pidz_active_ms = now;
-    pos_control->update_z_controller();    
+    pos_control->update_z_controller();
 }
 
 /*
@@ -815,7 +818,7 @@ void QuadPlane::check_attitude_relax(void)
     last_att_control_ms = now;
 }
 
-// init quadplane hover mode 
+// init quadplane hover mode
 void QuadPlane::init_hover(void)
 {
     // initialize vertical speeds and leash lengths
@@ -976,7 +979,7 @@ bool QuadPlane::is_flying_vtol(void) const
 
 /*
   smooth out descent rate for landing to prevent a jerk as we get to
-  land_final_alt. 
+  land_final_alt.
  */
 float QuadPlane::landing_descent_rate_cms(float height_above_ground) const
 {
@@ -1038,11 +1041,11 @@ void QuadPlane::control_loiter()
                                                   last_pidz_init_ms, last_pidz_init_ms+transition_time_ms*2);
         if (plane.nav_pitch_cd > pitch_limit_cd) {
             plane.nav_pitch_cd = pitch_limit_cd;
-            pos_control->set_limit_accel_xy();            
+            pos_control->set_limit_accel_xy();
         }
     }
-    
-    
+
+
     // call attitude controller with conservative smoothing gain of 4.0f
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,
@@ -1102,7 +1105,7 @@ float QuadPlane::get_desired_yaw_rate_cds(void)
 
     // add in weathervaning
     yaw_cds += get_weathervane_yaw_rate_cds();
-    
+
     return yaw_cds;
 }
 
@@ -1128,10 +1131,10 @@ void QuadPlane::init_throttle_wait(void)
         plane.is_flying()) {
         throttle_wait = false;
     } else {
-        throttle_wait = true;        
+        throttle_wait = true;
     }
 }
-    
+
 // set motor arming
 void QuadPlane::set_armed(bool armed)
 {
@@ -1164,7 +1167,7 @@ float QuadPlane::assist_climb_rate_cms(void) const
     if (dt_since_start < ramp_up_time_ms) {
         climb_rate = linear_interpolate(0, climb_rate, dt_since_start, 0, ramp_up_time_ms);
     }
-    
+
     return climb_rate;
 }
 
@@ -1221,7 +1224,7 @@ bool QuadPlane::assistance_needed(float aspeed)
         angle_error_start_ms = 0;
         return false;
     }
-    
+
     int32_t max_angle_cd = 100U*assist_angle;
     if ((labs(ahrs.roll_sensor - plane.nav_roll_cd) < max_angle_cd &&
          labs(ahrs.pitch_sensor - plane.nav_pitch_cd) < max_angle_cd)) {
@@ -1284,7 +1287,7 @@ void QuadPlane::update_transition(void)
     if (is_tailsitter() && transition_state == TRANSITION_AIRSPEED_WAIT) {
         transition_state = TRANSITION_ANGLE_WAIT_FW;
     }
-    
+
     /*
       see if we should provide some assistance
      */
@@ -1317,7 +1320,7 @@ void QuadPlane::update_transition(void)
             transition_low_airspeed_ms = 0;
         }
     }
-    
+
     // if rotors are fully forward then we are not transitioning,
     // unless we are waiting for airspeed to increase (in which case
     // the tilt will decrease rapidly)
@@ -1326,7 +1329,7 @@ void QuadPlane::update_transition(void)
         transition_start_ms = 0;
         transition_low_airspeed_ms = 0;
     }
-    
+
     if (transition_state < TRANSITION_TIMER) {
         // set a single loop pitch limit in TECS
         if (plane.ahrs.groundspeed() < 3) {
@@ -1344,7 +1347,7 @@ void QuadPlane::update_transition(void)
         // throttle calculation which is driven by pitch
         plane.TECS_controller.use_synthetic_airspeed();
     }
-    
+
     switch (transition_state) {
     case TRANSITION_AIRSPEED_WAIT: {
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
@@ -1388,7 +1391,7 @@ void QuadPlane::update_transition(void)
         attitude_control->set_throttle_mix_max();
         break;
     }
-        
+
     case TRANSITION_TIMER: {
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
         // after airspeed is reached we degrade throttle over the
@@ -1467,13 +1470,13 @@ void QuadPlane::update(void)
     if (!setup()) {
         return;
     }
-    
+
     if (plane.afs.should_crash_vehicle()) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
         motors->output();
         return;
     }
-    
+
     if (motor_test.running) {
         motor_test_output();
         return;
@@ -1492,14 +1495,14 @@ void QuadPlane::update(void)
         }
         pos_control->relax_alt_hold_controllers(0);
     }
-    
+
     if (!in_vtol_mode()) {
         update_transition();
     } else {
         const uint32_t now = AP_HAL::millis();
 
         assisted_flight = false;
-        
+
         // give full authority to attitude control
         attitude_control->set_throttle_mix_max();
 
@@ -1548,8 +1551,8 @@ void QuadPlane::update(void)
             }
             last_throttle = motors->get_throttle();
         }
-            
-        last_vtol_mode_ms = now;        
+
+        last_vtol_mode_ms = now;
     }
 
     // disable throttle_wait when throttle rises above 10%
@@ -1564,7 +1567,7 @@ void QuadPlane::update(void)
 }
 
 /*
-  see if motors should be shutdown. If they should be then change AP_Motors state to 
+  see if motors should be shutdown. If they should be then change AP_Motors state to
   AP_Motors::DESIRED_SHUT_DOWN
 
   This is a safety check to prevent accidental motor runs on the
@@ -1608,7 +1611,7 @@ void QuadPlane::check_throttle_suppression(void)
     if (plane.control_mode == AUTO && is_vtol_takeoff(plane.mission.get_current_nav_cmd().id)) {
         return;
     }
-    
+
     // motors should be in the spin when armed state to warn user they could become active
     motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
     motors->set_throttle(0);
@@ -1645,7 +1648,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
 
     // see if motors should be shut down
     check_throttle_suppression();
-    
+
     motors->output();
     if (motors->armed() && motors->get_throttle() > 0) {
         plane.logger.Write_Rate(ahrs_view, *motors, *attitude_control, *pos_control);
@@ -1660,7 +1663,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
     if (motors->get_throttle() > 0.01f || tilt.motors_active) {
         last_motors_active_ms = AP_HAL::millis();
     }
-    
+
 }
 
 /*
@@ -1764,7 +1767,7 @@ bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state)
         }
         plane.auto_state.vtol_mode = true;
         return true;
-        
+
     case MAV_VTOL_STATE_FW:
         if (plane.auto_state.vtol_mode) {
             gcs().send_text(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
@@ -1929,7 +1932,7 @@ void QuadPlane::vtol_position_controller(void)
             // stop integrator buildup
             pos_control->set_limit_accel_xy();
         }
-        
+
         // call attitude controller
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                              plane.nav_pitch_cd,
@@ -2000,7 +2003,7 @@ void QuadPlane::vtol_position_controller(void)
             float target_altitude = plane.next_WP_loc.alt;
             if (poscontrol.slow_descent) {
                 // gradually descend as we approach target
-                plane.auto_state.wp_proportion = location_path_proportion(plane.current_loc, 
+                plane.auto_state.wp_proportion = location_path_proportion(plane.current_loc,
                                                                           plane.prev_WP_loc, plane.next_WP_loc);
                 target_altitude = linear_interpolate(plane.prev_WP_loc.alt,
                                                      plane.next_WP_loc.alt,
@@ -2024,11 +2027,11 @@ void QuadPlane::vtol_position_controller(void)
     case QPOS_LAND_FINAL:
         pos_control->set_alt_target_from_climb_rate(-land_speed_cms, plane.G_Dt, true);
         break;
-        
+
     case QPOS_LAND_COMPLETE:
         break;
     }
-    
+
     run_z_controller();
 }
 
@@ -2057,7 +2060,7 @@ void QuadPlane::setup_target_position(void)
         last_auto_target = loc;
     }
     last_loiter_ms = now;
-    
+
     // setup vertical speed and acceleration
     pos_control->set_max_speed_z(-pilot_velocity_z_max, pilot_velocity_z_max);
     pos_control->set_max_accel_z(pilot_accel_z);
@@ -2109,7 +2112,7 @@ void QuadPlane::waypoint_controller(void)
     */
     // run wpnav controller
     wp_nav->update_wpnav();
-    
+
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_yaw(wp_nav->get_roll(),
                                                        wp_nav->get_pitch(),
@@ -2118,7 +2121,7 @@ void QuadPlane::waypoint_controller(void)
     // nav roll and pitch are controller by loiter controller
     plane.nav_roll_cd = wp_nav->get_roll();
     plane.nav_pitch_cd = wp_nav->get_pitch();
-    
+
     // climb based on altitude error
     pos_control->set_alt_target_from_climb_rate_ff(assist_climb_rate_cms(), plane.G_Dt, false);
     run_z_controller();
@@ -2227,7 +2230,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     // initialise position and desired velocity
     set_alt_target_current();
     pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
-    
+
     // also update nav_controller for status output
     plane.nav_controller->update_waypoint(plane.prev_WP_loc, plane.next_WP_loc);
     return true;
@@ -2245,7 +2248,7 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
     attitude_control->reset_rate_controller_I_terms();
     pos_control->get_accel_z_pid().reset_I();
     pos_control->get_vel_xy_pid().reset_I();
-    
+
     plane.set_next_WP(cmd.content.location);
     // initially aim for current altitude
     plane.next_WP_loc.alt = plane.current_loc.alt;
@@ -2259,7 +2262,7 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
     set_alt_target_current();
 
     plane.crash_state.is_crashed = false;
-    
+
     // also update nav_controller for status output
     plane.nav_controller->update_waypoint(plane.prev_WP_loc, plane.next_WP_loc);
     return true;
@@ -2281,7 +2284,7 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
     set_alt_target_current();
 
     plane.complete_auto_takeoff();
-    
+
     return true;
 }
 
@@ -2314,7 +2317,7 @@ void QuadPlane::check_land_complete(void)
         landing_detect.land_start_ms = 0;
         return;
     }
-           
+
     if ((now - landing_detect.land_start_ms) < 4000 ||
         (now - landing_detect.lower_limit_start_ms) < 5000) {
         // not landed yet
@@ -2429,7 +2432,7 @@ int8_t QuadPlane::forward_throttle_pct(void)
         return vel_forward.last_pct;
     }
     vel_forward.last_ms = AP_HAL::millis();
-    
+
     // work out the desired speed in forward direction
     const Vector3f &desired_velocity_cms = pos_control->get_desired_velocity();
     Vector3f vel_ned;
@@ -2457,14 +2460,14 @@ int8_t QuadPlane::forward_throttle_pct(void)
         fwd_vel_error = 0;
         vel_forward.integrator *= 0.95f;
     }
-    
+
     // integrator as throttle percentage (-100 to 100)
     vel_forward.integrator += fwd_vel_error * deltat * vel_forward.gain * 100;
 
     // inhibit reverse throttle and allow petrol engines with min > 0
     int8_t fwd_throttle_min = plane.have_reverse_thrust() ? 0 : plane.aparm.throttle_min;
     vel_forward.integrator = constrain_float(vel_forward.integrator, fwd_throttle_min, plane.aparm.throttle_max);
-    
+
     // If we are below alt_cutoff then scale down the effect until it turns off at alt_cutoff and decay the integrator
     float alt_cutoff = MAX(0,vel_forward_alt_cutoff);
     float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
@@ -2511,14 +2514,14 @@ float QuadPlane::get_weathervane_yaw_rate_cds(void)
     float roll = wp_nav->get_roll() / 100.0f;
     if (fabsf(roll) < weathervane.min_roll) {
         weathervane.last_output = 0;
-        return 0;        
+        return 0;
     }
     if (roll > 0) {
         roll -= weathervane.min_roll;
     } else {
         roll += weathervane.min_roll;
     }
-    
+
     float output = constrain_float((roll/45.0f) * weathervane.gain, -1, 1);
     if (should_relax()) {
         output = 0;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -402,6 +402,13 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("TRANS_FAIL", 8, QuadPlane, transition_failure, 0),
 
+    // @Param: TAILSIT_MOTMX
+    // @DisplayName: Tailsiter mask
+    // @Description: Bitmask of motors to remain active in forward flight for a 'copter' tailsitter. Non-zero indicates airframe is a tailsitter which pitches forward 90 degrees in forward flight modes.
+    // @User: Standard
+    // @Bitmask: 0:Motor 1,1:Motor 2,2:Motor 3,3:Motor 4, 4:Motor 5,5:Motor 6,6:Motor 7,7:Motor 8
+    AP_GROUPINFO("TAILSIT_MOTMX", 9, QuadPlane, tailsitter.motor_mask, 0),
+
     AP_GROUPEND
 };
 
@@ -575,6 +582,9 @@ bool QuadPlane::setup(void)
     default:
         motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsMatrix::var_info;
+        if (tailsitter.motor_mask != 0) {
+            rotation = ROTATION_PITCH_90;
+        }
         break;
     }
     const static char *strUnableToAllocate = "Unable to allocate";

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -424,6 +424,7 @@ private:
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
         AP_Float max_roll_angle;
+        AP_Int16 motor_mask;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -14,6 +14,8 @@
  */
 /*
   control code for tailsitters. Enabled by setting Q_FRAME_CLASS=10 
+  or by setting Q_TAILSIT_MOTMX nonzero and Q_FRAME_CLASS and Q_FRAME_TYPE
+  to a configuration supported by AP_MotorsMatrix
  */
 
 #include "Plane.h"
@@ -23,7 +25,8 @@
  */
 bool QuadPlane::is_tailsitter(void) const
 {
-    return available() && frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER;
+    return available() && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || 
+                           (tailsitter.motor_mask != 0));
 }
 
 /*
@@ -56,7 +59,9 @@ void QuadPlane::tailsitter_output(void)
     float tilt_left = 0.0f;
     float tilt_right = 0.0f;
 
+    // handle forward flight modes and transition to VTOL modes
     if (!tailsitter_active() || in_tailsitter_vtol_transition()) {
+        // in forward flight: set motor tilt servos and throttles using FW controller
         if (tailsitter.vectored_forward_gain > 0) {
             // thrust vectoring in fixed wing flight
             float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
@@ -67,22 +72,42 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
         
+        // get FW controller throttle demand and mask of motors enabled during forward flight
+        float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+        uint16_t mask = tailsitter.motor_mask;
         if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying() && hal.util->get_soft_armed()) {
             /*
-              during transitions to vtol mode set the throttle to the
-              hover throttle, and set the altitude controller
+              during transitions to vtol mode set the throttle to
+              hover thrust, center the rudder and set the altitude controller
               integrator to the same throttle level
              */
-            uint8_t throttle = motors->get_throttle_hover() * 100;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+            throttle = motors->get_throttle_hover() * 100;
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
+            
+            if (mask == 0) {
+                // override AP_MotorsTailsitter throttles during back transition
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+            }
         }
+        // set AP_MotorsMatrix throttles enabled for forward flight
+        motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
         return;
     }
     
+    // handle VTOL modes
+    if (tailsitter.motor_mask != 0) {
+        // if motor mask is nonzero, feed copter attitude controls to aerodynamic control surfaces
+        // (this is done in AP_MotorsTailsitter::output_to_motors, but AP_MotorsMatrix
+        // controls only the copter motors)
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, -motors->get_yaw()*4500.0f);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, motors->get_pitch()*4500.0f);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, motors->get_roll()*4500.0f);
+    }
+    // the MultiCopter rate controller has already been run in an earlier call 
+    // to motors_output() from quadplane.update()
     motors_output(false);
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
@@ -115,7 +140,6 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
     }
-
 
     if (tailsitter.input_mask_chan > 0 &&
         tailsitter.input_mask > 0 &&
@@ -218,6 +242,18 @@ void QuadPlane::tailsitter_speed_scaling(void)
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
 
+    // if no airspeed sensor reduce throws at large tilt angles (implies high airspeed)
+    if (!ahrs.airspeed_sensor_enabled()) {
+        // ramp down from 1 to max_atten at tilt angles from 45 to 80 degrees
+        const float max_atten = 0.25f;
+        const float c_trans_angle = cosf(M_PI_4);
+        const float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(80)));
+        const float beta = 1 - alpha * c_trans_angle;
+        const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
+        if (c_tilt < c_trans_angle) {
+            scaling = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
+        }
+    }
     const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -403,6 +403,15 @@ bool AP_MotorsMatrix::output_test_num(uint8_t output_channel, int16_t pwm)
     return true;
 }
 
+// disable torque-based yaw control by zeroing all yaw factors
+void AP_MotorsMatrix::disable_yaw_torque()
+{
+    for (int i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        // set yaw factors to zero
+        _yaw_factor[i] = 0;
+    }
+}
+
 // add_motor
 void AP_MotorsMatrix::add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order)
 {

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -54,7 +54,10 @@ public:
     // return the roll factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight
     float               get_roll_factor(uint8_t i) override { return _roll_factor[i]; }
-
+    
+    // disable use of motor torque for yaw control
+    void                disable_yaw_torque() override;
+    
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -172,6 +172,9 @@ public:
     // return the roll factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight
     virtual float       get_roll_factor(uint8_t i) { return 0.0f; }
+    
+    // disable use of motor torque for yaw control
+    virtual void        disable_yaw_torque() {}
 
     enum pwm_type { PWM_TYPE_NORMAL     = 0,
                     PWM_TYPE_ONESHOT    = 1,


### PR DESCRIPTION
Set Q_FRAME_CLASS to 1 (MOTOR_FRAME_QUAD) and Q_FRAME_TYPE to 0 (MOTOR_FRAME_TYPE_PLUS)
for an airframe with motors on the wings and vertical fin/subfin.
Set Q_TAILSIT_MOTMX to 3 to enable only the wing motors in forward flight; 15 to enable all 4.

Issue: must arm in a VTOL mode in order for motors to spool up properly. If armed in a FW mode, motors will not spin until entering a VTOL mode. This is because output_motors_mask now checks the spool_mode and AP_MotorsMultiCopter::output_logic is not invoked in FW modes, meaning the spool mode is "shutdown".