### PR TITLE
Libraries: Comment out unused methods

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -244,11 +244,12 @@ bool AP_Compass_AK8963::_setup_mode() {
     return _bus->register_write(AK8963_CNTL1, AK8963_CONTINUOUS_MODE2 | AK8963_16BIT_ADC);
 }
 
+#if 0  // Not used
 bool AP_Compass_AK8963::_reset()
 {
     return _bus->register_write(AK8963_CNTL2, AK8963_RESET);
 }
-
+#endif
 
 bool AP_Compass_AK8963::_calibrate()
 {

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -43,7 +43,9 @@ private:
     void _make_factory_sensitivity_adjustment(Vector3f &field) const;
     void _make_adc_sensitivity_adjustment(Vector3f &field) const;
 
+#if 0  // Not used
     bool _reset();
+#endif
     bool _setup_mode();
     bool _check_id();
     bool _calibrate();

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -121,6 +121,7 @@ errout:
     return false;
 }
 
+#if 0  // Not used
 void AP_Compass_LSM9DS1::_dump_registers()
 {
     hal.console->printf("LSMDS1 registers\n");
@@ -133,6 +134,7 @@ void AP_Compass_LSM9DS1::_dump_registers()
     }
     hal.console->printf("\n");
 }
+#endif
 
 void AP_Compass_LSM9DS1::_update(void)
 {

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -33,7 +33,9 @@ private:
     void _register_write(uint8_t reg, uint8_t val);
     void _register_modify(uint8_t reg, uint8_t clearbits, uint8_t setbits);
     bool _block_read(uint8_t reg, uint8_t *buf, uint32_t size);
+#if 0  // Not used
     void _dump_registers();
+#endif
 
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
     uint8_t _compass_instance;

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -203,6 +203,7 @@ void AP_Compass_QMC5883L::read()
     drain_accumulated_samples(_instance);
 }
 
+#if 0  // Not Used
 void AP_Compass_QMC5883L::_dump_registers()
 {
 	  printf("QMC5883L registers dump\n");
@@ -215,4 +216,4 @@ void AP_Compass_QMC5883L::_dump_registers()
 	        }
 	    }
 }
-
+#endif

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -54,8 +54,9 @@ private:
     AP_Compass_QMC5883L(AP_HAL::OwnPtr<AP_HAL::Device> dev,
                         bool force_external,
                         enum Rotation rotation);
-
+#if 0  // Not used
     void _dump_registers();
+#endif
     bool _check_whoami();
     void timer();
     bool init();

--- a/libraries/AP_GPS/AP_GPS_SBP2.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP2.cpp
@@ -437,6 +437,7 @@ AP_GPS_SBP2::_detect(struct SBP2_detect_state &state, uint8_t data)
     return false;
 }
 
+#if 0  // Not used
 void
 AP_GPS_SBP2::logging_log_full_update()
 {
@@ -456,6 +457,7 @@ AP_GPS_SBP2::logging_log_full_update()
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 };
+#endif
 
 void
 AP_GPS_SBP2::logging_log_raw_sbp(uint16_t msg_type,

--- a/libraries/AP_GPS/AP_GPS_SBP2.h
+++ b/libraries/AP_GPS/AP_GPS_SBP2.h
@@ -193,8 +193,9 @@ private:
     // ************************************************************************
     // Logging to AP_Logger
     // ************************************************************************
-
+#if 0  // Not used
     void logging_log_full_update();
+#endif
     void logging_ext_event();
     void logging_log_raw_sbp(uint16_t msg_type, uint16_t sender_id, uint8_t msg_len, uint8_t *msg_buff);
 

--- a/libraries/AP_Gripper/AP_Gripper_EPM.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_EPM.cpp
@@ -117,6 +117,7 @@ void AP_Gripper_EPM::update_gripper()
     }
 }
 
