### PR TITLE
Copter: Remove rangefinder distance pre arm check

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -172,14 +172,6 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         }
 #endif
 
-        #if RANGEFINDER_ENABLED == ENABLED && OPTFLOW == ENABLED
-        // check range finder if optflow enabled
-        if (copter.optflow.enabled() && !copter.rangefinder.pre_arm_check()) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "check range finder");
-            return false;
-        }
-        #endif
-
         #if FRAME_CONFIG == HELI_FRAME
         // check helicopter parameters
         if (!copter.motors->parameter_check(display_failure)) {

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -311,10 +311,6 @@ void RangeFinder::init(enum Rotation orientation_default)
             // present (although it may not be healthy)
             num_instances = i+1;
         }
-        // initialise pre-arm check variables
-        state[i].pre_arm_check = false;
-        state[i].pre_arm_distance_min = 9999;  // initialise to an arbitrary large value
-        state[i].pre_arm_distance_max = 0;
 
         // initialise status
         state[i].status = RangeFinder_NotConnected;
@@ -337,7 +333,6 @@ void RangeFinder::update(void)
                 continue;
             }
             drivers[i]->update();
-            drivers[i]->update_pre_arm_check();
         }
     }
 
@@ -629,22 +624,6 @@ uint8_t RangeFinder::range_valid_count_orient(enum Rotation orientation) const
         return 0;
     }
     return backend->range_valid_count();
-}
-
-/*
-  returns true if pre-arm checks have passed for all range finders
-  these checks involve the user lifting or rotating the vehicle so that sensor readings between
-  the min and 2m can be captured
- */
-bool RangeFinder::pre_arm_check() const
-{
-    for (uint8_t i=0; i<num_instances; i++) {
-        // if driver is valid but pre_arm_check is false, return false
-        if ((drivers[i] != nullptr) && (params[i].type != RangeFinder_TYPE_NONE) && !state[i].pre_arm_check) {
-            return false;
-        }
-    }
-    return true;
 }
 
 const Vector3f &RangeFinder::get_pos_offset_orient(enum Rotation orientation) const

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -91,9 +91,6 @@ public:
         uint16_t voltage_mv;            // voltage in millivolts, if applicable, otherwise 0
         enum RangeFinder_Status status; // sensor status
         uint8_t  range_valid_count;     // number of consecutive valid readings (maxes out at 10)
-        bool     pre_arm_check;         // true if sensor has passed pre-arm checks
-        uint16_t pre_arm_distance_min;  // min distance captured during pre-arm checks
-        uint16_t pre_arm_distance_max;  // max distance captured during pre-arm checks
         uint32_t last_reading_ms;       // system time of last successful update from sensor
 
         const struct AP_Param::GroupInfo *var_info;
@@ -153,13 +150,6 @@ public:
     void set_estimated_terrain_height(float height) {
         estimated_terrain_height = height;
     }
-
-    /*
-      returns true if pre-arm checks have passed for all range finders
-      these checks involve the user lifting or rotating the vehicle so that sensor readings between
-      the min and 2m can be captured
-     */
-    bool pre_arm_check() const;
 
     static RangeFinder *get_singleton(void) { return _singleton; }
 

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
@@ -79,28 +79,3 @@ void AP_RangeFinder_Backend::set_status(RangeFinder::RangeFinder_Status _status)
     }
 }
 
-/*
-  set pre-arm checks to passed if the range finder has been exercised through a reasonable range of movement
-      max distance sensed is at least 50cm > min distance sensed
-      max distance < 200cm
-      min distance sensed is within 10cm of ground clearance or sensor's minimum distance
- */
-void AP_RangeFinder_Backend::update_pre_arm_check()
-{
-    // return immediately if already passed or no sensor data
-    if (state.pre_arm_check || state.status == RangeFinder::RangeFinder_NotConnected || state.status == RangeFinder::RangeFinder_NoData) {
-        return;
-    }
-
-    // update min, max captured distances
-    state.pre_arm_distance_min = MIN(state.distance_cm, state.pre_arm_distance_min);
-    state.pre_arm_distance_max = MAX(state.distance_cm, state.pre_arm_distance_max);
-
-    // Check that the range finder has been exercised through a realistic range of movement
-    if (((state.pre_arm_distance_max - state.pre_arm_distance_min) >= RANGEFINDER_PREARM_REQUIRED_CHANGE_CM) &&
-         (state.pre_arm_distance_max < RANGEFINDER_PREARM_ALT_MAX_CM) &&
-         ((int16_t)state.pre_arm_distance_min < (MAX(params.ground_clearance_cm,params.min_distance_cm) + 10)) &&
-         ((int16_t)state.pre_arm_distance_min > (MIN(params.ground_clearance_cm,params.min_distance_cm) - 10))) {
-        state.pre_arm_check = true;
-    }
-}

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -33,8 +33,6 @@ public:
 
     virtual void handle_msg(mavlink_message_t *msg) { return; }
 
-    void update_pre_arm_check();
-
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }
     uint16_t voltage_mv() const { return state.voltage_mv; }


### PR DESCRIPTION
This check was really buggy, and also a frustrating one for users to deal with. The associated problems include:
  - We were using out of range (low or high) distances into the check, which could lead to the check being permanently failing
  - We use rangefinders in other orientations in the proximity library, which would mean you would have to somehow never see further then 2 meters till after you armed, then remove the obstruction blockage. (This is obviously hard/unsafe to do)
  - It's hard to pick up large vehicles, and to much tilt would defeat the check as well

This came up in the dev call, and got universal acceptance, and lets me help simplify the rangefinder. After #11078 all vehicles will be on the same rangefinder arming checks.