### PR TITLE
AP_Math: fixed inefficient sq() function

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -174,7 +174,8 @@ static inline constexpr float degrees(float rad)
 template<typename T>
 float sq(const T val)
 {
-    return powf(static_cast<float>(val), 2);
+    float v = static_cast<float>(val);
+    return v*v;
 }
 
 /*


### PR DESCRIPTION
calling powf() to calculate a square is very inefficient
