### PR TITLE
Restore G_Dt meaning in Sub and Plane

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -123,7 +123,7 @@ void Plane::setup()
 void Plane::loop()
 {
     scheduler.loop();
-    G_Dt = scheduler.get_loop_period_s();
+    G_Dt = scheduler.get_last_loop_time_s();
 }
 
 void Plane::update_soft_armed()

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -94,7 +94,7 @@ void Sub::setup()
 void Sub::loop()
 {
     scheduler.loop();
-    G_Dt = scheduler.get_loop_period_s();
+    G_Dt = scheduler.get_last_loop_time_s();
 }
 
 


### PR DESCRIPTION
Prior to e6cebdecd1a1db928d55b318b7c51a982aa1af46 G_Dt was based on actual loop times.  This restores that.
