### PR TITLE
Tools: autotest: raise throttle in loiter mode

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2230,6 +2230,7 @@ class AutoTestCopter(AutoTest):
 
     def test_position_target_message_mode(self):
         " Ensure that POSITION_TARGET_LOCAL_NED messages are sent in Guided Mode only "
+        self.hover()
         self.change_mode('LOITER')
         self.progress("Setting POSITION_TARGET_LOCAL_NED message rate to 10Hz")
         self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED, 10)


### PR DESCRIPTION
This avoids the vehicle hitting the ground while we're looking for
messages.


It also may hide a bug where RTL won't disarm or take off again if you're sitting on the ground. with your throttle at zero and disarm-delay at 0.
