### PR TITLE
Copter/WPNav/CircleNav: avoid casting to and from int32_t

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -532,8 +532,8 @@ void Copter::Mode::land_run_horizontal_control()
     // run loiter controller
     loiter_nav->update();
 
-    int32_t nav_roll  = loiter_nav->get_roll();
-    int32_t nav_pitch = loiter_nav->get_pitch();
+    float nav_roll  = loiter_nav->get_roll();
+    float nav_pitch = loiter_nav->get_pitch();
 
     if (g2.wp_navalt_min > 0) {
         // user has requested an altitude below which navigation

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -47,9 +47,9 @@ public:
     void update();
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    int32_t get_roll() const { return _pos_control.get_roll(); }
-    int32_t get_pitch() const { return _pos_control.get_pitch(); }
-    int32_t get_yaw() const { return _yaw; }
+    float get_roll() const { return _pos_control.get_roll(); }
+    float get_pitch() const { return _pos_control.get_pitch(); }
+    float get_yaw() const { return _yaw; }
 
     // get_closest_point_on_circle - returns closest point on the circle
     //  circle's center should already have been set

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -54,8 +54,8 @@ public:
     void update();
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    int32_t get_roll() const { return _pos_control.get_roll(); }
-    int32_t get_pitch() const { return _pos_control.get_pitch(); }
+    float get_roll() const { return _pos_control.get_roll(); }
+    float get_pitch() const { return _pos_control.get_pitch(); }
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -214,8 +214,8 @@ public:
     ///
 
     /// get desired roll, pitch which should be fed into stabilize controllers
-    int32_t get_roll() const { return _pos_control.get_roll(); }
-    int32_t get_pitch() const { return _pos_control.get_pitch(); }
+    float get_roll() const { return _pos_control.get_roll(); }
+    float get_pitch() const { return _pos_control.get_pitch(); }
 
     /// advance_wp_target_along_track - move target location along track from origin to destination
     bool advance_wp_target_along_track(float dt);


### PR DESCRIPTION
Poor PosControl.  Passing perfectly good floating point values back to its caller, only to have its valuable message garbled in translation to an int32 - and then, through sheer effrontery having those mangled values passed  back to its close friend, the AttitudeController.

Setting the world to rights, here we avoid the translation to/from floating point values as they're passed through the navigation controllers.
