### PR TITLE
Copter: fixed can't enter esc calibration by RC.

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -114,6 +114,9 @@ void Copter::init_ardupilot()
     // allocate the motors class
     allocate_motors();
 
+    // initialise rc channels including setting mode
+    rc().init();
+
     // sets up motors and output to escs
     init_rc_out();
 
@@ -226,9 +229,6 @@ void Copter::init_ardupilot()
 
     // initialise AP_Logger library
     logger.setVehicle_Startup_Writer(FUNCTOR_BIND(&copter, &Copter::Log_Write_Vehicle_Startup_Messages, void));
-
-    // initialise rc channels including setting mode
-    rc().init();
 
     startup_INS_ground();
 


### PR DESCRIPTION
Channels's ch_in should setup before using RC(channel_throttle) to esc calibration.