### PR TITLE
AP_Mission/AP_HAL_ChibiOS: watchdog: restore mission proposal

### DIFF
--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -29,6 +29,12 @@ public:
     // backup home state for restore on watchdog reset
     virtual bool get_backup_home_state(int32_t &lat, int32_t &lon, int32_t &alt_cm) const { return false; }
 
+    // backup last mission nav wp index for restore on watchdog reset
+    virtual void set_backup_prev_nav_cmd_state(uint32_t index) const {}
+
+    // backup last mission nav wp index for restore on watchdog reset
+    virtual bool get_backup_prev_nav_cmd_state(uint32_t &index) const { return false; }
+
     // backup atttude for restore on watchdog reset
     virtual void set_backup_attitude(int32_t roll_cd, int32_t pitch_cd, int32_t yaw_cd) const {}
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -360,6 +360,22 @@ bool Util::get_backup_home_state(int32_t &lat, int32_t &lon, int32_t &alt_cm) co
     return false;
 }
 
+// backup last mission nav wp index for restore on watchdog reset
+void Util::set_backup_prev_nav_cmd_state(uint32_t index) const
+{
+    stm32_set_prev_nav_cmd(index);
+}
+
+// backup last mission nav wp index for restore on watchdog reset
+bool Util::get_backup_prev_nav_cmd_state(uint32_t &index) const
+{
+    if (was_watchdog_reset()) {
+        stm32_get_prev_nav_cmd(&index);
+        return true;
+    }
+    return false;
+}
+
 // backup atttude for restore on watchdog reset
 void Util::set_backup_attitude(int32_t roll_cd, int32_t pitch_cd, int32_t yaw_cd) const
 {

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -80,6 +80,12 @@ public:
     // backup home state for restore on watchdog reset
     bool get_backup_home_state(int32_t &lat, int32_t &lon, int32_t &alt_cm) const override;
 
+    // backup last mission nav wp index for restore on watchdog reset
+    void set_backup_prev_nav_cmd_state(uint32_t index) const override;
+
+    // backup last mission nav wp index for restore on watchdog reset
+    bool get_backup_prev_nav_cmd_state(uint32_t &index) const override;
+
     // backup atttude for restore on watchdog reset
     void set_backup_attitude(int32_t roll_cd, int32_t pitch_cd, int32_t yaw_cd) const override;
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/watchdog.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/watchdog.c
@@ -45,8 +45,9 @@
 #define WDG_ARMED_BIT   0x02
 
 #define BKP_IDX_FLAGS   0x01
-#define BKP_IDX_HOME    0x02
-#define BKP_IDX_RPY     0x05
+#define BKP_IDX_HOME    0x02 //0x03 0x04 resrved for HOME
+#define BKP_IDX_RPY     0x05 //0x06 0x07 reserved for RPY
+#define BKP_IDX_NAVWP   0x08
 
 typedef struct
 {
@@ -185,6 +186,22 @@ void stm32_get_backup_home(int32_t *lat, int32_t *lon, int32_t *alt_cm)
     *lat = (int32_t)boot_backup_state[BKP_IDX_HOME];
     *lon = (int32_t)boot_backup_state[BKP_IDX_HOME+1];
     *alt_cm = (int32_t)boot_backup_state[BKP_IDX_HOME+2];
+}
+
+/*
+  set last nav wp index
+ */
+void stm32_set_prev_nav_cmd(uint32_t index)
+{
+    set_rtc_backup(BKP_IDX_NAVWP, index);
+}
+
+/*
+  get last nav wp index
+ */
+void stm32_get_prev_nav_cmd(uint32_t *index)
+{
+    *index = boot_backup_state[BKP_IDX_NAVWP];
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/watchdog.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/watchdog.h
@@ -60,6 +60,16 @@ void stm32_set_backup_home(int32_t lat, int32_t lon, int32_t alt_cm);
 void stm32_get_backup_home(int32_t *lat, int32_t *lon, int32_t *alt_cm);
 
 /*
+  set last nav wp index
+ */
+void stm32_set_prev_nav_cmd(uint32_t index);
+
+/*
+  get last nav wp index
+ */
+void stm32_get_prev_nav_cmd(uint32_t *index);
+
+/*
   set attitude in backup
  */
 void stm32_set_attitude(int32_t roll_cd, int32_t pitch_cd, int32_t yaw_cd);

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -549,6 +549,9 @@ private:
     /// sanity checks that the masked fields are not NaN's or infinite
     static MAV_MISSION_RESULT sanity_check_params(const mavlink_mission_item_int_t& packet);
 
+    void save_watchdog_prev_nav_cmd_idx();
+    void load_watchdog_nav_cmd_idx();
+
     // parameters
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)


### PR DESCRIPTION
A proposal to implement mission state on watchdog reset to allow AUTO recovery.
The idea to save prev_nav_cmd is that there can be commands after it that affects the current/next_nav_cmd. Also, some vehicles need prev_nav_cmd info.
So restore prev_nav_cmd and set current as prev+1 to process any commands in between.
Also restore mission state.

Tried to store/restore both into the uni32_t 4 bytes. Bitwise always confuses me :) So correct mistakes please.
I think it needs more testing and review of how vehicle code would behave if initial_mode is set to 10/AUTO for agricultural surveillance for example.


