### PR TITLE
Tools: waf: add -Werror=enum-compare

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -158,6 +158,7 @@ class Board:
             '-Wno-redundant-decls',
             '-Wno-unknown-pragmas',
             '-Werror=format-security',
+            '-Werror=enum-compare',
             '-Werror=array-bounds',
             '-Werror=uninitialized',
             '-Werror=init-self',


### PR DESCRIPTION
This catches using multiple different enumerations in one switch