### PR TITLE
Plane: Don't overwrite the quadplane loiter relax

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -895,7 +895,7 @@ void QuadPlane::init_loiter(void)
     last_loiter_ms = AP_HAL::millis();
 }
 
-void QuadPlane::init_land(void)
+void QuadPlane::init_qland(void)
 {
     init_loiter();
     throttle_wait = false;
@@ -1750,7 +1750,7 @@ bool QuadPlane::init_mode(void)
         init_loiter();
         break;
     case QLAND:
-        init_land();
+        init_qland();
         break;
     case QRTL:
         init_qrtl();
@@ -1877,7 +1877,7 @@ void QuadPlane::vtol_position_controller(void)
 
     case QPOS_POSITION1: {
         Vector2f diff_wp = location_diff(plane.current_loc, loc);
-        float distance = diff_wp.length();
+        const float distance = diff_wp.length();
 
         if (poscontrol.speed_scale <= 0) {
             // initialise scaling so we start off targeting our
@@ -1986,7 +1986,11 @@ void QuadPlane::vtol_position_controller(void)
         pos_control->set_desired_accel_xy(0.0f,0.0f);
 
         // set position control target and update
-        pos_control->set_xy_target(poscontrol.target.x, poscontrol.target.y);
+        if (should_relax()) {
+            loiter_nav->soften_for_landing();
+        } else {
+            pos_control->set_xy_target(poscontrol.target.x, poscontrol.target.y);
+        }
         pos_control->update_xy_controller();
 
         // nav roll and pitch are controller by position controller
@@ -2367,10 +2371,6 @@ bool QuadPlane::verify_vtol_land(void)
         poscontrol.state = QPOS_LAND_DESCEND;
         gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
         plane.set_next_WP(plane.next_WP_loc);
-    }
-
-    if (should_relax()) {
-        loiter_nav->soften_for_landing();
     }
 
     // at land_final_alt begin final landing

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -200,7 +200,7 @@ private:
     void control_hover(void);
 
     void init_loiter(void);
-    void init_land(void);
+    void init_qland(void);
     void control_loiter(void);
     void check_land_complete(void);
 


### PR DESCRIPTION
`vtol_position_controller` was overwriting the position controller everytime it was run, which causes an issue as the `soften_for_landing` call from the mission gets overwritten by this. The check can be factored out out of `verify_vtol_land` as all paths that call it already are calling the `vtol_position_controller`

The main concern here is if there are any code paths that were not calling this with a position set. From my audit it appears that all paths reset the state to `QPOS_POSITION1`. The last step of this is to reset the position to the current position, which should ensure that we never have a stale target loaded.

Due to inclement weather it's going to be a bit before I can flight test this on a real vehicle, and I will be doing more SITL testing, but it seems to be appropriate/safe thus far.