### PR TITLE
NavEKF: account for autopilot-to-body rotation in getQuaternion

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1046,7 +1046,9 @@ void NavEKF2::getQuaternion(int8_t instance, Quaternion &quat) const
 {
     if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getQuaternion(quat);
+        Matrix3f mat;
+        core[instance].getRotationBodyToNED(mat);
+        quat.from_rotation_matrix(mat);
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1071,7 +1071,9 @@ void NavEKF3::getQuaternion(int8_t instance, Quaternion &quat) const
 {
     if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
-        core[instance].getQuaternion(quat);
+        Matrix3f mat;
+        core[instance].getRotationBodyToNED(mat);
+        quat.from_rotation_matrix(mat);
     }
 }
 


### PR DESCRIPTION
method description:: "return the quaternions defining the rotation from NED to XYZ (body) axes", but did not account for rotation from autopilot to vehicle body frame
Fixes failure to arm (attitudes_inconsistent) when AHRS_TRIM is larger than threshold: see #10836