### PR TITLE
AP_GPS: Refactor get_singleton() to return a pointer

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1566,7 +1566,7 @@ namespace AP {
 
 AP_GPS &gps()
 {
-    return AP_GPS::get_singleton();
+    return *AP_GPS::get_singleton();
 }
 
 };

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -71,8 +71,8 @@ public:
     AP_GPS(const AP_GPS &other) = delete;
     AP_GPS &operator=(const AP_GPS&) = delete;
 
-    static AP_GPS &get_singleton() {
-        return *_singleton;
+    static AP_GPS *get_singleton() {
+        return _singleton;
     }
 
     // GPS driver types


### PR DESCRIPTION
Scripting needs a consistent access model for singletons. At the unconference I proposed the model of `foo *foo::get_singleton(void)` as the universal return type for singletons. Members of the `AP` namespace can still return a reference if desired, but anything within a class is expected to be called `get_singleton` and return a pointer which should be null checked (except in the `AP` namespace reference cases). This is needed to support the generator being consistent.

If I grepped our code base correctly, all our other singleton's actually already seem to adhere to this, with the exception of HAL_Chibios CAN clocks, which isn't something I think we generally publish, so I was leaving that one alone.