### PR TITLE
Vagrant: do not build JSBSIM by default on Vagrant images

### DIFF
--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -50,10 +50,11 @@ pip install pexpect
 
 sudo -u $VAGRANT_USER ln -fs /vagrant/Tools/vagrant/screenrc /home/$VAGRANT_USER/.screenrc
 
-# build JSB sim
+# install tools suitable for building JSB sim:
 apt-get install -y libtool automake autoconf libexpat1-dev
 #  libtool-bin
-sudo --login -u $VAGRANT_USER /vagrant/Tools/scripts/build-jsbsim.sh
+# we no longer build JSBSIM by default, but leaving this here anyway:
+#sudo --login -u $VAGRANT_USER /vagrant/Tools/scripts/build-jsbsim.sh
 
 # adjust environment for every login shell:
 DOT_PROFILE=/home/$VAGRANT_USER/.profile


### PR DESCRIPTION
Most people don't actually use JSBSIM for their simulations (we use our
built-on models by default now-adays).

Save some time on bringing the image up by not including JSBSIM by
default.

This was prompted by the master build of JSBSIM not compiling...