### PR TITLE
Add float designators to floating point constants (e.g. 1.0 -> 1.0f)

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -591,7 +591,7 @@ float Copter::Mode::get_pilot_desired_throttle() const
         throttle_in = 0.5f + ((float)(throttle_control-mid_stick)) * 0.5f / (float)(1000-mid_stick);
     }
 
-    float expo = constrain_float(-(thr_mid-0.5)/0.375, -0.5f, 1.0f);
+    const float expo = constrain_float(-(thr_mid-0.5f)/0.375f, -0.5f, 1.0f);
     // calculate the output throttle using the given expo function
     float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
     return throttle_out;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -669,13 +669,13 @@ private:
     void update_height_estimate(void);
 
     // minimum assumed height
-    const float height_min = 0.1;
+    const float height_min = 0.1f;
 
     // maximum scaling height
-    const float height_max = 3.0;
+    const float height_max = 3.0f;
 
     AP_Float flow_max;
-    AC_PI_2D flow_pi_xy{0.2, 0.3, 3000, 5, 0.0025};
+    AC_PI_2D flow_pi_xy{0.2f, 0.3f, 3000, 5, 0.0025f};
     AP_Float flow_filter_hz;
     AP_Int8  flow_min_quality;
     AP_Int8  brake_rate_dps;

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -206,7 +206,7 @@ void Copter::radio_passthrough_to_motors()
 {
     motors->set_radio_passthrough(channel_roll->norm_input(),
                                   channel_pitch->norm_input(),
-                                  channel_throttle->get_control_in_zero_dz()*0.001,
+                                  channel_throttle->get_control_in_zero_dz()*0.001f,
                                   channel_yaw->norm_input());
 }
 

--- a/libraries/AC_PID/AC_HELI_PID.h
+++ b/libraries/AC_PID/AC_HELI_PID.h
@@ -9,7 +9,7 @@
 #include <cmath>
 #include "AC_PID.h"
 
-#define AC_PID_LEAK_MIN     0.1  // Default I-term Leak Minimum
+static const float AC_PID_LEAK_MIN = 0.1f;  // Default I-term Leak Minimum
 
 /// @class	AC_HELI_PID
 /// @brief	Heli PID control class

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -102,7 +102,7 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @Units: s
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("LAG", 9, AC_PrecLand, _lag, 0.02), // 20ms is the old default buffer size (8 frames @ 400hz/2.5ms)
+    AP_GROUPINFO("LAG", 9, AC_PrecLand, _lag, 0.02f), // 20ms is the old default buffer size (8 frames @ 400hz/2.5ms)
 
     AP_GROUPEND
 };

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -129,8 +129,8 @@ void AC_Loiter::init_target()
     // update angle targets that will be passed to stabilize controller
     float roll_cd, pitch_cd;
     _pos_control.accel_to_lean_angles(_predicted_accel.x, _predicted_accel.y, roll_cd, pitch_cd);
-    _predicted_euler_angle.x = radians(roll_cd*0.01);
-    _predicted_euler_angle.y = radians(pitch_cd*0.01);
+    _predicted_euler_angle.x = radians(roll_cd*0.01f);
+    _predicted_euler_angle.y = radians(pitch_cd*0.01f);
     // set target position
     _pos_control.set_xy_target(curr_pos.x, curr_pos.y);
 

