### PR TITLE
Move Frsky Telemetry up into GCS - the base telemetry class

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -283,6 +283,7 @@ void Rover::one_second_loop(void)
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
     AP_Notify::flags.pre_arm_gps_check = true;
     AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
+    AP_Notify::flags.flying = hal.util->get_soft_armed();
 
     // cope with changes to mavlink system ID
     mavlink_system.sysid = g.sysid_this_mav;

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -4,7 +4,7 @@
 
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 
-MAV_TYPE GCS_MAVLINK_Rover::frame_type() const
+MAV_TYPE GCS_Rover::frame_type() const
 {
     if (rover.is_boat()) {
         return MAV_TYPE_SURFACE_BOAT;
@@ -55,7 +55,7 @@ MAV_MODE GCS_MAVLINK_Rover::base_mode() const
 return (MAV_MODE)_base_mode;
 }
 
-uint32_t GCS_MAVLINK_Rover::custom_mode() const
+uint32_t GCS_Rover::custom_mode() const
 {
     return rover.control_mode->mode_number();
 }

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -298,7 +298,7 @@ uint32_t GCS_MAVLINK_Rover::telem_delay() const
     return static_cast<uint32_t>(rover.g.telem_delay);
 }
 
-bool GCS_MAVLINK_Rover::vehicle_initialised() const
+bool GCS_Rover::vehicle_initialised() const
 {
     return rover.control_mode != &rover.mode_initializing;
 }

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -47,9 +47,7 @@ private:
 
     void packetReceived(const mavlink_status_t &status, mavlink_message_t &msg) override;
 
-    MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
-    uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
 
     int16_t vfr_hud_throttle() const override;

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -28,8 +28,6 @@ protected:
 
     bool persist_streamrates() const override { return true; }
 
-    bool vehicle_initialised() const override;
-
     bool set_home_to_current_location(bool lock) override;
     bool set_home(const Location& loc, bool lock) override;
     uint64_t capabilities() const override;

--- a/APMrover2/GCS_Rover.cpp
+++ b/APMrover2/GCS_Rover.cpp
@@ -117,8 +117,4 @@ void GCS_Rover::update_sensor_status_flags(void)
         control_sensors_enabled &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
         control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
     }
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // give mask of error flags to Frsky_Telemetry
-    rover.frsky_telemetry.update_sensor_status_flags(~control_sensors_health & control_sensors_enabled & control_sensors_present);
-#endif
 }

--- a/APMrover2/GCS_Rover.cpp
+++ b/APMrover2/GCS_Rover.cpp
@@ -4,6 +4,22 @@
 
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 
+bool GCS_Rover::simple_input_active() const
+{
+    if (rover.control_mode != &rover.mode_simple) {
+        return false;
+    }
+    return (rover.g2.simple_type == ModeSimple::Simple_InitialHeading);
+}
+
+bool GCS_Rover::supersimple_input_active() const
+{
+    if (rover.control_mode != &rover.mode_simple) {
+        return false;
+    }
+    return (rover.g2.simple_type == ModeSimple::Simple_CardinalDirections);
+}
+
 // update error mask of sensors and subsystems. The mask
 // uses the MAV_SYS_STATUS_* values from mavlink. If a bit is set
 // then it indicates that the sensor or subsystem is present but

--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -17,6 +17,9 @@ public:
     // return GCS link at offset ofs
     const GCS_MAVLINK_Rover &chan(const uint8_t ofs) const override { return _chan[ofs]; };
 
+    uint32_t custom_mode() const override;
+    MAV_TYPE frame_type() const override;
+
     void update_sensor_status_flags(void) override;
 
 private:

--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -20,6 +20,8 @@ public:
     uint32_t custom_mode() const override;
     MAV_TYPE frame_type() const override;
 
+    bool vehicle_initialised() const override;
+
     void update_sensor_status_flags(void) override;
 
 private:

--- a/APMrover2/GCS_Rover.h
+++ b/APMrover2/GCS_Rover.h
@@ -24,6 +24,9 @@ public:
 
     void update_sensor_status_flags(void) override;
 
+    bool simple_input_active() const override;
+    bool supersimple_input_active() const override;
+
 private:
 
     GCS_MAVLINK_Rover _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -37,7 +37,6 @@
 #include <AP_Camera/AP_Camera.h>                    // Camera triggering
 #include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library
 #include <AP_Declination/AP_Declination.h>          // Compass declination library
-#include <AP_Frsky_Telem/AP_Frsky_Telem.h>
 #include <AP_Devo_Telem/AP_Devo_Telem.h>
 #include <AP_GPS/AP_GPS.h>                          // ArduPilot GPS library
 #include <AP_InertialSensor/AP_InertialSensor.h>    // Inertial Sensor (uncalibated IMU) Library
