### PR TITLE
Rangefinder arming checks

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -742,7 +742,6 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_serial2_baud,       0,      AP_PARAM_INT16, "SERIAL2_BAUD" },
     { Parameters::k_param_throttle_min_old,   0,      AP_PARAM_INT8,  "MOT_THR_MIN" },
     { Parameters::k_param_throttle_max_old,   0,      AP_PARAM_INT8,  "MOT_THR_MAX" },
-
     { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
     { Parameters::k_param_pivot_turn_angle_old,   0,  AP_PARAM_INT16,  "WP_PIVOT_ANGLE" },
     { Parameters::k_param_waypoint_radius_old,    0,  AP_PARAM_FLOAT,  "WP_RADIUS" },
@@ -754,6 +753,7 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_g2,                34,      AP_PARAM_FLOAT,  "SAIL_ANGLE_IDEAL" },
     { Parameters::k_param_g2,                35,      AP_PARAM_FLOAT,  "SAIL_HEEL_MAX" },
     { Parameters::k_param_g2,                36,      AP_PARAM_FLOAT,  "SAIL_NO_GO_ANGLE" },
+    { Parameters::k_param_arming,             2,     AP_PARAM_INT16,  "ARMING_CHECK" },
 };
 
 void Rover::load_parameters(void)

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -160,6 +160,10 @@ void Rover::init_ardupilot()
 
     // flag that initialisation has completed
     initialised = true;
+
+#if AP_PARAM_KEY_DUMP
+    AP_Param::show_all(hal.console, true);
+#endif
 }
 
 //*********************************************************************************

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1043,8 +1043,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::Parameters::k_param_ch10_option_old,   0,      AP_PARAM_INT8,  "RC10_OPTION" },
     { Parameters::Parameters::k_param_ch11_option_old,   0,      AP_PARAM_INT8,  "RC11_OPTION" },
     { Parameters::Parameters::k_param_ch12_option_old,   0,      AP_PARAM_INT8,  "RC12_OPTION" },
-
     { Parameters::k_param_compass_enabled_deprecated,    0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
+    { Parameters::k_param_arming,             2,     AP_PARAM_INT16,  "ARMING_CHECK" },
 };
 
 void Copter::load_parameters(void)

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -255,6 +255,10 @@ void Copter::init_ardupilot()
 
     // flag that initialisation has completed
     ap.initialised = true;
+
+#if AP_PARAM_KEY_DUMP
+    AP_Param::show_all(hal.console, true);
+#endif
 }
 
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1302,8 +1302,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_fs_batt_mah,        0,      AP_PARAM_FLOAT, "BATT_LOW_MAH" },
 
     { Parameters::k_param_arming,             3,      AP_PARAM_INT8,  "ARMING_RUDDER" },
-
     { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
+    { Parameters::k_param_arming,           128,     AP_PARAM_INT16,  "ARMING_CHECK" },
 };
 
 void Plane::load_parameters(void)

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -184,6 +184,10 @@ void Plane::init_ardupilot()
 
     // disable safety if requested
     BoardConfig.init_safety();
+
+#if AP_PARAM_KEY_DUMP
+    AP_Param::show_all(hal.console, true);
+#endif
 }
 
 //********************************************************************************

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -651,8 +651,8 @@ const AP_Param::ConversionInfo conversion_table[] = {
     { Parameters::k_param_fs_batt_voltage,   0,      AP_PARAM_FLOAT,  "BATT_LOW_VOLT" },
     { Parameters::k_param_fs_batt_mah,       0,      AP_PARAM_FLOAT,  "BATT_LOW_MAH" },
     { Parameters::k_param_failsafe_battery_enabled,       0,      AP_PARAM_INT8,  "BATT_FS_LOW_ACT" },
-
     { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
+    { Parameters::k_param_arming,            2,     AP_PARAM_INT16,  "ARMING_CHECK" },
 };
 
 void Sub::load_parameters()

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -207,6 +207,10 @@ void Sub::init_ardupilot()
 
     // flag that initialisation has completed
     ap.initialised = true;
+
+#if AP_PARAM_KEY_DUMP
+    AP_Param::show_all(hal.console, true);
+#endif
 }
 
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -17,22 +17,23 @@ public:
     static AP_Arming *get_singleton();
 
     enum ArmingChecks {
-        ARMING_CHECK_NONE       = 0x0000,
-        ARMING_CHECK_ALL        = 0x0001,
-        ARMING_CHECK_BARO       = 0x0002,
-        ARMING_CHECK_COMPASS    = 0x0004,
-        ARMING_CHECK_GPS        = 0x0008,
-        ARMING_CHECK_INS        = 0x0010,
-        ARMING_CHECK_PARAMETERS = 0x0020,
-        ARMING_CHECK_RC         = 0x0040,
-        ARMING_CHECK_VOLTAGE    = 0x0080,
-        ARMING_CHECK_BATTERY    = 0x0100,
-        ARMING_CHECK_AIRSPEED   = 0x0200,
-        ARMING_CHECK_LOGGING    = 0x0400,
-        ARMING_CHECK_SWITCH     = 0x0800,
-        ARMING_CHECK_GPS_CONFIG = 0x1000,
-        ARMING_CHECK_SYSTEM     = 0x2000,
-        ARMING_CHECK_MISSION    = 0x4000,
+        ARMING_CHECK_NONE        = 0x0000,
+        ARMING_CHECK_ALL         = (1U << 0),
+        ARMING_CHECK_BARO        = (1U << 1),
+        ARMING_CHECK_COMPASS     = (1U << 2),
+        ARMING_CHECK_GPS         = (1U << 3),
+        ARMING_CHECK_INS         = (1U << 4),
+        ARMING_CHECK_PARAMETERS  = (1U << 5),
+        ARMING_CHECK_RC          = (1U << 6),
+        ARMING_CHECK_VOLTAGE     = (1U << 7),
+        ARMING_CHECK_BATTERY     = (1U << 8),
+        ARMING_CHECK_AIRSPEED    = (1U << 9),
+        ARMING_CHECK_LOGGING     = (1U << 10),
+        ARMING_CHECK_SWITCH      = (1U << 11),
+        ARMING_CHECK_GPS_CONFIG  = (1U << 12),
+        ARMING_CHECK_SYSTEM      = (1U << 13),
+        ARMING_CHECK_MISSION     = (1U << 14),
+        ARMING_CHECK_RANGEFINDER = (1U << 15),
     };
 
     enum class Method {
@@ -48,6 +49,8 @@ public:
         YES_MIN_PWM  = 1,
         YES_ZERO_PWM = 2
     };
