### PR TITLE
Use airspeed singleton when logging to avoid header dependency 

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -501,3 +501,12 @@ bool AP_Airspeed::all_healthy(void) const
 
 // singleton instance
 AP_Airspeed *AP_Airspeed::_singleton;
+
+namespace AP {
+
+AP_Airspeed *airspeed()
+{
+    return AP_Airspeed::get_singleton();
+}
+
+};

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -457,10 +457,7 @@ void AP_Airspeed::update(bool log)
     check_sensor_failures();
 
     if (log) {
-        AP_Logger *logger = AP_Logger::get_singleton();
-        if (logger != nullptr) {
-            logger->Write_Airspeed(*this);
-        }
+        AP::logger().Write_Airspeed();
     }
 }
 

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -101,18 +101,6 @@ public:
     }
     float get_differential_pressure(void) const { return get_differential_pressure(primary); }
 
-    // return the current calibration offset
-    float get_offset(uint8_t i) const {
-        return param[i].offset;
-    }
-    float get_offset(void) const { return get_offset(primary); }
-
-    // return the current corrected pressure
-    float get_corrected_pressure(uint8_t i) const {
-        return state[i].corrected_pressure;
-    }
-    float get_corrected_pressure(void) const { return get_corrected_pressure(primary); }
-
     // set the apparent to true airspeed ratio
     void set_EAS2TAS(uint8_t i, float v) {
         state[i].EAS2TAS = v;
@@ -124,12 +112,6 @@ public:
         return state[i].EAS2TAS;
     }
     float get_EAS2TAS(void) const { return get_EAS2TAS(primary); }
-
-    // get the failure health probability
-    float get_health_failure_probability(uint8_t i) const {
-        return state[i].failures.health_probability;
-    }
-    float get_health_failure_probability(void) const { return get_health_failure_probability(primary); }
 
     // update airspeed ratio calibration
     void update_calibration(const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
@@ -238,15 +220,36 @@ private:
     // return the differential pressure in Pascal for the last airspeed reading for the requested instance
     // returns 0 if the sensor is not enabled
     float get_pressure(uint8_t i);
+    // return the current corrected pressure
+    float get_corrected_pressure(uint8_t i) const {
+        return state[i].corrected_pressure;
+    }
+    float get_corrected_pressure(void) const {
+        return get_corrected_pressure(primary);
+    }
+    // get the failure health probability
+    float get_health_failure_probability(uint8_t i) const {
+        return state[i].failures.health_probability;
+    }
+    float get_health_failure_probability(void) const {
+        return get_health_failure_probability(primary);
+    }
+
     void update_calibration(uint8_t i, float raw_pressure);
     void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
     void send_airspeed_calibration(const Vector3f &vg);
+    // return the current calibration offset
+    float get_offset(uint8_t i) const {
+        return param[i].offset;
+    }
+    float get_offset(void) const { return get_offset(primary); }
 
     void check_sensor_failures();
     void check_sensor_ahrs_wind_max_failures(uint8_t i);
 
     AP_Airspeed_Backend *sensor[AIRSPEED_MAX_SENSORS];
 
+    void Log_Airspeed();
 };
 
 namespace AP {

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -248,3 +248,7 @@ private:
     AP_Airspeed_Backend *sensor[AIRSPEED_MAX_SENSORS];
 
 };
+
+namespace AP {
+    AP_Airspeed *airspeed();
+};

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -253,7 +253,6 @@ public:
     void Write_Camera(const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Trigger(const AP_AHRS &ahrs, const Location &current_loc);
     void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot);
-    void Write_Airspeed();
     void Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
     void Write_Current();

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -10,7 +10,6 @@
 #include <AP_RSSI/AP_RSSI.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mission/AP_Mission.h>
-#include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
@@ -254,7 +253,7 @@ public:
     void Write_Camera(const AP_AHRS &ahrs, const Location &current_loc, uint64_t timestamp_us=0);
     void Write_Trigger(const AP_AHRS &ahrs, const Location &current_loc);
     void Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t voltage, uint16_t current, int16_t temperature, uint16_t current_tot);
