### PR TITLE
Rover: stick mixing

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -32,13 +32,11 @@ MAV_MODE GCS_MAVLINK_Rover::base_mode() const
         _base_mode |= MAV_MODE_FLAG_GUIDED_ENABLED;
     }
 
-#if defined(ENABLE_STICK_MIXING) && (ENABLE_STICK_MIXING == ENABLED) // TODO ???? Remove !
-    if (control_mode->stick_mixing_enabled()) {
+    if (rover.g2.stick_mixing > 0 && rover.control_mode != &rover.mode_initializing) {
         // all modes except INITIALISING have some form of manual
         // override if stick mixing is enabled
         _base_mode |= MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
     }
-#endif
 
 #if HIL_MODE != HIL_MODE_DISABLED
     _base_mode |= MAV_MODE_FLAG_HIL_ENABLED;

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -701,6 +701,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(scripting, "SCR_", 41, ParametersG2, AP_Scripting),
 #endif
 
+    // @Param: STICK_MIXING
+    // @DisplayName: Stick Mixing
+    // @Description: When enabled, this adds steering user stick input in auto modes, allowing the user to have some degree of control without changing modes.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("STICK_MIXING", 42, ParametersG2, stick_mixing, 0),
+
     AP_GROUPEND
 };
 

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -397,6 +397,9 @@ public:
     // balance both pitch trim
     AP_Float bal_pitch_trim;
 
+    // stick mixing for auto modes
+    AP_Int8     stick_mixing;
+
 #ifdef ENABLE_SCRIPTING
     AP_Scripting scripting;
 #endif // ENABLE_SCRIPTING

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -511,7 +511,7 @@ void Mode::calc_steering_from_lateral_acceleration(float lat_accel, bool reverse
                                                                            g2.motors.limit.steer_left,
                                                                            g2.motors.limit.steer_right,
                                                                            rover.G_Dt);
-    g2.motors.set_steering(steering_out * 4500.0f);
+    set_steering(steering_out * 4500.0f);
 }
 
 // calculate steering output to drive towards desired heading
@@ -527,7 +527,7 @@ void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max_deg
                                                                          g2.motors.limit.steer_left,
                                                                          g2.motors.limit.steer_right,
                                                                          rover.G_Dt);
-    g2.motors.set_steering(steering_out * 4500.0f);
+    set_steering(steering_out * 4500.0f);
 }
 
 // calculate vehicle stopping point using current location, velocity and maximum acceleration
@@ -553,6 +553,11 @@ void Mode::calc_stopping_location(Location& stopping_loc)
     const Vector2f stopping_offset = velocity.normalized() * stopping_dist;
 
     stopping_loc.offset(stopping_offset.x, stopping_offset.y);
+}
+
+void Mode::set_steering(float steering_value)
+{
+    g2.motors.set_steering(steering_value);
 }
 
 Mode *Rover::mode_from_mode_num(const enum Mode::Number num)

--- a/APMrover2/mode.cpp
+++ b/APMrover2/mode.cpp
@@ -557,6 +557,10 @@ void Mode::calc_stopping_location(Location& stopping_loc)
 
 void Mode::set_steering(float steering_value)
 {
+    if (allows_stick_mixing() && g2.stick_mixing > 0) {
+        steering_value = channel_steer->stick_mixing((int16_t)steering_value);
+    }
+    steering_value = constrain_float(steering_value, -4500.0f, 4500.0f);
     g2.motors.set_steering(steering_value);
 }
 

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -73,6 +73,8 @@ public:
     // returns true if vehicle can be armed or disarmed from the transmitter in this mode
     virtual bool allows_arming_from_transmitter() { return !is_autopilot_mode(); }
 
+    bool allows_stick_mixing() const { return is_autopilot_mode(); }
+
     //
     // attributes for mavlink system status reporting
     //

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -195,6 +195,7 @@ protected:
     // steering_out is in the range -4500 ~ +4500 with positive numbers meaning rotate clockwise
     // throttle_out is in the range -100 ~ +100
     void get_pilot_input(float &steering_out, float &throttle_out);
