### PR TITLE
AP_ICEngine: add idle throttle percentage

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -217,7 +217,7 @@ void AP_ICEngine::update(void)
                 // reset initial height while disarmed
                 initial_height = -pos.z;
             }
-        } else if (idle_percent == 0) { // check if we should idle
+        } else if (idle_percent <= 0) { // check if we should idle
             // force ignition off when disarmed
             state = ICE_OFF;
         }
@@ -265,8 +265,11 @@ bool AP_ICEngine::throttle_override(uint8_t &percentage)
         return false;
     }
 
-    uint8_t current_throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
-    if (idle_percent > current_throttle && state == ICE_RUNNING) {
+    if (state == ICE_RUNNING &&
+        idle_percent > 0 &&
+        idle_percent < 100 &&
+        (int16_t)idle_percent > SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))
+    {
         percentage = (uint8_t)idle_percent;
         return true;
     }

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -89,6 +89,9 @@ private:
     // throttle percentage for engine start
     AP_Int8 start_percent;
 
+    // throttle percentage for engine idle
+    AP_Int8 idle_percent;
+
     // height when we enter ICE_START_HEIGHT_DELAY
     float initial_height;
 


### PR DESCRIPTION
This adds a idle percentage parameter. When the engine is in the running state minimum throttle will be limited to this new value. This includes when the aircraft is disarmed. 

This replaces the old THR_MIN functionality that seems to have been broken for some time (on plane at least)

https://github.com/ArduPilot/ardupilot/pull/11059