### PR TITLE
Tools: new waf argument "--uploadfast" instead of --upload

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -498,7 +498,14 @@ special group "all" selects all programs.
 
     g.add_option('--upload',
         action='store_true',
-        help='''Upload applicable targets to a connected device. Not all
+        help='''Upload applicable targets to a connected device at 115200 baud. Not all
+platforms may support this. Example: `waf copter --upload` means "build
+arducopter and upload it to my board".
+''')
+
+    g.add_option('--uploadfast',
+        action='store_true',
+        help='''Upload applicable targets to a connected device at 921600 baud. Not all
 platforms may support this. Example: `waf copter --upload` means "build
 arducopter and upload it to my board".
 ''')

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -54,7 +54,8 @@ class upload_fw(Task.Task):
     def run(self):
         upload_tools = self.env.get_flat('UPLOAD_TOOLS')
         src = self.inputs[0]
-        return self.exec_command("{} '{}/uploader.py' '{}'".format(self.env.get_flat('PYTHON'), upload_tools, src))
+        print("Uploading at baudrate %s" % self.env.UPLOAD_BAUD)
+        return self.exec_command("{} '{}/uploader.py' '{}' --baud-bootloader='{}' --baud-bootloader-flash='{}'".format(self.env.get_flat('PYTHON'), upload_tools, src, self.env.UPLOAD_BAUD, self.env.UPLOAD_BAUD))
 
     def exec_command(self, cmd, **kw):
         kw['stdout'] = sys.stdout
@@ -169,6 +170,12 @@ def chibios_firmware(self):
         generate_bin_task.set_run_after(default_params_task)
     
     if self.bld.options.upload:
+        self.env.UPLOAD_BAUD = "115200"
+        _upload_task = self.create_task('upload_fw', src=apj_target)
+        _upload_task.set_run_after(generate_apj_task)
+
+    if self.bld.options.uploadfast:
+        self.env.UPLOAD_BAUD = "921600"
         _upload_task = self.create_task('upload_fw', src=apj_target)
         _upload_task.set_run_after(generate_apj_task)
 

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -602,6 +602,8 @@ class uploader(object):
             self.__setbaud(self.baudrate_bootloader_flash)
             self.port.baudrate = self.baudrate_bootloader_flash
             self.__sync()
+        else:
+            print("Using baudrate %u" % self.baudrate_bootloader_flash)
 
         self.__erase("Erase  ")
         self.__program("Program", fw)


### PR DESCRIPTION
Current option of `./waf plane --upload` will upload the binary at 115200 baud

This adds a new argument `./waf plane --uploadfast` will do it at 921600 baud.

This only helps when updating the firmware over a real UART serial port, not USB.