### PR TITLE
Scripting: Introduce more types and nil punning

### DIFF
--- a/libraries/AP_Avoidance/AP_Avoidance.h
+++ b/libraries/AP_Avoidance/AP_Avoidance.h
@@ -201,8 +201,6 @@ private:
     HAL_Semaphore_Recursive _rsem;
 };
 
-float closest_distance_between_radial_and_point(const Vector2f &w,
-                                                const Vector2f &p);
 float closest_approach_xy(const Location &my_loc,
                           const Vector3f &my_vel,
                           const Location &obstacle_loc,

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -133,10 +133,6 @@ public:
     int32_t pack_capacity_mah(uint8_t instance) const;
     int32_t pack_capacity_mah() const { return pack_capacity_mah(AP_BATT_PRIMARY_INSTANCE); }
  
-    /// returns the failsafe state of the battery
-    BatteryFailsafe check_failsafe(const uint8_t instance);
-    void check_failsafes(void); // checks all batteries failsafes
-
     /// returns true if a battery failsafe has ever been triggered
     bool has_failsafed(void) const { return _has_triggered_failsafe; };
 
@@ -146,9 +142,6 @@ public:
     /// get_type - returns battery monitor type
     enum AP_BattMonitor_Params::BattMonitor_Type get_type() const { return get_type(AP_BATT_PRIMARY_INSTANCE); }
     enum AP_BattMonitor_Params::BattMonitor_Type get_type(uint8_t instance) const { return _params[instance].type(); }
-
-    /// set_monitoring - sets the monitor type (used for example sketch only)
-    void set_monitoring(uint8_t instance, uint8_t mon) { _params[instance]._type.set(mon); }
 
     /// true when (voltage * current) > watt_max
     bool overpower_detected() const;
@@ -190,6 +183,10 @@ private:
     uint8_t     _num_instances;                                     /// number of monitors
 
     void convert_params(void);
+
+    /// returns the failsafe state of the battery
+    BatteryFailsafe check_failsafe(const uint8_t instance);
+    void check_failsafes(void); // checks all batteries failsafes
 
     battery_failsafe_handler_fn_t _battery_failsafe_handler_fn;
     const int8_t *_failsafe_priorities; // array of failsafe priorities, sorted highest to lowest priority, -1 indicates no more entries

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -965,8 +965,8 @@ void AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
         ground_speed(1)*100,  // cm/s
         ground_course(1)*100, // 1/100 degrees,
         num_sats(1),
-        rtk_num_sats(1),
-        rtk_age_ms(1));
+        state[1].rtk_num_sats,
+        state[1].rtk_age_ms);
 }
 
 void AP_GPS::send_mavlink_gps_rtk(mavlink_channel_t chan, uint8_t inst)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -329,22 +329,6 @@ public:
         return have_vertical_velocity(primary_instance);
     }
 
-    // return number of satellites used for RTK calculation
-    uint8_t rtk_num_sats(uint8_t instance) const {
-        return state[instance].rtk_num_sats;
-    }
-    uint8_t rtk_num_sats(void) const {
-        return rtk_num_sats(primary_instance);
-    }
-
-    // return age of last baseline correction in milliseconds
-    uint32_t rtk_age_ms(uint8_t instance) const {
-        return state[instance].rtk_age_ms;
-    }
-    uint32_t rtk_age_ms(void) const {
-        return rtk_age_ms(primary_instance);
-    }
-
     // the expected lag (in seconds) in the position and velocity readings from the gps
     // return true if the GPS hardware configuration is known or the lag parameter has been set manually
     bool get_lag(uint8_t instance, float &lag_sec) const;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.c
@@ -1655,7 +1655,7 @@ int unlink(const char *pathname)
 }
 
 
-int remove(const char *pathname)
+int __wrap_remove(const char *pathname)
 {
     errno = 0;
     int res = f_unlink(pathname);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/posix.h
@@ -314,7 +314,7 @@ int mkdir ( const char *pathname , mode_t mode );
 int rename ( const char *oldpath , const char *newpath );
 int rmdir ( const char *pathname );
 int unlink ( const char *pathname );
-int remove(const char *pathname);
+int __wrap_remove(const char *pathname);
 int closedir ( DIR *dirp );
 DIR *opendir ( const char *pathdir );
 struct dirent *readdir ( DIR *dirp );

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -98,12 +98,20 @@ const AP_Param::GroupInfo AP_Relay::var_info[] = {
     AP_GROUPEND
 };
 
+AP_Relay *AP_Relay::singleton;
 
 extern const AP_HAL::HAL& hal;
 
 AP_Relay::AP_Relay(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (singleton != nullptr) {
+        AP_HAL::panic("AP_Relay must be singleton");
+    }
+#endif
+    singleton = this;
 }
 
 

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -38,9 +38,13 @@ public:
     // toggle the relay status
     void        toggle(uint8_t relay);
 
+    static AP_Relay *get_singleton(void) {return singleton; }
+
     static const struct AP_Param::GroupInfo        var_info[];
 
 private:
+    static AP_Relay *singleton;
+
     AP_Int8 _pin[AP_RELAY_NUM_RELAYS];
     AP_Int8 _default;
 };

--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -29,8 +29,8 @@ An example script is given below:
 ```lua
 function update () -- periodic function that will be called
   current_pos = Location()
-  AP_AHRS:get_position(current_pos)
-  distance = current_pos:get_distance(AP_AHRS:get_home()) -- calculate the distance from home
+  ahrs:get_position(current_pos)
+  distance = current_pos:get_distance(ahrs:get_home()) -- calculate the distance from home
   if distance > 1000 then -- if more then 1000 meters away
     distance = 1000;      -- clamp the distance to 1000 meters
   end

--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -28,7 +28,9 @@ An example script is given below:
 
 ```lua
 function update () -- periodic function that will be called
-  distance = ahrs:position():distance(ahrs:home()) -- calculate the distance from home
+  current_pos = Location()
+  AP_AHRS:get_position(current_pos)
+  distance = current_pos:get_distance(AP_AHRS:get_home()) -- calculate the distance from home
   if distance > 1000 then -- if more then 1000 meters away
     distance = 1000;      -- clamp the distance to 1000 meters
   end
@@ -36,6 +38,4 @@ function update () -- periodic function that will be called
 
   return update, 1000 -- request to be rerun again 1000 milliseconds (1 second) from now
 end
