### PR TITLE
forward X11 traffic by default in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.forward_x11 = true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
I was writing up a tutorial for getting SITL running inside Vagrant and it required X11 forwarding. Could we enable this flag by default in Vagrantfile? Or will this cause bad things to happen for other people? Ideas?

https://gist.github.com/drnic/7684ce449ef5cfa965166ddd907dd36a