### PR TITLE
autotest: Organize build order to start with the fastest tasks

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -709,7 +709,6 @@ if __name__ == "__main__":
     steps = [
         'prerequisites',
         'build.All',
-        'build.Binaries',
         'build.Parameters',
 
         'build.unit_tests',
@@ -743,6 +742,8 @@ if __name__ == "__main__":
         'dive.ArduSub',
 
         'convertgpx',
+
+        'build.Binaries',
     ]
 
     skipsteps = opts.skip.split(',')


### PR DESCRIPTION
autotest.ardupilot.org is resulting in TIMEOUT right now
The objective of this patch is to start with the fast tasks
Allowing us to build at least the most basic vehicles

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>