### PR TITLE
AP_NavEKF2 : Adding EXTNAV_ALTSC parameter to choose altitude source.

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -405,7 +405,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("IMU_MASK",     33, NavEKF2, _imuMask, 3),
-    
+
     // @Param: CHECK_SCALE
     // @DisplayName: GPS accuracy check scaler (%)
     // @Description: This scales the thresholds that are used to check GPS accuracy before it is used by the EKF. A value of 100 is the default. Values greater than 100 increase and values less than 100 reduce the maximum GPS error the EKF will accept. A value of 200 will double the allowable GPS error.
@@ -553,6 +553,14 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("EXTNAV_DELAY", 50, NavEKF2, _extnavDelay_ms, 10),
 
+    // @Param: EXTNAV_ALTSC
+    // @DisplayName: Height from ALT_SOURCE parameter used instead of EXTNAV_Z
+    // @Description: In case of indoor navigation, the altitude can be more accurate from the other sensor like rangefinder than the estimation from the external navigation system.
+    // @Values: 0:Disabled, 1:Enabled
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("EXTNAV_ALTSC", 51, NavEKF2, _extnav_use_alt_source, 0),
+
     AP_GROUPEND
 };
 
@@ -614,13 +622,13 @@ bool NavEKF2::InitialiseFilter(void)
     if (dataflash != nullptr) {
         logging.enabled = dataflash->log_replay();
     }
-    
+
     if (core == nullptr) {
 
         // don't run multiple filters for 1 IMU
         uint8_t mask = (1U<<ins.get_accel_count())-1;
         _imuMask.set(_imuMask.get() & mask);
-        
+
         // count IMUs from mask
         num_cores = 0;
         for (uint8_t i=0; i<7; i++) {
@@ -687,7 +695,7 @@ void NavEKF2::UpdateFilter(void)
     }
 
     imuSampleTime_us = AP_HAL::micros64();
-    
+
     const AP_InertialSensor &ins = AP::ins();
 
     bool statePredictEnabled[num_cores];
@@ -1491,4 +1499,3 @@ void NavEKF2::writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, c
         }
     }
 }
-

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -59,7 +59,7 @@ public:
 
     // check if we should write log messages
     void check_log_write(void);
-    
+
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
 
@@ -70,7 +70,7 @@ public:
     // returns the index of the IMU of the primary core
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIMUIndex(void) const;
-    
+
     // Write the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the primary instance
     // If a calculated solution is not available, use the best available data and return false
@@ -396,6 +396,7 @@ private:
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
     AP_Int8 _extnavDelay_ms;        // effective average delay of external nav system measurements relative to inertial measurements (msec)
+    AP_Int8  _extnav_use_alt_source;// In case of EXTNAV pose, use ALT_SOURCE parameter and not EXTNAV_Z for altitude
 
     // Tuning parameters
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration
@@ -435,7 +436,7 @@ private:
 
     // time at start of current filter update
     uint64_t imuSampleTime_us;
-    
+
     struct {
         uint32_t last_function_call;  // last time getLastYawYawResetAngle was called
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -800,8 +800,8 @@ void NavEKF2_core::selectHeightForFusion()
     baroDataToFuse = storedBaro.recall(baroDataDelayed, imuDataDelayed.time_ms);
 
     // select height source
-    if (extNavUsedForPos) {
-        // always use external vision as the height source if using for position.
+    if ((extNavUsedForPos) && (frontend->_extnav_use_alt_source == 0)) {
+        // Use external vision as the height source if using for position AND not using alt_source for pose
         activeHgtSource = HGT_SOURCE_EV;
     } else if (((frontend->_useRngSwHgt > 0) || (frontend->_altSource == 1)) && (imuSampleTime_ms - rngValidMeaTime_ms < 500)) {
         if (frontend->_altSource == 1) {
@@ -945,4 +945,3 @@ void NavEKF2_core::selectHeightForFusion()
         hgtTimeout = false;
     }
 }
-


### PR DESCRIPTION
This parameter lets the user choose for altitude between external navigation z, or the ALT_SOURCE selected like baro or rangefinder. Useful for SLAM robots, which are subject of drift.