### PR TITLE
Tools: waf: add -Werror=overloaded-virtual

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -177,6 +177,7 @@ class Board:
                 '-fcolor-diagnostics',
 
                 '-Werror=inconsistent-missing-override',
+                '-Werror=overloaded-virtual',
 
                 '-Wno-gnu-designator',
                 '-Wno-mismatched-tags',


### PR DESCRIPTION
This appears to be broken on my g++ - but working on my clang++
