### PR TITLE
Antenna tracker: mend most things

### DIFF
--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -202,7 +202,7 @@ private:
     static const AP_Param::Info var_info[];
     static const struct LogStructure log_structure[];
 
-     // true if the compass's initial location has been set
+    // true if the compass's initial location has been set
     bool compass_init_location;
 
     // AntennaTracker.cpp
@@ -273,6 +273,9 @@ private:
     void prepare_servos();
     void set_mode(enum ControlMode mode, mode_reason_t reason);
     bool should_log(uint32_t mask);
+    bool start_command_callback(const AP_Mission::Mission_Command& cmd) { return false; }
+    void exit_mission_callback() { return; }
+    bool verify_command_callback(const AP_Mission::Mission_Command& cmd) { return false; }
 
     // tracking.cpp
     void update_vehicle_pos_estimate();
@@ -284,6 +287,11 @@ private:
     void tracking_manual_control(const mavlink_manual_control_t &msg);
     void update_armed_disarmed();
 
+    // Mission library
+    AP_Mission mission{
+            FUNCTOR_BIND_MEMBER(&Tracker::start_command_callback, bool, const AP_Mission::Mission_Command &),
+            FUNCTOR_BIND_MEMBER(&Tracker::verify_command_callback, bool, const AP_Mission::Mission_Command &),
+            FUNCTOR_BIND_MEMBER(&Tracker::exit_mission_callback, void)};
 public:
     void mavlink_delay_cb();
 };

--- a/AntennaTracker/control_auto.cpp
+++ b/AntennaTracker/control_auto.cpp
@@ -60,6 +60,12 @@ void Tracker::calc_angle_error(float pitch, float yaw, bool direction_reversed)
     convert_ef_to_bf(ef_pitch_angle_error, ef_yaw_angle_error, bf_pitch_err, bf_yaw_err);
     nav_status.angle_error_pitch = bf_pitch_err;
     nav_status.angle_error_yaw = bf_yaw_err;
+
+    // set actual and desired for logging, note we are using angles not rates
+    g.pidPitch2Srv.set_desired_rate(pitch * 0.01);
+    g.pidPitch2Srv.set_actual_rate(ahrs_pitch * 0.01);
+    g.pidYaw2Srv.set_desired_rate(yaw * 0.01);
+    g.pidYaw2Srv.set_actual_rate(ahrs_yaw_cd * 0.01);
 }
 
 void Tracker::convert_ef_to_bf(float pitch, float yaw, float& bf_pitch, float& bf_yaw)


### PR DESCRIPTION
This fixes a few of the things broken with tracker. However still some issues with the pass through telemetry. I have been connecting directly to tracker with USB. When connected to copter it will only get its location back and a few messages, however with plane it seems to get back all the information it should. When connected to plane or copter there is no GCS control of either tracker or the remote vehicle. My theory is that no messages are getting to tracker or passed on, therefore only getting back what information is streamed by default? Before any connection is made to the remote vehicle tracker behaves as it should can change modes and parameters. Would be great full for some advise on the this pass through issue. 

Anyway fixed in this PR are:
- Starting lat and long prams now work as they should, and tracker reports its location as the one it is using to track with
- Can now arm and disarm from mission planner,  I did this by removing this if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) not sure what it does, couldn't find any other uses of it in the code-base
- Mission library is constructed, this is not used but it fixes annoying failed to update home location warnings in MP, I added placeholder mission commands that all return false. 
- Added gcs pid mask to report back the pid gains for pitch and yaw as with rover. Potentially useful but untested due to being locked out of all control once the pids are used and a remote vehicle has connected. 
