### PR TITLE
AP_Arming: correct use of failure messages as format strings

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -329,7 +329,7 @@ bool AP_Arming::ins_checks(bool report)
         // check AHRS attitudes are consistent
         char failure_msg[50] = {};
         if (!AP::ahrs().attitudes_consistent(failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_INS, report, failure_msg);
+            check_failed(ARMING_CHECK_INS, report, "%s", failure_msg);
             return false;
         }
     }
@@ -463,7 +463,7 @@ bool AP_Arming::battery_checks(bool report)
 
         char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
         if (!AP::battery().arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_BATTERY, report, buffer);
+            check_failed(ARMING_CHECK_BATTERY, report, "%s", buffer);
             return false;
         }
      }


### PR DESCRIPTION
This is important as if the returned string happens to contain
substitutions (%s in particular), we can attempt to pull random data
off the stack and incorporate it in the string.

This sort of bug is rather famous for serious explots in sendmail.

This could be bad if your stack is relatively full and the memory after
it is inaccessible.