### PR TITLE
AP_Common: correct type conversion issues in _assert_storage_size

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -114,10 +114,10 @@
 // templates are used for this because the compiler's output will
 // usually contain details of the template instantiation so you can
 // see how the actual size differs from the expected size.
-template<typename s, int s_size, int t> struct _assert_storage_size {
+template<typename s, size_t s_size, size_t t> struct _assert_storage_size {
     static_assert(s_size == t, "wrong size");
 };
-template<typename s, int t> struct assert_storage_size {
+template<typename s, size_t t> struct assert_storage_size {
     _assert_storage_size<s, sizeof(s), t> _member;
 };
 


### PR DESCRIPTION
`int` wasn't even a good guess for these template parameters.