@@ -299,10 +298,6 @@ private:
                            FUNCTOR_BIND_MEMBER(&Rover::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry;
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     AP_DEVO_Telem devo_telemetry;
 #endif

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -37,7 +37,6 @@
 #include <AP_Camera/AP_Camera.h>                    // Camera triggering
 #include <AP_Compass/AP_Compass.h>                  // ArduPilot Mega Magnetometer Library
 #include <AP_Declination/AP_Declination.h>          // Compass declination library
-#include <AP_Devo_Telem/AP_Devo_Telem.h>
 #include <AP_GPS/AP_GPS.h>                          // ArduPilot GPS library
 #include <AP_InertialSensor/AP_InertialSensor.h>    // Inertial Sensor (uncalibated IMU) Library
 #include <AP_L1_Control/AP_L1_Control.h>
@@ -297,10 +296,6 @@ private:
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Rover::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
-
-#if DEVO_TELEM_ENABLED == ENABLED
-    AP_DEVO_Telem devo_telemetry;
-#endif
 
     // 3D Location vectors
     // Location structure defined in AP_Common

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -579,13 +579,13 @@ public:
     void update() override;
     void init_heading();
 
-private:
-
     // simple type enum used for SIMPLE_TYPE parameter
     enum simple_type {
         Simple_InitialHeading = 0,
         Simple_CardinalDirections = 1,
     };
+
+private:
 
     float _initial_heading_cd;  // vehicle heading (in centi-degrees) at moment vehicle was armed
     float _desired_heading_cd;  // latest desired heading (in centi-degrees) from pilot

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -80,10 +80,6 @@ void Rover::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-#if DEVO_TELEM_ENABLED == ENABLED
-    devo_telemetry.init();
-#endif
-
 #if OSD_ENABLED == ENABLED
     osd.init();
 #endif
@@ -255,10 +251,6 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
     // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)
     // but it should be harmless to disable the fence temporarily in these situations as well
     g2.fence.manual_recovery_start();
-
-#if DEVO_TELEM_ENABLED == ENABLED
-    devo_telemetry.update_control_mode(control_mode->mode_number());
-#endif
 
 #if CAMERA == ENABLED
     camera.set_is_auto_mode(control_mode->mode_number() == Mode::Number::AUTO);

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -80,10 +80,6 @@ void Rover::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-    // setup frsky telemetry
-#if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.init((is_boat() ? MAV_TYPE_SURFACE_BOAT : MAV_TYPE_GROUND_ROVER));
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     devo_telemetry.init();
 #endif
@@ -260,9 +256,6 @@ bool Rover::set_mode(Mode &new_mode, mode_reason_t reason)
     // but it should be harmless to disable the fence temporarily in these situations as well
     g2.fence.manual_recovery_start();
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.update_control_mode(control_mode->mode_number());
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     devo_telemetry.update_control_mode(control_mode->mode_number());
 #endif

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -121,6 +121,8 @@ void Tracker::one_second_loop()
     // need to set "likely flying" when armed to allow for compass
     // learning to run
     ahrs.set_likely_flying(hal.util->get_soft_armed());
+
+    AP_Notify::flags.flying = hal.util->get_soft_armed();
 }
 
 void Tracker::ten_hz_logging_loop()

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -12,7 +12,7 @@
  *  pattern below when adding any new messages
  */
 
-MAV_TYPE GCS_MAVLINK_Tracker::frame_type() const
+MAV_TYPE GCS_Tracker::frame_type() const
 {
     return MAV_TYPE_ANTENNA_TRACKER;
 }
@@ -60,7 +60,7 @@ MAV_MODE GCS_MAVLINK_Tracker::base_mode() const
     return (MAV_MODE)_base_mode;
 }
 
-uint32_t GCS_MAVLINK_Tracker::custom_mode() const
+uint32_t GCS_Tracker::custom_mode() const
 {
     return tracker.control_mode;
 }

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -44,9 +44,7 @@ private:
     void handle_change_alt_request(AP_Mission::Mission_Command &cmd) override;
     void send_global_position_int() override;
 
-    MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
-    uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
 
 };

--- a/AntennaTracker/GCS_Tracker.cpp
+++ b/AntennaTracker/GCS_Tracker.cpp
@@ -109,3 +109,7 @@ void GCS_Tracker::update_sensor_status_flags()
         control_sensors_health &= ~(MAV_SYS_STATUS_SENSOR_3D_GYRO | MAV_SYS_STATUS_SENSOR_3D_ACCEL);
     }
 }
+
+// avoid building/linking Devo:
+AP_DEVO_Telem::AP_DEVO_Telem() {}
+void AP_DEVO_Telem::init() {};

--- a/AntennaTracker/GCS_Tracker.h
+++ b/AntennaTracker/GCS_Tracker.h
@@ -19,6 +19,9 @@ public:
 
     void update_sensor_status_flags() override;
 
+    uint32_t custom_mode() const override;
+    MAV_TYPE frame_type() const override;
+
 private:
 
     void request_datastream_position(uint8_t sysid, uint8_t compid);

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -445,6 +445,8 @@ void Copter::one_hz_loop()
     adsb.set_is_flying(!ap.land_complete);
 #endif
 
+    AP_Notify::flags.flying = !ap.land_complete;
+
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -109,9 +109,6 @@
  # include <AC_PrecLand/AC_PrecLand.h>
  # include <AP_IRLock/AP_IRLock.h>
 #endif
-#if FRSKY_TELEM_ENABLED == ENABLED
- # include <AP_Frsky_Telem/AP_Frsky_Telem.h>
-#endif
 #if ADSB_ENABLED == ENABLED
  # include <AP_ADSB/AP_ADSB.h>
 #endif
@@ -404,10 +401,6 @@ private:
                            FUNCTOR_BIND_MEMBER(&Copter::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry;
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     AP_DEVO_Telem devo_telemetry;
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -140,10 +140,6 @@
  # include <AP_Camera/AP_Camera.h>
 #endif
 
-#if DEVO_TELEM_ENABLED == ENABLED
- #include <AP_Devo_Telem/AP_Devo_Telem.h>
-#endif
-
 #if OSD_ENABLED == ENABLED
  #include <AP_OSD/AP_OSD.h>
 #endif
@@ -400,10 +396,6 @@ private:
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Copter::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
-
-#if DEVO_TELEM_ENABLED == ENABLED
-    AP_DEVO_Telem devo_telemetry;
-#endif
 
 #if OSD_ENABLED == ENABLED
     AP_OSD osd;

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -7,6 +7,16 @@ const char* GCS_Copter::frame_string() const
     return copter.get_frame_string();
 }
 
