### PR TITLE
Copter: Use explicit dependencies instead of hardcoded numbers

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -507,6 +507,9 @@ void Copter::one_hz_loop()
     // log terrain data
     terrain_logging();
 
+    // Update the ROI yaw loop rate divider if the user changes the main loop rate
+    flightmode->auto_yaw.update_roi_yaw_loop_rate(scheduler.get_loop_rate_hz());
+
 #if HAL_ADSB_ENABLED
     adsb.set_is_flying(!ap.land_complete);
 #endif

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -207,6 +207,9 @@ public:
                            int8_t direction,
                            bool relative_angle);
 
+        // the ROI yaw loop rate depends on the fast loop rate
+        void update_roi_yaw_loop_rate(uint16_t fast_loop_rate_hz);
+
     private:
 
         float look_ahead_yaw();
@@ -233,7 +236,10 @@ public:
         // turn rate (in cds) when auto_yaw_mode is set to AUTO_YAW_RATE
         float _rate_cds;
 
-        // used to reduce update rate to 100hz:
+        // used to reduce update rate to ROI_YAW_SCHEDULER_HZ (100hz):
+        uint8_t roi_yaw_divider;
+
+        // used to reduce update rate to ROI_YAW_SCHEDULER_HZ (100hz):
         uint8_t roi_yaw_counter;
 
     };


### PR DESCRIPTION
This is a remain of #7458