### PR TITLE
Plane: Loiter_to_alt sing/climb rate override

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -841,6 +841,7 @@ void Plane::update_alt()
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
                                                  aerodynamic_load_factor,
+                                                 tecs_sink_climb_rate_override(),
                                                  soaring_active);
     }
 }
@@ -913,7 +914,23 @@ void Plane::disarm_if_autoland_complete()
     }
 }
 
+/*
+  the sink/climb rate override that we pass to TECS
+ */
+float Plane::tecs_sink_climb_rate_override(void)
+{
+    float rate = 0;
 
+    if (control_mode == AUTO &&
+        mission.state() == AP_Mission::MISSION_RUNNING &&
+        mission.get_current_nav_cmd().id == MAV_CMD_NAV_LOITER_TO_ALT &&
+        mission.get_current_nav_cmd().content.loiter_to_alt.rate >= 0.1)
+    {
+        return mission.get_current_nav_cmd().content.loiter_to_alt.rate;
+    }
+
+    return 0;
+}
 
 /*
   the height above field elevation that we pass to TECS

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -514,8 +514,11 @@ private:
         // turn angle for next leg of mission
         float next_turn_angle {90};
 
-        // filtered sink rate for landing
+        // filtered current sink rate for landing
         float sink_rate;
+
+        // sink-rate demand override for missions that dictate altitude changes
+        float sink_rate_demand_override;
 
         // time when we first pass min GPS speed on takeoff
         uint32_t takeoff_speed_time_ms;
@@ -904,6 +907,7 @@ private:
     void geofence_disable_and_send_error_msg(const char *errorMsg);
     void disarm_if_autoland_complete();
     float tecs_hgt_afe(void);
+    float tecs_sink_climb_rate_override(void);
     void set_nav_controller(void);
     void loiter_angle_reset(void);
     void loiter_angle_update(void);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -730,7 +730,7 @@ bool Plane::verify_loiter_to_alt(const AP_Mission::Mission_Command &cmd)
 {
     bool result = false;
 
-    update_loiter(cmd.p1);
+    update_loiter(cmd.content.loiter_to_alt.radius);
 
     // condition_value == 0 means alt has never been reached
     if (condition_value == 0) {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -771,9 +771,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
-        cmd.p1 = fabsf(packet.param2);                  // param2 is radius in meters
+        cmd.content.loiter_to_alt.radius = fabsf(packet.param2);    // radius in meters
         cmd.content.location.loiter_ccw = (packet.param2 < 0);
         cmd.content.location.loiter_xtrack = (packet.param4 > 0); // 0 to xtrack from center of waypoint, 1 to xtrack from tangent exit location
+        cmd.content.loiter_to_alt.rate = isnan(packet.param3)?0:fabsf(packet.param3);   // climb/sink rate in meters/second
         break;
 
     case MAV_CMD_NAV_SPLINE_WAYPOINT:                   // MAV ID: 82
@@ -1206,10 +1207,11 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         break;
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
-        packet.param2 = cmd.p1;                        // loiter radius(m)
+        packet.param2 = abs(cmd.content.loiter_to_alt.radius);   // loiter radius(m)
         if (cmd.content.location.loiter_ccw) {
             packet.param2 = -packet.param2;
         }
+        packet.param3 = cmd.content.loiter_to_alt.rate;     // climb/sink rate in meters/second
         packet.param4 = cmd.content.location.loiter_xtrack; // 0 to xtrack from center of waypoint, 1 to xtrack from tangent exit location
         break;
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -184,6 +184,12 @@ public:
         uint8_t relative_angle; // 0 = absolute angle, 1 = relative angle
     };
 
+    // LOITER_TO_ALT structure
+    struct PACKED Loiter_To_Alt_Command {
+        uint16_t radius;        // abs(radius) packet.param2 in meters
+        float rate;             // climb/sink rate in meters/second. If positive, it temporarily overrides the system param for both sink and climb rate
+    };
+
     // winch command structure
     struct PACKED Winch_Command {
         uint8_t num;            // winch number
@@ -250,8 +256,11 @@ public:
         // navigation delay
         Navigation_Delay_Command nav_delay;
 
-        // navigation delay
+        // NAV_SET_YAW_SPEED
         Set_Yaw_Speed set_yaw_speed;
+
+        // LOITER_TO_ALT
+        Loiter_To_Alt_Command loiter_to_alt;
 
         // do-winch
         Winch_Command winch;

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -33,6 +33,7 @@ public:
 										int16_t throttle_nudge,
                                         float hgt_afe,
 										float load_factor,
+										float sink_climb_rate_override,
                                         bool soaring_active) = 0;
 
 	// demanded throttle in percentage

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -54,6 +54,7 @@ public:
                                int16_t throttle_nudge,
                                float hgt_afe,
                                float load_factor,
+                               float sink_climb_rate_override,
                                bool soaring_active) override;
 
     // demanded throttle in percentage
@@ -139,12 +140,17 @@ private:
     // reference to const AP_Landing to access it's params
     const AP_Landing &_landing;
     
+
+    // active value for param data
+    float _maxClimbRate;
+    float _maxSinkRate;
+
     // TECS tuning parameters
     AP_Float _hgtCompFiltOmega;
     AP_Float _spdCompFiltOmega;
-    AP_Float _maxClimbRate;
+    AP_Float _maxClimbRate_param;
     AP_Float _minSinkRate;
-    AP_Float _maxSinkRate;
+    AP_Float _maxSinkRate_param;
     AP_Float _timeConst;
     AP_Float _landTimeConst;
     AP_Float _ptchDamp;
@@ -359,7 +365,7 @@ private:
     void _update_pitch(void);
 
     // Initialise states and variables
-    void _initialise_states(int32_t ptchMinCO_cd, float hgt_afe);
+    void _initialise_states(const int32_t ptchMinCO_cd, const float hgt_afe, const float sink_climb_rate_override);
 
     // Calculate specific total energy rate limits
     void _update_STE_rate_lim(void);


### PR DESCRIPTION
Plane: Loiter_to_alt sing/climb rate override. mission item param 3 to dictate both the sink and climb rate while executing this mission item. If < 0.1 then the TECS param is used. This implementation ties climb/sink to same value.

Closes https://github.com/ArduPilot/ardupilot/issues/10487