### PR TITLE
EKF3: Preflight health check: always update height innov. filtered estimate

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -27,7 +27,7 @@ bool NavEKF3_core::healthy(void) const
     }
     // position and height innovations must be within limits when on-ground and in a static mode of operation
     float horizErrSq = sq(innovVelPos[3]) + sq(innovVelPos[4]);
-    if (onGround && (PV_AidingMode == AID_NONE) && ((horizErrSq > 1.0f) || (fabsf(hgtInnovFiltState) > 1.0f))) {
+    if (onGround && ((horizErrSq > 1.0f) || (fabsf(hgtInnovFiltState) > 1.0f))) {
         return false;
     }
 


### PR DESCRIPTION
This PR aims to have a stricter EKF height health check while on the ground before arming. Presently, the only check on altitude in the EKF health checks is on the attribute `hgtInnovFiltState`. However, it is not updated if the height estimate is **unhealthy** (barometer data not fused anymore, unit variance >1) and the vehicle is already in the aiding mode **AID_ABSOLUTE** or **AID_RELATIVE**, which can lead to deceptively think the filter is healthy while in fact it is not. 

What I propose is to always estimate `hgtInnovFiltState`, the difference between the estimated altitude and the baro height, while on the ground. This is done to detect a constant bias.