### PR TITLE
AP_HAL_ChibiOS: implement 'uint16_t millis16'

### DIFF
--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -159,6 +159,11 @@ uint32_t millis()
     return hrt_millis32();
 }
 
+uint16_t millis16()
+{
+    return hrt_millis32() & 0xFFFF;
+}
+
 uint64_t micros64()
 {
     return hrt_micros64();


### PR DESCRIPTION
Avoids going via millis() function.

Overrides weak symbol in main HAL.
