### PR TITLE
Plane: Manage quadplane throttle during RC failsafe

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -498,6 +498,9 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
 
     // reset steering integrator on mode change
     steerController.reset_I();    
+
+    // update RC failsafe, as mode change may have necessitated changing the failsafe throttle
+    control_failsafe();
 }
 
 // exit_mode - perform any cleanup required when leaving a flight mode


### PR DESCRIPTION
The current behavior is the moment a RC failsafe starts we immediately reset all control input values to 0. This is reasonable for all the flight control surfaces, and reasonable for throttle in a normal fixed wing mode, however with a quadplane this can lead to maximum rate descents (or freefall) if the vehicle was in a vertical flight mode. This instead simply resets the throttle to 50% input which would maintain altitude in any of the altitude hold modes, continues to land in QLand/QRTL, and in QSTABILIZE should result in hover throttle which avoids a sudden drop/spin on the airframe.

The extra call to `control_failsafe()` is required to ensure that if you swap from a quadplane mode to something like manual during the failsafe that there is not a momentary blip of 50% throttle.