### PR TITLE
AP_Logger: call wrap_360_cd on yaw values in WriteAttitudeView

### DIFF
--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1377,8 +1377,8 @@ void AP_Logger::Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets)
         roll            : (int16_t)ahrs.roll_sensor,
         control_pitch   : (int16_t)targets.y,
         pitch           : (int16_t)ahrs.pitch_sensor,
-        control_yaw     : (uint16_t)targets.z,
-        yaw             : (uint16_t)ahrs.yaw_sensor,
+        control_yaw     : (uint16_t)wrap_360_cd(targets.z),
+        yaw             : (uint16_t)wrap_360_cd(ahrs.yaw_sensor),
         error_rp        : (uint16_t)(ahrs.get_error_rp() * 100),
         error_yaw       : (uint16_t)(ahrs.get_error_yaw() * 100)
     };


### PR DESCRIPTION
This fixes wrapping discrepancies on target.z and makes WrteAttitudeView functionally the same as WriteAttitude.

@tridge I noticed this issue on DesYaw in a quad tailsitter log:
![yaw_anomaly](https://user-images.githubusercontent.com/2300221/52818358-cfefb700-3063-11e9-8624-24c5f2ce059a.png)
