### PR TITLE
Copter: Change specification of simple mode to definition name

### DIFF
--- a/ArduCopter/AP_State.cpp
+++ b/ArduCopter/AP_State.cpp
@@ -19,19 +19,19 @@ void Copter::set_auto_armed(bool b)
  *
  * @param [in] b 0:false or disabled, 1:true or SIMPLE, 2:SUPERSIMPLE
  */
-void Copter::set_simple_mode(uint8_t b)
+void Copter::set_simple_mode(SimpleMode b)
 {
-    if (ap.simple_mode != b) {
+    if (ap.simple_mode != static_cast<uint8_t>(b)) {
         switch (b) {
-            case 0:
+            case SimpleMode::OFF:
                 Log_Write_Event(DATA_SET_SIMPLE_OFF);
                 gcs().send_text(MAV_SEVERITY_INFO, "SIMPLE mode off");
                 break;
-            case 1:
+            case SimpleMode::ON:
                 Log_Write_Event(DATA_SET_SIMPLE_ON);
                 gcs().send_text(MAV_SEVERITY_INFO, "SIMPLE mode on");
                 break;
-            case 2:
+            case SimpleMode::SUPER:
             default:
                 // initialise super simple heading
                 update_super_simple_bearing(true);
@@ -39,7 +39,7 @@ void Copter::set_simple_mode(uint8_t b)
                 gcs().send_text(MAV_SEVERITY_INFO, "SUPERSIMPLE mode on");
                 break;
         }
-        ap.simple_mode = b;
+        ap.simple_mode = static_cast<uint8_t>(b);
     }
 }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -585,11 +585,15 @@ private:
     static_assert(_failsafe_priorities[ARRAY_SIZE(_failsafe_priorities) - 1] == -1,
                   "_failsafe_priorities is missing the sentinel");
 
-
+    enum class SimpleMode : uint8_t {
+        OFF = 0,  // simple mode off
+        ON,       // simple mode on
+        SUPER,    // super simple mode on
+    };
 
     // AP_State.cpp
     void set_auto_armed(bool b);
-    void set_simple_mode(uint8_t b);
+    void set_simple_mode(SimpleMode b);
     void set_failsafe_radio(bool b);
     void set_failsafe_gcs(bool b);
     void update_using_interlock();

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -39,9 +39,9 @@ void RC_Channel_Copter::mode_switch_changed(modeswitch_pos_t new_pos)
         // if none of the Aux Switches are set to Simple or Super Simple Mode then
         // set Simple Mode using stored parameters from EEPROM
         if (BIT_IS_SET(copter.g.super_simple, new_pos)) {
-            copter.set_simple_mode(2);
+            copter.set_simple_mode(Copter::SimpleMode::SUPER);
         } else {
-            copter.set_simple_mode(BIT_IS_SET(copter.g.simple_modes, new_pos));
+            copter.set_simple_mode(BIT_IS_SET(copter.g.simple_modes, new_pos) ? Copter::SimpleMode::ON : Copter::SimpleMode::OFF);
         }
     }
 }
@@ -157,12 +157,12 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
 
         case AUX_FUNC::SIMPLE_MODE:
             // low = simple mode off, middle or high position turns simple mode on
-            copter.set_simple_mode(ch_flag == HIGH || ch_flag == MIDDLE);
+            copter.set_simple_mode((ch_flag == HIGH || ch_flag == MIDDLE) ? Copter::SimpleMode::ON : Copter::SimpleMode::OFF);
             break;
 
         case AUX_FUNC::SUPERSIMPLE_MODE:
             // low = simple mode off, middle = simple mode, high = super simple mode
-            copter.set_simple_mode(ch_flag);
+            copter.set_simple_mode(static_cast<Copter::SimpleMode>(ch_flag));
             break;
 
         case AUX_FUNC::RTL:

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -579,11 +579,11 @@ void ToyMode::update()
         break;
 
     case ACTION_TOGGLE_SIMPLE:
-        copter.set_simple_mode(copter.ap.simple_mode?0:1);
+        copter.set_simple_mode(copter.ap.simple_mode ? Copter::SimpleMode::OFF : Copter::SimpleMode::ON);
         break;
 
     case ACTION_TOGGLE_SSIMPLE:
-        copter.set_simple_mode(copter.ap.simple_mode?0:2);
+        copter.set_simple_mode(copter.ap.simple_mode ? Copter::SimpleMode::OFF : Copter::SimpleMode::SUPER);
         break;
         
     case ACTION_ARM_LAND_RTL:


### PR DESCRIPTION
The value of this argument is not true or false.
0 is simple off, 1 is simple on, 2 is super simple on.
I change to specify 0, 1