### PR TITLE
AP_Scripting: Take the lock around interop calls

### DIFF
--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -28,14 +28,18 @@ An example script is given below:
 
 ```lua
 function update () -- periodic function that will be called
-  current_pos = Location()
-  ahrs:get_position(current_pos)
-  distance = current_pos:get_distance(ahrs:get_home()) -- calculate the distance from home
-  if distance > 1000 then -- if more then 1000 meters away
-    distance = 1000;      -- clamp the distance to 1000 meters
+  current_pos = ahrs:get_position()
+  home = ahrs:get_home()
+  if current_pos and home then
+    distance = current_pos:get_distance(ahrs:get_home()) -- calculate the distance from home
+    if distance > 1000 then -- if more then 1000 meters away
+      distance = 1000;      -- clamp the distance to 1000 meters
+    end
+    servo.set_output_pwm(96, 1000 + distance) -- set the servo assigned function 96 (scripting3) to a proportional value
   end
-  servo.set_output_pwm(96, 1000 + distance) -- set the servo assigned function 96 (scripting3) to a proportional value
 
   return update, 1000 -- request to be rerun again 1000 milliseconds (1 second) from now
 end
+
+return update, 1000 -- request to be rerun again 1000 milliseconds (1 second) from now
 ```

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -120,3 +120,7 @@ singleton AP_Relay method on void uint8_t 0 AP_RELAY_NUM_RELAYS
 singleton AP_Relay method off void uint8_t 0 AP_RELAY_NUM_RELAYS
 singleton AP_Relay method enabled boolean uint8_t 0 AP_RELAY_NUM_RELAYS
 singleton AP_Relay method toggle void uint8_t 0 AP_RELAY_NUM_RELAYS
+
+include GCS_MAVLink/GCS.h
+singleton GCS alias gcs
+singleton GCS method send_text void MAV_SEVERITY'enum MAV_SEVERITY_EMERGENCY MAV_SEVERITY_DEBUG string

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -16,6 +16,7 @@ userdata Location method get_vector_from_origin_NEU boolean Vector3f
 include AP_AHRS/AP_AHRS.h
 
 singleton AP_AHRS alias ahrs
