### PR TITLE
Rover: assign notify is_autopilot_mode flag

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -283,6 +283,7 @@ void Rover::startup_INS_ground(void)
 // update notify with mode change
 void Rover::notify_mode(const Mode *mode)
 {
+    AP_Notify::flags.autopilot_mode = mode->is_autopilot_mode();
     notify.flags.flight_mode = mode->mode_number();
     notify.set_flight_mode_str(mode->name4());
 }


### PR DESCRIPTION
Rover was never notifying AP_Notify that it's in an autopilot mode. This is useful for LEDs and displays