### PR TITLE
Rover: fix omni tri steering and lateral factors

### DIFF
--- a/APMrover2/AP_MotorsUGV.cpp
+++ b/APMrover2/AP_MotorsUGV.cpp
@@ -502,8 +502,8 @@ void AP_MotorsUGV::setup_omni()
 
     case FRAME_TYPE_OMNI3:
         _motors_num = 3;
-        add_omni_motor(0, 1.0f, 1.0f, -1.0f);
-        add_omni_motor(1, 0.0f, 1.0f, 1.0f);
+        add_omni_motor(0, 1.0f, -1.0f, -1.0f);
+        add_omni_motor(1, 0.0f, -1.0f, 1.0f);
         add_omni_motor(2, 1.0f, 1.0f, 1.0f);
         break;
 


### PR DESCRIPTION
This PR fixes the steering and lateral factors for the [Omni Tri vehicles](http://ardupilot.org/rover/docs/rover-motor-and-servo-connections.html#omni-vehicles) based on the discussion between @Ammarf and [Nando](https://discuss.ardupilot.org/u/nando) [here](https://discuss.ardupilot.org/t/rover-3-5-0-released/38191/25).

I do not have a vehicle to test this change so I'm hopeful that either Ammar or Nando can provide some feedback that they think this is correct.
