### PR TITLE
AP_ToshibaCAN: rpm, voltage and temp feedback

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -1348,16 +1348,13 @@ void AP_BLHeli::read_telemetry_packet(void)
 
     AP_Logger *df = AP_Logger::get_singleton();
     if (df && df->logging_enabled()) {
-        struct log_Esc pkt = {
-            LOG_PACKET_HEADER_INIT(uint8_t(LOG_ESC1_MSG+last_telem_esc)),
-            time_us     : AP_HAL::micros64(),
-            rpm         : int32_t(td.rpm*100U),
-            voltage     : td.voltage,
-            current     : td.current,
-            temperature : int16_t(td.temperature * 100U),
-            current_tot : td.consumption
-        };
-        df->WriteBlock(&pkt, sizeof(pkt));
+        df->Write_ESC(uint8_t(last_telem_esc),
+                      AP_HAL::micros64(),
+                      td.rpm*100U,
+                      td.voltage,
+                      td.current,
+                      td.temperature * 100U,
+                      td.consumption);
     }
     if (debug_level >= 2) {
         hal.console->printf("ESC[%u] T=%u V=%u C=%u con=%u RPM=%u t=%u\n",

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -627,16 +627,11 @@ void AP_KDECAN::update()
     // log ESC telemetry data
     for (uint8_t i = 0; i < _esc_max_node_id; i++) {
         if (telem_buffer[i].new_data) {
-            struct log_Esc pkt = {
-                LOG_PACKET_HEADER_INIT(uint8_t(LOG_ESC1_MSG+i)),
-                time_us     : telem_buffer[i].time,
-                rpm         : int32_t(telem_buffer[i].rpm * 60UL * 2 / num_poles * 100),
-                voltage     : telem_buffer[i].voltage,
-                current     : telem_buffer[i].current,
-                temperature : int16_t(telem_buffer[i].temp * 100U),
-                current_tot : 0
-            };
-            df->WriteBlock(&pkt, sizeof(pkt));
+            df->Write_ESC(i, telem_buffer[i].time,
+                          int32_t(telem_buffer[i].rpm * 60UL * 2 / num_poles * 100),
+                          telem_buffer[i].voltage,
+                          telem_buffer[i].current,
+                          int16_t(telem_buffer[i].temp * 100U), 0);
         }
     }
 }

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -190,7 +190,7 @@ public:
     void Write_CameraInfo(enum LogMessages msg, const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Camera(const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Trigger(const AP_AHRS &ahrs, const Location &current_loc);
-    void Write_ESC(void);
+    void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot);
     void Write_Airspeed(AP_Airspeed &airspeed);
     void Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -242,7 +242,6 @@ void AP_Logger::Write_RCOUT(void)
         chan14        : hal.rcout->read(13)
     };
     WriteBlock(&pkt, sizeof(pkt));
-    Write_ESC();
 }
 
 // Write an RSSI packet
@@ -1507,8 +1506,28 @@ bool AP_Logger_Backend::Write_Mode(uint8_t mode, uint8_t reason)
 }
 
 // Write ESC status messages
-void AP_Logger::Write_ESC(void)
+//   id starts from 0
+//   rpm is eRPM (rpm * 100)
+//   voltage is in centi-volts
+//   current is in centi-amps
+//   temperature is in centi-degrees Celsius
+//   current_tot is in centi-amp hours
+void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot)
 {
+    // sanity check id
+    if (id >= 8) {
+        return;
+    }
+    struct log_Esc pkt = {
+        LOG_PACKET_HEADER_INIT(uint8_t(LOG_ESC1_MSG+id)),
+        time_us     : time_us,
+        rpm         : rpm,
+        voltage     : voltage,
+        current     : current,
+        temperature : temperature,
+        current_tot : current_tot
+    };
+    WriteBlock(&pkt, sizeof(pkt));
 }
 
 // Write a AIRSPEED packet

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -243,7 +243,7 @@ bool AP_ToshibaCAN::write_frame(uavcan::CanFrame &out_frame, uavcan::MonotonicTi
     } while (!inout_mask.write);
 
     // send frame and return success
-    return (_can_driver->getIface(CAN_IFACE_INDEX)->send(out_frame, timeout, 0) == 1);
+    return (_can_driver->getIface(CAN_IFACE_INDEX)->send(out_frame, timeout, uavcan::CanIOFlagAbortOnError) == 1);
 }
 
 // called from SRV_Channels

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -38,6 +38,9 @@ public:
     // called from SRV_Channels
     void update();
 
+    // send ESC telemetry messages over MAVLink
+    void send_esc_telemetry_mavlink(uint8_t mav_chan);
+
 private:
 
     // loop to send output to ESCs in background thread
@@ -45,6 +48,9 @@ private:
 
     // write frame on CAN bus, returns true on success
     bool write_frame(uavcan::CanFrame &out_frame, uavcan::MonotonicTime timeout);