+bool GCS_Copter::simple_input_active() const
+{
+    return copter.ap.simple_mode == 1;
+}
+
+bool GCS_Copter::supersimple_input_active() const
+{
+    return copter.ap.simple_mode == 2;
+}
+
 // update error mask of sensors and subsystems. The mask
 // uses the MAV_SYS_STATUS_* values from mavlink. If a bit is set
 // then it indicates that the sensor or subsystem is present but

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -2,6 +2,11 @@
 
 #include "Copter.h"
 
+const char* GCS_Copter::frame_string() const
+{
+    return copter.get_frame_string();
+}
+
 // update error mask of sensors and subsystems. The mask
 // uses the MAV_SYS_STATUS_* values from mavlink. If a bit is set
 // then it indicates that the sensor or subsystem is present but
@@ -219,10 +224,5 @@ void GCS_Copter::update_sensor_status_flags(void)
     if (copter.fence.sys_status_failed()) {
         control_sensors_health &= ~MAV_SYS_STATUS_GEOFENCE;
     }
-#endif
-
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // give mask of error flags to Frsky_Telemetry
-    copter.frsky_telemetry.update_sensor_status_flags(~control_sensors_health & control_sensors_enabled & control_sensors_present);
 #endif
 }

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -29,6 +29,9 @@ public:
 
     bool vehicle_initialised() const override;
 
+    bool simple_input_active() const override;
+    bool supersimple_input_active() const override;
+
 private:
 
     GCS_MAVLINK_Copter _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -22,6 +22,11 @@ public:
 
     void update_sensor_status_flags(void) override;
 
+    uint32_t custom_mode() const override;
+    MAV_TYPE frame_type() const override;
+
+    const char* frame_string() const override;
+
 private:
 
     GCS_MAVLINK_Copter _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/ArduCopter/GCS_Copter.h
+++ b/ArduCopter/GCS_Copter.h
@@ -27,6 +27,8 @@ public:
 
     const char* frame_string() const override;
 
+    bool vehicle_initialised() const override;
+
 private:
 
     GCS_MAVLINK_Copter _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -223,7 +223,7 @@ uint32_t GCS_MAVLINK_Copter::telem_delay() const
     return (uint32_t)(copter.g.telem_delay);
 }
 
-bool GCS_MAVLINK_Copter::vehicle_initialised() const {
+bool GCS_Copter::vehicle_initialised() const {
     return copter.ap.initialised;
 }
 

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -18,7 +18,7 @@ void Copter::gcs_send_heartbeat(void)
  *  pattern below when adding any new messages
  */
 
-MAV_TYPE GCS_MAVLINK_Copter::frame_type() const
+MAV_TYPE GCS_Copter::frame_type() const
 {
     return copter.get_frame_mav_type();
 }
@@ -73,11 +73,10 @@ MAV_MODE GCS_MAVLINK_Copter::base_mode() const
     return (MAV_MODE)_base_mode;
 }
 
-uint32_t GCS_MAVLINK_Copter::custom_mode() const
+uint32_t GCS_Copter::custom_mode() const
 {
     return copter.control_mode;
 }
-
 
 MAV_STATE GCS_MAVLINK_Copter::system_status() const
 {

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -59,9 +59,7 @@ private:
     void packetReceived(const mavlink_status_t &status,
                         mavlink_message_t &msg) override;
 
-    MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
-    uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
 
     int16_t vfr_hud_throttle() const override;

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -54,8 +54,6 @@ private:
     void handle_rc_channels_override(const mavlink_message_t *msg) override;
     bool try_send_message(enum ap_message id) override;
 
-    bool vehicle_initialised() const override;
-
     void packetReceived(const mavlink_status_t &status,
                         mavlink_message_t &msg) override;
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -234,9 +234,6 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     fence.manual_recovery_start();
 #endif
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.update_control_mode(control_mode);
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     devo_telemetry.update_control_mode(control_mode);
 #endif

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -234,10 +234,6 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     fence.manual_recovery_start();
 #endif
 
-#if DEVO_TELEM_ENABLED == ENABLED
-    devo_telemetry.update_control_mode(control_mode);
-#endif
-
 #if CAMERA == ENABLED
     camera.set_is_auto_mode(control_mode == AUTO);
 #endif

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -87,11 +87,6 @@ void Copter::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-#if DEVO_TELEM_ENABLED == ENABLED
-    // setup devo
-    devo_telemetry.init();
-#endif
-
 #if OSD_ENABLED == ENABLED
     osd.init();
 #endif

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -87,13 +87,6 @@ void Copter::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // setup frsky, and pass a number of parameters to the library
-    frsky_telemetry.init(get_frame_mav_type(),
-                         &ap.value);
-    frsky_telemetry.set_frame_string(get_frame_string());
-#endif
-
 #if DEVO_TELEM_ENABLED == ENABLED
     // setup devo
     devo_telemetry.init();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2,7 +2,7 @@
 
 #include "Plane.h"
 
-MAV_TYPE GCS_MAVLINK_Plane::frame_type() const
+MAV_TYPE GCS_Plane::frame_type() const
 {
     return plane.quadplane.get_mav_type();
 }
@@ -87,7 +87,7 @@ MAV_MODE GCS_MAVLINK_Plane::base_mode() const
     return (MAV_MODE)_base_mode;
 }
 
-uint32_t GCS_MAVLINK_Plane::custom_mode() const
+uint32_t GCS_Plane::custom_mode() const
 {
     return plane.control_mode;
 }

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -55,9 +55,7 @@ private:
     bool try_send_message(enum ap_message id) override;
     void packetReceived(const mavlink_status_t &status, mavlink_message_t &msg) override;
 
-    MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
-    uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
 
     uint8_t radio_in_rssi() const;

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -218,9 +218,4 @@ void GCS_Plane::update_sensor_status_flags(void)
     if (!plane.battery.healthy() || plane.battery.has_failsafed()) {
         control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_BATTERY;
     }