+
+    void init(void);
 
     // these functions should not be used by Copter which holds the armed state in the motors library
     Required arming_required();
@@ -84,7 +87,7 @@ protected:
 
     // Parameters
     AP_Int8                 require;
-    AP_Int16                checks_to_perform;      // bitmask for which checks are required
+    AP_Int32                checks_to_perform;      // bitmask for which checks are required
     AP_Float                accel_error_threshold;
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
@@ -117,6 +120,8 @@ protected:
     bool manual_transmitter_checks(bool report);
 
     bool mission_checks(bool report);
+
+    bool rangefinder_checks(bool report);
 
     bool fence_checks(bool report);
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2325,6 +2325,7 @@ void AP_Param::show_all(AP_HAL::BetterStream *port, bool showKeyValues)
             port->printf("Key %i: Index %i: GroupElement %i  :  ", token.key, token.idx, token.group_element);
         }
         show(ap, token, type, port);
+        hal.scheduler->delay(1);
     }
 }
 #endif // AP_PARAM_KEY_DUMP

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1096,7 +1096,9 @@ void AP_Param::save(bool force_save)
         // when we are disarmed then loop waiting for a slot to become
         // available. This guarantees completion for large parameter
         // set loads
+        hal.scheduler->expect_delay_ms(1);
         hal.scheduler->delay_microseconds(500);
+        hal.scheduler->expect_delay_ms(0);
     }
 }
 
@@ -1118,7 +1120,9 @@ void AP_Param::flush(void)
 {
     uint16_t counter = 200; // 2 seconds max
     while (counter-- && save_queue.available()) {
+        hal.scheduler->expect_delay_ms(10);
         hal.scheduler->delay(10);
+        hal.scheduler->expect_delay_ms(0);
     }
 }
 
@@ -1745,6 +1749,9 @@ void AP_Param::convert_old_parameters(const struct ConversionInfo *conversion_ta
     for (uint8_t i=0; i<table_size; i++) {
         convert_old_parameter(&conversion_table[i], 1.0f, flags);
     }
+    // we need to flush here to prevent a later set_default_by_name()
+    // causing a save to be done on a converted parameter
+    flush();
 }
 
 /*

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -693,6 +693,18 @@ void RangeFinder::Log_RFND()
     }
 }
 
+bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_len) const
+{
+    for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
+        if ((params[i].type != RangeFinder_TYPE_NONE) && (drivers[i] == nullptr)) {
+          hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %d was not detected", i + 1);
+          return false;
+        }
+    }
+
+    return true;
+}
+
 RangeFinder *RangeFinder::_singleton;
 
 namespace AP {

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -111,6 +111,9 @@ public:
         return num_instances;
     }
 
+    // prearm checks
+    bool prearm_healthy(char *failure_msg, const uint8_t failure_msg_len) const;
+
     // detect and initialise any available rangefinders
     void init(enum Rotation orientation_default);
 


### PR DESCRIPTION
This starts on a global set of arming checks on rangefinders. For now it simply introduces the requirement that if a rangefinder was specified, then we must have created a driver for it.

This was actually pretty easy by itself, unfortunately it turns out we have consumed all the bits for `ARMING_CHECKS` so I had to add param conversion for it, to get it to have 32 bits (we can still only use 24 of them sadly).

This also makes it easier to dump the keys for conversion, just to make it a single define change in the future.

This is a draft as the conversion in Sub is not working correctly. For reference this is what the key dump prints on Sub:
`Key 75: Index 0: GroupElement 2  :  ARMING_CHECK: 17`