+#if 0  // Not used
 UAVCANCommand AP_Gripper_EPM::make_uavcan_command(uint16_t command) const
 {
     UAVCANCommand cmd;
@@ -124,6 +125,7 @@ UAVCANCommand AP_Gripper_EPM::make_uavcan_command(uint16_t command) const
     cmd.command = command;
     return cmd;
 }
+#endif
 
 
 bool AP_Gripper_EPM::released() const

--- a/libraries/AP_Gripper/AP_Gripper_EPM.h
+++ b/libraries/AP_Gripper/AP_Gripper_EPM.h
@@ -51,9 +51,9 @@ private:
     void        neutral();
 
     bool should_use_uavcan() const { return _uavcan_fd >= 0; }
-
+#if 0  // Not used
     struct UAVCANCommand make_uavcan_command(uint16_t command) const;
-
+#endif
     // UAVCAN driver fd
     int _uavcan_fd = -1;
 

--- a/libraries/AP_Logger/AP_Logger_DataFlash.cpp
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.cpp
@@ -278,6 +278,7 @@ void AP_Logger_DataFlash::WriteEnable(void)
     dev->transfer(&b, 1, NULL, 0);
 }
 
+#if 0  // Not used
 void AP_Logger_DataFlash::flash_test()
 {
     for (uint8_t i=1; i<=20; i++) {
@@ -299,5 +300,6 @@ void AP_Logger_DataFlash::flash_test()
         }
     }
 }
+#endif
 
 #endif // HAL_LOGGING_DATAFLASH

--- a/libraries/AP_Logger/AP_Logger_DataFlash.h
+++ b/libraries/AP_Logger/AP_Logger_DataFlash.h
@@ -30,7 +30,9 @@ private:
     
     void              WriteEnable();
     bool              getSectorCount(void);
+#if 0  // Not used
     void              flash_test(void);
+#endif
 
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
     AP_HAL::Semaphore *dev_sem;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.cpp
@@ -203,11 +203,13 @@ uint16_t AP_OpticalFlow_Pixart::reg_read16u(uint8_t reg)
     return low | (high<<8);
 }
 
+#if 0  // Not used
 // read from a 16 bit signed register
 int16_t AP_OpticalFlow_Pixart::reg_read16s(uint8_t reg)
 {
     return (int16_t)reg_read16u(reg);
 }
+#endif
 
 void AP_OpticalFlow_Pixart::srom_download(void)
 {

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Pixart.h
@@ -63,7 +63,9 @@ private:
     
     void reg_write(uint8_t reg, uint8_t value);
     uint8_t reg_read(uint8_t reg);
+#if 0  // Not used
     int16_t reg_read16s(uint8_t reg);
+#endif
     uint16_t reg_read16u(uint8_t reg);
 
     void srom_download(void);

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -230,6 +230,7 @@ void AP_Proximity_RPLidarA2::set_scan_mode()
     _rp_state = rp_responding;
 }
 
+#if 0  // Not used
 // send request for sensor health
 void AP_Proximity_RPLidarA2::send_request_for_health()                                    //not called yet
 {
@@ -241,6 +242,7 @@ void AP_Proximity_RPLidarA2::send_request_for_health()                          
     _last_request_ms = AP_HAL::millis();
     _rp_state = rp_health;
 }
+#endif
 
 void AP_Proximity_RPLidarA2::get_readings()
 {

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -73,7 +73,9 @@ private:
     void set_scan_mode();
 
     // send request for something from sensor
+#if 0  // Not used
     void send_request_for_health();
+#endif
     void parse_response_data();
     void parse_response_descriptor();
     void get_readings();

--- a/libraries/AP_Radio/AP_Radio_cypress.cpp
+++ b/libraries/AP_Radio/AP_Radio_cypress.cpp
@@ -637,6 +637,7 @@ void AP_Radio_cypress::radio_init(void)
 #endif
 }
 
+#if 0  // Not used
 void AP_Radio_cypress::dump_registers(uint8_t n)
 {
     for (uint8_t i=0; i<n; i++) {
@@ -650,6 +651,7 @@ void AP_Radio_cypress::dump_registers(uint8_t n)
         printf("\n");
     }
 }
