### PR TITLE
Tools: allow uploader.py to detect ttyS* on Ubuntu on Windows (WSL)

### DIFF
--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -64,8 +64,11 @@ import base64
 import time
 import array
 import os
+import platform
 
 from sys import platform as _platform
+
+is_WSL = bool("Microsoft" in platform.uname()[2])
 
 # default list of port names to look for autopilots
 default_ports = [ '/dev/serial/by-id/usb-Ardu*',
@@ -78,7 +81,7 @@ default_ports = [ '/dev/serial/by-id/usb-Ardu*',
                   '/dev/serial/by-id/usb-Holybro*',
                   '/dev/tty.usbmodem*']
 
-if "cygwin" in _platform:
+if "cygwin" in _platform or is_WSL:
     default_ports += [ '/dev/ttyS*' ]
     
 # Detect python version
@@ -771,9 +774,10 @@ def main():
                                   args.source_component)
 
                 except Exception as e:
-                    print("Exception creating uploader: %s" % str(e))
-                    # open failed, rate-limit our attempts
-                    time.sleep(0.05)
+                    if not is_WSL:
+                        # open failed, WSL must cycle through all ttyS* ports quickly but rate limit everything else
+                        print("Exception creating uploader: %s" % str(e))
+                        time.sleep(0.05)
 
                     # and loop to the next port
                     continue


### PR DESCRIPTION
WSL (Ubuntu on Windows) calls it's serial ports /dev/ttyS* and there is no /dev/serial/ so auto detection doesn't work if we don't specify ttyS* like we do in Cygwin. Note, the "platform" still shows "linux" so we have to check for a version.

It may be worthwhile to just add /dev/ttyS* all the time as long as that doesn't mess up linux.

Also note, there's /dev/ttyS1 -> /dev/ttyS128 and since the sleep was (0.05) once a device is found, and a set to bootloader command is sent, the bootloader actually runs, then launches the app again before we loop back around to detect it in the bootloader. I shortened the timer so that we loop the list faster.