### PR TITLE
Rover: increase RC timeout failsafe from 200ms to 500ms.

### DIFF
--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -125,7 +125,7 @@ void Rover::radio_failsafe_check(uint16_t pwm)
     }
 
     bool failed = pwm < static_cast<uint16_t>(g.fs_throttle_value);
-    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 200) {
+    if (AP_HAL::millis() - failsafe.last_valid_rc_ms > 500) {
         failed = true;
     }
     failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);


### PR DESCRIPTION
Rover: increase RC timeout failsafe from 200ms to 500ms.
- this allows for a smoother MAVLink_RC_Override over nasty lossy links