### PR TITLE
AC_Autotune: only save gains if disarmed in Autotune

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -499,6 +499,7 @@ public:
 
     void save_tuning_gains();
     void stop();
+    void reset();
 
 protected:
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -173,4 +173,9 @@ void Copter::ModeAutoTune::stop()
     copter.autotune.stop();
 }
 
+void Copter::ModeAutoTune::reset()
+{
+    copter.autotune.reset();
+}
+
 #endif  // AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -266,7 +266,11 @@ void Copter::init_disarm_motors()
 
 #if AUTOTUNE_ENABLED == ENABLED
     // save auto tuned parameters
-    mode_autotune.save_tuning_gains();
+    if (control_mode == AUTOTUNE) {;
+        mode_autotune.save_tuning_gains();
+    } else {
+        mode_autotune.reset();
+    }
 #endif
 
     // we are not in the air

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -502,7 +502,11 @@ bool Plane::disarm_motors(void)
     
 #if QAUTOTUNE_ENABLED
     //save qautotune gains if enabled and success
-    quadplane.qautotune.save_tuning_gains();
+    if (control_mode == &mode_qautotune) {
+        quadplane.qautotune.save_tuning_gains();
+    } else {
+        quadplane.qautotune.reset();
+    }
 #endif
 
     return true;

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -7,9 +7,12 @@ import pexpect
 from pymavlink import mavutil
 
 from common import AutoTest
+from common import AutoTestTimeoutException
+
 from pysim import util
 from pysim import vehicleinfo
 import operator
+
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
@@ -133,12 +136,17 @@ class AutoTestQuadPlane(AutoTest):
                 continue
             self.progress("STATUSTEXT (%u<%u): %s" % (now, deadline, m.text))
             if "AutoTune: Success" in m.text:
-                self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-                # near enough for now:
-                self.change_mode("QLAND")
-                self.mavproxy.expect("AutoTune: Saved gains for Roll Pitch Yaw")
-                self.mav.motors_disarmed_wait()
-                return
+                break
+        self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
+        self.set_rc(3, 1200)
+        self.wait_altitude(-5, 1, relative=True, timeout=30)
+        while self.get_sim_time_cached() < deadline:
+            self.mavproxy.send('disarm\n')
+            try:
+                self.wait_text("AutoTune: Saved gains for Roll Pitch Yaw", timeout=0.5)
+            except AutoTestTimeoutException as e:
+                continue
+            break
         self.mav.motors_disarmed_wait()
 
     def test_pid_tuning(self):

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -1215,9 +1215,7 @@ void AC_AutoTune::save_tuning_gains()
     update_gcs(AUTOTUNE_MESSAGE_SAVED_GAINS);
     Log_Write_Event(EVENT_AUTOTUNE_SAVEDGAINS);
 
-    // reset Autotune so that gains are not saved again and autotune can be run again.
-    mode = UNINITIALISED;
-    axes_completed = 0;
+    reset();
 }
 
 // update_gcs - send message to ground station

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -37,6 +37,12 @@ public:
     // stop tune, reverting gains
     void stop();
 
+    // reset Autotune so that gains are not saved again and autotune can be run again.
+    void reset() {
+        mode = UNINITIALISED;
+        axes_completed = 0;
+    }
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
bug fix for https://github.com/ArduPilot/ardupilot/issues/10411

This only saves gains if the copter or plane is disarmed in autotune mode. If disarmed in any other mode the autotune will be reset. I'm not sure if the tune was reset before this bug or just stopped. I think it makes sense to reset. 