### PR TITLE
EKF2/3: increase maximum optical flow sensor rate

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -73,7 +73,7 @@ bool NavEKF2_core::setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedTAS.init(OBS_BUFFER_LENGTH)) {
         return false;
     }
-    if(!storedOF.init(OBS_BUFFER_LENGTH)) {
+    if(!storedOF.init(FLOW_BUFFER_LENGTH)) {
         return false;
     }
     // Note: the use of dual range finders potentially doubles the amount of to be stored

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -755,6 +755,7 @@ private:
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH
     static const uint32_t OBS_BUFFER_LENGTH = 5;
+    static const uint32_t FLOW_BUFFER_LENGTH = 15;
 
     // Variables
     bool statesInitialised;         // boolean true when filter states have been initialised

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -456,6 +456,7 @@ private:
     const uint8_t gndGradientSigma = 50;           // RMS terrain gradient percentage assumed by the terrain height estimation
     const uint16_t fusionTimeStep_ms = 10;         // The minimum time interval between covariance predictions and measurement fusions in msec
     const uint8_t sensorIntervalMin_ms = 50;       // The minimum allowed time between measurements from any non-IMU sensor (msec)
+    const uint8_t flowIntervalMin_ms = 20;         // The minimum allowed time between measurements from optical flow sensors (msec)
 
     struct {
         bool enabled:1;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -103,6 +103,9 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     // limit to be no longer than the IMU buffer (we can't process data faster than the EKF prediction rate)
     obs_buffer_length = MIN(obs_buffer_length,imu_buffer_length);
 
+    // calculate buffer size for optical flow data
+    const uint8_t flow_buffer_length = MIN((ekf_delay_ms / _frontend->flowIntervalMin_ms) + 1, imu_buffer_length);
+
     if(!storedGPS.init(obs_buffer_length)) {
         return false;
     }
@@ -115,7 +118,7 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedTAS.init(obs_buffer_length)) {
         return false;
     }
-    if(!storedOF.init(obs_buffer_length)) {
+    if (!storedOF.init(flow_buffer_length)) {
         return false;
     }
     if(!storedBodyOdm.init(obs_buffer_length)) {
@@ -138,7 +141,12 @@ bool NavEKF3_core::setup_core(NavEKF3 *_frontend, uint8_t _imu_index, uint8_t _c
     if(!storedOutput.init(imu_buffer_length)) {
         return false;
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u , OBS=%u , dt=%6.4f",(unsigned)imu_index,(unsigned)imu_buffer_length,(unsigned)obs_buffer_length,(double)dtEkfAvg);
+    gcs().send_text(MAV_SEVERITY_INFO, "EKF3 IMU%u buffers, IMU=%u, OBS=%u, OF=%u, dt=%6.4f",
+                    (unsigned)imu_index,
+                    (unsigned)imu_buffer_length,
+                    (unsigned)obs_buffer_length,
+                    (unsigned)flow_buffer_length,
+                    (double)dtEkfAvg);
     return true;
 }
     


### PR DESCRIPTION
This PR allows the EKFs to handle high rate optical flow sensors like the [OpenMV camera](http://ardupilot.org/copter/docs/common-openmv-optflow.html) that sends data at 42hz.  The current limit is 20hz which is also very close (perhaps under) the rate of the popular CX-OF sensor which sends at between 20hz and 25hz.

The downside of this change is that it increases the EKF's memory consumption from 200 bytes to 1040 bytes per core.  This increase comes from the [obs_range_buffer_t structure](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF2/AP_NavEKF2_core.h#L456) (40bytes) in the obs_ring_buffer_t which increases from 5 elements ([OBS_BUFFER_LENGTH](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF2/AP_NavEKF2_core.h#L757)) to a maximum of 26 (imu_buffer_length).

Another alternative might be to create a new OF_BUFFER_LENGTH constant = 10 and then use this.  This would reduce the memory consumption and perhaps support up to 50hz of data?

The EKF2 change has been successfully tested by me and one other user in the VisionProjects gitter channel.