--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -164,13 +164,13 @@ void AP_Baro_DPS280::calculate_PT(int32_t UT, int32_t UP, float &pressure, float
 {
     const struct dps280_cal &cal = calibration;
     // scaling for 16x oversampling
-    const float scaling_16 = 1.0/253952;
+    const float scaling_16 = 1.0f/253952;
 
     float temp_scaled;
     float press_scaled;
 
     temp_scaled = float(UT) * scaling_16;
-    temperature = cal.C0 * 0.5 + cal.C1 * temp_scaled;
+    temperature = cal.C0 * 0.5f + cal.C1 * temp_scaled;
 
     press_scaled = float(UP) * scaling_16;
 

--- a/libraries/AP_Baro/AP_Baro_HIL.cpp
+++ b/libraries/AP_Baro/AP_Baro_HIL.cpp
@@ -74,7 +74,7 @@ void AP_Baro::SimpleUnderWaterAtmosphere(
     // \f$T(D)\approx\frac{S}{1.8 \cdot 10^{-4} \cdot S \cdot T + 1}\f$
     const float seaTempSurface = 15.0f; // Celsius
     const float S = seaTempSurface * 0.338f;
-    theta = 1.0f / ((1.8e-4) * S * (alt * 1e3) + 1.0f);
+    theta = 1.0f / ((1.8e-4f) * S * (alt * 1e3f) + 1.0f);
 }
 
 /*

--- a/libraries/AP_Baro/AP_Baro_ICM20789.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.cpp
@@ -296,7 +296,7 @@ static struct {
 void AP_Baro_ICM20789::convert_data(uint32_t Praw, uint32_t Traw)
 {
     // temperature is easy
-    float T = -45 + (175.0 / (1U<<16)) * Traw;
+    float T = -45 + (175.0f / (1U<<16)) * Traw;
 
     // pressure involves a few more calculations
     float P = get_pressure(Praw, Traw);

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -224,7 +224,7 @@ void AP_Baro_LPS2XH::_update_temperature(void)
     WITH_SEMAPHORE(_sem);
 
     if (_lps2xh_type == BARO_LPS25H) {
-        _temperature=((float)(Temp_Reg_s16/480)+42.5);
+        _temperature=((float)(Temp_Reg_s16/480)+42.5f);
     }
     if (_lps2xh_type == BARO_LPS22H) {
         _temperature=(float)(Temp_Reg_s16/100);
@@ -237,7 +237,7 @@ void AP_Baro_LPS2XH::_update_pressure(void)
     uint8_t pressure[3];
     _dev->read_registers(PRESS_OUT_XL_ADDR, pressure, 3);
     int32_t Pressure_Reg_s32 = ((uint32_t)pressure[2]<<16)|((uint32_t)pressure[1]<<8)|(uint32_t)pressure[0];
-    int32_t Pressure_mb = Pressure_Reg_s32 * (100.0 / 4096); // scale for pa
+    int32_t Pressure_mb = Pressure_Reg_s32 * (100.0f / 4096); // scale for pa
 
     WITH_SEMAPHORE(_sem);
     _pressure = Pressure_mb;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelFlow.cpp
@@ -81,7 +81,7 @@ void AP_BattMonitor_FuelFlow::read()
         _state.last_time_micros = now_us;
         return;
     }
-    float dt = (now_us - _state.last_time_micros) * 1.0e-6;
+    float dt = (now_us - _state.last_time_micros) * 1.0e-6f;
 
     if (dt < 1 && irq_state.pulse_count == 0) {
         // we allow for up to 1 second with no pulses to cope with low
@@ -101,13 +101,13 @@ void AP_BattMonitor_FuelFlow::read()
       this driver assumes that BATTx_AMP_PERVLT is set to give the
       number of millilitres per pulse.
      */
-    float irq_dt = state.total_us * 1.0e-6;
+    float irq_dt = state.total_us * 1.0e-6f;
     float litres, litres_pec_sec;
     if (state.pulse_count == 0) {
         litres = 0;
         litres_pec_sec = 0;
     } else {
-        litres = state.pulse_count * _params._curr_amp_per_volt * 0.001;
+        litres = state.pulse_count * _params._curr_amp_per_volt * 0.001f;
         litres_pec_sec = litres / irq_dt;
     }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_Solo.cpp
@@ -53,7 +53,7 @@ void AP_BattMonitor_SMBus_Solo::timer()
         // because the Solo's I2C bus is so noisy, it's worth not spending the
         // time and bus bandwidth to request the pack voltage as a seperate
         // transaction
-        _state.voltage = pack_voltage_mv * 1e-3;
+        _state.voltage = pack_voltage_mv * 1e-3f;
         _state.last_time_micros = tnow;
         _state.healthy = true;
     }

--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -140,8 +140,8 @@ bool AP_Beacon::get_origin(Location &origin_loc) const
 
     // return origin
     origin_loc = {};
-    origin_loc.lat = origin_lat * 1.0e7;
-    origin_loc.lng = origin_lon * 1.0e7;
+    origin_loc.lat = origin_lat * 1.0e7f;
+    origin_loc.lng = origin_lon * 1.0e7f;
     origin_loc.alt = origin_alt * 100;
 
     return true;

--- a/libraries/AP_Beacon/AP_Beacon_SITL.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_SITL.cpp
@@ -66,15 +66,15 @@ void AP_Beacon_SITL::update(void)
 
     // truth location of the flight vehicle
     Location current_loc;
-    current_loc.lat = sitl->state.latitude * 1.0e7;
-    current_loc.lng = sitl->state.longitude * 1.0e7;
-    current_loc.alt = sitl->state.altitude * 1.0e2;
+    current_loc.lat = sitl->state.latitude * 1.0e7f;
+    current_loc.lng = sitl->state.longitude * 1.0e7f;
+    current_loc.alt = sitl->state.altitude * 1.0e2f;
 
     // where the beacon system origin is located
     Location beacon_origin;
-    beacon_origin.lat = get_beacon_origin_lat() * 1.0e7;
-    beacon_origin.lng = get_beacon_origin_lon() * 1.0e7;
-    beacon_origin.alt = get_beacon_origin_alt() * 1.0e2;
+    beacon_origin.lat = get_beacon_origin_lat() * 1.0e7f;
+    beacon_origin.lng = get_beacon_origin_lon() * 1.0e7f;
+    beacon_origin.alt = get_beacon_origin_alt() * 1.0e2f;
 
     // position of each beacon
     Location beacon_loc = beacon_origin;

--- a/libraries/AP_Beacon/AP_Beacon_SITL.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_SITL.cpp
@@ -68,13 +68,13 @@ void AP_Beacon_SITL::update(void)
     Location current_loc;
     current_loc.lat = sitl->state.latitude * 1.0e7f;
     current_loc.lng = sitl->state.longitude * 1.0e7f;
-    current_loc.alt = sitl->state.altitude * 1.0e2f;
+    current_loc.alt = sitl->state.altitude * 1.0e2;
 
     // where the beacon system origin is located
     Location beacon_origin;
     beacon_origin.lat = get_beacon_origin_lat() * 1.0e7f;
     beacon_origin.lng = get_beacon_origin_lon() * 1.0e7f;
-    beacon_origin.alt = get_beacon_origin_alt() * 1.0e2f;
+    beacon_origin.alt = get_beacon_origin_alt() * 1.0e2;
 
     // position of each beacon
     Location beacon_loc = beacon_origin;
@@ -100,8 +100,8 @@ void AP_Beacon_SITL::update(void)
     Vector2f beac_diff = location_diff(beacon_origin, beacon_loc);
     Vector2f veh_diff = location_diff(beacon_origin, current_loc);
 
-    Vector3f veh_pos3d(veh_diff.x, veh_diff.y, (current_loc.alt - beacon_origin.alt)*1.0e-2);
-    Vector3f beac_pos3d(beac_diff.x, beac_diff.y, (beacon_origin.alt - beacon_loc.alt)*1.0e-2);
+    Vector3f veh_pos3d(veh_diff.x, veh_diff.y, (current_loc.alt - beacon_origin.alt)*1.0e-2f);
+    Vector3f beac_pos3d(beac_diff.x, beac_diff.y, (beacon_origin.alt - beacon_loc.alt)*1.0e-2f);
     Vector3f beac_veh_offset = veh_pos3d - beac_pos3d;
 
     set_beacon_position(beacon_id, beac_pos3d);

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -220,7 +220,7 @@ void AP_Compass_MMC3416::timer()
             have_initial_offset = true;
         } else {
             // low pass changes to the offset
-            offset = offset * 0.95 + new_offset * 0.05;
+            offset = offset * 0.95f + new_offset * 0.05f;
         }
 
 #if 0

