### PR TITLE
HAL_ChibiOS: fixed fallback to microSD for storage

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -74,7 +74,7 @@ void Storage::_storage_open(void)
     _flash_load();
 #elif defined(USE_POSIX)
     // allow for fallback to microSD based storage
-    sdcard_init();
+    sdcard_retry();
     
     log_fd = open(HAL_STORAGE_FILE, O_RDWR|O_CREAT);
     if (log_fd == -1) {
@@ -112,7 +112,7 @@ void Storage::_save_backup(void)
 {
 #ifdef USE_POSIX
     // allow for fallback to microSD based storage
-    sdcard_init();
+    sdcard_retry();
     int fd = open(HAL_STORAGE_BACKUP_FILE, O_WRONLY|O_CREAT|O_TRUNC);
     if (fd != -1) {
         write(fd, _buffer, CH_STORAGE_SIZE);

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -307,6 +307,6 @@ bool Util::get_system_id_unformatted(uint8_t buf[], uint8_t &len)
  */
 bool Util::fs_init(void)
 {
-    return sdcard_init();
+    return sdcard_retry();
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -93,6 +93,7 @@ bool sdcard_init()
     device = AP_HAL::get_HAL().spi->get_device("sdcard");
     if (!device) {
         printf("No sdcard SPI device found\n");
+        sdcard_running = false;
         return false;
     }
     device->set_slowdown(sd_slowdown);
@@ -126,8 +127,8 @@ bool sdcard_init()
         mkdir("/APM", 0777);
         return true;
     }
-    sdcard_running = false;
 #endif
+    sdcard_running = false;
 #endif
     return false;
 }
@@ -156,13 +157,15 @@ void sdcard_stop(void)
 #endif
 }
 
-void sdcard_retry(void)
+bool sdcard_retry(void)
 {
 #ifdef USE_POSIX
     if (!sdcard_running) {
         sdcard_init();
     }
+    return sdcard_running;
 #endif
+    return false;
 }
 
 #if HAL_USE_MMC_SPI

--- a/libraries/AP_HAL_ChibiOS/sdcard.h
+++ b/libraries/AP_HAL_ChibiOS/sdcard.h
@@ -17,4 +17,4 @@
 
 bool sdcard_init();
 void sdcard_stop();
-void sdcard_retry();
+bool sdcard_retry();


### PR DESCRIPTION
this is used when FRAM fails on a board with microSD support. The
double init caused the validate() in the FATFS code to fail