### PR TITLE
Move two location methods from ap_math to Location

### DIFF
--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -205,7 +205,7 @@ void Mode::set_desired_location(const struct Location& destination, float next_l
     // set final desired speed
     _desired_speed_final = 0.0f;
     if (!is_equal(next_leg_bearing_cd, MODE_NEXT_HEADING_UNKNOWN)) {
-        const float curr_leg_bearing_cd = get_bearing_cd(_origin, _destination);
+        const float curr_leg_bearing_cd = _origin.get_bearing_to(_destination);
         const float turn_angle_cd = wrap_180_cd(next_leg_bearing_cd - curr_leg_bearing_cd);
         if (fabsf(turn_angle_cd) < 10.0f) {
             // if turning less than 0.1 degrees vehicle can continue at full speed
@@ -432,7 +432,7 @@ float Mode::calc_reduced_speed_for_turn_or_distance(float desired_speed)
     const float turn_angle_rad = fabsf(radians(wp_yaw_diff * 0.01f));
 
     // calculate distance from vehicle to line + wp_overshoot
-    const float line_yaw_diff = wrap_180_cd(get_bearing_cd(_origin, _destination) - heading_cd);
+    const float line_yaw_diff = wrap_180_cd(_origin.get_bearing_to(_destination) - heading_cd);
     const float xtrack_error = rover.nav_controller->crosstrack_error();
     const float dist_from_line = fabsf(xtrack_error);
     const bool heading_away = is_positive(line_yaw_diff) == is_positive(xtrack_error);

--- a/APMrover2/mode_loiter.cpp
+++ b/APMrover2/mode_loiter.cpp
@@ -35,7 +35,7 @@ void ModeLoiter::update()
         _desired_speed = MIN((_distance_to_destination - g2.loit_radius) * 0.5f, g.speed_cruise);
 
         // calculate bearing to destination
-        _desired_yaw_cd = get_bearing_cd(rover.current_loc, _destination);
+        _desired_yaw_cd = rover.current_loc.get_bearing_to(_destination);
         _yaw_error_cd = wrap_180_cd(_desired_yaw_cd - ahrs.yaw_sensor);
         // if destination is behind vehicle, reverse towards it
         if (fabsf(_yaw_error_cd) > 9000 && g2.loit_type == 0) {

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -54,7 +54,7 @@ void Tracker::update_bearing_and_distance()
     // calculate bearing to vehicle
     // To-Do: remove need for check of control_mode
     if (control_mode != SCAN && !nav_status.manual_control_yaw) {
-        nav_status.bearing  = get_bearing_cd(current_loc, vehicle.location_estimate) * 0.01f;
+        nav_status.bearing  = current_loc.get_bearing_to(vehicle.location_estimate) * 0.01f;
     }
 
     // calculate distance to vehicle

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -168,7 +168,7 @@ bool Copter::ModeFollow::get_wp(Location &loc)
     float dist = g2.follow.get_distance_to_target();
     float bearing = g2.follow.get_bearing_to_target();
     loc = copter.current_loc;
-    location_update(loc, bearing, dist);
+    loc.offset_bearing(bearing, dist);
     return true;
 }
 

--- a/ArduCopter/navigation.cpp
+++ b/ArduCopter/navigation.cpp
@@ -23,7 +23,7 @@ uint32_t Copter::home_distance()
 int32_t Copter::home_bearing()
 {
     if (position_ok()) {
-        _home_bearing = get_bearing_cd(current_loc, ahrs.get_home());
+        _home_bearing = current_loc.get_bearing_to(ahrs.get_home());
     }
     return _home_bearing;
 }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -473,12 +473,12 @@ void Plane::do_continue_and_change_alt(const AP_Mission::Mission_Command& cmd)
         // use gps ground course based bearing hold
         steer_state.hold_course_cd = -1;
         bearing = AP::gps().ground_course_cd() * 0.01f;
-        location_update(next_WP_loc, bearing, 1000); // push it out 1km
+        next_WP_loc.offset_bearing(bearing, 1000); // push it out 1km
     } else {
         // use yaw based bearing hold
         steer_state.hold_course_cd = wrap_360_cd(ahrs.yaw_sensor);
         bearing = ahrs.yaw_sensor * 0.01f;
-        location_update(next_WP_loc, bearing, 1000); // push it out 1km
+        next_WP_loc.offset_bearing(bearing, 1000); // push it out 1km
     }
 
     next_WP_loc.alt = cmd.content.location.alt + home.alt;
@@ -788,7 +788,7 @@ bool Plane::verify_continue_and_change_alt()
         if (current_loc.get_distance(next_WP_loc) < 200.0f) {
             //push another 300 m down the line
             int32_t next_wp_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
-            location_update(next_WP_loc, next_wp_bearing_cd * 0.01f, 300.0f);
+            next_WP_loc.offset_bearing(next_wp_bearing_cd * 0.01f, 300.0f);
         }
 
         //keep flying the same course
@@ -1030,14 +1030,14 @@ bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
                 Location end = cmd.content.location;
 
                 // project a 1km waypoint to either side of the landing location
-                location_update(start, vtol_approach_s.approach_direction_deg + 180, 1000);
-                location_update(end, vtol_approach_s.approach_direction_deg, 1000);
+                start.offset_bearing(vtol_approach_s.approach_direction_deg + 180, 1000);
+                end.offset_bearing(vtol_approach_s.approach_direction_deg, 1000);
 
                 nav_controller->update_waypoint(start, end);
 
                 // check if we should move on to the next waypoint
                 Location breakout_loc = cmd.content.location;
-                location_update(breakout_loc, vtol_approach_s.approach_direction_deg + 180, quadplane.stopping_distance());
+                breakout_loc.offset_bearing(vtol_approach_s.approach_direction_deg + 180, quadplane.stopping_distance());
                 if(location_passed_point(current_loc, start, breakout_loc)) {
                     vtol_approach_s.approach_stage = VTOL_LANDING;
                     quadplane.do_vtol_land(cmd);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -787,7 +787,7 @@ bool Plane::verify_continue_and_change_alt()
         // Is the next_WP less than 200 m away?
         if (current_loc.get_distance(next_WP_loc) < 200.0f) {
             //push another 300 m down the line
-            int32_t next_wp_bearing_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
+            int32_t next_wp_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
             location_update(next_WP_loc, next_wp_bearing_cd * 0.01f, 300.0f);
         }
 
@@ -1079,7 +1079,7 @@ bool Plane::verify_loiter_heading(bool init)
     }
 
     // Bearing in degrees
-    int32_t bearing_cd = get_bearing_cd(current_loc,next_nav_cmd.content.location);
+    int32_t bearing_cd = current_loc.get_bearing_to(next_nav_cmd.content.location);
 
     // get current heading.
     int32_t heading_cd = gps.ground_course_cd();

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -283,9 +283,7 @@ void Plane::update_cruise()
     if (cruise_state.locked_heading) {
         next_WP_loc = prev_WP_loc;
         // always look 1km ahead
-        location_update(next_WP_loc,
-                        cruise_state.locked_heading_cd*0.01f, 
-                        prev_WP_loc.get_distance(current_loc) + 1000);
+        next_WP_loc.offset_bearing(cruise_state.locked_heading_cd*0.01f, prev_WP_loc.get_distance(current_loc) + 1000);
         nav_controller->update_waypoint(prev_WP_loc, next_WP_loc);
     }
 }

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -344,7 +344,7 @@ void Plane::setup_turn_angle(void)
         auto_state.next_turn_angle = 90.0f;
     } else {
         // get the heading of the current leg
-        int32_t ground_course_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
+        int32_t ground_course_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
 
         // work out the angle we need to turn through
         auto_state.next_turn_angle = wrap_180_cd(next_ground_course_cd - ground_course_cd) * 0.01f;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -30,6 +30,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/Semaphore.h>
+#include <AP_Common/Location.h>
 
 class OpticalFlow;
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -989,7 +989,7 @@ bool AP_AHRS_DCM::get_position(struct Location &loc) const
     if (_flags.fly_forward && _have_position) {
         float gps_delay_sec = 0;
         _gps.get_lag(gps_delay_sec);
-        location_update(loc, _gps.ground_course_cd() * 0.01f, _gps.ground_speed() * gps_delay_sec);
+        loc.offset_bearing(_gps.ground_course_cd() * 0.01f, _gps.ground_speed() * gps_delay_sec);
     }
     return _have_position;
 }

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -270,3 +270,16 @@ bool Location::sanitize(const Location &defaultLoc)
 
 // make sure we know what size the Location object is:
 assert_storage_size<Location, 16> _assert_storage_size_Location;
