### PR TITLE
waf: can set macros at configuration

### DIFF
--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -33,4 +33,5 @@ def build(bld):
         program_name='ardurover',
         program_groups=['bin', 'rover'],
         use=vehicle + '_libs',
+        defines=list(bld.env.MACRO_LIST)
     )

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -16,4 +16,5 @@ def build(bld):
         program_name='antennatracker',
         program_groups=['bin', 'antennatracker'],
         use=vehicle + '_libs',
+        defines=list(bld.env.MACRO_LIST)
     )

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -40,12 +40,12 @@ def build(bld):
         program_name='arducopter',
         program_groups=['bin', 'copter'],
         use=vehicle + '_libs',
-        defines=['FRAME_CONFIG=MULTICOPTER_FRAME'],
+        defines=['FRAME_CONFIG=MULTICOPTER_FRAME']+bld.env.MACRO_LIST,
         )
 
     bld.ap_program(
         program_name='arducopter-heli',
         program_groups=['bin', 'heli'],
         use=vehicle + '_libs',
-        defines=['FRAME_CONFIG=HELI_FRAME'],
+        defines=['FRAME_CONFIG=HELI_FRAME']+bld.env.MACRO_LIST,
         )

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -40,4 +40,5 @@ def build(bld):
         program_name='arduplane',
         program_groups=['bin', 'plane'],
         use=vehicle + '_libs',
+        defines=list(bld.env.MACRO_LIST)
     )

--- a/ArduSub/wscript
+++ b/ArduSub/wscript
@@ -27,4 +27,5 @@ def build(bld):
         program_name='ardusub',
         program_groups=['bin', 'sub'],
         use=vehicle + '_libs',
+        defines=list(bld.env.MACRO_LIST)
     )

--- a/wscript
+++ b/wscript
@@ -188,6 +188,12 @@ configuration in order to save typing.
         default=False,
         help='Force a static build')
 
+    g.add_option('--macro',
+        default=None,
+        action='append',
+        dest="macro_list",
+        help='define a macro: #define <string>')
+
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():
         paths = []
@@ -223,6 +229,10 @@ def configure(cfg):
     cfg.env.USE_NUTTX_IOFW = cfg.options.use_nuttx_iofw
 
     cfg.env.OPTIONS = cfg.options.__dict__
+
+    cfg.env.MACRO_LIST = []
+    if cfg.options.macro_list:
+        cfg.env.MACRO_LIST = cfg.options.macro_list
 
     # Allow to differentiate our build from the make build
     cfg.define('WAF_BUILD', 1)
@@ -307,6 +317,8 @@ def configure(cfg):
     cfg.env.prepend_value('DEFINES', [
         'SKETCHBOOK="' + cfg.srcnode.abspath() + '"',
     ])
+
+    cfg.msg('Macros defined', None if cfg.env.MACRO_LIST==[] else ', '.join(cfg.env.MACRO_LIST))
 
     # Always use system extensions
     cfg.define('_GNU_SOURCE', 1)


### PR DESCRIPTION
Allows users to set macros during the configuration step, using the --macro argument. e.g.
`./waf configure --macro LOGGING_ENABLED=0`
disables logging via a macro. This provides developers and others a option for setting configuration parameters other than modifying APM_Config.h

Tested with the example above in sitl.
ran build_all.sh with no errors.