-
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // give mask of error flags to Frsky_Telemetry
-    plane.frsky_telemetry.update_sensor_status_flags(~control_sensors_health & control_sensors_enabled & control_sensors_present);
-#endif
 }

--- a/ArduPlane/GCS_Plane.h
+++ b/ArduPlane/GCS_Plane.h
@@ -23,6 +23,8 @@ public:
 protected:
 
     void update_sensor_status_flags(void) override;
+    uint32_t custom_mode() const override;
+    MAV_TYPE frame_type() const override;
 
 private:
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -405,10 +405,6 @@ private:
                            FUNCTOR_BIND_MEMBER(&Plane::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // FrSky telemetry support
-    AP_Frsky_Telem frsky_telemetry;
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     // DEVO-M telemetry support
     AP_DEVO_Telem devo_telemetry;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -81,7 +81,6 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_BoardConfig/AP_BoardConfig_CAN.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
-#include <AP_Devo_Telem/AP_Devo_Telem.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
@@ -404,11 +403,6 @@ private:
     AP_BattMonitor battery{MASK_LOG_CURRENT,
                            FUNCTOR_BIND_MEMBER(&Plane::handle_battery_failsafe, void, const char*, const int8_t),
                            _failsafe_priorities};
-
-#if DEVO_TELEM_ENABLED == ENABLED
-    // DEVO-M telemetry support
-    AP_DEVO_Telem devo_telemetry;
-#endif
 
     // Airspeed Sensors
     AP_Airspeed airspeed;

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -155,9 +155,6 @@ void Plane::update_is_flying_5Hz(void)
     }
     previous_is_flying = new_is_flying;
     adsb.set_is_flying(new_is_flying);
-#if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.set_is_flying(new_is_flying);
-#endif
 #if STATS_ENABLED == ENABLED
     g2.stats.set_flying(new_is_flying);
 #endif

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -161,6 +161,7 @@ void Plane::update_is_flying_5Hz(void)
 #if STATS_ENABLED == ENABLED
     g2.stats.set_flying(new_is_flying);
 #endif
+    AP_Notify::flags.flying = new_is_flying;
 
     crash_detection_update();
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -138,7 +138,9 @@ public:
         int16_t  climb_rate;
         float    throttle_mix;
     };
-        
+
+    MAV_TYPE get_mav_type(void) const;
+
 private:
     AP_AHRS_NavEKF &ahrs;
     AP_Vehicle::MultiCopter aparm;
@@ -296,7 +298,6 @@ private:
 
     // HEARTBEAT mav_type override
     AP_Int8 mav_type;
-    MAV_TYPE get_mav_type(void) const;
     
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -96,11 +96,6 @@ void Plane::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-    // setup frsky
-#if FRSKY_TELEM_ENABLED == ENABLED
-    // setup frsky, and pass a number of parameters to the library
-    frsky_telemetry.init(MAV_TYPE_FIXED_WING);
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     devo_telemetry.init();
 #endif
@@ -308,9 +303,6 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
 
-#if FRSKY_TELEM_ENABLED == ENABLED
-    frsky_telemetry.update_control_mode(control_mode);
-#endif
 #if DEVO_TELEM_ENABLED == ENABLED
     devo_telemetry.update_control_mode(control_mode);
 #endif

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -96,10 +96,6 @@ void Plane::init_ardupilot()
     // setup telem slots with serial ports
     gcs().setup_uarts(serial_manager);
 
-#if DEVO_TELEM_ENABLED == ENABLED
-    devo_telemetry.init();
-#endif
-
 #if OSD_ENABLED == ENABLED
     osd.init();
 #endif
@@ -302,10 +298,6 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     control_mode = mode;
     previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
-
-#if DEVO_TELEM_ENABLED == ENABLED
-    devo_telemetry.update_control_mode(control_mode);
-#endif
 
 #if CAMERA == ENABLED
     camera.set_is_auto_mode(control_mode == AUTO);

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -266,6 +266,7 @@ void Sub::one_hz_loop()
     ap.pre_arm_check = arm_check;
     AP_Notify::flags.pre_arm_check = arm_check;
     AP_Notify::flags.pre_arm_gps_check = position_ok();
+    AP_Notify::flags.flying = motors.armed();
 
     if (should_log(MASK_LOG_ANY)) {
         Log_Write_Data(DATA_AP_STATE, ap.value);

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -232,7 +232,7 @@ uint8_t GCS_MAVLINK_Sub::sysid_my_gcs() const
     return sub.g.sysid_my_gcs;
 }
 
-bool GCS_MAVLINK_Sub::vehicle_initialised() const {
+bool GCS_Sub::vehicle_initialised() const {
     return sub.ap.initialised;
 }
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -17,7 +17,7 @@ void Sub::gcs_send_heartbeat()
  *  pattern below when adding any new messages
  */
 
-MAV_TYPE GCS_MAVLINK_Sub::frame_type() const
+MAV_TYPE GCS_Sub::frame_type() const
 {
     return MAV_TYPE_SUBMARINE;
 }
@@ -62,7 +62,7 @@ MAV_MODE GCS_MAVLINK_Sub::base_mode() const
     return (MAV_MODE)_base_mode;
 }
 
-uint32_t GCS_MAVLINK_Sub::custom_mode() const
+uint32_t GCS_Sub::custom_mode() const
 {
     return sub.control_mode;
 }

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -30,8 +30,6 @@ protected:
     int32_t global_position_int_alt() const override;
     int32_t global_position_int_relative_alt() const override;
 
-    bool vehicle_initialised() const override;
-
     bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
     bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -50,9 +50,7 @@ private:
 
     bool send_info(void);
 
-    MAV_TYPE frame_type() const override;
     MAV_MODE base_mode() const override;
