### PR TITLE
Fix GPS Health in ArduPlane

### DIFF
--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -105,7 +105,7 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION;
     }
 
-    if (gps.status() >= AP_GPS::GPS_OK_FIX_3D && gps.is_healthy()) {
+    if (gps.is_healthy()) {
         control_sensors_health |= MAV_SYS_STATUS_SENSOR_GPS;
     }
 #if OPTFLOW == ENABLED


### PR DESCRIPTION
Fix for (Incorrect) Use of GPS_OK_FIX_3D to determine GPS Health. This is a PR for issue raised in:

[https://github.com/ArduPilot/ardupilot/issues/11169](url)

This would make this code inline with code for GPS health in other vehicles such as Rover, Copter etc.