### PR TITLE
Return UNSUPPORTED for unsupported mission types 

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -316,11 +316,12 @@ protected:
     void handle_command_int(mavlink_message_t* msg);
     virtual MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
-    bool handle_mission_request_int_mission(const mavlink_mission_request_int_t &packet, mavlink_mission_item_int_t &ret_packet);
+    MAV_MISSION_RESULT handle_mission_request_int_mission(const mavlink_mission_request_int_t &packet, mavlink_mission_item_int_t &ret_packet);
     void handle_mission_request_list(AP_Mission &mission, mavlink_message_t *msg);
-    bool handle_mission_request_mission(const mavlink_message_t *msg,
-                                        const mavlink_mission_request_t &packet,
-                                        mavlink_mission_item_t &ret_packet);
+    MAV_MISSION_RESULT handle_mission_request_mission(
+        const mavlink_message_t *msg,
+        const mavlink_mission_request_t &packet,
+        mavlink_mission_item_t &ret_packet);
     void handle_mission_request(mavlink_message_t *msg);
     void handle_mission_request_int(mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -318,6 +318,7 @@ protected:
 
     void handle_mission_request_list(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_request(AP_Mission &mission, mavlink_message_t *msg);
+    void handle_mission_request_int(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);
     virtual void handle_mission_set_current(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_count(AP_Mission &mission, mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -316,9 +316,13 @@ protected:
     void handle_command_int(mavlink_message_t* msg);
     virtual MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet);
 
+    bool handle_mission_request_int_mission(const mavlink_mission_request_int_t &packet, mavlink_mission_item_int_t &ret_packet);
     void handle_mission_request_list(AP_Mission &mission, mavlink_message_t *msg);
-    void handle_mission_request(AP_Mission &mission, mavlink_message_t *msg);
-    void handle_mission_request_int(AP_Mission &mission, mavlink_message_t *msg);
+    bool handle_mission_request_mission(const mavlink_message_t *msg,
+                                        const mavlink_mission_request_t &packet,
+                                        mavlink_mission_item_t &ret_packet);
+    void handle_mission_request(mavlink_message_t *msg);
+    void handle_mission_request_int(mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);
     virtual void handle_mission_set_current(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_count(AP_Mission &mission, mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -489,11 +489,7 @@ void GCS_MAVLINK::handle_mission_request_int(mavlink_message_t *msg)
             goto mission_item_send_failed;
         }
 
-        /*
-          avoid the _send() function to save memory, as it avoids
-          the stack usage of the _send() function by using the already
-          declared ret_packet above
-         */
+        // we already have a filled structure, use it in place of _send:
         _mav_finalize_message_chan_send(chan, 
                                         MAVLINK_MSG_ID_MISSION_ITEM_INT,
                                         (const char *)&ret_packet,
@@ -570,11 +566,7 @@ void GCS_MAVLINK::handle_mission_request(mavlink_message_t *msg)
             goto mission_item_send_failed;
         }
 
-        /*
-          avoid the _send() function to save memory, as it avoids
-          the stack usage of the _send() function by using the already
-          declared ret_packet above
-         */
+        // we already have a filled structure, use it in place of _send:
         _mav_finalize_message_chan_send(chan, 
                                         MAVLINK_MSG_ID_MISSION_ITEM,
                                         (const char *)&ret_packet,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -469,8 +469,7 @@ void GCS_MAVLINK::handle_mission_request_int(mavlink_message_t *msg)
         mavlink_mission_request_int_t packet;
         mavlink_msg_mission_request_int_decode(msg, &packet);
 
-        mavlink_mission_item_int_t ret_packet;
-        memset(&ret_packet, 0, sizeof(ret_packet));
+        mavlink_mission_item_int_t ret_packet{};
 
         ret_packet.target_system = msg->sysid;
         ret_packet.target_component = msg->compid;
@@ -551,8 +550,7 @@ void GCS_MAVLINK::handle_mission_request(mavlink_message_t *msg)
         mavlink_mission_request_t packet;
         mavlink_msg_mission_request_decode(msg, &packet);
 
-        mavlink_mission_item_t ret_packet;
-        memset(&ret_packet, 0, sizeof(ret_packet));
+        mavlink_mission_item_t ret_packet{};
 
         ret_packet.target_system = msg->sysid;
         ret_packet.target_component = msg->compid;


### PR DESCRIPTION
General tidy-up of these functions in preparation for adding support for downloading fences with the mission protocol.
