### PR TITLE
GCS_MAVLink: add support for MAV_CMD_TRAP

### DIFF
--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1459,6 +1459,18 @@ class AutoTest(ABC):
         self.set_parameter("RNGFND1_SCALING", 12.12)
         self.set_parameter("RNGFND1_PIN", 0)
 
+    def send_debug_trap(self, timeout=6000):
+        self.progress("Sending trap to autopilot")
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DEBUG_TRAP,
+                     32451, # magic number to trap
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     timeout=timeout)
+
     def arm_vehicle(self, timeout=20):
         """Arm vehicle with mavlink arm message."""
         self.progress("Arm motors with MAVLink cmd")

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -170,6 +170,9 @@ public:
      */
     virtual bool fs_init(void) { return false; }
 
+    // attempt to trap the processor, presumably to enter an attached debugger
+    virtual bool trap() const { return false; }
+
 protected:
     // we start soft_armed false, so that actuators don't send any
     // values until the vehicle code has fully started

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -6,6 +6,11 @@
 #include "Semaphores.h"
 #include "ToneAlarm_SF.h"
 
+#if !defined(__CYGWIN__) && !defined(__CYGWIN64__)
+#include <sys/types.h>
+#include <signal.h>
+#endif
+
 class HALSITL::Util : public AP_HAL::Util {
 public:
     Util(SITL_State *_sitlState) :
@@ -51,6 +56,17 @@ public:
     bool was_watchdog_reset() const override { return getenv("SITL_WATCHDOG_RESET") != nullptr; }
 
     enum safety_state safety_switch_state(void) override;
+
+    bool trap() const override {
+#if defined(__CYGWIN__) || defined(__CYGWIN64__)
+        return false;
+#else
+        if (kill(0, SIGTRAP) == -1) {
+            return false;
+        }
+        return true;
+#endif
+    }
 
 private:
     SITL_State *sitlState;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -440,6 +440,7 @@ protected:
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_do_fence_enable(const mavlink_command_long_t &packet);
+    MAV_RESULT handle_command_debug_trap(const mavlink_command_long_t &packet);
 
     void handle_optical_flow(const mavlink_message_t &msg);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3608,6 +3608,18 @@ MAV_RESULT GCS_MAVLINK::handle_command_get_home_position(const mavlink_command_l
     return MAV_RESULT_ACCEPTED;
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_debug_trap(const mavlink_command_long_t &packet)
+{
+    // magic number must be supplied to trap; you must *really* mean it.
+    if (uint32_t(packet.param1) != 32451) {
+        return MAV_RESULT_DENIED;
+    }
+    if (hal.util->trap()) {
+        return MAV_RESULT_ACCEPTED;
+    }
+    return MAV_RESULT_UNSUPPORTED;
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_do_gripper(const mavlink_command_long_t &packet)
 {
     AP_Gripper *gripper = AP::gripper();
@@ -3773,6 +3785,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
 
     case MAV_CMD_GET_HOME_POSITION:
         result = handle_command_get_home_position(packet);
+        break;
+
+    case MAV_CMD_DEBUG_TRAP:
+        result = handle_command_debug_trap(packet);
         break;
 
     case MAV_CMD_PREFLIGHT_STORAGE:


### PR DESCRIPTION
To add some background here, I was attempting to debug a named autotest which didn't fail when run stand-alone, but did fail when run with everything else.  I needed to have a breakpoint in SITL on Rover handling a MAV_COMPONENT_ARM_DISARM, but I couldn't put that breakpoint in until right before the relevant call (or I'd be there all night saying "continue".  Being able to put `self.send_trap()` into the autotest was convenient, as I could then enable my breakpoints and hit "continue".
