### PR TITLE
AP_BoardConfig: Fix manipulating SPI device without holding semaphore

### DIFF
--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -133,10 +133,10 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
 #endif
         return false;
     }
-    dev->set_read_flag(read_flag);
     if (!dev->get_semaphore()->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
+    dev->set_read_flag(read_flag);
     uint8_t v;
     if (!dev->read_registers(regnum, &v, 1)) {
 #if SPI_PROBE_DEBUG


### PR DESCRIPTION
We shouldn't be running drivers at this point in the board, so it shouldn't be manifesting as a bug yet, but nothing guarantees this in the future, so it's worth actually holding the lock before manipulating the device.