### PR TITLE
Plane: Update GPS before updating current_loc

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -359,12 +359,12 @@ void Plane::airspeed_ratio_update(void)
  */
 void Plane::update_GPS_50Hz(void)
 {
+    gps.update();
+
     // get position from AHRS
     have_position = ahrs.get_position(current_loc);
     ahrs.get_relative_position_D_home(relative_altitude);
     relative_altitude *= -1.0f;
-
-    gps.update();
 }
 
 /*


### PR DESCRIPTION
Fixes 20ms of extra induced lag on the DCM position estimate. We tripped across this on the last dev call, but hadn't chased it up yet.