### PR TITLE
waf: make board name case insensitive in waf configure

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -294,6 +294,15 @@ Please use a replacement build as follows:
  px4-v4pro  Use DrotekP3Pro build
 ''' % ctx.env.BOARD)
 
+        boards = _board_classes.keys()
+        if not ctx.env.BOARD in boards:
+            # try case-insensitive match
+            for b in boards:
+                if b.upper() == ctx.env.BOARD.upper():
+                    ctx.env.BOARD = b
+                    break
+        if not ctx.env.BOARD in boards:
+            ctx.fatal("Invalid board '%s': choices are %s" % (ctx.env.BOARD, ', '.join(boards)))
         _board = _board_classes[ctx.env.BOARD]()
     return _board
 

--- a/wscript
+++ b/wscript
@@ -66,7 +66,6 @@ def options(opt):
     removed_names = boards.get_removed_boards()
     g.add_option('--board',
         action='store',
-        choices=boards_names + removed_names,
         default=None,
         help='Target board to build, choices are %s.' % ', '.join(boards_names))
 


### PR DESCRIPTION
as we use mixed case board names this makes life easier for developers
