### PR TITLE
travis: Use clang-7 and not clang-5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
       compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-quadplane sitltest-plane"
     - if: type != cron
-      compiler: "clang"
+      compiler: "clang-7"
       env: CI_BUILD_TARGET="sitltest-rover sitltest-sub""
     - language: python
       python: 3.7


### PR DESCRIPTION
This fix c8f726151b898980d916b67540bf5749a7bf7c21
It was building by default with clang-5.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>