### PR TITLE
Rover: rename custom to omni in AP_MotorsUGV

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -116,9 +116,9 @@ void AP_MotorsUGV::init()
     // set safety output
     setup_safety_output();
 
-    // setup motors for custom configs
+    // setup for omni vehicles
     if (rover.get_frame_type() != FRAME_TYPE_UNDEFINED) {
-        setup_motors();
+        setup_omni();
     }
 }
 
@@ -163,7 +163,7 @@ void AP_MotorsUGV::setup_servo_output()
     SRV_Channels::set_angle(SRV_Channel::k_throttleLeft,  1000);
     SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 1000);
 
-    // custom config motors set in power percent so -100 ... 100
+    // omni motors set in power percent so -100 ... 100
     for (uint8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
         SRV_Channels::set_angle(function, 100);
@@ -173,12 +173,12 @@ void AP_MotorsUGV::setup_servo_output()
     SRV_Channels::set_range(SRV_Channel::k_mainsail_sheet, 100);
 }
 
-// config for frames with vectored motors and custom motor configurations
-void AP_MotorsUGV::setup_motors()
+// setup for frames with omni motors
+void AP_MotorsUGV::setup_omni()
 {
     // remove existing motors
     for (int8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
-        clear_motors(i);
+        clear_omni_motors(i);
     }
 
     // hard coded factor configuration
@@ -190,31 +190,31 @@ void AP_MotorsUGV::setup_motors()
 
     case FRAME_TYPE_OMNI3:
         _motors_num = 3;
-        add_motor(0, 1.0f, 1.0f, -1.0f);
-        add_motor(1, 0.0f, 1.0f, 1.0f);
-        add_motor(2, 1.0f, 1.0f, 1.0f);
+        add_omni_motor(0, 1.0f, 1.0f, -1.0f);
+        add_omni_motor(1, 0.0f, 1.0f, 1.0f);
+        add_omni_motor(2, 1.0f, 1.0f, 1.0f);
         break;
 
     case FRAME_TYPE_OMNIX:
         _motors_num = 4,
-        add_motor(0, 1.0f, -1.0f, -1.0f);
-        add_motor(1, 1.0f, -1.0f, 1.0f);
-        add_motor(2, 1.0f, 1.0f, -1.0f);
-        add_motor(3, 1.0f, 1.0f, 1.0f);
+        add_omni_motor(0, 1.0f, -1.0f, -1.0f);
+        add_omni_motor(1, 1.0f, -1.0f, 1.0f);
+        add_omni_motor(2, 1.0f, 1.0f, -1.0f);
+        add_omni_motor(3, 1.0f, 1.0f, 1.0f);
         break;
 
     case FRAME_TYPE_OMNIPLUS:
         _motors_num = 4;
-        add_motor(0, 0.0f, 1.0f, 1.0f);
-        add_motor(1, 1.0f, 0.0f, 0.0f);
-        add_motor(2, 0.0f, -1.0f, 1.0f);
-        add_motor(3, 1.0f, 0.0f, 0.0f);
+        add_omni_motor(0, 0.0f, 1.0f, 1.0f);
+        add_omni_motor(1, 1.0f, 0.0f, 0.0f);
+        add_omni_motor(2, 0.0f, -1.0f, 1.0f);
+        add_omni_motor(3, 1.0f, 0.0f, 0.0f);
         break;
     }
 }
 
-// add motor using separate throttle, steering and lateral factors for frames with custom motor configurations
-void AP_MotorsUGV::add_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor)
+// add omni motor using separate throttle, steering and lateral factors
+void AP_MotorsUGV::add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor)
 {
     // ensure valid motor number is provided
     if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
@@ -224,12 +224,12 @@ void AP_MotorsUGV::add_motor(int8_t motor_num, float throttle_factor, float stee
         _steering_factor[motor_num] = steering_factor;
         _lateral_factor[motor_num] = lateral_factor;
 
-        add_motor_num(motor_num);
+        add_omni_motor_num(motor_num);
     }
 }
 
