### PR TITLE
Rover: magically set home when toggling first waypoint in

### DIFF
--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -78,6 +78,23 @@ void RC_Channel_Rover::do_aux_function_change_mode(Mode &mode,
     }
 }
 
+void RC_Channel_Rover::add_waypoint_for_current_loc()
+{
+    // create new mission command
+    AP_Mission::Mission_Command cmd = {};
+
+    // set new waypoint to current location
+    cmd.content.location = rover.current_loc;
+
+    // make the new command to a waypoint
+    cmd.id = MAV_CMD_NAV_WAYPOINT;
+
+    // save command
+    if (rover.mode_auto.mission.add_cmd(cmd)) {
+        hal.console->printf("Added waypoint %u", (unsigned)rover.mode_auto.mission.num_commands());
+    }
+}
+
 void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch (ch_option) {
@@ -101,19 +118,11 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
 
             // record the waypoint if not in auto mode
             if (rover.control_mode != &rover.mode_auto) {
-                // create new mission command
-                AP_Mission::Mission_Command cmd = {};
-
-                // set new waypoint to current location
-                cmd.content.location = rover.current_loc;
-
-                // make the new command to a waypoint
-                cmd.id = MAV_CMD_NAV_WAYPOINT;
-
-                // save command
-                if (rover.mode_auto.mission.add_cmd(cmd)) {
-                    hal.console->printf("Added waypoint %u", (unsigned)rover.mode_auto.mission.num_commands());
+                if (rover.mode_auto.mission.num_commands() == 0) {
+                    // add a home location....
+                    add_waypoint_for_current_loc();
                 }
+                add_waypoint_for_current_loc();
             }
         }
         break;

--- a/APMrover2/RC_Channel.h
+++ b/APMrover2/RC_Channel.h
@@ -22,6 +22,7 @@ private:
     void do_aux_function_change_mode(Mode &mode,
                                      const aux_switch_pos_t ch_flag);
 
+    void add_waypoint_for_current_loc();
 };
 
 class RC_Channels_Rover : public RC_Channels

--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -119,13 +119,13 @@ class AutoTestRover(AutoTest):
             self.set_parameter("RC7_OPTION", 7)
             self.set_parameter("RC8_OPTION", 58)
 
-            self.clear_wp()
-
             self.mavproxy.send('switch 5\n')
             self.wait_mode('MANUAL')
 
             self.wait_ready_to_arm()
             self.arm_vehicle()
+
+            self.clear_wp()
 
             # first aim north
             self.progress("\nTurn right towards north")
@@ -171,8 +171,10 @@ class AutoTestRover(AutoTest):
             self.progress("Checking number of saved waypoints")
             num_wp = self.save_mission_to_file(
                 os.path.join(testdir, "rover-ch7_mission.txt"))
-            if num_wp != 6:
-                raise NotAchievedException("Did not get 6 waypoints")
+            expected = 7 # home + 6 toggled in
+            if num_wp != expected:
+                raise NotAchievedException("Did not get %u waypoints; got %u" %
+                                           (expected, num_wp))
 
             # TODO: actually drive the mission
 


### PR DESCRIPTION
Currently the first toggle will put home in rather than the first
waypoint