### PR TITLE
Plane: call AHRS resetHeightDatum() on baro reset

### DIFF
--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -124,6 +124,7 @@ void Plane::update_home()
         }
     }
     barometer.update_calibration();
+    ahrs.resetHeightDatum();
 }
 
 void Plane::set_home_persistently(const Location &loc)


### PR DESCRIPTION
this prevents the AMSL estimate from the EKF going off badly if we
disarm at a high altitude

ping @WickedShell 