### PR TITLE
Copter: improve heading in Circle mode and LOITER_TURNS

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -573,12 +573,26 @@ bool Copter::ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 
 uint32_t Copter::ModeAuto::wp_distance() const
 {
-    return wp_nav->get_wp_distance_to_destination();
+    switch (_mode) {
+    case Auto_Circle:
+        return copter.circle_nav->get_distance_to_target();
+    case Auto_WP:
+    case Auto_CircleMoveToEdge:
+    default:
+        return wp_nav->get_wp_distance_to_destination();
+    }
 }
 
 int32_t Copter::ModeAuto::wp_bearing() const
 {
-    return wp_nav->get_wp_bearing_to_destination();
+    switch (_mode) {
+    case Auto_Circle:
+        return copter.circle_nav->get_bearing_to_target();
+    case Auto_WP:
+    case Auto_CircleMoveToEdge:
+    default:
+        return wp_nav->get_wp_bearing_to_destination();
+    }
 }
 
 bool Copter::ModeAuto::get_wp(Location& destination)

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -142,8 +142,8 @@ void AC_Circle::update()
         // update position controller target
         _pos_control.set_xy_target(target.x, target.y);
 
-        // heading is 180 deg from vehicles target position around circle
-        _yaw = wrap_PI(_angle-M_PI) * DEGX100;
+        // heading is from vehicle to center of circle
+        _yaw = get_bearing_cd(_inav.get_position(), _center);
     } else {
         // set target position to center
         Vector3f target;


### PR DESCRIPTION
This PR makes two improvements related to Circle mode

- fix a bug in the reporting of heading and distance to target while executing the LOITER_TURNS mission command in Auto mode.  Previously the values returned were coming from the waypoint controller which is only used to move the vehicle to the edge of the circle.  With this change, once the vehicle starts rotating it properly shows a target that is a few meters ahead of the vehicle (see image below)
- calculate the heading to the center of the circle during the update call (i.e. 400hz).  This uses an atan2 function which is a bit heavy but we have the CPU these days (it was originally done without the atan2 to save CPU on the old APM2.x boards)

The image below shows the before and after when executing a LOITER_TURNS command
![circle-yaw-fix](https://user-images.githubusercontent.com/1498098/56711403-a17a1080-6765-11e9-9af0-b8200807a22e.png)

- In the BEFORE image the red line is going to the right of the vehicle even though the vehicle is rotating in a clockwise direction.  It's stuck connected to the edge of the circle where the vehicle flew to.  In the AFTER it's correctly a few meters to the left of the vehicle
- The vehicle is rotating around home (see white house icon) but in the BEFORE image we can see the vehicle is pointed slightly to the right of Home.  In the AFTER image it is pointing much more closely to Home.
