### PR TITLE
Plane: further specialize MotorsMatrixTS and add rate-only option for QACRO mode

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -954,7 +954,11 @@ void QuadPlane::control_qacro(void)
         float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
 
         // run attitude controller
-        attitude_control->input_rate_bf_roll_pitch_yaw_3(target_roll, target_pitch, target_yaw);
+        if (plane.g.acro_locking) {
+            attitude_control->input_rate_bf_roll_pitch_yaw_3(target_roll, target_pitch, target_yaw);
+        } else {
+            attitude_control->input_rate_bf_roll_pitch_yaw_2(target_roll, target_pitch, target_yaw);
+        }
 
         // output pilot's throttle without angle boost
         attitude_control->set_throttle_out(throttle_out, false, 10.0f);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1815,7 +1815,7 @@ void QuadPlane::control_run(void)
     switch (plane.control_mode) {
     case QACRO:
         control_qacro();
-        break;
+        return; // skip the control surface calls below
     case QSTABILIZE:
         control_stabilize();
         break;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -77,30 +77,30 @@ void QuadPlane::tailsitter_output(void)
         float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
         if (hal.util->get_soft_armed()) {
             if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying()) {
-            /*
-              during transitions to vtol mode set the throttle to
-              hover thrust, center the rudder and set the altitude controller
-              integrator to the same throttle level
-             */
-            throttle = motors->get_throttle_hover() * 100;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
-            pos_control->get_accel_z_pid().set_integrator(throttle*10);
-            
-            if (mask == 0) {
-                // override AP_MotorsTailsitter throttles during back transition
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+                /*
+                  during transitions to vtol mode set the throttle to
+                  hover thrust, center the rudder and set the altitude controller
+                  integrator to the same throttle level
+                 */
+                throttle = motors->get_throttle_hover() * 100;
+                SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
+                pos_control->get_accel_z_pid().set_integrator(throttle*10);
+
+                if (mask == 0) {
+                    // override AP_MotorsTailsitter throttles during back transition
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+                }
             }
-        }
-        if (mask != 0) {
-            // set AP_MotorsMatrix throttles enabled for forward flight
-            motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
+            if (mask != 0) {
+                // set AP_MotorsMatrix throttles enabled for forward flight
+                motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
             }
         }
         return;
     }
-    
+
     // handle VTOL modes
     // the MultiCopter rate controller has already been run in an earlier call 
     // to motors_output() from quadplane.update()

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -211,8 +211,8 @@ void AC_AttitudeControl::reset_rate_controller_I_terms()
 //    _attitude_target_ang_vel have been defined. This ensures input modes can be changed without discontinuity.
 // 5. attitude_controller_run_quat is then run to pass the target angular velocities to the rate controllers and
 //    integrate them into the target attitude. Any errors between the target attitude and the measured attitude are
-//    corrected by first correcting the thrust vector until the angle between the target thrust vector measured
-//    trust vector drops below 2*AC_ATTITUDE_THRUST_ERROR_ANGLE. At this point the heading is also corrected.
+//    corrected by first correcting the thrust vector until the angle between the target thrust vector and measured
+//    thrust vector drops below 2*AC_ATTITUDE_THRUST_ERROR_ANGLE. At this point the heading is also corrected.
 
 
 
@@ -612,10 +612,10 @@ void AC_AttitudeControl::attitude_controller_run_quat()
     Quaternion desired_ang_vel_quat = to_to_from_quat.inverse()*attitude_target_ang_vel_quat*to_to_from_quat;
 
     // Correct the thrust vector and smoothly add feedforward and yaw input
-    if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE*2.0f){
+    if(_thrust_error_angle > _thrust_error_thresh*2.0f){
         _rate_target_ang_vel.z = _ahrs.get_gyro().z;
-    }else if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE){
-        float feedforward_scalar = (1.0f - (_thrust_error_angle-AC_ATTITUDE_THRUST_ERROR_ANGLE)/AC_ATTITUDE_THRUST_ERROR_ANGLE);
+    }else if(_thrust_error_angle > _thrust_error_thresh){
+        float feedforward_scalar = (1.0f - (_thrust_error_angle-_thrust_error_thresh)/_thrust_error_thresh);
         _rate_target_ang_vel.x += desired_ang_vel_quat.q2*feedforward_scalar;
         _rate_target_ang_vel.y += desired_ang_vel_quat.q3*feedforward_scalar;
         _rate_target_ang_vel.z += desired_ang_vel_quat.q4;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -301,6 +301,11 @@ public:
     // enable inverted flight on backends that support it
     virtual void set_inverted_flight(bool inverted) {}
     
+    // set thrust error angle threshold
+    void set_thrust_error_thresh(float thresh) {
+        _thrust_error_thresh = thresh;
+    }
+    
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -438,6 +443,9 @@ protected:
     // (would be expensive to compute from _attitude_target_quat)
     float _last_body_roll;
     float _last_euler_pitch;
+    
+    // thrust error angle threshold
+    float _thrust_error_thresh = AC_ATTITUDE_THRUST_ERROR_ANGLE;
 
 public:
     // log a CTRL message

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -260,6 +260,16 @@ void AC_AttitudeControl_Multi::rate_controller_run()
     _motors.set_pitch(rate_target_to_motor_pitch(gyro_latest.y, _rate_target_ang_vel.y));
     _motors.set_yaw(rate_target_to_motor_yaw(gyro_latest.z, _rate_target_ang_vel.z));
 
+    static int cnt=0;
+    if (cnt++ > 100) {
+        cnt = 0;
+        Vector3f rate_error = _rate_target_ang_vel - gyro_latest;
+        AP_HAL::get_HAL().console->printf("_rate_target_ang_vel: %5.3f %5.3f %5.3f, rate_error: : %5.3f %5.3f %5.3f, rpy_out: : %5.3f %5.3f %5.3f\n",
+                            _rate_target_ang_vel.x, _rate_target_ang_vel.y, _rate_target_ang_vel.z,
+                            rate_error.x, rate_error.y, rate_error.z,
+                            _motors.get_roll(), _motors.get_pitch(), _motors.get_yaw());
+    }
+
     control_monitor_update();
 }
 


### PR DESCRIPTION
Simplifies the logic for output_armed_stabilizing() in the same way as AP_MotorsTailsitter.

The rate-only option is selected by setting parameter ACRO_RATE_LOCKING to zero. It uses method 
input_rate_bf_roll_pitch_yaw_2 which does not use the target attitude in computing rate error.
This makes trim changes more apparent to the pilot, and is useful in adjusting the CG for optimum
performance. 

The original method (input_rate_bf_roll_pitch_yaw_3) is selected by setting ACRO_RATE_LOCKING to 1.
