### PR TITLE
Remove static aliases for rc members

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -56,7 +56,7 @@ void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool
     _num_channels = num_values;
     rc_frame_count++;
 #if !APM_BUILD_TYPE(APM_BUILD_iofirmware)
-    if (RC_Channels::ignore_rc_failsafe()) {
+    if (rc().ignore_rc_failsafe()) {
         in_failsafe = false;
     }
 #endif

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -353,7 +353,7 @@ bool RC_Channel::has_override() const
         return false;
     }
 
-    const float override_timeout_ms = RC_Channels::override_timeout->get() * 1e3f;
+    const float override_timeout_ms = rc().override_timeout_ms();
     return is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms);
 }
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -126,9 +126,9 @@ RC_Channel::get_reverse(void) const
 bool
 RC_Channel::update(void)
 {
-    if (has_override() && !(*RC_Channels::options & RC_IGNORE_OVERRIDES)) {
+    if (has_override() && !rc().ignore_overrides()) {
         radio_in = override_value;
-    } else if (!(*RC_Channels::options & RC_IGNORE_RECEIVER)) {
+    } else if (!rc().ignore_receiver()) {
         radio_in = hal.rcin->read(ch_in);
     } else {
         return false;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -338,7 +338,7 @@ void RC_Channel::set_override(const uint16_t v, const uint32_t timestamp_us)
     }
     last_override_time = timestamp_us != 0 ? timestamp_us : AP_HAL::millis();
     override_value = v;
-    RC_Channels::has_new_overrides = true;
+    rc().new_override_received();
 }
 
 void RC_Channel::clear_override()

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -16,13 +16,6 @@ public:
     // Constructor
     RC_Channel(void);
 
-    // used to get min/max/trim limit value based on _reverse
-    enum LimitValue {
-        RC_CHANNEL_LIMIT_TRIM,
-        RC_CHANNEL_LIMIT_MIN,
-        RC_CHANNEL_LIMIT_MAX
-    };
-
     enum InputIgnore {
         RC_IGNORE_RECEIVER  = (1 << 0), // RC receiver modules
         RC_IGNORE_OVERRIDES = (1 << 1), // MAVLink overrides

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -354,12 +354,17 @@ protected:
         IGNORE_FAILSAFE  = (1 << 2), // ignore RC failsafe bits
     };
 
+    void new_override_received() {
+        has_new_overrides = true;
+    }
+
 private:
     static RC_Channels *_singleton;
     // this static arrangement is to avoid static pointers in AP_Param tables
     static RC_Channel *channels;
 
-    static bool has_new_overrides;
+    bool has_new_overrides;
+
     AP_Float _override_timeout;
     AP_Int32  _options;
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -16,12 +16,6 @@ public:
     // Constructor
     RC_Channel(void);
 
-    enum InputIgnore {
-        RC_IGNORE_RECEIVER  = (1 << 0), // RC receiver modules
-        RC_IGNORE_OVERRIDES = (1 << 1), // MAVLink overrides
-        RC_IGNORE_FAILSAFE  = (1 << 2), // ignore RC failsafe bits
-    };
-
     enum ChannelType {
         RC_CHANNEL_TYPE_ANGLE = 0,
         RC_CHANNEL_TYPE_RANGE = 1,
@@ -200,6 +194,7 @@ protected:
         // no action by default (e.g. Tracker, Sub, who do their own thing)
     };
 
+
 private:
 
     // pwm is stored here
@@ -335,10 +330,26 @@ public:
     }
 
     // should we ignore RC failsafe bits from receivers?
-    static bool ignore_rc_failsafe(void) {
-        return options && ((*options) & RC_Channel::RC_IGNORE_FAILSAFE) != 0;
+    bool ignore_rc_failsafe(void) const {
+        return _options & uint32_t(Option::IGNORE_FAILSAFE);
     }
-    
+
+    bool ignore_overrides() const {
+        return _options & uint32_t(Option::IGNORE_OVERRIDES);
+    }
+
+    bool ignore_receiver() const {
+        return _options & uint32_t(Option::IGNORE_RECEIVER);
+    }
+
+protected:
+
+    enum class Option {
+        IGNORE_RECEIVER  = (1 << 0), // RC receiver modules
+        IGNORE_OVERRIDES = (1 << 1), // MAVLink overrides
+        IGNORE_FAILSAFE  = (1 << 2), // ignore RC failsafe bits
+    };
+
 private:
     static RC_Channels *_singleton;
     // this static arrangement is to avoid static pointers in AP_Param tables
@@ -346,7 +357,6 @@ private:
 
     static bool has_new_overrides;
     static AP_Float *override_timeout;
-    static AP_Int32 *options;
     AP_Float _override_timeout;
     AP_Int32  _options;
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -342,6 +342,10 @@ public:
         return _options & uint32_t(Option::IGNORE_RECEIVER);
     }
 
+    float override_timeout_ms() const {
+        return _override_timeout.get() * 1e3f;
+    }
+
 protected:
 
     enum class Option {
@@ -356,7 +360,6 @@ private:
     static RC_Channel *channels;
 
     static bool has_new_overrides;
-    static AP_Float *override_timeout;
     AP_Float _override_timeout;
     AP_Int32  _options;
 

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -30,7 +30,6 @@ extern const AP_HAL::HAL& hal;
 
 bool RC_Channels::has_new_overrides;
 AP_Float *RC_Channels::override_timeout;
-AP_Int32 *RC_Channels::options;
 
 /*
   channels group object constructor
@@ -38,7 +37,6 @@ AP_Int32 *RC_Channels::options;
 RC_Channels::RC_Channels(void)
 {
     override_timeout = &_override_timeout;
-    options = &_options;
 
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -29,15 +29,12 @@ extern const AP_HAL::HAL& hal;
 #include "RC_Channel.h"
 
 bool RC_Channels::has_new_overrides;
-AP_Float *RC_Channels::override_timeout;
 
 /*
   channels group object constructor
  */
 RC_Channels::RC_Channels(void)
 {
-    override_timeout = &_override_timeout;
-
     // set defaults from the parameter table
     AP_Param::setup_object_defaults(this, var_info);
 

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -28,8 +28,6 @@ extern const AP_HAL::HAL& hal;
 
 #include "RC_Channel.h"
 
-bool RC_Channels::has_new_overrides;
-
 /*
   channels group object constructor
  */


### PR DESCRIPTION
```
as-is:
bin/arducopter  1028660  1152  195644  1225456

options non-static:
bin/arducopter  1028644  1152  195644  1225440

+timeout non-static:
bin/arducopter  1028628  1152  195644  1225424

+has_new_overrides non-static+method:
bin/arducopter  1028596  1152  195644  1225392
```

... and a few bytes of RAM.