+
+
+// return bearing in centi-degrees from location to loc2
+int32_t Location::get_bearing_to(const struct Location &loc2) const
+{
+    const int32_t off_x = loc2.lng - lng;
+    const int32_t off_y = (loc2.lat - lat) / loc2.longitude_scale();
+    int32_t bearing = 9000 + atan2f(-off_y, off_x) * DEGX100;
+    if (bearing < 0) {
+        bearing += 36000;
+    }
+    return bearing;
+}

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -232,6 +232,20 @@ void Location::offset(float ofs_north, float ofs_east)
     }
 }
 
+/*
+ *  extrapolate latitude/longitude given bearing and distance
+ * Note that this function is accurate to about 1mm at a distance of
+ * 100m. This function has the advantage that it works in relative
+ * positions, so it keeps the accuracy even when dealing with small
+ * distances and floating point numbers
+ */
+void Location::offset_bearing(float bearing, float distance)
+{
+    const float ofs_north = cosf(radians(bearing)) * distance;
+    const float ofs_east  = sinf(radians(bearing)) * distance;
+    offset(ofs_north, ofs_east);
+}
+
 float Location::longitude_scale() const
 {
     float scale = cosf(lat * (1.0e-7f * DEG_TO_RAD));

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -85,6 +85,9 @@ public:
 
     void zero(void);
 
+    // return bearing in centi-degrees from location to loc2
+    int32_t get_bearing_to(const struct Location &loc2) const;
+
     /*
      * convert invalid waypoint with useful data. return true if location changed
      */

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -75,6 +75,9 @@ public:
     // extrapolate latitude/longitude given distances (in meters) north and east
     void offset(float ofs_north, float ofs_east);
 
+    // extrapolate latitude/longitude given bearing and distance
+    void offset_bearing(float bearing, float distance);
+
     // longitude_scale - returns the scaler to compensate for
     // shrinking longitude as you move north or south from the equator
     // Note: this does not include the scaling to convert

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -27,6 +27,7 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Common/AP_FWVersion.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Common/Location.h>
 
 #include <stdio.h>
 
@@ -733,7 +734,7 @@ uint32_t AP_Frsky_Telem::calc_home(void)
             // distance between vehicle and home_loc in meters
             home = prep_number(roundf(home_loc.get_distance(loc)), 3, 2);
             // angle from front of vehicle to the direction of home_loc in 3 degree increments (just in case, limit to 127 (0x7F) since the value is stored on 7 bits)
-            home |= (((uint8_t)roundf(get_bearing_cd(loc,home_loc) * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
+            home |= (((uint8_t)roundf(loc.get_bearing_to(home_loc) * 0.00333f)) & HOME_BEARING_LIMIT)<<HOME_BEARING_OFFSET;
         }
         // altitude between vehicle and home_loc
         _relative_home_altitude = loc.alt;

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -224,7 +224,7 @@ void AP_L1_Control::update_waypoint(const struct Location &prev_WP, const struct
     Vector2f _groundspeed_vector = _ahrs.groundspeed_vector();
 
     // update _target_bearing_cd
-    _target_bearing_cd = get_bearing_cd(_current_loc, next_WP);
+    _target_bearing_cd = _current_loc.get_bearing_to(next_WP);
 
     //Calculate groundspeed
     float groundSpeed = _groundspeed_vector.length();
@@ -360,7 +360,7 @@ void AP_L1_Control::update_loiter(const struct Location &center_WP, float radius
 
 
     // update _target_bearing_cd
-    _target_bearing_cd = get_bearing_cd(_current_loc, center_WP);
+    _target_bearing_cd = _current_loc.get_bearing_to(center_WP);
 
 
     // Calculate time varying control parameters

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -18,6 +18,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Navigation/AP_Navigation.h>
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
+#include <AP_Common/Location.h>
 
 class AP_L1_Control : public AP_Navigation {
 public:

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -21,6 +21,7 @@
 #include <AP_SpdHgtControl/AP_SpdHgtControl.h>
 #include <AP_Navigation/AP_Navigation.h>
 #include "AP_Landing_Deepstall.h"
+#include <AP_Common/Location.h>
 
 /// @class  AP_Landing
 /// @brief  Class managing ArduPlane landing methods

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -174,7 +174,7 @@ void AP_Landing_Deepstall::verify_abort_landing(const Location &prev_WP_loc, Loc
     // when aborting a landing, mimic the verify_takeoff with steering hold. Once
     // the altitude has been reached, restart the landing sequence
     throttle_suppressed = false;
-    landing.nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
+    landing.nav_controller->update_heading_hold(prev_WP_loc.get_bearing_to(next_WP_loc));
 }
 
 

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -138,9 +138,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     struct Location land_WP_loc = next_WP_loc;
 
     int32_t land_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
-    location_update(land_WP_loc,
-                    land_bearing_cd*0.01f,
-                    prev_WP_loc.get_distance(current_loc) + 200);
+    land_WP_loc.offset_bearing(land_bearing_cd * 0.01f, prev_WP_loc.get_distance(current_loc) + 200);
     nav_controller->update_waypoint(prev_WP_loc, land_WP_loc);
 
     // once landed and stationary, post some statistics
@@ -294,11 +292,11 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     // now calculate our aim point, which is before the landing
     // point and above it
     Location loc = next_WP_loc;
-    location_update(loc, land_bearing_cd*0.01f, -flare_distance);
+    loc.offset_bearing(land_bearing_cd * 0.01f, -flare_distance);
     loc.alt += aim_height*100;
 
     // calculate point along that slope 500m ahead
-    location_update(loc, land_bearing_cd*0.01f, land_projection);
+    loc.offset_bearing(land_bearing_cd * 0.01f, land_projection);
     loc.alt -= slope * land_projection * 100;
 
     // setup the offset_cm for set_target_altitude_proportion()

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -39,7 +39,7 @@ void AP_Landing::type_slope_verify_abort_landing(const Location &prev_WP_loc, Lo
     // when aborting a landing, mimic the verify_takeoff with steering hold. Once
     // the altitude has been reached, restart the landing sequence
     throttle_suppressed = false;
-    nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
+    nav_controller->update_heading_hold(prev_WP_loc.get_bearing_to(next_WP_loc));
 }
 
 /*
@@ -136,7 +136,8 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
       prevents sudden turns if we overshoot the landing point
      */
     struct Location land_WP_loc = next_WP_loc;
-    int32_t land_bearing_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
+
+    int32_t land_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
     location_update(land_WP_loc,
                     land_bearing_cd*0.01f,
                     prev_WP_loc.get_distance(current_loc) + 200);
@@ -288,7 +289,7 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     // project a point 500 meters past the landing point, passing
     // through the landing point
     const float land_projection = 500;
-    int32_t land_bearing_cd = get_bearing_cd(prev_WP_loc, next_WP_loc);
+    int32_t land_bearing_cd = prev_WP_loc.get_bearing_to(next_WP_loc);
 
     // now calculate our aim point, which is before the landing
     // point and above it

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -76,7 +76,7 @@ static void test_one_offset(const struct Location &loc,
     hal.console->printf("location_offset took %u usec\n",
                         (unsigned)(AP_HAL::micros() - t1));
     dist2 = loc.get_distance(loc2);
-    bearing2 = get_bearing_cd(loc, loc2) * 0.01f;
+    bearing2 = loc.get_bearing_to(loc2) * 0.01f;
     float brg_error = bearing2-bearing;
     if (brg_error > 180) {
         brg_error -= 360;

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -30,16 +30,6 @@ float get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destina
     return norm(destination.x-origin.x,destination.y-origin.y);
 }
 
-// return bearing in centi-degrees between two locations
-int32_t get_bearing_cd(const struct Location &loc1, const struct Location &loc2)
-{
-    int32_t off_x = loc2.lng - loc1.lng;
-    const int32_t off_y = (loc2.lat - loc1.lat) / loc2.longitude_scale();
-    int32_t bearing = 9000 + atan2f(-off_y, off_x) * DEGX100;
-    if (bearing < 0) bearing += 36000;
-    return bearing;
-}
-
 // return bearing in centi-degrees between two positions
 float get_bearing_cd(const Vector3f &origin, const Vector3f &destination)
 {

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -73,19 +73,7 @@ float location_path_proportion(const struct Location &location,
     return (vec1 * vec2) / dsquared;
 }
 
-/*
- *  extrapolate latitude/longitude given bearing and distance
- * Note that this function is accurate to about 1mm at a distance of 
- * 100m. This function has the advantage that it works in relative
- * positions, so it keeps the accuracy even when dealing with small
- * distances and floating point numbers
- */
-void location_update(struct Location &loc, float bearing, float distance)
-{
-    float ofs_north = cosf(radians(bearing))*distance;
-    float ofs_east  = sinf(radians(bearing))*distance;
-    loc.offset(ofs_north, ofs_east);
-}
+
 
 /*
   return the distance in meters in North/East plane as a N/E vector

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -22,9 +22,6 @@
 // return horizontal distance in centimeters between two positions
 float        get_horizontal_distance_cm(const Vector3f &origin, const Vector3f &destination);
 
-// return bearing in centi-degrees between two locations
-int32_t      get_bearing_cd(const struct Location &loc1, const struct Location &loc2);
-
 // return bearing in centi-degrees between two positions
 float        get_bearing_cd(const Vector3f &origin, const Vector3f &destination);
 

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -42,9 +42,6 @@ float       location_path_proportion(const struct Location &location,
                                const struct Location &point1,
                                const struct Location &point2);
 
-//  extrapolate latitude/longitude given bearing and distance
-void        location_update(struct Location &loc, float bearing, float distance);
-
 /*
   return the distance in meters in North/East plane as a N/E vector
   from loc1 to loc2

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -381,7 +381,7 @@ int32_t AP_Mission::get_next_ground_course_cd(int32_t default_angle)
     if (cmd.id == MAV_CMD_NAV_SET_YAW_SPEED) {
         return (_nav_cmd.content.set_yaw_speed.angle_deg * 100);
     }
-    return get_bearing_cd(_nav_cmd.content.location, cmd.content.location);
+    return _nav_cmd.content.location.get_bearing_to(cmd.content.location);
 }
 
 // set_current_cmd - jumps to command specified by index

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -29,6 +29,7 @@
 #include <AP_RSSI/AP_RSSI.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Stats/AP_Stats.h>
+#include <AP_Common/Location.h>
 
 #include <ctype.h>
 #include <GCS_MAVLink/GCS.h>
@@ -630,7 +631,7 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
     if (ahrs.get_position(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
         float distance = home_loc.get_distance(loc);
-        int32_t angle = wrap_360_cd(get_bearing_cd(loc, home_loc) - ahrs.yaw_sensor);
+        int32_t angle = wrap_360_cd(loc.get_bearing_to(home_loc) - ahrs.yaw_sensor);
         int32_t interval = 36000 / SYM_ARROW_COUNT;
         if (distance < 2.0f) {
             //avoid fast rotating arrow at small distances

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -107,7 +107,7 @@ bool AP_Proximity_SITL::get_distance_to_fence(float angle_deg, float &distance) 
     while (max_dist - min_dist > PROXIMITY_ACCURACY) {
         float test_dist = (max_dist+min_dist)*0.5f;
         Location loc = current_loc;
-        location_update(loc, angle_deg, test_dist);
+        loc.offset_bearing(angle_deg, test_dist);
         Vector2l vecloc(loc.lat, loc.lng);
         if (fence_loader.boundary_breached(vecloc, fence_count->get(), fence)) {
             max_dist = test_dist;

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -5,6 +5,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #include <AC_Fence/AC_PolyFence_loader.h>
+#include <AP_Common/Location.h>
 
 class AP_Proximity_SITL : public AP_Proximity_Backend
 {

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1,6 +1,7 @@
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_Common/Location.h>
 
 #include "lua_bindings.h"
 
@@ -230,9 +231,7 @@ static int location_project(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    location_update(*check_location(L, -3),
-                    luaL_checknumber(L, -2),
-                    luaL_checknumber(L, -1));
+    (*check_location(L, -3)).offset_bearing(luaL_checknumber(L, -2), luaL_checknumber(L, -1));
 
     lua_pop(L, 2);
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -271,7 +271,7 @@ float AP_Terrain::lookahead(float bearing, float distance, float climb_ratio)
 
     // check for terrain at grid spacing intervals
     while (distance > 0) {
-        location_update(loc, bearing, grid_spacing);
+        loc.offset_bearing(bearing, grid_spacing);
         climb += climb_ratio * grid_spacing;
         distance -= grid_spacing;
         float height;

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -17,6 +17,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Common/Location.h>
 
 #if (HAL_OS_POSIX_IO || HAL_OS_FATFS_IO) && defined(HAL_BOARD_TERRAIN_DIRECTORY)
 #define AP_TERRAIN_AVAILABLE 1

--- a/libraries/AP_Terrain/TerrainMission.cpp
+++ b/libraries/AP_Terrain/TerrainMission.cpp
@@ -82,7 +82,7 @@ void AP_Terrain::update_mission_data(void)
         // spacings away at 45, 135, 225 and 315 degrees, and the
         // point itself
         if (next_mission_pos != 4) {
-            location_update(cmd.content.location, 45+90*next_mission_pos, grid_spacing.get() * 10);
+            cmd.content.location.offset_bearing(45+90*next_mission_pos, grid_spacing.get() * 10);
         }
 
         // we have a mission command to check


### PR DESCRIPTION
This is the first step to remove AP_Math dependency on location. 
It moves to two methods and correct the header inclusion on some places.
location_update is rename to offset_bearing to be consistant with offset function on Location