### PR TITLE
Linux: added support for GPIO scripts

### DIFF
--- a/Tools/Frame_params/Parrot_Disco/gpio.sh
+++ b/Tools/Frame_params/Parrot_Disco/gpio.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# this is a script triggered from GPIO changes. It is setup to take photos
+# start/stop recording and start/stop streaming on a disco
+
+PIN="$1"
+VALUE="$2"
+echo "got pin=$PIN value=$VALUE"
+
+PATH=$PATH:/bin:/usr/bin:/data/ftp/internal_000/ardupilot
+export PATH
+
+cd /data/ftp/internal_000/ardupilot
+
+if [ $PIN = 100 ]; then
+    # take photo when high
+    if [ $VALUE = 1 ]; then
+        echo "$(date) Taking picture" >> gpio.log
+        /usr/bin/pimpctl take-picture front
+    fi
+fi
+
+if [ $PIN = 101 ]; then
+    # recording start/stop
+    if [ $VALUE = 1 ]; then
+        echo "$(date) Starting recording" >> gpio.log
+        /usr/bin/pimpctl recording-start front
+    else
+        echo "$(date) Stopping recording" >> gpio.log
+        /usr/bin/pimpctl recording-stop front
+    fi
+fi
+
+if [ $PIN = 102 ]; then
+    GCS_IP=$(netstat -n|grep 14550 | head -1 | awk '{print $5}'| cut -d: -f1)
+    # streaming start/stop
+    if [ $VALUE = 1 ]; then
+        echo "$(date) Starting streaming to $GCS_IP 8888" >> gpio.log
+        /usr/bin/pimpctl stream-start front $GCS_IP 8888
+    else
+        echo "$(date) Stopping streaming to $GCS_IP 8888" >> gpio.log
+        /usr/bin/pimpctl stream-stop front $GCS_IP 8888
+    fi
+fi

--- a/Tools/Frame_params/Parrot_Disco/start_ardupilot.sh
+++ b/Tools/Frame_params/Parrot_Disco/start_ardupilot.sh
@@ -1,20 +1,39 @@
 #!/bin/sh
 
-cd /data/ftp/internal_000/APM
+cd /data/ftp/internal_000/ardupilot
 (
- date
+ /bin/date
+ /bin/ls
 
+ /bin/dragon_ipc.sh dragon_shutdown
+ /bin/sleep 2
+ /usr/bin/killall -KILL dragon-prog
+ /bin/sleep 1
+
+ echo "step2"
  # stop stock led daemon
- pstop ledd
+ /usr/bin/pstop ledd
+
+ # setup for video
+ /usr/bin/media-ctl -l '"mt9f002 0-0010":0->"avicam.0":0[1]'
+ /usr/bin/media-ctl -l '"avicam_dummy_dev.0":0->"avicam.0":0[0]'
+ /usr/bin/prestart dxowrapperd
+ /usr/bin/prestart pimp
+
+ echo "step3"
 
  # startup fan
  echo 1 > /sys/devices/platform/user_gpio/FAN/value
- 
+
+ # setup GPS
+ echo 1 > /sys/devices/platform/user_gpio/RESET_GNSS/value
+ /bin/sleep 1
+ echo 0 > /sys/devices/platform/user_gpio/RESET_GNSS/value
+
+ echo "step4"
+
  while :; do
     echo "$(date) Starting arduplane"
    ./arduplane -A udp:192.168.42.255:14550:bcast -B /dev/ttyPA1 -C udp:192.168.43.255:14550:bcast --module-directory modules
  done
-) >> start_ardupilot.log 2>&1 &
-
-
-
+) >> start_ardupilot.log 2>&1

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -120,6 +120,7 @@
     // the disco has challenges with its magnetic setup
     #define AP_COMPASS_OFFSETS_MAX_DEFAULT 2200
     #define HAL_BATT_MONITOR_DEFAULT AP_BattMonitor_Params::BattMonitor_TYPE_BEBOP
+    #define HAL_GPIO_SCRIPT "/data/ftp/internal_000/ardupilot/gpio.sh"
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
     #define HAL_GPIO_A_LED_PIN 0
     #define HAL_GPIO_B_LED_PIN 1

--- a/libraries/AP_HAL_Linux/GPIO_Sysfs.h
+++ b/libraries/AP_HAL_Linux/GPIO_Sysfs.h
@@ -2,6 +2,7 @@
 
 #include "AP_HAL_Linux.h"
 #include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/RingBuffer.h>
 
 #include "GPIO.h"
 
@@ -67,6 +68,31 @@ protected:
      * Note: the pin is ignored if already exported.
      */
     static bool _export_pin(uint8_t vpin);
+
+#ifdef HAL_GPIO_SCRIPT
+    /*
+      support for calling external scripts based on GPIO writes
+     */
+    void _gpio_script_write(uint8_t vpin, uint8_t value);
+
+    /*
+      thread to run scripts
+     */
+    void _gpio_script_thread(void);
+
+    /*
+      control structures for _gpio_script_write
+     */
+    typedef struct {
+        uint8_t pin;
+        uint8_t value;
+    } pin_value_t;
+
+    struct {
+        bool thread_created;
+        ObjectBuffer<pin_value_t> pending{10};
+    } _script;
+#endif // HAL_GPIO_SCRIPT
 };
 
 }


### PR DESCRIPTION
This gets video controls going on the disco by allowing users to run arbitrary scripts associated with GPIOs. These can be connected via the RELAY_PIN settings, which allows for control via RCn_OPTION, mavlink, missions etc
