### PR TITLE
Plane: qstabilize throttle midpoint and expo

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -532,6 +532,9 @@ public:
     // dual motor tailsitter rudder to differential thrust scaling: 0-100%
     AP_Int8 rudd_dt_gain;
 
+    // QACRO mode max yaw rate in deg/sec
+    AP_Int16 acro_yaw_rate;
+
     // mask of channels to do manual pass-thru for
     AP_Int32 manual_rc_mask;
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -416,6 +416,33 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Increment: .1
     // @User: Advanced
     AP_GROUPINFO("THROTTLE_EXPO", 10, QuadPlane, throttle_expo, 0.2),
+
+    // @Param: ACRO_RLL_RATE
+    // @DisplayName: QACRO mode roll rate
+    // @Description: The maximum roll rate at full stick deflection in QACRO mode
+    // @Units: deg/s
+    // @Range: 10 500
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("ACRO_RLL_RATE", 11, QuadPlane, acro_roll_rate, 360),
+
+    // @Param: ACRO_PIT_RATE
+    // @DisplayName: QACRO mode pitch rate
+    // @Description: The maximum pitch rate at full stick deflection in QACRO mode
+    // @Units: deg/s
+    // @Range: 10 500
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("ACRO_PIT_RATE", 12, QuadPlane, acro_pitch_rate, 180),
+
+    // @Param: ACRO_YAW_RATE
+    // @DisplayName: QACRO mode yaw rate
+    // @Description: The maximum yaw rate at full stick deflection in QACRO mode
+    // @Units: deg/s
+    // @Range: 10 500
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("ACRO_YAW_RATE", 13, QuadPlane, acro_yaw_rate, 90),
     AP_GROUPEND
 };
 
@@ -914,8 +941,11 @@ void QuadPlane::hold_hover(float target_climb_rate)
 
 float QuadPlane::get_pilot_throttle()
 {
-    // get normalized throttle [0,1]
-    float throttle_in = (float)plane.channel_throttle->get_control_in() / plane.channel_throttle->get_range();
+    // get scaled throttle input
+    float throttle_in = plane.channel_throttle->get_control_in();
+
+    // normalize to [0,1]
+    throttle_in /= plane.channel_throttle->get_range();
 
     // get hover throttle level [0,1]
     float thr_mid = motors->get_throttle_hover();
@@ -940,17 +970,16 @@ void QuadPlane::control_qacro(void)
 
         // convert the input to the desired body frame rate
         float target_roll = 0;
-        float target_pitch = plane.channel_pitch->norm_input() * plane.g.acro_pitch_rate * 100.0f;
+        float target_pitch = plane.channel_pitch->norm_input() * acro_pitch_rate * 100.0f;
         float target_yaw = 0;
         if (is_tailsitter()) {
             // Note that the 90 degree Y rotation for copter mode swaps body-frame roll and yaw
             // acro_roll_rate param applies to yaw in copter frame
-            // no parameter for acro yaw rate; just use the normal one since the default is 100 deg/sec
-            target_roll =  plane.channel_rudder->norm_input() * yaw_rate_max * 100.0f;
-            target_yaw  = -plane.channel_roll->norm_input() * plane.g.acro_roll_rate * 100.0f;
+            target_roll =  plane.channel_rudder->norm_input() * acro_roll_rate * 100.0f;
+            target_yaw  = -plane.channel_roll->norm_input() * acro_yaw_rate * 100.0f;
         } else {
-            target_roll = plane.channel_roll->norm_input() * plane.g.acro_roll_rate * 100.0f;
-            target_yaw  = plane.channel_rudder->norm_input() * yaw_rate_max * 100.0;
+            target_roll = plane.channel_roll->norm_input() * acro_roll_rate * 100.0f;
+            target_yaw  = plane.channel_rudder->norm_input() * acro_yaw_rate * 100.0;
         }
 
         float throttle_out = get_pilot_throttle();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -416,7 +416,6 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Increment: .1
     // @User: Advanced
     AP_GROUPINFO("THROTTLE_EXPO", 10, QuadPlane, throttle_expo, 0.2),
-
     AP_GROUPEND
 };
 
