### PR TITLE
GCS_MAVLink: Don't send BATTERY_STATUS if no driver was selected

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -143,8 +143,8 @@ public:
     int8_t get_highest_failsafe_priority(void) const { return _highest_failsafe_priority; };
 
     /// get_type - returns battery monitor type
-    enum AP_BattMonitor_Params::BattMonitor_Type get_type() { return get_type(AP_BATT_PRIMARY_INSTANCE); }
-    enum AP_BattMonitor_Params::BattMonitor_Type get_type(uint8_t instance) { return _params[instance].type(); }
+    enum AP_BattMonitor_Params::BattMonitor_Type get_type() const { return get_type(AP_BATT_PRIMARY_INSTANCE); }
+    enum AP_BattMonitor_Params::BattMonitor_Type get_type(uint8_t instance) const { return _params[instance].type(); }
 
     /// set_monitoring - sets the monitor type (used for example sketch only)
     void set_monitoring(uint8_t instance, uint8_t mon) { _params[instance]._type.set(mon); }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -256,8 +256,10 @@ bool GCS_MAVLINK::send_battery_status() const
     const AP_BattMonitor &battery = AP::battery();
 
     for(uint8_t i = 0; i < battery.num_instances(); i++) {
-        CHECK_PAYLOAD_SIZE(BATTERY_STATUS);
-        send_battery_status(battery, i);
+        if (battery.get_type(i) != AP_BattMonitor_Params::BattMonitor_Type::BattMonitor_TYPE_NONE) {
+            CHECK_PAYLOAD_SIZE(BATTERY_STATUS);
+            send_battery_status(battery, i);
+        }
     }
     return true;
 }


### PR DESCRIPTION
The short form is that num_instances is always set based on the highest loaded driver. I was doing some testing, and it was convenient to turn off one of the earlier monitors I had enabled, but we still sent the BATTERY_STATUS message for the slot which wasted bandwidth, and lead to confusion on the GCS for why it was still seemingly enabled.