### PR TITLE
Move home-setting sanity checks into AP_AHRS::set_home

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -166,7 +166,9 @@ void Rover::ahrs_update()
 
     // set home from EKF if necessary and possible
     if (!ahrs.home_is_set()) {
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // ignore this failure
+        }
     }
 
     // if using the EKF get a speed update now (from accelerometers)

--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -93,7 +93,9 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
             // if disarmed clear mission and set home to current location
             if (!rover.arming.is_armed()) {
                 rover.mode_auto.mission.clear();
-                rover.set_home_to_current_location(false);
+                if (!rover.set_home_to_current_location(false)) {
+                    // ignored
+                }
                 return;
             }
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -406,8 +406,8 @@ private:
     void update_mission(void);
 
     // commands.cpp
-    bool set_home_to_current_location(bool lock);
-    bool set_home(const Location& loc, bool lock);
+    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
     void update_home();
 
     // compat.cpp

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -19,14 +19,6 @@ bool Rover::set_home_to_current_location(bool lock)
 //  returns true if home location set successfully
 bool Rover::set_home(const Location& loc, bool lock)
 {
-    // check location is valid
-    if (loc.lat == 0 && loc.lng == 0 && loc.alt == 0) {
-        return false;
-    }
-    if (!check_latlng(loc)) {
-        return false;
-    }
-
     const bool home_was_set = ahrs.home_is_set();
 
     // set ahrs home

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -30,7 +30,9 @@ bool Rover::set_home(const Location& loc, bool lock)
     const bool home_was_set = ahrs.home_is_set();
 
     // set ahrs home
-    ahrs.set_home(loc);
+    if (!ahrs.set_home(loc)) {
+        return false;
+    }
 
     if (!home_was_set) {
         // log new home position which mission library will pull from ahrs
@@ -82,5 +84,7 @@ void Rover::update_home()
         return;
     }
 
-    ahrs.set_home(loc);
+    if (!ahrs.set_home(loc)) {
+        // silently ignored...
+    }
 }

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -349,9 +349,13 @@ void ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 && rover.have_position) {
-        rover.set_home_to_current_location(false);
+        if (!rover.set_home_to_current_location(false)) {
+            // ignored...
+        }
     } else {
-        rover.set_home(cmd.content.location, false);
+        if (!rover.set_home(cmd.content.location, false)) {
+            // ignored...
+        }
     }
 }
 

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -28,8 +28,8 @@ protected:
         return 0; // what if we have been picked up and carried somewhere?
     }
 
-    bool set_home_to_current_location(bool lock) override { return false; }
-    bool set_home(const Location& loc, bool lock) override { return false; }
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED { return false; }
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED { return false; }
 
 private:
 

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -156,7 +156,9 @@ void Tracker::set_home(struct Location temp)
     // check EKF origin has been set
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
-        ahrs.set_home(temp);
+        if (!ahrs.set_home(temp)) {
+            // ignore error silently
+        }
     }
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -673,8 +673,8 @@ private:
     // commands.cpp
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location(bool lock);
-    bool set_home(const Location& loc, bool lock);
+    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
 
     // compassmot.cpp

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -699,10 +699,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
             if (!is_zero(packet.param1)) {
                 return MAV_RESULT_FAILED;
             }
-            // sanity check location
-            if (!check_latlng(packet.param5, packet.param6)) {
-                return MAV_RESULT_FAILED;
-            }
             Location new_home_loc;
             new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
             new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
@@ -1253,10 +1249,6 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
                 // silently ignored
             }
         } else {
-            // sanity check location
-            if (!check_latlng(packet.latitude, packet.longitude)) {
-                break;
-            }
             Location new_home_loc;
             new_home_loc.lat = packet.latitude;
             new_home_loc.lng = packet.longitude;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1249,7 +1249,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
         mavlink_set_home_position_t packet;
         mavlink_msg_set_home_position_decode(msg, &packet);
         if((packet.latitude == 0) && (packet.longitude == 0) && (packet.altitude == 0)) {
-            copter.set_home_to_current_location(true);
+            if (!copter.set_home_to_current_location(true)) {
+                // silently ignored
+            }
         } else {
             // sanity check location
             if (!check_latlng(packet.latitude, packet.longitude)) {
@@ -1259,7 +1261,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             new_home_loc.lat = packet.latitude;
             new_home_loc.lng = packet.longitude;
             new_home_loc.alt = packet.altitude / 10;
-            copter.set_home(new_home_loc, true);
+            if (!copter.set_home(new_home_loc, true)) {
+                // silently ignored
+            }
         }
         break;
     }

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -38,8 +38,8 @@ protected:
 
     void handle_mount_message(const mavlink_message_t* msg) override;
 
-    bool set_home_to_current_location(bool lock) override;
-    bool set_home(const Location& loc, bool lock) override;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 
 private:
 

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -13,7 +13,9 @@ void Copter::update_home_from_EKF()
         set_home_to_current_location_inflight();
     } else {
         // move home to current ekf location (this will set home_state to HOME_SET)
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // ignore failure
+        }
     }
 }
 