@@ -916,11 +915,10 @@ void QuadPlane::hold_hover(float target_climb_rate)
 float QuadPlane::get_pilot_throttle()
 {
     // get normalized throttle [0,1]
-    float throttle_in = plane.channel_throttle->get_control_in() / plane.channel_throttle->get_range();
+    float throttle_in = (float)plane.channel_throttle->get_control_in() / plane.channel_throttle->get_range();
 
     // get hover throttle level [0,1]
     float thr_mid = motors->get_throttle_hover();
-
     float thrust_curve_expo = constrain_float(throttle_expo, 0.0f, 1.0f);
 
     // this puts mid stick at hover throttle

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -409,6 +409,14 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Bitmask: 0:Motor 1,1:Motor 2,2:Motor 3,3:Motor 4, 4:Motor 5,5:Motor 6,6:Motor 7,7:Motor 8
     AP_GROUPINFO("TAILSIT_MOTMX", 9, QuadPlane, tailsitter.motor_mask, 0),
 
+    // @Param: THROTTLE_EXPO
+    // @DisplayName: Throttle expo strength
+    // @Description: Amount of curvature in throttle curve: 0 is linear, 1 is cubic
+    // @Range: 0 1
+    // @Increment: .1
+    // @User: Advanced
+    AP_GROUPINFO("THROTTLE_EXPO", 10, QuadPlane, throttle_expo, 0.2),
+
     AP_GROUPEND
 };
 
@@ -795,7 +803,7 @@ void QuadPlane::control_stabilize(void)
     }
 
     // normal QSTABILIZE mode
-    float pilot_throttle_scaled = plane.get_throttle_input() / 100.0f;
+    float pilot_throttle_scaled = get_pilot_throttle();
     hold_stabilize(pilot_throttle_scaled);
 
 }
@@ -905,6 +913,20 @@ void QuadPlane::hold_hover(float target_climb_rate)
     run_z_controller();
 }
 
+float QuadPlane::get_pilot_throttle()
+{
+    // get normalized throttle [0,1]
+    float throttle_in = plane.channel_throttle->get_control_in() / plane.channel_throttle->get_range();
+
+    // get hover throttle level [0,1]
+    float thr_mid = motors->get_throttle_hover();
+
+    float thrust_curve_expo = constrain_float(throttle_expo, 0.0f, 1.0f);
+
+    // this puts mid stick at hover throttle
+    return throttle_curve(thr_mid, thrust_curve_expo, throttle_in);;
+}
+
 /*
   control QACRO mode
  */
@@ -933,29 +955,7 @@ void QuadPlane::control_qacro(void)
             target_yaw  = plane.channel_rudder->norm_input() * yaw_rate_max * 100.0;
         }
 
-        // get pilot's desired throttle
-        int16_t mid_stick = plane.channel_throttle->get_control_mid();
-        // protect against unlikely divide by zero
-        if (mid_stick <= 0) {
-            mid_stick = 50;
-        }
-        float thr_mid = motors->get_throttle_hover();
-        int16_t throttle_control = plane.channel_throttle->get_control_in();
-        float throttle_in;
-        if (throttle_control < mid_stick) {
-            // below the deadband
-            throttle_in = ((float)throttle_control) * 0.5f / (float)mid_stick;
-        } else if (throttle_control > mid_stick) {
-            // above the deadband
-            throttle_in = 0.5f + ((float)(throttle_control - mid_stick)) * 0.5f / (float)(100 - mid_stick);
-        } else {
-            // must be in the deadband
-            throttle_in = 0.5f;
-        }
-
-        float expo = constrain_float(-(thr_mid - 0.5) / 0.375, -0.5f, 1.0f);
-        // calculate the output throttle using the given expo function
-        float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
+        float throttle_out = get_pilot_throttle();
 
         // run attitude controller
         if (plane.g.acro_locking) {
@@ -1751,6 +1751,11 @@ void QuadPlane::update_throttle_hover()
 
     // do not update while climbing or descending
     if (!is_zero(pos_control->get_desired_velocity().z)) {
+        return;
+    }
+
+    // do not update if quadplane forward motor is running (wing may be generating lift)
+    if (!is_tailsitter() && (SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) != 0)) {
         return;
     }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -211,6 +211,7 @@ private:
 
     void check_attitude_relax(void);
     void init_qacro(void);
