### PR TITLE
Plane: remove trig calls from constexpr

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -268,12 +268,18 @@ void QuadPlane::tailsitter_speed_scaling(void)
         } else {
             // if no airspeed sensor reduce control surface throws at large tilt
             // angles (assuming high airspeed)
-
             // ramp down from 1 to max_atten at tilt angles over trans_angle
             // (angles here are represented by their cosines)
-            constexpr float c_trans_angle = cosf(.125f * M_PI);
-            constexpr float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(90)));
+
+            // Note that the cosf call will be necessary if trans_angle becomes a parameter
+            // but the C language spec does not guarantee that trig functions can be used
+            // in constant expressions, even though gcc currently allows it.
+            constexpr float c_trans_angle = 0.9238795; // cosf(.125f * M_PI)
+
+            // alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(90)));
+            constexpr float alpha = (1 - max_atten) / c_trans_angle;
             constexpr float beta = 1 - alpha * c_trans_angle;
+
             const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
             if (c_tilt < c_trans_angle) {
                 spd_scaler = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);


### PR DESCRIPTION
@drnic @peterbarker @tridge 
alternative to https://github.com/ArduPilot/ardupilot/pull/10870 which retains use of constexpr