### PR TITLE
NFC: Fix include on some libs

### DIFF
--- a/libraries/AP_IOMCU/iofirmware/analog.h
+++ b/libraries/AP_IOMCU/iofirmware/analog.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <stdint.h>
 /*
   initialise adc
  */

--- a/libraries/AP_IOMCU/iofirmware/iofirmware.h
+++ b/libraries/AP_IOMCU/iofirmware/iofirmware.h
@@ -1,4 +1,8 @@
+#pragma once
+
+#include <stdint.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Common/AP_Common.h>
 #include <AP_RCProtocol/AP_RCProtocol.h>
 
 

--- a/libraries/AP_IOMCU/iofirmware/ioprotocol.h
+++ b/libraries/AP_IOMCU/iofirmware/ioprotocol.h
@@ -1,3 +1,7 @@
+#pragma once
+
+#include <stdint.h>
+#include <AP_Common/AP_Common.h>
 /*
   common protocol definitions between AP_IOMCU and iofirmware
  */

--- a/libraries/AP_IOMCU/iofirmware/mixer.cpp
+++ b/libraries/AP_IOMCU/iofirmware/mixer.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include "iofirmware.h"
 

--- a/libraries/AP_IOMCU/iofirmware/rc.cpp
+++ b/libraries/AP_IOMCU/iofirmware/rc.cpp
@@ -21,6 +21,8 @@
 #include "hal.h"
 #include "iofirmware.h"
 #include "rc.h"
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include <AP_SBusOut/AP_SBusOut.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_IOMCU/iofirmware/rc.h
+++ b/libraries/AP_IOMCU/iofirmware/rc.h
@@ -1,2 +1,4 @@
+#pragma once
 
+#include <stdint.h>
 void sbus_out_write(uint16_t *channels, uint8_t nchannels);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -1,5 +1,3 @@
-#include <AP_Common/AP_Common.h>
-#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "AP_RangeFinder_Params.h"
 #include "AP_RangeFinder.h"
 

--- a/libraries/AP_RobotisServo/AP_RobotisServo.cpp
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.cpp
@@ -35,6 +35,8 @@
 */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include <SRV_Channel/SRV_Channel.h>
 
 #include "AP_RobotisServo.h"

--- a/libraries/AP_RobotisServo/AP_RobotisServo.h
+++ b/libraries/AP_RobotisServo/AP_RobotisServo.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Param/AP_Param.h>
 
 class AP_RobotisServo {

--- a/libraries/AP_SBusOut/AP_SBusOut.cpp
+++ b/libraries/AP_SBusOut/AP_SBusOut.cpp
@@ -38,6 +38,7 @@
  *
  */
 #include "AP_SBusOut.h"
+#include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <SRV_Channel/SRV_Channel.h>
 

--- a/libraries/AP_SBusOut/AP_SBusOut.h
+++ b/libraries/AP_SBusOut/AP_SBusOut.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Param/AP_Param.h>
 
 class AP_SBusOut {

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 #include "AP_SerialManager.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -21,10 +21,9 @@
  */
 #pragma once
 
-#include <AP_Math/AP_Math.h>
-#include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Param/AP_Param.h>
 
 // we have hal.uartA to hal.uartG
 #define SERIALMANAGER_NUM_PORTS 7


### PR DESCRIPTION
The includes were wrongly done on AP_Serial_manager, so I add needed AP_Param.h, remove unecessary one's and that trigger include failure on AP_SBusOut and AP_ROBotisServo, so I fixed them too.