### PR TITLE
AP_Logger: prevent to arm again if we failed to write for long time

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -1108,6 +1108,10 @@ bool AP_Logger_File::logging_failed() const
         // Good.
         return true;
     }
+    uint32_t tnow = AP_HAL::millis();
+    if (logging_started() && logging_enabled() && tnow - _last_write_ms > 30000) {
+        return true;
+    }
 
     return false;
 }


### PR DESCRIPTION
this should warn when we didn't manage to log correctly after a fly 