### PR TITLE
Libraries: Change to shared CRC16 method

### DIFF
--- a/libraries/AP_HAL/utility/srxl.cpp
+++ b/libraries/AP_HAL/utility/srxl.cpp
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <AP_Math/crc.h>
 #include "srxl.h"
 
 
@@ -67,31 +68,6 @@ static uint16_t crc_receiver = 0U;                  /* CRC extracted from srxl d
 
 
 static uint16_t max_channels;
-
-
-
-
-/**
- * This function calculates the 16bit crc as used throughout the srxl protocol variants
- *
- * This function is intended to be called whenever a new byte shall be added to the crc.
- * Simply provide the old crc and the new data byte and the function return the new crc value.
- *
- * To start a new crc calculation for a new srxl frame, provide parameter crc=0 and the first byte of the frame.
- *
- * @param[in]   crc - start value for crc
- * @param[in]   new_byte - byte that shall be included in crc calculation
- * @return      calculated crc
- */
-static uint16_t srxl_crc16 (uint16_t crc, uint8_t new_byte)
-{
-    uint8_t loop;
-    crc = crc ^ (uint16_t)new_byte << 8;
-    for(loop = 0; loop < 8; loop++) {
-		crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
-	}
-    return crc;
-}
 
 
 /**
@@ -297,7 +273,7 @@ int srxl_decode(uint64_t timestamp_us, uint8_t byte, uint8_t *num_values, uint16
     switch (decode_state) {
     case STATE_NEW:   /* buffer header byte and prepare for frame reception and decoding */
         buffer[0U]=byte;
-        crc_fmu = srxl_crc16(0U,byte);
+        crc_fmu = crc_xmodem_update(0U,byte);
         buflen = 1U;
         decode_state_next = STATE_COLLECT;
         break;
