### PR TITLE
AP_OpticalFlow: Delay PX4Flow Init Timing

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -83,7 +83,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
         }
         retry_attempt++;
         if (!success) {
-            hal.scheduler->delay(10);
+            hal.scheduler->delay(1000);
         }
     }
     return success;

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -60,7 +60,7 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
     uint8_t retry_attempt = 0;
 
     while (!success && retry_attempt < PX4FLOW_INIT_RETRIES) {
-        for (uint8_t bus = 0; bus < 3; bus++) {
+        for (uint8_t bus = 0; bus <= 3; bus++) {
     #ifdef HAL_OPTFLOW_PX4FLOW_I2C_BUS
             // only one bus from HAL
             if (bus != HAL_OPTFLOW_PX4FLOW_I2C_BUS) {


### PR DESCRIPTION
Due to Ardupilot bootup is so fast, the PX4Flow init progress will end before PX4Flow boot successful.

Tested connect or disconnect PX4Flow, both works well.