### PR TITLE
Reduce tailsitter control surface gains at large tilt angles if no airspeed sensor

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1249,6 +1249,10 @@ bool QuadPlane::assistance_needed(float aspeed)
  */
 void QuadPlane::update_transition(void)
 {
+    if (tailsitter.motor_mask != 0) {
+        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+    }
+
     if (plane.control_mode == MANUAL ||
         plane.control_mode == ACRO ||
         plane.control_mode == TRAINING) {
@@ -1263,7 +1267,7 @@ void QuadPlane::update_transition(void)
         assisted_flight = false;
         return;
     }
-
+    
     const uint32_t now = millis();
 
     if (!hal.util->get_soft_armed()) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -402,6 +402,13 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("TRANS_FAIL", 8, QuadPlane, transition_failure, 0),
 
+    // @Param: TAILSIT_MOTMX
+    // @DisplayName: Tailsiter mask
+    // @Description: Bitmask of motors to remain active in forward flight for a 'copter' tailsitter. Non-zero indicates airframe is a tailsitter which pitches forward 90 degrees in forward flight modes.
+    // @User: Standard
+    // @Bitmask: 0:Motor 1,1:Motor 2,2:Motor 3,3:Motor 4, 4:Motor 5,5:Motor 6,6:Motor 7,7:Motor 8
+    AP_GROUPINFO("TAILSIT_MOTMX", 9, QuadPlane, tailsitter.motor_mask, 0),
+
     AP_GROUPEND
 };
 
@@ -575,6 +582,9 @@ bool QuadPlane::setup(void)
     default:
         motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
         motors_var_info = AP_MotorsMatrix::var_info;
+        if (tailsitter.motor_mask != 0) {
+            rotation = ROTATION_PITCH_90;
+        }
         break;
     }
     const static char *strUnableToAllocate = "Unable to allocate";

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -424,6 +424,7 @@ private:
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
         AP_Float max_roll_angle;
+        AP_Int16 motor_mask;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -14,6 +14,8 @@
  */
 /*
   control code for tailsitters. Enabled by setting Q_FRAME_CLASS=10 
+  or by setting Q_TAILSIT_MOTMX nonzero and Q_FRAME_CLASS and Q_FRAME_TYPE
+  to a configuration supported by AP_MotorsMatrix
  */
 
 #include "Plane.h"
@@ -23,7 +25,8 @@
  */
 bool QuadPlane::is_tailsitter(void) const
 {
-    return available() && frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER;
+    return available() && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || 
+                           (tailsitter.motor_mask != 0));
 }
 
 /*
@@ -56,7 +59,9 @@ void QuadPlane::tailsitter_output(void)
     float tilt_left = 0.0f;
     float tilt_right = 0.0f;
 
+    // handle forward flight modes and transition to VTOL modes
     if (!tailsitter_active() || in_tailsitter_vtol_transition()) {
+        // in forward flight: set motor tilt servos and throttles using FW controller
         if (tailsitter.vectored_forward_gain > 0) {
             // thrust vectoring in fixed wing flight
             float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
@@ -67,22 +72,42 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
         
+        // get FW controller throttle demand and mask of motors enabled during forward flight
+        float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+        uint16_t mask = tailsitter.motor_mask;
         if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying() && hal.util->get_soft_armed()) {
             /*
-              during transitions to vtol mode set the throttle to the
-              hover throttle, and set the altitude controller
+              during transitions to vtol mode set the throttle to
+              hover thrust, center the rudder and set the altitude controller
               integrator to the same throttle level
              */
-            uint8_t throttle = motors->get_throttle_hover() * 100;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+            throttle = motors->get_throttle_hover() * 100;
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
+            
+            if (mask == 0) {
+                // override AP_MotorsTailsitter throttles during back transition
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+            }
         }
+        // set AP_MotorsMatrix throttles enabled for forward flight
+        motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
         return;
     }
     
+    // handle VTOL modes
+    if (tailsitter.motor_mask != 0) {
+        // if motor mask is nonzero, feed copter attitude controls to aerodynamic control surfaces
+        // (this is done in AP_MotorsTailsitter::output_to_motors, but AP_MotorsMatrix
+        // controls only the copter motors)
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, -motors->get_yaw()*4500.0f);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, motors->get_pitch()*4500.0f);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, motors->get_roll()*4500.0f);
+    }
+    // the MultiCopter rate controller has already been run in an earlier call 
+    // to motors_output() from quadplane.update()
     motors_output(false);
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
@@ -115,7 +140,6 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
     }
-
 
     if (tailsitter.input_mask_chan > 0 &&
         tailsitter.input_mask > 0 &&
@@ -218,6 +242,18 @@ void QuadPlane::tailsitter_speed_scaling(void)
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
 
+    // if no airspeed sensor reduce throws at large tilt angles (implies high airspeed)
+    if (!ahrs.airspeed_sensor_enabled()) {
+        // ramp down from 1 to max_atten at tilt angles from 45 to 80 degrees
+        const float max_atten = 0.25f;
+        const float c_trans_angle = cosf(M_PI_4);
+        const float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(80)));
+        const float beta = 1 - alpha * c_trans_angle;
+        const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
+        if (c_tilt < c_trans_angle) {
+            scaling = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
+        }
+    }
     const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -141,6 +141,7 @@ void QuadPlane::tailsitter_output(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
     }
 
+
     if (tailsitter.input_mask_chan > 0 &&
         tailsitter.input_mask > 0 &&
         RC_Channels::get_radio_in(tailsitter.input_mask_chan-1) > 1700) {

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -221,7 +221,7 @@ void QuadPlane::tiltrotor_update(void)
   transitioning to fixed wing flight, in order to gain airspeed,
   whereas when transitioning to VTOL flight we want to lean to towards
   lower fwd throttle. So we raise the throttle on the tilted motors
-  when transitioning to fixed wing, and lower throttle on tilted
+  when transitioning to fixed wing, and lower throttle on non-tilted
   motors when transitioning to VTOL
  */
 void QuadPlane::tilt_compensate_down(float *thrust, uint8_t num_motors)

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -697,6 +697,7 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // the range 0 to 1
 void AP_MotorsMulticopter::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
 {
+    output_logic();
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
             if (mask & (1U<<i)) {


### PR DESCRIPTION
includes PR #10324 
tested in SITL with RF8 Stryker_quad tailsitter
