### PR TITLE
AP_Math: remove code duplication

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -810,19 +810,19 @@ void GCS_MAVLINK_Rover::handleMessage(mavlink_message_t* msg)
                     const float ne_x = packet.x * rover.ahrs.cos_yaw() - packet.y * rover.ahrs.sin_yaw();
                     const float ne_y = packet.x * rover.ahrs.sin_yaw() + packet.y * rover.ahrs.cos_yaw();
                     // add offset to current location
-                    location_offset(target_loc, ne_x, ne_y);
+                    target_loc.offset(ne_x, ne_y);
                     }
                     break;
 
                 case MAV_FRAME_LOCAL_OFFSET_NED:
                     // add offset to current location
-                    location_offset(target_loc, packet.x, packet.y);
+                    target_loc.offset(packet.x, packet.y);
                     break;
 
                 default:
                     // MAV_FRAME_LOCAL_NED interpret as an offset from home
                     target_loc = rover.ahrs.get_home();
-                    location_offset(target_loc, packet.x, packet.y);
+                    target_loc.offset(packet.x, packet.y);
                     break;
                 }
             }

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -71,7 +71,7 @@ void Rover::update_home()
     barometer.update_calibration();
 
     if (ahrs.home_is_set() &&
-        get_distance(loc, ahrs.get_home()) < DISTANCE_HOME_MINCHANGE) {
+        loc.get_distance(ahrs.get_home()) < DISTANCE_HOME_MINCHANGE) {
         // insufficiently moved from current home - don't change it
         return;
     }

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -199,7 +199,7 @@ void Mode::set_desired_location(const struct Location& destination, float next_l
     _destination = destination;
 
     // initialise distance
-    _distance_to_destination = get_distance(_origin, _destination);
+    _distance_to_destination = _origin.get_distance(_destination);
     _reached_destination = false;
 
     // set final desired speed
@@ -231,7 +231,7 @@ bool Mode::set_desired_location_NED(const Vector3f& destination, float next_leg_
         return false;
     }
     // apply offset
-    location_offset(destination_ned, destination.x, destination.y);
+    destination_ned.offset(destination.x, destination.y);
     set_desired_location(destination_ned, next_leg_bearing_cd);
     return true;
 }
@@ -552,7 +552,7 @@ void Mode::calc_stopping_location(Location& stopping_loc)
     // calculate stopping position from current location in meters
     const Vector2f stopping_offset = velocity.normalized() * stopping_dist;
 
