### PR TITLE
Copter: use height-above-ground for landing gear deployment

### DIFF
--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -29,8 +29,8 @@ void Copter::landinggear_update()
 
     last_deploy_status = landinggear.deployed();
 
-    // support height based triggering using rangefinder or altitude above home
-    float height = current_loc.alt * 0.01;
+    // support height based triggering using rangefinder or altitude above ground
+    int32_t height_cm = flightmode->get_alt_above_ground();
 
     // use rangefinder if available
     switch (rangefinder.status_orient(ROTATION_PITCH_270)) {
@@ -41,15 +41,15 @@ void Copter::landinggear_update()
 
     case RangeFinder::RangeFinder_OutOfRangeLow:
         // altitude is close to zero (gear should deploy)
-        height = 0.0f;
+        height_cm = 0;
         break;
 
     case RangeFinder::RangeFinder_OutOfRangeHigh:
     case RangeFinder::RangeFinder_Good:
         // use last good reading
-        height = rangefinder_state.alt_cm_filt.get() * 0.01;
+        height_cm = rangefinder_state.alt_cm_filt.get();
         break;
     }
 
-    landinggear.update(height);
+    landinggear.update(height_cm * 0.01f); // convert cm->m for update call
 }


### PR DESCRIPTION
If landing well away from home this may allow the landing gear to deploy at an appropriate time.

It seems to me at the moment that if you don't have a rangefinder and fly somewhere higher than your home position then you could hit the ground without gear deployed, whereas if you used the terrain database (or in some other way the vehicle generally knows its height-above-ground) you may choose to put the gear down.

Note that this now uses a method marked as used-for-landing.
