### PR TITLE
Moving Log_Write_AutoTune to mode_autotune.cpp

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -476,6 +476,7 @@ public:
     bool is_autopilot() const override { return false; }
     void save_tuning_gains();
     void stop();
+    void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt);
 
 protected:
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -173,4 +173,25 @@ void Copter::ModeAutoTune::stop()
     copter.autotune.stop();
 }
 
+void Copter::ModeAutoTune::Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt)
+{
+    AP::logger().Write(
+        "ATUN",
+        "TimeUS,Axis,TuneStep,Targ,Min,Max,RP,RD,SP,ddt",
+        "s--ddd---o",
+        "F--BBB---0",
+        "QBBfffffff",
+        AP_HAL::micros64(),
+        axis,
+        tune_step,
+        meas_target*0.01f,
+        meas_min*0.01f,
+        meas_max*0.01f,
+        new_gain_rp,
+        new_gain_rd,
+        new_gain_sp,
+        new_ddt);
+}
+
+
 #endif  // AUTOTUNE_ENABLED == ENABLED


### PR DESCRIPTION
As mentioned here #8008, i have moved the Implementation of ```Log_Write_AutoTune``` from ```AC_AutoTune.cpp``` to ```mode_autotune.cpp``` without removing anything .... i was supposed to find the implementation in ```Log.cpp``` but nothing was there and there was no declaration for the function in ```ModeAutoTune``` class which i had to do for this to work.

I don't know if someone cares about this change or not but here it is if someone cares to merge it.
Thanks ^ ^