### PR TITLE
Use class on Arming enumerations

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -282,7 +282,7 @@ void Rover::one_second_loop(void)
     // update notify flags
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
     AP_Notify::flags.pre_arm_gps_check = true;
-    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::NO;
+    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
 
     // cope with changes to mavlink system ID
     mavlink_system.sysid = g.sysid_this_mav;

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -607,7 +607,7 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_long_packet(const mavlink_command_l
     case MAV_CMD_COMPONENT_ARM_DISARM:
         if (is_equal(packet.param1, 1.0f)) {
             // run pre_arm_checks and arm_checks and display failures
-            if (rover.arm_motors(AP_Arming::MAVLINK)) {
+            if (rover.arm_motors(AP_Arming::Method::MAVLINK)) {
                 return MAV_RESULT_ACCEPTED;
             } else {
                 return MAV_RESULT_FAILED;

--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -137,7 +137,7 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
     // arm or disarm the motors
     case ARMDISARM:
         if (ch_flag == HIGH) {
-            rover.arm_motors(AP_Arming::RUDDER);
+            rover.arm_motors(AP_Arming::Method::RUDDER);
         } else if (ch_flag == LOW) {
             rover.disarm_motors();
         }

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -512,7 +512,7 @@ private:
     uint8_t check_digital_pin(uint8_t pin);
     bool should_log(uint32_t mask);
     void change_arm_state(void);
-    bool arm_motors(AP_Arming::ArmingMethod method);
+    bool arm_motors(AP_Arming::Method method);
     bool disarm_motors(void);
     bool is_boat() const;
 

--- a/APMrover2/motor_test.cpp
+++ b/APMrover2/motor_test.cpp
@@ -126,7 +126,7 @@ MAV_RESULT Rover::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor
 
             // arm motors
             if (!arming.is_armed()) {
-                arm_motors(AP_Arming::ArmingMethod::MOTORTEST);
+                arm_motors(AP_Arming::Method::MOTORTEST);
             }
 
             // disable failsafes

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -42,8 +42,8 @@ void Rover::init_rc_in()
 void Rover::rudder_arm_disarm_check()
 {
     // check if arming/disarm using rudder is allowed
-    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
-    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
+    const AP_Arming::RudderArming arming_rudder = arming.get_rudder_arming_type();
+    if (arming_rudder == AP_Arming::RudderArming::IS_DISABLED) {
         return;
     }
 
@@ -72,14 +72,14 @@ void Rover::rudder_arm_disarm_check()
                 }
             } else {
                 // time to arm!
-                arm_motors(AP_Arming::RUDDER);
+                arm_motors(AP_Arming::Method::RUDDER);
                 rudder_arm_timer = 0;
             }
         } else {
             // not at full right rudder
             rudder_arm_timer = 0;
         }
-    } else if ((arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM) && !g2.motors.active()) {
+    } else if ((arming_rudder == AP_Arming::RudderArming::ARMDISARM) && !g2.motors.active()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
         if (channel_steer->get_control_in() < -4000) {
             const uint32_t now = millis();

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -335,7 +335,7 @@ void Rover::change_arm_state(void)
 /*
   arm motors
  */
-bool Rover::arm_motors(AP_Arming::ArmingMethod method)
+bool Rover::arm_motors(AP_Arming::Method method)
 {
     if (!arming.arm(method)) {
         AP_Notify::events.arming_failed = true;

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -16,7 +16,7 @@ void AP_Arming_Copter::update(void)
 }
 
 // performs pre-arm checks and arming checks
-bool AP_Arming_Copter::all_checks_passing(ArmingMethod method)
+bool AP_Arming_Copter::all_checks_passing(AP_Arming::Method method)
 {
     set_pre_arm_check(pre_arm_checks(true));
 
@@ -443,7 +443,7 @@ bool AP_Arming_Copter::pre_arm_proximity_check(bool display_failure)
 // arm_checks - perform final checks before arming
 //  always called just before arming.  Return true if ok to arm
 //  has side-effect that logging is started
-bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::ArmingMethod method)
+bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::Method method)
 {
     const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
 
@@ -476,7 +476,7 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::ArmingMethod 
     control_mode_t control_mode = copter.control_mode;
 
     // always check if the current mode allows arming
-    if (!copter.flightmode->allows_arming(method == AP_Arming::ArmingMethod::MAVLINK)) {
+    if (!copter.flightmode->allows_arming(method == AP_Arming::Method::MAVLINK)) {
         check_failed(ARMING_CHECK_NONE, display_failure, "Mode not armable");
         return false;
     }
@@ -540,7 +540,7 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::ArmingMethod 
         }
 
         // check throttle is not too high - skips checks if arming from GCS in Guided
-        if (!(method == AP_Arming::ArmingMethod::MAVLINK && (control_mode == GUIDED || control_mode == GUIDED_NOGPS))) {
+        if (!(method == AP_Arming::Method::MAVLINK && (control_mode == GUIDED || control_mode == GUIDED_NOGPS))) {
             // above top of deadband is too always high
             if (copter.get_pilot_desired_climb_rate(copter.channel_throttle->get_control_in()) > 0.0f) {
                 check_failed(ARMING_CHECK_RC, display_failure, "%s too high", rc_item);

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -12,7 +12,7 @@ public:
     {
         // default REQUIRE parameter to 1 (Copter does not have an
         // actual ARMING_REQUIRE parameter)
-        require.set_default(YES_MIN_PWM);
+        require.set_default((uint8_t)Required::YES_MIN_PWM);
     }
 
     /* Do not allow copies */
@@ -20,7 +20,7 @@ public:
     AP_Arming_Copter &operator=(const AP_Arming_Copter&) = delete;
 
     void update(void);
-    bool all_checks_passing(ArmingMethod method);
+    bool all_checks_passing(AP_Arming::Method method);
 
     bool rc_calibration_checks(bool display_failure) override;
 
@@ -30,7 +30,7 @@ protected:
     bool pre_arm_ekf_attitude_check();
     bool pre_arm_terrain_check(bool display_failure);
     bool pre_arm_proximity_check(bool display_failure);
-    bool arm_checks(bool display_failure, AP_Arming::ArmingMethod method);
+    bool arm_checks(bool display_failure, AP_Arming::Method method);
 
     // NOTE! the following check functions *DO* call into AP_Arming:
     bool ins_checks(bool display_failure) override;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -770,7 +770,7 @@ private:
     // motors.cpp
     void arm_motors_check();
     void auto_disarm_check();
-    bool init_arm_motors(AP_Arming::ArmingMethod method, bool do_arming_checks=true);
+    bool init_arm_motors(AP_Arming::Method method, bool do_arming_checks=true);
     void init_disarm_motors();
     void motors_output();
     void lost_vehicle_check();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -708,7 +708,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
         if (is_equal(packet.param1,1.0f)) {
             // attempt to arm and return success or failure
             const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-            if (copter.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK, do_arming_checks)) {
+            if (copter.init_arm_motors(AP_Arming::Method::MAVLINK, do_arming_checks)) {
                 return MAV_RESULT_ACCEPTED;
             }
         } else if (is_zero(packet.param1))  {
@@ -824,7 +824,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_long_packet(const mavlink_command_
 
         if (!copter.motors->armed()) {
             // if disarmed, arm motors
-            copter.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK);
+            copter.init_arm_motors(AP_Arming::Method::MAVLINK);
         } else if (copter.ap.land_complete) {
             // if armed and landed, takeoff
             if (copter.set_mode(LOITER, MODE_REASON_GCS_COMMAND)) {

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -404,7 +404,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
             // arm or disarm the vehicle
             switch (ch_flag) {
             case HIGH:
-                copter.init_arm_motors(AP_Arming::ArmingMethod::AUXSWITCH);
+                copter.init_arm_motors(AP_Arming::Method::AUXSWITCH);
                 // remember that we are using an arming switch, for use by set_throttle_zero_flag
                 copter.ap.armed_with_switch = true;
                 break;

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -14,8 +14,8 @@ void Copter::arm_motors_check()
     static int16_t arming_counter;
 
     // check if arming/disarm using rudder is allowed
-    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
-    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
+    AP_Arming::RudderArming arming_rudder = arming.get_rudder_arming_type();
+    if (arming_rudder == AP_Arming::RudderArming::IS_DISABLED) {
         return;
     }
 
@@ -45,7 +45,7 @@ void Copter::arm_motors_check()
         // arm the motors and configure for flight
         if (arming_counter == ARM_DELAY && !motors->armed()) {
             // reset arming counter if arming fail
-            if (!init_arm_motors(AP_Arming::ArmingMethod::RUDDER)) {
+            if (!init_arm_motors(AP_Arming::Method::RUDDER)) {
                 arming_counter = 0;
             }
         }
@@ -58,7 +58,7 @@ void Copter::arm_motors_check()
         }
 
     // full left and rudder disarming is enabled
-    } else if ((yaw_in < -4000) && (arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM)) {
+    } else if ((yaw_in < -4000) && (arming_rudder == AP_Arming::RudderArming::ARMDISARM)) {
         if (!flightmode->has_manual_throttle() && !ap.land_complete) {
             arming_counter = 0;
             return;
@@ -133,7 +133,7 @@ void Copter::auto_disarm_check()
 
 // init_arm_motors - performs arming process including initialisation of barometer and gyros
 //  returns false if arming failed because of pre-arm checks, arming checks or a gyro calibration failure
-bool Copter::init_arm_motors(const AP_Arming::ArmingMethod method, const bool do_arming_checks)
+bool Copter::init_arm_motors(const AP_Arming::Method method, const bool do_arming_checks)
 {
     static bool in_arm_motors = false;
 

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -424,7 +424,7 @@ void ToyMode::update()
         if (throttle_high_counter >= TOY_LAND_ARM_COUNT) {
             gcs().send_text(MAV_SEVERITY_INFO, "Tmode: throttle arm");
             arm_check_compass();
-            if (!copter.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK) && (flags & FLAG_UPGRADE_LOITER) && copter.control_mode == LOITER) {
+            if (!copter.init_arm_motors(AP_Arming::Method::MAVLINK) && (flags & FLAG_UPGRADE_LOITER) && copter.control_mode == LOITER) {
                 /*
                   support auto-switching to ALT_HOLD, then upgrade to LOITER once GPS available
                  */
@@ -433,7 +433,7 @@ void ToyMode::update()
 #if AC_FENCE == ENABLED
                     copter.fence.enable(false);
 #endif
-                    if (!copter.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK)) {
+                    if (!copter.init_arm_motors(AP_Arming::Method::MAVLINK)) {
                         // go back to LOITER
                         gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: ALT_HOLD arm failed");
                         set_and_remember_mode(LOITER, MODE_REASON_TMODE);
@@ -625,7 +625,7 @@ void ToyMode::update()
 #if AC_FENCE == ENABLED
             copter.fence.enable(false);
 #endif
-            if (copter.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK)) {
+            if (copter.init_arm_motors(AP_Arming::Method::MAVLINK)) {
                 load_test.running = true;
                 gcs().send_text(MAV_SEVERITY_INFO, "Tmode: load_test on");
             } else {
@@ -803,7 +803,7 @@ void ToyMode::action_arm(void)
         // we want GPS and checks are passing, arm and enable fence
         copter.fence.enable(true);
 #endif
-        copter.init_arm_motors(AP_Arming::ArmingMethod::RUDDER);
+        copter.init_arm_motors(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
             gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: GPS arming failed");
@@ -819,7 +819,7 @@ void ToyMode::action_arm(void)
         // non-GPS mode
         copter.fence.enable(false);
 #endif
-        copter.init_arm_motors(AP_Arming::ArmingMethod::RUDDER);
+        copter.init_arm_motors(AP_Arming::Method::RUDDER);
         if (!copter.motors->armed()) {
             AP_Notify::events.arming_failed = true;
             gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: non-GPS arming failed");

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -281,7 +281,7 @@ void Plane::one_second_loop()
     // update notify flags
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
     AP_Notify::flags.pre_arm_gps_check = true;
-    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::NO;
+    AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::Required::NO;
 
 #if AP_TERRAIN_AVAILABLE
     if (should_log(MASK_LOG_GPS)) {
@@ -905,7 +905,7 @@ void Plane::disarm_if_autoland_complete()
 {
     if (landing.get_disarm_delay() > 0 &&
         !is_flying() &&
-        arming.arming_required() != AP_Arming::NO &&
+        arming.arming_required() != AP_Arming::Required::NO &&
         arming.is_armed()) {
         /* we have auto disarm enabled. See if enough time has passed */
         if (millis() - auto_state.last_flying_ms >= landing.get_disarm_delay()*1000UL) {

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -871,7 +871,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_long_packet(const mavlink_command_l
         if (is_equal(packet.param1,1.0f)) {
             // run pre_arm_checks and arm_checks and display failures
             const bool do_arming_checks = !is_equal(packet.param2,magic_force_arm_value);
-            if (plane.arm_motors(AP_Arming::MAVLINK, do_arming_checks)) {
+            if (plane.arm_motors(AP_Arming::Method::MAVLINK, do_arming_checks)) {
                 return MAV_RESULT_ACCEPTED;
             }
             return MAV_RESULT_FAILED;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -925,7 +925,7 @@ private:
     int8_t throttle_percentage(void);
     void change_arm_state(void);
     bool disarm_motors(void);
-    bool arm_motors(AP_Arming::ArmingMethod method, bool do_arming_checks=true);
+    bool arm_motors(AP_Arming::Method method, bool do_arming_checks=true);
     bool auto_takeoff_check(void);
     void takeoff_calc_roll(void);
     void takeoff_calc_pitch(void);

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -62,7 +62,7 @@ void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const aux_swi
         // arm or disarm the vehicle
         switch (ch_flag) {
         case HIGH:
-            plane.arm_motors(AP_Arming::ArmingMethod::AUXSWITCH, true);
+            plane.arm_motors(AP_Arming::Method::AUXSWITCH, true);
             break;
         case MIDDLE:
             // nothing

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1179,7 +1179,7 @@ void QuadPlane::control_loiter()
 float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
 {
     if (plane.get_throttle_input() <= 0 && !plane.auto_throttle_mode &&
-        plane.arming.get_rudder_arming_type() != AP_Arming::ARMING_RUDDER_DISABLED) {
+        plane.arming.get_rudder_arming_type() != AP_Arming::RudderArming::IS_DISABLED) {
         // the user may be trying to disarm
         return 0;
     }

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -40,7 +40,7 @@ void Plane::set_control_channels(void)
         SRV_Channels::set_angle(SRV_Channel::k_throttleRight, 100);
     }
 
-    if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
+    if (!arming.is_armed() && arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::SRV_CHANNEL_LIMIT_TRIM:SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     }
 
@@ -86,7 +86,7 @@ void Plane::init_rc_out_main()
     
     // setup PX4 to output the min throttle when safety off if arming
     // is setup for min on disarm
-    if (arming.arming_required() == AP_Arming::YES_MIN_PWM) {
+    if (arming.arming_required() == AP_Arming::Required::YES_MIN_PWM) {
         SRV_Channels::set_safety_limit(SRV_Channel::k_throttle, have_reverse_thrust()?SRV_Channel::SRV_CHANNEL_LIMIT_TRIM:SRV_Channel::SRV_CHANNEL_LIMIT_MIN);
     }
 }
@@ -112,9 +112,9 @@ void Plane::init_rc_out_aux()
 */
 void Plane::rudder_arm_disarm_check()
 {
-    AP_Arming::ArmingRudder arming_rudder = arming.get_rudder_arming_type();
+    AP_Arming::RudderArming arming_rudder = arming.get_rudder_arming_type();
 
-    if (arming_rudder == AP_Arming::ARMING_RUDDER_DISABLED) {
+    if (arming_rudder == AP_Arming::RudderArming::IS_DISABLED) {
         //parameter disallows rudder arming/disabling
         return;
     }
@@ -146,14 +146,14 @@ void Plane::rudder_arm_disarm_check()
                 }
 			} else {
 				//time to arm!
-				arm_motors(AP_Arming::RUDDER);
+				arm_motors(AP_Arming::Method::RUDDER);
 				rudder_arm_timer = 0;
 			}
 		} else {
 			// not at full right rudder
 			rudder_arm_timer = 0;
 		}
-	} else if ((arming_rudder == AP_Arming::ARMING_RUDDER_ARMDISARM) && !is_flying()) {
+	} else if ((arming_rudder == AP_Arming::RudderArming::ARMDISARM) && !is_flying()) {
 		// when armed and not flying, full left rudder starts disarming counter
 		if (channel_rudder->get_control_in() < -4000) {
 			uint32_t now = millis();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -370,7 +370,7 @@ void Plane::set_servos_controlled(void)
                                     constrain_int16(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle), min_throttle, max_throttle));
     
     if (!hal.util->get_soft_armed()) {
-        if (arming.arming_required() == AP_Arming::YES_ZERO_PWM) {
+        if (arming.arming_required() == AP_Arming::Required::YES_ZERO_PWM) {
             SRV_Channels::set_output_limit(SRV_Channel::k_throttle, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
@@ -583,7 +583,7 @@ void Plane::servos_twin_engine_mix(void)
         throttle_right = constrain_float(throttle - 50 * rudder_dt, 0, 100);
     }
     if (!hal.util->get_soft_armed()) {
-        if (arming.arming_required() == AP_Arming::YES_ZERO_PWM) {
+        if (arming.arming_required() == AP_Arming::Required::YES_ZERO_PWM) {
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleLeft, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
             SRV_Channels::set_output_limit(SRV_Channel::k_throttleRight, SRV_Channel::SRV_CHANNEL_LIMIT_ZERO_PWM);
         } else {
@@ -687,18 +687,18 @@ void Plane::set_servos(void)
         //Some ESCs get noisy (beep error msgs) if PWM == 0.
         //This little segment aims to avoid this.
         switch (arming.arming_required()) { 
-        case AP_Arming::NO:
+        case AP_Arming::Required::NO:
             //keep existing behavior: do nothing to radio_out
             //(don't disarm throttle channel even if AP_Arming class is)
             break;
 
-        case AP_Arming::YES_ZERO_PWM:
+        case AP_Arming::Required::YES_ZERO_PWM:
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttle, 0);
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, 0);
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, 0);
             break;
 
-        case AP_Arming::YES_MIN_PWM:
+        case AP_Arming::Required::YES_MIN_PWM:
         default:
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0);
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, 0);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -757,7 +757,7 @@ void Plane::change_arm_state(void)
 /*
   arm motors
  */
-bool Plane::arm_motors(const AP_Arming::ArmingMethod method, const bool do_arming_checks)
+bool Plane::arm_motors(const AP_Arming::Method method, const bool do_arming_checks)
 {
     if (!arming.arm(method, do_arming_checks)) {
         return false;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -562,7 +562,7 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
     case MAV_CMD_COMPONENT_ARM_DISARM:
         if (is_equal(packet.param1,1.0f)) {
             // attempt to arm and return success or failure
-            if (sub.init_arm_motors(AP_Arming::ArmingMethod::MAVLINK)) {
+            if (sub.init_arm_motors(AP_Arming::Method::MAVLINK)) {
                 return MAV_RESULT_ACCEPTED;
             }
         } else if (is_zero(packet.param1))  {

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -591,7 +591,7 @@ private:
     void update_surface_and_bottom_detector();
     void set_surfaced(bool at_surface);
     void set_bottomed(bool at_bottom);
-    bool init_arm_motors(AP_Arming::ArmingMethod method);
+    bool init_arm_motors(AP_Arming::Method method);
     void init_disarm_motors();
     void motors_output();
     Vector3f pv_location_to_vector(const Location& loc);

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -130,11 +130,11 @@ void Sub::handle_jsbutton_press(uint8_t button, bool shift, bool held)
         if (motors.armed()) {
             init_disarm_motors();
         } else {
-            init_arm_motors(AP_Arming::ArmingMethod::MAVLINK);
+            init_arm_motors(AP_Arming::Method::MAVLINK);
         }
         break;
     case JSButton::button_function_t::k_arm:
-        init_arm_motors(AP_Arming::ArmingMethod::MAVLINK);
+        init_arm_motors(AP_Arming::Method::MAVLINK);
         break;
     case JSButton::button_function_t::k_disarm:
         init_disarm_motors();

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -8,7 +8,7 @@ void Sub::enable_motor_output()
 
 // init_arm_motors - performs arming process including initialisation of barometer and gyros
 //  returns false if arming failed because of pre-arm checks, arming checks or a gyro calibration failure
-bool Sub::init_arm_motors(AP_Arming::ArmingMethod method)
+bool Sub::init_arm_motors(AP_Arming::Method method)
 {
     static bool in_arm_motors = false;
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -44,9 +44,9 @@
 #define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
-  #define ARMING_RUDDER_DEFAULT         ARMING_RUDDER_ARMONLY
+  #define ARMING_RUDDER_DEFAULT         (uint8_t)RudderArming::ARMONLY
 #else
-  #define ARMING_RUDDER_DEFAULT         ARMING_RUDDER_ARMDISARM
+  #define ARMING_RUDDER_DEFAULT         (uint8_t)RudderArming::ARMDISARM
 #endif
 
 extern const AP_HAL::HAL& hal;
@@ -122,7 +122,7 @@ uint16_t AP_Arming::compass_magfield_expected() const
 
 bool AP_Arming::is_armed()
 {
-    return (ArmingRequired)require.get() == NO || armed;
+    return (Required)require.get() == Required::NO || armed;
 }
 
 uint16_t AP_Arming::get_enabled_checks()
@@ -723,7 +723,7 @@ bool AP_Arming::fence_checks(bool display_failure)
 bool AP_Arming::pre_arm_checks(bool report)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-    if (armed || require == NO) {
+    if (armed || require == (uint8_t)Required::NO) {
         // if we are already armed or don't need any arming checks
         // then skip the checks
         return true;
@@ -745,7 +745,7 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  can_checks(report);
 }
 
-bool AP_Arming::arm_checks(ArmingMethod method)
+bool AP_Arming::arm_checks(AP_Arming::Method method)
 {
     // ensure the GPS drivers are ready on any final changes
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
@@ -777,7 +777,7 @@ bool AP_Arming::arm_checks(ArmingMethod method)
 }
 
 //returns true if arming occurred successfully
-bool AP_Arming::arm(AP_Arming::ArmingMethod method, const bool do_arming_checks)
+bool AP_Arming::arm(AP_Arming::Method method, const bool do_arming_checks)
 {
 #if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
     // Copter should never use this function
@@ -839,9 +839,9 @@ bool AP_Arming::disarm()
 #endif
 }
 
-AP_Arming::ArmingRequired AP_Arming::arming_required() 
+AP_Arming::Required AP_Arming::arming_required() 
 {
-    return (AP_Arming::ArmingRequired)require.get();
+    return (AP_Arming::Required)require.get();
 }
 
 // Copter and sub share the same RC input limits

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -33,22 +33,22 @@ public:
         ARMING_CHECK_MISSION    = 0x4000,
     };
 
-    enum ArmingMethod {
+    enum class Method {
         RUDDER,
         MAVLINK,
         AUXSWITCH,
         MOTORTEST,
     };
 
-    enum ArmingRequired {
+    enum class Required {
         NO           = 0,
         YES_MIN_PWM  = 1,
         YES_ZERO_PWM = 2
     };
 
     // these functions should not be used by Copter which holds the armed state in the motors library
-    ArmingRequired arming_required();
-    virtual bool arm(ArmingMethod method, bool do_arming_checks=true);
+    Required arming_required();
+    virtual bool arm(AP_Arming::Method method, bool do_arming_checks=true);
     bool disarm();
     bool is_armed();
 
@@ -61,18 +61,19 @@ public:
     // some arming checks have side-effects, or require some form of state
     // change to have occurred, and thus should not be done as pre-arm
     // checks.  Those go here:
-    bool arm_checks(ArmingMethod method);
+    bool arm_checks(AP_Arming::Method method);
 
     // get expected magnetic field strength
     uint16_t compass_magfield_expected() const;
 
     // rudder arming support
-    enum ArmingRudder {
-        ARMING_RUDDER_DISABLED  = 0,
-        ARMING_RUDDER_ARMONLY   = 1,
-        ARMING_RUDDER_ARMDISARM = 2
+    enum class RudderArming {
+        IS_DISABLED  = 0, // DISABLED leaks in from vehicle defines.h
+        ARMONLY   = 1,
+        ARMDISARM = 2
     };
-    ArmingRudder get_rudder_arming_type() const { return (ArmingRudder)_rudder_arming.get(); }
+
+    RudderArming get_rudder_arming_type() const { return (RudderArming)_rudder_arming.get(); }
 
     static const struct AP_Param::GroupInfo        var_info[];
 


### PR DESCRIPTION
This makes things a little clearer in some respects (`AP_Arming::NO` -> `AP_Arming::RudderArming::NO`), and uses C++ namespacing in place of traditional namespacing (`AP_Arming::ARMING_RUDDER_ARMDISARM` -> `AP_Arming::RudderArming::ARMDISARM`) in other places.
