### PR TITLE
TradHeli Acro virtual_flybar

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -456,7 +456,7 @@ const AP_Param::Info Copter::var_info[] = {
 #if MODE_ACRO_ENABLED == ENABLED || MODE_SPORT_ENABLED == ENABLED
     // @Param: ACRO_BAL_ROLL
     // @DisplayName: Acro Balance Roll
-    // @Description: rate at which roll angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster.
+    // @Description: rate at which roll angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster. For helicopter sets the decay rate of the virtual flybar in the roll axis. A higher value causes faster decay of desired to actual attitude.
     // @Range: 0 3
     // @Increment: 0.1
     // @User: Advanced
@@ -464,7 +464,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // @Param: ACRO_BAL_PITCH
     // @DisplayName: Acro Balance Pitch
-    // @Description: rate at which pitch angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster.
+    // @Description: rate at which pitch angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster. For helicopter sets the decay rate of the virtual flybar in the pitch axis. A higher value causes faster decay of desired to actual attitude.
     // @Range: 0 3
     // @Increment: 0.1
     // @User: Advanced

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -236,6 +236,7 @@ public:
 
     bool init(bool ignore_checks) override;
     void run() override;
+    void virtual_flybar( float &roll_out, float &pitch_out, float &yaw_out, float pitch_leak, float roll_leak);
 
 protected:
 private:

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -52,9 +52,9 @@ void Copter::ModeAcro_Heli::run()
         get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
         if (g.acro_trainer == ACRO_TRAINER_DISABLED) {
             if (ap.land_complete) {
-                virtual_flybar(target_roll, target_pitch, target_yaw, 3.0f, 3.0f)
+                virtual_flybar(target_roll, target_pitch, target_yaw, 3.0f, 3.0f);
             } else {
-                virtual_flybar(target_roll, target_pitch, target_yaw, g.acro_balance_pitch, g.acro_balance_roll)
+                virtual_flybar(target_roll, target_pitch, target_yaw, g.acro_balance_pitch, g.acro_balance_roll);
             }
         }
         if (motors->supports_yaw_passthrough()) {

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -50,7 +50,13 @@ void Copter::ModeAcro_Heli::run()
     if (!motors->has_flybar()){
         // convert the input to the desired body frame rate
         get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
-
+        if (g.acro_trainer == ACRO_TRAINER_DISABLED) {
+            if (ap.land_complete) {
+                virtual_flybar(target_roll, target_pitch, target_yaw, 3.0f, 3.0f)
+            } else {
+                virtual_flybar(target_roll, target_pitch, target_yaw, g.acro_balance_pitch, g.acro_balance_roll)
+            }
+        }
         if (motors->supports_yaw_passthrough()) {
             // if the tail on a flybar heli has an external gyro then
             // also use no deadzone for the yaw control and
@@ -92,5 +98,32 @@ void Copter::ModeAcro_Heli::run()
     attitude_control->set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);
 }
 
+
+// virtual_flybar - acts like a flybar by leaking target atttitude back to current attitude
+void Copter::ModeAcro_Heli::virtual_flybar( float &roll_out, float &pitch_out, float &yaw_out, float pitch_leak, float roll_leak)
+{
+    Vector3f rate_ef_level, rate_bf_level;
+
+    // get attitude targets
+    const Vector3f att_target = attitude_control->get_att_target_euler_cd();
+
+    // Calculate Heli mode earth frame rate command for roll
+    rate_ef_level.x = -wrap_180_cd(att_target.x - ahrs.roll_sensor) * roll_leak;
+
+    // Calculate Heli  mode earth frame rate command for pitch
+    rate_ef_level.y = -wrap_180_cd(att_target.y - ahrs.pitch_sensor) * pitch_leak;
+
+    // Calculate earth frame rate command for yaw
+    rate_ef_level.z = 0;
+
+    // convert earth-frame level rates to body-frame level rates
+    attitude_control->euler_rate_to_ang_vel(attitude_control->get_att_target_euler_cd()*radians(0.01f), rate_ef_level, rate_bf_level);
+
+    // combine earth frame rate corrections with rate requests
+    roll_out += rate_bf_level.x;
+    pitch_out += rate_bf_level.y;
+    yaw_out += rate_bf_level.z;
+
+}
 #endif  //HELI_FRAME
 #endif  //MODE_ACRO_ENABLED == ENABLED

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -50,9 +50,12 @@ void Copter::ModeAcro_Heli::run()
     if (!motors->has_flybar()){
         // convert the input to the desired body frame rate
         get_pilot_desired_angle_rates(channel_roll->get_control_in(), channel_pitch->get_control_in(), channel_yaw->get_control_in(), target_roll, target_pitch, target_yaw);
+        // only mimic flybar response when trainer mode is disabled
         if (g.acro_trainer == ACRO_TRAINER_DISABLED) {
+            // while landed always leak off target attitude to current attitude
             if (ap.land_complete) {
                 virtual_flybar(target_roll, target_pitch, target_yaw, 3.0f, 3.0f);
+            // while flying use acro balance parameters for leak rate
             } else {
                 virtual_flybar(target_roll, target_pitch, target_yaw, g.acro_balance_pitch, g.acro_balance_roll);
             }
@@ -107,16 +110,16 @@ void Copter::ModeAcro_Heli::virtual_flybar( float &roll_out, float &pitch_out, f
     // get attitude targets
     const Vector3f att_target = attitude_control->get_att_target_euler_cd();
 
-    // Calculate Heli mode earth frame rate command for roll
+    // Calculate earth frame rate command for roll leak to current attitude
     rate_ef_level.x = -wrap_180_cd(att_target.x - ahrs.roll_sensor) * roll_leak;
 
-    // Calculate Heli  mode earth frame rate command for pitch
+    // Calculate earth frame rate command for pitch leak to current attitude
     rate_ef_level.y = -wrap_180_cd(att_target.y - ahrs.pitch_sensor) * pitch_leak;
 
     // Calculate earth frame rate command for yaw
     rate_ef_level.z = 0;
 
-    // convert earth-frame level rates to body-frame level rates
+    // convert earth-frame leak rates to body-frame leak rates
     attitude_control->euler_rate_to_ang_vel(attitude_control->get_att_target_euler_cd()*radians(0.01f), rate_ef_level, rate_bf_level);
 
     // combine earth frame rate corrections with rate requests


### PR DESCRIPTION
This changes the default behavior of acro flight mode for helicopter to use a virtual flybar instead of pure rate control when Acro Trainer is disabled. This does not change the Acro Trainer or the default behavior of acro flight mode for multicopters.

Flight testing has been performed on Copter 3.6 as per the information in this thread on the discuss forum.
https://discuss.ardupilot.org/t/new-ardupilot-acro-vbar-mode-for-helicopters/39544