### PR TITLE
Add not-spinning to fly_motor_fail

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1377,6 +1377,9 @@ class AutoTestCopter(AutoTest):
                 self.progress("  Yaw: %f deg" % int_error_yaw)
                 self.progress("----")
 
+                if int_error_yaw_rate > 0.1:
+                    raise NotAchievedException("Vehicle is spinning")
+
                 if alt_delta < -20:
                     raise NotAchievedException("Vehicle is descending")
 

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -1226,7 +1226,9 @@ class AutoTest(ABC):
         """Validate and return the mode number from a string or int."""
         mode_map = self.mav.mode_mapping()
         if mode_map is None:
-            raise ErrorException("No mode map")
+            mav_type = self.mav.messages['HEARTBEAT'].type
+            mav_autopilot = self.mav.messages['HEARTBEAT'].autopilot
+            raise ErrorException("No mode map for (mav_type=%s mav_autopilot=%s)" % (mav_type, mav_autopilot))
         if isinstance(mode, str):
             if mode in mode_map:
                 return mode_map.get(mode)


### PR DESCRIPTION
Hexa would pass this test when it really shouldn't as the default layout may maintain altitude but spins rapidly.