-// add a motor and set up default output function
-void AP_MotorsUGV::add_motor_num(int8_t motor_num)
+// add an omni motor and set up default output function
+void AP_MotorsUGV::add_omni_motor_num(int8_t motor_num)
 {
     // ensure a valid motor number is provided
     if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
@@ -242,8 +242,8 @@ void AP_MotorsUGV::add_motor_num(int8_t motor_num)
     }
 }
 
-// disable motor and remove all throttle, steering and lateral factor for this motor
-void AP_MotorsUGV::clear_motors(int8_t motor_num)
+// disable omni motor and remove all throttle, steering and lateral factor for this motor
+void AP_MotorsUGV::clear_omni_motors(int8_t motor_num)
 {
     // ensure valid motor number is provided
     if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
@@ -338,8 +338,8 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
     // output for skid steering style frames
     output_skid_steering(armed, _steering, _throttle, dt);
 
-    // output for frames with vectored and custom motor configurations
-    output_custom_config(armed, _steering, _throttle, _lateral);
+    // output for omni frames
+    output_omni(armed, _steering, _throttle, _lateral);
 
     // output to mainsail
     output_mainsail();
@@ -501,7 +501,7 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
         }
         return false;
     }
-    // check if one of custom config motors hasn't been configured
+    // check all omni motor outputs have been configured
     for (uint8_t i=0; i<_motors_num; i++)
     {
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
@@ -672,8 +672,8 @@ void AP_MotorsUGV::output_skid_steering(bool armed, float steering, float thrott
     output_throttle(SRV_Channel::k_throttleRight, 100.0f * motor_right, dt);
 }
 
-// output for custom configurations
-void AP_MotorsUGV::output_custom_config(bool armed, float steering, float throttle, float lateral)
+// output for omni frames
+void AP_MotorsUGV::output_omni(bool armed, float steering, float throttle, float lateral)
 {
     // exit immediately if the frame type is set to UNDEFINED
     if (rover.get_frame_type() == FRAME_TYPE_UNDEFINED) {

--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -173,87 +173,6 @@ void AP_MotorsUGV::setup_servo_output()
     SRV_Channels::set_range(SRV_Channel::k_mainsail_sheet, 100);
 }
 
-// setup for frames with omni motors
-void AP_MotorsUGV::setup_omni()
-{
-    // remove existing motors
-    for (int8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
-        clear_omni_motors(i);
-    }
-
-    // hard coded factor configuration
-    switch (rover.get_frame_type()) {
-
-    //   FRAME TYPE NAME
-    case FRAME_TYPE_UNDEFINED:
-        break;
-
-    case FRAME_TYPE_OMNI3:
-        _motors_num = 3;
-        add_omni_motor(0, 1.0f, 1.0f, -1.0f);
-        add_omni_motor(1, 0.0f, 1.0f, 1.0f);
-        add_omni_motor(2, 1.0f, 1.0f, 1.0f);
-        break;
-
-    case FRAME_TYPE_OMNIX:
-        _motors_num = 4,
-        add_omni_motor(0, 1.0f, -1.0f, -1.0f);
-        add_omni_motor(1, 1.0f, -1.0f, 1.0f);
-        add_omni_motor(2, 1.0f, 1.0f, -1.0f);
-        add_omni_motor(3, 1.0f, 1.0f, 1.0f);
-        break;
-
-    case FRAME_TYPE_OMNIPLUS:
-        _motors_num = 4;
-        add_omni_motor(0, 0.0f, 1.0f, 1.0f);
-        add_omni_motor(1, 1.0f, 0.0f, 0.0f);
-        add_omni_motor(2, 0.0f, -1.0f, 1.0f);
-        add_omni_motor(3, 1.0f, 0.0f, 0.0f);
-        break;
-    }
-}
-
-// add omni motor using separate throttle, steering and lateral factors
-void AP_MotorsUGV::add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor)
-{
-    // ensure valid motor number is provided
-    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
-
-        // set throttle, steering and lateral factors
-        _throttle_factor[motor_num] = throttle_factor;
-        _steering_factor[motor_num] = steering_factor;
-        _lateral_factor[motor_num] = lateral_factor;
-
-        add_omni_motor_num(motor_num);
-    }
-}
-
-// add an omni motor and set up default output function
-void AP_MotorsUGV::add_omni_motor_num(int8_t motor_num)
-{
-    // ensure a valid motor number is provided
-    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
-        uint8_t chan;
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
-        SRV_Channels::set_aux_channel_default(function, motor_num);
-        if (!SRV_Channels::find_channel(function, chan)) {
-            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
-        }
-    }
-}
-
-// disable omni motor and remove all throttle, steering and lateral factor for this motor
-void AP_MotorsUGV::clear_omni_motors(int8_t motor_num)
-{
-    // ensure valid motor number is provided
-    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
-        // disable the motor and set factors to zero
-        _throttle_factor[motor_num] = 0;
-        _steering_factor[motor_num] = 0;
-        _lateral_factor[motor_num] = 0;
-    }
-}
-
 // set steering as a value from -4500 to +4500
 //   apply_scaling should be set to false for manual modes where
 //   no scaling by speed or angle should be performed
