### PR TITLE
Copter: move check for position up

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -200,6 +200,14 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     }
 #endif
 
+    if (!ignore_checks &&
+        new_flightmode->requires_GPS() &&
+        !copter.position_ok()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s requires position", new_flightmode->name());
+        Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE,mode);
+        return false;
+    }
+
     if (!new_flightmode->init(ignore_checks)) {
         gcs().send_text(MAV_SEVERITY_WARNING,"Flight mode change failed");
         Log_Write_Error(ERROR_SUBSYSTEM_FLIGHT_MODE,mode);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -22,7 +22,7 @@
 // auto_init - initialise auto controller
 bool Copter::ModeAuto::init(bool ignore_checks)
 {
-    if ((copter.position_ok() && mission.num_commands() > 1) || ignore_checks) {
+    if (mission.num_commands() > 1 || ignore_checks) {
         _mode = Auto_Loiter;
 
         // reject switching to auto mode if landed with motors armed but first command is not a takeoff (reduce chance of flips)

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -9,22 +9,22 @@
 // brake_init - initialise brake controller
 bool Copter::ModeBrake::init(bool ignore_checks)
 {
-        // set target to current position
-        wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
+    // set target to current position
+    wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
 
-        // initialize vertical speed and acceleration
-        pos_control->set_max_speed_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z);
-        pos_control->set_max_accel_z(BRAKE_MODE_DECEL_RATE);
+    // initialize vertical speed and acceleration
+    pos_control->set_max_speed_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z);
+    pos_control->set_max_accel_z(BRAKE_MODE_DECEL_RATE);
 
-        // initialise position and desired velocity
-        if (!pos_control->is_active_z()) {
-            pos_control->set_alt_target_to_current_alt();
-            pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
-        }
+    // initialise position and desired velocity
+    if (!pos_control->is_active_z()) {
+        pos_control->set_alt_target_to_current_alt();
+        pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
+    }
 
-        _timeout_ms = 0;
+    _timeout_ms = 0;
 
-        return true;
+    return true;
 }
 
 // brake_run - runs the brake controller

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -9,8 +9,6 @@
 // brake_init - initialise brake controller
 bool Copter::ModeBrake::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
-
         // set target to current position
         wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
 
@@ -27,9 +25,6 @@ bool Copter::ModeBrake::init(bool ignore_checks)
         _timeout_ms = 0;
 
         return true;
-    }else{
-        return false;
-    }
 }
 
 // brake_run - runs the brake controller

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -9,7 +9,6 @@
 // circle_init - initialise circle controller flight mode
 bool Copter::ModeCircle::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
         pilot_yaw_override = false;
 
         // initialize speeds and accelerations
@@ -22,9 +21,6 @@ bool Copter::ModeCircle::init(bool ignore_checks)
         copter.circle_nav->init();
 
         return true;
-    }else{
-        return false;
-    }
 }
 
 // circle_run - runs the circle flight mode

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -9,18 +9,18 @@
 // circle_init - initialise circle controller flight mode
 bool Copter::ModeCircle::init(bool ignore_checks)
 {
-        pilot_yaw_override = false;
+    pilot_yaw_override = false;
 
-        // initialize speeds and accelerations
-        pos_control->set_max_speed_xy(wp_nav->get_default_speed_xy());
-        pos_control->set_max_accel_xy(wp_nav->get_wp_acceleration());
-        pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
-        pos_control->set_max_accel_z(g.pilot_accel_z);
+    // initialize speeds and accelerations
+    pos_control->set_max_speed_xy(wp_nav->get_default_speed_xy());
+    pos_control->set_max_accel_xy(wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
+    pos_control->set_max_accel_z(g.pilot_accel_z);
 
-        // initialise circle controller including setting the circle center based on vehicle speed
-        copter.circle_nav->init();
+    // initialise circle controller including setting the circle center based on vehicle speed
+    copter.circle_nav->init();
 
-        return true;
+    return true;
 }
 
 // circle_run - runs the circle flight mode

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -31,11 +31,7 @@
 // drift_init - initialise drift controller
 bool Copter::ModeDrift::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
-        return true;
-    }else{
-        return false;
-    }
+    return true;
 }
 
 // drift_run - runs the drift controller

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -40,13 +40,9 @@ struct Guided_Limit {
 // guided_init - initialise guided controller
 bool Copter::ModeGuided::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
         // start in position control mode
         pos_control_start();
         return true;
-    }else{
-        return false;
-    }
 }
 
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -40,9 +40,9 @@ struct Guided_Limit {
 // guided_init - initialise guided controller
 bool Copter::ModeGuided::init(bool ignore_checks)
 {
-        // start in position control mode
-        pos_control_start();
-        return true;
+    // start in position control mode
+    pos_control_start();
+    return true;
 }
 
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -9,7 +9,6 @@
 // loiter_init - initialise loiter controller
 bool Copter::ModeLoiter::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
         if (!copter.failsafe.radio) {
             float target_roll, target_pitch;
             // apply SIMPLE mode transform to pilot inputs
@@ -33,9 +32,6 @@ bool Copter::ModeLoiter::init(bool ignore_checks)
         }
 
         return true;
-    } else {
-        return false;
-    }
 }
 
 #if PRECISION_LANDING == ENABLED

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -9,29 +9,29 @@
 // loiter_init - initialise loiter controller
 bool Copter::ModeLoiter::init(bool ignore_checks)
 {
-        if (!copter.failsafe.radio) {
-            float target_roll, target_pitch;
-            // apply SIMPLE mode transform to pilot inputs
-            update_simple_mode();
+    if (!copter.failsafe.radio) {
+        float target_roll, target_pitch;
+        // apply SIMPLE mode transform to pilot inputs
+        update_simple_mode();
 
-            // convert pilot input to lean angles
-            get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
+        // convert pilot input to lean angles
+        get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max());
 
-            // process pilot's roll and pitch input
-            loiter_nav->set_pilot_desired_acceleration(target_roll, target_pitch, G_Dt);
-        } else {
-            // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
-            loiter_nav->clear_pilot_desired_acceleration();
-        }
-        loiter_nav->init_target();
+        // process pilot's roll and pitch input
+        loiter_nav->set_pilot_desired_acceleration(target_roll, target_pitch, G_Dt);
+    } else {
+        // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
+        loiter_nav->clear_pilot_desired_acceleration();
+    }
+    loiter_nav->init_target();
 