-    void Write_Airspeed(AP_Airspeed &airspeed);
+    void Write_Airspeed();
     void Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Write_AttitudeView(AP_AHRS_View &ahrs, const Vector3f &targets);
     void Write_Current();

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -8,7 +8,6 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Motors/AP_Motors.h>
-#include <AP_Airspeed/AP_Airspeed.h>
 #include <AC_AttitudeControl/AC_AttitudeControl.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AP_RangeFinder/RangeFinder_Backend.h>
@@ -1528,40 +1527,6 @@ void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t vo
         current_tot : current_tot
     };
     WriteBlock(&pkt, sizeof(pkt));
-}
-
-// Write a AIRSPEED packet
-void AP_Logger::Write_Airspeed()
-{
-    AP_Airspeed *airspeed = AP::airspeed();
-    if (airspeed == nullptr) {
-        return;
-    }
-
-    uint64_t now = AP_HAL::micros64();
-    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-        if (!airspeed->enabled(i)) {
-            continue;
-        }
-        float temperature;
-        if (!airspeed->get_temperature(i, temperature)) {
-            temperature = 0;
-        }
-        struct log_AIRSPEED pkt = {
-            LOG_PACKET_HEADER_INIT(i==0?LOG_ARSP_MSG:LOG_ASP2_MSG),
-            time_us       : now,
-            airspeed      : airspeed->get_raw_airspeed(i),
-            diffpressure  : airspeed->get_differential_pressure(i),
-            temperature   : (int16_t)(temperature * 100.0f),
-            rawpressure   : airspeed->get_corrected_pressure(i),
-            offset        : airspeed->get_offset(i),
-            use           : airspeed->use(i),
-            healthy       : airspeed->healthy(i),
-            health_prob   : airspeed->get_health_failure_probability(i),
-            primary       : airspeed->get_primary()
-        };
-        WriteBlock(&pkt, sizeof(pkt));
-    }
 }
 
 // Write a Yaw PID packet

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -8,6 +8,7 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Motors/AP_Motors.h>
+#include <AP_Airspeed/AP_Airspeed.h>
 #include <AC_AttitudeControl/AC_AttitudeControl.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AP_RangeFinder/RangeFinder_Backend.h>
@@ -1530,29 +1531,34 @@ void AP_Logger::Write_ESC(uint8_t id, uint64_t time_us, int32_t rpm, uint16_t vo
 }
 
 // Write a AIRSPEED packet
-void AP_Logger::Write_Airspeed(AP_Airspeed &airspeed)
+void AP_Logger::Write_Airspeed()
 {
+    AP_Airspeed *airspeed = AP::airspeed();
+    if (airspeed == nullptr) {
+        return;
+    }
+
     uint64_t now = AP_HAL::micros64();
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-        if (!airspeed.enabled(i)) {
+        if (!airspeed->enabled(i)) {
             continue;
         }
         float temperature;
-        if (!airspeed.get_temperature(i, temperature)) {
+        if (!airspeed->get_temperature(i, temperature)) {
             temperature = 0;
         }
         struct log_AIRSPEED pkt = {
             LOG_PACKET_HEADER_INIT(i==0?LOG_ARSP_MSG:LOG_ASP2_MSG),
             time_us       : now,
-            airspeed      : airspeed.get_raw_airspeed(i),
-            diffpressure  : airspeed.get_differential_pressure(i),
+            airspeed      : airspeed->get_raw_airspeed(i),
+            diffpressure  : airspeed->get_differential_pressure(i),
             temperature   : (int16_t)(temperature * 100.0f),
-            rawpressure   : airspeed.get_corrected_pressure(i),
-            offset        : airspeed.get_offset(i),
-            use           : airspeed.use(i),
-            healthy       : airspeed.healthy(i),
-            health_prob   : airspeed.get_health_failure_probability(i),
-            primary       : airspeed.get_primary()
+            rawpressure   : airspeed->get_corrected_pressure(i),
+            offset        : airspeed->get_offset(i),
+            use           : airspeed->use(i),
+            healthy       : airspeed->healthy(i),
+            health_prob   : airspeed->get_health_failure_probability(i),
+            primary       : airspeed->get_primary()
         };
         WriteBlock(&pkt, sizeof(pkt));
     }


### PR DESCRIPTION
Reduces cross-header deps