@@ -565,6 +484,87 @@ void AP_MotorsUGV::setup_pwm_type()
     default:
         // do nothing
         break;
+    }
+}
+
+// setup for frames with omni motors
+void AP_MotorsUGV::setup_omni()
+{
+    // remove existing motors
+    for (int8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
+        clear_omni_motors(i);
+    }
+
+    // hard coded factor configuration
+    switch (rover.get_frame_type()) {
+
+    //   FRAME TYPE NAME
+    case FRAME_TYPE_UNDEFINED:
+        break;
+
+    case FRAME_TYPE_OMNI3:
+        _motors_num = 3;
+        add_omni_motor(0, 1.0f, 1.0f, -1.0f);
+        add_omni_motor(1, 0.0f, 1.0f, 1.0f);
+        add_omni_motor(2, 1.0f, 1.0f, 1.0f);
+        break;
+
+    case FRAME_TYPE_OMNIX:
+        _motors_num = 4,
+        add_omni_motor(0, 1.0f, -1.0f, -1.0f);
+        add_omni_motor(1, 1.0f, -1.0f, 1.0f);
+        add_omni_motor(2, 1.0f, 1.0f, -1.0f);
+        add_omni_motor(3, 1.0f, 1.0f, 1.0f);
+        break;
+
+    case FRAME_TYPE_OMNIPLUS:
+        _motors_num = 4;
+        add_omni_motor(0, 0.0f, 1.0f, 1.0f);
+        add_omni_motor(1, 1.0f, 0.0f, 0.0f);
+        add_omni_motor(2, 0.0f, -1.0f, 1.0f);
+        add_omni_motor(3, 1.0f, 0.0f, 0.0f);
+        break;
+    }
+}
+
+// add omni motor using separate throttle, steering and lateral factors
+void AP_MotorsUGV::add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor)
+{
+    // ensure valid motor number is provided
+    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
+
+        // set throttle, steering and lateral factors
+        _throttle_factor[motor_num] = throttle_factor;
+        _steering_factor[motor_num] = steering_factor;
+        _lateral_factor[motor_num] = lateral_factor;
+
+        add_omni_motor_num(motor_num);
+    }
+}
+
+// add an omni motor and set up default output function
+void AP_MotorsUGV::add_omni_motor_num(int8_t motor_num)
+{
+    // ensure a valid motor number is provided
+    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
+        uint8_t chan;
+        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channels::set_aux_channel_default(function, motor_num);
+        if (!SRV_Channels::find_channel(function, chan)) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
+        }
+    }
+}
+
+// disable omni motor and remove all throttle, steering and lateral factor for this motor
+void AP_MotorsUGV::clear_omni_motors(int8_t motor_num)
+{
+    // ensure valid motor number is provided
+    if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
+        // disable the motor and set factors to zero
+        _throttle_factor[motor_num] = 0;
+        _steering_factor[motor_num] = 0;
+        _lateral_factor[motor_num] = 0;
     }
 }
 

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -31,7 +31,7 @@ public:
         MOTOR_TEST_LAST
     };
 