@@ -315,7 +291,7 @@ int srxl_decode(uint64_t timestamp_us, uint8_t byte, uint8_t *num_values, uint16
         buflen++;
         /* CRC not over last 2 frame bytes as these bytes inhabitate the crc */
         if (buflen <= (frame_len_full-2)) {
-           crc_fmu = srxl_crc16(crc_fmu,byte);
+           crc_fmu = crc_xmodem_update(crc_fmu,byte);
         }
         if(  buflen == frame_len_full ) {
             /* CRC check here */

--- a/libraries/AP_HAL/utility/sumd.cpp
+++ b/libraries/AP_HAL/utility/sumd.cpp
@@ -45,6 +45,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <AP_Math/crc.h>
 #include "sumd.h"
 
 #define SUMD_MAX_CHANNELS	32
@@ -116,18 +117,6 @@ static uint8_t _rxlen;
 static ReceiverFcPacketHoTT _rxpacket;
 
 
-static uint16_t sumd_crc16(uint16_t crc, uint8_t value)
-{
-	int i;
-	crc ^= (uint16_t)value << 8;
-
-	for (i = 0; i < 8; i++) {
-		crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
-	}
-
-	return crc;
-}
-
 static uint8_t sumd_crc8(uint8_t crc, uint8_t value)
 {
 	crc += value;
@@ -153,7 +142,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			_crc16 = 0x0000;
 			_crc8 = 0x00;
 			_crcOK = false;
-			_crc16 = sumd_crc16(_crc16, byte);
+			_crc16 = crc_xmodem_update(_crc16, byte);
 			_crc8 = sumd_crc8(_crc8, byte);
 			_decode_state = SUMD_DECODE_STATE_GOT_HEADER;
 
@@ -176,7 +165,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			}
 
 			if (_sumd) {
-				_crc16 = sumd_crc16(_crc16, byte);
+				_crc16 = crc_xmodem_update(_crc16, byte);
 
 			} else {
 				_crc8 = sumd_crc8(_crc8, byte);
@@ -199,7 +188,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			_rxpacket.length = byte;
 
 			if (_sumd) {
-				_crc16 = sumd_crc16(_crc16, byte);
+				_crc16 = crc_xmodem_update(_crc16, byte);
 
 			} else {
 				_crc8 = sumd_crc8(_crc8, byte);
@@ -222,7 +211,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		_rxpacket.sumd_data[_rxlen] = byte;
 
 		if (_sumd) {
-			_crc16 = sumd_crc16(_crc16, byte);
+			_crc16 = crc_xmodem_update(_crc16, byte);
 
 		} else {
 			_crc8 = sumd_crc8(_crc8, byte);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SRXL.h
@@ -43,7 +43,6 @@ public:
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
-    static uint16_t srxl_crc16(uint16_t crc, uint8_t new_byte);
     int srxl_channels_get_v1v2(uint16_t max_values, uint8_t *num_values, uint16_t *values, bool *failsafe_state);
     int srxl_channels_get_v5(uint16_t max_values, uint8_t *num_values, uint16_t *values, bool *failsafe_state);
     uint8_t buffer[SRXL_FRAMELEN_MAX];       /* buffer for raw srxl frame data in correct order --> buffer[0]=byte0  buffer[1]=byte1  */

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
@@ -43,6 +43,7 @@
  * @author Marco Bauer <marco@wtns.de>
  */
 #include "AP_RCProtocol_SUMD.h"
+#include <AP_Math/crc.h>
 
 #define SUMD_HEADER_LENGTH	3
 #define SUMD_HEADER_ID		0xA8
@@ -63,18 +64,6 @@
 
 // #define SUMD_DEBUG
 extern const AP_HAL::HAL& hal;
-
-uint16_t AP_RCProtocol_SUMD::sumd_crc16(uint16_t crc, uint8_t value)
-{
-    int i;
-    crc ^= (uint16_t)value << 8;
-
-    for (i = 0; i < 8; i++) {
-        crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
-    }
-
-    return crc;
-}
 
 uint8_t AP_RCProtocol_SUMD::sumd_crc8(uint8_t crc, uint8_t value)
 {
@@ -107,7 +96,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
             _crc16 = 0x0000;
             _crc8 = 0x00;
             _crcOK = false;
-            _crc16 = sumd_crc16(_crc16, byte);
+            _crc16 = crc_xmodem_update(_crc16, byte);
             _crc8 = sumd_crc8(_crc8, byte);
             _decode_state = SUMD_DECODE_STATE_GOT_HEADER;
 
@@ -127,7 +116,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
             }
 
             if (_sumd) {
-                _crc16 = sumd_crc16(_crc16, byte);
+                _crc16 = crc_xmodem_update(_crc16, byte);
 
             } else {
                 _crc8 = sumd_crc8(_crc8, byte);
@@ -150,7 +139,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
             _rxpacket.length = byte;
 
             if (_sumd) {
-                _crc16 = sumd_crc16(_crc16, byte);
+                _crc16 = crc_xmodem_update(_crc16, byte);
 
             } else {
                 _crc8 = sumd_crc8(_crc8, byte);
@@ -173,7 +162,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
         _rxpacket.sumd_data[_rxlen] = byte;
 
         if (_sumd) {
-            _crc16 = sumd_crc16(_crc16, byte);
+            _crc16 = crc_xmodem_update(_crc16, byte);
 
         } else {
             _crc8 = sumd_crc8(_crc8, byte);
@@ -341,4 +330,3 @@ void AP_RCProtocol_SUMD::process_byte(uint8_t byte, uint32_t baudrate)
     }
     _process_byte(AP_HAL::micros(), byte);
 }
-

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
@@ -30,7 +30,6 @@ public:
 
 private:
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
-    static uint16_t sumd_crc16(uint16_t crc, uint8_t value);
     static uint8_t sumd_crc8(uint8_t crc, uint8_t value);
 
 #pragma pack(push, 1)

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -331,7 +331,7 @@ public:
 
     // should we ignore RC failsafe bits from receivers?
     bool ignore_rc_failsafe(void) const {
-        return _options & uint32_t(Option::IGNORE_FAILSAFE);
+        return get_singleton() != nullptr && (_options & uint32_t(Option::IGNORE_FAILSAFE));
     }
 
     bool ignore_overrides() const {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -785,7 +785,9 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
 void Aircraft::add_shove_forces(Vector3f &rot_accel, Vector3f &body_accel)
 {
     const uint32_t now = AP_HAL::millis();
-
+    if (sitl == nullptr) {
+        return;
+    }
     if (sitl->shove.t == 0) {
         return;
     }


### PR DESCRIPTION
Several classes have methods locally for calculating CRC16 values.
There was a method in the CRC class to calculate the same CRC16 value.
I think it is better to use this method.