### PR TITLE
Tracker: if found target in scan mode then switch to auto mode

### DIFF
--- a/AntennaTracker/control_scan.cpp
+++ b/AntennaTracker/control_scan.cpp
@@ -35,4 +35,9 @@ void Tracker::update_scan(void)
     }
 
     update_auto();
+
+    // if found a valid target switch to AUTO
+    if (control_mode != AUTO && tracker.target_set) {
+        set_mode(AUTO, MODE_REASON_INITIALISED);
+    }
 }


### PR DESCRIPTION
This is a change in behavior for tracker, if a target is found in SCAN mode tracker will switch to AUTO. Once in AUTO if the target is lost it will scan as it usually would in AUTO.