### PR TITLE
Improve EKF core IMU failover logic - WIP

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -296,9 +296,6 @@ private:
     void update_EKF2(void);
     void update_EKF3(void);
 
-    // get the index of the current primary IMU
-    uint8_t get_primary_IMU_index(void) const;
-
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL::SITL *_sitl;
     uint32_t _last_body_odm_update_ms = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1464,6 +1464,10 @@ check_sample:
  */
 bool AP_InertialSensor::get_delta_angle(uint8_t i, Vector3f &delta_angle) const
 {
+    if (i >= INS_MAX_INSTANCES) {
+        return false;
+    }
+
     if (_delta_angle_valid[i]) {
         delta_angle = _delta_angle[i];
         return true;
@@ -1481,6 +1485,10 @@ bool AP_InertialSensor::get_delta_angle(uint8_t i, Vector3f &delta_angle) const
 */
 bool AP_InertialSensor::get_delta_velocity(uint8_t i, Vector3f &delta_velocity) const
 {
+    if (i >= INS_MAX_INSTANCES) {
+        return false;
+    }
+
     if (_delta_velocity_valid[i]) {
         delta_velocity = _delta_velocity[i];
         return true;
@@ -1497,7 +1505,7 @@ bool AP_InertialSensor::get_delta_velocity(uint8_t i, Vector3f &delta_velocity) 
 float AP_InertialSensor::get_delta_velocity_dt(uint8_t i) const
 {
     float ret;
-    if (_delta_velocity_valid[i]) {
+    if (i < INS_MAX_INSTANCES && _delta_velocity_valid[i]) {
         ret = _delta_velocity_dt[i];
     } else {
         ret = get_delta_time();
@@ -1512,7 +1520,7 @@ float AP_InertialSensor::get_delta_velocity_dt(uint8_t i) const
 float AP_InertialSensor::get_delta_angle_dt(uint8_t i) const
 {
     float ret;
-    if (_delta_angle_valid[i] && _delta_angle_dt[i] > 0) {
+    if (i < INS_MAX_INSTANCES && _delta_angle_valid[i] && _delta_angle_dt[i] > 0) {
         ret = _delta_angle_dt[i];
     } else {
         ret = get_delta_time();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1313,26 +1313,15 @@ void AP_InertialSensor::update(void)
             }
         }
 
-        for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            if (_gyro_healthy[i] && _gyro_error_count[i] > _gyro_startup_error_count[i] && have_zero_gyro_error_count) {
-                // we prefer not to use a gyro that has had errors
-                _gyro_healthy[i] = false;
-            }
-            if (_accel_healthy[i] && _accel_error_count[i] > _accel_startup_error_count[i] && have_zero_accel_error_count) {
-                // we prefer not to use a accel that has had errors
-                _accel_healthy[i] = false;
-            }
-        }
-
         // set primary to first healthy accel and gyro
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            if (_gyro_healthy[i] && _use[i]) {
+            if (_gyro_healthy[i] && _use[i] && (_gyro_error_count[i] <= _gyro_startup_error_count[i] || !have_zero_gyro_error_count)) {
                 _primary_gyro = i;
                 break;
             }
         }
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            if (_accel_healthy[i] && _use[i]) {
+            if (_accel_healthy[i] && _use[i] && (_accel_error_count[i] >= _accel_startup_error_count[i] || !have_zero_accel_error_count)) {
                 _primary_accel = i;
                 break;
             }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -274,6 +274,14 @@ public:
     // return time in microseconds of last update() call
     uint32_t get_last_update_usec(void) const { return _last_update_usec; }
 
+    void kill_imu(uint8_t imu_idx, bool kill_it) {
+        if (kill_it) {
+            imu_kill_mask |= (1U<<imu_idx);
+        } else {
+            imu_kill_mask &= ~(1U<<imu_idx);
+        }
+    }
+
     enum IMU_SENSOR_TYPE {
         IMU_SENSOR_TYPE_ACCEL = 0,
         IMU_SENSOR_TYPE_GYRO = 1,
@@ -575,6 +583,8 @@ private:
     uint32_t _gyro_startup_error_count[INS_MAX_INSTANCES];
     bool _startup_error_counts_set;
     uint32_t _startup_ms;
+
+    uint8_t imu_kill_mask;
 };
 
 namespace AP {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -131,6 +131,9 @@ void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vecto
  */
 void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &gyro)
 {
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     _imu._gyro[instance] = gyro;
     _imu._gyro_healthy[instance] = true;
 
@@ -144,6 +147,9 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
                                                             const Vector3f &gyro,
                                                             uint64_t sample_us)
 {
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     float dt;
 
     _update_sensor_rate(_imu._sample_gyro_count[instance], _imu._sample_gyro_start_us[instance],
@@ -244,6 +250,9 @@ void AP_InertialSensor_Backend::log_gyro_raw(uint8_t instance, const uint64_t sa
  */
 void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f &accel)
 {
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     _imu._accel[instance] = accel;
     _imu._accel_healthy[instance] = true;
 
@@ -277,6 +286,9 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              uint64_t sample_us,
                                                              bool fsync_set)
 {
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     float dt;
 
     _update_sensor_rate(_imu._sample_accel_count[instance], _imu._sample_accel_start_us[instance],
@@ -413,6 +425,9 @@ uint16_t AP_InertialSensor_Backend::get_sample_rate_hz(void) const
  */
 void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float temperature)
 {
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     _imu._temperature[instance] = temperature;
 
     /* give the temperature to the control loop in order to keep it constant*/
@@ -428,6 +443,9 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
 {    
     WITH_SEMAPHORE(_sem);
 
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     if (_imu._new_gyro_data[instance]) {
         _publish_gyro(instance, _imu._gyro_filtered[instance]);
         _imu._new_gyro_data[instance] = false;
@@ -447,6 +465,9 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance)
 {    
     WITH_SEMAPHORE(_sem);
 
+    if ((1U<<instance) & _imu.imu_kill_mask) {
+        return;
+    }
     if (_imu._new_accel_data[instance]) {
         _publish_accel(instance, _imu._accel_filtered[instance]);
         _imu._new_accel_data[instance] = false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -179,15 +179,19 @@ void AP_InertialSensor_SITL::timer_update(void)
 #endif
     for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
         if (now >= next_accel_sample[i]) {
-            generate_accel(i);
-            while (now >= next_accel_sample[i]) {
-                next_accel_sample[i] += 1000000UL / accel_sample_hz[i];
+            if (((1U<<i) & sitl->accel_fail_mask) == 0) {
+                generate_accel(i);
+                while (now >= next_accel_sample[i]) {
+                    next_accel_sample[i] += 1000000UL / accel_sample_hz[i];
+                }
             }
         }
         if (now >= next_gyro_sample[i]) {
-            generate_gyro(i);
-            while (now >= next_gyro_sample[i]) {
-                next_gyro_sample[i] += 1000000UL / gyro_sample_hz[i];
+            if (((1U<<i) & sitl->gyro_fail_mask) == 0) {
+                generate_gyro(i);
+                while (now >= next_gyro_sample[i]) {
+                    next_gyro_sample[i] += 1000000UL / gyro_sample_hz[i];
+                }
             }
         }
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -704,6 +704,12 @@ void NavEKF2::selectCoreIMUs(void) {
     const AP_InertialSensor &ins = AP::ins();
 
     for (uint8_t i=0; i<num_cores; i++) {
+        // If this core is not using its initial IMU and its initial IMU is healthy, switch it
+        if ((core[i].getGyroIndex() != core_initial_imu[i] || core[i].getAccelIndex() != core_initial_imu[i]) && ins.use_accel(core_initial_imu[i]) && ins.use_gyro(core_initial_imu[i])) {
+            core[i].switchGyros(core_initial_imu[i], gyroBiasGuess[core_initial_imu[i]], gyroScaleGuess[core_initial_imu[i]]);
+            core[i].switchAccels(core_initial_imu[i], accelZBiasGuess[core_initial_imu[i]]);
+        }
+
         if (!ins.use_gyro(core[i].getGyroIndex()) || !ins.use_accel(core[i].getAccelIndex())) {
             bool success = false;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -54,6 +54,9 @@ public:
     // Initialise the filter
     bool InitialiseFilter(void);
 
+    // Checks for cores with unhealthy IMUs and switches them to different IMUs
+    void selectCoreIMUs(void);
+
     // Update Filter States - this should be called whenever new IMU data is available
     void UpdateFilter(void);
 
@@ -69,9 +72,13 @@ public:
     // return -1 if no primary core selected
     int8_t getPrimaryCoreIndex(void) const;
 
-    // returns the index of the IMU of the primary core
+    // returns the index of the gyro of the primary core
     // return -1 if no primary core selected
-    int8_t getPrimaryCoreIMUIndex(void) const;
+    int8_t getPrimaryCoreGyroIndex(void) const;
+
+    // returns the index of the accel of the primary core
+    // return -1 if no primary core selected
+    int8_t getPrimaryCoreAccelIndex(void) const;
     
     // Write the last calculated NE position relative to the reference point (m) for the specified instance.
     // An out of range instance (eg -1) returns data for the primary instance

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -30,6 +30,7 @@
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 class NavEKF2_core;
 class AP_AHRS;
@@ -492,4 +493,9 @@ private:
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
     void updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_primary);
+
+    uint8_t core_initial_imu[8];
+    Vector3f gyroBiasGuess[INS_MAX_INSTANCES];
+    float accelZBiasGuess[INS_MAX_INSTANCES];
+    Vector3f gyroScaleGuess[INS_MAX_INSTANCES];
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -265,7 +265,7 @@ void NavEKF2_core::setAidingMode()
         switch (PV_AidingMode) {
         case AID_NONE:
             // We have ceased aiding
-            gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 IMU%u has stopped aiding",(unsigned)imu_index);
+            gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 %u (g%u a%u) has stopped aiding",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
             // When not aiding, estimate orientation & height fusing synthetic constant position and zero velocity measurement to constrain tilt errors
             posTimeout = true;
             velTimeout = true;            
@@ -284,7 +284,7 @@ void NavEKF2_core::setAidingMode()
 
         case AID_RELATIVE:
             // We have commenced aiding, but GPS usage has been prohibited so use optical flow only
-            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using optical flow",(unsigned)imu_index);
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) is using optical flow",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
             posTimeout = true;
             velTimeout = true;
             // Reset the last valid flow measurement time
@@ -299,20 +299,20 @@ void NavEKF2_core::setAidingMode()
             bool canUseExtNav = readyToUseExtNav();
             // We have commenced aiding and GPS usage is allowed
             if (canUseGPS) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using GPS",(unsigned)imu_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) is using GPS",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
             }
             posTimeout = false;
             velTimeout = false;
             // We have commenced aiding and range beacon usage is allowed
             if (canUseRangeBeacon) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using range beacons",(unsigned)imu_index);
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NE = %3.1f,%3.1f (m)",(unsigned)imu_index,(double)receiverPos.x,(double)receiverPos.y);
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial beacon pos D offset = %3.1f (m)",(unsigned)imu_index,(double)bcnPosOffset);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) is using range beacons",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) initial pos NE = %3.1f,%3.1f (m)",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index,(double)receiverPos.x,(double)receiverPos.y);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) initial beacon pos D offset = %3.1f (m)",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index,(double)bcnPosOffset);
             }
             // We have commenced aiding and external nav usage is allowed
             if (canUseExtNav) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u is using external nav data",(unsigned)imu_index);
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)imu_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) is using external nav data",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) initial pos NED = %3.1f,%3.1f,%3.1f (m)",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index,(double)extNavDataDelayed.pos.x,(double)extNavDataDelayed.pos.y,(double)extNavDataDelayed.pos.z);
                 // handle yaw reset as special case
                 extNavYawResetRequest = true;
                 controlMagYawReset();
@@ -345,7 +345,7 @@ void NavEKF2_core::checkAttitudeAlignmentStatus()
     tiltErrFilt = alpha*temp + (1.0f-alpha)*tiltErrFilt;
     if (tiltErrFilt < 0.005f && !tiltAlignComplete) {
         tiltAlignComplete = true;
-        gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u tilt alignment complete",(unsigned)imu_index);
+        gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) tilt alignment complete",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
     }
 
     // submit yaw and magnetic field reset requests depending on whether we have compass data
@@ -441,7 +441,7 @@ void NavEKF2_core::setOrigin()
     // define Earth rotation vector in the NED navigation frame at the origin
     calcEarthRateNED(earthRateNED, _ahrs->get_home().lat);
     validOrigin = true;
-    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u Origin set to GPS",(unsigned)imu_index);
+    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) Origin set to GPS",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
 }
 
 // record a yaw reset event

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -109,7 +109,7 @@ void NavEKF2_core::controlMagYawReset()
 
             // send initial alignment status to console
             if (!yawAlignComplete) {
-                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u ext nav yaw alignment complete",(unsigned)imu_index);
+                gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) ext nav yaw alignment complete",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
             }
 
             // record the reset as complete and also record the in-flight reset as complete to stop further resets when height is gained
@@ -142,14 +142,14 @@ void NavEKF2_core::controlMagYawReset()
 
                 // send initial alignment status to console
                 if (!yawAlignComplete) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u initial yaw alignment complete",(unsigned)imu_index);
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) initial yaw alignment complete",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
                 }
 
                 // send in-flight yaw alignment status to console
                 if (finalResetRequest) {
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u in-flight yaw alignment complete",(unsigned)imu_index);
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) in-flight yaw alignment complete",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
                 } else if (interimResetRequest) {
-                    gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 IMU%u ground mag anomaly, yaw re-aligned",(unsigned)imu_index);
+                    gcs().send_text(MAV_SEVERITY_WARNING, "EKF2 %u (g%u a%u) ground mag anomaly, yaw re-aligned",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
                 }
 
                 // update the yaw reset completed status
@@ -200,7 +200,7 @@ void NavEKF2_core::realignYawGPS()
             ResetPosition();
 
             // send yaw alignment information to console
-            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u yaw aligned to GPS velocity",(unsigned)imu_index);
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 %u (g%u a%u) yaw aligned to GPS velocity",(unsigned)core_index, (unsigned)gyro_index, (unsigned)accel_index);
 
             // zero the attitude covariances because the correlations will now be invalid
             zeroAttCovOnly();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -232,7 +232,7 @@ void NavEKF2_core::readMagData()
                 // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
                 if (_ahrs->get_compass()->use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
                     magSelectIndex = tempIndex;
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)gyro_index,magSelectIndex);
                     // reset the timeout flag and timer
                     magTimeout = false;
                     lastHealthyMagTime_ms = imuSampleTime_ms;
@@ -304,10 +304,10 @@ void NavEKF2_core::readIMUData()
     // the imu sample time is used as a common time reference throughout the filter
     imuSampleTime_ms = AP_HAL::millis();
 
-    readDeltaVelocity(imu_index, imuDataNew.delVel, imuDataNew.delVelDT);
-    accelPosOffset = ins.get_imu_pos_offset(imu_index);
+    readDeltaVelocity(accel_index, imuDataNew.delVel, imuDataNew.delVelDT);
+    accelPosOffset = ins.get_imu_pos_offset(accel_index);
 
-    readDeltaAngle(imu_index, imuDataNew.delAng, imuDataNew.delAngDT);
+    readDeltaAngle(gyro_index, imuDataNew.delAng, imuDataNew.delAngDT);
 
     // Get current time stamp
     imuDataNew.time_ms = imuSampleTime_ms;
@@ -539,7 +539,7 @@ void NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng
 
     ins.get_delta_angle(ins_index,dAng);
     frontend->logging.log_imu = true;
-    dAng_dt = MAX(ins.get_delta_angle_dt(imu_index),1.0e-4f);
+    dAng_dt = MAX(ins.get_delta_angle_dt(ins_index),1.0e-4f);
     dAng_dt = MIN(dAng_dt,1.0e-1f);
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -304,21 +304,10 @@ void NavEKF2_core::readIMUData()
     // the imu sample time is used as a common time reference throughout the filter
     imuSampleTime_ms = AP_HAL::millis();
 
-    // use the nominated imu or primary if not available
-    if (ins.use_accel(imu_index)) {
-        readDeltaVelocity(imu_index, imuDataNew.delVel, imuDataNew.delVelDT);
-        accelPosOffset = ins.get_imu_pos_offset(imu_index);
-    } else {
-        readDeltaVelocity(ins.get_primary_accel(), imuDataNew.delVel, imuDataNew.delVelDT);
-        accelPosOffset = ins.get_imu_pos_offset(ins.get_primary_accel());
-    }
+    readDeltaVelocity(imu_index, imuDataNew.delVel, imuDataNew.delVelDT);
+    accelPosOffset = ins.get_imu_pos_offset(imu_index);
 
-    // Get delta angle data from primary gyro or primary if not available
-    if (ins.use_gyro(imu_index)) {
-        readDeltaAngle(imu_index, imuDataNew.delAng, imuDataNew.delAngDT);
-    } else {
-        readDeltaAngle(ins.get_primary_gyro(), imuDataNew.delAng, imuDataNew.delAngDT);
-    }
+    readDeltaAngle(imu_index, imuDataNew.delAng, imuDataNew.delAngDT);
 
     // Get current time stamp
     imuDataNew.time_ms = imuSampleTime_ms;
@@ -403,16 +392,12 @@ void NavEKF2_core::readIMUData()
 
 // read the delta velocity and corresponding time interval from the IMU
 // return false if data is not available
-bool NavEKF2_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt) {
+void NavEKF2_core::readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt) {
     const AP_InertialSensor &ins = AP::ins();
 
-    if (ins_index < ins.get_accel_count()) {
-        ins.get_delta_velocity(ins_index,dVel);
-        dVel_dt = MAX(ins.get_delta_velocity_dt(ins_index),1.0e-4f);
-        dVel_dt = MIN(dVel_dt,1.0e-1f);
-        return true;
-    }
-    return false;
+    ins.get_delta_velocity(ins_index,dVel);
+    dVel_dt = MAX(ins.get_delta_velocity_dt(ins_index),1.0e-4f);
+    dVel_dt = MIN(dVel_dt,1.0e-1f);
 }
 
 /********************************************************
@@ -549,17 +534,13 @@ void NavEKF2_core::readGpsData()
 
 // read the delta angle and corresponding time interval from the IMU
 // return false if data is not available
-bool NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt) {
+void NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt) {
     const AP_InertialSensor &ins = AP::ins();
 
-    if (ins_index < ins.get_gyro_count()) {
-        ins.get_delta_angle(ins_index,dAng);
-        frontend->logging.log_imu = true;
-        dAng_dt = MAX(ins.get_delta_angle_dt(imu_index),1.0e-4f);
-        dAng_dt = MIN(dAng_dt,1.0e-1f);
-        return true;
-    }
-    return false;
+    ins.get_delta_angle(ins_index,dAng);
+    frontend->logging.log_imu = true;
+    dAng_dt = MAX(ins.get_delta_angle_dt(imu_index),1.0e-4f);
+    dAng_dt = MIN(dAng_dt,1.0e-1f);
 }
 
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -131,6 +131,19 @@ void NavEKF2_core::getGyroBias(Vector3f &gyroBias) const
     gyroBias = stateStruct.gyro_bias / dtEkfAvg;
 }
 
+// return body axis gyro scale factor
+void NavEKF2_core::getGyroScale(Vector3f &gyroScale) const
+{
+    if (!statesInitialised) {
+        gyroScale.x = gyroScale.y = gyroScale.z = 1;
+        return;
+    }
+
+    gyroScale.x = stateStruct.gyro_scale.x;
+    gyroScale.y = stateStruct.gyro_scale.y;
+    gyroScale.z = stateStruct.gyro_scale.z;
+}
+
 // return body axis gyro scale factor error as a percentage
 void NavEKF2_core::getGyroScaleErrorPercentage(Vector3f &gyroScale) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -96,6 +96,25 @@ bool NavEKF2_core::setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _c
 
     return true;
 }
+
+void NavEKF2_core::switchIMUs(uint8_t _new_imu_index)
+{
+    if (imu_index != _new_imu_index) {
+        imu_index = _new_imu_index;
+        zeroRows(P,9,15);
+        zeroCols(P,9,15);
+        // gyro biases
+        P[9][9] = sq(radians(InitialGyroBiasUncertainty() * dtEkfAvg));
+        P[10][10] = P[9][9];
+        P[11][11] = P[9][9];
+        // gyro scale factor biases
+        P[12][12] = sq(1e-3);
+        P[13][13] = P[12][12];
+        P[14][14] = P[12][12];
+        // Z delta velocity bias
+        P[15][15] = sq(INIT_ACCEL_BIAS_UNCERTAINTY * dtEkfAvg);
+    }
+}
     
 
 /********************************************************

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -751,6 +751,9 @@ private:
 
     // update timing statistics structure
     void updateTimingStatistics(void);
+
+    // change the imu_index and reset the imu bias state variances and covariances
+    void switchIMUs(uint8_t _new_imu_index);
     
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -64,7 +64,7 @@ public:
     NavEKF2_core(void);
 
     // setup this core backend
-    bool setup_core(NavEKF2 *_frontend, uint8_t _imu_index, uint8_t _core_index);
+    bool setup_core(NavEKF2 *_frontend, uint8_t _gyro_index, uint8_t _accel_index, uint8_t _core_index);
     
     // Initialise the states from accelerometer and magnetometer data (if present)
     // This method can only be used when the vehicle is static
@@ -302,8 +302,17 @@ public:
     // publish output observer angular, velocity and position tracking error
     void getOutputTrackingError(Vector3f &error) const;
 
-    // get the IMU index
-    uint8_t getIMUIndex(void) const { return imu_index; }
+    // get the gyro index
+    uint8_t getGyroIndex(void) const { return gyro_index; }
+
+    // get the accel index
+    uint8_t getAccelIndex(void) const { return accel_index; }
+
+    // change the gyro index and reset gyro bias and scale factor states and covariances
+    void switchGyros(uint8_t _new_gyro_index);
+
+    // change the accel index and reset accel biasstates and covariances
+    void switchAccels(uint8_t _new_accel_index);
 
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);
@@ -325,7 +334,8 @@ public:
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 *frontend;
-    uint8_t imu_index;
+    uint8_t gyro_index;
+    uint8_t accel_index;
     uint8_t core_index;
     uint8_t imu_buffer_length;
 
@@ -751,9 +761,6 @@ private:
 
     // update timing statistics structure
     void updateTimingStatistics(void);
-
-    // change the imu_index and reset the imu bias state variances and covariances
-    void switchIMUs(uint8_t _new_imu_index);
     
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -575,8 +575,8 @@ private:
     void CovarianceInit();
 
     // helper functions for readIMUData
-    bool readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt);
-    bool readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt);
+    void readDeltaVelocity(uint8_t ins_index, Vector3f &dVel, float &dVel_dt);
+    void readDeltaAngle(uint8_t ins_index, Vector3f &dAng, float &dAng_dt);
 
     // helper functions for correcting IMU data
     void correctDeltaAngle(Vector3f &delAng, float delAngDT);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -105,6 +105,9 @@ public:
     // return body axis gyro bias estimates in rad/sec
     void getGyroBias(Vector3f &gyroBias) const;
 
+    // return body axis gyro scale factor
+    void getGyroScale(Vector3f &gyroScale) const;
+
     // return body axis gyro scale factor error as a percentage
     void getGyroScaleErrorPercentage(Vector3f &gyroScale) const;
 
@@ -309,10 +312,10 @@ public:
     uint8_t getAccelIndex(void) const { return accel_index; }
 
     // change the gyro index and reset gyro bias and scale factor states and covariances
-    void switchGyros(uint8_t _new_gyro_index);
+    void switchGyros(uint8_t _new_gyro_index, const Vector3f& gyro_bias_guess, const Vector3f& gyro_scale_guess);
 
     // change the accel index and reset accel biasstates and covariances
-    void switchAccels(uint8_t _new_accel_index);
+    void switchAccels(uint8_t _new_accel_index, float accel_z_bias_guess);
 
     // get timing statistics structure
     void getTimingStatistics(struct ekf_timing &timing);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -449,6 +449,8 @@ void RC_Channel::init_aux_function(const aux_func_t ch_option, const aux_switch_
     case AUX_FUNC::GRIPPER:
     case AUX_FUNC::SPRAYER:
     case AUX_FUNC::GPS_DISABLE:
+    case AUX_FUNC::KILL_IMU1:
+    case AUX_FUNC::KILL_IMU2:
         do_aux_function(ch_option, ch_flag);
         break;
     default:
@@ -716,6 +718,20 @@ void RC_Channel::do_aux_function(const aux_func_t ch_option, const aux_switch_po
             break;
         }
     }
+    case AUX_FUNC::KILL_IMU1:
+        if (ch_flag == HIGH) {
+            AP::ins().kill_imu(0, true);
+        } else {
+            AP::ins().kill_imu(0, false);
+        }
+        break;
+    case AUX_FUNC::KILL_IMU2:
+        if (ch_flag == HIGH) {
+            AP::ins().kill_imu(1, true);
+        } else {
+            AP::ins().kill_imu(1, false);
+        }
+        break;
    break;
 
     default:

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -168,7 +168,9 @@ public:
         ALTHOLD   =           70, // althold mode
         FLOWHOLD  =           71, // flowhold mode
         CIRCLE    =           72, // circle mode
-        DRIFT     =           73  // drift mode
+        DRIFT     =           73, // drift mode
+        KILL_IMU1 =          100,
+        KILL_IMU2 =          101,
         // if you add something here, make sure to update the documentation of the parameter in RC_Channel.cpp!
         // also, if you add an option >255, you will need to fix duplicate_options_exist
     };

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -156,6 +156,10 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     // optical flow sensor measurement noise in rad/sec
     AP_GROUPINFO("FLOW_RND",   34, SITL,  flow_noise,  0.05f),
 
+    // accel and gyro fail masks
+    AP_GROUPINFO("GYR_FAIL_MSK",   35, SITL,  gyro_fail_mask,  0),
+    AP_GROUPINFO("ACC_FAIL_MSK",   36, SITL,  accel_fail_mask,  0),
+
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -231,6 +231,10 @@ public:
     // vibration frequencies in Hz on each axis
     AP_Vector3f vibe_freq;
 
+    // gyro and accel fail masks
+    AP_Int8 gyro_fail_mask;
+    AP_Int8 accel_fail_mask;
+
     struct {
         AP_Float x;
         AP_Float y;


### PR DESCRIPTION
This patch
- Only improves the IMU failover logic within an EKF core - it does not change the logic for EKF core switching
- Moves the core IMU selection logic from AP_NavEKF_core to AP_NavEKF
- Resets the IMU bias states and covariances when an EKF core switches IMUs
- Uses the following logic to select a new accelerometer and gyro for an EKF core when its accelerometer and gyro become unhealthy:
```
    Try to find a paired gyro and accel that are both healthy w/ INS_USE=1 and configured to be used in EK2_IMU_MASK
    If that failed, try to find a paired gyro and accel that are both healthy w/ INS_USE=1
    If that failed, fall back on ins.get_primary_gyro and ins.get_primary_accel
```

TODO:
- Implement for EKF3
- Trigger a primary core change when the primary core's IMU becomes unhealthy - no change in functionality here
- Implement switching back to the initial IMU if the initial IMU becomes healthy for some period of time
- Pre-arm check for consistency between EK2_IMU_MASK and INS_USE*
- SITL test for failed IMU