### PR TITLE
AP_Rangefinder: Fix VL53L1X ignoring return status

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
@@ -21,6 +21,33 @@ protected:
     }
 
 private:
+    enum DeviceError : uint8_t
+    {
+        NOUPDATE                    = 0,
+        VCSELCONTINUITYTESTFAILURE  = 1,
+        VCSELWATCHDOGTESTFAILURE    = 2,
+        NOVHVVALUEFOUND             = 3,
+        MSRCNOTARGET                = 4,
+        RANGEPHASECHECK             = 5,
+        SIGMATHRESHOLDCHECK         = 6,
+        PHASECONSISTENCY            = 7,
+        MINCLIP                     = 8,
+        RANGECOMPLETE               = 9,
+        ALGOUNDERFLOW               = 10,
+        ALGOOVERFLOW                = 11,
+        RANGEIGNORETHRESHOLD        = 12,
+        USERROICLIP                 = 13,
+        REFSPADCHARNOTENOUGHDPADS   = 14,
+        REFSPADCHARMORETHANTARGET   = 15,
+        REFSPADCHARLESSTHANTARGET   = 16,
+        MULTCLIPFAIL                = 17,
+        GPHSTREAMCOUNT0READY        = 18,
+        RANGECOMPLETE_NO_WRAP_CHECK = 19,
+        EVENTCONSISTENCY            = 20,
+        MINSIGNALEVENTCHECK         = 21,
+        RANGECOMPLETE_MERGED_PULSE  = 22,
+    };
+
     // register addresses from API vl53l1x_register_map.h
     enum regAddr : uint16_t
     {


### PR DESCRIPTION
The VL53L1X provides a status register, this returns a number of intresting errors, such as phase consistency, or no target found, both of which indicate we shouldn't use the reading. By looking at this status we can actually remove the noisy signal/weird results that happen on out of range targets. I've only tested this indoors thus far.

This also corrects the fact that we don't grab the semaphore when adding new readings, which gives us a race condition on data reading.

This has only been desk tested thus far, but is working as expected.