### PR TITLE
EKF2: added EK2_AFFINITY for sensor affinity control

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -313,6 +313,9 @@ void AP_Airspeed::init()
             delete sensor[i];
             sensor[i] = nullptr;
         }
+        if (sensor[i] != nullptr) {
+            num_sensors = i+1;
+        }
     }
 }
 

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -158,6 +158,9 @@ public:
     // get current primary sensor
     uint8_t get_primary(void) const { return primary; }
 
+    // get number of sensors
+    uint8_t get_num_sensors(void) const { return num_sensors; }
+    
     static AP_Airspeed *get_singleton() { return _singleton; }
 
     // return the current corrected pressure, public for AP_Periph
@@ -223,7 +226,8 @@ private:
 
     // current primary sensor
     uint8_t primary;
-    
+    uint8_t num_sensors;
+
     void read(uint8_t i);
     // return the differential pressure in Pascal for the last airspeed reading for the requested instance
     // returns 0 if the sensor is not enabled

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -55,6 +55,9 @@ public:
     // check if all baros are healthy - used for SYS_STATUS report
     bool all_healthy(void) const;
 
+    // get primary sensor
+    uint8_t get_primary(void) const { return _primary; }
+
     // pressure in Pascal. Divide by 100 for millibars or hectopascals
     float get_pressure(void) const { return get_pressure(_primary); }
     float get_pressure(uint8_t instance) const { return sensors[instance].pressure; }

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -448,7 +448,6 @@ struct PACKED log_NKF2 {
     int16_t magX;
     int16_t magY;
     int16_t magZ;
-    uint8_t index;
 };
 
 struct PACKED log_XKF2 {
@@ -569,6 +568,17 @@ struct PACKED log_NKF5 {
     float angErr;
     float velErr;
     float posErr;
+};
+
+// common sensor selection log message
+struct PACKED log_EKFS {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t core;
+    uint8_t mag_index;
+    uint8_t baro_index;
+    uint8_t gps_index;
+    uint8_t airspeed_index;
 };
 
 struct PACKED log_Quaternion {
@@ -1778,7 +1788,6 @@ struct PACKED log_Arm_Disarm {
 // @Field: MX: Magnetic field strength (body X-axis)
 // @Field: MY: Magnetic field strength (body Y-axis)
 // @Field: MZ: Magnetic field strength (body Z-axis)
-// @Field: MI: Magnetometer used for data
 
 // @LoggerMessage: NKF3
 // @Description: EKF2 innovations
@@ -1829,6 +1838,15 @@ struct PACKED log_Arm_Disarm {
 // @Field: eAng: Magnitude of angular error
 // @Field: eVel: Magnitude of velocity error
 // @Field: ePos: Magnitude of position error
+
+// @LoggerMessage: NKFS
+// @Description: EKF2 sensor selection
+// @Field: TimeUS: Time since system startup
+// @Field: C: EKF2 core this data is for
+// @Field: MI: compass selection index
+// @Field: BI: barometer selection index
+// @Field: GI: GPS selection index
+// @Field: AI: airspeed selection index
 
 // @LoggerMessage: NKQ
 // @Description: EKF2 quaternion defining the rotation from NED to XYZ (autopilot) axes
@@ -2406,7 +2424,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QBccCfffffffccce","TimeUS,C,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ,OH", "s#ddhnnnnmmmkkkm", "F-BBB0000000BBBB" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \
-      "NKF2","QBbccccchhhhhhB","TimeUS,C,AZbias,GSX,GSY,GSZ,VWN,VWE,MN,ME,MD,MX,MY,MZ,MI", "s#----nnGGGGGG-", "F-----BBCCCCCC-" }, \
+      "NKF2","QBbccccchhhhhh","TimeUS,C,AZbias,GSX,GSY,GSZ,VWN,VWE,MN,ME,MD,MX,MY,MZ", "s#----nnGGGGGG", "F-----BBCCCCCC" }, \
     { LOG_NKF3_MSG, sizeof(log_NKF3), \
       "NKF3","QBcccccchhhcc","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT", "s#nnnmmmGGG??", "F-BBBBBBCCCBB" }, \
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
@@ -2415,6 +2433,8 @@ struct PACKED log_Arm_Disarm {
       "NKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos", "s----m???mrnm", "F----BBBBB000" }, \
     { LOG_NKF10_MSG, sizeof(log_RngBcnDebug), \
       "NKF0","QBccCCcccccccc","TimeUS,ID,rng,innov,SIV,TR,BPN,BPE,BPD,OFH,OFL,OFN,OFE,OFD", "s-m---mmmmmmmm", "F-B---BBBBBBBB" }, \
+    { LOG_NKFS_MSG, sizeof(log_EKFS), \
+      "NKFS","QBBBBB","TimeUS,C,MI,BI,GI,AI", "s#----", "F-----" }, \
     { LOG_NKQ_MSG, sizeof(log_Quaternion), "NKQ", QUAT_FMT, QUAT_LABELS, QUAT_UNITS, QUAT_MULTS }, \
     { LOG_XKF1_MSG, sizeof(log_EKF1), \
       "XKF1","QBccCfffffffccce","TimeUS,C,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ,OH", "s#ddhnnnnmmmkkkm", "F-BBB0000000BBBB" }, \
@@ -2569,6 +2589,7 @@ enum LogMessages : uint8_t {
     LOG_NKF4_MSG,
     LOG_NKF5_MSG,
     LOG_NKF10_MSG,
+    LOG_NKFS_MSG,
     LOG_NKQ_MSG,
     LOG_XKF1_MSG,
     LOG_XKF2_MSG,

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -609,7 +609,14 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("GSF_RST_MAX", 57, NavEKF2, _gsfResetMaxCount, 2),
-    
+
+    // @Param: AFFINITY
+    // @DisplayName: EKF2 Sensor Addinity Options
+    // @Description: These options control the affinity between sensor instances and EKF cores
+    // @User: Advanced
+    // @Bitmask: 0:EnableGPSAffinity,1:EnableBaroAffinity,2:EnableCompassAffinity,3:EnableAirspeedAffinity
+    AP_GROUPINFO("AFFINITY", 58, NavEKF2, _affinity, 0),
+
     AP_GROUPEND
 };
 
@@ -799,8 +806,8 @@ void NavEKF2::UpdateFilter(void)
         for (uint8_t coreIndex=0; coreIndex<num_cores; coreIndex++) {
 
             if (coreIndex != primary) {
-                // an alternative core is available for selection only if healthy and if states have been updated on this time step
-                bool altCoreAvailable = core[coreIndex].healthy() && statePredictEnabled[coreIndex];
+                // an alternative core is available for selection only if healthy
+                bool altCoreAvailable = core[coreIndex].healthy();
 
                 // If the primary core is unhealthy and another core is available, then switch now
                 // If the primary core is still healthy,then switching is optional and will only be done if

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1109,6 +1109,39 @@ uint8_t NavEKF2::getActiveMag(int8_t instance) const
     }
 }
 
+// return the baro in use for the specified instance
+uint8_t NavEKF2::getActiveBaro(int8_t instance) const
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (core) {
+        return core[instance].getActiveBaro();
+    } else {
+        return 255;
+    }
+}
+
+// return the GPS in use for the specified instance
+uint8_t NavEKF2::getActiveGPS(int8_t instance) const
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (core) {
+        return core[instance].getActiveGPS();
+    } else {
+        return 255;
+    }
+}
+
+// return the airspeed sensor in use for the specified instance
+uint8_t NavEKF2::getActiveAirspeed(int8_t instance) const
+{
+    if (instance < 0 || instance >= num_cores) instance = primary;
+    if (core) {
+        return core[instance].getActiveAirspeed();
+    } else {
+        return 255;
+    }
+}
+
 // Return estimated magnetometer offsets
 // Return true if magnetometer offsets are valid
 bool NavEKF2::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -151,9 +151,12 @@ public:
     // An out of range instance (eg -1) returns data for the primary instance
     void getMagXYZ(int8_t instance, Vector3f &magXYZ) const;
 
