### PR TITLE
AP_Motors:Heli_RSC Add heli rotor speed governor

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -151,7 +151,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_InertialSensor,    &copter.ins,                 periodic,       400,  50),
     SCHED_TASK_CLASS(AP_Scheduler,         &copter.scheduler,           update_logging, 0.1,  75),
 #if RPM_ENABLED == ENABLED
-    SCHED_TASK(rpm_update,            10,    200),
+    SCHED_TASK(rpm_update,            40,    200),
 #endif
     SCHED_TASK(compass_cal_update,   100,    100),
     SCHED_TASK(accel_cal_update,      10,    100),

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -280,6 +280,8 @@ struct PACKED log_Heli {
     uint64_t time_us;
     float    desired_rotor_speed;
     float    main_rotor_speed;
+    float    governor_output;
+    float    control_output;
 };
 
 #if FRAME_CONFIG == HELI_FRAME
@@ -291,6 +293,8 @@ void Copter::Log_Write_Heli()
         time_us                 : AP_HAL::micros64(),
         desired_rotor_speed     : motors->get_desired_rotor_speed(),
         main_rotor_speed        : motors->get_main_rotor_speed(),
+        governor_output         : motors->get_governor_output(),
+        control_output          : motors->get_control_output(),
     };
     logger.WriteBlock(&pkt_heli, sizeof(pkt_heli));
 }
@@ -403,7 +407,7 @@ const struct LogStructure Copter::log_structure[] = {
       "DFLT",  "QBf",         "TimeUS,Id,Value", "s--", "F--" },
 #if FRAME_CONFIG == HELI_FRAME
     { LOG_HELI_MSG, sizeof(log_Heli),
-      "HELI",  "Qff",         "TimeUS,DRRPM,ERRPM", "s--", "F--" },
+      "HELI",  "Qffff",        "TimeUS,DRRPM,ERRPM,Gov,Throt", "s----", "F----" },
 #endif
 #if PRECISION_LANDING == ENABLED
     { LOG_PRECLAND_MSG, sizeof(log_Precland),

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1339,5 +1339,17 @@ void Copter::convert_tradheli_parameters(void)
             AP_Param::convert_old_parameter(&dualheli_conversion_info[i], 1.0f);
         }
     }