+#endif
 
 /*
   read one register value

--- a/libraries/AP_Radio/AP_Radio_cypress.h
+++ b/libraries/AP_Radio/AP_Radio_cypress.h
@@ -80,9 +80,9 @@ private:
     static AP_Radio_cypress *radio_singleton;
 
     void radio_init(void);
-    
+#if 0  // Not used    
     void dump_registers(uint8_t n);
-
+#endif
     void force_initial_state(void);
     void set_channel(uint8_t channel);
     uint8_t read_status_debounced(uint8_t adr);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.cpp
@@ -467,6 +467,7 @@ uint16_t AP_RangeFinder_VL53L1X::read_register16(uint16_t reg)
     return be16toh(v);
 }
 
+#if 0  // Not used
 uint32_t AP_RangeFinder_VL53L1X::read_register32(uint16_t reg)
 {
     uint32_t v = 0;
@@ -474,6 +475,7 @@ uint32_t AP_RangeFinder_VL53L1X::read_register32(uint16_t reg)
     dev->transfer(b, 2, (uint8_t *)&v, 4);
     return be32toh(v);
 }
+#endif
 
 void AP_RangeFinder_VL53L1X::write_register(uint16_t reg, uint8_t value)
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L1X.h
@@ -1276,7 +1276,9 @@ private:
 
     uint8_t read_register(uint16_t reg);
     uint16_t read_register16(uint16_t reg);
+#if 0  // Not used
     uint32_t read_register32(uint16_t reg);
+#endif
     void write_register(uint16_t reg, uint8_t value);
     void write_register16(uint16_t reg, uint16_t value);
     void write_register32(uint16_t reg, uint32_t value);

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -74,6 +74,7 @@ float SimRover::calc_yaw_rate(float steering, float speed)
     return rate;
 }
 
+#if 0  // Not used
 /*
   return lateral acceleration in m/s/s
 */
@@ -83,6 +84,7 @@ float SimRover::calc_lat_accel(float steering_angle, float speed)
     float accel = radians(yaw_rate) * speed;
     return accel;
 }
+#endif
 
 /*
   update the rover simulation by one time step

--- a/libraries/SITL/SIM_Rover.h
+++ b/libraries/SITL/SIM_Rover.h
@@ -47,7 +47,9 @@ private:
 
     float turn_circle(float steering);
     float calc_yaw_rate(float steering, float speed);
+#if 0  // Not used
     float calc_lat_accel(float steering_angle, float speed);
+#endif
 };
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -85,6 +85,7 @@ float Sailboat::get_yaw_rate(float steering, float speed) const
     return rate;
 }
 
+#if 0  // Not used
 // return lateral acceleration in m/s/s given a steering input (in the range -1 to +1) and speed in m/s
 float Sailboat::get_lat_accel(float steering, float speed) const
 {
@@ -92,6 +93,7 @@ float Sailboat::get_lat_accel(float steering, float speed) const
     float accel = radians(yaw_rate) * speed;
     return accel;
 }
+#endif
 
 /*
   update the sailboat simulation by one time step

--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -47,10 +47,10 @@ private:
 
     // return yaw rate in deg/sec given a steering input (in the range -1 to +1) and speed in m/s
     float get_yaw_rate(float steering, float speed) const;
-
+#if 0  // Not used
     // return lateral acceleration in m/s/s given a steering input (in the range -1 to +1) and speed in m/s
     float get_lat_accel(float steering, float speed) const;
-
+#endif
     float steering_angle_max;   // vehicle steering mechanism's max angle in degrees
     float turning_circle;       // vehicle minimum turning circle diameter in meters
 


### PR DESCRIPTION
I found with the cppcheck tool that there is an unused method.
I could not easily determine which method is being used and which method is being used.
I thought that it could be easily determined by specifying it with #if 0 and #endif preprocessors.