--- a/libraries/AP_Compass/Compass_PerMotor.cpp
+++ b/libraries/AP_Compass/Compass_PerMotor.cpp
@@ -116,7 +116,7 @@ float Compass_PerMotor::scaled_output(uint8_t motor)
     uint16_t pwm = hal.rcout->read_last_sent(motor_map[motor]);
 
     // get 0 to 1 motor demand
-    float output = (hal.rcout->scale_esc_to_unity(pwm)+1) * 0.5;
+    float output = (hal.rcout->scale_esc_to_unity(pwm)+1) * 0.5f;
 
     if (output <= 0) {
         return 0;

--- a/libraries/AP_Compass/Compass_PerMotor.h
+++ b/libraries/AP_Compass/Compass_PerMotor.h
@@ -21,7 +21,7 @@ public:
     
     void set_voltage(float _voltage) {
         // simple low-pass on voltage
-        voltage = 0.9 * voltage + 0.1 * _voltage;
+        voltage = 0.9f * voltage + 0.1f * _voltage;
     }
 
     void calibration_start(void);

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -44,7 +44,7 @@ void CompassLearn::update(void)
 
         // setup the expected earth field at this location
         float declination_deg=0, inclination_deg=0, intensity_gauss=0;
-        AP_Declination::get_mag_field_ef(loc.lat*1.0e-7, loc.lng*1.0e-7, intensity_gauss, declination_deg, inclination_deg);
+        AP_Declination::get_mag_field_ef(loc.lat*1.0e-7f, loc.lng*1.0e-7f, intensity_gauss, declination_deg, inclination_deg);
 
         // create earth field
         mag_ef = Vector3f(intensity_gauss*1000, 0.0, 0.0);
@@ -213,7 +213,7 @@ void CompassLearn::process_sample(const struct sample &s)
             predicted_offsets[i] = offsets;
         } else {
             // lowpass the predicted offsets and the error
-            const float learn_rate = 0.92;
+            const float learn_rate = 0.92f;
             predicted_offsets[i] = predicted_offsets[i] * learn_rate + offsets * (1-learn_rate);
             errors[i] = errors[i] * learn_rate + delta * (1-learn_rate);
         }

