### PR TITLE
Tools: autotest: improve test reliability

### DIFF
--- a/Tools/autotest/apmrover2.py
+++ b/Tools/autotest/apmrover2.py
@@ -715,6 +715,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("chan3=%f want=%f" % (m.chan3_raw, normal_rc_throttle))
             if m.chan3_raw == normal_rc_throttle:
                 break
+        self.disarm_vehicle()
 
     def test_rc_overrides(self):
         self.context_push()


### PR DESCRIPTION
Also remove redundant reset code

Tools: autotest: drain mav and all pexexpects before running each test

Tools: autotest: increase some timeouts for failures when running under GDB

Tools: autotest: correct ordering of operations in mount test