### PR TITLE
Modify Sub's DEPTH_SENSOR error logging

### DIFF
--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -73,7 +73,10 @@ void Sub::failsafe_sensors_check()
 
     // We need a depth sensor to do any sort of auto z control
     if (sensor_health.depth) {
-        failsafe.sensor_health = false;
+        if (failsafe.sensor_health) {
+            AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_SENSORS, LogErrorCode::ERROR_RESOLVED);
+            failsafe.sensor_health = false;
+        }
         return;
     }
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -164,7 +164,7 @@ enum class LogErrorCode : uint8_t {
     EKFCHECK_VARIANCE_CLEARED = 0,
 // Baro specific error codes
     BARO_GLITCH = 2,
-    BAD_DEPTH = 0, // sub-only
+    BAD_DEPTH = 3, // sub-only
 // GPS specific error coces
     GPS_GLITCH = 2,
 };


### PR DESCRIPTION
This is very much a functional change.  Stop using "0" for "error occured" (start using "3"), and also log "error cleared" with "0".