@@ -75,7 +77,9 @@ bool Copter::set_home(const Location& loc, bool lock)
     const bool home_was_set = ahrs.home_is_set();
 
     // set ahrs home (used for RTL)
-    ahrs.set_home(loc);
+    if (!ahrs.set_home(loc)) {
+        return false;
+    }
 
     // init inav and compass declination
     if (!home_was_set) {

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -58,11 +58,6 @@ bool Copter::set_home_to_current_location(bool lock) {
 //  returns true if home location set successfully
 bool Copter::set_home(const Location& loc, bool lock)
 {
-    // check location is valid
-    if (loc.lat == 0 && loc.lng == 0) {
-        return false;
-    }
-
     // check EKF origin has been set
     Location ekf_origin;
     if (!ahrs.get_origin(ekf_origin)) {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1360,9 +1360,13 @@ void Copter::ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Copter::ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
-        copter.set_home_to_current_location(false);
+        if (!copter.set_home_to_current_location(false)) {
+            // ignore failure
+        }
     } else {
-        copter.set_home(cmd.content.location, false);
+        if (!copter.set_home(cmd.content.location, false)) {
+            // ignore failure
+        }
     }
 }
 

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -188,7 +188,9 @@ bool Copter::init_arm_motors(const AP_Arming::ArmingMethod method, const bool do
         arming_altitude_m = 0;        
     } else if (!ahrs.home_is_locked()) {
         // Reset home position if it has already been set before (but not locked)
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // ignore failure
+        }
 
         // remember the height when we armed
         arming_altitude_m = inertial_nav.get_altitude() * 0.01;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -382,7 +382,9 @@ void Plane::update_GPS_10Hz(void)
                 ground_start_count = 5;
 
             } else {
-                set_home_persistently(gps.location());
+                if (!set_home_persistently(gps.location())) {
+                    // silently ignore failure...
+                }
 
                 next_WP_loc = prev_WP_loc = home;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -982,14 +982,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
             if (!is_zero(packet.param1)) {
                 return MAV_RESULT_FAILED;
             }
-            if (is_zero(packet.param5) && is_zero(packet.param6) && is_zero(packet.param7)) {
-                // don't allow the 0,0 position
-                return MAV_RESULT_FAILED;
-            }
-            // sanity check location
-            if (!check_latlng(packet.param5,packet.param6)) {
-                return MAV_RESULT_FAILED;
-            }
             Location new_home_loc {};
             new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
             new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
@@ -1294,14 +1286,6 @@ void GCS_MAVLINK_Plane::handleMessage(mavlink_message_t* msg)
     {
         mavlink_set_home_position_t packet;
         mavlink_msg_set_home_position_decode(msg, &packet);
-        if((packet.latitude == 0) && (packet.longitude == 0) && (packet.altitude == 0)) {
-            // don't allow the 0,0 position
-            break;
-        }
-        // sanity check location
-        if (!check_latlng(packet.latitude,packet.longitude)) {
-            break;
-        }
         Location new_home_loc {};
         new_home_loc.lat = packet.latitude;
         new_home_loc.lng = packet.longitude;

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -37,8 +37,8 @@ protected:
 
     bool persist_streamrates() const override { return true; }
 
-    bool set_home_to_current_location(bool lock) override;
-    bool set_home(const Location& loc, bool lock) override;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 
 private:
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -854,7 +854,7 @@ private:
     void set_guided_WP(void);
     void update_home();
     // set home location and store it persistently:
-    void set_home_persistently(const Location &loc);
+    bool set_home_persistently(const Location &loc) WARN_IF_UNUSED;
     void do_RTL(int32_t alt);
     bool verify_takeoff();
     bool verify_loiter_unlim(const AP_Mission::Mission_Command &cmd);

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -120,17 +120,23 @@ void Plane::update_home()
     if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         Location loc;
         if(ahrs.get_position(loc)) {
-            AP::ahrs().set_home(loc);
+            if (!AP::ahrs().set_home(loc)) {
+                // silently fail
+            }
         }
     }
     barometer.update_calibration();
     ahrs.resetHeightDatum();
 }
 
-void Plane::set_home_persistently(const Location &loc)
+bool Plane::set_home_persistently(const Location &loc)
 {
-    AP::ahrs().set_home(loc);
+    if (!AP::ahrs().set_home(loc)) {
+        return false;
+    }
 
     // Save Home to EEPROM
     mission.write_home_to_storage();
+
+    return true;
 }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -901,10 +901,13 @@ void Plane::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 && gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
-        set_home_persistently(gps.location());
+        if (!set_home_persistently(gps.location())) {
+            // silently ignore error
+        }
     } else {
-        AP::ahrs().set_home(cmd.content.location);
-        gcs().send_ekf_origin();
+        if (AP::ahrs().set_home(cmd.content.location)) {
+            gcs().send_ekf_origin();
+        }
     }
 }
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -905,8 +905,8 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
             // silently ignore error
         }
     } else {
-        if (AP::ahrs().set_home(cmd.content.location)) {
-            gcs().send_ekf_origin();
+        if (!AP::ahrs().set_home(cmd.content.location)) {
+            // silently ignore failure
         }
     }
 }

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -681,10 +681,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
             if (!is_zero(packet.param1)) {
                 return MAV_RESULT_FAILED;
             }
