### PR TITLE
AP_HAL_ChibiOS: fix F35Lightning compiler warnings

### DIFF
--- a/libraries/AP_HAL_ChibiOS/stdio.cpp
+++ b/libraries/AP_HAL_ChibiOS/stdio.cpp
@@ -167,6 +167,7 @@ __wrap_sscanf (const char *buf, const char *fmt, ...)
     return (count);
 }
 
+#if defined(HAL_OS_FATFS_IO) && HAL_OS_FATFS_IO
 static char *
 _getbase(char *p, int *basep)
 {
@@ -260,7 +261,6 @@ static int16_t atob(uint32_t *vp, char *p, int base)
 }
 
 
-#if defined(HAL_OS_FATFS_IO) && HAL_OS_FATFS_IO
 /*
  *  vsscanf(buf,fmt,ap)
  */


### PR DESCRIPTION
Fixes stdio.cpp atop & _getbase defined but not used on building F35Lightning firmware