### PR TITLE
Add Autotest badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5331/badge.svg)](https://scan.coverity.com/projects/ardupilot-ardupilot)
 
+[![Autotest Status](http://autotest.ardupilot.org/autotest-badge.svg)](http://autotest.ardupilot.org/)
+
 ## The ArduPilot project is made up of: ##
 
 - ArduCopter (or APM:Copter) : [code](https://github.com/ArduPilot/ardupilot/tree/master/ArduCopter), [wiki](http://ardupilot.org/copter/index.html)

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -490,6 +490,31 @@ class TestResults(object):
         for f in glob.glob(buildlogs_path(pattern)):
             self.addimage(name, os.path.basename(f))
 
+    def generate_badge(self):
+        """
+        Gets the badge template, populates and saves the result to buildlogs
+        path.
+        """
+        passed_tests = len([t for t in self.tests if "PASSED" in t.result])
+        total_tests = len(self.tests)
+        badge_color = "#4c1" if passed_tests == total_tests else "#e05d44"
+
+        badge_text = "{0}/{1}".format(passed_tests, total_tests)
+        # Text length so it is not stretched by svg
+        text_length = len(badge_text) * 70
+
+        # Load template file
+        template_path = 'Tools/autotest/web/autotest-badge-template.svg'
+        with open(util.reltopdir(template_path), "r") as f:
+            template = f.read()
+
+        # Add our results to the template
+        badge = template.format(color=badge_color,
+                                text=badge_text,
+                                text_length=text_length)
+        with open(buildlogs_path("autotest-badge.svg"), "w") as f:
+            f.write(badge)
+
 
 def write_webresults(results_to_write):
     """Write webpage results."""
@@ -501,6 +526,7 @@ def write_webresults(results_to_write):
         f.close()
     for f in glob.glob(util.reltopdir('Tools/autotest/web/*.png')):
         shutil.copy(f, buildlogs_path(os.path.basename(f)))
+    results_to_write.generate_badge()
 
 
 def write_fullresults():

--- a/Tools/autotest/web/autotest-badge-template.svg
+++ b/Tools/autotest/web/autotest-badge-template.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="104" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="a">
+        <rect width="104" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+        <path fill="#555" d="M0 0h57v20H0z"/>
+        <path fill="{color}" d="M57 0h47v20H57z"/> 4c1
+        <path fill="url(#b)" d="M0 0h104v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+        <text x="295" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="470">Autotest</text>
+        <text x="295" y="140" transform="scale(.1)" textLength="470">Autotest</text>
+        <text x="795" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{text_length}">{text}</text>
+        <text x="795" y="140" transform="scale(.1)" textLength="{text_length}">{text}</text>
+    </g>
+</svg>

--- a/Tools/autotest/web/index.html
+++ b/Tools/autotest/web/index.html
@@ -32,6 +32,7 @@ Servers by <a href=http://www.jDrones.com/>jDrones</a>
 </div>
 
 <h2>Test Results</h2>
+<img src="autotest-badge.svg"></img>
 
 <ul id="testresults">
 ${{tests:<li>${name} - ${result} (${elapsed} seconds)</li>


### PR DESCRIPTION
This adds badges for the Autotest results in the Autotest web interface itself and to our Readme. Hopefully this improves awareness of failing tests there.

Passing:
> ![passing test](https://user-images.githubusercontent.com/4013804/52438368-3f175980-2b00-11e9-938c-8ca8525957b5.png)

Failing:
> ![failing test](https://user-images.githubusercontent.com/4013804/52438399-4fc7cf80-2b00-11e9-919b-e91a05e40109.png)

The [badge](https://img.shields.io/badge/Autotest-1\2-red.svg) is downloaded from the [shields.io](https://shields.io) website into the `buildlogs` folder and is acessible at `/autotest-badge.svg` so we can point at it from our Readme.

PS: The Readme image will be broken until the Autotest runs with these changes.

Fix #9589 