### PR TITLE
Fix Location warning on gcc8

### DIFF
--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -56,7 +56,7 @@ struct Location AP_InertialNav_NavEKF::get_origin() const
     struct Location ret;
      if (!_ahrs_ekf.get_origin(ret)) {
          // initialise location to all zeros if EKF origin not yet set
-         memset(&ret, 0, sizeof(ret));
+         ret.zero();
      }
     return ret;
 }

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -10,7 +10,6 @@
 
 #include "definitions.h"
 #include "edc.h"
-#include "location.h"
 #include "matrix3.h"
 #include "polygon.h"
 #include "quaternion.h"
@@ -18,6 +17,7 @@
 #include "vector2.h"
 #include "vector3.h"
 #include "spline5.h"
+#include "location.h"
 
 // define AP_Param types AP_Vector3f and Ap_Matrix3f
 AP_PARAMDEFV(Vector3f, Vector3f, AP_PARAM_VECTOR3F);

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include "AP_Math.h"
 #include "location.h"
-#include "AP_Common/Location.h"
 
 // return horizontal distance between two positions in cm
 float get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destination)

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -7,6 +7,7 @@
 
 #include "vector2.h"
 #include "vector3.h"
+#include <AP_Common/Location.h>
 
 // scaling factor from 1e-7 degrees to meters at equator
 // == 1.0e-7 * DEG_TO_RAD * RADIUS_OF_EARTH

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include "vector3.h"
+#include "vector2.h"
 
 // 3x3 matrix with elements of type T
 template <typename T>


### PR DESCRIPTION
Error was : 
````
../../libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp: In member function ‘virtual Location AP_InertialNav_NavEKF::get_origin() const’:
../../libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp:59:37: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct Location’; use assignment or value-initialization instead [-Wclass-memaccess]
          memset(&ret, 0, sizeof(ret));
````
As Location class is zero initialized by default there is no need to explicitly memset to zero