### PR TITLE
QuadPlane TVBS: set plane.nav_roll/pitch in QACRO mode

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -16,11 +16,15 @@ void Plane::Log_Write_Attitude(void)
         //Plane does not have the concept of navyaw. This is a placeholder.
         targets.z = 0;
     }
-    
+
     if (quadplane.tailsitter_active() || quadplane.in_vtol_mode()) {
         // we need the attitude targets from the AC_AttitudeControl controller, as they
-        // account for the acceleration limits
-        targets = quadplane.attitude_control->get_att_target_euler_cd();
+        // account for the acceleration limits.
+        // Also, for bodyframe roll input types, _attitude_target_euler_angle is not maintained
+        // since Euler angles are not used and it is a waste of cpu to compute them at the loop rate.
+        // Get them from the quaternion instead:
+        quadplane.attitude_control->get_attitude_target_quat().to_euler(targets.x, targets.y, targets.z);
+        targets *= degrees(100.0f);
         logger.Write_AttitudeView(*quadplane.ahrs_view, targets);
     } else {
         logger.Write_Attitude(ahrs, targets);

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -17,6 +17,13 @@ bool ModeQStabilize::_enter()
 
 void ModeQStabilize::update()
 {
+    if (plane.quadplane.tailsitter_active() && (plane.control_mode == &plane.mode_qacro)) {
+        // get nav_roll and nav_pitch from multicopter attitude controller
+        Vector3f att_target = plane.quadplane.attitude_control->get_att_target_euler_cd();
+        plane.nav_pitch_cd = att_target.y;
+        plane.nav_roll_cd = att_target.x;
+        return;
+    }
     // set nav_roll and nav_pitch using sticks
     int16_t roll_limit = MIN(plane.roll_limit_cd, plane.quadplane.aparm.angle_max);
     plane.nav_roll_cd  = (plane.channel_roll->get_control_in() / 4500.0) * roll_limit;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -131,7 +131,10 @@ void QuadPlane::tailsitter_output(void)
         int32_t pitch_error_cd = (plane.nav_pitch_cd - ahrs_view->pitch_sensor) * 0.5;
         float extra_pitch = constrain_float(pitch_error_cd, -SERVO_MAX, SERVO_MAX) / SERVO_MAX;
         float extra_sign = extra_pitch > 0?1:-1;
-        float extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter.vectored_hover_power) * SERVO_MAX;
+        float extra_elevator = 0;
+        if (!is_zero(extra_pitch)) {
+            extra_elevator = extra_sign * powf(fabsf(extra_pitch), tailsitter.vectored_hover_power) * SERVO_MAX;
+        }
         tilt_left  = extra_elevator + tilt_left * tailsitter.vectored_hover_gain;
         tilt_right = extra_elevator + tilt_right * tailsitter.vectored_hover_gain;
         if (fabsf(tilt_left) >= SERVO_MAX || fabsf(tilt_right) >= SERVO_MAX) {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -349,9 +349,9 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw(float euler_roll_angle
 void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
 {
     // Convert from centidegrees on public interface to radians
-    float euler_yaw_rate = radians(euler_yaw_rate_cds * 0.01f);
-    float euler_pitch = radians(euler_pitch_cd * 0.01f);
-    float body_roll = radians(body_roll_cd * 0.01f);
+    float euler_yaw_rate = radians(euler_yaw_rate_cds*0.01f);
+    float euler_pitch = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
+    float body_roll   = radians(constrain_float(body_roll_cd   * 0.01f, -90.0f, 90.0f));
 
     // new heading
     _attitude_target_euler_angle.z = wrap_PI(_attitude_target_euler_angle.z + euler_yaw_rate * _dt);
@@ -368,10 +368,6 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float 
     Quaternion bf_yaw_Q;
     bf_yaw_Q.from_axis_angle(Vector3f(-cosf(euler_pitch), 0, 0), body_roll);
     _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
-
-    // calculate the attitude target euler angles
-    _attitude_target_euler_angle.x = _attitude_target_quat.get_euler_roll();
-    _attitude_target_euler_angle.y = _attitude_target_quat.get_euler_pitch();
 
     // Set rate feedforward requests to zero
     _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
@@ -395,9 +391,9 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_m(float 
 void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(float euler_yaw_rate_cds, float euler_pitch_cd, float body_roll_cd)
 {
     // Convert from centidegrees on public interface to radians
-    float euler_yaw_rate = radians(euler_yaw_rate_cds * 0.01f);
-    float euler_pitch = radians(euler_pitch_cd * 0.01f);
-    float body_roll = radians(body_roll_cd * 0.01f);
+    float euler_yaw_rate = radians(euler_yaw_rate_cds*0.01f);
+    float euler_pitch = radians(constrain_float(euler_pitch_cd * 0.01f, -90.0f, 90.0f));
+    float body_roll   = radians(constrain_float(body_roll_cd   * 0.01f, -90.0f, 90.0f));
 
     const float cpitch = cosf(euler_pitch);
     const float spitch = fabsf(sinf(euler_pitch));
@@ -418,10 +414,6 @@ void AC_AttitudeControl::input_euler_rate_yaw_euler_angle_pitch_bf_roll_p(float 
     Quaternion bf_yaw_Q;
     bf_yaw_Q.from_axis_angle(Vector3f(cpitch, 0, 0), euler_yaw_rate);
     _attitude_target_quat = _attitude_target_quat * bf_roll_Q * bf_yaw_Q;
-
-    // calculate the attitude target euler angles
-    _attitude_target_euler_angle.x = _attitude_target_quat.get_euler_roll();
-    _attitude_target_euler_angle.y = _attitude_target_quat.get_euler_pitch();
 
     // Set rate feedforward requests to zero
     _attitude_target_euler_rate = Vector3f(0.0f, 0.0f, 0.0f);
@@ -551,9 +543,19 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, 
     float yaw_rate_rads = radians(yaw_rate_bf_cds * 0.01f);
 
     // Update attitude error
-    Vector3f gyro_latest = _ahrs.get_gyro_latest();
+    Vector3f attitude_error_vector;
+    _attitude_ang_error.to_axis_angle(attitude_error_vector);
+
     Quaternion attitude_ang_error_update_quat;
-    attitude_ang_error_update_quat.from_axis_angle(Vector3f((_attitude_target_ang_vel.x - gyro_latest.x) * _dt, (_attitude_target_ang_vel.y - gyro_latest.y) * _dt, (_attitude_target_ang_vel.z - gyro_latest.z) * _dt));
+    // limit the integrated error angle
+    float err_mag = attitude_error_vector.length();
+    if (err_mag > AC_ATTITUDE_THRUST_ERROR_ANGLE) {
+        attitude_error_vector *= AC_ATTITUDE_THRUST_ERROR_ANGLE / err_mag;
+        _attitude_ang_error.from_axis_angle(attitude_error_vector);
+    }
+
+    Vector3f gyro_latest = _ahrs.get_gyro_latest();
+    attitude_ang_error_update_quat.from_axis_angle(Vector3f((_attitude_target_ang_vel.x-gyro_latest.x) * _dt, (_attitude_target_ang_vel.y-gyro_latest.y) * _dt, (_attitude_target_ang_vel.z-gyro_latest.z) * _dt));
     _attitude_ang_error = attitude_ang_error_update_quat * _attitude_ang_error;
 
     // Compute acceleration-limited body frame rates
@@ -577,7 +579,6 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, 
     ang_vel_to_euler_rate(_attitude_target_euler_angle, _attitude_target_ang_vel, _attitude_target_euler_rate);
 
     // Compute the angular velocity target from the integrated rate error
-    Vector3f attitude_error_vector;
     _attitude_ang_error.to_axis_angle(attitude_error_vector);
     _rate_target_ang_vel = update_ang_vel_target_from_att_error(attitude_error_vector);
     _rate_target_ang_vel += _attitude_target_ang_vel;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -177,6 +177,9 @@ public:
     // same result with the fewest multiplications. Even though it may look like a bug, it is intentional. See issue 4895.
     Vector3f get_att_target_euler_cd() const { return _attitude_target_euler_angle * degrees(100.0f); }
 
+    // Return the body-to-NED target attitude used by the quadplane-specific attitude control input methods
+    Quaternion get_attitude_target_quat() const { return _attitude_target_quat; }
+
     // Return the angle between the target thrust vector and the current thrust vector.
     float get_att_error_angle_deg() const { return degrees(_thrust_error_angle); }
 


### PR DESCRIPTION
Using plane.nav_pitch_cd resulted in motors tilting up when flying level in Q modes.
It might also be a good idea to disable this when in flight to avoid the possibility of inducing control instability during attitude upsets. But is_flying() doesn't seem to be the right test...