-    uint32_t custom_mode() const override;
     MAV_STATE system_status() const override;
 
     int16_t vfr_hud_throttle() const override;

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -132,3 +132,6 @@ void GCS_Sub::update_sensor_status_flags()
     }
 }
 
+// avoid building/linking Devo:
+AP_DEVO_Telem::AP_DEVO_Telem() {}
+void AP_DEVO_Telem::init() {};

--- a/ArduSub/GCS_Sub.h
+++ b/ArduSub/GCS_Sub.h
@@ -22,6 +22,9 @@ public:
 
     void update_sensor_status_flags() override;
 
+    uint32_t custom_mode() const override;
+    MAV_TYPE frame_type() const override;
+
 private:
 
     GCS_MAVLINK_Sub _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/ArduSub/GCS_Sub.h
+++ b/ArduSub/GCS_Sub.h
@@ -25,6 +25,8 @@ public:
     uint32_t custom_mode() const override;
     MAV_TYPE frame_type() const override;
 
+    bool vehicle_initialised() const override;
+
 private:
 
     GCS_MAVLINK_Sub _chan[MAVLINK_COMM_NUM_BUFFERS];

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -968,4 +968,8 @@ void AP_Camera::control(float, float, float, float, float, float) {}
 void AP_Camera::configure(float, float, float, float, float, float, float) {}
 bool AP_AdvancedFailsafe::gcs_terminate(bool should_terminate, const char *reason) { return false; }
 
+// avoid building/linking Devo:
+AP_DEVO_Telem::AP_DEVO_Telem() {}
+void AP_DEVO_Telem::init() {};
+
 AP_HAL_MAIN_CALLBACKS(&replay);

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -29,6 +29,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -76,7 +77,7 @@ uint32_t AP_DEVO_Telem::gpsDdToDmsFormat(float ddm)
 
 #define DEVO_SPEED_FACTOR 0.0194384f
 
-void AP_DEVO_Telem::send_frames(uint8_t control_mode)
+void AP_DEVO_Telem::send_frames()
 {
     // return immediately if not initialised
     if (_port == nullptr) {
@@ -109,7 +110,7 @@ void AP_DEVO_Telem::send_frames(uint8_t control_mode)
 
 
     devoPacket.volt = roundf(AP::battery().voltage() * 10.0f);
-    devoPacket.temp = control_mode; // Send mode as temperature
+    devoPacket.temp = gcs().custom_mode(); // Send mode as temperature
 
     devoPacket.checksum8 = 0; // Init Checksum with zero Byte
 
@@ -127,6 +128,6 @@ void AP_DEVO_Telem::tick(void)
 
     if (now - _last_frame_ms > 1000) {
         _last_frame_ms = now;
-        send_frames(_control_mode);
+        send_frames();
     }
 }

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.h
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.h
@@ -29,13 +29,6 @@ public:
 
     void init();
 
-    // update flight control mode. The control mode is vehicle type specific
-    void update_control_mode(uint8_t mode)
-    {
-        _control_mode = mode;
-    }
-
-
 private:
     typedef struct PACKED {
         uint8_t header;                                ///< 0xAA for a valid packet
@@ -54,11 +47,9 @@ private:
     void tick(void);
 
     // send_frames - sends updates down telemetry link
-    void send_frames(uint8_t control_mode);
+    void send_frames();
 
     DevoMPacket devoPacket;
-
-    uint8_t _control_mode;
 
     AP_HAL::UARTDriver *_port;              // UART used to send data to receiver
     uint32_t _last_frame_ms;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -50,6 +50,7 @@ void AP_Frsky_Telem::init(const uint32_t *ap_valuep)
         _protocol = AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough; // FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
         // make frsky_telemetry available to GCS_MAVLINK (used to queue statustext messages from GCS_MAVLINK)
         // add firmware and frame info to message queue
+        const char* _frame_string = gcs().frame_string();
         if (_frame_string == nullptr) {
             queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
         } else {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -703,7 +703,7 @@ uint32_t AP_Frsky_Telem::calc_ap_status(void)
     // simple/super simple modes flags
     ap_status |= (uint8_t)((*_ap.valuep) & AP_SSIMPLE_FLAGS)<<AP_SSIMPLE_OFFSET;
     // is_flying flag
-    ap_status |= (uint8_t)(((*_ap.valuep) & AP_LANDCOMPLETE_FLAG) ^ AP_LANDCOMPLETE_FLAG);
+    ap_status |= (uint8_t)(AP_Notify::flags.flying) << AP_FLYING_OFFSET;
     // armed flag
     ap_status |= (uint8_t)(AP_Notify::flags.armed)<<AP_ARMED_OFFSET;
     // battery failsafe flag

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -37,8 +37,7 @@ ObjectArray<mavlink_statustext_t> AP_Frsky_Telem::_statustext_queue(FRSKY_TELEM_
 /*
  * init - perform required initialisation
  */
-void AP_Frsky_Telem::init(const uint8_t mav_type,
-                          const uint32_t *ap_valuep)
+void AP_Frsky_Telem::init(const uint32_t *ap_valuep)
 {
     const AP_SerialManager &serial_manager = AP::serialmanager();
 
@@ -50,7 +49,6 @@ void AP_Frsky_Telem::init(const uint8_t mav_type,
     } else if ((_port = serial_manager.find_serial(AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough, 0))) {
         _protocol = AP_SerialManager::SerialProtocol_FrSky_SPort_Passthrough; // FrSky SPort and SPort Passthrough (OpenTX) protocols (X-receivers)
         // make frsky_telemetry available to GCS_MAVLINK (used to queue statustext messages from GCS_MAVLINK)
-        gcs().register_frsky_telemetry_callback(this);
         // add firmware and frame info to message queue
         if (_frame_string == nullptr) {
             queue_message(MAV_SEVERITY_INFO, AP::fwversion().fw_string);
@@ -60,7 +58,6 @@ void AP_Frsky_Telem::init(const uint8_t mav_type,
             queue_message(MAV_SEVERITY_INFO, firmware_buf);
         }
         // save main parameters locally
-        _params.mav_type = mav_type; // frame type (see MAV_TYPE in Mavlink definition file common.h)
         if (ap_valuep == nullptr) { // ap bit-field
             _ap.value = 0x2000; // set "initialised" to 1 for rover and plane
             _ap.valuep = &_ap.value;
@@ -271,7 +268,7 @@ void AP_Frsky_Telem::send_SPort(void)
                             send_uint32(DATA_ID_TEMP2, (uint16_t)(AP::gps().num_sats() * 10 + AP::gps().status())); // send GPS status and number of satellites as num_sats*10 + status (to fit into a uint8_t)
                             break;
                         case 1:
-                            send_uint32(DATA_ID_TEMP1, _ap.control_mode); // send flight mode
+                            send_uint32(DATA_ID_TEMP1, gcs().custom_mode()); // send flight mode
                             break;
                     }
                     if (_SPort.various_call++ > 1) _SPort.various_call = 0;
@@ -298,7 +295,7 @@ void AP_Frsky_Telem::send_D(void)
     if (now - _D.last_200ms_frame >= 200) {
         _D.last_200ms_frame = now;
         send_uint16(DATA_ID_TEMP2, (uint16_t)(AP::gps().num_sats() * 10 + AP::gps().status())); // send GPS status and number of satellites as num_sats*10 + status (to fit into a uint8_t)
-        send_uint16(DATA_ID_TEMP1, _ap.control_mode); // send flight mode
+        send_uint16(DATA_ID_TEMP1, gcs().custom_mode()); // send flight mode
         send_uint16(DATA_ID_FUEL, (uint16_t)roundf(_battery.capacity_remaining_pct())); // send battery remaining
         send_uint16(DATA_ID_VFAS, (uint16_t)roundf(_battery.voltage() * 10.0f)); // send battery voltage
         send_uint16(DATA_ID_CURRENT, (uint16_t)roundf(_battery.current_amps() * 10.0f)); // send current consumption
@@ -499,42 +496,44 @@ void AP_Frsky_Telem::check_sensor_status_flags(void)
 {
     uint32_t now = AP_HAL::millis();
 
+    const uint32_t _sensor_status_flags = sensor_status_flags();
+
     if ((now - check_sensor_status_timer) >= 5000) { // prevent repeating any system_status messages unless 5 seconds have passed
         // only one error is reported at a time (in order of preference). Same setup and displayed messages as Mission Planner.
-        if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_GPS) > 0) {
+        if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_GPS) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad GPS Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_GYRO) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_GYRO) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad Gyro Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_ACCEL) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_ACCEL) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad Accel Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_MAG) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_3D_MAG) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad Compass Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad Baro Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_LASER_POSITION) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_LASER_POSITION) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad LiDAR Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad OptFlow Health");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_TERRAIN) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_TERRAIN) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad or No Terrain Data");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_GEOFENCE) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_GEOFENCE) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Geofence Breach");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_AHRS) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_AHRS) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad AHRS");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_SENSOR_RC_RECEIVER) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_SENSOR_RC_RECEIVER) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "No RC Receiver");
             check_sensor_status_timer = now;
