### PR TITLE
change astylerc to match Plane style

### DIFF
--- a/Tools/CodeStyle/astylerc
+++ b/Tools/CodeStyle/astylerc
@@ -1,9 +1,10 @@
-style=stroustrup
+style=linux
+keep-one-line-statements
 add-brackets
 indent=spaces=4
 indent-col1-comments
 min-conditional-indent=0
 suffix=none
 lineend=linux
-unpad-paren
 pad-header
+


### PR DESCRIPTION
style=linux changes only trailing whitespace using astyle 3.1 
but style=stroustrup moves braces around