### PR TITLE
Replace defined array_size by template version

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -79,9 +79,21 @@
 #define LOWBYTE(i) ((uint8_t)(i))
 #define HIGHBYTE(i) ((uint8_t)(((uint16_t)(i))>>8))
 
-#define ARRAY_SIZE(_arr) (sizeof(_arr) / sizeof(_arr[0]))
-
 #define UINT16_VALUE(hbyte, lbyte) (static_cast<uint16_t>((hbyte<<8)|lbyte))
+
+// #define ARRAY_SIZE(_arr) (sizeof(_arr) / sizeof(_arr[0]))
+// taken from https://en.cppreference.com/w/cpp/iterator/size
+template <class T, size_t N>
+constexpr size_t ARRAY_SIZE(const T (&array)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto ARRAY_SIZE(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
 
 /*
  * See UNUSED_RESULT. The difference is that it receives @uniq_ as the name to

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -16,6 +16,7 @@
  */
 #include "GPIO.h"
 
+#include <AP_Common/AP_Common.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 using namespace ChibiOS;

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -32,9 +32,6 @@ static struct gpio_entry {
     uint8_t mode;
 } _gpio_tab[] = HAL_GPIO_PINS;
 
-#define NUM_PINS ARRAY_SIZE(_gpio_tab)
-#define PIN_ENABLED(pin) ((pin)<NUM_PINS && _gpio_tab[pin].enabled)
-
 /*
   map a user pin number to a GPIO table entry
  */

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -37,7 +37,7 @@ static struct gpio_entry {
  */
 static struct gpio_entry *gpio_by_pin_num(uint8_t pin_num, bool check_enabled=true)
 {
-    for (uint8_t i=0; i<ARRAY_SIZE(_gpio_tab); i++) {
+    for (uint8_t i=0; i<std::extent<decltype(_gpio_tab)>::value; i++) {
         if (pin_num == _gpio_tab[i].pin_num) {
             if (check_enabled && !_gpio_tab[i].enabled) {
                 return NULL;
@@ -45,7 +45,7 @@ static struct gpio_entry *gpio_by_pin_num(uint8_t pin_num, bool check_enabled=tr
             return &_gpio_tab[i];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 static void pal_interrupt_cb(void *arg);
@@ -58,7 +58,7 @@ void GPIO::init()
 {
     // auto-disable pins being used for PWM output based on BRD_PWM_COUNT parameter
     uint8_t pwm_count = AP_BoardConfig::get_pwm_count();
-    for (uint8_t i=0; i<ARRAY_SIZE(_gpio_tab); i++) {
+    for (uint8_t i=0; i<std::extent<decltype(_gpio_tab)>::value; i++) {
         struct gpio_entry *g = &_gpio_tab[i];
         if (g->pwm_num != 0) {
             g->enabled = g->pwm_num > pwm_count;
@@ -258,4 +258,3 @@ void pal_interrupt_cb_functor(void *arg)
     }
     (g->fn)(g->pin_num, palReadLine(g->pal_line), now);
 }
-

--- a/libraries/AP_HAL_Linux/AnalogIn_IIO.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_IIO.cpp
@@ -2,6 +2,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/Semaphore.h>
+#include <AP_Common/AP_Common.h>
 
 extern const AP_HAL::HAL &hal;
 

--- a/libraries/AP_HAL_Linux/GPIO_Aero.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Aero.cpp
@@ -19,6 +19,7 @@
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
 
 #include "GPIO_Aero.h"
+#include <AP_Common/AP_Common.h>
 
 const unsigned Linux::GPIO_Sysfs::pin_table[] = {
     [AERO_GPIO_BMI160_INT1] = 411,

--- a/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
@@ -2,6 +2,7 @@
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
 #include "GPIO_Bebop.h"
+#include <AP_Common/AP_Common.h>
 
 const unsigned Linux::GPIO_Sysfs::pin_table[] = {
     [BEBOP_GPIO_CAMV_NRST] = 129,

--- a/libraries/AP_HAL_Linux/GPIO_Disco.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Disco.cpp
@@ -3,6 +3,7 @@
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
 
 #include "GPIO_Disco.h"
+#include <AP_Common/AP_Common.h>
 
 const unsigned Linux::GPIO_Sysfs::pin_table[] = {
     [DISCO_GPIO_MPU6050_DRDY] = 91,

--- a/libraries/AP_HAL_Linux/GPIO_Edge.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Edge.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Edge.h"
+#include <AP_Common/AP_Common.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE
 

--- a/libraries/AP_HAL_Linux/GPIO_Navio.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Navio.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Navio.h"
+#include <AP_Common/AP_Common.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
 

--- a/libraries/AP_HAL_Linux/GPIO_Navio2.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Navio2.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #include "GPIO_Navio2.h"
+#include <AP_Common/AP_Common.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
 

--- a/libraries/AP_HAL_Linux/RCInput_Navio2.h
+++ b/libraries/AP_HAL_Linux/RCInput_Navio2.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "RCInput.h"
-
+#include <AP_Common/AP_Common.h>
 
 namespace Linux {
 

--- a/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Disco.cpp
@@ -23,6 +23,7 @@
 #include "RCOutput_Disco.h"
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
 #include <stdio.h>
 
 namespace Linux {

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
 
 using namespace Linux;
 

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -29,6 +29,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/OwnPtr.h>
+#include <AP_Common/AP_Common.h>
 
 #include "GPIO.h"
 #include "PollerThread.h"

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -12,6 +12,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_Common/AP_Common.h>
 
 #include "RCInput.h"
 #include "SPIUARTDriver.h"

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>
+#include <AP_Common/AP_Common.h>
 
 using namespace HALSITL;
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -18,6 +18,7 @@
 #include <AP_Param/AP_Param.h>
 #include <SITL/SIM_JSBSim.h>
 #include <AP_HAL/utility/Socket.h>
+#include <AP_Common/AP_Common.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <AP_HAL/utility/getopt_cpp.h>
 #include <AP_Logger/AP_Logger_SITL.h>
+#include <AP_Common/AP_Common.h>
 
 #include <SITL/SIM_Multicopter.h>
 #include <SITL/SIM_Helicopter.h>

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
 
 #include <errno.h>
 #include <sys/ioctl.h>

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -1,5 +1,6 @@
 #include "Util.h"
 #include <sys/time.h>
+#include <AP_Common/AP_Common.h>
 
 #ifdef WITH_SITL_TONEALARM
 HALSITL::ToneAlarm_SF HALSITL::Util::_toneAlarm;

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -14,6 +14,7 @@
 #include "HAL_SITL_Class.h"
 
 #include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
 #include <SITL/SITL.h>
 #include "Scheduler.h"
 #include "UARTDriver.h"

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1402,9 +1402,9 @@ void AP_Logger::Write_Current_instance(const uint64_t time_us,
             cell_pkt.cell_voltages[i] = cells.cells[i] + 1;
         }
         WriteBlock(&cell_pkt, sizeof(cell_pkt));
-
         // check battery structure can hold all cells
-        static_assert(ARRAY_SIZE(cells.cells) == (sizeof(cell_pkt.cell_voltages) / sizeof(cell_pkt.cell_voltages[0])),
+        // ARRAY_SIZE cannot be use as cells or cell_voltages cannot be used in const expression, solved in C++17
+        static_assert(std::extent<decltype(cells.cells)>::value == std::extent<decltype(cell_pkt.cell_voltages)>::value,
                       "Battery cell number doesn't match in library and log structure");
     }
 }

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -30,7 +30,7 @@ const AP_ROMFS::embedded_file AP_ROMFS::files[] = {};
 */
 const uint8_t *AP_ROMFS::find_file(const char *name, uint32_t &size)
 {
-    for (uint16_t i=0; i<ARRAY_SIZE(files); i++) {
+    for (uint16_t i=0; i<std::extent<decltype(files)>::value; i++) {
         if (strcmp(name, files[i].filename) == 0) {
             size = files[i].size;
             return files[i].contents;


### PR DESCRIPTION
Replace the definied array_size by the template version : 
pro : 
- type safe
- debuggable
- ensure compile time calculation
- no impact on compile time
- no impact on binary size

cons : it find to "errors" in the code : 
the first one was : 
````
../../libraries/AP_Logger/LogFile.cpp: In member function ‘void AP_Logger::Write_Current_instance(uint64_t, uint8_t, LogMessages, LogMessages)’:
../../libraries/AP_Logger/LogFile.cpp:1422:9: error: non-constant condition for static assertion
         static_assert(ARRAY_SIZE(cells.cells) == (sizeof(cell_pkt.cell_voltages) / sizeof(cell_pkt.cell_voltages[0])),
         ^~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
````
This one could be solve easily by using MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN

The second is a little more complex.
````
../../libraries/AP_ROMFS/AP_ROMFS.cpp: In static member function ‘static const uint8_t* AP_ROMFS::find_file(const char*, uint32_t&)’:
../../libraries/AP_ROMFS/AP_ROMFS.cpp:33:42: error: no matching function for call to ‘ARRAY_SIZE(const AP_ROMFS::embedded_file [0])’
     for (uint16_t i=0; i<ARRAY_SIZE(files); i++) {
                                          ^
compilation terminated due to -Wfatal-errors.
````
 On SITL with don't have ROMFS, that mean that AP_ROMFS::files is empty. Thus we cannot calculate its size. Unfortunately, we need to compile AP_ROMFS on sitl because of AP_OSD. Even if the flag WITH_SITL_OSD, is not passed, we use AP_ROMFS::find_decompress in AP_OSD_MAX7456 that is compiled by default as osd backend. My solution here was to prevent the calculation of files size and directly return the nullptr.