### PR TITLE
ArduPlane: add QACRO mode for tailsitters

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -679,7 +679,7 @@ void Plane::update_flight_mode(void)
 
         break;
     }
-        
+    case QACRO:
     case INITIALISING:
         // handled elsewhere
         break;
@@ -775,6 +775,7 @@ void Plane::update_navigation()
     case QLAND:
     case QRTL:
     case QAUTOTUNE:
+    case QACRO:
         // nothing to do
         break;
     }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -155,6 +155,7 @@ void Plane::stabilize_stick_mixing_direct()
         control_mode == QLOITER ||
         control_mode == QLAND ||
         control_mode == QRTL ||
+        control_mode == QACRO ||
         control_mode == TRAINING ||
         control_mode == QAUTOTUNE) {
         return;
@@ -185,6 +186,7 @@ void Plane::stabilize_stick_mixing_fbw()
         control_mode == QLOITER ||
         control_mode == QLAND ||
         control_mode == QRTL ||
+        control_mode == QACRO ||
         control_mode == TRAINING ||
         control_mode == QAUTOTUNE ||
         (control_mode == AUTO && g.auto_fbw_steer == 42)) {
@@ -396,6 +398,7 @@ void Plane::stabilize()
                 control_mode == QLOITER ||
                 control_mode == QLAND ||
                 control_mode == QRTL ||
+                control_mode == QACRO ||
                 control_mode == QAUTOTUNE) &&
                !quadplane.in_tailsitter_vtol_transition()) {
         quadplane.control_run();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -23,6 +23,7 @@ MAV_MODE GCS_MAVLINK_Plane::base_mode() const
     case MANUAL:
     case TRAINING:
     case ACRO:
+    case QACRO:
         _base_mode = MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
         break;
     case STABILIZE:

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -77,6 +77,7 @@ void GCS_Plane::update_sensor_status_flags(void)
         break;
 
     case ACRO:
+    case QACRO:
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL; // 3D angular rate control
         break;
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -66,7 +66,8 @@ enum FlightMode {
     QLOITER       = 19,
     QLAND         = 20,
     QRTL          = 21,
-    QAUTOTUNE	  = 22
+    QAUTOTUNE     = 22,
+    QACRO         = 23,
 };
 
 enum mode_reason_t {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1845,7 +1845,12 @@ bool QuadPlane::init_mode(void)
         return qautotune.init();
 #endif
     case QACRO:
-        init_qacro();
+        if (is_tailsitter()) {
+            init_qacro();
+        } else {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "QACRO mode refused");
+            return false;
+        }
         break;
     default:
         break;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -196,6 +196,8 @@ private:
     void control_stabilize(void);
 
     void check_attitude_relax(void);
+    void init_qacro(void);
+    void control_qacro(void);
     void init_hover(void);
     void control_hover(void);
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -473,6 +473,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     case QLAND:
     case QRTL:
     case QAUTOTUNE:
+    case QACRO:
         throttle_allows_nudging = true;
         auto_navigation_mode = false;
         if (!quadplane.init_mode()) {


### PR DESCRIPTION
use acro_r/p/y_rate params in qacro
port ACRO throttle handling from copter
*really* needs this patch to fly well: https://github.com/ArduPilot/ardupilot/pull/10690