### PR TITLE
AP_OpticalFlow: support cx-of on all boards

### DIFF
--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -104,9 +104,6 @@ void OpticalFlow::init(uint32_t log_bit)
         if (backend == nullptr) {
             backend = AP_OpticalFlow_PX4Flow::detect(*this);
         }
-        if (backend == nullptr) {
-            backend = AP_OpticalFlow_CXOF::detect(*this);
-        }
 #elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
         backend = new AP_OpticalFlow_SITL(*this);
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
@@ -118,6 +115,9 @@ void OpticalFlow::init(uint32_t log_bit)
 #elif defined(HAL_HAVE_PIXARTFLOW_SPI)
         backend = AP_OpticalFlow_Pixart::detect("pixartflow", *this);
 #endif
+        if (backend == nullptr) {
+            backend = AP_OpticalFlow_CXOF::detect(*this);
+        }
     }
 
     if (backend != nullptr) {


### PR DESCRIPTION
This enables the CX-OF optical flow sensor to be used on all boards by moving it's "detect" to the very end of the front-end's init() method.  I've tested this on a Pixhawk and it appears to work OK.  I can't easily test this on my own matek 405-wing board but I will confirm will one or two members of the community.