### PR TITLE
AP_IOMCU: remove 2s delay on boot and skip crc check on watchdog

### DIFF
--- a/libraries/AP_IOMCU/AP_IOMCU.cpp
+++ b/libraries/AP_IOMCU/AP_IOMCU.cpp
@@ -61,11 +61,8 @@ void AP_IOMCU::init(void)
     uart.set_blocking_writes(false);
     uart.set_unbuffered_writes(true);
 
-    // check IO firmware CRC
-    hal.scheduler->delay(2000);
-    
     AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
-    if (!boardconfig || boardconfig->io_enabled() == 1) {
+    if ((!boardconfig || boardconfig->io_enabled() == 1) && !hal.util->was_watchdog_reset()) {
         check_crc();
     } else {
         crc_is_ok = true;


### PR DESCRIPTION
thanks to @Jaaaky for the suggestion in #11232