### PR TITLE
Copter: motor spool changes part 2

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -537,8 +537,7 @@ private:
     // Tradheli flags
     typedef struct {
         uint8_t dynamic_flight          : 1;    // 0   // true if we are moving at a significant speed (used to turn on/off leaky I terms)
-        uint8_t init_targets_on_arming  : 1;    // 1   // true if we have been disarmed, and need to reset rate controller targets when we arm
-        uint8_t inverted_flight         : 1;    // 2   // true for inverted flight mode
+        uint8_t inverted_flight         : 1;    // 1   // true for inverted flight mode
     } heli_flags_t;
     heli_flags_t heli_flags;
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -176,30 +176,6 @@ enum SmartRTLState {
     SmartRTL_Land
 };
 
-// Alt_Hold states
-enum AltHoldModeState {
-    AltHold_MotorStopped,
-    AltHold_Takeoff,
-    AltHold_Flying,
-    AltHold_Landed
-};
-
-// Loiter states
-enum LoiterModeState {
-    Loiter_MotorStopped,
-    Loiter_Takeoff,
-    Loiter_Flying,
-    Loiter_Landed
-};
-
-// Sport states
-enum SportModeState {
-    Sport_MotorStopped,
-    Sport_Takeoff,
-    Sport_Flying,
-    Sport_Landed
-};
-
 // Flip states
 enum FlipState {
     Flip_Start,

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -23,7 +23,7 @@ void Copter::heli_init()
 // should be called at 50hz
 void Copter::check_dynamic_flight(void)
 {
-    if (!motors->armed() || !motors->rotor_runup_complete() ||
+    if (motors->get_spool_mode() != AP_Motors::THROTTLE_UNLIMITED ||
         control_mode == LAND || (control_mode==RTL && mode_rtl.state() == RTL_Land) || (control_mode == AUTO && mode_auto.mode() == Auto_Land)) {
         heli_dynamic_flight_counter = 0;
         heli_flags.dynamic_flight = false;

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -47,7 +47,7 @@ void Copter::update_land_detector()
     } else if (ap.land_complete) {
 #if FRAME_CONFIG == HELI_FRAME
         // if rotor speed and collective pitch are high then clear landing flag
-        if (motors->get_throttle() > get_non_takeoff_throttle() && !motors->limit.throttle_lower && motors->rotor_runup_complete()) {
+        if (motors->get_throttle() > get_non_takeoff_throttle() && !motors->limit.throttle_lower && motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
 #else
         // if throttle output is high then clear landing flag
         if (motors->get_throttle() > get_non_takeoff_throttle()) {

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -407,10 +407,10 @@ void Copter::Mode::zero_throttle_and_hold_attitude()
     attitude_control->set_throttle_out(0.0f, false, copter.g.throttle_filt);
 }
 
-void Copter::Mode::make_safe_shut_down()
+void Copter::Mode::make_safe_spool_down()
 {
     // command aircraft to initiate the shutdown process
-    motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+    motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
     switch (motors->get_spool_mode()) {
 
     case AP_Motors::SHUT_DOWN:

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -193,7 +193,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter a non-manual throttle mode if the
     // rotor runup is not complete
-    if (!ignore_checks && !new_flightmode->has_manual_throttle() && !motors->rotor_runup_complete()){
+    if (!ignore_checks && !new_flightmode->has_manual_throttle() && (motors->get_spool_mode() == AP_Motors::SPOOL_UP || motors->get_spool_mode() == AP_Motors::SPOOL_DOWN)) {
         gcs().send_text(MAV_SEVERITY_WARNING,"Flight mode change failed");
         AP::logger().Write_Error(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;
@@ -381,12 +381,11 @@ bool Copter::Mode::_TakeOff::triggered(const float target_climb_rate) const
         // can't takeoff unless we want to go up...
         return false;
     }
-#if FRAME_CONFIG == HELI_FRAME
-    if (!copter.motors->rotor_runup_complete()) {
-        // hold heli on the ground until rotor speed runup has finished
+    if (copter.motors->get_spool_mode() != AP_Motors::THROTTLE_UNLIMITED) {
+        // hold aircraft on the ground until rotor speed runup has finished
         return false;
     }
-#endif
+
     return true;
 }
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -425,10 +425,6 @@ void Copter::Mode::make_safe_shut_down()
         break;
     }
 
-    // we may need to move this out
-    wp_nav->wp_and_spline_init();
-    // we may need to move this out
-    loiter_nav->init_target();
     pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
     pos_control->update_z_controller();
     // we may need to move this out

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -396,14 +396,43 @@ void Copter::Mode::zero_throttle_and_relax_ac(bool spool_up)
     } else {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
     }
-#if FRAME_CONFIG == HELI_FRAME
-    // Helicopters always stabilize roll/pitch/yaw
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
     attitude_control->set_throttle_out(0.0f, false, copter.g.throttle_filt);
-#else
-    // multicopters do not stabilize roll/pitch/yaw when disarmed
-    attitude_control->set_throttle_out_unstabilized(0.0f, true, copter.g.throttle_filt);
-#endif
+}
+
+void Copter::Mode::zero_throttle_and_hold_attitude()
+{
+    // run attitude controller
+    attitude_control->input_rate_bf_roll_pitch_yaw(0.0f, 0.0f, 0.0f);
+    attitude_control->set_throttle_out(0.0f, false, copter.g.throttle_filt);
+}
+
+void Copter::Mode::make_safe_shut_down()
+{
+    // command aircraft to initiate the shutdown process
+    motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+    switch (motors->get_spool_mode()) {
+
+    case AP_Motors::SHUT_DOWN:
+    case AP_Motors::GROUND_IDLE:
+        // relax controllers during idle states
+        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->set_yaw_target_to_current_heading();
+        break;
+
+    default:
+        // while transitioning though active states continue to operate normally
+        break;
+    }
+
+    // we may need to move this out
+    wp_nav->wp_and_spline_init();
+    // we may need to move this out
+    loiter_nav->init_target();
+    pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
+    pos_control->update_z_controller();
+    // we may need to move this out
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
 }
 
 /*
@@ -594,6 +623,58 @@ float Copter::Mode::get_pilot_desired_throttle() const
     // calculate the output throttle using the given expo function
     float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
     return throttle_out;
+}
+
+Copter::Mode::AltHoldModeState Copter::Mode::get_alt_hold_state(float target_climb_rate_cms)
+{
+    // Alt Hold State Machine Determination
+    if (!motors->armed()) {
+        // the aircraft should moved to a shut down state
+        motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+
+        // transition through states as aircraft spools down
+        switch (motors->get_spool_mode()) {
+
+        case AP_Motors::SHUT_DOWN:
+            return AltHold_MotorStopped;
+
+        case AP_Motors::DESIRED_GROUND_IDLE:
+            return AltHold_Landed_Ground_Idle;
+
+        default:
+            return AltHold_Landed_Pre_Takeoff;
+        }
+
+    } else if (takeoff.running() || takeoff.triggered(target_climb_rate_cms)) {
+        // the aircraft is currently landed or taking off, asking for a positive climb rate and in THROTTLE_UNLIMITED
+        // the aircraft should progress through the take off procedure
+        return AltHold_Takeoff;
+
+    } else if (!ap.auto_armed || ap.land_complete) {
+        // the aircraft is armed and landed
+        if (target_climb_rate_cms < 0.0f && !ap.using_interlock) {
+            // the aircraft should move to a ground idle state
+            motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
+
+        } else {
+            // the aircraft should prepare for imminent take off
+            motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+        }
+
+        if (motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
+            // the aircraft is waiting in ground idle
+            return AltHold_Landed_Ground_Idle;
+
+        } else {
+            // the aircraft can leave the ground at any time
+            return AltHold_Landed_Pre_Takeoff;
+        }
+
+    } else {
+        // the aircraft is in a flying state
+        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+        return AltHold_Flying;
+    }
 }
 
 // pass-through functions to reduce code churn on conversion;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -116,6 +116,8 @@ protected:
 
     // helper functions
     void zero_throttle_and_relax_ac(bool spool_up = false);
+    void zero_throttle_and_hold_attitude();
+    void make_safe_shut_down();
 
     // functions to control landing
     // in modes that support landing
@@ -125,6 +127,16 @@ protected:
 
     // return expected input throttle setting to hover:
     virtual float throttle_hover() const;
+
+    // Alt_Hold based flight mode states used in Alt_Hold, Loiter, and Sport
+    enum AltHoldModeState {
+        AltHold_MotorStopped,
+        AltHold_Takeoff,
+        AltHold_Landed_Ground_Idle,
+        AltHold_Landed_Pre_Takeoff,
+        AltHold_Flying
+    };
+    AltHoldModeState get_alt_hold_state(float target_climb_rate_cms);
 
     // convenience references to avoid code churn in conversion:
     Parameters &g;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -117,7 +117,7 @@ protected:
     // helper functions
     void zero_throttle_and_relax_ac(bool spool_up = false);
     void zero_throttle_and_hold_attitude();
-    void make_safe_shut_down();
+    void make_safe_spool_down();
 
     // functions to control landing
     // in modes that support landing

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -26,11 +26,11 @@ void Copter::ModeAcro::run()
 
     if (motors->get_spool_mode() == AP_Motors::SHUT_DOWN) {
         // Motors Stopped
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->set_attitude_target_to_current_attitude();
         attitude_control->reset_rate_controller_I_terms();
     } else if (motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
         // Landed
-        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->set_attitude_target_to_current_attitude();
         attitude_control->reset_rate_controller_I_terms();
     } else if (motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
         // clear landing flag above zero throttle

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -59,8 +59,6 @@ void Copter::ModeAcro_Heli::run()
         }
     }
 
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-
     if (!motors->has_flybar()){
         // convert the input to the desired body frame rate
         get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -21,7 +21,6 @@ bool Copter::ModeAltHold::init(bool ignore_checks)
 // should be called at 100hz or more
 void Copter::ModeAltHold::run()
 {
-    AltHoldModeState althold_state;
     float takeoff_climb_rate = 0.0f;
 
     // initialize vertical speeds and acceleration
@@ -43,40 +42,30 @@ void Copter::ModeAltHold::run()
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // Alt Hold State Machine Determination
-    if (!motors->armed() || !motors->get_interlock()) {
-        althold_state = AltHold_MotorStopped;
-    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
-        althold_state = AltHold_Takeoff;
-    } else if (!ap.auto_armed || ap.land_complete) {
-        althold_state = AltHold_Landed;
-    } else {
-        althold_state = AltHold_Flying;
-    }
+    AltHoldModeState althold_state = get_alt_hold_state(target_climb_rate);
 
     // Alt Hold State Machine
     switch (althold_state) {
 
     case AltHold_MotorStopped:
 
-        motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_yaw_target_to_current_heading();
-#if FRAME_CONFIG == HELI_FRAME    
-        // force descent rate and call position controller
-        pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
-        if (ap.land_complete_maybe) {
-            pos_control->relax_alt_hold_controllers(0.0f);
-        }
-#else
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
-#endif
-        pos_control->update_z_controller();
+        break;
+
+    case AltHold_Landed_Ground_Idle:
+
+        attitude_control->reset_rate_controller_I_terms();
+        attitude_control->set_yaw_target_to_current_heading();
+        // FALLTHROUGH
+
+    case AltHold_Landed_Pre_Takeoff:
+
+        pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         break;
 
     case AltHold_Takeoff:
-        // set motors to full range
-        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
         // initiate take-off
         if (!takeoff.running()) {
@@ -93,38 +82,9 @@ void Copter::ModeAltHold::run()
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
-        // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
-
-        // call position controller
+        // set position controller targets
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
         pos_control->add_takeoff_climb_rate(takeoff_climb_rate, G_Dt);
-        pos_control->update_z_controller();
-        break;
-
-    case AltHold_Landed:
-
-#if FRAME_CONFIG == HELI_FRAME    
-        // helicopters do not spool down when landed.  Only when commanded to go to ground idle by pilot.
-        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-
-        if (motors->init_targets_on_arming()) {
-            attitude_control->reset_rate_controller_I_terms();
-            attitude_control->set_yaw_target_to_current_heading();
-        }
-#else
-        // set motors to spin-when-armed if throttle below deadzone, otherwise full range (but motors will only spin at min throttle)
-        if (target_climb_rate < 0.0f) {
-            motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        } else {
-            motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-        }
-        attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
-#endif
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
-        pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
-        pos_control->update_z_controller();
         break;
 
     case AltHold_Flying:
@@ -135,18 +95,20 @@ void Copter::ModeAltHold::run()
         copter.avoid.adjust_roll_pitch(target_roll, target_pitch, copter.aparm.angle_max);
 #endif
 
-        // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
-
         // adjust climb rate using rangefinder
         target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
-        // call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
-        pos_control->update_z_controller();
         break;
     }
+
+    // call attitude controller
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
+
+    // call z-axis position controller
+    pos_control->update_z_controller();
+
 }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -742,6 +742,7 @@ void Copter::ModeAuto::wp_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        wp_nav->wp_and_spline_init();
         return;
     }
 
@@ -771,6 +772,7 @@ void Copter::ModeAuto::spline_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        wp_nav->wp_and_spline_init();
         return;
     }
 
@@ -815,6 +817,7 @@ void Copter::ModeAuto::land_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        loiter_nav->init_target();
         return;
     }
 
@@ -869,6 +872,7 @@ void Copter::ModeAuto::loiter_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        wp_nav->wp_and_spline_init();
         return;
     }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -729,16 +729,6 @@ void Copter::ModeAuto::takeoff_run()
 //      called by auto_run at 100hz or more
 void Copter::ModeAuto::wp_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
-        //    (of course it would be better if people just used take-off)
-        zero_throttle_and_relax_ac();
-        // clear i term when we're taking off
-        set_throttle_takeoff();
-        return;
-    }
-
     // process pilot's yaw input
     float target_yaw_rate = 0;
     if (!copter.failsafe.radio) {
@@ -747,6 +737,12 @@ void Copter::ModeAuto::wp_run()
         if (!is_zero(target_yaw_rate)) {
             auto_yaw.set_mode(AUTO_YAW_HOLD);
         }
+    }
+
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
+        return;
     }
 
     // set motors to full range
@@ -772,13 +768,9 @@ void Copter::ModeAuto::wp_run()
 //      called by auto_run at 100hz or more
 void Copter::ModeAuto::spline_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
-        //    (of course it would be better if people just used take-off)
-        zero_throttle_and_relax_ac();
-        // clear i term when we're taking off
-        set_throttle_takeoff();
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -815,12 +807,14 @@ void Copter::ModeAuto::spline_run()
 //      called by auto_run at 100hz or more
 void Copter::ModeAuto::land_run()
 {
-    // if not auto armed or landed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        // set target to current position
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+    // disarm when the landing detector says we've landed
+    if (ap.land_complete) {
+        copter.init_disarm_motors();
+    }
+
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -872,9 +866,9 @@ void Copter::ModeAuto::nav_guided_run()
 //      called by auto_run at 100hz or more
 void Copter::ModeAuto::loiter_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -1515,7 +1509,7 @@ bool Copter::ModeAuto::verify_land()
 
         case LandStateType_Descending:
             // rely on THROTTLE_LAND mode to correctly update landing status
-            retval = ap.land_complete;
+            retval = ap.land_complete && (motors->get_spool_mode() == AP_Motors::GROUND_IDLE);
             break;
 
         default:

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -741,7 +741,7 @@ void Copter::ModeAuto::wp_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         wp_nav->wp_and_spline_init();
         return;
     }
@@ -771,7 +771,7 @@ void Copter::ModeAuto::spline_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         wp_nav->wp_and_spline_init();
         return;
     }
@@ -809,14 +809,10 @@ void Copter::ModeAuto::spline_run()
 //      called by auto_run at 100hz or more
 void Copter::ModeAuto::land_run()
 {
-    // disarm when the landing detector says we've landed
-    if (ap.land_complete && motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
-        copter.init_disarm_motors();
-    }
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         loiter_nav->init_target();
         return;
     }
@@ -871,7 +867,7 @@ void Copter::ModeAuto::loiter_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         wp_nav->wp_and_spline_init();
         return;
     }
@@ -1731,7 +1727,9 @@ bool Copter::ModeAuto::verify_loiter_to_alt()
 // returns true with RTL has completed successfully
 bool Copter::ModeAuto::verify_RTL()
 {
-    return (copter.mode_rtl.state_complete() && (copter.mode_rtl.state() == RTL_FinalDescent || copter.mode_rtl.state() == RTL_Land));
+    return (copter.mode_rtl.state_complete() && 
+    (copter.mode_rtl.state() == RTL_FinalDescent || copter.mode_rtl.state() == RTL_Land) &&
+    (motors->get_spool_mode() == AP_Motors::GROUND_IDLE));
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -810,7 +810,7 @@ void Copter::ModeAuto::spline_run()
 void Copter::ModeAuto::land_run()
 {
     // disarm when the landing detector says we've landed
-    if (ap.land_complete) {
+    if (ap.land_complete && motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
         copter.init_disarm_motors();
     }
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -999,11 +999,11 @@ void Copter::ModeAuto::payload_place_run()
 
 bool Copter::ModeAuto::payload_place_run_should_run()
 {
-    // muts be armed
+    // must be armed
     if (!motors->armed()) {
         return false;
     }
-    // muts be auto-armed
+    // must be auto-armed
     if (!ap.auto_armed) {
         return false;
     }

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -52,8 +52,6 @@ void Copter::ModeBrake::run()
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), 0.0f);
 
-    // body-frame rate controller is run directly from 100hz loop
-
     // update altitude target and call position controller
     // protects heli's from inflight motor interlock disable
     if (motors->get_desired_spool_state() == AP_Motors::DESIRED_GROUND_IDLE && !ap.land_complete) {

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -33,7 +33,7 @@ void Copter::ModeBrake::run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
         return;
     }

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -34,6 +34,7 @@ void Copter::ModeBrake::run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
         return;
     }
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -61,7 +61,12 @@ void Copter::ModeBrake::run()
     // body-frame rate controller is run directly from 100hz loop
 
     // update altitude target and call position controller
-    pos_control->set_alt_target_from_climb_rate_ff(0.0f, G_Dt, false);
+    // protects heli's from inflight motor interlock disable
+    if (motors->get_desired_spool_state() == AP_Motors::DESIRED_GROUND_IDLE && !ap.land_complete) {
+        pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
+    } else {
+        pos_control->set_alt_target_from_climb_rate_ff(0.0f, G_Dt, false);
+    }
     pos_control->update_z_controller();
 
     if (_timeout_ms != 0 && millis()-_timeout_start >= _timeout_ms) {

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -31,26 +31,19 @@ bool Copter::ModeBrake::init(bool ignore_checks)
 // should be called at 100hz or more
 void Copter::ModeBrake::run()
 {
-    // if not auto armed set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        wp_nav->init_brake_target(BRAKE_MODE_DECEL_RATE);
-        zero_throttle_and_relax_ac();
-        pos_control->relax_alt_hold_controllers(0.0f);
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
+
+    // set motors to full range
+    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // relax stop target if we might be landed
     if (ap.land_complete_maybe) {
         loiter_nav->soften_for_landing();
     }
-
-    // if landed immediately disarm
-    if (ap.land_complete) {
-        copter.init_disarm_motors();
-    }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // run brake controller
     wp_nav->update_brake();

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -27,41 +27,30 @@ bool Copter::ModeCircle::init(bool ignore_checks)
 // should be called at 100hz or more
 void Copter::ModeCircle::run()
 {
-    float target_yaw_rate = 0;
-    float target_climb_rate = 0;
-
     // initialize speeds and accelerations
     pos_control->set_max_speed_xy(wp_nav->get_default_speed_xy());
     pos_control->set_max_accel_xy(wp_nav->get_wp_acceleration());
     pos_control->set_max_speed_z(-get_pilot_speed_dn(), g.pilot_speed_up);
     pos_control->set_max_accel_z(g.pilot_accel_z);
-    
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
-        // To-Do: add some initialisation of position controllers
-        zero_throttle_and_relax_ac();
-        pos_control->set_alt_target_to_current_alt();
-        return;
+
+    // get pilot's desired yaw rate (or zero if in radio failsafe)
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    if (!is_zero(target_yaw_rate)) {
+        pilot_yaw_override = true;
     }
 
-    // process pilot inputs
-    if (!copter.failsafe.radio) {
-        // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-        if (!is_zero(target_yaw_rate)) {
-            pilot_yaw_override = true;
-        }
+    // get pilot desired climb rate (or zero if in radio failsafe)
+    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    // adjust climb rate using rangefinder
+    if (copter.rangefinder_alt_ok()) {
+        // if rangefinder is ok, use surface tracking
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+    }
 
-        // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
-
-        // check for pilot requested take-off
-        if (ap.land_complete && target_climb_rate > 0) {
-            // indicate we are taking off
-            set_land_complete(false);
-            // clear i term when we're taking off
-            set_throttle_takeoff();
-        }
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
+        return;
     }
 
     // set motors to full range
@@ -80,9 +69,6 @@ void Copter::ModeCircle::run()
                                                            copter.circle_nav->get_pitch(),
                                                            copter.circle_nav->get_yaw(), true);
     }
-
-    // adjust climb rate using rangefinder
-    target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
 
     // update altitude target and call position controller
     // protects heli's from inflight motor interlock disable

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -49,7 +49,7 @@ void Copter::ModeCircle::run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -64,7 +64,7 @@ void Copter::ModeCircle::run()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(copter.circle_nav->get_roll(),
                                                                       copter.circle_nav->get_pitch(),
                                                                       target_yaw_rate);
-    }else{
+    } else {
         attitude_control->input_euler_angle_roll_pitch_yaw(copter.circle_nav->get_roll(),
                                                            copter.circle_nav->get_pitch(),
                                                            copter.circle_nav->get_yaw(), true);

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -85,7 +85,12 @@ void Copter::ModeCircle::run()
     target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
 
     // update altitude target and call position controller
-    pos_control->set_alt_target_from_climb_rate(target_climb_rate, G_Dt, false);
+    // protects heli's from inflight motor interlock disable
+    if (motors->get_desired_spool_state() == AP_Motors::DESIRED_GROUND_IDLE && !ap.land_complete) {
+        pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
+    } else {
+        pos_control->set_alt_target_from_climb_rate(target_climb_rate, G_Dt, false);
+    }
     pos_control->update_z_controller();
 }
 

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -52,29 +52,29 @@ void Copter::ModeDrift::run()
     float roll_vel =  vel.y * ahrs.cos_yaw() - vel.x * ahrs.sin_yaw(); // body roll vel
     float pitch_vel = vel.y * ahrs.sin_yaw() + vel.x * ahrs.cos_yaw(); // body pitch vel
 
-    // gain sceduling for Yaw
+    // gain scheduling for yaw
     float pitch_vel2 = MIN(fabsf(pitch_vel), 2000);
     float target_yaw_rate = ((float)target_roll/1.0f) * (1.0f - (pitch_vel2 / 5000.0f)) * g.acro_yaw_p;
 
     roll_vel = constrain_float(roll_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
     pitch_vel = constrain_float(pitch_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
-    
+
     roll_input = roll_input * .96f + (float)channel_yaw->get_control_in() * .04f;
 
-    //convert user input into desired roll velocity
+    // convert user input into desired roll velocity
     float roll_vel_error = roll_vel - (roll_input / DRIFT_SPEEDGAIN);
 
-    // Roll velocity is feed into roll acceleration to minimize slip
+    // roll velocity is feed into roll acceleration to minimize slip
     target_roll = roll_vel_error * -DRIFT_SPEEDGAIN;
     target_roll = constrain_float(target_roll, -4500.0f, 4500.0f);
 
     // If we let go of sticks, bring us to a stop
-    if(is_zero(target_pitch)){
+    if (is_zero(target_pitch)) {
         // .14/ (.03 * 100) = 4.6 seconds till full braking
         braker += .03f;
         braker = MIN(braker, DRIFT_SPEEDGAIN);
         target_pitch = pitch_vel * braker;
-    }else{
+    } else {
         braker = 0.0f;
     }
 

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -102,6 +102,9 @@ void Copter::ModeFlip::run()
     // get pilot's desired throttle
     float throttle_out = get_pilot_desired_throttle();
 
+    // set motors to full range
+    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+
     // get corrected angle based on direction and axis of rotation
     // we flip the sign of flip_angle to minimize the code repetition
     int32_t flip_angle;
@@ -208,9 +211,6 @@ void Copter::ModeFlip::run()
         AP::logger().Write_Error(LogErrorSubsystem::FLIP, LogErrorCode::FLIP_ABANDONED);
         break;
     }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // output pilot's throttle without angle boost
     attitude_control->set_throttle_out(throttle_out, false, g.throttle_filt);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -84,13 +84,6 @@ Copter::ModeFlowHold::ModeFlowHold(void) : Mode()
 // flowhold_init - initialise flowhold controller
 bool Copter::ModeFlowHold::init(bool ignore_checks)
 {
-#if FRAME_CONFIG == HELI_FRAME
-    // do not allow helis to enter Flow Hold if the Rotor Runup is not complete
-    if (!ignore_checks && !motors->rotor_runup_complete()){
-        return false;
-    }
-#endif
-
     if (!copter.optflow.enabled() || !copter.optflow.healthy()) {
         return false;
     }

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -226,7 +226,7 @@ void Copter::ModeFlowHold::run()
     copter.pos_control->set_max_accel_z(copter.g.pilot_accel_z);
 
     // apply SIMPLE mode transform to pilot inputs
-    copter.update_simple_mode();
+    update_simple_mode();
 
     // check for filter change
     if (!is_equal(flow_filter.get_cutoff_freq(), flow_filter_hz.get())) {

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -26,11 +26,14 @@ bool Copter::ModeFollow::init(const bool ignore_checks)
 
 void Copter::ModeFollow::run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
+
+    // set motors to full range
+    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // re-use guided mode's velocity controller
     // Note: this is safe from interference from GCSs and companion computer's whose guided mode

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -28,7 +28,7 @@ void Copter::ModeFollow::run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -395,8 +395,8 @@ void Copter::Mode::auto_takeoff_run()
     }
 
 #if FRAME_CONFIG == HELI_FRAME
-    // helicopters stay in landed state until rotor speed runup has finished
-    if (motors->rotor_runup_complete()) {
+    // aircraft stays in landed state until rotor speed runup has finished
+    if (motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
         set_land_complete(false);
     } else {
         // initialise wpnav targets

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -380,6 +380,7 @@ void Copter::Mode::auto_takeoff_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed) {
         make_safe_shut_down();
+        wp_nav->shift_wp_origin_to_current_pos();
         return;
     }
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -379,7 +379,7 @@ void Copter::Mode::auto_takeoff_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         wp_nav->shift_wp_origin_to_current_pos();
         return;
     }
@@ -427,7 +427,7 @@ void Copter::ModeGuided::pos_control_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -469,7 +469,7 @@ void Copter::ModeGuided::vel_control_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -522,7 +522,7 @@ void Copter::ModeGuided::posvel_control_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -606,7 +606,7 @@ void Copter::ModeGuided::angle_control_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || (ap.land_complete && (guided_angle_state.climb_rate_cms <= 0.0f))) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -61,6 +61,7 @@ void Copter::ModeLand::gps_run()
     // Land State Machine Determination
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        loiter_nav->init_target();
     } else {
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -54,7 +54,7 @@ void Copter::ModeLand::run()
 void Copter::ModeLand::gps_run()
 {
     // disarm when the landing detector says we've landed
-    if (ap.land_complete) {
+    if (ap.land_complete && motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
         copter.init_disarm_motors();
     }
 
@@ -105,7 +105,7 @@ void Copter::ModeLand::nogps_run()
     }
 
     // disarm when the landing detector says we've landed
-    if (ap.land_complete) {
+    if (ap.land_complete && motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
         copter.init_disarm_motors();
     }
 

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -60,7 +60,7 @@ void Copter::ModeLand::gps_run()
 
     // Land State Machine Determination
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         loiter_nav->init_target();
     } else {
         // set motors to full range
@@ -111,7 +111,7 @@ void Copter::ModeLand::nogps_run()
 
     // Land State Machine Determination
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
     } else {
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -122,7 +122,7 @@ void Copter::ModeLoiter::run()
         attitude_control->set_yaw_target_to_current_heading();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         loiter_nav->init_target();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
         pos_control->update_z_controller();
         break;
 

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -74,8 +74,6 @@ void Copter::ModeLoiter::precision_loiter_xy()
 // should be called at 100hz or more
 void Copter::ModeLoiter::run()
 {
-    LoiterModeState loiter_state;
-
     float target_roll, target_pitch;
     float target_yaw_rate = 0.0f;
     float target_climb_rate = 0.0f;
@@ -113,42 +111,22 @@ void Copter::ModeLoiter::run()
     }
 
     // Loiter State Machine Determination
-    if (!motors->armed() || !motors->get_interlock()) {
-        loiter_state = Loiter_MotorStopped;
-    } else if (takeoff.running() || takeoff.triggered(target_climb_rate)) {
-        loiter_state = Loiter_Takeoff;
-    } else if (!ap.auto_armed || ap.land_complete) {
-        loiter_state = Loiter_Landed;
-    } else {
-        loiter_state = Loiter_Flying;
-    }
+    AltHoldModeState loiter_state = get_alt_hold_state(target_climb_rate);
 
     // Loiter State Machine
     switch (loiter_state) {
 
-    case Loiter_MotorStopped:
+    case AltHold_MotorStopped:
 
-        motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
-#if FRAME_CONFIG == HELI_FRAME
-        // force descent rate and call position controller
-        pos_control->set_alt_target_from_climb_rate(-abs(g.land_speed), G_Dt, false);
-        if (ap.land_complete_maybe) {
-            pos_control->relax_alt_hold_controllers(0.0f);
-        }
-#else
-        loiter_nav->init_target();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_yaw_target_to_current_heading();
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
-#endif
-        loiter_nav->update();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
+        loiter_nav->init_target();
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
         pos_control->update_z_controller();
         break;
 
-    case Loiter_Takeoff:
-        // set motors to full range
-        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+    case AltHold_Takeoff:
 
         // initiate take-off
         if (!takeoff.running()) {
@@ -177,27 +155,21 @@ void Copter::ModeLoiter::run()
         pos_control->update_z_controller();
         break;
 
-    case Loiter_Landed:
-#if FRAME_CONFIG == HELI_FRAME
-        // helicopters do not spool down when landed.  Only when commanded to go to ground idle by pilot.
-        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-#else
-        // set motors to spin-when-armed if throttle below deadzone, otherwise full range (but motors will only spin at min throttle)
-        if (target_climb_rate < 0.0f) {
-            motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        } else {
-            motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-        }
-#endif
-        loiter_nav->init_target();
+    case AltHold_Landed_Ground_Idle:
+
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_yaw_target_to_current_heading();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0, 0, 0);
+        // FALLTHROUGH
+
+    case AltHold_Landed_Pre_Takeoff:
+
+        loiter_nav->init_target();
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
         pos_control->relax_alt_hold_controllers(0.0f);   // forces throttle output to go to zero
         pos_control->update_z_controller();
         break;
 
-    case Loiter_Flying:
+    case AltHold_Flying:
 
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
@@ -220,7 +192,6 @@ void Copter::ModeLoiter::run()
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
-        // update altitude target and call position controller
         pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, G_Dt, false);
         pos_control->update_z_controller();
         break;

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -443,9 +443,6 @@ void Copter::ModePosHold::run()
             break;
     }
 
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-
     //
     // Shared roll & pitch states (POSHOLD_BRAKE_TO_LOITER and POSHOLD_LOITER)
     //

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -103,7 +103,7 @@ bool Copter::ModePosHold::init(bool ignore_checks)
         // if landed begin in loiter mode
         poshold.roll_mode = POSHOLD_LOITER;
         poshold.pitch_mode = POSHOLD_LOITER;
-    }else{
+    } else {
         // if not landed start in pilot override to avoid hard twitch
         poshold.roll_mode = POSHOLD_PILOT_OVERRIDE;
         poshold.pitch_mode = POSHOLD_PILOT_OVERRIDE;

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -127,10 +127,9 @@ void Copter::ModeRTL::return_start()
 //      called by rtl_run at 100hz or more
 void Copter::ModeRTL::climb_return_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        // To-Do: re-initialise wpnav targets
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -185,10 +184,9 @@ void Copter::ModeRTL::loiterathome_start()
 //      called by rtl_run at 100hz or more
 void Copter::ModeRTL::loiterathome_run()
 {
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        // To-Do: re-initialise wpnav targets
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -258,12 +256,9 @@ void Copter::ModeRTL::descent_run()
     float target_pitch = 0.0f;
     float target_yaw_rate = 0.0f;
 
-    // if not auto armed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        // set target to current position
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -358,20 +353,17 @@ bool Copter::ModeRTL::landing_gear_should_be_deployed() const
 //      called by rtl_run at 100hz or more
 void Copter::ModeRTL::land_run(bool disarm_on_land)
 {
-    // if not auto armed or landing completed or motor interlock not enabled set throttle to zero and exit immediately
-    if (!motors->armed() || !ap.auto_armed || ap.land_complete || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        // set target to current position
-        loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+    // check if we've completed this stage of RTL
+    _state_complete = ap.land_complete;
 
-        // disarm when the landing detector says we've landed
-        if (ap.land_complete && disarm_on_land) {
-            copter.init_disarm_motors();
-        }
+    // disarm when the landing detector says we've landed
+    if (disarm_on_land && ap.land_complete) {
+        copter.init_disarm_motors();
+    }
 
-        // check if we've completed this stage of RTL
-        _state_complete = ap.land_complete;
+    // if not armed set throttle to zero and exit immediately
+    if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
+        make_safe_shut_down();
         return;
     }
 
@@ -380,9 +372,6 @@ void Copter::ModeRTL::land_run(bool disarm_on_land)
 
     land_run_horizontal_control();
     land_run_vertical_control();
-
-    // check if we've completed this stage of RTL
-    _state_complete = ap.land_complete;
 }
 
 void Copter::ModeRTL::build_path(bool terrain_following_allowed)

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -357,7 +357,7 @@ void Copter::ModeRTL::land_run(bool disarm_on_land)
     _state_complete = ap.land_complete;
 
     // disarm when the landing detector says we've landed
-    if (disarm_on_land && ap.land_complete) {
+    if (disarm_on_land && ap.land_complete && motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
         copter.init_disarm_motors();
     }
 

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -129,7 +129,7 @@ void Copter::ModeRTL::climb_return_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -186,7 +186,7 @@ void Copter::ModeRTL::loiterathome_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -258,7 +258,7 @@ void Copter::ModeRTL::descent_run()
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         return;
     }
 
@@ -363,7 +363,7 @@ void Copter::ModeRTL::land_run(bool disarm_on_land)
 
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
-        make_safe_shut_down();
+        make_safe_spool_down();
         loiter_nav->init_target();
         return;
     }

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -364,6 +364,7 @@ void Copter::ModeRTL::land_run(bool disarm_on_land)
     // if not armed set throttle to zero and exit immediately
     if (!motors->armed() || !ap.auto_armed || ap.land_complete) {
         make_safe_shut_down();
+        loiter_nav->init_target();
         return;
     }
 

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -8,28 +8,40 @@
 // should be called at 100hz or more
 void Copter::ModeStabilize::run()
 {
-    float target_roll, target_pitch;
-    float target_yaw_rate;
-
-    // if not armed set throttle to zero and exit immediately
-    if (!motors->armed() || ap.throttle_zero || !motors->get_interlock()) {
-        zero_throttle_and_relax_ac();
-        return;
-    }
-
-    // clear landing flag
-    set_land_complete(false);
-
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-
-    // apply SIMPLE mode transform to pilot inputs
+    // apply simple mode transform to pilot inputs
     update_simple_mode();
 
     // convert pilot input to lean angles
+    float target_roll, target_pitch;
     get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+    float target_yaw_rate = get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+
+    if (!motors->armed()) {
+        // Motors should be Stopped
+        motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+    } else if (ap.throttle_zero) {
+        // Attempting to Land
+        motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
+    } else {
+        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+    }
+
+    if (motors->get_spool_mode() == AP_Motors::SHUT_DOWN) {
+        // Motors Stopped
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
+    } else if (motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
+        // Landed
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
+    } else if (motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
+        // clear landing flag above zero throttle
+        if (!motors->limit.throttle_lower) {
+            set_land_complete(false);
+        }
+    }
 
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -46,8 +46,6 @@ void Copter::ModeStabilize::run()
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
 
-    // body-frame rate controller is run directly from 100hz loop
-
     // output pilot's throttle
     attitude_control->set_throttle_out(get_pilot_desired_throttle(),
                                        true,

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -22,22 +22,7 @@ void Copter::ModeStabilize_Heli::run()
     float target_yaw_rate;
     float pilot_throttle_scaled;
 
-    // Tradheli should not reset roll, pitch, yaw targets when motors are not runup, because
-    // we may be in autorotation flight.  These should be reset only when transitioning from disarmed
-    // to armed, because the pilot will have placed the helicopter down on the landing pad.  This is so
-    // that the servos move in a realistic fashion while disarmed for operational checks.
-    // Also, unlike multicopters we do not set throttle (i.e. collective pitch) to zero so the swash servos move
     
-    if (motors->init_targets_on_arming()) {
-        attitude_control->reset_rate_controller_I_terms();
-        attitude_control->set_yaw_target_to_current_heading();
-    }
-
-    // clear landing flag above zero throttle
-    if (motors->armed() && motors->get_interlock() && motors->rotor_runup_complete() && !ap.throttle_zero) {
-        set_land_complete(false);
-    }
-
     motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
 
     // apply SIMPLE mode transform to pilot inputs
@@ -51,6 +36,36 @@ void Copter::ModeStabilize_Heli::run()
 
     // get pilot's desired throttle
     pilot_throttle_scaled = copter.input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());
+
+    // Tradheli should not reset roll, pitch, yaw targets when motors are not runup while flying, because
+    // we may be in autorotation flight.  This is so that the servos move in a realistic fashion while disarmed
+    // for operational checks. Also, unlike multicopters we do not set throttle (i.e. collective pitch) to zero
+    // so the swash servos move.
+
+    if (!motors->armed()) {
+        // Motors should be Stopped
+        motors->set_desired_spool_state(AP_Motors::DESIRED_SHUT_DOWN);
+    } else {
+        // heli will not let the spool state progress to THROTTLE_UNLIMITED until motor interlock is enabled
+        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+    }
+
+    if (motors->get_spool_mode() == AP_Motors::SHUT_DOWN) {
+        // Motors Stopped
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
+    } else if (motors->get_spool_mode() == AP_Motors::GROUND_IDLE) {
+        // Landed
+        if (motors->init_targets_on_arming()) {
+            attitude_control->set_yaw_target_to_current_heading();
+            attitude_control->reset_rate_controller_I_terms();
+        }
+    } else if (motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
+        // clear landing flag above zero throttle
+        if (!motors->limit.throttle_lower) {
+            set_land_complete(false);
+        }
+    }
 
     // call attitude controller
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -22,9 +22,6 @@ void Copter::ModeStabilize_Heli::run()
     float target_yaw_rate;
     float pilot_throttle_scaled;
 
-    
-    motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
-
     // apply SIMPLE mode transform to pilot inputs
     update_simple_mode();
 

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -34,7 +34,6 @@ void Copter::ModeThrow::run()
     Throw_PosHold - the copter is kept at a constant position and height
     */
 
-    // Don't enter THROW mode if interlock will prevent motors running
     if (!motors->armed()) {
         // state machine entry is always from a disarmed state
         stage = Throw_Disarmed;
@@ -116,6 +115,8 @@ void Copter::ModeThrow::run()
         }
 
         // demand zero throttle (motors will be stopped anyway) and continually reset the attitude controller
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_throttle_out(0,true,g.throttle_filt);
         break;
 
@@ -129,6 +130,8 @@ void Copter::ModeThrow::run()
         }
 
         // Hold throttle at zero during the throw and continually reset the attitude controller
+        attitude_control->set_yaw_target_to_current_heading();
+        attitude_control->reset_rate_controller_I_terms();
         attitude_control->set_throttle_out(0,true,g.throttle_filt);
 
         // Play the waiting for throw tone sequence to alert the user

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -35,7 +35,7 @@ void Copter::ModeThrow::run()
     */
 
     // Don't enter THROW mode if interlock will prevent motors running
-    if (!motors->armed() && motors->get_interlock()) {
+    if (!motors->armed()) {
         // state machine entry is always from a disarmed state
         stage = Throw_Disarmed;
 
@@ -116,7 +116,7 @@ void Copter::ModeThrow::run()
         }
 
         // demand zero throttle (motors will be stopped anyway) and continually reset the attitude controller
-        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
         break;
 
     case Throw_Detecting:
@@ -129,7 +129,7 @@ void Copter::ModeThrow::run()
         }
 
         // Hold throttle at zero during the throw and continually reset the attitude controller
-        attitude_control->set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(0,true,g.throttle_filt);
 
         // Play the waiting for throw tone sequence to alert the user
         AP_Notify::flags.waiting_for_throw = true;

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -93,13 +93,11 @@ void Copter::auto_disarm_check()
         return;
     }
 
-#if FRAME_CONFIG == HELI_FRAME
     // if the rotor is still spinning, don't initiate auto disarm
-    if (motors->rotor_speed_above_critical()) {
+    if (motors->get_spool_mode() != AP_Motors::GROUND_IDLE) {
         auto_disarm_begin = tnow_ms;
         return;
     }
-#endif
 
     // always allow auto disarm if using interlock switch or motors are Emergency Stopped
     if ((ap.using_interlock && !motors->get_interlock()) || SRV_Channels::get_emergency_stop()) {

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -368,28 +368,26 @@ void Copter::update_auto_armed()
         if(flightmode->has_manual_throttle() && ap.throttle_zero && !failsafe.radio) {
             set_auto_armed(false);
         }
-#if FRAME_CONFIG == HELI_FRAME
         // if helicopters are on the ground, and the motor is switched off, auto-armed should be false
         // so that rotor runup is checked again before attempting to take-off
-        if(ap.land_complete && !motors->rotor_runup_complete()) {
+        if(ap.land_complete && motors->get_spool_mode() != AP_Motors::THROTTLE_UNLIMITED && ap.using_interlock) {
             set_auto_armed(false);
         }
-#endif // HELI_FRAME
     }else{
         // arm checks
         
-#if FRAME_CONFIG == HELI_FRAME
         // for tradheli if motors are armed and throttle is above zero and the motor is started, auto_armed should be true
-        if(motors->armed() && !ap.throttle_zero && motors->rotor_runup_complete()) {
-            set_auto_armed(true);
-        }
-#else
+        if(motors->armed() && ap.using_interlock) {
+            if(!ap.throttle_zero && motors->get_spool_mode() == AP_Motors::THROTTLE_UNLIMITED) {
+                set_auto_armed(true);
+            }
         // if motors are armed and throttle is above zero auto_armed should be true
         // if motors are armed and we are in throw mode, then auto_armed should be true
-        if(motors->armed() && (!ap.throttle_zero || control_mode == THROW)) {
-            set_auto_armed(true);
+        } else if (motors->armed() && !ap.using_interlock) {
+            if(!ap.throttle_zero || control_mode == THROW) {
+                set_auto_armed(true);
+            }
         }
-#endif // HELI_FRAME
     }
 }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -32,12 +32,10 @@ bool Copter::Mode::do_user_takeoff(float takeoff_alt_cm, bool must_navigate)
         return false;
     }
 
-#if FRAME_CONFIG == HELI_FRAME
     // Helicopters should return false if MAVlink takeoff command is received while the rotor is not spinning
-    if (!copter.motors->rotor_runup_complete()) {
+    if (motors->get_spool_mode() != AP_Motors::THROTTLE_UNLIMITED && ap.using_interlock) {
         return false;
     }
-#endif
 
     if (!do_user_takeoff_start(takeoff_alt_cm)) {
         return false;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -773,11 +773,10 @@ void QuadPlane::hold_stabilize(float throttle_in)
 
     if (throttle_in <= 0) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        if (is_tailsitter()) {
+        attitude_control->set_throttle_out(0, true, 0);
+        if (!is_tailsitter()) {
             // always stabilize with tailsitters so we can do belly takeoffs
-            attitude_control->set_throttle_out(0, true, 0);
-        } else {
-            attitude_control->set_throttle_out_unstabilized(0, true, 0);
+            attitude_control->relax_attitude_controllers();
         }
     } else {
         motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
@@ -912,7 +911,8 @@ void QuadPlane::control_qacro(void)
 {
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control->set_throttle_out_unstabilized(0, true, 0);
+        attitude_control->set_throttle_out(0, true, 0);
+        attitude_control->relax_attitude_controllers();
     } else {
         check_attitude_relax();
 
@@ -976,7 +976,8 @@ void QuadPlane::control_hover(void)
 {
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control->set_throttle_out_unstabilized(0, true, 0);
+        attitude_control->set_throttle_out(0, true, 0);
+        attitude_control->relax_attitude_controllers();
         pos_control->relax_alt_hold_controllers(0);
     } else {
         hold_hover(get_pilot_desired_climb_rate_cms());
@@ -1104,7 +1105,8 @@ void QuadPlane::control_loiter()
 {
     if (throttle_wait) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control->set_throttle_out_unstabilized(0, true, 0);
+        attitude_control->set_throttle_out(0, true, 0);
+        attitude_control->relax_attitude_controllers();
         pos_control->relax_alt_hold_controllers(0);
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();

--- a/ArduSub/control_acro.cpp
+++ b/ArduSub/control_acro.cpp
@@ -27,7 +27,8 @@ void Sub::acro_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 

--- a/ArduSub/control_althold.cpp
+++ b/ArduSub/control_althold.cpp
@@ -39,7 +39,8 @@ void Sub::althold_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
         last_pilot_heading = ahrs.yaw_sensor;
         return;

--- a/ArduSub/control_auto.cpp
+++ b/ArduSub/control_auto.cpp
@@ -118,8 +118,8 @@ void Sub::auto_wp_run()
         // call attitude controller
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 
@@ -203,9 +203,9 @@ void Sub::auto_spline_run()
         // To-Do: reset waypoint origin to current location because vehicle is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 
@@ -391,7 +391,8 @@ void Sub::auto_loiter_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
 
         return;
     }
@@ -675,7 +676,8 @@ void Sub::auto_terrain_recover_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 

--- a/ArduSub/control_circle.cpp
+++ b/ArduSub/control_circle.cpp
@@ -43,8 +43,8 @@ void Sub::circle_run()
         // To-Do: add some initialisation of position controllers
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduSub/control_guided.cpp
+++ b/ArduSub/control_guided.cpp
@@ -293,8 +293,8 @@ void Sub::guided_pos_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 
@@ -344,8 +344,8 @@ void Sub::guided_vel_control_run()
         pos_control.init_vel_controller_xyz();
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 
@@ -399,8 +399,8 @@ void Sub::guided_posvel_control_run()
         pos_control.set_desired_velocity(Vector3f(0,0,0));
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 
@@ -469,8 +469,8 @@ void Sub::guided_angle_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control.set_throttle_out_unstabilized(0.0f,true,g.throttle_filt);
-
+        attitude_control.set_throttle_out(0.0f,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
         return;
     }

--- a/ArduSub/control_manual.cpp
+++ b/ArduSub/control_manual.cpp
@@ -20,7 +20,8 @@ void Sub::manual_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 

--- a/ArduSub/control_poshold.cpp
+++ b/ArduSub/control_poshold.cpp
@@ -43,7 +43,8 @@ void Sub::poshold_run()
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
         loiter_nav.clear_pilot_desired_acceleration();
         loiter_nav.init_target();
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         pos_control.relax_alt_hold_controllers(motors.get_throttle_hover());
         return;
     }

--- a/ArduSub/control_stabilize.cpp
+++ b/ArduSub/control_stabilize.cpp
@@ -21,7 +21,8 @@ void Sub::stabilize_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         last_pilot_heading = ahrs.yaw_sensor;
         return;
     }

--- a/ArduSub/control_surface.cpp
+++ b/ArduSub/control_surface.cpp
@@ -28,7 +28,8 @@ void Sub::surface_run()
     if (!motors.armed()) {
         motors.output_min();
         motors.set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
+        attitude_control.set_throttle_out(0,true,g.throttle_filt);
+        attitude_control.relax_attitude_controllers();
         return;
     }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -147,18 +147,6 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     AP_GROUPEND
 };
 
-// Set output throttle and disable stabilization
-void AC_AttitudeControl::set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control, float filter_cutoff)
-{
-    _throttle_in = throttle_in;
-    _motors.set_throttle_filter_cutoff(filter_cutoff);
-    if (reset_attitude_control) {
-        relax_attitude_controllers();
-    }
-    _motors.set_throttle(throttle_in);
-    _angle_boost = 0.0f;
-}
-
 // Ensure attitude controller have zero errors to relax rate controller output
 void AC_AttitudeControl::relax_attitude_controllers()
 {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -228,9 +228,6 @@ public:
     // Set output throttle
     virtual void set_throttle_out(float throttle_in, bool apply_angle_boost, float filt_cutoff) = 0;
 
-    // Set output throttle and disable stabilization
-    void set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control, float filt_cutoff);
-
     // get throttle passed into attitude controller (i.e. throttle_in provided to set_throttle_out)
     float get_throttle_in() const { return _throttle_in; }
 

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -349,7 +349,7 @@ void AC_AutoTune::run()
     // this should not actually be possible because of the init() checks
     if (!motors->armed() || !motors->get_interlock()) {
         motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
-        attitude_control->set_throttle_out_unstabilized(0.0f, true, 0);
+        attitude_control->set_throttle_out(0.0f, true, 0.0f);
         pos_control->relax_alt_hold_controllers(0.0f);
         return;
     }


### PR DESCRIPTION
This PR builds on [this earlier PR from bnsgeyer that added spool logic to the AP_Motors library for TradHelis](https://github.com/ArduPilot/ardupilot/pull/10212) and [replaces this earlier PR](https://github.com/ArduPilot/ardupilot/pull/7894).

The changes in this PR are:

- TradHeli replaces some calls to **rotor_runup_complete** with checks of the motor spool state
- Flight mode state logic is consolidated across many modes
- make_safe_shut_down function is added and used instead of immediately calling init_disarm().  The purpose is to maintain attitude control while the propellers are slowing down which is especially important on tradhelis
- calls to attitude_control::set_throttle_out_unstabilized (which simply turned off attitude control) are replaced with calls that attempt to maintain attitude control as long as possible.
- knock-on impacts to Plane and Sub are also included although these are mostly non-functional changes
- minor formatting fixes

As a side note, the commits are probably over-squashed.  I could probably split out the "Copter: consolidate mode state decisions" into multiple commits if that would help with the review.

There are a lot of changes in this PR so although it passes Travis it will need careful review before merging.

Contributors to this PR are @bnsgeyer, @lthall and some help from @rmackay9.