-        // initialise position and desired velocity
-        if (!pos_control->is_active_z()) {
-            pos_control->set_alt_target_to_current_alt();
-            pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
-        }
+    // initialise position and desired velocity
+    if (!pos_control->is_active_z()) {
+        pos_control->set_alt_target_to_current_alt();
+        pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
+    }
 
-        return true;
+    return true;
 }
 
 #if PRECISION_LANDING == ENABLED

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -74,11 +74,6 @@ static struct {
 // poshold_init - initialise PosHold controller
 bool Copter::ModePosHold::init(bool ignore_checks)
 {
-    // fail to initialise PosHold mode if no GPS lock
-    if (!copter.position_ok() && !ignore_checks) {
-        return false;
-    }
-    
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
     pos_control->set_max_accel_z(g.pilot_accel_z);

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -12,11 +12,11 @@
 // rtl_init - initialise rtl controller
 bool Copter::ModeRTL::init(bool ignore_checks)
 {
-        // initialise waypoint and spline controller
-        wp_nav->wp_and_spline_init();
-        build_path(!copter.failsafe.terrain);
-        climb_start();
-        return true;
+    // initialise waypoint and spline controller
+    wp_nav->wp_and_spline_init();
+    build_path(!copter.failsafe.terrain);
+    climb_start();
+    return true;
 }
 
 // re-start RTL with terrain following disabled

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -12,15 +12,11 @@
 // rtl_init - initialise rtl controller
 bool Copter::ModeRTL::init(bool ignore_checks)
 {
-    if (copter.position_ok() || ignore_checks) {
         // initialise waypoint and spline controller
         wp_nav->wp_and_spline_init();
         build_path(!copter.failsafe.terrain);
         climb_start();
         return true;
-    }else{
-        return false;
-    }
 }
 
 // re-start RTL with terrain following disabled

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -11,7 +11,7 @@
 
 bool Copter::ModeSmartRTL::init(bool ignore_checks)
 {
-    if ((copter.position_ok() || ignore_checks) && g2.smart_rtl.is_active()) {
+    if (g2.smart_rtl.is_active()) {
         // initialise waypoint and spline controller
         wp_nav->wp_and_spline_init();
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -11,10 +11,6 @@
 // initialise zigzag controller
 bool Copter::ModeZigZag::init(bool ignore_checks)
 {
-    if (!copter.position_ok() && !ignore_checks) {
-        return false;
-    }
-
     // initialize's loiter position and velocity on xy-axes from current pos and velocity
     loiter_nav->clear_pilot_desired_acceleration();
     loiter_nav->init_target();

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2734,6 +2734,22 @@ class AutoTestCopter(AutoTest):
         if ex is not None:
             raise ex
 
+    def test_arm_feature(self):
+        # ensure we can't switch to LOITER without position
+        self.progress("Ensure we can't enter LOITER without position")
+        self.context_push()
+        self.set_parameter("GPS_TYPE", 0)
+        self.reboot_sitl()
+        self.change_mode('STABILIZE')
+        self.arm_vehicle()
+        self.mavproxy.send("mode LOITER\n")
+        self.mavproxy.expect("requires position")
+        self.disarm_vehicle()
+        self.context_pop()
+        self.reboot_sitl()
+
+        super(AutoTestCopter, self).test_arm_feature()
+
     def initial_mode(self):
         return "STABILIZE"
 


### PR DESCRIPTION
While this does not have the effect of enforcing we have a position before you your multicopter up into the air, it *does* have the effect of not allowing you to enter throw mode if your position is not good.  The latter should be a prereq for the former.

We do need to fix `requires_gps` vs `requires_position`; fences and optical flow based positioning are just really confused at the moment.
