### PR TITLE
 AP_BoardConfig: add targetted check for cube black internal sensors (Copter-3.6 backport)

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -153,7 +153,7 @@ bool AP_Baro_MS56XX::_init()
 /**
  * MS56XX crc4 method from datasheet for 16 bytes (8 short values)
  */
-static uint16_t crc4(uint16_t *data)
+uint16_t AP_Baro_MS56XX::crc4(uint16_t *data)
 {
     uint16_t n_rem = 0;
     uint8_t n_bit;

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -27,6 +27,8 @@ public:
     };
 
     static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev, enum MS56XX_TYPE ms56xx_type = BARO_MS5611);
+
+    static uint16_t crc4(uint16_t *data);
     
 private:
     /*

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -191,7 +191,7 @@ private:
     void board_setup_drivers(void);
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
-    bool check_cubeblack(void);
+    void check_cubeblack(void);
     void board_autodetect(void);
 
 #endif // AP_FEATURE_BOARD_DETECT

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -191,6 +191,7 @@ private:
     void board_setup_drivers(void);
     bool spi_check_register(const char *devname, uint8_t regnum, uint8_t value, uint8_t read_flag = 0x80);
     void validate_board_type(void);
+    bool check_cubeblack(void);
     void board_autodetect(void);
 
 #endif // AP_FEATURE_BOARD_DETECT

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -148,14 +148,16 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
 
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
-    AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
-    if (!dev || !dev_sem) {
+    if (!dev) {
 #if SPI_PROBE_DEBUG
         hal.console->printf("%s: no device\n", devname);
 #endif
         return false;
     }
-    if (!dev_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+
+    AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
+
+    if (!dev_sem || !dev_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         return false;
     }
 

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -146,6 +146,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
+#if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     if (!dev) {
@@ -203,6 +204,7 @@ static bool check_ms5611(const char* devname) {
 
     return true;
 }
+#endif
 
 #define MPUREG_WHOAMI 0x75
 #define MPU_WHOAMI_MPU60X0  0x68

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -18,6 +18,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_BoardConfig.h"
+#include <AP_Baro/AP_Baro_MS5611.h>
 #include <stdio.h>
 
 extern const AP_HAL::HAL& hal;
@@ -145,34 +146,6 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
-/**
- * MS56XX crc4 method from datasheet for 16 bytes (8 short values)
- */
-static uint16_t crc4(uint16_t *data)
-{
-    uint16_t n_rem = 0;
-    uint8_t n_bit;
-
-    for (uint8_t cnt = 0; cnt < 16; cnt++) {
-        /* uneven bytes */
-        if (cnt & 1) {
-            n_rem ^= (uint8_t)((data[cnt >> 1]) & 0x00FF);
-        } else {
-            n_rem ^= (uint8_t)(data[cnt >> 1] >> 8);
-        }
-
-        for (n_bit = 8; n_bit > 0; n_bit--) {
-            if (n_rem & 0x8000) {
-                n_rem = (n_rem << 1) ^ 0x3000;
-            } else {
-                n_rem = (n_rem << 1);
-            }
-        }
-    }
-
-    return (n_rem >> 12) & 0xF;
-}
-
 static bool check_ms5611(const char* devname) {
     auto dev = hal.spi->get_device(devname);
     AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
@@ -215,7 +188,7 @@ static bool check_ms5611(const char* devname) {
     uint16_t crc_read = prom[7]&0xf;
     prom[7] &= 0xff00;
 
-    if (crc_read != crc4(prom) || all_zero) {
+    if (crc_read != AP_Baro_MS56XX::crc4(prom) || all_zero) {
 #if SPI_PROBE_DEBUG
         hal.console->printf("%s: crc fail\n", devname);
 #endif
@@ -274,6 +247,27 @@ void AP_BoardConfig::validate_board_type(void)
 }
 
 
+void AP_BoardConfig::check_cubeblack(void)
+{
+#if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
+    if (state.board_type != PX4_BOARD_PIXHAWK2) {
+        state.board_type.set(PX4_BOARD_PIXHAWK2);
+    }
+
+    bool success = true;
+    if (!spi_check_register("mpu9250", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
+    if (!spi_check_register("mpu9250_ext", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
+    if (!spi_check_register("lsm9ds0_ext_g", LSMREG_WHOAMI, LSM_WHOAMI_L3GD20)) { success = false; }
+    if (!spi_check_register("lsm9ds0_ext_am", LSMREG_WHOAMI, LSM_WHOAMI_LSM303D)) { success = false; }
+    if (!check_ms5611("ms5611")) { success = false; }
+    if (!check_ms5611("ms5611_ext")) { success = false; }
+
+    if (!success) {
+        sensor_config_error("Failed to init CubeBlack - sensor mismatch");
+    }
+#endif
+}
+
 
 /*
   auto-detect board type
@@ -281,24 +275,8 @@ void AP_BoardConfig::validate_board_type(void)
 void AP_BoardConfig::board_autodetect(void)
 {
 #if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
-    {
-        if (state.board_type != PX4_BOARD_PIXHAWK2) {
-            state.board_type.set(PX4_BOARD_PIXHAWK2);
-        }
-
-        bool success = true;
-        if (!spi_check_register("mpu9250", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
-        if (!spi_check_register("mpu9250_ext", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
-        if (!spi_check_register("lsm9ds0_ext_g", LSMREG_WHOAMI, LSM_WHOAMI_L3GD20)) { success = false; }
-        if (!spi_check_register("lsm9ds0_ext_am", LSMREG_WHOAMI, LSM_WHOAMI_LSM303D)) { success = false; }
-        if (!check_ms5611("ms5611")) { success = false; }
-        if (!check_ms5611("ms5611_ext")) { success = false; }
-
-        if (!success) {
-            sensor_config_error("Failed to init CubeBlack - sensor mismatch");
-        }
-        return;
-    }
+    check_cubeblack();
+    return;
 #endif
 
     if (state.board_type != PX4_BOARD_AUTO) {

--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -145,6 +145,90 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
     return v == value;
 }
 
+/**
+ * MS56XX crc4 method from datasheet for 16 bytes (8 short values)
+ */
+static uint16_t crc4(uint16_t *data)
+{
+    uint16_t n_rem = 0;
+    uint8_t n_bit;
+
+    for (uint8_t cnt = 0; cnt < 16; cnt++) {
+        /* uneven bytes */
+        if (cnt & 1) {
+            n_rem ^= (uint8_t)((data[cnt >> 1]) & 0x00FF);
+        } else {
+            n_rem ^= (uint8_t)(data[cnt >> 1] >> 8);
+        }
+
+        for (n_bit = 8; n_bit > 0; n_bit--) {
+            if (n_rem & 0x8000) {
+                n_rem = (n_rem << 1) ^ 0x3000;
+            } else {
+                n_rem = (n_rem << 1);
+            }
+        }
+    }
+
+    return (n_rem >> 12) & 0xF;
+}
+
+static bool check_ms5611(const char* devname) {
+    auto dev = hal.spi->get_device(devname);
+    AP_HAL::Semaphore *dev_sem = dev->get_semaphore();
+    if (!dev || !dev_sem) {
+#if SPI_PROBE_DEBUG
+        hal.console->printf("%s: no device\n", devname);
+#endif
+        return false;
+    }
+    if (!dev_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
+        return false;
+    }
+
+    static const uint8_t CMD_MS56XX_RESET = 0x1E;
+    static const uint8_t CMD_MS56XX_PROM = 0xA0;
+
+    dev->transfer(&CMD_MS56XX_RESET, 1, nullptr, 0);
+    hal.scheduler->delay(4);
+
+    uint16_t prom[8];
+    bool all_zero = true;
+    for (uint8_t i = 0; i < 8; i++) {
+        const uint8_t reg = CMD_MS56XX_PROM + (i << 1);
+        uint8_t val[2];
+        if (!dev->transfer(&reg, 1, val, sizeof(val))) {
+            dev_sem->give();
+#if SPI_PROBE_DEBUG
+            hal.console->printf("%s: transfer fail\n", devname);
+#endif
+            return false;
+        }
+        prom[i] = (val[0] << 8) | val[1];
+
+        if (prom[i] != 0) {
+            all_zero = false;
+        }
+    }
+    dev_sem->give();
+
+    uint16_t crc_read = prom[7]&0xf;
+    prom[7] &= 0xff00;
+
+    if (crc_read != crc4(prom) || all_zero) {
+#if SPI_PROBE_DEBUG
+        hal.console->printf("%s: crc fail\n", devname);
+#endif
+        return false;
+    }
+
+#if SPI_PROBE_DEBUG
+    hal.console->printf("%s: found successfully\n", devname);
+#endif
+
+    return true;
+}
+
 #define MPUREG_WHOAMI 0x75
 #define MPU_WHOAMI_MPU60X0  0x68
 #define MPU_WHOAMI_MPU9250  0x71
@@ -153,6 +237,7 @@ bool AP_BoardConfig::spi_check_register(const char *devname, uint8_t regnum, uin
 
 #define LSMREG_WHOAMI 0x0f
 #define LSM_WHOAMI_LSM303D 0x49
+#define LSM_WHOAMI_L3GD20 0xd4
 
 /*
   validation of the board type
@@ -188,11 +273,34 @@ void AP_BoardConfig::validate_board_type(void)
 #endif
 }
 
+
+
 /*
   auto-detect board type
  */
 void AP_BoardConfig::board_autodetect(void)
 {
+#if defined(HAL_CHIBIOS_ARCH_CUBEBLACK)
+    {
+        if (state.board_type != PX4_BOARD_PIXHAWK2) {
+            state.board_type.set(PX4_BOARD_PIXHAWK2);
+        }
+
+        bool success = true;
+        if (!spi_check_register("mpu9250", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
+        if (!spi_check_register("mpu9250_ext", MPUREG_WHOAMI, MPU_WHOAMI_MPU9250)) { success = false; }
+        if (!spi_check_register("lsm9ds0_ext_g", LSMREG_WHOAMI, LSM_WHOAMI_L3GD20)) { success = false; }
+        if (!spi_check_register("lsm9ds0_ext_am", LSMREG_WHOAMI, LSM_WHOAMI_LSM303D)) { success = false; }
+        if (!check_ms5611("ms5611")) { success = false; }
+        if (!check_ms5611("ms5611_ext")) { success = false; }
+
+        if (!success) {
+            sensor_config_error("Failed to init CubeBlack - sensor mismatch");
+        }
+        return;
+    }
+#endif
+
     if (state.board_type != PX4_BOARD_AUTO) {
         validate_board_type();
         // user has chosen a board type

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/hwdef.dat
@@ -4,6 +4,8 @@
 
 include ../fmuv3/hwdef.dat
 
+define HAL_CHIBIOS_ARCH_CUBEBLACK 1
+
 # USB setup
 USB_VENDOR 0x2DAE # ONLY FOR USE BY HEX! NOBODY ELSE
 USB_PRODUCT 0x1011


### PR DESCRIPTION
This is #11173 but cherry-picked onto the Copter-3.6 branch.