### PR TITLE
Add support for REQUEST_MESSAGE message

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -1032,6 +1032,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
              "Test MAV_CMD_SET_MESSAGE_INTERVAL",
              self.test_set_message_interval),
 
+            ("REQUEST_MESSAGE",
+             "Test MAV_CMD_REQUEST_MESSAGE",
+             self.test_request_message),
+
             ("SYSID_ENFORCE",
              "Test enforcement of SYSID_MYGCS",
              self.test_sysid_enforce),

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2306,6 +2306,9 @@ class AutoTest(ABC):
             if abs(rate - want_rate) > 2:
                 raise NotAchievedException("Did not get expected rate")
 
+            self.progress("Resetting CAMERA_FEEDBACK rate to zero")
+            self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_CAMERA_FEEDBACK, -1)
+
             non_existant_id = 145
             self.mavproxy.send("long GET_MESSAGE_INTERVAL %u\n" %
                                (non_existant_id))
@@ -2324,6 +2327,26 @@ class AutoTest(ABC):
             sr = self.sitl_streamrate()
             self.mavproxy.send("set streamrate %u\n" % sr)
             raise e
+
+    def test_request_message(self, timeout=60):
+        rate = round(self.get_message_rate("CAMERA_FEEDBACK", 10))
+        if rate != 0:
+            raise PreconditionFailedException("Receving camera feedback")
+        # temporarily use a constant in place of
+        # mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE until we have a
+        # pymavlink release:
+        self.run_cmd(512,
+                     180,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     timeout=timeout)
+        m = self.mav.recv_match(type='CAMERA_FEEDBACK', blocking=True, timeout=1)
+        if m is None:
+            raise NotAchievedException("Requested CAMERA_FEEDBACK did not arrive")
 
     def clear_mission(self):
         self.mavproxy.send("wp clear\n")

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -374,6 +374,7 @@ protected:
     MAV_RESULT handle_command_set_message_interval(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_message_interval(const mavlink_command_long_t &packet);
     bool get_ap_message_interval(ap_message id, uint16_t &interval_ms) const;
+    MAV_RESULT handle_command_request_message(const mavlink_command_long_t &packet);
 
     MAV_RESULT handle_rc_bind(const mavlink_command_long_t &packet);
     virtual MAV_RESULT handle_flight_termination(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2316,6 +2316,17 @@ MAV_RESULT GCS_MAVLINK::handle_command_set_message_interval(const mavlink_comman
     return MAV_RESULT_FAILED;
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_long_t &packet)
+{
+    const uint32_t mavlink_id = (uint32_t)packet.param1;
+    const ap_message id = mavlink_id_to_ap_message_id(mavlink_id);
+    if (id == MSG_LAST) {
+        return MAV_RESULT_FAILED;
+    }
+    send_message(id);
+    return MAV_RESULT_ACCEPTED;
+}
+
 bool GCS_MAVLINK::get_ap_message_interval(ap_message id, uint16_t &interval_ms) const
 {
     // check if it's a specially-handled message:
@@ -3655,6 +3666,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
 
     case MAV_CMD_GET_MESSAGE_INTERVAL:
         result = handle_command_get_message_interval(packet);
+        break;
+
+    case MAV_CMD_REQUEST_MESSAGE:
+        result = handle_command_request_message(packet);
         break;
 
     case MAV_CMD_DO_SET_SERVO:


### PR DESCRIPTION
Basically an alternative to requesting a message stream for a message.

This sort of message would become redundant:
```


      <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
        <description>Request autopilot capabilities</description>
        <param index="1">1: Request autopilot version</param>
        <param index="2">Reserved (all remaining params)</param>
      </entry>
      <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
        <description>Request camera information (CAMERA_INFORMATION).</description>
        <param index="1">0: No action 1: Request camera capabilities</param>
        <param index="2">Reserved (all remaining params)</param>
      </entry>
      <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
        <description>Request camera settings (CAMERA_SETTINGS).</description>
        <param index="1">0: No Action 1: Request camera settings</param>
        <param index="2">Reserved (all remaining params)</param>
      </entry>
```