-        } else if ((_ap.sensor_status_flags & MAV_SYS_STATUS_LOGGING) > 0) {
+        } else if ((_sensor_status_flags & MAV_SYS_STATUS_LOGGING) > 0) {
             queue_message(MAV_SEVERITY_CRITICAL, "Bad Logging");
             check_sensor_status_timer = now;
         }
@@ -598,7 +597,7 @@ uint32_t AP_Frsky_Telem::calc_param(void)
     _paramID++;
     switch(_paramID) {
     case 1:
-        param = _params.mav_type; // frame type (see MAV_TYPE in Mavlink definition file common.h)
+        param = gcs().frame_type(); // see MAV_TYPE in Mavlink definition file common.h
         break;
     case 2: // was used to send the battery failsafe voltage
     case 3: // was used to send the battery failsafe capacity in mAh
@@ -699,7 +698,7 @@ uint32_t AP_Frsky_Telem::calc_ap_status(void)
     uint8_t imu_temp = (uint8_t) roundf(constrain_float(AP::ins().get_temperature(0), AP_IMU_TEMP_MIN, AP_IMU_TEMP_MAX) - AP_IMU_TEMP_MIN);
 
     // control/flight mode number (limit to 31 (0x1F) since the value is stored on 5 bits)
-    ap_status = (uint8_t)((_ap.control_mode+1) & AP_CONTROL_MODE_LIMIT);
+    ap_status = (uint8_t)((gcs().custom_mode()+1) & AP_CONTROL_MODE_LIMIT);
     // simple/super simple modes flags
     ap_status |= (uint8_t)((*_ap.valuep) & AP_SSIMPLE_FLAGS)<<AP_SSIMPLE_OFFSET;
     // is_flying flag
@@ -932,4 +931,14 @@ void AP_Frsky_Telem::calc_gps_position(void)
         _gps.speed_in_meter = 0;
         _gps.speed_in_centimeter = 0;
     }
+}
+
+uint32_t AP_Frsky_Telem::sensor_status_flags() const
+{
+    uint32_t present;
+    uint32_t enabled;
+    uint32_t health;
+    gcs().get_sensor_status_flags(present, enabled, health);
+
+    return ~health & enabled & present;
 }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -85,9 +85,8 @@ for FrSky SPort Passthrough
 #define BATT_TOTALMAH_OFFSET        17
 // for autopilot status data
 #define AP_CONTROL_MODE_LIMIT       0x1F
