### PR TITLE
Plane: add param Q_TILT_BIAS_CH for RC control of motor tilt forward bias

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -443,6 +443,13 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("ACRO_YAW_RATE", 13, QuadPlane, acro_yaw_rate, 90),
+
+    // @Param: TILT_BIAS_CH
+    // @DisplayName: Tilt bias channel
+    // @Description: RC channel for manual forward bias of motor tilt.
+    // @Range 0 16
+    AP_GROUPINFO("TILT_BIAS_CH", 14, QuadPlane, tilt.bias_chan, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -425,6 +425,7 @@ private:
         AP_Int16 max_rate_down_dps;
         AP_Int8  max_angle_deg;
         AP_Int8  tilt_type;
+        AP_Int8  bias_chan;
         AP_Float tilt_yaw_angle;
         float current_tilt;
         float current_throttle;
@@ -486,6 +487,7 @@ private:
     }
     bool tiltrotor_fully_fwd(void);
     float tilt_max_change(bool up);
+    float tilt_get_biased_tilt(void);
 
     void afs_terminate(void);
     bool guided_mode_enabled(void);

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -111,6 +111,7 @@ void QuadPlane::tiltrotor_continuous_update(void)
     */
     if (plane.control_mode == &plane.mode_qstabilize ||
         plane.control_mode == &plane.mode_qhover ||
+        plane.control_mode == &plane.mode_qacro ||
         plane.control_mode == &plane.mode_qautotune) {
         tiltrotor_slew(0);
         return;
@@ -374,17 +375,13 @@ void QuadPlane::tiltrotor_vectored_yaw(void)
 
     // calculate the basic tilt amount from current_tilt
     float base_output = zero_out + (tilt_get_biased_tilt() * (1 - zero_out));
-    
-    float tilt_threshold = (tilt.max_angle_deg/90.0f);
-    bool no_yaw = (tilt_get_biased_tilt() > tilt_threshold);
-    if (no_yaw) {
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft,  1000 * base_output);
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 1000 * base_output);
-    } else {
-        float yaw_out = motors->get_yaw();
-        float yaw_range = zero_out;
 
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft,  1000 * (base_output + yaw_out * yaw_range));
-        SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 1000 * (base_output - yaw_out * yaw_range));
+    float tilt_threshold = (tilt.max_angle_deg/90.0f);
+    float yaw_range = zero_out;
+    float yaw_out = 0.0f;
+    if (tilt_get_biased_tilt() < tilt_threshold) {
+        yaw_out = motors->get_yaw() * yaw_range;
     }
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft,  1000 * (base_output + yaw_out));
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, 1000 * (base_output - yaw_out));
 }


### PR DESCRIPTION
this lets you use a knob or slider to tilt the motors forward for higher speed in VTOL modes
Has no effect on FW modes with the motors fully forward.