### PR TITLE
Move updating of compass SYS_STATUS flags upt to base class

### DIFF
--- a/APMrover2/GCS_Rover.cpp
+++ b/APMrover2/GCS_Rover.cpp
@@ -23,10 +23,6 @@ bool GCS_Rover::supersimple_input_active() const
 void GCS_Rover::update_vehicle_sensor_status_flags(void)
 {
     // first what sensors/controllers we have
-    if (AP::compass().enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     const AP_GPS &gps = AP::gps();
     if (gps.status() > AP_GPS::NO_GPS) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_GPS;
@@ -62,11 +58,6 @@ void GCS_Rover::update_vehicle_sensor_status_flags(void)
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL; // X/Y position control
     }
 
-    AP_AHRS &ahrs = AP::ahrs();
-
-    if (AP::compass().enabled() && AP::compass().healthy(0) && ahrs.use_compass()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }

--- a/AntennaTracker/GCS_Tracker.cpp
+++ b/AntennaTracker/GCS_Tracker.cpp
@@ -57,22 +57,12 @@ void GCS_Tracker::update_vehicle_sensor_status_flags()
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
     // first what sensors/controllers we have
-    if (AP::compass().enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     const AP_GPS &gps = AP::gps();
     if (gps.status() > AP_GPS::NO_GPS) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_GPS;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_GPS;
     }
 
-    AP_AHRS &ahrs = AP::ahrs();
-
-    const Compass &compass = AP::compass();
-    if (AP::compass().enabled() && compass.healthy(0) && ahrs.use_compass()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -34,10 +34,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
-    if (AP::compass().enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     const AP_GPS &gps = AP::gps();
     if (gps.status() > AP_GPS::NO_GPS) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_GPS;
@@ -127,11 +123,6 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
     }
 #endif
 
-    AP_AHRS &ahrs = AP::ahrs();
-    const Compass &compass = AP::compass();
-    if (compass.enabled() && compass.healthy() && ahrs.use_compass()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -4,11 +4,6 @@
 void GCS_Plane::update_vehicle_sensor_status_flags(void)
 {
     // first what sensors/controllers we have
-    if (AP::compass().enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
-
     const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
     if (airspeed && airspeed->enabled()) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
@@ -110,12 +105,6 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;
     }
 
-    AP_AHRS &ahrs = AP::ahrs();
-
-    const Compass &compass = AP::compass();
-    if (AP::compass().enabled() && compass.healthy() && ahrs.use_compass()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }

--- a/ArduSub/GCS_Sub.cpp
+++ b/ArduSub/GCS_Sub.cpp
@@ -20,10 +20,6 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
     // first what sensors/controllers we have
-    if (AP::compass().enabled()) {
-        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
-    }
     if (sub.ap.depth_sensor_present) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
@@ -64,11 +60,6 @@ void GCS_Sub::update_vehicle_sensor_status_flags()
     control_sensors_health &= ~MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE; // check the internal barometer only
     if (sub.sensor_health.depth) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
-    }
-    AP_AHRS &ahrs = AP::ahrs();
-    const Compass &compass = AP::compass();
-    if (AP::compass().enabled() && compass.healthy() && ahrs.use_compass()) {
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
     }
     if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -88,6 +88,15 @@ void GCS::update_sensor_status_flags()
         }
     }
 
+    const Compass &compass = AP::compass();
+    if (AP::compass().enabled()) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_3D_MAG;
+        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_MAG;
+    }
+    if (compass.enabled() && compass.healthy() && ahrs.use_compass()) {
+        control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_MAG;
+    }
+
     const AP_Baro &barometer = AP::baro();
     control_sensors_present |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
     control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;


### PR DESCRIPTION
There is a behaviour change for Rover and Tracker here; it was only checking the health of compass 0, now it checks all of them like every other vehicle.
