### PR TITLE
Clean up headers

### DIFF
--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -6,6 +6,7 @@ The init_ardupilot function processes everything we need for an in - air restart
 *****************************************************************************/
 
 #include "Rover.h"
+#include <AP_Common/AP_FWVersion.h>
 
 static void mavlink_delay_cb_static()
 {

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -2,6 +2,8 @@
 
 #include "Tracker.h"
 
+#include <AP_Camera/AP_Camera.h>
+
 /*
  *  !!NOTE!!
  *

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -59,6 +59,7 @@
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Beacon/AP_Beacon.h>
+#include <AP_Common/AP_FWVersion.h>
 
 // Configuration
 #include "config.h"

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -77,6 +77,7 @@
 #include <AP_SmartRTL/AP_SmartRTL.h>
 #include <AP_TempCalibration/AP_TempCalibration.h>
 #include <AC_AutoTune/AC_AutoTune.h>
+#include <AP_Common/AP_FWVersion.h>
 
 // Configuration
 #include "defines.h"

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
 
 class GCS_MAVLINK_Plane : public GCS_MAVLINK
 {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -1,4 +1,5 @@
 #include "Plane.h"
+#include <AP_Common/AP_FWVersion.h>
 
 /*****************************************************************************
 *   The init_ardupilot function processes everything we need for an in - air restart

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -76,6 +76,7 @@
 #include <AP_JSButton/AP_JSButton.h>   // Joystick/gamepad button function assignment
 #include <AP_LeakDetector/AP_LeakDetector.h> // Leak detector
 #include <AP_TemperatureSensor/TSYS01.h>
+#include <AP_Common/AP_FWVersion.h>
 
 // Local modules
 #include "defines.h"

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -28,6 +28,8 @@
 #include "DataFlashFileReader.h"
 #include "Replay.h"
 
+#include <AP_Camera/AP_Camera.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -36,6 +36,8 @@
   #endif
 #endif
 
+#include <AP_Logger/AP_Logger.h>
+
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
 #define AP_ARMING_COMPASS_MAGFIELD_MIN  185     // 0.35 * 530 milligauss
 #define AP_ARMING_COMPASS_MAGFIELD_MAX  875     // 1.65 * 530 milligauss

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -44,6 +44,8 @@
 #include "AP_Baro_UAVCAN.h"
 #endif
 
+#include <AP_Logger/AP_Logger.h>
+
 #define INTERNAL_TEMPERATURE_CLAMP 35.0f
 
 #ifndef HAL_BARO_FILTER_DEFAULT

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -5,6 +5,9 @@
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
+#include <SRV_Channel/SRV_Channel.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_GPS/AP_GPS.h>
 
 // ------------------------------
 #define CAM_DEBUG DISABLED

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -5,9 +5,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Relay/AP_Relay.h>
-#include <AP_GPS/AP_GPS.h>
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_Mission/AP_Mission.h>
 
 #define AP_CAMERA_TRIGGER_TYPE_SERVO                0
 #define AP_CAMERA_TRIGGER_TYPE_RELAY                1

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -4,6 +4,7 @@
 
 #include "AP_Compass.h"
 #include <GCS_MAVLink/GCS.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 extern const AP_HAL::HAL &hal;
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -24,8 +24,8 @@
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_Common/AP_FWVersion.h>
 #include <GCS_MAVLink/GCS.h>
 
 #include <stdio.h>

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -19,11 +19,8 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Math/AP_Math.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include "GPS_detect_state.h"
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_RTC/AP_RTC.h>
 
 /**
    maximum number of GPS instances available on this platform. If more
@@ -32,11 +29,7 @@
 #define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not include virtual GPS created by blending receiver data
 #define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximum number of GPS instances including the 'virtual' GPS created by blending receiver data
 #define GPS_BLENDED_INSTANCE GPS_MAX_RECEIVERS  // the virtual blended GPS is always the highest instance (2)
-#define GPS_RTK_INJECT_TO_ALL 127
-#define GPS_MAX_RATE_MS 200 // maximum value of rate_ms (i.e. slowest update rate) is 5hz or 200ms
 #define GPS_UNKNOWN_DOP UINT16_MAX // set unknown DOP's to maximum value, which is also correct for MAVLink
-#define GPS_WORST_LAG_SEC 0.22f // worst lag value any GPS driver is expected to return, expressed in seconds
-#define GPS_MAX_DELTA_MS 245 // 200 ms (5Hz) + 45 ms buffer
 
 // the number of GPS leap seconds
 #define GPS_LEAPSECONDS_MILLIS 18000ULL
@@ -545,7 +538,7 @@ private:
     Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS]; // Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
     float _hgt_offset_cm[GPS_MAX_RECEIVERS]; // Filtered height offset from GPS instance relative to blended solution in _output_state.location (cm)
     Vector3f _blended_antenna_offset; // blended antenna offset
-    float _blended_lag_sec = 0.001f * GPS_MAX_RATE_MS; // blended receiver lag in seconds
+    float _blended_lag_sec; // blended receiver lag in seconds
     float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
     uint32_t _last_time_updated[GPS_MAX_RECEIVERS]; // the last value of state.last_gps_time_ms read for that GPS instance - used to detect new data.
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -15,6 +15,7 @@
 
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
+#include <AP_Logger/AP_Logger.h>
 
 #define GPS_BACKEND_DEBUGGING 0
 

--- a/libraries/AP_InertialSensor/BatchSampler.cpp
+++ b/libraries/AP_InertialSensor/BatchSampler.cpp
@@ -1,5 +1,6 @@
 #include "AP_InertialSensor.h"
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
 
 // Class level parameters
 const AP_Param::GroupInfo AP_InertialSensor::BatchSampler::var_info[] = {

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -34,6 +34,7 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Motors/AP_Motors.h>
+#include <AP_Logger/AP_Logger.h>
 
 #include "AP_KDECAN.h"
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -6,12 +6,9 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_GPS/AP_GPS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_RSSI/AP_RSSI.h>
-#include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -2,9 +2,6 @@
 
 #include "AP_Logger_Backend.h"
 
-#include <AP_Mission/AP_Mission.h>
-#include <AP_Rally/AP_Rally.h>
-
 class LoggerMessageWriter {
 public:
 

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -1,6 +1,7 @@
 #include "AP_Mission.h"
 
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Camera/AP_Camera.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -21,12 +21,9 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <AP_GPS/AP_GPS.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Common/Location.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
-#include <RC_Channel/RC_Channel.h>
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_Logger/AP_Logger.h>
 
 // maximum number of mounts
 #define AP_MOUNT_MAX_INSTANCES          1

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -1,4 +1,5 @@
 #include "AP_Mount_Backend.h"
+#include <AP_AHRS/AP_AHRS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -124,16 +125,10 @@ void AP_Mount_Backend::update_targets_from_rc()
     }
 }
 
-// returns the angle (degrees*100) that the RC_Channel input is receiving
-int32_t AP_Mount_Backend::angle_input(const RC_Channel* rc, int16_t angle_min, int16_t angle_max)
-{
-    return (rc->norm_input() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min;
-}
-
 // returns the angle (radians) that the RC_Channel input is receiving
 float AP_Mount_Backend::angle_input_rad(const RC_Channel* rc, int16_t angle_min, int16_t angle_max)
 {
-    return radians(angle_input(rc, angle_min, angle_max)*0.01f);
+    return radians(((rc->norm_input() + 1.0f) * 0.5f * (angle_max - angle_min) + angle_min)*0.01f);
 }
 
 // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (and radians) to point at the given target

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -21,6 +21,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include "AP_Mount.h"
+#include <RC_Channel/RC_Channel.h>
 
 class AP_Mount_Backend
 {
@@ -82,8 +83,7 @@ protected:
     // update_targets_from_rc - updates angle targets (i.e. _angle_ef_target_rad) using input from receiver
     void update_targets_from_rc();
 
-    // angle_input, angle_input_rad - convert RC input into an earth-frame target angle
-    int32_t angle_input(const RC_Channel* rc, int16_t angle_min, int16_t angle_max);
+    // angle_input_rad - convert RC input into an earth-frame target angle
     float angle_input_rad(const RC_Channel* rc, int16_t angle_min, int16_t angle_max);
 
     // calc_angle_to_location - calculates the earth-frame roll, tilt and pan angles (and radians) to point at the given target

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -17,7 +17,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_Math/AP_Math.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include "AP_RangeFinder_Params.h"
 

--- a/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
+++ b/libraries/AP_ToshibaCAN/AP_ToshibaCAN.cpp
@@ -27,6 +27,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
 #include "AP_ToshibaCAN.h"
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -41,6 +41,7 @@
 #include <AP_BattMonitor/AP_BattMonitor_UAVCAN.h>
 #include <AP_Compass/AP_Compass_UAVCAN.h>
 #include <AP_Airspeed/AP_Airspeed_UAVCAN.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 #define LED_DELAY_US 50000
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -16,6 +16,7 @@
 #include "AP_VisualOdom.h"
 #include "AP_VisualOdom_Backend.h"
 #include "AP_VisualOdom_MAV.h"
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL &hal;
 

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -18,7 +18,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <GCS_MAVLink/GCS.h>
 
 class AP_VisualOdom_Backend;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -1,4 +1,5 @@
 #include "GCS.h"
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -11,18 +11,13 @@
 #include <stdint.h>
 #include "MAVLink_routing.h"
 #include <AP_SerialManager/AP_SerialManager.h>
-#include <AP_Mount/AP_Mount.h>
 #include <AP_Avoidance/AP_Avoidance.h>
-#include <AP_Proximity/AP_Proximity.h>
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
-#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
-#include <AP_Camera/AP_Camera.h>
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
-#include <AP_VisualOdom/AP_VisualOdom.h>
-#include <AP_Common/AP_FWVersion.h>
 #include <AP_RTC/JitterCorrection.h>
 #include <AP_Common/Bitmask.h>
 #include <AP_Devo_Telem/AP_Devo_Telem.h>
+#include <RC_Channel/RC_Channel.h>
 
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -22,10 +22,13 @@
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_RangeFinder/RangeFinder_Backend.h>
 #include <AP_Airspeed/AP_Airspeed.h>
+#include <AP_Camera/AP_Camera.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_Common/Semaphore.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_Mount/AP_Mount.h>
+#include <AP_Common/AP_FWVersion.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 
 #include "GCS.h"

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -1,4 +1,5 @@
 #include "GCS.h"
+#include <AP_Common/AP_FWVersion.h>
 
 const AP_FWVersion AP_FWVersion::fwver
 {

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -19,6 +19,7 @@
 
 #include "AP_Common/AP_FWVersion.h"
 #include "GCS.h"
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/GCS_MAVLink/GCS_Rally.cpp
+++ b/libraries/GCS_MAVLink/GCS_Rally.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "GCS.h"
+#include <AP_Rally/AP_Rally.h>
 
 void GCS_MAVLINK::handle_rally_point(mavlink_message_t *msg)
 {

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -5,6 +5,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Common/AP_FWVersion.h>
 
 void setup();
 void loop();

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -31,8 +31,10 @@ extern const AP_HAL::HAL& hal;
 
 #include <AC_Avoidance/AC_Avoid.h>
 #include <AC_Sprayer/AC_Sprayer.h>
+#include <AP_Camera/AP_Camera.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_LandingGear/AP_LandingGear.h>
+#include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
 
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN


### PR DESCRIPTION
This was a mistake that went out of control, and I decided to stick with it. I was trying to slightly reduce the scope of files that had to be recompiled. I deleted some stuff from `AP_Mount.h` and this just spawned many/many other include errors elsewhere. Apparently we were dependent upon this including stuff in order to get it into `GCS_MAVLink.h`, which in turn was used to propagate everywhere else. I stuck with the cleanup, but it was more then I was looking to do originally. There are apparently lots of circular dependencies in `GCS_MAVLink.h`