### PR TITLE
Tools: waf: ignore -Waddress-of-packed-member

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -173,6 +173,7 @@ class Board:
             '-Werror=unused-variable',
             '-Wfatal-errors',
             '-Wno-trigraphs',
+            '-Wno-address-of-packed-member',
         ]
 
         if 'clang++' in cfg.env.COMPILER_CXX:


### PR DESCRIPTION
In file included from libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/../common/common.h:1139,
                 from libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h:956,
                 from libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/mavlink.h:32,
                 from ../../libraries/GCS_MAVLink/GCS_MAVLink.h:73,
                 from ../../libraries/AP_Compass/AP_Compass.h:10,
                 from ../../libraries/AP_AHRS/AP_AHRS.h:25,
                 from ../../libraries/APM_Control/AP_PitchController.h:3,
                 from ../../libraries/APM_Control/AP_PitchController.cpp:20:
libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/../common/./mavlink_msg_attitude_quaternion_cov.h: In function ‘uint16_t mavlink_msg_attitude_quaternion_cov_encode(uint8_t, uint8_t, mavlink_message_t*, const mavlink_attitude_quaternion_cov_t*)’:
libraries/GCS_MAVLink/include/mavlink/v2.0/ardupilotmega/../common/./mavlink_msg_attitude_quaternion_cov.h:147:144: warning: taking address of packed member of ‘__mavlink_attitude_quaternion_cov_t’ may result in an unaligned pointer value [-Waddress-of-packed-member]

  147 |     return mavlink_msg_attitude_quaternion_cov_pack(system_id, component_id, msg, attitude_quaternion_cov->time_usec, attitude_quaternion_cov->q, attitude_quaternion_cov->rollspeed, attitude_quaternion_cov->pitchspeed, attitude_quaternion_cov->yawspeed, attitude_quaternion_cov->covariance);
      |                                                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~^

This warning started appearing with gcc 9. Several of those per
compilation unit.

All architectures we support allow unaligned access - it may be more
expensive, but should work. So just ignore the warning.