### PR TITLE
AP_Airspeed: Fix race condition in SDP3X leading to garbage data

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -196,13 +196,6 @@ void AP_Airspeed_SDP3X::_timer()
  */
 float AP_Airspeed_SDP3X::_correct_pressure(float press)
 {
-    float temperature;
-    AP_Baro *baro = AP_Baro::get_singleton();
-
-    if (baro == nullptr) {
-        return press;
-    }
-
     float sign = 1.0f;
     
     // fix for tube order
@@ -227,7 +220,17 @@ float AP_Airspeed_SDP3X::_correct_pressure(float press)
         return 0.0f;
     }
 
-    get_temperature(temperature);
+    AP_Baro *baro = AP_Baro::get_singleton();
+
+    if (baro == nullptr) {
+        return press;
+    }
+
+    float temperature;
+    if (!get_temperature(temperature)) {
+        return press;
+    }
+
     float rho_air = baro->get_pressure() / (ISA_GAS_CONSTANT * (temperature + C_TO_KELVIN));
 
     /*


### PR DESCRIPTION
`get_temperature(float &)` can fail, in which case it doesn't assign to the float. We were ignoring that, so if we were right on the threshold of failing that conversion for any reason we would have used garbage data off the stack and propagated it out. This was found by Clang static analysis.

This also tries to do the tube order correction regardless of if the baro is actually present or not, although this sensor should never be used without a baro on the system.