### PR TITLE
added check to help people find proplem with autotune not twitching

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -180,6 +180,26 @@ bool AC_AutoTune::init_internals(bool _use_poshold,
         Log_Write_Event(EVENT_AUTOTUNE_PILOT_TESTING);
         break;
     }
+     //Stabilize P Gains need to be less than 10 for autotune to be successful 
+    double stabilize_roll_p = attitude_control->get_angle_roll_p().kP();
+    double stabilize_pitch_p = attitude_control->get_angle_pitch_p().kP();
+    double stabilize_yaw_p = attitude_control->get_angle_yaw_p().kP();
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Current stabilize roll Gain: %f", stabilize_roll_p);
+    gcs().send_text(MAV_SEVERITY_INFO, "Current stabilize pitch Gain: %f", stabilize_pitch_p );
+    gcs().send_text(MAV_SEVERITY_INFO, "Current stabilize yaw gain %f", stabilize_yaw_p );
+    if(stabilize_roll_p > 4.5f)
+    {
+        gcs().send_text(MAV_SEVERITY_INFO, "It is recommended ATC_ANG_RLL_P = 4.5" );
+    }
+    if(stabilize_pitch_p > 4.5f)
+    {
+        gcs().send_text(MAV_SEVERITY_INFO, "It is recommended ATC_ANG_PIT_P = 4.5" );
+    }
+    if(stabilize_yaw_p > 4.5f)
+    {
+        gcs().send_text(MAV_SEVERITY_INFO, "It is recommended ATC_ANG_YAW_P to = 4.5" );
+    }
 
     have_position = false;
 


### PR DESCRIPTION
This patch adds a check to see if the stabilize P gains are the default. If they are not the default then it will send a message to the GCS station recommending to the user to reset them to default. This patch has been created due to users observation with arducopter not twitching and not running. Autotune typically fails when the gains are > than 10, but it seems like good practice to set them to default when starting a new tune. The goal of this patch is to give users a hint as to why autotune is failing.

Here is the discussion in which we discovered this problem 
[ardupilot discourse](https://discuss.ardupilot.org/t/autotune-not-tuning-h-frame/39502/6) 