### PR TITLE
AP_OSD: Switch screens basing on ARM state

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -203,6 +203,7 @@ public:
         TOGGLE=0,
         PWM_RANGE=1,
         AUTO_SWITCH=2,
+        ARM_STATE=3,
     };
 
     AP_Int8 osd_type;
@@ -263,7 +264,8 @@ private:
     bool switch_debouncer;
     uint32_t last_switch_ms;
     struct NavInfo nav_info;
-
+    bool ever_armed;
+    
     uint32_t last_update_ms;
     float last_distance_m;
     float max_dist_m;


### PR DESCRIPTION
(There is a related issue was somewhere, but I didn't found it)

New screen switching method implementation that does switch screens depending on armed/disarmed state.

There are two behaviors possible, depending on the numbers of the enabled screens:
1. Only screen 1 and 2 are enabled:
- After vehicle turned on, screen 2 is shown (example it could contain prearm checks and statistics)
- After vehicle armed, screen 1 is shown (flight gauges)
- After disarm, screen 2 shown again.

2. Screens 1, 2 and 3 are enabled:
- After vehicle turned on, screen 2 is shown (prearm checks)
- After vehicle armed, screen 1 is shown (flight gauges)
- After disarm, screen 3 shown (statistics)