### PR TITLE
Copter: (WIP) Descend to RTL altitude while cruising home

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -929,7 +929,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_AutoTune/AC_AutoTune.cpp
     AP_SUBGROUPPTR(autotune_ptr, "AUTOTUNE_",  29, ParametersG2, Copter::AutoTune),
 #endif
-    
+
+    // @Param: RTL_CRUISE_DESC
+    // @DisplayName: RTL Cruise Descent
+    // @Description: Copter will descend to the RTL altitude while flying towards home if above the RTL altitude
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("RTL_CRUISE_DESC", 30, ParametersG2, rtl_cruise_descent, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -583,6 +583,9 @@ public:
     // we need a pointer to autotune for the G2 table
     void *autotune_ptr;
 #endif
+
+    // RTL Cruise Descent enable/disable
+    AP_Int8 rtl_cruise_descent;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -933,6 +933,7 @@ private:
     void loiterathome_run();
     void build_path(bool terrain_following_allowed);
     void compute_return_target(bool terrain_following_allowed);
+    void compute_cruise_descent();
 
     // RTL
     RTLState _state = RTL_InitialClimb;  // records state of rtl (initial climb, returning home, etc)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -78,6 +78,15 @@ public:
     /// set current target horizontal speed during wp navigation
     void set_speed_xy(float speed_cms);
 
+    /// get current target horizontal velocity during wp navigation
+    float get_max_speed_xy() const { return _pos_control.get_max_speed_xy(); }
+
+    /// get current target descent velocity during wp navigation
+    float get_max_speed_down() const { return _pos_control.get_max_speed_down(); }
+
+    /// get current target climb velocity during wp navigation
+    float get_max_speed_up() const { return _pos_control.get_max_speed_up(); }
+
     /// set current target climb or descent rate during wp navigation
     void set_speed_up(float speed_up_cms);
     void set_speed_down(float speed_down_cms);


### PR DESCRIPTION
This new option will allow the copter to descend down to the set `RTL_ALTITUDE` while cruising home.  For example, my RTL altitude is almost always set for 150ft which is high enough to clear all obstructions in the area. So if I'm at 350ft when RTL is invoked, the copter will descend from 350 down to 150 while flying towards home.  This is much more efficient than cruising home straight and level, then vertically descending upon arrival.  It will use less time and less battery.  Obviously, this option should only be used if you ensure your `rtl_altitude` parameter is high enough to clear all obstacles.

* If new parameter `rtl_cruise_desc` is disabled (default), behavior is unchanged.
* If copter is below `rtl_altitude`, behavior is unchanged.
* If new parameter `rtl_cruise_desc` _enabled_ (1) and copter is above `rtl_altitude`, the new cruise descent will take place.  It will still respect the `rtl_climb_min` setting.

Since 3D position navigation will alter the horizontal and vertical speed to make an nice even descent profile, I had to do some math to calculate a target altitude it can reach **without slowing down**.  If it can reach `rtl_altitude` while staying under the `wpnav_speed_dn`, parameter, the target altitude is just the rtl altitude.  If it cannot descend fast enough to reach the rtl altitude, we compute an altitude it can reach, and that becomes the new target altitude.

**HELP:**  The position controller doesn't seem to even try reaching the WPNAV_SPEED parameters when navigating in 3D.  If you tell it to fly to somewhere at some different altitude, it always travels way slower and climbs/descends way slower than it needs to.  It would be perfectly capable of getting there at or under the WPNAV_SPEED* parameters, but doesn't even try.  It does so at about half the rate.  This is not specific to my PR.  It does this regardless, even in guided mode.  SITL will show this.  For this reason, I can't actually use this PR in practice because it slows the RTL way down.