-            // sanity check location
-            if (!check_latlng(packet.param5, packet.param6)) {
-                return MAV_RESULT_FAILED;
-            }
             Location new_home_loc;
             new_home_loc.lat = (int32_t)(packet.param5 * 1.0e7f);
             new_home_loc.lng = (int32_t)(packet.param6 * 1.0e7f);
@@ -949,10 +945,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
                 // ignore this failure
             }
         } else {
-            // sanity check location
-            if (!check_latlng(packet.latitude, packet.longitude)) {
-                break;
-            }
             Location new_home_loc;
             new_home_loc.lat = packet.latitude;
             new_home_loc.lng = packet.longitude;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -945,7 +945,9 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         mavlink_set_home_position_t packet;
         mavlink_msg_set_home_position_decode(msg, &packet);
         if ((packet.latitude == 0) && (packet.longitude == 0) && (packet.altitude == 0)) {
-            sub.set_home_to_current_location(true);
+            if (!sub.set_home_to_current_location(true)) {
+                // ignore this failure
+            }
         } else {
             // sanity check location
             if (!check_latlng(packet.latitude, packet.longitude)) {
@@ -958,7 +960,9 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
             if (sub.far_from_EKF_origin(new_home_loc)) {
                 break;
             }
-            sub.set_home(new_home_loc, true);
+            if (!sub.set_home(new_home_loc, true)) {
+                // silently ignored
+            }
         }
         break;
     }

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -32,8 +32,8 @@ protected:
 
     bool vehicle_initialised() const override;
 
-    bool set_home_to_current_location(bool lock) override;
-    bool set_home(const Location& loc, bool lock) override;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 
 private:
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -507,8 +507,8 @@ private:
     void userhook_SuperSlowLoop();
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location(bool lock);
-    bool set_home(const Location& loc, bool lock);
+    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
     void exit_mission();
     bool verify_loiter_unlimited();

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -13,7 +13,9 @@ void Sub::update_home_from_EKF()
         set_home_to_current_location_inflight();
     } else {
         // move home to current ekf location (this will set home_state to HOME_SET)
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // ignore this failure
+        }
     }
 }
 
@@ -25,7 +27,9 @@ void Sub::set_home_to_current_location_inflight()
     if (inertial_nav.get_location(temp_loc)) {
         const struct Location &ekf_origin = inertial_nav.get_origin();
         temp_loc.alt = ekf_origin.alt;
-        set_home(temp_loc, false);
+        if (!set_home(temp_loc, false)) {
+            // ignore this failure
+        }
     }
 }
 
@@ -65,7 +69,9 @@ bool Sub::set_home(const Location& loc, bool lock)
     const bool home_was_set = ahrs.home_is_set();
 
     // set ahrs home (used for RTL)
