### PR TITLE
Rename all singletons to unify them

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -957,7 +957,7 @@ void ToyMode::handle_message(mavlink_message_t *msg)
         AP_Notify::flags.video_recording = 1;
     } else if (strncmp(m.name, "WIFICHAN", 10) == 0) {
 #if HAL_RCINPUT_WITH_AP_RADIO
-        AP_Radio *radio = AP_Radio::instance();
+        AP_Radio *radio = AP_Radio::get_singleton();
         if (radio) {
             radio->set_wifi_channel(m.value);
         }

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -140,7 +140,7 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
     pos_control = _pos_control;
     ahrs_view = _ahrs_view;
     inertial_nav = _inertial_nav;
-    motors = AP_Motors::get_instance();
+    motors = AP_Motors::get_singleton();
 
     switch (mode) {
     case FAILED:

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -50,13 +50,13 @@ const AP_Param::GroupInfo AC_Sprayer::var_info[] = {
 
 AC_Sprayer::AC_Sprayer()
 {
-    if (_s_instance) {
+    if (_singleton) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Too many sprayers");
 #endif
         return;
     }
-    _s_instance = this;
+    _singleton = this;
 
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -74,10 +74,10 @@ AC_Sprayer::AC_Sprayer()
 /*
  * Get the AP_Sprayer singleton
  */
-AC_Sprayer *AC_Sprayer::_s_instance = nullptr;
-AC_Sprayer *AC_Sprayer::get_instance()
+AC_Sprayer *AC_Sprayer::_singleton;
+AC_Sprayer *AC_Sprayer::get_singleton()
 {
-    return _s_instance;
+    return _singleton;
 }
 
 void AC_Sprayer::run(const bool true_false)
@@ -190,7 +190,7 @@ namespace AP {
 
 AC_Sprayer *sprayer()
 {
-    return AC_Sprayer::get_instance();
+    return AC_Sprayer::get_singleton();
 }
 
 };

--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -38,8 +38,8 @@ public:
     AC_Sprayer(const AC_Sprayer &other) = delete;
     AC_Sprayer &operator=(const AC_Sprayer&) = delete;
 
-    static AC_Sprayer *get_instance();
-    static AC_Sprayer *_s_instance;
+    static AC_Sprayer *get_singleton();
+    static AC_Sprayer *_singleton;
 
     /// run - allow or disallow spraying to occur
     void run(bool true_false);

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -266,7 +266,7 @@ void AP_AutoTune::check_save(void)
  */
 void AP_AutoTune::log_param_change(float v, const char *suffix)
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (!dataflash->logging_started()) {
         return;
     }
@@ -327,7 +327,7 @@ void AP_AutoTune::save_gains(const ATGains &v)
 
 void AP_AutoTune::write_log(float servo, float demanded, float achieved)
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (!dataflash->logging_started()) {
         return;
     }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -475,7 +475,7 @@ Vector2f AP_AHRS::rotate_body_to_earth2D(const Vector2f &bf) const
 // log ahrs home and EKF origin to dataflash
 void AP_AHRS::Log_Write_Home_And_Origin()
 {
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df == nullptr) {
         return;
     }

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -457,7 +457,7 @@ void AP_Airspeed::update(bool log)
     check_sensor_failures();
 
     if (log) {
-        AP_Logger *_dataflash = AP_Logger::instance();
+        AP_Logger *_dataflash = AP_Logger::get_singleton();
         if (_dataflash != nullptr) {
             _dataflash->Write_Airspeed(*this);
         }

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -197,7 +197,7 @@ void AP_Airspeed_SDP3X::_timer()
 float AP_Airspeed_SDP3X::_correct_pressure(float press)
 {
     float temperature;
-    AP_Baro *baro = AP_Baro::get_instance();
+    AP_Baro *baro = AP_Baro::get_singleton();
 
     if (baro == nullptr) {
         return press;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -731,7 +731,7 @@ bool AP_Arming::arm_checks(ArmingMethod method)
     // the arming check flag is set - disabling the arming check
     // should not stop logging from working.
 
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df->logging_present()) {
         // If we're configured to log, prep it
         df->PrepForArming();
@@ -794,7 +794,7 @@ bool AP_Arming::disarm()
     gcs().send_text(MAV_SEVERITY_INFO, "Throttle disarmed");
 
 #if HAL_HAVE_SAFETY_SWITCH
-    AP_BoardConfig *board_cfg = AP_BoardConfig::get_instance();
+    AP_BoardConfig *board_cfg = AP_BoardConfig::get_singleton();
     if ((board_cfg != nullptr) &&
         (board_cfg->get_safety_button_options() & AP_BoardConfig::BOARD_SAFETY_OPTION_SAFETY_ON_DISARM)) {
         hal.rcout->force_safety_on();

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -118,14 +118,14 @@ const AP_Param::GroupInfo AP_BLHeli::var_info[] = {
     AP_GROUPEND
 };
 
-AP_BLHeli *AP_BLHeli::singleton;
+AP_BLHeli *AP_BLHeli::_singleton;
 
 // constructor
 AP_BLHeli::AP_BLHeli(void)
 {
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);
-    singleton = this;
+    _singleton = this;
     last_control_port = -1;
 }
 
@@ -1250,7 +1250,7 @@ void AP_BLHeli::update(void)
       plane and copter can use AP_Motors to get an automatic mask
      */
     if (channel_auto.get() == 1) {
-        AP_Motors *motors = AP_Motors::get_instance();
+        AP_Motors *motors = AP_Motors::get_singleton();
         if (motors) {
             mask |= motors->get_motor_mask();
         }
@@ -1273,7 +1273,7 @@ void AP_BLHeli::update(void)
     debug("ESC: %u motors mask=0x%04x", num_motors, mask);
 
     if (telem_rate > 0) {
-        AP_SerialManager *serial_manager = AP_SerialManager::get_instance();
+        AP_SerialManager *serial_manager = AP_SerialManager::get_singleton();
         if (serial_manager) {
             telem_uart = serial_manager->find_serial(AP_SerialManager::SerialProtocol_ESCTelemetry,0);
         }
@@ -1346,7 +1346,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     last_telem[last_telem_esc] = td;
     last_telem[last_telem_esc].count++;
 
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df && df->logging_enabled()) {
         struct log_Esc pkt = {
             LOG_PACKET_HEADER_INIT(uint8_t(LOG_ESC1_MSG+last_telem_esc)),

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -59,14 +59,14 @@ public:
     bool get_telem_data(uint8_t esc_index, struct telem_data &td);
 
     static AP_BLHeli *get_singleton(void) {
-        return singleton;
+        return _singleton;
     }
 
     // send ESC telemetry messages over MAVLink
     void send_esc_telemetry_mavlink(uint8_t mav_chan);
     
 private:
-    static AP_BLHeli *singleton;
+    static AP_BLHeli *_singleton;
     
     // mask of channels to use for BLHeli protocol
     AP_Int32 channel_mask;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -165,14 +165,14 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
 };
 
 // singleton instance
-AP_Baro *AP_Baro::_instance;
+AP_Baro *AP_Baro::_singleton;
 
 /*
   AP_Baro constructor
  */
 AP_Baro::AP_Baro()
 {
-    _instance = this;
+    _singleton = this;
 
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -707,7 +707,7 @@ void AP_Baro::_probe_i2c_barometers(void)
 
 bool AP_Baro::should_df_log() const
 {
-    AP_Logger *instance = AP_Logger::instance();
+    AP_Logger *instance = AP_Logger::get_singleton();
     if (instance == nullptr) {
         return false;
     }
@@ -841,7 +841,7 @@ namespace AP {
 
 AP_Baro &baro()
 {
-    return *AP_Baro::get_instance();
+    return *AP_Baro::get_singleton();
 }
 
 };

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -31,8 +31,8 @@ public:
     AP_Baro &operator=(const AP_Baro&) = delete;
 
     // get singleton
-    static AP_Baro *get_instance(void) {
-        return _instance;
+    static AP_Baro *get_singleton(void) {
+        return _singleton;
     }
 
     // barometer types
@@ -183,7 +183,7 @@ public:
 
 private:
     // singleton
-    static AP_Baro *_instance;
+    static AP_Baro *_singleton;
     
     // how many drivers do we have?
     uint8_t _num_drivers;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -238,7 +238,7 @@ AP_BattMonitor::read()
         }
     }
 
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df->should_log(_log_battery_bit)) {
         df->Write_Current();
         df->Write_Power();
@@ -494,7 +494,7 @@ namespace AP {
 
 AP_BattMonitor &battery()
 {
-    return AP_BattMonitor::battery();
+    return *AP_BattMonitor::get_singleton();
 }
 
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -54,8 +54,8 @@ public:
     AP_BattMonitor(const AP_BattMonitor &other) = delete;
     AP_BattMonitor &operator=(const AP_BattMonitor&) = delete;
 
-    static AP_BattMonitor &battery() {
-        return *_singleton;
+    static AP_BattMonitor *get_singleton() {
+        return _singleton;
     }
 
     struct cells {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -105,7 +105,7 @@
 #endif
 
 extern const AP_HAL::HAL& hal;
-AP_BoardConfig *AP_BoardConfig::instance;
+AP_BoardConfig *AP_BoardConfig::_singleton;
 
 // table of user settable parameters
 const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -32,7 +32,7 @@ extern "C" typedef int (*main_fn_t)(int argc, char **);
 class AP_BoardConfig {
 public:
     AP_BoardConfig() {
-        instance = this;
+        _singleton = this;
         AP_Param::setup_object_defaults(this, var_info);
     };
 
@@ -41,8 +41,8 @@ public:
     AP_BoardConfig &operator=(const AP_BoardConfig&) = delete;
 
     // singleton support
-    static AP_BoardConfig *get_instance(void) {
-        return instance;
+    static AP_BoardConfig *get_singleton(void) {
+        return _singleton;
     }
     
     void init(void);
@@ -106,7 +106,7 @@ public:
     // crc check of IO firmware on startup
     static uint8_t io_enabled(void) {
 #if AP_FEATURE_BOARD_DETECT
-        return instance?uint8_t(instance->state.io_enable.get()):0;
+        return _singleton?uint8_t(_singleton->state.io_enable.get()):0;
 #else
         return 0;
 #endif
@@ -114,7 +114,7 @@ public:
 
     // get number of PWM outputs enabled on FMU
     static uint8_t get_pwm_count(void) {
-        return instance?instance->pwm_count.get():8;
+        return _singleton?_singleton->pwm_count.get():8;
     }
 
 #if HAL_HAVE_SAFETY_SWITCH
@@ -143,25 +143,25 @@ public:
 #if HAL_HAVE_BOARD_VOLTAGE
     // get minimum board voltage
     static float get_minimum_board_voltage(void) {
-        return instance?instance->_vbus_min.get():0;
+        return _singleton?_singleton->_vbus_min.get():0;
     }
 #endif
 
 #if HAL_HAVE_SERVO_VOLTAGE
     // get minimum servo voltage
     static float get_minimum_servo_voltage(void) {
-        return instance?instance->_vservo_min.get():0;
+        return _singleton?_singleton->_vservo_min.get():0;
     }
 #endif
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     static uint8_t get_sdcard_slowdown(void) {
-        return instance?instance->_sdcard_slowdown.get():0;
+        return _singleton?_singleton->_sdcard_slowdown.get():0;
     }
 #endif
     
 private:
-    static AP_BoardConfig *instance;
+    static AP_BoardConfig *_singleton;
     
     AP_Int16 vehicleSerialNumber;
     AP_Int8 pwm_count;

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -390,7 +390,7 @@ void AP_Camera::setup_feedback_callback(void)
 // log_picture - log picture taken and send feedback to GCS
 void AP_Camera::log_picture()
 {
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df == nullptr) {
         return;
     }
@@ -437,7 +437,7 @@ void AP_Camera::update_trigger()
         _camera_trigger_logged = _camera_trigger_count;
 
         gcs().send_message(MSG_CAMERA_FEEDBACK);
-        AP_Logger *df = AP_Logger::instance();
+        AP_Logger *df = AP_Logger::get_singleton();
         if (df != nullptr) {
             if (df->should_log(log_camera_bit)) {
                 uint32_t tdiff = AP_HAL::micros() - timestamp32;

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -91,7 +91,7 @@ AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(AP_HAL::OwnPtr<AP_HAL::I2CD
     if (!dev) {
         return nullptr;
     }
-    AP_InertialSensor &ins = *AP_InertialSensor::get_instance();
+    AP_InertialSensor &ins = *AP_InertialSensor::get_singleton();
 
     /* Allow MPU9250 to shortcut auxiliary bus and host bus */
     ins.detect_backends();
@@ -102,7 +102,7 @@ AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(AP_HAL::OwnPtr<AP_HAL::I2CD
 AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(uint8_t mpu9250_instance,
                                                      enum Rotation rotation)
 {
-    AP_InertialSensor &ins = *AP_InertialSensor::get_instance();
+    AP_InertialSensor &ins = *AP_InertialSensor::get_singleton();
 
     AP_AK8963_BusDriver *bus =
         new AP_AK8963_BusDriver_Auxiliary(ins, HAL_INS_MPU9250_SPI, mpu9250_instance, AK8963_I2C_ADDR);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -130,7 +130,7 @@ AP_Compass_Backend *AP_Compass_HMC5843::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
 
 AP_Compass_Backend *AP_Compass_HMC5843::probe_mpu6000(enum Rotation rotation)
 {
-    AP_InertialSensor &ins = *AP_InertialSensor::get_instance();
+    AP_InertialSensor &ins = *AP_InertialSensor::get_singleton();
 
     AP_HMC5843_BusDriver *bus =
         new AP_HMC5843_BusDriver_Auxiliary(ins, HAL_INS_MPU60XX_SPI,

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -561,7 +561,7 @@ AP_GPS::GPS_Status AP_GPS::highest_supported_status(uint8_t instance) const
 
 bool AP_GPS::should_df_log() const
 {
-    AP_Logger *instance = AP_Logger::instance();
+    AP_Logger *instance = AP_Logger::get_singleton();
     if (instance == nullptr) {
         return false;
     }
@@ -1546,7 +1546,7 @@ namespace AP {
 
 AP_GPS &gps()
 {
-    return AP_GPS::gps();
+    return AP_GPS::get_singleton();
 }
 
 };

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -71,7 +71,7 @@ public:
     AP_GPS(const AP_GPS &other) = delete;
     AP_GPS &operator=(const AP_GPS&) = delete;
 
-    static AP_GPS &gps() {
+    static AP_GPS &get_singleton() {
         return *_singleton;
     }
 

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -70,13 +70,13 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
 
 AP_Gripper::AP_Gripper()
 {
-    if (_s_instance) {
+    if (_singleton) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Too many grippers");
 #endif
         return;
     }
-    _s_instance = this;
+    _singleton = this;
 
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -84,10 +84,10 @@ AP_Gripper::AP_Gripper()
 /*
  * Get the AP_Gripper singleton
  */
-AP_Gripper *AP_Gripper::_s_instance = nullptr;
-AP_Gripper *AP_Gripper::get_instance()
+AP_Gripper *AP_Gripper::_singleton = nullptr;
+AP_Gripper *AP_Gripper::get_singleton()
 {
-    return _s_instance;
+    return _singleton;
 }
 
 void AP_Gripper::init()
@@ -155,7 +155,7 @@ namespace AP {
 
 AP_Gripper *gripper()
 {
-    return AP_Gripper::get_instance();
+    return AP_Gripper::get_singleton();
 }
 
 };

--- a/libraries/AP_Gripper/AP_Gripper.h
+++ b/libraries/AP_Gripper/AP_Gripper.h
@@ -26,8 +26,8 @@ public:
     AP_Gripper(const AP_Gripper &other) = delete;
     AP_Gripper &operator=(const AP_Gripper&) = delete;
 
-    static AP_Gripper *get_instance();
-    static AP_Gripper *_s_instance;
+    static AP_Gripper *get_singleton();
+    static AP_Gripper *_singleton;
 
     // indicate whether this module is enabled or not
     bool enabled() const { return _enabled; }

--- a/libraries/AP_HAL_ChibiOS/CANClock.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANClock.cpp
@@ -348,7 +348,7 @@ void setUtcSyncParams(const UtcSyncParams& params)
 
 } // namespace clock
 
-SystemClock& SystemClock::instance()
+SystemClock& SystemClock::get_singleton()
 {
     static union SystemClockStorage {
         uavcan::uint8_t buffer[sizeof(SystemClock)];

--- a/libraries/AP_HAL_ChibiOS/CANClock.h
+++ b/libraries/AP_HAL_ChibiOS/CANClock.h
@@ -158,7 +158,7 @@ public:
      * Calls clock::init() as needed.
      * This function is thread safe.
      */
-    static SystemClock& instance();
+    static SystemClock& get_singleton();
 };
 
 }

--- a/libraries/AP_HAL_ChibiOS/CANSerialRouter.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANSerialRouter.cpp
@@ -26,7 +26,7 @@ extern const AP_HAL::HAL& hal;
 
 SLCANRouter &slcan_router()
 {
-    return *SLCANRouter::instance();
+    return *SLCANRouter::get_singleton();
 }
 
 void SLCANRouter::init(ChibiOS_CAN::CanIface* can_if, ChibiOS_CAN::BusEvent* update_event)
@@ -38,7 +38,7 @@ void SLCANRouter::init(ChibiOS_CAN::CanIface* can_if, ChibiOS_CAN::BusEvent* upd
 
 void SLCANRouter::run()
 {
-    _port = AP_SerialManager::get_instance()->get_serial_by_id(AP::can().get_slcan_serial());
+    _port = AP_SerialManager::get_singleton()->get_serial_by_id(AP::can().get_slcan_serial());
     if (_slcan_if.init(921600, SLCAN::CAN::OperatingMode::NormalMode, _port) < 0) {
         return;
     }

--- a/libraries/AP_HAL_ChibiOS/CANSerialRouter.h
+++ b/libraries/AP_HAL_ChibiOS/CANSerialRouter.h
@@ -67,7 +67,7 @@ public:
     void slcan2can_router_trampoline(void);
     void can2slcan_router_trampoline(void);
     void run(void);
-    static SLCANRouter* instance()
+    static SLCANRouter* get_singleton()
     {
         if (_singleton == nullptr) {
             _singleton = new SLCANRouter;

--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -66,7 +66,7 @@ bool RCInput::new_input()
 #if HAL_RCINPUT_WITH_AP_RADIO
     if (!_radio_init) {
         _radio_init = true;
-        radio = AP_Radio::instance();
+        radio = AP_Radio::get_singleton();
         if (radio) {
             radio->init();
         }

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1445,7 +1445,7 @@ void RCOutput::safety_update(void)
     }
     safety_update_ms = now;
 
-    AP_BoardConfig *boardconfig = AP_BoardConfig::get_instance();
+    AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
 
     if (boardconfig) {
         // remember mask of channels to allow with safety on

--- a/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.cpp
+++ b/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.cpp
@@ -29,11 +29,11 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 // singleton instance
-SoftSigReaderInt *SoftSigReaderInt::_instance;
+SoftSigReaderInt *SoftSigReaderInt::_singleton;
 
 SoftSigReaderInt::SoftSigReaderInt()
 {
-    _instance = this;
+    _singleton = this;
 }
 
 eicuchannel_t SoftSigReaderInt::get_pair_channel(eicuchannel_t channel)
@@ -97,7 +97,7 @@ void SoftSigReaderInt::_irq_handler(EICUDriver *eicup, eicuchannel_t aux_channel
     pulse.w0 = eicup->tim->CCR[channel];
     pulse.w1 = eicup->tim->CCR[aux_channel];
     
-    _instance->sigbuf.push(pulse);
+    _singleton->sigbuf.push(pulse);
 
     //check for missed interrupt 
     uint32_t mask = (STM32_TIM_SR_CC1OF << channel) | (STM32_TIM_SR_CC1OF << aux_channel);
@@ -106,7 +106,7 @@ void SoftSigReaderInt::_irq_handler(EICUDriver *eicup, eicuchannel_t aux_channel
         //try to reset RCProtocol parser by returning invalid value (i.e. 0 width pulse)
         pulse.w0 = 0;
         pulse.w1 = 0;
-        _instance->sigbuf.push(pulse);
+        _singleton->sigbuf.push(pulse);
         //reset overcapture mask
         eicup->tim->SR &= ~mask;
     }

--- a/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.h
+++ b/libraries/AP_HAL_ChibiOS/SoftSigReaderInt.h
@@ -35,16 +35,16 @@ public:
     SoftSigReaderInt &operator=(const SoftSigReaderInt&) = delete;
 
     // get singleton
-    static SoftSigReaderInt *get_instance(void)
+    static SoftSigReaderInt *get_singleton(void)
     {
-        return _instance;
+        return _singleton;
     }
 
     void init(EICUDriver* icu_drv, eicuchannel_t chan);
     bool read(uint32_t &widths0, uint32_t &widths1);
 private:
     // singleton
-    static SoftSigReaderInt *_instance;
+    static SoftSigReaderInt *_singleton;
 
     static void _irq_handler(EICUDriver *eicup, eicuchannel_t channel);
     

--- a/libraries/AP_HAL_Linux/Perf.cpp
+++ b/libraries/AP_HAL_Linux/Perf.cpp
@@ -35,7 +35,7 @@ using namespace Linux;
 
 static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
-Perf *Perf::_instance;
+Perf *Perf::_singleton;
 
 static inline uint64_t now_nsec()
 {
@@ -44,13 +44,13 @@ static inline uint64_t now_nsec()
     return ts.tv_nsec + (ts.tv_sec * AP_NSEC_PER_SEC);
 }
 
-Perf *Perf::get_instance()
+Perf *Perf::get_singleton()
 {
-    if (!_instance) {
-        _instance = new Perf();
+    if (!_singleton) {
+        _singleton = new Perf();
     }
 
-    return _instance;
+    return _singleton;
 }
 
 void Perf::_debug_counters()

--- a/libraries/AP_HAL_Linux/Perf.h
+++ b/libraries/AP_HAL_Linux/Perf.h
@@ -64,7 +64,7 @@ class Perf {
 public:
     ~Perf();
 
-    static Perf *get_instance();
+    static Perf *get_singleton();
 
     perf_counter_t add(perf_counter_type type, const char *name);
 
@@ -75,7 +75,7 @@ public:
     unsigned int get_update_count() { return _update_count; }
 
 private:
-    static Perf *_instance;
+    static Perf *_singleton;
 
     Perf();
 

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -75,22 +75,22 @@ public:
 
     perf_counter_t perf_alloc(enum perf_counter_type t, const char *name) override
     {
-        return Perf::get_instance()->add(t, name);
+        return Perf::get_singleton()->add(t, name);
     }
 
     void perf_begin(perf_counter_t perf) override
     {
-        return Perf::get_instance()->begin(perf);
+        return Perf::get_singleton()->begin(perf);
     }
 
     void perf_end(perf_counter_t perf) override
     {
-        return Perf::get_instance()->end(perf);
+        return Perf::get_singleton()->end(perf);
     }
 
     void perf_count(perf_counter_t perf) override
     {
-        return Perf::get_instance()->count(perf);
+        return Perf::get_singleton()->count(perf);
     }
 
     int get_hw_arm32();

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -74,8 +74,8 @@ void SITL_State::_sitl_setup(const char *home_str)
 
     // find the barometer object if it exists
     _sitl = AP::sitl();
-    _barometer = AP_Baro::get_instance();
-    _ins = AP_InertialSensor::get_instance();
+    _barometer = AP_Baro::get_singleton();
+    _ins = AP_InertialSensor::get_singleton();
     _compass = Compass::get_singleton();
 #if AP_TERRAIN_AVAILABLE
     _terrain = reinterpret_cast<AP_Terrain *>(AP_Param::find_object("TERRAIN_"));

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -59,7 +59,7 @@ void AP_IOMCU::init(void)
     // check IO firmware CRC
     hal.scheduler->delay(2000);
     
-    AP_BoardConfig *boardconfig = AP_BoardConfig::get_instance();
+    AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
     if (!boardconfig || boardconfig->io_enabled() == 1) {
         check_crc();
     } else {
@@ -304,7 +304,7 @@ void AP_IOMCU::read_status()
         last_safety_options = 0xFFFF;
 
         // also check if the safety should be definately off.
-        AP_BoardConfig *boardconfig = AP_BoardConfig::get_instance();
+        AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
         if (!boardconfig) {
             return;
         }
@@ -656,7 +656,7 @@ void AP_IOMCU::set_brushed_mode(void)
 // handling of BRD_SAFETYOPTION parameter
 void AP_IOMCU::update_safety_options(void)
 {
-    AP_BoardConfig *boardconfig = AP_BoardConfig::get_instance();
+    AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
     if (!boardconfig) {
         return;
     }

--- a/libraries/AP_IOMCU/iofirmware/rc.cpp
+++ b/libraries/AP_IOMCU/iofirmware/rc.cpp
@@ -66,7 +66,7 @@ void AP_IOMCU_FW::rcin_serial_init(void)
                                &sd3_listener,
                                EVENT_MASK(1),
                                SD_PARITY_ERROR);
-    rcprotocol = AP_RCProtocol::get_instance();
+    rcprotocol = AP_RCProtocol::get_singleton();
 
     // disable input for SBUS with pulses, we will use the UART for
     // SBUS.

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -455,16 +455,16 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     AP_GROUPEND
 };
 
-AP_InertialSensor *AP_InertialSensor::_s_instance = nullptr;
+AP_InertialSensor *AP_InertialSensor::_singleton = nullptr;
 
 AP_InertialSensor::AP_InertialSensor() :
     _board_orientation(ROTATION_NONE),
     _log_raw_bit(-1)
 {
-    if (_s_instance) {
+    if (_singleton) {
         AP_HAL::panic("Too many inertial sensors");
     }
-    _s_instance = this;
+    _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _gyro_cal_ok[i] = true;
@@ -481,12 +481,12 @@ AP_InertialSensor::AP_InertialSensor() :
 /*
  * Get the AP_InertialSensor singleton
  */
-AP_InertialSensor *AP_InertialSensor::get_instance()
+AP_InertialSensor *AP_InertialSensor::get_singleton()
 {
-    if (!_s_instance) {
-        _s_instance = new AP_InertialSensor();
+    if (!_singleton) {
+        _singleton = new AP_InertialSensor();
     }
-    return _s_instance;
+    return _singleton;
 }
 
 /*
@@ -1994,7 +1994,7 @@ namespace AP {
 
 AP_InertialSensor &ins()
 {
-    return *AP_InertialSensor::get_instance();
+    return *AP_InertialSensor::get_singleton();
 }
 
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -55,7 +55,7 @@ public:
     AP_InertialSensor(const AP_InertialSensor &other) = delete;
     AP_InertialSensor &operator=(const AP_InertialSensor&) = delete;
 
-    static AP_InertialSensor *get_instance();
+    static AP_InertialSensor *get_singleton();
 
     enum Gyro_Calibration_Timing {
         GYRO_CAL_NEVER = 0,
@@ -553,7 +553,7 @@ private:
     AP_Int8 _acc_body_aligned;
     AP_Int8 _trim_option;
 
-    static AP_InertialSensor *_s_instance;
+    static AP_InertialSensor *_singleton;
     AP_AccelCal* _acal;
 
     AccelCalibrator *_accel_calibrator;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -216,7 +216,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
 
 void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &gyro)
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash == nullptr) {
         // should not have been called
         return;
@@ -348,7 +348,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_sensor_rate_sample(uint8_t inst
 
 void AP_InertialSensor_Backend::log_accel_raw(uint8_t instance, const uint64_t sample_us, const Vector3f &accel)
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash == nullptr) {
         // should not have been called
         return;
@@ -465,7 +465,7 @@ bool AP_InertialSensor_Backend::should_log_imu_raw() const
         // tracker does not set a bit
         return false;
     }
-    const AP_Logger *instance = AP_Logger::instance();
+    const AP_Logger *instance = AP_Logger::get_singleton();
     if (instance == nullptr) {
         return false;
     }

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -176,7 +176,7 @@ void AP_InertialSensor::BatchSampler::push_data_to_log()
         // avoid flooding AP_Logger's buffer
         return;
     }
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash == nullptr) {
         // should not have been called
         return;
@@ -250,7 +250,7 @@ bool AP_InertialSensor::BatchSampler::should_log(uint8_t _instance, IMU_SENSOR_T
     if (data_write_offset >= _required_count) {
         return false;
     }
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash == nullptr) {
         return false;
     }

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -600,7 +600,7 @@ void AP_KDECAN::update()
         debug_can(2, "KDECAN: failed to get PWM semaphore on write\n\r");
     }
 
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
 
     if (df == nullptr || !df->should_log(0xFFFFFFFF)) {
         return;
@@ -658,7 +658,7 @@ bool AP_KDECAN::pre_arm_check(const char* &reason)
     _enum_sem.give();
 
     uint16_t motors_mask = 0;
-    AP_Motors *motors = AP_Motors::get_instance();
+    AP_Motors *motors = AP_Motors::get_singleton();
 
     if (motors) {
         motors_mask = motors->get_motor_mask();

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -107,7 +107,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
             
             // Check if the landing gear was deployed before landing
             // If not - go around
-            AP_LandingGear *LG_inst = AP_LandingGear::instance();
+            AP_LandingGear *LG_inst = AP_LandingGear::get_singleton();
             if (LG_inst != nullptr && !LG_inst->check_before_land()) {
                 type_slope_request_go_around();
                 gcs().send_text(MAV_SEVERITY_CRITICAL, "Landing gear was not deployed");

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -32,7 +32,7 @@ public:
     AP_LandingGear &operator=(const AP_LandingGear&) = delete;
     
     // get singleton instance
-    static AP_LandingGear *instance(void) {
+    static AP_LandingGear *get_singleton(void) {
         return _singleton;
     }
 

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -8,7 +8,7 @@
 #include "AP_Logger_MAVLink.h"
 #include <GCS_MAVLink/GCS.h>
 
-AP_Logger *AP_Logger::_instance;
+AP_Logger *AP_Logger::_singleton;
 
 extern const AP_HAL::HAL& hal;
 
@@ -79,11 +79,11 @@ AP_Logger::AP_Logger(const AP_Int32 &log_bitmask)
     : _log_bitmask(log_bitmask)
 {
     AP_Param::setup_object_defaults(this, var_info);
-    if (_instance != nullptr) {
+    if (_singleton != nullptr) {
         AP_HAL::panic("AP_Logger must be singleton");
     }
 
-    _instance = this;
+    _singleton = this;
 }
 
 void AP_Logger::Init(const struct LogStructure *structures, uint8_t num_types)
@@ -1067,7 +1067,11 @@ void AP_Logger::Write_Event(Log_Event id)
     WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
-AP_Logger &AP::logger()
+namespace AP {
+
+AP_Logger &logger()
 {
-    return *AP_Logger::instance();
+    return *AP_Logger::get_singleton();
 }
+
+};

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -123,8 +123,8 @@ public:
     AP_Logger &operator=(const AP_Logger&) = delete;
 
     // get singleton instance
-    static AP_Logger *instance(void) {
-        return _instance;
+    static AP_Logger *get_singleton(void) {
+        return _singleton;
     }
 
     // initialisation
@@ -376,7 +376,7 @@ private:
 
     void backend_starting_new_log(const AP_Logger_Backend *backend);
 
-    static AP_Logger *_instance;
+    static AP_Logger *_singleton;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     bool validate_structure(const struct LogStructure *logstructure, int16_t offset);

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -27,7 +27,7 @@
 extern const AP_HAL::HAL& hal;
 
 // singleton instance
-AP_Motors *AP_Motors::_instance;
+AP_Motors *AP_Motors::_singleton;
 
 // Constructor
 AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
@@ -38,7 +38,7 @@ AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     _spool_mode(SHUT_DOWN),
     _air_density_ratio(1.0f)
 {
-    _instance = this;
+    _singleton = this;
 
     // setup throttle filtering
     _throttle_filter.set_cutoff_frequency(0.0f);

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -64,7 +64,7 @@ public:
     AP_Motors(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 
     // singleton support
-    static AP_Motors *get_instance(void) { return _instance; }
+    static AP_Motors *get_singleton(void) { return _singleton; }
 
     // check initialisation succeeded
     bool                initialised_ok() const { return _flags.initialised_ok; }
@@ -244,5 +244,5 @@ protected:
     float               _thrust_boost_ratio;    // choice between highest and second highest motor output for output mixing (0 ~ 1). Zero is normal operation
 
 private:
-    static AP_Motors *_instance;
+    static AP_Motors *_singleton;
 };

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -118,7 +118,7 @@ void AP_Mount_SoloGimbal::handle_gimbal_report(mavlink_channel_t chan, const mav
     _gimbal.update_target(_angle_ef_target_rad);
     _gimbal.receive_feedback(chan,msg);
 
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df == nullptr) {
         return;
     }

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -383,7 +383,7 @@ void SoloGimbal::update_target(const Vector3f &newTarget)
 
 void SoloGimbal::write_logs()
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash == nullptr) {
         return;
     }

--- a/libraries/AP_Mount/SoloGimbal_Parameters.cpp
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.cpp
@@ -185,7 +185,7 @@ void SoloGimbal_Parameters::handle_param_value(const mavlink_message_t *msg)
     mavlink_param_value_t packet;
     mavlink_msg_param_value_decode(msg, &packet);
 
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash != nullptr) {
         dataflash->Write_Parameter(packet.param_id, packet.param_value);
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -611,7 +611,7 @@ bool NavEKF2::InitialiseFilter(void)
     _framesPerPrediction = uint8_t((EKF_TARGET_DT / (_frameTimeUsec * 1.0e-6) + 0.5));
 
     // see if we will be doing logging
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash != nullptr) {
         logging.enabled = dataflash->log_replay();
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -635,7 +635,7 @@ bool NavEKF3::InitialiseFilter(void)
     if (core == nullptr) {
 
         // see if we will be doing logging
-        AP_Logger *dataflash = AP_Logger::instance();
+        AP_Logger *dataflash = AP_Logger::get_singleton();
         if (dataflash != nullptr) {
             logging.enabled = dataflash->log_replay();
         }

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -36,7 +36,7 @@
 
 extern const AP_HAL::HAL& hal;
 
-AP_Notify *AP_Notify::_instance;
+AP_Notify *AP_Notify::_singleton;
 
 #define CONFIG_NOTIFY_DEVICES_MAX 6
 
@@ -154,10 +154,10 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
 AP_Notify::AP_Notify()
 {
     AP_Param::setup_object_defaults(this, var_info);
-    if (_instance != nullptr) {
+    if (_singleton != nullptr) {
         AP_HAL::panic("AP_Notify must be singleton");
     }
-    _instance = this;
+    _singleton = this;
 }
 
 // static flags, to allow for direct class update from device drivers

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -47,8 +47,8 @@ public:
     AP_Notify &operator=(const AP_Notify&) = delete;
 
     // get singleton instance
-    static AP_Notify *instance(void) {
-        return _instance;
+    static AP_Notify *get_singleton(void) {
+        return _singleton;
     }
     
     // Oreo LED Themes
@@ -154,7 +154,7 @@ public:
 
 private:
 
-    static AP_Notify *_instance;
+    static AP_Notify *_singleton;
 
     void add_backend_helper(NotifyDevice *backend);
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -252,7 +252,7 @@ void AP_OSD::stats()
     alt = -alt;
     max_alt_m = fmaxf(max_alt_m, alt);
     // maximum current
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     float amps = battery.current_amps();
     max_current_a = fmaxf(max_current_a, amps);
 }

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -433,7 +433,7 @@ void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     uint8_t pct = battery.capacity_remaining_pct();
     uint8_t p = (100 - pct) / 16.6;
     float v = battery.voltage();
@@ -442,7 +442,7 @@ void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_rssi(uint8_t x, uint8_t y)
 {
-    AP_RSSI *ap_rssi = AP_RSSI::get_instance();
+    AP_RSSI *ap_rssi = AP_RSSI::get_singleton();
     if (ap_rssi) {
         int rssiv = ap_rssi->read_receiver_rssi_uint8();
         rssiv = (rssiv * 99) / 255;
@@ -452,14 +452,14 @@ void AP_OSD_Screen::draw_rssi(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_current(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     float amps = battery.current_amps();
     backend->write(x, y, false, "%2.1f%c", (double)amps, SYM_AMP);
 }
 
 void AP_OSD_Screen::draw_fltmode(uint8_t x, uint8_t y)
 {
-    AP_Notify * notify = AP_Notify::instance();
+    AP_Notify * notify = AP_Notify::get_singleton();
     char arm;
     if (AP_Notify::flags.armed) {
         arm = SYM_ARMED;
@@ -481,7 +481,7 @@ void AP_OSD_Screen::draw_sats(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_batused(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     backend->write(x,y, false, "%4d%c", (int)battery.consumed_mah(), SYM_MAH);
 }
 
@@ -489,7 +489,7 @@ void AP_OSD_Screen::draw_batused(uint8_t x, uint8_t y)
 //Thanks to night-ghost for the approach.
 void AP_OSD_Screen::draw_message(uint8_t x, uint8_t y)
 {
-    AP_Notify * notify = AP_Notify::instance();
+    AP_Notify * notify = AP_Notify::get_singleton();
     if (notify) {
         int32_t visible_time = AP_HAL::millis() - notify->get_text_updated_millis();
         if (visible_time < osd->msgtime_s *1000) {
@@ -901,7 +901,7 @@ void  AP_OSD_Screen::draw_flightime(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_eff(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     AP_AHRS &ahrs = AP::ahrs();
     Vector2f v = ahrs.groundspeed_vector();
     float speed = u_scale(SPEED,v.length());
@@ -923,7 +923,7 @@ void AP_OSD_Screen::draw_climbeff(uint8_t x, uint8_t y)
         vspd = AP::baro().get_climb_rate();
     }
     if (vspd < 0.0) vspd = 0.0;
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     float amps = battery.current_amps();
     if (amps > 0.0) {
         backend->write(x, y, false,"%c%c%3.1f%c",SYM_PTCHUP,SYM_EFF,(double)(3.6f * u_scale(VSPEED,vspd)/amps),unit_icon);
@@ -956,7 +956,7 @@ void AP_OSD_Screen::draw_atemp(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_bat2_vlt(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     uint8_t pct2 = battery.capacity_remaining_pct(1);
     uint8_t p2 = (100 - pct2) / 16.6;
     float v2 = battery.voltage(1);
@@ -965,7 +965,7 @@ void AP_OSD_Screen::draw_bat2_vlt(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_bat2used(uint8_t x, uint8_t y)
 {
-    AP_BattMonitor &battery = AP_BattMonitor::battery();
+    AP_BattMonitor &battery = AP::battery();
     float ah = battery.consumed_mah(1) / 1000;
     if (battery.consumed_mah(1) <= 9999) {
         backend->write(x,y, false, "%4d%c", (int)battery.consumed_mah(1), SYM_MAH);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -57,7 +57,7 @@ AP_OpticalFlow_CXOF::AP_OpticalFlow_CXOF(OpticalFlow &_frontend, AP_HAL::UARTDri
 // detect the device
 AP_OpticalFlow_CXOF *AP_OpticalFlow_CXOF::detect(OpticalFlow &_frontend)
 {
-    AP_SerialManager *serial_manager = AP::serialmanager().get_instance();
+    AP_SerialManager *serial_manager = AP::serialmanager().get_singleton();
     if (serial_manager == nullptr) {
         return nullptr;
     }

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -156,7 +156,7 @@ void OpticalFlow::update_state(const OpticalFlow_state &state)
 
 void OpticalFlow::Log_Write_Optflow()
 {
-    AP_Logger *instance = AP_Logger::instance();
+    AP_Logger *instance = AP_Logger::get_singleton();
     if (instance == nullptr) {
         return;
     }

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -24,7 +24,7 @@
 #include "AP_RCProtocol_ST24.h"
 
 // singleton
-AP_RCProtocol *AP_RCProtocol::instance;
+AP_RCProtocol *AP_RCProtocol::_singleton;
 
 void AP_RCProtocol::init()
 {
@@ -45,7 +45,7 @@ AP_RCProtocol::~AP_RCProtocol()
             backend[i] = nullptr;
         }
     }
-    instance = nullptr;
+    _singleton = nullptr;
 }
 
 void AP_RCProtocol::process_pulse(uint32_t width_s0, uint32_t width_s1)

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -26,7 +26,7 @@ class AP_RCProtocol_Backend;
 class AP_RCProtocol {
 public:
     AP_RCProtocol() {
-        instance = this;
+        _singleton = this;
     }
     ~AP_RCProtocol();
 
@@ -79,8 +79,8 @@ public:
     }
     
     // access to singleton
-    static AP_RCProtocol *get_instance(void) {
-        return instance;
+    static AP_RCProtocol *get_singleton(void) {
+        return _singleton;
     }
 
 private:
@@ -93,7 +93,7 @@ private:
     bool _valid_serial_prot = false;
     uint8_t _good_frames[NONE];
 
-    static AP_RCProtocol *instance;
+    static AP_RCProtocol *_singleton;
 };
 
 #include "AP_RCProtocol_Backend.h"

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -100,10 +100,10 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] = {
 AP_RSSI::AP_RSSI()
 {       
     AP_Param::setup_object_defaults(this, var_info);
-    if (_s_instance) {
+    if (_singleton) {
         AP_HAL::panic("Too many RSSI sensors");
     }
-    _s_instance = this;
+    _singleton = this;
 }
 
 // destructor
@@ -114,9 +114,9 @@ AP_RSSI::~AP_RSSI(void)
 /*
  * Get the AP_RSSI singleton
  */
-AP_RSSI *AP_RSSI::get_instance()
+AP_RSSI *AP_RSSI::get_singleton()
 {
-    return _s_instance;
+    return _singleton;
 }
 
 // Initialize the rssi object and prepare it for use
@@ -310,13 +310,13 @@ void AP_RSSI::irq_handler(uint8_t pin, bool pin_high, uint32_t timestamp_us)
     }
 }
 
-AP_RSSI *AP_RSSI::_s_instance = nullptr;
+AP_RSSI *AP_RSSI::_singleton = nullptr;
 
 namespace AP {
 
 AP_RSSI *rssi()
 {
-    return AP_RSSI::get_instance();
+    return AP_RSSI::get_singleton();
 }
 
 };

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -38,7 +38,7 @@ public:
     // destructor
     ~AP_RSSI(void);
 
-    static AP_RSSI *get_instance();
+    static AP_RSSI *get_singleton();
 
     // Initialize the rssi object and prepare it for use
     void init();
@@ -59,7 +59,7 @@ public:
 
 private:
 
-    static AP_RSSI *_s_instance;
+    static AP_RSSI *_singleton;
 
     // RSSI parameters
     AP_Int8         rssi_type;                              // Type of RSSI being used

--- a/libraries/AP_Radio/AP_Radio.cpp
+++ b/libraries/AP_Radio/AP_Radio.cpp
@@ -140,10 +140,10 @@ AP_Radio *AP_Radio::_instance;
 AP_Radio::AP_Radio(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
-    if (_instance != nullptr) {
+    if (_singleton != nullptr) {
         AP_HAL::panic("Multiple AP_Radio declarations");
     }
-    _instance = this;
+    _singleton = this;
 }
 
 bool AP_Radio::init(void)

--- a/libraries/AP_Radio/AP_Radio.h
+++ b/libraries/AP_Radio/AP_Radio.h
@@ -86,8 +86,8 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // get singleton instance
-    static AP_Radio *instance(void) {
-        return _instance;
+    static AP_Radio *get_singleton(void) {
+        return _singleton;
     }
 
     // handle a data96 mavlink packet for fw upload
@@ -117,5 +117,5 @@ private:
     AP_Int8 auto_bind_time;
     AP_Int8 auto_bind_rssi;
     
-    static AP_Radio *_instance;
+    static AP_Radio *_singleton;
 };

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -241,7 +241,7 @@ enum {
 #define AUTOBIND_CHANNEL 12
 
 // object instance for trampoline
-AP_Radio_cypress *AP_Radio_cypress::radio_instance;
+AP_Radio_cypress *AP_Radio_cypress::radio_singleton;
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 thread_t *AP_Radio_cypress::_irq_handler_ctx;
 #endif
@@ -252,7 +252,7 @@ AP_Radio_cypress::AP_Radio_cypress(AP_Radio &_radio) :
     AP_Radio_backend(_radio)
 {
     // link to instance for irq_trampoline
-    radio_instance = this;
+    radio_singleton = this;
 }
 
 /*
@@ -1197,10 +1197,10 @@ void AP_Radio_cypress::irq_handler_thd(void *arg)
     while(true) {
         eventmask_t evt = chEvtWaitAny(ALL_EVENTS);
         if (evt & EVT_IRQ) {
-            radio_instance->irq_handler();
+            radio_singleton->irq_handler();
         }
         if (evt & EVT_TIMEOUT) {
-            radio_instance->irq_timeout();
+            radio_singleton->irq_timeout();
         }
     }
 }

--- a/libraries/AP_Radio/AP_Radio_cypress.h
+++ b/libraries/AP_Radio/AP_Radio_cypress.h
@@ -77,7 +77,7 @@ public:
     
 private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
-    static AP_Radio_cypress *radio_instance;
+    static AP_Radio_cypress *radio_singleton;
 
     void radio_init(void);
     

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -181,7 +181,7 @@ void AP_SBusOut::init() {
         sbus_frame_interval = 3700;
     }
 
-    AP_SerialManager *serial_manager = AP_SerialManager::get_instance();
+    AP_SerialManager *serial_manager = AP_SerialManager::get_singleton();
     if (!serial_manager) {
         return;
     }

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -63,13 +63,13 @@ const AP_Param::GroupInfo AP_Scheduler::var_info[] = {
 AP_Scheduler::AP_Scheduler(scheduler_fastloop_fn_t fastloop_fn) :
     _fastloop_fn(fastloop_fn)
 {
-    if (_s_instance) {
+    if (_singleton) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         AP_HAL::panic("Too many schedulers");
 #endif
         return;
     }
-    _s_instance = this;
+    _singleton = this;
 
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -85,10 +85,10 @@ AP_Scheduler::AP_Scheduler(scheduler_fastloop_fn_t fastloop_fn) :
 /*
  * Get the AP_Scheduler singleton
  */
-AP_Scheduler *AP_Scheduler::_s_instance = nullptr;
-AP_Scheduler *AP_Scheduler::get_instance()
+AP_Scheduler *AP_Scheduler::_singleton;
+AP_Scheduler *AP_Scheduler::get_singleton()
 {
-    return _s_instance;
+    return _singleton;
 }
 
 // initialise the scheduler
@@ -305,7 +305,7 @@ namespace AP {
 
 AP_Scheduler &scheduler()
 {
-    return *AP_Scheduler::get_instance();
+    return *AP_Scheduler::get_singleton();
 }
 
 };

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -62,8 +62,8 @@ public:
     AP_Scheduler(const AP_Scheduler &other) = delete;
     AP_Scheduler &operator=(const AP_Scheduler&) = delete;
 
-    static AP_Scheduler *get_instance();
-    static AP_Scheduler *_s_instance;
+    static AP_Scheduler *get_singleton();
+    static AP_Scheduler *_singleton;
 
     FUNCTOR_TYPEDEF(task_fn_t, void);
 

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -226,12 +226,12 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
 };
 
 // singleton instance
-AP_SerialManager *AP_SerialManager::_instance;
+AP_SerialManager *AP_SerialManager::_singleton;
 
 // Constructor
 AP_SerialManager::AP_SerialManager()
 {
-    _instance = this;
+    _singleton = this;
     // setup parameter defaults
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -555,7 +555,7 @@ namespace AP {
 
 AP_SerialManager &serialmanager()
 {
-    return *AP_SerialManager::get_instance();
+    return *AP_SerialManager::get_singleton();
 }
 
 }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -109,8 +109,8 @@ public:
     };
 
     // get singleton instance
-    static AP_SerialManager *get_instance(void) {
-        return _instance;
+    static AP_SerialManager *get_singleton(void) {
+        return _singleton;
     }
     
     // init_console - initialise console at default baud rate
@@ -154,7 +154,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
-    static AP_SerialManager *_instance;
+    static AP_SerialManager *_singleton;
     
     // array of uart info
     struct UARTState {

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -713,7 +713,7 @@ public:
         }
     };
 
-    static class GCS *instance() {
+    static class GCS *get_singleton() {
         return _singleton;
     }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1842,7 +1842,7 @@ void GCS_MAVLINK::send_ahrs()
 */
 void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text)
 {
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash != nullptr) {
         dataflash->Write_Message(text);
     }
@@ -1852,7 +1852,7 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
         frsky_telemetry_p->queue_message(severity, text);
     }
 
-    AP_Notify *notify = AP_Notify::instance();
+    AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
         notify->send_text(text);
     }
@@ -2481,7 +2481,7 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_long_t &pa
     // send ack before we reboot
     mavlink_msg_command_ack_send(chan, packet.command, MAV_RESULT_ACCEPTED);
     // Notify might want to blink some LEDs:
-    AP_Notify *notify = AP_Notify::instance();
+    AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
         AP_Notify::flags.firmware_update = 1;
         notify->update();
@@ -2574,7 +2574,7 @@ void GCS_MAVLINK::handle_timesync(mavlink_message_t *msg)
                         msg->sysid,
                         round_trip_time_us*0.001f);
 #endif
-        AP_Logger *df = AP_Logger::instance();
+        AP_Logger *df = AP_Logger::get_singleton();
         if (df != nullptr) {
             AP::logger().Write(
                 "TSYN",
@@ -2625,7 +2625,7 @@ void GCS_MAVLINK::send_timesync()
 
 void GCS_MAVLINK::handle_statustext(mavlink_message_t *msg)
 {
-    AP_Logger *df = AP_Logger::instance();
+    AP_Logger *df = AP_Logger::get_singleton();
     if (df == nullptr) {
         return;
     }
@@ -2757,7 +2757,7 @@ void GCS_MAVLINK::handle_data_packet(mavlink_message_t *msg)
     case 42:
     case 43: {
         // pass to AP_Radio (for firmware upload and playing test tunes)
-        AP_Radio *radio = AP_Radio::instance();
+        AP_Radio *radio = AP_Radio::get_singleton();
         if (radio != nullptr) {
             radio->handle_data_packet(chan, m);
         }
@@ -4317,5 +4317,5 @@ void GCS::passthru_timer(void)
 
 GCS &gcs()
 {
-    return *GCS::instance();
+    return *GCS::get_singleton();
 }

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -292,7 +292,7 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg)
     // save the change
     vp->save(force_save);
 
-    AP_Logger *AP_Logger = AP_Logger::instance();
+    AP_Logger *AP_Logger = AP_Logger::get_singleton();
     if (AP_Logger != nullptr) {
         AP_Logger->Write_Parameter(key, vp->cast_to_float(var_type));
     }
@@ -319,7 +319,7 @@ void GCS::send_parameter_value(const char *param_name, ap_var_type param_type, f
         }
     }
     // also log to AP_Logger
-    AP_Logger *dataflash = AP_Logger::instance();
+    AP_Logger *dataflash = AP_Logger::get_singleton();
     if (dataflash != nullptr) {
         dataflash->Write_Parameter(param_name, param_value);
     }

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -665,7 +665,7 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         break;
 
     case LANDING_GEAR: {
-        AP_LandingGear *lg = AP_LandingGear::instance();
+        AP_LandingGear *lg = AP_LandingGear::get_singleton();
         if (lg == nullptr) {
             break;
         }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -28,7 +28,7 @@ extern const AP_HAL::HAL& hal;
 
 namespace SITL {
 
-SITL *SITL::_s_instance = nullptr;
+SITL *SITL::_singleton = nullptr;
 
 // table of user settable parameters
 const AP_Param::GroupInfo SITL::var_info[] = {
@@ -254,7 +254,7 @@ namespace AP {
 
 SITL::SITL *sitl()
 {
-    return SITL::SITL::get_instance();
+    return SITL::SITL::get_singleton();
 }
 
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -65,18 +65,18 @@ public:
         mag_ofs.set(Vector3f(5, 13, -18));
         AP_Param::setup_object_defaults(this, var_info);
         AP_Param::setup_object_defaults(this, var_info2);
-        if (_s_instance != nullptr) {
+        if (_singleton != nullptr) {
             AP_HAL::panic("Too many SITL instances");
         }
-        _s_instance = this;
+        _singleton = this;
     }
 
     /* Do not allow copies */
     SITL(const SITL &other) = delete;
     SITL &operator=(const SITL&) = delete;
 
-    static SITL *_s_instance;
-    static SITL *get_instance() { return _s_instance; }
+    static SITL *_singleton;
+    static SITL *get_singleton() { return _singleton; }
 
     enum GPSType {
         GPS_TYPE_NONE  = 0,

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -471,7 +471,7 @@ private:
 
     // this static arrangement is to avoid having static objects in AP_Param tables
     static SRV_Channel *channels;
-    static SRV_Channels *instance;
+    static SRV_Channels *_singleton;
 
     // support for Volz protocol
     AP_Volz_Protocol volz;

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -153,7 +153,7 @@ void SRV_Channels::update_aux_servo_function(void)
 /// Should be called after the the servo functions have been initialized
 void SRV_Channels::enable_aux_servos()
 {
-    hal.rcout->set_default_rate(uint16_t(instance->default_rate.get()));
+    hal.rcout->set_default_rate(uint16_t(_singleton->default_rate.get()));
 
     update_aux_servo_function();
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -36,7 +36,7 @@
 extern const AP_HAL::HAL& hal;
 
 SRV_Channel *SRV_Channels::channels;
-SRV_Channels *SRV_Channels::instance;
+SRV_Channels *SRV_Channels::_singleton;
 AP_Volz_Protocol *SRV_Channels::volz_ptr;
 AP_SBusOut *SRV_Channels::sbus_ptr;
 AP_RobotisServo *SRV_Channels::robotis_ptr;
@@ -160,7 +160,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
  */
 SRV_Channels::SRV_Channels(void)
 {
-    instance = this;
+    _singleton = this;
     channels = obj_channels;
 
     // set defaults from the parameter table


### PR DESCRIPTION
This is a non-functional change to rename all usage of singletons to:
_singleton
get_singleton()

and no longer use a mixture of instance, _instance, _s_instance.

A follow-up PR after this merges is to unify how all singletons get initialized and defied in AP::