### PR TITLE
AP_RangeFinder: Change the maximum distance of VL53L0X.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L0X.cpp
@@ -780,7 +780,7 @@ void AP_RangeFinder_VL53L0X::update(void)
 void AP_RangeFinder_VL53L0X::timer(void)
 {
     uint16_t range_mm;
-    if (get_reading(range_mm) && range_mm < 8000) {
+    if (get_reading(range_mm) && range_mm <= 2000) {
         sum_mm += range_mm;
         counter++;
     }


### PR DESCRIPTION
I have stated that the public maximum value of VL53L0X is 2m.
I think that it is better to make it a published value.
https://www.pololu.com/file/0J1187/VL53L0X.pdf