### PR TITLE
AP_Motors: add support for Hexa-H frame

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -602,6 +602,15 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_6,-150, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4);
                     success = true;
                     break;
+                case MOTOR_FRAME_TYPE_H:
+                    // H is same as X except middle motors are closer to center
+                    add_motor_raw(AP_MOTORS_MOT_1, -1.0f, 0.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 2);
+                    add_motor_raw(AP_MOTORS_MOT_2, 1.0f, 0.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
+                    add_motor_raw(AP_MOTORS_MOT_3, 1.0f, 1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 6);
+                    add_motor_raw(AP_MOTORS_MOT_4, -1.0f, -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
+                    add_motor_raw(AP_MOTORS_MOT_5, -1.0f, 1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
+                    add_motor_raw(AP_MOTORS_MOT_6, 1.0f, -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 4);
+                    success = true;
                 default:
                     // hexa frame class does not support this frame type
                     break;


### PR DESCRIPTION
This frame is the same as a HexaX except that middle motors are closer to center.
![HexaH-ver2](https://user-images.githubusercontent.com/1498098/55934157-b4231e80-5c6a-11e9-9457-1753d45a0678.png)


This frame uses the same motor order and propeller direction as the Hexa X frame and overall roll and pitch factors have been kept the same as a HexaX to allow users to more easily switch between HexaX and HexaH without re-tuning.

This has not yet been tested in SITL or on a real vehicle but it will be in the next month.