-#define AP_SSIMPLE_FLAGS            0x6
+#define AP_SIMPLE_OFFSET            3
 #define AP_SSIMPLE_OFFSET           4
-#define AP_INITIALIZED_FLAG         0x2000
 #define AP_FLYING_OFFSET            6
 #define AP_ARMED_OFFSET             8
 #define AP_BATT_FS_OFFSET           9
@@ -120,7 +119,7 @@ public:
     AP_Frsky_Telem &operator=(const AP_Frsky_Telem&) = delete;
 
     // init - perform required initialisation
-    void init(const uint32_t *ap_valuep = nullptr);
+    void init();
 
     // add statustext message to FrSky lib message queue
     void queue_message(MAV_SEVERITY severity, const char *text);
@@ -138,12 +137,6 @@ private:
     AP_SerialManager::SerialProtocol _protocol; // protocol used - detected using SerialManager's SERIAL#_PROTOCOL parameter
     bool _initialised_uart;
     uint16_t _crc;
-
-    struct
-    {
-        uint32_t value;
-        const uint32_t *valuep;
-    } _ap;
 
     uint32_t check_sensor_status_timer;
     uint32_t check_ekf_status_timer;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -120,14 +120,10 @@ public:
     AP_Frsky_Telem &operator=(const AP_Frsky_Telem&) = delete;
 
     // init - perform required initialisation
-    void init(const uint8_t mav_type,
-              const uint32_t *ap_valuep = nullptr);
+    void init(const uint32_t *ap_valuep = nullptr);
 
     // add statustext message to FrSky lib message queue
     void queue_message(MAV_SEVERITY severity, const char *text);
-
-    // update flight control mode. The control mode is vehicle type specific
-    void update_control_mode(uint8_t mode) { _ap.control_mode = mode; }
 
     // update whether we're flying (used for Plane)
     // set land_complete flag to 0 if is_flying
@@ -138,7 +134,7 @@ public:
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
-    void update_sensor_status_flags(uint32_t error_mask) { _ap.sensor_status_flags = error_mask; }
+    uint32_t sensor_status_flags() const;
 
     static ObjectArray<mavlink_statustext_t> _statustext_queue;
 
@@ -154,15 +150,8 @@ private:
 
     struct
     {
-        uint8_t mav_type; // frame type (see MAV_TYPE in Mavlink definition file common.h)
-    } _params;
-    
-    struct
-    {
-        uint8_t control_mode;
         uint32_t value;
         const uint32_t *valuep;
-        uint32_t sensor_status_flags;
     } _ap;
 
     uint32_t check_sensor_status_timer;

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -87,8 +87,8 @@ for FrSky SPort Passthrough
 #define AP_CONTROL_MODE_LIMIT       0x1F
 #define AP_SSIMPLE_FLAGS            0x6
 #define AP_SSIMPLE_OFFSET           4
-#define AP_LANDCOMPLETE_FLAG        0x80
 #define AP_INITIALIZED_FLAG         0x2000
+#define AP_FLYING_OFFSET            6
 #define AP_ARMED_OFFSET             8
 #define AP_BATT_FS_OFFSET           9
 #define AP_EKF_FS_OFFSET            10
@@ -124,11 +124,6 @@ public:
 
     // add statustext message to FrSky lib message queue
     void queue_message(MAV_SEVERITY severity, const char *text);
-
-    // update whether we're flying (used for Plane)
-    // set land_complete flag to 0 if is_flying
-    // set land_complete flag to 1 if not flying
-    void set_is_flying(bool is_flying) { (is_flying) ? (_ap.value &= ~AP_LANDCOMPLETE_FLAG) : (_ap.value |= AP_LANDCOMPLETE_FLAG); }
 
     // update error mask of sensors and subsystems. The mask uses the
     // MAV_SYS_STATUS_* values from mavlink. If a bit is set then it

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -138,15 +138,11 @@ public:
 
     static ObjectArray<mavlink_statustext_t> _statustext_queue;
 
-    void set_frame_string(const char *string) { _frame_string = string; }
-
 private:
     AP_HAL::UARTDriver *_port;                  // UART used to send data to FrSky receiver
     AP_SerialManager::SerialProtocol _protocol; // protocol used - detected using SerialManager's SERIAL#_PROTOCOL parameter
     bool _initialised_uart;
     uint16_t _crc;
