### PR TITLE
Header cleanups - AP_HAL::Semaphore needs WARN_IF_UNUSED

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -3,6 +3,8 @@
 #include <AP_Math/AP_Math.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_HAL/AP_HAL.h>
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <GCS_MAVLink/GCS.h>
 
 // ------------------------------
 #define CAM_DEBUG DISABLED

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -4,8 +4,6 @@
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
-#include <GCS_MAVLink/GCS_MAVLink.h>
-#include <GCS_MAVLink/GCS.h>
 #include <AP_Relay/AP_Relay.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -58,12 +58,6 @@
  #define WARN_IF_UNUSED
 #endif
 
-// use this to avoid issues between C++11 with NuttX and C++10 on
-// other platforms.
-#if !(defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
-# define constexpr const
-#endif
-
 #define NORETURN __attribute__ ((noreturn))
 
 #define ToRad(x) radians(x)	// *pi/180

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <AP_HAL/AP_HAL_Boards.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -52,6 +51,20 @@
 #ifndef FALLTHROUGH
 #  define FALLTHROUGH
 #endif
+
+#ifdef __GNUC__
+ #define WARN_IF_UNUSED __attribute__ ((warn_unused_result))
+#else
+ #define WARN_IF_UNUSED
+#endif
+
+// use this to avoid issues between C++11 with NuttX and C++10 on
+// other platforms.
+#if !(defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
+# define constexpr const
+#endif
+
+#define NORETURN __attribute__ ((noreturn))
 
 #define ToRad(x) radians(x)	// *pi/180
 #define ToDeg(x) degrees(x)	// *180/pi
@@ -124,13 +137,3 @@ template<typename s, int t> struct assert_storage_size {
   False otherwise.
 */
 bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
-
-/*
-  useful debugging macro for SITL
- */
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#include <stdio.h>
-#define SITL_printf(fmt, args ...) do { ::printf("%s(%u): " fmt, __FILE__, __LINE__, ##args); } while(0)
-#else
-#define SITL_printf(fmt, args ...)
-#endif

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -14,10 +14,11 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
-#include <GCS_MAVLink/GCS.h>
 #include "AP_Follow.h"
 #include <ctype.h>
 #include <stdio.h>
+
+#include <AP_AHRS/AP_AHRS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -18,7 +18,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AC_PID/AC_P.h>
 #include <AP_RTC/JitterCorrection.h>

--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -1,22 +1,10 @@
 #pragma once
 
+#include <AP_HAL/AP_HAL_Boards.h>
+
 /*
   macros to allow code to build on multiple platforms more easily
  */
-
-#ifdef __GNUC__
- #define WARN_IF_UNUSED __attribute__ ((warn_unused_result))
-#else
- #define WARN_IF_UNUSED
-#endif
-
-// use this to avoid issues between C++11 with NuttX and C++10 on
-// other platforms.
-#if !(defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
-# define constexpr const
-#endif
-
-#define NORETURN __attribute__ ((noreturn))
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 /*

--- a/libraries/AP_HAL/Semaphores.h
+++ b/libraries/AP_HAL/Semaphores.h
@@ -2,6 +2,8 @@
 
 #include "AP_HAL_Namespace.h"
 
+#include <AP_Common/AP_Common.h>
+
 #define HAL_SEMAPHORE_BLOCK_FOREVER 0
 
 class AP_HAL::Semaphore {

--- a/libraries/AP_HAL_Linux/GPIO_Aero.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Aero.cpp
@@ -18,8 +18,6 @@
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
 
-#include <AP_Common/AP_Common.h>
-
 #include "GPIO_Aero.h"
 
 const unsigned Linux::GPIO_Sysfs::pin_table[] = {

--- a/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
@@ -1,4 +1,4 @@
-#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
 #include "GPIO_Bebop.h"

--- a/libraries/AP_HAL_Linux/GPIO_Disco.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Disco.cpp
@@ -1,4 +1,4 @@
-#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
 

--- a/libraries/AP_HAL_Linux/GPIO_Edge.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Edge.cpp
@@ -1,4 +1,4 @@
-#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Edge.h"
 

--- a/libraries/AP_HAL_Linux/GPIO_Navio.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Navio.cpp
@@ -1,4 +1,4 @@
-#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Navio.h"
 

--- a/libraries/AP_HAL_Linux/GPIO_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Navio2.cpp
@@ -1,4 +1,4 @@
-#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Navio2.h"
 

--- a/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
@@ -22,7 +22,6 @@
  */
 #include "RCOutput_Disco.h"
 
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <stdio.h>
 

--- a/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
@@ -16,7 +16,6 @@
  */
 #include "RCOutput_Sysfs.h"
 
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 

--- a/libraries/AP_Logger/AP_Logger_SITL.cpp
+++ b/libraries/AP_Logger/AP_Logger_SITL.cpp
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <stdio.h>
 
 #define DF_PAGE_SIZE 256UL
 #define DF_PAGE_PER_SECTOR 16 // 4k sectors

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -318,7 +318,7 @@ RC_Channel::percent_input() const
 }
 
 /*
-  Return true if the channel is at trim and within the DZ
+  return true if input is within deadzone of trim
 */
 bool RC_Channel::in_trim_dz() const
 {

--- a/libraries/SITL/SIM_Sprayer.cpp
+++ b/libraries/SITL/SIM_Sprayer.cpp
@@ -20,6 +20,8 @@
 #include "AP_HAL/AP_HAL.h"
 #include "AP_Math/AP_Math.h"
 
+#include <stdio.h>
+
 using namespace SITL;
 
 // table of user settable parameters


### PR DESCRIPTION
Move attribute definitions all into AP_Common, rather than being split between two files

Remove unused SITL_printf macros

Stop AP_Common including board information

Include AP_Common.h in AP_HAL::Sempahore for WARN_IF_UNUSED; this was the cause of a circular import problem fixed by other commits in this patch.

Some small other cleanups.