-    location_offset(stopping_loc, stopping_offset.x, stopping_offset.y);
+    stopping_loc.offset(stopping_offset.x, stopping_offset.y);
 }
 
 Mode *Rover::mode_from_mode_num(const enum Mode::Number num)

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -36,7 +36,7 @@ void ModeAuto::update()
     switch (_submode) {
         case Auto_WP:
         {
-            _distance_to_destination = get_distance(rover.current_loc, _destination);
+            _distance_to_destination = rover.current_loc.get_distance(_destination);
             const bool near_wp = _distance_to_destination <= rover.g.waypoint_radius;
             // check if we've reached the destination
             if (!_reached_destination && (near_wp || location_passed_point(rover.current_loc, _origin, _destination))) {

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -18,7 +18,7 @@ void ModeGuided::update()
     switch (_guided_mode) {
         case Guided_WP:
         {
-            _distance_to_destination = get_distance(rover.current_loc, _destination);
+            _distance_to_destination = rover.current_loc.get_distance(_destination);
             const bool near_wp = _distance_to_destination <= rover.g.waypoint_radius;
             // check if we've reached the destination
             if (!_reached_destination && (near_wp || location_passed_point(rover.current_loc, _origin, _destination))) {

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -21,7 +21,7 @@ bool ModeLoiter::_enter()
 void ModeLoiter::update()
 {
     // get distance (in meters) to destination
-    _distance_to_destination = get_distance(rover.current_loc, _destination);
+    _distance_to_destination = rover.current_loc.get_distance(_destination);
 
     // if within loiter radius slew desired speed towards zero and use existing desired heading
     if (_distance_to_destination <= g2.loit_radius) {

--- a/APMrover2/mode_rtl.cpp
+++ b/APMrover2/mode_rtl.cpp
@@ -25,7 +25,7 @@ bool ModeRTL::_enter()
 void ModeRTL::update()
 {
     // calculate distance to home
-    _distance_to_destination = get_distance(rover.current_loc, _destination);
+    _distance_to_destination = rover.current_loc.get_distance(_destination);
     const bool near_wp = _distance_to_destination <= rover.g.waypoint_radius;
     // check if we've reached the destination
     if (!_reached_destination && (near_wp || location_passed_point(rover.current_loc, _origin, _destination))) {

--- a/APMrover2/mode_smart_rtl.cpp
+++ b/APMrover2/mode_smart_rtl.cpp
@@ -59,7 +59,7 @@ void ModeSmartRTL::update()
                 }
             }
             // check if we've reached the next point
-            _distance_to_destination = get_distance(rover.current_loc, _destination);
+            _distance_to_destination = rover.current_loc.get_distance(_destination);
             if (_distance_to_destination <= rover.g.waypoint_radius || location_passed_point(rover.current_loc, _origin, _destination)) {
                 _load_point = true;
             }

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -15,7 +15,7 @@ void Tracker::update_vehicle_pos_estimate()
         vehicle.location_estimate = vehicle.location;
         float north_offset = vehicle.vel.x * dt;
         float east_offset = vehicle.vel.y * dt;
-        location_offset(vehicle.location_estimate, north_offset, east_offset);
+        vehicle.location_estimate.offset(north_offset, east_offset);
     	vehicle.location_estimate.alt += vehicle.vel.z * 100.0f * dt;
         // set valid_location flag
         vehicle.location_valid = true;
@@ -56,7 +56,7 @@ void Tracker::update_bearing_and_distance()
     }
 
     // calculate distance to vehicle
-    nav_status.distance = get_distance(current_loc, vehicle.location_estimate);
+    nav_status.distance = current_loc.get_distance(vehicle.location_estimate);
 
     // calculate altitude difference to vehicle using gps
     if (g.alt_source == ALT_SOURCE_GPS){

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -107,7 +107,7 @@ bool Copter::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
     const struct Location &ekf_origin = inertial_nav.get_origin();
-    if (get_distance(ekf_origin, loc) > EKF_ORIGIN_MAX_DIST_M) {
+    if (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M) {
         return true;
     }
 

--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -14,7 +14,7 @@ void Copter::run_nav_updates(void)
 uint32_t Copter::home_distance()
 {
     if (position_ok()) {
-        _home_distance = get_distance_cm(current_loc, ahrs.get_home());
+        _home_distance = current_loc.get_distance(ahrs.get_home()) * 100;
     }
     return _home_distance;
 }

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -826,7 +826,7 @@ void Plane::update_alt()
 
         float distance_beyond_land_wp = 0;
         if (flight_stage == AP_Vehicle::FixedWing::FLIGHT_LAND && location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
-            distance_beyond_land_wp = get_distance(current_loc, next_WP_loc);
+            distance_beyond_land_wp = current_loc.get_distance(next_WP_loc);
         }
 
         bool soaring_active = false;

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -65,7 +65,7 @@ void Plane::setup_glide_slope(void)
 {
     // establish the distance we are travelling to the next waypoint,
     // for calculating out rate of change of altitude
-    auto_state.wp_distance = get_distance(current_loc, next_WP_loc);
+    auto_state.wp_distance = current_loc.get_distance(next_WP_loc);
     auto_state.wp_proportion = location_path_proportion(current_loc, 
                                                         prev_WP_loc, next_WP_loc);
     SpdHgt_Controller->set_path_proportion(auto_state.wp_proportion);

--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -194,7 +194,7 @@ bool AP_Avoidance_Plane::handle_avoidance_horizontal(const AP_Avoidance::Obstacl
         velocity_neu *= 10000;
 
         // set target
-        location_offset(plane.guided_WP_loc, velocity_neu.x, velocity_neu.y);
+        plane.guided_WP_loc.offset(velocity_neu.x, velocity_neu.y);
         return true;
     }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -582,7 +582,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
     uint8_t cmd_acceptance_distance = LOWBYTE(cmd.p1); // radius in meters to accept reaching the wp
 
     if (cmd_passby > 0) {
-        float dist = get_distance(prev_WP_loc, flex_next_WP_loc);
+        float dist = prev_WP_loc.get_distance(flex_next_WP_loc);
 
         if (!is_zero(dist)) {
             float factor = (dist + cmd_passby) / dist;
@@ -624,7 +624,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
     if (auto_state.wp_distance <= acceptance_distance_m) {
         gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%i dist %um",
                           (unsigned)mission.get_current_nav_cmd().index,
-                          (unsigned)get_distance(current_loc, flex_next_WP_loc));
+                          (unsigned)current_loc.get_distance(flex_next_WP_loc));
         return true;
 	}
 
@@ -632,7 +632,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
     if (location_passed_point(current_loc, prev_WP_loc, flex_next_WP_loc)) {
         gcs().send_text(MAV_SEVERITY_INFO, "Passed waypoint #%i dist %um",
                           (unsigned)mission.get_current_nav_cmd().index,
-                          (unsigned)get_distance(current_loc, flex_next_WP_loc));
+                          (unsigned)current_loc.get_distance(flex_next_WP_loc));
         return true;
     }
 
@@ -770,7 +770,7 @@ bool Plane::verify_continue_and_change_alt()
     }
     else {
         // Is the next_WP less than 200 m away?
-        if (get_distance(current_loc, next_WP_loc) < 200.0f) {
+        if (current_loc.get_distance(next_WP_loc) < 200.0f) {
             //push another 300 m down the line
             int32_t next_wp_bearing_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
             location_update(next_WP_loc, next_wp_bearing_cd * 0.01f, 300.0f);
@@ -976,8 +976,8 @@ bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
 
                 // validate that the vehicle is at least the expected distance away from the loiter point
                 // require an angle total of at least 2 centidegrees, due to special casing of 1 centidegree
-                if (((fabsf(get_distance(cmd.content.location, current_loc) - radius) > 5.0f) &&
-                      (get_distance(cmd.content.location, current_loc) < radius)) ||
+                if (((fabsf(cmd.content.location.get_distance(current_loc) - radius) > 5.0f) &&
+                      (cmd.content.location.get_distance(current_loc) < radius)) ||
                     (loiter.sum_cd < 2)) {
                     nav_controller->update_loiter(cmd.content.location, radius, direction);
                     break;
@@ -1055,7 +1055,7 @@ bool Plane::verify_loiter_heading(bool init)
         return true;
     }
 
-    if (get_distance(next_WP_loc, next_nav_cmd.content.location) < abs(aparm.loiter_radius)) {
+    if (next_WP_loc.get_distance(next_nav_cmd.content.location) < abs(aparm.loiter_radius)) {
         /* Whenever next waypoint is within the loiter radius,
            maintaining loiter would prevent us from ever pointing toward the next waypoint.
            Hence break out of loiter immediately

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -223,7 +223,7 @@ void Plane::crash_detection_update(void)
 
                 // did we "crash" within 75m of the landing location? Probably just a hard landing
                 crashed_near_land_waypoint =
-                        get_distance(current_loc, mission.get_current_nav_cmd().content.location) < 75;
+                        current_loc.get_distance(mission.get_current_nav_cmd().content.location) < 75;
 
                 // trigger hard landing event right away, or never again. This inhibits a false hard landing
                 // event when, for example, a minute after a good landing you pick the plane up and

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -86,7 +86,7 @@ void Plane::navigate()
 
     // waypoint distance from plane
     // ----------------------------
-    auto_state.wp_distance = get_distance(current_loc, next_WP_loc);
+    auto_state.wp_distance = current_loc.get_distance(next_WP_loc);
     auto_state.wp_proportion = location_path_proportion(current_loc, 
                                                         prev_WP_loc, next_WP_loc);
     SpdHgt_Controller->set_path_proportion(auto_state.wp_proportion);
@@ -225,7 +225,7 @@ void Plane::update_loiter(uint16_t radius)
     } else if ((loiter.start_time_ms == 0 &&
                 (control_mode == AUTO || control_mode == GUIDED) &&
                 auto_state.crosstrack &&
-                get_distance(current_loc, next_WP_loc) > radius*3) ||
+                current_loc.get_distance(next_WP_loc) > radius*3) ||
                (control_mode == RTL && quadplane.available() && quadplane.rtl_mode == 1)) {
         /*
           if never reached loiter point and using crosstrack and somewhat far away from loiter point
@@ -285,7 +285,7 @@ void Plane::update_cruise()
         // always look 1km ahead
         location_update(next_WP_loc,
                         cruise_state.locked_heading_cd*0.01f, 
-                        get_distance(prev_WP_loc, current_loc) + 1000);
+                        prev_WP_loc.get_distance(current_loc) + 1000);
         nav_controller->update_waypoint(prev_WP_loc, next_WP_loc);
     }
 }

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -99,5 +99,5 @@ bool Sub::far_from_EKF_origin(const Location& loc)
 {
     // check distance to EKF origin
     const struct Location &ekf_origin = inertial_nav.get_origin();
-    return (get_distance(ekf_origin, loc) > EKF_ORIGIN_MAX_DIST_M);
+    return (ekf_origin.get_distance(loc) > EKF_ORIGIN_MAX_DIST_M);
 }

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -768,7 +768,7 @@ void Replay::log_check_solution(void)
     float pitch_error = degrees(fabsf(euler.y - check_state.euler.y));
     float yaw_error = wrap_180_cd(100*degrees(fabsf(euler.z - check_state.euler.z)))*0.01f;
     float vel_error = (velocity - check_state.velocity).length();
-    float pos_error = get_distance(check_state.pos, loc);
+    float pos_error = check_state.pos.get_distance(loc);
 
     check_result.max_roll_error  = MAX(check_result.max_roll_error,  roll_error);
     check_result.max_pitch_error = MAX(check_result.max_pitch_error, pitch_error);

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -379,7 +379,7 @@ bool AC_Fence::check_destination_within_fence(const Location& loc)
 
     // Circular fence check
     if ((get_enabled_fences() & AC_FENCE_TYPE_CIRCLE)) {
-        if ((get_distance_cm(AP::ahrs().get_home(), loc) * 0.01f) > _circle_radius) {
+        if (AP::ahrs().get_home().get_distance(loc) > _circle_radius) {
             return false;
         }
     }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -984,7 +984,7 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
     loc.alt = AP::baro().get_altitude() * 100 + _home.alt;
     loc.relative_alt = 0;
     loc.terrain_alt = 0;
-    location_offset(loc, _position_offset_north, _position_offset_east);
+    loc.offset(_position_offset_north, _position_offset_east);
     const AP_GPS &_gps = AP::gps();
     if (_flags.fly_forward && _have_position) {
         float gps_delay_sec = 0;

--- a/libraries/AP_Avoidance/AP_Avoidance.cpp
+++ b/libraries/AP_Avoidance/AP_Avoidance.cpp
@@ -371,7 +371,7 @@ void AP_Avoidance::update_threat_level(const Location &my_loc,
     // level is none - but only *once the GCS has been informed*!
     obstacle.closest_approach_xy = closest_xy;
     obstacle.closest_approach_z = closest_z;
-    float current_distance = get_distance(my_loc, obstacle_loc);
+    float current_distance = my_loc.get_distance(obstacle_loc);
     obstacle.distance_to_closest_approach = current_distance - closest_xy;
     Vector2f net_velocity_ne = Vector2f(my_vel[0] - obstacle_vel[0], my_vel[1] - obstacle_vel[1]);
     obstacle.time_to_closest_approach = 0.0f;

--- a/libraries/AP_Beacon/AP_Beacon_SITL.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_SITL.cpp
@@ -81,19 +81,19 @@ void AP_Beacon_SITL::update(void)
     switch (beacon_id) {
     case 0:
         // NE corner
-        location_offset(beacon_loc, ORIGIN_OFFSET_NORTH + BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST + BEACON_SPACING_EAST/2);
+        beacon_loc.offset(ORIGIN_OFFSET_NORTH + BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST + BEACON_SPACING_EAST/2);
         break;
     case 1:
         // SE corner
-        location_offset(beacon_loc, ORIGIN_OFFSET_NORTH - BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST + BEACON_SPACING_EAST/2);
+        beacon_loc.offset(ORIGIN_OFFSET_NORTH - BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST + BEACON_SPACING_EAST/2);
         break;
     case 2:
         // SW corner
-        location_offset(beacon_loc, ORIGIN_OFFSET_NORTH - BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST - BEACON_SPACING_EAST/2);
+        beacon_loc.offset(ORIGIN_OFFSET_NORTH - BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST - BEACON_SPACING_EAST/2);
         break;
     case 3:
         // NW corner
-        location_offset(beacon_loc, ORIGIN_OFFSET_NORTH + BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST - BEACON_SPACING_EAST/2);
+        beacon_loc.offset(ORIGIN_OFFSET_NORTH + BEACON_SPACING_NORTH/2, ORIGIN_OFFSET_EAST - BEACON_SPACING_EAST/2);
         break;
     }
 

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -312,7 +312,7 @@ void AP_Camera::update()
         return;
     }
 
-    if (get_distance(current_loc, _last_location) < _trigg_dist) {
+    if (current_loc.get_distance(_last_location) < _trigg_dist) {
         return;
     }
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -152,7 +152,7 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
 
     // project the vehicle position
     Location last_loc = _target_location;
-    location_offset(last_loc, vel_ned.x * dt, vel_ned.y * dt);
+    last_loc.offset(vel_ned.x * dt, vel_ned.y * dt);
     last_loc.alt -= vel_ned.z * 100.0f * dt; // convert m/s to cm/s, multiply by dt.  minus because NED
 
     // return latest position estimate

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -731,7 +731,7 @@ uint32_t AP_Frsky_Telem::calc_home(void)
         const Location &home_loc = _ahrs.get_home();
         if (home_loc.lat != 0 || home_loc.lng != 0) {
             // distance between vehicle and home_loc in meters
-            home = prep_number(roundf(get_distance(home_loc, loc)), 3, 2);
+            home = prep_number(roundf(home_loc.get_distance(loc)), 3, 2);
             // angle from front of vehicle to the direction of home_loc in 3 degree increments (just in case, limit to 127 (0x7F) since the value is stored on 7 bits)
             home |= (((uint8_t)roundf(get_bearing_cd(loc,home_loc) * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
         }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1435,7 +1435,7 @@ void AP_GPS::calc_blended_state(void)
     }
 
     // Add the sum of weighted offsets to the reference location to obtain the blended location
-    location_offset(state[GPS_BLENDED_INSTANCE].location, blended_NE_offset_m.x, blended_NE_offset_m.y);
+    state[GPS_BLENDED_INSTANCE].location.offset(blended_NE_offset_m.x, blended_NE_offset_m.y);
     state[GPS_BLENDED_INSTANCE].location.alt += (int)blended_alt_offset_cm;
 
     // Calculate ground speed and course from blended velocity vector
@@ -1474,7 +1474,7 @@ void AP_GPS::calc_blended_state(void)
     Location corrected_location[GPS_MAX_RECEIVERS];
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         corrected_location[i] = state[i].location;
-        location_offset(corrected_location[i], _NE_pos_offset_m[i].x, _NE_pos_offset_m[i].y);
+        corrected_location[i].offset(_NE_pos_offset_m[i].x, _NE_pos_offset_m[i].y);
         corrected_location[i].alt += (int)(_hgt_offset_cm[i]);
     }
 

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -117,7 +117,7 @@ private:
     // same as land_slope but sampled once before a rangefinder changes the slope. This should be the original mission planned slope
     float initial_slope;
 
-    // calculated approach slope during auto-landing: ((prev_WP_loc.alt - next_WP_loc.alt)*0.01f - flare_sec * sink_rate) / get_distance(prev_WP_loc, next_WP_loc)
+    // calculated approach slope during auto-landing: ((prev_WP_loc.alt - next_WP_loc.alt)*0.01f - flare_sec * sink_rate) / prev_WP_loc.get_distance(next_WP_loc)
     float slope;
 
     AP_Mission &mission;

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -187,7 +187,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
 {
     switch (stage) {
     case DEEPSTALL_STAGE_FLY_TO_LANDING:
-        if (get_distance(current_loc, landing_point) > abs(2 * landing.aparm.loiter_radius)) {
+        if (current_loc.get_distance(landing_point) > abs(2 * landing.aparm.loiter_radius)) {
             landing.nav_controller->update_waypoint(current_loc, landing_point);
             return false;
         }
@@ -239,7 +239,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
         memcpy(&breakout_location, &current_loc, sizeof(Location));
         FALLTHROUGH;
     case DEEPSTALL_STAGE_FLY_TO_ARC:
-        if (get_distance(current_loc, arc_entry) > 2 * landing.aparm.loiter_radius) {
+        if (current_loc.get_distance(arc_entry) > 2 * landing.aparm.loiter_radius) {
             landing.nav_controller->update_waypoint(breakout_location, arc_entry);
             return false;
         }

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -100,7 +100,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
                 gcs().send_text(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
                                   (double)height, (double)sink_rate,
                                   (double)AP::gps().ground_speed(),
-                                  (double)get_distance(current_loc, next_WP_loc));
+                                  (double)current_loc.get_distance(next_WP_loc));
             }
             
             type_slope_stage = SLOPE_STAGE_FINAL;
@@ -139,14 +139,14 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     int32_t land_bearing_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
     location_update(land_WP_loc,
                     land_bearing_cd*0.01f,
-                    get_distance(prev_WP_loc, current_loc) + 200);
+                    prev_WP_loc.get_distance(current_loc) + 200);
     nav_controller->update_waypoint(prev_WP_loc, land_WP_loc);
 
     // once landed and stationary, post some statistics
     // this is done before disarm_if_autoland_complete() so that it happens on the next loop after the disarm
     if (type_slope_flags.post_stats && !is_armed) {
         type_slope_flags.post_stats = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)get_distance(current_loc, next_WP_loc));
+        gcs().send_text(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)current_loc.get_distance(next_WP_loc));
     }
 
     // check if we should auto-disarm after a confirmed landing
@@ -179,7 +179,7 @@ void AP_Landing::type_slope_adjust_landing_slope_for_rangefinder_bump(AP_Vehicle
     rangefinder_state.last_stable_correction = rangefinder_state.correction;
 
     float corrected_alt_m = (adjusted_altitude_cm_fn() - next_WP_loc.alt)*0.01f - rangefinder_state.correction;
-    float total_distance_m = get_distance(prev_WP_loc, next_WP_loc);
+    float total_distance_m = prev_WP_loc.get_distance(next_WP_loc);
     float top_of_glide_slope_alt_m = total_distance_m * corrected_alt_m / wp_distance;
     prev_WP_loc.alt = top_of_glide_slope_alt_m*100 + next_WP_loc.alt;
 
@@ -229,7 +229,7 @@ bool AP_Landing::type_slope_request_go_around(void)
  */
 void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm)
 {
-    float total_distance = get_distance(prev_WP_loc, next_WP_loc);
+    float total_distance = prev_WP_loc.get_distance(next_WP_loc);
 
     // If someone mistakenly puts all 0's in their LAND command then total_distance
     // will be calculated as 0 and cause a divide by 0 error below.  Lets avoid that.

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -72,10 +72,10 @@ static void test_one_offset(const struct Location &loc,
 
     loc2 = loc;
     uint32_t t1 = AP_HAL::micros();
-    location_offset(loc2, ofs_north, ofs_east);
+    loc2.offset(ofs_north, ofs_east);
     hal.console->printf("location_offset took %u usec\n",
                         (unsigned)(AP_HAL::micros() - t1));
-    dist2 = get_distance(loc, loc2);
+    dist2 = loc.get_distance(loc2);
     bearing2 = get_bearing_cd(loc, loc2) * 0.01f;
     float brg_error = bearing2-bearing;
     if (brg_error > 180) {
@@ -134,19 +134,19 @@ static void test_accuracy(void)
     loc2 = loc;
     loc2.lat += 10000000;
     v2 = Vector2f(loc2.lat * 1.0e-7f, loc2.lng * 1.0e-7f);
-    hal.console->printf("1 degree lat dist=%.4f\n", (double)get_distance(loc, loc2));
+    hal.console->printf("1 degree lat dist=%.4f\n", (double)loc.get_distance(loc2));
 
     loc2 = loc;
     loc2.lng += 10000000;
     v2 = Vector2f(loc2.lat * 1.0e-7f, loc2.lng * 1.0e-7f);
-    hal.console->printf("1 degree lng dist=%.4f\n", (double)get_distance(loc, loc2));
+    hal.console->printf("1 degree lng dist=%.4f\n", (double)loc.get_distance(loc2));
 
     for (int32_t i = 0; i < 100; i++) {
         loc2 = loc;
         loc2.lat += i;
         v2 = Vector2f((loc.lat + i) * 1.0e-7f, loc.lng * 1.0e-7f);
         if (v2 != v) {
-            hal.console->printf("lat v2 != v at i=%d dist=%.4f\n", (int)i, (double)get_distance(loc, loc2));
+            hal.console->printf("lat v2 != v at i=%d dist=%.4f\n", (int)i, (double)loc.get_distance(loc2));
             break;
         }
     }
@@ -155,7 +155,7 @@ static void test_accuracy(void)
         loc2.lng += i;
         v2 = Vector2f(loc.lat * 1.0e-7f, (loc.lng + i) * 1.0e-7f);
         if (v2 != v) {
-            hal.console->printf("lng v2 != v at i=%d dist=%.4f\n", (int)i, (double)get_distance(loc, loc2));
+            hal.console->printf("lng v2 != v at i=%d dist=%.4f\n", (int)i, (double)loc.get_distance(loc2));
             break;
         }
     }
@@ -165,7 +165,7 @@ static void test_accuracy(void)
         loc2.lat -= i;
         v2 = Vector2f((loc.lat - i) * 1.0e-7f, loc.lng * 1.0e-7f);
         if (v2 != v) {
-            hal.console->printf("-lat v2 != v at i=%d dist=%.4f\n", (int)i, (double)get_distance(loc, loc2));
+            hal.console->printf("-lat v2 != v at i=%d dist=%.4f\n", (int)i, (double)loc.get_distance(loc2));
             break;
         }
     }
@@ -174,7 +174,7 @@ static void test_accuracy(void)
         loc2.lng -= i;
         v2 = Vector2f(loc.lat * 1.0e-7f, (loc.lng - i) * 1.0e-7f);
         if (v2 != v) {
-            hal.console->printf("-lng v2 != v at i=%d dist=%.4f\n", (int)i, (double)get_distance(loc, loc2));
+            hal.console->printf("-lng v2 != v at i=%d dist=%.4f\n", (int)i, (double)loc.get_distance(loc2));
             break;
         }
     }

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -31,22 +31,6 @@ float longitude_scale(const struct Location &loc)
     return constrain_float(scale, 0.01f, 1.0f);
 }
 
-
-
-// return distance in meters between two locations
-float get_distance(const struct Location &loc1, const struct Location &loc2)
-{
-    float dlat              = (float)(loc2.lat - loc1.lat);
-    float dlong             = ((float)(loc2.lng - loc1.lng)) * longitude_scale(loc2);
-    return norm(dlat, dlong) * LOCATION_SCALING_FACTOR;
-}
-
-// return distance in centimeters to between two locations
-uint32_t get_distance_cm(const struct Location &loc1, const struct Location &loc2)
-{
-    return get_distance(loc1, loc2) * 100;
-}
-
 // return horizontal distance between two positions in cm
 float get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destination)
 {
@@ -117,20 +101,7 @@ void location_update(struct Location &loc, float bearing, float distance)
 {
     float ofs_north = cosf(radians(bearing))*distance;
     float ofs_east  = sinf(radians(bearing))*distance;
-    location_offset(loc, ofs_north, ofs_east);
-}
-
-/*
- *  extrapolate latitude/longitude given distances north and east
- */
-void location_offset(struct Location &loc, float ofs_north, float ofs_east)
-{
-    if (!is_zero(ofs_north) || !is_zero(ofs_east)) {
-        int32_t dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
-        int32_t dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale(loc);
-        loc.lat += dlat;
-        loc.lng += dlng;
-    }
+    loc.offset(ofs_north, ofs_east);
 }
 
 /*

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -21,12 +21,6 @@
 // Note: this does not include the scaling to convert longitude/latitude points to meters or centimeters
 float        longitude_scale(const struct Location &loc);
 
-// return distance in meters between two locations
-float        get_distance(const struct Location &loc1, const struct Location &loc2);
-
-// return distance in centimeters between two locations
-uint32_t     get_distance_cm(const struct Location &loc1, const struct Location &loc2);
-
 // return horizontal distance in centimeters between two positions
 float        get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destination);
 
@@ -55,9 +49,6 @@ float       location_path_proportion(const struct Location &location,
 
 //  extrapolate latitude/longitude given bearing and distance
 void        location_update(struct Location &loc, float bearing, float distance);
-
-// extrapolate latitude/longitude given distances north and east
-void        location_offset(struct Location &loc, float ofs_north, float ofs_east);
 
 /*
   return the distance in meters in North/East plane as a N/E vector

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1777,7 +1777,7 @@ uint16_t AP_Mission::get_landing_sequence_start()
             continue;
         }
         if (tmp.id == MAV_CMD_DO_LAND_START) {
-            float tmp_distance = get_distance(tmp.content.location, current_loc);
+            float tmp_distance = tmp.content.location.get_distance(current_loc);
             if (min_distance < 0 || tmp_distance < min_distance) {
                 min_distance = tmp_distance;
                 landing_start_index = i;
@@ -1826,7 +1826,7 @@ bool AP_Mission::jump_to_abort_landing_sequence(void)
                 continue;
             }
             if (tmp.id == MAV_CMD_DO_GO_AROUND) {
-                float tmp_distance = get_distance(tmp.content.location, current_loc);
+                float tmp_distance = tmp.content.location.get_distance(current_loc);
                 if (tmp_distance < min_distance) {
                     min_distance = tmp_distance;
                     abort_index = i;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -328,7 +328,7 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
             loc.lat = EKF_origin.lat;
             loc.lng = EKF_origin.lng;
             // correct for IMU offset (EKF calculations are at the IMU position)
-            location_offset(loc, (outputDataNew.position.x + posOffsetNED.x), (outputDataNew.position.y + posOffsetNED.y));
+            loc.offset((outputDataNew.position.x + posOffsetNED.x), (outputDataNew.position.y + posOffsetNED.y));
             return true;
         } else {
             // we could be in constant position mode  because the vehicle has taken off without GPS, or has lost GPS
@@ -342,7 +342,7 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
             } else {
                 // if no GPS fix, provide last known position before entering the mode
                 // correct for IMU offset (EKF calculations are at the IMU position)
-                location_offset(loc, (lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
+                loc.offset((lastKnownPositionNE.x + posOffsetNED.x), (lastKnownPositionNE.y + posOffsetNED.y));
                 return false;
             }
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -325,7 +325,7 @@ bool NavEKF3_core::getLLH(struct Location &loc) const
         if (filterStatus.flags.horiz_pos_abs || filterStatus.flags.horiz_pos_rel) {
             loc.lat = EKF_origin.lat;
             loc.lng = EKF_origin.lng;
-            location_offset(loc, outputDataNew.position.x, outputDataNew.position.y);
+            loc.offset(outputDataNew.position.x, outputDataNew.position.y);
             return true;
         } else {
             // we could be in constant position mode  because the vehicle has taken off without GPS, or has lost GPS
@@ -338,7 +338,7 @@ bool NavEKF3_core::getLLH(struct Location &loc) const
                 return true;
             } else {
                 // if no GPS fix, provide last known position before entering the mode
-                location_offset(loc, lastKnownPositionNE.x, lastKnownPositionNE.y);
+                loc.offset(lastKnownPositionNE.x, lastKnownPositionNE.y);
                 return false;
             }
         }

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -242,7 +242,7 @@ void AP_OSD::stats()
     Location loc;
     if (ahrs.get_position(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
-        float distance = get_distance(home_loc, loc);
+        float distance = home_loc.get_distance(loc);
         max_dist_m = fmaxf(max_dist_m, distance);
     }
     

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -629,7 +629,7 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
     Location loc;
     if (ahrs.get_position(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
-        float distance = get_distance(home_loc, loc);
+        float distance = home_loc.get_distance(loc);
         int32_t angle = wrap_360_cd(get_bearing_cd(loc, home_loc) - ahrs.yaw_sensor);
         int32_t interval = 36000 / SYM_ARROW_COUNT;
         if (distance < 2.0f) {

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -126,7 +126,7 @@ bool AP_Rally::find_nearest_rally_point(const Location &current_loc, RallyLocati
             continue;
         }
         Location rally_loc = rally_location_to_location(next_rally);
-        float dis = get_distance(current_loc, rally_loc);
+        float dis = current_loc.get_distance(rally_loc);
 
         if (is_valid(rally_loc) && (dis < min_dis || min_dis < 0)) {
             min_dis = dis;
@@ -158,7 +158,7 @@ Location AP_Rally::calc_best_rally_or_home_location(const Location &current_loc,
     if (find_nearest_rally_point(current_loc, ral_loc)) {
         Location loc = rally_location_to_location(ral_loc);
         // use the rally point if it's closer then home, or we aren't generally considering home as acceptable
-        if (!_rally_incl_home  || (get_distance(current_loc, loc) < get_distance(current_loc, return_loc))) {
+        if (!_rally_incl_home  || (current_loc.get_distance(loc) < current_loc.get_distance(return_loc))) {
             return_loc = rally_location_to_location(ral_loc);
         }
     }

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -219,8 +219,7 @@ static int location_distance(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    lua_pushnumber(L, get_distance(*check_location(L, -2),
-                                   *check_location(L, -1)));
+    lua_pushnumber(L, *check_location(L, -2).get_distance(*check_location(L, -1)));
 
     return 1;
 }
@@ -272,7 +271,7 @@ static int location_offset(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    location_offset(*check_location(L, -3),
+    *check_location(L, -3).offset(
                     luaL_checknumber(L, -2),
                     luaL_checknumber(L, -1));
 

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -141,7 +141,7 @@ SoaringController::SoaringController(AP_AHRS &ahrs, AP_SpdHgtControl &spdHgt, co
 void SoaringController::get_target(Location &wp)
 {
     wp = _prev_update_location;
-    location_offset(wp, _ekf.X[2], _ekf.X[3]);
+    wp.offset(_ekf.X[2], _ekf.X[3]);
 }
 
 bool SoaringController::suppress_throttle()

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -118,9 +118,8 @@ void AP_Terrain::send_request(mavlink_channel_t chan)
     for (int8_t x=-1; x<=1; x++) {
         for (int8_t y=-1; y<=1; y++) {
             Location loc2 = loc;
-            location_offset(loc2, 
-                            x*TERRAIN_GRID_BLOCK_SIZE_X*0.7f*grid_spacing,
-                            y*TERRAIN_GRID_BLOCK_SIZE_Y*0.7f*grid_spacing);
+            loc2.offset(x*TERRAIN_GRID_BLOCK_SIZE_X*0.7f*grid_spacing,
+                        y*TERRAIN_GRID_BLOCK_SIZE_Y*0.7f*grid_spacing);
             struct grid_info info2;
             calculate_grid_info(loc2, info2);            
             if (request_missing(chan, info2)) {
@@ -301,7 +300,7 @@ void AP_Terrain::handle_terrain_data(mavlink_message_t *msg)
         Location loc2;
         loc2.lat = grid.lat;
         loc2.lng = grid.lon;
-        location_offset(loc2, 28*grid_spacing, 32*grid_spacing);
+        loc2.offset(28*grid_spacing, 32*grid_spacing);
         hal.console->printf("--lat=%12.7f --lon=%12.7f %u\n",
                             loc2.lat*1.0e-7f,
                             loc2.lng*1.0e-7f,

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -230,7 +230,7 @@ void AP_Terrain::seek_offset(void)
     loc2.lng = (block.lon_degrees+1)*10*1000*1000L;
 
     // shift another two blocks east to ensure room is available
-    location_offset(loc2, 0, 2*grid_spacing*TERRAIN_GRID_BLOCK_SIZE_Y);
+    loc2.offset(0, 2*grid_spacing*TERRAIN_GRID_BLOCK_SIZE_Y);
     Vector2f offset = location_diff(loc1, loc2);
     uint16_t east_blocks = offset.y / (grid_spacing*TERRAIN_GRID_BLOCK_SIZE_Y);
 

--- a/libraries/AP_Terrain/TerrainUtil.cpp
+++ b/libraries/AP_Terrain/TerrainUtil.cpp
@@ -100,9 +100,8 @@ void AP_Terrain::calculate_grid_info(const Location &loc, struct grid_info &info
     info.frac_y = (offset.y - idx_y * grid_spacing) / grid_spacing;
 
     // calculate lat/lon of SW corner of 32*28 grid_block
-    location_offset(ref, 
-                    info.grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X * (float)grid_spacing,
-                    info.grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y * (float)grid_spacing);
+    ref.offset(info.grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X * (float)grid_spacing,
+               info.grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y * (float)grid_spacing);
     info.grid_lat = ref.lat;
     info.grid_lon = ref.lng;
 

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -190,10 +190,10 @@ void ADSB::send_report(void)
             ADSB_Vehicle &vehicle = vehicles[i];
             Location loc = home;
 
-            location_offset(loc, vehicle.position.x, vehicle.position.y);
+            loc.offset(vehicle.position.x, vehicle.position.y);
 
             // re-init when exceeding radius range
-            if (get_distance(home, loc) > _sitl->adsb_radius_m) {
+            if (home.get_distance(loc) > _sitl->adsb_radius_m) {
                 vehicle.initialised = false;
             }
             

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -180,7 +180,7 @@ bool Aircraft::on_ground() const
 void Aircraft::update_position(void)
 {
     location = home;
-    location_offset(location, position.x, position.y);
+    location.offset(position.x, position.y);
 
     location.alt  = static_cast<int32_t>(home.alt - position.z * 100.0f);
 
@@ -683,7 +683,7 @@ void Aircraft::smooth_sensors(void)
     smoothing.position += smoothing.velocity_ef * delta_time;
 
     smoothing.location = home;
-    location_offset(smoothing.location, smoothing.position.x, smoothing.position.y);
+    smoothing.location.offset(smoothing.position.x, smoothing.position.y);
     smoothing.location.alt  = static_cast<int32_t>(home.alt - smoothing.position.z * 100.0f);
 
     smoothing.last_update_us = now;

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -306,9 +306,9 @@ bool XPlane::receive_data(void)
     accel_earth.z += GRAVITY_MSS;
     
     // the position may slowly deviate due to float accuracy and longitude scaling
-    if (get_distance(loc, location) > 4 || abs(loc.alt - location.alt)*0.01f > 2.0f) {
+    if (loc.get_distance(location) > 4 || abs(loc.alt - location.alt)*0.01f > 2.0f) {
         printf("X-Plane home reset dist=%f alt=%.1f/%.1f\n",
-               get_distance(loc, location), loc.alt*0.01f, location.alt*0.01f);
+               loc.get_distance(location), loc.alt*0.01f, location.alt*0.01f);
         // reset home location
         position_zero(-pos.x, -pos.y, -pos.z);
         home.lat = loc.lat;


### PR DESCRIPTION
Use functions from the Location class where possible.

On ArduCopter CubeBlack target this saves 212 bytes.

Before:

```
Target          Text     Data  BSS     Total  
----------------------------------------------
bin/arducopter  1017320  1152  195640  1214112

```

after:

```
Target          Text     Data  BSS     Total  
----------------------------------------------
bin/arducopter  1017108  1152  195644  1213904

```
