### PR TITLE
AP_Baro: use int64_t for intermediate values

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -442,7 +442,7 @@ void AP_Baro_MS56XX::_calculate_5607()
 // Calculate Temperature and compensated Pressure in real units (Celsius degrees*100, mbar*100).
 void AP_Baro_MS56XX::_calculate_5637()
 {
-    int32_t dT, TEMP;
+    int32_t dT;
     int64_t OFF, SENS;
     int32_t raw_pressure = _D1;
     int32_t raw_temperature = _D2;
@@ -451,7 +451,7 @@ void AP_Baro_MS56XX::_calculate_5637()
     // sub -15c temperature compensation is not included
 
     dT = raw_temperature - (((uint32_t)_cal_reg.c5) << 8);
-    TEMP = 2000 + ((int64_t)dT * (int64_t)_cal_reg.c6) / 8388608;
+    int64_t TEMP = 2000 + ((int64_t)dT * (int64_t)_cal_reg.c6) / 8388608;
     OFF = (int64_t)_cal_reg.c2 * (int64_t)131072 + ((int64_t)_cal_reg.c4 * (int64_t)dT) / (int64_t)64;
     SENS = (int64_t)_cal_reg.c1 * (int64_t)65536 + ((int64_t)_cal_reg.c3 * (int64_t)dT) / (int64_t)128;
 
@@ -467,7 +467,7 @@ void AP_Baro_MS56XX::_calculate_5637()
         SENS = SENS - SENS2;
     }
 
-    int32_t pressure = ((int64_t)raw_pressure * SENS / (int64_t)2097152 - OFF) / (int64_t)32768;
+    const int64_t pressure = ((int64_t)raw_pressure * SENS / (int64_t)2097152 - OFF) / (int64_t)32768;
     float temperature = TEMP * 0.01f;
     _copy_to_frontend(_instance, (float)pressure, temperature);
 }
@@ -475,7 +475,7 @@ void AP_Baro_MS56XX::_calculate_5637()
 // Calculate Temperature and compensated Pressure in real units (Celsius degrees*100, mbar*100).
 void AP_Baro_MS56XX::_calculate_5837()
 {
-    int32_t dT, TEMP;
+    int32_t dT;
     int64_t OFF, SENS;
     int32_t raw_pressure = _D1;
     int32_t raw_temperature = _D2;
@@ -484,7 +484,7 @@ void AP_Baro_MS56XX::_calculate_5837()
     // sub -15c temperature compensation is not included
 
     dT = raw_temperature - (((uint32_t)_cal_reg.c5) << 8);
-    TEMP = 2000 + ((int64_t)dT * (int64_t)_cal_reg.c6) / 8388608;
+    int64_t TEMP = 2000 + ((int64_t)dT * (int64_t)_cal_reg.c6) / 8388608;
     OFF = (int64_t)_cal_reg.c2 * (int64_t)65536 + ((int64_t)_cal_reg.c4 * (int64_t)dT) / (int64_t)128;
     SENS = (int64_t)_cal_reg.c1 * (int64_t)32768 + ((int64_t)_cal_reg.c3 * (int64_t)dT) / (int64_t)256;
 
@@ -500,7 +500,7 @@ void AP_Baro_MS56XX::_calculate_5837()
         SENS = SENS - SENS2;
     }
 
-    int32_t pressure = ((int64_t)raw_pressure * SENS / (int64_t)2097152 - OFF) / (int64_t)8192;
+    int64_t pressure = ((int64_t)raw_pressure * SENS / (int64_t)2097152 - OFF) / (int64_t)8192;
     pressure = pressure * 10; // MS5837 only reports to 0.1 mbar
     float temperature = TEMP * 0.01f;
 


### PR DESCRIPTION
pointless loss of precision otherwise