### PR TITLE
Fix bad parameter reads on rover

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -174,7 +174,7 @@ private:
     AP_Baro barometer;
     Compass compass;
     AP_InertialSensor ins;
-    RangeFinder rangefinder{serial_manager, ROTATION_NONE};
+    RangeFinder rangefinder{serial_manager};
     AP_Button button;
 
     // flight modes convenience array

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -92,7 +92,7 @@ void Rover::init_ardupilot()
     AP::compass().init();
 
     // initialise rangefinder
-    rangefinder.init();
+    rangefinder.init(ROTATION_NONE);
 
     // init proximity sensor
     init_proximity();

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -112,7 +112,7 @@ private:
 
     AP_InertialSensor ins;
 
-    RangeFinder rng{serial_manager, ROTATION_NONE};
+    RangeFinder rng{serial_manager};
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -236,7 +236,7 @@ private:
     Compass compass;
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
+    RangeFinder rangefinder{serial_manager};
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -13,7 +13,7 @@ void Copter::read_barometer(void)
 void Copter::init_rangefinder(void)
 {
 #if RANGEFINDER_ENABLED == ENABLED
-   rangefinder.init();
+   rangefinder.init(ROTATION_PITCH_270);
    rangefinder_state.alt_cm_filt.set_cutoff_frequency(RANGEFINDER_WPNAV_FILT_HZ);
    rangefinder_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_270);
 #endif

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -222,7 +222,7 @@ private:
 
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
+    RangeFinder rangefinder{serial_manager};
 
     AP_Vehicle::FixedWing::Rangefinder_State rangefinder_state;
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -86,7 +86,7 @@ void Plane::init_ardupilot()
     barometer.init();
 
     // initialise rangefinder
-    rangefinder.init();
+    rangefinder.init(ROTATION_PITCH_270);
 
     // initialise battery monitoring
     battery.init();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -177,7 +177,7 @@ private:
     Compass compass;
     AP_InertialSensor ins;
 
-    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
+    RangeFinder rangefinder{serial_manager};
     struct {
         bool enabled:1;
         bool alt_healthy:1; // true if we can trust the altitude from the rangefinder

--- a/ArduSub/sensors.cpp
+++ b/ArduSub/sensors.cpp
@@ -13,7 +13,7 @@ void Sub::read_barometer()
 void Sub::init_rangefinder()
 {
 #if RANGEFINDER_ENABLED == ENABLED
-    rangefinder.init();
+    rangefinder.init(ROTATION_PITCH_270);
     rangefinder_state.alt_cm_filt.set_cutoff_frequency(RANGEFINDER_WPNAV_FILT_HZ);
     rangefinder_state.enabled = rangefinder.has_orientation(ROTATION_PITCH_270);
 #endif

--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -60,7 +60,7 @@ public:
     AP_GPS gps;
     Compass compass;
     AP_SerialManager serial_manager;
-    RangeFinder rng{serial_manager, ROTATION_PITCH_270};
+    RangeFinder rng{serial_manager};
     NavEKF2 EKF2{&ahrs, rng};
     NavEKF3 EKF3{&ahrs, rng};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3};

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -24,7 +24,7 @@ static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
+    RangeFinder sonar{serial_manager};
     NavEKF2 EKF2{&ahrs, sonar};
     NavEKF3 EKF3{&ahrs, sonar};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3,

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/AP_OpticalFlow_test.cpp
@@ -26,7 +26,7 @@ public:
     Compass compass;
     AP_InertialSensor ins;
     AP_SerialManager serial_manager;
-    RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
+    RangeFinder sonar{serial_manager};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
     NavEKF2 EKF2{&ahrs, sonar};
     NavEKF3 EKF3{&ahrs, sonar};

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -147,15 +147,10 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 
 const AP_Param::GroupInfo *RangeFinder::backend_var_info[RANGEFINDER_MAX_INSTANCES];
 
-RangeFinder::RangeFinder(AP_SerialManager &_serial_manager, enum Rotation orientation_default) :
+RangeFinder::RangeFinder(AP_SerialManager &_serial_manager) :
     serial_manager(_serial_manager)
 {
     AP_Param::setup_object_defaults(this, var_info);
-
-    // set orientation defaults
-    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
-        params[i].orientation.set_default(orientation_default);
-    }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (_singleton != nullptr) {
@@ -290,7 +285,7 @@ void RangeFinder::convert_params(void) {
   finders here. For now we won't allow for hot-plugging of
   rangefinders.
  */
-void RangeFinder::init(void)
+void RangeFinder::init(enum Rotation orientation_default)
 {
     if (num_instances != 0) {
         // init called a 2nd time?
@@ -298,6 +293,11 @@ void RangeFinder::init(void)
     }
 
     convert_params();
+
+    // set orientation defaults
+    for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
+        params[i].orientation.set_default(orientation_default);
+    }
 
     for (uint8_t i=0, serial_instance = 0; i<RANGEFINDER_MAX_INSTANCES; i++) {
         // serial_instance will be increased inside detect_instance

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -38,7 +38,7 @@ class RangeFinder
     friend class AP_RangeFinder_Backend;
 
 public:
-    RangeFinder(AP_SerialManager &_serial_manager, enum Rotation orientation_default);
+    RangeFinder(AP_SerialManager &_serial_manager);
 
     /* Do not allow copies */
     RangeFinder(const RangeFinder &other) = delete;
@@ -110,7 +110,7 @@ public:
     }
 
     // detect and initialise any available rangefinders
-    void init(void);
+    void init(enum Rotation orientation_default);
 
     // update state of all rangefinders. Should be called at around
     // 10Hz from main loop

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -11,7 +11,7 @@ void loop();
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 static AP_SerialManager serial_manager;
-static RangeFinder sonar{serial_manager, ROTATION_PITCH_270};
+static RangeFinder sonar{serial_manager};
 
 void setup()
 {
@@ -25,7 +25,7 @@ void setup()
 
     // initialise sensor, delaying to make debug easier
     hal.scheduler->delay(2000);
-    sonar.init();
+    sonar.init(ROTATION_PITCH_270);
     hal.console->printf("RangeFinder: %d devices detected\n", sonar.num_sensors());
 }
 

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -20,7 +20,7 @@ static AP_SerialManager serial_manager;
 
 class DummyVehicle {
 public:
-    RangeFinder rangefinder{serial_manager, ROTATION_PITCH_270};
+    RangeFinder rangefinder{serial_manager};
     NavEKF2 EKF2{&ahrs, rangefinder};
     NavEKF3 EKF3{&ahrs, rangefinder};
     AP_AHRS_NavEKF ahrs{EKF2, EKF3, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};


### PR DESCRIPTION
This resolves #10510. What was happening is the rangefinder initializer was running before the AP_Param `_storage` initializer got to run. This lead to a `_storage.size()` of 0. The net effect is that we are unable to set the default orientation of the rangefinders. This is currently only happening on rover, but it depends entirely upon compiler decisions, and could easily happen on the other vehicles (or with the cross compiled output and we are just missing it).

The simple fix is to never try and manipulate a parameter during the constructor, which is what's presented here.

The only question I have is if there is any risk on the call to `AP_Param::setup_object_defaults(this, var_info);` misbehaving because it needs to read storage for any reason. It seems fine as far as I can tell, but I thought I'd ask if someone had a chance to audit it further.

This fixes #10510