### PR TITLE
Copter: Return currently assigned local target

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1140,6 +1140,24 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             copter.mode_guided.set_destination(pos_neu_cm, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         }
 
+        // Return newly assigned local target
+        mavlink_msg_position_target_local_ned_send(
+            chan,
+            AP_HAL::millis(),
+            packet.coordinate_frame,
+            packet.type_mask,
+            packet.x,
+            packet.y,
+            packet.z,
+            packet.vx,
+            packet.vy,
+            packet.vz,
+            packet.afx,
+            packet.afy,
+            packet.afz,
+            packet.yaw,
+            packet.yaw_rate);
+
         break;
     }
 #endif


### PR DESCRIPTION
When an operator sends the SET_POSITION_TARGET_LOCAL_NED message there exists no acknowledgement of the command. This commit adds functionality for the copter to return the assigned local target. Please check Issue #8686 for more details