### PR TITLE
Add PID_TUNING support to Tracker / move sending of that up

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -171,9 +171,14 @@ void Rover::send_rpm(mavlink_channel_t chan)
 /*
   send PID tuning message
  */
-void Rover::send_pid_tuning(mavlink_channel_t chan)
+void GCS_MAVLINK_Rover::send_pid_tuning()
 {
+    Parameters &g = rover.g;
+    ParametersG2 &g2 = rover.g2;
+    const AP_AHRS &ahrs = AP::ahrs();
+
     const AP_Logger::PID_Info *pid_info;
+
     // steering PID
     if (g.gcs_pid_mask & 1) {
         pid_info = &g2.attitude_control.get_steering_rate_pid().get_pid_info();
@@ -331,11 +336,6 @@ bool GCS_MAVLINK_Rover::try_send_message(enum ap_message id)
     case MSG_WIND:
         CHECK_PAYLOAD_SIZE(WIND);
         rover.g2.windvane.send_wind(chan);
-        break;
-
-    case MSG_PID_TUNING:
-        CHECK_PAYLOAD_SIZE(PID_TUNING);
-        rover.send_pid_tuning(chan);
         break;
 
     default:

--- a/APMrover2/GCS_Mavlink.h
+++ b/APMrover2/GCS_Mavlink.h
@@ -35,6 +35,7 @@ protected:
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;
+    void send_pid_tuning() override;
 
 private:
 

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -431,7 +431,6 @@ private:
 
     // GCS_Mavlink.cpp
     void send_servo_out(mavlink_channel_t chan);
-    void send_pid_tuning(mavlink_channel_t chan);
     void send_rpm(mavlink_channel_t chan);
     void send_wheel_encoder_distance(mavlink_channel_t chan);
 

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -92,8 +92,9 @@ void GCS_MAVLINK_Tracker::send_nav_controller_output() const
 /*
   send PID tuning message
  */
-void Tracker::send_pid_tuning(mavlink_channel_t chan)
+void GCS_MAVLINK_Tracker::send_pid_tuning()
 {
+    const Parameters &g = tracker.g;
 
     // Pitch PID
     if (g.gcs_pid_mask & 1) {
@@ -137,23 +138,6 @@ bool GCS_MAVLINK_Tracker::handle_guided_request(AP_Mission::Mission_Command&)
 void GCS_MAVLINK_Tracker::handle_change_alt_request(AP_Mission::Mission_Command&)
 {
     // do nothing
-}
-
-
-// try to send a message, return false if it won't fit in the serial tx buffer
-bool GCS_MAVLINK_Tracker::try_send_message(enum ap_message id)
-{
-    switch (id) {
-
-    case MSG_PID_TUNING:
-        CHECK_PAYLOAD_SIZE(PID_TUNING);
-        tracker.send_pid_tuning(chan);
-        break;
-
-    default:
-        return GCS_MAVLINK::try_send_message(id);
-    }
-    return true;
 }
 
 /*

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -33,6 +33,7 @@ protected:
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;
+    void send_pid_tuning() override;
 
 private:
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -381,6 +381,14 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Path: ../libraries/AP_BattMonitor/AP_BattMonitor.cpp
     GOBJECT(battery,                "BATT", AP_BattMonitor),
 
+    // @Param: GCS_PID_MASK
+    // @DisplayName: GCS PID tuning mask
+    // @Description: bitmask of PIDs to send MAVLink PID_TUNING messages for
+    // @User: Advanced
+    // @Values: 0:None,1:Pitch,2:Yaw
+    // @Bitmask: 0:Pitch,1:Yaw
+    GSCALAR(gcs_pid_mask,           "GCS_PID_MASK",     0),
+
     AP_VAREND
 };
 

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -114,6 +114,7 @@ public:
         k_param_command_total = 220,
 
         // 254,255: reserved
+        k_param_gcs_pid_mask = 225,
     };
 
     AP_Int16 format_version;
@@ -149,6 +150,7 @@ public:
     AP_Int16 distance_min;          // target's must be at least this distance from tracker to be tracked
     AP_Int16 pitch_min;
     AP_Int16 pitch_max;
+    AP_Int16 gcs_pid_mask;
 
     // Waypoints
     //

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -219,6 +219,7 @@ private:
 
     // GCS_Mavlink.cpp
     void send_nav_controller_output(mavlink_channel_t chan);
+    void send_pid_tuning(mavlink_channel_t chan);
 
     // Log.cpp
     void Log_Write_Attitude();

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -219,7 +219,6 @@ private:
 
     // GCS_Mavlink.cpp
     void send_nav_controller_output(mavlink_channel_t chan);
-    void send_pid_tuning(mavlink_channel_t chan);
 
     // Log.cpp
     void Log_Write_Attitude();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -268,11 +268,6 @@ bool GCS_MAVLINK_Copter::try_send_message(enum ap_message id)
         // unused
         break;
 
-    case MSG_PID_TUNING:
-        CHECK_PAYLOAD_SIZE(PID_TUNING);
-        send_pid_tuning();
-        break;
-
     case MSG_ADSB_VEHICLE:
 #if ADSB_ENABLED == ENABLED
         CHECK_PAYLOAD_SIZE(ADSB_VEHICLE);

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -64,6 +64,6 @@ private:
     int16_t vfr_hud_throttle() const override;
     float vfr_hud_alt() const override;
 
-    void send_pid_tuning();
+    void send_pid_tuning() override;
 
 };

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -42,8 +42,11 @@ protected:
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;
+    void send_pid_tuning() override;
 
 private:
+
+    void send_pid_info(const AP_Logger::PID_Info *pid_info, const uint8_t axis, const float achieved);
 
     void handleMessage(mavlink_message_t * msg) override;
     bool handle_guided_request(AP_Mission::Mission_Command &cmd) override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -792,8 +792,6 @@ private:
     void send_fence_status(mavlink_channel_t chan);
     void send_servo_out(mavlink_channel_t chan);
     void send_wind(mavlink_channel_t chan);
-    void send_pid_info(const mavlink_channel_t chan, const AP_Logger::PID_Info *pid_info, const uint8_t axis, const float achieved);
-    void send_pid_tuning(mavlink_channel_t chan);
     void send_rpm(mavlink_channel_t chan);
 
     void send_aoa_ssa(mavlink_channel_t chan);

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -166,8 +166,12 @@ bool GCS_MAVLINK_Sub::send_info()
 /*
   send PID tuning message
  */
-void Sub::send_pid_tuning(mavlink_channel_t chan)
+void GCS_MAVLINK_Sub::send_pid_tuning()
 {
+    const Parameters &g = sub.g;
+    AP_AHRS &ahrs = AP::ahrs();
+    AC_AttitudeControl_Sub &attitude_control = sub.attitude_control;
+
     const Vector3f &gyro = ahrs.get_gyro();
     if (g.gcs_pid_mask & 1) {
         const AP_Logger::PID_Info &pid_info = attitude_control.get_rate_roll_pid().get_pid_info();
@@ -209,7 +213,7 @@ void Sub::send_pid_tuning(mavlink_channel_t chan)
         }
     }
     if (g.gcs_pid_mask & 8) {
-        const AP_Logger::PID_Info &pid_info = pos_control.get_accel_z_pid().get_pid_info();
+        const AP_Logger::PID_Info &pid_info = sub.pos_control.get_accel_z_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info.desired*0.01f,
                                     -(ahrs.get_accel_ef_blended().z + GRAVITY_MSS),
@@ -261,11 +265,6 @@ bool GCS_MAVLINK_Sub::try_send_message(enum ap_message id)
         CHECK_PAYLOAD_SIZE(TERRAIN_REQUEST);
         sub.terrain.send_request(chan);
 #endif
-        break;
-
-    case MSG_PID_TUNING:
-        CHECK_PAYLOAD_SIZE(PID_TUNING);
-        sub.send_pid_tuning(chan);
         break;
 
     default:

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -36,6 +36,8 @@ protected:
     bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 
     void send_nav_controller_output() const override;
+    void send_pid_tuning() override;
+
     uint64_t capabilities() const override;
 
 private:

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -479,7 +479,6 @@ private:
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();
 #endif
-    void send_pid_tuning(mavlink_channel_t chan);
     void Log_Write_Control_Tuning();
     void Log_Write_Performance();
     void Log_Write_Attitude();

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -870,6 +870,10 @@ class AutoTestPlane(AutoTest):
     def default_mode(self):
         return "MANUAL"
 
+    def test_pid_tuning(self):
+        self.change_mode("FBWA") # we don't update PIDs in MANUAL
+        super(AutoTestPlane, self).test_pid_tuning()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2244,8 +2244,23 @@ switch value'''
     def disabled_tests(self):
         return {}
 
+    def test_pid_tuning(self):
+        self.progress("making sure we're not getting PID_TUNING messages")
+        m = self.mav.recv_match(type='PID_TUNING', blocking=True, timeout=1)
+        if m is not None:
+            raise PreconditionFailedException("Receiving PID_TUNING already")
+        self.set_parameter("GCS_PID_MASK", 1)
+        self.progress("making sure we are now getting PID_TUNING messages")
+        m = self.mav.recv_match(type='PID_TUNING', blocking=True, timeout=1)
+        if m is None:
+            raise PreconditionFailedException("Did not start to get PID_TUNING message")
+
     def tests(self):
         return [
+            ("PIDTuning",
+             "Test PID Tuning",
+             self.test_pid_tuning),
+
             ("ArmFeatures", "Arm features", self.test_arm_feature),
 
             ("SetHome",

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -186,6 +186,10 @@ class AutoTestQuadPlane(AutoTest):
                 return
         self.mav.motors_disarmed_wait()
 
+    def test_pid_tuning(self):
+        self.change_mode("FBWA") # we don't update PIDs in MANUAL
+        super(AutoTestQuadPlane, self).test_pid_tuning()
+
     def default_mode(self):
         return "MANUAL"
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -196,6 +196,7 @@ public:
     virtual void send_rangefinder() const;
     void send_proximity() const;
     virtual void send_nav_controller_output() const = 0;
+    virtual void send_pid_tuning() = 0;
     void send_ahrs2();
     void send_ahrs3();
     void send_system_time();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4137,6 +4137,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         send_ahrs3();
         break;
 
+    case MSG_PID_TUNING:
+        CHECK_PAYLOAD_SIZE(PID_TUNING);
+        send_pid_tuning();
+        break;
+
     case MSG_NAV_CONTROLLER_OUTPUT:
         CHECK_PAYLOAD_SIZE(NAV_CONTROLLER_OUTPUT);
         send_nav_controller_output();

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -37,6 +37,7 @@ protected:
     bool set_home(const Location& loc, bool lock) override { return false; }
 
     void send_nav_controller_output() const override {};
+    void send_pid_tuning() override {};
 };
 
 /*

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -39,6 +39,7 @@ protected:
     uint32_t custom_mode() const override { return 3; } // magic number
     MAV_STATE system_status() const override { return MAV_STATE_CALIBRATING; }
     void send_nav_controller_output() const override {};
+    void send_pid_tuning() override {};
 
     bool set_home_to_current_location(bool lock) override { return false; }
     bool set_home(const Location& loc, bool lock) override { return false; }


### PR DESCRIPTION
PID_TUNING support has been extracted from one of  @IamPete1 's PRs.

Since all our vehicles now support that message I've moved the relevant functions into the GCS_MAVLink class.  In the future I hope to factor some of the logic for these functions up into the GCS_MAVLink base class; Copter's implementation of `send_pid_tuning` hints as to what we might be able to do.

I have not made the function `const` as I'd like to NOT send all PIDs out in one big blurt of data, but cycle through each in turn.  That will require keeping state.
