### PR TITLE
Tools: pexpect python dependency used by autotest

### DIFF
--- a/Tools/scripts/install-prereqs-mac.sh
+++ b/Tools/scripts/install-prereqs-mac.sh
@@ -26,7 +26,7 @@ else
     echo "pip installed"
 fi
 
-pip2 install --user pyserial future empy mavproxy
+pip2 install --user pyserial future empy mavproxy pexpect
 
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")


### PR DESCRIPTION
Install pexpect for autotest to fix:

```
Tools/autotest/autotest.py --help
Traceback (most recent call last):
  File "Tools/autotest/autotest.py", line 20, in <module>
    import apmrover2
  File "/Users/drnic/Projects/flightcontrollers/ardupilot/Tools/autotest/apmrover2.py", line 7, in <module>
    import pexpect
ImportError: No module named pexpect
```