-    // return the magnetometer in use for the specified instance
+    // return the sensor in use for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
     uint8_t getActiveMag(int8_t instance) const;
+    uint8_t getActiveBaro(int8_t instance) const;
+    uint8_t getActiveGPS(int8_t instance) const;
+    uint8_t getActiveAirspeed(int8_t instance) const;
 
     // Return estimated magnetometer offsets
     // Return true if magnetometer offsets are valid
@@ -564,6 +567,7 @@ private:
     void Log_Write_NKF3(uint8_t core, uint64_t time_us) const;
     void Log_Write_NKF4(uint8_t core, uint64_t time_us) const;
     void Log_Write_NKF5(uint64_t time_us) const;
+    void Log_Write_NKFS(uint8_t core, uint64_t time_us) const;
     void Log_Write_Quaternion(uint8_t core, uint64_t time_us) const;
     void Log_Write_Beacon(uint64_t time_us) const;
     void Log_Write_GSF(uint8_t core, uint64_t time_us) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -446,6 +446,7 @@ private:
     AP_Int8 _gsfUseMask;            // mask controlling which EKF2 instances will use EKF-GSF yaw estimator data to assit with yaw resets
     AP_Int16 _gsfResetDelay;        // number of mSec from loss of navigation to requesting a reset using EKF-GSF yaw estimator data
     AP_Int8 _gsfResetMaxCount;      // maximum number of times the EKF2 is allowed to reset it's yaw to the EKF-GSF estimate
