### PR TITLE
Heartbeat interval handled by library instead of vehicle

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -254,9 +254,6 @@ void Rover::update_logging2(void)
  */
 void Rover::one_second_loop(void)
 {
-    // send a heartbeat
-    gcs().send_message(MSG_HEARTBEAT);
-
     // allow orientation change at runtime to aid config
     ahrs.update_orientation();
 

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -83,9 +83,6 @@ void Tracker::loop()
 
 void Tracker::one_second_loop()
 {
-    // send a heartbeat
-    gcs().send_message(MSG_HEARTBEAT);
-
     // make it possible to change orientation at runtime
     ahrs.update_orientation();
 

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -136,7 +136,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(landinggear_update,    10,     75),
     SCHED_TASK(lost_vehicle_check,    10,     50),
     SCHED_TASK_CLASS(GCS,                  (GCS*)&copter._gcs,          update_receive, 400, 180),
-    SCHED_TASK(gcs_send_heartbeat,     1,    110),
     SCHED_TASK_CLASS(GCS,                  (GCS*)&copter._gcs,          update_send,    400, 550),
 #if MOUNT == ENABLED
     SCHED_TASK_CLASS(AP_Mount,             &copter.camera_mount,        update,          50,  75),

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -258,9 +258,6 @@ extern AP_IOMCU iomcu;
 
 void Plane::one_second_loop()
 {
-    // send a heartbeat
-    gcs().send_message(MSG_HEARTBEAT);
-
     // make it possible to change control channel ordering at runtime
     set_control_channels();
 

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -39,7 +39,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Notify,           &sub.notify,       update,              50,  90),
     SCHED_TASK(one_hz_loop,            1,    100),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_receive,     400, 180),
-    SCHED_TASK(gcs_send_heartbeat,     1,    110),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_send,        400, 550),
 #if MOUNT == ENABLED
     SCHED_TASK_CLASS(AP_Mount,            &sub.camera_mount, update,              50,  75),

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4428,10 +4428,17 @@ void GCS_MAVLINK::initialise_message_intervals_from_streamrates()
     for (uint8_t i=0; all_stream_entries[i].ap_message_ids != nullptr; i++) {
         initialise_message_intervals_for_stream(all_stream_entries[i].stream_id);
     }
+    set_mavlink_message_id_interval(MAVLINK_MSG_ID_HEARTBEAT, 1000);
 }
 
 bool GCS_MAVLINK::get_default_interval_for_ap_message(const ap_message id, uint16_t &interval) const
 {
+    if (id == MSG_HEARTBEAT) {
+        // handle heartbeat requests as a special case because heartbeat is not "streamed"
+        interval = 1000;
+        return true;
+    }
+
     // find which stream this ap_message is in
     for (uint8_t i=0; all_stream_entries[i].ap_message_ids != nullptr; i++) {
         const GCS_MAVLINK::stream_entries &entries = all_stream_entries[i];


### PR DESCRIPTION
Heartbeat interval handled by library instead of vehicle.

There's one additional special handling which could be removed in [mavlink_delay_cb](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_Mavlink.cpp#L1279).