### PR TITLE
Copter: fix drastic slow-down and early landing in Auto

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -402,7 +402,6 @@ private:
 #endif
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
-
     // Loiter control
     uint16_t loiter_time_max;                // How long we should stay in Loiter Mode for mission scripting (time in seconds)
     uint32_t loiter_time;                    // How long have we been loitering - The start time in millis

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -402,7 +402,6 @@ private:
 #endif
     bool verify_nav_delay(const AP_Mission::Mission_Command& cmd);
 
-    void auto_spline_start(const Location& destination, bool stopped_at_start, AC_WPNav::spline_segment_end_type seg_end_type, const Location& next_destination);
 
     // Loiter control
     uint16_t loiter_time_max;                // How long we should stay in Loiter Mode for mission scripting (time in seconds)

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1096,8 +1096,33 @@ void Copter::ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     // if no delay as well as not final waypoint set the waypoint as "fast"
     AP_Mission::Mission_Command temp_cmd;
+    bool fast_waypoint = false;
     if (loiter_time_max == 0 && mission.get_next_nav_cmd(cmd.index+1, temp_cmd)) {
-        copter.wp_nav->set_fast_waypoint(true);
+
+        // whether vehicle should stop at the target position depends upon the next command
+        switch (temp_cmd.id) {
+            case MAV_CMD_NAV_WAYPOINT:
+            case MAV_CMD_NAV_LOITER_UNLIM:
+            case MAV_CMD_NAV_LOITER_TURNS:
+            case MAV_CMD_NAV_LOITER_TIME:
+            case MAV_CMD_NAV_LAND:
+            case MAV_CMD_NAV_SPLINE_WAYPOINT:
+                // if next command's lat, lon is specified then do not slowdown at this waypoint
+                if ((temp_cmd.content.location.lat != 0) || (temp_cmd.content.location.lng != 0)) {
+                    fast_waypoint = true;
+                }
+                break;
+            case MAV_CMD_NAV_RETURN_TO_LAUNCH:
+                // do not stop for RTL
+                fast_waypoint = true;
+                break;
+            case MAV_CMD_NAV_TAKEOFF:
+            default:
+                // always stop for takeoff commands
+                // for unsupported commands it is safer to stop
+                break;
+        }
+        copter.wp_nav->set_fast_waypoint(fast_waypoint);
     }
 }
 


### PR DESCRIPTION
This PR fixes this issue https://github.com/ArduPilot/ardupilot/issues/10617 in which the vehicle was not slowing down before the Land command was initiated.  Because the slow-down was skipped the vehicle would also end up landing before the previous command's target position was reached.

The screen shot from SITL below shows a simple mission where Waypoint 3 is placed right on home.  Despite this, the vehicle lands several meters before home (the vehicle's position on the map is where it ended up landing)
![before](https://user-images.githubusercontent.com/1498098/53316545-b2e0a100-390b-11e9-9d49-809238ea8f9e.png)

The graph below shows the target position before and after this PR.  Note the jump in position target in the BEFORE graph.
![before-after-position-target](https://user-images.githubusercontent.com/1498098/53316491-79a83100-390b-11e9-9284-2b3630d6fd91.png)

The graph below shows the accompanying aggressive slow-down of the vehicle BEFORE and the much smoother slowdown AFTER.
![before-after-pitch](https://user-images.githubusercontent.com/1498098/53316675-24b8ea80-390c-11e9-9b26-ddd0f3ed96bc.png)

I also tested this change with a longer mission with different waypoints to check that it all worked correctly.  It all worked as expected and resolved some other "reversing" behaviour when LOITER commands had (lat,lon) set to (0,0)
![many-test-mission](https://user-images.githubusercontent.com/1498098/53316704-39957e00-390c-11e9-9036-0ca9ce50ea8f.png)
![multi-command-test-position-comparison](https://user-images.githubusercontent.com/1498098/53316717-40bc8c00-390c-11e9-9845-67000562a5be.png)