### PR TITLE
Plane: is_flying_vtol: if spool mode is shut down we are not flying

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -950,6 +950,10 @@ bool QuadPlane::is_flying_vtol(void) const
     if (!available()) {
         return false;
     }
+    if (motors->get_spool_mode() == AP_Motors::SHUT_DOWN) {
+        // assume that with no motor outputs we're not flying in VTOL mode
+        return false;
+    }
     if (motors->get_throttle() > 0.01f) {
         // if we are demanding more than 1% throttle then don't consider aircraft landed
         return true;


### PR DESCRIPTION
The subsequent check for get_throttle passes if you switch from QHOVER
to MANUAL on the ground while armed.  get_throttle returns > 0.01 - but
the motors are shut down so no output occurs.


... there is still the issue of why `get_throttle` climbs, of course.