+    void set_steering(float steering_value);
 
     // references to avoid code churn:
     class AP_AHRS &ahrs;

--- a/APMrover2/mode_acro.cpp
+++ b/APMrover2/mode_acro.cpp
@@ -43,7 +43,7 @@ void ModeAcro::update()
                                                               rover.G_Dt);
     }
 
-    g2.motors.set_steering(steering_out * 4500.0f);
+    set_steering(steering_out * 4500.0f);
 }
 
 bool ModeAcro::requires_velocity() const

--- a/APMrover2/mode_guided.cpp
+++ b/APMrover2/mode_guided.cpp
@@ -80,7 +80,7 @@ void ModeGuided::update()
                                                                             g2.motors.limit.steer_left,
                                                                             g2.motors.limit.steer_right,
                                                                             rover.G_Dt);
-                g2.motors.set_steering(steering_out * 4500.0f);
+                set_steering(steering_out * 4500.0f);
                 calc_throttle(_desired_speed, true, true);
             } else {
                 // we have reached the destination so stay here

--- a/APMrover2/mode_steering.cpp
+++ b/APMrover2/mode_steering.cpp
@@ -28,7 +28,7 @@ void ModeSteering::update()
                                                                           g2.motors.limit.steer_left,
                                                                           g2.motors.limit.steer_right,
                                                                           rover.G_Dt);
-        g2.motors.set_steering(steering_out * 4500.0f);
+        set_steering(steering_out * 4500.0f);
     } else {
         // In steering mode we control lateral acceleration directly.
         // For regular steering vehicles we use the maximum lateral acceleration

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1003,7 +1003,6 @@ private:
     bool stick_mixing_enabled(void);
     void stabilize_roll(float speed_scaler);
     void stabilize_pitch(float speed_scaler);
-    static void stick_mix_channel(RC_Channel *channel, int16_t &servo_out);
     void stabilize_stick_mixing_direct();
     void stabilize_stick_mixing_fbw();
     void stabilize_yaw(float speed_scaler);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -359,6 +359,26 @@ bool RC_Channel::has_override() const
     return is_positive(override_timeout_ms) && ((AP_HAL::millis() - last_override_time) < (uint32_t)override_timeout_ms);
 }
 
+/*
+  perform stick mixing on one channel
+  This type of stick mixing reduces the influence of the auto
+  controller as it increases the influence of the users stick input,
+  allowing the user full deflection if needed
+ */
+int16_t RC_Channel::stick_mixing(const int16_t servo_in)
+{
+    float ch_inf = (float)(radio_in - radio_trim);
+    ch_inf = fabsf(ch_inf);
+    ch_inf = MIN(ch_inf, 400.0f);
+    ch_inf = ((400.0f - ch_inf) / 400.0f);
+
+    int16_t servo_out = servo_in;
+    servo_out *= ch_inf;
+    servo_out += control_in;
+
+    return servo_out;
+}
+
 //
 // support for auxillary switches:
 //

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -71,6 +71,8 @@ public:
     void       set_override(const uint16_t v, const uint32_t timestamp_us);
     bool       has_override() const;
 
+    int16_t    stick_mixing(const int16_t servo_in);
+
     // get control input with zero deadzone
     int16_t    get_control_in_zero_dz(void) const;
 


### PR DESCRIPTION
This creates a new rover param STICK_MIXING which is the same as STICK_MIXING=1 (Direct) for plane. This also includes a refactor of the plane direct mixing to relocate it to RC_Channel so that both vehicles can take advantage of it.

This is for modes: AUTO, Guided, Loiter, RTL, SmartRTL, Follow

I left one of the Rover commit unsquashed because I think it's important to show the non-functional refactor of set_steering().

TODO:
- this only works for pilot type = 0 and 2 (DEFAULT and DIR_REVERSED_WHEN_REVERSING). It does NOT properly handle pilot type 1 and 3 (TWO_PADDLES and DIR_UNCHANGED_WHEN_REVERSING).

