### PR TITLE
 AP_BoardConfig: add targetted check for cube black internal sensors

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -153,7 +153,7 @@ bool AP_Baro_MS56XX::_init()
 /**
  * MS56XX crc4 method from datasheet for 16 bytes (8 short values)
  */
-static uint16_t crc4(uint16_t *data)
+uint16_t AP_Baro_MS56XX::crc4(uint16_t *data)
 {
     uint16_t n_rem = 0;
     uint8_t n_bit;

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -39,6 +39,8 @@ public:
     };
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev, enum MS56XX_TYPE ms56xx_type = BARO_MS5611);
+
+    static uint16_t crc4(uint16_t *data);
     
 private:
     /*

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -194,6 +194,7 @@ private:
     void board_setup_drivers(void);
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
+    bool check_cubeblack(void);
     void board_autodetect(void);
 
 #endif // AP_FEATURE_BOARD_DETECT

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -194,7 +194,7 @@ private:
     void board_setup_drivers(void);
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
-    bool check_cubeblack(void);
+    void check_cubeblack(void);
     void board_autodetect(void);
 
 #endif // AP_FEATURE_BOARD_DETECT

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -153,6 +153,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
+#if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     if (!dev) {
@@ -210,6 +211,7 @@ static bool check_ms5611(const char* devname) {
 
     return true;
 }
+#endif
 
 #define MPUREG_WHOAMI 0x75
 #define MPU_WHOAMI_MPU60X0  0x68

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -155,14 +155,16 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
 
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
-    AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
-    if (!dev || !dev_sem) {
+    if (!dev) {
 #if SPI_PROBE_DEBUG
         hal.console->printf("%s: no device\n", devname);
 #endif
         return false;
     }
-    if (!dev_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+
+    AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
+
+    if (!dev_sem || !dev_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
@@ -4,6 +4,8 @@
 
 include ../fmuv3/hwdef.dat
 
+define HAL_CHIBIOS_ARCH_CUBEBLACK 1
+
 env OPTIMIZE -O3
 
 # USB setup


### PR DESCRIPTION
Since MS5611 irritatingly doesn't have a WHOAMI register, I had to do a fairly complicated CRC check on its PROM.