+    const AP_Param::ConversionInfo allheli_conversion_info[] = {
+        { Parameters::k_param_motors, 1280, AP_PARAM_INT16, "H_RSC_CRV_000" },
+        { Parameters::k_param_motors, 1344, AP_PARAM_INT16, "H_RSC_CRV_025" },
+        { Parameters::k_param_motors, 1408, AP_PARAM_INT16, "H_RSC_CRV_050" },
+        { Parameters::k_param_motors, 1472, AP_PARAM_INT16, "H_RSC_CRV_075" },
+        { Parameters::k_param_motors, 1536, AP_PARAM_INT16, "H_RSC_CRV_100" },
+    };
+    // convert dual heli parameters without scaling
+    uint8_t table_size = ARRAY_SIZE(allheli_conversion_info);
+    for (uint8_t i=0; i<table_size; i++) {
+        AP_Param::convert_old_parameter(&allheli_conversion_info[i], 0.1f);
+    }
 }
 #endif

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -146,7 +146,7 @@ void Copter::heli_update_rotor_speed_targets()
     }
     switch (rsc_control_mode) {
         case ROTOR_CONTROL_MODE_SPEED_PASSTHROUGH:
-            // pass through pilot desired rotor speed if control input is higher than 10, creating a deadband at the bottom
+            // pass through pilot desired rotor speed from the RC
             if (motors->get_interlock()) {
                 motors->set_desired_rotor_speed(rsc_control_deglitched);
             } else {
@@ -156,9 +156,12 @@ void Copter::heli_update_rotor_speed_targets()
         case ROTOR_CONTROL_MODE_SPEED_SETPOINT:
         case ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT:
         case ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT:
-            // pass setpoint through as desired rotor speed, this is almost pointless as the Setpoint serves no function in this mode
-            // other than being used to create a crude estimate of rotor speed
+            // pass setpoint through as desired rotor speed. Needs work, this is pointless as it is
+            // not used by closed loop control. Being used as a catch-all for other modes regardless
+            // of whether or not they actually use it
+            // set rpm from rotor speed sensor
             if (motors->get_interlock()) {
+                motors->set_rpm(rpm_sensor.get_rpm(0));
                 motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
             }else{
                 motors->set_desired_rotor_speed(0.0f);

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -157,11 +157,11 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
 
     // @Group: RSC_CRV_
     // @Path: AP_MotorsHeli_RSC.cpp
-    AP_SUBGROUPINFO(_rsc_thrcrv, "RSC_CRV_", 27, AP_MotorsHeli, RSCThrCrvInt16Param),
+    AP_SUBGROUPINFO(_rsc_thrcrv, "RSC_CRV_", 27, AP_MotorsHeli, RSCThrCrvParam),
 
     // @Group: RSC_GOV_
     // @Path: AP_MotorsHeli_RSC.cpp
-    AP_SUBGROUPINFO(_rsc_gov, "RSC_GOV_", 28, AP_MotorsHeli, RSCGovFloatParam),
+    AP_SUBGROUPINFO(_rsc_gov, "RSC_GOV_", 28, AP_MotorsHeli, RSCGovParam),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -77,7 +77,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Param: RSC_MODE
     // @DisplayName: Rotor Speed Control Mode
     // @Description: Determines the method of rotor speed control
-    // @Values: 1:Ch8 Input, 2:SetPoint, 3:Throttle Curve
+    // @Values: 1:Ch8 Input, 2:SetPoint, 3:Throttle Curve, 4:Governor
     // @User: Standard
     AP_GROUPINFO("RSC_MODE", 8, AP_MotorsHeli, _rsc_mode, (int8_t)ROTOR_CONTROL_MODE_SPEED_PASSTHROUGH),
 
@@ -192,6 +192,38 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Increment: 10
     // @User: Standard
     AP_GROUPINFO("RSC_THRCRV_100", 24, AP_MotorsHeli, _rsc_thrcrv[4], AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT),
+
+    // @Param: RSC_GOV_SET
+    // @DisplayName: Governor RPM Setting
+    // @Description: Main rotor rpm setting that governor maintains when engaged
+    // @Range: 800 3500
+    // @Increment: 10
+    // @User: Standard
+    AP_GROUPINFO("RSC_GOV_SET", 25, AP_MotorsHeli, _rsc_governor_setpoint, AP_MOTORS_HELI_RSC_GOVERNOR_SET_DEFAULT),
+    
+    // @Param: RSC_GOV_DISGAG
+    // @DisplayName: Throttle Percentage for Governor Disengage
+    // @Description: Percentage of throttle where the governor will disenage to allow return to flight idle power
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RSC_GOV_DISGAG", 26, AP_MotorsHeli, _rsc_governor_disengage, AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE),
+
+    // @Param: RSC_GOV_DROOP
+    // @DisplayName: Governor Droop Setting
+    // @Description: Governor droop response under load, 0-100%. Higher value is quicker response but may cause surging
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RSC_GOV_DROOP", 27, AP_MotorsHeli, _rsc_governor_droop_setting, AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT),
+
+    // @Param: RSC_GOV_TC
+    // @DisplayName: Governor Throttle Curve Gain
+    // @Description: Percentage of throttle curve gain in governor output
+    // @Range: 50 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RSC_GOV_TC", 28, AP_MotorsHeli, _rsc_governor_tc, AP_MOTORS_HELI_RSC_GOVERNOR_TC),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -153,77 +153,15 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RSC_SLEWRATE", 19, AP_MotorsHeli, _rsc_slewrate, 0),
 
-    // @Param: RSC_THRCRV_0
-    // @DisplayName: Throttle Servo Position for 0 percent collective
-    // @Description: Throttle Servo Position for 0 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
-    // @Range: 0 1000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_THRCRV_0", 20, AP_MotorsHeli, _rsc_thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
+    // indices 20 to 25 was throttle curve. Do not use this index in the future.
 
-    // @Param: RSC_THRCRV_25
-    // @DisplayName: Throttle Servo Position for 25 percent collective
-    // @Description: Throttle Servo Position for 25 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
-    // @Range: 0 1000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_THRCRV_25", 21, AP_MotorsHeli, _rsc_thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
+    // @Group: RSC_CRV_
+    // @Path: AP_MotorsHeli_RSC.cpp
+    AP_SUBGROUPINFO(_rsc_thrcrv, "RSC_CRV_", 27, AP_MotorsHeli, RSCThrCrvInt16Param),
 
-    // @Param: RSC_THRCRV_50
-    // @DisplayName: Throttle Servo Position for 50 percent collective
-    // @Description: Throttle Servo Position for 50 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
-    // @Range: 0 1000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_THRCRV_50", 22, AP_MotorsHeli, _rsc_thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
-
-    // @Param: RSC_THRCRV_75
-    // @DisplayName: Throttle Servo Position for 75 percent collective
-    // @Description: Throttle Servo Position for 75 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
-    // @Range: 0 1000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_THRCRV_75", 23, AP_MotorsHeli, _rsc_thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
-
-    // @Param: RSC_THRCRV_100
-    // @DisplayName: Throttle Servo Position for 100 percent collective
-    // @Description: Throttle Servo Position for 100 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
-    // @Range: 0 1000
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_THRCRV_100", 24, AP_MotorsHeli, _rsc_thrcrv[4], AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT),
-
-    // @Param: RSC_GOV_SET
-    // @DisplayName: Governor RPM Setting
-    // @Description: Main rotor rpm setting that governor maintains when engaged
-    // @Range: 800 3500
-    // @Increment: 10
-    // @User: Standard
-    AP_GROUPINFO("RSC_GOV_SET", 25, AP_MotorsHeli, _rsc_governor_setpoint, AP_MOTORS_HELI_RSC_GOVERNOR_SET_DEFAULT),
-    
-    // @Param: RSC_GOV_DISGAG
-    // @DisplayName: Throttle Percentage for Governor Disengage
-    // @Description: Percentage of throttle where the governor will disenage to allow return to flight idle power
-    // @Range: 0 50
-    // @Increment: 1
-    // @User: Standard
-    AP_GROUPINFO("RSC_GOV_DISGAG", 26, AP_MotorsHeli, _rsc_governor_disengage, AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE),
-
-    // @Param: RSC_GOV_DROOP
-    // @DisplayName: Governor Droop Setting
-    // @Description: Governor droop response under load, 0-100%. Higher value is quicker response but may cause surging
-    // @Range: 0 100
-    // @Increment: 1
-    // @User: Standard
-    AP_GROUPINFO("RSC_GOV_DROOP", 27, AP_MotorsHeli, _rsc_governor_droop_setting, AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT),
-
-    // @Param: RSC_GOV_TC
-    // @DisplayName: Governor Throttle Curve Gain
-    // @Description: Percentage of throttle curve gain in governor output
-    // @Range: 50 100
-    // @Increment: 1
-    // @User: Standard
-    AP_GROUPINFO("RSC_GOV_TC", 28, AP_MotorsHeli, _rsc_governor_tc, AP_MOTORS_HELI_RSC_GOVERNOR_TC),
+    // @Group: RSC_GOV_
+    // @Path: AP_MotorsHeli_RSC.cpp
+    AP_SUBGROUPINFO(_rsc_gov, "RSC_GOV_", 28, AP_MotorsHeli, RSCGovFloatParam),
 
     AP_GROUPEND
 };
@@ -559,5 +497,18 @@ void AP_MotorsHeli::rc_write_swash(uint8_t chan, float swash_in)
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
 
-
+// enable_parameters - enables the rsc parameters for the rsc mode
+void AP_MotorsHeli::enable_rsc_parameters(void)
+{
+    if (_rsc_mode == (int8_t)ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT || _rsc_mode == (int8_t)ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
+        _rsc_thrcrv.set_thrcrv_enable(1);
+    } else {
+        _rsc_thrcrv.set_thrcrv_enable(0);
+    }
+    if (_rsc_mode == (int8_t)ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
+        _rsc_gov.set_gov_enable(1);
+    } else {
+        _rsc_gov.set_gov_enable(0);
+    }
+}
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -31,17 +31,6 @@
 
 // RSC output defaults
 #define AP_MOTORS_HELI_RSC_IDLE_DEFAULT         0
-#define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     250
-#define AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT    320
-#define AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT    380
-#define AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT    500
-#define AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT   1000
-
-// RSC governor defaults
-#define AP_MOTORS_HELI_RSC_GOVERNOR_SET_DEFAULT   1500
-#define AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE     25
-#define AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT 30
-#define AP_MOTORS_HELI_RSC_GOVERNOR_TC            90
 
 // default main rotor ramp up time in seconds
 #define AP_MOTORS_HELI_RSC_RAMP_TIME            1       // 1 second to ramp output to main rotor ESC to setpoint
@@ -147,6 +136,9 @@ public:
     // support passing init_targets_on_arming flag to greater code
     bool init_targets_on_arming() const { return _heliflags.init_targets_on_arming; }
 
+    void enable_rsc_parameters(void);
+
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -161,6 +153,9 @@ protected:
         SERVO_CONTROL_MODE_MANUAL_MIN,
         SERVO_CONTROL_MODE_MANUAL_OSCILLATE,
     };
+
+    RSCThrCrvInt16Param   _rsc_thrcrv;
+    RSCGovFloatParam      _rsc_gov;
 
     // output - sends commands to the motors
     void output_armed_stabilizing() override;
@@ -225,13 +220,8 @@ protected:
     AP_Int16        _land_collective_min;       // Minimum collective when landed or landing
     AP_Int16        _rsc_critical;              // Rotor speed below which flight is not possible
     AP_Int16        _rsc_idle_output;           // Rotor control output while at idle
-    AP_Int16        _rsc_thrcrv[5];             // throttle value sent to throttle servo at 0, 25, 50, 75 and 100 percent collective
     AP_Int16        _rsc_slewrate;              // throttle slew rate (percentage per second)
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
-    AP_Float        _rsc_governor_disengage;    // sets the throttle percent where the governor disengages for return to flight idle
-    AP_Int16        _rsc_governor_setpoint;     // sets rotor speed for governor
-    AP_Float        _rsc_governor_droop_setting;// governor response to droop under load
-    AP_Float        _rsc_governor_tc;           // governor throttle curve weighting, range 50-100%
 
     // internal variables
     float           _collective_mid_pct = 0.0f;      // collective mid parameter value converted to 0 ~ 1 range

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -154,8 +154,8 @@ protected:
         SERVO_CONTROL_MODE_MANUAL_OSCILLATE,
     };
 
