### PR TITLE
Add NMEA output

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -83,6 +83,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_LandingGear',
     'AP_RobotisServo',
     'AP_ToshibaCAN',
+    'AP_NMEA_Output',
 ]
 
 def get_legacy_defines(sketch_name):

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -18,6 +18,7 @@
 #include "AP_AHRS_View.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_NMEA_Output/AP_NMEA_Output.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -158,6 +159,16 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
 
     AP_GROUPEND
 };
+
+// init sets up INS board orientation
+void AP_AHRS::init()
+{
+    update_orientation();
+
+#if !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE
+    _nmea_out = AP_NMEA_Output::probe();
+#endif
+}
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
 Vector3f AP_AHRS::get_gyro_latest(void) const
@@ -491,6 +502,15 @@ void AP_AHRS::Log_Write_Home_And_Origin()
     }
 }
 
+
+void AP_AHRS::update_nmea_out()
+{
+#if !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE
+    if (_nmea_out != nullptr) {
+        _nmea_out->update();
+    }
+#endif
+}
 
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -31,6 +31,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/Location.h>
 
+class AP_NMEA_Output;
 class OpticalFlow;
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
@@ -86,9 +87,7 @@ public:
     }
 
     // init sets up INS board orientation
-    virtual void init() {
-        update_orientation();
-    };
+    virtual void init();
 
     // Accessors
     void set_fly_forward(bool b) {
@@ -590,6 +589,7 @@ public:
     }
 
 protected:
+    void update_nmea_out();
 
     // multi-thread access support
     HAL_Semaphore_Recursive _rsem;
@@ -698,6 +698,7 @@ protected:
 private:
     static AP_AHRS *_singleton;
 
+    AP_NMEA_Output* _nmea_out;
 };
 
 #include "AP_AHRS_DCM.h"

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -130,6 +130,11 @@ void AP_AHRS_NavEKF::update(bool skip_ins_update)
         // update optional alternative attitude view
         _view->update(skip_ins_update);
     }
+
+#if !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE
+    // update NMEA output
+    update_nmea_out();
+#endif
 }
 
 void AP_AHRS_NavEKF::update_DCM(bool skip_ins_update)

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -674,7 +674,7 @@ void SITL_State::_update_gps_nmea(const struct gps_data *d, uint8_t instance)
                      d->have_lock?_sitl->gps_numsats:3,
                      2.0,
                      d->altitude);