--- a/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
+++ b/libraries/AP_Devo_Telem/AP_Devo_Telem.cpp
@@ -53,13 +53,13 @@ uint32_t AP_DEVO_Telem::gpsDdToDmsFormat(float ddm)
     int32_t deg = (int32_t)ddm;
     float mm = (ddm - deg) * 60.0f;
 
-    mm = ((float)deg * 100.0f + mm) /100.0;
+    mm = ((float)deg * 100.0f + mm) /100.0f;
 
     if ((mm < -180.0f) || (mm > 180.0f)) {
         mm = 0.0f;
     }
 
-    return mm * 1.0e7;
+    return mm * 1.0e7f;
 }
 
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
@@ -256,7 +256,7 @@ void AP_InertialSensor_BMI055::read_fifo_accel(void)
         return;
     }
     // data is 12 bits with 16g range, 7.81mg/LSB
-    const float scale = 7.81 * 0.001 * GRAVITY_MSS / 16.0;
+    const float scale = 7.81 * 0.001 * GRAVITY_MSS / 16.0f;
     for (uint8_t i = 0; i < num_frames; i++) {
         const uint8_t *d = &data[i*6];
         int16_t xyz[3] {
@@ -277,7 +277,7 @@ void AP_InertialSensor_BMI055::read_fifo_accel(void)
         if (!dev_accel->read_registers(REGA_ACCD_TEMP, (uint8_t *)&t, 1)) {
             _inc_accel_error_count(accel_instance);
         } else {
-            float temp_degc = (0.5 * t) + 23.0;
+            float temp_degc = (0.5f * t) + 23.0f;
             _publish_temperature(accel_instance, temp_degc);
         }
     }
@@ -313,7 +313,7 @@ void AP_InertialSensor_BMI055::read_fifo_gyro(void)
     }
 
     // data is 16 bits with 2000dps range