+
+    // read frame on CAN bus, returns true on success
+    bool read_frame(uavcan::CanFrame &recv_frame, uavcan::MonotonicTime timeout);
 
     bool _initialized;
     char _thread_name[9];
@@ -59,6 +65,19 @@ private:
     uint16_t update_count_buffered; // counter when outputs copied to buffer before before sending to ESCs
     uint16_t update_count_sent;     // counter of outputs successfully sent
     uint8_t send_stage;             // stage of sending algorithm (each stage sends one frame to ESCs)
+
+    // telemetry data (rpm, voltage)
+    HAL_Semaphore _telem_sem;
+    struct telemetry_info_t {
+        uint16_t rpm;
+        uint16_t millivolts;
+        uint16_t count;
+        bool new_data;
+    } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
+    uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
+
+    // bitmask of which escs seem to be present
+    uint16_t _esc_present_bitmask;
 
     // structure for sending motor lock command to ESC
     union motor_lock_cmd_t {
@@ -86,6 +105,38 @@ private:
             uint16_t motor3;
             uint16_t motor2;
             uint16_t motor1;
+        };
+        uint8_t data[8];
+    };
+
+    // structure for requesting data from ESC
+    union motor_request_data_cmd_t {
+        struct PACKED {
+            uint8_t motor2:4;
+            uint8_t motor1:4;
+            uint8_t motor4:4;
+            uint8_t motor3:4;
+            uint8_t motor6:4;
+            uint8_t motor5:4;
+            uint8_t motor8:4;
+            uint8_t motor7:4;
+            uint8_t motor10:4;
+            uint8_t motor9:4;
+            uint8_t motor12:4;
+            uint8_t motor11:4;
+        };
+        uint8_t data[6];
+    };
+
+    // structure for replies from ESC of data1 (rpm and voltage)
+    union motor_reply_data1_t {
+        struct PACKED {
+            uint8_t rxng:1;
+            uint8_t state:7;
+            uint16_t rpm;
+            uint16_t reserved;
+            uint16_t millivolts;
+            uint8_t position_est_error;
         };
         uint8_t data[8];
     };

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.h
@@ -71,10 +71,12 @@ private:
     struct telemetry_info_t {
         uint16_t rpm;
         uint16_t millivolts;
+        uint16_t temperature;
         uint16_t count;
         bool new_data;
     } _telemetry[TOSHIBACAN_MAX_NUM_ESCS];
     uint32_t _telemetry_req_ms;     // system time (in milliseconds) to request data from escs (updated at 10hz)
+    uint8_t _telemetry_temp_req_counter;    // counter used to trigger temp data requests from ESCs (10x slower than other telem data)
 
     // bitmask of which escs seem to be present
     uint16_t _esc_present_bitmask;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -47,6 +47,7 @@
   #if APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_ArduSub)
     #include <AP_KDECAN/AP_KDECAN.h>
   #endif
+  #include <AP_ToshibaCAN/AP_ToshibaCAN.h>
 #endif
 
 extern const AP_HAL::HAL& hal;
@@ -4125,8 +4126,15 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
                     if (ap_kdecan != nullptr) {
                         ap_kdecan->send_mavlink(uint8_t(chan));
                     }
-                    break;
 #endif
+                    break;
+                }
+                case AP_BoardConfig_CAN::Protocol_Type_ToshibaCAN: {
+                    AP_ToshibaCAN *ap_tcan = AP_ToshibaCAN::get_tcan(i);
+                    if (ap_tcan != nullptr) {
+                        ap_tcan->send_esc_telemetry_mavlink(uint8_t(chan));
+                    }
+                    break;
                 }
                 case AP_BoardConfig_CAN::Protocol_Type_UAVCAN:
                 case AP_BoardConfig_CAN::Protocol_Type_None:


### PR DESCRIPTION
This PR add support for retrieving rpm, voltage and temperature from the ESCs and then logging it to the onboard logger and also reporting it to the GCSs using the send [ESC_TELEMETRY_1_TO_4](https://mavlink.io/en/messages/ardupilotmega.html#ESC_TELEMETRY_1_TO_4) and similar mavlink messages.

This PR also implements the previously empty AP_Logger::Write_ESC() method and uses it within the AP_BLHeli and AP_KDECAN libraries.  There should be no functional changes for these two libraries.

One thing that could perhaps be done better in this PR is shortening the code we use to fill in the motor_request_data_cmd_t structures. 

This has been tested on real a Cube autopilot with two ESCs connected.  Below is a screen shot of the rpm from the two ESCs during a motor test.
![bench-test](https://user-images.githubusercontent.com/1498098/52564524-c8ec5d00-2e47-11e9-9118-e9a9b4f74555.png)
