### PR TITLE
Copter tailsitters: specialize motor controls

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -954,7 +954,11 @@ void QuadPlane::control_qacro(void)
         float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
 
         // run attitude controller
-        attitude_control->input_rate_bf_roll_pitch_yaw_3(target_roll, target_pitch, target_yaw);
+        if (plane.g.acro_locking) {
+            attitude_control->input_rate_bf_roll_pitch_yaw_3(target_roll, target_pitch, target_yaw);
+        } else {
+            attitude_control->input_rate_bf_roll_pitch_yaw_2(target_roll, target_pitch, target_yaw);
+        }
 
         // output pilot's throttle without angle boost
         attitude_control->set_throttle_out(throttle_out, false, 10.0f);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1815,7 +1815,9 @@ void QuadPlane::control_run(void)
     switch (plane.control_mode) {
     case QACRO:
         control_qacro();
-        break;
+        // QACRO uses only the multicopter controller
+        // so skip the Plane attitude control calls below
+        return;
     case QSTABILIZE:
         control_stabilize();
         break;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -77,30 +77,30 @@ void QuadPlane::tailsitter_output(void)
         float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
         if (hal.util->get_soft_armed()) {
             if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying()) {
-            /*
-              during transitions to vtol mode set the throttle to
-              hover thrust, center the rudder and set the altitude controller
-              integrator to the same throttle level
-             */
-            throttle = motors->get_throttle_hover() * 100;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
-            pos_control->get_accel_z_pid().set_integrator(throttle*10);
-            
-            if (mask == 0) {
-                // override AP_MotorsTailsitter throttles during back transition
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+                /*
+                  during transitions to vtol mode set the throttle to
+                  hover thrust, center the rudder and set the altitude controller
+                  integrator to the same throttle level
+                 */
+                throttle = motors->get_throttle_hover() * 100;
+                SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
+                pos_control->get_accel_z_pid().set_integrator(throttle*10);
+
+                if (mask == 0) {
+                    // override AP_MotorsTailsitter throttles during back transition
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                    SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+                }
             }
-        }
-        if (mask != 0) {
-            // set AP_MotorsMatrix throttles enabled for forward flight
-            motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
+            if (mask != 0) {
+                // set AP_MotorsMatrix throttles enabled for forward flight
+                motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
             }
         }
         return;
     }
-    
+
     // handle VTOL modes
     // the MultiCopter rate controller has already been run in an earlier call 
     // to motors_output() from quadplane.update()


### PR DESCRIPTION
Simplifies the logic for output_armed_stabilizing() in the same way as AP_MotorsTailsitter.

The rate-only option is selected by setting parameter ACRO_RATE_LOCKING to zero. It uses method
input_rate_bf_roll_pitch_yaw_2 which does not use the target attitude in computing rate error.
This makes trim changes more apparent to the pilot, and is useful in adjusting the CG for optimum
performance.

The original method (input_rate_bf_roll_pitch_yaw_3) is selected by setting ACRO_RATE_LOCKING to 1.