### PR TITLE
More AHRS WARN_IF_UNUSED

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -537,9 +537,6 @@ public:
         return false;
     }
 
-    // time that the AHRS has been up
-    virtual uint32_t uptime_ms(void) const = 0;
-
     // get the selected ekf type, for allocation decisions
     int8_t get_ekf_type(void) const {
         return _ekf_type;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -281,11 +281,11 @@ public:
 
     // return an airspeed estimate if available. return true
     // if we have an estimate
-    virtual bool airspeed_estimate(float *airspeed_ret) const;
+    virtual bool airspeed_estimate(float *airspeed_ret) const WARN_IF_UNUSED;
 
     // return a true airspeed estimate (navigation airspeed) if
     // available. return true if we have an estimate
-    bool airspeed_estimate_true(float *airspeed_ret) const {
+    bool airspeed_estimate_true(float *airspeed_ret) const WARN_IF_UNUSED {
         if (!airspeed_estimate(airspeed_ret)) {
             return false;
         }
@@ -318,52 +318,52 @@ public:
     // return a ground velocity in meters/second, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is
     // true
-    virtual bool get_velocity_NED(Vector3f &vec) const {
+    virtual bool get_velocity_NED(Vector3f &vec) const WARN_IF_UNUSED {
         return false;
     }
 
     // returns the expected NED magnetic field
-    virtual bool get_expected_mag_field_NED(Vector3f &ret) const {
+    virtual bool get_expected_mag_field_NED(Vector3f &ret) const WARN_IF_UNUSED {
         return false;
     }
 
     // returns the estimated magnetic field offsets in body frame
-    virtual bool get_mag_field_correction(Vector3f &ret) const {
+    virtual bool get_mag_field_correction(Vector3f &ret) const WARN_IF_UNUSED {
         return false;
     }
 
     // return a position relative to home in meters, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is
     // true
-    virtual bool get_relative_position_NED_home(Vector3f &vec) const {
+    virtual bool get_relative_position_NED_home(Vector3f &vec) const WARN_IF_UNUSED {
         return false;
     }
 
     // return a position relative to origin in meters, North/East/Down
     // order. This will only be accurate if have_inertial_nav() is
     // true
-    virtual bool get_relative_position_NED_origin(Vector3f &vec) const {
+    virtual bool get_relative_position_NED_origin(Vector3f &vec) const WARN_IF_UNUSED {
         return false;
     }
     // return a position relative to home in meters, North/East
     // order. Return true if estimate is valid
-    virtual bool get_relative_position_NE_home(Vector2f &vecNE) const {
+    virtual bool get_relative_position_NE_home(Vector2f &vecNE) const WARN_IF_UNUSED {
         return false;
     }
 
     // return a position relative to origin in meters, North/East
     // order. Return true if estimate is valid
-    virtual bool get_relative_position_NE_origin(Vector2f &vecNE) const {
+    virtual bool get_relative_position_NE_origin(Vector2f &vecNE) const WARN_IF_UNUSED {
         return false;
     }
 
     // return a Down position relative to home in meters
     // if EKF is unavailable will return the baro altitude
-    virtual void get_relative_position_D_home(float &posD) const = 0;
+    virtual void get_relative_position_D_home(float &posD) const WARN_IF_UNUSED = 0;
 
     // return a Down position relative to origin in meters
     // Return true if estimate is valid
-    virtual bool get_relative_position_D_origin(float &posD) const {
+    virtual bool get_relative_position_D_origin(float &posD) const WARN_IF_UNUSED {
         return false;
     }
 
@@ -428,17 +428,17 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // return secondary attitude solution if available, as eulers in radians
-    virtual bool get_secondary_attitude(Vector3f &eulers) const {
+    virtual bool get_secondary_attitude(Vector3f &eulers) const WARN_IF_UNUSED {
         return false;
     }
 
     // return secondary attitude solution if available, as quaternion
-    virtual bool get_secondary_quaternion(Quaternion &quat) const {
+    virtual bool get_secondary_quaternion(Quaternion &quat) const WARN_IF_UNUSED {
         return false;
     }
 
     // return secondary position solution if available
-    virtual bool get_secondary_position(struct Location &loc) const {
+    virtual bool get_secondary_position(struct Location &loc) const WARN_IF_UNUSED {
         return false;
     }
 
@@ -504,19 +504,19 @@ public:
 
     // return the amount of NE position change in metres due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) const {
+    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) const WARN_IF_UNUSED {
         return 0;
     };
 
     // return the amount of NE velocity change in metres/sec due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) const {
+    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) const WARN_IF_UNUSED {
         return 0;
     };
 
     // return the amount of vertical position change due to the last reset in meters
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosDownReset(float &posDelta) const {
+    virtual uint32_t getLastPosDownReset(float &posDelta) const WARN_IF_UNUSED {
         return 0;
     };
 
@@ -525,7 +525,7 @@ public:
     // Adjusts the EKf origin height so that the EKF height + origin height is the same as before
     // Returns true if the height datum reset has been performed
     // If using a range finder for height no reset is performed and it returns false
-    virtual bool resetHeightDatum(void) {
+    virtual bool resetHeightDatum(void) WARN_IF_UNUSED {
         return false;
     }
 
@@ -575,7 +575,7 @@ public:
     // get_hgt_ctrl_limit - get maximum height to be observed by the
     // control loops in meters and a validity flag.  It will return
     // false when no limiting is required
-    virtual bool get_hgt_ctrl_limit(float &limit) const { return false; };
+    virtual bool get_hgt_ctrl_limit(float &limit) const WARN_IF_UNUSED { return false; };
 
     // Write position and quaternion data from an external navigation system
     virtual void writeExtNavData(const Vector3f &sensOffset, const Vector3f &pos, const Quaternion &quat, float posErr, float angErr, uint32_t timeStamp_ms, uint32_t resetTime_ms) { }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1075,14 +1075,3 @@ bool AP_AHRS_DCM::healthy(void) const
     // consider ourselves healthy if there have been no failures for 5 seconds
     return (_last_failure_ms == 0 || AP_HAL::millis() - _last_failure_ms > 5000);
 }
-
-/*
-  return amount of time that AHRS has been up
- */
-uint32_t AP_AHRS_DCM::uptime_ms(void) const
-{
-    if (_last_startup_ms == 0) {
-        return 0;
-    }
-    return AP_HAL::millis() - _last_startup_ms;
-}

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -102,9 +102,6 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 
-    // time that the AHRS has been up
-    uint32_t uptime_ms() const override;
-
 private:
     float _ki;
     float _ki_yaw;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -76,7 +76,7 @@ public:
       wrappers around ahrs functions which pass-thru directly. See
       AP_AHRS.h for description of each function
      */
-    bool get_position(struct Location &loc) const {
+    bool get_position(struct Location &loc) const WARN_IF_UNUSED {
         return ahrs.get_position(loc);
     }
 
@@ -84,11 +84,11 @@ public:
         return ahrs.wind_estimate();
     }
 
-    bool airspeed_estimate(float *airspeed_ret) const {
+    bool airspeed_estimate(float *airspeed_ret) const WARN_IF_UNUSED {
         return ahrs.airspeed_estimate(airspeed_ret);
     }
 
-    bool airspeed_estimate_true(float *airspeed_ret) const {
+    bool airspeed_estimate_true(float *airspeed_ret) const WARN_IF_UNUSED {
         return ahrs.airspeed_estimate_true(airspeed_ret);
     }
 
@@ -100,27 +100,27 @@ public:
         return ahrs.groundspeed_vector();
     }
 
-    bool get_velocity_NED(Vector3f &vec) const {
+    bool get_velocity_NED(Vector3f &vec) const WARN_IF_UNUSED {
         return ahrs.get_velocity_NED(vec);
     }
 
-    bool get_expected_mag_field_NED(Vector3f &ret) const {
+    bool get_expected_mag_field_NED(Vector3f &ret) const WARN_IF_UNUSED {
         return ahrs.get_expected_mag_field_NED(ret);
     }
 
-    bool get_relative_position_NED_home(Vector3f &vec) const {
+    bool get_relative_position_NED_home(Vector3f &vec) const WARN_IF_UNUSED {
         return ahrs.get_relative_position_NED_home(vec);
     }
 
-    bool get_relative_position_NED_origin(Vector3f &vec) const {
+    bool get_relative_position_NED_origin(Vector3f &vec) const WARN_IF_UNUSED {
         return ahrs.get_relative_position_NED_origin(vec);
     }
 
-    bool get_relative_position_NE_home(Vector2f &vecNE) const {
+    bool get_relative_position_NE_home(Vector2f &vecNE) const WARN_IF_UNUSED {
         return ahrs.get_relative_position_NE_home(vecNE);
     }
 
-    bool get_relative_position_NE_origin(Vector2f &vecNE) const {
+    bool get_relative_position_NE_origin(Vector2f &vecNE) const WARN_IF_UNUSED {
         return ahrs.get_relative_position_NE_origin(vecNE);
     }
 
@@ -128,7 +128,7 @@ public:
         ahrs.get_relative_position_D_home(posD);
     }
 
-    bool get_relative_position_D_origin(float &posD) const {
+    bool get_relative_position_D_origin(float &posD) const WARN_IF_UNUSED {
         return ahrs.get_relative_position_D_origin(posD);
     }
 
@@ -140,11 +140,11 @@ public:
         return ahrs.get_accel_ef_blended();
     }
 
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) const {
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) const WARN_IF_UNUSED {
         return ahrs.getLastPosNorthEastReset(pos);
     }
 
-    uint32_t getLastPosDownReset(float &posDelta) const {
+    uint32_t getLastPosDownReset(float &posDelta) const WARN_IF_UNUSED {
         return ahrs.getLastPosDownReset(posDelta);
     }
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -759,7 +759,9 @@ uint32_t AP_Frsky_Telem::calc_velandyaw(void)
     Vector3f velNED {};
 
     // if we can't get velocity then we use zero for vertical velocity
-    _ahrs.get_velocity_NED(velNED);
+    if (!_ahrs.get_velocity_NED(velNED)) {
+      velNED.zero();
+    }
     // vertical velocity in dm/s
     velandyaw = prep_number(roundf(-velNED.z * 10), 2, 1);
     // horizontal velocity in dm/s (use airspeed if available and enabled - even if not used - otherwise use groundspeed)

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -337,7 +337,10 @@ bool AP_Landing_Deepstall::override_servos(void)
 
     // use the current airspeed to dictate the travel limits
     float airspeed;
-    landing.ahrs.airspeed_estimate(&airspeed);
+    if (!landing.ahrs.airspeed_estimate(&airspeed)) {
+        airspeed = 0; // safely forces control to the deepstall steering since we don't have an estimate
+    }
+
 
     // only allow the deepstall steering controller to run below the handoff airspeed
     if (slew_progress >= 1.0f || airspeed <= handoff_airspeed) {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -473,10 +473,9 @@ void AP_Logger::Write_AHRS2(AP_AHRS &ahrs)
     Vector3f euler;
     struct Location loc;
     Quaternion quat;
-    if (!ahrs.get_secondary_attitude(euler) || !ahrs.get_secondary_position(loc)) {
+    if (!ahrs.get_secondary_attitude(euler) || !ahrs.get_secondary_position(loc) || !ahrs.get_secondary_quaternion(quat)) {
         return;
     }
-    ahrs.get_secondary_quaternion(quat);
     struct log_AHRS pkt = {
         LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
         time_us : AP_HAL::micros64(),

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -443,12 +443,10 @@ protected:
     virtual int32_t global_position_int_alt() const;
     virtual int32_t global_position_int_relative_alt() const;
 
-    // these methods are called after vfr_hud_velned is updated
     virtual float vfr_hud_climbrate() const;
     virtual float vfr_hud_airspeed() const;
     virtual int16_t vfr_hud_throttle() const { return 0; }
     virtual float vfr_hud_alt() const;
-    Vector3f vfr_hud_velned;
 
     static constexpr const float magic_force_arm_value = 2989.0f;
     static constexpr const float magic_force_disarm_value = 21196.0f;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2460,7 +2460,11 @@ float GCS_MAVLINK::vfr_hud_airspeed() const
 
 float GCS_MAVLINK::vfr_hud_climbrate() const
 {
-    return -vfr_hud_velned.z;
+    Vector3f velned;
+    if (!AP::ahrs().get_velocity_NED(velned)) {
+      velned.zero();
+    }
+    return -velned.z;
 }
 
 float GCS_MAVLINK::vfr_hud_alt() const
@@ -2474,7 +2478,6 @@ void GCS_MAVLINK::send_vfr_hud()
 
     // return values ignored; we send stale data
     ahrs.get_position(global_position_current_loc);
-    ahrs.get_velocity_NED(vfr_hud_velned);
 
     mavlink_msg_vfr_hud_send(
         chan,
@@ -3892,7 +3895,9 @@ void GCS_MAVLINK::send_global_position_int()
     ahrs.get_position(global_position_current_loc); // return value ignored; we send stale data
 
     Vector3f vel;
-    ahrs.get_velocity_NED(vel);
+    if (!ahrs.get_velocity_NED(vel)) {
+        vel.zero();
+    }
 
     mavlink_msg_global_position_int_send(
         chan,


### PR DESCRIPTION
Following on from the dev call this introduces more usage of WARN_IF_UNUSED on the AHRS. Key things to note:
  - Some places like FrskyTelem had a comment that says send 0 if not available, but the library may actually manipulate the passed in reference even though it returned false. In these cases I made us honor the commented behavior.
  - The AP_Landing error was an actual bug if you somehow don't have an airspeed estimate (although it is expected to always have one on plane)
  - I removed the persistent cached velocity_NED from GCS_MAVLink. This has 2 effects, the first (and the reason I did it), it removes the ability to use an old stale value by accident in the future. And the second one is this now means that if you fallback to DCM we report a climb rate of 0, rather then freezing on whatever the most recent EKF climb rate estimate was. This is a real behavior change but I think it's correct. (Ideally we should provide get_velocity_NED() for DCM)
  - The AHRS `WARN_IF_UNUSED` commits can be squashed, I just did them in different passes, and decided to keep them separate for review.