### PR TITLE
AP_AHRS: Warn if the return from get_origin isn't checked.

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -549,7 +549,9 @@ bool AC_Fence::load_polygon_from_eeprom(bool force_reload)
         return false;
     }
     struct Location ekf_origin {};
-    AP::ahrs().get_origin(ekf_origin);
+    if (!AP::ahrs().get_origin(ekf_origin)) {
+        return false;
+    }
 
     // sanity check total
     _total = constrain_int16(_total, 0, _poly_loader.max_points());

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -470,10 +470,10 @@ public:
     // set the EKF's origin location in 10e7 degrees.  This should only
     // be called when the EKF has no absolute position reference (i.e. GPS)
     // from which to decide the origin on its own
-    virtual bool set_origin(const Location &loc) { return false; }
+    virtual bool set_origin(const Location &loc) WARN_IF_UNUSED { return false; }
 
     // returns the inertial navigation origin in lat/lon/alt
-    virtual bool get_origin(Location &ret) const { return false; }
+    virtual bool get_origin(Location &ret) const  WARN_IF_UNUSED { return false; }
 
     void Log_Write_Home_And_Origin();
 


### PR DESCRIPTION
This is a pattern I'd like to see show up in more places. On something like the call for origin we should always be checking that it was provided and filled in correctly, and I'd like to see the compiler enforce it.

It was a fairly easy fix for AC_Fence to enable this, and it's fairly obvious in the fence case how this can blow up if it ever didn't return the origin. (Fence is mostly protected by the call to `get_location()` first, so this isn't a critical bug, but it would be easy to refactor the code to expose the bug. In fact from a local manipulation perspective we shouldn't even be asking the EKF for the current location since we never use it, and overwrite it. But it was currently the only lock to try and check that a valid origin was loaded. I'm not chasing that now, I just wanted to highlight how easy it is to break stuff without this kind of check.