### PR TITLE
Plane: prevent loss of control when Q_ENABLE is set while flying

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1565,7 +1565,7 @@ void QuadPlane::update(void)
   This is a safety check to prevent accidental motor runs on the
   ground, such as if RC fails and QRTL is started
  */
-void QuadPlane::check_throttle_suppression(void)
+void QuadPlane::update_throttle_suppression(void)
 {
     // if the motors have been running in the last 2 seconds then
     // allow them to run now
@@ -1614,7 +1614,7 @@ void QuadPlane::check_throttle_suppression(void)
 //  called at 100hz
 void QuadPlane::update_throttle_hover()
 {
-    if (!enable) {
+    if (!available()) {
         return;
     }
     
@@ -1667,7 +1667,7 @@ void QuadPlane::motors_output(bool run_rate_controller)
     }
 
     // see if motors should be shut down
-    check_throttle_suppression();
+    update_throttle_suppression();
     
     motors->output();
     if (motors->armed() && motors->get_throttle() > 0) {
@@ -1809,7 +1809,7 @@ bool QuadPlane::handle_do_vtol_transition(enum MAV_VTOL_STATE state)
  */
 bool QuadPlane::in_vtol_auto(void) const
 {
-    if (!enable) {
+    if (!available()) {
         return false;
     }
     if (plane.control_mode != AUTO) {
@@ -1842,7 +1842,7 @@ bool QuadPlane::in_vtol_auto(void) const
  */
 bool QuadPlane::in_vtol_mode(void) const
 {
-    if (!enable) {
+    if (!available()) {
         return false;
     }
     return (plane.control_mode == QSTABILIZE ||

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -223,7 +223,7 @@ private:
     void guided_start(void);
     void guided_update(void);
 
-    void check_throttle_suppression(void);
+    void update_throttle_suppression(void);
 
     void run_z_controller(void);
 


### PR DESCRIPTION
The key point here actually crept up on my by accident. I noticed we inconsistently swap between `available()` and `enable` for early return checking. The problem with enable is that you can get into the situation where Q_ENABLE wasn't set on the ground, and is changed in flight. This results in the aircraft not allocating objects (because we refuse to do setup while armed), but then `update_throttle_hover` can do a nullptr dereference, and `in_vtol_auto` can report true causing the vehicle to hand control over (until we segfault in `update_throttle_hover` anyways).

I took a paranoid approach of converting everything that used enable to `available()`. I made `available()` also check `enable`, but I'm not really sure that is the correct action. (setting enable to 0 while flying could then result in not updating motors/leaving them free spinning at last commanded throttle).

Also rename `check_throttle_suppression` to `update_throttle_suppression` to reflect that this actually can change the outputs.