### PR TITLE
AP_HAL_SITL: fix ‘heap’ shadowing

### DIFF
--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -79,13 +79,13 @@ void *HALSITL::Util::allocate_heap_memory(size_t size)
     return (void *)new_heap;
 }
 
-void *HALSITL::Util::heap_realloc(void *heap, void *ptr, size_t new_size)
+void *HALSITL::Util::heap_realloc(void *heap_ptr, void *ptr, size_t new_size)
 {
-    if (heap == nullptr) {
+    if (heap_ptr == nullptr) {
         return nullptr;
     }
 
-    struct heap *heapp = (struct heap*)heap;
+    struct heap *heapp = (struct heap*)heap_ptr;
 
     // extract appropriate headers
     size_t old_size = 0;


### PR DESCRIPTION
you need --enable-scripting to see the failure