### PR TITLE
Arming: Allow checking all EKF cores for health

### DIFF
--- a/APMrover2/AP_Arming.cpp
+++ b/APMrover2/AP_Arming.cpp
@@ -42,6 +42,18 @@ bool AP_Arming_Rover::pre_arm_rc_checks(const bool display_failure)
 // performs pre_arm gps related checks and returns true if passed
 bool AP_Arming_Rover::gps_checks(bool display_failure)
 {
+    const AP_AHRS &ahrs = AP::ahrs();
+
+    // always check if inertial nav has started and is ready
+    if (!ahrs.prearm_healthy()) {
+        const char *reason = ahrs.prearm_failure_reason();
+        if (reason == nullptr) {
+            reason = "AHRS not healthy";
+        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "%s", reason);
+        return false;
+    }
+
     if (!rover.control_mode->requires_position() && !rover.control_mode->requires_velocity()) {
         // we don't care!
         return true;
@@ -55,7 +67,7 @@ bool AP_Arming_Rover::gps_checks(bool display_failure)
 
     // ensure position esetimate is ok
     if (!rover.ekf_position_ok()) {
-        const char *reason = AP::ahrs().prearm_failure_reason();
+        const char *reason = ahrs.prearm_failure_reason();
         if (reason == nullptr) {
             reason = "Need Position Estimate";
         }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -286,8 +286,12 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     const AP_AHRS_NavEKF &ahrs = AP::ahrs_navekf();
 
     // always check if inertial nav has started and is ready
-    if (!ahrs.healthy()) {
-        check_failed(ARMING_CHECK_NONE, display_failure, "AHRS not healthy");
+    if (!ahrs.prearm_healthy()) {
+        const char *reason = ahrs.prearm_failure_reason();
+        if (reason == nullptr) {
+            reason = "AHRS not healthy";
+        }
+        check_failed(ARMING_CHECK_NONE, display_failure, "%s", reason);
         return false;
     }
 

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -105,7 +105,7 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
     // additional plane specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!AP::ahrs().healthy()) {
+        if (!AP::ahrs().prearm_healthy()) {
             const char *reason = AP::ahrs().prearm_failure_reason();
             if (reason == nullptr) {
                 reason = "AHRS not healthy";

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -31,7 +31,7 @@ bool AP_Arming_Sub::ins_checks(bool display_failure)
     // additional sub-specific checks
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
-        if (!AP::ahrs().healthy()) {
+        if (!AP::ahrs().prearm_healthy()) {
             const char *reason = AP::ahrs().prearm_failure_reason();
             if (reason == nullptr) {
                 reason = "AHRS not healthy";

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -497,6 +497,8 @@ public:
     // is the AHRS subsystem healthy?
     virtual bool healthy(void) const = 0;
 
+    virtual bool prearm_healthy(void) const { return healthy(); }
+
     // true if the AHRS has completed initialisation
     virtual bool initialised(void) const {
         return true;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -1114,6 +1114,33 @@ bool AP_AHRS_NavEKF::healthy(void) const
     return AP_AHRS_DCM::healthy();
 }
 
+bool AP_AHRS_NavEKF::prearm_healthy(void) const
+{
+    bool prearm_health = false;
+    switch (ekf_type()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    case EKF_TYPE_SITL:
+#endif
+    case EKF_TYPE_NONE:
+        prearm_health = true;
+        break;
+
+    case EKF_TYPE2:
+    default:
+        if (_ekf2_started && EKF2.all_cores_healthy()) {
+            prearm_health = true;
+        }
+        break;
+
+    case EKF_TYPE3:
+        if (_ekf3_started && EKF3.all_cores_healthy()) {
+            prearm_health = true;
+        }
+        break;
+    }
+   return prearm_health && healthy();
+}
+
 void AP_AHRS_NavEKF::set_ekf_use(bool setting)
 {
     _ekf_type.set(setting?1:0);

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -175,6 +175,8 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 
+    bool prearm_healthy() const override;
+
     // true if the AHRS has completed initialisation
     bool initialised() const override;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -768,6 +768,19 @@ bool NavEKF2::healthy(void) const
     return core[primary].healthy();
 }
 
+bool NavEKF2::all_cores_healthy(void) const
+{
+    if (!core) {
+        return false;
+    }
+    for (uint8_t i = 0; i < num_cores; i++) {
+        if (!core[i].healthy()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // returns the index of the primary core
 // return -1 if no primary core selected
 int8_t NavEKF2::getPrimaryCoreIndex(void) const
@@ -1361,7 +1374,13 @@ const char *NavEKF2::prearm_failure_reason(void) const
     if (!core) {
         return nullptr;
     }
-    return core[primary].prearm_failure_reason();
+    for (uint8_t i = 0; i < num_cores; i++) {
+        const char * failure = core[i].prearm_failure_reason();
+        if (failure != nullptr) {
+            return failure;
+        }
+    }
+    return nullptr;
 }
 
 // Returns the amount of vertical position change due to the last reset or core switch in metres

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -62,6 +62,8 @@ public:
     
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
+    // Ensure that all started cores are considered healthy
+    bool all_cores_healthy(void) const;
 
     // returns the index of the primary core
     // return -1 if no primary core selected

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -804,6 +804,19 @@ bool NavEKF3::healthy(void) const
     return core[primary].healthy();
 }
 
+bool NavEKF3::all_cores_healthy(void) const
+{
+    if (!core) {
+        return false;
+    }
+    for (uint8_t i = 0; i < num_cores; i++) {
+        if (!core[i].healthy()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // returns the index of the primary core
 // return -1 if no primary core selected
 int8_t NavEKF3::getPrimaryCoreIndex(void) const
@@ -1447,7 +1460,13 @@ const char *NavEKF3::prearm_failure_reason(void) const
     if (!core) {
         return nullptr;
     }
-    return core[primary].prearm_failure_reason();
+    for (uint8_t i = 0; i < num_cores; i++) {
+        const char * failure = core[primary].prearm_failure_reason();
+        if (failure != nullptr) {
+            return failure;
+        }
+    }
+    return nullptr;
 }
 
 // Returns the amount of vertical position change due to the last reset or core switch in metres

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -59,6 +59,8 @@ public:
     
     // Check basic filter health metrics and return a consolidated health status
     bool healthy(void) const;
+    // Check that all cores are started and healthy
+    bool all_cores_healthy(void) const;
 
     // returns the index of the primary core
     // return -1 if no primary core selected


### PR DESCRIPTION
This is intended to actually check that all the EKF cores are actually healthy, rather then just having the primary core be healthy. I didn't tag the other vehicles yet, as it wasn't obvious to me under what situations Copter/Rover want to run the check.

Overall I'd love to see the AHRS arming check become common.

I haven't flight tested this yet, was just spun out as a side effect of Paul's presentation, and should be reviewed more.