### PR TITLE
AP_OpticalFlow: Make PX4FLOW work on Pixhawk4 I2C A

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -60,7 +60,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
     uint8_t retry_attempt = 0;
 
     while (!success && retry_attempt < PX4FLOW_INIT_RETRIES) {
-        for (uint8_t bus = 0; bus < 3; bus++) {
+        for (uint8_t bus = 0; bus <= 3; bus++) {
     #ifdef HAL_OPTFLOW_PX4FLOW_I2C_BUS
             // only one bus from HAL
             if (bus != HAL_OPTFLOW_PX4FLOW_I2C_BUS) {


### PR DESCRIPTION
Current driver didn't detecte Pixhawk I2C A port which I2C bus 3.
![image](https://user-images.githubusercontent.com/4748411/57177679-3208cd00-6e99-11e9-9084-d42273339e01.png)
![image](https://user-images.githubusercontent.com/4748411/57177684-3b923500-6e99-11e9-8500-1b748c1ebce8.png)

This will Fix #11070

Test ok:
![image](https://user-images.githubusercontent.com/4748411/57177690-54024f80-6e99-11e9-88ed-0050604d4896.png)

Known issue:
1. Current ArduPilot boot up too fast, the init progress before PX4FLOW ready, users need to power PX4FLOW first.
Fixed in #11267 
2. Mission Planner doesn't show opt_* values in status page.
Opened a issue at Mission planner
https://github.com/ArduPilot/MissionPlanner/issues/2141
Fixed, I changed to another computer, then it's ok.
