### PR TITLE
RC_Channel: Move aux_func to class enum

### DIFF
--- a/APMrover2/RC_Channel.cpp
+++ b/APMrover2/RC_Channel.cpp
@@ -33,18 +33,18 @@ void RC_Channel_Rover::init_aux_function(const aux_func_t ch_option, const aux_s
     // init channel options
     switch(ch_option) {
         // the following functions do not need initialising:
-    case SAVE_WP:
-    case LEARN_CRUISE:
-    case ARMDISARM:
-    case MANUAL:
-    case ACRO:
-    case STEERING:
-    case HOLD:
-    case AUTO:
-    case GUIDED:
-    case LOITER:
-    case FOLLOW:
-    case SAILBOAT_TACK:
+    case AUX_FUNC::SAVE_WP:
+    case AUX_FUNC::LEARN_CRUISE:
+    case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::MANUAL:
+    case AUX_FUNC::ACRO:
+    case AUX_FUNC::STEERING:
+    case AUX_FUNC::HOLD:
+    case AUX_FUNC::AUTO:
+    case AUX_FUNC::GUIDED:
+    case AUX_FUNC::LOITER:
+    case AUX_FUNC::FOLLOW:
+    case AUX_FUNC::SAILBOAT_TACK:
         break;
     default:
         RC_Channel::init_aux_function(ch_option, ch_flag);
@@ -98,9 +98,9 @@ void RC_Channel_Rover::add_waypoint_for_current_loc()
 void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch (ch_option) {
-    case DO_NOTHING:
+    case AUX_FUNC::DO_NOTHING:
         break;
-    case SAVE_WP:
+    case AUX_FUNC::SAVE_WP:
         if (ch_flag == HIGH) {
             // do nothing if in AUTO mode
             if (rover.control_mode == &rover.mode_auto) {
@@ -128,14 +128,14 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
         break;
 
     // learn cruise speed and throttle
-    case LEARN_CRUISE:
+    case AUX_FUNC::LEARN_CRUISE:
         if (ch_flag == HIGH) {
             rover.cruise_learn_start();
         }
         break;
 
     // arm or disarm the motors
-    case ARMDISARM:
+    case AUX_FUNC::ARMDISARM:
         if (ch_flag == HIGH) {
             rover.arm_motors(AP_Arming::Method::RUDDER);
         } else if (ch_flag == LOW) {
@@ -144,62 +144,62 @@ void RC_Channel_Rover::do_aux_function(const aux_func_t ch_option, const aux_swi
         break;
 
     // set mode to Manual
-    case MANUAL:
+    case AUX_FUNC::MANUAL:
         do_aux_function_change_mode(rover.mode_manual, ch_flag);
         break;
 
     // set mode to Acro
-    case ACRO:
+    case AUX_FUNC::ACRO:
         do_aux_function_change_mode(rover.mode_acro, ch_flag);
         break;
 
     // set mode to Steering
-    case STEERING:
+    case AUX_FUNC::STEERING:
         do_aux_function_change_mode(rover.mode_steering, ch_flag);
         break;
 
     // set mode to Hold
-    case HOLD:
+    case AUX_FUNC::HOLD:
         do_aux_function_change_mode(rover.mode_hold, ch_flag);
         break;
 
     // set mode to Auto
-    case AUTO:
+    case AUX_FUNC::AUTO:
         do_aux_function_change_mode(rover.mode_auto, ch_flag);
         break;
 
     // set mode to RTL
-    case RTL:
+    case AUX_FUNC::RTL:
         do_aux_function_change_mode(rover.mode_rtl, ch_flag);
         break;
 
     // set mode to SmartRTL
-    case SMART_RTL:
+    case AUX_FUNC::SMART_RTL:
         do_aux_function_change_mode(rover.mode_smartrtl, ch_flag);
         break;
 
     // set mode to Guided
-    case GUIDED:
+    case AUX_FUNC::GUIDED:
         do_aux_function_change_mode(rover.mode_guided, ch_flag);
         break;
 
     // Set mode to LOITER
-    case LOITER:
+    case AUX_FUNC::LOITER:
         do_aux_function_change_mode(rover.mode_loiter, ch_flag);
         break;
 
     // Set mode to Follow
-    case FOLLOW:
+    case AUX_FUNC::FOLLOW:
         do_aux_function_change_mode(rover.mode_follow, ch_flag);
         break;
 
     // set mode to Simple
-    case SIMPLE:
+    case AUX_FUNC::SIMPLE:
         do_aux_function_change_mode(rover.mode_simple, ch_flag);
         break;
 
     // trigger sailboat tack
-    case SAILBOAT_TACK:
+    case AUX_FUNC::SAILBOAT_TACK:
         // any switch movement interpreted as request to tack
         rover.control_mode->handle_tack_request();
         break;

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -34,8 +34,8 @@ bool AP_Arming_Copter::pre_arm_checks(bool display_failure)
 
     // check if motor interlock and Emergency Stop aux switches are used
     // at the same time.  This cannot be allowed.
-    if (rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_INTERLOCK) &&
-        rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP)){
+    if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_INTERLOCK) &&
+        rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP)){
         check_failed(ARMING_CHECK_NONE, display_failure, "Interlock/E-Stop Conflict");
         return false;
     }
@@ -484,10 +484,10 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, AP_Arming::Method method
 
     // if we are not using Emergency Stop switch option, force Estop false to ensure motors
     // can run normally
-    if (!rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP)){
+    if (!rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP)){
         SRV_Channels::set_emergency_stop(false);
         // if we are using motor Estop switch, it must not be in Estop position
-    } else if (rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_ESTOP) && SRV_Channels::get_emergency_stop()){
+    } else if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_ESTOP) && SRV_Channels::get_emergency_stop()){
         gcs().send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Emergency Stopped");
         return false;
     }

