### PR TITLE
GCS_MAVLink: use Location to change alt frames

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1040,8 +1040,15 @@ bool AP_AHRS_DCM::set_home(const Location &loc)
     if (!check_latlng(loc)) {
         return false;
     }
+    // home must always be global frame at the moment as .alt is
+    // accessed directly by the vehicles and they may not be rigorous
+    // in checking the frame type.
+    Location tmp = loc;
+    if (!tmp.change_alt_frame(Location::ALT_FRAME_ABSOLUTE)) {
+        return false;
+    }
 
-    _home = loc;
+    _home = tmp;
     _home_is_set = true;
 
     // log ahrs home and ekf origin dataflash


### PR DESCRIPTION
Based on earlier changes to  MAVLINK_MSG_ID_SET_POSITION_TARGET_GLOBAL_INT in Copter.

