### PR TITLE
support different thrust_error_angle threshold for tailsitters

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -619,6 +619,10 @@ bool QuadPlane::setup(void)
         hal.console->printf("%s attitude_control\n", strUnableToAllocate);
         goto failed;
     }
+    // copter tailsitters need a larger thrust error angle threshold than multicopters
+    if (tailsitter.motor_mask != 0) {
+        attitude_control->set_thrust_error_thresh(radians(120.0f));
+    }
     AP_Param::load_object_from_eeprom(attitude_control, attitude_control->var_info);
     pos_control = new AC_PosControl(*ahrs_view, inertial_nav, *motors, *attitude_control);
     if (!pos_control) {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -211,8 +211,8 @@ void AC_AttitudeControl::reset_rate_controller_I_terms()
 //    _attitude_target_ang_vel have been defined. This ensures input modes can be changed without discontinuity.
 // 5. attitude_controller_run_quat is then run to pass the target angular velocities to the rate controllers and
 //    integrate them into the target attitude. Any errors between the target attitude and the measured attitude are
-//    corrected by first correcting the thrust vector until the angle between the target thrust vector measured
-//    trust vector drops below 2*AC_ATTITUDE_THRUST_ERROR_ANGLE. At this point the heading is also corrected.
+//    corrected by first correcting the thrust vector until the angle between the target thrust vector and measured
+//    thrust vector drops below 2*AC_ATTITUDE_THRUST_ERROR_ANGLE. At this point the heading is also corrected.
 
 
 
@@ -612,10 +612,10 @@ void AC_AttitudeControl::attitude_controller_run_quat()
     Quaternion desired_ang_vel_quat = to_to_from_quat.inverse()*attitude_target_ang_vel_quat*to_to_from_quat;
 
     // Correct the thrust vector and smoothly add feedforward and yaw input
-    if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE*2.0f){
+    if(_thrust_error_angle > _thrust_error_thresh*2.0f){
         _rate_target_ang_vel.z = _ahrs.get_gyro().z;
-    }else if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE){
-        float feedforward_scalar = (1.0f - (_thrust_error_angle-AC_ATTITUDE_THRUST_ERROR_ANGLE)/AC_ATTITUDE_THRUST_ERROR_ANGLE);
+    }else if(_thrust_error_angle > _thrust_error_thresh){
+        float feedforward_scalar = (1.0f - (_thrust_error_angle-_thrust_error_thresh)/_thrust_error_thresh);
         _rate_target_ang_vel.x += desired_ang_vel_quat.q2*feedforward_scalar;
         _rate_target_ang_vel.y += desired_ang_vel_quat.q3*feedforward_scalar;
         _rate_target_ang_vel.z += desired_ang_vel_quat.q4;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -301,6 +301,11 @@ public:
     // enable inverted flight on backends that support it
     virtual void set_inverted_flight(bool inverted) {}
     
+    // set thrust error angle threshold
+    void set_thrust_error_thresh(float thresh) {
+        _thrust_error_thresh = thresh;
+    }
+    
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -438,6 +443,9 @@ protected:
     // (would be expensive to compute from _attitude_target_quat)
     float _last_body_roll;
     float _last_euler_pitch;
+    
+    // thrust error angle threshold
+    float _thrust_error_thresh = AC_ATTITUDE_THRUST_ERROR_ANGLE;
 
 public:
     // log a CTRL message


### PR DESCRIPTION
changes a threshold from macro to instance attribute (initialized to original value) and adds a setter which is called from quadplane setup()
All flight testing for quad tailsitters has been done with the macro threshold value changed to 120 degrees