### PR TITLE
Copter: Tradheli- removes suppression of hover_trim_roll on auto takeoff

### DIFF
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -159,10 +159,6 @@ void Copter::Mode::auto_takeoff_attitude_run(float target_yaw_rate)
         // we haven't reached the takeoff navigation altitude yet
         nav_roll = 0;
         nav_pitch = 0;
-#if FRAME_CONFIG == HELI_FRAME
-        // prevent hover roll starting till past specified altitude
-        copter.hover_roll_trim_scalar_slew = 0;        
-#endif
         // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
         pos_control->set_limit_accel_xy();
     } else {


### PR DESCRIPTION
hover roll trim is designed to help reduce drift in a hover caused by the tail rotor.  there is no reason to inhibit the aircraft taking up the hover roll trim on auto takeoff as it helps the aircraft maintain position.  this was tested in sitl with realflight (raptor) using both no wind and highly turbulent wind.  there were no issues with auto takeoff.