### PR TITLE
ArduPlane: add rudder to tailsitter gain scaling

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -282,9 +282,10 @@ void QuadPlane::tailsitter_speed_scaling(void)
     }
     last_scale = scale;
 
-    const SRV_Channel::Aux_servo_function_t functions[4] = {
+    const SRV_Channel::Aux_servo_function_t functions[5] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,
+        SRV_Channel::Aux_servo_function_t::k_rudder,
         SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft,
         SRV_Channel::Aux_servo_function_t::k_tiltMotorRight};
     for (uint8_t i=0; i<ARRAY_SIZE(functions); i++) {


### PR DESCRIPTION
@IamPete1 With this addition, the AddictionX can do over 100 kph in QACRO and FBWA with ARSPD_USE=0 and 1 using my manual tuning gains for the copter controller.
But if I run qautotune, the gains go up by a factor of 4 and severe oscillation results. 

Question: are the qautotune gains correct?  
If so, then I need to increase the hard-wired attenuation in my angle/throttle gain scaling method by a factor of 4 or just give up and add a parameter or two.  But it would be nice if one didn't have more tuning params to deal with.
``` 
                       manual       qautotune
Q_A_RAT_PIT_D          0.0036       0.0010
Q_A_RAT_PIT_I          0.2500       1.0290
Q_A_RAT_PIT_P          0.2500       1.0290
Q_A_RAT_RLL_D          0.0070       0.0010
Q_A_RAT_RLL_I          0.1500       0.7130
Q_A_RAT_RLL_P          0.1500       0.7130
Q_A_RAT_YAW_FILT       5.0000       1.0000
Q_A_RAT_YAW_I          0.0180       0.0754
Q_A_RAT_YAW_P          0.1800       0.7540
```