### PR TITLE
Plane: VTOL Pitch trim bug fix for none tailsitters

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -119,7 +119,7 @@ void GCS_MAVLINK_Plane::send_attitude() const
     float p = ahrs.pitch - radians(plane.g.pitch_trim_cd*0.01f);
     float y = ahrs.yaw;
     
-    if (plane.quadplane.tailsitter_active()) {
+    if (plane.quadplane.in_vtol_mode()) {
         r = plane.quadplane.ahrs_view->roll;
         p = plane.quadplane.ahrs_view->pitch;
         y = plane.quadplane.ahrs_view->yaw;

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -42,6 +42,8 @@ AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_
     _pitch_trim_deg = pitch_trim_deg;
     // Add pitch trim
     rot_view.from_euler(0, radians(wrap_360(y_angle + pitch_trim_deg)), 0);
+    rot_view_T = rot_view;
+    rot_view_T.transpose();
 
     // setup initial state
     update();
@@ -51,6 +53,8 @@ AP_AHRS_View::AP_AHRS_View(AP_AHRS &_ahrs, enum Rotation _rotation, float pitch_
 void AP_AHRS_View::set_pitch_trim(float trim_deg) {
     _pitch_trim_deg = trim_deg; 
     rot_view.from_euler(0, radians(wrap_360(y_angle + _pitch_trim_deg)), 0);
+    rot_view_T = rot_view;
+    rot_view_T.transpose();
 };
 
 // update state
@@ -60,11 +64,8 @@ void AP_AHRS_View::update(bool skip_ins_update)
     gyro = ahrs.get_gyro();
 
     if (!is_zero(y_angle + _pitch_trim_deg)) {
-        Matrix3f &r = rot_body_to_ned;
-        r.transpose();
-        r = rot_view * r;
-        r.transpose();
-        gyro.rotate(rotation);
+        rot_body_to_ned = rot_body_to_ned * rot_view_T;
+        gyro = rot_view * gyro;
     }
 
     rot_body_to_ned.to_euler(&roll, &pitch, &yaw);

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -59,7 +59,7 @@ void AP_AHRS_View::update(bool skip_ins_update)
     rot_body_to_ned = ahrs.get_rotation_body_to_ned();
     gyro = ahrs.get_gyro();
 
-    if (!is_zero(y_angle)) {
+    if (!is_zero(y_angle + _pitch_trim_deg)) {
         Matrix3f &r = rot_body_to_ned;
         r.transpose();
         r = rot_view * r;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -183,7 +183,10 @@ private:
     const enum Rotation rotation;
     AP_AHRS &ahrs;
 
+    // body frame rotation for this View
     Matrix3f rot_view;
+    // transpose of rot_view
+    Matrix3f rot_view_T;
     Matrix3f rot_body_to_ned;
     Vector3f gyro;
 


### PR DESCRIPTION
This fixes the pitch trim parameter to allow it to be used for all Quadplanes, previously despite being available it would only work with tailsitters