### PR TITLE
AP_HAL_SITL: read all available SITL RC input packets

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -229,13 +229,26 @@ int SITL_State::sim_fd(const char *name, const char *arg)
  */
 void SITL_State::_check_rc_input(void)
 {
-    ssize_t size;
+    uint32_t count = 0;
+    while (_read_rc_sitl_input()) {
+        count++;
+    }
+
+    if (count > 100) {
+        ::fprintf(stderr, "Read %u rc inputs\n", count);
+    }
+}
+
+bool SITL_State::_read_rc_sitl_input()
+{
     struct pwm_packet {
         uint16_t pwm[16];
     } pwm_pkt;
 
-    size = _sitl_rc_in.recv(&pwm_pkt, sizeof(pwm_pkt), 0);
+    const ssize_t size = _sitl_rc_in.recv(&pwm_pkt, sizeof(pwm_pkt), 0);
     switch (size) {
+    case -1:
+        return false;
     case 8*2:
     case 16*2: {
         // a packet giving the receiver PWM inputs
@@ -250,9 +263,12 @@ void SITL_State::_check_rc_input(void)
                 pwm_input[i] = pwm_pkt.pwm[i];
             }
         }
-        break;
+        return true;
     }
+    default:
+        AP_HAL::panic("Malformed SITL RC input (%li)", size);
     }
+    return false;
 }
 
 /*

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -133,6 +133,7 @@ private:
     void _update_airspeed(float airspeed);
     void _update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *d, uint8_t instance);
     void _check_rc_input(void);
+    bool _read_rc_sitl_input();
     void _fdm_input_local(void);
     void _output_to_flightgear(void);
     void _simulator_servos(struct sitl_input &input);


### PR DESCRIPTION
MAVProxy runs on its own clock.  While our clock is stopped for whatever
reason MAVProxy will continue to send RC input.  This patch always gives
us the most recent RC input from MAVProxy.

Also add sanity check on packet received