### PR TITLE
Scripting: Enable remaining vehicles

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -703,6 +703,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BAL_PITCH_TRIM", 40, ParametersG2, bal_pitch_trim, 0),
 
+#ifdef ENABLE_SCRIPTING
+    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    AP_SUBGROUPINFO(scripting, "SCR_", 41, ParametersG2, AP_Scripting),
+#endif
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -399,6 +399,11 @@ public:
 
     // balance both pitch trim
     AP_Float bal_pitch_trim;
+
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting scripting;
+#endif // ENABLE_SCRIPTING
+
 };
 
 extern const AP_Param::Info var_info[];

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -81,6 +81,11 @@
 #include <AP_Follow/AP_Follow.h>
 #include <AP_OSD/AP_OSD.h>
 #include <AP_WindVane/AP_WindVane.h>
+
+#ifdef ENABLE_SCRIPTING
+#include <AP_Scripting/AP_Scripting.h>
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -196,6 +196,12 @@ void Rover::startup_ground(void)
         );
 #endif
 
+#ifdef ENABLE_SCRIPTING
+    if (!g2.scripting.init()) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
+    }
+#endif // ENABLE_SCRIPTING
+
     // we don't want writes to the serial port to cause us to pause
     // so set serial ports non-blocking once we are ready to drive
     serial_manager.set_blocking_writes_all(false);

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -370,6 +370,11 @@ const AP_Param::Info Tracker::var_info[] = {
     // @User: Standard
 	GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),
 
+#ifdef ENABLE_SCRIPTING
+    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    GOBJECT(scripting, "SCR_", AP_Scripting),
+#endif
+
     // @Param: CMD_TOTAL
     // @DisplayName: Number of loaded mission items
     // @Description: Set to 1 if HOME location has been loaded by the ground station. Do not change this manually.

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -108,6 +108,8 @@ public:
         k_param_rc_channels,
         k_param_servo_channels,
 
+        k_param_scripting = 219,
+
         //
         // 220: Waypoint data
         //

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -69,6 +69,10 @@
 #include "GCS_Mavlink.h"
 #include "GCS_Tracker.h"
 
+#ifdef ENABLE_SCRIPTING
+#include <AP_Scripting/AP_Scripting.h>
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif
@@ -154,6 +158,10 @@ private:
     struct Location current_loc;
 
     enum ControlMode control_mode  = INITIALISING;
+
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting scripting;
+#endif
 
     // Vehicle state
     struct {

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -53,6 +53,12 @@ void Tracker::init_tracker()
     log_init();
 #endif
 
+#ifdef ENABLE_SCRIPTING
+    if (!scripting.init()) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
+    }
+#endif // ENABLE_SCRIPTING
+
     // initialise compass
     init_compass();
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -170,6 +170,10 @@
  #include <AP_RPM/AP_RPM.h>
 #endif
 
+#ifdef ENABLE_SCRIPTING
+#include <AP_Scripting/AP_Scripting.h>
+#endif
+
 // Local modules
 #ifdef USER_PARAMS_ENABLED
 #include "UserParameters.h"

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -929,6 +929,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/AC_AutoTune/AC_AutoTune.cpp
     AP_SUBGROUPPTR(autotune_ptr, "AUTOTUNE_",  29, ParametersG2, Copter::AutoTune),
 #endif
+
+#ifdef ENABLE_SCRIPTING
+    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    AP_SUBGROUPINFO(scripting, "SCR_", 30, ParametersG2, AP_Scripting),
+#endif
     
     AP_GROUPEND
 };

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -583,6 +583,11 @@ public:
     // we need a pointer to autotune for the G2 table
     void *autotune_ptr;
 #endif
+
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting scripting;
+#endif // ENABLE_SCRIPTING
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -244,6 +244,12 @@ void Copter::init_ardupilot()
 
     startup_INS_ground();
 
+#ifdef ENABLE_SCRIPTING
+    if (!g2.scripting.init()) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
+    }
+#endif // ENABLE_SCRIPTING
+
     // set landed flags
     set_land_complete(true);
     set_land_complete_maybe(true);

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -634,6 +634,11 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: ../libraries/RC_Channel/RC_Channels_VarInfo.h
     AP_SUBGROUPINFO(rc_channels, "RC", 17, ParametersG2, RC_Channels),
 
+#ifdef ENABLE_SCRIPTING
+    // Scripting is intentionally not showing up in the parameter docs until it is a more standard feature
+    AP_SUBGROUPINFO(scripting, "SCR_", 18, ParametersG2, AP_Scripting),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -4,6 +4,10 @@
 
 #include <AP_Gripper/AP_Gripper.h>
 
+#ifdef ENABLE_SCRIPTING
+#include <AP_Scripting/AP_Scripting.h>
+#endif
+
 // Global parameter class.
 //
 class Parameters {
@@ -331,6 +335,11 @@ public:
 
     // control over servo output ranges
     SRV_Channels servo_channels;
+
+#ifdef ENABLE_SCRIPTING
+    AP_Scripting scripting;
+#endif // ENABLE_SCRIPTING
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -119,6 +119,10 @@
 #include <AP_Camera/AP_Camera.h>          // Photo or video camera
 #endif
 
+#ifdef ENABLE_SCRIPTING
+#include <AP_Scripting/AP_Scripting.h>
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -190,6 +190,12 @@ void Sub::init_ardupilot()
 
     startup_INS_ground();
 
+#ifdef ENABLE_SCRIPTING
+    if (!g2.scripting.init()) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Scripting failed to start");
+    }
+#endif // ENABLE_SCRIPTING
+
     // we don't want writes to the serial port to cause us to pause
     // mid-flight, so set the serial ports non-blocking once we are
     // ready to fly

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -219,7 +219,7 @@ static int location_distance(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    lua_pushnumber(L, *check_location(L, -2).get_distance(*check_location(L, -1)));
+    lua_pushnumber(L, check_location(L, -2)->get_distance(*check_location(L, -1)));
 
     return 1;
 }
@@ -271,9 +271,8 @@ static int location_offset(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    *check_location(L, -3).offset(
-                    luaL_checknumber(L, -2),
-                    luaL_checknumber(L, -1));
+    check_location(L, -3)->offset(luaL_checknumber(L, -2),
+                                  luaL_checknumber(L, -1));
 
     lua_pop(L, 2);
 


### PR DESCRIPTION
This fixes the regressions to location introduced in #10500 which broke scripting. This also allows all the vehicles to run scripts if they want. This has been SITL tested with a script on all the vehicles and runs appropriately.