### PR TITLE
Copter: Exclude unnecessary option mode

### DIFF
--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -24,11 +24,14 @@ MAV_COLLISION_ACTION AP_Avoidance_Copter::handle_avoidance(const AP_Avoidance::O
     }
 
     // take no action in some flight modes
-    if (copter.control_mode == LAND ||
+    if (copter.control_mode == LAND
 #if MODE_THROW_ENABLED == ENABLED
-        copter.control_mode == THROW ||
+        || copter.control_mode == THROW
 #endif
-        copter.control_mode == FLIP) {
+#if MODE_FLIP_ENABLED == ENABLED
+        || copter.control_mode == FLIP
+#endif
+        ) {
         actual_action = MAV_COLLISION_ACTION_NONE;
     }
 

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -24,7 +24,14 @@ void Copter::crash_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (control_mode == ACRO || control_mode == FLIP) {
+    if (0
+#if MODE_ACRO_ENABLED == ENABLED
+        || control_mode == ACRO
+#endif
+#if MODE_FLIP_ENABLED == ENABLED
+        || control_mode == FLIP
+#endif
+    ) {
         crash_counter = 0;
         return;
     }
@@ -154,7 +161,14 @@ void Copter::parachute_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (control_mode == ACRO || control_mode == FLIP) {
+    if (0
+#if MODE_ACRO_ENABLED == ENABLED
+        || control_mode == ACRO
+#endif
+#if MODE_FLIP_ENABLED == ENABLED
+        || control_mode == FLIP
+#endif
+    ) {
         control_loss_count = 0;
         return;
     }
@@ -224,7 +238,7 @@ void Copter::parachute_release()
 }
 
 // parachute_manual_release - trigger the release of the parachute, after performing some checks for pilot error
-//   checks if the vehicle is landed 
+//   checks if the vehicle is landed
 void Copter::parachute_manual_release()
 {
     // exit immediately if parachute is not enabled

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -51,7 +51,11 @@ bool Copter::ModeFlip::init(bool ignore_checks)
     }
 
     // if in acro or stabilize ensure throttle is above zero
-    if (ap.throttle_zero && (copter.control_mode == ACRO || copter.control_mode == STABILIZE)) {
+    if (ap.throttle_zero && (copter.control_mode == STABILIZE
+#if MODE_ACRO_ENABLED == ENABLED
+        || copter.control_mode == ACRO
+#endif
+        )) {
         return false;
     }
 


### PR DESCRIPTION
I saw the preprocessor excluding the judgment of the mode which became an option.
I found a judgment that is not excluded.
I thought that it would be better to unify.