### PR TITLE
remove collective position pre-arm check for heli

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -547,10 +547,12 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::Method method
                 return false;
             }
             // in manual modes throttle must be at zero
+            #if FRAME_CONFIG != HELI_FRAME
             if ((copter.flightmode->has_manual_throttle() || control_mode == DRIFT) && copter.channel_throttle->get_control_in() > 0) {
                 check_failed(ARMING_CHECK_RC, display_failure, "%s too high", rc_item);
                 return false;
             }
+            #endif
         }
     }
 


### PR DESCRIPTION
This fixes a bug for heli where the pre-arm check fails with collective at neutral position