### PR TITLE
GCS_MAVLink: use Is_active_mavlink() instead of get_active_mavlink() & (1<<chan)

### DIFF
--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -142,20 +142,16 @@ void AP_Button::timer_update(void)
  */
 void AP_Button::send_report(void)
 {
-    uint8_t chan_mask = GCS_MAVLINK::active_channel_mask();
-    uint32_t now = AP_HAL::millis();
-    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
-        if ((chan_mask & (1U<<i)) == 0) {
+    const uint32_t now = AP_HAL::millis();
+    for (uint8_t chan=0; chan<MAVLINK_COMM_NUM_BUFFERS; chan++) {
+        if (!GCS_MAVLINK::is_active_channel((mavlink_channel_t)chan) || !HAVE_PAYLOAD_SPACE(chan, BUTTON_CHANGE)) {
             // not active
             continue;
         }
-        mavlink_channel_t chan = (mavlink_channel_t)i;
-        if (HAVE_PAYLOAD_SPACE(chan, BUTTON_CHANGE)) {
-            mavlink_msg_button_change_send(chan,
-                                           now,
-                                           (uint32_t)last_change_time_ms,
-                                           last_mask);
-        }
+        mavlink_msg_button_change_send((mavlink_channel_t)chan,
+                                       now,
+                                       (uint32_t)last_change_time_ms,
+                                       last_mask);
     }
 }
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -27,10 +27,10 @@
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
 
 // check if a message will fit in the payload space available
-#define PAYLOAD_SIZE(chan, id) (GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
-#define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= PAYLOAD_SIZE(chan, id))
-#define CHECK_PAYLOAD_SIZE(id) if (comm_get_txspace(chan) < packet_overhead()+MAVLINK_MSG_ID_ ## id ## _LEN) return false
-#define CHECK_PAYLOAD_SIZE2(id) if (!HAVE_PAYLOAD_SPACE(chan, id)) return false
+#define PAYLOAD_SIZE(chan, id) (GCS_MAVLINK::packet_overhead_chan((mavlink_channel_t)chan)+MAVLINK_MSG_ID_ ## id ## _LEN)
+#define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace((mavlink_channel_t)chan) >= PAYLOAD_SIZE(chan, id))
+#define CHECK_PAYLOAD_SIZE(id) if (comm_get_txspace((mavlink_channel_t)chan) < packet_overhead()+MAVLINK_MSG_ID_ ## id ## _LEN) return false
+#define CHECK_PAYLOAD_SIZE2(id) if (!HAVE_PAYLOAD_SPACE((mavlink_channel_t)chan, id)) return false
 
 //  GCS Message ID's
 /// NOTE: to ensure we never block on sending MAVLink messages
@@ -231,6 +231,7 @@ public:
     // return a bitmap of active channels. Used by libraries to loop
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }
+    static bool is_active_channel(const mavlink_channel_t chan) { return mavlink_active & (1U<<chan); }
 
     // return a bitmap of streaming channels
     static uint8_t streaming_channel_mask(void) { return chan_is_streaming; }


### PR DESCRIPTION
 non-functional change

GCS_MAVLink: use Is_active_mavlink() instead of get_active_mavlink() & (1<<chan)

then applied it in to a couple places which cleaned things up a bit, easier to read.