### PR TITLE
Copter: stop changing frame to home when home not set

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -15,13 +15,9 @@ void Copter::read_inertia()
         return;
     }
 
-    Location::AltFrame frame;
+    current_loc.set_alt_cm(inertial_nav.get_altitude(),
+                           Location::AltFrame::ABOVE_ORIGIN);
     if (ahrs.home_is_set()) {
-        frame = Location::AltFrame::ABOVE_HOME;
-    } else {
-        // without home use alt above the EKF origin
-        frame = Location::AltFrame::ABOVE_ORIGIN;
+        current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
     }
-    current_loc.set_alt_cm(inertial_nav.get_altitude(), frame);
-    current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
 }


### PR DESCRIPTION
This was just a logic fail.  Never change frame current-loc frame to home frame if we don't have a home set!
