### PR TITLE
Tools/autotest: use frame and VehicleInfo in AutoTestQuadPlane

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -8,6 +8,7 @@ from pymavlink import mavutil
 
 from common import AutoTest
 from pysim import util
+from pysim import vehicleinfo
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
@@ -55,7 +56,9 @@ class AutoTestQuadPlane(AutoTest):
 
         self.mavproxy_logfile = self.open_mavproxy_logfile()
 
-        defaults_file = os.path.join(testdir, 'default_params/quadplane.parm')
+        vinfo = vehicleinfo.VehicleInfo()
+        defaults_file = vinfo.options["ArduPlane"]["frames"][self.frame]["default_params_filename"]
+
         self.sitl = util.start_SITL(self.binary,
                                     wipe=True,
                                     model=self.frame,


### PR DESCRIPTION
./Tools/autotest/autotest.py --frame=quadplane-tilttrivec fly.QuadPlane
now uses the dafault params specified in VehicleInfo
I think this should be correct, but a test fails:
```
AUTOTEST: Wait EKF.flags: errors=128
APM: EKF2 IMU0 is using GPS
APM: EKF2 IMU1 is using GPS
AUTOTEST: EKF Flags OK
AUTOTEST: Arm motors with MAVLink cmd
APM: PreArm: 3D Accel calibration needed
Got MAVLink msg: COMMAND_ACK {command : 400, result : 4}
AUTOTEST: ACK received: COMMAND_ACK {command : 400, result : 4}
AUTOTEST: Exception caught: Traceback (most recent call last):
  File "/home/markw/linux_git/kd0aij/ardupilot/Tools/autotest/common.py", line 1541, in run_one_test
    test_function()
  File "/home/markw/linux_git/kd0aij/ardupilot/Tools/autotest/quadplane.py", line 188, in <lambda>
    lambda: self.fly_mission(m, f))
  File "/home/markw/linux_git/kd0aij/ardupilot/Tools/autotest/quadplane.py", line 114, in fly_mission
    self.arm_vehicle()
  File "/home/markw/linux_git/kd0aij/ardupilot/Tools/autotest/common.py", line 755, in arm_vehicle
    timeout=timeout)
  File "/home/markw/linux_git/kd0aij/ardupilot/Tools/autotest/common.py", line 983, in run_cmd
    m.result))
ValueError: Expected 0 got 4
```
