### PR TITLE
Copter: speed up EKF failsafe by checking if velocity innovations > 2x FS_EKF_THRESH

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -105,7 +105,9 @@ bool Copter::ekf_over_threshold()
     if (mag_variance.length() >= g.fs_ekf_thresh) {
         over_thresh_count++;
     }
-    if (vel_variance >= g.fs_ekf_thresh) {
+    if (vel_variance >= (2.0f * g.fs_ekf_thresh)) {
+        over_thresh_count+=2;
+    } else if (vel_variance >= g.fs_ekf_thresh) {
         over_thresh_count++;
     }
     if (position_variance >= g.fs_ekf_thresh) {


### PR DESCRIPTION
fix #10466 

I tested it with skyviper journey GPS and attack it using GPS jammer. After GPS is jammed, my drone went crazy but when SV go up to twice FS_EKF_THRESH, EKF failsafe is triggered and landing. In my test, SP and SM did not go over 0.8 (default  FS_EKF_THRESH), so EKF failsafe was not triggered in current master.
![ekf_fs1](https://user-images.githubusercontent.com/19793511/54260238-520bc680-45a3-11e9-8598-7bf142995d22.jpg)
![ekf_fs2](https://user-images.githubusercontent.com/19793511/54260256-6223a600-45a3-11e9-94ae-51ee692209e9.jpg)

