### PR TITLE
Copter: Return currently assigned local target

### DIFF
--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -25,6 +25,7 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet) override;
 
     void send_position_target_global_int() override;
+    void send_position_target_local_ned() override;
 
     MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -90,6 +90,7 @@ enum ap_message : uint8_t {
     MSG_WHEEL_DISTANCE,
     MSG_MISSION_ITEM_REACHED,
     MSG_POSITION_TARGET_GLOBAL_INT,
+    MSG_POSITION_TARGET_LOCAL_NED,
     MSG_ADSB_VEHICLE,
     MSG_BATTERY_STATUS,
     MSG_AOA_SSA,
@@ -227,6 +228,7 @@ public:
     void send_home_position() const;
     void send_gps_global_origin() const;
     virtual void send_position_target_global_int() { };
+    virtual void send_position_target_local_ned() { };
     void send_servo_output_raw();
     static void send_collision_all(const AP_Avoidance::Obstacle &threat, MAV_COLLISION_ACTION behaviour);
     void send_accelcal_vehicle_position(uint32_t position);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -950,6 +950,7 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_RPM,                   MSG_RPM},
         { MAVLINK_MSG_ID_MISSION_ITEM_REACHED,  MSG_MISSION_ITEM_REACHED},
         { MAVLINK_MSG_ID_POSITION_TARGET_GLOBAL_INT,  MSG_POSITION_TARGET_GLOBAL_INT},
+        { MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED,  MSG_POSITION_TARGET_LOCAL_NED},
         { MAVLINK_MSG_ID_ADSB_VEHICLE,          MSG_ADSB_VEHICLE},
         { MAVLINK_MSG_ID_BATTERY_STATUS,        MSG_BATTERY_STATUS},
         { MAVLINK_MSG_ID_AOA_SSA,               MSG_AOA_SSA},
@@ -4185,6 +4186,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_POSITION_TARGET_GLOBAL_INT:
         CHECK_PAYLOAD_SIZE(POSITION_TARGET_GLOBAL_INT);
         send_position_target_global_int();
+        break;
+
+    case MSG_POSITION_TARGET_LOCAL_NED:
+        CHECK_PAYLOAD_SIZE(POSITION_TARGET_LOCAL_NED);
+        send_position_target_local_ned();
         break;
 
     case MSG_POWER_STATUS:


### PR DESCRIPTION
When an operator sends the SET_POSITION_TARGET_LOCAL_NED message there exists no acknowledgement of the command. This commit adds functionality for the copter to return the assigned local target. Please check Issue #8686 for more details