### PR TITLE
AP_Logger: simplify the message writers

### DIFF
--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -25,7 +25,7 @@ void LoggerMessageWriter_DFLogStart::reset()
     _writeentiremission.reset();
     _writeallrallypoints.reset();
 
-    stage = ls_blockwriter_stage_init;
+    stage = ls_blockwriter_stage_formats;
     next_format_to_send = 0;
     _next_unit_to_send = 0;
     _next_multiplier_to_send = 0;
@@ -36,10 +36,6 @@ void LoggerMessageWriter_DFLogStart::reset()
 void LoggerMessageWriter_DFLogStart::process()
 {
     switch(stage) {
-    case ls_blockwriter_stage_init:
-        stage = ls_blockwriter_stage_formats;
-        FALLTHROUGH;
-
     case ls_blockwriter_stage_formats:
         // write log formats so the log is self-describing
         while (next_format_to_send < _dataflash_backend->num_types()) {
@@ -140,7 +136,7 @@ void LoggerMessageWriter_DFLogStart::process()
 void LoggerMessageWriter_WriteSysInfo::reset()
 {
     LoggerMessageWriter::reset();
-    stage = ws_blockwriter_stage_init;
+    stage = ws_blockwriter_stage_formats;
 }
 
 void LoggerMessageWriter_WriteSysInfo::process() {
@@ -148,7 +144,7 @@ void LoggerMessageWriter_WriteSysInfo::process() {
 
     switch(stage) {
 
-    case ws_blockwriter_stage_init:
+    case ws_blockwriter_stage_formats:
         stage = ws_blockwriter_stage_firmware_string;
         FALLTHROUGH;
 
@@ -200,14 +196,6 @@ void LoggerMessageWriter_WriteAllRallyPoints::process()
 
     switch(stage) {
 
-    case ar_blockwriter_stage_init:
-        if (_rally == nullptr) {
-            stage = ar_blockwriter_stage_done;
-            break;
-        }
-        stage = ar_blockwriter_stage_write_new_rally_message;
-        FALLTHROUGH;
-
     case ar_blockwriter_stage_write_new_rally_message:
         if (! _dataflash_backend->Write_Message("New rally")) {
             return; // call me again
@@ -241,7 +229,7 @@ void LoggerMessageWriter_WriteAllRallyPoints::process()
 void LoggerMessageWriter_WriteAllRallyPoints::reset()
 {
     LoggerMessageWriter::reset();
-    stage = ar_blockwriter_stage_init;
+    stage = ar_blockwriter_stage_write_new_rally_message;
     _rally_number_to_send = 0;
 }
 
@@ -253,15 +241,6 @@ void LoggerMessageWriter_WriteEntireMission::process() {
     }
 
     switch(stage) {
-
-    case em_blockwriter_stage_init:
-        if (_mission == nullptr) {
-            stage = em_blockwriter_stage_done;
-            break;
-        } else {
-            stage = em_blockwriter_stage_write_new_mission_message;
-        }
-        FALLTHROUGH;
 
     case em_blockwriter_stage_write_new_mission_message:
         if (! _dataflash_backend->Write_Message("New mission")) {
@@ -296,6 +275,6 @@ void LoggerMessageWriter_WriteEntireMission::process() {
 void LoggerMessageWriter_WriteEntireMission::reset()
 {
     LoggerMessageWriter::reset();
-    stage = em_blockwriter_stage_init;
+    stage = em_blockwriter_stage_write_new_mission_message;
     _mission_number_to_send = 0;
 }

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -29,13 +29,13 @@ public:
     void process() override;
 
 private:
-    enum write_sysinfo_blockwriter_stage {
-        ws_blockwriter_stage_init,
+    enum write_sysinfo_blockwriter_stage : uint8_t {
+        ws_blockwriter_stage_formats = 0,
         ws_blockwriter_stage_firmware_string,
         ws_blockwriter_stage_git_versions,
         ws_blockwriter_stage_system_id
     };
-    write_sysinfo_blockwriter_stage stage = ws_blockwriter_stage_init;
+    write_sysinfo_blockwriter_stage stage;
 };
 
 class LoggerMessageWriter_WriteEntireMission : public LoggerMessageWriter {
@@ -46,14 +46,13 @@ public:
 
 private:
     enum entire_mission_blockwriter_stage {
-        em_blockwriter_stage_init,
-        em_blockwriter_stage_write_new_mission_message,
+        em_blockwriter_stage_write_new_mission_message = 0,
         em_blockwriter_stage_write_mission_items,
         em_blockwriter_stage_done
     };
 
-    uint16_t _mission_number_to_send = 0;
-    entire_mission_blockwriter_stage stage = em_blockwriter_stage_init;
+    uint16_t _mission_number_to_send;
+    entire_mission_blockwriter_stage stage;
 };
 
 class LoggerMessageWriter_WriteAllRallyPoints : public LoggerMessageWriter {
@@ -64,14 +63,13 @@ public:
 
 private:
     enum all_rally_points_blockwriter_stage {
-        ar_blockwriter_stage_init,
-        ar_blockwriter_stage_write_new_rally_message,
+        ar_blockwriter_stage_write_new_rally_message = 0,
         ar_blockwriter_stage_write_all_rally_points,
         ar_blockwriter_stage_done
     };
 
-    uint16_t _rally_number_to_send = 0;
-    all_rally_points_blockwriter_stage stage = ar_blockwriter_stage_init;
+    uint16_t _rally_number_to_send;
+    all_rally_points_blockwriter_stage stage;
 };
 
 class LoggerMessageWriter_DFLogStart : public LoggerMessageWriter {
@@ -97,8 +95,7 @@ public:
 private:
 
     enum log_start_blockwriter_stage {
-        ls_blockwriter_stage_init,
-        ls_blockwriter_stage_formats,
+        ls_blockwriter_stage_formats = 0,
         ls_blockwriter_stage_units,
         ls_blockwriter_stage_multipliers,
         ls_blockwriter_stage_format_units,
@@ -110,9 +107,9 @@ private:
         ls_blockwriter_stage_done,
     };
 
-    bool _fmt_done = false;
+    bool _fmt_done;
 
-    log_start_blockwriter_stage stage = ls_blockwriter_stage_init;
+    log_start_blockwriter_stage stage;
 
     uint16_t next_format_to_send;
 


### PR DESCRIPTION
Specifically:
  - Remove some unreachable nullptr checks
  - Remove a noop stage
  - Remove unneeded initializers