### PR TITLE
waf: fixed case insensitive board name

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -296,12 +296,6 @@ Please use a replacement build as follows:
 
         boards = _board_classes.keys()
         if not ctx.env.BOARD in boards:
-            # try case-insensitive match
-            for b in boards:
-                if b.upper() == ctx.env.BOARD.upper():
-                    ctx.env.BOARD = b
-                    break
-        if not ctx.env.BOARD in boards:
             ctx.fatal("Invalid board '%s': choices are %s" % (ctx.env.BOARD, ', '.join(boards)))
         _board = _board_classes[ctx.env.BOARD]()
     return _board

--- a/wscript
+++ b/wscript
@@ -325,6 +325,13 @@ def configure(cfg):
     if cfg.options.board is None:
         cfg.options.board = 'sitl'
 
+    boards_names = boards.get_boards_names()
+    if not cfg.options.board in boards_names:
+        for b in boards_names:
+            if b.upper() == cfg.options.board.upper():
+                cfg.options.board = b
+                break
+        
     cfg.env.BOARD = cfg.options.board
     cfg.env.DEBUG = cfg.options.debug
     cfg.env.AUTOCONFIG = cfg.options.autoconfig


### PR DESCRIPTION
The previous patch didn't work if you did "rm -rf build" first
