### PR TITLE
ChibiOS, INS: 2 small fixes for chibis watchdog

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -230,7 +230,7 @@ bool Util::flash_bootloader()
     uint32_t fw_size;
     const char *fw_name = "bootloader.bin";
 
-    hal.scheduler->expect_delay_ms(5000);
+    hal.scheduler->expect_delay_ms(11000);
 
     uint8_t *fw = AP_ROMFS::find_decompress(fw_name, fw_size);
     if (!fw) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1860,6 +1860,7 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
         return MAV_RESULT_TEMPORARILY_REJECTED;
     }
 
+    hal.scheduler->expect_delay_ms(20000);
     // record we are calibrating
     _calibrating = true;
 
@@ -1998,6 +1999,8 @@ MAV_RESULT AP_InertialSensor::simple_accel_cal()
 
     // stop flashing leds
     AP_Notify::flags.initialising = false;
+
+    hal.scheduler->expect_delay_ms(0);
 
     return result;
 }


### PR DESCRIPTION
1st fix for accelcalsimple which currently instantly triggers watchdog reset
2nd for bootloader flash as the functions has 10 max attempts loop where each round waits for a second
