### PR TITLE
Feature/fix storagemanager layout size

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -209,9 +209,6 @@ void Copter::setup()
     // Load the default values of variables listed in var_info[]s
     AP_Param::setup_sketch_defaults();
 
-    // setup storage layout for copter
-    StorageManager::set_layout_copter();
-
     init_ardupilot();
 
     // initialise the main loop scheduler

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -25,6 +25,23 @@
 
 extern const AP_HAL::HAL& hal;
 
+
+/*
+  use just one area per storage type for boards with 4k of
+  storage. Use larger areas for other boards
+ */
+#if HAL_STORAGE_SIZE >= 16384
+#define STORAGE_NUM_AREAS 14
+#elif HAL_STORAGE_SIZE >= 15360
+#define STORAGE_NUM_AREAS 11
+#elif HAL_STORAGE_SIZE >= 8192
+#define STORAGE_NUM_AREAS 10
+#elif HAL_STORAGE_SIZE >= 4096
+#define STORAGE_NUM_AREAS 4
+#else
+#error "Unsupported storage size"
+#endif
+
 /*
   the layouts below are carefully designed to ensure backwards
   compatibility with older firmwares
@@ -35,7 +52,7 @@ extern const AP_HAL::HAL& hal;
   On PX4v1 this gives 309 waypoints, 30 rally points and 52 fence points
   On Pixhawk this gives 724 waypoints, 50 rally points and 84 fence points
  */
-const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
+const StorageManager::StorageArea StorageManager::layout[] = {
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
 /*
   layout for copter.

--- a/libraries/StorageManager/StorageManager.cpp
+++ b/libraries/StorageManager/StorageManager.cpp
@@ -95,8 +95,7 @@ const StorageManager::StorageArea StorageManager::layout[STORAGE_NUM_AREAS] = {
  */
 void StorageManager::erase(void)
 {
-    uint8_t blk[16];
-    memset(blk, 0, sizeof(blk));
+    uint8_t blk[16]{0};
     for (uint8_t i=0; i<STORAGE_NUM_AREAS; i++) {
         const StorageManager::StorageArea &area = StorageManager::layout[i];
         uint16_t length = area.length;

--- a/libraries/StorageManager/StorageManager.h
+++ b/libraries/StorageManager/StorageManager.h
@@ -22,21 +22,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-/*
-  use just one area per storage type for boards with 4k of
-  storage. Use larger areas for other boards
- */
-#if HAL_STORAGE_SIZE >= 16384
-#define STORAGE_NUM_AREAS 14
-#elif HAL_STORAGE_SIZE >= 15360
-#define STORAGE_NUM_AREAS 11
-#elif HAL_STORAGE_SIZE >= 8192
-#define STORAGE_NUM_AREAS 10
-#elif HAL_STORAGE_SIZE >= 4096
-#define STORAGE_NUM_AREAS 4
-#else
-#error "Unsupported storage size"
-#endif
 
 /*
   The StorageManager holds the layout of non-volatile storeage
@@ -64,7 +49,7 @@ private:
     };
 
     // available layouts
-    static const StorageArea layout[STORAGE_NUM_AREAS];
+    static const StorageArea layout[];
 
 };
 

--- a/libraries/StorageManager/StorageManager.h
+++ b/libraries/StorageManager/StorageManager.h
@@ -56,9 +56,6 @@ public:
     // erase whole of storage
     static void erase(void);
 
-    // setup for copter layout of storage
-    static void set_layout_copter(void) { layout = layout_copter; }
-
 private:
     struct StorageArea {
         StorageType type;
@@ -67,9 +64,8 @@ private:
     };
 
     // available layouts
-    static const StorageArea layout_copter[STORAGE_NUM_AREAS];
-    static const StorageArea layout_default[STORAGE_NUM_AREAS];
-    static const StorageArea *layout;
+    static const StorageArea layout[STORAGE_NUM_AREAS];
+
 };
 
 /*


### PR DESCRIPTION
fix https://github.com/ArduPilot/ardupilot/issues/10389
use compile time option to define storage layout. It solve the issue and reduce the build size.
I also remove the memset as direct initialisation to zero is faster in this case and gain some size.
I move the define to the cpp to reduce scope