+singleton AP_AHRS semaphore
 singleton AP_AHRS method get_position boolean Location'Null
 singleton AP_AHRS method get_home Location
 singleton AP_AHRS method get_gyro Vector3f

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -26,8 +26,7 @@ int check_arguments(lua_State *L, int expected_arguments, const char *fn_name) {
 
 // servo binding
 
-int lua_servo_set_output_pwm(lua_State *L);
-int lua_servo_set_output_pwm(lua_State *L) {
+static int lua_servo_set_output_pwm(lua_State *L) {
     check_arguments(L, 2, "set_output_pwm");
 
     const SRV_Channel::Aux_servo_function_t servo_function = (SRV_Channel::Aux_servo_function_t)luaL_checkinteger(L, -2);
@@ -44,7 +43,7 @@ int lua_servo_set_output_pwm(lua_State *L) {
 }
 
 // millis
-int lua_millis(lua_State *L) {
+static int lua_millis(lua_State *L) {
     check_arguments(L, 0, "millis");
 
     new_uint32_t(L);

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -11,6 +11,11 @@ int new_uint32_t(lua_State *L) {
     return 1;
 }
 
+uint32_t * check_uint32_t(lua_State *L, int arg) {
+    void *data = luaL_checkudata(L, arg, "uint32_t");
+    return static_cast<uint32_t *>(data);
+}
+
 uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     { // userdata
         const uint32_t * ud = static_cast<uint32_t *>(luaL_testudata(L, arg, "uint32_t"));

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "lua_boxed_numerics.h"
 
+
 extern const AP_HAL::HAL& hal;
 
 int new_uint32_t(lua_State *L) {
@@ -16,7 +17,7 @@ uint32_t * check_uint32_t(lua_State *L, int arg) {
     return static_cast<uint32_t *>(data);
 }
 
-uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
+static uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     { // userdata
         const uint32_t * ud = static_cast<uint32_t *>(luaL_testudata(L, arg, "uint32_t"));
         if (ud != nullptr) {

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -3,6 +3,7 @@
 #include "lua/src/lua.hpp"
 
 int new_uint32_t(lua_State *L);
+uint32_t *check_uint32_t(lua_State *L, int arg);
 
 void load_boxed_numerics(lua_State *L);
 void load_boxed_numerics_sandbox(lua_State *L);

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -257,7 +257,7 @@ static int Vector2f_is_zero(lua_State *L) {
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_zero(
-);
+        );
 
     return 0;
 }
@@ -272,7 +272,7 @@ static int Vector2f_is_inf(lua_State *L) {
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_inf(
-);
+        );
 
     return 0;
 }
@@ -287,7 +287,7 @@ static int Vector2f_is_nan(lua_State *L) {
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_nan(
-);
+        );
 
     return 0;
 }
@@ -302,7 +302,7 @@ static int Vector2f_normalize(lua_State *L) {
 
     Vector2f * ud = check_Vector2f(L, 1);
     ud->normalize(
-);
+        );
 
     return 0;
 }
@@ -317,7 +317,7 @@ static int Vector2f_length(lua_State *L) {
 
     Vector2f * ud = check_Vector2f(L, 1);
     const float data = ud->length(
-);
+        );
 
     lua_pushnumber(L, data);
     return 1;
@@ -363,7 +363,7 @@ static int Vector3f_is_zero(lua_State *L) {
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_zero(
-);
+        );
 
     return 0;
 }
@@ -378,7 +378,7 @@ static int Vector3f_is_inf(lua_State *L) {
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_inf(
-);
+        );
 
     return 0;
 }
@@ -393,7 +393,7 @@ static int Vector3f_is_nan(lua_State *L) {
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_nan(
-);
+        );
 
     return 0;
 }
@@ -408,7 +408,7 @@ static int Vector3f_normalize(lua_State *L) {
 
     Vector3f * ud = check_Vector3f(L, 1);
     ud->normalize(
-);
+        );
 
     return 0;
 }
@@ -423,7 +423,7 @@ static int Vector3f_length(lua_State *L) {
 
     Vector3f * ud = check_Vector3f(L, 1);
     const float data = ud->length(
-);
+        );
 
     lua_pushnumber(L, data);
     return 1;
@@ -560,7 +560,7 @@ const luaL_Reg Location_meta[] = {
 };
 
 static int AP_Relay_toggle(lua_State *L) {
-    // 1 uint8_t 121 : 8
+    // 1 uint8_t 122 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -583,7 +583,7 @@ static int AP_Relay_toggle(lua_State *L) {
 }
 
 static int AP_Relay_enabled(lua_State *L) {
-    // 1 uint8_t 120 : 8
+    // 1 uint8_t 121 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -607,7 +607,7 @@ static int AP_Relay_enabled(lua_State *L) {
 }
 
 static int AP_Relay_off(lua_State *L) {
-    // 1 uint8_t 119 : 8
+    // 1 uint8_t 120 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -630,7 +630,7 @@ static int AP_Relay_off(lua_State *L) {
 }
 
 static int AP_Relay_on(lua_State *L) {
-    // 1 uint8_t 118 : 8
+    // 1 uint8_t 119 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -653,8 +653,8 @@ static int AP_Relay_on(lua_State *L) {
 }
 
 static int AP_Terrain_height_above_terrain(lua_State *L) {
-    // 1 float 113 : 6
-    // 2 bool 113 : 7
+    // 1 float 114 : 6
+    // 2 bool 114 : 7
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -682,9 +682,9 @@ static int AP_Terrain_height_above_terrain(lua_State *L) {
 }
 
 static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
-    // 1 float 112 : 8
-    // 2 float 112 : 9
-    // 3 bool 112 : 10
+    // 1 float 113 : 8
+    // 2 float 113 : 9
+    // 3 bool 113 : 10
     const int args = lua_gettop(L);
     if (args > 3) {
         return luaL_argerror(L, args, "too many arguments");
@@ -716,8 +716,8 @@ static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
 }
 
 static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
-    // 1 float 111 : 6
-    // 2 bool 111 : 7
+    // 1 float 112 : 6
+    // 2 bool 112 : 7
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -745,9 +745,9 @@ static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
 }
 
 static int AP_Terrain_height_amsl(lua_State *L) {
-    // 1 Location 110 : 6
-    // 2 float 110 : 7
-    // 3 bool 110 : 8
+    // 1 Location 111 : 6
+    // 2 float 111 : 7
+    // 3 bool 111 : 8
     const int args = lua_gettop(L);
     if (args > 3) {
         return luaL_argerror(L, args, "too many arguments");
@@ -790,7 +790,7 @@ static int AP_Terrain_status(lua_State *L) {
     }
 
     const uint8_t data = ud->status(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
@@ -810,7 +810,7 @@ static int AP_Terrain_enabled(lua_State *L) {
     }
 
     const bool data = ud->enabled(
-);
+        );
 
     lua_pushboolean(L, data);
     return 1;
@@ -830,14 +830,14 @@ static int RangeFinder_num_sensors(lua_State *L) {
     }
 
     const uint8_t data = ud->num_sensors(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 userdata 98 : 6
+    // 1 userdata 99 : 6
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -871,7 +871,7 @@ static int AP_GPS_first_unconfigured_gps(lua_State *L) {
     }
 
     const uint8_t data = ud->first_unconfigured_gps(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
@@ -891,14 +891,14 @@ static int AP_GPS_all_configured(lua_State *L) {
     }
 
     const bool data = ud->all_configured(
-);
+        );
 
     lua_pushboolean(L, data);
     return 1;
 }
 
 static int AP_GPS_get_antenna_offset(lua_State *L) {
-    // 1 uint8_t 69 : 8
+    // 1 uint8_t 70 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -923,7 +923,7 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
 }
 
 static int AP_GPS_have_vertical_velocity(lua_State *L) {
-    // 1 uint8_t 68 : 8
+    // 1 uint8_t 69 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -947,7 +947,7 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
 }
 
 static int AP_GPS_last_message_time_ms(lua_State *L) {
-    // 1 uint8_t 67 : 8
+    // 1 uint8_t 68 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -972,7 +972,7 @@ static int AP_GPS_last_message_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_last_fix_time_ms(lua_State *L) {
-    // 1 uint8_t 66 : 8
+    // 1 uint8_t 67 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -997,7 +997,7 @@ static int AP_GPS_last_fix_time_ms(lua_State *L) {
 }
 
 static int AP_GPS_get_vdop(lua_State *L) {
-    // 1 uint8_t 65 : 8
+    // 1 uint8_t 66 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1021,7 +1021,7 @@ static int AP_GPS_get_vdop(lua_State *L) {
 }
 
 static int AP_GPS_get_hdop(lua_State *L) {
-    // 1 uint8_t 64 : 8
+    // 1 uint8_t 65 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1045,7 +1045,7 @@ static int AP_GPS_get_hdop(lua_State *L) {
 }
 
 static int AP_GPS_time_week_ms(lua_State *L) {
-    // 1 uint8_t 63 : 8
+    // 1 uint8_t 64 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1070,7 +1070,7 @@ static int AP_GPS_time_week_ms(lua_State *L) {
 }
 
 static int AP_GPS_time_week(lua_State *L) {
-    // 1 uint8_t 62 : 8
+    // 1 uint8_t 63 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1094,7 +1094,7 @@ static int AP_GPS_time_week(lua_State *L) {
 }
 
 static int AP_GPS_num_sats(lua_State *L) {
-    // 1 uint8_t 61 : 8
+    // 1 uint8_t 62 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1118,7 +1118,7 @@ static int AP_GPS_num_sats(lua_State *L) {
 }
 
 static int AP_GPS_ground_course(lua_State *L) {
-    // 1 uint8_t 60 : 8
+    // 1 uint8_t 61 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1142,7 +1142,7 @@ static int AP_GPS_ground_course(lua_State *L) {
 }
 
 static int AP_GPS_ground_speed(lua_State *L) {
-    // 1 uint8_t 59 : 8
+    // 1 uint8_t 60 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1166,7 +1166,7 @@ static int AP_GPS_ground_speed(lua_State *L) {
 }
 
 static int AP_GPS_velocity(lua_State *L) {
-    // 1 uint8_t 58 : 8
+    // 1 uint8_t 59 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1191,8 +1191,8 @@ static int AP_GPS_velocity(lua_State *L) {
 }
 
 static int AP_GPS_vertical_accuracy(lua_State *L) {
-    // 1 uint8_t 57 : 8
-    // 2 float 57 : 9
+    // 1 uint8_t 58 : 8
+    // 2 float 58 : 9
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1222,8 +1222,8 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_horizontal_accuracy(lua_State *L) {
-    // 1 uint8_t 56 : 8
-    // 2 float 56 : 9
+    // 1 uint8_t 57 : 8
+    // 2 float 57 : 9
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1253,8 +1253,8 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_speed_accuracy(lua_State *L) {
-    // 1 uint8_t 55 : 8
-    // 2 float 55 : 9
+    // 1 uint8_t 56 : 8
+    // 2 float 56 : 9
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1284,7 +1284,7 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
 }
 
 static int AP_GPS_location(lua_State *L) {
-    // 1 uint8_t 54 : 8
+    // 1 uint8_t 55 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1309,7 +1309,7 @@ static int AP_GPS_location(lua_State *L) {
 }
 
 static int AP_GPS_status(lua_State *L) {
-    // 1 uint8_t 53 : 8
+    // 1 uint8_t 54 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1346,7 +1346,7 @@ static int AP_GPS_primary_sensor(lua_State *L) {
     }
 
     const uint8_t data = ud->primary_sensor(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
@@ -1366,15 +1366,15 @@ static int AP_GPS_num_sensors(lua_State *L) {
     }
 
     const uint8_t data = ud->num_sensors(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
 }
 
 static int AP_BattMonitor_get_temperature(lua_State *L) {
-    // 1 float 46 : 6
-    // 2 uint8_t 46 : 9
+    // 1 float 47 : 6
+    // 2 uint8_t 47 : 9
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1404,7 +1404,7 @@ static int AP_BattMonitor_get_temperature(lua_State *L) {
 }
 
 static int AP_BattMonitor_overpower_detected(lua_State *L) {
-    // 1 uint8_t 45 : 8
+    // 1 uint8_t 46 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1441,14 +1441,14 @@ static int AP_BattMonitor_has_failsafed(lua_State *L) {
     }
 
     const bool data = ud->has_failsafed(
-);
+        );
 
     lua_pushboolean(L, data);
     return 1;
 }
 
 static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
-    // 1 uint8_t 43 : 8
+    // 1 uint8_t 44 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1472,7 +1472,7 @@ static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
 }
 
 static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
-    // 1 uint8_t 42 : 8
+    // 1 uint8_t 43 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1496,7 +1496,7 @@ static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
 }
 
 static int AP_BattMonitor_consumed_wh(lua_State *L) {
-    // 1 uint8_t 41 : 8
+    // 1 uint8_t 42 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1520,7 +1520,7 @@ static int AP_BattMonitor_consumed_wh(lua_State *L) {
 }
 
 static int AP_BattMonitor_consumed_mah(lua_State *L) {
-    // 1 uint8_t 40 : 8
+    // 1 uint8_t 41 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1544,7 +1544,7 @@ static int AP_BattMonitor_consumed_mah(lua_State *L) {
 }
 
 static int AP_BattMonitor_current_amps(lua_State *L) {
-    // 1 uint8_t 39 : 8
+    // 1 uint8_t 40 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1568,7 +1568,7 @@ static int AP_BattMonitor_current_amps(lua_State *L) {
 }
 
 static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
-    // 1 uint8_t 38 : 8
+    // 1 uint8_t 39 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1592,7 +1592,7 @@ static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
 }
 
 static int AP_BattMonitor_voltage(lua_State *L) {
-    // 1 uint8_t 37 : 8
+    // 1 uint8_t 38 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1616,7 +1616,7 @@ static int AP_BattMonitor_voltage(lua_State *L) {
 }
 
 static int AP_BattMonitor_has_current(lua_State *L) {
-    // 1 uint8_t 36 : 8
+    // 1 uint8_t 37 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1640,7 +1640,7 @@ static int AP_BattMonitor_has_current(lua_State *L) {
 }
 
 static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
-    // 1 uint8_t 35 : 8
+    // 1 uint8_t 36 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1664,7 +1664,7 @@ static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
 }
 
 static int AP_BattMonitor_healthy(lua_State *L) {
-    // 1 uint8_t 34 : 8
+    // 1 uint8_t 35 : 8
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1701,7 +1701,7 @@ static int AP_BattMonitor_num_instances(lua_State *L) {
     }
 
     const uint8_t data = ud->num_instances(
-);
+        );
 
     lua_pushinteger(L, data);
     return 1;
@@ -1720,9 +1720,11 @@ static int AP_AHRS_prearm_healthy(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const bool data = ud->prearm_healthy(
-);
+        );
 
+    ud->get_semaphore().give();
     lua_pushboolean(L, data);
     return 1;
 }
