### PR TITLE
Plane: Fix not logging quadplane control, and over logging attitude control

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1670,11 +1670,12 @@ void QuadPlane::motors_output(bool run_rate_controller)
     check_throttle_suppression();
     
     motors->output();
-    if (motors->armed() && motors->get_throttle() > 0) {
+    if (motors->armed() && motors->get_spool_mode() != AP_Motors::spool_up_down_mode::SHUT_DOWN) {
         plane.logger.Write_Rate(ahrs_view, *motors, *attitude_control, *pos_control);
         Log_Write_QControl_Tuning();
         const uint32_t now = AP_HAL::millis();
         if (now - last_ctrl_log_ms > 100) {
+            last_ctrl_log_ms = now;
             attitude_control->control_monitor_log();
         }
     }


### PR DESCRIPTION
The check for throttle > 0 meant that when landing at low throttle we stop logging QTUN which hurts log analysis. `last_ctrl_log_ms` was never being updated which causes us to over log the control message (300Hz normally for the expensive varargs logging method).

I considered making `control_monitor_log` do the time management as copter/sub call this at 10Hz, but due to scheduling jitter this would cause dropped messages on those vehicles, so rather then changing the logging call site I just decided to fix the intended rate limiting on plane.