### PR TITLE
SITL: Reliably sync to JSBSim simulation time

### DIFF
--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -133,7 +133,9 @@ bool JSBSim::create_templates(void)
         AP_HAL::panic("Unable to create jsbsim fgout script %s", jsbsim_fgout);
     }
     fprintf(f, "<?xml version=\"1.0\"?>\n"
-            "<output name=\"127.0.0.1\" type=\"FLIGHTGEAR\" port=\"%u\" protocol=\"UDP\" rate=\"%f\"/>\n",
+            "<output name=\"127.0.0.1\" type=\"FLIGHTGEAR\" port=\"%u\" protocol=\"UDP\" rate=\"%f\">\n"
+            "  <time type=\"simulation\" resolution=\"1e-6\"/>\n"
+            "</output>",
             fdm_port, rate_hz);
     fclose(f);
 

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -198,9 +198,11 @@ bool JSBSim::start_JSBSim(void)
         }
         char *logdirective;
         char *script;
+        char *nice;
 
         asprintf(&logdirective, "--logdirectivefile=%s", jsbsim_fgout);
         asprintf(&script, "--script=%s", jsbsim_script);
+        asprintf(&nice, "--nice=%.8f", 10*1e-9);
 
         if (chdir(autotest_dir) != 0) {
             perror(autotest_dir);
@@ -209,10 +211,9 @@ bool JSBSim::start_JSBSim(void)
 
         int ret = execlp("JSBSim",
                          "JSBSim",
-                         "--realtime",
                          "--suspend",
-                         "--nice",
                          "--simulation-rate=1000",
+                         nice,
                          logdirective,
                          script,
                          nullptr);


### PR DESCRIPTION
This is a fix to solve the synchronization issues between JSBSim and Ardupilot SITL. This was first reported by @simfinite [in this post on the Discuss page](https://discuss.ardupilot.org/t/arduplane-jsbsim-synchronization-lock-step-mechanism-issues/38781)

Since then, this topic has been extensively discussed on issue #10612 

@simfinite has another slightly different workaround which can be seen in this commit: https://github.com/simfinite/ardupilot/commit/8485904142b46f2c0255852b1d0a93482fcb664a

Note that both approaches require changes in the JSBSim source code to transmit the JSBSim simulation time using the currently unused parameter `curr_time`
A PR for making the change has been opened in the JSBSim repo: https://github.com/JSBSim-Team/jsbsim/pull/187
Therefore this PR can be merged only after the above one is merged into JSBSim

A few results after this fix-

Video of the simulation with this PR: https://drive.google.com/open?id=1HCJVeFOXrGiPQccsg3Z1R5U0efZmQzAk

Before the fix, a log of the time-lag between JSBSim and SITL
```
time lag: 9264000 us, ArduPlane time: 31497000 us , JSBSim time: 22233000 us
time lag: 9264000 us, ArduPlane time: 31498000 us , JSBSim time: 22234000 us
time lag: 9264000 us, ArduPlane time: 31499000 us , JSBSim time: 22235000 us
time lag: 9265000 us, ArduPlane time: 31500000 us , JSBSim time: 22235000 us
time lag: 9265000 us, ArduPlane time: 31501000 us , JSBSim time: 22236000 us
time lag: 9266000 us, ArduPlane time: 31502000 us , JSBSim time: 22236000 us
time lag: 9266000 us, ArduPlane time: 31503000 us , JSBSim time: 22237000 us
time lag: 9266000 us, ArduPlane time: 31504000 us , JSBSim time: 22238000 us
time lag: 9267000 us, ArduPlane time: 31505000 us , JSBSim time: 22238000 us
time lag: 9267000 us, ArduPlane time: 31506000 us , JSBSim time: 22239000 us
time lag: 9267000 us, ArduPlane time: 31507000 us , JSBSim time: 22240000 us
time lag: 9268000 us, ArduPlane time: 31508000 us , JSBSim time: 22240000 us
time lag: 9268000 us, ArduPlane time: 31509000 us , JSBSim time: 22241000 us
time lag: 9269000 us, ArduPlane time: 31510000 us , JSBSim time: 22241000 us
time lag: 9269000 us, ArduPlane time: 31511000 us , JSBSim time: 22242000 us
time lag: 9269000 us, ArduPlane time: 31512000 us , JSBSim time: 22243000 us
time lag: 9270000 us, ArduPlane time: 31513000 us , JSBSim time: 22243000 us
time lag: 9270000 us, ArduPlane time: 31514000 us , JSBSim time: 22244000 us
time lag: 9270000 us, ArduPlane time: 31515000 us , JSBSim time: 22245000 us
time lag: 9271000 us, ArduPlane time: 31516000 us , JSBSim time: 22245000 us
time lag: 9271000 us, ArduPlane time: 31517000 us , JSBSim time: 22246000 us
time lag: 9272000 us, ArduPlane time: 31518000 us , JSBSim time: 22246000 us
time lag: 9272000 us, ArduPlane time: 31519000 us , JSBSim time: 22247000 us
time lag: 9272000 us, ArduPlane time: 31520000 us , JSBSim time: 22248000 us
time lag: 9273000 us, ArduPlane time: 31521000 us , JSBSim time: 22248000 us
time lag: 9273000 us, ArduPlane time: 31522000 us , JSBSim time: 22249000 us
time lag: 9273000 us, ArduPlane time: 31523000 us , JSBSim time: 22250000 us
time lag: 9274000 us, ArduPlane time: 31524000 us , JSBSim time: 22250000 us
time lag: 9274000 us, ArduPlane time: 31525000 us , JSBSim time: 22251000 us
time lag: 9274000 us, ArduPlane time: 31526000 us , JSBSim time: 22252000 us
time lag: 9274000 us, ArduPlane time: 31527000 us , JSBSim time: 22253000 us
time lag: 9274000 us, ArduPlane time: 31528000 us , JSBSim time: 22254000 us
time lag: 9274000 us, ArduPlane time: 31529000 us , JSBSim time: 22255000 us
time lag: 9274000 us, ArduPlane time: 31530000 us , JSBSim time: 22256000 us
time lag: 9274000 us, ArduPlane time: 31531000 us , JSBSim time: 22257000 us
```

Afterwards:
```
time lag: 0 us, ArduPlane time: 19435000 us , JSBSim time: 19435000 us
time lag: 0 us, ArduPlane time: 19436000 us , JSBSim time: 19436000 us
time lag: 0 us, ArduPlane time: 19437000 us , JSBSim time: 19437000 us
time lag: 0 us, ArduPlane time: 19438000 us , JSBSim time: 19438000 us
time lag: 0 us, ArduPlane time: 19439000 us , JSBSim time: 19439000 us
time lag: 0 us, ArduPlane time: 19440000 us , JSBSim time: 19440000 us
time lag: 0 us, ArduPlane time: 19441000 us , JSBSim time: 19441000 us
time lag: 0 us, ArduPlane time: 19442000 us , JSBSim time: 19442000 us
time lag: 0 us, ArduPlane time: 19443000 us , JSBSim time: 19443000 us
time lag: 0 us, ArduPlane time: 19444000 us , JSBSim time: 19444000 us
time lag: 0 us, ArduPlane time: 19445000 us , JSBSim time: 19445000 us
time lag: 0 us, ArduPlane time: 19446000 us , JSBSim time: 19446000 us
time lag: 0 us, ArduPlane time: 19447000 us , JSBSim time: 19447000 us
time lag: 0 us, ArduPlane time: 19448000 us , JSBSim time: 19448000 us
time lag: 0 us, ArduPlane time: 19449000 us , JSBSim time: 19449000 us
time lag: 0 us, ArduPlane time: 19450000 us , JSBSim time: 19450000 us
time lag: 0 us, ArduPlane time: 19451000 us , JSBSim time: 19451000 us
time lag: 0 us, ArduPlane time: 19452000 us , JSBSim time: 19452000 us
```

While looking into this matter, a few other inconsistencies were found

JSBSim is currently being run in realtime mode (with the `--realtime` flag). The problem is that in realtime mode, the `iterate 1` command that is being used to let JSBSim run one frame and suspend afterwards [is not supported](https://github.com/JSBSim-Team/jsbsim/blob/06f4ce37619d73c619c6296d1f602b10088bd95d/src/JSBSim.cpp#L507). This is being used to implement Lock-step Scheduling
It can be seen from the [JSBSim sources](https://github.com/JSBSim-Team/jsbsim/blob/06f4ce37619d73c619c6296d1f602b10088bd95d/src/JSBSim.cpp) (lines 515-545) that in realtime mode, more than one frame can be executed each time JSBSim runs.

Therefore, in order to use the `iterate` command, JSBSim needs to be run in Batch mode. This has also been discussed in the issue
My other branch with commits for this: https://github.com/rajat2004/ardupilot/tree/jsbsim-test2

Also, the simulation rate is currently fixed at 1000Hz, i.e. it's not set as a defined parameter but hardcoded into the time-step and XML file. This can also be changed. 

The above issues can also be fixed in this PR itself or in different ones