### PR TITLE
AHRS: add pre-arm check that attitudes are consistent

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -52,7 +52,7 @@ class AP_AHRS
 {
 public:
     friend class AP_AHRS_View;
-    
+
     // Constructor
     AP_AHRS() :
         _vehicle_class(AHRS_VEHICLE_UNKNOWN),
@@ -130,7 +130,7 @@ public:
         }
         return AP_HAL::millis() - _last_flying_ms;
     }
-    
+
     AHRS_VehicleClass get_vehicle_class(void) const {
         return _vehicle_class;
     }
@@ -189,7 +189,7 @@ public:
     virtual uint8_t get_primary_gyro_index(void) const {
         return AP::ins().get_primary_gyro();
     }
-    
+
     // accelerometer values in the earth frame in m/s/s
     virtual const Vector3f &get_accel_ef(uint8_t i) const {
         return _accel_ef[i];
@@ -223,7 +223,7 @@ public:
     virtual bool have_ekf_logging(void) const {
         return false;
     }
-    
+
     // Euler angles (radians)
     float roll;
     float pitch;
@@ -269,7 +269,7 @@ public:
 
     // get rotation matrix specifically from DCM backend (used for compass calibrator)
     virtual const Matrix3f &get_DCM_rotation_body_to_ned(void) const = 0;
-    
+
     // get our current position estimate. Return true if a position is available,
     // otherwise false. This call fills in lat, lng and alt
     virtual bool get_position(struct Location &loc) const = 0;
@@ -436,7 +436,7 @@ public:
     virtual bool get_secondary_quaternion(Quaternion &quat) const {
         return false;
     }
-    
+
     // return secondary position solution if available
     virtual bool get_secondary_position(struct Location &loc) const {
         return false;
@@ -528,7 +528,7 @@ public:
     virtual bool resetHeightDatum(void) {
         return false;
     }
-    
+
     // get_variances - provides the innovations normalised using the innovation variance where a value of 0
     // indicates perfect consistency between the measurement and the EKF solution and a value of of 1 is the maximum
     // inconsistency that will be accepted by the filter
@@ -536,7 +536,7 @@ public:
     virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const {
         return false;
     }
-    
+
     // time that the AHRS has been up
     virtual uint32_t uptime_ms(void) const = 0;
 
@@ -569,7 +569,7 @@ public:
     // rotate a 2D vector from earth frame to body frame
     // in input, x is forward, y is right
     Vector2f rotate_body_to_earth2D(const Vector2f &bf) const;
-    
+
     virtual void update_AOA_SSA(void);
 
     // get_hgt_ctrl_limit - get maximum height to be observed by the
@@ -584,12 +584,12 @@ public:
     HAL_Semaphore &get_semaphore(void) {
         return _rsem;
     }
-    
+
 protected:
-    
+
     // multi-thread access support
     HAL_Semaphore_Recursive _rsem;
-    
+
     AHRS_VehicleClass _vehicle_class;
 
     // settable parameters
@@ -627,7 +627,7 @@ protected:
     void calc_trig(const Matrix3f &rot,
                    float &cr, float &cp, float &cy,
                    float &sr, float &sp, float &sy) const;
-    
+
     // update_trig - recalculates _cos_roll, _cos_pitch, etc based on latest attitude
     //      should be called after _dcm_matrix is updated
     void update_trig(void);

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -216,6 +216,9 @@ public:
         return nullptr;
     }
 
+    // check all cores providing consistent attitudes for prearm checks
+    virtual bool attitudes_consistent() const { return true; }
+
     // is the EKF backend doing its own sensor logging?
     virtual bool have_ekf_logging(void) const {
         return false;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -55,7 +55,7 @@ public:
 
     // get rotation matrix specifically from DCM backend (used for compass calibrator)
     const Matrix3f &get_DCM_rotation_body_to_ned(void) const override { return _body_dcm_matrix; }
-    
+
     // return the current drift correction integrator value
     const Vector3f &get_gyro_drift() const override {
         return _omega_I;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -188,6 +188,9 @@ public:
     // report any reason for why the backend is refusing to initialise
     const char *prearm_failure_reason(void) const override;
 
+    // check all cores providing consistent attitudes for prearm checks
+    bool attitudes_consistent() const override;
+
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng) const override;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -102,13 +102,13 @@ public:
     const NavEKF3 &get_NavEKF3_const(void) const {
         return EKF3;
     }
-    
+
     // return secondary attitude solution if available, as eulers in radians
     bool get_secondary_attitude(Vector3f &eulers) const override;
 
     // return secondary attitude solution if available, as quaternion
     bool get_secondary_quaternion(Quaternion &quat) const override;
-    
+
     // return secondary position solution if available
     bool get_secondary_position(struct Location &loc) const override;
 
@@ -216,7 +216,7 @@ public:
 
     // send a EKF_STATUS_REPORT for current EKF
     void send_ekf_status_report(mavlink_channel_t chan) const;
-    
+
     // get_hgt_ctrl_limit - get maximum height to be observed by the control loops in meters and a validity flag
     // this is used to limit height during optical flow navigation
     // it will return invalid when no limiting is required
@@ -293,7 +293,7 @@ private:
 
     // get the index of the current primary IMU
     uint8_t get_primary_IMU_index(void) const;
-    
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL *_sitl;
     uint32_t _last_body_odm_update_ms = 0;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -115,7 +115,7 @@ public:
     bool get_relative_position_NED_origin(Vector3f &vec) const {
         return ahrs.get_relative_position_NED_origin(vec);
     }
-    
+
     bool get_relative_position_NE_home(Vector2f &vecNE) const {
         return ahrs.get_relative_position_NE_home(vecNE);
     }
@@ -123,7 +123,7 @@ public:
     bool get_relative_position_NE_origin(Vector2f &vecNE) const {
         return ahrs.get_relative_position_NE_origin(vecNE);
     }
-    
+
     void get_relative_position_D_home(float &posD) const {
         ahrs.get_relative_position_D_home(posD);
     }
@@ -131,7 +131,7 @@ public:
     bool get_relative_position_D_origin(float &posD) const {
         return ahrs.get_relative_position_D_origin(posD);
     }
-    
+
     float groundspeed(void) {
         return ahrs.groundspeed();
     }
@@ -155,7 +155,7 @@ public:
     // rotate a 2D vector from earth frame to body frame
     // in input, x is forward, y is right
     Vector2f rotate_body_to_earth2D(const Vector2f &bf) const;
-    
+
     // return the average size of the roll/pitch error estimate
     // since last call
     float get_error_rp(void) const {
@@ -167,7 +167,7 @@ public:
     float get_error_yaw(void) const {
         return ahrs.get_error_yaw();
     }
-    
+
     float roll;
     float pitch;
     float yaw;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -325,6 +325,12 @@ bool AP_Arming::ins_checks(bool report)
             check_failed(ARMING_CHECK_INS, report, "Gyros inconsistent");
             return false;
         }
+
+        // check AHRS attitudes are consistent
+        if (!AP::ahrs().attitudes_consistent()) {
+            check_failed(ARMING_CHECK_INS, report, "Attitudes inconsistent");
+            return false;
+        }
     }
 
     return true;
@@ -336,13 +342,13 @@ bool AP_Arming::compass_checks(bool report)
 
     // check if compass is calibrating
     if (_compass.is_calibrating()) {
-        check_failed(ARMING_CHECK_COMPASS, report, "Compass calibration running");
+        check_failed(ARMING_CHECK_NONE, report, "Compass calibration running");
         return false;
     }
 
     // check if compass has calibrated and requires reboot
     if (_compass.compass_cal_requires_reboot()) {
-        check_failed(ARMING_CHECK_COMPASS, report, "Compass calibrated requires reboot");
+        check_failed(ARMING_CHECK_NONE, report, "Compass calibrated requires reboot");
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -332,10 +332,22 @@ bool AP_Arming::ins_checks(bool report)
 
 bool AP_Arming::compass_checks(bool report)
 {
+    Compass &_compass = AP::compass();
+
+    // check if compass is calibrating
+    if (_compass.is_calibrating()) {
+        check_failed(ARMING_CHECK_COMPASS, report, "Compass calibration running");
+        return false;
+    }
+
+    // check if compass has calibrated and requires reboot
+    if (_compass.compass_cal_requires_reboot()) {
+        check_failed(ARMING_CHECK_COMPASS, report, "Compass calibrated requires reboot");
+        return false;
+    }
+
     if ((checks_to_perform) & ARMING_CHECK_ALL ||
         (checks_to_perform) & ARMING_CHECK_COMPASS) {
-
-        Compass &_compass = AP::compass();
 
         // avoid Compass::use_for_yaw(void) as it implicitly calls healthy() which can
         // incorrectly skip the remaining checks, pass the primary instance directly
@@ -351,18 +363,6 @@ bool AP_Arming::compass_checks(bool report)
         // check compass learning is on or offsets have been set
         if (!_compass.learn_offsets_enabled() && !_compass.configured()) {
             check_failed(ARMING_CHECK_COMPASS, report, "Compass not calibrated");
-            return false;
-        }
-
-        //check if compass is calibrating
-        if (_compass.is_calibrating()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compass calibration running");
-            return false;
-        }
-
-        //check if compass has calibrated and requires reboot
-        if (_compass.compass_cal_requires_reboot()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compass calibrated requires reboot");
             return false;
         }
 

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -366,3 +366,9 @@ Quaternion Quaternion::operator/(const Quaternion &v) const
     ret.q4 = (rquat0*quat3 - rquat1*quat2 + rquat2*quat1 - rquat3*quat0);
     return ret;
 }
+
+// angular difference in radians between quaternions
+Quaternion Quaternion::angular_difference(const Quaternion &v) const
+{
+    return v.inverse() * *this;
+}

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -141,4 +141,7 @@ public:
     Quaternion operator*(const Quaternion &v) const;
     Quaternion &operator*=(const Quaternion &v);
     Quaternion operator/(const Quaternion &v) const;
+
+    // angular difference between quaternions
+    Quaternion angular_difference(const Quaternion &v) const;
 };


### PR DESCRIPTION
This PR adds and changes two pre-arm checks to resolve [this issue](https://github.com/ArduPilot/ardupilot/issues/10569) which stems from a [crash of a vehicle running Copter-3.6.6](https://discuss.ardupilot.org/t/crash-with-3-6-6-copter/38764/4) where the backup EKF flipped over while the vehicle was disarmed (probably because the user ran a compass calibration but did not reboot the board because the pre-arm compass checks were disabled).

- makes the compass calibration pre-arm checks mandatory (i.e. they cannot be turned off)
- adds a new attitude check that all AHRSs (DCM, EKF2, EKF3) are close to the attitude from whichever of these is primary.  The threshold is set to 5deg roll/pitch, 15deg yaw.  This new check is part of the INS pre-arm checks.

This has been tested in SITL by adding some debug and then setting these parameters to throw off some of the attitude estimates.

To make the roll/pitch check fail I adjusted the accelerometer offsets as follows:
- param set INS_ACCOFS_X 1

To make the yaw check fail I set the compass offsets as follows:
- param set COMPASS_OFS_X 200
- param set COMPASS_OFS_Y 200

Picture of some SITL testing
![att-check-sitl](https://user-images.githubusercontent.com/1498098/53070631-29079100-3523-11e9-868a-797362444c97.png)
