### PR TITLE
AP_TemperatureSensor: fix TSYS01 warning on SITL

### DIFF
--- a/libraries/AP_TemperatureSensor/TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/TSYS01.cpp
@@ -15,6 +15,9 @@ static const uint8_t TSYS01_CMD_READ_ADC    = 0x00;
 
 bool TSYS01::init(uint8_t bus)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    return false;
+#endif
     _dev = std::move(hal.i2c_mgr->get_device(bus, TSYS01_ADDR));
     if (!_dev) {
         printf("TSYS01 device is null!");


### PR DESCRIPTION
prevent "TSYS01 device is null!" warning on SITL !