### PR TITLE
Tailsitters: further specialize AP_MotorsMatrixTS, add tailsitter attitude controller

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -738,17 +738,25 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     check_attitude_relax();
 
     if (in_vtol_mode() || is_tailsitter()) {
-        if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL) {
-            // Angle mode attitude control for pitch and body-frame roll, rate control for yaw.
-            // this version interprets the first argument as yaw rate and the third as roll angle
-            // because it is intended to be used with Q_TAILSIT_INPUT=1 where the roll and yaw sticks
-            // act in the tailsitter's body frame (i.e. roll is MC/earth frame yaw and
-            // yaw is MC/earth frame roll)
-            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(plane.nav_roll_cd,
-                                                                             plane.nav_pitch_cd,
-                                                                             yaw_rate_cds);
+        if (is_tailsitter()) {
+            // Use tailsitter-specific attitude controllers
+            if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL) {
+                // Angle mode attitude control for pitch and body-frame roll, rate control for yaw.
+                // this version interprets the first argument as yaw rate and the third as roll angle
+                // because it is intended to be used with Q_TAILSIT_INPUT=1 where the roll and yaw sticks
+                // act in the tailsitter's body frame (i.e. roll is MC/earth frame yaw and
+                // yaw is MC/earth frame roll)
+                attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(plane.nav_roll_cd,
+                                                                                 plane.nav_pitch_cd,
+                                                                                 yaw_rate_cds);
+            } else {
+                // use euler angle attitude control for copter tailsitters
+                attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_ts(plane.nav_roll_cd,
+                                                                                 plane.nav_pitch_cd,
+                                                                                 yaw_rate_cds);
+            }
         } else {
-            // use euler angle attitude control
+            // use the multicopter euler angle attitude controller
             attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                           plane.nav_pitch_cd,
                                                                           yaw_rate_cds);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -131,6 +131,9 @@ public:
     // Command an euler roll and pitch angle and an euler yaw rate with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_euler_rate_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
 
+    // Command an euler roll and pitch angle and an euler yaw rate with no feedforward or smoothing
+    virtual void input_euler_angle_roll_pitch_euler_rate_yaw_ts(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+
     // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw);
 


### PR DESCRIPTION
further customizes and reduces complexity of the motor and attitude control logic for tailsitters

Tested in SITL with the RealFlight8 AddictionX and Stryker_quad
Should be no functional change for non-tailsitters.