### PR TITLE
Copter: ZigZag maintains altitude above terrain using range finder

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -121,7 +121,7 @@ float Copter::get_non_takeoff_throttle()
 
 // get_surface_tracking_climb_rate - hold copter at the desired distance above the ground
 //      returns climb rate (in cm/s) which should be passed to the position controller
-float Copter::get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt)
+float Copter::get_surface_tracking_climb_rate(int16_t target_rate)
 {
 #if RANGEFINDER_ENABLED == ENABLED
     if (!copter.rangefinder_alt_ok()) {
@@ -130,9 +130,10 @@ float Copter::get_surface_tracking_climb_rate(int16_t target_rate, float current
     }
 
     static uint32_t last_call_ms = 0;
+    const float current_alt = inertial_nav.get_altitude();
+    const float current_alt_target = pos_control->get_alt_target();
     float distance_error;
     float velocity_correction;
-    float current_alt = inertial_nav.get_altitude();
 
     uint32_t now = millis();
 
@@ -146,7 +147,7 @@ float Copter::get_surface_tracking_climb_rate(int16_t target_rate, float current
 
     // adjust rangefinder target alt if motors have not hit their limits
     if ((target_rate<0 && !motors->limit.throttle_lower) || (target_rate>0 && !motors->limit.throttle_upper)) {
-        target_rangefinder_alt += target_rate * dt;
+        target_rangefinder_alt += target_rate * G_Dt;
     }
 
     /*

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -187,6 +187,25 @@ float Copter::get_surface_tracking_climb_rate(int16_t target_rate)
 #endif
 }
 
+// get surfacing tracking alt
+// returns true if there is a valid target
+bool Copter::get_surface_tracking_target_alt_cm(float &target_alt_cm) const
+{
+    // check target has been updated recently
+    if (AP_HAL::millis() - surface_tracking.last_update_ms > SURFACE_TRACKING_TIMEOUT_MS) {
+        return false;
+    }
+    target_alt_cm = surface_tracking.target_alt_cm;
+    return true;
+}
+
+// set surface tracking target altitude
+void Copter::set_surface_tracking_target_alt_cm(float target_alt_cm)
+{
+    surface_tracking.target_alt_cm = target_alt_cm;
+    surface_tracking.last_update_ms = AP_HAL::millis();
+}
+
 // get target climb rate reduced to avoid obstacles and altitude fence
 float Copter::get_avoidance_adjusted_climbrate(float target_rate)
 {

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -75,7 +75,7 @@ void Copter::set_throttle_takeoff()
 float Copter::get_pilot_desired_climb_rate(float throttle_control)
 {
     // throttle failsafe check
-    if( failsafe.radio ) {
+    if (failsafe.radio) {
         return 0.0f;
     }
 
@@ -86,7 +86,7 @@ float Copter::get_pilot_desired_climb_rate(float throttle_control)
         g2.toy_mode.throttle_adjust(throttle_control);
     }
 #endif
-    
+
     float desired_rate = 0.0f;
     float mid_stick = get_throttle_mid();
     float deadband_top = mid_stick + g.throttle_deadzone;
@@ -102,10 +102,10 @@ float Copter::get_pilot_desired_climb_rate(float throttle_control)
     if (throttle_control < deadband_bottom) {
         // below the deadband
         desired_rate = get_pilot_speed_dn() * (throttle_control-deadband_bottom) / deadband_bottom;
-    }else if (throttle_control > deadband_top) {
+    } else if (throttle_control > deadband_top) {
         // above the deadband
         desired_rate = g.pilot_speed_up * (throttle_control-deadband_top) / (1000.0f-deadband_top);
-    }else{
+    } else {
         // must be in the deadband
         desired_rate = 0.0f;
     }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -247,6 +247,12 @@ private:
         int8_t glitch_count;
     } rangefinder_state = { false, false, 0, 0 };
 
+    struct {
+        float target_alt_cm;        // desired altitude in cm above the ground
+        uint32_t last_update_ms;    // system time of last update to target_alt_cm
+        bool valid_for_logging;     // true if target_alt_cm is valid for logging
+    } surface_tracking;
+
 #if RPM_ENABLED == ENABLED
     AP_RPM rpm_sensor;
 #endif
@@ -402,8 +408,6 @@ private:
 #endif
 
     // Altitude
-    float target_rangefinder_alt;   // desired altitude in cm above the ground
-    bool target_rangefinder_alt_used; // true if mode is using target_rangefinder_alt
     int32_t baro_alt;            // barometer altitude in cm above home
     LowPassFilterVector3f land_accel_ef_filter; // accelerations for land and crash detector tests
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -622,6 +622,8 @@ private:
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle();
     float get_surface_tracking_climb_rate(int16_t target_rate);
+    bool get_surface_tracking_target_alt_cm(float &target_alt_cm) const;
+    void set_surface_tracking_target_alt_cm(float target_alt_cm);
     float get_avoidance_adjusted_climbrate(float target_rate);
     void set_accel_throttle_I_from_pilot_throttle();
     void rotate_body_frame_to_NE(float &x, float &y);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -617,7 +617,7 @@ private:
     void set_throttle_takeoff();
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_non_takeoff_throttle();
-    float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
+    float get_surface_tracking_climb_rate(int16_t target_rate);
     float get_avoidance_adjusted_climbrate(float target_rate);
     void set_accel_throttle_I_from_pilot_throttle();
     void rotate_body_frame_to_NE(float &x, float &y);

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -39,11 +39,11 @@ void Copter::Log_Write_Control_Tuning()
         target_climb_rate_cms = pos_control->get_vel_target_z();
     }
 
-    float _target_rangefinder_alt;
-    if (target_rangefinder_alt_used) {
-        _target_rangefinder_alt = target_rangefinder_alt * 0.01f; // cm->m
+    float surface_tracking_target_alt;
+    if (surface_tracking.valid_for_logging) {
+        surface_tracking_target_alt = surface_tracking.target_alt_cm * 0.01f; // cm->m
     } else {
-        _target_rangefinder_alt = logger.quiet_nan();
+        surface_tracking_target_alt = logger.quiet_nan();
     }
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CONTROL_TUNING_MSG),
@@ -55,7 +55,7 @@ void Copter::Log_Write_Control_Tuning()
         desired_alt         : des_alt_m,
         inav_alt            : inertial_nav.get_altitude() / 100.0f,
         baro_alt            : baro_alt,
-        desired_rangefinder_alt : _target_rangefinder_alt,
+        desired_rangefinder_alt : surface_tracking_target_alt,
         rangefinder_alt     : rangefinder_state.alt_cm,
         terr_alt            : terr_alt,
         target_climb_rate   : target_climb_rate_cms,

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -522,7 +522,7 @@ void RC_Channel_Copter::do_aux_function(const aux_func_t ch_option, const aux_sw
                         copter.mode_zigzag.save_or_move_to_destination(0);
                         break;
                     case MIDDLE:
-                        copter.mode_zigzag.return_to_manual_control();
+                        copter.mode_zigzag.return_to_manual_control(false);
                         break;
                     case HIGH:
                         copter.mode_zigzag.save_or_move_to_destination(1);

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -88,16 +88,20 @@
  # define RANGEFINDER_HEALTH_MAX 3          // number of good reads that indicates a healthy rangefinder
 #endif
 
+#ifndef RANGEFINDER_TIMEOUT_MS
+# define RANGEFINDER_TIMEOUT_MS 1000        // rangefinder filter reset if no updates from sensor in 1 second
+#endif
+
 #ifndef RANGEFINDER_GAIN_DEFAULT
  # define RANGEFINDER_GAIN_DEFAULT 0.8f     // gain for controlling how quickly rangefinder range adjusts target altitude (lower means slower reaction)
 #endif
 
-#ifndef THR_SURFACE_TRACKING_VELZ_MAX
- # define THR_SURFACE_TRACKING_VELZ_MAX 150 // max vertical speed change while surface tracking with rangefinder
+#ifndef SURFACE_TRACKING_VELZ_MAX
+ # define SURFACE_TRACKING_VELZ_MAX 150     // max vertical speed change while surface tracking with rangefinder
 #endif
 
-#ifndef RANGEFINDER_TIMEOUT_MS
- # define RANGEFINDER_TIMEOUT_MS  1000      // desired rangefinder alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
+#ifndef SURFACE_TRACKING_TIMEOUT_MS
+ # define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
 #endif
 
 #ifndef RANGEFINDER_WPNAV_FILT_HZ

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -688,9 +688,9 @@ Copter::Mode::AltHoldModeState Copter::Mode::get_alt_hold_state(float target_cli
 // these are candidates for moving into the Mode base
 // class.
 
-float Copter::Mode::get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt)
+float Copter::Mode::get_surface_tracking_climb_rate(int16_t target_rate)
 {
-    return copter.get_surface_tracking_climb_rate(target_rate, current_alt_target, dt);
+    return copter.get_surface_tracking_climb_rate(target_rate);
 }
 
 float Copter::Mode::get_pilot_desired_yaw_rate(int16_t stick_angle)

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -693,6 +693,16 @@ float Copter::Mode::get_surface_tracking_climb_rate(int16_t target_rate)
     return copter.get_surface_tracking_climb_rate(target_rate);
 }
 
+bool Copter::Mode::get_surface_tracking_target_alt_cm(float &target_alt_cm) const
+{
+    return copter.get_surface_tracking_target_alt_cm(target_alt_cm);
+}
+
+void Copter::Mode::set_surface_tracking_target_alt_cm(float target_alt_cm)
+{
+   copter.set_surface_tracking_target_alt_cm(target_alt_cm);
+}
+
 float Copter::Mode::get_pilot_desired_yaw_rate(int16_t stick_angle)
 {
     return copter.get_pilot_desired_yaw_rate(stick_angle);

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -265,7 +265,7 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
 // called at 100hz or more
 void Copter::update_flight_mode()
 {
-    target_rangefinder_alt_used = false;
+    surface_tracking.valid_for_logging = false; // invalidate surface tracking alt, flight mode will set to true if used
 
     flightmode->run();
 }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -687,22 +687,6 @@ Copter::Mode::AltHoldModeState Copter::Mode::get_alt_hold_state(float target_cli
 // pass-through functions to reduce code churn on conversion;
 // these are candidates for moving into the Mode base
 // class.
-
-float Copter::Mode::get_surface_tracking_climb_rate(int16_t target_rate)
-{
-    return copter.get_surface_tracking_climb_rate(target_rate);
-}
-
-bool Copter::Mode::get_surface_tracking_target_alt_cm(float &target_alt_cm) const
-{
-    return copter.get_surface_tracking_target_alt_cm(target_alt_cm);
-}
-
-void Copter::Mode::set_surface_tracking_target_alt_cm(float target_alt_cm)
-{
-   copter.set_surface_tracking_target_alt_cm(target_alt_cm);
-}
-
 float Copter::Mode::get_pilot_desired_yaw_rate(int16_t stick_angle)
 {
     return copter.get_pilot_desired_yaw_rate(stick_angle);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -197,9 +197,6 @@ protected:
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
-    float get_surface_tracking_climb_rate(int16_t target_rate);
-    bool get_surface_tracking_target_alt_cm(float &target_alt_cm) const;
-    void set_surface_tracking_target_alt_cm(float target_alt_cm);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_pilot_desired_throttle() const;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -198,6 +198,8 @@ protected:
     // these are candidates for moving into the Mode base
     // class.
     float get_surface_tracking_climb_rate(int16_t target_rate);
+    bool get_surface_tracking_target_alt_cm(float &target_alt_cm) const;
+    void set_surface_tracking_target_alt_cm(float target_alt_cm);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_pilot_desired_throttle() const;
@@ -1206,7 +1208,7 @@ public:
     void save_or_move_to_destination(uint8_t dest_num);
 
     // return manual control to the pilot
-    void return_to_manual_control();
+    void return_to_manual_control(bool maintain_target);
 
 protected:
 
@@ -1218,7 +1220,7 @@ private:
     void auto_control();
     void manual_control();
     bool reached_destination();
-    bool calculate_next_dest(uint8_t position_num, Vector3f& next_dest) const;
+    bool calculate_next_dest(uint8_t position_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const;
 
     Vector2f dest_A;    // in NEU frame in cm relative to ekf origin
     Vector2f dest_B;    // in NEU frame in cm relative to ekf origin

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -197,7 +197,7 @@ protected:
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
-    float get_surface_tracking_climb_rate(int16_t target_rate, float current_alt_target, float dt);
+    float get_surface_tracking_climb_rate(int16_t target_rate);
     float get_pilot_desired_yaw_rate(int16_t stick_angle);
     float get_pilot_desired_climb_rate(float throttle_control);
     float get_pilot_desired_throttle() const;

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -96,7 +96,7 @@ void Copter::ModeAltHold::run()
 #endif
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -96,7 +96,7 @@ void Copter::ModeAltHold::run()
 #endif
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -44,7 +44,7 @@ void Copter::ModeCircle::run()
     // adjust climb rate using rangefinder
     if (copter.rangefinder_alt_ok()) {
         // if rangefinder is ok, use surface tracking
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
     }
 
     // if not armed set throttle to zero and exit immediately

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -44,7 +44,7 @@ void Copter::ModeCircle::run()
     // adjust climb rate using rangefinder
     if (copter.rangefinder_alt_ok()) {
         // if rangefinder is ok, use surface tracking
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
     }
 
     // if not armed set throttle to zero and exit immediately

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -300,7 +300,7 @@ void Copter::ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = copter.get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -300,7 +300,7 @@ void Copter::ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate, copter.pos_control->get_alt_target(), copter.G_Dt);
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = copter.get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -187,7 +187,7 @@ void Copter::ModeLoiter::run()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -187,7 +187,7 @@ void Copter::ModeLoiter::run()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -234,7 +234,7 @@ void Copter::ModePosHold::run()
         // adjust climb rate using rangefinder
         if (copter.rangefinder_alt_ok()) {
             // if rangefinder is ok, use surface tracking
-            target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+            target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -234,7 +234,7 @@ void Copter::ModePosHold::run()
         // adjust climb rate using rangefinder
         if (copter.rangefinder_alt_ok()) {
             // if rangefinder is ok, use surface tracking
-            target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+            target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -121,7 +121,7 @@ void Copter::ModeSport::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -121,7 +121,7 @@ void Copter::ModeSport::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // adjust climb rate using rangefinder
-        target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+        target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
 
         // get avoidance adjusted climb rate
         target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -192,7 +192,7 @@ void Copter::ModeZigZag::manual_control()
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
 
     // adjust climb rate using rangefinder
-    target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate, pos_control->get_alt_target(), G_Dt);
+    target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
 
     // get avoidance adjusted climb rate
     target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -125,7 +125,7 @@ void Copter::ModeZigZag::return_to_manual_control(bool maintain_target)
         const Vector3f wp_dest = wp_nav->get_wp_destination();
         loiter_nav->init_target(wp_dest);
         if (maintain_target && wp_nav->origin_and_destination_are_terrain_alt()) {
-            set_surface_tracking_target_alt_cm(wp_dest.z);
+            copter.set_surface_tracking_target_alt_cm(wp_dest.z);
         }
         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: manual control");
     }
@@ -200,7 +200,7 @@ void Copter::ModeZigZag::manual_control()
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
 
     // adjust climb rate using rangefinder
-    target_climb_rate = get_surface_tracking_climb_rate(target_climb_rate);
+    target_climb_rate = copter.get_surface_tracking_climb_rate(target_climb_rate);
 
     // get avoidance adjusted climb rate
     target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
@@ -283,7 +283,7 @@ bool Copter::ModeZigZag::calculate_next_dest(uint8_t dest_num, bool use_wpnav_al
         // if we have a downward facing range finder then use terrain altitude targets
         terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used();
         if (terrain_alt) {
-            if (!get_surface_tracking_target_alt_cm(next_dest.z)) {
+            if (!copter.get_surface_tracking_target_alt_cm(next_dest.z)) {
                 next_dest.z = copter.rangefinder_state.alt_cm_filt.get();
             }
         } else {

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -48,8 +48,7 @@ void Copter::ModeZigZag::run()
         // if vehicle has reached destination switch to manual control
         if (reached_destination()) {
             AP_Notify::events.waypoint_complete = 1;
-            stage = MANUAL_REGAIN;
-            loiter_nav->init_target(wp_nav->get_wp_destination());
+            return_to_manual_control(true);
         } else {
             auto_control();
         }
@@ -100,10 +99,10 @@ void Copter::ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
         case MANUAL_REGAIN:
             // A and B have been defined, move vehicle to destination A or B
             Vector3f next_dest;
-            if (calculate_next_dest(dest_num, next_dest)) {
-                // initialise waypoint controller
+            bool terr_alt;
+            if (calculate_next_dest(dest_num, stage == AUTO, next_dest, terr_alt)) {
                 wp_nav->wp_and_spline_init();
-                if (wp_nav->set_wp_destination(next_dest, false)) {
+                if (wp_nav->set_wp_destination(next_dest, terr_alt)) {
                     stage = AUTO;
                     reach_wp_time_ms = 0;
                     if (dest_num == 0) {
@@ -118,12 +117,16 @@ void Copter::ModeZigZag::save_or_move_to_destination(uint8_t dest_num)
 }
 
 // return manual control to the pilot
-void Copter::ModeZigZag::return_to_manual_control()
+void Copter::ModeZigZag::return_to_manual_control(bool maintain_target)
 {
     if (stage == AUTO) {
         stage = MANUAL_REGAIN;
         loiter_nav->clear_pilot_desired_acceleration();
-        loiter_nav->init_target();
+        const Vector3f wp_dest = wp_nav->get_wp_destination();
+        loiter_nav->init_target(wp_dest);
+        if (maintain_target && wp_nav->origin_and_destination_are_terrain_alt()) {
+            set_surface_tracking_target_alt_cm(wp_dest.z);
+        }
         gcs().send_text(MAV_SEVERITY_INFO, "ZigZag: manual control");
     }
 }
@@ -142,14 +145,19 @@ void Copter::ModeZigZag::auto_control()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // run waypoint controller
-    copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
+    const bool wpnav_ok = wp_nav->update_wpnav();
 
     // call z-axis position controller (wp_nav should have already updated its alt target)
     pos_control->update_z_controller();
 
     // call attitude controller
     // roll & pitch from waypoint controller, yaw rate from pilot
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);        
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
+
+    // if wpnav failed (because of lack of terrain data) switch back to pilot control for next iteration
+    if (!wpnav_ok) {
+        return_to_manual_control(false);
+    }
 }
 
 // manual_control - process manual control
@@ -226,7 +234,9 @@ bool Copter::ModeZigZag::reached_destination()
 }
 
 // calculate next destination according to vector A-B and current position
-bool Copter::ModeZigZag::calculate_next_dest(uint8_t dest_num, Vector3f& next_dest) const
+// use_wpnav_alt should be true if waypoint controller's altitude target should be used, false for position control or current altitude target
+// terrain_alt is returned as true if the next_dest should be considered a terrain alt
+bool Copter::ModeZigZag::calculate_next_dest(uint8_t dest_num, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const
 {
     // sanity check dest_num
     if (dest_num > 1) {
@@ -264,7 +274,22 @@ bool Copter::ModeZigZag::calculate_next_dest(uint8_t dest_num, Vector3f& next_de
     const Vector2f closest2d = Vector2f::closest_point(curr_pos2d, perp1, perp2);
     next_dest.x = closest2d.x;
     next_dest.y = closest2d.y;
-    next_dest.z = pos_control->is_active_z() ? pos_control->get_alt_target() : curr_pos.z;
+
+    if (use_wpnav_alt) {
+        // get altitude target from waypoint controller
+        terrain_alt = wp_nav->origin_and_destination_are_terrain_alt();
+        next_dest.z = wp_nav->get_wp_destination().z;
+    } else {
+        // if we have a downward facing range finder then use terrain altitude targets
+        terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used();
+        if (terrain_alt) {
+            if (!get_surface_tracking_target_alt_cm(next_dest.z)) {
+                next_dest.z = copter.rangefinder_state.alt_cm_filt.get();
+            }
+        } else {
+            next_dest.z = pos_control->is_active_z() ? pos_control->get_alt_target() : curr_pos.z;
+        }
+    }
 
     return true;
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -106,6 +106,9 @@ public:
     /// get origin using position vector (distance from ekf origin in cm)
     const Vector3f &get_wp_origin() const { return _origin; }
 
+    /// true if origin.z and destination.z are alt-above-terrain, false if alt-above-ekf-origin
+    bool origin_and_destination_are_terrain_alt() const { return _terrain_alt; }
+
     /// set_wp_destination waypoint using location class
     ///     returns false if conversion from location to vector from ekf origin cannot be calculated
     bool set_wp_destination(const Location& destination);

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -57,6 +57,9 @@ public:
     /// provide rangefinder altitude
     void set_rangefinder_alt(bool use, bool healthy, float alt_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_alt_cm = alt_cm; }
 
+    // return true if range finder may be used for terrain following
+    bool rangefinder_used() const { return _rangefinder_use && _rangefinder_healthy; }
+
     ///
     /// brake controller
     ///


### PR DESCRIPTION
This PR allows [ZigZag mode](https://discuss.ardupilot.org/t/zigzag-mode-for-copter-3-7/33717) to maintain its altitude above the terrain (using lidar) when travelling between points A and B using a range finder.  Note that ZigZag mode has always supported "surface tracking" (aka terrain following) while the Pilot was controlling the vehicle (aka stage = MANUAL_REGAIN) but once the user moved the switch position to fly to one of the two defined points it would just fly at the current altitude-above-ekf-origin.

[See this blog for details on how ZigZag mode works](https://discuss.ardupilot.org/t/zigzag-mode-for-copter-3-7/33717)

Changes include:

- AC_WPNav gets two accessors:

  - rangefinder_used allows ZigZag to determine if the waypoint controller is capable of terrain following (i.e. a range finder is attached and WPNAV_RFND_USE = 1)
  - origin_and_destination_are_terrain_alt() allows ZigZag to know if the waypoint controllers' latest destination alt is a terrain alt or an alt-above-ekf-origin

- Copter adds a get/set_surface_tracking_target_alt_cm methods to get and set the surface tracking feature's target alt-above-terrain
- When ZigZag enters AUTO stage it sets the waypoint controller's target to the surface-tracking-target-alt (if available)
- When ZigZag enter MANUAL stage (i.e. pilot controlled) is passes the waypoint controller's target alt-above-terrain (if available) into surface-tracking
- ZigZag now switches to MANUAL if the wpnav fails to update which can only be caused by missing terrain data (i.e. the range finder has failed).

This PR also makes these partially related clean-ups:

- reduce arguments passed into the get_surface_tracking_climb_rate function (they were always the same)
- move surface tracking variables into a structure.

This has been tested in SITL and I will test fly it on a real vehicle in the coming days