### PR TITLE
Tools: scripts: Suggest exporting JSBSim path after building

### DIFF
--- a/Tools/scripts/build-jsbsim.sh
+++ b/Tools/scripts/build-jsbsim.sh
@@ -20,4 +20,10 @@ else
     cmake -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_BUILD_TYPE=Release ..
     make -j2
 fi
+
+if [[ ! -n $(echo $PATH | grep jsbsim) ]]; then
+    echo "Add the JSBSim executable to your PATH using - export PATH=\$PATH:~/jsbsim/build/src"
+    echo "Add the above command to ~/.bashrc to automatically set the path everytime a new terminal is launched"
+fi
+
 echo "---------- $0 end ----------"


### PR DESCRIPTION
Without setting the environment variable, JSBSim doesn't start
![jsbsim](https://user-images.githubusercontent.com/37938604/56439462-cacd1380-6303-11e9-8502-ae27f1a3fda5.png)

Discussed in https://github.com/ArduPilot/ardupilot_wiki/pull/1717