+    float get_pilot_throttle(void);
     void control_qacro(void);
     void init_hover(void);
     void control_hover(void);
@@ -309,7 +310,10 @@ private:
 
     // HEARTBEAT mav_type override
     AP_Int8 mav_type;
-    
+
+    // manual throttle curve expo strength
+    AP_Float throttle_expo;
+
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -314,6 +314,11 @@ private:
     // manual throttle curve expo strength
     AP_Float throttle_expo;
 
+    // QACRO mode max roll/pitch/yaw rates
+    AP_Float acro_roll_rate;
+    AP_Float acro_pitch_rate;
+    AP_Float acro_yaw_rate;
+
     // time we last got an EKF yaw reset
     uint32_t ekfYawReset_ms;
 

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -76,7 +76,7 @@ template float safe_sqrt<float>(const float v);
 template float safe_sqrt<double>(const double v);
 
 /*
-  linear interpolation based on a variable in a range
+ * linear interpolation based on a variable in a range
  */
 float linear_interpolate(float low_output, float high_output,
                          float var_value,
@@ -90,6 +90,35 @@ float linear_interpolate(float low_output, float high_output,
     }
     float p = (var_value - var_low) / (var_high - var_low);
     return low_output + p * (high_output - low_output);
+}
+
+/* cubic "expo" curve generator
+ * alpha range: [0,1] min to max expo
+ * input range: [-1,1]
+ */
+float expo_curve(float alpha, float x)
+{
+    return (1.0f - alpha) * x + alpha * x * x * x;
+}
+
+/* throttle curve generator
+ * thr_mid: output at mid stick
+ * alpha: expo coefficient
+ * thr_in: [0-1]
+ */
+float throttle_curve(float thr_mid, float alpha, float thr_in)
+{
+    float alpha2 = alpha + 1.25 * (1.0f - alpha) * (0.5f - thr_mid) / 0.5f;
+    alpha2 = constrain_float(alpha2, 0.0f, 1.0f);
+    float thr_out = 0.0f;
+    if (thr_in < 0.5f) {
+        float t = linear_interpolate(-1.0f, 0.0f, thr_in, 0.0f, 0.5f);
+        thr_out = linear_interpolate(0.0f, thr_mid, expo_curve(alpha, t), -1.0f, 0.0f);
+    } else {
+        float t = linear_interpolate(0.0f, 1.0f, thr_in, 0.5f, 1.0f);
+        thr_out = linear_interpolate(thr_mid, 1.0f, expo_curve(alpha2, t), 0.0f, 1.0f);
+    }
+    return thr_out;
 }
 
 template <typename T>

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -247,6 +247,19 @@ float linear_interpolate(float low_output, float high_output,
                          float var_value,
                          float var_low, float var_high);
 
+/* cubic "expo" curve generator 
+ * alpha range: [0,1] min to max expo
+ * input range: [-1,1]
+ */
+float expo_curve(float alpha, float input);
+
+/* throttle curve generator
+ * thr_mid: output at mid stick
+ * alpha: expo coefficient
+ * thr_in: [0-1]
+ */
+float throttle_curve(float thr_mid, float alpha, float thr_in);
+
 /* simple 16 bit random number generator */
 uint16_t get_random16(void);
 


### PR DESCRIPTION
@IamPete1 This brings the hover thrust midpoint and throttle expo to all quadplanes. It eliminates the throttle discontinuity between QACRO/QHOVER/QLOITER and QSTABILIZE modes and works well for copter tailsitters. 
Let me know if you think this is an improvement for regular quadplanes, or if it should restricted to tailsitters.