### PR TITLE
Copter: Guided_NoGPS does not require GPS

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -764,7 +764,7 @@ public:
     bool init(bool ignore_checks) override;
     void run() override;
 
-    bool requires_GPS() const override { return true; }
+    bool requires_GPS() const override { return false; }
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return from_gcs; }
     bool is_autopilot() const override { return true; }


### PR DESCRIPTION
A small but important fix to Guided_NoGPS mode's arming checks.  The whole purpose of Guided_NoGPS is that it doesn't require a GPS, without this it provides no advantages over regular Guided mode.

Thanks to @jmachuca77 for finding this!