### PR TITLE
ChibiOS: added timeouts on all SPI transfers

### DIFF
--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -125,7 +125,7 @@ private:
     static uint32_t derive_freq_flag_bus(uint8_t busid, uint32_t _frequency);
     uint32_t derive_freq_flag(uint32_t _frequency);
     // low level transfer function
-    bool do_transfer(const uint8_t *send, uint8_t *recv, uint32_t len);
+    bool do_transfer(const uint8_t *send, uint8_t *recv, uint32_t len) WARN_IF_UNUSED;
 };
 
 class SPIDeviceManager : public AP_HAL::SPIDeviceManager {

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -74,9 +74,6 @@ public:
     /* See AP_HAL::Device::set_speed() */
     bool set_speed(AP_HAL::Device::Speed speed) override;
 
-    // low level transfer function
-    void do_transfer(const uint8_t *send, uint8_t *recv, uint32_t len);
-
     /* See AP_HAL::Device::transfer() */
     bool transfer(const uint8_t *send, uint32_t send_len,
                   uint8_t *recv, uint32_t recv_len) override;
@@ -127,6 +124,8 @@ private:
     static void *spi_thread(void *arg);
     static uint32_t derive_freq_flag_bus(uint8_t busid, uint32_t _frequency);
     uint32_t derive_freq_flag(uint32_t _frequency);
+    // low level transfer function
+    bool do_transfer(const uint8_t *send, uint8_t *recv, uint32_t len);
 };
 
 class SPIDeviceManager : public AP_HAL::SPIDeviceManager {

--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -47,6 +47,7 @@ public:
         watchdog_reset              = (1U << 11),
         iomcu_reset                 = (1U << 12),
         iomcu_fail                  = (1U << 13),
+        spi_fail                    = (1U << 14),
     };
 
     void error(const AP_InternalError::error_t error);


### PR DESCRIPTION
this is never expected to trigger unless we have a severe MCU error as SPI transfers don't rely on a response from a device.
The only case that we could get a timeout is when a bug leads to use doing transfers from memory that does not support the DMA transaction (such as on H7). This change turns that from a immediately fatal lockup into a bus error and failed sensor