-    ahrs.set_home(loc);
+    if (!ahrs.set_home(loc)) {
+        return false;
+    }
 
     // init inav and compass declination
     if (!home_was_set) {

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -55,11 +55,6 @@ bool Sub::set_home_to_current_location(bool lock)
 //  returns true if home location set successfully
 bool Sub::set_home(const Location& loc, bool lock)
 {
-    // check location is valid
-    if (loc.lat == 0 && loc.lng == 0) {
-        return false;
-    }
-
     // check if EKF origin has been set
     Location ekf_origin;
     if (!ahrs.get_origin(ekf_origin)) {

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -765,10 +765,14 @@ void Sub::do_change_speed(const AP_Mission::Mission_Command& cmd)
 void Sub::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // silently ignore this failure
+        }
     } else {
         if (!far_from_EKF_origin(cmd.content.location)) {
-            set_home(cmd.content.location, false);
+            if (!set_home(cmd.content.location, false)) {
+                // silently ignore this failure
+            }
         }
     }
 }

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -52,7 +52,9 @@ bool Sub::init_arm_motors(AP_Arming::ArmingMethod method)
         // Log_Write_Event(DATA_EKF_ALT_RESET);
     } else if (ahrs.home_is_set() && !ahrs.home_is_locked()) {
         // Reset home position if it has already been set before (but not locked)
-        set_home_to_current_location(false);
+        if (!set_home_to_current_location(false)) {
+            // ignore this failure
+        }
     }
 	
     // enable gps velocity based centrefugal force compensation

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -639,7 +639,9 @@ void Replay::read_sensors(const char *type)
                      loc.lng * 1.0e-7f,
                      loc.alt * 0.01f,
                      AP_HAL::millis()*0.001f);
-            _vehicle.ahrs.set_home(loc);
+            if (!_vehicle.ahrs.set_home(loc)) {
+                ::printf("Failed to set home to that location!");
+            }
             _vehicle.compass.set_initial_location(loc.lat, loc.lng);
             done_home_init = true;
         }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -462,7 +462,7 @@ public:
     // set the home location in 10e7 degrees. This should be called
     // when the vehicle is at this position. It is assumed that the
     // current barometer and GPS altitudes correspond to this altitude
-    virtual void set_home(const Location &loc) = 0;
+    virtual bool set_home(const Location &loc) WARN_IF_UNUSED = 0;
 
     // set the EKF's origin location in 10e7 degrees.  This should only
     // be called when the EKF has no absolute position reference (i.e. GPS)

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1031,7 +1031,7 @@ bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret) const
     return ret;
 }
 
-void AP_AHRS_DCM::set_home(const Location &loc)
+bool AP_AHRS_DCM::set_home(const Location &loc)
 {
     _home = loc;
     _home_is_set = true;
@@ -1042,6 +1042,8 @@ void AP_AHRS_DCM::set_home(const Location &loc)
     // send new home and ekf origin to GCS
     gcs().send_home();
     gcs().send_ekf_origin();
+
+    return true;
 }
 
 //  a relative ground position to home in meters, Down

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1033,6 +1033,14 @@ bool AP_AHRS_DCM::airspeed_estimate(float *airspeed_ret) const
 
 bool AP_AHRS_DCM::set_home(const Location &loc)
 {
+    // check location is valid
+    if (loc.lat == 0 && loc.lng == 0 && loc.alt == 0) {
+        return false;
+    }
+    if (!check_latlng(loc)) {
+        return false;
+    }
+
     _home = loc;
     _home_is_set = true;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -96,7 +96,7 @@ public:
 
     bool            use_compass() override;
 
-    void set_home(const Location &loc) override;
+    bool set_home(const Location &loc) override WARN_IF_UNUSED;
     void estimate_wind(void);
 
     // is the AHRS subsystem healthy?

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3631,20 +3631,12 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_do_set_home(const mavlink_command_int
     if (!is_zero(packet.param1)) {
         return MAV_RESULT_FAILED;
     }
-    if ((packet.x == 0) && (packet.y == 0) && is_zero(packet.z)) {
-        // don't allow the 0,0 position
-        return MAV_RESULT_FAILED;
-    }
     // check frame type is supported
     if (packet.frame != MAV_FRAME_GLOBAL &&
         packet.frame != MAV_FRAME_GLOBAL_INT &&
         packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT &&
         packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
         return MAV_RESULT_UNSUPPORTED;
-    }
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_FAILED;
     }
     Location new_home_loc {};
     new_home_loc.lat = packet.x;


### PR DESCRIPTION
One thing's clear to me from this PR - we ignore failure-to-set-home a lot.

One wonders how significant a failure to set home in a mission is and what we should do about it, for example.
