### PR TITLE
Copter: fix auto-disarm check

### DIFF
--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -94,7 +94,7 @@ void Copter::auto_disarm_check()
     }
 
     // if the rotor is still spinning, don't initiate auto disarm
-    if (motors->get_spool_state() != AP_Motors::SpoolState::GROUND_IDLE) {
+    if (motors->get_spool_state() > AP_Motors::SpoolState::GROUND_IDLE) {
         auto_disarm_begin = tnow_ms;
         return;
     }


### PR DESCRIPTION
This PR addresses issue https://github.com/ArduPilot/ardupilot/issues/11097 that was introduced as part of the recent Spool Logic changes to master (this issue is not in Copter-3.6).  The check changed was previously a traditional helicopter only check but it is run for multicopters post-spool changes.  The underlying cause of the problem is that multcopter's spool-state goes to SHUT_DOWN when Emergency Stop is engaged so they were failing the check.

This has been tested in SITL on a multicopter:

Test1 (check that auto-disarm with estop is working):

- armed and took off in Loiter to height of 1m
- engaged Emergency Stop from aux switch
- vehicle fell to the ground, 5 seconds later vehicle disarmed (half of DISARM_DELAY parameter value)

Test2 (check that vehicle recovers from Emergency Stop if switched off quickly):

- armed and took off in Loiter to height of 50m
- engaged Emergency Stop from aux switch ("rc 9 2000")
- vehicle fell 20m
- disengaged Emergency Stop ("rc 9 1000")
- vehicle recovered (no crash)

Test 3 (check that regular auto disarm is working):

- armed and took off in Loiter to height of 10m
- landed vehicel ("rc 3 1000")
- vehicle disarmed after 10seconds