### PR TITLE
Add logging of IOMCU stats, raise threshold of failures for IOMCU to be unhealthy

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -310,6 +310,12 @@ void Plane::one_second_loop()
     // indicates that the sensor or subsystem is present but not
     // functioning correctly
     gcs().update_sensor_status_flags();
+
+#if HAL_WITH_IO_MCU
+    if (should_log(MASK_LOG_PM)) {
+        iomcu.log();
+    }
+#endif
 }
 
 void Plane::compass_save()

--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -801,7 +801,7 @@ void AP_IOMCU::set_safety_mask(uint16_t chmask)
  */
 bool AP_IOMCU::healthy(void)
 {
-    return crc_is_ok && stats.protocol_fail_count == 0;
+    return crc_is_ok && stats.protocol_fail_count > 5;
 }
 
 /*

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -99,6 +99,9 @@ public:
     // shutdown IO protocol (for reboot)
     void shutdown();
 
+    // log stats
+    void log(void);
+
     // setup for FMU failsafe mixing
     bool setup_mixing(RCMapper *rcmap, int8_t override_chan,
                       float mixing_gain, uint16_t manual_rc_mask);
@@ -203,7 +206,14 @@ private:
     bool initialised;
     bool is_chibios_backend;
 
-    uint32_t protocol_fail_count;
+    struct statistics {
+        uint32_t protocol_fail_count; // current communication failures since last success
+        uint32_t total_fail_count;    // total communication failures
+        uint32_t failed_event_count;  // failed events
+        uint32_t uart_fail_count;     // counter of failed write attempts
+        uint32_t uart_write_count;    // counter of attempts to write to the UART
+        uint8_t failed_event; // most recent failed event
+    } stats;
 
     // firmware upload
     const char *fw_name = "io_firmware.bin";
@@ -226,7 +236,7 @@ private:
     bool reboot();
 
     bool check_crc(void);
-    
+
     enum {
         PROTO_NOP               = 0x00,
         PROTO_OK                = 0x10,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -294,6 +294,17 @@ struct PACKED log_Gimbal3 {
     int16_t az_torque_cmd;
 };
 
+struct PACKED log_IOMCU {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint32_t total_fail_count;
+    uint32_t current_fail_count;
+    uint32_t event_fail_count;
+    uint32_t uart_fail_count;
+    uint32_t uart_write_count;
+    uint8_t most_recent_failed_event;
+};
+
 struct PACKED log_RCIN {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1259,6 +1270,8 @@ Format characters in the format string for binary log messages
       "IMU",  IMU_FMT,     IMU_LABELS, IMU_UNITS, IMU_MULTS }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \
       "MSG",  "QZ",     "TimeUS,Message", "s-", "F-"}, \
+    { LOG_IOMCU_MSG, sizeof(log_IOMCU), \
+      "IOMC",  "QIIIIIB",     "TimeUS,TotFail,CurrFail,EvtFail,UARTFail,UARTWrite,FailedEvt", "s------", "F------" }, \
     { LOG_RCIN_MSG, sizeof(log_RCIN), \
       "RCIN",  "QHHHHHHHHHHHHHH",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14", "sYYYYYYYYYYYYYY", "F--------------" }, \
     { LOG_RCOUT_MSG, sizeof(log_RCOUT), \
@@ -1561,6 +1574,7 @@ enum LogMessages : uint8_t {
     LOG_GPSB_MSG,
     LOG_IMU_MSG,
     LOG_MESSAGE_MSG,
+    LOG_IOMCU_MSG,
     LOG_RCIN_MSG,
     LOG_RCOUT_MSG,
     LOG_RSSI_MSG,


### PR DESCRIPTION
We fail ~0.6% of all writes to the IOMCU. This is an arming check, which leads to very brief transients of failing the arming checks, which it is possible to hit. This raises the threshold for the IOMCU to be considered unhealthy to be more then 5 failures with communicating with the IOMCU. My testing shows they accumulate at a rate of 2Hz normally, and we issue these at a high rate.

This also brings in a bunch of logging for the IOMCU library to allow us to have general insights to this. I had more logging during testing, but this is the minimum set I think that is currently helpful. I'm hoping @peterbarker has suggestions on where I can stick the call to log that would be common code, rather then copy pasting it. The logging code is technically a race condition as well, although I've currently taken the approach of ignoring that as it will be better by the next log call. With that being said if it bothers anyone for any reasons I can go back in and add the required locking.