### PR TITLE
AP_Common: Move LOCATION_ALT_MAX_M declaration from AP_Common.h to Lo…

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -62,8 +62,6 @@
     inline uint8_t &operator[](size_t i) { return reinterpret_cast<uint8_t *>(this)[i]; }           \
     inline uint8_t operator[](size_t i) const { return reinterpret_cast<const uint8_t *>(this)[i]; }
 
-#define LOCATION_ALT_MAX_M  83000   // maximum altitude (in meters) that can be fit into Location structure's alt field
-
 /*
   check if bit bitnumber is set in value, returned as a
   bool. Bitnumber starts at 0 for the first bit

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -14,6 +14,8 @@
 class AP_AHRS_NavEKF;
 class AP_Terrain;
 
+#define LOCATION_ALT_MAX_M  83000   // maximum altitude (in meters) that can be fit into Location structure's alt field
+
 class Location
 {
 public:


### PR DESCRIPTION
…cation.h

This reduces the scope of this constant, and moves it to the file that actually depends on it