### PR TITLE
Add scripting target to CI

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -85,6 +85,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "sitl-scripting" ]; then
+        echo "Building scripting"
+        $waf configure --enable-scripting
+        $waf clean
+        $waf all
+        continue
+    fi
+
     if [ "$t" == "revo-bootloader" ]; then
         echo "Building revo bootloader"
         $waf configure --board revo-mini --bootloader


### PR DESCRIPTION
This just adds a compilation test for scripting to CI. This is intended to come in on Semaphore rather then travis in the end, but I'm just testing it on Travis first. ~Do not merge this with the travis commit attached.~