### PR TITLE
AP_GPS: Remove external event from Septentrio driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -22,7 +22,6 @@
 
 #include "AP_GPS.h"
 #include "AP_GPS_SBF.h"
-#include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
@@ -234,35 +233,6 @@ AP_GPS_SBF::parse(uint8_t temp)
     return false;
 }
 
-void
-AP_GPS_SBF::log_ExtEventPVTGeodetic(const msg4007 &temp)
-{
-    if (!should_log()) {
-        return;
-    }
-
-    uint64_t now = AP_HAL::micros64();
-
-    struct log_GPS_SBF_EVENT header = {
-        LOG_PACKET_HEADER_INIT(LOG_GPS_SBF_EVENT_MSG),
-        time_us:now,
-        TOW:temp.TOW,
-        WNc:temp.WNc,
-        Mode:temp.Mode,
-        Error:temp.Error,
-        Latitude:temp.Latitude*RAD_TO_DEG_DOUBLE,
-        Longitude:temp.Longitude*RAD_TO_DEG_DOUBLE,
-        Height:temp.Height,
-        Undulation:temp.Undulation,
-        Vn:temp.Vn,
-        Ve:temp.Ve,
-        Vu:temp.Vu,
-        COG:temp.COG
-    };
-
-    AP::logger().WriteBlock(&header, sizeof(header));
-}
-
 bool
 AP_GPS_SBF::process_message(void)
 {
@@ -271,9 +241,6 @@ AP_GPS_SBF::process_message(void)
     Debug("BlockID %d", blockid);
 
     switch (blockid) {
-    case ExtEventPVTGeodetic:
-        log_ExtEventPVTGeodetic(sbf_msg.data.msg4007u);
-        break;
     case PVTGeodetic:
     {
         const msg4007 &temp = sbf_msg.data.msg4007u;

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -62,7 +62,7 @@ private:
     uint8_t _init_blob_index = 0;
     uint32_t _init_blob_time = 0;
     const char* _initialisation_blob[5] = {
-    "sso, Stream1, COM1, PVTGeodetic+DOP+ExtEventPVTGeodetic+ReceiverStatus+VelCovGeodetic, msec100\n",
+    "sso, Stream1, COM1, PVTGeodetic+DOP+ReceiverStatus+VelCovGeodetic, msec100\n",
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
@@ -83,7 +83,6 @@ private:
         DOP = 4001,
         PVTGeodetic = 4007,
         ReceiverStatus = 4014,
-        ExtEventPVTGeodetic = 4038,
         VelCovGeodetic = 5908
     };
 
@@ -196,10 +195,8 @@ private:
         uint16_t read;
     } sbf_msg;
 
-    void log_ExtEventPVTGeodetic(const msg4007 &temp);
-
     enum {
-        SOFTWARE      = (1 << 3),   // set upon detection of a software warning or  error. This bit is reset by the command  “lif, error”
+        SOFTWARE      = (1 << 3),   // set upon detection of a software warning or  error. This bit is reset by the command lif, error
         WATCHDOG      = (1 << 4),   // set when the watch-dog expired at least once since the last power-on.
         CONGESTION    = (1 << 6),   // set when an output data congestion has been detected on at least one of the communication ports of the receiver during the last second.
         MISSEDEVENT   = (1 << 8),   // set when an external event congestion has been detected during the last second. It indicates that the receiver is receiving too many events on its EVENTx pins.

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -22,7 +22,6 @@
 #include "AP_GPS.h"
 #include "GPS_Backend.h"
 
-#define SBF_SETUP_MSG "\nsso, Stream1, COM1, PVTGeodetic+DOP+ExtEventPVTGeodetic, msec100\n"
 #define SBF_DISK_ACTIVITY (1 << 7)
 #define SBF_DISK_FULL     (1 << 8)
 #define SBF_DISK_MOUNTED  (1 << 9)
@@ -66,7 +65,7 @@ private:
     "srd, Moderate, UAV\n",
     "sem, PVT, 5\n",
     "spm, Rover, all\n",
-    "sso, Stream2, Dsk1, postprocess+event+comment, msec100\n"};
+    "sso, Stream2, Dsk1, postprocess+event+comment+ReceiverStatus, msec100\n"};
     uint32_t _config_last_ack_time;
 
     const char* _port_enable = "\nSSSSSSSSSS\n";


### PR DESCRIPTION
The Septentrio driver was logging camera feedback that the GPS witnessed. This was useful from a minimum hardware perspective, but it does pose a safety risk to flight. If to many events are triggered (due to noise on the input pin, or a truly fast camera) you can create congestion on the serial port to the GPS and the position data gets delayed. We detect this in the health bits, but the lag the data experiences becomes significant enough that the EKF will start rejecting the GPS data. This leads to oscillations in the sky, and all kinds of horrifying stuff happening. To correct for this I've removed the feedback into ArduPilot. I'm happy to restore it in the future if there is a patch on the GPS firmware that would prevent this from blocking the flight critical positioning data. As a note the GPS did detect the buffer overflow/port congestion, and we did detect it on the ArduPilot side. This does not have any impact on the PPK workflow, all events are still logged to the GPS SD card the same as they were before.

Example of external event induced lag (this line of timestamps should be perfectly flat, instead of bending in the middle):
![Figure_1](https://user-images.githubusercontent.com/567688/55663463-f8c63a00-57d2-11e9-8f2e-ad60d2641875.png)

This also makes a change to ensure that we log receiver status to the GPS SD card. This is useful for problem analysis, when the statustext message from the autopilot gets lost, or the user has misplaced the log files.

This was test flown on a AsteRx-M2

@amilcarlucas this patch may be of interest to you.