### PR TITLE
Update AP_Airspeed_MS4525.cpp

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS4525.cpp
@@ -44,6 +44,7 @@ bool AP_Airspeed_MS4525::init()
         { 1, MS4525D0_I2C_ADDR },
         { 0, MS4525D0_I2C_ADDR },
         { 2, MS4525D0_I2C_ADDR },
+        { 3, MS4525D0_I2C_ADDR },
     };
     bool found = false;
     for (uint8_t i=0; i<ARRAY_SIZE(addresses); i++) {


### PR DESCRIPTION
update airspeed sensor to read and work with Pixhawk 4 adding { 3, MS4525D0_I2C_ADDR }, to the code