### PR TITLE
GCS_MAVLink: only process targetted packets with my component id

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -126,7 +126,8 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
     bool broadcast_component = (target_component == 0 || target_component == -1);
     bool match_system = broadcast_system || (target_system == mavlink_system.sysid);
     bool match_component = match_system && (broadcast_component || 
-                                            (target_component == mavlink_system.compid));
+                                            ((target_component == mavlink_system.compid) ||
+                                             target_component == MAV_COMP_ID_LOG));
     bool process_locally = match_system && match_component;
 
     if (process_locally && !broadcast_system && !broadcast_component) {
@@ -172,7 +173,7 @@ bool MAVLink_routing::check_and_forward(mavlink_channel_t in_channel, const mavl
         }
     }
 
-    if (!forwarded && match_system) {
+    if (!forwarded && match_system && match_component) {
         process_locally = true;
     }
 


### PR DESCRIPTION
This makes the assumption that GCSs do not attempt to (e.g.) target their
camera messages which we are currently handling to MAV_COMP_ID_CAMERA

Scenario: someone forgets to turn on their companion computer.  Discovers it is unreachable in-flight.  Decides to try to reboot it.  We reboot the autopilot instead.