-
-return update, 0 -- immediately run the update function
 ```

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -16,7 +16,7 @@ userdata Location method get_vector_from_origin_NEU boolean Vector3f
 include AP_AHRS/AP_AHRS.h
 
 singleton AP_AHRS alias ahrs
-singleton AP_AHRS method get_position boolean Location
+singleton AP_AHRS method get_position boolean Location'Null
 singleton AP_AHRS method get_home Location
 
 include AP_Math/AP_Math.h

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -15,6 +15,7 @@ userdata Location method get_vector_from_origin_NEU boolean Vector3f
 
 include AP_AHRS/AP_AHRS.h
 
+singleton AP_AHRS alias ahrs
 singleton AP_AHRS method get_position boolean Location
 singleton AP_AHRS method get_home Location
 
@@ -25,7 +26,9 @@ userdata Vector3f field y float read write -FLT_MAX FLT_MAX
 userdata Vector3f field z float read write -FLT_MAX FLT_MAX
 
 include AP_Notify/AP_Notify.h
+singleton notify alias notify
 singleton AP_Notify method play_tune void string
 
 include AP_RangeFinder/AP_RangeFinder.h
+singleton RangeFinder alias rangefinder
 singleton RangeFinder method num_sensors uint8_t

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -59,8 +59,12 @@ singleton AP_GPS method velocity Vector3f uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method ground_speed float uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method ground_course float uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method num_sats uint8_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method time_week uint16_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method time_week_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method get_hdop uint16_t uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method get_vdop uint16_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method last_fix_time_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method last_message_time_ms uint32_t uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 GPS_MAX_INSTANCES
 singleton AP_GPS method all_configured boolean

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -15,8 +15,8 @@ userdata Location method get_vector_from_origin_NEU boolean Vector3f
 
 include AP_AHRS/AP_AHRS.h
 
-singleton ahrs method get_position boolean Location
-singleton ahrs method get_home Location
+singleton AP_AHRS method get_position boolean Location
+singleton AP_AHRS method get_home Location
 
 include AP_Math/AP_Math.h
 
@@ -25,4 +25,7 @@ userdata Vector3f field y float read write -FLT_MAX FLT_MAX
 userdata Vector3f field z float read write -FLT_MAX FLT_MAX
 
 include AP_Notify/AP_Notify.h
-singleton notify method play_tune void string
+singleton AP_Notify method play_tune void string
+
+include AP_RangeFinder/AP_RangeFinder.h
+singleton RangeFinder method num_sensors uint8_t

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -18,12 +18,72 @@ include AP_AHRS/AP_AHRS.h
 singleton AP_AHRS alias ahrs
 singleton AP_AHRS method get_position boolean Location'Null
 singleton AP_AHRS method get_home Location
+singleton AP_AHRS method get_gyro Vector3f
+singleton AP_AHRS method get_hagl boolean float'Null
+singleton AP_AHRS method wind_estimate Vector3f
+singleton AP_AHRS method groundspeed_vector Vector2f
+singleton AP_AHRS method get_velocity_NED boolean Vector3f'Null
+singleton AP_AHRS method get_relative_position_NED_home boolean Vector3f'Null
+singleton AP_AHRS method home_is_set boolean
+singleton AP_AHRS method prearm_healthy boolean
+
+include AP_BattMonitor/AP_BattMonitor.h
+
+singleton AP_BattMonitor alias battery
+singleton AP_BattMonitor method num_instances uint8_t
+singleton AP_BattMonitor method healthy boolean uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method has_consumed_energy boolean uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method has_current boolean uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method voltage float uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method voltage_resting_estimate float uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method current_amps float uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method consumed_mah float uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method consumed_wh float uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method capacity_remaining_pct uint8_t uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method pack_capacity_mah int32_t uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method has_failsafed boolean
+singleton AP_BattMonitor method overpower_detected boolean uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+singleton AP_BattMonitor method get_temperature boolean float'Null uint8_t 0 AP_BATT_MONITOR_MAX_INSTANCES
+
+include AP_GPS/AP_GPS.h
+
+singleton AP_GPS alias gps
+singleton AP_GPS method num_sensors uint8_t
+singleton AP_GPS method primary_sensor uint8_t
+singleton AP_GPS method status uint8_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method location Location uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method speed_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES float'Null
+singleton AP_GPS method horizontal_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES float'Null
+singleton AP_GPS method vertical_accuracy boolean uint8_t 0 GPS_MAX_INSTANCES float'Null
+singleton AP_GPS method velocity Vector3f uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method ground_speed float uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method ground_course float uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method num_sats uint8_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method get_hdop uint16_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method get_vdop uint16_t uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 GPS_MAX_INSTANCES
+singleton AP_GPS method all_configured boolean
+singleton AP_GPS method first_unconfigured_gps uint8_t
 
 include AP_Math/AP_Math.h
 
 userdata Vector3f field x float read write -FLT_MAX FLT_MAX
 userdata Vector3f field y float read write -FLT_MAX FLT_MAX
 userdata Vector3f field z float read write -FLT_MAX FLT_MAX
+userdata Vector3f method length float
+userdata Vector3f method normalize void
+userdata Vector3f method is_nan void
+userdata Vector3f method is_inf void
+userdata Vector3f method is_zero void
+
+userdata Vector2f field x float read write -FLT_MAX FLT_MAX
+userdata Vector2f field y float read write -FLT_MAX FLT_MAX
+userdata Vector2f method length float
+userdata Vector2f method normalize void
+userdata Vector2f method is_nan void
+userdata Vector2f method is_inf void
+userdata Vector2f method is_zero void
 
 include AP_Notify/AP_Notify.h
 singleton notify alias notify

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -76,6 +76,8 @@ userdata Vector3f method normalize void
 userdata Vector3f method is_nan void
 userdata Vector3f method is_inf void
 userdata Vector3f method is_zero void
+userdata Vector3f operator +
+userdata Vector3f operator -
 
 userdata Vector2f field x float read write -FLT_MAX FLT_MAX
 userdata Vector2f field y float read write -FLT_MAX FLT_MAX
@@ -84,6 +86,8 @@ userdata Vector2f method normalize void
 userdata Vector2f method is_nan void
 userdata Vector2f method is_inf void
 userdata Vector2f method is_zero void
+userdata Vector2f operator +
+userdata Vector2f operator -
 
 include AP_Notify/AP_Notify.h
 singleton notify alias notify

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -13,11 +13,6 @@ userdata Location method get_distance float Location
 userdata Location method offset void float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX
 userdata Location method get_vector_from_origin_NEU boolean Vector3f
 
-#include AP_Arming/AP_Arming.h
-singleton AP_Arming alias arming
-singleton AP_Arming method is_armed boolean
-singleton AP_Arming method pre_arm_checks boolean boolean
-
 include AP_AHRS/AP_AHRS.h
 
 singleton AP_AHRS alias ahrs

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -102,6 +102,16 @@ include AP_RangeFinder/AP_RangeFinder.h
 singleton RangeFinder alias rangefinder
 singleton RangeFinder method num_sensors uint8_t
 
+include AP_Terrain/AP_Terrain.h
+
+singleton AP_Terrain alias terrain
+singleton AP_Terrain method enabled boolean
+singleton AP_Terrain method status uint8_t
+singleton AP_Terrain method height_amsl boolean Location float'Null boolean
+singleton AP_Terrain method height_terrain_difference_home boolean float'Null boolean
+singleton AP_Terrain method height_relative_home_equivalent boolean float -FLT_MAX FLT_MAX float'Null boolean
+singleton AP_Terrain method height_above_terrain boolean float'Null boolean
+
 include AP_Relay/AP_Relay.h
 
 singleton AP_Relay alias relay

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -13,6 +13,11 @@ userdata Location method get_distance float Location
 userdata Location method offset void float -FLT_MAX FLT_MAX float -FLT_MAX FLT_MAX
 userdata Location method get_vector_from_origin_NEU boolean Vector3f
 
+#include AP_Arming/AP_Arming.h
+singleton AP_Arming alias arming
+singleton AP_Arming method is_armed boolean
+singleton AP_Arming method pre_arm_checks boolean boolean
+
 include AP_AHRS/AP_AHRS.h
 
 singleton AP_AHRS alias ahrs
@@ -94,5 +99,14 @@ singleton notify alias notify
 singleton AP_Notify method play_tune void string
 
 include AP_RangeFinder/AP_RangeFinder.h
+
 singleton RangeFinder alias rangefinder
 singleton RangeFinder method num_sensors uint8_t
+
+include AP_Relay/AP_Relay.h
+
+singleton AP_Relay alias relay
+singleton AP_Relay method on void uint8_t 0 AP_RELAY_NUM_RELAYS
+singleton AP_Relay method off void uint8_t 0 AP_RELAY_NUM_RELAYS
+singleton AP_Relay method enabled boolean uint8_t 0 AP_RELAY_NUM_RELAYS
+singleton AP_Relay method toggle void uint8_t 0 AP_RELAY_NUM_RELAYS

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -716,6 +716,7 @@ void emit_userdata_allocators(void) {
   struct userdata * node = parsed_userdata;
   while (node) {
     fprintf(source, "int new_%s(lua_State *L) {\n", node->name);
+    fprintf(source, "    luaL_checkstack(L, 2, \"Out of stack\");\n"); // ensure we have sufficent stack to push the return
     fprintf(source, "    %s *ud = (%s *)lua_newuserdata(L, sizeof(%s));\n", node->name, node->name, node->name);
     fprintf(source, "    new (ud) %s();\n", node->name);
     fprintf(source, "    luaL_getmetatable(L, \"%s\");\n", node->name);
@@ -1296,6 +1297,7 @@ void emit_loaders(void) {
   fprintf(source, "};\n\n");
 
   fprintf(source, "void load_generated_bindings(lua_State *L) {\n");
+  fprintf(source, "    luaL_checkstack(L, 5, \"Out of stack\");\n"); // this is more stack space then we need, but should never fail
   fprintf(source, "    // userdata metatables\n");
   fprintf(source, "    for (uint32_t i = 0; i < ARRAY_SIZE(userdata_fun); i++) {\n");
   fprintf(source, "        luaL_newmetatable(L, userdata_fun[i].name);\n");

--- a/libraries/AP_Scripting/lua/src/linit.c
+++ b/libraries/AP_Scripting/lua/src/linit.c
@@ -44,7 +44,7 @@ static const luaL_Reg loadedlibs[] = {
 //  {LUA_LOADLIBNAME, luaopen_package},
 //  {LUA_COLIBNAME, luaopen_coroutine},
   {LUA_TABLIBNAME, luaopen_table},
-//  {LUA_IOLIBNAME, luaopen_io},
+  {LUA_IOLIBNAME, luaopen_io},
 //  {LUA_OSLIBNAME, luaopen_os},
   {LUA_STRLIBNAME, luaopen_string},
   {LUA_MATHLIBNAME, luaopen_math},

--- a/libraries/AP_Scripting/lua/src/liolib.c
+++ b/libraries/AP_Scripting/lua/src/liolib.c
@@ -1,4 +1,3 @@
-#if 0
 /*
 ** $Id: liolib.c,v 2.151.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Standard I/O (and system) library
@@ -207,7 +206,7 @@ static int aux_close (lua_State *L) {
 }
 
 
-static int f_close (lua_State *L) {
+static int lf_close (lua_State *L) {
   tofile(L);  /* make sure argument is an open stream */
   return aux_close(L);
 }
@@ -216,7 +215,7 @@ static int f_close (lua_State *L) {
 static int io_close (lua_State *L) {
   if (lua_isnone(L, 1))  /* no argument? */
     lua_getfield(L, LUA_REGISTRYINDEX, IO_OUTPUT);  /* use standard output */
-  return f_close(L);
+  return lf_close(L);
 }
 
 
@@ -582,7 +581,7 @@ static int io_read (lua_State *L) {
 }
 
 
-static int f_read (lua_State *L) {
+static int lf_read (lua_State *L) {
   return g_read(L, tofile(L), 2);
 }
 
@@ -647,7 +646,7 @@ static int io_write (lua_State *L) {
 }
 
 
-static int f_write (lua_State *L) {
+static int lf_write (lua_State *L) {
   FILE *f = tofile(L);
   lua_pushvalue(L, 1);  /* push file at the stack top (to be returned) */
   return g_write(L, f, 2);
@@ -673,6 +672,7 @@ static int f_seek (lua_State *L) {
 }
 
 
+#if 0
 static int f_setvbuf (lua_State *L) {
   static const int mode[] = {_IONBF, _IOFBF, _IOLBF};
   static const char *const modenames[] = {"no", "full", "line", NULL};
@@ -682,7 +682,7 @@ static int f_setvbuf (lua_State *L) {
   int res = setvbuf(f, NULL, mode[op], (size_t)sz);
   return luaL_fileresult(L, res == 0, NULL);
 }
-
+#endif
 
 
 static int io_flush (lua_State *L) {
@@ -718,13 +718,13 @@ static const luaL_Reg iolib[] = {
 ** methods for file handles
 */
 static const luaL_Reg flib[] = {
-  {"close", f_close},
+  {"close", lf_close},
   {"flush", f_flush},
   {"lines", f_lines},
-  {"read", f_read},
+  {"read", lf_read},
   {"seek", f_seek},
-  {"setvbuf", f_setvbuf},
-  {"write", f_write},
+//  {"setvbuf", f_setvbuf},
+  {"write", lf_write},
   {"__gc", f_gc},
   {"__tostring", f_tostring},
   {NULL, NULL}
@@ -775,4 +775,3 @@ LUAMOD_API int luaopen_io (lua_State *L) {
   return 1;
 }
 
-#endif

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -28,7 +28,7 @@ int lua_gcs_send_text(lua_State *L);
 int lua_gcs_send_text(lua_State *L) {
     check_arguments(L, 1, "send_text");
 
-    const char* str = lua_tostring(L, -1);
+    const char* str = luaL_checkstring(L, -1);
 
     gcs().send_text(MAV_SEVERITY_INFO, str);
     return 0;

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -1,0 +1,192 @@
+#include <AP_HAL/AP_HAL.h>
+#include "lua_boxed_numerics.h"
+
+extern const AP_HAL::HAL& hal;
+
+int new_uint32_t(lua_State *L) {
+    luaL_checkstack(L, 2, "Out of stack");
+    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = 0; // allocated memory is already zerod, no need to manipulate this
+    luaL_getmetatable(L, "uint32_t");
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
+    { // userdata
+        const uint32_t * ud = static_cast<uint32_t *>(luaL_testudata(L, arg, "uint32_t"));
+        if (ud != nullptr) {
+            return *ud;
+        }
+    }
+    { // integer
+
+        // if this assert fails, you will need to add an upper bounds
+        // check that ensures the value isn't greater then UINT32_MAX
+        static_assert(sizeof(lua_Number) == sizeof(uint32_t), "32 bit integers are only supported");
+
+        int success;
+        const lua_Integer v = lua_tointegerx(L, arg, &success);
+        if (success && v >= 0) {
+            return static_cast<uint32_t>(v);
+        }
+    }
+    { // float
+        int success;
+        const lua_Number v = lua_tonumberx(L, arg, &success);
+        if (success && v >= 0 && v <= UINT32_MAX) {
+            return static_cast<uint32_t>(v);
+        }
+    }
+    // failure
+    return luaL_argerror(L, arg, "Unable to coerce to uint32_t");
+}
+
+#define UINT32_T_BOX_OP(name, sym) \
+    static int uint32_t___##name(lua_State *L) { \
+        const int args = lua_gettop(L); \
+        if (args > 2) { \
+            return luaL_argerror(L, args, "too many arguments"); \
+        } else if (args < 2) { \
+            return luaL_argerror(L, args, "too few arguments"); \
+        } \
+          \
+        uint32_t v1 = coerce_to_uint32_t(L, 1); \
+        uint32_t v2 = coerce_to_uint32_t(L, 2); \
+          \
+        new_uint32_t(L); \
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = v1 sym v2; \
+        return 1; \
+    }
+
+UINT32_T_BOX_OP(add, +)
+UINT32_T_BOX_OP(sub, -)
+UINT32_T_BOX_OP(mul, *)
+UINT32_T_BOX_OP(div, /)
+UINT32_T_BOX_OP(mod, %)
+UINT32_T_BOX_OP(idiv, /)
+UINT32_T_BOX_OP(band, &)
+UINT32_T_BOX_OP(bor, |)
+UINT32_T_BOX_OP(bxor, ^)
+UINT32_T_BOX_OP(shl, <<)
+UINT32_T_BOX_OP(shr, >>)
+
+#define UINT32_T_BOX_OP_BOOL(name, sym) \
+    static int uint32_t___##name(lua_State *L) { \
+        const int args = lua_gettop(L); \
+        luaL_checkstack(L, 1, "Out of stack"); \
+        if (args > 2) { \
+            return luaL_argerror(L, args, "too many arguments"); \
+        } else if (args < 2) { \
+            return luaL_argerror(L, args, "too few arguments"); \
+        } \
+          \
+        uint32_t v1 = coerce_to_uint32_t(L, 1); \
+        uint32_t v2 = coerce_to_uint32_t(L, 2); \
+          \
+        lua_pushboolean(L, v1 sym v2); \
+        return 1; \
+    }
+
+UINT32_T_BOX_OP_BOOL(eq, =)
+UINT32_T_BOX_OP_BOOL(lt, <)
+UINT32_T_BOX_OP_BOOL(le, <=)
+
+#define UINT32_T_BOX_OP_UNARY(name, sym) \
+    static int uint32_t___##name(lua_State *L) { \
+        const int args = lua_gettop(L); \
+        luaL_checkstack(L, 1, "Out of stack"); \
+        if (args != 1) { \
+            return luaL_argerror(L, args, "Expected 1 argument"); \
+        } \
+          \
+        uint32_t v1 = coerce_to_uint32_t(L, 1); \
+          \
+        new_uint32_t(L); \
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = sym v1; \
+        return 1; \
+    }
+
+// DO NOT SUPPORT UNARY NEGATION
+UINT32_T_BOX_OP_UNARY(bnot, ~)
+
+static int uint32_t_toint(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args != 1) {
+        return luaL_argerror(L, args, "Expected 1 argument");
+    }
+
+    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+
+    lua_pushinteger(L, static_cast<lua_Integer>(v));
+
+    return 1;
+}
+
+static int uint32_t_tofloat(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args != 1) {
+        return luaL_argerror(L, args, "Expected 1 argument");
+    }
+
+    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+
+    lua_pushnumber(L, static_cast<lua_Number>(v));
+
+    return 1;
+}
+
+static int uint32_t___tostring(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args != 1) {
+        return luaL_argerror(L, args, "Expected 1 argument");
+    }
+
+    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+
+    char buf[32];
+    hal.util->snprintf(buf, ARRAY_SIZE(buf), "%u", (unsigned)v);
+
+    lua_pushstring(L, buf);
+
+    return 1;
+}
+
+const luaL_Reg uint32_t_meta[] = {
+    {"__add", uint32_t___add},
+    {"__sub", uint32_t___sub},
+    {"__mul", uint32_t___mul},
+    {"__div", uint32_t___div},
+    {"__mod", uint32_t___mod},
+    {"__idiv", uint32_t___idiv},
+    {"__band", uint32_t___band},
+    {"__bor", uint32_t___bor},
+    {"__bxor", uint32_t___bxor},
+    {"__shl", uint32_t___shl},
+    {"__shr", uint32_t___shr},
+    {"__shr", uint32_t___shr},
+    {"__eq", uint32_t___eq},
+    {"__lt", uint32_t___lt},
+    {"__le", uint32_t___le},
+    {"__bnot", uint32_t___bnot},
+    {"__tostring", uint32_t___tostring},
+    {"toint", uint32_t_toint},
+    {"tofloat", uint32_t_tofloat},
+    {NULL, NULL}
+};
+
+void load_boxed_numerics(lua_State *L) {
+    luaL_checkstack(L, 5, "Out of stack");
+    luaL_newmetatable(L, "uint32_t");
+    luaL_setfuncs(L, uint32_t_meta, 0);
+    lua_pushstring(L, "__index");
+    lua_pushvalue(L, -2);
+    lua_settable(L, -3);
+    lua_pop(L, 1);
+}
+
+void load_boxed_numerics_sandbox(lua_State *L) {
+    // if there are ever more drivers then move to a table based solution
+    lua_pushstring(L, "uint32_t");
+    lua_pushcfunction(L, new_uint32_t);
+    lua_settable(L, -3);
+}

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -2,5 +2,7 @@
 
 #include "lua/src/lua.hpp"
 
+int new_uint32_t(lua_State *L);
+
 void load_boxed_numerics(lua_State *L);
 void load_boxed_numerics_sandbox(lua_State *L);

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "lua/src/lua.hpp"
+
+void load_boxed_numerics(lua_State *L);
+void load_boxed_numerics_sandbox(lua_State *L);

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -190,6 +190,8 @@ int Location_get_vector_from_origin_NEU(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
+    luaL_checkudata(L, 1, "Location");
+
     Location * ud = check_Location(L, 1);
     Vector3f & data_2 = *check_Vector3f(L, 2);
     const bool data = ud->get_vector_from_origin_NEU(
@@ -206,6 +208,8 @@ int Location_offset(lua_State *L) {
     } else if (args < 3) {
         return luaL_argerror(L, args, "too few arguments");
     }
+
+    luaL_checkudata(L, 1, "Location");
 
     Location * ud = check_Location(L, 1);
     const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
@@ -226,6 +230,8 @@ int Location_get_distance(lua_State *L) {
     } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
+
+    luaL_checkudata(L, 1, "Location");
 
     Location * ud = check_Location(L, 1);
     Location & data_2 = *check_Location(L, 2);
@@ -266,12 +272,12 @@ int RangeFinder_num_sensors(lua_State *L) {
 
     luaL_checkudata(L, 1, "rangefinder");
 
-    RangeFinder *singleton = RangeFinder::get_singleton();
-    if (singleton == nullptr) {
+    RangeFinder * ud = RangeFinder::get_singleton();
+    if (ud == nullptr) {
         return luaL_argerror(L, args, "rangefinder not supported on this firmware");
     }
 
-    const uint8_t data = singleton->num_sensors(
+    const uint8_t data = ud->num_sensors(
 );
 
     lua_pushinteger(L, data);
@@ -288,13 +294,13 @@ int AP_Notify_play_tune(lua_State *L) {
 
     luaL_checkudata(L, 1, "AP_Notify");
 
-    AP_Notify *singleton = AP_Notify::get_singleton();
-    if (singleton == nullptr) {
+    AP_Notify * ud = AP_Notify::get_singleton();
+    if (ud == nullptr) {
         return luaL_argerror(L, args, "AP_Notify not supported on this firmware");
     }
 
     const char * data_2 = luaL_checkstring(L, 2);
-    singleton->play_tune(
+    ud->play_tune(
             data_2);
 
     return 0;
@@ -310,12 +316,12 @@ int AP_AHRS_get_home(lua_State *L) {
 
     luaL_checkudata(L, 1, "ahrs");
 
-    AP_AHRS *singleton = AP_AHRS::get_singleton();
-    if (singleton == nullptr) {
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
-    const Location &data = singleton->get_home(
+    const Location &data = ud->get_home(
 );
 
     new_Location(L);
@@ -325,24 +331,29 @@ int AP_AHRS_get_home(lua_State *L) {
 
 int AP_AHRS_get_position(lua_State *L) {
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
     luaL_checkudata(L, 1, "ahrs");
 
-    AP_AHRS *singleton = AP_AHRS::get_singleton();
-    if (singleton == nullptr) {
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
-    Location & data_2 = *check_Location(L, 2);
-    const bool data = singleton->get_position(
-            data_2);
+    Location data_5002 = {};
+    const bool data = ud->get_position(
+            data_5002);
 
-    lua_pushboolean(L, data);
+    if (data) {
+        new_Location(L);
+        *check_Location(L, -1) = data_5002;
+    } else {
+    lua_pushnil(L);
+    }
     return 1;
 }
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,5 +1,6 @@
 // auto generated bindings, don't manually edit
 #include "lua_generated_bindings.h"
+#include "lua_boxed_numerics.h"
 #include <AP_Relay/AP_Relay.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
@@ -12,7 +13,8 @@
 
 int new_Vector2f(lua_State *L) {
     luaL_checkstack(L, 2, "Out of stack");
-    Vector2f *ud = (Vector2f *)lua_newuserdata(L, sizeof(Vector2f));
+    void *ud = lua_newuserdata(L, sizeof(Vector2f));
+    memset(ud, 0, sizeof(Vector2f));
     new (ud) Vector2f();
     luaL_getmetatable(L, "Vector2f");
     lua_setmetatable(L, -2);
@@ -21,7 +23,8 @@ int new_Vector2f(lua_State *L) {
 
 int new_Vector3f(lua_State *L) {
     luaL_checkstack(L, 2, "Out of stack");
-    Vector3f *ud = (Vector3f *)lua_newuserdata(L, sizeof(Vector3f));
+    void *ud = lua_newuserdata(L, sizeof(Vector3f));
+    memset(ud, 0, sizeof(Vector3f));
     new (ud) Vector3f();
     luaL_getmetatable(L, "Vector3f");
     lua_setmetatable(L, -2);
@@ -30,7 +33,8 @@ int new_Vector3f(lua_State *L) {
 
 int new_Location(lua_State *L) {
     luaL_checkstack(L, 2, "Out of stack");
-    Location *ud = (Location *)lua_newuserdata(L, sizeof(Location));
+    void *ud = lua_newuserdata(L, sizeof(Location));
+    memset(ud, 0, sizeof(Location));
     new (ud) Location();
     luaL_getmetatable(L, "Location");
     lua_setmetatable(L, -2);
@@ -1792,6 +1796,8 @@ void load_generated_bindings(lua_State *L) {
         lua_setmetatable(L, -2);
         lua_setglobal(L, singleton_fun[i].name);
     }
+
+    load_boxed_numerics(L);
 }
 
 const char *singletons[] = {
@@ -1824,4 +1830,6 @@ void load_generated_sandbox(lua_State *L) {
         lua_pushcfunction(L, new_userdata[i].fun);
         lua_settable(L, -3);
     }
+
+    load_boxed_numerics_sandbox(L);
 }

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -264,10 +264,11 @@ int RangeFinder_num_sensors(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "RangeFinder");
+    luaL_checkudata(L, 1, "rangefinder");
 
-    RangeFinder *singleton = RangeFinder::get_singleton();    if (singleton == nullptr) {
-        return luaL_argerror(L, args, "RangeFinder not supported on this firmware");
+    RangeFinder *singleton = RangeFinder::get_singleton();
+    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "rangefinder not supported on this firmware");
     }
 
     const uint8_t data = singleton->num_sensors(
@@ -287,7 +288,8 @@ int AP_Notify_play_tune(lua_State *L) {
 
     luaL_checkudata(L, 1, "AP_Notify");
 
-    AP_Notify *singleton = AP_Notify::get_singleton();    if (singleton == nullptr) {
+    AP_Notify *singleton = AP_Notify::get_singleton();
+    if (singleton == nullptr) {
         return luaL_argerror(L, args, "AP_Notify not supported on this firmware");
     }
 
@@ -306,10 +308,11 @@ int AP_AHRS_get_home(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "AP_AHRS");
+    luaL_checkudata(L, 1, "ahrs");
 
-    AP_AHRS *singleton = AP_AHRS::get_singleton();    if (singleton == nullptr) {
-        return luaL_argerror(L, args, "AP_AHRS not supported on this firmware");
+    AP_AHRS *singleton = AP_AHRS::get_singleton();
+    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
     const Location &data = singleton->get_home(
@@ -328,10 +331,11 @@ int AP_AHRS_get_position(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "AP_AHRS");
+    luaL_checkudata(L, 1, "ahrs");
 
-    AP_AHRS *singleton = AP_AHRS::get_singleton();    if (singleton == nullptr) {
-        return luaL_argerror(L, args, "AP_AHRS not supported on this firmware");
+    AP_AHRS *singleton = AP_AHRS::get_singleton();
+    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
     Location & data_2 = *check_Location(L, 2);
@@ -349,6 +353,10 @@ const luaL_Reg RangeFinder_meta[] = {
 
 const luaL_Reg AP_Notify_meta[] = {
     {"play_tune", AP_Notify_play_tune},
+    {NULL, NULL}
+};
+
+const luaL_Reg notify_meta[] = {
     {NULL, NULL}
 };
 
@@ -370,9 +378,10 @@ const struct singleton_fun {
     const char *name;
     const luaL_Reg *reg;
 } singleton_fun[] = {
-    {"RangeFinder", RangeFinder_meta},
+    {"rangefinder", RangeFinder_meta},
     {"AP_Notify", AP_Notify_meta},
-    {"AP_AHRS", AP_AHRS_meta},
+    {"notify", notify_meta},
+    {"ahrs", AP_AHRS_meta},
 };
 
 void load_generated_bindings(lua_State *L) {
@@ -402,9 +411,10 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
-    "RangeFinder",
+    "rangefinder",
     "AP_Notify",
-    "AP_AHRS",
+    "notify",
+    "ahrs",
 };
 
 const struct userdata {

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -3,9 +3,18 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_GPS/AP_GPS.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 
+
+int new_Vector2f(lua_State *L) {
+    Vector2f *ud = (Vector2f *)lua_newuserdata(L, sizeof(Vector2f));
+    new (ud) Vector2f();
+    luaL_getmetatable(L, "Vector2f");
+    lua_setmetatable(L, -2);
+    return 1;
+}
 
 int new_Vector3f(lua_State *L) {
     Vector3f *ud = (Vector3f *)lua_newuserdata(L, sizeof(Vector3f));
@@ -23,6 +32,11 @@ int new_Location(lua_State *L) {
     return 1;
 }
 
+Vector2f * check_Vector2f(lua_State *L, int arg) {
+    void *data = luaL_checkudata(L, arg, "Vector2f");
+    return (Vector2f *)data;
+}
+
 Vector3f * check_Vector3f(lua_State *L, int arg) {
     void *data = luaL_checkudata(L, arg, "Vector3f");
     return (Vector3f *)data;
@@ -33,7 +47,43 @@ Location * check_Location(lua_State *L, int arg) {
     return (Location *)data;
 }
 
-int Vector3f_z(lua_State *L) {
+static int Vector2f_y(lua_State *L) {
+    Vector2f *ud = check_Vector2f(L, 1);
+    switch(lua_gettop(L)) {
+        case 1:
+            lua_pushnumber(L, ud->y);
+            return 1;
+        case 2: {
+            const float raw_data_2 = luaL_checknumber(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "y out of range");
+            const float data_2 = raw_data_2;
+            ud->y = data_2;
+            return 0;
+         }
+        default:
+            return luaL_argerror(L, lua_gettop(L), "too many arguments");
+    }
+}
+
+static int Vector2f_x(lua_State *L) {
+    Vector2f *ud = check_Vector2f(L, 1);
+    switch(lua_gettop(L)) {
+        case 1:
+            lua_pushnumber(L, ud->x);
+            return 1;
+        case 2: {
+            const float raw_data_2 = luaL_checknumber(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "x out of range");
+            const float data_2 = raw_data_2;
+            ud->x = data_2;
+            return 0;
+         }
+        default:
+            return luaL_argerror(L, lua_gettop(L), "too many arguments");
+    }
+}
+
+static int Vector3f_z(lua_State *L) {
     Vector3f *ud = check_Vector3f(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -51,7 +101,7 @@ int Vector3f_z(lua_State *L) {
     }
 }
 
-int Vector3f_y(lua_State *L) {
+static int Vector3f_y(lua_State *L) {
     Vector3f *ud = check_Vector3f(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -69,7 +119,7 @@ int Vector3f_y(lua_State *L) {
     }
 }
 
-int Vector3f_x(lua_State *L) {
+static int Vector3f_x(lua_State *L) {
     Vector3f *ud = check_Vector3f(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -87,7 +137,7 @@ int Vector3f_x(lua_State *L) {
     }
 }
 
-int Location_loiter_xtrack(lua_State *L) {
+static int Location_loiter_xtrack(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -103,7 +153,7 @@ int Location_loiter_xtrack(lua_State *L) {
     }
 }
 
-int Location_origin_alt(lua_State *L) {
+static int Location_origin_alt(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -119,7 +169,7 @@ int Location_origin_alt(lua_State *L) {
     }
 }
 
-int Location_terrain_alt(lua_State *L) {
+static int Location_terrain_alt(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -135,7 +185,7 @@ int Location_terrain_alt(lua_State *L) {
     }
 }
 
-int Location_relative_alt(lua_State *L) {
+static int Location_relative_alt(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -151,7 +201,7 @@ int Location_relative_alt(lua_State *L) {
     }
 }
 
-int Location_lng(lua_State *L) {
+static int Location_lng(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -169,7 +219,7 @@ int Location_lng(lua_State *L) {
     }
 }
 
-int Location_lat(lua_State *L) {
+static int Location_lat(lua_State *L) {
     Location *ud = check_Location(L, 1);
     switch(lua_gettop(L)) {
         case 1:
@@ -187,11 +237,184 @@ int Location_lat(lua_State *L) {
     }
 }
 
-int Location_get_vector_from_origin_NEU(lua_State *L) {
+static int Vector2f_is_zero(lua_State *L) {
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector2f");
+
+    Vector2f * ud = check_Vector2f(L, 1);
+    ud->is_zero(
+);
+
+    return 0;
+}
+
+static int Vector2f_is_inf(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector2f");
+
+    Vector2f * ud = check_Vector2f(L, 1);
+    ud->is_inf(
+);
+
+    return 0;
+}
+
+static int Vector2f_is_nan(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector2f");
+
+    Vector2f * ud = check_Vector2f(L, 1);
+    ud->is_nan(
+);
+
+    return 0;
+}
+
+static int Vector2f_normalize(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector2f");
+
+    Vector2f * ud = check_Vector2f(L, 1);
+    ud->normalize(
+);
+
+    return 0;
+}
+
+static int Vector2f_length(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector2f");
+
+    Vector2f * ud = check_Vector2f(L, 1);
+    const float data = ud->length(
+);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int Vector3f_is_zero(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector3f");
+
+    Vector3f * ud = check_Vector3f(L, 1);
+    ud->is_zero(
+);
+
+    return 0;
+}
+
+static int Vector3f_is_inf(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector3f");
+
+    Vector3f * ud = check_Vector3f(L, 1);
+    ud->is_inf(
+);
+
+    return 0;
+}
+
+static int Vector3f_is_nan(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector3f");
+
+    Vector3f * ud = check_Vector3f(L, 1);
+    ud->is_nan(
+);
+
+    return 0;
+}
+
+static int Vector3f_normalize(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector3f");
+
+    Vector3f * ud = check_Vector3f(L, 1);
+    ud->normalize(
+);
+
+    return 0;
+}
+
+static int Vector3f_length(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "Vector3f");
+
+    Vector3f * ud = check_Vector3f(L, 1);
+    const float data = ud->length(
+);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int Location_get_vector_from_origin_NEU(lua_State *L) {
+    // 1 Vector3f 14 : 6
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
@@ -206,11 +429,13 @@ int Location_get_vector_from_origin_NEU(lua_State *L) {
     return 1;
 }
 
-int Location_offset(lua_State *L) {
+static int Location_offset(lua_State *L) {
+    // 1 float 13 : 8
+    // 2 float 13 : 11
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 5) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 5) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
@@ -230,11 +455,12 @@ int Location_offset(lua_State *L) {
     return 0;
 }
 
-int Location_get_distance(lua_State *L) {
+static int Location_get_distance(lua_State *L) {
+    // 1 Location 12 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 3) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 3) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
@@ -249,10 +475,26 @@ int Location_get_distance(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg Vector2f_meta[] = {
+    {"y", Vector2f_y},
+    {"x", Vector2f_x},
+    {"is_zero", Vector2f_is_zero},
+    {"is_inf", Vector2f_is_inf},
+    {"is_nan", Vector2f_is_nan},
+    {"normalize", Vector2f_normalize},
+    {"length", Vector2f_length},
+    {NULL, NULL}
+};
+
 const luaL_Reg Vector3f_meta[] = {
     {"z", Vector3f_z},
     {"y", Vector3f_y},
     {"x", Vector3f_x},
+    {"is_zero", Vector3f_is_zero},
+    {"is_inf", Vector3f_is_inf},
+    {"is_nan", Vector3f_is_nan},
+    {"normalize", Vector3f_normalize},
+    {"length", Vector3f_length},
     {NULL, NULL}
 };
 
@@ -269,7 +511,7 @@ const luaL_Reg Location_meta[] = {
     {NULL, NULL}
 };
 
-int RangeFinder_num_sensors(lua_State *L) {
+static int RangeFinder_num_sensors(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -291,11 +533,12 @@ int RangeFinder_num_sensors(lua_State *L) {
     return 1;
 }
 
-int AP_Notify_play_tune(lua_State *L) {
+static int AP_Notify_play_tune(lua_State *L) {
+    // 1 string 90 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 3) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 3) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
@@ -313,7 +556,656 @@ int AP_Notify_play_tune(lua_State *L) {
     return 0;
 }
 
-int AP_AHRS_get_home(lua_State *L) {
+static int AP_GPS_first_unconfigured_gps(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const uint8_t data = ud->first_unconfigured_gps(
+);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_all_configured(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const bool data = ud->all_configured(
+);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_GPS_get_antenna_offset(lua_State *L) {
+    // 1 uint8_t 65 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const Vector3f &data = ud->get_antenna_offset(
+            data_2);
+
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = data;
+    return 1;
+}
+
+static int AP_GPS_have_vertical_velocity(lua_State *L) {
+    // 1 uint8_t 64 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->have_vertical_velocity(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_GPS_get_vdop(lua_State *L) {
+    // 1 uint8_t 63 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint16_t data = ud->get_vdop(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_get_hdop(lua_State *L) {
+    // 1 uint8_t 62 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint16_t data = ud->get_hdop(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_num_sats(lua_State *L) {
+    // 1 uint8_t 61 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint8_t data = ud->num_sats(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_ground_course(lua_State *L) {
+    // 1 uint8_t 60 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->ground_course(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_GPS_ground_speed(lua_State *L) {
+    // 1 uint8_t 59 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->ground_speed(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_GPS_velocity(lua_State *L) {
+    // 1 uint8_t 58 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const Vector3f &data = ud->velocity(
+            data_2);
+
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = data;
+    return 1;
+}
+
+static int AP_GPS_vertical_accuracy(lua_State *L) {
+    // 1 uint8_t 57 : 8
+    // 2 float 57 : 9
+    const int args = lua_gettop(L);
+    if (args > 4) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 4) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    float data_5003 = {};
+    const bool data = ud->vertical_accuracy(
+            data_2,
+            data_5003);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_GPS_horizontal_accuracy(lua_State *L) {
+    // 1 uint8_t 56 : 8
+    // 2 float 56 : 9
+    const int args = lua_gettop(L);
+    if (args > 4) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 4) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    float data_5003 = {};
+    const bool data = ud->horizontal_accuracy(
+            data_2,
+            data_5003);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_GPS_speed_accuracy(lua_State *L) {
+    // 1 uint8_t 55 : 8
+    // 2 float 55 : 9
+    const int args = lua_gettop(L);
+    if (args > 4) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 4) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    float data_5003 = {};
+    const bool data = ud->speed_accuracy(
+            data_2,
+            data_5003);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_GPS_location(lua_State *L) {
+    // 1 uint8_t 54 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const Location &data = ud->location(
+            data_2);
+
+    new_Location(L);
+    *check_Location(L, -1) = data;
+    return 1;
+}
+
+static int AP_GPS_status(lua_State *L) {
+    // 1 uint8_t 53 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint8_t data = ud->status(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_primary_sensor(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const uint8_t data = ud->primary_sensor(
+);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_GPS_num_sensors(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "gps");
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const uint8_t data = ud->num_sensors(
+);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_AHRS_prearm_healthy(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    const bool data = ud->prearm_healthy(
+);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_AHRS_home_is_set(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    const bool data = ud->home_is_set(
+);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
+    // 1 Vector3f 26 : 6
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    Vector3f data_5002 = {};
+    const bool data = ud->get_relative_position_NED_home(
+            data_5002);
+
+    if (data) {
+        new_Vector3f(L);
+        *check_Vector3f(L, -1) = data_5002;
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_AHRS_get_velocity_NED(lua_State *L) {
+    // 1 Vector3f 25 : 6
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    Vector3f data_5002 = {};
+    const bool data = ud->get_velocity_NED(
+            data_5002);
+
+    if (data) {
+        new_Vector3f(L);
+        *check_Vector3f(L, -1) = data_5002;
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_AHRS_groundspeed_vector(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    const Vector2f &data = ud->groundspeed_vector(
+);
+
+    new_Vector2f(L);
+    *check_Vector2f(L, -1) = data;
+    return 1;
+}
+
+static int AP_AHRS_wind_estimate(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    const Vector3f &data = ud->wind_estimate(
+);
+
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = data;
+    return 1;
+}
+
+static int AP_AHRS_get_hagl(lua_State *L) {
+    // 1 float 22 : 6
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    float data_5002 = {};
+    const bool data = ud->get_hagl(
+            data_5002);
+
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_AHRS_get_gyro(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "ahrs");
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    const Vector3f &data = ud->get_gyro(
+);
+
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = data;
+    return 1;
+}
+
+static int AP_AHRS_get_home(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -336,11 +1228,12 @@ int AP_AHRS_get_home(lua_State *L) {
     return 1;
 }
 
-int AP_AHRS_get_position(lua_State *L) {
+static int AP_AHRS_get_position(lua_State *L) {
+    // 1 Location 19 : 6
     const int args = lua_gettop(L);
-    if (args > 1) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
@@ -378,7 +1271,36 @@ const luaL_Reg notify_meta[] = {
     {NULL, NULL}
 };
 
+const luaL_Reg AP_GPS_meta[] = {
+    {"first_unconfigured_gps", AP_GPS_first_unconfigured_gps},
+    {"all_configured", AP_GPS_all_configured},
+    {"get_antenna_offset", AP_GPS_get_antenna_offset},
+    {"have_vertical_velocity", AP_GPS_have_vertical_velocity},
+    {"get_vdop", AP_GPS_get_vdop},
+    {"get_hdop", AP_GPS_get_hdop},
+    {"num_sats", AP_GPS_num_sats},
+    {"ground_course", AP_GPS_ground_course},
+    {"ground_speed", AP_GPS_ground_speed},
+    {"velocity", AP_GPS_velocity},
+    {"vertical_accuracy", AP_GPS_vertical_accuracy},
+    {"horizontal_accuracy", AP_GPS_horizontal_accuracy},
+    {"speed_accuracy", AP_GPS_speed_accuracy},
+    {"location", AP_GPS_location},
+    {"status", AP_GPS_status},
+    {"primary_sensor", AP_GPS_primary_sensor},
+    {"num_sensors", AP_GPS_num_sensors},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_AHRS_meta[] = {
+    {"prearm_healthy", AP_AHRS_prearm_healthy},
+    {"home_is_set", AP_AHRS_home_is_set},
+    {"get_relative_position_NED_home", AP_AHRS_get_relative_position_NED_home},
+    {"get_velocity_NED", AP_AHRS_get_velocity_NED},
+    {"groundspeed_vector", AP_AHRS_groundspeed_vector},
+    {"wind_estimate", AP_AHRS_wind_estimate},
+    {"get_hagl", AP_AHRS_get_hagl},
+    {"get_gyro", AP_AHRS_get_gyro},
     {"get_home", AP_AHRS_get_home},
     {"get_position", AP_AHRS_get_position},
     {NULL, NULL}
@@ -388,6 +1310,7 @@ const struct userdata_fun {
     const char *name;
     const luaL_Reg *reg;
 } userdata_fun[] = {
+    {"Vector2f", Vector2f_meta},
     {"Vector3f", Vector3f_meta},
     {"Location", Location_meta},
 };
@@ -399,6 +1322,7 @@ const struct singleton_fun {
     {"rangefinder", RangeFinder_meta},
     {"AP_Notify", AP_Notify_meta},
     {"notify", notify_meta},
+    {"gps", AP_GPS_meta},
     {"ahrs", AP_AHRS_meta},
 };
 
@@ -432,6 +1356,7 @@ const char *singletons[] = {
     "rangefinder",
     "AP_Notify",
     "notify",
+    "gps",
     "ahrs",
 };
 
@@ -439,6 +1364,7 @@ const struct userdata {
     const char *name;
     const lua_CFunction fun;
 } new_userdata[] = {
+    {"Vector2f", new_Vector2f},
     {"Vector3f", new_Vector3f},
     {"Location", new_Location},
 };

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -4,6 +4,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 
@@ -245,8 +246,6 @@ static int Vector2f_is_zero(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector2f");
-
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_zero(
 );
@@ -261,8 +260,6 @@ static int Vector2f_is_inf(lua_State *L) {
     } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Vector2f");
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_inf(
@@ -279,8 +276,6 @@ static int Vector2f_is_nan(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector2f");
-
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_nan(
 );
@@ -295,8 +290,6 @@ static int Vector2f_normalize(lua_State *L) {
     } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Vector2f");
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->normalize(
@@ -313,13 +306,41 @@ static int Vector2f_length(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector2f");
-
     Vector2f * ud = check_Vector2f(L, 1);
     const float data = ud->length(
 );
 
     lua_pushnumber(L, data);
+    return 1;
+}
+
+static int Vector2f___add(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    Vector2f *ud = check_Vector2f(L, 1);
+    Vector2f *ud2 = check_Vector2f(L, 2);
+    new_Vector2f(L);
+    *check_Vector2f(L, -1) = *ud + *ud2;;
+    return 1;
+}
+
+static int Vector2f___sub(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    Vector2f *ud = check_Vector2f(L, 1);
+    Vector2f *ud2 = check_Vector2f(L, 2);
+    new_Vector2f(L);
+    *check_Vector2f(L, -1) = *ud - *ud2;;
     return 1;
 }
 
@@ -330,8 +351,6 @@ static int Vector3f_is_zero(lua_State *L) {
     } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Vector3f");
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_zero(
@@ -348,8 +367,6 @@ static int Vector3f_is_inf(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector3f");
-
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_inf(
 );
@@ -364,8 +381,6 @@ static int Vector3f_is_nan(lua_State *L) {
     } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Vector3f");
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_nan(
@@ -382,8 +397,6 @@ static int Vector3f_normalize(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector3f");
-
     Vector3f * ud = check_Vector3f(L, 1);
     ud->normalize(
 );
@@ -399,8 +412,6 @@ static int Vector3f_length(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Vector3f");
-
     Vector3f * ud = check_Vector3f(L, 1);
     const float data = ud->length(
 );
@@ -409,16 +420,44 @@ static int Vector3f_length(lua_State *L) {
     return 1;
 }
 
-static int Location_get_vector_from_origin_NEU(lua_State *L) {
-    // 1 Vector3f 14 : 6
+static int Vector3f___add(lua_State *L) {
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "Location");
+    Vector3f *ud = check_Vector3f(L, 1);
+    Vector3f *ud2 = check_Vector3f(L, 2);
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = *ud + *ud2;;
+    return 1;
+}
+
+static int Vector3f___sub(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    Vector3f *ud = check_Vector3f(L, 1);
+    Vector3f *ud2 = check_Vector3f(L, 2);
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = *ud - *ud2;;
+    return 1;
+}
+
+static int Location_get_vector_from_origin_NEU(lua_State *L) {
+    // 1 Vector3f 14 : 6
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
 
     Location * ud = check_Location(L, 1);
     Vector3f & data_2 = *check_Vector3f(L, 2);
@@ -433,13 +472,11 @@ static int Location_offset(lua_State *L) {
     // 1 float 13 : 8
     // 2 float 13 : 11
     const int args = lua_gettop(L);
-    if (args > 5) {
+    if (args > 3) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 5) {
+    } else if (args < 3) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Location");
 
     Location * ud = check_Location(L, 1);
     const float raw_data_2 = luaL_checknumber(L, 2);
@@ -458,13 +495,11 @@ static int Location_offset(lua_State *L) {
 static int Location_get_distance(lua_State *L) {
     // 1 Location 12 : 6
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "Location");
 
     Location * ud = check_Location(L, 1);
     Location & data_2 = *check_Location(L, 2);
@@ -483,6 +518,8 @@ const luaL_Reg Vector2f_meta[] = {
     {"is_nan", Vector2f_is_nan},
     {"normalize", Vector2f_normalize},
     {"length", Vector2f_length},
+    {"__add", Vector2f___add},
+    {"__sub", Vector2f___sub},
     {NULL, NULL}
 };
 
@@ -495,6 +532,8 @@ const luaL_Reg Vector3f_meta[] = {
     {"is_nan", Vector3f_is_nan},
     {"normalize", Vector3f_normalize},
     {"length", Vector3f_length},
+    {"__add", Vector3f___add},
+    {"__sub", Vector3f___sub},
     {NULL, NULL}
 };
 
@@ -519,8 +558,6 @@ static int RangeFinder_num_sensors(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "rangefinder");
-
     RangeFinder * ud = RangeFinder::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "rangefinder not supported on this firmware");
@@ -534,15 +571,13 @@ static int RangeFinder_num_sensors(lua_State *L) {
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 string 90 : 6
+    // 1 string 94 : 6
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "AP_Notify");
 
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
@@ -564,8 +599,6 @@ static int AP_GPS_first_unconfigured_gps(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "gps");
-
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
@@ -586,8 +619,6 @@ static int AP_GPS_all_configured(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "gps");
-
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
@@ -603,13 +634,11 @@ static int AP_GPS_all_configured(lua_State *L) {
 static int AP_GPS_get_antenna_offset(lua_State *L) {
     // 1 uint8_t 65 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -630,13 +659,11 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
 static int AP_GPS_have_vertical_velocity(lua_State *L) {
     // 1 uint8_t 64 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -656,13 +683,11 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
 static int AP_GPS_get_vdop(lua_State *L) {
     // 1 uint8_t 63 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -682,13 +707,11 @@ static int AP_GPS_get_vdop(lua_State *L) {
 static int AP_GPS_get_hdop(lua_State *L) {
     // 1 uint8_t 62 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -708,13 +731,11 @@ static int AP_GPS_get_hdop(lua_State *L) {
 static int AP_GPS_num_sats(lua_State *L) {
     // 1 uint8_t 61 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -734,13 +755,11 @@ static int AP_GPS_num_sats(lua_State *L) {
 static int AP_GPS_ground_course(lua_State *L) {
     // 1 uint8_t 60 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -760,13 +779,11 @@ static int AP_GPS_ground_course(lua_State *L) {
 static int AP_GPS_ground_speed(lua_State *L) {
     // 1 uint8_t 59 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -786,13 +803,11 @@ static int AP_GPS_ground_speed(lua_State *L) {
 static int AP_GPS_velocity(lua_State *L) {
     // 1 uint8_t 58 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -814,13 +829,11 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
     // 1 uint8_t 57 : 8
     // 2 float 57 : 9
     const int args = lua_gettop(L);
-    if (args > 4) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 4) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -847,13 +860,11 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
     // 1 uint8_t 56 : 8
     // 2 float 56 : 9
     const int args = lua_gettop(L);
-    if (args > 4) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 4) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -880,13 +891,11 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
     // 1 uint8_t 55 : 8
     // 2 float 55 : 9
     const int args = lua_gettop(L);
-    if (args > 4) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 4) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -912,13 +921,11 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
 static int AP_GPS_location(lua_State *L) {
     // 1 uint8_t 54 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -939,13 +946,11 @@ static int AP_GPS_location(lua_State *L) {
 static int AP_GPS_status(lua_State *L) {
     // 1 uint8_t 53 : 8
     const int args = lua_gettop(L);
-    if (args > 3) {
+    if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
+    } else if (args < 2) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "gps");
 
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
@@ -970,8 +975,6 @@ static int AP_GPS_primary_sensor(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "gps");
-
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
@@ -992,14 +995,347 @@ static int AP_GPS_num_sensors(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "gps");
-
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
     const uint8_t data = ud->num_sensors(
+);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_get_temperature(lua_State *L) {
+    // 1 float 46 : 6
+    // 2 uint8_t 46 : 9
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    float data_5002 = {};
+    const int raw_data_3 = luaL_checkinteger(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 3, "argument out of range");
+    const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
+    const bool data = ud->get_temperature(
+            data_5002,
+            data_3);
+
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_BattMonitor_overpower_detected(lua_State *L) {
+    // 1 uint8_t 45 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->overpower_detected(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_has_failsafed(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const bool data = ud->has_failsafed(
+);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
+    // 1 uint8_t 43 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const int32_t data = ud->pack_capacity_mah(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
+    // 1 uint8_t 42 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint8_t data = ud->capacity_remaining_pct(
+            data_2);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_consumed_wh(lua_State *L) {
+    // 1 uint8_t 41 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->consumed_wh(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_consumed_mah(lua_State *L) {
+    // 1 uint8_t 40 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->consumed_mah(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_current_amps(lua_State *L) {
+    // 1 uint8_t 39 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->current_amps(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
+    // 1 uint8_t 38 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->voltage_resting_estimate(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_voltage(lua_State *L) {
+    // 1 uint8_t 37 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const float data = ud->voltage(
+            data_2);
+
+    lua_pushnumber(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_has_current(lua_State *L) {
+    // 1 uint8_t 36 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->has_current(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
+    // 1 uint8_t 35 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->has_consumed_energy(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_healthy(lua_State *L) {
+    // 1 uint8_t 34 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->healthy(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_BattMonitor_num_instances(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "battery not supported on this firmware");
+    }
+
+    const uint8_t data = ud->num_instances(
 );
 
     lua_pushinteger(L, data);
@@ -1013,8 +1349,6 @@ static int AP_AHRS_prearm_healthy(lua_State *L) {
     } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "ahrs");
 
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1036,8 +1370,6 @@ static int AP_AHRS_home_is_set(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
@@ -1053,13 +1385,11 @@ static int AP_AHRS_home_is_set(lua_State *L) {
 static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
     // 1 Vector3f 26 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "ahrs");
 
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1082,13 +1412,11 @@ static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
 static int AP_AHRS_get_velocity_NED(lua_State *L) {
     // 1 Vector3f 25 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "ahrs");
 
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1116,8 +1444,6 @@ static int AP_AHRS_groundspeed_vector(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
@@ -1139,8 +1465,6 @@ static int AP_AHRS_wind_estimate(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
@@ -1157,13 +1481,11 @@ static int AP_AHRS_wind_estimate(lua_State *L) {
 static int AP_AHRS_get_hagl(lua_State *L) {
     // 1 float 22 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "ahrs");
 
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1190,8 +1512,6 @@ static int AP_AHRS_get_gyro(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
@@ -1213,8 +1533,6 @@ static int AP_AHRS_get_home(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
@@ -1231,13 +1549,11 @@ static int AP_AHRS_get_home(lua_State *L) {
 static int AP_AHRS_get_position(lua_State *L) {
     // 1 Location 19 : 6
     const int args = lua_gettop(L);
-    if (args > 2) {
+    if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
+    } else if (args < 1) {
         return luaL_argerror(L, args, "too few arguments");
     }
-
-    luaL_checkudata(L, 1, "ahrs");
 
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
@@ -1292,6 +1608,24 @@ const luaL_Reg AP_GPS_meta[] = {
     {NULL, NULL}
 };
 
+const luaL_Reg AP_BattMonitor_meta[] = {
+    {"get_temperature", AP_BattMonitor_get_temperature},
+    {"overpower_detected", AP_BattMonitor_overpower_detected},
+    {"has_failsafed", AP_BattMonitor_has_failsafed},
+    {"pack_capacity_mah", AP_BattMonitor_pack_capacity_mah},
+    {"capacity_remaining_pct", AP_BattMonitor_capacity_remaining_pct},
+    {"consumed_wh", AP_BattMonitor_consumed_wh},
+    {"consumed_mah", AP_BattMonitor_consumed_mah},
+    {"current_amps", AP_BattMonitor_current_amps},
+    {"voltage_resting_estimate", AP_BattMonitor_voltage_resting_estimate},
+    {"voltage", AP_BattMonitor_voltage},
+    {"has_current", AP_BattMonitor_has_current},
+    {"has_consumed_energy", AP_BattMonitor_has_consumed_energy},
+    {"healthy", AP_BattMonitor_healthy},
+    {"num_instances", AP_BattMonitor_num_instances},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_AHRS_meta[] = {
     {"prearm_healthy", AP_AHRS_prearm_healthy},
     {"home_is_set", AP_AHRS_home_is_set},
@@ -1323,6 +1657,7 @@ const struct singleton_fun {
     {"AP_Notify", AP_Notify_meta},
     {"notify", notify_meta},
     {"gps", AP_GPS_meta},
+    {"battery", AP_BattMonitor_meta},
     {"ahrs", AP_AHRS_meta},
 };
 
@@ -1357,6 +1692,7 @@ const char *singletons[] = {
     "AP_Notify",
     "notify",
     "gps",
+    "battery",
     "ahrs",
 };
 

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -217,7 +217,7 @@ static int Location_lng(lua_State *L) {
             lua_pushinteger(L, ud->lng);
             return 1;
         case 2: {
-            const int raw_data_2 = luaL_checkinteger(L, 2);
+            const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
             luaL_argcheck(L, ((raw_data_2 >= MAX(-1800000000, INT32_MIN)) && (raw_data_2 <= MIN(1800000000, INT32_MAX))), 2, "lng out of range");
             const int32_t data_2 = raw_data_2;
             ud->lng = data_2;
@@ -235,7 +235,7 @@ static int Location_lat(lua_State *L) {
             lua_pushinteger(L, ud->lat);
             return 1;
         case 2: {
-            const int raw_data_2 = luaL_checkinteger(L, 2);
+            const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
             luaL_argcheck(L, ((raw_data_2 >= MAX(-900000000, INT32_MIN)) && (raw_data_2 <= MIN(900000000, INT32_MAX))), 2, "lat out of range");
             const int32_t data_2 = raw_data_2;
             ud->lat = data_2;
@@ -559,7 +559,7 @@ const luaL_Reg Location_meta[] = {
 };
 
 static int AP_Relay_toggle(lua_State *L) {
-    // 1 uint8_t 107 : 8
+    // 1 uint8_t 111 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -572,7 +572,7 @@ static int AP_Relay_toggle(lua_State *L) {
         return luaL_argerror(L, args, "relay not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     ud->toggle(
@@ -582,7 +582,7 @@ static int AP_Relay_toggle(lua_State *L) {
 }
 
 static int AP_Relay_enabled(lua_State *L) {
-    // 1 uint8_t 106 : 8
+    // 1 uint8_t 110 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -595,7 +595,7 @@ static int AP_Relay_enabled(lua_State *L) {
         return luaL_argerror(L, args, "relay not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const bool data = ud->enabled(
@@ -606,7 +606,7 @@ static int AP_Relay_enabled(lua_State *L) {
 }
 
 static int AP_Relay_off(lua_State *L) {
-    // 1 uint8_t 105 : 8
+    // 1 uint8_t 109 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -619,7 +619,7 @@ static int AP_Relay_off(lua_State *L) {
         return luaL_argerror(L, args, "relay not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     ud->off(
@@ -629,7 +629,7 @@ static int AP_Relay_off(lua_State *L) {
 }
 
 static int AP_Relay_on(lua_State *L) {
-    // 1 uint8_t 104 : 8
+    // 1 uint8_t 108 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -642,7 +642,7 @@ static int AP_Relay_on(lua_State *L) {
         return luaL_argerror(L, args, "relay not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     ud->on(
@@ -672,7 +672,7 @@ static int RangeFinder_num_sensors(lua_State *L) {
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 string 94 : 6
+    // 1 userdata 98 : 6
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -733,6 +733,105 @@ static int AP_GPS_all_configured(lua_State *L) {
 }
 
 static int AP_GPS_get_antenna_offset(lua_State *L) {
+    // 1 uint8_t 69 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const Vector3f &data = ud->get_antenna_offset(
+            data_2);
+
+    new_Vector3f(L);
+    *check_Vector3f(L, -1) = data;
+    return 1;
+}
+
+static int AP_GPS_have_vertical_velocity(lua_State *L) {
+    // 1 uint8_t 68 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->have_vertical_velocity(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_GPS_last_message_time_ms(lua_State *L) {
+    // 1 uint8_t 67 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint32_t data = ud->last_message_time_ms(
+            data_2);
+
+        new_uint32_t(L);
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = data;
+    return 1;
+}
+
+static int AP_GPS_last_fix_time_ms(lua_State *L) {
+    // 1 uint8_t 66 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_GPS * ud = AP_GPS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gps not supported on this firmware");
+    }
+
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const uint32_t data = ud->last_fix_time_ms(
+            data_2);
+
+        new_uint32_t(L);
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = data;
+    return 1;
+}
+
+static int AP_GPS_get_vdop(lua_State *L) {
     // 1 uint8_t 65 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
@@ -746,18 +845,17 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const Vector3f &data = ud->get_antenna_offset(
+    const uint16_t data = ud->get_vdop(
             data_2);
 
-    new_Vector3f(L);
-    *check_Vector3f(L, -1) = data;
+    lua_pushinteger(L, data);
     return 1;
 }
 
-static int AP_GPS_have_vertical_velocity(lua_State *L) {
+static int AP_GPS_get_hdop(lua_State *L) {
     // 1 uint8_t 64 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
@@ -771,17 +869,17 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const bool data = ud->have_vertical_velocity(
+    const uint16_t data = ud->get_hdop(
             data_2);
 
-    lua_pushboolean(L, data);
+    lua_pushinteger(L, data);
     return 1;
 }
 
-static int AP_GPS_get_vdop(lua_State *L) {
+static int AP_GPS_time_week_ms(lua_State *L) {
     // 1 uint8_t 63 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
@@ -795,17 +893,18 @@ static int AP_GPS_get_vdop(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const uint16_t data = ud->get_vdop(
+    const uint32_t data = ud->time_week_ms(
             data_2);
 
-    lua_pushinteger(L, data);
+        new_uint32_t(L);
+        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = data;
     return 1;
 }
 
-static int AP_GPS_get_hdop(lua_State *L) {
+static int AP_GPS_time_week(lua_State *L) {
     // 1 uint8_t 62 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
@@ -819,10 +918,10 @@ static int AP_GPS_get_hdop(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
-    const uint16_t data = ud->get_hdop(
+    const uint16_t data = ud->time_week(
             data_2);
 
     lua_pushinteger(L, data);
@@ -843,7 +942,7 @@ static int AP_GPS_num_sats(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const uint8_t data = ud->num_sats(
@@ -867,7 +966,7 @@ static int AP_GPS_ground_course(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->ground_course(
@@ -891,7 +990,7 @@ static int AP_GPS_ground_speed(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->ground_speed(
@@ -915,7 +1014,7 @@ static int AP_GPS_velocity(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const Vector3f &data = ud->velocity(
@@ -941,7 +1040,7 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     float data_5003 = {};
@@ -972,7 +1071,7 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     float data_5003 = {};
@@ -1003,7 +1102,7 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     float data_5003 = {};
@@ -1033,7 +1132,7 @@ static int AP_GPS_location(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const Location &data = ud->location(
@@ -1058,7 +1157,7 @@ static int AP_GPS_status(lua_State *L) {
         return luaL_argerror(L, args, "gps not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(GPS_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const uint8_t data = ud->status(
@@ -1124,7 +1223,7 @@ static int AP_BattMonitor_get_temperature(lua_State *L) {
     }
 
     float data_5002 = {};
-    const int raw_data_3 = luaL_checkinteger(L, 3);
+    const lua_Integer raw_data_3 = luaL_checkinteger(L, 3);
     luaL_argcheck(L, ((raw_data_3 >= MAX(0, 0)) && (raw_data_3 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 3, "argument out of range");
     const uint8_t data_3 = static_cast<uint8_t>(raw_data_3);
     const bool data = ud->get_temperature(
@@ -1153,7 +1252,7 @@ static int AP_BattMonitor_overpower_detected(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const bool data = ud->overpower_detected(
@@ -1197,7 +1296,7 @@ static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const int32_t data = ud->pack_capacity_mah(
@@ -1221,7 +1320,7 @@ static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const uint8_t data = ud->capacity_remaining_pct(
@@ -1245,7 +1344,7 @@ static int AP_BattMonitor_consumed_wh(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->consumed_wh(
@@ -1269,7 +1368,7 @@ static int AP_BattMonitor_consumed_mah(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->consumed_mah(
@@ -1293,7 +1392,7 @@ static int AP_BattMonitor_current_amps(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->current_amps(
@@ -1317,7 +1416,7 @@ static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->voltage_resting_estimate(
@@ -1341,7 +1440,7 @@ static int AP_BattMonitor_voltage(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const float data = ud->voltage(
@@ -1365,7 +1464,7 @@ static int AP_BattMonitor_has_current(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const bool data = ud->has_current(
@@ -1389,7 +1488,7 @@ static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const bool data = ud->has_consumed_energy(
@@ -1413,7 +1512,7 @@ static int AP_BattMonitor_healthy(lua_State *L) {
         return luaL_argerror(L, args, "battery not supported on this firmware");
     }
 
-    const int raw_data_2 = luaL_checkinteger(L, 2);
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_BATT_MONITOR_MAX_INSTANCES, UINT8_MAX))), 2, "argument out of range");
     const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
     const bool data = ud->healthy(
@@ -1701,8 +1800,12 @@ const luaL_Reg AP_GPS_meta[] = {
     {"all_configured", AP_GPS_all_configured},
     {"get_antenna_offset", AP_GPS_get_antenna_offset},
     {"have_vertical_velocity", AP_GPS_have_vertical_velocity},
+    {"last_message_time_ms", AP_GPS_last_message_time_ms},
+    {"last_fix_time_ms", AP_GPS_last_fix_time_ms},
     {"get_vdop", AP_GPS_get_vdop},
     {"get_hdop", AP_GPS_get_hdop},
+    {"time_week_ms", AP_GPS_time_week_ms},
+    {"time_week", AP_GPS_time_week},
     {"num_sats", AP_GPS_num_sats},
     {"ground_course", AP_GPS_ground_course},
     {"ground_speed", AP_GPS_ground_speed},

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,5 +1,6 @@
 // auto generated bindings, don't manually edit
 #include "lua_generated_bindings.h"
+#include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -39,7 +40,7 @@ int Vector3f_z(lua_State *L) {
             lua_pushnumber(L, ud->z);
             return 1;
         case 2: {
-            const float data_2 = luaL_checknumber(L, 2);
+            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
             luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "z out of range");
             ud->z = data_2;
             return 0;
@@ -56,7 +57,7 @@ int Vector3f_y(lua_State *L) {
             lua_pushnumber(L, ud->y);
             return 1;
         case 2: {
-            const float data_2 = luaL_checknumber(L, 2);
+            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
             luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "y out of range");
             ud->y = data_2;
             return 0;
@@ -73,7 +74,7 @@ int Vector3f_x(lua_State *L) {
             lua_pushnumber(L, ud->x);
             return 1;
         case 2: {
-            const float data_2 = luaL_checknumber(L, 2);
+            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
             luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "x out of range");
             ud->x = data_2;
             return 0;
@@ -90,7 +91,7 @@ int Location_loiter_xtrack(lua_State *L) {
             lua_pushinteger(L, ud->loiter_xtrack);
             return 1;
         case 2: {
-            const bool data_2 = lua_toboolean(L, 2);
+            const bool data_2 = static_cast<bool>(lua_toboolean(L, 2));
             ud->loiter_xtrack = data_2;
             return 0;
          }
@@ -106,7 +107,7 @@ int Location_origin_alt(lua_State *L) {
             lua_pushinteger(L, ud->origin_alt);
             return 1;
         case 2: {
-            const bool data_2 = lua_toboolean(L, 2);
+            const bool data_2 = static_cast<bool>(lua_toboolean(L, 2));
             ud->origin_alt = data_2;
             return 0;
          }
@@ -122,7 +123,7 @@ int Location_terrain_alt(lua_State *L) {
             lua_pushinteger(L, ud->terrain_alt);
             return 1;
         case 2: {
-            const bool data_2 = lua_toboolean(L, 2);
+            const bool data_2 = static_cast<bool>(lua_toboolean(L, 2));
             ud->terrain_alt = data_2;
             return 0;
          }
@@ -138,7 +139,7 @@ int Location_relative_alt(lua_State *L) {
             lua_pushinteger(L, ud->relative_alt);
             return 1;
         case 2: {
-            const bool data_2 = lua_toboolean(L, 2);
+            const bool data_2 = static_cast<bool>(lua_toboolean(L, 2));
             ud->relative_alt = data_2;
             return 0;
          }
@@ -154,7 +155,7 @@ int Location_lng(lua_State *L) {
             lua_pushinteger(L, ud->lng);
             return 1;
         case 2: {
-            const int32_t data_2 = luaL_checkinteger(L, 2);
+            const int32_t data_2 = static_cast<int32_t>(luaL_checkinteger(L, 2));
             luaL_argcheck(L, ((data_2 >= -1800000000) && (data_2 <= 1800000000)), 2, "lng out of range");
             ud->lng = data_2;
             return 0;
@@ -171,7 +172,7 @@ int Location_lat(lua_State *L) {
             lua_pushinteger(L, ud->lat);
             return 1;
         case 2: {
-            const int32_t data_2 = luaL_checkinteger(L, 2);
+            const int32_t data_2 = static_cast<int32_t>(luaL_checkinteger(L, 2));
             luaL_argcheck(L, ((data_2 >= -900000000) && (data_2 <= 900000000)), 2, "lat out of range");
             ud->lat = data_2;
             return 0;
@@ -207,9 +208,9 @@ int Location_offset(lua_State *L) {
     }
 
     Location * ud = check_Location(L, 1);
-    const float data_2 = luaL_checknumber(L, 2);
+    const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
     luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "argument out of range");
-    const float data_3 = luaL_checknumber(L, 3);
+    const float data_3 = static_cast<float>(luaL_checknumber(L, 3));
     luaL_argcheck(L, ((data_3 >= -FLT_MAX) && (data_3 <= FLT_MAX)), 3, "argument out of range");
     ud->offset(
             data_2,
@@ -255,23 +256,7 @@ const luaL_Reg Location_meta[] = {
     {NULL, NULL}
 };
 
-int notify_play_tune(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
-    luaL_checkudata(L, 1, "notify");
-    const char * data_2 = luaL_checkstring(L, 2);
-    AP::notify().play_tune(
-            data_2);
-
-    return 0;
-}
-
-int ahrs_get_home(lua_State *L) {
+int RangeFinder_num_sensors(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -279,16 +264,20 @@ int ahrs_get_home(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
-    const Location &data = AP::ahrs().get_home(
+    luaL_checkudata(L, 1, "RangeFinder");
+
+    RangeFinder *singleton = RangeFinder::get_singleton();    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "RangeFinder not supported on this firmware");
+    }
+
+    const uint8_t data = singleton->num_sensors(
 );
 
-    new_Location(L);
-    *check_Location(L, -1) = data;
+    lua_pushinteger(L, data);
     return 1;
 }
 
-int ahrs_get_position(lua_State *L) {
+int AP_Notify_play_tune(lua_State *L) {
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -296,23 +285,76 @@ int ahrs_get_position(lua_State *L) {
         return luaL_argerror(L, args, "too few arguments");
     }
 
-    luaL_checkudata(L, 1, "ahrs");
+    luaL_checkudata(L, 1, "AP_Notify");
+
+    AP_Notify *singleton = AP_Notify::get_singleton();    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "AP_Notify not supported on this firmware");
+    }
+
+    const char * data_2 = luaL_checkstring(L, 2);
+    singleton->play_tune(
+            data_2);
+
+    return 0;
+}
+
+int AP_AHRS_get_home(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "AP_AHRS");
+
+    AP_AHRS *singleton = AP_AHRS::get_singleton();    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "AP_AHRS not supported on this firmware");
+    }
+
+    const Location &data = singleton->get_home(
+);
+
+    new_Location(L);
+    *check_Location(L, -1) = data;
+    return 1;
+}
+
+int AP_AHRS_get_position(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    luaL_checkudata(L, 1, "AP_AHRS");
+
+    AP_AHRS *singleton = AP_AHRS::get_singleton();    if (singleton == nullptr) {
+        return luaL_argerror(L, args, "AP_AHRS not supported on this firmware");
+    }
+
     Location & data_2 = *check_Location(L, 2);
-    const bool data = AP::ahrs().get_position(
+    const bool data = singleton->get_position(
             data_2);
 
     lua_pushboolean(L, data);
     return 1;
 }
 
-const luaL_Reg notify_meta[] = {
-    {"play_tune", notify_play_tune},
+const luaL_Reg RangeFinder_meta[] = {
+    {"num_sensors", RangeFinder_num_sensors},
     {NULL, NULL}
 };
 
-const luaL_Reg ahrs_meta[] = {
-    {"get_home", ahrs_get_home},
-    {"get_position", ahrs_get_position},
+const luaL_Reg AP_Notify_meta[] = {
+    {"play_tune", AP_Notify_play_tune},
+    {NULL, NULL}
+};
+
+const luaL_Reg AP_AHRS_meta[] = {
+    {"get_home", AP_AHRS_get_home},
+    {"get_position", AP_AHRS_get_position},
     {NULL, NULL}
 };
 
@@ -328,8 +370,9 @@ const struct singleton_fun {
     const char *name;
     const luaL_Reg *reg;
 } singleton_fun[] = {
-    {"notify", notify_meta},
-    {"ahrs", ahrs_meta},
+    {"RangeFinder", RangeFinder_meta},
+    {"AP_Notify", AP_Notify_meta},
+    {"AP_AHRS", AP_AHRS_meta},
 };
 
 void load_generated_bindings(lua_State *L) {
@@ -359,8 +402,9 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
-    "notify",
-    "ahrs",
+    "RangeFinder",
+    "AP_Notify",
+    "AP_AHRS",
 };
 
 const struct userdata {

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -40,8 +40,9 @@ int Vector3f_z(lua_State *L) {
             lua_pushnumber(L, ud->z);
             return 1;
         case 2: {
-            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
-            luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "z out of range");
+            const float raw_data_2 = luaL_checknumber(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "z out of range");
+            const float data_2 = raw_data_2;
             ud->z = data_2;
             return 0;
          }
@@ -57,8 +58,9 @@ int Vector3f_y(lua_State *L) {
             lua_pushnumber(L, ud->y);
             return 1;
         case 2: {
-            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
-            luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "y out of range");
+            const float raw_data_2 = luaL_checknumber(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "y out of range");
+            const float data_2 = raw_data_2;
             ud->y = data_2;
             return 0;
          }
@@ -74,8 +76,9 @@ int Vector3f_x(lua_State *L) {
             lua_pushnumber(L, ud->x);
             return 1;
         case 2: {
-            const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
-            luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "x out of range");
+            const float raw_data_2 = luaL_checknumber(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "x out of range");
+            const float data_2 = raw_data_2;
             ud->x = data_2;
             return 0;
          }
@@ -155,8 +158,9 @@ int Location_lng(lua_State *L) {
             lua_pushinteger(L, ud->lng);
             return 1;
         case 2: {
-            const int32_t data_2 = static_cast<int32_t>(luaL_checkinteger(L, 2));
-            luaL_argcheck(L, ((data_2 >= -1800000000) && (data_2 <= 1800000000)), 2, "lng out of range");
+            const int raw_data_2 = luaL_checkinteger(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-1800000000, INT32_MIN)) && (raw_data_2 <= MIN(1800000000, INT32_MAX))), 2, "lng out of range");
+            const int32_t data_2 = raw_data_2;
             ud->lng = data_2;
             return 0;
          }
@@ -172,8 +176,9 @@ int Location_lat(lua_State *L) {
             lua_pushinteger(L, ud->lat);
             return 1;
         case 2: {
-            const int32_t data_2 = static_cast<int32_t>(luaL_checkinteger(L, 2));
-            luaL_argcheck(L, ((data_2 >= -900000000) && (data_2 <= 900000000)), 2, "lat out of range");
+            const int raw_data_2 = luaL_checkinteger(L, 2);
+            luaL_argcheck(L, ((raw_data_2 >= MAX(-900000000, INT32_MIN)) && (raw_data_2 <= MIN(900000000, INT32_MAX))), 2, "lat out of range");
+            const int32_t data_2 = raw_data_2;
             ud->lat = data_2;
             return 0;
          }
@@ -212,10 +217,12 @@ int Location_offset(lua_State *L) {
     luaL_checkudata(L, 1, "Location");
 
     Location * ud = check_Location(L, 1);
-    const float data_2 = static_cast<float>(luaL_checknumber(L, 2));
-    luaL_argcheck(L, ((data_2 >= -FLT_MAX) && (data_2 <= FLT_MAX)), 2, "argument out of range");
-    const float data_3 = static_cast<float>(luaL_checknumber(L, 3));
-    luaL_argcheck(L, ((data_3 >= -FLT_MAX) && (data_3 <= FLT_MAX)), 3, "argument out of range");
+    const float raw_data_2 = luaL_checknumber(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "argument out of range");
+    const float data_2 = raw_data_2;
+    const float raw_data_3 = luaL_checknumber(L, 3);
+    luaL_argcheck(L, ((raw_data_3 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_3 <= MIN(FLT_MAX, INFINITY))), 3, "argument out of range");
+    const float data_3 = raw_data_3;
     ud->offset(
             data_2,
             data_3);
@@ -352,7 +359,7 @@ int AP_AHRS_get_position(lua_State *L) {
         new_Location(L);
         *check_Location(L, -1) = data_5002;
     } else {
-    lua_pushnil(L);
+        lua_pushnil(L);
     }
     return 1;
 }

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -2,6 +2,7 @@
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
 #include <AP_Relay/AP_Relay.h>
+#include <AP_Terrain/AP_Terrain.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
@@ -559,7 +560,7 @@ const luaL_Reg Location_meta[] = {
 };
 
 static int AP_Relay_toggle(lua_State *L) {
-    // 1 uint8_t 111 : 8
+    // 1 uint8_t 121 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -582,7 +583,7 @@ static int AP_Relay_toggle(lua_State *L) {
 }
 
 static int AP_Relay_enabled(lua_State *L) {
-    // 1 uint8_t 110 : 8
+    // 1 uint8_t 120 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -606,7 +607,7 @@ static int AP_Relay_enabled(lua_State *L) {
 }
 
 static int AP_Relay_off(lua_State *L) {
-    // 1 uint8_t 109 : 8
+    // 1 uint8_t 119 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -629,7 +630,7 @@ static int AP_Relay_off(lua_State *L) {
 }
 
 static int AP_Relay_on(lua_State *L) {
-    // 1 uint8_t 108 : 8
+    // 1 uint8_t 118 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -649,6 +650,170 @@ static int AP_Relay_on(lua_State *L) {
             data_2);
 
     return 0;
+}
+
+static int AP_Terrain_height_above_terrain(lua_State *L) {
+    // 1 float 113 : 6
+    // 2 bool 113 : 7
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    float data_5002 = {};
+    const bool data_3 = static_cast<bool>(lua_toboolean(L, 3));
+    const bool data = ud->height_above_terrain(
+            data_5002,
+            data_3);
+
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
+    // 1 float 112 : 8
+    // 2 float 112 : 9
+    // 3 bool 112 : 10
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    const float raw_data_2 = luaL_checknumber(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "argument out of range");
+    const float data_2 = raw_data_2;
+    float data_5003 = {};
+    const bool data_4 = static_cast<bool>(lua_toboolean(L, 4));
+    const bool data = ud->height_relative_home_equivalent(
+            data_2,
+            data_5003,
+            data_4);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
+    // 1 float 111 : 6
+    // 2 bool 111 : 7
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    float data_5002 = {};
+    const bool data_3 = static_cast<bool>(lua_toboolean(L, 3));
+    const bool data = ud->height_terrain_difference_home(
+            data_5002,
+            data_3);
+
+    if (data) {
+        lua_pushnumber(L, data_5002);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_Terrain_height_amsl(lua_State *L) {
+    // 1 Location 110 : 6
+    // 2 float 110 : 7
+    // 3 bool 110 : 8
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    Location & data_2 = *check_Location(L, 2);
+    float data_5003 = {};
+    const bool data_4 = static_cast<bool>(lua_toboolean(L, 4));
+    const bool data = ud->height_amsl(
+            data_2,
+            data_5003,
+            data_4);
+
+    if (data) {
+        lua_pushnumber(L, data_5003);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_Terrain_status(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    const uint8_t data = ud->status(
+);
+
+    lua_pushinteger(L, data);
+    return 1;
+}
+
+static int AP_Terrain_enabled(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Terrain * ud = AP_Terrain::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "terrain not supported on this firmware");
+    }
+
+    const bool data = ud->enabled(
+);
+
+    lua_pushboolean(L, data);
+    return 1;
 }
 
 static int RangeFinder_num_sensors(lua_State *L) {
@@ -1781,6 +1946,16 @@ const luaL_Reg AP_Relay_meta[] = {
     {NULL, NULL}
 };
 
+const luaL_Reg AP_Terrain_meta[] = {
+    {"height_above_terrain", AP_Terrain_height_above_terrain},
+    {"height_relative_home_equivalent", AP_Terrain_height_relative_home_equivalent},
+    {"height_terrain_difference_home", AP_Terrain_height_terrain_difference_home},
+    {"height_amsl", AP_Terrain_height_amsl},
+    {"status", AP_Terrain_status},
+    {"enabled", AP_Terrain_enabled},
+    {NULL, NULL}
+};
+
 const luaL_Reg RangeFinder_meta[] = {
     {"num_sensors", RangeFinder_num_sensors},
     {NULL, NULL}
@@ -1866,6 +2041,7 @@ const struct singleton_fun {
     const luaL_Reg *reg;
 } singleton_fun[] = {
     {"relay", AP_Relay_meta},
+    {"terrain", AP_Terrain_meta},
     {"rangefinder", RangeFinder_meta},
     {"AP_Notify", AP_Notify_meta},
     {"notify", notify_meta},
@@ -1905,6 +2081,7 @@ void load_generated_bindings(lua_State *L) {
 
 const char *singletons[] = {
     "relay",
+    "terrain",
     "rangefinder",
     "AP_Notify",
     "notify",

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,5 +1,6 @@
 // auto generated bindings, don't manually edit
 #include "lua_generated_bindings.h"
+#include <AP_Relay/AP_Relay.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
@@ -549,6 +550,99 @@ const luaL_Reg Location_meta[] = {
     {"get_distance", Location_get_distance},
     {NULL, NULL}
 };
+
+static int AP_Relay_toggle(lua_State *L) {
+    // 1 uint8_t 107 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Relay * ud = AP_Relay::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "relay not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    ud->toggle(
+            data_2);
+
+    return 0;
+}
+
+static int AP_Relay_enabled(lua_State *L) {
+    // 1 uint8_t 106 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Relay * ud = AP_Relay::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "relay not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    const bool data = ud->enabled(
+            data_2);
+
+    lua_pushboolean(L, data);
+    return 1;
+}
+
+static int AP_Relay_off(lua_State *L) {
+    // 1 uint8_t 105 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Relay * ud = AP_Relay::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "relay not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    ud->off(
+            data_2);
+
+    return 0;
+}
+
+static int AP_Relay_on(lua_State *L) {
+    // 1 uint8_t 104 : 8
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 2) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Relay * ud = AP_Relay::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "relay not supported on this firmware");
+    }
+
+    const int raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(0, 0)) && (raw_data_2 <= MIN(AP_RELAY_NUM_RELAYS, UINT8_MAX))), 2, "argument out of range");
+    const uint8_t data_2 = static_cast<uint8_t>(raw_data_2);
+    ud->on(
+            data_2);
+
+    return 0;
+}
 
 static int RangeFinder_num_sensors(lua_State *L) {
     const int args = lua_gettop(L);
@@ -1573,6 +1667,14 @@ static int AP_AHRS_get_position(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg AP_Relay_meta[] = {
+    {"toggle", AP_Relay_toggle},
+    {"enabled", AP_Relay_enabled},
+    {"off", AP_Relay_off},
+    {"on", AP_Relay_on},
+    {NULL, NULL}
+};
+
 const luaL_Reg RangeFinder_meta[] = {
     {"num_sensors", RangeFinder_num_sensors},
     {NULL, NULL}
@@ -1653,6 +1755,7 @@ const struct singleton_fun {
     const char *name;
     const luaL_Reg *reg;
 } singleton_fun[] = {
+    {"relay", AP_Relay_meta},
     {"rangefinder", RangeFinder_meta},
     {"AP_Notify", AP_Notify_meta},
     {"notify", notify_meta},
@@ -1688,6 +1791,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "relay",
     "rangefinder",
     "AP_Notify",
     "notify",

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -11,6 +11,7 @@
 
 
 int new_Vector2f(lua_State *L) {
+    luaL_checkstack(L, 2, "Out of stack");
     Vector2f *ud = (Vector2f *)lua_newuserdata(L, sizeof(Vector2f));
     new (ud) Vector2f();
     luaL_getmetatable(L, "Vector2f");
@@ -19,6 +20,7 @@ int new_Vector2f(lua_State *L) {
 }
 
 int new_Vector3f(lua_State *L) {
+    luaL_checkstack(L, 2, "Out of stack");
     Vector3f *ud = (Vector3f *)lua_newuserdata(L, sizeof(Vector3f));
     new (ud) Vector3f();
     luaL_getmetatable(L, "Vector3f");
@@ -27,6 +29,7 @@ int new_Vector3f(lua_State *L) {
 }
 
 int new_Location(lua_State *L) {
+    luaL_checkstack(L, 2, "Out of stack");
     Location *ud = (Location *)lua_newuserdata(L, sizeof(Location));
     new (ud) Location();
     luaL_getmetatable(L, "Location");
@@ -1765,6 +1768,7 @@ const struct singleton_fun {
 };
 
 void load_generated_bindings(lua_State *L) {
+    luaL_checkstack(L, 5, "Out of stack");
     // userdata metatables
     for (uint32_t i = 0; i < ARRAY_SIZE(userdata_fun); i++) {
         luaL_newmetatable(L, userdata_fun[i].name);

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit
+#include <AP_Relay/AP_Relay.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -4,6 +4,7 @@
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 #include "lua/src/lua.hpp"

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit
+#include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,6 +1,7 @@
 #pragma once
 // auto generated bindings, don't manually edit
 #include <AP_Relay/AP_Relay.h>
+#include <AP_Terrain/AP_Terrain.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -3,11 +3,14 @@
 #include <AP_RangeFinder/AP_RangeFinder.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_GPS/AP_GPS.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/Location.h>
 #include "lua/src/lua.hpp"
 #include <new>
 
+int new_Vector2f(lua_State *L);
+Vector2f * check_Vector2f(lua_State *L, int arg);
 int new_Vector3f(lua_State *L);
 Vector3f * check_Vector3f(lua_State *L, int arg);
 int new_Location(lua_State *L);

--- a/libraries/AP_Scripting/scripts/sandbox.lua
+++ b/libraries/AP_Scripting/scripts/sandbox.lua
@@ -9,6 +9,8 @@ function get_sandbox_env ()
           tostring = tostring,
           type = type,
           unpack = unpack,
+          io = { close = io.close, flush = io.flush, input = io.input, open = io.open, output = io.output,
+                 popen = io.popen, read = io.read, type = io.type, write = io.write},
           string = { byte = string.byte, char = string.char, find = string.find, 
                      format = string.format, gmatch = string.gmatch, gsub = string.gsub, 
                      len = string.len, lower = string.lower, match = string.match, 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -35,6 +35,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_Terrain *AP_Terrain::singleton;
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Param: ENABLE
@@ -62,6 +64,13 @@ AP_Terrain::AP_Terrain(const AP_Mission &_mission) :
     fd(-1)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (singleton != nullptr) {
+        AP_HAL::panic("Terrain must be singleton");
+    }
+#endif
+    singleton = this;
 }
 
 /*

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -82,6 +82,8 @@ public:
     AP_Terrain(const AP_Terrain &other) = delete;
     AP_Terrain &operator=(const AP_Terrain&) = delete;
 
+    static AP_Terrain *get_singleton(void) { return singleton; }
+
     enum TerrainStatus {
         TerrainStatusDisabled  = 0, // not enabled
         TerrainStatusUnhealthy = 1, // no terrain data for current location
@@ -413,5 +415,7 @@ private:
 
     // status
     enum TerrainStatus system_status = TerrainStatusDisabled;
+
+    static AP_Terrain *singleton;
 };
 #endif // AP_TERRAIN_AVAILABLE


### PR DESCRIPTION
This introduces more primitive types to the generator (giving us `int8_t`, `uint8_t`, `int16_t`, `uint16_t`, `int32_t` and `float` types). The main one missing still is support for `uint32_t` which will require a boxed type to avoid losing precision/weird interactions with Lua.

This also starts to introduce nil punning. This is still something I'm playing around with, on the one hand I really want it, on the other hand there are enough limitations/corner cases I'm still debating. The short form is that instead of a boolean returning function filling out arguments by passing in objects, it will return a nil value, or a new object that has been filled in. This makes the following transformation:
```Lua
foo = Location() -- allocate a new Location object
if ahrs:get_position(foo) then -- fill in foo then return
  -- do stuff
end
```
into
```Lua
foo = ahrs:get_position() -- foo is now either nil or a Location
if foo then -- step in here if foo isn't nil
  -- do stuff
end
```

Pros:
  - You can't use an invalid position/something not filled in (will throw an exception)
  - It takes a very small change to allow the assert() function from Lua to be used instead

Cons:
  - Each call must allocate a new object, doesn't allow reuse of a previous one
  - If the called function wants to read as well as write to the object then this doesn't work. C++ doesn't let us annotate this well enough to get compilier assistance, so this could be problematic in the future. (Nil punning only makes sense on fetchers though, so this is less likely then it otherwise sounds)

I'm not fully convinced if I want to keep the nil punning stuff in the future, but it's in at the moment to experiment with it (and if we don't tag things as `'Null` in the generator then we stop using it, so it's easy to roll back if we want.