### PR TITLE
Update CI loads and Python3 compat problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,6 @@ matrix:
     - if: type != cron
       compiler: "gcc"
       env: CI_BUILD_TARGET="revo-bootloader iofirmware stm32f7 stm32h7 fmuv2-plane"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="revo-mini configure-all"
     - if: type != cron
       compiler: "gcc"
       env: CI_BUILD_TARGET="sitltest-copter"

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -152,7 +152,7 @@ def generate_DMAMUX_map_mask(peripheral_list, channel_mask, noshare_list, dma_ex
         base = idx % 16
         for i in range(16):
             found = None
-            for ii in range(base,16) + range(0,base):
+            for ii in list(range(base,16)) + list(range(0,base)):
                 if (1<<ii) & available == 0:
                     continue
 


### PR DESCRIPTION
This moves an entire travis task to semaphore onto what was the px4-v3 build task. This task was completely empty on master, so it was wasting time, and on stable branches it will now just take longer to run, but this at least allows the normal CI runs to be faster.

The `list` usage in DMA resolver is needed to enable Python3 builds of F7 boards.

EDIT: I've already made the corresponding Semaphore changes, this means until this goes in one sub task on semaphore is going to fail reliably.