+    AP_Int32 _affinity;             // bitmask of sensor affinity options
 
 // Possible values for _flowUse
 #define FLOW_USE_NONE    0

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -52,7 +52,6 @@ void NavEKF2::Log_Write_NKF2(uint8_t _core, uint64_t time_us) const
     Vector3f magNED;
     Vector3f magXYZ;
     Vector3f gyroScaleFactor;
-    uint8_t magIndex = getActiveMag(_core);
     getAccelZBias(_core,azbias);
     getWind(_core,wind);
     getMagNED(_core,magNED);
@@ -74,9 +73,27 @@ void NavEKF2::Log_Write_NKF2(uint8_t _core, uint64_t time_us) const
         magX    : (int16_t)(magXYZ.x),
         magY    : (int16_t)(magXYZ.y),
         magZ    : (int16_t)(magXYZ.z),
-        index   : (uint8_t)(magIndex)
     };
     AP::logger().WriteBlock(&pkt2, sizeof(pkt2));
+}
+
+void NavEKF2::Log_Write_NKFS(uint8_t _core, uint64_t time_us) const
+{
+    // Write sensor selection EKF packet
+    uint8_t magIndex = getActiveMag(_core);
+    uint8_t baroIndex = getActiveBaro(_core);
+    uint8_t GPSIndex = getActiveGPS(_core);
+    uint8_t airspeedIndex = getActiveAirspeed(_core);
+    const struct log_EKFS pkt {
+        LOG_PACKET_HEADER_INIT(LOG_NKFS_MSG),
+        time_us : time_us,
+        core    : _core,
+        mag_index      : (uint8_t)(magIndex),
+        baro_index     : (uint8_t)(baroIndex),
+        gps_index      : (uint8_t)(GPSIndex),
+        airspeed_index : (uint8_t)(airspeedIndex),
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
 void NavEKF2::Log_Write_NKF3(uint8_t _core, uint64_t time_us) const
@@ -252,6 +269,7 @@ void NavEKF2::Log_Write()
         Log_Write_NKF2(i, time_us);
         Log_Write_NKF3(i, time_us);
         Log_Write_NKF4(i, time_us);
+        Log_Write_NKFS(i, time_us);
         Log_Write_Quaternion(i, time_us);
         Log_Write_GSF(i, time_us);
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -48,7 +48,7 @@ float NavEKF2_core::errorScore() const
         // Check GPS fusion performance
         score = MAX(score, 0.5f * (velTestRatio + posTestRatio));
         // Check altimeter fusion performance
-        score = MAX(score, hgtTestRatio);
+        score = MAX(score, hgtTestRatio*2);
         // Check attitude corrections
         const float tiltErrThreshold = 0.05f;
         score = MAX(score, tiltErrFilt / tiltErrThreshold);
@@ -256,9 +256,10 @@ bool NavEKF2_core::getPosNE(Vector2f &posNE) const
     } else {
         // In constant position mode the EKF position states are at the origin, so we cannot use them as a position estimate
         if(validOrigin) {
-            if ((AP::gps().status() >= AP_GPS::GPS_OK_FIX_2D)) {
+            auto &gps = AP::gps();
+            if ((gps.status(selected_gps) >= AP_GPS::GPS_OK_FIX_2D)) {
                 // If the origin has been set and we have GPS, then return the GPS position relative to the origin
-                const struct Location &gpsloc = AP::gps().location();
+                const struct Location &gpsloc = gps.location(selected_gps);
                 const Vector2f tempPosNE = EKF_origin.get_distance_NE(gpsloc);
                 posNE.x = tempPosNE.x;
                 posNE.y = tempPosNE.y;
@@ -340,9 +341,9 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
         } else {
             // we could be in constant position mode  because the vehicle has taken off without GPS, or has lost GPS
             // in this mode we cannot use the EKF states to estimate position so will return the best available data
-            if ((gps.status() >= AP_GPS::GPS_OK_FIX_2D)) {
+            if ((gps.status(selected_gps) >= AP_GPS::GPS_OK_FIX_2D)) {
                 // we have a GPS position fix to return
-                const struct Location &gpsloc = gps.location();
+                const struct Location &gpsloc = gps.location(selected_gps);
                 loc.lat = gpsloc.lat;
                 loc.lng = gpsloc.lng;
                 return true;
@@ -362,8 +363,8 @@ bool NavEKF2_core::getLLH(struct Location &loc) const
     } else {
         // If no origin has been defined for the EKF, then we cannot use its position states so return a raw
         // GPS reading if available and return false
-        if ((gps.status() >= AP_GPS::GPS_OK_FIX_3D)) {
-            const struct Location &gpsloc = gps.location();
+        if ((gps.status(selected_gps) >= AP_GPS::GPS_OK_FIX_3D)) {
+            const struct Location &gpsloc = gps.location(selected_gps);
             loc = gpsloc;
             loc.relative_alt = 0;
             loc.terrain_alt = 0;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -446,6 +446,24 @@ uint8_t NavEKF2_core::getActiveMag() const
     return (uint8_t)magSelectIndex;
 }
 
+// return the index for the active barometer
+uint8_t NavEKF2_core::getActiveBaro() const
+{
+    return (uint8_t)selected_baro;
+}
+
+// return the index for the active GPS
+uint8_t NavEKF2_core::getActiveGPS() const
+{
+    return (uint8_t)selected_gps;
+}
+
+// return the index for the active airspeed
+uint8_t NavEKF2_core::getActiveAirspeed() const
+{
+    return (uint8_t)selected_airspeed;
+}
+
 // return the innovations for the NED Pos, NED Vel, XYZ Mag and Vtas measurements
 void  NavEKF2_core::getInnovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -59,7 +59,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
 
     // Check for significant change in GPS position if disarmed which indicates bad GPS
     // This check can only be used when the vehicle is stationary
-    const struct Location &gpsloc = gps.location(); // Current location
+    const struct Location &gpsloc = gps.location(preferred_gps); // Current location
     const float posFiltTimeConst = 10.0f; // time constant used to decay position drift
     // calculate time lapsed since last update and limit to prevent numerical errors
     float deltaTime = constrain_float(float(imuDataDelayed.time_ms - lastPreAlignGpsCheckTime_ms)*0.001f,0.01f,posFiltTimeConst);
@@ -87,18 +87,18 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
 
     // Check that the vertical GPS vertical velocity is reasonable after noise filtering
     bool gpsVertVelFail;
-    if (gps.have_vertical_velocity() && onGround) {
+    if (gps.have_vertical_velocity(preferred_gps) && onGround) {
         // check that the average vertical GPS velocity is close to zero
         gpsVertVelFilt = 0.1f * gpsDataNew.vel.z + 0.9f * gpsVertVelFilt;
         gpsVertVelFilt = constrain_float(gpsVertVelFilt,-10.0f,10.0f);
         gpsVertVelFail = (fabsf(gpsVertVelFilt) > 0.3f*checkScaler) && (frontend->_gpsCheck & MASK_GPS_VERT_SPD);
-    } else if ((frontend->_fusionModeGPS == 0) && !gps.have_vertical_velocity()) {
+    } else if ((frontend->_fusionModeGPS == 0) && !gps.have_vertical_velocity(preferred_gps)) {
         // If the EKF settings require vertical GPS velocity and the receiver is not outputting it, then fail
         gpsVertVelFail = true;
         // if we have a 3D fix with no vertical velocity and
         // EK2_GPS_TYPE=0 then change it to 1. It means the GPS is not
         // capable of giving a vertical velocity
-        if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
+        if (gps.status(preferred_gps) >= AP_GPS::GPS_OK_FIX_3D) {
             frontend->_fusionModeGPS.set(1);
             gcs().send_text(MAV_SEVERITY_WARNING, "EK2: Changed EK2_GPS_TYPE to 1");
         }
@@ -140,7 +140,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     // fail if horiziontal position accuracy not sufficient
     float hAcc = 0.0f;
     bool hAccFail;
-    if (gps.horizontal_accuracy(hAcc)) {
+    if (gps.horizontal_accuracy(preferred_gps, hAcc)) {
         hAccFail = (hAcc > 5.0f*checkScaler)  && (frontend->_gpsCheck & MASK_GPS_POS_ERR);
     } else {
         hAccFail =  false;
@@ -159,7 +159,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     // Check for vertical GPS accuracy
     float vAcc = 0.0f;
     bool vAccFail = false;
-    if (gps.vertical_accuracy(vAcc)) {
+    if (gps.vertical_accuracy(preferred_gps, vAcc)) {
         vAccFail = (vAcc > 7.5f * checkScaler) && (frontend->_gpsCheck & MASK_GPS_POS_ERR);
     }
     // Report check result as a text string and bitmask
@@ -186,24 +186,24 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // fail if satellite geometry is poor
-    bool hdopFail = (gps.get_hdop() > 250)  && (frontend->_gpsCheck & MASK_GPS_HDOP);
+    bool hdopFail = (gps.get_hdop(preferred_gps) > 250)  && (frontend->_gpsCheck & MASK_GPS_HDOP);
 
     // Report check result as a text string and bitmask
     if (hdopFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS HDOP %.1f (needs 2.5)", (double)(0.01f * gps.get_hdop()));
+                           "GPS HDOP %.1f (needs 2.5)", (double)(0.01f * gps.get_hdop(preferred_gps)));
         gpsCheckStatus.bad_hdop = true;
     } else {
         gpsCheckStatus.bad_hdop = false;
     }
 
     // fail if not enough sats
-    bool numSatsFail = (gps.num_sats() < 6) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsFail = (gps.num_sats(preferred_gps) < 6) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS numsats %u (needs 6)", gps.num_sats());
+                           "GPS numsats %u (needs 6)", gps.num_sats(preferred_gps));
         gpsCheckStatus.bad_sats = true;
     } else {
         gpsCheckStatus.bad_sats = false;
@@ -269,7 +269,7 @@ void NavEKF2_core::calcGpsGoodForFlight(void)
 
     // get the receivers reported speed accuracy
     float gpsSpdAccRaw;
-    if (!AP::gps().speed_accuracy(gpsSpdAccRaw)) {
+    if (!AP::gps().speed_accuracy(selected_gps, gpsSpdAccRaw)) {
         gpsSpdAccRaw = 0.0f;
     }
 
@@ -329,9 +329,9 @@ void NavEKF2_core::detectFlight()
         bool largeHgtChange = false;
 
         // trigger at 8 m/s airspeed
-        if (_ahrs->airspeed_sensor_enabled()) {
-            const AP_Airspeed *airspeed = _ahrs->get_airspeed();
-            if (airspeed->get_airspeed() * AP::ahrs().get_EAS2TAS() > 10.0f) {
+        const auto *arsp = AP::airspeed();
+        if (arsp && arsp->healthy(selected_airspeed) && arsp->use(selected_airspeed)) {
+            if (arsp->get_airspeed(selected_airspeed) * _ahrs->get_EAS2TAS() > 10.0f) {
                 highAirSpd = true;
             }
         }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -406,8 +406,11 @@ void NavEKF2_core::InitialiseVariablesMag()
 // This method can only be used when the vehicle is static
 bool NavEKF2_core::InitialiseFilterBootstrap(void)
 {
+    // update sensor selection (for affinity)
+    update_sensor_selection();
+
     // If we are a plane and don't have GPS lock then don't initialise
-    if (assume_zero_sideslip() && AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+    if (assume_zero_sideslip() && AP::gps().status(preferred_gps) < AP_GPS::GPS_OK_FIX_3D) {
         hal.util->snprintf(prearm_fail_string,
                            sizeof(prearm_fail_string),
                            "EKF2 init failure: No GPS lock");
@@ -577,6 +580,9 @@ void NavEKF2_core::UpdateFilter(bool predict)
     hal.util->perf_begin(_perf_UpdateFilter);
 
     fill_scratch_variables();
+
+    // update sensor selection (for affinity)
+    update_sensor_selection();
 
     // TODO - in-flight restart method
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -156,8 +156,11 @@ public:
     // return body magnetic field estimates in measurement units / 1000
     void getMagXYZ(Vector3f &magXYZ) const;
 
-    // return the index for the active magnetometer
+    // return the index for the active sensors
     uint8_t getActiveMag() const;
+    uint8_t getActiveBaro() const;
+    uint8_t getActiveGPS() const;
+    uint8_t getActiveAirspeed() const;
 
     // Return estimated magnetometer offsets
     // Return true if magnetometer offsets are valid

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1291,4 +1291,28 @@ private:
     uint32_t EKFGSF_yaw_reset_request_ms;   // timestamp of last emergency yaw reset request (uSec)
     uint8_t EKFGSF_yaw_reset_count;         // number of emergency yaw resets performed
     bool EKFGSF_run_filterbank;             // true when the filter bank is active
+
+    // bits in EK2_AFFINITY
+    enum ekf_affinity {
+        EKF_AFFINITY_GPS  = (1U<<0),
+        EKF_AFFINITY_BARO = (1U<<1),
+        EKF_AFFINITY_MAG  = (1U<<2),
+        EKF_AFFINITY_ARSP = (1U<<3),
+    };
+
+    // update selected_sensors for this core
+    void update_sensor_selection(void);
+    void update_gps_selection(void);
+    void update_mag_selection(void);
+    void update_baro_selection(void);
+    void update_airspeed_selection(void);
+
+    // selected and preferred sensor instances. We separate selected
+    // from preferred so that calcGpsGoodToAlign() can ensure the
+    // preferred sensor is ready. Note that magSelectIndex is used for
+    // compass selection
+    uint8_t selected_gps;
+    uint8_t preferred_gps;
+    uint8_t selected_baro;
+    uint8_t selected_airspeed;
 };


### PR DESCRIPTION
This adds a EK2_AFFINITY bitmask, allowing control of affinity between IMUs and other sensors (GPS, mag, baro and airspeed)
This provides for a more statistically robust way of using multiple sensors when the airframe is known to have multiple "good" sensors. EKF lane changing is used to select the lane with the best sensors

