### PR TITLE
Avoid int32_t <-> float conversions in AC_AutoTune

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -450,7 +450,7 @@ protected:
     bool start(void) override;
     bool position_ok() override;
     float get_pilot_desired_climb_rate_cms(void) const override;
-    void get_pilot_desired_rp_yrate_cd(int32_t &roll_cd, int32_t &pitch_cd, int32_t &yaw_rate_cds) override;
+    void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) override;
     void init_z_limits() override;
     void Log_Write_Event(enum at_event id) override;
     void log_pids() override;

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -61,7 +61,7 @@ void Copter::AutoTune::run()
         copter.attitude_control->reset_rate_controller_I_terms();
         copter.attitude_control->set_yaw_target_to_current_heading();
 
-        int32_t target_roll, target_pitch, target_yaw_rate;
+        float target_roll, target_pitch, target_yaw_rate;
         get_pilot_desired_rp_yrate_cd(target_roll, target_pitch, target_yaw_rate);
 
         copter.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
@@ -90,17 +90,11 @@ float Copter::AutoTune::get_pilot_desired_climb_rate_cms(void) const
 /*
   get stick roll, pitch and yaw rate
  */
-void Copter::AutoTune::get_pilot_desired_rp_yrate_cd(int32_t &des_roll_cd, int32_t &des_pitch_cd, int32_t &yaw_rate_cds)
+void Copter::AutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pitch_cd, float &yaw_rate_cds)
 {
-    // map from int32_t to float
-    float des_roll, des_pitch;
-
-    copter.mode_autotune.get_pilot_desired_lean_angles(des_roll, des_pitch, copter.aparm.angle_max,
+    copter.mode_autotune.get_pilot_desired_lean_angles(des_roll_cd, des_pitch_cd, copter.aparm.angle_max,
                                                        copter.attitude_control->get_althold_lean_angle_max());
     yaw_rate_cds = copter.mode_autotune.get_pilot_desired_yaw_rate(copter.channel_yaw->get_control_in());
-
-    des_roll_cd = des_roll;
-    des_pitch_cd = des_pitch;
 }
 
 /*

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -27,7 +27,7 @@ float QAutoTune::get_pilot_desired_climb_rate_cms(void) const
     return plane.quadplane.get_pilot_desired_climb_rate_cms();
 }
 
-void QAutoTune::get_pilot_desired_rp_yrate_cd(int32_t &des_roll_cd, int32_t &des_pitch_cd, int32_t &yaw_rate_cds)
+void QAutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pitch_cd, float &yaw_rate_cds)
 {
     if (plane.channel_roll->get_control_in() == 0 && plane.channel_pitch->get_control_in() == 0) {
         des_roll_cd = 0;

--- a/ArduPlane/qautotune.h
+++ b/ArduPlane/qautotune.h
@@ -21,7 +21,7 @@ public:
 
 protected:
     float get_pilot_desired_climb_rate_cms(void) const override;
-    void get_pilot_desired_rp_yrate_cd(int32_t &roll_cd, int32_t &pitch_cd, int32_t &yaw_rate_cds) override;
+    void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) override;
     void init_z_limits() override;
     void Log_Write_Event(enum at_event id) override;
     void log_pids() override;

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -344,8 +344,6 @@ void AC_AutoTune::do_gcs_announcements()
 // should be called at 100hz or more
 void AC_AutoTune::run()
 {
-    int32_t target_climb_rate_cms;
-
     // initialize vertical speeds and acceleration
     init_z_limits();
 
@@ -362,10 +360,10 @@ void AC_AutoTune::run()
     get_pilot_desired_rp_yrate_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
     // get pilot desired climb rate
-    target_climb_rate_cms = get_pilot_desired_climb_rate_cms();
+    const float target_climb_rate_cms = get_pilot_desired_climb_rate_cms();
 
     bool zero_rp_input = target_roll_cd == 0 && target_pitch_cd == 0;
-    if (!zero_rp_input || target_yaw_rate_cds != 0 || target_climb_rate_cms != 0) {
+    if (!zero_rp_input || target_yaw_rate_cds != 0 || !is_zero(target_climb_rate_cms)) {
         if (!pilot_override) {
             pilot_override = true;
             // set gains to their original values

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -356,14 +356,14 @@ void AC_AutoTune::run()
         return;
     }
 
-    int32_t target_roll_cd, target_pitch_cd, target_yaw_rate_cds;
+    float target_roll_cd, target_pitch_cd, target_yaw_rate_cds;
     get_pilot_desired_rp_yrate_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
     // get pilot desired climb rate
     const float target_climb_rate_cms = get_pilot_desired_climb_rate_cms();
 
-    bool zero_rp_input = target_roll_cd == 0 && target_pitch_cd == 0;
-    if (!zero_rp_input || target_yaw_rate_cds != 0 || !is_zero(target_climb_rate_cms)) {
+    const bool zero_rp_input = is_zero(target_roll_cd) && is_zero(target_pitch_cd);
+    if (!zero_rp_input || !is_zero(target_yaw_rate_cds) || !is_zero(target_climb_rate_cms)) {
         if (!pilot_override) {
             pilot_override = true;
             // set gains to their original values
@@ -1618,7 +1618,7 @@ bool AC_AutoTune::position_ok(void)
 }
 
 // get attitude for slow position hold in autotune mode
-void AC_AutoTune::get_poshold_attitude(int32_t &roll_cd_out, int32_t &pitch_cd_out, int32_t &yaw_cd_out)
+void AC_AutoTune::get_poshold_attitude(float &roll_cd_out, float &pitch_cd_out, float &yaw_cd_out)
 {
     roll_cd_out = pitch_cd_out = 0;
 

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -48,7 +48,7 @@ protected:
     virtual float get_pilot_desired_climb_rate_cms(void) const = 0;
 
     // get pilot input for designed roll and pitch, and yaw rate
-    virtual void get_pilot_desired_rp_yrate_cd(int32_t &roll_cd, int32_t &pitch_cd, int32_t &yaw_rate_cds) = 0;
+    virtual void get_pilot_desired_rp_yrate_cd(float &roll_cd, float &pitch_cd, float &yaw_rate_cds) = 0;
 
     // init pos controller Z velocity and accel limits
     virtual void init_z_limits() = 0;
@@ -103,7 +103,7 @@ private:
     void updating_rate_p_up_d_down(float &tune_d, float tune_d_min, float tune_d_step_ratio, float &tune_p, float tune_p_min, float tune_p_max, float tune_p_step_ratio, float rate_target, float meas_rate_min, float meas_rate_max);
     void updating_angle_p_down(float &tune_p, float tune_p_min, float tune_p_step_ratio, float angle_target, float meas_angle_max, float meas_rate_min, float meas_rate_max);
     void updating_angle_p_up(float &tune_p, float tune_p_max, float tune_p_step_ratio, float angle_target, float meas_angle_max, float meas_rate_min, float meas_rate_max);
-    void get_poshold_attitude(int32_t &roll_cd, int32_t &pitch_cd, int32_t &yaw_cd);
+    void get_poshold_attitude(float &roll_cd, float &pitch_cd, float &yaw_cd);
 
     void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt);
     void Log_Write_AutoTuneDetails(float angle_cd, float rate_cds);
@@ -192,7 +192,7 @@ private:
     int8_t   counter;                               // counter for tuning gains
     float    target_rate, start_rate;               // target and start rate
     float    target_angle, start_angle;             // target and start angles
-    int32_t  desired_yaw_cd;                        // yaw heading during tune
+    float    desired_yaw_cd;                        // yaw heading during tune
     float    rate_max, test_accel_max;              // maximum acceleration variables
     float    step_scaler;                           // scaler to reduce maximum target step
     float    abort_angle;                           // Angle that test is aborted
@@ -213,7 +213,7 @@ private:
     uint32_t announce_time;
     float lean_angle;
     float rotation_rate;
-    int32_t roll_cd, pitch_cd;
+    float roll_cd, pitch_cd;
 
     struct {
         LEVEL_ISSUE issue{LEVEL_ISSUE_NONE};


### PR DESCRIPTION
... pretty sure these values must be getting motion sickness from being shunted backwards and forwards.
