### PR TITLE
Rover: add param FS_THR_TIMEOUT

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -701,6 +701,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(scripting, "SCR_", 41, ParametersG2, AP_Scripting),
 #endif
 
+    // @Param: FS_THR_TIMEOUT
+    // @DisplayName: Failsafe for RC throttle timeout
+    // @Description: Failsafe for RC throttle timeout. If there is no RC throttle input, either from an RC receiver or MAVLink override command, in this amount of time then a RC throttle failsafe occurs. Set to 0 to disable.
+    // @Units: s
+    // @Range: 0 2
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("FS_THR_TIMEOUT", 42, ParametersG2, fs_thr_timeout, 0.5f),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -397,6 +397,8 @@ public:
     // balance both pitch trim
     AP_Float bal_pitch_trim;
 
+    AP_Float fs_thr_timeout;
+
 #ifdef ENABLE_SCRIPTING
     AP_Scripting scripting;
 #endif // ENABLE_SCRIPTING

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -125,7 +125,7 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     }
 
     bool failed = pwm < static_cast<uint16_t>(g.fs_throttle_value);
-    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 200) {
+    if (g2.fs_thr_timeout > 0 && AP_HAL::millis() - failsafe.last_valid_rc_ms >= (g2.fs_thr_timeout * 1000)) {
         failed = true;
     }
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);


### PR DESCRIPTION
Description: Failsafe for RC timeout. If there is no RC input, either from an RC receiver or MAVLink override command, in this amount of time then a RC throttle failsafe occurs. Set to 0 to disable.


Note, this changes the timeout from a hardcoded 200ms to a param defaulted at 500ms. 
@rmackay9 originally added this for AION a while back and 200 is just too short for MAVLink based high-latency links. Changing it to a param allows for application/link-specific scenarios.