### PR TITLE
Copter: fix issue with 1st spline waypoint being skipped

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -467,7 +467,7 @@ bool AC_PosControl::is_active_z() const
 void AC_PosControl::update_z_controller()
 {
     // check time since last cast
-    uint64_t now_us = AP_HAL::micros64();
+    const uint64_t now_us = AP_HAL::micros64();
     if (now_us - _last_update_z_us > POSCONTROL_ACTIVE_TIMEOUT_US) {
         _flags.reset_rate_to_accel_z = true;
         _flags.reset_accel_to_throttle = true;
@@ -797,7 +797,7 @@ void AC_PosControl::init_xy_controller()
 void AC_PosControl::update_xy_controller()
 {
     // compute dt
-    uint64_t now_us = AP_HAL::micros64();
+    const uint64_t now_us = AP_HAL::micros64();
     float dt = (now_us - _last_update_xy_us) * 1.0e-6f;
 
     // sanity check dt
@@ -823,7 +823,7 @@ void AC_PosControl::update_xy_controller()
 
 float AC_PosControl::time_since_last_xy_update() const
 {
-    uint64_t now_us = AP_HAL::micros64();
+    const uint64_t now_us = AP_HAL::micros64();
     return (now_us - _last_update_xy_us) * 1.0e-6f;
 }
 
@@ -894,7 +894,7 @@ void AC_PosControl::init_vel_controller_xyz()
 void AC_PosControl::update_vel_controller_xy()
 {
     // capture time since last iteration
-    uint64_t now_us = AP_HAL::micros64();
+    const uint64_t now_us = AP_HAL::micros64();
     float dt = (now_us - _last_update_xy_us) * 1.0e-6f;
 
     // sanity check dt

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -460,19 +460,19 @@ void AC_PosControl::init_takeoff()
 // is_active_z - returns true if the z-axis position controller has been run very recently
 bool AC_PosControl::is_active_z() const
 {
-    return ((AP_HAL::millis() - _last_update_z_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
+    return ((AP_HAL::micros64() - _last_update_z_us) <= POSCONTROL_ACTIVE_TIMEOUT_US);
 }
 
 /// update_z_controller - fly to altitude in cm above home
 void AC_PosControl::update_z_controller()
 {
     // check time since last cast
-    uint32_t now = AP_HAL::millis();
-    if (now - _last_update_z_ms > POSCONTROL_ACTIVE_TIMEOUT_MS) {
+    uint64_t now_us = AP_HAL::micros64();
+    if (now_us - _last_update_z_us > POSCONTROL_ACTIVE_TIMEOUT_US) {
         _flags.reset_rate_to_accel_z = true;
         _flags.reset_accel_to_throttle = true;
     }
-    _last_update_z_ms = now;
+    _last_update_z_us = now_us;
 
     // check for ekf altitude reset
     check_for_ekf_z_reset();
@@ -756,7 +756,7 @@ int32_t AC_PosControl::get_bearing_to_target() const
 // is_active_xy - returns true if the xy position controller has been run very recently
 bool AC_PosControl::is_active_xy() const
 {
-    return ((AP_HAL::millis() - _last_update_xy_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
+    return ((AP_HAL::micros64() - _last_update_xy_us) <= POSCONTROL_ACTIVE_TIMEOUT_US);
 }
 
 /// get_lean_angle_max_cd - returns the maximum lean angle the autopilot may request
@@ -797,11 +797,11 @@ void AC_PosControl::init_xy_controller()
 void AC_PosControl::update_xy_controller()
 {
     // compute dt
-    uint32_t now = AP_HAL::millis();
-    float dt = (now - _last_update_xy_ms)*0.001f;
+    uint64_t now_us = AP_HAL::micros64();
+    float dt = (now_us - _last_update_xy_us) * 1.0e-6f;
 
     // sanity check dt
-    if (dt >= POSCONTROL_ACTIVE_TIMEOUT_MS*1.0e-3f) {
+    if (dt >= POSCONTROL_ACTIVE_TIMEOUT_US * 1.0e-6f) {
         dt = 0.0f;
     }
 
@@ -818,13 +818,13 @@ void AC_PosControl::update_xy_controller()
     run_xy_controller(dt);
 
     // update xy update time
-    _last_update_xy_ms = now;
+    _last_update_xy_us = now_us;
 }
 
 float AC_PosControl::time_since_last_xy_update() const
 {
-    uint32_t now = AP_HAL::millis();
-    return (now - _last_update_xy_ms)*0.001f;
+    uint64_t now_us = AP_HAL::micros64();
+    return (now_us - _last_update_xy_us) * 1.0e-6f;
 }
 
 // write log to dataflash
@@ -894,8 +894,8 @@ void AC_PosControl::init_vel_controller_xyz()
 void AC_PosControl::update_vel_controller_xy()
 {
     // capture time since last iteration
-    uint32_t now = AP_HAL::millis();
-    float dt = (now - _last_update_xy_ms)*0.001f;
+    uint64_t now_us = AP_HAL::micros64();
+    float dt = (now_us - _last_update_xy_us) * 1.0e-6f;
 
     // sanity check dt
     if (dt >= 0.2f) {
@@ -916,7 +916,7 @@ void AC_PosControl::update_vel_controller_xy()
     run_xy_controller(dt);
 
     // update xy update time
-    _last_update_xy_ms = now;
+    _last_update_xy_us = now_us;
 }
 
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -31,7 +31,7 @@
 #define POSCONTROL_DT_50HZ                      0.02f   // time difference in seconds for 50hz update rate
 #define POSCONTROL_DT_400HZ                     0.0025f // time difference in seconds for 400hz update rate
 
-#define POSCONTROL_ACTIVE_TIMEOUT_MS            200     // position controller is considered active if it has been called within the past 0.2 seconds
+#define POSCONTROL_ACTIVE_TIMEOUT_US            200000  // position controller is considered active if it has been called within the past 0.2 seconds
 
 #define POSCONTROL_VEL_ERROR_CUTOFF_FREQ        4.0f    // low-pass filter on velocity error (unit: hz)
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ         2.0f    // low-pass filter on accel error (unit: hz)
@@ -380,8 +380,8 @@ protected:
 
     // internal variables
     float       _dt;                    // time difference (in seconds) between calls from the main program
-    uint32_t    _last_update_xy_ms;     // system time of last update_xy_controller call
-    uint32_t    _last_update_z_ms;      // system time of last update_z_controller call
+    uint64_t    _last_update_xy_us;     // system time (in microseconds) since last update_xy_controller call
+    uint64_t    _last_update_z_us;      // system time (in microseconds) of last update_z_controller call
     float       _speed_down_cms;        // max descent rate in cm/s
     float       _speed_up_cms;          // max climb rate in cm/s
     float       _speed_cms;             // max horizontal speed in cm/s

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -509,11 +509,8 @@ bool AC_WPNav::update_wpnav()
 {
     bool ret = true;
 
-    // calculate dt
-    float dt = _pos_control.time_since_last_xy_update();
-    if (dt >= 0.2f) {
-        dt = 0.0f;
-    }
+    // get dt from pos controller
+    float dt = _pos_control.get_dt();
 
     // allow the accel and speed values to be set without changing
     // out of auto mode. This makes it easier to tune auto flight
@@ -685,10 +682,8 @@ bool AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const V
     // mission is "active" if wpnav has been called recently and vehicle reached the previous waypoint
     bool prev_segment_exists = (_flags.reached_destination && ((AP_HAL::millis() - _wp_last_update) < 1000));
 
-    float dt = _pos_control.time_since_last_xy_update();
-    if (dt >= 0.2f) {
-        dt = 0.0f;
-    }
+    // get dt from pos controller
+    float dt = _pos_control.get_dt();
 
     // check _wp_accel_cmss is reasonable to avoid divide by zero
     if (_wp_accel_cmss <= 0) {
@@ -805,11 +800,8 @@ bool AC_WPNav::update_spline()
 
     bool ret = true;
 
-    // calculate dt
-    float dt = _pos_control.time_since_last_xy_update();
-    if (dt >= 0.2f) {
-        dt = 0.0f;
-    }
+    // get dt from pos controller
+    float dt = _pos_control.get_dt();
 
     // advance the target if necessary
     if (!advance_spline_target_along_track(dt)) {


### PR DESCRIPTION
This PR resolves two separate issues found while investigating [this issue](https://github.com/ArduPilot/ardupilot/issues/9657).  Special thanks to @SwiftGust whose [PR](https://github.com/ArduPilot/ardupilot/pull/9710) clarified the problem.

- AC_WPNav's straight-line-waypoint and spline-waypoint controllers take dt (the time since the last iteration) directly from AC_PosControl instead of calculating it themself.  This causes the dt to be non-zero on the first iteration of the spline controller which leads to a non-zero initial target velocity so we avoid the divide-by-zero check in [AC_WPNav::advice_spline_along_track divide-by-zero check](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_WPNav/AC_WPNav.cpp#L856) which is what caused the waypoint to be skipped.
- AC_PosControl's dt calculations are changed to use microseconds instead of milliseconds.  This extra accuracy is required because we run the position controllers at 400hz (2.5ms).

This has been tested in SITL.  Below is a before-and-after picture showing show the 1st spline waypoint is no longer skipped.
![spline-skip-mission](https://user-images.githubusercontent.com/1498098/51725814-a87e7d80-20a7-11e9-93c9-3043b17c69d5.png)
![before-after-all-wp](https://user-images.githubusercontent.com/1498098/51725858-d1067780-20a7-11e9-9af6-f2e413668658.png)

Below is a screenshot of the AC_PosControl dt values (output using some debug code) before and after the change.
![dt-before-after](https://user-images.githubusercontent.com/1498098/51725958-483c0b80-20a8-11e9-9520-a662e8fcc9cd.png)

Finally here is a screenshot of the roll and pitch angles during a short mission - there's actually no noticeable change from a user's point of view.  This just shows that the AC_PosControl change actually has very little effect.
![before-after-2nd-wp-only](https://user-images.githubusercontent.com/1498098/51725965-5b4edb80-20a8-11e9-8c41-995d3ae5d549.png)



