### PR TITLE
Ahrs: improve attitude consistency check

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -217,7 +217,7 @@ public:
     }
 
     // check all cores providing consistent attitudes for prearm checks
-    virtual bool attitudes_consistent() const { return true; }
+    virtual bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const { return true; }
 
     // is the EKF backend doing its own sensor logging?
     virtual bool have_ekf_logging(void) const {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -189,7 +189,7 @@ public:
     const char *prearm_failure_reason(void) const override;
 
     // check all cores providing consistent attitudes for prearm checks
-    bool attitudes_consistent() const override;
+    bool attitudes_consistent(char *failure_msg, const uint8_t failure_msg_len) const override;
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -327,8 +327,9 @@ bool AP_Arming::ins_checks(bool report)
         }
 
         // check AHRS attitudes are consistent
-        if (!AP::ahrs().attitudes_consistent()) {
-            check_failed(ARMING_CHECK_INS, report, "Attitudes inconsistent");
+        char failure_msg[50] = {};
+        if (!AP::ahrs().attitudes_consistent(failure_msg, ARRAY_SIZE(failure_msg))) {
+            check_failed(ARMING_CHECK_INS, report, failure_msg);
             return false;
         }
     }


### PR DESCRIPTION
This PR makes two small improvements to the cross-EKF/DCM attitude consistency check:

- only checks yaw if compasses are being used
- provides better feedback on which EKF (or DCM) is failing the consistency check and by how much

I've tested this on a Cube autopilot running Copter and it seems to work.  Previously when all three COMPASS_USEx params were set to 0 it was very easy to make it fail because the yaw angle diff would be large but after these changes the message rarely appears.
![att-consistency-check](https://user-images.githubusercontent.com/1498098/53862385-8c68e700-402a-11e9-9ea7-62a76f6c39b5.png)