-    // supported custom motor configurations
+    // supported omni motor configurations
     enum frame_type {
         FRAME_TYPE_UNDEFINED = 0,
         FRAME_TYPE_OMNI3 = 1,
@@ -51,17 +51,17 @@ public:
     // setup servo output ranges
     void setup_servo_output();
 
-    // config for frames with vectored motors
-    void setup_motors();
+    // setup for frames with omni motors
+    void setup_omni();
 
-    // add motor using separate throttle, steering and lateral factors for frames with custom motor configuration
-    void add_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor);
+    // add omni motor using separate throttle, steering and lateral factors
+    void add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor);
 
     // add a motor and set up output function
-    void add_motor_num(int8_t motor_num);
+    void add_omni_motor_num(int8_t motor_num);
 
-    // disable motor and remove all throttle, steering and lateral factor for this motor
-    void clear_motors(int8_t motor_num);
+    // disable omni motor and remove all throttle, steering and lateral factor for this motor
+    void clear_omni_motors(int8_t motor_num);
 
     // get or set steering as a value from -4500 to +4500
     //   apply_scaling should be set to false for manual modes where
@@ -134,8 +134,8 @@ protected:
     // output to skid steering channels
     void output_skid_steering(bool armed, float steering, float throttle, float dt);
 
-    // output for vectored and custom motors configuration
-    void output_custom_config(bool armed, float steering, float throttle, float lateral);
+    // output for omni motors
+    void output_omni(bool armed, float steering, float throttle, float lateral);
 
     // output throttle (-100 ~ +100) to a throttle channel.  Sets relays if required
     // dt is the main loop time interval and is required when rate control is required
@@ -180,7 +180,7 @@ protected:
     float   _lateral;  // requested lateral input as a value from -100 to +100
     float   _mainsail;  // requested mainsail input as a value from 0 to 100
 
-    // custom config variables
+    // omni variables
     float   _throttle_factor[AP_MOTORS_NUM_MOTORS_MAX];
     float   _steering_factor[AP_MOTORS_NUM_MOTORS_MAX];
     float   _lateral_factor[AP_MOTORS_NUM_MOTORS_MAX];

--- a/APMrover2/AP_MotorsUGV.h
+++ b/APMrover2/AP_MotorsUGV.h
@@ -51,18 +51,6 @@ public:
     // setup servo output ranges
     void setup_servo_output();
 
-    // setup for frames with omni motors
-    void setup_omni();
-
-    // add omni motor using separate throttle, steering and lateral factors
-    void add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor);
-
-    // add a motor and set up output function
-    void add_omni_motor_num(int8_t motor_num);
-
-    // disable omni motor and remove all throttle, steering and lateral factor for this motor
-    void clear_omni_motors(int8_t motor_num);
-
     // get or set steering as a value from -4500 to +4500
     //   apply_scaling should be set to false for manual modes where
     //   no scaling by speed or angle should e performed
@@ -127,6 +115,18 @@ protected:
 
     // setup pwm output type
     void setup_pwm_type();
+
+    // setup for frames with omni motors
+    void setup_omni();
+
+    // add omni motor using separate throttle, steering and lateral factors
+    void add_omni_motor(int8_t motor_num, float throttle_factor, float steering_factor, float lateral_factor);
+
+    // add a motor and set up output function
+    void add_omni_motor_num(int8_t motor_num);
+
+    // disable omni motor and remove all throttle, steering and lateral factor for this motor
+    void clear_omni_motors(int8_t motor_num);
 
     // output to regular steering and throttle channels
     void output_regular(bool armed, float ground_speed, float steering, float throttle);


### PR DESCRIPTION
This should be a non-functional change to do two small things:

- rename methods in AP_MotorsUGV from "custom" to "omni".  We are using the word "omni" to describe vehicles these methods refer to and "custom" implies that the user can customise the setup which is not really correct - there are no user facing parameters that allow the user to specify the motor setup.
- move these omni methods to be "protected" instead of "public" because they are never called from outside the AP_MotorsUGV class