-    RSCThrCrvInt16Param   _rsc_thrcrv;
-    RSCGovFloatParam      _rsc_gov;
+    RSCThrCrvParam   _rsc_thrcrv;
+    RSCGovParam      _rsc_gov;
 
     // output - sends commands to the motors
     void output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -93,7 +93,7 @@ public:
     float get_rsc_setpoint() const { return _rsc_setpoint * 0.001f; }
     
     // set_rpm - for rotor speed governor
-    virtual void set_rpm(int16_t rotor_rpm) = 0;
+    virtual void set_rpm(float rotor_rpm) = 0;
 
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     virtual void set_desired_rotor_speed(float desired_speed) = 0;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -206,6 +206,12 @@ void AP_MotorsHeli_Dual::set_desired_rotor_speed(float desired_speed)
     _rotor.set_desired_speed(desired_speed);
 }
 
+// set_rotor_rpm - used for governor with speed sensor
+void AP_MotorsHeli_Dual::set_rpm(int16_t rotor_rpm)
+{
+    _rotor.set_rotor_rpm(rotor_rpm);
+}
+
 // calculate_armed_scalars
 void AP_MotorsHeli_Dual::calculate_armed_scalars()
 {
@@ -218,6 +224,10 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     _rotor.set_critical_speed(_rsc_critical*0.001f);
     _rotor.set_idle_output(_rsc_idle_output*0.001f);
     _rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
+    _rotor.set_governor_disengage(_rsc_governor_disengage*0.01f);
+    _rotor.set_governor_droop_setting(_rsc_governor_droop_setting*0.01f);
+    _rotor.set_governor_setpoint(_rsc_governor_setpoint);
+    _rotor.set_governor_tc(_rsc_governor_tc*0.01f);
 }
 
 // calculate_scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -215,19 +215,23 @@ void AP_MotorsHeli_Dual::set_rpm(int16_t rotor_rpm)
 // calculate_armed_scalars
 void AP_MotorsHeli_Dual::calculate_armed_scalars()
 {
-    float thrcrv[5];
-    for (uint8_t i = 0; i < 5; i++) {
-        thrcrv[i]=_rsc_thrcrv[i]*0.001f;
-    } 
+    // Set common RSC variables
     _rotor.set_ramp_time(_rsc_ramp_time);
     _rotor.set_runup_time(_rsc_runup_time);
     _rotor.set_critical_speed(_rsc_critical*0.001f);
     _rotor.set_idle_output(_rsc_idle_output*0.001f);
-    _rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
-    _rotor.set_governor_disengage(_rsc_governor_disengage*0.01f);
-    _rotor.set_governor_droop_setting(_rsc_governor_droop_setting*0.01f);
-    _rotor.set_governor_setpoint(_rsc_governor_setpoint);
-    _rotor.set_governor_tc(_rsc_governor_tc*0.01f);
+    _rotor.set_slewrate(_rsc_slewrate);
+
+    // Set rsc mode specific parameters
+    if (_rsc_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
+        _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
+    } else if (_rsc_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
+        _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
+        _rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
+        _rotor.set_governor_droop_setting(_rsc_gov.get_droop_setting()*0.01f);
+        _rotor.set_governor_setpoint(_rsc_gov.get_setpoint());
+        _rotor.set_governor_tc(_rsc_gov.get_tc()*0.01f);
+    }
 }
 
 // calculate_scalars
@@ -263,6 +267,7 @@ void AP_MotorsHeli_Dual::calculate_scalars()
 
     // set mode of main rotor controller and trigger recalculation of scalars
     _rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    enable_rsc_parameters();
     calculate_armed_scalars();
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -228,9 +228,10 @@ void AP_MotorsHeli_Dual::calculate_armed_scalars()
     } else if (_rsc_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
         _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
-        _rotor.set_governor_droop_setting(_rsc_gov.get_droop_setting()*0.01f);
-        _rotor.set_governor_setpoint(_rsc_gov.get_setpoint());
-        _rotor.set_governor_tc(_rsc_gov.get_tc()*0.01f);
+        _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
+        _rotor.set_governor_reference(_rsc_gov.get_reference());
+        _rotor.set_governor_range(_rsc_gov.get_range());
+        _rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -207,7 +207,7 @@ void AP_MotorsHeli_Dual::set_desired_rotor_speed(float desired_speed)
 }
 
 // set_rotor_rpm - used for governor with speed sensor
