### PR TITLE
AP_GPS: fix out-of-bounds array access

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1105,6 +1105,10 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
     // always enusre a lag is provided
     lag_sec = GPS_WORST_LAG_SEC;
 
+    if (instance >= GPS_MAX_INSTANCES) {
+        return false;
+    }
+
     // return lag of blended GPS
     if (instance == GPS_BLENDED_INSTANCE) {
         lag_sec = _blended_lag_sec;
@@ -1133,12 +1137,17 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
 // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
 const Vector3f &AP_GPS::get_antenna_offset(uint8_t instance) const
 {
-    if (instance == GPS_MAX_RECEIVERS) {
+    if (instance >= GPS_MAX_INSTANCES) {
+        // we have to return a reference so use instance 0
+        return _antenna_offset[0];
+    }
+
+    if (instance == GPS_BLENDED_INSTANCE) {
         // return an offset for the blended GPS solution
         return _blended_antenna_offset;
-    } else {
-        return _antenna_offset[instance];
     }
+
+    return _antenna_offset[instance];
 }
 
 /*
@@ -1526,9 +1535,20 @@ void AP_GPS::calc_blended_state(void)
     timing[GPS_BLENDED_INSTANCE].last_message_time_ms = (uint32_t)temp_time_2;
 }
 
-bool AP_GPS::is_healthy(uint8_t instance) const {
-    return drivers[instance] != nullptr &&
-           last_message_delta_time_ms(instance) < GPS_MAX_DELTA_MS &&
+bool AP_GPS::is_healthy(uint8_t instance) const
+{
+    if (instance >= GPS_MAX_INSTANCES) {
+        return false;
+    }
+
+    bool last_msg_valid = last_message_delta_time_ms(instance) < GPS_MAX_DELTA_MS;
+
+    if (instance == GPS_BLENDED_INSTANCE) {
+        return last_msg_valid && blend_health_check();
+    }
+
+    return last_msg_valid &&
+           drivers[instance] != nullptr &&
            drivers[instance]->is_healthy();
 }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1174,7 +1174,7 @@ bool AP_GPS::calc_blend_weights(void)
     memset(&_blend_weights, 0, sizeof(_blend_weights));
 
     // exit immediately if not enough receivers to do blending
-    if (num_instances < 2 || drivers[1] == nullptr || _type[1] == GPS_TYPE_NONE) {
+    if (state[0].status <= NO_FIX || state[1].status <= NO_FIX) {
         return false;
     }
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -471,8 +471,8 @@ private:
         uint16_t delta_time_ms;
     };
     // Note allowance for an additional instance to contain blended data
-    GPS_timing timing[GPS_MAX_RECEIVERS+1];
-    GPS_State state[GPS_MAX_RECEIVERS+1];
+    GPS_timing timing[GPS_MAX_INSTANCES];
+    GPS_State state[GPS_MAX_INSTANCES];
     AP_GPS_Backend *drivers[GPS_MAX_RECEIVERS];
     AP_HAL::UARTDriver *_port[GPS_MAX_RECEIVERS];
 


### PR DESCRIPTION
This was found on the `is_healthy` method - it didn't check for the instance number, but mostly it didn't special cased the blending instance leading to an out-of-bounds array access.
I didn't do an exhaustive search for others, but did go through the file looking for more: I patched two other methods and didn't see other cases.

The `is_healthy` bug has been here for around 1 year and 5 months; looks to affect Copter 3.6, Plane 3.9, Rover 3.2 and up. @rmackay9 @tridge in my opinion, this should be backported.

The reason this wasn't detected for so long was due to a conjugation of effects:
- it only happens when blending is used
- the out-of-bounds array access ended up accessing the first `port` variable (a UART driver)
- when calling the inexistent `is_healthy` on the UART driver, it actually called `is_initialized`, which 99.9% of time returns true

The way this was caught when a user with two UAVCAN GPS changed SERIAL3_PROTOCOL to a non-GPS protocol, which led to `port` having a _nullptr_ and subsequently an unhealthy GPS warning. Disabling blending or changing a different SERIALx_PROTOCOL "fixes" the warning as expected.