### PR TITLE
Add support for setting uart parity on Linux boards

### DIFF
--- a/libraries/AP_HAL_Linux/SerialDevice.h
+++ b/libraries/AP_HAL_Linux/SerialDevice.h
@@ -20,4 +20,7 @@ public:
     {
         /* most devices simply ignore this setting */
     };
+
+    /* Depends on lower level to implement, most devices are fine with defaults */
+    virtual void set_parity(int v) { }
 };

--- a/libraries/AP_HAL_Linux/UARTDevice.cpp
+++ b/libraries/AP_HAL_Linux/UARTDevice.cpp
@@ -130,3 +130,23 @@ void UARTDevice::set_flow_control(AP_HAL::UARTDriver::flow_control flow_control_
 
     _flow_control = flow_control_setting;
 }
+
+void UARTDevice::set_parity(int v)
+{
+    struct termios t;
+    tcgetattr(_fd, &t);
+    if (v != 0) {
+        // enable parity
+        t.c_cflag |= PARENB;
+        if (v == 1) {
+            t.c_cflag |= PARODD;
+        } else {
+            t.c_cflag &= ~PARODD;
+        }
+    }
+    else {
+        // disable parity
+        t.c_cflag &= ~PARENB;
+    }
+    tcsetattr(_fd, TCSANOW, &t);
+}

--- a/libraries/AP_HAL_Linux/UARTDevice.h
+++ b/libraries/AP_HAL_Linux/UARTDevice.h
@@ -19,6 +19,7 @@ public:
     {
         return _flow_control;
     }
+    virtual void set_parity(int v) override;
 
 private:
     void _disable_crlf();

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -457,6 +457,10 @@ void UARTDriver::_timer_tick(void)
     _in_timer = false;
 }
 
+void UARTDriver::configure_parity(uint8_t v) {
+    _device->set_parity(v);
+}
+
 /*
   return timestamp estimate in microseconds for when the start of
   a nbytes packet arrived on the uart. This should be treated as a

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -45,6 +45,8 @@ public:
         return _device->get_flow_control();
     }
 
+    virtual void configure_parity(uint8_t v);
+
     virtual void set_flow_control(enum flow_control flow_control_setting) override
    {
        _device->set_flow_control(flow_control_setting);


### PR DESCRIPTION
I found that I was unable to set the parity for a Linux UART device, this commit simply adds the ability to set the UART parity in AP_HAL_Linux in the same way that it's done for AP_HAL_VRBRAIN.