### PR TITLE
AP_Baro: Fix not healthy by watchdog reset

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -183,6 +183,12 @@ AP_Baro::AP_Baro()
 // the altitude() or climb_rate() interfaces can be used
 void AP_Baro::calibrate(bool save)
 {
+    // start by assuming all sensors are calibrated (for healthy() test)
+    for (uint8_t i=0; i<_num_sensors; i++) {
+        sensors[i].calibrated = true;
+        sensors[i].alt_ok = true;
+    }
+
     if (hal.util->was_watchdog_reset()) {
         gcs().send_text(MAV_SEVERITY_INFO, "Baro: skipping calibration");
         return;
@@ -192,12 +198,6 @@ void AP_Baro::calibrate(bool save)
     // reset the altitude offset when we calibrate. The altitude
     // offset is supposed to be for within a flight
     _alt_offset.set_and_save(0);
-
-    // start by assuming all sensors are calibrated (for healthy() test)
-    for (uint8_t i=0; i<_num_sensors; i++) {
-        sensors[i].calibrated = true;
-        sensors[i].alt_ok = true;
-    }
 
     // let the barometer settle for a full second after startup
     // the MS5611 reads quite a long way off for the first second,


### PR DESCRIPTION
Skip calibrated and all_ok checks on reset. This doesn't affect actual health check as it still checks for readings.
This fixes pre-arm: barometer not healthy problem reported in  #11232