### PR TITLE
Plane: remove pointless update_notify shim

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -56,7 +56,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_ServoRelayEvents, &plane.ServoRelayEvents, update_events,          50,  150),
     SCHED_TASK_CLASS(AP_BattMonitor, &plane.battery, read, 10, 300),
     SCHED_TASK_CLASS(AP_Baro, &plane.barometer, accumulate, 50, 150),
-    SCHED_TASK(update_notify,          50,    300),
+    SCHED_TASK_CLASS(AP_Notify,      &plane.notify,  update, 50, 300),
     SCHED_TASK(read_rangefinder,       50,    100),
     SCHED_TASK_CLASS(AP_ICEngine, &plane.g2.ice_control, update, 10, 100),
     SCHED_TASK(compass_cal_update,     50,    50),

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -945,7 +945,6 @@ private:
     void check_long_failsafe();
     void check_short_failsafe();
     void startup_INS_ground(void);
-    void update_notify();
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);
     void change_arm_state(void);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -419,13 +419,6 @@ void Plane::startup_INS_ground(void)
     }
 }
 
-// updates the status of the notify objects
-// should be called at 50hz
-void Plane::update_notify()
-{
-    notify.update();
-}
-
 // sets notify object flight mode information
 void Plane::notify_mode(const Mode& mode)
 {


### PR DESCRIPTION
Apparently this takes 300us where Copter takes 90.  Colour me sceptical.
