### PR TITLE
AP_ADSB: add logging

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -149,7 +149,7 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Param: LOG
     // @DisplayName: ADS-B logging
     // @Description: 0: no logging, 1: log only special ID, 2:log all
-    // @Values: 0: no logging, 1: log only special ID, 2:log all
+    // @Values: 0:no logging,1:log only special ID,2:log all
     // @User: Advanced
     AP_GROUPINFO("LOG",  14, AP_ADSB, _log, 1),
 
@@ -889,7 +889,7 @@ bool AP_ADSB::get_vehicle_by_ICAO(const uint32_t icao, adsb_vehicle_t &vehicle) 
 }
 
 /*
- * Write dataflash log of a vehicle
+ * Write vehicle to log
  */
 void AP_ADSB::write_log(const adsb_vehicle_t &vehicle)
 {

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -194,4 +194,12 @@ private:
 
     void push_sample(adsb_vehicle_t &vehicle);
 
+    // logging
+    AP_Int8 _log;
+    void write_log(const adsb_vehicle_t &vehicle);
+    enum logging {
+        NONE            = 0,
+        SPECIAL_ONLY    = 1,
+        ALL             = 2
+    };
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -725,6 +725,19 @@ struct PACKED log_WheelEncoder {
     uint8_t quality_1;
 };
 
+struct PACKED log_ADSB {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint32_t ICAO_address;
+    int32_t lat;
+    int32_t lng;
+    int32_t alt;
+    uint16_t heading;
+    uint16_t hor_velocity;
+    int16_t ver_velocity;
+    uint16_t squawk;
+};
+
 struct PACKED log_Current_Cells {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1484,7 +1497,9 @@ Format characters in the format string for binary log messages
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY", "s-EEEE", "F-0000" }, \
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \
-      "WENC",  "Qfbfb", "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" }
+      "WENC",  "Qfbfb", "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" }, \
+    { LOG_ADSB_MSG, sizeof(log_ADSB), \
+      "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }
 
 
 // #if SBP_HW_LOGGING
@@ -1660,6 +1675,7 @@ enum LogMessages : uint8_t {
     LOG_WHEELENCODER_MSG,
     LOG_MAV_MSG,
     LOG_ERROR_MSG,
+    LOG_ADSB_MSG,
 
     _LOG_LAST_MSG_
 };


### PR DESCRIPTION
This adds logging to the ADSB library. By default this logs only the special ID aircraft if one is set. Parameter also gives the option to log nothing or everything. Logs everything received over ADSB except call sign because I couldn't work out how to log a character array.

Tested in SITL using Plane.