### PR TITLE
Fix AP_RangeFinder_TeraRangerI2C.cpp: gives zero values in Plane

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -105,7 +105,7 @@ bool AP_RangeFinder_TeraRangerI2C::init(void)
 
     dev->set_retries(1);
 
-    dev->register_periodic_callback(50000,
+    dev->register_periodic_callback(10000,
                                     FUNCTOR_BIND_MEMBER(&AP_RangeFinder_TeraRangerI2C::timer, void));
 
     return true;
@@ -158,7 +158,7 @@ bool AP_RangeFinder_TeraRangerI2C::process_raw_measure(uint16_t raw_distance, ui
 }
 
 /*
-  timer called at 20Hz
+  timer called at 100Hz, EVO sensors max freq is 100..240Hz
 */
 void AP_RangeFinder_TeraRangerI2C::timer(void)
 {
@@ -190,8 +190,8 @@ void AP_RangeFinder_TeraRangerI2C::update(void)
         state.last_reading_ms = AP_HAL::millis();
         accum.sum = 0;
         accum.count = 0;
-        update_status();
-    } else {
+        update_status();        
+    } else if (AP_HAL::millis() - state.last_reading_ms > 200) {
         set_status(RangeFinder::RangeFinder_NoData);
     }
 }


### PR DESCRIPTION
Try to fix this issue:
https://github.com/ArduPilot/ardupilot/issues/10428

The distance from Terarangers rangefinders (SONR.Dist) jumps continously to zero values because measurements are updated at 20Hz but polled at 50Hz (only in Plane, in Copter both threads run at 20Hz)

Proposed solution is:
 - increase measurements rate to 100Hz (Teraranger EVO units work at 100 .. 240Hz)
 - if, for any reason, there is no available data, does not set_status(RangeFinder::RangeFinder_NoData) until 200ms have passed, as the code in other rangefinder drivers.

Thanks for considering.