### PR TITLE
ChibiOS: fixed BDMA on STM32H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -32,8 +32,8 @@ static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 DeviceBus::DeviceBus(uint8_t _thread_priority) :
         thread_priority(_thread_priority)
 {
-    bouncebuffer_init(&bounce_buffer_tx, 10);
-    bouncebuffer_init(&bounce_buffer_rx, 10);
+    bouncebuffer_init(&bounce_buffer_tx, 10, false);
+    bouncebuffer_init(&bounce_buffer_rx, 10, false);
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -398,8 +398,11 @@ void SPIDevice::test_clock_freq(void)
         hal.scheduler->delay(1000);
         hal.console->printf("Waiting %u\n", AP_HAL::millis());
     }
-    hal.console->printf("SPI1_CLOCK=%u SPI2_CLOCK=%u SPI3_CLOCK=%u SPI4_CLOCK=%u\n",
-                        SPI1_CLOCK, SPI2_CLOCK, SPI3_CLOCK, SPI4_CLOCK);
+    hal.console->printf("CLOCKS=\n");
+    for (uint8_t i=0; i<ARRAY_SIZE(bus_clocks); i++) {
+        hal.console->printf("%u:%u ", i+1, bus_clocks[i]);
+    }
+    hal.console->printf("\n");
 
     // we will send 1024 bytes without any CS asserted and measure the
     // time it takes to do the transfer

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.c
@@ -36,12 +36,13 @@
 /*
   initialise a bouncebuffer
  */
-void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_bytes)
+void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_bytes, bool sdcard)
 {
     (*bouncebuffer) = calloc(1, sizeof(struct bouncebuffer_t));
     osalDbgAssert(((*bouncebuffer) != NULL), "bouncebuffer init");
+    (*bouncebuffer)->is_sdcard = sdcard;
     if (prealloc_bytes) {
-        (*bouncebuffer)->dma_buf = malloc_dma(prealloc_bytes);
+        (*bouncebuffer)->dma_buf = sdcard?malloc_sdcard_dma(prealloc_bytes):malloc_dma(prealloc_bytes);
         osalDbgAssert(((*bouncebuffer)->dma_buf != NULL), "bouncebuffer preallocate");
         (*bouncebuffer)->size = prealloc_bytes;
     }
@@ -64,7 +65,7 @@ void bouncebuffer_setup_read(struct bouncebuffer_t *bouncebuffer, uint8_t **buf,
         if (bouncebuffer->size > 0) {
             free(bouncebuffer->dma_buf);
         }
-        bouncebuffer->dma_buf = malloc_dma(size);
+        bouncebuffer->dma_buf = bouncebuffer->is_sdcard?malloc_sdcard_dma(size):malloc_dma(size);
         osalDbgAssert((bouncebuffer->dma_buf != NULL), "bouncebuffer read allocate");
         bouncebuffer->size = size;
     }
@@ -105,7 +106,7 @@ void bouncebuffer_setup_write(struct bouncebuffer_t *bouncebuffer, const uint8_t
         if (bouncebuffer->size > 0) {
             free(bouncebuffer->dma_buf);
         }
-        bouncebuffer->dma_buf = malloc_dma(size);
+        bouncebuffer->dma_buf = bouncebuffer->is_sdcard?malloc_sdcard_dma(size):malloc_dma(size);
         osalDbgAssert((bouncebuffer->dma_buf != NULL), "bouncebuffer write allocate");
         bouncebuffer->size = size;
     }

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/bouncebuffer.h
@@ -16,12 +16,13 @@ struct bouncebuffer_t {
     uint8_t *orig_buf;
     uint32_t size;
     bool busy;
+    bool is_sdcard;
 };
 
 /*
   initialise a bouncebuffer
  */
-void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_bytes);
+void bouncebuffer_init(struct bouncebuffer_t **bouncebuffer, uint32_t prealloc_bytes, bool sdcard);
 
 /*
   setup for reading from a device into memory, allocating a bouncebuffer if needed

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32_util.h
@@ -31,6 +31,7 @@ void show_stack_usage(void);
 // allocation functions in malloc.c    
 size_t mem_available(void);
 void *malloc_dma(size_t size);
+void *malloc_sdcard_dma(size_t size);
 void *malloc_fastmem(size_t size);
 thread_t *thread_create_alloc(size_t size, const char *name, tprio_t prio, tfunc_t pf, void *arg);
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -15,14 +15,15 @@ mcu = {
     'UDID_START' : 0x1FF1E800,
 
     # ram map, as list of (address, size-kb, flags)
-    # flags of 1 means DMA-capable
+    # flags of 1 means DMA-capable (DMA and BDMA)
     # flags of 2 means faster memory for CPU intensive work
+    # flags of 4 means memory can be used for SDMMC DMA
     'RAM_MAP' : [
-        (0x24000000, 512, 1), # AXI SRAM
-        (0x30000000, 288, 1), # SRAM1, SRAM2, SRAM3
-        (0x38000000,  64, 1), # SRAM4
+        (0x20000000, 128, 2), # DTCM, tightly coupled, no DMA, fast
+        (0x30000000, 288, 0), # SRAM1, SRAM2, SRAM3
+        (0x38000000,  64, 1), # SRAM4. This supports both DMA and BDMA ops
+        (0x24000000, 512, 4), # AXI SRAM. Use this for SDMMC IDMA ops
         (0x00000400,  63, 2), # ITCM (first 1k removed, to keep address 0 unused)
-        (0x20000000, 128, 2), # DTCM, tightly coupled, no DMA
     ]
 }
 

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -56,7 +56,7 @@ bool sdcard_init()
 #if HAL_USE_SDC
 
     if (SDCD1.bouncebuffer == nullptr) {
-        bouncebuffer_init(&SDCD1.bouncebuffer, 512);
+        bouncebuffer_init(&SDCD1.bouncebuffer, 512, true);
     }
 
     if (sdcard_running) {


### PR DESCRIPTION
This fixes access to SPI6 by separating out DMA memory pools for DMA, BDMA and IDMA
