### PR TITLE
AP_RPM: set health false if disabled during runtime

### DIFF
--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -132,9 +132,11 @@ void AP_RPM::update(void)
     for (uint8_t i=0; i<num_instances; i++) {
         if (drivers[i] != nullptr) {
             if (_type[i] == RPM_TYPE_NONE) {
-                // allow user to disable a RPM sensor at runtime
+                // allow user to disable an RPM sensor at runtime and force it to re-learn the quality if re-enabled.
+                state[i].signal_quality = 0;
                 continue;
             }
+
             drivers[i]->update();
         }
     }
@@ -145,7 +147,7 @@ void AP_RPM::update(void)
  */
 bool AP_RPM::healthy(uint8_t instance) const
 {
-    if (instance >= num_instances) {
+    if (instance >= num_instances || _type[instance] == RPM_TYPE_NONE) {
         return false;
     }
 


### PR DESCRIPTION
Force RPM health false if disabled during runtime. Before we were just not running the update so the old health status would linger forever. Now we also reset the quality which forces us to relearn the quality when re-enabled