### PR TITLE
SITL: added SIM_BAUDRATE_EN parameter

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -123,6 +123,7 @@ private:
     bool _is_udp;
     bool _packetise;
     uint16_t _mc_myport;
+    uint32_t last_tick_us;
 };
 
 #endif

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -141,6 +141,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     // @Path: ./SIM_Parachute.cpp
     AP_SUBGROUPINFO(parachute_sim, "PARA_", 27, SITL, Parachute),
 
+    // vibration frequencies on each axis
+    AP_GROUPINFO("BAUDLIMIT_EN",   28, SITL,  telem_baudlimit_enable, 0),
+
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -167,6 +167,7 @@ public:
     AP_Int16 pin_mask; // for GPIO emulation
     AP_Float speedup; // simulation speedup
     AP_Int8  odom_enable; // enable visual odomotry data
+    AP_Int8  telem_baudlimit_enable; // enable baudrate limiting on links
 
     // wind control
     enum WindType {


### PR DESCRIPTION
This is a first step to simulating real serial devices with TCP, to allow easier testing of bandwidth limited links in SITL