### PR TITLE
Copter: Tradheli-fixes hover roll trim ramp time

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -86,7 +86,7 @@ void Copter::update_heli_control_dynamics(void)
     hover_roll_trim_scalar_slew = constrain_int16(hover_roll_trim_scalar_slew, 0, scheduler.get_loop_rate_hz());
 
     // set hover roll trim scalar, will ramp from 0 to 1 over 1 second after we think helicopter has taken off
-    attitude_control->set_hover_roll_trim_scalar((float)(hover_roll_trim_scalar_slew/scheduler.get_loop_rate_hz()));
+    attitude_control->set_hover_roll_trim_scalar((float) hover_roll_trim_scalar_slew/(float) scheduler.get_loop_rate_hz());
 }
 
 // heli_update_landing_swash - sets swash plate flag so higher minimum is used when landed or landing


### PR DESCRIPTION
This PR will allow the hover roll trim to ramp in over 1 second like it was originally intended as indicated in code comments.  In reviewing this code it was discovered that the hover_roll_trim_scalar_slew was type cast incorrectly which caused the hover roll trim to be applied instantaneously instead of ramped in.