### PR TITLE
Copter: Tradheli - enables motor interlock set with RCX_OPTION

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -211,6 +211,14 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             }
             return false;
         }
+        // Ensure an Aux Channel is configured for motor interlock
+        if (rc().find_channel_for_option(RC_Channel::aux_func_t::MOTOR_INTERLOCK) == nullptr) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Motor Interlock not configured");
+            }
+            return false;
+        }
+
         #endif // HELI_FRAME
 
         // check for missing terrain data

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1194,6 +1194,7 @@ void Copter::convert_pid_parameters(void)
         { "PSC_VELXY_D", 0.0f },
         { "PSC_VELXY_I", 0.5f },
         { "PSC_VELXY_P", 1.0f },
+        { "RC8_OPTION", 32 },
     };
     AP_Param::set_defaults_from_table(heli_defaults_table, ARRAY_SIZE(heli_defaults_table));
 #endif


### PR DESCRIPTION
This PR enables trad heli users to set the motor interlock RC channel (not SERVO) using the RCX_OPTION parameter to a channel other than channel 8.  Up to this point, trad heli users were required to use channel 8 switch motor interlock states.  Along with the interlock feature, the rotor speed control input for the passthough feature uses the same channel that is set for motor interlock for the RCX_OPTION parameter.
The changes include changing the RC8_OPTION to motor interlock when upgrading to Copter 3.7 so this should be transparent to our users.  

@rmackay9 please check the heli_update_rotor_speed_targets in heli.cpp.  I had to initialize rsc_control_deglitched since I was using if statements to ensure motor interlock was being used.  I was concerned with the initialization of the parameter with it being filtered before setting the rotor speed using it.  It all seems to work with the different RSC modes.

Testing was conducted in SITL with realflight to verify functionality and upgrade feature worked properly.  Specifically looked at RSC passthrough and setpoint modes.  Did not have to look at the others as they used the same case statement as setpoint.
