### PR TITLE
AC_AttitudeControl: improve tailsitter bodyframe roll control

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -278,7 +278,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Param: TAILSIT_INPUT
     // @DisplayName: Tailsitter input type
     // @Description: This controls whether stick input when hovering as a tailsitter follows the conventions for fixed wing hovering or multicopter hovering. When multicopter input is selected the roll stick will roll the aircraft in earth frame and yaw stick will yaw in earth frame. When using fixed wing input the roll and yaw sticks are swapped so that the roll stick controls earth-frame yaw and rudder controls earth-frame roll. When body-frame roll is selected, the yaw stick controls earth-frame yaw rate and the roll stick controls roll in the tailsitter's body frame.
-    // @Values: 0:MultiCopterInput,1:FixedWingInput,2:BodyFrameRoll
+    // @Values: 0:MultiCopterInput,1:FixedWingInput,2:BodyFrameRoll_M,3:BodyFrameRoll_P
     AP_GROUPINFO("TAILSIT_INPUT", 50, QuadPlane, tailsitter.input_type, TAILSITTER_INPUT_MULTICOPTER),
 
     // @Param: TAILSIT_MASK
@@ -738,15 +738,19 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     check_attitude_relax();
 
     if (in_vtol_mode() || is_tailsitter()) {
-        if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL) {
+        if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M) {
             // Angle mode attitude control for pitch and body-frame roll, rate control for yaw.
             // this version interprets the first argument as yaw rate and the third as roll angle
             // because it is intended to be used with Q_TAILSIT_INPUT=1 where the roll and yaw sticks
             // act in the tailsitter's body frame (i.e. roll is MC/earth frame yaw and
             // yaw is MC/earth frame roll)
-            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll(plane.nav_roll_cd,
-                                                                             plane.nav_pitch_cd,
-                                                                             yaw_rate_cds);
+            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(plane.nav_roll_cd,
+                                                                               plane.nav_pitch_cd,
+                                                                               yaw_rate_cds);
+        } else if (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P) {
+            attitude_control->input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(plane.nav_roll_cd,
+                                                                               plane.nav_pitch_cd,
+                                                                               yaw_rate_cds);
         } else {
             // use euler angle attitude control
             attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -414,7 +414,8 @@ private:
     enum tailsitter_input {
         TAILSITTER_INPUT_MULTICOPTER = 0,
         TAILSITTER_INPUT_PLANE       = 1,
-        TAILSITTER_INPUT_BF_ROLL     = 2,
+        TAILSITTER_INPUT_BF_ROLL_M   = 2,
+        TAILSITTER_INPUT_BF_ROLL_P   = 3,
     };
 
     enum tailsitter_mask {

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -210,7 +210,8 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 void QuadPlane::tailsitter_check_input(void)
 {
     if (tailsitter_active() &&
-        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL ||
+        (tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_P ||
+         tailsitter.input_type == TAILSITTER_INPUT_BF_ROLL_M ||
          tailsitter.input_type == TAILSITTER_INPUT_PLANE)) {
         // the user has asked for body frame controls when tailsitter
         // is active. We switch around the control_in value for the

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -366,32 +366,21 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll(float eu
     float euler_pitch = radians(euler_pitch_cd*0.01f);
     float body_roll = radians(body_roll_cd*0.01f);
 
-    // back out the body roll to get current euler_yaw
-    Quaternion bf_roll_Q;
-    bf_roll_Q.from_axis_angle(Vector3f(0, 0, -_last_body_roll));
-    Quaternion base_att_Q = _attitude_target_quat * bf_roll_Q;
-
-    // avoid Euler singularities
-    if (_last_euler_pitch > M_PI_4) {
-        base_att_Q.rotate(Vector3f(0,-M_PI_2,0));
-    } else if (_last_euler_pitch < -M_PI_4) {
-        base_att_Q.rotate(Vector3f(0,M_PI_2,0));
-    }
-
-    // current heading
-    float heading = base_att_Q.get_euler_yaw();
-
     // new heading
-    heading = wrap_PI(heading + euler_yaw_rate * _dt);
+    _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
 
     // init attitude target to desired euler yaw and pitch with zero roll
-    _attitude_target_quat.from_euler(0, euler_pitch, heading);
-    _last_euler_pitch = euler_pitch;
+    _attitude_target_quat.from_euler(0, euler_pitch, _attitude_target_euler_angle.z);
 
-    // apply body-frame yaw (this is roll for a tailsitter in forward flight)
-    bf_roll_Q.from_axis_angle(Vector3f(0, 0, body_roll));
-    _last_body_roll = body_roll;
-    _attitude_target_quat = _attitude_target_quat * bf_roll_Q;
+    // apply body-frame yaw/roll (this is roll/yaw for a tailsitter in forward flight)
+    // rotate body_roll axis by |sin(pitch angle)|
+    Quaternion bf_roll_Q;
+    bf_roll_Q.from_axis_angle(Vector3f(0, 0, fabsf(sinf(euler_pitch)) * body_roll));
+
+    // rotate body_yaw axis by cos(pitch angle)
+    Quaternion bf_yaw_Q;
+    bf_yaw_Q.from_axis_angle(Vector3f(-cosf(euler_pitch), 0, 0), body_roll);
+    _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
 
     // Set rate feedforward requests to zero
     _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -434,11 +434,6 @@ protected:
     // true in inverted flight mode
     bool _inverted_flight;
 
-    // state for input_euler_rate_yaw_euler_angle_pitch_bf_roll()
-    // (would be expensive to compute from _attitude_target_quat)
-    float _last_body_roll;
-    float _last_euler_pitch;
-
 public:
     // log a CTRL message
     void control_monitor_log(void);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -134,8 +134,13 @@ public:
     // Command an euler roll, pitch and yaw angle with angular velocity feedforward and smoothing
     virtual void input_euler_angle_roll_pitch_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, bool slew_yaw);
 
-    // Command euler yaw rate and pitch angle with roll angle specified in body frame 
-    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+    // Command euler yaw rate and pitch angle with roll angle specified in body frame with multicopter style controls
+    // (used only by tailsitter quadplanes)
+    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+
+    // Command euler yaw rate and pitch angle with roll angle specified in body frame with plane style controls
+    // (used only by tailsitter quadplanes)
+    virtual void input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
 
     // Command an euler roll, pitch, and yaw rate with angular velocity feedforward and smoothing
     void input_euler_rate_roll_pitch_yaw(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);


### PR DESCRIPTION
Splits the roll command input into bodyframe roll and yaw as a function of Euler pitch.
Behaves similar to INPUT_TYPE_MULTICOPTER when hovering and similar to QACRO in cruise attitudes.