@@ -1740,14 +1742,45 @@ static int AP_AHRS_home_is_set(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const bool data = ud->home_is_set(
-);
+        );
 
+    ud->get_semaphore().give();
     lua_pushboolean(L, data);
     return 1;
 }
 
 static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
+    // 1 Vector3f 27 : 6
+    const int args = lua_gettop(L);
+    if (args > 1) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_AHRS * ud = AP_AHRS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+    }
+
+    Vector3f data_5002 = {};
+    ud->get_semaphore().take_blocking();
+    const bool data = ud->get_relative_position_NED_home(
+            data_5002);
+
+    ud->get_semaphore().give();
+    if (data) {
+        new_Vector3f(L);
+        *check_Vector3f(L, -1) = data_5002;
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int AP_AHRS_get_velocity_NED(lua_State *L) {
     // 1 Vector3f 26 : 6
     const int args = lua_gettop(L);
     if (args > 1) {
@@ -1762,36 +1795,11 @@ static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
     }
 
     Vector3f data_5002 = {};
-    const bool data = ud->get_relative_position_NED_home(
-            data_5002);
-
-    if (data) {
-        new_Vector3f(L);
-        *check_Vector3f(L, -1) = data_5002;
-    } else {
-        lua_pushnil(L);
-    }
-    return 1;
-}
-
-static int AP_AHRS_get_velocity_NED(lua_State *L) {
-    // 1 Vector3f 25 : 6
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
-    AP_AHRS * ud = AP_AHRS::get_singleton();
-    if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
-    }
-
-    Vector3f data_5002 = {};
+    ud->get_semaphore().take_blocking();
     const bool data = ud->get_velocity_NED(
             data_5002);
 
+    ud->get_semaphore().give();
     if (data) {
         new_Vector3f(L);
         *check_Vector3f(L, -1) = data_5002;
@@ -1814,9 +1822,11 @@ static int AP_AHRS_groundspeed_vector(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const Vector2f &data = ud->groundspeed_vector(
-);
+        );
 
+    ud->get_semaphore().give();
     new_Vector2f(L);
     *check_Vector2f(L, -1) = data;
     return 1;
@@ -1835,16 +1845,18 @@ static int AP_AHRS_wind_estimate(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const Vector3f &data = ud->wind_estimate(
-);
+        );
 
+    ud->get_semaphore().give();
     new_Vector3f(L);
     *check_Vector3f(L, -1) = data;
     return 1;
 }
 
 static int AP_AHRS_get_hagl(lua_State *L) {
-    // 1 float 22 : 6
+    // 1 float 23 : 6
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1858,9 +1870,11 @@ static int AP_AHRS_get_hagl(lua_State *L) {
     }
 
     float data_5002 = {};
+    ud->get_semaphore().take_blocking();
     const bool data = ud->get_hagl(
             data_5002);
 
+    ud->get_semaphore().give();
     if (data) {
         lua_pushnumber(L, data_5002);
     } else {
@@ -1882,9 +1896,11 @@ static int AP_AHRS_get_gyro(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const Vector3f &data = ud->get_gyro(
-);
+        );
 
+    ud->get_semaphore().give();
     new_Vector3f(L);
     *check_Vector3f(L, -1) = data;
     return 1;
@@ -1903,16 +1919,18 @@ static int AP_AHRS_get_home(lua_State *L) {
         return luaL_argerror(L, args, "ahrs not supported on this firmware");
     }
 
+    ud->get_semaphore().take_blocking();
     const Location &data = ud->get_home(
-);
+        );
 
+    ud->get_semaphore().give();
     new_Location(L);
     *check_Location(L, -1) = data;
     return 1;
 }
 
 static int AP_AHRS_get_position(lua_State *L) {
-    // 1 Location 19 : 6
+    // 1 Location 20 : 6
     const int args = lua_gettop(L);
     if (args > 1) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1926,9 +1944,11 @@ static int AP_AHRS_get_position(lua_State *L) {
     }
 
     Location data_5002 = {};
+    ud->get_semaphore().take_blocking();
     const bool data = ud->get_position(
             data_5002);
 
+    ud->get_semaphore().give();
     if (data) {
         new_Location(L);
         *check_Location(L, -1) = data_5002;

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -478,7 +478,7 @@ static int GCS_send_text(lua_State *L) {
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
-    luaL_argcheck(L, ((raw_data_2 >= MAX(MAV_SEVERITY_EMERGENCY, INT32_MIN)) && (raw_data_2 <= MIN(MAV_SEVERITY_DEBUG, INT32_MAX))), 2, "argument out of range");
+    luaL_argcheck(L, ((raw_data_2 >= MAV_SEVERITY_EMERGENCY) && (raw_data_2 <= MAV_SEVERITY_DEBUG)), 2, "argument out of range");
     const MAV_SEVERITY data_2 = static_cast<MAV_SEVERITY>(raw_data_2);
     const char * data_3 = luaL_checkstring(L, 3);
     ud->send_text(

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -1,6 +1,7 @@
 // auto generated bindings, don't manually edit
 #include "lua_generated_bindings.h"
 #include "lua_boxed_numerics.h"
+#include <GCS_MAVLink/GCS.h>
 #include <AP_Relay/AP_Relay.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
@@ -559,6 +560,32 @@ const luaL_Reg Location_meta[] = {
     {NULL, NULL}
 };
 
+static int GCS_send_text(lua_State *L) {
+    // 1 MAV_SEVERITY 126 : 8
+    // 2 enum 126 : 9
+    const int args = lua_gettop(L);
+    if (args > 3) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    GCS * ud = GCS::get_singleton();
+    if (ud == nullptr) {
+        return luaL_argerror(L, args, "gcs not supported on this firmware");
+    }
+
+    const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
+    luaL_argcheck(L, ((raw_data_2 >= MAX(MAV_SEVERITY_EMERGENCY, INT32_MIN)) && (raw_data_2 <= MIN(MAV_SEVERITY_DEBUG, INT32_MAX))), 2, "argument out of range");
+    const MAV_SEVERITY data_2 = static_cast<MAV_SEVERITY>(raw_data_2);
+    const char * data_3 = luaL_checkstring(L, 3);
+    ud->send_text(
+            data_2,
+            data_3);
+
+    return 0;
+}
+
 static int AP_Relay_toggle(lua_State *L) {
     // 1 uint8_t 122 : 8
     const int args = lua_gettop(L);
@@ -837,7 +864,7 @@ static int RangeFinder_num_sensors(lua_State *L) {
 }
 
 static int AP_Notify_play_tune(lua_State *L) {
-    // 1 userdata 99 : 6
+    // 1 enum 99 : 6
     const int args = lua_gettop(L);
     if (args > 2) {
         return luaL_argerror(L, args, "too many arguments");
@@ -1958,6 +1985,11 @@ static int AP_AHRS_get_position(lua_State *L) {
     return 1;
 }
 
+const luaL_Reg GCS_meta[] = {
+    {"send_text", GCS_send_text},
+    {NULL, NULL}
+};
+
 const luaL_Reg AP_Relay_meta[] = {
     {"toggle", AP_Relay_toggle},
     {"enabled", AP_Relay_enabled},
@@ -2060,6 +2092,7 @@ const struct singleton_fun {
     const char *name;
     const luaL_Reg *reg;
 } singleton_fun[] = {
+    {"gcs", GCS_meta},
     {"relay", AP_Relay_meta},
     {"terrain", AP_Terrain_meta},
     {"rangefinder", RangeFinder_meta},
@@ -2100,6 +2133,7 @@ void load_generated_bindings(lua_State *L) {
 }
 
 const char *singletons[] = {
+    "gcs",
     "relay",
     "terrain",
     "rangefinder",

--- a/libraries/AP_Scripting/lua_generated_bindings.cpp
+++ b/libraries/AP_Scripting/lua_generated_bindings.cpp
@@ -13,6 +13,16 @@
 #include <AP_Common/Location.h>
 
 
+static int binding_argcheck(lua_State *L, int expected_arg_count) {
+    const int args = lua_gettop(L);
+    if (args > expected_arg_count) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < expected_arg_count) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+    return 0;
+}
+
 int new_Vector2f(lua_State *L) {
     luaL_checkstack(L, 2, "Out of stack");
     void *ud = lua_newuserdata(L, sizeof(Vector2f));
@@ -249,13 +259,7 @@ static int Location_lat(lua_State *L) {
 }
 
 static int Vector2f_is_zero(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_zero(
         );
@@ -264,13 +268,7 @@ static int Vector2f_is_zero(lua_State *L) {
 }
 
 static int Vector2f_is_inf(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_inf(
         );
@@ -279,13 +277,7 @@ static int Vector2f_is_inf(lua_State *L) {
 }
 
 static int Vector2f_is_nan(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector2f * ud = check_Vector2f(L, 1);
     ud->is_nan(
         );
@@ -294,13 +286,7 @@ static int Vector2f_is_nan(lua_State *L) {
 }
 
 static int Vector2f_normalize(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector2f * ud = check_Vector2f(L, 1);
     ud->normalize(
         );
@@ -309,13 +295,7 @@ static int Vector2f_normalize(lua_State *L) {
 }
 
 static int Vector2f_length(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector2f * ud = check_Vector2f(L, 1);
     const float data = ud->length(
         );
@@ -325,13 +305,7 @@ static int Vector2f_length(lua_State *L) {
 }
 
 static int Vector2f___add(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Vector2f *ud = check_Vector2f(L, 1);
     Vector2f *ud2 = check_Vector2f(L, 2);
     new_Vector2f(L);
@@ -340,13 +314,7 @@ static int Vector2f___add(lua_State *L) {
 }
 
 static int Vector2f___sub(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Vector2f *ud = check_Vector2f(L, 1);
     Vector2f *ud2 = check_Vector2f(L, 2);
     new_Vector2f(L);
@@ -355,13 +323,7 @@ static int Vector2f___sub(lua_State *L) {
 }
 
 static int Vector3f_is_zero(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_zero(
         );
@@ -370,13 +332,7 @@ static int Vector3f_is_zero(lua_State *L) {
 }
 
 static int Vector3f_is_inf(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_inf(
         );
@@ -385,13 +341,7 @@ static int Vector3f_is_inf(lua_State *L) {
 }
 
 static int Vector3f_is_nan(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector3f * ud = check_Vector3f(L, 1);
     ud->is_nan(
         );
@@ -400,13 +350,7 @@ static int Vector3f_is_nan(lua_State *L) {
 }
 
 static int Vector3f_normalize(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector3f * ud = check_Vector3f(L, 1);
     ud->normalize(
         );
@@ -415,13 +359,7 @@ static int Vector3f_normalize(lua_State *L) {
 }
 
 static int Vector3f_length(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     Vector3f * ud = check_Vector3f(L, 1);
     const float data = ud->length(
         );
@@ -431,13 +369,7 @@ static int Vector3f_length(lua_State *L) {
 }
 
 static int Vector3f___add(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Vector3f *ud = check_Vector3f(L, 1);
     Vector3f *ud2 = check_Vector3f(L, 2);
     new_Vector3f(L);
@@ -446,13 +378,7 @@ static int Vector3f___add(lua_State *L) {
 }
 
 static int Vector3f___sub(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Vector3f *ud = check_Vector3f(L, 1);
     Vector3f *ud2 = check_Vector3f(L, 2);
     new_Vector3f(L);
@@ -462,13 +388,7 @@ static int Vector3f___sub(lua_State *L) {
 
 static int Location_get_vector_from_origin_NEU(lua_State *L) {
     // 1 Vector3f 14 : 6
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Location * ud = check_Location(L, 1);
     Vector3f & data_2 = *check_Vector3f(L, 2);
     const bool data = ud->get_vector_from_origin_NEU(
@@ -481,13 +401,7 @@ static int Location_get_vector_from_origin_NEU(lua_State *L) {
 static int Location_offset(lua_State *L) {
     // 1 float 13 : 8
     // 2 float 13 : 11
-    const int args = lua_gettop(L);
-    if (args > 3) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 3);
     Location * ud = check_Location(L, 1);
     const float raw_data_2 = luaL_checknumber(L, 2);
     luaL_argcheck(L, ((raw_data_2 >= MAX(-FLT_MAX, -INFINITY)) && (raw_data_2 <= MIN(FLT_MAX, INFINITY))), 2, "argument out of range");
@@ -504,13 +418,7 @@ static int Location_offset(lua_State *L) {
 
 static int Location_get_distance(lua_State *L) {
     // 1 Location 12 : 6
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     Location * ud = check_Location(L, 1);
     Location & data_2 = *check_Location(L, 2);
     const float data = ud->get_distance(
@@ -563,16 +471,10 @@ const luaL_Reg Location_meta[] = {
 static int GCS_send_text(lua_State *L) {
     // 1 MAV_SEVERITY 126 : 8
     // 2 enum 126 : 9
-    const int args = lua_gettop(L);
-    if (args > 3) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 3);
     GCS * ud = GCS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gcs not supported on this firmware");
+        return luaL_argerror(L, 3, "gcs not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -588,16 +490,10 @@ static int GCS_send_text(lua_State *L) {
 
 static int AP_Relay_toggle(lua_State *L) {
     // 1 uint8_t 122 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "relay not supported on this firmware");
+        return luaL_argerror(L, 2, "relay not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -611,16 +507,10 @@ static int AP_Relay_toggle(lua_State *L) {
 
 static int AP_Relay_enabled(lua_State *L) {
     // 1 uint8_t 121 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "relay not supported on this firmware");
+        return luaL_argerror(L, 2, "relay not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -635,16 +525,10 @@ static int AP_Relay_enabled(lua_State *L) {
 
 static int AP_Relay_off(lua_State *L) {
     // 1 uint8_t 120 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "relay not supported on this firmware");
+        return luaL_argerror(L, 2, "relay not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -658,16 +542,10 @@ static int AP_Relay_off(lua_State *L) {
 
 static int AP_Relay_on(lua_State *L) {
     // 1 uint8_t 119 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Relay * ud = AP_Relay::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "relay not supported on this firmware");
+        return luaL_argerror(L, 2, "relay not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -682,16 +560,10 @@ static int AP_Relay_on(lua_State *L) {
 static int AP_Terrain_height_above_terrain(lua_State *L) {
     // 1 float 114 : 6
     // 2 bool 114 : 7
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 2, "terrain not supported on this firmware");
     }
 
     float data_5002 = {};
@@ -712,16 +584,10 @@ static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
     // 1 float 113 : 8
     // 2 float 113 : 9
     // 3 bool 113 : 10
-    const int args = lua_gettop(L);
-    if (args > 3) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 3);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 3, "terrain not supported on this firmware");
     }
 
     const float raw_data_2 = luaL_checknumber(L, 2);
@@ -745,16 +611,10 @@ static int AP_Terrain_height_relative_home_equivalent(lua_State *L) {
 static int AP_Terrain_height_terrain_difference_home(lua_State *L) {
     // 1 float 112 : 6
     // 2 bool 112 : 7
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 2, "terrain not supported on this firmware");
     }
 
     float data_5002 = {};
@@ -775,16 +635,10 @@ static int AP_Terrain_height_amsl(lua_State *L) {
     // 1 Location 111 : 6
     // 2 float 111 : 7
     // 3 bool 111 : 8
-    const int args = lua_gettop(L);
-    if (args > 3) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 3) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 3);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 3, "terrain not supported on this firmware");
     }
 
     Location & data_2 = *check_Location(L, 2);
@@ -804,16 +658,10 @@ static int AP_Terrain_height_amsl(lua_State *L) {
 }
 
 static int AP_Terrain_status(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     const uint8_t data = ud->status(
@@ -824,16 +672,10 @@ static int AP_Terrain_status(lua_State *L) {
 }
 
 static int AP_Terrain_enabled(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_Terrain * ud = AP_Terrain::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "terrain not supported on this firmware");
+        return luaL_argerror(L, 1, "terrain not supported on this firmware");
     }
 
     const bool data = ud->enabled(
@@ -844,16 +686,10 @@ static int AP_Terrain_enabled(lua_State *L) {
 }
 
 static int RangeFinder_num_sensors(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     RangeFinder * ud = RangeFinder::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "rangefinder not supported on this firmware");
+        return luaL_argerror(L, 1, "rangefinder not supported on this firmware");
     }
 
     const uint8_t data = ud->num_sensors(
@@ -865,16 +701,10 @@ static int RangeFinder_num_sensors(lua_State *L) {
 
 static int AP_Notify_play_tune(lua_State *L) {
     // 1 enum 99 : 6
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_Notify * ud = AP_Notify::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "AP_Notify not supported on this firmware");
+        return luaL_argerror(L, 2, "AP_Notify not supported on this firmware");
     }
 
     const char * data_2 = luaL_checkstring(L, 2);
@@ -885,16 +715,10 @@ static int AP_Notify_play_tune(lua_State *L) {
 }
 
 static int AP_GPS_first_unconfigured_gps(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     const uint8_t data = ud->first_unconfigured_gps(
@@ -905,16 +729,10 @@ static int AP_GPS_first_unconfigured_gps(lua_State *L) {
 }
 
 static int AP_GPS_all_configured(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     const bool data = ud->all_configured(
@@ -926,16 +744,10 @@ static int AP_GPS_all_configured(lua_State *L) {
 
 static int AP_GPS_get_antenna_offset(lua_State *L) {
     // 1 uint8_t 70 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -951,16 +763,10 @@ static int AP_GPS_get_antenna_offset(lua_State *L) {
 
 static int AP_GPS_have_vertical_velocity(lua_State *L) {
     // 1 uint8_t 69 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -975,16 +781,10 @@ static int AP_GPS_have_vertical_velocity(lua_State *L) {
 
 static int AP_GPS_last_message_time_ms(lua_State *L) {
     // 1 uint8_t 68 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1000,16 +800,10 @@ static int AP_GPS_last_message_time_ms(lua_State *L) {
 
 static int AP_GPS_last_fix_time_ms(lua_State *L) {
     // 1 uint8_t 67 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1025,16 +819,10 @@ static int AP_GPS_last_fix_time_ms(lua_State *L) {
 
 static int AP_GPS_get_vdop(lua_State *L) {
     // 1 uint8_t 66 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1049,16 +837,10 @@ static int AP_GPS_get_vdop(lua_State *L) {
 
 static int AP_GPS_get_hdop(lua_State *L) {
     // 1 uint8_t 65 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1073,16 +855,10 @@ static int AP_GPS_get_hdop(lua_State *L) {
 
 static int AP_GPS_time_week_ms(lua_State *L) {
     // 1 uint8_t 64 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1098,16 +874,10 @@ static int AP_GPS_time_week_ms(lua_State *L) {
 
 static int AP_GPS_time_week(lua_State *L) {
     // 1 uint8_t 63 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1122,16 +892,10 @@ static int AP_GPS_time_week(lua_State *L) {
 
 static int AP_GPS_num_sats(lua_State *L) {
     // 1 uint8_t 62 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1146,16 +910,10 @@ static int AP_GPS_num_sats(lua_State *L) {
 
 static int AP_GPS_ground_course(lua_State *L) {
     // 1 uint8_t 61 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1170,16 +928,10 @@ static int AP_GPS_ground_course(lua_State *L) {
 
 static int AP_GPS_ground_speed(lua_State *L) {
     // 1 uint8_t 60 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1194,16 +946,10 @@ static int AP_GPS_ground_speed(lua_State *L) {
 
 static int AP_GPS_velocity(lua_State *L) {
     // 1 uint8_t 59 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1220,16 +966,10 @@ static int AP_GPS_velocity(lua_State *L) {
 static int AP_GPS_vertical_accuracy(lua_State *L) {
     // 1 uint8_t 58 : 8
     // 2 float 58 : 9
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1251,16 +991,10 @@ static int AP_GPS_vertical_accuracy(lua_State *L) {
 static int AP_GPS_horizontal_accuracy(lua_State *L) {
     // 1 uint8_t 57 : 8
     // 2 float 57 : 9
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1282,16 +1016,10 @@ static int AP_GPS_horizontal_accuracy(lua_State *L) {
 static int AP_GPS_speed_accuracy(lua_State *L) {
     // 1 uint8_t 56 : 8
     // 2 float 56 : 9
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1312,16 +1040,10 @@ static int AP_GPS_speed_accuracy(lua_State *L) {
 
 static int AP_GPS_location(lua_State *L) {
     // 1 uint8_t 55 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1337,16 +1059,10 @@ static int AP_GPS_location(lua_State *L) {
 
 static int AP_GPS_status(lua_State *L) {
     // 1 uint8_t 54 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 2, "gps not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1360,16 +1076,10 @@ static int AP_GPS_status(lua_State *L) {
 }
 
 static int AP_GPS_primary_sensor(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     const uint8_t data = ud->primary_sensor(
@@ -1380,16 +1090,10 @@ static int AP_GPS_primary_sensor(lua_State *L) {
 }
 
 static int AP_GPS_num_sensors(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_GPS * ud = AP_GPS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "gps not supported on this firmware");
+        return luaL_argerror(L, 1, "gps not supported on this firmware");
     }
 
     const uint8_t data = ud->num_sensors(
@@ -1402,16 +1106,10 @@ static int AP_GPS_num_sensors(lua_State *L) {
 static int AP_BattMonitor_get_temperature(lua_State *L) {
     // 1 float 47 : 6
     // 2 uint8_t 47 : 9
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     float data_5002 = {};
@@ -1432,16 +1130,10 @@ static int AP_BattMonitor_get_temperature(lua_State *L) {
 
 static int AP_BattMonitor_overpower_detected(lua_State *L) {
     // 1 uint8_t 46 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1455,16 +1147,10 @@ static int AP_BattMonitor_overpower_detected(lua_State *L) {
 }
 
 static int AP_BattMonitor_has_failsafed(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     const bool data = ud->has_failsafed(
@@ -1476,16 +1162,10 @@ static int AP_BattMonitor_has_failsafed(lua_State *L) {
 
 static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
     // 1 uint8_t 44 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1500,16 +1180,10 @@ static int AP_BattMonitor_pack_capacity_mah(lua_State *L) {
 
 static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
     // 1 uint8_t 43 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1524,16 +1198,10 @@ static int AP_BattMonitor_capacity_remaining_pct(lua_State *L) {
 
 static int AP_BattMonitor_consumed_wh(lua_State *L) {
     // 1 uint8_t 42 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1548,16 +1216,10 @@ static int AP_BattMonitor_consumed_wh(lua_State *L) {
 
 static int AP_BattMonitor_consumed_mah(lua_State *L) {
     // 1 uint8_t 41 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1572,16 +1234,10 @@ static int AP_BattMonitor_consumed_mah(lua_State *L) {
 
 static int AP_BattMonitor_current_amps(lua_State *L) {
     // 1 uint8_t 40 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1596,16 +1252,10 @@ static int AP_BattMonitor_current_amps(lua_State *L) {
 
 static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
     // 1 uint8_t 39 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1620,16 +1270,10 @@ static int AP_BattMonitor_voltage_resting_estimate(lua_State *L) {
 
 static int AP_BattMonitor_voltage(lua_State *L) {
     // 1 uint8_t 38 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1644,16 +1288,10 @@ static int AP_BattMonitor_voltage(lua_State *L) {
 
 static int AP_BattMonitor_has_current(lua_State *L) {
     // 1 uint8_t 37 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1668,16 +1306,10 @@ static int AP_BattMonitor_has_current(lua_State *L) {
 
 static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
     // 1 uint8_t 36 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1692,16 +1324,10 @@ static int AP_BattMonitor_has_consumed_energy(lua_State *L) {
 
 static int AP_BattMonitor_healthy(lua_State *L) {
     // 1 uint8_t 35 : 8
-    const int args = lua_gettop(L);
-    if (args > 2) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 2) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 2);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 2, "battery not supported on this firmware");
     }
 
     const lua_Integer raw_data_2 = luaL_checkinteger(L, 2);
@@ -1715,16 +1341,10 @@ static int AP_BattMonitor_healthy(lua_State *L) {
 }
 
 static int AP_BattMonitor_num_instances(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_BattMonitor * ud = AP_BattMonitor::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "battery not supported on this firmware");
+        return luaL_argerror(L, 1, "battery not supported on this firmware");
     }
 
     const uint8_t data = ud->num_instances(
@@ -1735,16 +1355,10 @@ static int AP_BattMonitor_num_instances(lua_State *L) {
 }
 
 static int AP_AHRS_prearm_healthy(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1757,16 +1371,10 @@ static int AP_AHRS_prearm_healthy(lua_State *L) {
 }
 
 static int AP_AHRS_home_is_set(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1780,16 +1388,10 @@ static int AP_AHRS_home_is_set(lua_State *L) {
 
 static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
     // 1 Vector3f 27 : 6
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     Vector3f data_5002 = {};
@@ -1809,16 +1411,10 @@ static int AP_AHRS_get_relative_position_NED_home(lua_State *L) {
 
 static int AP_AHRS_get_velocity_NED(lua_State *L) {
     // 1 Vector3f 26 : 6
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     Vector3f data_5002 = {};
@@ -1837,16 +1433,10 @@ static int AP_AHRS_get_velocity_NED(lua_State *L) {
 }
 
 static int AP_AHRS_groundspeed_vector(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1860,16 +1450,10 @@ static int AP_AHRS_groundspeed_vector(lua_State *L) {
 }
 
 static int AP_AHRS_wind_estimate(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1884,16 +1468,10 @@ static int AP_AHRS_wind_estimate(lua_State *L) {
 
 static int AP_AHRS_get_hagl(lua_State *L) {
     // 1 float 23 : 6
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     float data_5002 = {};
@@ -1911,16 +1489,10 @@ static int AP_AHRS_get_hagl(lua_State *L) {
 }
 
 static int AP_AHRS_get_gyro(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1934,16 +1506,10 @@ static int AP_AHRS_get_gyro(lua_State *L) {
 }
 
 static int AP_AHRS_get_home(lua_State *L) {
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     ud->get_semaphore().take_blocking();
@@ -1958,16 +1524,10 @@ static int AP_AHRS_get_home(lua_State *L) {
 
 static int AP_AHRS_get_position(lua_State *L) {
     // 1 Location 20 : 6
-    const int args = lua_gettop(L);
-    if (args > 1) {
-        return luaL_argerror(L, args, "too many arguments");
-    } else if (args < 1) {
-        return luaL_argerror(L, args, "too few arguments");
-    }
-
+    binding_argcheck(L, 1);
     AP_AHRS * ud = AP_AHRS::get_singleton();
     if (ud == nullptr) {
-        return luaL_argerror(L, args, "ahrs not supported on this firmware");
+        return luaL_argerror(L, 1, "ahrs not supported on this firmware");
     }
 
     Location data_5002 = {};

--- a/libraries/AP_Scripting/lua_generated_bindings.h
+++ b/libraries/AP_Scripting/lua_generated_bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 // auto generated bindings, don't manually edit
+#include <GCS_MAVLink/GCS.h>
 #include <AP_Relay/AP_Relay.h>
 #include <AP_Terrain/AP_Terrain.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>

--- a/libraries/AP_Scripting/scripts/sandbox.lua
+++ b/libraries/AP_Scripting/scripts/sandbox.lua
@@ -30,7 +30,7 @@ function get_sandbox_env ()
                    codepoint = utf8.codepoint, len = utf8.len, offsets = utf8.offsets},
 
           -- ArduPilot specific
-          gcs = { send_text = gcs.send_text},
+          millis = millis,
           servo = { set_output_pwm = servo.set_output_pwm},
         }
 end


### PR DESCRIPTION
This primarily is an update that allows for taking a libraries singleton (expected to have the signature of `get_semaphore(void)`). This ensures that the call into the library should have consistent state (assuming that others actually grab the semaphore correctly, which isn't currently happening (#11199 is the first pass at correcting that).

This also allows passing enum types as arguments/return values rather then coercing blindly to an integer type.

Finally this extracts some common code to a helper. As it currently stands the compilier automatically inlines it for us everytime, but by keeping it extracted now it's easy to tag it as noinline in the future. (This saves ~2.7K of flash currently, we can afford the flash space at the moment, but it's worth making this an easy option to enable.)