--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -86,6 +86,6 @@ void Copter::update_using_interlock()
 #else
     // check if we are using motor interlock control on an aux switch or are in throw mode
     // which uses the interlock to stop motors while the copter is being thrown
-    ap.using_interlock = rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_INTERLOCK) != nullptr;
+    ap.using_interlock = rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_INTERLOCK) != nullptr;
 #endif
 }

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -34,8 +34,8 @@ void RC_Channel_Copter::mode_switch_changed(modeswitch_pos_t new_pos)
         AP_Notify::events.user_mode_change = 1;
     }
 
-    if (!rc().find_channel_for_option(SIMPLE_MODE) &&
-        !rc().find_channel_for_option(SUPERSIMPLE_MODE)) {
+    if (!rc().find_channel_for_option(AUX_FUNC::SIMPLE_MODE) &&
+        !rc().find_channel_for_option(AUX_FUNC::SUPERSIMPLE_MODE)) {
         // if none of the Aux Switches are set to Simple or Super Simple Mode then
         // set Simple Mode using stored parameters from EEPROM
         if (BIT_IS_SET(copter.g.super_simple, new_pos)) {
@@ -63,47 +63,47 @@ void RC_Channel_Copter::init_aux_function(const aux_func_t ch_option, const aux_
 {
     // init channel options
     switch(ch_option) {
-    case SIMPLE_MODE:
-    case RANGEFINDER:
-    case FENCE:
-    case SUPERSIMPLE_MODE:
-    case ACRO_TRAINER:
-    case PARACHUTE_ENABLE:
-    case PARACHUTE_3POS:      // we trust the vehicle will be disarmed so even if switch is in release position the chute will not release
-    case RETRACT_MOUNT:
-    case MISSION_RESET:
-    case ATTCON_FEEDFWD:
-    case ATTCON_ACCEL_LIM:
-    case MOTOR_INTERLOCK:
-    case AVOID_ADSB:
-    case PRECISION_LOITER:
-    case INVERTED:
-    case WINCH_ENABLE:
+    case AUX_FUNC::SIMPLE_MODE:
+    case AUX_FUNC::RANGEFINDER:
+    case AUX_FUNC::FENCE:
+    case AUX_FUNC::SUPERSIMPLE_MODE:
+    case AUX_FUNC::ACRO_TRAINER:
+    case AUX_FUNC::PARACHUTE_ENABLE:
+    case AUX_FUNC::PARACHUTE_3POS:      // we trust the vehicle will be disarmed so even if switch is in release position the chute will not release
+    case AUX_FUNC::RETRACT_MOUNT:
+    case AUX_FUNC::MISSION_RESET:
+    case AUX_FUNC::ATTCON_FEEDFWD:
+    case AUX_FUNC::ATTCON_ACCEL_LIM:
+    case AUX_FUNC::MOTOR_INTERLOCK:
+    case AUX_FUNC::AVOID_ADSB:
+    case AUX_FUNC::PRECISION_LOITER:
+    case AUX_FUNC::INVERTED:
+    case AUX_FUNC::WINCH_ENABLE:
         do_aux_function(ch_option, ch_flag);
         break;
     // the following functions do not need to be initialised:
-    case FLIP:
-    case RTL:
-    case SAVE_TRIM:
-    case SAVE_WP:
-    case RESETTOARMEDYAW:
-    case AUTO:
-    case AUTOTUNE:
-    case LAND:
-    case BRAKE:
-    case THROW:
-    case SMART_RTL:
-    case GUIDED:
-    case LOITER:
-    case FOLLOW:
-    case PARACHUTE_RELEASE:
-    case ARMDISARM:
-    case WINCH_CONTROL:
-    case USER_FUNC1:
-    case USER_FUNC2:
-    case USER_FUNC3:
-    case ZIGZAG:
-    case ZIGZAG_SaveWP:
+    case AUX_FUNC::FLIP:
+    case AUX_FUNC::RTL:
+    case AUX_FUNC::SAVE_TRIM:
+    case AUX_FUNC::SAVE_WP:
+    case AUX_FUNC::RESETTOARMEDYAW:
+    case AUX_FUNC::AUTO:
+    case AUX_FUNC::AUTOTUNE:
+    case AUX_FUNC::LAND:
+    case AUX_FUNC::BRAKE:
+    case AUX_FUNC::THROW:
+    case AUX_FUNC::SMART_RTL:
+    case AUX_FUNC::GUIDED:
+    case AUX_FUNC::LOITER:
+    case AUX_FUNC::FOLLOW:
+    case AUX_FUNC::PARACHUTE_RELEASE:
+    case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::WINCH_CONTROL:
+    case AUX_FUNC::USER_FUNC1:
+    case AUX_FUNC::USER_FUNC2:
+    case AUX_FUNC::USER_FUNC3:
+    case AUX_FUNC::ZIGZAG:
+    case AUX_FUNC::ZIGZAG_SaveWP:
         break;
     default:
         RC_Channel::init_aux_function(ch_option, ch_flag);
@@ -142,36 +142,36 @@ void RC_Channel_Copter::do_aux_function_change_mode(const control_mode_t mode,
 void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch(ch_option) {
-        case FLIP:
+        case AUX_FUNC::FLIP:
             // flip if switch is on, positive throttle and we're actually flying
             if (ch_flag == aux_switch_pos_t::HIGH) {
                 copter.set_mode(control_mode_t::FLIP, MODE_REASON_TX_COMMAND);
             }
             break;
 
-        case SIMPLE_MODE:
+        case AUX_FUNC::SIMPLE_MODE:
             // low = simple mode off, middle or high position turns simple mode on
             copter.set_simple_mode(ch_flag == HIGH || ch_flag == MIDDLE);
             break;
 
-        case SUPERSIMPLE_MODE:
+        case AUX_FUNC::SUPERSIMPLE_MODE:
             // low = simple mode off, middle = simple mode, high = super simple mode
             copter.set_simple_mode(ch_flag);
             break;
 
-        case RTL:
+        case AUX_FUNC::RTL:
 #if MODE_RTL_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::RTL, ch_flag);
 #endif
             break;
 
-        case SAVE_TRIM:
+        case AUX_FUNC::SAVE_TRIM:
             if ((ch_flag == HIGH) && (copter.control_mode <= control_mode_t::ACRO) && (copter.channel_throttle->get_control_in() == 0)) {
                 copter.save_trim();
             }
             break;
 
-        case SAVE_WP:
+        case AUX_FUNC::SAVE_WP:
 #if MODE_AUTO_ENABLED == ENABLED
             // save waypoint when switch is brought high
             if (ch_flag == HIGH) {
@@ -223,7 +223,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case MISSION_RESET:
+        case AUX_FUNC::MISSION_RESET:
 #if MODE_AUTO_ENABLED == ENABLED
             if (ch_flag == HIGH) {
                 copter.mode_auto.mission.reset();
@@ -231,13 +231,13 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case AUTO:
+        case AUX_FUNC::AUTO:
 #if MODE_AUTO_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::AUTO, ch_flag);
 #endif
             break;
 
-        case RANGEFINDER:
+        case AUX_FUNC::RANGEFINDER:
             // enable or disable the rangefinder
 #if RANGEFINDER_ENABLED == ENABLED
             if ((ch_flag == HIGH) && copter.rangefinder.has_orientation(ROTATION_PITCH_270)) {
@@ -248,7 +248,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case FENCE:
+        case AUX_FUNC::FENCE:
 #if AC_FENCE == ENABLED
             // enable or disable the fence
             if (ch_flag == HIGH) {
@@ -261,7 +261,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case ACRO_TRAINER:
+        case AUX_FUNC::ACRO_TRAINER:
 #if MODE_ACRO_ENABLED == ENABLED
             switch(ch_flag) {
                 case LOW:
@@ -280,36 +280,36 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case AUTOTUNE:
+        case AUX_FUNC::AUTOTUNE:
 #if AUTOTUNE_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::AUTOTUNE, ch_flag);
 #endif
             break;
 
-        case LAND:
+        case AUX_FUNC::LAND:
             do_aux_function_change_mode(control_mode_t::LAND, ch_flag);
             break;
 
-        case GUIDED:
+        case AUX_FUNC::GUIDED:
             do_aux_function_change_mode(control_mode_t::GUIDED, ch_flag);
             break;
 
-        case LOITER:
+        case AUX_FUNC::LOITER:
             do_aux_function_change_mode(control_mode_t::LOITER, ch_flag);
             break;
 
-        case FOLLOW:
+        case AUX_FUNC::FOLLOW:
             do_aux_function_change_mode(control_mode_t::FOLLOW, ch_flag);
             break;
 
-        case PARACHUTE_ENABLE:
+        case AUX_FUNC::PARACHUTE_ENABLE:
 #if PARACHUTE == ENABLED
             // Parachute enable/disable
             copter.parachute.enabled(ch_flag == HIGH);
 #endif
             break;
 
-        case PARACHUTE_RELEASE:
+        case AUX_FUNC::PARACHUTE_RELEASE:
 #if PARACHUTE == ENABLED
             if (ch_flag == HIGH) {
                 copter.parachute_manual_release();
@@ -317,7 +317,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case PARACHUTE_3POS:
+        case AUX_FUNC::PARACHUTE_3POS:
 #if PARACHUTE == ENABLED
             // Parachute disable, enable, release with 3 position switch
             switch (ch_flag) {
@@ -337,17 +337,17 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case ATTCON_FEEDFWD:
+        case AUX_FUNC::ATTCON_FEEDFWD:
             // enable or disable feed forward
             copter.attitude_control->bf_feedforward(ch_flag == HIGH);
             break;
 
-        case ATTCON_ACCEL_LIM:
+        case AUX_FUNC::ATTCON_ACCEL_LIM:
             // enable or disable accel limiting by restoring defaults
             copter.attitude_control->accel_limiting(ch_flag == HIGH);
             break;
 
-        case RETRACT_MOUNT:
+        case AUX_FUNC::RETRACT_MOUNT:
 #if MOUNT == ENABLE
             switch (ch_flag) {
                 case HIGH:
@@ -363,25 +363,25 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case MOTOR_INTERLOCK:
+        case AUX_FUNC::MOTOR_INTERLOCK:
             // Turn on when above LOW, because channel will also be used for speed
             // control signal in tradheli
             copter.ap.motor_interlock_switch = (ch_flag == HIGH || ch_flag == MIDDLE);
             break;
 
-        case BRAKE:
+        case AUX_FUNC::BRAKE:
 #if MODE_BRAKE_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::BRAKE, ch_flag);
 #endif
             break;
 
-        case THROW:
+        case AUX_FUNC::THROW:
 #if MODE_THROW_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::THROW, ch_flag);
 #endif
             break;
 
-        case AVOID_ADSB:
+        case AUX_FUNC::AVOID_ADSB:
 #if ADSB_ENABLED == ENABLED
             // enable or disable AP_Avoidance
             if (ch_flag == HIGH) {
@@ -394,7 +394,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case PRECISION_LOITER:
+        case AUX_FUNC::PRECISION_LOITER:
 #if PRECISION_LANDING == ENABLED && MODE_LOITER_ENABLED == ENABLED
             switch (ch_flag) {
                 case HIGH:
@@ -410,7 +410,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case ARMDISARM:
+        case AUX_FUNC::ARMDISARM:
             // arm or disarm the vehicle
             switch (ch_flag) {
             case HIGH:
@@ -427,13 +427,13 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
             }
             break;
 
-        case SMART_RTL:
+        case AUX_FUNC::SMART_RTL:
 #if MODE_SMARTRTL_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::SMART_RTL, ch_flag);
 #endif
             break;
 
-        case INVERTED:
+        case AUX_FUNC::INVERTED:
 #if FRAME_CONFIG == HELI_FRAME
             switch (ch_flag) {
             case HIGH:
@@ -453,7 +453,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case WINCH_ENABLE:
+        case AUX_FUNC::WINCH_ENABLE:
 #if WINCH_ENABLED == ENABLED
             switch (ch_flag) {
                 case HIGH:
@@ -470,7 +470,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 #endif
             break;
 
-        case WINCH_CONTROL:
+        case AUX_FUNC::WINCH_CONTROL:
 #if WINCH_ENABLED == ENABLED
             switch (ch_flag) {
                 case LOW:
@@ -492,23 +492,23 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
         case USER_FUNC1:
             userhook_auxSwitch1(ch_flag);
             break;
-            
+
         case USER_FUNC2:
             userhook_auxSwitch2(ch_flag);
             break;
-            
+
         case USER_FUNC3:
             userhook_auxSwitch3(ch_flag);
             break;
 #endif
 
-        case ZIGZAG:
+        case AUX_FUNC::ZIGZAG:
 #if MODE_ZIGZAG_ENABLED == ENABLED
             do_aux_function_change_mode(control_mode_t::ZIGZAG, ch_flag);
 #endif
             break;
 
-        case ZIGZAG_SaveWP:
+        case AUX_FUNC::ZIGZAG_SaveWP:
 #if MODE_ZIGZAG_ENABLED == ENABLED
             if (copter.flightmode == &copter.mode_zigzag) {
                 switch (ch_flag) {

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -140,7 +140,7 @@ void Copter::heli_update_rotor_speed_targets()
     // get rotor control method
     uint8_t rsc_control_mode = motors->get_rsc_mode();
     float rsc_control_deglitched = 0.0f;
-    RC_Channel *rc_ptr = rc().find_channel_for_option(RC_Channel::aux_func::MOTOR_INTERLOCK);
+    RC_Channel *rc_ptr = rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_INTERLOCK);
     if (rc_ptr != nullptr) {
         rsc_control_deglitched = rotor_speed_deglitch_filter.apply((float)rc_ptr->get_control_in()) * 0.001f;
     }

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -351,7 +351,7 @@ void Copter::lost_vehicle_check()
     static uint8_t soundalarm_counter;
 
     // disable if aux switch is setup to vehicle alarm as the two could interfere
-    if (rc().find_channel_for_option(RC_Channel::aux_func::LOST_VEHICLE_SOUND)) {
+    if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::LOST_VEHICLE_SOUND)) {
         return;
     }
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -32,11 +32,11 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 {
     switch(ch_option) {
     // the following functions do not need to be initialised:
-    case ARMDISARM:
-    case INVERTED:
+    case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::INVERTED:
         break;
 
-    case REVERSE_THROTTLE:
+    case AUX_FUNC::REVERSE_THROTTLE:
         plane.have_reverse_throttle_rc_option = true;
         // setup input throttle as a range. This is needed as init_aux_function is called
         // after set_control_channels()
@@ -58,7 +58,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::aux_func_t ch_option,
 void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch(ch_option) {
-    case ARMDISARM:
+    case AUX_FUNC::ARMDISARM:
         // arm or disarm the vehicle
         switch (ch_flag) {
         case HIGH:
@@ -72,11 +72,11 @@ void RC_Channel_Plane::do_aux_function(const aux_func_t ch_option, const aux_swi
             break;
         }
         break;
-    case INVERTED:
+    case AUX_FUNC::INVERTED:
         plane.inverted_flight = (ch_flag == HIGH);
         break;
 
-    case REVERSE_THROTTLE:
+    case AUX_FUNC::REVERSE_THROTTLE:
         plane.reversed_throttle = (ch_flag == HIGH);
         gcs().send_text(MAV_SEVERITY_INFO, "RevThrottle: %s", plane.reversed_throttle?"ENABLE":"DISABLE");
         break;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -425,28 +425,28 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
 {
     // init channel options
     switch(ch_option) {
-    case RC_OVERRIDE_ENABLE:
-    case AVOID_PROXIMITY:
+    case AUX_FUNC::RC_OVERRIDE_ENABLE:
+    case AUX_FUNC::AVOID_PROXIMITY:
         do_aux_function(ch_option, ch_flag);
         break;
     // the following functions to not need to be initialised:
-    case RELAY:
-    case RELAY2:
-    case RELAY3:
-    case RELAY4:
-    case RELAY5:
-    case RELAY6:
-    case CAMERA_TRIGGER:
-    case LOST_VEHICLE_SOUND:
-    case DO_NOTHING:
-    case CLEAR_WP:
-    case COMPASS_LEARN:
-    case LANDING_GEAR:
+    case AUX_FUNC::RELAY:
+    case AUX_FUNC::RELAY2:
+    case AUX_FUNC::RELAY3:
+    case AUX_FUNC::RELAY4:
+    case AUX_FUNC::RELAY5:
+    case AUX_FUNC::RELAY6:
+    case AUX_FUNC::CAMERA_TRIGGER:
+    case AUX_FUNC::LOST_VEHICLE_SOUND:
+    case AUX_FUNC::DO_NOTHING:
+    case AUX_FUNC::CLEAR_WP:
+    case AUX_FUNC::COMPASS_LEARN:
+    case AUX_FUNC::LANDING_GEAR:
         break;
-    case MOTOR_ESTOP:
-    case GRIPPER:
-    case SPRAYER:
-    case GPS_DISABLE:
+    case AUX_FUNC::MOTOR_ESTOP:
+    case AUX_FUNC::GRIPPER:
+    case AUX_FUNC::SPRAYER:
+    case AUX_FUNC::GPS_DISABLE:
         do_aux_function(ch_option, ch_flag);
         break;
     default:
@@ -461,7 +461,7 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
 void RC_Channel::read_aux()
 {
     const aux_func_t _option = (aux_func_t)option.get();
-    if (_option == DO_NOTHING) {
+    if (_option == AUX_FUNC::DO_NOTHING) {
         // may wish to add special cases for other "AUXSW" things
         // here e.g. RCMAP_ROLL etc once they become options
         return;
@@ -611,61 +611,61 @@ void RC_Channel::do_aux_function_rc_override_enable(const aux_switch_pos_t ch_fl
 void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_pos_t ch_flag)
 {
     switch(ch_option) {
-    case CAMERA_TRIGGER:
+    case AUX_FUNC::CAMERA_TRIGGER:
         do_aux_function_camera_trigger(ch_flag);
         break;
 
-    case GRIPPER:
+    case AUX_FUNC::GRIPPER:
         do_aux_function_gripper(ch_flag);
         break;
 
-    case RC_OVERRIDE_ENABLE:
+    case AUX_FUNC::RC_OVERRIDE_ENABLE:
         // Allow or disallow RC_Override
         do_aux_function_rc_override_enable(ch_flag);
         break;
 
-    case AVOID_PROXIMITY:
+    case AUX_FUNC::AVOID_PROXIMITY:
         do_aux_function_avoid_proximity(ch_flag);
         break;
 
-    case RELAY:
+    case AUX_FUNC::RELAY:
         do_aux_function_relay(0, ch_flag == HIGH);
         break;
-    case RELAY2:
+    case AUX_FUNC::RELAY2:
         do_aux_function_relay(1, ch_flag == HIGH);
         break;
-    case RELAY3:
+    case AUX_FUNC::RELAY3:
         do_aux_function_relay(2, ch_flag == HIGH);
         break;
-    case RELAY4:
+    case AUX_FUNC::RELAY4:
         do_aux_function_relay(3, ch_flag == HIGH);
         break;
-    case RELAY5:
+    case AUX_FUNC::RELAY5:
         do_aux_function_relay(4, ch_flag == HIGH);
         break;
-    case RELAY6:
+    case AUX_FUNC::RELAY6:
         do_aux_function_relay(5, ch_flag == HIGH);
         break;
-    case CLEAR_WP:
+    case AUX_FUNC::CLEAR_WP:
         do_aux_function_clear_wp(ch_flag);
         break;
 
-    case SPRAYER:
+    case AUX_FUNC::SPRAYER:
         do_aux_function_sprayer(ch_flag);
         break;
 
-    case LOST_VEHICLE_SOUND:
+    case AUX_FUNC::LOST_VEHICLE_SOUND:
         do_aux_function_lost_vehicle_sound(ch_flag);
         break;
 
-    case COMPASS_LEARN:
+    case AUX_FUNC::COMPASS_LEARN:
         if (ch_flag == HIGH) {
             Compass &compass = AP::compass();
             compass.set_learn_type(Compass::LEARN_INFLIGHT, false);
         }
         break;
 
-    case LANDING_GEAR: {
+    case AUX_FUNC::LANDING_GEAR: {
         AP_LandingGear *lg = AP_LandingGear::get_singleton();
         if (lg == nullptr) {
             break;
@@ -684,11 +684,11 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
         break;
     }
 
-    case GPS_DISABLE:
+    case AUX_FUNC::GPS_DISABLE:
         AP::gps().force_disable(ch_flag == HIGH);
         break;
 
-    case MOTOR_ESTOP:
+    case AUX_FUNC::MOTOR_ESTOP:
         switch (ch_flag) {
         case HIGH: {
             SRV_Channels::set_emergency_stop(true);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -98,7 +98,7 @@ public:
     void read_aux();
 
     // Aux Switch enumeration
-    enum aux_func {
+    enum class AUX_FUNC {
         DO_NOTHING =           0, // aux switch disabled
         FLIP =                 2, // flip
         SIMPLE_MODE =          3, // change to simple mode
@@ -166,7 +166,7 @@ public:
         // if you add something here, make sure to update the documentation of the parameter in RC_Channel.cpp!
         // also, if you add an option >255, you will need to fix duplicate_options_exist
     };
-    typedef enum aux_func aux_func_t;
+    typedef enum AUX_FUNC aux_func_t;
 
 protected:
 


### PR DESCRIPTION
aux_func declaration shadows enums of mavlink ardupilotmega
RC_Channel declares `PARACHUTE_ENABLE = 21`
ardupilotmega defines it as `PARACHUTE_ENABLE=1`

This fix a compilation error with clang-8

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>