-
-    const char *_frame_string;
 
     struct
     {

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -78,6 +78,7 @@ public:
         uint8_t gps_num_sats;     // number of sats
         uint8_t flight_mode;      // flight mode
         bool armed;               // 0 = disarmed, 1 = armed
+        bool flying;              // 0 = not flying, 1 = flying/driving/diving/tracking
         bool pre_arm_check;       // true if passing pre arm checks
         bool pre_arm_gps_check;   // true if passing pre arm gps checks
         bool save_trim;           // true if gathering trim data

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -736,6 +736,7 @@ public:
 
     virtual uint32_t custom_mode() const = 0;
     virtual MAV_TYPE frame_type() const = 0;
+    virtual const char* frame_string() const { return nullptr; }
 
     void send_text(MAV_SEVERITY severity, const char *fmt, ...);
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -777,6 +777,9 @@ public:
     void get_sensor_status_flags(uint32_t &present, uint32_t &enabled, uint32_t &health);
     virtual bool vehicle_initialised() const { return true; }
 
+    virtual bool simple_input_active() const { return false; }
+    virtual bool supersimple_input_active() const { return false; }
+
 protected:
 
     uint32_t control_sensors_present;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -435,8 +435,6 @@ protected:
     void send_hwstatus();
     void handle_data_packet(mavlink_message_t *msg);
 
-    virtual bool vehicle_initialised() const { return true; }
-
     // these two methods are called after current_loc is updated:
     virtual int32_t global_position_int_alt() const;
     virtual int32_t global_position_int_relative_alt() const;
@@ -777,6 +775,7 @@ public:
     void update_passthru();
 
     void get_sensor_status_flags(uint32_t &present, uint32_t &enabled, uint32_t &health);
+    virtual bool vehicle_initialised() const { return true; }
 
 protected:
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -23,6 +23,7 @@
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_RTC/JitterCorrection.h>
 #include <AP_Common/Bitmask.h>
+#include <AP_Devo_Telem/AP_Devo_Telem.h>
 
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
 
@@ -764,6 +765,9 @@ public:
 
     // frsky backend
     AP_Frsky_Telem frsky;
+
+    // Devo backend
+    AP_DEVO_Telem devo_telemetry;
 
     // install an alternative protocol handler
     bool install_alternative_protocol(mavlink_channel_t chan, GCS_MAVLINK::protocol_handler_fn_t handler);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -302,9 +302,7 @@ protected:
     virtual bool set_mode(uint8_t mode) = 0;
     void set_ekf_origin(const Location& loc);
 
-    virtual MAV_TYPE frame_type() const = 0;
     virtual MAV_MODE base_mode() const = 0;
-    virtual uint32_t custom_mode() const = 0;
     virtual MAV_STATE system_status() const = 0;
 
     virtual MAV_VTOL_STATE vtol_state() const { return MAV_VTOL_STATE_UNDEFINED; }
@@ -602,9 +600,6 @@ private:
     // mavlink routing object
     static MAVLink_routing routing;
 
-    // pointer to static frsky_telem for queueing of text messages
-    static AP_Frsky_Telem *frsky_telemetry_p;
- 
     static const AP_SerialManager *serialmanager_p;
 
     struct pending_param_request {
@@ -739,6 +734,9 @@ public:
         return _singleton;
     }
 
+    virtual uint32_t custom_mode() const = 0;
+    virtual MAV_TYPE frame_type() const = 0;
+
     void send_text(MAV_SEVERITY severity, const char *fmt, ...);
     void send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list);
     virtual void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text);
@@ -765,17 +763,9 @@ public:
         _out_of_time = val;
     }
 
-    /*
-      set a frsky_telem pointer for queueing
-     */
-    void register_frsky_telemetry_callback(AP_Frsky_Telem *frsky_telemetry) {
-        frsky_telemetry_p = frsky_telemetry;
-    }
+    // frsky backend
+    AP_Frsky_Telem frsky;
 
-    // static frsky_telem pointer to support queueing text messages
-    AP_Frsky_Telem *frsky_telemetry_p;
-
-    
     // install an alternative protocol handler
     bool install_alternative_protocol(mavlink_channel_t chan, GCS_MAVLINK::protocol_handler_fn_t handler);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1892,9 +1892,7 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
     }
 
     // add statustext message to FrSky lib queue
-    if (frsky_telemetry_p != NULL) {
-        frsky_telemetry_p->queue_message(severity, text);
-    }
+    frsky.queue_message(severity, text);
 
     AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
@@ -2017,6 +2015,8 @@ void GCS::setup_uarts(AP_SerialManager &serial_manager)
     for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
         chan(i).setup_uart(serial_manager, AP_SerialManager::SerialProtocol_MAVLink, i);
     }
+
+    frsky.init();
 }
 
 // report battery2 state
@@ -2271,10 +2271,10 @@ void GCS_MAVLINK::send_heartbeat() const
 {
     mavlink_msg_heartbeat_send(
         chan,
-        frame_type(),
+        gcs().frame_type(),
         MAV_AUTOPILOT_ARDUPILOTMEGA,
         base_mode(),
-        custom_mode(),
+        gcs().custom_mode(),
         system_status());
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2017,6 +2017,8 @@ void GCS::setup_uarts(AP_SerialManager &serial_manager)
     }
 
     frsky.init();
+
+    devo_telemetry.init();
 }
 
 // report battery2 state

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -198,7 +198,7 @@ void GCS_MAVLINK::send_meminfo(void)
 // report power supply status
 void GCS_MAVLINK::send_power_status(void)
 {
-    if (!vehicle_initialised()) {
+    if (!gcs().vehicle_initialised()) {
         // avoid unnecessary errors being reported to user
         return;
     }
@@ -3822,7 +3822,7 @@ void GCS_MAVLINK::send_sys_status()
 {
     // send extended status only once vehicle has been initialised
     // to avoid unnecessary errors being reported to user
-    if (!vehicle_initialised()) {
+    if (!gcs().vehicle_initialised()) {
         return;
     }
 

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -28,9 +28,7 @@ protected:
     bool set_mode(uint8_t mode) override { return false; };
 
     // dummy information:
-    MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
-    uint32_t custom_mode() const override { return 3; } // magic number
     MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
 
     bool set_home_to_current_location(bool lock) override { return false; }
@@ -56,4 +54,7 @@ class GCS_Dummy : public GCS
     void send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *text) { hal.console->printf("TOGCS: %s\n", text); }
 
     void update_sensor_status_flags(void) override {};
+
+    MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }
+    uint32_t custom_mode() const override { return 3; } // magic number
 };

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -34,9 +34,7 @@ protected:
     bool set_mode(uint8_t mode) override { return false; };
 
     // dummy information:
-    MAV_TYPE frame_type() const override { return MAV_TYPE_FIXED_WING; }
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
-    uint32_t custom_mode() const override { return 3; } // magic number
     MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};


### PR DESCRIPTION
We could rename AP_GPS to AP_Telemetry and `gcs()` to `telem()`

Only Rover has been moved to it.  I expect the other vehicles to not compile ATM.

Currently based on top of a separate PR which makes Frsky use singletons.
