### PR TITLE
AP_Common: Semaphore is missing an include

### DIFF
--- a/libraries/AP_Common/Semaphore.h
+++ b/libraries/AP_Common/Semaphore.h
@@ -27,6 +27,8 @@
   The WITH_SEMAPHORE() macro can be used with either type of semaphore
  */
 
+#include <AP_HAL/Semaphores.h>
+
 namespace AP_HAL {
 class Semaphore;
 }


### PR DESCRIPTION
Everyone who is already including common/Semaphore has extra includes to make this compile. This reduces that dependancy. After we merge this, we can probably remove a bunch of includes throughout the library