-    const float scale = radians(2000.0) / 32767.0;
+    const float scale = radians(2000.0f) / 32767.0f;
     for (uint8_t i = 0; i < num_frames; i++) {
         const uint8_t *d = &data[i*6];
         int16_t xyz[3] {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -333,7 +333,7 @@ void AP_InertialSensor_BMI088::read_fifo_accel(void)
         } else {
             uint16_t temp_uint11 = (tbuf[0]<<3) | (tbuf[1]>>5);
             int16_t temp_int11 = temp_uint11>1023?temp_uint11-2048:temp_uint11;
-            float temp_degc = temp_int11 * 0.125 + 23;
+            float temp_degc = temp_int11 * 0.125f + 23;
             _publish_temperature(accel_instance, temp_degc);
         }
     }
@@ -365,7 +365,7 @@ void AP_InertialSensor_BMI088::read_fifo_gyro(void)
     }
 
     // data is 16 bits with 2000dps range
-    const float scale = radians(2000.0) / 32767.0;
+    const float scale = radians(2000.0f) / 32767.0f;
     for (uint8_t i = 0; i < num_frames; i++) {
         const uint8_t *d = &data[i*6];
         int16_t xyz[3] {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -62,18 +62,18 @@ void AP_InertialSensor_Backend::_update_sensor_rate(uint16_t &count, uint32_t &s
     } else {
         count++;
         if (now - start_us > 1000000UL) {
-            float observed_rate_hz = count * 1.0e6 / (now - start_us);
+            float observed_rate_hz = count * 1.0e6f / (now - start_us);
 #if SENSOR_RATE_DEBUG
             printf("RATE: %.1f should be %.1f\n", observed_rate_hz, rate_hz);
 #endif
-            float filter_constant = 0.98;
-            float upper_limit = 1.05;
-            float lower_limit = 0.95;
+            float filter_constant = 0.98f;
+            float upper_limit = 1.05f;
+            float lower_limit = 0.95f;
             if (AP_HAL::millis() < 30000) {
                 // converge quickly for first 30s, then more slowly
-                filter_constant = 0.8;
-                upper_limit = 2.0;
-                lower_limit = 0.5;
+                filter_constant = 0.8f;
+                upper_limit = 2.0f;
+                lower_limit = 0.5f;
             }
             observed_rate_hz = constrain_float(observed_rate_hz, rate_hz*lower_limit, rate_hz*upper_limit);
             rate_hz = filter_constant * rate_hz + (1-filter_constant) * observed_rate_hz;
@@ -158,7 +158,7 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
       difference between the two is whether sample_us is provided.
      */
     if (sample_us != 0 && _imu._gyro_last_sample_us[instance] != 0) {
-        dt = (sample_us - _imu._gyro_last_sample_us[instance]) * 1.0e-6;
+        dt = (sample_us - _imu._gyro_last_sample_us[instance]) * 1.0e-6f;
     } else {
         // don't accept below 100Hz
         if (_imu._gyro_raw_sample_rates[instance] < 100) {
@@ -291,7 +291,7 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
       difference between the two is whether sample_us is provided.
      */
     if (sample_us != 0 && _imu._accel_last_sample_us[instance] != 0) {
-        dt = (sample_us - _imu._accel_last_sample_us[instance]) * 1.0e-6;
+        dt = (sample_us - _imu._accel_last_sample_us[instance]) * 1.0e-6f;
     } else {
         // don't accept below 100Hz
         if (_imu._accel_raw_sample_rates[instance] < 100) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -226,30 +226,30 @@ void AP_InertialSensor_Invensense::start()
      */
     switch (_mpu_type) {
     case Invensense_MPU9250:
-        temp_zero = 21;
-        temp_sensitivity = 1.0/340;
+        temp_zero = 21.0f;
+        temp_sensitivity = 1.0f/340;
         break;
 
     case Invensense_MPU6000:
     case Invensense_MPU6500:
-        temp_zero = 36.53;
-        temp_sensitivity = 1.0/340;
+        temp_zero = 36.53f;
+        temp_sensitivity = 1.0f/340;
         break;
 
     case Invensense_ICM20608:
     case Invensense_ICM20602:
     case Invensense_ICM20601:
-        temp_zero = 25;
-        temp_sensitivity = 1.0/326.8; 
+        temp_zero = 25.0f;
+        temp_sensitivity = 1.0f/326.8f;
         break;
 
     case Invensense_ICM20789:
-        temp_zero = 25;
-        temp_sensitivity = 0.003;
+        temp_zero = 25.0f;
+        temp_sensitivity = 0.003f;
         break;
     case Invensense_ICM20689:
-        temp_zero = 25;
-        temp_sensitivity = 0.003;
+        temp_zero = 25.0f;
+        temp_sensitivity = 0.003f;
         break;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -112,8 +112,8 @@ private:
     uint8_t _gyro_instance;
     uint8_t _accel_instance;
 
-    float temp_sensitivity = 1.0/340; // degC/LSB
-    float temp_zero = 36.53; // degC
+    float temp_sensitivity = 1.0f/340; // degC/LSB
+    float temp_zero = 36.53f; // degC
     
     float _temp_filtered;
     float _accel_scale;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -674,7 +674,7 @@ void AP_InertialSensor_LSM9DS0::_set_accel_scale(accel_scale scale)
     _accel_scale = (((float) scale + 1.0f) * 2.0f) / 32768.0f;
     if (scale == A_SCALE_16G) {
         /* the datasheet shows an exception for +-16G */
-        _accel_scale = 0.000732;
+        _accel_scale = 0.000732f;
     }
     /* convert to G/LSB to (m/s/s)/LSB */
     _accel_scale *= GRAVITY_MSS;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
@@ -403,7 +403,7 @@ void AP_InertialSensor_LSM9DS1::_set_accel_scale(accel_scale scale)
     _accel_scale = (((float) scale + 1.0f) * 2.0f) / 32768.0f;
     if (scale == A_SCALE_16G) {
         /* the datasheet shows an exception for +-16G */
-        _accel_scale = 0.000732;
+        _accel_scale = 0.000732f;
     }
     /* convert to G/LSB to (m/s/s)/LSB */
     _accel_scale *= GRAVITY_MSS;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -80,7 +80,7 @@ void AP_InertialSensor_SITL::generate_accel(uint8_t instance)
         yAccel += accel_noise * rand_float();
         zAccel += accel_noise * rand_float();
     } else {
-        float t = AP_HAL::micros() * 1.0e-6;
+        float t = AP_HAL::micros() * 1.0e-6f;
         xAccel += sinf(t * 2 * M_PI * vibe_freq.x) * accel_noise;
         yAccel += sinf(t * 2 * M_PI * vibe_freq.y) * accel_noise;
         zAccel += sinf(t * 2 * M_PI * vibe_freq.z) * accel_noise;
@@ -145,7 +145,7 @@ void AP_InertialSensor_SITL::generate_gyro(uint8_t instance)
         q += gyro_noise * rand_float();
         r += gyro_noise * rand_float();
     } else {
-        float t = AP_HAL::micros() * 1.0e-6;
+        float t = AP_HAL::micros() * 1.0e-6f;
         p += sinf(t * 2 * M_PI * vibe_freq.x) * gyro_noise;
         q += sinf(t * 2 * M_PI * vibe_freq.y) * gyro_noise;
         r += sinf(t * 2 * M_PI * vibe_freq.z) * gyro_noise;
@@ -155,9 +155,9 @@ void AP_InertialSensor_SITL::generate_gyro(uint8_t instance)
 
     // add in gyro scaling
     Vector3f scale = sitl->gyro_scale;
-    gyro.x *= (1 + scale.x*0.01);
-    gyro.y *= (1 + scale.y*0.01);
-    gyro.z *= (1 + scale.z*0.01);
+    gyro.x *= (1 + scale.x*0.01f);
+    gyro.y *= (1 + scale.y*0.01f);
+    gyro.z *= (1 + scale.z*0.01f);
 
     _rotate_and_correct_gyro(gyro_instance[instance], gyro);
     

--- a/libraries/AP_Math/matrixN.cpp
+++ b/libraries/AP_Math/matrixN.cpp
@@ -48,7 +48,7 @@ void MatrixN<T,N>::force_symmetry(void)
 {
     for (uint8_t i = 0; i < N; i++) {
         for (uint8_t j = 0; j < (i - 1); j++) {
-            v[i][j] = (v[i][j] + v[j][i]) * 0.5;
+            v[i][j] = (v[i][j] + v[j][i]) * 0.5f;
             v[j][i] = v[i][j];
         }
     }

--- a/libraries/AP_Math/matrixN.cpp
+++ b/libraries/AP_Math/matrixN.cpp
@@ -48,7 +48,7 @@ void MatrixN<T,N>::force_symmetry(void)
 {
     for (uint8_t i = 0; i < N; i++) {
         for (uint8_t j = 0; j < (i - 1); j++) {
-            v[i][j] = (v[i][j] + v[j][i]) * 0.5f;
+            v[i][j] = (v[i][j] + v[j][i]) / 2;
             v[j][i] = v[i][j];
         }
     }

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -126,7 +126,7 @@ public:
     // get the time-allowed-per-loop in seconds
     float get_loop_period_s() {
         if (is_zero(_loop_period_s)) {
-            _loop_period_s = 1.0 / _loop_rate_hz;
+            _loop_period_s = 1.0f / _loop_rate_hz;
         }
         return _loop_period_s;
     }

--- a/libraries/AP_TempCalibration/AP_TempCalibration.h
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.h
@@ -67,7 +67,7 @@ private:
 
     const float exp_limit_max = 2;
     const float exp_limit_min = 0;
-    float learn_delta = 0.01;
+    float learn_delta = 0.01f;
     
     // require observation of at least 5 degrees of temp range to
     // start learning

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1323,7 +1323,7 @@ bool GCS_MAVLINK::set_ap_message_interval(enum ap_message id, uint16_t interval_
     // send messages out at most 80% of main loop rate
     if (interval_ms != 0 &&
         interval_ms*800 < AP::scheduler().get_loop_period_us()) {
-        interval_ms = AP::scheduler().get_loop_period_us()/800.0;
+        interval_ms = AP::scheduler().get_loop_period_us()/800.0f;
     }
 
     // check if it's a specially-handled message:


### PR DESCRIPTION
The compiler can warn us about bad things we're doing in terms of floating point conversions (`-Wfloat-conversion`).  It's picked up several things like https://github.com/ArduPilot/ardupilot/pull/10997 which I'll be PR'ing over the next little while.  See https://github.com/ArduPilot/ardupilot/pull/10983 where we're playing with the full `-Wconversion` - which probably won't be feasible.

These double-to-float warnings will make it impossible for us to move to (e.g.) `-Wfloat-conversion`; the warnings seem to be emitted regardless of the floating-point-constants directive.  Thus these patches to explicitly type the floating point constants.
