### PR TITLE
Plane: add crow flap options parameter, allows 'full house' wing

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1189,20 +1189,22 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 #endif
 
     // @Param: DSPOILER_CROW_W1
-    // @DisplayName: Differential spoiler crow flaps inner weight
-    // @Description: This is amount of deflection applied to the two inner surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 25.
+    // @DisplayName: Differential spoiler crow flaps outer weight
+    // @Description: This is amount of deflection applied to the two outer surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 25.
     // @Range: 0 100
+    // @Units: %
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("DSPOILER_CROW_W1", 17, ParametersG2, crow_flap_weight1, 0),
+    AP_GROUPINFO("DSPOILER_CROW_W1", 17, ParametersG2, crow_flap_weight_outer, 0),
 
     // @Param: DSPOILER_CROW_W2
-    // @DisplayName: Differential spoiler crow flaps outer weight
-    // @Description: This is amount of deflection applied to the two outer  surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 45.
+    // @DisplayName: Differential spoiler crow flaps inner weight
+    // @Description: This is amount of deflection applied to the two inner surfaces for differential spoilers for flaps to give crow flaps. It is a number from 0 to 100. At zero no crow flaps are applied. A recommended starting value is 45.
     // @Range: 0 100
+    // @Units: %
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("DSPOILER_CROW_W2", 18, ParametersG2, crow_flap_weight2, 0),
+    AP_GROUPINFO("DSPOILER_CROW_W2", 18, ParametersG2, crow_flap_weight_inner, 0),
 
     // @Param: TKOFF_TIMEOUT
     // @DisplayName: Takeoff timeout
@@ -1212,7 +1214,24 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Units: s
     // @User: User
     AP_GROUPINFO("TKOFF_TIMEOUT", 19, ParametersG2, takeoff_timeout, 0),
-    
+
+    // @Param: DSPOILER_OPTS
+    // @DisplayName: Differential spoiler and crow flaps options
+    // @Description: Differential spoiler and crow flaps options
+    // @Values: 0: none, 1: D spoilers have pitch input, 2: use both control surfaces on each wing for roll, 4: Progressive crow, flaps only first (0-50% flap in) then crow flaps (50 - 100% flap in)
+    // @Bitmask: 0:pitch control, 1:full span, 2:Progressive crow
+    // @User: Advanced
+    AP_GROUPINFO("DSPOILER_OPTS", 20, ParametersG2, crow_flap_options, 3),
+
+    // @Param: DSPOILER_AILMTCH
+    // @DisplayName: Differential spoiler aileron matching
+    // @Description: This scales down the inner flaps so less than full downwards range can be used for differential spoiler and full span ailerons, 100 is use full range, upwards travel is unaffected
+    // @Range: 0 100
+    // @Units: %
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("DSPOILER_AILMTCH", 21, ParametersG2, crow_flap_aileron_matching, 100),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -557,8 +557,10 @@ public:
 #endif
 
     // crow flaps weighting
-    AP_Int8 crow_flap_weight1;
-    AP_Int8 crow_flap_weight2;
+    AP_Int8 crow_flap_weight_outer;
+    AP_Int8 crow_flap_weight_inner;
+    AP_Int8 crow_flap_options;
+    AP_Int8 crow_flap_aileron_matching;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -182,3 +182,10 @@ enum FlightOptions {
     DISABLE_TOFF_ATTITUDE_CHK = (1 << 2),
     CRUISE_TRIM_AIRSPEED = (1 << 3),
 };
+
+enum CrowFlapOptions {
+    FLYINGWING       = (1 << 0),
+    FULLSPAN         = (1 << 1),
+    PROGRESSIVE_CROW = (1 << 2),
+}; 
+


### PR DESCRIPTION
fix for https://github.com/ArduPilot/ardupilot/issues/8009 and https://github.com/ArduPilot/ardupilot/issues/10036

Allow a 'full house' glider as outlined here https://www.youtube.com/watch?v=gqjIg6fB_fQ only missing camber control but I think that is probably not that useful in our case. 

This adds a new bit mask and a parameter. The bit mask allows three features to be enabled or disabled. 

- use aileron vs elevon as input for mixer, current code uses elevon so can only be used for flying wings
- full span ailerons, current code does this, now it can be turned off so only the outer flaps are used for aileron and inner used for differential rudder and flaps
- progressive flap, current code puts outer up as inner go down, progressive flap puts inner down first 0 to 50% flap, then from 50 to 100% the outers are put up. I think this is more useful, half can then be used for just flaps for extra lift and full gives full crow for stopping. 

This also adds a parameter to allow flap down travel to be limited to a percentage of full travel when used as aileron and in differential rudder. This allows flaps with lots of down travel to be used as full span ailerons.

By default the parameters give no change to current behavior, 

vid of SITL testing: https://youtu.be/25VIhl6fEPw
