### PR TITLE
Fix gcc8 warning

### DIFF
--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -144,7 +144,6 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 Tracker::Tracker(void)
     : logger(g.log_bitmask)
 {
-    memset(&vehicle, 0, sizeof(vehicle));
 }
 
 Tracker tracker;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -500,7 +500,7 @@ assert_storage_size<PackedContent, 12> assert_storage_size_PackedContent;
 bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) const
 {
     WITH_SEMAPHORE(_rsem);
-    
+
     // exit immediately if index is beyond last command but we always let cmd #0 (i.e. home) be read
     if (index >= (unsigned)_cmd_total && index != 0) {
         return false;
@@ -545,7 +545,8 @@ bool AP_Mission::read_cmd_from_storage(uint16_t index, Mission_Command& cmd) con
             // all other options in Content are assumed to be packed:
             static_assert(sizeof(cmd.content) >= 12,
                           "content is big enough to take bytes");
-            memcpy(&cmd.content, packed_content.bytes, 12);
+            // (void *) cast to specify gcc that we know that we are copy byte into a non trivial type and leaving 4 bytes untouched
+            memcpy((void *)&cmd.content, packed_content.bytes, 12);
         }
 
         // set command's index to it's position in eeprom


### PR DESCRIPTION
This fix two gcc8 warning :
```
../../AntennaTracker/AntennaTracker.cpp: In constructor ‘Tracker::Tracker()’:
../../AntennaTracker/AntennaTracker.cpp:147:40: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct Tracker::<unnamed>’; use assignment or value-initialization instead [-Wclass-memaccess]
     memset(&vehicle, 0, sizeof(vehicle));
                                        ^
In file included from ../../AntennaTracker/AntennaTracker.cpp:20:
../../AntennaTracker/Tracker.h:167:12: note: ‘struct Tracker::<unnamed>’ declared here
     struct {

```
There memset is not necessary as we could just zero init the structure

and 

```
../../libraries/AP_Mission/AP_Mission.cpp: In member function ‘bool AP_Mission::read_cmd_from_storage(uint16_t, AP_Mission::Mission_Command&) const’:
../../libraries/AP_Mission/AP_Mission.cpp:548:58: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of a non-trivial type ‘union AP_Mission::Content’ leaves 4 bytes unchanged [-Wclass-memaccess]
             memcpy(&cmd.content, packed_content.bytes, 12);
                                                          ^
In file included from ../../libraries/AP_Mission/AP_Mission.cpp:4:
../../libraries/AP_Mission/AP_Mission.h:195:11: note: ‘union AP_Mission::Content’ declared here
     union Content {
           ^~~~~~~
```

This one is more tricky, as it is currently working with memcpy, the simplier is to use (void *) to tell gcc that we know what we are doing and leave a comment about it.