### PR TITLE
Add battery failsafe reset capability

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -124,13 +124,12 @@ bool AP_Arming_Copter::board_voltage_checks(bool display_failure)
 
     // check battery voltage
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_VOLTAGE)) {
-        if (copter.battery.has_failsafed()) {
-            check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
-            return false;
-        }
-
         // call parent battery checks
         if (!AP_Arming::battery_checks(display_failure)) {
+            return false;
+        }
+        if (copter.battery.has_failsafed()) {
+            check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
             return false;
         }
     }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -494,6 +494,17 @@ void AP_BattMonitor::checkPoweringOff(void)
     }
 }
 
+void AP_BattMonitor::clear_failsafe_flags() {
+    if (_has_triggered_failsafe) {
+        _has_triggered_failsafe = false;
+        AP_Notify::flags.failsafe_battery = false;
+        _highest_failsafe_priority = INT8_MAX;
+        for (uint8_t i = 0; i < _num_instances; i++) {
+            state[i].failsafe = AP_BattMonitor::BatteryFailsafe_None;
+        }
+    }
+}
+
 namespace AP {
 
 AP_BattMonitor &battery()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -174,6 +174,8 @@ public:
     // sends powering off mavlink broadcasts and sets notify flag
     void checkPoweringOff(void);
 
+    void clear_failsafe_flags();
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -168,7 +168,9 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
     result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
     result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
-
+    if (is_positive(_params._arming_minimum_voltage) && result) {
+        _mon.clear_failsafe_flags();
+    }
     return result;
 }
 


### PR DESCRIPTION
Usefull battery swap or charging. It use the BATT_ARM_VOLT value to clear the failsafe.
Test as been added, the default behavior is not changed.
Currently it clear the failsafe on all battery. We could rework later to select which failsafe should be cleared by adding a parameter for each battery.
This is used by AzurDrones solution