-    float speed_knots = norm(d->speedN, d->speedE)*1.94384449f;
+    float speed_knots = norm(d->speedN, d->speedE) * M_PER_SEC_TO_KNOTS;
     float heading = ToDeg(atan2f(d->speedE, d->speedN));
     if (heading < 0) {
         heading += 360.0f;

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -73,6 +73,8 @@ static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 
 #define C_TO_KELVIN 273.15f
 
+#define M_PER_SEC_TO_KNOTS 1.94384449f
+
 // Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
 #define ISA_GAS_CONSTANT 287.26f
 #define ISA_LAPSE_RATE 0.0065f

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -1,0 +1,181 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+   Author: Francisco Ferreira (some code is copied from sitl_gps.cpp)
+
+ */
+
+#include "AP_NMEA_Output.h"
+
+#if !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE
+
+#include <AP_Math/definitions.h>
+#include <AP_RTC/AP_RTC.h>
+#include <AP_SerialManager/AP_SerialManager.h>
+
+#include <stdio.h>
+#include <time.h>
+
+AP_NMEA_Output* AP_NMEA_Output::_singleton;
+
+AP_NMEA_Output::AP_NMEA_Output()
+{
+    AP_SerialManager& sm = AP::serialmanager();
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(_uart); i++) {
+        _uart[i] = sm.find_serial(AP_SerialManager::SerialProtocol_NMEAOutput, i);
+
+        if (_uart[i] == nullptr) {
+            break;
+        }
+        _num_outputs++;
+    }
+}
+
+AP_NMEA_Output* AP_NMEA_Output::probe()
+{
+    if (!_singleton && AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_NMEAOutput, 0) != nullptr) {
+       _singleton = new AP_NMEA_Output();
+    }
+
+    return _singleton;
+}
+
+uint8_t AP_NMEA_Output::_nmea_checksum(const char *str)
+{
+    uint8_t checksum = 0;
+    const uint8_t* bytes = (const uint8_t*) str;
+
+    for (uint16_t i = 1; str[i]; i++) {
+        checksum ^= bytes[i];
+    }
+
+    return checksum;
+}
+
+void AP_NMEA_Output::update()
+{
+    uint16_t now = AP_HAL::millis16();
+    uint16_t time_diff = now - _last_sent;
+
+    // only send at 10Hz
+    if (time_diff < 100) {
+        return;
+    }
+
+    // get time and date
+    uint64_t time_usec;
+    bool time_valid = AP::rtc().get_utc_usec(time_usec);
+
+    if (!time_valid) {
+        return;
+    }
+
+    // not completely accurate, our time includes leap seconds and time_t should be without
+    time_t time_sec = time_usec / 1000000;
+    struct tm* tm = gmtime(&time_sec);
+
+    // format time string
+    char tstring[11];
+    snprintf(tstring, sizeof(tstring), "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+
+    // format date string
+    char dstring[7];
+    snprintf(dstring, sizeof(dstring), "%02u%02u%02u", tm->tm_mday, tm->tm_mon+1, tm->tm_year % 100);
+
+    AP_AHRS_NavEKF& ahrs = AP::ahrs_navekf();
+
+    // get location (note: get_position from AHRS always returns true after having GPS position once)
+    Location loc;
+    bool pos_valid = ahrs.get_location(loc);
+
+    // format latitude
+    char lat_string[13];
+    float deg = fabsf(loc.lat * 1.0e-7f);
+    snprintf(lat_string,
+             sizeof(lat_string),
+             "%02u%08.5f,%c",
+             (unsigned) deg,
+             double((deg - int(deg)) * 60),
+             loc.lat < 0 ? 'S' : 'N');
+
+    // format longitude
+    char lng_string[14];
+    deg = fabsf(loc.lng * 1.0e-7f);
+    snprintf(lng_string,
+             sizeof(lng_string),
+             "%03u%08.5f,%c",
+             (unsigned) deg,
+             double((deg - int(deg)) * 60),
+             loc.lng < 0 ? 'W' : 'E');
+
+    // format GGA message
+    char* gga = nullptr;
+    int16_t gga_res = asprintf(&gga,
+                               "$GPGGA,%s,%s,%s,%01d,%02d,%04.1f,%07.2f,M,0.0,M,,",
+                               tstring,
+                               lat_string,
+                               lng_string,
+                               pos_valid ? 1 : 0,
+                               pos_valid ? 6 : 3,
+                               2.0,
+                               loc.alt * 0.01f);
+    char gga_end[6];
+    snprintf(gga_end, sizeof(gga_end), "*%02X\r\n", (unsigned) _nmea_checksum(gga));
+
+    // get speed
+    Vector2f speed = ahrs.groundspeed_vector();
+    float speed_knots = norm(speed.x, speed.y) * M_PER_SEC_TO_KNOTS;
+    float heading = wrap_360(degrees(atan2f(speed.x, speed.y)));
+
+    // format RMC message
+    char* rmc = nullptr;
+    int16_t rmc_res = asprintf(&rmc,
+                               "$GPRMC,%s,%c,%s,%s,%.2f,%.2f,%s,,",
+                               tstring,
+                               pos_valid ? 'A' : 'V',
+                               lat_string,
+                               lng_string,
+                               speed_knots,
+                               heading,
+                               dstring);
+    char rmc_end[6];
+    snprintf(rmc_end, sizeof(rmc_end), "*%02X\r\n", (unsigned) _nmea_checksum(rmc));
+
+    // send to all NMEA output ports
+    for (uint8_t i = 0; i < _num_outputs; i++) {
+        if (gga_res != -1) {
+            _uart[i]->write(gga);
+            _uart[i]->write(gga_end);
+        }
+
+        if (rmc_res != -1) {
+            _uart[i]->write(rmc);
+            _uart[i]->write(rmc_end);
+        }
+    }
+
+    if (gga_res != -1) {
+        free(gga);
+    }
+
+    if (rmc_res != -1) {
+        free(rmc);
+    }
+
+    _last_sent = now;
+}
+
+#endif  // !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.h
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.h
@@ -1,0 +1,53 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+   Author: Francisco Ferreira
+
+ */
+
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_AHRS/AP_AHRS.h>
+
+#if !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE
+
+#include <AP_SerialManager/AP_SerialManager.h>
+
+class AP_NMEA_Output {
+
+public:
+    static AP_NMEA_Output* probe();
+
+    /* Do not allow copies */
+    AP_NMEA_Output(const AP_NMEA_Output &other) = delete;
+    AP_NMEA_Output &operator=(const AP_NMEA_Output&) = delete;
+
+    void update();
+
+private:
+    AP_NMEA_Output();
+
+    uint8_t _nmea_checksum(const char *str);
+
+    static AP_NMEA_Output* _singleton;
+
+    uint8_t _num_outputs;
+    AP_HAL::UARTDriver* _uart[SERIALMANAGER_NUM_PORTS];
+
+    uint16_t _last_sent;
+};
+
+#endif  // !HAL_MINIMIZE_FEATURES && AP_AHRS_NAVEKF_AVAILABLE

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
@@ -79,7 +79,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SERIAL2_PROTOCOL_DEFAULT),
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SerialProtocol_GPS),
@@ -109,7 +109,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SerialProtocol_GPS),
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
@@ -141,7 +141,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 6_PROTOCOL
     // @DisplayName: Serial6 protocol selection
     // @Description: Control what protocol Serial6 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("6_PROTOCOL",  12, AP_SerialManager, state[6].protocol, SERIAL6_PROTOCOL),
@@ -354,6 +354,10 @@ void AP_SerialManager::init()
                                          AP_SERIALMANAGER_ROBOTIS_BUFSIZE_TX);
                     state[i].uart->set_unbuffered_writes(true);
                     state[i].uart->set_flow_control(AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE);
+                    break;
+
+                default:
+                    state[i].uart->begin(map_baudrate(state[i].baud));
                     break;
             }
         }

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -105,6 +105,7 @@ public:
         SerialProtocol_Devo_Telem = 17,
         SerialProtocol_OpticalFlow = 18,
         SerialProtocol_Robotis = 19,
+        SerialProtocol_NMEAOutput = 20,
     };
 
     // get singleton instance


### PR DESCRIPTION
This PR adds NMEA output if you enable it via SERIALx_PROTOCOL (set it to 20) - it supports multiple outputs. Data is output at fixed 10Hz.

It is currently done directly from AHRS so I didn't have to add it to each vehicle (and there are no parameters), but it's easily changeable since I did it as a library.