-void AP_MotorsHeli_Dual::set_rpm(int16_t rotor_rpm)
+void AP_MotorsHeli_Dual::set_rpm(float rotor_rpm)
 {
     _rotor.set_rotor_rpm(rotor_rpm);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -59,7 +59,7 @@ public:
     void output_to_motors() override;
 
     // set_rpm - for rotor speed governor
-    void set_rpm(int16_t rotor_rpm) override;
+    void set_rpm(float rotor_rpm) override;
 
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -58,6 +58,9 @@ public:
     // output_to_motors - sends values out to the motors
     void output_to_motors() override;
 
+    // set_rpm - for rotor speed governor
+    void set_rpm(int16_t rotor_rpm) override;
+
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;
 
@@ -69,6 +72,12 @@ public:
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
     bool rotor_speed_above_critical() const  override { return _rotor.get_rotor_speed() > _rotor.get_critical_speed(); }
+    
+    // get_governor_output
+    float get_governor_output() const { return _rotor.get_governor_output(); }
+    
+    // get_control_output
+    float get_control_output() const { return _rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -74,10 +74,10 @@ public:
     bool rotor_speed_above_critical() const  override { return _rotor.get_rotor_speed() > _rotor.get_critical_speed(); }
     
     // get_governor_output
-    float get_governor_output() const { return _rotor.get_governor_output(); }
+    float get_governor_output() const override { return _rotor.get_governor_output(); }
     
     // get_control_output
-    float get_control_output() const { return _rotor.get_control_output(); }
+    float get_control_output() const override { return _rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -97,7 +97,7 @@ void AP_MotorsHeli_Quad::set_desired_rotor_speed(float desired_speed)
 }
 
 // set_rotor_rpm - used for governor with speed sensor
-void AP_MotorsHeli_Quad::set_rpm(int16_t rotor_rpm)
+void AP_MotorsHeli_Quad::set_rpm(float rotor_rpm)
 {
     _rotor.set_rotor_rpm(rotor_rpm);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -96,6 +96,12 @@ void AP_MotorsHeli_Quad::set_desired_rotor_speed(float desired_speed)
     _rotor.set_desired_speed(desired_speed);
 }
 
+// set_rotor_rpm - used for governor with speed sensor
+void AP_MotorsHeli_Quad::set_rpm(int16_t rotor_rpm)
+{
+    _rotor.set_rotor_rpm(rotor_rpm);
+}
+
 // calculate_armed_scalars
 void AP_MotorsHeli_Quad::calculate_armed_scalars()
 {
@@ -108,6 +114,10 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     _rotor.set_critical_speed(_rsc_critical*0.001f);
     _rotor.set_idle_output(_rsc_idle_output*0.001f);
     _rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
+    _rotor.set_governor_disengage(_rsc_governor_disengage*0.01f);
+    _rotor.set_governor_droop_setting(_rsc_governor_droop_setting*0.01f);
+    _rotor.set_governor_setpoint(_rsc_governor_setpoint);
+    _rotor.set_governor_tc(_rsc_governor_tc*0.01f);
 }
 
 // calculate_scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -118,9 +118,10 @@ void AP_MotorsHeli_Quad::calculate_armed_scalars()
     } else if (_rsc_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
         _rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
-        _rotor.set_governor_droop_setting(_rsc_gov.get_droop_setting()*0.01f);
-        _rotor.set_governor_setpoint(_rsc_gov.get_setpoint());
-        _rotor.set_governor_tc(_rsc_gov.get_tc()*0.01f);
+        _rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
+        _rotor.set_governor_reference(_rsc_gov.get_reference());
+        _rotor.set_governor_range(_rsc_gov.get_range());
+        _rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -40,7 +40,7 @@ public:
     void output_to_motors() override;
 
     // set_rpm - for rotor speed governor
-    void set_rpm(int16_t rotor_rpm) override;
+    void set_rpm(float rotor_rpm) override;
 
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -39,6 +39,9 @@ public:
     // output_to_motors - sends values out to the motors
     void output_to_motors() override;
 
+    // set_rpm - for rotor speed governor
+    void set_rpm(int16_t rotor_rpm) override;
+
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1000
     void set_desired_rotor_speed(float desired_speed) override;
 
@@ -50,6 +53,12 @@ public:
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
     bool rotor_speed_above_critical() const  override { return _rotor.get_rotor_speed() > _rotor.get_critical_speed(); }
+    
+    // get_governor_output
+    float get_governor_output() const { return _rotor.get_governor_output(); }
+    
+    // get_control_output
+    float get_control_output() const { return _rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -55,10 +55,10 @@ public:
     bool rotor_speed_above_critical() const  override { return _rotor.get_rotor_speed() > _rotor.get_critical_speed(); }
     
     // get_governor_output
-    float get_governor_output() const { return _rotor.get_governor_output(); }
+    float get_governor_output() const override { return _rotor.get_governor_output(); }
     
     // get_control_output
-    float get_control_output() const { return _rotor.get_control_output(); }
+    float get_control_output() const override { return _rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -20,6 +20,112 @@
 
 extern const AP_HAL::HAL& hal;
 
+const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable settings for RSC Setpoint
+    // @Description: Automatically set when RSC Setpoint mode is selected. Should not be set manually.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCThrCrvInt16Param, enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: 0
+    // @DisplayName: Throttle Servo Position in percent for 0 percent collective
+    // @Description: Throttle Servo Position in percent for 0 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("0", 2, RSCThrCrvInt16Param, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
+
+    // @Param: 25
+    // @DisplayName: Throttle Servo Position for 25 percent collective
+    // @Description: Throttle Servo Position for 25 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("25", 3, RSCThrCrvInt16Param, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
+
+    // @Param: 50
+    // @DisplayName: Throttle Servo Position for 50 percent collective
+    // @Description: Throttle Servo Position for 50 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("50", 4, RSCThrCrvInt16Param, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
+
+    // @Param: 75
+    // @DisplayName: Throttle Servo Position for 75 percent collective
+    // @Description: Throttle Servo Position for 75 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("75", 5, RSCThrCrvInt16Param, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
+
+    // @Param: 100
+    // @DisplayName: Throttle Servo Position for 100 percent collective
+    // @Description: Throttle Servo Position for 100 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("100", 6, RSCThrCrvInt16Param, thrcrv[4], AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT),
+
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable settings for RSC Governor
+    // @Description: Automatically set when RSC Governor mode is selected. Should not be set manually.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCGovFloatParam, enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: SETPNT
+    // @DisplayName: Governor RPM Setting
+    // @Description: Main rotor rpm setting that governor maintains when engaged
+    // @Range: 800 3500
+    // @Increment: 10
+    // @User: Standard
+    AP_GROUPINFO("SETPNT", 2, RSCGovFloatParam, setpoint, AP_MOTORS_HELI_RSC_GOVERNOR_SET_DEFAULT),
+
+    // @Param: DISGAG
+    // @DisplayName: Throttle Percentage for Governor Disengage
+    // @Description: Percentage of throttle where the governor will disenage to allow return to flight idle power
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("DISGAG", 3, RSCGovFloatParam, disengage, AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE),
+
+    // @Param: DROOP
+    // @DisplayName: Governor Droop Setting
+    // @Description: Governor droop response under load, 0-100%. Higher value is quicker response but may cause surging
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("DROOP", 4, RSCGovFloatParam, droop_setting, AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT),
+
+    // @Param: TC
+    // @DisplayName: Governor Throttle Curve Gain
+    // @Description: Percentage of throttle curve gain in governor output
+    // @Range: 50 100
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("TC", 5, RSCGovFloatParam, tc, AP_MOTORS_HELI_RSC_GOVERNOR_TC),
+
+    AP_GROUPEND
+};
+
+RSCThrCrvInt16Param::RSCThrCrvInt16Param(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+RSCGovFloatParam::RSCGovFloatParam(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
 // init_servo - servo initialization on start-up
 void AP_MotorsHeli_RSC::init_servo()
 {
@@ -33,7 +139,7 @@ void AP_MotorsHeli_RSC::init_servo()
 
 // set_power_output_range
 // TODO: Look at possibly calling this at a slower rate.  Doesn't need to be called every cycle.
-void AP_MotorsHeli_RSC::set_throttle_curve(float thrcrv[5], uint16_t slewrate)
+void AP_MotorsHeli_RSC::set_throttle_curve(float thrcrv[5])
 {
 
     // Ensure user inputs are within parameter limits
@@ -43,7 +149,6 @@ void AP_MotorsHeli_RSC::set_throttle_curve(float thrcrv[5], uint16_t slewrate)
     // Calculate the spline polynomials for the throttle curve
     splinterp5(thrcrv,_thrcrv_poly);
 
-    _power_slewrate = slewrate;
 }
 
 // output - update value to send to ESC/Servo
@@ -238,4 +343,3 @@ float AP_MotorsHeli_RSC::calculate_desired_throttle(float collective_in)
     return throttle;
 
 }
-

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -29,41 +29,41 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO_FLAGS("ENABLE", 1, RSCThrCrvInt16Param, enable, 0, AP_PARAM_FLAG_ENABLE),
 
-    // @Param: 0
+    // @Param: 000
     // @DisplayName: Throttle Servo Position in percent for 0 percent collective
     // @Description: Throttle Servo Position in percent for 0 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("0", 2, RSCThrCrvInt16Param, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
+    AP_GROUPINFO("000", 2, RSCThrCrvInt16Param, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
 
-    // @Param: 25
-    // @DisplayName: Throttle Servo Position for 25 percent collective
-    // @Description: Throttle Servo Position for 25 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Param: 025
+    // @DisplayName: Throttle Servo Position in percent for 25 percent collective
+    // @Description: Throttle Servo Position in percent for 25 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("25", 3, RSCThrCrvInt16Param, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
+    AP_GROUPINFO("025", 3, RSCThrCrvInt16Param, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
 
-    // @Param: 50
-    // @DisplayName: Throttle Servo Position for 50 percent collective
-    // @Description: Throttle Servo Position for 50 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Param: 050
+    // @DisplayName: Throttle Servo Position in percent for 50 percent collective
+    // @Description: Throttle Servo Position in percent for 50 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("50", 4, RSCThrCrvInt16Param, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
+    AP_GROUPINFO("050", 4, RSCThrCrvInt16Param, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
 
-    // @Param: 75
-    // @DisplayName: Throttle Servo Position for 75 percent collective
-    // @Description: Throttle Servo Position for 75 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @Param: 075
+    // @DisplayName: Throttle Servo Position in percent for 75 percent collective
+    // @Description: Throttle Servo Position in percent for 75 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("75", 5, RSCThrCrvInt16Param, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
+    AP_GROUPINFO("075", 5, RSCThrCrvInt16Param, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
 
     // @Param: 100
-    // @DisplayName: Throttle Servo Position for 100 percent collective
-    // @Description: Throttle Servo Position for 100 percent collective. This is on a scale from 0 to 1000, where 1000 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
+    // @DisplayName: Throttle Servo Position in percent for 100 percent collective
+    // @Description: Throttle Servo Position in percent for 100 percent collective. This is on a scale from 0 to 100, where 100 is full throttle and 0 is zero throttle. Actual PWM values are controlled by SERVOX_MIN and SERVOX_MAX. The 0 percent collective is defined by H_COL_MIN and 100 percent collective is defined by H_COL_MAX.
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -20,14 +20,14 @@
 
 extern const AP_HAL::HAL& hal;
 
-const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
+const AP_Param::GroupInfo RSCThrCrvParam::var_info[] = {
 
     // @Param: ENABLE
     // @DisplayName: Enable settings for RSC Setpoint
     // @Description: Automatically set when RSC Setpoint mode is selected. Should not be set manually.
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCThrCrvInt16Param, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCThrCrvParam, enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: 000
     // @DisplayName: Throttle Servo Position in percent for 0 percent collective
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("000", 2, RSCThrCrvInt16Param, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
+    AP_GROUPINFO("000", 2, RSCThrCrvParam, thrcrv[0], AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT),
 
     // @Param: 025
     // @DisplayName: Throttle Servo Position in percent for 25 percent collective
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("025", 3, RSCThrCrvInt16Param, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
+    AP_GROUPINFO("025", 3, RSCThrCrvParam, thrcrv[1], AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT),
 
     // @Param: 050
     // @DisplayName: Throttle Servo Position in percent for 50 percent collective
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("050", 4, RSCThrCrvInt16Param, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
+    AP_GROUPINFO("050", 4, RSCThrCrvParam, thrcrv[2], AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT),
 
     // @Param: 075
     // @DisplayName: Throttle Servo Position in percent for 75 percent collective
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("075", 5, RSCThrCrvInt16Param, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
+    AP_GROUPINFO("075", 5, RSCThrCrvParam, thrcrv[3], AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT),
 
     // @Param: 100
     // @DisplayName: Throttle Servo Position in percent for 100 percent collective
@@ -67,19 +67,19 @@ const AP_Param::GroupInfo RSCThrCrvInt16Param::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("100", 6, RSCThrCrvInt16Param, thrcrv[4], AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT),
+    AP_GROUPINFO("100", 6, RSCThrCrvParam, thrcrv[4], AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT),
 
     AP_GROUPEND
 };
 
-const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
+const AP_Param::GroupInfo RSCGovParam::var_info[] = {
 
     // @Param: ENABLE
     // @DisplayName: Enable settings for RSC Governor
     // @Description: Automatically set when RSC Governor mode is selected. Should not be set manually.
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCGovFloatParam, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE", 1, RSCGovParam, enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: SETPNT
     // @DisplayName: Governor RPM Reference Setting
@@ -87,7 +87,7 @@ const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
     // @Range: 800 3500
     // @Increment: 10
     // @User: Standard
-    AP_GROUPINFO("SETPNT", 2, RSCGovFloatParam, reference, AP_MOTORS_HELI_RSC_GOVERNOR_SETPNT_DEFAULT),
+    AP_GROUPINFO("SETPNT", 2, RSCGovParam, reference, AP_MOTORS_HELI_RSC_GOVERNOR_SETPNT_DEFAULT),
 
     // @Param: DISGAG
     // @DisplayName: Throttle Percentage for Governor Disengage
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
     // @Range: 0 50
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("DISGAG", 3, RSCGovFloatParam, disengage, AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE_DEFAULT),
+    AP_GROUPINFO("DISGAG", 3, RSCGovParam, disengage, AP_MOTORS_HELI_RSC_GOVERNOR_DISENGAGE_DEFAULT),
 
     // @Param: DROOP
     // @DisplayName: Governor Droop Response Setting
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("DROOP", 4, RSCGovFloatParam, droop_response, AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT),
+    AP_GROUPINFO("DROOP", 4, RSCGovParam, droop_response, AP_MOTORS_HELI_RSC_GOVERNOR_DROOP_DEFAULT),
 
     // @Param: THRCURVE
     // @DisplayName: Governor Throttle Curve Gain
@@ -111,7 +111,7 @@ const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
     // @Range: 50 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("THRCURVE", 5, RSCGovFloatParam, thrcurve, AP_MOTORS_HELI_RSC_GOVERNOR_THRCURVE_DEFAULT),
+    AP_GROUPINFO("THRCURVE", 5, RSCGovParam, thrcurve, AP_MOTORS_HELI_RSC_GOVERNOR_THRCURVE_DEFAULT),
     
     // @Param: RANGE
     // @DisplayName: Governor Operational Range
@@ -119,17 +119,17 @@ const AP_Param::GroupInfo RSCGovFloatParam::var_info[] = {
     // @Range: 50 200
     // @Increment: 10
     // @User: Standard
-    AP_GROUPINFO("RANGE", 6, RSCGovFloatParam, range, AP_MOTORS_HELI_RSC_GOVERNOR_RANGE_DEFAULT),
+    AP_GROUPINFO("RANGE", 6, RSCGovParam, range, AP_MOTORS_HELI_RSC_GOVERNOR_RANGE_DEFAULT),
 
     AP_GROUPEND
 };
 
-RSCThrCrvInt16Param::RSCThrCrvInt16Param(void)
+RSCThrCrvParam::RSCThrCrvParam(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-RSCGovFloatParam::RSCGovFloatParam(void)
+RSCGovParam::RSCGovParam(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -5,15 +5,12 @@
 #include <RC_Channel/RC_Channel.h>
 #include <SRV_Channel/SRV_Channel.h>
 
-// default main rotor speed (ch8 out) as a number from 0 ~ 1000
-#define AP_MOTORS_HELI_RSC_SETPOINT             700
-
 // Throttle Curve Defaults
-#define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     250
-#define AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT    320
-#define AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT    380
-#define AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT    500
-#define AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT   1000
+#define AP_MOTORS_HELI_RSC_THRCRV_0_DEFAULT     25
+#define AP_MOTORS_HELI_RSC_THRCRV_25_DEFAULT    32
+#define AP_MOTORS_HELI_RSC_THRCRV_50_DEFAULT    38
+#define AP_MOTORS_HELI_RSC_THRCRV_75_DEFAULT    50
+#define AP_MOTORS_HELI_RSC_THRCRV_100_DEFAULT   100
 
 // RSC governor defaults
 #define AP_MOTORS_HELI_RSC_GOVERNOR_SET_DEFAULT   1500
@@ -163,7 +160,7 @@ public:
     float * get_thrcrv() {
         static float throttlecurve[5];
         for (uint8_t i = 0; i < 5; i++) {
-            throttlecurve[i] = (float)thrcrv[i] * 0.001f;
+            throttlecurve[i] = (float)thrcrv[i] * 0.01f;
         }
         return throttlecurve;
     }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -69,7 +69,7 @@ public:
     float       get_rotor_speed() const;
     
     // set_rotor_rpm - when speed sensor is available for governor
-    void        set_rotor_rpm(int16_t rotor_rpm) {_rotor_rpm = rotor_rpm; }
+    void        set_rotor_rpm(int16_t rotor_rpm) {_rotor_rpm = (float)rotor_rpm; }
     
     // get_governor_output
     float       get_governor_output() const { return _governor_output; }
@@ -113,11 +113,11 @@ private:
     float           _thrcrv_poly[4][4];             // spline polynomials for throttle curve interpolation
     uint16_t        _power_slewrate = 0;            // slewrate for throttle (percentage per second)
     float           _collective_in;                 // collective in for throttle curve calculation, range 0-1.0f
-    int16_t         _rotor_rpm;                     // rotor rpm from speed sensor for governor
+    float           _rotor_rpm;                     // rotor rpm from speed sensor for governor
     float           _governor_disengage = 0.0f;     // throttle percentage where governor disenages to allow return to flight idle
     float           _governor_droop_setting = 0.0f; // governor droop setting, range 0-100%
     float           _governor_output = 0.0f;        // governor output for rotor speed control
-    int16_t         _governor_setpoint = 0.0f;      // governor speed setpoint, range 800-3500 rpm
+    float           _governor_setpoint = 0.0f;      // governor speed setpoint, range 800-3500 rpm
     bool            _governor_engage = false;       // RSC governor status flag for soft-start
     float           _governor_tc = 0.0f;            // governor throttle curve gain, range 50-100%
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -49,6 +49,13 @@ public:
     float       get_idle_output() { return _idle_output; }
     void        set_idle_output(float idle_output) { _idle_output = idle_output; }
 
+    // set engine governor parameters
+    void        set_governor_disengage(float governor_disengage) {_governor_disengage = governor_disengage; }
+    void        set_governor_droop_setting(float governor_droop_setting) { _governor_droop_setting = governor_droop_setting; }
+    void        set_governor_output(float governor_output) {_governor_output = governor_output; }
+    void        set_governor_setpoint(float governor_setpoint) { _governor_setpoint = governor_setpoint; }
+    void        set_governor_tc(float governor_tc) {_governor_tc = governor_tc; }
+
     // get_desired_speed
     float       get_desired_speed() const { return _desired_speed; }
 
@@ -58,8 +65,14 @@ public:
     // get_control_speed
     float       get_control_output() const { return _control_output; }
 
-    // get_rotor_speed - return estimated or measured rotor speed
+    // get_rotor_speed - estimated rotor speed when no governor or rpm sensor is used
     float       get_rotor_speed() const;
+    
+    // set_rotor_rpm - when speed sensor is available for governor
+    void        set_rotor_rpm(int16_t rotor_rpm) {_rotor_rpm = rotor_rpm; }
+    
+    // get_governor_output
+    float       get_governor_output() const { return _governor_output; }
 
     // is_runup_complete
     bool        is_runup_complete() const { return _runup_complete; }
@@ -88,18 +101,25 @@ private:
 
     // internal variables
     RotorControlMode _control_mode = ROTOR_CONTROL_MODE_DISABLED;   // motor control mode, Passthrough or Setpoint
-    float           _critical_speed = 0.0f;     // rotor speed below which flight is not possible
-    float           _idle_output = 0.0f;        // motor output idle speed
-    float           _desired_speed = 0.0f;      // latest desired rotor speed from pilot
-    float           _control_output = 0.0f;     // latest logic controlled output
-    float           _rotor_ramp_output = 0.0f;  // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
-    float           _rotor_runup_output = 0.0f; // scalar used to store status of rotor run-up time (0.0-1.0f)
-    int8_t          _ramp_time = 0;             // time in seconds for the output to the main rotor's ESC to reach full speed
-    int8_t          _runup_time = 0;            // time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
-    bool            _runup_complete = false;    // flag for determining if runup is complete
-    float           _thrcrv_poly[4][4];         // spline polynomials for throttle curve interpolation
-    uint16_t        _power_slewrate = 0;        // slewrate for throttle (percentage per second)
-    float           _collective_in;             // collective in for throttle curve calculation, range 0-1.0f
+    float           _critical_speed = 0.0f;         // rotor speed below which flight is not possible
+    float           _idle_output = 0.0f;            // motor output idle speed
+    float           _desired_speed = 0.0f;          // latest desired rotor speed from pilot
+    float           _control_output = 0.0f;         // latest logic controlled output
+    float           _rotor_ramp_output = 0.0f;      // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
+    float           _rotor_runup_output = 0.0f;     // scalar used to store status of rotor run-up time (0.0-1.0f)
+    int8_t          _ramp_time = 0;                 // time in seconds for the output to the main rotor's ESC to reach full speed
+    int8_t          _runup_time = 0;                // time in seconds for the main rotor to reach full speed.  Must be longer than _rsc_ramp_time
+    bool            _runup_complete = false;        // flag for determining if runup is complete
+    float           _thrcrv_poly[4][4];             // spline polynomials for throttle curve interpolation
+    uint16_t        _power_slewrate = 0;            // slewrate for throttle (percentage per second)
+    float           _collective_in;                 // collective in for throttle curve calculation, range 0-1.0f
+    int16_t         _rotor_rpm;                     // rotor rpm from speed sensor for governor
+    float           _governor_disengage = 0.0f;     // throttle percentage where governor disenages to allow return to flight idle
+    float           _governor_droop_setting = 0.0f; // governor droop setting, range 0-100%
+    float           _governor_output = 0.0f;        // governor output for rotor speed control
+    int16_t         _governor_setpoint = 0.0f;      // governor speed setpoint, range 800-3500 rpm
+    bool            _governor_engage = false;       // RSC governor status flag for soft-start
+    float           _governor_tc = 0.0f;            // governor throttle curve gain, range 50-100%
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -153,9 +153,9 @@ private:
     float           calculate_desired_throttle(float collective_in);
 };
 
-class RSCThrCrvInt16Param {
+class RSCThrCrvParam {
 public:
-    RSCThrCrvInt16Param(void);
+    RSCThrCrvParam(void);
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -174,9 +174,9 @@ private:
 
 };
 
-class RSCGovFloatParam {
+class RSCGovParam {
 public:
-    RSCGovFloatParam(void);
+    RSCGovParam(void);
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -84,7 +84,7 @@ public:
     float       get_rotor_speed() const;
     
     // set_rotor_rpm - when speed sensor is available for governor
-    void        set_rotor_rpm(int16_t rotor_rpm) {_rotor_rpm = (float)rotor_rpm; }
+    void        set_rotor_rpm(float rotor_rpm) {_rotor_rpm = (float)rotor_rpm; }
     
     // get_governor_output
     float       get_governor_output() const { return _governor_output; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -231,9 +231,10 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
     } else if (_rsc_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
         _main_rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
         _main_rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
-        _main_rotor.set_governor_droop_setting(_rsc_gov.get_droop_setting()*0.01f);
-        _main_rotor.set_governor_setpoint(_rsc_gov.get_setpoint());
-        _main_rotor.set_governor_tc(_rsc_gov.get_tc()*0.01f);
+        _main_rotor.set_governor_droop_response(_rsc_gov.get_droop_response()*0.01f);
+        _main_rotor.set_governor_reference(_rsc_gov.get_reference());
+        _main_rotor.set_governor_range(_rsc_gov.get_range());
+        _main_rotor.set_governor_thrcurve(_rsc_gov.get_thrcurve()*0.01f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -210,7 +210,7 @@ void AP_MotorsHeli_Single::set_desired_rotor_speed(float desired_speed)
 }
 
 // set_rotor_rpm - used for governor with speed sensor
-void AP_MotorsHeli_Single::set_rpm(int16_t rotor_rpm)
+void AP_MotorsHeli_Single::set_rpm(float rotor_rpm)
 {
     _main_rotor.set_rotor_rpm(rotor_rpm);
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -218,21 +218,24 @@ void AP_MotorsHeli_Single::set_rpm(int16_t rotor_rpm)
 // calculate_scalars - recalculates various scalers used.
 void AP_MotorsHeli_Single::calculate_armed_scalars()
 {
-    float thrcrv[5];
-    for (uint8_t i = 0; i < 5; i++) {
-        thrcrv[i]=_rsc_thrcrv[i]*0.001f;
-    }
+    // Set common RSC variables
     _main_rotor.set_ramp_time(_rsc_ramp_time);
     _main_rotor.set_runup_time(_rsc_runup_time);
     _main_rotor.set_critical_speed(_rsc_critical*0.001f);
     _main_rotor.set_idle_output(_rsc_idle_output*0.001f);
-    _main_rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
-    _main_rotor.set_governor_disengage(_rsc_governor_disengage*0.01f);
-    _main_rotor.set_governor_droop_setting(_rsc_governor_droop_setting*0.01f);
-    _main_rotor.set_governor_setpoint(_rsc_governor_setpoint);
-    _main_rotor.set_governor_tc(_rsc_governor_tc*0.01f);
-   }
+    _main_rotor.set_slewrate(_rsc_slewrate);
 
+    // Set rsc mode specific parameters
+    if (_rsc_mode == ROTOR_CONTROL_MODE_OPEN_LOOP_POWER_OUTPUT) {
+        _main_rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
+    } else if (_rsc_mode == ROTOR_CONTROL_MODE_CLOSED_LOOP_POWER_OUTPUT) {
+        _main_rotor.set_throttle_curve(_rsc_thrcrv.get_thrcrv());
+        _main_rotor.set_governor_disengage(_rsc_gov.get_disengage()*0.01f);
+        _main_rotor.set_governor_droop_setting(_rsc_gov.get_droop_setting()*0.01f);
+        _main_rotor.set_governor_setpoint(_rsc_gov.get_setpoint());
+        _main_rotor.set_governor_tc(_rsc_gov.get_tc()*0.01f);
+    }
+}
 
 // calculate_scalars - recalculates various scalers used.
 void AP_MotorsHeli_Single::calculate_scalars()
@@ -253,6 +256,7 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
     // send setpoints to main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    enable_rsc_parameters();
     calculate_armed_scalars();
 
     // send setpoints to DDVP rotor controller and trigger recalculation of scalars

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -134,7 +134,7 @@ bool AP_MotorsHeli_Single::init_outputs()
         }
     }
 
-    if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {            
+    if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_SERVO_EXTGYRO) {
         // External Gyro uses PWM output thus servo endpoints are forced
         SRV_Channels::set_output_min_max(SRV_Channels::get_motor_function(AP_MOTORS_HELI_SINGLE_EXTGYRO), 1000, 2000);
     }
@@ -209,6 +209,12 @@ void AP_MotorsHeli_Single::set_desired_rotor_speed(float desired_speed)
     _tail_rotor.set_desired_speed(_direct_drive_tailspeed*0.001f);
 }
 
+// set_rotor_rpm - used for governor with speed sensor
+void AP_MotorsHeli_Single::set_rpm(int16_t rotor_rpm)
+{
+    _main_rotor.set_rotor_rpm(rotor_rpm);
+}
+
 // calculate_scalars - recalculates various scalers used.
 void AP_MotorsHeli_Single::calculate_armed_scalars()
 {
@@ -221,7 +227,11 @@ void AP_MotorsHeli_Single::calculate_armed_scalars()
     _main_rotor.set_critical_speed(_rsc_critical*0.001f);
     _main_rotor.set_idle_output(_rsc_idle_output*0.001f);
     _main_rotor.set_throttle_curve(thrcrv, (uint16_t)_rsc_slewrate.get());
-}
+    _main_rotor.set_governor_disengage(_rsc_governor_disengage*0.01f);
+    _main_rotor.set_governor_droop_setting(_rsc_governor_droop_setting*0.01f);
+    _main_rotor.set_governor_setpoint(_rsc_governor_setpoint);
+    _main_rotor.set_governor_tc(_rsc_governor_tc*0.01f);
+   }
 
 
 // calculate_scalars - recalculates various scalers used.

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -61,7 +61,7 @@ public:
     void set_desired_rotor_speed(float desired_speed) override;
 
     // set_rpm - for rotor speed governor
-    void set_rpm(int16_t rotor_rpm) override;
+    void set_rpm(float rotor_rpm) override;
 
     // get_main_rotor_speed - estimated rotor speed when no speed sensor or governor is used
     float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -60,7 +60,10 @@ public:
     // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
     void set_desired_rotor_speed(float desired_speed) override;
 
-    // get_main_rotor_speed - gets estimated or measured main rotor speed
+    // set_rpm - for rotor speed governor
+    void set_rpm(int16_t rotor_rpm) override;
+
+    // get_main_rotor_speed - estimated rotor speed when no speed sensor or governor is used
     float get_main_rotor_speed() const  override { return _main_rotor.get_rotor_speed(); }
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
@@ -68,6 +71,12 @@ public:
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
     bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
+    
+    // get_governor_output
+    float get_governor_output() const { return _main_rotor.get_governor_output(); }
+    
+    // get_control_output
+    float get_control_output() const { return _main_rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -73,10 +73,10 @@ public:
     bool rotor_speed_above_critical() const  override { return _main_rotor.get_rotor_speed() > _main_rotor.get_critical_speed(); }
     
     // get_governor_output
-    float get_governor_output() const { return _main_rotor.get_governor_output(); }
+    float get_governor_output() const override { return _main_rotor.get_governor_output(); }
     
     // get_control_output
-    float get_control_output() const { return _main_rotor.get_control_output(); }
+    float get_control_output() const override{ return _main_rotor.get_control_output(); }
 
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;


### PR DESCRIPTION
This adds a rotor speed governor to the Heli_RSC. It completes the open/closed loop throttle control modes for the Heli_RSC. It has been extensively flight tested over several months. It is primarily intended for piston engine helicopters, or Wren 44i/50i turbine engine helicopters that do not have a governor in their FADEC. But has also been tested on electric.

It also adds logging for the governor and throttle output.