### PR TITLE
AP_HAL_SITL: fix pthread SITL build on MacOS

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -4,6 +4,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_HAL_SITL_Namespace.h"
 #include <sys/time.h>
+#include <pthread.h>
 
 #define SITL_SCHEDULER_MAX_TIMER_PROCS 4
 


### PR DESCRIPTION
This fixes the following error on sim_vehicle:

```
In file included from ../../libraries/AP_HAL_SITL/system.cpp:7:
../../libraries/AP_HAL_SITL/Scheduler.h:81:5: fatal error: unknown type name 'pthread_t'
    pthread_t _main_ctx;
```

@tridge can you check if this is OK?