### PR TITLE
Singleton refactor

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -219,15 +219,12 @@ const AP_Param::GroupInfo AP_Airspeed::var_info[] = {
 
 AP_Airspeed::AP_Airspeed()
 {
+    SINGLETON_INIT();
+
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
         state[i].EAS2TAS = 1;
     }
     AP_Param::setup_object_defaults(this, var_info);
-
-    if (_singleton != nullptr) {
-        AP_HAL::panic("AP_Airspeed must be singleton");
-    }
-    _singleton = this;
 }
 
 void AP_Airspeed::init()
@@ -502,5 +499,10 @@ bool AP_Airspeed::all_healthy(void) const
     return true;
 }
 
-// singleton instance
+// singleton instance. Should only ever be set in the constructor.
 AP_Airspeed *AP_Airspeed::_singleton;
+namespace AP {
+    AP_Airspeed *airspeed() {
+        return AP_Airspeed::get_singleton();
+    }
+}

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -249,3 +249,7 @@ private:
 
     AP_Airspeed_Backend *sensor[AIRSPEED_MAX_SENSORS];
 };
+
+namespace AP {
+    AP_Airspeed *airspeed();
+};

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -385,7 +385,7 @@ float AP_Baro::get_external_temperature(const uint8_t instance) const
     
     // if we don't have an external temperature then try to use temperature
     // from the airspeed sensor
-    AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
+    AP_Airspeed *airspeed = AP::airspeed();
     if (airspeed != nullptr) {
         float temperature;
         if (airspeed->healthy() && airspeed->get_temperature(temperature)) {

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -136,3 +136,18 @@ bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 #else
 #define SITL_printf(fmt, args ...)
 #endif
+
+
+/*
+ * Singleton macros
+ */
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+  #define SINGLETON_INIT_FAIL_MSG()     AP_HAL::panic("%s must be singleton", __FUNCTION__);
+#else
+  #define SINGLETON_INIT_FAIL_MSG()     gcs().send_text(MAV_SEVERITY_EMERGENCY,"%s must be singleton", __FUNCTION__);
+#endif
+
+#define SINGLETON_INIT()    if (_singleton != nullptr) { \
+                                SINGLETON_INIT_FAIL_MSG(); \
+                            } \
+                            _singleton = this;


### PR DESCRIPTION
This is an example of AP_Airspeed for how we can unify the Singleton instance in the constructor. Once we agree on the method, we/I can deploy it to all other libraries.

- use a macro from AP_Common in constructor
- macro call is always first thing in the constructor
- namespace AP stuff in the header
- namespace AP stuff in the cpp
- use AP::library() instead of library::get_singleton() throughout library.
- singleton is not assigned to nullptr in header
- singleton is never set to nullptr in deconstructor
- all singleton classes should delete the copy "=" operator

downside: using AP:: instead of library:: costs 8 bytes of flash.