### PR TITLE
Fix Azure autotest runs

### DIFF
--- a/.azure/autotest_template.yml
+++ b/.azure/autotest_template.yml
@@ -10,7 +10,7 @@ jobs:
   steps:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
-  - script: choco install gcc-g++ python2 python2-devel python2-future python2-lxml python27-pip python2-pexpect python2-numpy git gettext libcrypt-devel --source cygwin
+  - script: choco install gcc-g++ python27 python27-devel python2-future python27-lxml python27-pip python27-pexpect python27-numpy git gettext libcrypt-devel --source cygwin
     displayName: 'Install Cygwin packages'
   - script: git submodule update --recursive --init modules/mavlink
     displayName: Initialize MAVLink submodule

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
   - script: choco install cygwin --params "/InstallDir:C:\Cygwin /NoStartMenu /NoAdmin"
     displayName: 'Install Cygwin'
 
-  - script: choco install cygwin32-gcc-g++ python2 python2-future python2-lxml git gettext --source cygwin
+  - script: choco install cygwin32-gcc-g++ python27 python2-future python27-lxml git gettext --source cygwin
     displayName: 'Install Cygwin packages'
 
   - script: C:\Cygwin\bin\bash --login -c "cd $(cygpath '%BUILD_SOURCESDIRECTORY%') &&

--- a/Tools/autotest/common.py
+++ b/Tools/autotest/common.py
@@ -2637,7 +2637,7 @@ switch value'''
                      0,
                      0,
                      0,
-                     timeout=2,
+                     timeout=4,
                      want_result=mavutil.mavlink.MAV_RESULT_FAILED)
         self.context_pop()
         self.run_cmd(mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
@@ -2648,7 +2648,7 @@ switch value'''
                      0,
                      0,
                      0,
-                     timeout=2,
+                     timeout=4,
                      want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED)
         self.disarm_vehicle()
 


### PR DESCRIPTION
This (partially) fixes the autotest daily runs on Azure. It's partially because several tests still regularly fail - these tests also fail sometimes on other CIs so it's not an exclusive of Azure though.

@peterbarker Regarding commits in autotest:

- 1st one: this is for the case where we test RC failsafe in Plane (I've seen it fail in other CIs too); it is too fast doing short and long failsafes and the way we checked if the mode changed would drop the message showing the mode change for short failsafe.
I think that what I did is actually what we want - when checking if there was a mode change, we want to check if it happened, even if another one happened after it.
One possible improvement here might be that before doing something that expects a mode change, we explicitly drain the messages.

- 2nd one: that timeout increase made the test always pass in Azure
- 3rd one: I wouldn't merge this, it still **very** regularly fails the tests with those large timeouts. I left it here to call for attention for these two tests and asking: should the timeouts be using the simulation time instead of real time?

Needs https://github.com/ArduPilot/mavlink/pull/94