### PR TITLE
Make constraining a NaN an internal error

### DIFF
--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -43,6 +43,7 @@ public:
         logger_bad_current_block    = (1U <<  7),
         logger_blockcount_mismatch  = (1U <<  8),
         logger_dequeue_failure      = (1U <<  9),
+        constraining_nan            = (1U << 10),
     };
 
     void error(const AP_InternalError::error_t error);

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -2,6 +2,8 @@
 
 #include <float.h>
 
+#include <AP_InternalError/AP_InternalError.h>
+
 /*
  * is_equal(): Integer implementation, provided for convenience and
  * compatibility with old code. Expands to the same as comparing the values
@@ -185,6 +187,7 @@ T constrain_value(const T amt, const T low, const T high)
     // errors through any function that uses constrain_value(). The normal
     // float semantics already handle -Inf and +Inf
     if (isnan(amt)) {
+        AP::internalerror().error(AP_InternalError::error_t::constraining_nan);
         return (low + high) / 2;
     }
 


### PR DESCRIPTION
We should never be asked to constrain a NaN.  It impinges on their natural dignity.

Adding this call ensures we will start to know if dealing with NaNs becomes a problem.
